### PR TITLE
Use configured low-tier model for title generation

### DIFF
--- a/brain/app/api/routers/cortex/__init__.py
+++ b/brain/app/api/routers/cortex/__init__.py
@@ -31,7 +31,6 @@ from brain.app.api.routers.cortex._helpers import (  # noqa: F401
     _caller_is_service_principal,
     _create_feedback_triggers,
     _extract_mentions,
-    _generate_title_gpu,
     _infer_feedback_tags,
     _parse_message_type,
     _presence_cleanup,
@@ -47,6 +46,7 @@ from brain.app.api.routers.cortex._helpers import (  # noqa: F401
     _validate_idea_org,
     _validate_idea_org_orm,
 )
+from brain.systems.cortex.title_generation import generate_display_title  # noqa: F401
 
 # Re-export endpoint functions referenced by tests
 from brain.app.api.routers.cortex._auth_keys import (  # noqa: F401

--- a/brain/app/api/routers/cortex/_helpers.py
+++ b/brain/app/api/routers/cortex/_helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import threading
 import time
 import uuid
@@ -66,16 +65,6 @@ UPLOAD_FALLBACK_CONTENT_TYPES = {
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "zip": "application/zip",
 }
-
-_TITLE_GENERATION_SYSTEM_PROMPT = (
-    "You generate concise display titles for raw thoughts and idea drafts. "
-    "Return only the title text. Keep it specific, descriptive, and compact. "
-    "Target 3 to 6 words when possible. Do not add explanations, quotes, bullets, or prefixes."
-)
-_TITLE_PREFIX_RE = re.compile(
-    r"^(?:title|suggested title|headline|summary title)\s*:\s*",
-    re.IGNORECASE,
-)
 
 _IMPLICIT_FEEDBACK_RULES = [
     ("memory_failure", ("does not remember", "forgot context", "not leverage memories", "doesn't remember", "remember anything")),
@@ -204,122 +193,6 @@ def _record_implicit_feedback(idea_id: str, content: str, tags: list[str]) -> No
                 run.metadata_ = metadata
     except Exception:
         logger.exception("Failed to persist implicit feedback for idea %s", idea_id)
-
-
-def _build_title_generation_prompt(raw_text: str) -> str:
-    thought = (raw_text or "").strip()[:500]
-    return (
-        f"{_TITLE_GENERATION_SYSTEM_PROMPT}\n\n"
-        "Raw thought or idea:\n"
-        f"{thought}\n\n"
-        "Title:"
-    )
-
-
-def _build_title_generation_user_prompt(raw_text: str) -> str:
-    thought = (raw_text or "").strip()[:500]
-    return (
-        "Raw thought or idea:\n"
-        f"{thought}\n\n"
-        "Return the best concise display title."
-    )
-
-
-def _normalize_generated_title(title: str | None) -> str | None:
-    title = (title or "").strip()
-    if not title:
-        return None
-
-    first_line = next((line.strip() for line in title.splitlines() if line.strip()), "")
-    candidate = _TITLE_PREFIX_RE.sub("", first_line).strip()
-    candidate = candidate.strip("`\"'“”‘’[](){} ")
-    candidate = re.sub(r"\s+", " ", candidate).strip()
-
-    if candidate.endswith((".", "!", "?", ";")) and len(candidate) > 4:
-        candidate = candidate[:-1].strip()
-
-    if candidate and 2 < len(candidate) < 60:
-        return candidate
-    return None
-
-
-def _generate_title_local(raw_text: str, *, client=None) -> str | None:
-    if client is None:
-        from brain.platform.gpu_client import get_client
-        client = get_client()
-    return _normalize_generated_title(
-        client.generate(
-            prompt=_build_title_generation_prompt(raw_text),
-            max_tokens=20,
-            temperature=0.3,
-            think=False,
-            fallback_policy="local-only",
-        )
-    )
-
-
-def _local_title_runtime_ready(client) -> bool:
-    try:
-        return client.is_ready("llm")
-    except Exception:
-        # If health probing fails, still attempt generation once before falling back.
-        return True
-
-
-def _generate_title_hosted_fallback(
-    raw_text: str,
-    *,
-    user_id: str | None = None,
-    org_id: str | None = None,
-) -> str | None:
-    from brain.platform.integrations.completions import simple_text_completion
-    from brain.platform.providers.model_policy import get_model_for_tier, resolve_default_provider
-
-    provider = resolve_default_provider(user_id=user_id, org_id=org_id)
-    model = get_model_for_tier(
-        "low",
-        provider=provider,
-        include_provider_prefix=True,
-        user_id=user_id,
-        org_id=org_id,
-    )
-    return _normalize_generated_title(
-        simple_text_completion(
-            _build_title_generation_user_prompt(raw_text),
-            model=model,
-            max_tokens=20,
-            user_id=user_id,
-            org_id=org_id,
-            system_prompt=_TITLE_GENERATION_SYSTEM_PROMPT,
-        )
-    )
-
-
-def _generate_title_gpu(
-    raw_text: str,
-    *,
-    user_id: str | None = None,
-    org_id: str | None = None,
-) -> str | None:
-    try:
-        from brain.platform.gpu_client import get_client
-
-        client = get_client()
-        if _local_title_runtime_ready(client):
-            title = _generate_title_local(raw_text, client=client)
-            if title:
-                return title
-            logger.info("Local title generation returned no usable title; falling back to hosted model")
-        else:
-            logger.info("Local title generation skipped because the llm worker is not ready")
-    except Exception as e:
-        logger.warning(f"GPU server title generation failed: {e}")
-
-    try:
-        return _generate_title_hosted_fallback(raw_text, user_id=user_id, org_id=org_id)
-    except Exception as e:
-        logger.warning(f"Hosted title generation fallback failed: {e}")
-        return None
 
 
 def _create_feedback_triggers(skill_used: str, task_summary: str, note: str):

--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -40,6 +40,7 @@ from brain.platform.db.repositories.ideas import (
     IdeaThreadRepository,
 )
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
 
 
 def _last_human_thread_author(idea_id: str, db: Session):
@@ -394,6 +395,7 @@ def list_archived_ideas(
 @router.post("/ideas", response_model=IdeaRead, status_code=201)
 async def create_idea(
     body: IdeaCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
@@ -428,6 +430,13 @@ async def create_idea(
         )
     db.flush()
     db.commit()
+    background_tasks.add_task(
+        generate_and_store_idea_display_title,
+        idea_id=str(idea.id),
+        raw_title=idea.title,
+        user_id=str(user.get("id")) if user.get("id") else None,
+        org_id=str(org_id) if org_id else None,
+    )
     await ws_manager.broadcast_product_event(
         "idea_created",
         {"idea_id": idea.id, "title": idea.title},

--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -24,7 +24,6 @@ from brain.app.api.routers.cortex._helpers import (
     UPLOAD_FALLBACK_CONTENT_TYPES,
     VIDEO_EXTENSIONS,
     _caller_is_service_principal,
-    _generate_title_gpu,
     _require_idea_for_user,
     _row_to_dict,
 )
@@ -38,6 +37,10 @@ from brain.app.api.routers.ws import ws_manager
 from brain.app.api.authorization import require_org_context
 from brain.platform.db.repositories.ideas import IdeaConnectionRepository
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.title_generation import (
+    generate_and_store_idea_display_title,
+    generate_display_title,
+)
 from brain.systems.services.runtime_introspection import get_provider_auth_status
 
 logger = logging.getLogger(__name__)
@@ -516,7 +519,7 @@ async def generate_title(request: Request, user: dict[str, Any] = Depends(get_cu
     text_content = data.get("text", "").strip()
     if not text_content:
         raise HTTPException(status_code=400, detail="text is required")
-    title = _generate_title_gpu(
+    title = generate_display_title(
         text_content,
         user_id=user.get("id"),
         org_id=user.get("org_id"),
@@ -528,7 +531,6 @@ async def generate_title(request: Request, user: dict[str, Any] = Depends(get_cu
 
 @router.post("/backfill-titles")
 def backfill_titles(user: dict[str, Any] = Depends(get_current_user)):
-    from brain.systems.cortex.events import publish
     org_id = user.get("org_id")
     user_id = user.get("id")
     with UnitOfWork() as uow:
@@ -543,17 +545,13 @@ def backfill_titles(user: dict[str, Any] = Depends(get_current_user)):
 
     count = 0
     for idea_id, idea_title in ideas_to_process:
-        title = _generate_title_gpu(
-            idea_title,
-            user_id=user.get("id"),
-            org_id=user.get("org_id"),
+        result = generate_and_store_idea_display_title(
+            str(idea_id),
+            user_id=user_id,
+            org_id=org_id,
+            raw_title=idea_title,
         )
-        if title:
-            with UnitOfWork() as uow:
-                idea = uow.session.get(Idea, idea_id)
-                if idea:
-                    idea.display_title = title
-            publish("title_generated", {"idea_id": str(idea_id), "title": title})
+        if result.updated:
             count += 1
     return {"ok": True, "generated": count, "total": len(ideas_to_process)}
 

--- a/brain/platform/integrations/completions.py
+++ b/brain/platform/integrations/completions.py
@@ -37,6 +37,7 @@ def simple_text_completion(
     user_id: str | None = None,
     org_id: str | None = None,
     system_prompt: str | None = None,
+    reasoning_effort: str | None = None,
     operation_type: str | None = None,
 ) -> str | None:
     """Run a simple single-turn completion and return the text content."""
@@ -69,6 +70,7 @@ def simple_text_completion(
         max_output_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],
         system=effective_system_prompt,
+        reasoning_effort=reasoning_effort,
         extra_headers=llm.build_request_headers() or None,
         operation_type=operation_type,
     ))

--- a/brain/systems/cortex/title_generation.py
+++ b/brain/systems/cortex/title_generation.py
@@ -1,0 +1,314 @@
+"""Cortex display-title generation."""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+TITLE_GENERATION_SYSTEM_PROMPT = (
+    "You generate concise display titles for raw thoughts and idea drafts. "
+    "Return only the title text. Keep it specific, descriptive, and compact. "
+    "Target 3 to 6 words when possible. Do not add explanations, quotes, bullets, or prefixes."
+)
+TITLE_PREFIX_RE = re.compile(
+    r"^(?:title|suggested title|headline|summary title)\s*:\s*",
+    re.IGNORECASE,
+)
+TITLE_MODEL_TIER = "low"
+TITLE_REASONING_EFFORT = "low"
+TITLE_INPUT_CHAR_LIMIT = 500
+TITLE_MAX_TOKENS = 20
+
+
+@dataclass(frozen=True)
+class StoredDisplayTitle:
+    idea_id: str
+    title: str | None = None
+    updated: bool = False
+    skipped_reason: str | None = None
+
+
+def _title_generation_local_prompt(raw_text: str) -> str:
+    thought = (raw_text or "").strip()[:TITLE_INPUT_CHAR_LIMIT]
+    return (
+        f"{TITLE_GENERATION_SYSTEM_PROMPT}\n\n"
+        "Raw thought or idea:\n"
+        f"{thought}\n\n"
+        "Title:"
+    )
+
+
+def _title_generation_user_prompt(raw_text: str) -> str:
+    thought = (raw_text or "").strip()[:TITLE_INPUT_CHAR_LIMIT]
+    return (
+        "Raw thought or idea:\n"
+        f"{thought}\n\n"
+        "Return the best concise display title."
+    )
+
+
+def normalize_generated_title(title: str | None) -> str | None:
+    title = (title or "").strip()
+    if not title:
+        return None
+
+    first_line = next((line.strip() for line in title.splitlines() if line.strip()), "")
+    candidate = TITLE_PREFIX_RE.sub("", first_line).strip()
+    candidate = candidate.strip("`\"'\u201c\u201d\u2018\u2019[](){} ")
+    candidate = re.sub(r"\s+", " ", candidate).strip()
+
+    if candidate.endswith((".", "!", "?", ";")) and len(candidate) > 4:
+        candidate = candidate[:-1].strip()
+
+    if candidate and 2 < len(candidate) < 60:
+        return candidate
+    return None
+
+
+def _strip_provider_prefix(model: str | None) -> str:
+    value = (model or "").strip()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    return value
+
+
+def is_local_title_model(model: str | None) -> bool:
+    normalized = _strip_provider_prefix(model).strip().lower()
+    return (
+        normalized == "local"
+        or normalized == "gpu_server"
+        or normalized.startswith("local/")
+        or normalized.startswith("gpu_server/")
+        or normalized.startswith("brain.platform.gpu/")
+    )
+
+
+def _provider_model_spec(provider: str, model: str) -> str:
+    value = (model or "").strip()
+    if value.startswith(("anthropic/", "openai/")):
+        return value
+    if value.startswith("anthropic:"):
+        return f"anthropic/{value[len('anthropic:'):]}"
+    if value.startswith("openai:"):
+        return f"openai/{value[len('openai:'):]}"
+    return f"{provider}/{value}"
+
+
+def _local_title_runtime_ready(client) -> bool:
+    try:
+        return client.is_ready("llm")
+    except Exception:
+        # If health probing fails, still attempt generation once.
+        return True
+
+
+def _generate_with_local_title_model(raw_text: str) -> str | None:
+    try:
+        from brain.platform.gpu_client import get_client
+
+        client = get_client()
+        if not _local_title_runtime_ready(client):
+            logger.info("Local title generation skipped because the configured low-tier llm worker is not ready")
+            return None
+
+        return normalize_generated_title(
+            client.generate(
+                prompt=_title_generation_local_prompt(raw_text),
+                max_tokens=TITLE_MAX_TOKENS,
+                temperature=0.3,
+                think=False,
+                fallback_policy="local-only",
+            )
+        )
+    except Exception as exc:
+        logger.warning("Local title generation failed: %s", exc)
+        return None
+
+
+def _generate_with_provider_title_model(
+    raw_text: str,
+    *,
+    model: str,
+    user_id: str | None,
+    org_id: str | None,
+) -> str | None:
+    try:
+        from brain.platform.integrations.completions import simple_text_completion
+
+        return normalize_generated_title(
+            simple_text_completion(
+                _title_generation_user_prompt(raw_text),
+                model=model,
+                max_tokens=TITLE_MAX_TOKENS,
+                user_id=user_id,
+                org_id=org_id,
+                system_prompt=TITLE_GENERATION_SYSTEM_PROMPT,
+                reasoning_effort=TITLE_REASONING_EFFORT,
+                operation_type="title_generation",
+            )
+        )
+    except Exception as exc:
+        logger.warning("Provider title generation failed: %s", exc)
+        return None
+
+
+def generate_display_title(
+    raw_text: str,
+    *,
+    user_id: str | None = None,
+    org_id: str | None = None,
+) -> str | None:
+    """Generate a display title using the configured low-intelligence model."""
+    if not (raw_text or "").strip():
+        return None
+
+    try:
+        from brain.platform.providers.model_policy import get_model_for_tier, resolve_default_provider
+
+        provider = resolve_default_provider(user_id=user_id, org_id=org_id)
+        model = get_model_for_tier(
+            TITLE_MODEL_TIER,
+            provider=provider,
+            include_provider_prefix=False,
+            user_id=user_id,
+            org_id=org_id,
+        )
+    except Exception as exc:
+        logger.warning("Title model resolution failed: %s", exc)
+        return None
+
+    if is_local_title_model(model):
+        return _generate_with_local_title_model(raw_text)
+
+    return _generate_with_provider_title_model(
+        raw_text,
+        model=_provider_model_spec(provider, model),
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+
+def _blank(value: str | None) -> bool:
+    return not str(value or "").strip()
+
+
+def _idea_title_source(
+    idea_id: str,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+    raw_title: str | None,
+) -> tuple[str | None, str | None]:
+    from brain.platform.db.models.idea import Idea
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    with UnitOfWork() as uow:
+        idea = uow.session.get(Idea, str(idea_id))
+        if idea is None:
+            return None, "missing"
+        if getattr(idea, "archived_at", None) is not None:
+            return None, "archived"
+        if not _blank(getattr(idea, "display_title", None)):
+            return None, "already_titled"
+        if org_id and str(getattr(idea, "org_id", "") or "") != str(org_id):
+            return None, "scope_mismatch"
+        if not org_id and user_id and str(getattr(idea, "user_id", "") or "") != str(user_id):
+            return None, "scope_mismatch"
+
+        title = str(getattr(idea, "title", "") or "").strip()
+        if not title and raw_title:
+            title = str(raw_title).strip()
+        if not title:
+            return None, "empty_title"
+        return title, None
+
+
+def _store_generated_display_title(
+    idea_id: str,
+    *,
+    source_title: str,
+    display_title: str,
+    user_id: str | None,
+    org_id: str | None,
+) -> bool:
+    from sqlalchemy import func, or_, update
+
+    from brain.platform.db.models.idea import Idea
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    with UnitOfWork() as uow:
+        stmt = (
+            update(Idea)
+            .where(
+                Idea.id == str(idea_id),
+                Idea.title == source_title,
+                Idea.archived_at.is_(None),
+                or_(Idea.display_title.is_(None), func.trim(Idea.display_title) == ""),
+            )
+            .values(display_title=display_title)
+        )
+        if org_id:
+            stmt = stmt.where(Idea.org_id == str(org_id))
+        elif user_id:
+            stmt = stmt.where(Idea.user_id == str(user_id))
+
+        result = uow.session.execute(stmt)
+        return int(getattr(result, "rowcount", 0) or 0) == 1
+
+
+def _publish_generated_display_title(
+    idea_id: str,
+    title: str,
+    *,
+    org_id: str | None,
+) -> None:
+    from brain.systems.cortex.events import publish
+
+    payload: dict[str, str] = {"idea_id": str(idea_id), "title": title}
+    if org_id:
+        payload["org_id"] = str(org_id)
+    publish("title_generated", payload)
+
+
+def generate_and_store_idea_display_title(
+    idea_id: str,
+    *,
+    user_id: str | None = None,
+    org_id: str | None = None,
+    raw_title: str | None = None,
+    publish_update: bool = True,
+) -> StoredDisplayTitle:
+    """Generate, store, and publish a display title for an idea if it still needs one."""
+    source_title, skipped_reason = _idea_title_source(
+        idea_id,
+        user_id=user_id,
+        org_id=org_id,
+        raw_title=raw_title,
+    )
+    if skipped_reason or not source_title:
+        return StoredDisplayTitle(idea_id=str(idea_id), skipped_reason=skipped_reason or "empty_title")
+
+    title = generate_display_title(source_title, user_id=user_id, org_id=org_id)
+    if not title:
+        return StoredDisplayTitle(idea_id=str(idea_id), skipped_reason="generation_failed")
+
+    updated = _store_generated_display_title(
+        idea_id,
+        source_title=source_title,
+        display_title=title,
+        user_id=user_id,
+        org_id=org_id,
+    )
+    if not updated:
+        return StoredDisplayTitle(idea_id=str(idea_id), title=title, skipped_reason="stale")
+
+    if publish_update:
+        try:
+            _publish_generated_display_title(idea_id, title, org_id=org_id)
+        except Exception:
+            logger.exception("Failed to publish generated title for idea %s", idea_id)
+
+    return StoredDisplayTitle(idea_id=str(idea_id), title=title, updated=True)

--- a/frontend/src/lib/features/cortex/api/cortexApi.ts
+++ b/frontend/src/lib/features/cortex/api/cortexApi.ts
@@ -54,7 +54,6 @@ type CortexApiMethods = {
   splitIdea: typeof api.splitIdea;
   timelineData: (limit?: number) => Promise<CortexTimelineItem>;
   uploadFile: (file: File) => Promise<UploadedCortexFile>;
-  generateTitle: typeof api.generateTitle;
   notifyCortex: typeof api.notifyCortex;
   updateProfile: typeof api.updateProfile;
   listProjectContextProfiles: typeof api.listProjectContextProfiles;
@@ -99,7 +98,6 @@ export const cortexApi = pickTypedApiMethods<CortexApiMethods>([
   'splitIdea',
   'timelineData',
   'uploadFile',
-  'generateTitle',
   'notifyCortex',
   'updateProfile',
   'listProjectContextProfiles',
@@ -144,7 +142,6 @@ export const {
   splitIdea,
   timelineData,
   uploadFile,
-  generateTitle,
   notifyCortex,
   updateProfile,
   listProjectContextProfiles,

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -1331,16 +1331,6 @@ class CortexStore {
     try {
       const idea = await api.createIdea({ title, description });
       bloop();
-      // Fire-and-forget: generate a concise display title via local LLM
-      api.generateTitle(title).then((r) => {
-        if (r?.title) {
-          api.updateIdea(idea.id, { display_title: r.title });
-          // Update local state so UI reflects the generated title immediately
-          this.ideas = this.ideas.map((i) =>
-            i.id === idea.id ? { ...i, display_title: r.title } : i,
-          );
-        }
-      }).catch(() => {});
       // The typed text becomes the first thread message and queues Illo by default.
       // Set status optimistically BEFORE adding to ideas array so the
       // SVG birth animation renders with the correct color immediately.

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -929,7 +929,9 @@ async def test_create_idea(client, mock_session_factory):
     ) as MockRepo, patch(
         "brain.app.api.routers.cortex._ideas.ws_manager.broadcast_product_event",
         side_effect=_broadcast,
-    ):
+    ), patch(
+        "brain.app.api.routers.cortex._ideas.generate_and_store_idea_display_title"
+    ) as mock_generate_title:
         MockRepo.return_value.create.return_value = idea
         resp = await client.post(
             "/api/cortex/ideas",
@@ -944,6 +946,12 @@ async def test_create_idea(client, mock_session_factory):
             {"org_id": "test-org"},
         )
     ]
+    mock_generate_title.assert_called_once_with(
+        idea_id=str(idea.id),
+        raw_title="New Idea",
+        user_id="user-1",
+        org_id="test-org",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -38,6 +38,25 @@ class TestSimpleTextCompletion:
 
     @patch("brain.platform.integrations.completions.get_provider")
     @patch("brain.platform.integrations.completions.resolve_llm_client")
+    def test_passes_reasoning_effort_to_provider_request(self, mock_resolve, mock_get_provider):
+        from brain.platform.integrations.completions import simple_text_completion
+
+        llm = MagicMock()
+        llm.provider = "openai"
+        llm.client = object()
+        llm.build_request_headers.return_value = {}
+        mock_resolve.return_value = llm
+
+        provider = MagicMock()
+        provider.create.return_value = MagicMock(content=[MagicMock(type="text", text="ok")])
+        mock_get_provider.return_value = provider
+
+        assert simple_text_completion("hi", reasoning_effort="low") == "ok"
+        request = provider.create.call_args.args[0]
+        assert request.reasoning_effort == "low"
+
+    @patch("brain.platform.integrations.completions.get_provider")
+    @patch("brain.platform.integrations.completions.resolve_llm_client")
     def test_returns_none_when_no_text_blocks(self, mock_resolve, mock_get_provider):
         from brain.platform.integrations.completions import simple_text_completion
 

--- a/tests/test_cortex_orm.py
+++ b/tests/test_cortex_orm.py
@@ -196,18 +196,29 @@ class TestExtractMentions:
         assert _extract_mentions("no mentions here") == []
 
 
-# ── GPU title generation ───────────────────────────────────────
+# ── Low-tier title generation ──────────────────────────────────
 
-class TestGenerateTitleGpu:
-    @patch("brain.platform.integrations.completions.simple_text_completion")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_returns_local_title_without_fallback(self, mock_get_client, mock_simple_text_completion):
-        from brain.app.api.routers.cortex import _generate_title_gpu
+class TestGenerateTitleLowTier:
+    def test_uses_local_gpu_when_configured_low_tier_model_is_local(self):
+        from brain.systems.cortex.title_generation import generate_display_title
 
-        mock_get_client.return_value.generate.return_value = "Great Title"
-        mock_get_client.return_value.is_ready.return_value = True
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai") as mock_resolve_default_provider, \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b") as mock_get_model_for_tier, \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.generate.return_value = "Great Title"
+            mock_get_client.return_value.is_ready.return_value = True
 
-        assert _generate_title_gpu("some raw text") == "Great Title"
+            assert generate_display_title("some raw text", user_id="user-1", org_id="org-1") == "Great Title"
+
+        mock_resolve_default_provider.assert_called_once_with(user_id="user-1", org_id="org-1")
+        mock_get_model_for_tier.assert_called_once_with(
+            "low",
+            provider="openai",
+            include_provider_prefix=False,
+            user_id="user-1",
+            org_id="org-1",
+        )
         mock_get_client.return_value.is_ready.assert_called_once_with("llm")
         mock_get_client.return_value.generate.assert_called_once()
         kwargs = mock_get_client.return_value.generate.call_args.kwargs
@@ -215,27 +226,20 @@ class TestGenerateTitleGpu:
         assert kwargs["think"] is False
         mock_simple_text_completion.assert_not_called()
 
-    @patch("brain.platform.providers.model_policy.get_model_for_tier")
-    @patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai")
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value="Fallback Title")
-    @patch("brain.platform.gpu_client.get_client", side_effect=Exception("no GPU"))
-    def test_falls_back_to_provider_low_tier_model(
-        self,
-        mock_get_client,
-        mock_simple_text_completion,
-        mock_resolve_default_provider,
-        mock_get_model_for_tier,
-    ):
-        from brain.app.api.routers.cortex import _generate_title_gpu
+    def test_uses_configured_api_low_tier_model_with_user_context(self):
+        from brain.systems.cortex.title_generation import generate_display_title
 
-        mock_get_model_for_tier.return_value = "openai/gpt-5-mini"
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai") as mock_resolve_default_provider, \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="gpt-5-mini") as mock_get_model_for_tier, \
+             patch("brain.platform.integrations.completions.simple_text_completion", return_value="Provider Title") as mock_simple_text_completion, \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client:
+            assert generate_display_title("some raw text", user_id="user-1", org_id="org-1") == "Provider Title"
 
-        assert _generate_title_gpu("some raw text", user_id="user-1", org_id="org-1") == "Fallback Title"
         mock_resolve_default_provider.assert_called_once_with(user_id="user-1", org_id="org-1")
         mock_get_model_for_tier.assert_called_once_with(
             "low",
             provider="openai",
-            include_provider_prefix=True,
+            include_provider_prefix=False,
             user_id="user-1",
             org_id="org-1",
         )
@@ -245,35 +249,43 @@ class TestGenerateTitleGpu:
         assert kwargs["user_id"] == "user-1"
         assert kwargs["org_id"] == "org-1"
         assert kwargs["system_prompt"]
+        assert kwargs["reasoning_effort"] == "low"
+        assert kwargs["operation_type"] == "title_generation"
+        mock_get_client.assert_not_called()
 
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value=" x ")
-    @patch("brain.platform.gpu_client.get_client", side_effect=Exception("no GPU"))
-    def test_returns_none_when_fallback_title_invalid(self, mock_get_client, mock_simple_text_completion):
-        from brain.app.api.routers.cortex import _generate_title_gpu
+    def test_returns_none_when_configured_api_title_invalid(self):
+        from brain.systems.cortex.title_generation import generate_display_title
 
-        assert _generate_title_gpu("some raw text") is None
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="gpt-5-mini"), \
+             patch("brain.platform.integrations.completions.simple_text_completion", return_value=" x "):
+            assert generate_display_title("some raw text") is None
 
-    @patch("brain.platform.integrations.completions.simple_text_completion")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_normalizes_local_title_output(self, mock_get_client, mock_simple_text_completion):
-        from brain.app.api.routers.cortex import _generate_title_gpu
+    def test_normalizes_local_title_output(self):
+        from brain.systems.cortex.title_generation import generate_display_title
 
-        mock_get_client.return_value.is_ready.return_value = True
-        mock_get_client.return_value.generate.return_value = 'Title: "Sharper Idea Framing"\n\nExplanation'
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b"), \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.is_ready.return_value = True
+            mock_get_client.return_value.generate.return_value = 'Title: "Sharper Idea Framing"\n\nExplanation'
 
-        assert _generate_title_gpu("some raw text") == "Sharper Idea Framing"
+            assert generate_display_title("some raw text") == "Sharper Idea Framing"
         mock_simple_text_completion.assert_not_called()
 
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value="Fallback Title")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_skips_local_generation_when_llm_worker_not_ready(self, mock_get_client, mock_simple_text_completion):
-        from brain.app.api.routers.cortex import _generate_title_gpu
+    def test_returns_none_when_configured_local_worker_not_ready(self):
+        from brain.systems.cortex.title_generation import generate_display_title
 
-        mock_get_client.return_value.is_ready.return_value = False
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b"), \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.is_ready.return_value = False
 
-        assert _generate_title_gpu("some raw text") == "Fallback Title"
+            assert generate_display_title("some raw text") is None
         mock_get_client.return_value.generate.assert_not_called()
-        mock_simple_text_completion.assert_called_once()
+        mock_simple_text_completion.assert_not_called()
 
 
 class TestTitleRoutes:
@@ -287,7 +299,7 @@ class TestTitleRoutes:
 
         user = {"id": "user-1", "org_id": "org-1"}
 
-        with patch("brain.app.api.routers.cortex._misc._generate_title_gpu", return_value="Threaded Title") as mock_generate_title:
+        with patch("brain.app.api.routers.cortex._misc.generate_display_title", return_value="Threaded Title") as mock_generate_title:
             result = asyncio.run(generate_title(FakeRequest(), user=user))
 
         assert result == {"title": "Threaded Title"}
@@ -297,10 +309,10 @@ class TestTitleRoutes:
             org_id="org-1",
         )
 
-    @patch("brain.systems.cortex.events.publish")
     @patch("brain.app.api.routers.cortex._misc.UnitOfWork")
-    def test_backfill_titles_threads_authenticated_user_context(self, mock_uow_cls, mock_publish):
+    def test_backfill_titles_threads_authenticated_user_context(self, mock_uow_cls):
         from brain.app.api.routers.cortex._misc import backfill_titles
+        from brain.systems.cortex.title_generation import StoredDisplayTitle
 
         idea_without_title = _make_idea(id="idea-1", title="Raw idea", display_title=None, archived_at=None)
 
@@ -308,23 +320,21 @@ class TestTitleRoutes:
         list_uow.__enter__.return_value = list_uow
         list_uow.session.scalars.return_value.all.return_value = [idea_without_title]
 
-        update_uow = MagicMock()
-        update_uow.__enter__.return_value = update_uow
-        update_uow.session.get.return_value = idea_without_title
+        mock_uow_cls.return_value = list_uow
 
-        mock_uow_cls.side_effect = [list_uow, update_uow]
-
-        with patch("brain.app.api.routers.cortex._misc._generate_title_gpu", return_value="Generated Title") as mock_generate_title:
+        with patch(
+            "brain.app.api.routers.cortex._misc.generate_and_store_idea_display_title",
+            return_value=StoredDisplayTitle(idea_id="idea-1", title="Generated Title", updated=True),
+        ) as mock_generate_title:
             result = backfill_titles(user={"id": "user-1", "org_id": "org-1"})
 
         assert result == {"ok": True, "generated": 1, "total": 1}
         mock_generate_title.assert_called_once_with(
-            "Raw idea",
+            "idea-1",
+            raw_title="Raw idea",
             user_id="user-1",
             org_id="org-1",
         )
-        assert idea_without_title.display_title == "Generated Title"
-        mock_publish.assert_called_once_with("title_generated", {"idea_id": "idea-1", "title": "Generated Title"})
 
     @patch("brain.app.api.routers.cortex._misc.UnitOfWork")
     def test_backfill_titles_scopes_query_to_org(self, mock_uow_cls):
@@ -357,3 +367,89 @@ class TestTitleRoutes:
         stmt = list_uow.session.scalars.call_args.args[0]
         compiled = str(stmt)
         assert "ideas.user_id" in compiled
+
+
+class TestStoredIdeaTitleGeneration:
+    @patch("brain.systems.cortex.title_generation._publish_generated_display_title")
+    @patch("brain.platform.db.repositories.unit_of_work.UnitOfWork")
+    def test_generates_stores_and_publishes_title(self, mock_uow_cls, mock_publish):
+        from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
+
+        idea = _make_idea(id="idea-1", title="Raw idea", display_title=None, org_id="org-1")
+        read_uow = MagicMock()
+        read_uow.__enter__.return_value = read_uow
+        read_uow.session.get.return_value = idea
+        write_uow = MagicMock()
+        write_uow.__enter__.return_value = write_uow
+        write_uow.session.execute.return_value.rowcount = 1
+        mock_uow_cls.side_effect = [read_uow, write_uow]
+
+        with patch("brain.systems.cortex.title_generation.generate_display_title", return_value="Generated Title") as mock_generate:
+            result = generate_and_store_idea_display_title(
+                "idea-1",
+                raw_title="Raw idea",
+                user_id="user-1",
+                org_id="org-1",
+            )
+
+        assert result.updated is True
+        assert result.title == "Generated Title"
+        mock_generate.assert_called_once_with(
+            "Raw idea",
+            user_id="user-1",
+            org_id="org-1",
+        )
+        write_uow.session.execute.assert_called_once()
+        mock_publish.assert_called_once_with("idea-1", "Generated Title", org_id="org-1")
+
+    @patch("brain.systems.cortex.title_generation._publish_generated_display_title")
+    @patch("brain.platform.db.repositories.unit_of_work.UnitOfWork")
+    def test_does_not_overwrite_existing_display_title(self, mock_uow_cls, mock_publish):
+        from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
+
+        idea = _make_idea(id="idea-1", title="Raw idea", display_title="Manual Title", org_id="org-1")
+        read_uow = MagicMock()
+        read_uow.__enter__.return_value = read_uow
+        read_uow.session.get.return_value = idea
+        mock_uow_cls.return_value = read_uow
+
+        with patch("brain.systems.cortex.title_generation.generate_display_title") as mock_generate:
+            result = generate_and_store_idea_display_title(
+                "idea-1",
+                raw_title="Raw idea",
+                user_id="user-1",
+                org_id="org-1",
+            )
+
+        assert result.updated is False
+        assert result.skipped_reason == "already_titled"
+        mock_generate.assert_not_called()
+        read_uow.session.execute.assert_not_called()
+        mock_publish.assert_not_called()
+
+    @patch("brain.systems.cortex.title_generation._publish_generated_display_title")
+    @patch("brain.platform.db.repositories.unit_of_work.UnitOfWork")
+    def test_does_not_publish_stale_title_write(self, mock_uow_cls, mock_publish):
+        from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
+
+        idea = _make_idea(id="idea-1", title="Raw idea", display_title=None, org_id="org-1")
+        read_uow = MagicMock()
+        read_uow.__enter__.return_value = read_uow
+        read_uow.session.get.return_value = idea
+        write_uow = MagicMock()
+        write_uow.__enter__.return_value = write_uow
+        write_uow.session.execute.return_value.rowcount = 0
+        mock_uow_cls.side_effect = [read_uow, write_uow]
+
+        with patch("brain.systems.cortex.title_generation.generate_display_title", return_value="Generated Title"):
+            result = generate_and_store_idea_display_title(
+                "idea-1",
+                raw_title="Raw idea",
+                user_id="user-1",
+                org_id="org-1",
+            )
+
+        assert result.updated is False
+        assert result.title == "Generated Title"
+        assert result.skipped_reason == "stale"
+        mock_publish.assert_not_called()

--- a/tests/test_cortex_split.py
+++ b/tests/test_cortex_split.py
@@ -52,9 +52,9 @@ class TestPublicImports:
         from brain.app.api.routers.cortex import _create_feedback_triggers
         assert callable(_create_feedback_triggers)
 
-    def test_generate_title_gpu(self):
-        from brain.app.api.routers.cortex import _generate_title_gpu
-        assert callable(_generate_title_gpu)
+    def test_generate_display_title(self):
+        from brain.app.api.routers.cortex import generate_display_title
+        assert callable(generate_display_title)
 
     def test_presence_join(self):
         from brain.app.api.routers.cortex import _presence_join


### PR DESCRIPTION
## Summary
- Move Cortex display-title generation into a dedicated title generation module instead of keeping it as an API/GPU helper
- Resolve title generation through the configured low-intelligence model: local low-tier models use the GPU worker with thinking disabled, API low-tier models use the provider completion path with user/org context
- Pass low reasoning effort for API-backed title generation when the provider/model supports it
- Trigger display-title generation automatically after idea creation, outside the create request path, then publish `title_generated` so the frontend replaces the temporary raw title over websocket
- Remove frontend create-flow title generation so the backend owns summarization, and reuse the backend store/publish path for title backfills
- Add stale-write guards so generated titles do not overwrite manual titles, archived ideas, scoped-out ideas, or ideas whose raw title changed while generation was running

## Tests
- `pytest tests/test_api_cortex.py -k "create_idea or create_thread_message"`
- `pytest tests/test_cortex_orm.py -k "GenerateTitle or TitleRoutes or StoredIdeaTitleGeneration"`
- `pytest tests/test_cortex_split.py -k "generate_display_title"`
- `pytest tests/test_completions.py -k "SimpleTextCompletion"`
- `python3 -m py_compile brain/app/api/routers/cortex/_ideas.py brain/app/api/routers/cortex/_misc.py brain/platform/integrations/completions.py brain/systems/cortex/title_generation.py tests/test_api_cortex.py tests/test_cortex_orm.py`
- `npm --prefix frontend run check` (passes with two pre-existing Svelte warnings in memory screens)