### PR TITLE
Refine project context resource flow

### DIFF
--- a/brain/app/api/routers/cortex/_helpers.py
+++ b/brain/app/api/routers/cortex/_helpers.py
@@ -258,6 +258,36 @@ def _generate_title_local(raw_text: str, *, client=None) -> str | None:
     )
 
 
+def _strip_model_provider_prefix(model: str | None) -> str:
+    value = (model or "").strip()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    return value
+
+
+def _is_local_title_model(model: str | None) -> bool:
+    normalized = _strip_model_provider_prefix(model).strip().lower()
+    return (
+        normalized == "local"
+        or normalized == "gpu_server"
+        or normalized.startswith("local/")
+        or normalized.startswith("gpu_server/")
+        or normalized.startswith("brain.platform.gpu/")
+    )
+
+
+def _provider_model_spec(provider: str, model: str) -> str:
+    value = (model or "").strip()
+    if value.startswith(("anthropic/", "openai/")):
+        return value
+    if value.startswith("anthropic:"):
+        return f"anthropic/{value[len('anthropic:'):]}"
+    if value.startswith("openai:"):
+        return f"openai/{value[len('openai:'):]}"
+    return f"{provider}/{value}"
+
+
 def _local_title_runtime_ready(client) -> bool:
     try:
         return client.is_ready("llm")
@@ -266,23 +296,15 @@ def _local_title_runtime_ready(client) -> bool:
         return True
 
 
