### PR TITLE
Add source-tracked ignored files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,73 @@
+# Optional local overrides. Copy to .env only if you want file-based local config.
+# Never commit real .env files or secrets.
+
+# Runtime mode
+ILLO_ENV=development
+# Required in production services. ./illo creates an ignored local default in
+# .illo/runtime.env when this is left empty.
+SECRET_KEY=
+
+# Database
+DB_HOST=127.0.0.1
+# Leave DB_PORT commented for local development if you want ./illo to choose an
+# alternate Docker pgvector port automatically when 5432 is already occupied.
+# DB_PORT=5432
+DB_NAME=illo_memory
+DB_USER=illo
+DB_PASSWORD=change-me
+
+# Runtime-private state (ignored by git)
+# Stores local operator context, generated journals/logs, exports, and scratch data.
+ILLO_PRIVATE_HOME=.illo
+# Optional overrides:
+# JOURNAL_DIR=.illo/journal
+# AGENT_CONTEXT_DIR=.illo/agent-context
+# AGENT_CHECKLIST_PATH=.illo/agent-context/pre-flight-checklist.md
+# BRAIN_LOG_DIR=.illo/logs
+
+# Local Codex auth fallback is convenient for single-user laptop dev only.
+# Leave this disabled in shared or production environments.
+ILLO_ALLOW_LOCAL_CODEX_AUTH_FALLBACK=0
+# The launcher refuses to kill unknown processes on app ports by default.
+# Set only when you intentionally want ./illo to reclaim 8000/5173/9800.
+# ILLO_FORCE_KILL_PORTS=1
+
+# Required for encrypted Vault storage. ./illo creates an ignored local default
+# in .illo/runtime.env when this is left empty. Generate a production value with:
+# python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+VAULT_MASTER_KEY=
+
+# LLM providers (choose what you use)
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+
+# Remote System tabs use the Illo server /auth/callback route for Codex sign-in.
+# Set to 0 to force the localhost bridge/manual callback flow.
+# ILLO_OPENAI_OAUTH_SERVER_CALLBACK=1
+
+# Embeddings: api is the easiest public default; gpu/cpu are also supported.
+EMBEDDING_BACKEND=api
+EMBEDDING_API_PROVIDER=gemini
+EMBEDDING_API_KEY=
+EMBEDDING_API_MODEL=gemini-embedding-2
+EMBEDDING_DIM=768
+
+# GPU embedding/LLM workers (optional)
+GPU_SERVER_URL=http://127.0.0.1:9800
+GPU_RECLAIM_CONFLICTING_PROCESSES=0
+# Leave model downloads lazy until the System tab opts into GPU embeddings.
+# Set ILLO_DOWNLOAD_GPU_MODELS=1 before ./illo setup to prefetch local GPU models.
+# ILLO_DOWNLOAD_GPU_MODELS=1
+GPU_EMBEDDING_VRAM_MB=15000
+GPU_LLM_VRAM_MB=9000
+# GPU_PRELOAD_EMBEDDING=1
+GPU_EMBEDDING_LOAD_TIMEOUT_SECONDS=300
+GPU_LLM_LOAD_TIMEOUT_SECONDS=300
+GPU_EMBEDDING_MAX_BATCH_SIZE=16
+EMBEDDING_WORKER_WARMUP_WAIT_SECONDS=180
+EMBEDDING_WORKER_RESTART_TIMEOUT_SECONDS=300
+LLM_MODEL=
+
+# Workspace root for project-context integrations (optional)
+WORKSPACE_ROOT=

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Pre-push hook: block direct pushes to main.
+
+while read local_ref local_sha remote_ref remote_sha; do
+    if echo "$remote_ref" | grep -qE "refs/heads/main$"; then
+        echo "❌ Direct push to main blocked."
+        echo "   Use: python3 -m cli.safe_deploy --title \"...\" --body \"...\""
+        echo "   Or create a PR manually."
+        exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
Adds the two tracked files from uwear-ai/illo-brain@main that are ignored by the imported .gitignore: .env.example and .githooks/pre-push.