### PR TITLE
Improve Illo workspace awareness tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ brain/uploads/
 
 # Optional private local tool notes
 /TOOLS.md
+/doc/
 
 # Internal historical content not shipped in the public repo
 /docs/archive/

--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -38,7 +38,7 @@ INTRO_RUN_SETTLED_STATUSES = {
     RunStatus.COMPLETED.value,
 }
 
-INTRO_PROMPT = "Introduce yourself to this new user and say how you can help them."
+INTRO_PROMPT = "Illo, introduce yourself and help me finish setting up this workspace."
 
 
 def _intro_ref(user_id: str) -> str:
@@ -73,11 +73,11 @@ def _latest_intro_run_status(session: Any, *, idea_id: str) -> str | None:
     return str(status) if status else None
 
 
-def _intro_metadata() -> dict[str, str]:
+def _intro_metadata(prompt_visibility: str = "hidden") -> dict[str, str]:
     return {
         "origin": "onboarding",
         "onboarding_step": "runtime_ready_intro",
-        "prompt_visibility": "hidden",
+        "prompt_visibility": prompt_visibility,
         "execution_profile": "fast",
         "provider": "openai",
         "model": INTRO_MODEL,
@@ -98,6 +98,32 @@ def _route_intro_run(session: Any, *, idea: Idea, user: dict[str, Any]) -> Any:
         priority=1,
     )
     return route_trigger(trigger, session=session)
+
+
+@router.post("/runtime-ready-intro-draft")
+def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) -> dict[str, Any]:
+    """Return the visible composer draft for the runtime-ready intro flow."""
+    user_id = str(user.get("id") or "")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    org_id = require_org_context(user)
+    status = get_provider_auth_status(user_id=user_id, org_id=org_id, provider="openai")
+    if not status.get("runtime_key_available"):
+        raise HTTPException(status_code=409, detail="OpenAI runtime is not connected yet.")
+
+    with UnitOfWork() as uow:
+        existing = _find_existing_intro(uow.session, org_id=org_id, user_id=user_id)
+        return {
+            "ok": True,
+            "idea_id": str(existing.id) if existing is not None else None,
+            "should_play": existing is None,
+            "prompt": INTRO_PROMPT,
+            "title": INTRO_TITLE,
+            "display_title": INTRO_DISPLAY_TITLE,
+            "origin": INTRO_ORIGIN,
+            "origin_ref": _intro_ref(user_id),
+            "run_metadata": _intro_metadata("visible_composer"),
+        }
 
 
 @router.post("/runtime-ready-intro")

--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -38,7 +38,7 @@ INTRO_RUN_SETTLED_STATUSES = {
     RunStatus.COMPLETED.value,
 }
 
-INTRO_PROMPT = "Illo, introduce yourself and help me finish setting up this workspace."
+INTRO_PROMPT = "Illo works well solo. Introduce yourself and help me finish setting up this workspace."
 
 
 def _intro_ref(user_id: str) -> str:

--- a/brain/platform/db/alembic/env.py
+++ b/brain/platform/db/alembic/env.py
@@ -35,6 +35,18 @@ def _ensure_alembic_version_capacity(connection: Connection) -> None:
     if connection.dialect.name != "postgresql":
         return
 
+    connection.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS alembic_version (
+                version_num VARCHAR(%d) NOT NULL,
+                CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+            )
+            """
+            % ALEMBIC_VERSION_NUM_MAX_LENGTH
+        )
+    )
+
     current_length = connection.execute(
         text(
             """

--- a/brain/platform/db/alembic/versions/0000_legacy_notification_preferences_bridge.py
+++ b/brain/platform/db/alembic/versions/0000_legacy_notification_preferences_bridge.py
@@ -1,0 +1,22 @@
+"""Legacy notification preferences compatibility bridge.
+
+Revision ID: 0006_user_notification_preferences
+Revises:
+Create Date: 2026-05-08
+"""
+
+from __future__ import annotations
+
+
+revision = "0006_user_notification_preferences"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Existing illo-brain databases may already be stamped at this legacy head."""
+
+
+def downgrade() -> None:
+    """No schema changes are associated with the legacy stamp."""

--- a/brain/platform/db/alembic/versions/0001_public_schema_baseline.py
+++ b/brain/platform/db/alembic/versions/0001_public_schema_baseline.py
@@ -1,7 +1,7 @@
 """Public schema baseline.
 
 Revision ID: 0001_public_schema_baseline
-Revises:
+Revises: 0006_user_notification_preferences
 Create Date: 2026-05-07
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 
 revision = "0001_public_schema_baseline"
-down_revision = None
+down_revision = "0006_user_notification_preferences"
 branch_labels = None
 depends_on = None
 