-def _generate_title_hosted_fallback(
+def _generate_title_with_provider_model(
     raw_text: str,
     *,
+    model: str,
     user_id: str | None = None,
     org_id: str | None = None,
 ) -> str | None:
     from brain.platform.integrations.completions import simple_text_completion
-    from brain.platform.providers.model_policy import get_model_for_tier, resolve_default_provider
 
-    provider = resolve_default_provider(user_id=user_id, org_id=org_id)
-    model = get_model_for_tier(
-        "low",
-        provider=provider,
-        include_provider_prefix=True,
-        user_id=user_id,
-        org_id=org_id,
-    )
     return _normalize_generated_title(
         simple_text_completion(
             _build_title_generation_user_prompt(raw_text),
@@ -301,6 +323,40 @@ def _generate_title_gpu(
     user_id: str | None = None,
     org_id: str | None = None,
 ) -> str | None:
+    """Generate a title with the configured low-intelligence model.
+
+    Kept under the historical function name because tests and router exports
+    import it directly, but the runtime is no longer GPU-first. The org/user
+    low-tier mapping decides whether this call goes to the local GPU worker or
+    to the provider API with the authenticated user context.
+    """
+    try:
+        from brain.platform.providers.model_policy import get_model_for_tier, resolve_default_provider
+
+        provider = resolve_default_provider(user_id=user_id, org_id=org_id)
+        model = get_model_for_tier(
+            "low",
+            provider=provider,
+            include_provider_prefix=False,
+            user_id=user_id,
+            org_id=org_id,
+        )
+    except Exception as e:
+        logger.warning(f"Low-tier title model resolution failed: {e}")
+        return None
+
+    if not _is_local_title_model(model):
+        try:
+            return _generate_title_with_provider_model(
+                raw_text,
+                model=_provider_model_spec(provider, model),
+                user_id=user_id,
+                org_id=org_id,
+            )
+        except Exception as e:
+            logger.warning(f"Provider title generation failed: {e}")
+            return None
+
     try:
         from brain.platform.gpu_client import get_client
 
@@ -309,17 +365,12 @@ def _generate_title_gpu(
             title = _generate_title_local(raw_text, client=client)
             if title:
                 return title
-            logger.info("Local title generation returned no usable title; falling back to hosted model")
+            logger.info("Local title generation returned no usable title")
         else:
-            logger.info("Local title generation skipped because the llm worker is not ready")
+            logger.info("Local title generation skipped because the configured low-tier llm worker is not ready")
     except Exception as e:
         logger.warning(f"GPU server title generation failed: {e}")
-
-    try:
-        return _generate_title_hosted_fallback(raw_text, user_id=user_id, org_id=org_id)
-    except Exception as e:
-        logger.warning(f"Hosted title generation fallback failed: {e}")
-        return None
+    return None
 
 
 def _create_feedback_triggers(skill_used: str, task_summary: str, note: str):

--- a/brain/systems/cortex/project_context/uploads.py
+++ b/brain/systems/cortex/project_context/uploads.py
@@ -9,59 +9,8 @@ from typing import Any
 
 
 PROJECT_CONTEXT_UPLOAD_MAX_FILES = 200
-PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE = 1_000_000
+PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE = 10_000_000
 PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE = 20_000_000
-PROJECT_CONTEXT_ALLOWED_FILENAMES = {
-    "Dockerfile",
-    "Makefile",
-    "README",
-    "LICENSE",
-    "NOTICE",
-    ".env.example",
-}
-PROJECT_CONTEXT_ALLOWED_EXTENSIONS = {
-    "c",
-    "cc",
-    "cfg",
-    "conf",
-    "cpp",
-    "cs",
-    "css",
-    "csv",
-    "dockerfile",
-    "env",
-    "go",
-    "graphql",
-    "h",
-    "hpp",
-    "html",
-    "ini",
-    "java",
-    "js",
-    "json",
-    "jsx",
-    "kt",
-    "lock",
-    "log",
-    "md",
-    "mdx",
-    "mjs",
-    "py",
-    "rb",
-    "rs",
-    "scss",
-    "sh",
-    "sql",
-    "svelte",
-    "toml",
-    "ts",
-    "tsx",
-    "txt",
-    "vue",
-    "xml",
-    "yaml",
-    "yml",
-}
 
 
 def safe_upload_relative_path(value: str, fallback: str) -> str:
@@ -78,16 +27,6 @@ def safe_upload_relative_path(value: str, fallback: str) -> str:
     if not parts:
         parts = [re.sub(r"[^A-Za-z0-9._ -]+", "_", fallback or "file").strip(" .") or "file"]
     return str(PurePosixPath(*parts))
-
-
-def project_context_upload_allowed(relative_path: str) -> bool:
-    name = Path(relative_path).name
-    if name in PROJECT_CONTEXT_ALLOWED_FILENAMES:
-        return True
-    if "." not in name:
-        return name in PROJECT_CONTEXT_ALLOWED_FILENAMES
-    ext = name.rsplit(".", 1)[-1].lower()
-    return ext in PROJECT_CONTEXT_ALLOWED_EXTENSIONS
 
 
 def unique_upload_relative_path(relative_path: str, used_paths: set[str]) -> str:
@@ -150,13 +89,7 @@ async def save_project_context_uploads(
             continue
         relative_hint = relative_paths[index] if index < len(relative_paths) else original_name
         relative_path = safe_upload_relative_path(relative_hint, original_name)
-        if not project_context_upload_allowed(relative_path):
-            skip_upload(skipped, original_name, "File type is not supported for Project Context snapshots")
-            continue
         data = await upload.read(PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE + 1)
-        if b"\x00" in data[:4096]:
-            skip_upload(skipped, original_name, "Binary files are not attached to Project Context")
-            continue
         if len(data) > PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE:
             skip_upload(
                 skipped,
@@ -191,7 +124,7 @@ async def save_project_context_uploads(
         raise ProjectContextUploadError(
             422,
             {
-                "error": "No readable Project Context files could be uploaded",
+                "error": "No Project Context files could be uploaded",
                 "skipped_files": skipped[:20],
             },
         )

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,4 +1,10 @@
 const BASE = '';
+const DEFAULT_API_TIMEOUT_MS = 20_000;
+const PROJECT_CONTEXT_UPLOAD_TIMEOUT_MS = 30_000;
+
+type ApiRequestInit = RequestInit & {
+  timeoutMs?: number;
+};
 
 type PreloadedJson<T> = {
   ok: boolean;
@@ -6,7 +12,7 @@ type PreloadedJson<T> = {
   error?: unknown;
 };
 
-function takePreloadedJson<T>(path: string, init?: RequestInit): Promise<T> | null {
+function takePreloadedJson<T>(path: string, init?: ApiRequestInit): Promise<T> | null {
   if (typeof window === 'undefined') return null;
   const method = String(init?.method || 'GET').toUpperCase();
   if (method !== 'GET' || init?.body) return null;
@@ -22,20 +28,37 @@ function takePreloadedJson<T>(path: string, init?: RequestInit): Promise<T> | nu
   });
 }
 
-async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+async function fetchJson<T>(path: string, init?: ApiRequestInit): Promise<T> {
   const preloaded = takePreloadedJson<T>(path, init);
   if (preloaded) return preloaded;
 
-  const { headers: extraHeaders, ...rest } = init ?? {};
-  const res = await fetch(`${BASE}${path}`, {
-    ...rest,
-    headers: { 'Content-Type': 'application/json', ...(extraHeaders as Record<string, string>) },
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: res.statusText }));
-    throw { status: res.status, detail: err.error || err.detail || res.statusText };
+  const {
+    headers: extraHeaders,
+    timeoutMs = DEFAULT_API_TIMEOUT_MS,
+    signal,
+    ...rest
+  } = init ?? {};
+  const controller = !signal && timeoutMs > 0 ? new AbortController() : null;
+  const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      ...rest,
+      signal: signal ?? controller?.signal,
+      headers: { 'Content-Type': 'application/json', ...(extraHeaders as Record<string, string>) },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      throw { status: res.status, detail: err.error || err.detail || res.statusText };
+    }
+    return res.json();
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw { status: 0, detail: 'Request timed out. Check the local server and try again.' };
+    }
+    throw err;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
   }
-  return res.json();
 }
 
 function withQuery(
@@ -643,7 +666,7 @@ export const api = {
       form.append('relative_paths', relativePaths?.[index] || file.name);
     });
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60_000);
+    const timeoutId = setTimeout(() => controller.abort(), PROJECT_CONTEXT_UPLOAD_TIMEOUT_MS);
     return fetch('/api/cortex/project-context/local-files', {
       method: 'POST',
       body: form,
@@ -658,7 +681,7 @@ export const api = {
       })
       .catch((err) => {
         if (err?.name === 'AbortError') {
-          throw { detail: 'Project Context upload timed out. Try a smaller file or folder snapshot.' };
+          throw { detail: 'Project Context upload timed out before the local server responded.' };
         }
         throw err;
       })

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -642,13 +642,27 @@ export const api = {
       form.append('files', file);
       form.append('relative_paths', relativePaths?.[index] || file.name);
     });
-    return fetch('/api/cortex/project-context/local-files', { method: 'POST', body: form }).then(async (r) => {
-      if (!r.ok) {
-        const err = await r.json().catch(() => ({ detail: 'Upload failed' }));
-        throw { status: r.status, detail: err.error || err.detail || 'Upload failed' };
-      }
-      return r.json();
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60_000);
+    return fetch('/api/cortex/project-context/local-files', {
+      method: 'POST',
+      body: form,
+      signal: controller.signal,
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({ detail: 'Upload failed' }));
+          throw { status: r.status, detail: err.error || err.detail || 'Upload failed' };
+        }
+        return r.json();
+      })
+      .catch((err) => {
+        if (err?.name === 'AbortError') {
+          throw { detail: 'Project Context upload timed out. Try a smaller file or folder snapshot.' };
+        }
+        throw err;
+      })
+      .finally(() => clearTimeout(timeoutId));
   },
   listIdeaProjectContext: (ideaId: string) =>
     fetchJson<any[]>(`/api/cortex/ideas/${ideaId}/project-context`),

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextConnectorMenu.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextConnectorMenu.svelte
@@ -12,14 +12,12 @@
 <div class="project-connector-grid">
   <button type="button" class="project-connector-card" onclick={() => onOpen?.('github')}>
     <ConstellationIcon name="git-branch" size={16} stroke={2} />
-    <span><strong>GitHub repo</strong><small>Add a repository as project context</small></span>
+    <span class="project-connector-card-copy"><strong>GitHub repo</strong><small>Add a repository as project context</small></span>
+    <ConstellationIcon name="chevron-right" size={15} stroke={1.9} className="project-connector-card-caret" />
   </button>
-  <button type="button" class="project-connector-card" onclick={() => onOpen?.('folder')}>
+  <button type="button" class="project-connector-card" onclick={() => onOpen?.('local')}>
     <ConstellationIcon name="folder" size={16} stroke={2} />
-    <span><strong>Folder tree</strong><small>Upload a folder snapshot and keep relative paths</small></span>
-  </button>
-  <button type="button" class="project-connector-card" onclick={() => onOpen?.('file')}>
-    <ConstellationIcon name="file" size={16} stroke={2} />
-    <span><strong>Individual files</strong><small>Upload one or more standalone files</small></span>
+    <span class="project-connector-card-copy"><strong>Files or folders</strong><small>Upload standalone files or a folder snapshot</small></span>
+    <ConstellationIcon name="chevron-right" size={15} stroke={1.9} className="project-connector-card-caret" />
   </button>
 </div>

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { ConstellationIcon } from '$lib/components/constellation';
   import type { ProjectContextResource } from '$lib/utils/projectContext';
   import ProjectContextConnectorMenu from './ProjectContextConnectorMenu.svelte';
