### PR TITLE
Refine onboarding runtime setup flow

### DIFF
--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -77,9 +77,9 @@ class OpenAIOAuthExchangeRequest(BaseModel):
 
 
 class OpenAIOAuthStartResponse(BaseModel):
-    url: str
-    state: str
-    redirect_uri: str
+    url: str = Field(min_length=1)
+    state: str = Field(min_length=1)
+    redirect_uri: str = Field(min_length=1)
     expires_in_seconds: int
     callback_available: bool = True
     callback_detail: str | None = None

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -14,6 +14,7 @@
   import type { EmbedderKey, RuntimeOption, RuntimeSettings } from '../system/types';
 
   type OnboardingStatus = 'loading' | 'missing' | 'connecting' | 'connected' | 'error';
+  type OnboardingStep = 'openai' | 'memory';
   type NoticeState = {
     tone: 'success' | 'warning' | 'danger' | 'info';
     title: string;
@@ -35,10 +36,12 @@
   let embedderApiKey = $state('');
   let savingMemory = $state(false);
   let memorySaved = $state(false);
+  let activeStep = $state<OnboardingStep>('openai');
 
   const isWorking = $derived(status === 'loading' || status === 'connecting');
-  const showManualCallback = $derived(Boolean(oauthUrl && !oauthCallbackAvailable));
+  const showManualCallback = $derived(Boolean(!oauthCallbackAvailable && (oauthUrl || oauthState || status === 'connecting')));
   const connectLabel = $derived(status === 'connected' ? 'Continue' : 'Connect OpenAI');
+  const isMemoryStep = $derived(activeStep === 'memory');
   const embedderOptions = $derived(memoryEmbedderOptions());
   const selectedEmbedderNeedsKey = $derived(usesApiEmbedder(selectedEmbedder));
   const selectedEmbedderHasKey = $derived(hasApiKeyForEmbedder(selectedEmbedder));
@@ -46,6 +49,14 @@
   const selectedEmbedderLabel = $derived(embedderLabel(selectedEmbedder));
   const selectedEmbedderArticle = $derived(selectedEmbedder === 'openai' ? 'an' : 'a');
   const selectedEmbedderPlaceholder = $derived(selectedEmbedder === 'gemini' ? 'Google AI Studio key' : 'sk-...');
+  const canManageMemorySetup = $derived(runtimeSettings?.permissions?.can_manage_settings ?? false);
+  const showMemorySetup = $derived(canManageMemorySetup && !memorySaved);
+  const pageTitle = $derived(isMemoryStep ? 'Set up memory' : 'Connect OpenAI');
+  const pageLede = $derived(
+    isMemoryStep
+      ? 'Choose how Illo should remember, retrieve, and summarize workspace context.'
+      : 'Connect your OpenAI account so Illo can start working with you in Cortex.',
+  );
 
   onMount(() => {
     void loadRuntime();
@@ -69,15 +80,37 @@
     notice = null;
     try {
       const runtime = await api.runtimeSettings();
-      runtimeSettings = runtime;
-      status = runtime?.connection?.status === 'connected' ? 'connected' : 'missing';
-      selectedEmbedder = runtime?.memory?.embedder || 'local_gpu';
-      selectedEmbeddingModel = runtime?.memory?.embedding_model || defaultEmbeddingModel(selectedEmbedder, runtime);
-      memorySaved = runtime?.memory?.embedding_status === 'ready';
+      hydrateRuntime(runtime);
+      if (runtimeHasOnboardingOpenAIConnection(runtime)) {
+        status = 'connected';
+        if (runtimeNeedsMemorySetup(runtime)) {
+          activeStep = 'memory';
+          return;
+        }
+        await openCortexIntro();
+        return;
+      }
+      activeStep = 'openai';
+      status = 'missing';
     } catch (error) {
       status = 'error';
       notice = errorNotice('Could not load onboarding.', error, 'Refresh and try again.');
     }
+  }
+
+  function hydrateRuntime(runtime: RuntimeSettings) {
+    runtimeSettings = runtime;
+    selectedEmbedder = runtime?.memory?.embedder || 'local_gpu';
+    selectedEmbeddingModel = runtime?.memory?.embedding_model || defaultEmbeddingModel(selectedEmbedder, runtime);
+    memorySaved = runtime?.memory?.embedding_status === 'ready';
+  }
+
+  function runtimeNeedsMemorySetup(runtime: RuntimeSettings) {
+    return Boolean(runtime?.permissions?.can_manage_settings && runtime?.memory?.embedding_status !== 'ready');
+  }
+
+  function runtimeHasOnboardingOpenAIConnection(runtime: RuntimeSettings) {
+    return Boolean(runtime?.connection?.status === 'connected' && ['user_default', 'org_main'].includes(runtime.connection.source || ''));
   }
 
   function selectEmbedder(embedder: EmbedderKey) {
@@ -91,7 +124,7 @@
   }
 
   async function saveMemorySetup() {
-    if (!runtimeSettings) return;
+    if (!runtimeSettings || !showMemorySetup) return;
     const value = embedderApiKey.trim();
     if (selectedEmbedderNeedsKey && !selectedEmbedderHasKey && !value) {
       notice = { tone: 'warning', title: `Paste ${selectedEmbedderArticle} ${selectedEmbedderLabel} API key first.` };
@@ -113,17 +146,28 @@
       });
       embedderApiKey = '';
       runtimeSettings = { ...runtimeSettings, memory };
-      memorySaved = true;
+      memorySaved = memory?.embedding_status === 'ready';
       notice = {
         tone: 'success',
         title: 'Memory setup saved.',
         detail: `${selectedEmbedderLabel} will power memory, retrieval, and summaries.`,
       };
+      if (memorySaved) activeStep = 'openai';
+      await openCortexIntro();
     } catch (error) {
-      notice = errorNotice('Memory setup was not saved.', error, 'You can continue to Cortex and add it later.');
+      notice = errorNotice('Memory setup was not saved.', error, 'Skip for now, or update it later in AI Runtime.');
     } finally {
       savingMemory = false;
     }
+  }
+
+  async function skipMemorySetup() {
+    notice = {
+      tone: 'info',
+      title: 'Memory setup skipped.',
+      detail: 'You can configure memory later in AI Runtime.',
+    };
+    await openCortexIntro();
   }
 
   function memoryEmbedderOptions(): RuntimeOption[] {
@@ -211,14 +255,20 @@
         }
       }
 