--- a/brain/systems/runs/evidence.py
+++ b/brain/systems/runs/evidence.py
@@ -85,6 +85,13 @@ def normalize_tool_call_evidence(
         "list_files": _search_tool_record,
         "brain_recall": _brain_recall_record,
         "query_workspace_data": _workspace_data_record,
+        "read_workspace_overview": _workspace_data_record,
+        "read_team_activity": _workspace_data_record,
+        "read_project_contexts": _workspace_data_record,
+        "read_team_members": _workspace_data_record,
+        "read_workspace_records": _workspace_data_record,
+        "read_cycles": _workspace_data_record,
+        "read_workspace_apps": _workspace_data_record,
         "brain_skills": _brain_skills_record,
         "skill_view": _skill_view_record,
         "semantic_search": _semantic_search_record,
@@ -523,11 +530,11 @@ def _workspace_data_record(
         "warnings": warnings[:5],
         "scope": result.get("scope") if isinstance(result.get("scope"), Mapping) else None,
     }
-    summary = f"query_workspace_data {status}: {total or 0} records across {len(checked_sources)} sources"
+    summary = f"{tool_name} {status}: {total or 0} records across {len(checked_sources)} sources"
     person = _first_text(args.get("person"))
     if person:
         summary += f" for {_clean_text(person, 80)}"
-    return _make_record("workspace_data", "tool:query_workspace_data", status, summary, details, provenance)
+    return _make_record("workspace_data", f"tool:{tool_name}", status, summary, details, provenance)
 
 
 def _brain_skills_record(

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -27,6 +27,30 @@ _WORKSPACE_ACTIVITY_PHRASES = (
     "teammate activity",
     "workspace activity",
 )
+_WORKSPACE_OVERVIEW_PHRASES = (
+    "finish setting up this workspace",
+    "help me finish setting up this workspace",
+    "introduce yourself",
+    "what can you see",
+    "what do you know about this workspace",
+    "what is this workspace",
+    "workspace overview",
+    "workspace setup",
+)
+_PROJECT_CONTEXT_PHRASES = (
+    "connected repo",
+    "connected repos",
+    "connected docs",
+    "project context",
+    "project contexts",
+    "what projects",
+)
+_WORKSPACE_RECORD_PHRASES = (
+    "domain records",
+    "structured records",
+    "team database",
+    "workspace records",
+)
 
 
 def _normalized_text(message: str | None) -> str:
@@ -40,6 +64,13 @@ def _looks_like_workspace_activity_question(message: str | None) -> bool:
     if any(pattern.search(text) for pattern in _PERSON_ACTIVITY_PATTERNS):
         return True
     return any(phrase in text for phrase in _WORKSPACE_ACTIVITY_PHRASES)
+
+
+def _looks_like_any_phrase(message: str | None, phrases: tuple[str, ...]) -> bool:
+    text = _normalized_text(message)
+    if not text:
+        return False
+    return any(phrase in text for phrase in phrases)
 
 
 def required_introspection_tool(
@@ -58,8 +89,38 @@ def required_introspection_tool(
     if registration and registration.context_route is not None:
         route = registration.context_route
         return tool, f"This question requires {tool}. {route.description}"
+    if _looks_like_any_phrase(message, _WORKSPACE_OVERVIEW_PHRASES):
+        tool = "read_workspace_overview"
+        registration = get_tool_registration(tool)
+        if registration and registration.context_route is not None:
+            route = registration.context_route
+            return (
+                tool,
+                f"This question asks for a current workspace overview or setup status. Use {tool} "
+                f"before answering from memory. {route.description}",
+            )
+    if _looks_like_any_phrase(message, _PROJECT_CONTEXT_PHRASES):
+        tool = "read_project_contexts"
+        registration = get_tool_registration(tool)
+        if registration and registration.context_route is not None:
+            route = registration.context_route
+            return (
+                tool,
+                f"This question asks what project context is connected. Use {tool} "
+                f"before answering from memory. {route.description}",
+            )
+    if _looks_like_any_phrase(message, _WORKSPACE_RECORD_PHRASES):
+        tool = "read_workspace_records"
+        registration = get_tool_registration(tool)
+        if registration and registration.context_route is not None:
+            route = registration.context_route
+            return (
+                tool,
+                f"This question asks about structured workspace records. Use {tool} "
+                f"before answering from memory. {route.description}",
+            )
     if _looks_like_workspace_activity_question(message):
-        tool = "query_workspace_data"
+        tool = "read_team_activity"
         registration = get_tool_registration(tool)
         if registration and registration.context_route is not None:
             route = registration.context_route

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -28,9 +28,30 @@ Operating rules:
 - Preserve user changes and avoid unrelated refactors.
 - Skills are optional accelerators. Load one when the user explicitly names it or when it clearly pays for itself.
 - A `/skill` mention is an explicit skill command. Treat it as a signal that the user is interested in that skill and it may be relevant context; load the card, summary, or procedure only if useful.
+- For onboarding/setup introductions, inspect the workspace first and distinguish configured context from things Illo can help set up next.
+- Do not describe low-level implementation tools such as browser primitives, shell commands, file readers, or raw tool names as product capabilities.
 - Do not build a coordinator run graph in Fast. Escalate to Deep only when autonomy, parallel workers, assignments, or long verification are genuinely useful.
 - Stream useful progress through activity updates and answer in normal conversational prose.
 """
+
+_ONBOARDING_HIDDEN_TOOL_PREFIXES = ("browser_",)
+
+
+def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
+    tools = build_agent_tools("worker")
+    metadata = runtime.request.metadata if isinstance(runtime.request.metadata, dict) else {}
+    is_onboarding_intro = (
+        metadata.get("origin") == "onboarding"
+        or metadata.get("required_response") == "introduce_and_continue_setup"
+        or metadata.get("onboarding_step") == "runtime_ready_intro"
+    )
+    if not is_onboarding_intro:
+        return tools
+    return [
+        tool
+        for tool in tools
+        if not str(tool.get("name") or "").startswith(_ONBOARDING_HIDDEN_TOOL_PREFIXES)
+    ]
 
 
 def _workspace_root(workspace_ref: dict[str, Any]) -> str | None:
@@ -104,7 +125,7 @@ class FastRecipe(BaseRunRecipe):
             session_id=f"agent-run-{runtime.run.id}",
             model=str(model),
             thinking=str(thinking),
-            tools=build_agent_tools("worker"),
+            tools=_agent_tools_for_runtime(runtime),
             tool_handlers=tool_handlers,
             persist_session=True,
             workspace_root=workspace_root,

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -54,7 +54,16 @@ from brain.systems.runs.tool_catalog.handlers.session_tools import (
 )
 from brain.systems.runs.tool_catalog.handlers.activity import _handle_my_activity
 from brain.systems.runs.tool_catalog.handlers.web import _handle_web_fetch, _handle_web_search
-from brain.systems.runs.tool_catalog.handlers.workspace_data import _handle_query_workspace_data
+from brain.systems.runs.tool_catalog.handlers.workspace_data import (
+    _handle_query_workspace_data,
+    _handle_read_cycles,
+    _handle_read_project_contexts,
+    _handle_read_team_activity,
+    _handle_read_team_members,
+    _handle_read_workspace_apps,
+    _handle_read_workspace_overview,
+    _handle_read_workspace_records,
+)
 from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
 
 
@@ -119,6 +128,13 @@ def _get_tool_handlers(
             org_id=getattr(_agent_context, "org_id", None),
         ),
         "query_workspace_data": _handle_query_workspace_data,
+        "read_workspace_overview": _handle_read_workspace_overview,
+        "read_team_activity": _handle_read_team_activity,
+        "read_project_contexts": _handle_read_project_contexts,
+        "read_team_members": _handle_read_team_members,
+        "read_workspace_records": _handle_read_workspace_records,
+        "read_cycles": _handle_read_cycles,
+        "read_workspace_apps": _handle_read_workspace_apps,
         "read_thread_messages": _handle_read_thread_messages,
         "post_chat_message": lambda **kw: _patched_private(
             "_handle_post_chat_message",

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -9,7 +9,7 @@ import json
 import uuid
 from typing import Any, Mapping
 
-from sqlalchemy import String, cast, func, or_, select
+from sqlalchemy import String, and_, cast, func, or_, select
 
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
 
@@ -68,6 +68,8 @@ def _time_bounds(
     window = (time_window or "last_7d").strip().lower()
     end = _parse_datetime(end_at) or now
     start = _parse_datetime(start_at)
+    if window in {"all", "any", "none"}:
+        return None, None, "all"
     if window == "custom":
         return start, end, window
     if window == "today":
@@ -277,6 +279,75 @@ def _latest_run_final_answers(session: Any, run_ids: list[int]) -> dict[int, str
             if answer:
                 answers[run_id_int] = answer
     return answers
+
+
+def _project_context_resource_summary(context: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(context, Mapping):
+        return {"count": 0, "items": []}
+    resources = [item for item in (context.get("resources") or []) if isinstance(item, Mapping)]
+    return {
+        "count": len(resources),
+        "items": [
+            {
+                "id": item.get("id"),
+                "kind": item.get("kind") or item.get("type"),
+                "label": item.get("label") or item.get("name"),
+                "path": item.get("path"),
+                "repo": item.get("repo"),
+                "uri": item.get("uri"),
+            }
+            for item in resources[:10]
+        ],
+    }
+
+
+def _query_team_members(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    org_id: str | None,
+    user_id: str | None,
+    person_ids: list[str],
+    search: str | None,
+    limit: int,
+) -> None:
+    from brain.platform.db.models.org import User
+
+    stmt = select(User).order_by(User.created_at.desc()).limit(limit)
+    if org_id:
+        stmt = stmt.where(User.org_id == org_id)
+    elif user_id:
+        stmt = stmt.where(User.id == user_id)
+    else:
+        payload["warnings"].append({"source": "team_members", "error": "org_id or user_id required"})
+        payload["sources"]["team_members"] = []
+        return
+    if person_ids:
+        stmt = stmt.where(User.id.in_(person_ids))
+    text_match = _text_filter(search, User.name, User.email, User.role)
+    if text_match is not None:
+        stmt = stmt.where(text_match)
+
+    rows = session.scalars(stmt).all()
+    payload["sources"]["team_members"] = [
+        {
+            "id": str(user.id),
+            "type": "team_member",
+            "created_at": _serialize_dt(user.created_at),
+            "user_id": str(user.id),
+            "org_id": str(user.org_id) if user.org_id is not None else None,
+            "name": user.name,
+            "email": user.email,
+            "role": user.role,
+            "approved": bool(user.approved),
+            "attribution_enabled": bool(user.attribution_enabled),
+            "default_provider": user.default_provider,
+            "provenance": {"table": "users", "id": str(user.id)},
+        }
+        for user in rows
+    ]
 
 
 def _query_runs(
@@ -533,6 +604,140 @@ def _query_tool_calls(
             "provenance": {"table": "agent_run_events", "id": int(event.id)},
         }
         for event, run, idea in rows
+    ]
+
+
+def _query_project_profiles(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    org_id: str | None,
+    user_id: str | None,
+    person_ids: list[str],
+    search: str | None,
+    include_archived: bool,
+    limit: int,
+) -> None:
+    if not org_id:
+        payload["warnings"].append({"source": "project_profiles", "error": "org_id required"})
+        payload["sources"]["project_profiles"] = []
+        return
+    from brain.platform.db.models.idea import ProjectProfile
+    from brain.platform.db.models.org import User
+
+    stmt = (
+        select(ProjectProfile, User)
+        .outerjoin(User, User.id == ProjectProfile.user_id)
+        .where(ProjectProfile.org_id == org_id)
+        .order_by(ProjectProfile.created_at.desc())
+        .limit(limit)
+    )
+    stmt = _apply_date_bounds(stmt, ProjectProfile.created_at, start, end)
+    if person_ids:
+        stmt = stmt.where(ProjectProfile.user_id.in_(person_ids))
+    elif user_id and not org_id:
+        stmt = stmt.where(ProjectProfile.user_id == user_id)
+    if not include_archived:
+        stmt = stmt.where(ProjectProfile.active.is_(True))
+    text_match = _text_filter(
+        search,
+        ProjectProfile.slug,
+        ProjectProfile.name,
+        ProjectProfile.description,
+    )
+    if text_match is not None:
+        stmt = stmt.where(text_match)
+
+    rows = session.execute(stmt).all()
+    payload["sources"]["project_profiles"] = [
+        {
+            "id": str(profile.id),
+            "type": "project_profile",
+            "created_at": _serialize_dt(profile.created_at),
+            "slug": profile.slug,
+            "name": profile.name,
+            "description": _snippet(profile.description),
+            "active": bool(profile.active),
+            "user_id": str(profile.user_id) if profile.user_id is not None else None,
+            "user_name": user.name if user else None,
+            "org_id": str(profile.org_id) if profile.org_id is not None else None,
+            "default_environment_binding_id": profile.default_environment_binding_id,
+            "resources": _project_context_resource_summary(profile.project_context),
+            "metadata": _jsonable(profile.metadata_ or {}),
+            "provenance": {"table": "project_profiles", "id": str(profile.id)},
+        }
+        for profile, user in rows
+    ]
+
+
+def _query_project_attachments(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    org_id: str | None,
+    user_id: str | None,
+    person_ids: list[str],
+    idea_id: str | None,
+    search: str | None,
+    include_archived: bool,
+    limit: int,
+) -> None:
+    from brain.platform.db.models.idea import Idea, IdeaProjectAttachment, ProjectProfile
+    from brain.platform.db.models.org import User
+
+    stmt = (
+        select(IdeaProjectAttachment, Idea, ProjectProfile, User)
+        .join(Idea, Idea.id == IdeaProjectAttachment.idea_id)
+        .outerjoin(ProjectProfile, ProjectProfile.id == IdeaProjectAttachment.project_profile_id)
+        .outerjoin(User, User.id == IdeaProjectAttachment.attached_by)
+        .order_by(IdeaProjectAttachment.created_at.desc(), IdeaProjectAttachment.id.desc())
+        .limit(limit)
+    )
+    stmt = _scope_idea(stmt, Idea, org_id=org_id, user_id=user_id)
+    stmt = _apply_date_bounds(stmt, IdeaProjectAttachment.created_at, start, end)
+    if idea_id:
+        stmt = stmt.where(IdeaProjectAttachment.idea_id == idea_id)
+    if person_ids:
+        stmt = stmt.where(or_(IdeaProjectAttachment.attached_by.in_(person_ids), Idea.user_id.in_(person_ids)))
+    if not include_archived:
+        stmt = stmt.where(IdeaProjectAttachment.status != "invalid")
+    text_match = _text_filter(
+        search,
+        Idea.title,
+        Idea.display_title,
+        ProjectProfile.slug,
+        ProjectProfile.name,
+        IdeaProjectAttachment.status,
+    )
+    if text_match is not None:
+        stmt = stmt.where(text_match)
+
+    rows = session.execute(stmt).all()
+    payload["sources"]["project_attachments"] = [
+        {
+            "id": int(attachment.id),
+            "type": "project_attachment",
+            "created_at": _serialize_dt(attachment.created_at),
+            "idea_id": str(attachment.idea_id),
+            "idea_title": _idea_title(idea),
+            "project_profile_id": str(attachment.project_profile_id) if attachment.project_profile_id else None,
+            "project_name": profile.name if profile else None,
+            "project_slug": profile.slug if profile else None,
+            "attached_by": str(attachment.attached_by) if attachment.attached_by else None,
+            "user_id": str(attachment.attached_by) if attachment.attached_by else None,
+            "user_name": user.name if user else None,
+            "status": attachment.status,
+            "validation_errors": _jsonable(attachment.validation_errors or []),
+            "resources": _project_context_resource_summary(attachment.snapshot),
+            "permission_scope": _jsonable(attachment.permission_scope or {}),
+            "environment_binding_id": attachment.environment_binding_id,
+            "provenance": {"table": "idea_project_attachments", "id": int(attachment.id)},
+        }
+        for attachment, idea, profile, user in rows
     ]
 
 
@@ -801,42 +1006,164 @@ def _query_app_state(
     ]
 
 
-def _query_memories(
+def _scope_cycle(
+    stmt: Any,
+    Cycle: Any,
+    User: Any,
+    *,
+    org_id: str | None,
+    user_id: str | None,
+) -> Any:
+    if org_id:
+        org_user_ids = select(User.id).where(User.org_id == org_id)
+        return stmt.where(or_(Cycle.org_id == org_id, and_(Cycle.org_id.is_(None), Cycle.user_id.in_(org_user_ids))))
+    if user_id:
+        return stmt.where(Cycle.user_id == user_id)
+    return stmt
+
+
+def _query_cycles(
+    session: Any,
     payload: dict[str, Any],
     *,
-    query: str | None,
-    search: str | None,
-    user_id: str | None,
+    start: datetime | None,
+    end: datetime | None,
     org_id: str | None,
+    user_id: str | None,
+    person_ids: list[str],
+    search: str | None,
+    include_archived: bool,
     limit: int,
 ) -> None:
-    recall_query = (search or query or "").strip()
-    if not recall_query:
-        payload["sources"]["memories"] = []
-        payload["warnings"].append({"source": "memories", "error": "query or search required for memory recall"})
-        return
-    from brain.app.mcp.server import tool_brain_recall
+    from brain.platform.db.models.cycle import Cycle
+    from brain.platform.db.models.idea import Idea
+    from brain.platform.db.models.org import User
 
-    result = tool_brain_recall(
-        query=recall_query,
-        limit=min(max(limit, 1), 10),
-        user_id=user_id,
-        org_id=org_id,
-        expand_lazy_load=True,
+    stmt = (
+        select(Cycle, User, Idea)
+        .outerjoin(User, User.id == Cycle.user_id)
+        .outerjoin(Idea, Idea.id == Cycle.target_idea_id)
+        .order_by(Cycle.updated_at.desc().nullslast(), Cycle.created_at.desc())
+        .limit(limit)
     )
-    memories = result.get("memories") if isinstance(result, Mapping) else []
-    payload["sources"]["memories"] = [
+    stmt = _scope_cycle(stmt, Cycle, User, org_id=org_id, user_id=user_id)
+    stmt = _apply_date_bounds(stmt, Cycle.updated_at, start, end)
+    if person_ids:
+        stmt = stmt.where(Cycle.user_id.in_(person_ids))
+    if not include_archived:
+        stmt = stmt.where(Cycle.deleted_at.is_(None))
+    text_match = _text_filter(
+        search,
+        Cycle.name,
+        Cycle.prompt,
+        Cycle.schedule_expr,
+        Cycle.last_status,
+        Cycle.last_error,
+        Idea.title,
+        Idea.display_title,
+    )
+    if text_match is not None:
+        stmt = stmt.where(text_match)
+
+    rows = session.execute(stmt).all()
+    payload["sources"]["cycles"] = [
         {
-            "id": memory.get("id"),
-            "type": "memory",
-            "memory_type": memory.get("type"),
-            "created_at": memory.get("created_at"),
-            "content": _snippet(memory.get("content"), 520),
-            "score": memory.get("similarity") or memory.get("score"),
-            "provenance": {"table": "memories", "id": memory.get("id")},
+            "id": int(cycle.id),
+            "type": "cycle",
+            "created_at": _serialize_dt(cycle.created_at),
+            "updated_at": _serialize_dt(cycle.updated_at),
+            "user_id": str(cycle.user_id) if cycle.user_id is not None else None,
+            "user_name": user.name if user else None,
+            "org_id": str(cycle.org_id) if cycle.org_id is not None else None,
+            "name": cycle.name,
+            "prompt": _snippet(cycle.prompt, 520),
+            "schedule_expr": cycle.schedule_expr,
+            "timezone": cycle.timezone,
+            "enabled": bool(cycle.enabled),
+            "target_idea_id": str(cycle.target_idea_id) if cycle.target_idea_id else None,
+            "idea_id": str(cycle.target_idea_id) if cycle.target_idea_id else None,
+            "idea_title": _idea_title(idea),
+            "next_run_at": _serialize_dt(cycle.next_run_at),
+            "last_run_at": _serialize_dt(cycle.last_run_at),
+            "last_status": cycle.last_status,
+            "last_error": _snippet(cycle.last_error),
+            "deleted_at": _serialize_dt(cycle.deleted_at),
+            "provenance": {"table": "cycles", "id": int(cycle.id)},
         }
-        for memory in memories
-        if isinstance(memory, Mapping)
+        for cycle, user, idea in rows
+    ]
+
+
+def _query_cycle_runs(
+    session: Any,
+    payload: dict[str, Any],
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    org_id: str | None,
+    user_id: str | None,
+    person_ids: list[str],
+    idea_id: str | None,
+    search: str | None,
+    include_archived: bool,
+    limit: int,
+) -> None:
+    from brain.platform.db.models.cycle import Cycle, CycleRun
+    from brain.platform.db.models.idea import Idea
+    from brain.platform.db.models.org import User
+
+    stmt = (
+        select(CycleRun, Cycle, User, Idea)
+        .join(Cycle, Cycle.id == CycleRun.cycle_id)
+        .outerjoin(User, User.id == Cycle.user_id)
+        .outerjoin(Idea, Idea.id == CycleRun.idea_id)
+        .order_by(CycleRun.created_at.desc(), CycleRun.id.desc())
+        .limit(limit)
+    )
+    stmt = _scope_cycle(stmt, Cycle, User, org_id=org_id, user_id=user_id)
+    stmt = _apply_date_bounds(stmt, CycleRun.created_at, start, end)
+    if idea_id:
+        stmt = stmt.where(CycleRun.idea_id == idea_id)
+    if person_ids:
+        stmt = stmt.where(Cycle.user_id.in_(person_ids))
+    if not include_archived:
+        stmt = stmt.where(Cycle.deleted_at.is_(None))
+    text_match = _text_filter(
+        search,
+        Cycle.name,
+        CycleRun.status,
+        CycleRun.error,
+        CycleRun.skip_reason,
+        CycleRun.prompt_snapshot,
+        Idea.title,
+        Idea.display_title,
+    )
+    if text_match is not None:
+        stmt = stmt.where(text_match)
+
+    rows = session.execute(stmt).all()
+    payload["sources"]["cycle_runs"] = [
+        {
+            "id": int(run.id),
+            "type": "cycle_run",
+            "created_at": _serialize_dt(run.created_at),
+            "scheduled_for": _serialize_dt(run.scheduled_for),
+            "started_at": _serialize_dt(run.started_at),
+            "completed_at": _serialize_dt(run.completed_at),
+            "cycle_id": int(run.cycle_id),
+            "cycle_name": cycle.name,
+            "status": run.status,
+            "error": _snippet(run.error),
+            "skip_reason": run.skip_reason,
+            "idea_id": str(run.idea_id) if run.idea_id else None,
+            "idea_title": _idea_title(idea),
+            "run_id": int(run.run_id) if run.run_id is not None else None,
+            "prompt_snapshot": _snippet(run.prompt_snapshot, 520),
+            "user_id": str(cycle.user_id) if cycle.user_id else None,
+            "user_name": user.name if user else None,
+            "provenance": {"table": "cycle_runs", "id": int(run.id)},
+        }
+        for run, cycle, user, idea in rows
     ]
 
 
@@ -854,7 +1181,17 @@ def _activity_sort_key(item: Mapping[str, Any]) -> datetime:
 
 
 def _activity_title(record: Mapping[str, Any]) -> str | None:
-    for key in ("idea_title", "title", "name", "app_name", "domain_name", "key", "slug"):
+    for key in (
+        "idea_title",
+        "title",
+        "name",
+        "project_name",
+        "cycle_name",
+        "app_name",
+        "domain_name",
+        "key",
+        "slug",
+    ):
         value = record.get(key)
         if value:
             return _snippet(value, 160)
@@ -878,6 +1215,25 @@ def _activity_summary(source: str, record: Mapping[str, Any]) -> str | None:
         )
     if source in {"ideas", "workspace_apps"}:
         return _snippet(record.get("working_memory") or record.get("description"), 280)
+    if source == "project_profiles":
+        resources = record.get("resources") if isinstance(record.get("resources"), Mapping) else {}
+        return _snippet(
+            record.get("description") or f"{resources.get('count', 0)} project resources",
+            280,
+        )
+    if source == "project_attachments":
+        resources = record.get("resources") if isinstance(record.get("resources"), Mapping) else {}
+        return _snippet(
+            f"Attached {resources.get('count', 0)} project resources; status {record.get('status')}",
+            280,
+        )
+    if source == "cycles":
+        return _snippet(
+            f"{record.get('schedule_expr')} {record.get('timezone')} next={record.get('next_run_at')} last={record.get('last_status')}",
+            280,
+        )
+    if source == "cycle_runs":
+        return _snippet(record.get("error") or record.get("prompt_snapshot"), 280)
     if source == "app_state":
         return _snippet(record.get("data"), 280)
     if source in {"domain_records", "domain_events", "domains"}:
@@ -895,6 +1251,7 @@ def _activity_user_id(record: Mapping[str, Any]) -> str | None:
         "updated_by_user_id",
         "anchor_user_id",
         "actor_id",
+        "attached_by",
     ):
         value = record.get(key)
         if value:
@@ -931,6 +1288,20 @@ def _build_activity_items(payload: Mapping[str, Any], *, limit: int = 30) -> lis
             })
     items.sort(key=_activity_sort_key, reverse=True)
     return items[: max(1, int(limit or 30))]
+
+
+def _run_team_members(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
+    _query_team_members(
+        session,
+        payload,
+        start=ctx.start,
+        end=ctx.end,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        person_ids=ctx.person_ids,
+        search=ctx.search,
+        limit=ctx.limit,
+    )
 
 
 def _run_runs(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
@@ -991,6 +1362,37 @@ def _run_tool_calls(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQue
         person_ids=ctx.person_ids,
         idea_id=ctx.idea_id,
         search=ctx.search,
+        limit=ctx.limit,
+    )
+
+
+def _run_project_profiles(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
+    _query_project_profiles(
+        session,
+        payload,
+        start=ctx.start,
+        end=ctx.end,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        person_ids=ctx.person_ids,
+        search=ctx.search,
+        include_archived=ctx.include_archived,
+        limit=ctx.limit,
+    )
+
+
+def _run_project_attachments(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
+    _query_project_attachments(
+        session,
+        payload,
+        start=ctx.start,
+        end=ctx.end,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        person_ids=ctx.person_ids,
+        idea_id=ctx.idea_id,
+        search=ctx.search,
+        include_archived=ctx.include_archived,
         limit=ctx.limit,
     )
 
@@ -1067,18 +1469,44 @@ def _run_app_state(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQuer
     )
 
 
-def _run_memories(_session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
-    _query_memories(
+def _run_cycles(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
+    _query_cycles(
+        session,
         payload,
-        query=ctx.query,
-        search=ctx.search,
-        user_id=ctx.user_id,
+        start=ctx.start,
+        end=ctx.end,
         org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        person_ids=ctx.person_ids,
+        search=ctx.search,
+        include_archived=ctx.include_archived,
+        limit=ctx.limit,
+    )
+
+
+def _run_cycle_runs(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQueryContext) -> None:
+    _query_cycle_runs(
+        session,
+        payload,
+        start=ctx.start,
+        end=ctx.end,
+        org_id=ctx.org_id,
+        user_id=ctx.user_id,
+        person_ids=ctx.person_ids,
+        idea_id=ctx.idea_id,
+        search=ctx.search,
+        include_archived=ctx.include_archived,
         limit=ctx.limit,
     )
 
 
 _SOURCE_ADAPTERS: dict[str, WorkspaceDataSource] = {
+    "team_members": WorkspaceDataSource(
+        name="team_members",
+        description="Workspace roster: users, roles, emails, approval state, and attribution settings.",
+        groups=("all", "team", "people"),
+        handler=_run_team_members,
+    ),
     "runs": WorkspaceDataSource(
         name="runs",
         description="Cortex run/run records with statuses, messages, output summaries, and cost/tool metadata.",
@@ -1103,22 +1531,34 @@ _SOURCE_ADAPTERS: dict[str, WorkspaceDataSource] = {
         groups=("all", "activity"),
         handler=_run_tool_calls,
     ),
+    "project_profiles": WorkspaceDataSource(
+        name="project_profiles",
+        description="Reusable Project Context profiles with resources such as repos, files, folders, docs, and metadata.",
+        groups=("all", "projects", "project_contexts"),
+        handler=_run_project_profiles,
+    ),
+    "project_attachments": WorkspaceDataSource(
+        name="project_attachments",
+        description="Project Context snapshots attached to Cortex thoughts, including validation and resource summaries.",
+        groups=("all", "activity", "projects", "project_contexts"),
+        handler=_run_project_attachments,
+    ),
     "domains": WorkspaceDataSource(
         name="domains",
-        description="Domain schema records.",
-        groups=("all", "domain"),
+        description="Domain schema records for user-created structured workspace databases.",
+        groups=("all", "domain", "records"),
         handler=_run_domains,
     ),
     "domain_records": WorkspaceDataSource(
         name="domain_records",
         description="Domain object records and structured data.",
-        groups=("all", "domain"),
+        groups=("all", "domain", "records"),
         handler=_run_domain_records,
     ),
     "domain_events": WorkspaceDataSource(
         name="domain_events",
         description="Domain audit/event stream records.",
-        groups=("all", "activity", "domain"),
+        groups=("all", "activity", "domain", "records"),
         handler=_run_domain_events,
     ),
     "workspace_apps": WorkspaceDataSource(
@@ -1133,12 +1573,17 @@ _SOURCE_ADAPTERS: dict[str, WorkspaceDataSource] = {
         groups=("all", "apps"),
         handler=_run_app_state,
     ),
-    "memories": WorkspaceDataSource(
-        name="memories",
-        description="Optional semantic memory recall, included only when explicitly requested.",
-        groups=("memory",),
-        handler=_run_memories,
-        db_backed=False,
+    "cycles": WorkspaceDataSource(
+        name="cycles",
+        description="Workspace Cycles: recurring Illo prompts, schedules, enabled state, and last/next run status.",
+        groups=("all", "cycles"),
+        handler=_run_cycles,
+    ),
+    "cycle_runs": WorkspaceDataSource(
+        name="cycle_runs",
+        description="Individual Cycle run history with status, linked thought, run id, and prompt snapshot.",
+        groups=("all", "activity", "cycles"),
+        handler=_run_cycle_runs,
     ),
 }
 
@@ -1296,6 +1741,105 @@ def query_workspace_data(
     return payload
 
 
+def _workspace_query_scope(
+    *,
+    idea_id: str | None = None,
+    domain_id: int | None = None,
+    object_key: str | None = None,
+    include_archived: bool = False,
+    default_current_idea: bool = False,
+) -> dict[str, Any]:
+    run = getattr(_agent_context, "run", None)
+    execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
+    scoped_idea_id = idea_id
+    if scoped_idea_id is None and default_current_idea:
+        scoped_idea_id = getattr(_agent_context, "idea_id", None) or execution_metadata.get("idea_id")
+    return {
+        "idea_id": scoped_idea_id,
+        "domain_id": domain_id,
+        "object_key": object_key,
+        "include_archived": include_archived,
+        "user_id": getattr(_agent_context, "user_id", None) or execution_metadata.get("user_id"),
+        "org_id": getattr(_agent_context, "org_id", None) or execution_metadata.get("org_id"),
+        "run_id": getattr(run, "run_id", None) or execution_metadata.get("run_id"),
+    }
+
+
+def _query_workspace_data_for_agent(**kwargs: Any) -> dict[str, Any]:
+    scope_kwargs = _workspace_query_scope(
+        idea_id=kwargs.pop("idea_id", None),
+        domain_id=kwargs.pop("domain_id", None),
+        object_key=kwargs.pop("object_key", None),
+        include_archived=bool(kwargs.pop("include_archived", False)),
+        default_current_idea=bool(kwargs.pop("_default_current_idea", False)),
+    )
+    return query_workspace_data(**kwargs, **scope_kwargs)
+
+
+def _workspace_view_payload(view: str, payload: dict[str, Any]) -> dict[str, Any]:
+    payload["view"] = view
+    payload.setdefault("answering_guidance", [])
+    return payload
+
+
+def _build_workspace_overview(payload: Mapping[str, Any]) -> dict[str, Any]:
+    sources = payload.get("sources") if isinstance(payload.get("sources"), Mapping) else {}
+    counts = payload.get("counts") if isinstance(payload.get("counts"), Mapping) else {}
+    gaps: list[str] = []
+    if int(counts.get("project_profiles") or 0) == 0 and int(counts.get("project_attachments") or 0) == 0:
+        gaps.append("No reusable Project Context profiles or thread attachments were found.")
+    if int(counts.get("domains") or 0) == 0:
+        gaps.append("No user-created Domains were found for structured workspace records.")
+    if int(counts.get("workspace_apps") or 0) == 0:
+        gaps.append("No generated workspace apps or dashboards were found.")
+    if int(counts.get("cycles") or 0) == 0:
+        gaps.append("No recurring Cycles were found.")
+
+    return {
+        "team_members": (sources.get("team_members") or [])[:10],
+        "active_or_recent_thoughts": (sources.get("ideas") or [])[:10],
+        "recent_activity": (payload.get("activity_items") or [])[:10],
+        "project_contexts": {
+            "profiles": (sources.get("project_profiles") or [])[:10],
+            "attachments": (sources.get("project_attachments") or [])[:10],
+        },
+        "structured_records": {
+            "domains": (sources.get("domains") or [])[:10],
+            "recent_records": (sources.get("domain_records") or [])[:10],
+        },
+        "workspace_apps": (sources.get("workspace_apps") or [])[:10],
+        "cycles": (sources.get("cycles") or [])[:10],
+        "setup_gaps": gaps,
+    }
+
+
+def _add_team_member_activity_summary(payload: dict[str, Any]) -> None:
+    sources = payload.get("sources") if isinstance(payload.get("sources"), Mapping) else {}
+    members = sources.get("team_members") if isinstance(sources.get("team_members"), list) else []
+    activity = payload.get("activity_items") if isinstance(payload.get("activity_items"), list) else []
+    by_user: dict[str, dict[str, Any]] = {}
+    for item in activity:
+        if not isinstance(item, Mapping):
+            continue
+        user_id = str(item.get("user_id") or "")
+        if not user_id:
+            continue
+        summary = by_user.setdefault(user_id, {"count": 0, "latest": []})
+        summary["count"] += 1
+        if len(summary["latest"]) < 5:
+            summary["latest"].append(item)
+    payload["member_activity"] = [
+        {
+            "user_id": member.get("user_id") or member.get("id"),
+            "name": member.get("name"),
+            "email": member.get("email"),
+            **by_user.get(str(member.get("user_id") or member.get("id") or ""), {"count": 0, "latest": []}),
+        }
+        for member in members
+        if isinstance(member, Mapping)
+    ]
+
+
 def _handle_query_workspace_data(
     sources: list[str] | None = None,
     query: str | None = None,
@@ -1310,9 +1854,7 @@ def _handle_query_workspace_data(
     object_key: str | None = None,
     include_archived: bool = False,
 ) -> str:
-    run = getattr(_agent_context, "run", None)
-    execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
-    payload = query_workspace_data(
+    payload = _query_workspace_data_for_agent(
         sources=sources,
         query=query,
         search=search,
@@ -1321,12 +1863,216 @@ def _handle_query_workspace_data(
         start_at=start_at,
         end_at=end_at,
         limit=limit,
-        idea_id=idea_id or getattr(_agent_context, "idea_id", None) or execution_metadata.get("idea_id"),
+        idea_id=idea_id,
         domain_id=domain_id,
         object_key=object_key,
         include_archived=include_archived,
-        user_id=getattr(_agent_context, "user_id", None) or execution_metadata.get("user_id"),
-        org_id=getattr(_agent_context, "org_id", None) or execution_metadata.get("org_id"),
-        run_id=getattr(run, "run_id", None) or execution_metadata.get("run_id"),
+        _default_current_idea=True,
     )
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_workspace_overview(
+    query: str | None = None,
+    time_window: str = "all",
+    limit: int = 10,
+    include_archived: bool = False,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=[
+            "team_members",
+            "ideas",
+            "threads",
+            "runs",
+            "project_profiles",
+            "project_attachments",
+            "domains",
+            "domain_records",
+            "workspace_apps",
+            "cycles",
+        ],
+        query=query or "workspace overview",
+        time_window=time_window,
+        limit=limit,
+        include_archived=include_archived,
+    )
+    payload = _workspace_view_payload("workspace_overview", payload)
+    payload["overview"] = _build_workspace_overview(payload)
+    payload["answering_guidance"] = [
+        "Distinguish what already exists in this workspace from what Illo can help set up.",
+        "Use setup_gaps to avoid overclaiming configured project context, Domains, apps, or Cycles.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_team_activity(
+    query: str | None = None,
+    search: str | None = None,
+    person: str | None = None,
+    time_window: str = "last_7d",
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    idea_id: str | None = None,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=["activity"],
+        query=query or "team activity",
+        search=search,
+        person=person,
+        time_window=time_window,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        idea_id=idea_id,
+    )
+    payload = _workspace_view_payload("team_activity", payload)
+    payload["answering_guidance"] = [
+        "Base recaps on activity_items first, then use per-source rows for detail.",
+        "When results are empty, say what was checked instead of guessing from memory.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_project_contexts(
+    query: str | None = None,
+    search: str | None = None,
+    idea_id: str | None = None,
+    time_window: str = "all",
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    include_inactive: bool = False,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=["project_contexts"],
+        query=query or "project contexts",
+        search=search,
+        time_window=time_window,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        idea_id=idea_id,
+        include_archived=include_inactive,
+    )
+    payload = _workspace_view_payload("project_contexts", payload)
+    payload["answering_guidance"] = [
+        "Use profiles for reusable workspace-level context and attachments for context bound to a Cortex thought.",
+        "If no resources are present, explain that Illo can help create or attach Project Context.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_team_members(
+    query: str | None = None,
+    search: str | None = None,
+    person: str | None = None,
+    time_window: str = "all",
+    limit: int = 20,
+    include_activity: bool = True,
+) -> str:
+    sources = ["team_members", "runs", "threads", "ideas"] if include_activity else ["team_members"]
+    payload = _query_workspace_data_for_agent(
+        sources=sources,
+        query=query or "team members",
+        search=search,
+        person=person,
+        time_window=time_window,
+        limit=limit,
+    )
+    payload = _workspace_view_payload("team_members", payload)
+    if include_activity:
+        _add_team_member_activity_summary(payload)
+    payload["answering_guidance"] = [
+        "Use roster rows for identity/role facts and member_activity for recent work signals.",
+        "Avoid inferring availability, intent, or ownership beyond the records returned.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_workspace_records(
+    query: str | None = None,
+    search: str | None = None,
+    domain_id: int | None = None,
+    object_key: str | None = None,
+    time_window: str = "all",
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    include_archived: bool = False,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=["records"],
+        query=query or "workspace records",
+        search=search,
+        domain_id=domain_id,
+        object_key=object_key,
+        time_window=time_window,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        include_archived=include_archived,
+    )
+    payload = _workspace_view_payload("workspace_records", payload)
+    payload["answering_guidance"] = [
+        "Domains are user-created structured databases, not the system's raw database tables.",
+        "Use Domain schemas to explain what each record type is for before summarizing records.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_cycles(
+    query: str | None = None,
+    search: str | None = None,
+    person: str | None = None,
+    time_window: str = "all",
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    include_deleted: bool = False,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=["cycles"],
+        query=query or "workspace cycles",
+        search=search,
+        person=person,
+        time_window=time_window,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        include_archived=include_deleted,
+    )
+    payload = _workspace_view_payload("cycles", payload)
+    payload["answering_guidance"] = [
+        "Use cycles for recurring configuration and cycle_runs for actual execution history.",
+        "Distinguish enabled/disabled/deleted Cycles when summarizing scheduled work.",
+    ]
+    return json.dumps(payload, default=str)
+
+
+def _handle_read_workspace_apps(
+    query: str | None = None,
+    search: str | None = None,
+    time_window: str = "all",
+    start_at: str | None = None,
+    end_at: str | None = None,
+    limit: int = 20,
+    include_archived: bool = False,
+    include_state: bool = True,
+) -> str:
+    payload = _query_workspace_data_for_agent(
+        sources=["apps"] if include_state else ["workspace_apps"],
+        query=query or "workspace apps",
+        search=search,
+        time_window=time_window,
+        start_at=start_at,
+        end_at=end_at,
+        limit=limit,
+        include_archived=include_archived,
+    )
+    payload = _workspace_view_payload("workspace_apps", payload)
+    payload["answering_guidance"] = [
+        "Use workspace_apps for app identity/metadata and app_state only for app-local UI state.",
+        "Recordful apps should be backed by Domains; app-local state is not the workspace database.",
+    ]
     return json.dumps(payload, default=str)

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -79,7 +79,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "permission": "read_memory",
         "output_budget_chars": 8_000,
         "context_route": {
-            "description": "Search remembered context and prior lessons. Use for memory, recall, prior context, and temporal recaps that are about Illo/user memory rather than source-of-truth workspace records.",
+            "description": "Search long-term semantic memories. Use for remembered lessons, facts, patterns, and episodes; use read_workspace_* tools for source-of-truth workspace records and current team activity.",
             "domains": ["memory", "remembered context", "prior lessons", "broad memory recap"],
             "scopes": ["narrow", "broad"],
             "empty_result_policy": "fallback_full_pipeline_when_broad",
@@ -126,8 +126,8 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "parallel_safety": "safe",
         "output_budget_chars": 12_000,
         "context_route": {
-            "description": "Read raw stored messages from the current persistent agent thread when the durable handoff summary lacks an exact older detail.",
-            "domains": ["thread transcript", "raw conversation", "prior messages", "handoff provenance"],
+            "description": "Read raw stored messages from this agent run's persistent LLM session when the durable handoff summary lacks an exact older detail. This is not the user's Cortex workspace thread.",
+            "domains": ["agent session transcript", "thread transcript", "raw LLM conversation", "prior messages", "handoff provenance"],
             "scopes": ["narrow"],
         },
     },
@@ -137,10 +137,9 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "evidence_emitter": True,
         "context_route": {
             "description": (
-                "Query DB-backed workspace/product records outside memory: runs, thread messages, "
-                "ideas, tool calls, Domains, domain records/events, workspace apps, app state, and "
-                "optional memory recall. Use for teammate activity, workspace activity, product data, "
-                "artifacts, and operational records; read activity_items first for newest cross-source signals."
+                "Low-level read-only query over Illospace DB-backed workspace truth: team members, "
+                "Cortex ideas/thread messages, runs, tool calls, Project Contexts, Domains/records, "
+                "workspace apps/state, and Cycles. Prefer specific read_workspace_* tools for normal answers."
             ),
             "domains": [
                 "workspace records",
@@ -150,13 +149,86 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
                 "thread messages",
                 "ideas",
                 "tool calls",
+                "team members",
+                "project contexts",
                 "domains",
                 "domain records",
                 "workspace apps",
                 "artifacts",
                 "app state",
+                "cycles",
             ],
             "scopes": ["narrow"],
+        },
+    },
+    "read_workspace_overview": {
+        "permission": "read_activity",
+        "output_budget_chars": 22_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read a curated overview of the workspace: team members, active thoughts, recent runs/messages, Project Context, Domains, apps, Cycles, and setup gaps. Use first for onboarding, setup, and broad 'what can you see?' questions.",
+            "domains": ["workspace overview", "workspace setup", "onboarding", "available context", "workspace awareness"],
+            "scopes": ["broad"],
+        },
+    },
+    "read_team_activity": {
+        "permission": "read_activity",
+        "output_budget_chars": 18_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read recent human and Illo activity across Cortex messages, ideas, runs, tool calls, Domain events, Project Context attachments, apps, and Cycle runs.",
+            "domains": ["team activity", "teammate activity", "workspace activity", "recent activity", "what changed", "what Illo did"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
+    "read_project_contexts": {
+        "permission": "read_activity",
+        "output_budget_chars": 18_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read Project Context profiles and thread attachments: resources, repos, files, docs, validation, permission scope, and attached thoughts.",
+            "domains": ["project context", "projects", "connected repos", "connected docs", "workspace resources"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
+    "read_team_members": {
+        "permission": "read_activity",
+        "output_budget_chars": 14_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read the workspace roster and optional nearby activity for people. Use for who is here, roles, ownership, and named teammate activity.",
+            "domains": ["team members", "workspace roster", "people", "roles", "ownership", "who is working on what"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
+    "read_workspace_records": {
+        "permission": "read_activity",
+        "output_budget_chars": 18_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read user-created structured workspace data: Domain schemas, typed records, and Domain audit events.",
+            "domains": ["workspace records", "domains", "domain records", "structured data", "trackers", "team database"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
+    "read_cycles": {
+        "permission": "read_activity",
+        "output_budget_chars": 14_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read workspace Cycles and Cycle runs: recurring prompts, schedules, enabled state, last/next run, linked thoughts, and status.",
+            "domains": ["cycles", "recurring work", "scheduled work", "check-ins", "automations", "reports"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
+    "read_workspace_apps": {
+        "permission": "read_activity",
+        "output_budget_chars": 18_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read generated workspace apps, dashboards, metadata, and app-local state.",
+            "domains": ["workspace apps", "dashboards", "generated apps", "app state", "workspace UI"],
+            "scopes": ["narrow", "broad"],
         },
     },
     "manage_cycle": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -7,13 +7,44 @@ tier constants. These are pure data — no handlers, no side effects.
 from __future__ import annotations
 
 
+_WORKSPACE_TIME_WINDOW_VALUES = [
+    "all",
+    "today",
+    "yesterday",
+    "last_24h",
+    "this_week",
+    "last_7d",
+    "this_month",
+    "last_30d",
+    "custom",
+]
+
+
+_WORKSPACE_TIME_WINDOW_SCHEMA = {
+    "type": "string",
+    "enum": _WORKSPACE_TIME_WINDOW_VALUES,
+    "default": "last_7d",
+    "description": "Relative time window. Use custom with start_at/end_at.",
+}
+
+_WORKSPACE_ALL_TIME_WINDOW_SCHEMA = {
+    **_WORKSPACE_TIME_WINDOW_SCHEMA,
+    "default": "all",
+    "description": "Relative time window. Use all for current/existing workspace state, or custom with start_at/end_at.",
+}
+
+
 # ── Brain Tools ───────────────────────────────────────────────
 # Available to all agents (coordinator + workers)
 
 BRAIN_TOOLS = [
     {
         "name": "brain_recall",
-        "description": "Search brain memories semantically. Returns the most relevant memories for the query.",
+        "description": (
+            "Search Illo's long-term semantic memories: durable lessons, facts, patterns, and episodes. "
+            "Use this for remembered context. For current workspace truth, team activity, Domains, projects, "
+            "apps, Cycles, or thread records, use the read_workspace_* tools instead."
+        ),
         "input_schema": {
             "type": "object",
             "properties": {
@@ -198,10 +229,11 @@ BRAIN_TOOLS = [
     {
         "name": "read_thread_messages",
         "description": (
-            "Read or search raw stored messages from the current persistent agent thread when "
-            "the durable handoff summary is too thin or an older exact detail matters. Defaults "
-            "to the current session; use recent for latest turns, range for indexes, or search "
-            "for literal text."
+            "Read or search raw stored messages from this agent run's persistent LLM session when "
+            "the durable handoff summary is too thin or an older exact detail matters. This is not "
+            "the user's Cortex workspace thread; use read_team_activity or query_workspace_data for "
+            "Cortex idea/thread history. Defaults to the current session; use recent for latest turns, "
+            "range for indexes, or search for literal text."
         ),
         "input_schema": {
             "type": "object",
@@ -227,10 +259,11 @@ BRAIN_TOOLS = [
     {
         "name": "query_workspace_data",
         "description": (
-            "Query DB-backed workspace truth outside memories: runs, thread messages, "
-            "ideas, tool calls, Domains, workspace apps, app state, and optional memory recall. "
-            "Use for temporal or teammate activity questions before answering from memory alone; "
-            "read activity_items first for the newest cross-source signals."
+            "Low-level read-only query over Illospace DB-backed workspace truth: team members, "
+            "Cortex ideas/thread messages, agent runs, tool calls, Project Context profiles, "
+            "Domains and records, workspace apps/state, and Cycles. Prefer the more specific "
+            "read_workspace_* tools for normal answers; use this when you need exact source "
+            "selection or a cross-source query. This does not search semantic memories; use brain_recall for that."
         ),
         "input_schema": {
             "type": "object",
@@ -238,24 +271,36 @@ BRAIN_TOOLS = [
                 "sources": {
                     "type": "array",
                     "description": (
-                        "Data sources to inspect. Use ['activity'] for teammate/workspace "
-                        "activity or ['all'] for the default broad set."
+                        "DB-backed data sources to inspect. Use ['activity'] for recent teammate/workspace "
+                        "activity, ['project_contexts'] for project profiles/attachments, ['records'] for "
+                        "Domains and records, ['apps'] for workspace apps/state, or ['all'] for the default broad set."
                     ),
                     "items": {
                         "type": "string",
                         "enum": [
                             "all",
                             "activity",
+                            "team",
+                            "people",
+                            "team_members",
                             "runs",
                             "threads",
                             "ideas",
                             "tool_calls",
+                            "projects",
+                            "project_contexts",
+                            "project_profiles",
+                            "project_attachments",
+                            "records",
+                            "domain",
                             "domains",
                             "domain_records",
                             "domain_events",
+                            "apps",
                             "workspace_apps",
                             "app_state",
-                            "memories",
+                            "cycles",
+                            "cycle_runs",
                         ],
                     },
                 },
@@ -272,19 +317,7 @@ BRAIN_TOOLS = [
                     "description": "Optional teammate/user name or email to scope activity to.",
                 },
                 "time_window": {
-                    "type": "string",
-                    "enum": [
-                        "today",
-                        "yesterday",
-                        "last_24h",
-                        "this_week",
-                        "last_7d",
-                        "this_month",
-                        "last_30d",
-                        "custom",
-                    ],
-                    "default": "last_7d",
-                    "description": "Relative time window. Use custom with start_at/end_at.",
+                    **_WORKSPACE_TIME_WINDOW_SCHEMA,
                 },
                 "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
@@ -297,11 +330,164 @@ BRAIN_TOOLS = [
         },
     },
     {
+        "name": "read_workspace_overview",
+        "description": (
+            "Read a curated overview of the current Illospace workspace before introducing Illo, "
+            "answering broad setup questions, or explaining what context is available. Returns team members, "
+            "active/recent Cortex thoughts, recent agent runs/messages, Project Context profiles and attachments, "
+            "Domains/records, workspace apps, Cycles, and setup gaps. Use this first for 'what is this workspace?', "
+            "'what can you see?', and onboarding setup guidance."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the overview lookup."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "limit": {"type": "integer", "description": "Max records per source (default 10)", "default": 10},
+                "include_archived": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    {
+        "name": "read_team_activity",
+        "description": (
+            "Read recent human and Illo activity in this workspace: Cortex thread messages, ideas, agent runs, "
+            "tool-call summaries, Domain events, Project Context attachments, workspace app updates, and Cycle runs. "
+            "Use before answering questions like 'what happened?', 'what is the team working on?', "
+            "'what did Illo do?', or 'what changed recently?'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the activity lookup."},
+                "search": {
+                    "type": "string",
+                    "description": "Optional literal text filter for titles, messages, records, tool names, apps, or cycles.",
+                },
+                "person": {"type": "string", "description": "Optional teammate/user name or email to scope activity to."},
+                "time_window": {**_WORKSPACE_TIME_WINDOW_SCHEMA},
+                "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
+                "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
+                "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
+                "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter."},
+            },
+        },
+    },
+    {
+        "name": "read_project_contexts",
+        "description": (
+            "Read reusable Project Context profiles and thread attachments: project names, resources, repos/files/docs, "
+            "validation status, permission scope, and which Cortex thoughts have attached context. Use for questions "
+            "about what projects Illo knows, which code/docs are connected, or how to improve project context."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the project context lookup."},
+                "search": {"type": "string", "description": "Optional text filter for profile names, slugs, descriptions, or idea titles."},
+                "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter for attachments."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
+                "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
+                "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
+                "include_inactive": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    {
+        "name": "read_team_members",
+        "description": (
+            "Read the workspace roster and, by default, nearby activity for those people. Use for questions about "
+            "who is in the workspace, roles, ownership, or what a named teammate appears to be working on. "
+            "This is read-only and should be used before answering teammate-activity questions from memory."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the team lookup."},
+                "search": {"type": "string", "description": "Optional text filter for names, emails, or roles."},
+                "person": {"type": "string", "description": "Optional teammate/user name or email to focus on."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "limit": {"type": "integer", "description": "Max team/activity records per source (default 20)", "default": 20},
+                "include_activity": {
+                    "type": "boolean",
+                    "description": "Also include recent activity rows for the matched people.",
+                    "default": True,
+                },
+            },
+        },
+    },
+    {
+        "name": "read_workspace_records",
+        "description": (
+            "Read user-created structured workspace data: Domain schemas, typed records, and Domain audit events. "
+            "Use this for questions about trackers, leads, bugs, tasks, decisions, research records, or any team "
+            "database stored as a Domain. Use manage_domain only when you need to create or change records."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the records lookup."},
+                "search": {"type": "string", "description": "Optional literal text filter for domain names, record titles, or record text."},
+                "domain_id": {"type": "integer", "description": "Optional Domain id filter."},
+                "object_key": {"type": "string", "description": "Optional Domain object key filter."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
+                "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
+                "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
+                "include_archived": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    {
+        "name": "read_cycles",
+        "description": (
+            "Read workspace Cycles and Cycle runs: recurring prompts, schedules, enabled state, last/next run, "
+            "linked thoughts, and recent run status. Use this for questions about recurring check-ins, reports, "
+            "automations, or what scheduled Illo work exists. Use manage_cycle only to create, update, delete, or run one."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the Cycle lookup."},
+                "search": {"type": "string", "description": "Optional text filter for Cycle names, prompts, statuses, or linked ideas."},
+                "person": {"type": "string", "description": "Optional owner name or email to scope Cycles to."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
+                "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
+                "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
+                "include_deleted": {"type": "boolean", "default": False},
+            },
+        },
+    },
+    {
+        "name": "read_workspace_apps",
+        "description": (
+            "Read generated workspace apps/dashboards and optional app-local state. Use this for questions about "
+            "what apps exist, what dashboards are available, or what UI state an app currently stores. "
+            "Use manage_workspace_app only when creating, updating, archiving, restoring, or changing app state."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Reason for the workspace app lookup."},
+                "search": {"type": "string", "description": "Optional text filter for app names, keys, descriptions, or state keys."},
+                "time_window": {**_WORKSPACE_ALL_TIME_WINDOW_SCHEMA},
+                "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
+                "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
+                "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
+                "include_archived": {"type": "boolean", "default": False},
+                "include_state": {"type": "boolean", "description": "Include app-local state rows.", "default": True},
+            },
+        },
+    },
+    {
         "name": "manage_cycle",
         "description": (
-            "Create, list, update, delete, or run workspace Cycles. Use when the user asks "
-            "Illo to set up or manage recurring work. Actions: 'create', 'list', "
-            "'update', 'delete', 'run'."
+            "Create, update, delete, list, or manually run workspace Cycles, which are recurring "
+            "Illo prompts/check-ins/reports. This is the action tool. For answering questions about "
+            "which Cycles exist or what ran recently, prefer read_cycles first. Actions: 'create', "
+            "'list', 'update', 'delete', 'run'."
         ),
         "input_schema": {
             "type": "object",
@@ -352,10 +538,11 @@ DOMAIN_TOOLS = [
     {
         "name": "manage_domain",
         "description": (
-            "Create and maintain org-wide custom Domains: shared team databases with "
-            "object types, typed records, relations, and audit events. Use for requests "
-            "like creating a tracker, adding fields, recording items, querying records, "
-            "linking records, or deleting/archiving domains and domain records."
+            "Create and maintain org-wide custom Domains: user-created shared team databases with "
+            "object types, typed records, relations, and audit events. This is the action/exact-object "
+            "tool for creating trackers, adding fields, recording or updating items, linking records, "
+            "or deleting/archiving Domains and records. For broad awareness questions about existing "
+            "workspace records, prefer read_workspace_records first."
         ),
         "input_schema": {
             "type": "object",
@@ -444,7 +631,9 @@ CORTEX_IDEA_TOOLS = [
             "or use status=queued/working so a starter message and AgentRun are created. "
             "Use this for requests about thoughts, threads, idea threads, or ideas, such as "
             "'archive this thread', 'rename this thought', 'mark this resolved', or "
-            "'restore that idea'. idea_id defaults to the current Cortex thread/idea when one is bound."
+            "'restore that idea'. This is the action/exact-thread tool. For recent team-wide thread "
+            "activity, prefer read_team_activity first. idea_id defaults to the current Cortex "
+            "thread/idea when one is bound."
         ),
         "input_schema": {
             "type": "object",
@@ -563,8 +752,10 @@ PROJECT_TOOLS = [
         "name": "manage_project",
         "description": (
             "Create, list, update, archive, attach, and maintain Cortex Project Context profiles. "
-            "Use when the user asks to manage a project/folder/context bundle, add or remove files/repos/folders, "
-            "or attach reusable project context to the current thread. Thread attachments do not require a project."
+            "This is the action tool for managing project/folder/context bundles, adding or removing "
+            "files/repos/folders/docs, or attaching reusable project context to the current thread. "
+            "For awareness questions about what project context exists or what Illo can see, prefer "
+            "read_project_contexts first. Thread attachments do not require a project."
         ),
         "input_schema": {
             "type": "object",
@@ -629,11 +820,12 @@ WORKSPACE_APP_TOOLS = [
         "name": "manage_workspace_app",
         "description": (
             "Create, list, update, archive, and persist state for generated workspace apps. "
-            "Use after designing a small UI surface or dashboard that should remain available "
+            "This is the action tool to create or change a small UI surface or dashboard that should remain available "
             "inside Cortex. Prefer renderer_key='generated-ui-app' and source_kind='json' with "
             "a structured generated UI spec. Use renderer_key='sandboxed-html-app' only as a "
             "custom HTML escape-hatch runtime. Recordful apps must use manage_domain first; app-local "
             "state is only for UI preferences, filters, drafts, and ephemeral interface state. "
+            "For awareness questions about what apps exist or current app state, prefer read_workspace_apps first. "
             "New generated apps must pass the workspace app contract before they are persisted."
         ),
         "input_schema": {
@@ -1465,7 +1657,9 @@ COORDINATOR_TOOLS = (
 # Brain gate: these tool names satisfy the "brain context accessed" requirement
 _BRAIN_TOOL_NAMES = frozenset({
     "brain_recall", "brain_guardrails", "brain_skills", "skill_view", "skill_asset",
-    "brain_encode", "runtime_settings", "query_workspace_data",
+    "brain_encode", "runtime_settings", "query_workspace_data", "read_workspace_overview",
+    "read_team_activity", "read_project_contexts", "read_team_members", "read_workspace_records",
+    "read_cycles", "read_workspace_apps",
 })
 
 # Brain gate: these tools require brain context before first use

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -20,6 +20,7 @@ from brain.systems.runs.tool_catalog.handlers.projects import *  # noqa: F401,F4
 from brain.systems.runs.tool_catalog.handlers.session_tools import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.skills import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.web import *  # noqa: F401,F403
+from brain.systems.runs.tool_catalog.handlers.workspace_data import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.workspace_apps import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.composition import get_tools_with_extended
 
@@ -65,6 +66,14 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_session_read",
     "_handle_session_write",
     "_handle_my_activity",
+    "_handle_query_workspace_data",
+    "_handle_read_cycles",
+    "_handle_read_project_contexts",
+    "_handle_read_team_activity",
+    "_handle_read_team_members",
+    "_handle_read_workspace_apps",
+    "_handle_read_workspace_overview",
+    "_handle_read_workspace_records",
     "_handle_web_fetch",
     "_handle_web_search",
 )

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1028,6 +1028,21 @@ export const api = {
     fetchJson<any>('/api/runtime-settings/memory/check', { method: 'POST' }),
 
   // Onboarding
+  runtimeReadyIntroDraft: () =>
+    fetchJson<{
+      ok: boolean;
+      idea_id?: string | null;
+      should_play: boolean;
+      prompt: string;
+      title: string;
+      display_title: string;
+      origin: string;
+      origin_ref: string;
+      run_metadata?: Record<string, any> | null;
+    }>(
+      '/api/onboarding/runtime-ready-intro-draft',
+      { method: 'POST' },
+    ),
   startRuntimeReadyIntro: () =>
     fetchJson<{ ok: boolean; idea_id: string; created: boolean; run_id?: number | null }>(
       '/api/onboarding/runtime-ready-intro',

--- a/frontend/src/lib/components/constellation/ConstellationSignalStatusIndicator.svelte
+++ b/frontend/src/lib/components/constellation/ConstellationSignalStatusIndicator.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import type { ConstellationSignalState } from './constellationTypes';
+
+  export type ConstellationSignalStatusIndicatorState = ConstellationSignalState | 'unread';
+  export type ConstellationSignalStatusIndicatorPlacement = 'inline' | 'anchor';
+
+  let {
+    state = 'idle',
+    placement = 'inline',
+    animated = true,
+    label,
+    className = '',
+    style = '',
+  }: {
+    state?: ConstellationSignalStatusIndicatorState;
+    placement?: ConstellationSignalStatusIndicatorPlacement;
+    animated?: boolean;
+    label?: string;
+    className?: string;
+    style?: string;
+  } = $props();
+
+  const resolvedState = $derived(state === 'done' ? 'unread' : state);
+  const resolvedLabel = $derived(
+    label ??
+      (resolvedState === 'working'
+        ? 'Illo is working'
+        : resolvedState === 'unread'
+          ? 'Unread thread'
+          : 'Idle thread'),
+  );
+  const rootClass = $derived(
+    [
+      'constellation-signal-status-indicator',
+      `constellation-signal-status-indicator-${resolvedState}`,
+      `constellation-signal-status-indicator-placement-${placement}`,
+      animated ? 'is-animated' : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
+</script>
+
+<span class={rootClass} {style} aria-label={resolvedLabel} title={resolvedLabel} role="img">
+  {#if resolvedState === 'working'}
+    <span class="constellation-signal-status-indicator-spinner" aria-hidden="true"></span>
+  {:else if resolvedState === 'unread'}
+    <span class="constellation-signal-status-indicator-unread-beacon" aria-hidden="true"></span>
+  {:else}
+    <span class="constellation-signal-status-indicator-idle-dot" aria-hidden="true"></span>
+  {/if}
+</span>
+
+<style>
+  .constellation-signal-status-indicator {
+    --constellation-signal-status-size: 16px;
+    --constellation-signal-status-idle-size: 7px;
+    --constellation-signal-status-color: var(
+      --blob-unread-color,
+      var(--thread-accent, var(--constellation-color-spectral))
+    );
+    --constellation-signal-status-idle-color: var(
+      --constellation-thread-header-status-idle-dot,
+      var(--constellation-thread-header-activity-dot, var(--constellation-color-text-muted))
+    );
+    --constellation-signal-status-idle-ring: var(
+      --constellation-thread-header-status-idle-ring,
+      var(--constellation-thread-header-activity-ring, rgba(240, 240, 250, 0.12))
+    );
+
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--constellation-signal-status-size);
+    height: var(--constellation-signal-status-size);
+    flex: 0 0 var(--constellation-signal-status-size);
+    color: var(--constellation-signal-status-color);
+    pointer-events: none;
+  }
+
+  .constellation-signal-status-indicator-placement-anchor {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    z-index: 2;
+    transform: translate(38%, -34%);
+  }
+
+  .constellation-signal-status-indicator-idle-dot {
+    width: var(--constellation-signal-status-idle-size);
+    height: var(--constellation-signal-status-idle-size);
+    border-radius: var(--constellation-radius-pill);
+    background: var(--constellation-signal-status-idle-color);
+    box-shadow: 0 0 0 1px var(--constellation-signal-status-idle-ring);
+  }
+
+  .constellation-signal-status-indicator-unread-beacon {
+    width: var(--constellation-signal-status-size);
+    height: var(--constellation-signal-status-size);
+    border-radius: var(--constellation-radius-pill);
+    background:
+      radial-gradient(circle at 42% 35%, rgba(255, 255, 255, 0.36), transparent 34%),
+      color-mix(in srgb, var(--constellation-signal-status-color) 74%, rgba(240, 240, 250, 0.22));
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--constellation-signal-status-color) 34%, rgba(240, 240, 250, 0.18)),
+      0 0 14px color-mix(in srgb, var(--constellation-signal-status-color) 48%, transparent);
+    opacity: 0.92;
+  }
+
+  .constellation-signal-status-indicator-spinner {
+    width: var(--constellation-signal-status-size);
+    height: var(--constellation-signal-status-size);
+    box-sizing: border-box;
+    border-radius: var(--constellation-radius-pill);
+    border: 4px solid transparent;
+    border-top-color: color-mix(in srgb, var(--constellation-signal-status-color) 74%, rgba(240, 240, 250, 0.22));
+    border-right-color: color-mix(in srgb, var(--constellation-signal-status-color) 74%, rgba(240, 240, 250, 0.22));
+    background: transparent;
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--constellation-signal-status-color) 48%, transparent));
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  .is-animated .constellation-signal-status-indicator-unread-beacon {
+    animation: constellation-signal-status-indicator-unread-beacon 3.6s ease-in-out infinite;
+  }
+
+  .is-animated .constellation-signal-status-indicator-spinner {
+    animation: constellation-signal-status-indicator-spinner-sync-spin 1.25s ease-in-out infinite;
+  }
+
+  @keyframes constellation-signal-status-indicator-unread-beacon {
+    0%,
+    100% {
+      opacity: 0.68;
+      box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--constellation-signal-status-color) 28%, rgba(240, 240, 250, 0.14)),
+        0 0 10px color-mix(in srgb, var(--constellation-signal-status-color) 36%, transparent);
+    }
+
+    50% {
+      opacity: 1;
+      box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--constellation-signal-status-color) 38%, rgba(240, 240, 250, 0.18)),
+        0 0 20px color-mix(in srgb, var(--constellation-signal-status-color) 62%, transparent);
+    }
+  }
+
+  @keyframes constellation-signal-status-indicator-spinner-sync-spin {
+    0% {
+      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--constellation-signal-status-color) 42%, transparent));
+      transform: rotate(0deg) scale(1);
+    }
+
+    16% {
+      filter: drop-shadow(0 0 18px color-mix(in srgb, var(--constellation-signal-status-color) 66%, transparent));
+      transform: rotate(118deg) scale(1.1);
+    }
+
+    30% {
+      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--constellation-signal-status-color) 46%, transparent));
+      transform: rotate(174deg) scale(0.96);
+    }
+
+    46% {
+      filter: drop-shadow(0 0 16px color-mix(in srgb, var(--constellation-signal-status-color) 58%, transparent));
+      transform: rotate(268deg) scale(1.06);
+    }
+
+    64% {
+      filter: drop-shadow(0 0 13px color-mix(in srgb, var(--constellation-signal-status-color) 48%, transparent));
+      transform: rotate(312deg) scale(1);
+    }
+
+    100% {
+      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--constellation-signal-status-color) 42%, transparent));
+      transform: rotate(360deg) scale(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .is-animated .constellation-signal-status-indicator-unread-beacon,
+    .is-animated .constellation-signal-status-indicator-spinner {
+      animation: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/constellation/SignalBlob.svelte
+++ b/frontend/src/lib/components/constellation/SignalBlob.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ConstellationIcon, { type ConstellationIconName } from './ConstellationIcon.svelte';
+  import ConstellationSignalStatusIndicator from './ConstellationSignalStatusIndicator.svelte';
   import type {
     ConstellationScale,
     ConstellationShape,
@@ -263,11 +264,11 @@
     {/if}
 
     {#if showUnreadNotification}
-      <span class="constellation-signal-blob-unread-beacon" aria-hidden="true"></span>
+      <ConstellationSignalStatusIndicator state="unread" placement="anchor" {animated} label="Unread thread" />
     {/if}
 
     {#if showWorkingIndicator}
-      <span class="constellation-signal-blob-working-spinner" aria-hidden="true"></span>
+      <ConstellationSignalStatusIndicator state="working" placement="anchor" {animated} label="Illo is working" />
     {/if}
 
     {#if attachmentCount > 0}
@@ -528,8 +529,6 @@
 
   .constellation-signal-blob-owner-seed,
   .constellation-signal-blob-status-anchor,
-  .constellation-signal-blob-working-spinner,
-  .constellation-signal-blob-unread-beacon,
   .constellation-signal-blob-attachment-badge {
     position: absolute;
     z-index: 2;
@@ -1058,38 +1057,6 @@
       0 0 14px color-mix(in srgb, var(--blob-shadow) 72%, transparent);
   }
 
-  .constellation-signal-blob-unread-beacon {
-    top: 7px;
-    right: 7px;
-    width: 16px;
-    height: 16px;
-    border-radius: 999px;
-    background:
-      radial-gradient(circle at 42% 35%, rgba(255, 255, 255, 0.36), transparent 34%),
-      color-mix(in srgb, var(--blob-unread-color) 74%, rgba(240, 240, 250, 0.22));
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, var(--blob-unread-color) 34%, rgba(240, 240, 250, 0.18)),
-      0 0 14px color-mix(in srgb, var(--blob-unread-color) 48%, transparent);
-    opacity: 0.92;
-    transform: translate(38%, -34%);
-  }
-
-  .constellation-signal-blob-working-spinner {
-    top: 7px;
-    right: 7px;
-    width: 16px;
-    height: 16px;
-    box-sizing: border-box;
-    border-radius: 999px;
-    border: 4px solid transparent;
-    border-top-color: color-mix(in srgb, var(--blob-unread-color) 74%, rgba(240, 240, 250, 0.22));
-    border-right-color: color-mix(in srgb, var(--blob-unread-color) 74%, rgba(240, 240, 250, 0.22));
-    background: transparent;
-    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--blob-unread-color) 48%, transparent));
-    opacity: 1;
-    transform: translate(38%, -34%) rotate(0deg);
-  }
-
   .is-animated.constellation-signal-blob-working .constellation-signal-blob-body {
     animation: constellation-signal-blob-working-heartbeat 1.25s ease-in-out infinite;
   }
@@ -1128,14 +1095,6 @@
 
   .is-animated .constellation-signal-blob-status-risk-dot {
     animation: constellation-signal-blob-cue-dot-pulse 2.5s ease-in-out infinite;
-  }
-
-  .is-animated .constellation-signal-blob-unread-beacon {
-    animation: constellation-signal-blob-unread-beacon 3.6s ease-in-out infinite;
-  }
-
-  .is-animated .constellation-signal-blob-working-spinner {
-    animation: constellation-signal-blob-working-spinner-sync-spin 1.25s ease-in-out infinite;
   }
 
   .constellation-signal-blob-interactive:is(:hover, :focus-visible) {
@@ -1279,29 +1238,6 @@
     }
   }
 
-  @keyframes constellation-signal-blob-unread-beacon {
-    0%,
-    100% {
-      opacity: 0.68;
-      box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--blob-unread-color) 28%, rgba(240, 240, 250, 0.14)),
-        0 0 10px color-mix(in srgb, var(--blob-unread-color) 36%, transparent);
-    }
-
-    50% {
-      opacity: 1;
-      box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--blob-unread-color) 38%, rgba(240, 240, 250, 0.18)),
-        0 0 20px color-mix(in srgb, var(--blob-unread-color) 62%, transparent);
-    }
-  }
-
-  @keyframes constellation-signal-blob-working-spinner-spin {
-    to {
-      transform: translate(38%, -34%) rotate(360deg);
-    }
-  }
-
   @keyframes constellation-signal-blob-working-heartbeat {
     0%,
     100% {
@@ -1330,38 +1266,6 @@
     }
   }
 
-  @keyframes constellation-signal-blob-working-spinner-sync-spin {
-    0% {
-      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--blob-unread-color) 42%, transparent));
-      transform: translate(38%, -34%) rotate(0deg) scale(1);
-    }
-
-    16% {
-      filter: drop-shadow(0 0 18px color-mix(in srgb, var(--blob-unread-color) 66%, transparent));
-      transform: translate(38%, -34%) rotate(118deg) scale(1.1);
-    }
-
-    30% {
-      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--blob-unread-color) 46%, transparent));
-      transform: translate(38%, -34%) rotate(174deg) scale(0.96);
-    }
-
-    46% {
-      filter: drop-shadow(0 0 16px color-mix(in srgb, var(--blob-unread-color) 58%, transparent));
-      transform: translate(38%, -34%) rotate(268deg) scale(1.06);
-    }
-
-    64% {
-      filter: drop-shadow(0 0 13px color-mix(in srgb, var(--blob-unread-color) 48%, transparent));
-      transform: translate(38%, -34%) rotate(312deg) scale(1);
-    }
-
-    100% {
-      filter: drop-shadow(0 0 12px color-mix(in srgb, var(--blob-unread-color) 42%, transparent));
-      transform: translate(38%, -34%) rotate(360deg) scale(1);
-    }
-  }
-
   @media (prefers-reduced-motion: reduce) {
     .is-animated .constellation-signal-blob-surface,
     .is-animated.constellation-signal-blob-working:not(.constellation-signal-blob-presence-inside) .constellation-signal-blob-surface,
@@ -1371,8 +1275,6 @@
     .is-animated .constellation-signal-blob-status-inside span,
     .is-animated .constellation-signal-blob-status-attention-dot,
     .is-animated .constellation-signal-blob-status-risk-dot,
-    .is-animated .constellation-signal-blob-unread-beacon,
-    .is-animated .constellation-signal-blob-working-spinner,
     .is-animated.constellation-signal-blob-working .constellation-signal-blob-body {
       animation: none;
     }

--- a/frontend/src/lib/components/constellation/index.ts
+++ b/frontend/src/lib/components/constellation/index.ts
@@ -24,6 +24,11 @@ export { default as ConstellationPresenceStack } from './ConstellationPresenceSt
 export { default as ConstellationSelectChip } from './ConstellationSelectChip.svelte';
 export { default as ConstellationSection } from './ConstellationSection.svelte';
 export { default as ConstellationSectionHeader } from './ConstellationSectionHeader.svelte';
+export { default as ConstellationSignalStatusIndicator } from './ConstellationSignalStatusIndicator.svelte';
+export type {
+  ConstellationSignalStatusIndicatorPlacement,
+  ConstellationSignalStatusIndicatorState,
+} from './ConstellationSignalStatusIndicator.svelte';
 export { default as ConstellationSkeletonBlock } from './ConstellationSkeletonBlock.svelte';
 export { default as ConstellationSplitLayout } from './ConstellationSplitLayout.svelte';
 export { default as ConstellationTextInput } from './ConstellationTextInput.svelte';

--- a/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
@@ -42,19 +42,48 @@
   } from '$lib/utils/projectContext';
   import type { SlashCommandToken } from '$lib/utils/slashCommand';
   import type { CortexWorkspacePoint } from '$lib/features/workspace-scene/domain/workspacePoint';
+  import type { CortexCreateIdeaOptions } from '$lib/stores/cortex.svelte';
+  import type { AgentRunOptions } from '$lib/types/cortex';
+
+  type WorkspaceComposerAutoDraft = {
+    id: string;
+    text: string;
+    origin?: string | null;
+    originRef?: string | null;
+    displayTitle?: string | null;
+    runMetadata?: Record<string, any> | null;
+    delayMs?: number;
+    typeIntervalMs?: number;
+    submitDelayMs?: number;
+  };
+
+  type AutoDraftCompletion = {
+    id: string;
+    status: 'submitted' | 'skipped' | 'cancelled';
+    ideaId?: string;
+  };
+
+  type SubmitPromptOptions = {
+    createOptions?: CortexCreateIdeaOptions;
+    runOptions?: AgentRunOptions;
+  };
 
   let {
     context = null,
     projectContextInitialOpen = false,
     projectContextInitialProfileId = 'none',
     projectContextLoadServerProfiles = true,
+    autoDraft = null,
     onthreadintent,
+    onAutoDraftComplete,
   }: {
     context?: CortexWorkspacePoint | null;
     projectContextInitialOpen?: boolean;
     projectContextInitialProfileId?: string;
     projectContextLoadServerProfiles?: boolean;
+    autoDraft?: WorkspaceComposerAutoDraft | null;
     onthreadintent?: (origin: { x: number; y: number }) => void;
+    onAutoDraftComplete?: (completion: AutoDraftCompletion) => void;
   } = $props();
 
   let inputValue = $state('');
@@ -68,6 +97,8 @@
   let projectContextSnapshot = $state<ProjectContextSnapshotLike | null>(null);
   let projectContextValid = $state(true);
   let projectContextError = $state<string | null>(null);
+  let autoDraftPlaybackId: string | null = null;
+  let autoDraftRunToken = 0;
   type CreationBehavior = 'open-thread' | 'keep-workspace';
 
   let viewportHeight = $state(800);
@@ -190,7 +221,10 @@
     await cortex.selectIdea(ideaId);
   }
 
-  async function submitPrompt(behavior: CreationBehavior = 'open-thread') {
+  async function submitPrompt(
+    behavior: CreationBehavior = 'open-thread',
+    submitOptions: SubmitPromptOptions = {},
+  ) {
     const text = inputValue.trim();
     const baseAttachments = [...pendingAttachments];
     if ((!text && baseAttachments.length === 0) || sending) return;
@@ -205,6 +239,10 @@
       const messageText = text || '(attachment)';
       const selectedProjectContext = projectContextSnapshot;
       const attachments = buildWorkspaceComposerAttachmentsWithProjectContext(baseAttachments, selectedProjectContext);
+      const runOptions = {
+        ...cortex.runSettingsOptions(),
+        ...(submitOptions.runOptions ?? {}),
+      };
       const idea = worldOrigin
         ? await cortex.createIdeaAt(
             messageText,
@@ -213,9 +251,17 @@
             undefined,
             attachments,
             text,
-            cortex.runSettingsOptions(),
+            runOptions,
+            submitOptions.createOptions,
           )
-        : await cortex.createIdea(messageText, undefined, attachments, text, cortex.runSettingsOptions());
+        : await cortex.createIdea(
+            messageText,
+            undefined,
+            attachments,
+            text,
+            runOptions,
+            submitOptions.createOptions,
+          );
       if (!idea?.id) return;
       await saveWorkspaceComposerProjectContext(
         idea.id,
@@ -234,11 +280,70 @@
         onthreadintent?.(composerOrigin());
         await openCreatedThread(idea.id);
       }
+      return idea;
     } finally {
       sending = false;
       await syncComposerHeight();
     }
   }
+
+  function sleep(ms: number) {
+    return new Promise((resolve) => window.setTimeout(resolve, ms));
+  }
+
+  async function playAutoDraft(draft: WorkspaceComposerAutoDraft, token: number) {
+    await tick();
+    await sleep(draft.delayMs ?? 320);
+    if (token !== autoDraftRunToken) return;
+    if (inputValue.trim() || pendingAttachments.length > 0 || sending) {
+      onAutoDraftComplete?.({ id: draft.id, status: 'skipped' });
+      return;
+    }
+
+    textareaEl?.focus();
+    inputValue = '';
+    await syncComposerHeight();
+
+    const intervalMs = draft.typeIntervalMs ?? 18;
+    for (let index = 1; index <= draft.text.length; index += 1) {
+      if (token !== autoDraftRunToken) return;
+      inputValue = draft.text.slice(0, index);
+      await syncComposerHeight();
+      await sleep(intervalMs);
+    }
+
+    if (token !== autoDraftRunToken) return;
+    await sleep(draft.submitDelayMs ?? 520);
+    if (token !== autoDraftRunToken) return;
+
+    const idea = await submitPrompt('open-thread', {
+      createOptions: {
+        origin: draft.origin,
+        originRef: draft.originRef,
+        displayTitle: draft.displayTitle,
+      },
+      runOptions: draft.runMetadata ? { metadata: draft.runMetadata } : undefined,
+    });
+
+    onAutoDraftComplete?.({
+      id: draft.id,
+      status: idea?.id ? 'submitted' : 'cancelled',
+      ideaId: idea?.id,
+    });
+  }
+
+  $effect(() => {
+    const draft = autoDraft;
+    if (!draft || autoDraftPlaybackId === draft.id) return;
+    autoDraftPlaybackId = draft.id;
+    const token = autoDraftRunToken + 1;
+    autoDraftRunToken = token;
+    void playAutoDraft(draft, token);
+
+    return () => {
+      if (autoDraftRunToken === token) autoDraftRunToken += 1;
+    };
+  });
 
   function handleKeydown(event: KeyboardEvent) {
     if (mentionRef?.handleKey(event)) return;

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -36,8 +36,22 @@
   import CortexLocalPreviewControls from '$lib/features/cortex/components/LocalPreviewControls.svelte';
   import WorkspaceChatDock from '$lib/features/cortex/components/chat/WorkspaceChatDock.svelte';
   import type { CortexChatDockTopLevelMode } from '$lib/features/cortex/components/chat/ChatDockSeam.svelte';
+  import { api } from '$lib/api/client';
 
   const RUNTIME_READY_ONBOARDING_PARAM = 'runtime-ready';
+  const WORKSPACE_ARRIVAL_DURATION_MS = 1320;
+  const RUNTIME_READY_INTRO_DELAY_MS = 1560;
+  type RuntimeReadyComposerDraft = {
+    id: string;
+    text: string;
+    origin?: string | null;
+    originRef?: string | null;
+    displayTitle?: string | null;
+    runMetadata?: Record<string, any> | null;
+    delayMs?: number;
+    typeIntervalMs?: number;
+    submitDelayMs?: number;
+  };
   const workspaceOverlay = createWorkspaceOverlayController();
   const threadStage = createWorkspaceThreadStageController();
   const lazyComponents = createLazyComponentController();
@@ -50,6 +64,12 @@
   let workspacePinsWsReady = false;
   let workspaceEl: HTMLDivElement | undefined = $state();
   let workspaceSceneSidecarsReady = $state(false);
+  let workspaceArrivalActive = $state(true);
+  let workspaceArrivalSettled = $state(false);
+  let runtimeReadyIntroHandled = $state(false);
+  let runtimeReadyIntroStarting = $state(false);
+  let runtimeReadyIntroTimer: ReturnType<typeof setTimeout> | null = null;
+  let runtimeReadyComposerDraft = $state<RuntimeReadyComposerDraft | null>(null);
   let lastRequestedIdeaId = $state<string | null>(null);
   let initialDirectThreadIdeaId = $state<string | null>($page.url.searchParams.get('idea'));
   let directThreadUrlPending = $state(Boolean($page.url.searchParams.get('idea')));
@@ -85,16 +105,71 @@
   }
 
   function isRuntimeReadyIntroIdea(idea: Idea | null | undefined) {
-    return idea?.origin === 'onboarding' && idea.agent_details?.onboarding?.intro === true;
+    return (
+      idea?.origin === 'onboarding'
+      && (
+        idea.agent_details?.onboarding?.intro === true
+        || idea.origin_ref?.startsWith('runtime-ready-intro:')
+      )
+    );
   }
 
-  function clearRuntimeReadyOnboardingUrl() {
-    if (!browser || !isRuntimeReadyOnboardingUrl() || !isRuntimeReadyIntroIdea(cortex.selectedIdea)) return;
+  function runtimeReadyIntroIsDeferred() {
+    return isRuntimeReadyOnboardingUrl() && !$page.url.searchParams.get('idea');
+  }
+
+  function runtimeReadyIntroOpenExisting() {
+    return $page.url.searchParams.get('open_existing') === '1';
+  }
+
+  function clearRuntimeReadyOnboardingUrl(options: { requireIntroIdea?: boolean } = {}) {
+    const { requireIntroIdea = true } = options;
+    if (!browser || !isRuntimeReadyOnboardingUrl()) return;
+    if (requireIntroIdea && !isRuntimeReadyIntroIdea(cortex.selectedIdea)) return;
     const url = new URL(window.location.href);
     url.searchParams.delete('idea');
     url.searchParams.delete('onboarding');
+    url.searchParams.delete('open_existing');
     const nextPath = `${url.pathname}${url.search}${url.hash}`;
     window.history.replaceState(window.history.state, '', nextPath);
+  }
+
+  async function startDeferredRuntimeReadyIntro() {
+    if (runtimeReadyIntroHandled || runtimeReadyIntroStarting) return;
+    runtimeReadyIntroHandled = true;
+    runtimeReadyIntroStarting = true;
+    try {
+      const intro = await api.runtimeReadyIntroDraft();
+      if (!intro?.should_play) {
+        if (intro?.idea_id && runtimeReadyIntroOpenExisting()) {
+          threadStage.setCenteredOrigin('50%', '54%');
+          await cortex.loadDirectThread(intro.idea_id);
+        }
+        clearRuntimeReadyOnboardingUrl({ requireIntroIdea: false });
+        return;
+      }
+      runtimeReadyComposerDraft = {
+        id: `${intro.origin_ref}:${Date.now()}`,
+        text: intro.prompt,
+        origin: intro.origin,
+        originRef: intro.origin_ref,
+        displayTitle: intro.display_title,
+        runMetadata: intro.run_metadata,
+        delayMs: 360,
+        typeIntervalMs: 18,
+        submitDelayMs: 620,
+      };
+    } catch (err: any) {
+      ui.toast(err?.detail || err?.message || 'Illo intro did not start.', 'error');
+      clearRuntimeReadyOnboardingUrl({ requireIntroIdea: false });
+    } finally {
+      runtimeReadyIntroStarting = false;
+    }
+  }
+
+  function handleRuntimeReadyAutoDraftComplete() {
+    runtimeReadyComposerDraft = null;
+    clearRuntimeReadyOnboardingUrl({ requireIntroIdea: false });
   }
 
   $effect(() => {
@@ -462,6 +537,29 @@
   const cortexWorkspaceLoading = $derived(
     cortex.loading || (!directThreadUrlPending && !directThreadActive && !workspaceSceneSidecarsReady),
   );
+  const workspaceVisualReady = $derived(
+    shouldRenderWorkspaceScene
+      ? (cortex.view === 'list' ? Boolean(CortexListViewComponent) : Boolean(WorkspaceSceneComponent))
+      : cortexSurfaceReady,
+  );
+  const workspaceArrivalReady = $derived(cortexSurfaceReady && workspaceVisualReady);
+
+  $effect(() => {
+    if (!browser || workspaceArrivalSettled || !workspaceArrivalReady) return;
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      workspaceArrivalActive = false;
+      workspaceArrivalSettled = true;
+      return;
+    }
+
+    workspaceArrivalActive = true;
+    const timeout = window.setTimeout(() => {
+      workspaceArrivalActive = false;
+      workspaceArrivalSettled = true;
+    }, WORKSPACE_ARRIVAL_DURATION_MS);
+
+    return () => window.clearTimeout(timeout);
+  });
 
   const createLazyComponentLoader = lazyComponents.createLoader;
 
@@ -711,6 +809,33 @@
     }
   });
 
+  $effect(() => {
+    if (
+      !browser
+      || runtimeReadyIntroHandled
+      || runtimeReadyIntroStarting
+      || !runtimeReadyIntroIsDeferred()
+      || cortexWorkspaceLoading
+      || !workspaceArrivalReady
+      || !WorkspaceComposerComponent
+      || cortex.panelOpen
+      || runtimeReadyComposerDraft
+    ) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      runtimeReadyIntroTimer = null;
+      void startDeferredRuntimeReadyIntro();
+    }, RUNTIME_READY_INTRO_DELAY_MS);
+    runtimeReadyIntroTimer = timeout;
+
+    return () => {
+      if (runtimeReadyIntroTimer === timeout) runtimeReadyIntroTimer = null;
+      window.clearTimeout(timeout);
+    };
+  });
+
   onMount(() => {
     const requestedIdeaId = $page.url.searchParams.get('idea');
     initialDirectThreadIdeaId = requestedIdeaId;
@@ -740,6 +865,10 @@
   });
 
   onDestroy(() => {
+    if (runtimeReadyIntroTimer) {
+      clearTimeout(runtimeReadyIntroTimer);
+      runtimeReadyIntroTimer = null;
+    }
     if (isRuntimeReadyIntroIdea(cortex.selectedIdea)) {
       void cortex.selectIdea(null);
     }
@@ -763,6 +892,7 @@
   class="cortex-page"
   class:panel-open={cortex.panelOpen}
   class:canvas-open={cortex.canvasOpen}
+  class:is-arriving={workspaceArrivalActive}
   style={threadWorkspaceStyle}
 >
   <div class="cortex-workspace" bind:this={workspaceEl}>
@@ -783,6 +913,8 @@
         'cortex-workspace-backdrop',
         directThreadActive ? 'is-direct-thread' : '',
       ].filter(Boolean).join(' ')}
+      toolbarClassName="workspace-toolbar-slot"
+      composerClassName="workspace-composer-slot"
     >
           {#snippet canvas()}
             <div class="cortex-main">
@@ -860,7 +992,12 @@
                 out:fly={{ y: 14, duration: 180 }}
               >
                 {#if WorkspaceComposerComponent}
-                  <WorkspaceComposerComponent context={workspaceOverlay.composerContext} onthreadintent={handleWorkspaceThreadIntent} />
+                  <WorkspaceComposerComponent
+                    context={workspaceOverlay.composerContext}
+                    autoDraft={runtimeReadyComposerDraft}
+                    onthreadintent={handleWorkspaceThreadIntent}
+                    onAutoDraftComplete={handleRuntimeReadyAutoDraftComplete}
+                  />
                 {/if}
               </div>
             {/if}
@@ -1138,6 +1275,26 @@
     pointer-events: auto;
   }
 
+  .cortex-page.is-arriving :global(.workspace-toolbar-slot) {
+    animation: cortex-toolbar-arrive 640ms cubic-bezier(0.22, 1, 0.36, 1) 240ms both;
+  }
+
+  .cortex-page.is-arriving .workspace-archive-bin-shell {
+    animation: cortex-edge-bin-arrive 640ms cubic-bezier(0.22, 1, 0.36, 1) 420ms both;
+  }
+
+  .cortex-page.is-arriving :global(.workspace-composer-slot) {
+    animation: cortex-composer-arrive 680ms cubic-bezier(0.22, 1, 0.36, 1) 360ms both;
+  }
+
+  .cortex-page.is-arriving .cortex-main :global(.constellation-astre-own) {
+    animation: cortex-own-astre-arrive 780ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both;
+  }
+
+  .cortex-page.is-arriving .cortex-main :global(.constellation-astre:not(.constellation-astre-own)) {
+    animation: cortex-field-astre-arrive 640ms cubic-bezier(0.22, 1, 0.36, 1) 260ms both;
+  }
+
   .cortex-page :global(.workspace-theme-toggle) {
     --constellation-control-button-secondary-text: var(--constellation-system-chrome-text);
     --constellation-control-toggle-active-background: var(--constellation-system-chrome-active-background);
@@ -1311,6 +1468,82 @@
     50% { opacity: 1; }
   }
 
+  @keyframes cortex-own-astre-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(12px) saturate(1.28) brightness(1.14);
+      transform: translate(-50%, -50%) scale(0.22);
+    }
+
+    62% {
+      opacity: 1;
+      filter: blur(0) saturate(1.16) brightness(1.08);
+      transform: translate(-50%, -50%) scale(1.08);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translate(-50%, -50%) scale(var(--astre-scale));
+    }
+  }
+
+  @keyframes cortex-field-astre-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(5px) saturate(1.16);
+      transform: translate(-50%, -50%) scale(0.72);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translate(-50%, -50%) scale(var(--astre-scale));
+    }
+  }
+
+  @keyframes cortex-toolbar-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(3px);
+      transform: translate3d(34px, -2px, 0);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  @keyframes cortex-edge-bin-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(3px);
+      transform: translate3d(30px, 0, 0) scale(0.985);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  @keyframes cortex-composer-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(3px);
+      transform: translateX(-50%) translateY(30px) scale(0.985);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translateX(-50%) translateY(0) scale(1);
+    }
+  }
+
   @media (max-width: 900px) {
     .cortex-page {
       --workspace-bottom-surface-idle-height: clamp(132px, 20svh, 190px);
@@ -1342,6 +1575,15 @@
 
     :global(.constellation-workspace-backdrop.cortex-workspace-backdrop) {
       --constellation-workspace-backdrop-composer-width: min(calc(100% - 28px), 360px);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cortex-page.is-arriving :global(.workspace-toolbar-slot),
+    .cortex-page.is-arriving .workspace-archive-bin-shell,
+    .cortex-page.is-arriving :global(.workspace-composer-slot),
+    .cortex-page.is-arriving .cortex-main :global(.constellation-astre) {
+      animation: none !important;
     }
   }
 

--- a/frontend/src/lib/features/cortex/components/chat/WorkspaceChatDock.css
+++ b/frontend/src/lib/features/cortex/components/chat/WorkspaceChatDock.css
@@ -531,6 +531,11 @@
     scrollbar-color: var(--mini-chat-shell-border) transparent;
   }
 
+  .workspace-chat-dock.is-corner .chat-pane-stream > :first-child,
+  .workspace-chat-dock.is-corner .chat-dm-stream > :first-child {
+    margin-top: auto;
+  }
+
   .workspace-chat-dock.is-corner .chat-conversation-header,
   .workspace-chat-dock.is-corner .chat-message-actions,
   .workspace-chat-dock.is-corner .chat-thread-summary-arrow,
@@ -870,7 +875,12 @@
     font-size: var(--mini-chat-body-size);
     line-height: 1.38;
     overflow-y: auto;
+    scrollbar-width: none;
     text-shadow: var(--mini-chat-text-shadow);
+  }
+
+  .workspace-chat-dock.is-corner .chat-composer-shell.is-room .chat-composer-textarea::-webkit-scrollbar {
+    display: none;
   }
 
   .workspace-chat-dock.is-corner .chat-composer-textarea::placeholder {

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -86,6 +86,7 @@
     visibleThreadStreamItems,
   } from '$lib/features/threads/domain/threadStreamAdapter';
   import type {
+    CortexThreadStageHeaderStatusState,
     CortexThreadStageTranscriptItem,
   } from '$lib/features/threads/domain/threadTranscriptAdapter';
 
@@ -174,6 +175,11 @@
   const statusLabel = $derived(
     STATUS_LABELS[idea?.status ?? 'idle'] ?? (idea?.status ? idea.status.replaceAll('_', ' ') : 'Idle'),
   );
+  const headerStatusState = $derived.by((): CortexThreadStageHeaderStatusState => {
+    if (runInfo || idea?.status === 'working') return 'working';
+    if (idea?.status === 'done') return 'unread';
+    return 'idle';
+  });
   const dockLayoutMaxWidth = $derived.by(() => {
     if (!browserOpen || threadStageContentWidth <= 0) return dockMaxWidth;
 
@@ -249,6 +255,7 @@
     return {
       title: ideaDisplayTitle(selectedIdea),
       statusLabel,
+      statusState: headerStatusState,
       panelOpen: browserOpen,
       onTogglePanel: () => {
         if (!browserOpen) void workspaceApps.load({ silent: true });

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -6,6 +6,7 @@
     ConstellationIconButton,
     ConstellationPill,
     ConstellationPresenceSeed,
+    ConstellationSignalStatusIndicator,
   } from '$lib/components/constellation';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
   import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
@@ -125,20 +126,23 @@
     return item.status === 'queued' || item.status === 'starting' || item.status === 'running';
   }
 
-  function isHeaderWorking() {
+  function getHeaderStatusState() {
+    if (header?.statusState) return header.statusState;
+
     const status = header?.statusLabel?.toLowerCase() ?? '';
     const runStatus = header?.runStatus?.toLowerCase() ?? '';
-    return status.includes('working') || ['queued', 'starting', 'running'].some((value) => runStatus.includes(value));
+    if (status.includes('working') || ['queued', 'starting', 'running'].some((value) => runStatus.includes(value))) {
+      return 'working';
+    }
+    if (status.includes('unread') || status.includes('done')) return 'unread';
+    return 'idle';
   }
 
-  function getHeaderActivityLabel() {
-    return isHeaderWorking() ? 'Working' : 'Idle';
-  }
-
-  function getHeaderActivityClass() {
-    return ['thread-header-activity-cue', isHeaderWorking() ? 'is-working' : '']
-      .filter(Boolean)
-      .join(' ');
+  function getHeaderStatusLabel() {
+    const state = getHeaderStatusState();
+    if (state === 'working') return 'Illo is working';
+    if (state === 'unread') return 'Unread thread';
+    return 'Idle thread';
   }
 
   function isRunExpanded(item: CortexThreadStageRunItem, index: number) {
@@ -443,17 +447,12 @@
   {:else if header}
     <header class="thread-panel-header thread-column">
       <div class="thread-header-title-row">
-        <span class="thread-header-title-dot"></span>
+        <ConstellationSignalStatusIndicator
+          state={getHeaderStatusState()}
+          label={getHeaderStatusLabel()}
+          className="thread-header-status-indicator"
+        />
         <h1 class="thread-header-title" title={header.title}>{header.title}</h1>
-
-        <span
-          class={getHeaderActivityClass()}
-          aria-label={`Illo is ${getHeaderActivityLabel().toLowerCase()}`}
-          title={`Illo is ${getHeaderActivityLabel().toLowerCase()}`}
-        >
-          <span class="thread-header-activity-dot" aria-hidden="true"></span>
-          <span>{getHeaderActivityLabel()}</span>
-        </span>
 
         {#if header.onToggleSecondaryPanel || header.onTogglePanel}
           <div class="thread-header-panel-toggle-group">
@@ -1361,13 +1360,10 @@
     min-width: 0;
   }
 
-  .thread-header-title-dot {
-    width: 7px;
-    height: 7px;
-    flex-shrink: 0;
-    border-radius: var(--thread-radius-pill);
-    background: var(--thread-accent, var(--thread-color-spectral));
-    box-shadow: 0 0 10px rgba(var(--thread-accent-rgb, 141, 183, 255), 0.28);
+  .thread-header-title-row :global(.thread-header-status-indicator) {
+    --constellation-signal-status-color: var(--thread-accent, var(--thread-color-spectral));
+    --constellation-signal-status-idle-color: var(--constellation-thread-header-status-idle-dot);
+    --constellation-signal-status-idle-ring: var(--constellation-thread-header-status-idle-ring);
   }
 
   .thread-header-title {
@@ -1383,39 +1379,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .thread-header-activity-cue {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    flex: 0 0 auto;
-    min-width: 0;
-    color: var(--constellation-thread-header-activity-text);
-    font-family: var(--thread-font-mono);
-    font-size: 9px;
-    letter-spacing: 0.12em;
-    line-height: 1;
-    text-transform: uppercase;
-  }
-
-  .thread-header-activity-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: var(--thread-radius-pill);
-    background: var(--constellation-thread-header-activity-dot);
-    box-shadow: 0 0 0 1px var(--constellation-thread-header-activity-ring);
-  }
-
-  .thread-header-activity-cue.is-working {
-    color: var(--constellation-thread-header-working-text);
-  }
-
-  .thread-header-activity-cue.is-working .thread-header-activity-dot {
-    background: var(--constellation-thread-header-working-dot);
-    box-shadow:
-      0 0 0 1px var(--constellation-thread-header-working-ring),
-      0 0 12px var(--constellation-thread-header-working-glow);
   }
 
   .thread-header-panel-toggle-group {

--- a/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
@@ -20,6 +20,7 @@ export const CORTEX_THREAD_STAGE_RUN_STATUSES = [
 ] as const;
 export type CortexThreadStageRunStatus =
   (typeof CORTEX_THREAD_STAGE_RUN_STATUSES)[number];
+export type CortexThreadStageHeaderStatusState = 'idle' | 'working' | 'unread';
 
 export const CORTEX_THREAD_STAGE_RUN_STEP_STATUSES = [
   'pending',
@@ -34,6 +35,7 @@ export type CortexThreadStageRunStepStatus =
 export interface CortexThreadStageHeaderConfig {
   title: string;
   statusLabel: string;
+  statusState?: CortexThreadStageHeaderStatusState;
   panelOpen?: boolean;
   onTogglePanel?: () => void;
   secondaryPanelOpen?: boolean;

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -1376,6 +1376,7 @@
 
   function primitiveAstreClass(astre: PrimitiveAstreVisual) {
     return [
+      astre.id === auth.user?.id ? 'constellation-astre-own' : '',
       primitiveAstreIsLit(astre) ? 'constellation-astre-emphasis' : '',
       astre.id === dragTargetAnchorId ? 'constellation-astre-drop-target' : '',
     ]

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -86,6 +86,12 @@ export type {
   VaultSecretPrompt,
 } from '$lib/types/cortex';
 
+export interface CortexCreateIdeaOptions {
+  origin?: string | null;
+  originRef?: string | null;
+  displayTitle?: string | null;
+}
+
 class CortexStore {
   ideas = $state<Idea[]>([]);
   connections = $state<Connection[]>([]);
@@ -1306,6 +1312,7 @@ class CortexStore {
     attachments: any[] = [],
     runContent = title,
     options: AgentRunOptions = {},
+    createOptions: CortexCreateIdeaOptions = {},
   ) {
     const origin = this.birthContext;
     return this.createIdeaAt(
@@ -1316,6 +1323,7 @@ class CortexStore {
       attachments,
       runContent,
       options,
+      createOptions,
     );
   }
 
@@ -1327,20 +1335,29 @@ class CortexStore {
     attachments: any[] = [],
     runContent = title,
     options: AgentRunOptions = {},
+    createOptions: CortexCreateIdeaOptions = {},
   ) {
     try {
-      const idea = await api.createIdea({ title, description });
+      const ideaInput: Record<string, any> = { title, description };
+      if (createOptions.origin) ideaInput.origin = createOptions.origin;
+      if (createOptions.originRef) ideaInput.origin_ref = createOptions.originRef;
+      const idea = await api.createIdea(ideaInput);
       bloop();
-      // Fire-and-forget: generate a concise display title via local LLM
-      api.generateTitle(title).then((r) => {
-        if (r?.title) {
-          api.updateIdea(idea.id, { display_title: r.title });
-          // Update local state so UI reflects the generated title immediately
-          this.ideas = this.ideas.map((i) =>
-            i.id === idea.id ? { ...i, display_title: r.title } : i,
-          );
-        }
-      }).catch(() => {});
+      if (createOptions.displayTitle) {
+        idea.display_title = createOptions.displayTitle;
+        api.updateIdea(idea.id, { display_title: createOptions.displayTitle }).catch(() => {});
+      } else {
+        // Fire-and-forget: generate a concise display title via local LLM
+        api.generateTitle(title).then((r) => {
+          if (r?.title) {
+            api.updateIdea(idea.id, { display_title: r.title });
+            // Update local state so UI reflects the generated title immediately
+            this.ideas = this.ideas.map((i) =>
+              i.id === idea.id ? { ...i, display_title: r.title } : i,
+            );
+          }
+        }).catch(() => {});
+      }
       // The typed text becomes the first thread message and queues Illo by default.
       // Set status optimistically BEFORE adding to ideas array so the
       // SVG birth animation renders with the correct color immediately.

--- a/frontend/src/lib/styles/constellation.css
+++ b/frontend/src/lib/styles/constellation.css
@@ -445,6 +445,8 @@
   --constellation-data-table-empty: rgba(240, 240, 250, 0.5);
 
   --constellation-thread-header-title: #ffffff;
+  --constellation-thread-header-status-idle-dot: rgba(240, 240, 250, 0.34);
+  --constellation-thread-header-status-idle-ring: rgba(240, 240, 250, 0.12);
   --constellation-thread-header-activity-text: rgba(240, 240, 250, 0.42);
   --constellation-thread-header-activity-dot: rgba(240, 240, 250, 0.34);
   --constellation-thread-header-activity-ring: rgba(240, 240, 250, 0.12);
@@ -980,6 +982,8 @@
   --constellation-data-table-empty: rgba(82, 98, 111, 0.74);
 
   --constellation-thread-header-title: rgba(18, 27, 36, 0.96);
+  --constellation-thread-header-status-idle-dot: rgba(82, 98, 111, 0.34);
+  --constellation-thread-header-status-idle-ring: rgba(82, 98, 111, 0.14);
   --constellation-thread-header-activity-text: rgba(82, 98, 111, 0.58);
   --constellation-thread-header-activity-dot: rgba(82, 98, 111, 0.34);
   --constellation-thread-header-activity-ring: rgba(82, 98, 111, 0.14);

--- a/frontend/src/lib/types/cortex.ts
+++ b/frontend/src/lib/types/cortex.ts
@@ -5,6 +5,7 @@ export interface Idea {
   description: string | null;
   status: string;
   origin: string;
+  origin_ref?: string | null;
   salience_score: number;
   position_x: number | null;
   position_y: number | null;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -27,7 +27,11 @@
     dev && currentPath === '/cycles' && $page.url.searchParams.get('preview') === '1',
   );
   let isPreviewPage = $derived(isVaultPreviewPage || isCyclesPreviewPage);
+  let showNavRail = $derived(!auth.loading && !isLoginPage && !isPreviewPage && !isOnboardingPage);
   let showSearch = $state(false);
+  let navRailArrivalActive = $state(false);
+  let navRailArrivalPlayed = $state(false);
+  let navRailArrivalTimer: ReturnType<typeof setTimeout> | null = null;
   const wsTabId =
     typeof crypto !== 'undefined' && 'randomUUID' in crypto
       ? crypto.randomUUID()
@@ -39,6 +43,25 @@
       showSearch = !showSearch;
     }
   }
+
+  $effect(() => {
+    if (!showNavRail || navRailArrivalPlayed) return;
+    navRailArrivalPlayed = true;
+
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+
+    navRailArrivalActive = true;
+    const timeout = window.setTimeout(() => {
+      navRailArrivalActive = false;
+      if (navRailArrivalTimer === timeout) navRailArrivalTimer = null;
+    }, 620);
+    navRailArrivalTimer = timeout;
+
+    return () => {
+      if (navRailArrivalTimer === timeout) navRailArrivalTimer = null;
+      window.clearTimeout(timeout);
+    };
+  });
 
   onMount(async () => {
     theme.init();
@@ -73,6 +96,10 @@
   });
 
   onDestroy(() => {
+    if (navRailArrivalTimer) {
+      clearTimeout(navRailArrivalTimer);
+      navRailArrivalTimer = null;
+    }
     document.removeEventListener('keydown', handleKeydown);
   });
 
@@ -84,8 +111,8 @@
   {@render children()}
 {:else}
   <div class="app-layout" class:cortex-layout={isCortexPage}>
-    {#if !isPreviewPage && !isOnboardingPage}
-      <ConstellationNavRail />
+    {#if showNavRail}
+      <ConstellationNavRail className={navRailArrivalActive ? 'constellation-nav-rail-arriving' : ''} />
     {/if}
     <main
       class="main-content"
@@ -114,6 +141,9 @@
   }
   .app-layout.cortex-layout {
     overflow: hidden;
+  }
+  :global(.constellation-nav-rail.constellation-nav-rail-arriving) {
+    animation: cortex-nav-rail-arrive 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
   }
   .main-content {
     flex: 1;
@@ -162,5 +192,23 @@
     height: 100vh;
     color: var(--text-2);
     font-family: var(--font-sans);
+  }
+  @keyframes cortex-nav-rail-arrive {
+    0% {
+      opacity: 0;
+      filter: blur(3px);
+      transform: translate3d(-24px, 0, 0);
+    }
+
+    100% {
+      opacity: 1;
+      filter: none;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    :global(.constellation-nav-rail.constellation-nav-rail-arriving) {
+      animation: none !important;
+    }
   }
 </style>

--- a/frontend/src/routes/auth/OpenAIOAuthCallback.svelte
+++ b/frontend/src/routes/auth/OpenAIOAuthCallback.svelte
@@ -52,19 +52,8 @@
   }
 
   async function cortexIntroUrl() {
-    try {
-      const intro = await api.startRuntimeReadyIntro();
-      if (intro?.idea_id) {
-        const params = new URLSearchParams({
-          idea: intro.idea_id,
-          onboarding: 'runtime-ready',
-        });
-        return `/cortex?${params.toString()}`;
-      }
-    } catch {
-      // The System page listener also starts the intro when this is a popup.
-    }
-    return '/cortex';
+    const params = new URLSearchParams({ onboarding: 'runtime-ready' });
+    return `/cortex?${params.toString()}`;
   }
 
   function scheduleCompletion(returnUrl: string) {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -238,16 +238,8 @@
         await goto('/onboarding');
         return;
       }
-      const intro = await api.startRuntimeReadyIntro();
-      if (intro?.created && intro.idea_id) {
-        const params = new URLSearchParams({
-          idea: intro.idea_id,
-          onboarding: 'runtime-ready',
-        });
-        await goto(`/cortex?${params.toString()}`);
-        return;
-      }
-      await goto('/cortex');
+      const params = new URLSearchParams({ onboarding: 'runtime-ready' });
+      await goto(`/cortex?${params.toString()}`);
     } catch {
       await goto('/onboarding');
     } finally {

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -308,16 +308,8 @@
     status = 'connected';
     notice = { tone: 'success', title: 'OpenAI connected.' };
     try {
-      const intro = await api.startRuntimeReadyIntro();
-      if (intro?.idea_id) {
-        const params = new URLSearchParams({
-          idea: intro.idea_id,
-          onboarding: 'runtime-ready',
-        });
-        await goto(`/cortex?${params.toString()}`);
-        return;
-      }
-      await goto('/cortex');
+      const params = new URLSearchParams({ onboarding: 'runtime-ready' });
+      await goto(`/cortex?${params.toString()}`);
     } catch (error) {
       status = 'connected';
       notice = errorNotice('OpenAI connected, but Cortex did not open.', error, 'Open Cortex from the sidebar.');

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -335,20 +335,13 @@
     if (startingIntro) return;
     startingIntro = true;
     try {
-      const intro = await api.startRuntimeReadyIntro();
-      if (intro?.idea_id && (intro.created || openExisting)) {
-        const params = new URLSearchParams({
-          idea: intro.idea_id,
-          onboarding: 'runtime-ready',
-        });
-        await goto(`/cortex?${params.toString()}`);
-        return;
-      }
-      await goto('/cortex');
+      const params = new URLSearchParams({ onboarding: 'runtime-ready' });
+      if (openExisting) params.set('open_existing', '1');
+      await goto(`/cortex?${params.toString()}`);
     } catch (error) {
       await loadSettings();
       notice = errorNotice(
-        'Runtime connected, but the intro thread did not start.',
+        'Runtime connected, but Cortex did not open.',
         error,
         'Open Cortex to continue.',
       );

--- a/illo
+++ b/illo
@@ -193,6 +193,53 @@ run_psql_no_prompt() {
   env PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-3}" "$psql_bin" -w "$@"
 }
 
+db_connection_ok() {
+  local db_host="$1"
+  local db_port="$2"
+  local db_name="$3"
+  local db_user="$4"
+  local db_pass="$5"
+
+  if psql_available; then
+    export PGPASSWORD="$db_pass"
+    run_psql_no_prompt -h "$db_host" -p "$db_port" -U "$db_user" -d "$db_name" -c "SELECT 1" \
+      >/dev/null 2>&1
+    local status=$?
+    unset PGPASSWORD
+    return "$status"
+  fi
+
+  local python_bin
+  python_bin="$(launcher_python_bin)"
+  DB_HOST="$db_host" \
+  DB_PORT="$db_port" \
+  DB_NAME="$db_name" \
+  DB_USER="$db_user" \
+  DB_PASSWORD="$db_pass" \
+    "$python_bin" - <<'PY' >/dev/null 2>&1
+import os
+import sys
+
+try:
+    import psycopg2
+except Exception:
+    sys.exit(1)
+
+try:
+    conn = psycopg2.connect(
+        host=os.environ["DB_HOST"],
+        port=int(os.environ["DB_PORT"]),
+        dbname=os.environ["DB_NAME"],
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        connect_timeout=3,
+    )
+    conn.close()
+except Exception:
+    sys.exit(1)
+PY
+}
+
 # ── Source optional env files ─────────────────────────────
 
 runtime_env_file_path() {
@@ -1237,12 +1284,9 @@ ensure_db() {
   elif [ $db_reachable -ne 0 ] && tcp_port_listening "$db_host" "$db_port"; then
     postgres_listening=0
   fi
-  export PGPASSWORD="$db_pass"
-  if [ $db_reachable -ne 0 ] && psql_available && \
-     run_psql_no_prompt -h "$db_host" -p "$db_port" -U "$db_user" -d "$db_name" -c "SELECT 1" &>/dev/null 2>&1; then
+  if [ $db_reachable -ne 0 ] && db_connection_ok "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"; then
     db_reachable=0
   fi
-  unset PGPASSWORD
 
   if [ $db_reachable -eq 0 ]; then
     dim "Database reachable at $db_host:$db_port"
@@ -1253,12 +1297,9 @@ ensure_db() {
         warn "Postgres is listening at $db_host:$db_port, but Illo cannot connect to '$db_name' as '$db_user'"
         dim "No DB_* settings were provided — trying to bootstrap the default Illo database in local Postgres..."
         if bootstrap_local_postgres_db "$db_host" "$db_port" "$db_user" "$db_pass" "$db_name"; then
-          export PGPASSWORD="$db_pass"
-          if psql_available && \
-             run_psql_no_prompt -h "$db_host" -p "$db_port" -U "$db_user" -d "$db_name" -c "SELECT 1" &>/dev/null 2>&1; then
+          if db_connection_ok "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"; then
             db_reachable=0
           fi
-          unset PGPASSWORD
           if [ $db_reachable -eq 0 ]; then
             info "Database bootstrapped in local Postgres at $db_host:$db_port"
           fi

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -349,6 +349,30 @@ def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance(monke
     assert any(_artifact_type(artifact) == "file_observation" for artifact in runtime.store.artifacts)
 
 
+def test_fast_onboarding_tool_surface_hides_browser_primitives(monkeypatch):
+    from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_agent_tools",
+        lambda role: [
+            {"name": "read_workspace_overview"},
+            {"name": "browser_session_open"},
+            {"name": "browser_click"},
+        ],
+    )
+
+    runtime = SimpleNamespace(
+        request=SimpleNamespace(
+            metadata={
+                "origin": "onboarding",
+                "required_response": "introduce_and_continue_setup",
+            }
+        )
+    )
+
+    assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == ["read_workspace_overview"]
+
+
 def test_runtime_drain_steering_can_use_isolated_durable_drain():
     from brain.systems.runs.steering import SteeringMessage
 

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -143,6 +143,13 @@ class TestToolDefinitionContracts:
             "runtime_settings",
             "read_thread_messages",
             "query_workspace_data",
+            "read_workspace_overview",
+            "read_team_activity",
+            "read_project_contexts",
+            "read_team_members",
+            "read_workspace_records",
+            "read_cycles",
+            "read_workspace_apps",
             "manage_cycle",
         }
         actual = {t["name"] for t in BRAIN_TOOLS}

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -116,6 +116,7 @@ def test_env_py_widens_alembic_version_column_for_long_revision_ids():
 
     env_content = (ALEMBIC_DIR / "env.py").read_text()
     assert "ALEMBIC_VERSION_NUM_MAX_LENGTH = 255" in env_content
+    assert "CREATE TABLE IF NOT EXISTS alembic_version" in env_content
     assert "ALTER TABLE alembic_version" in env_content
     assert "version_num TYPE VARCHAR" in env_content
 

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -13,6 +13,7 @@ ALEMBIC_DIR = ROOT / "brain" / "platform" / "db" / "alembic"
 VERSIONS_DIR = ALEMBIC_DIR / "versions"
 
 PUBLIC_BASELINE = "0001_public_schema_baseline.py"
+LEGACY_STAMP_BRIDGE = "0000_legacy_notification_preferences_bridge.py"
 BROAD_DESTRUCTIVE_SQL_PATTERNS = (
     r"\bDROP\s+DATABASE\b",
     r"\bDROP\s+SCHEMA\b",
@@ -28,6 +29,14 @@ def _migration_files() -> list[Path]:
         path
         for path in sorted(VERSIONS_DIR.glob("*.py"))
         if path.name != "__init__.py"
+    ]
+
+
+def _material_schema_migration_files() -> list[Path]:
+    return [
+        path
+        for path in _migration_files()
+        if path.name != LEGACY_STAMP_BRIDGE
     ]
 
 
@@ -182,7 +191,7 @@ def test_alembic_revision_headers_match_identifiers():
 
 def test_public_tree_has_single_schema_baseline():
     """Fresh public releases start from one current-state schema baseline."""
-    migration_files = _migration_files()
+    migration_files = _material_schema_migration_files()
     assert [path.name for path in migration_files] == [PUBLIC_BASELINE]
 
     content = (VERSIONS_DIR / PUBLIC_BASELINE).read_text()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -76,6 +76,8 @@ def test_workspace_data_tool_is_read_only_agent_run_surface():
     assert "team activity" in registration.context_route.domains
     assert "query_workspace_data" in context_route_tool_names()
     assert "query_workspace_data" in _get_tool_handlers()
+    assert "read_workspace_overview" in _get_tool_handlers()
+    assert "read_team_activity" in _get_tool_handlers()
 
 
 def test_context_route_surface_is_registry_driven():
@@ -84,12 +86,26 @@ def test_context_route_surface_is_registry_driven():
     names = context_route_tool_names()
     routes = {route["name"]: route for route in context_route_payload()}
 
-    assert names == {"brain_recall", "my_activity", "query_workspace_data", "read_thread_messages", "runtime_settings"}
+    assert names == {
+        "brain_recall",
+        "my_activity",
+        "query_workspace_data",
+        "read_cycles",
+        "read_project_contexts",
+        "read_team_activity",
+        "read_team_members",
+        "read_thread_messages",
+        "read_workspace_apps",
+        "read_workspace_overview",
+        "read_workspace_records",
+        "runtime_settings",
+    }
     assert set(routes) == names
     assert "broad" in routes["brain_recall"]["scopes"]
     assert "thread transcript" in routes["read_thread_messages"]["domains"]
     assert routes["query_workspace_data"]["empty_result_policy"] == "answer_honestly"
     assert "workspace records" in routes["query_workspace_data"]["domains"]
+    assert "workspace setup" in routes["read_workspace_overview"]["domains"]
 
 
 def test_workspace_activity_question_requires_workspace_data():
@@ -97,9 +113,19 @@ def test_workspace_activity_question_requires_workspace_data():
 
     tool, message = required_introspection_tool("Hey illo what is Alex working on?")
 
-    assert tool == "query_workspace_data"
+    assert tool == "read_team_activity"
     assert message is not None
     assert "current workspace/team activity" in message
+
+
+def test_onboarding_intro_requires_workspace_overview():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Illo, introduce yourself and help me finish setting up this workspace.")
+
+    assert tool == "read_workspace_overview"
+    assert message is not None
+    assert "workspace overview" in message
 
 
 def test_memory_question_does_not_force_workspace_data():
@@ -114,19 +140,28 @@ def test_workspace_data_sources_are_adapter_registered():
     adapters = _source_adapters()
 
     assert "runs" in adapters
-    assert "memories" in adapters
-    assert adapters["memories"].db_backed is False
+    assert "team_members" in adapters
+    assert "project_profiles" in adapters
+    assert "project_attachments" in adapters
+    assert "cycles" in adapters
+    assert "cycle_runs" in adapters
+    assert "memories" not in adapters
     assert "memories" not in _normalize_sources(None)
-    assert _normalize_sources(["memory"]) == ["memories"]
+    assert _normalize_sources(["memory"]) == _normalize_sources(None)
     assert _normalize_sources(["activity"]) == [
         "runs",
         "threads",
         "ideas",
         "tool_calls",
+        "project_attachments",
         "domain_events",
         "workspace_apps",
+        "cycle_runs",
     ]
     assert _normalize_sources(["apps"]) == ["workspace_apps", "app_state"]
+    assert _normalize_sources(["records"]) == ["domains", "domain_records", "domain_events"]
+    assert _normalize_sources(["project_contexts"]) == ["project_profiles", "project_attachments"]
+    assert _normalize_sources(["cycles"]) == ["cycles", "cycle_runs"]
 
 
 def test_side_effecting_tools_declare_action_metadata():


### PR DESCRIPTION
## Summary
- add semantic read tools for workspace overview, team activity, project context, team members, records, Cycles, and apps
- keep `query_workspace_data` as the low-level DB-backed engine and remove semantic memory from that surface
- route onboarding/setup and workspace-awareness questions through the right read tools, and hide browser primitives from the onboarding intro tool surface

## Tests
- `venv/bin/pytest tests/test_tool_registry.py tests/test_workspace_data_query.py tests/test_agent_split.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestBrainGate tests/test_agent_run_runtime.py::test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance tests/test_agent_run_runtime.py::test_fast_onboarding_tool_surface_hides_browser_primitives tests/test_agent_run_runtime.py::test_fast_recipe_infers_workspace_root_from_project_context_snapshot tests/test_onboarding_runtime_intro.py -q`