+  import ProjectContextGitHubConnector from './ProjectContextGitHubConnector.svelte';
+  import ProjectContextLocalConnector from './ProjectContextLocalConnector.svelte';
   import ProjectContextResourcePills from './ProjectContextResourcePills.svelte';
   import type { ConnectorMode } from './projectContextProfiles';
 
@@ -31,31 +34,23 @@
   } = $props();
 
   let connectorMode = $state<ConnectorMode>('menu');
-  let ProjectContextGitHubConnector = $state<any>(null);
-  let ProjectContextLocalConnector = $state<any>(null);
-
-  async function loadGitHubConnector() {
-    if (ProjectContextGitHubConnector) return;
-    const module = await import('./ProjectContextGitHubConnector.svelte');
-    ProjectContextGitHubConnector = module.default;
-  }
-
-  async function loadLocalConnector() {
-    if (ProjectContextLocalConnector) return;
-    const module = await import('./ProjectContextLocalConnector.svelte');
-    ProjectContextLocalConnector = module.default;
-  }
 
   function openConnector(nextMode: ConnectorMode) {
     connectorMode = nextMode;
-    if (nextMode === 'github') void loadGitHubConnector();
-    if (nextMode === 'folder' || nextMode === 'file') void loadLocalConnector();
   }
+
+  const connectorTitle = $derived(
+    connectorMode === 'github'
+      ? 'GitHub repo'
+      : connectorMode === 'local'
+        ? 'Files or folders'
+        : '',
+  );
 </script>
 
 <div class="project-create-intro">
   <strong>Projects are saved context containers.</strong>
-  <span>Create one empty, or add resources now. A resource can be a GitHub repo, a folder tree, or individual files.</span>
+  <span>Create one empty, or add resources now. A resource can be a GitHub repo or local files and folders.</span>
 </div>
 
 <div class="project-create-fields">
@@ -71,29 +66,29 @@
   />
 </div>
 