-      notice = {
-        tone: 'info',
-        title: 'OpenAI sign-in opened.',
-        detail:
-          oauthCallbackMode === 'server'
-            ? 'Finish in the OpenAI window. It will return automatically.'
-            : 'Finish in the OpenAI window. This page will continue when it returns.',
-      };
+      notice = oauthCallbackAvailable
+        ? {
+            tone: 'info',
+            title: 'OpenAI sign-in opened.',
+            detail:
+              oauthCallbackMode === 'server'
+                ? 'Finish in the OpenAI window. It will return automatically.'
+                : 'Finish in the OpenAI window. This page will update when it returns.',
+          }
+        : {
+            tone: 'warning',
+            title: 'OpenAI sign-in opened.',
+            detail: result.callback_detail || 'Finish sign-in, then paste the callback URL below.',
+          };
     } catch (error) {
       status = 'missing';
       notice = errorNotice('Could not start OpenAI sign-in.', error, 'Try again.');
@@ -241,7 +291,7 @@
     notice = null;
     try {
       await api.exchangeRuntimeOpenAIOAuth({ callback });
-      await openCortexIntro();
+      await confirmOpenAIConnection();
     } catch (error) {
       status = 'missing';
       notice = errorNotice('OpenAI sign-in failed.', error, 'Start the sign-in again.');
@@ -267,7 +317,7 @@
     }
 
     if (data.status === 'success') {
-      await confirmOpenAIAndContinue();
+      await confirmOpenAIConnection();
       return;
     }
 
@@ -284,11 +334,27 @@
     }
   }
 
-  async function confirmOpenAIAndContinue() {
+  async function confirmOpenAIConnection() {
     status = 'connecting';
     try {
       const runtime = await api.runtimeSettings();
-      if (runtime?.connection?.status === 'connected') {
+      if (runtimeHasOnboardingOpenAIConnection(runtime)) {
+        hydrateRuntime(runtime);
+        oauthUrl = '';
+        oauthState = '';
+        oauthCallback = '';
+        oauthCallbackAvailable = true;
+        oauthCallbackMode = 'local_bridge';
+        status = 'connected';
+        if (runtimeNeedsMemorySetup(runtime)) {
+          activeStep = 'memory';
+          notice = {
+            tone: 'success',
+            title: 'OpenAI connected.',
+            detail: 'Set up memory now, or skip and configure it later in AI Runtime.',
+          };
+          return;
+        }
         await openCortexIntro();
         return;
       }
@@ -350,7 +416,7 @@
 </script>
 
 <svelte:head>
-  <title>Connect OpenAI</title>
+  <title>{pageTitle}</title>
 </svelte:head>
 
 <main class="onboarding-shell">
@@ -362,103 +428,123 @@
     <ConstellationPanel padding="lg" tone={status === 'connected' ? 'success' : 'info'} className="onboarding-panel">
       <div class="onboarding-copy">
         <p class="eyebrow">Workspace ready</p>
-        <h1>Connect OpenAI</h1>
-        <p class="lede">Connect your OpenAI account so Illo can start working with you in Cortex.</p>
+        <h1>{pageTitle}</h1>
+        <p class="lede">{pageLede}</p>
+      </div>
+
+      <div class="step-strip" aria-label="Onboarding progress">
+        <div class:active={!isMemoryStep} class:complete={status === 'connected'} class="step-pill">
+          <span>1</span>
+          <strong>OpenAI</strong>
+        </div>
+        <div class:active={isMemoryStep} class:pending={!isMemoryStep} class="step-pill">
+          <span>2</span>
+          <strong>Memory</strong>
+        </div>
       </div>
 
       {#if notice}
         <ConstellationNotice title={notice.title} description={notice.detail || ''} tone={notice.tone} compact />
       {/if}
 
-      <div class="setup-section">
-        <div class="section-copy">
-          <div class="section-title">
-            <span class:connected={status === 'connected'}></span>
-            <div>
-              <strong>{status === 'connected' ? 'OpenAI connected' : 'OpenAI account'}</strong>
-              <p>
-                {#if status === 'connecting'}
-                  Waiting for OpenAI to finish.
-                {:else if status === 'connected'}
-                  Continue and Illo will introduce itself.
-                {:else}
-                  Required for Illo to think and respond.
-                {/if}
-              </p>
+      {#if !isMemoryStep}
+        <div class="setup-section">
+          <div class="section-copy">
+            <div class="section-title">
+              <span class:connected={status === 'connected'}></span>
+              <div>
+                <strong>{status === 'connected' ? 'OpenAI connected' : 'OpenAI account'}</strong>
+                <p>
+                  {#if status === 'connecting'}
+                    Waiting for OpenAI to finish.
+                  {:else if status === 'connected'}
+                    Continue and Illo will introduce itself.
+                  {:else}
+                    Required for Illo to think and respond.
+                  {/if}
+                </p>
+              </div>
             </div>
           </div>
-        </div>
 
-        <ConstellationButton onclick={primaryAction} loading={isWorking} loadingLabel="Working">
-          {#snippet leadingVisual()}
-            <ConstellationIcon name={status === 'connected' ? 'cortex' : 'external-link'} size={14} />
-          {/snippet}
-          {connectLabel}
-        </ConstellationButton>
-      </div>
-
-      <div class="setup-section memory-section">
-        <div class="section-copy memory-copy">
-          <div class="section-title">
-            <span class:connected={memorySaved}></span>
-            <div>
-              <strong>{memorySaved ? `${selectedEmbedderLabel} memory saved` : 'Memory setup'}</strong>
-              <p>Optional, but recommended for memory, retrieval, and summaries.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="memory-controls" class:has-key-input={needsMemoryApiKeyInput}>
-          <div class="embedder-choice" aria-label="Memory embedder">
-            {#each embedderOptions as option}
-              <button
-                type="button"
-                class:selected={selectedEmbedder === option.key}
-                disabled={option.disabled}
-                onclick={() => selectEmbedder(option.key as EmbedderKey)}
-              >
-                {optionLabel(option)}
-              </button>
-            {/each}
-          </div>
-
-          {#if needsMemoryApiKeyInput}
-            <ConstellationTextInput
-              bind:value={embedderApiKey}
-              type="password"
-              placeholder={selectedEmbedderPlaceholder}
-              autocomplete="off"
-            />
-          {/if}
-
-          <ConstellationButton
-            variant="secondary"
-            className="memory-save-button"
-            onclick={saveMemorySetup}
-            loading={savingMemory}
-            loadingLabel="Saving"
-          >
-            Save memory
+          <ConstellationButton onclick={primaryAction} loading={isWorking} loadingLabel="Working">
+            {#snippet leadingVisual()}
+              <ConstellationIcon name={status === 'connected' ? 'cortex' : 'external-link'} size={14} />
+            {/snippet}
+            {connectLabel}
           </ConstellationButton>
-        </div>
-      </div>
 
-      {#if showManualCallback}
-        <div class="manual-callback">
-          <label for="openai-callback">Callback URL</label>
-          <div class="manual-row">
-            <ConstellationTextInput
-              id="openai-callback"
-              bind:value={oauthCallback}
-              placeholder="http://localhost:1455/auth/callback?code=..."
-              autocomplete="off"
-            />
-            <ConstellationButton variant="secondary" onclick={finishManualCallback} loading={oauthExchangeInFlight}>
-              Finish
-            </ConstellationButton>
+          {#if showManualCallback}
+            <div class="manual-callback">
+              <label for="openai-callback">Callback URL</label>
+              <div class="manual-row">
+                <ConstellationTextInput
+                  id="openai-callback"
+                  bind:value={oauthCallback}
+                  placeholder="http://localhost:1455/auth/callback?code=..."
+                  autocomplete="off"
+                />
+                <ConstellationButton variant="secondary" onclick={finishManualCallback} loading={oauthExchangeInFlight}>
+                  Finish
+                </ConstellationButton>
+              </div>
+            </div>
+          {/if}
+        </div>
+      {:else if showMemorySetup}
+        <div class="setup-section memory-section">
+          <div class="section-copy memory-copy">
+            <div class="section-title">
+              <span></span>
+              <div>
+                <strong>Memory setup</strong>
+                <p>Optional for onboarding, recommended for context-aware work.</p>
+              </div>
+            </div>
           </div>
+
+          <div class="memory-controls" class:has-key-input={needsMemoryApiKeyInput}>
+            <div class="embedder-choice" aria-label="Memory embedder">
+              {#each embedderOptions as option}
+                <button
+                  type="button"
+                  class:selected={selectedEmbedder === option.key}
+                  disabled={option.disabled}
+                  onclick={() => selectEmbedder(option.key as EmbedderKey)}
+                >
+                  {optionLabel(option)}
+                </button>
+              {/each}
+            </div>
+
+            {#if needsMemoryApiKeyInput}
+              <ConstellationTextInput
+                bind:value={embedderApiKey}
+                type="password"
+                placeholder={selectedEmbedderPlaceholder}
+                autocomplete="off"
+              />
+            {/if}
+
+            <div class="memory-actions">
+              <ConstellationButton
+                className="memory-save-button"
+                onclick={saveMemorySetup}
+                loading={savingMemory}
+                loadingLabel="Saving"
+              >
+                Confirm and continue
+              </ConstellationButton>
+              <ConstellationButton variant="secondary" onclick={skipMemorySetup} disabled={savingMemory}>
+                Skip for now
+              </ConstellationButton>
+            </div>
+          </div>
+
+          <p class="runtime-note">You can configure this later in AI Runtime.</p>
         </div>
       {/if}
+
     </ConstellationPanel>
   </section>
 </main>
@@ -507,7 +593,8 @@
   h1,
   .lede,
   .section-title p,
-  .manual-callback label {
+  .manual-callback label,
+  .runtime-note {
     margin: 0;
   }
 
@@ -530,10 +617,66 @@
   }
 
   .lede,
-  .section-title p {
+  .section-title p,
+  .runtime-note {
     color: var(--constellation-color-text-secondary);
     font-size: 13px;
     line-height: 1.45;
+  }
+
+  .step-strip {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .step-pill {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    min-height: 42px;
+    padding: 8px 10px;
+    border: 1px solid var(--constellation-surface-panel-separator);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--constellation-surface-nested-background) 64%, transparent);
+    color: var(--constellation-color-text-secondary);
+  }
+
+  .step-pill span {
+    display: inline-grid;
+    flex: 0 0 auto;
+    width: 22px;
+    height: 22px;
+    place-items: center;
+    border-radius: var(--constellation-radius-pill);
+    background: var(--constellation-control-field-background);
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono);
+    font-size: var(--constellation-type-meta);
+    font-weight: 700;
+  }
+
+  .step-pill strong {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 13px;
+    font-weight: 650;
+  }
+
+  .step-pill.active {
+    border-color: color-mix(in srgb, var(--constellation-color-accent, #5ecfa0) 42%, var(--constellation-surface-panel-separator));
+    background: color-mix(in srgb, var(--constellation-color-accent, #5ecfa0) 10%, var(--constellation-surface-nested-background));
+    color: var(--constellation-color-text-primary);
+  }
+
+  .step-pill.complete span {
+    background: var(--constellation-control-pill-success-text);
+    color: var(--constellation-surface-panel-background);
+  }
+
+  .step-pill.pending {
+    opacity: 0.66;
   }
 
   .setup-section {
@@ -593,7 +736,7 @@
   }
 
   .memory-controls.has-key-input {
-    grid-template-columns: minmax(210px, 0.9fr) minmax(210px, 1fr) auto;
+    grid-template-columns: minmax(210px, 0.9fr) minmax(210px, 1fr);
   }
 
   .memory-controls :global(.constellation-text-input) {
@@ -602,6 +745,19 @@
 
   .memory-controls :global(.memory-save-button) {
     justify-self: end;
+  }
+
+  .memory-controls.has-key-input .memory-actions {
+    grid-column: 1 / -1;
+    justify-self: end;
+  }
+
+  .memory-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-end;
+    min-width: 0;
   }
 
   .embedder-choice {
@@ -648,6 +804,7 @@
 
   .manual-callback {
     display: grid;
+    grid-column: 1 / -1;
     gap: 10px;
   }
 
@@ -670,6 +827,25 @@
     .manual-row {
       grid-template-columns: 1fr;
       align-items: stretch;
+    }
+
+    .step-strip {
+      grid-template-columns: 1fr;
+    }
+
+    .memory-controls.has-key-input .memory-actions {
+      grid-column: auto;
+      justify-self: stretch;
+    }
+
+    .memory-actions {
+      display: grid;
+      grid-template-columns: 1fr;
+      justify-content: stretch;
+    }
+
+    .memory-actions :global(.constellation-button) {
+      width: 100%;
     }
 
     .memory-controls :global(.memory-save-button) {

--- a/tests/test_runtime_settings_oauth_start_route.py
+++ b/tests/test_runtime_settings_oauth_start_route.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from fastapi import FastAPI
+from pydantic import ValidationError
 from starlette.testclient import TestClient
 
 from brain.app.api.deps import rate_limit
 from brain.systems.runtime_settings import router as runtime_router
+from brain.systems.runtime_settings.schemas import OpenAIOAuthStartResponse
 
 
 def _client() -> TestClient:
@@ -37,6 +40,14 @@ def test_openai_oauth_start_accepts_empty_post_body():
     assert response.status_code == 200
     assert response.json()["state"] == "state-123"
     assert start.call_args.kwargs["callback_mode"] == "auto"
+
+
+def test_openai_oauth_start_response_requires_authorize_values():
+    payload = _oauth_response()
+    payload["url"] = ""
+
+    with pytest.raises(ValidationError):
+        OpenAIOAuthStartResponse.model_validate(payload)
 
 
 def test_openai_oauth_start_accepts_valid_callback_mode_json():


### PR DESCRIPTION
## Summary
- Convert onboarding into a focused OpenAI step followed by a memory step only when memory setup is still needed.
- Keep manual OAuth callback input directly under the OpenAI account step and advance to memory instead of immediately redirecting.
- Add confirm/skip memory actions that continue into Cortex, plus backend response validation for OAuth start values.

## Verification
- npm run check
- pytest tests/test_openai_user_auth_connect.py tests/test_runtime_settings_oauth_start_route.py -q
- Verified in Codex in-app browser: OpenAI step -> manual callback -> memory step -> skip to Cortex.