-<div class="connector-tabs" aria-label="Project resource options">
-  <button type="button" class:active={connectorMode === 'menu'} onclick={() => { connectorMode = 'menu'; }}>Add resources</button>
-  <button type="button" class:active={connectorMode === 'github'} onclick={() => openConnector('github')}>Repo</button>
-  <button type="button" class:active={connectorMode === 'folder'} onclick={() => openConnector('folder')}>Folder</button>
-  <button type="button" class:active={connectorMode === 'file'} onclick={() => openConnector('file')}>Files</button>
-</div>
-
 {#if connectorMode === 'menu'}
   <ProjectContextConnectorMenu onOpen={openConnector} />
-{:else if connectorMode === 'github'}
-  {#if ProjectContextGitHubConnector}
+{:else}
+  <div class="connector-view-header">
+    <button
+      type="button"
+      class="connector-back-button"
+      aria-label="Back to resource options"
+      onclick={() => { connectorMode = 'menu'; }}
+    >
+      <ConstellationIcon name="chevron-left" size={14} stroke={2} />
+      <span>Resources</span>
+    </button>
+    <span class="connector-view-title">{connectorTitle}</span>
+  </div>
+
+  {#if connectorMode === 'github'}
     <ProjectContextGitHubConnector onAddResources={onAddResources} />
   {:else}
-    <div class="project-context-muted compact">Loading connector...</div>
-  {/if}
-{:else}
-  {#if ProjectContextLocalConnector}
     <ProjectContextLocalConnector
-      mode={connectorMode === 'file' ? 'file' : 'folder'}
+      mode="local"
       onAddResources={onAddResources}
     />
-  {:else}
-    <div class="project-context-muted compact">Loading connector...</div>
   {/if}
 {/if}
 

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextGitHubTokenControl.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextGitHubTokenControl.svelte
@@ -51,6 +51,20 @@
     onSaveToken?: () => void;
     onClearVaultError?: () => void;
   } = $props();
+
+  const ADD_TOKEN_SELECT_VALUE = '__add_github_token__';
+
+  function handleVaultTokenChange(event: Event) {
+    const select = event.currentTarget as HTMLSelectElement;
+    const nextValue = select.value;
+    if (nextValue === ADD_TOKEN_SELECT_VALUE) {
+      onOpenAuth?.();
+      select.value = vaultTokenKey;
+      return;
+    }
+    vaultTokenKey = nextValue;
+    onSelectVaultKey?.(vaultTokenKey);
+  }
 </script>
 
 <div class="github-connect-row">
@@ -62,25 +76,26 @@
     <select
       aria-label="GitHub Vault token"
       value={vaultTokenKey}
-      disabled={githubLoading || vaultSecrets.length === 0}
-      onchange={(event) => {
-        vaultTokenKey = (event.currentTarget as HTMLSelectElement).value;
-        onSelectVaultKey?.(vaultTokenKey);
-      }}
+      disabled={githubLoading}
+      onchange={handleVaultTokenChange}
     >
       {#if vaultSecrets.length === 0}
         <option value="">No GitHub token in Vault</option>
       {:else}
         <option value="">Choose Vault token</option>
-        {#each vaultSecrets as secret}
-          <option value={secret.key_name}>{secret.key_name}{secret.is_shared ? ' - shared' : ''}</option>
-        {/each}
+        <optgroup label="Saved tokens">
+          {#each vaultSecrets as secret}
+            <option value={secret.key_name}>{secret.key_name}{secret.is_shared ? ' - shared' : ''}</option>
+          {/each}
+        </optgroup>
       {/if}
+      <optgroup label="Actions">
+        <option value={ADD_TOKEN_SELECT_VALUE}>Add GitHub token...</option>
+      </optgroup>
     </select>
     <button type="button" onclick={onConnect} disabled={githubLoading || !vaultTokenKey}>
       {githubLoading && vaultTokenKey ? 'Connecting...' : 'Connect'}
     </button>
-    <button type="button" onclick={onOpenAuth}>Add token</button>
     <button
       class="project-context-icon-command compact"
       type="button"

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextLocalConnector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextLocalConnector.svelte
@@ -4,28 +4,28 @@
   import type { ProjectContextResource } from '$lib/utils/projectContext';
   import {
     enableFolderPicker,
-    readDroppedEntry,
-    relativePathForFile,
+    entriesFromDataTransfer,
+    entriesFromFileList,
+    filterProjectContextUploadEntries,
     uploadedFileResource,
     uploadedFolderResources,
     uploadSkippedSummary,
-    type DataTransferItemWithEntry,
     type DroppedEntryFile,
-    type FileSystemEntryLike,
   } from '$lib/utils/projectContextLocal';
   import { projectContextErrorDetail } from './projectContextProfiles';
 
   let {
-    mode = 'folder',
+    mode = 'local',
     onAddResources,
   }: {
-    mode?: 'folder' | 'file';
+    mode?: 'folder' | 'file' | 'local';
     onAddResources?: (resources: ProjectContextResource[]) => void;
   } = $props();
 
   let localDropActive = $state(false);
   let localDropError = $state('');
   let localUploading = $state(false);
+  let localPickerMenuOpen = $state(false);
   let folderInputEl: HTMLInputElement | undefined = $state();
   let fileInputEl: HTMLInputElement | undefined = $state();
 
@@ -35,16 +35,22 @@
     preferFolderResource: boolean,
   ) {
     if (!entries.length || localUploading) return 0;
+    const filtered = filterProjectContextUploadEntries(entries);
+    const clientSkipped = uploadSkippedSummary(filtered.skippedFiles);
+    if (!filtered.entries.length) {
+      localDropError = clientSkipped || 'No files found that fit the upload limits.';
+      return 0;
+    }
     localUploading = true;
     localDropError = '';
     try {
       const result = await uploadProjectContextFiles(
-        entries.map((entry) => entry.file),
-        entries.map((entry) => entry.relativePath),
+        filtered.entries.map((entry) => entry.file),
+        filtered.entries.map((entry) => entry.relativePath),
       );
       const uploadedFiles = Array.isArray(result?.files) ? result.files : [];
       if (!uploadedFiles.length) {
-        localDropError = 'No readable Project Context files were uploaded.';
+        localDropError = 'No Project Context files were uploaded.';
         return 0;
       }
       const shouldCreateFolders = preferFolderResource || uploadedFiles.some((file: any) => String(file.relative_path ?? '').includes('/'));
@@ -52,7 +58,10 @@
         ? uploadedFolderResources(uploadedFiles, source)
         : uploadedFiles.map((file: any) => uploadedFileResource(file, source));
       onAddResources?.(resources);
-      const skipped = uploadSkippedSummary(result?.skipped_files);
+      const skipped = uploadSkippedSummary([
+        ...filtered.skippedFiles,
+        ...(Array.isArray(result?.skipped_files) ? result.skipped_files : []),
+      ]);
       if (skipped) localDropError = skipped;
       return resources.length;
     } catch (err: any) {
@@ -68,25 +77,12 @@
     }
   }
 
-  async function handleFolderSelect(event: Event) {
-    const input = event.currentTarget as HTMLInputElement;
-    const files = Array.from(input.files ?? []);
-    if (files.length) {
-      await uploadLocalProjectFiles(
-        files.map((file) => ({ file, relativePath: relativePathForFile(file) })),
-        'browser-folder-upload',
-        true,
-      );
-    }
-    input.value = '';
-  }
-
   async function handleFileSelect(event: Event) {
     const input = event.currentTarget as HTMLInputElement;
     const files = Array.from(input.files ?? []);
     if (files.length) {
       await uploadLocalProjectFiles(
-        files.map((file) => ({ file, relativePath: relativePathForFile(file) })),
+        entriesFromFileList(files),
         'browser-file-upload',
         false,
       );
@@ -94,25 +90,40 @@
     input.value = '';
   }
 
-  async function addDroppedFileList(files: File[]) {
-    if (!files.length) return 0;
-    const entries = files.map((file) => ({ file, relativePath: relativePathForFile(file) }));
-    const hasFolderPaths = entries.some((entry) => entry.relativePath.includes('/'));
-    return uploadLocalProjectFiles(entries, hasFolderPaths ? 'browser-folder-drop' : 'browser-file-drop', mode === 'folder' || hasFolderPaths);
-  }
-
-  async function addDroppedEntries(entries: FileSystemEntryLike[]) {
-    let added = 0;
-    for (const entry of entries) {
-      const files = await readDroppedEntry(entry);
-      if (!files.length) continue;
-      added += await uploadLocalProjectFiles(
-        files,
-        mode === 'file' && entry.isFile ? 'browser-file-drop' : 'browser-folder-drop',
-        !(mode === 'file' && entry.isFile),
+  async function handleFolderSelect(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = Array.from(input.files ?? []);
+    if (files.length) {
+      await uploadLocalProjectFiles(
+        entriesFromFileList(files),
+        'browser-folder-upload',
+        true,
       );
     }
-    return added;
+    input.value = '';
+  }
+
+  function toggleLocalPickerMenu() {
+    if (localUploading) return;
+    localPickerMenuOpen = !localPickerMenuOpen;
+    localDropError = '';
+  }
+
+  function chooseFiles() {
+    localPickerMenuOpen = false;
+    fileInputEl?.click();
+  }
+
+  function chooseFolder() {
+    localPickerMenuOpen = false;
+    folderInputEl?.click();
+  }
+
+  async function addDroppedFileList(files: File[]) {
+    if (!files.length) return 0;
+    const entries = entriesFromFileList(files);
+    const hasFolderPaths = entries.some((entry) => entry.relativePath.includes('/'));
+    return uploadLocalProjectFiles(entries, hasFolderPaths ? 'browser-folder-drop' : 'browser-file-drop', mode === 'folder' || hasFolderPaths);
   }
 
   function prepareLocalDrop(event: DragEvent) {
@@ -145,19 +156,21 @@
   async function handleLocalDrop(event: DragEvent) {
     prepareLocalDrop(event);
     localDropActive = false;
+    localPickerMenuOpen = false;
     localDropError = '';
     const transfer = event.dataTransfer;
     if (!transfer) return;
     try {
-      const entries = Array.from(transfer.items ?? []).reduce<FileSystemEntryLike[]>((acc, item) => {
-        const entry = (item as unknown as DataTransferItemWithEntry).webkitGetAsEntry?.();
-        if (entry) acc.push(entry);
-        return acc;
-      }, []);
+      const entries = await entriesFromDataTransfer(transfer);
+      const hasFolderPaths = entries.some((entry) => entry.relativePath.includes('/'));
       const added = entries.length
-        ? await addDroppedEntries(entries)
+        ? await uploadLocalProjectFiles(
+          entries,
+          hasFolderPaths ? 'browser-folder-drop' : 'browser-file-drop',
+          mode === 'folder' || hasFolderPaths,
+        )
         : await addDroppedFileList(Array.from(transfer.files ?? []));
-      if (!added) {
+      if (!added && !localDropError) {
         localDropError = 'No files found in this drop.';
       }
     } catch {
@@ -191,8 +204,10 @@
     class="local-drop-zone"
     class:active={localDropActive}
     disabled={localUploading}
-    aria-label={mode === 'folder' ? 'Upload a folder tree' : 'Upload individual files'}
-    onclick={() => mode === 'folder' ? folderInputEl?.click() : fileInputEl?.click()}
+    aria-label="Drop files or folders"
+    aria-expanded={localPickerMenuOpen}
+    aria-haspopup="menu"
+    onclick={toggleLocalPickerMenu}
     ondragenter={handleLocalDragEnter}
     ondragover={handleLocalDragOver}
     ondragleave={handleLocalDragLeave}
@@ -203,11 +218,23 @@
       <strong>
         {localUploading
           ? 'Uploading snapshot...'
-          : (localDropActive ? 'Release to upload' : (mode === 'folder' ? 'Choose or drop a folder tree' : 'Choose or drop files'))}
+          : (localDropActive ? 'Release to upload' : 'Drop files or folders')}
       </strong>
-      <small>{mode === 'folder' ? 'Best when related files live under one root folder' : 'Best for standalone docs, screenshots, or small source files'}</small>
+      <small>Select files, select a folder, or drop either here</small>
     </span>
   </button>
+  {#if localPickerMenuOpen}
+    <div class="local-picker-menu" role="menu" aria-label="Choose local resource type">
+      <button type="button" role="menuitem" disabled={localUploading} onclick={chooseFiles}>
+        <ConstellationIcon name="file" size={16} stroke={2} />
+        <span><strong>Files</strong><small>Select one or more files</small></span>
+      </button>
+      <button type="button" role="menuitem" disabled={localUploading} onclick={chooseFolder}>
+        <ConstellationIcon name="folder" size={16} stroke={2} />
+        <span><strong>Folder</strong><small>Preserve nested paths</small></span>
+      </button>
+    </div>
+  {/if}
   {#if localDropError}
     <p class="project-context-error">{localDropError}</p>
   {/if}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextLocalConnector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextLocalConnector.svelte
@@ -25,6 +25,7 @@
   let localDropActive = $state(false);
   let localDropError = $state('');
   let localUploading = $state(false);
+  let localUploadLabel = $state('');
   let localPickerMenuOpen = $state(false);
   let folderInputEl: HTMLInputElement | undefined = $state();
   let fileInputEl: HTMLInputElement | undefined = $state();
@@ -42,6 +43,9 @@
       return 0;
     }
     localUploading = true;
+    localUploadLabel = filtered.entries.length === 1
+      ? 'Uploading 1 file...'
+      : `Uploading ${filtered.entries.length} files...`;
     localDropError = '';
     try {
       const result = await uploadProjectContextFiles(
@@ -74,6 +78,7 @@
       return 0;
     } finally {
       localUploading = false;
+      localUploadLabel = '';
     }
   }
 
@@ -161,6 +166,7 @@
     const transfer = event.dataTransfer;
     if (!transfer) return;
     try {
+      localUploadLabel = 'Preparing files...';
       const entries = await entriesFromDataTransfer(transfer);
       const hasFolderPaths = entries.some((entry) => entry.relativePath.includes('/'));
       const added = entries.length
@@ -175,6 +181,8 @@
       }
     } catch {
       localDropError = 'Could not read dropped files.';
+    } finally {
+      if (!localUploading) localUploadLabel = '';
     }
   }
 </script>
@@ -217,7 +225,7 @@
     <span>
       <strong>
         {localUploading
-          ? 'Uploading snapshot...'
+          ? (localUploadLabel || 'Uploading files...')
           : (localDropActive ? 'Release to upload' : 'Drop files or folders')}
       </strong>
       <small>Select files, select a folder, or drop either here</small>

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -693,18 +693,15 @@
     gap: 8px;
   }
 
-  .connector-tabs {
+  .connector-view-header {
     display: flex;
-    gap: 2px;
-    margin-bottom: 0;
-    padding: 3px;
-    border: 1px solid var(--project-context-tab-track-border);
-    border-radius: 10px;
-    background: var(--project-context-tab-track-background);
-    overflow-x: auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 30px;
   }
 
-  .connector-tabs button,
+  .connector-back-button,
   .project-context-secondary,
   .project-context-primary,
   .github-connect-row button,
@@ -724,18 +721,23 @@
     cursor: pointer;
   }
 
-  .connector-tabs button {
-    flex: 1 0 auto;
+  .connector-back-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
     min-height: 28px;
-    border: 0;
-    border-radius: 7px;
-    padding: 6px 8px;
-    font-size: 11px;
+    padding: 6px 9px 6px 7px;
   }
 
-  .connector-tabs button.active {
-    background: var(--project-context-tab-active-background);
-    color: var(--project-context-tab-active-text);
+  .connector-view-title {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--project-context-field-value);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .project-context-primary {
@@ -750,7 +752,9 @@
   .github-repo-search-control button:disabled,
   .github-token-row button:disabled,
   .github-save-row button:disabled,
-  .github-search-row button:disabled {
+  .github-search-row button:disabled,
+  .local-drop-zone:disabled,
+  .local-picker-menu button:disabled {
     cursor: not-allowed;
     opacity: 0.48;
   }
@@ -798,19 +802,53 @@
     background: var(--project-context-drop-active-background);
   }
 
+  .local-picker-menu {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    padding: 6px;
+    border: 1px solid var(--project-context-repo-menu-border);
+    border-radius: 10px;
+    background: var(--project-context-repo-menu-background);
+  }
+
+  .local-picker-menu button {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    min-height: 42px;
+    box-sizing: border-box;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 7px 8px;
+    background: transparent;
+    color: var(--project-context-card-text);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .local-picker-menu button:hover {
+    border-color: var(--project-context-repo-option-hover-border);
+    background: var(--project-context-repo-option-hover-background);
+  }
+
   .project-connector-card {
     justify-content: flex-start;
   }
 
+  .project-connector-card-copy,
   .project-connector-card span,
-  .local-drop-zone span {
+  .local-drop-zone span,
+  .local-picker-menu span {
     display: grid;
     gap: 3px;
     min-width: 0;
   }
 
   .project-connector-card strong,
-  .local-drop-zone strong {
+  .local-drop-zone strong,
+  .local-picker-menu strong {
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 12px;
@@ -818,12 +856,20 @@
   }
 
   .project-connector-card small,
-  .local-drop-zone small {
-    overflow: hidden;
-    text-overflow: ellipsis;
+  .local-drop-zone small,
+  .local-picker-menu small {
+    overflow: visible;
+    text-overflow: clip;
     color: var(--project-context-card-meta);
     font-size: 11px;
-    white-space: nowrap;
+    line-height: 1.25;
+    white-space: normal;
+  }
+
+  .project-connector-card-caret {
+    margin-left: auto;
+    color: var(--project-context-card-meta);
+    flex: 0 0 auto;
   }
 
   .connector-panel {
@@ -1057,7 +1103,8 @@
     .github-repo-select-row,
     .github-token-row,
     .github-save-row,
-    .github-search-row {
+    .github-search-row,
+    .local-picker-menu {
       grid-template-columns: 1fr;
       display: grid;
     }

--- a/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
@@ -76,15 +76,8 @@ export function projectContextErrorDetail(err: any, fallback: string): string {
 
 export function vaultProjectContextErrorMessage(err: any, fallback = 'Vault unavailable.'): string {
   const detail = projectContextErrorDetail(err, fallback);
-  const normalized = detail.toLowerCase();
   if (detail.includes('VAULT_MASTER_KEY') || detail.toLowerCase().includes('vault master key')) {
     return 'Vault is not configured on this server. Set VAULT_MASTER_KEY to save or reveal tokens.';
-  }
-  if (normalized === 'internal server error') {
-    return 'Vault is unavailable right now. Public GitHub search still works.';
-  }
-  if (normalized.includes('timed out')) {
-    return 'Vault check timed out. Public GitHub search still works.';
   }
   return detail;
 }

--- a/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
@@ -8,7 +8,7 @@ export type ProjectContextProfile = {
   serverProfileId?: string;
 };
 
-export type ConnectorMode = 'menu' | 'github' | 'folder' | 'file';
+export type ConnectorMode = 'menu' | 'github' | 'local';
 
 const RESOURCE_TYPE_LABELS: Record<string, string> = {
   repo: 'GitHub',

--- a/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
@@ -76,8 +76,15 @@ export function projectContextErrorDetail(err: any, fallback: string): string {
 
 export function vaultProjectContextErrorMessage(err: any, fallback = 'Vault unavailable.'): string {
   const detail = projectContextErrorDetail(err, fallback);
+  const normalized = detail.toLowerCase();
   if (detail.includes('VAULT_MASTER_KEY') || detail.toLowerCase().includes('vault master key')) {
     return 'Vault is not configured on this server. Set VAULT_MASTER_KEY to save or reveal tokens.';
+  }
+  if (normalized === 'internal server error') {
+    return 'Vault is unavailable right now. Public GitHub search still works.';
+  }
+  if (normalized.includes('timed out')) {
+    return 'Vault check timed out. Public GitHub search still works.';
   }
   return detail;
 }

--- a/frontend/src/lib/utils/projectContextLocal.test.js
+++ b/frontend/src/lib/utils/projectContextLocal.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  filterProjectContextUploadEntries,
+  PROJECT_CONTEXT_UPLOAD_MAX_FILES,
+  PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE,
+  PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE,
+} from './projectContextLocal.ts';
+
+function entry(relativePath, size = 100) {
+  return {
+    file: {
+      name: relativePath.split('/').at(-1) || 'file',
+      size,
+    },
+    relativePath,
+  };
+}
+
+test('keeps arbitrary document types before sending multipart data', () => {
+  const result = filterProjectContextUploadEntries([
+    entry('src/App.svelte'),
+    entry('reference/karoid_ai.pdf'),
+    entry('research/custom.dataset'),
+    entry('docs/wireframe.png'),
+    entry('docs/large.md', PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE + 1),
+  ]);
+
+  assert.deepEqual(result.entries.map((item) => item.relativePath), [
+    'src/App.svelte',
+    'reference/karoid_ai.pdf',
+    'research/custom.dataset',
+    'docs/wireframe.png',
+  ]);
+  assert.equal(result.skippedFiles.length, 1);
+  assert.match(result.skippedFiles[0].reason, /larger than/);
+});
+
+test('caps local Project Context uploads to backend limits', () => {
+  const result = filterProjectContextUploadEntries(
+    Array.from({ length: PROJECT_CONTEXT_UPLOAD_MAX_FILES + 2 }, (_, index) => entry(`src/file-${index}.ts`)),
+  );
+
+  assert.equal(result.entries.length, PROJECT_CONTEXT_UPLOAD_MAX_FILES);
+  assert.equal(result.skippedFiles.length, 2);
+  assert.match(result.skippedFiles[0].reason, /Only the first 200/);
+});
+
+test('caps local Project Context upload total size', () => {
+  const fileSize = 1_000_000;
+  const result = filterProjectContextUploadEntries(
+    Array.from({ length: PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE / fileSize + 1 }, (_, index) => entry(`docs/file-${index}.md`, fileSize)),
+  );
+
+  assert.equal(result.entries.length, PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE / fileSize);
+  assert.equal(result.skippedFiles.length, 1);
+  assert.match(result.skippedFiles[0].reason, /capped at 20 MB/);
+});

--- a/frontend/src/lib/utils/projectContextLocal.ts
+++ b/frontend/src/lib/utils/projectContextLocal.ts
@@ -36,6 +36,21 @@ export type ProjectContextUploadedFile = {
   size?: number;
 };
 
+export type ProjectContextUploadSkip = {
+  filename?: string;
+  reason?: string;
+};
+
+export type ProjectContextUploadFilterResult = {
+  entries: DroppedEntryFile[];
+  skippedFiles: ProjectContextUploadSkip[];
+};
+
+export const PROJECT_CONTEXT_UPLOAD_MAX_FILES = 200;
+export const PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE = 10_000_000;
+export const PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE = 20_000_000;
+const PROJECT_CONTEXT_ENTRY_READ_TIMEOUT_MS = 8_000;
+
 export function enableFolderPicker(node: HTMLInputElement) {
   const folderNode = node as HTMLInputElement & { webkitdirectory?: boolean; directory?: boolean };
   folderNode.webkitdirectory = true;
@@ -53,6 +68,64 @@ export function uploadSkippedSummary(skippedFiles: Array<{ filename?: string; re
   const first = skippedFiles[0];
   const suffix = skippedFiles.length > 1 ? ` (${skippedFiles.length} skipped)` : '';
   return `${first.filename ?? 'Some files'}: ${first.reason ?? 'Skipped'}${suffix}`;
+}
+
+function timeoutError(label: string): Error {
+  return new Error(`${label} took too long to read.`);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(timeoutError(label)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+export function filterProjectContextUploadEntries(entries: DroppedEntryFile[]): ProjectContextUploadFilterResult {
+  const accepted: DroppedEntryFile[] = [];
+  const skippedFiles: ProjectContextUploadSkip[] = [];
+  let totalSize = 0;
+
+  for (const entry of entries) {
+    const filename = entry.relativePath || entry.file.name || 'file';
+    const size = typeof entry.file.size === 'number' ? entry.file.size : 0;
+
+    if (accepted.length >= PROJECT_CONTEXT_UPLOAD_MAX_FILES) {
+      skippedFiles.push({
+        filename,
+        reason: `Only the first ${PROJECT_CONTEXT_UPLOAD_MAX_FILES} supported files are attached`,
+      });
+      continue;
+    }
+    if (size > PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE) {
+      skippedFiles.push({
+        filename,
+        reason: `File is larger than ${PROJECT_CONTEXT_UPLOAD_MAX_FILE_SIZE / 1_000_000} MB`,
+      });
+      continue;
+    }
+    if (totalSize + size > PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE) {
+      skippedFiles.push({
+        filename,
+        reason: `Project Context upload is capped at ${PROJECT_CONTEXT_UPLOAD_MAX_TOTAL_SIZE / 1_000_000} MB`,
+      });
+      continue;
+    }
+
+    accepted.push(entry);
+    totalSize += size;
+  }
+
+  return { entries: accepted, skippedFiles };
 }
 
 export function uploadedFileResource(file: ProjectContextUploadedFile, source: string): ProjectContextResource {
@@ -100,32 +173,40 @@ export function uploadedFolderResources(
 }
 
 export function readFileEntry(entry: FileSystemFileEntryLike, relativePath: string): Promise<DroppedEntryFile> {
-  return new Promise((resolve, reject) => {
-    entry.file(
-      (file) => resolve({ file, relativePath }),
-      (error) => reject(error),
-    );
-  });
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      entry.file(
+        (file) => resolve({ file, relativePath }),
+        (error) => reject(error),
+      );
+    }),
+    PROJECT_CONTEXT_ENTRY_READ_TIMEOUT_MS,
+    relativePath,
+  );
 }
 
 export function readDirectoryEntries(reader: FileSystemDirectoryReaderLike): Promise<FileSystemEntryLike[]> {
-  return new Promise((resolve, reject) => {
-    const entries: FileSystemEntryLike[] = [];
-    const readBatch = () => {
-      reader.readEntries(
-        (batch) => {
-          if (!batch.length) {
-            resolve(entries);
-            return;
-          }
-          entries.push(...batch);
-          readBatch();
-        },
-        (error) => reject(error),
-      );
-    };
-    readBatch();
-  });
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      const entries: FileSystemEntryLike[] = [];
+      const readBatch = () => {
+        reader.readEntries(
+          (batch) => {
+            if (!batch.length) {
+              resolve(entries);
+              return;
+            }
+            entries.push(...batch);
+            readBatch();
+          },
+          (error) => reject(error),
+        );
+      };
+      readBatch();
+    }),
+    PROJECT_CONTEXT_ENTRY_READ_TIMEOUT_MS,
+    'Folder',
+  );
 }
 
 export async function readDroppedEntry(entry: FileSystemEntryLike, parentPath = ''): Promise<DroppedEntryFile[]> {
@@ -138,4 +219,29 @@ export async function readDroppedEntry(entry: FileSystemEntryLike, parentPath = 
   const entries = await readDirectoryEntries(reader);
   const groups = await Promise.all(entries.map((item) => readDroppedEntry(item, relativePath)));
   return groups.flat();
+}
+
+export function entriesFromFileList(files: File[]): DroppedEntryFile[] {
+  return files.map((file) => ({ file, relativePath: relativePathForFile(file) }));
+}
+
+export async function entriesFromDataTransfer(transfer: DataTransfer): Promise<DroppedEntryFile[]> {
+  const fallbackFiles = Array.from(transfer.files ?? []);
+  const fileSystemEntries = Array.from(transfer.items ?? []).reduce<FileSystemEntryLike[]>((acc, item) => {
+    const entry = (item as unknown as DataTransferItemWithEntry).webkitGetAsEntry?.();
+    if (entry) acc.push(entry);
+    return acc;
+  }, []);
+
+  if (!fileSystemEntries.length) {
+    return entriesFromFileList(fallbackFiles);
+  }
+
+  try {
+    const entryGroups = await Promise.all(fileSystemEntries.map((entry) => readDroppedEntry(entry)));
+    const entries = entryGroups.flat();
+    return entries.length ? entries : entriesFromFileList(fallbackFiles);
+  } catch {
+    return entriesFromFileList(fallbackFiles);
+  }
 }

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1532,6 +1532,25 @@ async def test_project_context_local_upload_keeps_duplicate_names_distinct(clien
 
 
 @pytest.mark.asyncio
+async def test_project_context_local_upload_accepts_binary_documents(client, tmp_path, monkeypatch):
+    from brain.app.api.routers.cortex import _project_context as pc_mod
+
+    monkeypatch.setattr(pc_mod, "UPLOAD_DIR", tmp_path)
+    content = b"%PDF-1.7\x00binary project context"
+    resp = await client.post(
+        "/api/cortex/project-context/local-files",
+        data={"relative_paths": "docs/karoid_ai.pdf"},
+        files={"files": ("karoid_ai.pdf", content, "application/pdf")},
+    )
+
+    assert resp.status_code == 200
+    uploaded = resp.json()["files"][0]
+    assert uploaded["relative_path"] == "docs/karoid_ai.pdf"
+    assert uploaded["mime"] == "application/pdf"
+    assert Path(uploaded["storage_path"]).read_bytes() == content
+
+
+@pytest.mark.asyncio
 async def test_attach_idea_project_context_persists_snapshot_scope_and_env_binding(client, mock_session_factory):
     idea = _make_idea(id="idea-1", org_id="org-1")
     mock_session_factory.get.return_value = idea

--- a/tests/test_cortex_orm.py
+++ b/tests/test_cortex_orm.py
@@ -196,18 +196,29 @@ class TestExtractMentions:
         assert _extract_mentions("no mentions here") == []
 
 
-# ── GPU title generation ───────────────────────────────────────
+# ── Low-tier title generation ──────────────────────────────────
 
-class TestGenerateTitleGpu:
-    @patch("brain.platform.integrations.completions.simple_text_completion")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_returns_local_title_without_fallback(self, mock_get_client, mock_simple_text_completion):
+class TestGenerateTitleLowTier:
+    def test_uses_local_gpu_when_configured_low_tier_model_is_local(self):
         from brain.app.api.routers.cortex import _generate_title_gpu
 
-        mock_get_client.return_value.generate.return_value = "Great Title"
-        mock_get_client.return_value.is_ready.return_value = True
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai") as mock_resolve_default_provider, \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b") as mock_get_model_for_tier, \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.generate.return_value = "Great Title"
+            mock_get_client.return_value.is_ready.return_value = True
 
-        assert _generate_title_gpu("some raw text") == "Great Title"
+            assert _generate_title_gpu("some raw text", user_id="user-1", org_id="org-1") == "Great Title"
+
+        mock_resolve_default_provider.assert_called_once_with(user_id="user-1", org_id="org-1")
+        mock_get_model_for_tier.assert_called_once_with(
+            "low",
+            provider="openai",
+            include_provider_prefix=False,
+            user_id="user-1",
+            org_id="org-1",
+        )
         mock_get_client.return_value.is_ready.assert_called_once_with("llm")
         mock_get_client.return_value.generate.assert_called_once()
         kwargs = mock_get_client.return_value.generate.call_args.kwargs
@@ -215,27 +226,20 @@ class TestGenerateTitleGpu:
         assert kwargs["think"] is False
         mock_simple_text_completion.assert_not_called()
 
-    @patch("brain.platform.providers.model_policy.get_model_for_tier")
-    @patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai")
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value="Fallback Title")
-    @patch("brain.platform.gpu_client.get_client", side_effect=Exception("no GPU"))
-    def test_falls_back_to_provider_low_tier_model(
-        self,
-        mock_get_client,
-        mock_simple_text_completion,
-        mock_resolve_default_provider,
-        mock_get_model_for_tier,
-    ):
+    def test_uses_configured_api_low_tier_model_with_user_context(self):
         from brain.app.api.routers.cortex import _generate_title_gpu
 
-        mock_get_model_for_tier.return_value = "openai/gpt-5-mini"
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai") as mock_resolve_default_provider, \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="gpt-5-mini") as mock_get_model_for_tier, \
+             patch("brain.platform.integrations.completions.simple_text_completion", return_value="Provider Title") as mock_simple_text_completion, \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client:
+            assert _generate_title_gpu("some raw text", user_id="user-1", org_id="org-1") == "Provider Title"
 
-        assert _generate_title_gpu("some raw text", user_id="user-1", org_id="org-1") == "Fallback Title"
         mock_resolve_default_provider.assert_called_once_with(user_id="user-1", org_id="org-1")
         mock_get_model_for_tier.assert_called_once_with(
             "low",
             provider="openai",
-            include_provider_prefix=True,
+            include_provider_prefix=False,
             user_id="user-1",
             org_id="org-1",
         )
@@ -245,35 +249,41 @@ class TestGenerateTitleGpu:
         assert kwargs["user_id"] == "user-1"
         assert kwargs["org_id"] == "org-1"
         assert kwargs["system_prompt"]
+        mock_get_client.assert_not_called()
 
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value=" x ")
-    @patch("brain.platform.gpu_client.get_client", side_effect=Exception("no GPU"))
-    def test_returns_none_when_fallback_title_invalid(self, mock_get_client, mock_simple_text_completion):
+    def test_returns_none_when_configured_api_title_invalid(self):
         from brain.app.api.routers.cortex import _generate_title_gpu
 
-        assert _generate_title_gpu("some raw text") is None
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="gpt-5-mini"), \
+             patch("brain.platform.integrations.completions.simple_text_completion", return_value=" x "):
+            assert _generate_title_gpu("some raw text") is None
 
-    @patch("brain.platform.integrations.completions.simple_text_completion")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_normalizes_local_title_output(self, mock_get_client, mock_simple_text_completion):
+    def test_normalizes_local_title_output(self):
         from brain.app.api.routers.cortex import _generate_title_gpu
 
-        mock_get_client.return_value.is_ready.return_value = True
-        mock_get_client.return_value.generate.return_value = 'Title: "Sharper Idea Framing"\n\nExplanation'
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b"), \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.is_ready.return_value = True
+            mock_get_client.return_value.generate.return_value = 'Title: "Sharper Idea Framing"\n\nExplanation'
 
-        assert _generate_title_gpu("some raw text") == "Sharper Idea Framing"
+            assert _generate_title_gpu("some raw text") == "Sharper Idea Framing"
         mock_simple_text_completion.assert_not_called()
 
-    @patch("brain.platform.integrations.completions.simple_text_completion", return_value="Fallback Title")
-    @patch("brain.platform.gpu_client.get_client")
-    def test_skips_local_generation_when_llm_worker_not_ready(self, mock_get_client, mock_simple_text_completion):
+    def test_returns_none_when_configured_local_worker_not_ready(self):
         from brain.app.api.routers.cortex import _generate_title_gpu
 
-        mock_get_client.return_value.is_ready.return_value = False
+        with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="openai"), \
+             patch("brain.platform.providers.model_policy.get_model_for_tier", return_value="brain.platform.gpu/qwen3.5:4b"), \
+             patch("brain.platform.gpu_client.get_client") as mock_get_client, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            mock_get_client.return_value.is_ready.return_value = False
 
-        assert _generate_title_gpu("some raw text") == "Fallback Title"
+            assert _generate_title_gpu("some raw text") is None
         mock_get_client.return_value.generate.assert_not_called()
-        mock_simple_text_completion.assert_called_once()
+        mock_simple_text_completion.assert_not_called()
 
 
 class TestTitleRoutes:


### PR DESCRIPTION
## Summary
- Replace project resource tabs with card drill-in for GitHub and files/folders
- Consolidate local uploads behind one drop target with file/folder choices and drag/drop fallback handling
- Accept arbitrary Project Context documents/binaries while keeping only count and size upload limits

## Validation
- npm test -- projectContextLocal
- npm run check
- npm run build
- pytest tests/test_api_cortex.py -k "project_context_local"
- Browser checked http://127.0.0.1:5178/cortex project creation flow
- Direct upload checked PDF-style binary through backend and frontend proxy
