### PR TITLE
Route deploy commands to compose stack

### DIFF
--- a/illo
+++ b/illo
@@ -2339,8 +2339,8 @@ usage() {
   echo -e "  ${GREEN}dev-start${NC}    Development mode alias (owns local runtime)"
   echo -e "  ${GREEN}setup${NC}        Run setup only"
   echo -e "  ${GREEN}start${NC}        Production-safe API mode (standalone worker owns AgentRuns)"
-  echo -e "  ${GREEN}deploy${NC}       Run production-safe deploy script"
-  echo -e "  ${GREEN}native${NC}       Native deploy alias"
+  echo -e "  ${GREEN}deploy${NC}       Compose team-server deploy commands"
+  echo -e "  ${GREEN}native${NC}       Native/systemd deploy alias"
   echo -e "  ${GREEN}doctor${NC}       Validate configuration (pass --production for prod)"
   echo -e "  ${GREEN}uninstall${NC}    Remove local runtime, config, and Illo Docker DB"
   echo -e "  ${GREEN}worker-status${NC} Show active AgentRuns and worker service state"
@@ -2350,8 +2350,72 @@ usage() {
   echo ""
 }
 
+deploy_compose() {
+  local env_file="${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}"
+  docker compose --env-file "$env_file" -f "$ROOT/deploy/compose/docker-compose.yml" "$@"
+}
+
+deploy_usage() {
+  cat <<'EOF'
+Usage: ./illo deploy <command> [options]
+
+Commands:
+  init      Create/update deploy/compose/.env secrets
+  up        Start or update the Compose stack
+  upgrade   Pull/build images, run migrations, and restart the Compose stack
+  status    Show Compose service status
+  logs      Show Compose service logs
+  doctor    Validate Compose deployment health
+  backup    Back up Compose Postgres
+  restore   Restore a Compose Postgres backup
+  build     Build Compose images
+  down      Stop the Compose stack
+  native    Run the advanced native/systemd deploy path
+EOF
+}
+
 deploy_command() {
-  "$ROOT/ops/deploy.sh" "$@"
+  local command="${1:-}"
+  case "$command" in
+    ""|-h|--help)
+      deploy_usage
+      ;;
+    init)
+      "$ROOT/deploy/scripts/init-secrets.sh" "${@:2}"
+      ;;
+    up|upgrade)
+      "$ROOT/deploy/scripts/upgrade.sh" "${@:2}"
+      ;;
+    status|ps)
+      deploy_compose ps "${@:2}"
+      ;;
+    logs)
+      deploy_compose logs "${@:2}"
+      ;;
+    doctor)
+      "$ROOT/deploy/scripts/doctor.sh" "${@:2}"
+      ;;
+    backup)
+      "$ROOT/deploy/scripts/backup.sh" "${@:2}"
+      ;;
+    restore)
+      "$ROOT/deploy/scripts/restore.sh" "${@:2}"
+      ;;
+    build)
+      deploy_compose build "${@:2}"
+      ;;
+    down)
+      deploy_compose down "${@:2}"
+      ;;
+    native)
+      "$ROOT/ops/deploy.sh" "${@:2}"
+      ;;
+    *)
+      echo "Unknown deploy command: $command" >&2
+      deploy_usage >&2
+      exit 2
+      ;;
+  esac
 }
 
 begin_launch_log "$*"
@@ -2377,7 +2441,7 @@ case "${1:-}" in
     ;;
   native)
     check_prereqs
-    deploy_command "${@:2}"
+    deploy_command native "${@:2}"
     ;;
   doctor)
     check_prereqs

--- a/ops/deploy-remote.sh
+++ b/ops/deploy-remote.sh
@@ -10,8 +10,7 @@
 #   git fetch origin main
 #   git checkout -f -B main origin/main
 #   git reset --hard origin/main
-#   source venv/bin/activate
-#   ./ops/deploy.sh
+#   deploy/scripts/upgrade.sh --build --no-pull
 #
 # Passwords are intentionally not stored here; SSH will prompt when needed.
 set -euo pipefail
@@ -21,6 +20,7 @@ REMOTE_HOST="${ILLO_DEPLOY_HOST:-}"
 REMOTE_DIR="${ILLO_DEPLOY_DIR:-illo-brain}"
 TRANSPORT="${ILLO_DEPLOY_TRANSPORT:-ssh}"
 MODE="${ILLO_DEPLOY_MODE:-stream}"
+DEPLOY_COMMAND="${ILLO_DEPLOY_COMMAND:-deploy/scripts/upgrade.sh --build --no-pull}"
 WAIT_FOR_HEALTH="1"
 HEALTH_TIMEOUT_SECONDS="${ILLO_DEPLOY_HEALTH_TIMEOUT_SECONDS:-600}"
 HEALTH_URL="${ILLO_DEPLOY_HEALTH_URL:-http://127.0.0.1:8000/api/health/ready}"
@@ -43,12 +43,15 @@ Options:
                  Use plain ssh or tailscale ssh. Default: ssh.
   --health-url URL
                  Override readiness URL. Default: http://127.0.0.1:8000/api/health/ready
+  --command CMD  Override remote deploy command.
+                 Default: deploy/scripts/upgrade.sh --build --no-pull
   -h, --help     Show this help.
 
 Environment overrides:
   ILLO_DEPLOY_HOST, ILLO_DEPLOY_USER, ILLO_DEPLOY_DIR,
   ILLO_DEPLOY_TRANSPORT, ILLO_DEPLOY_MODE,
-  ILLO_DEPLOY_HEALTH_TIMEOUT_SECONDS, ILLO_DEPLOY_HEALTH_URL
+  ILLO_DEPLOY_HEALTH_TIMEOUT_SECONDS, ILLO_DEPLOY_HEALTH_URL,
+  ILLO_DEPLOY_COMMAND
 USAGE
 }
 
@@ -90,6 +93,10 @@ while [[ $# -gt 0 ]]; do
       HEALTH_URL="${2:?--health-url requires a value}"
       shift 2
       ;;
+    --command)
+      DEPLOY_COMMAND="${2:?--command requires a value}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -120,6 +127,7 @@ fi
 
 TARGET="${REMOTE_USER}@${REMOTE_HOST}"
 REMOTE_DIR_Q="$(printf '%q' "$REMOTE_DIR")"
+DEPLOY_COMMAND_Q="$(printf '%q' "$DEPLOY_COMMAND")"
 HEALTH_TIMEOUT_Q="$(printf '%q' "$HEALTH_TIMEOUT_SECONDS")"
 HEALTH_URL_Q="$(printf '%q' "$HEALTH_URL")"
 
@@ -149,13 +157,14 @@ echo "Deploying Illo Brain on $TARGET"
 echo "Remote checkout: $REMOTE_DIR"
 echo "Transport: $TRANSPORT"
 echo "Mode: $MODE"
+echo "Deploy command: $DEPLOY_COMMAND"
 if [[ "$MODE" != "attach" && "$WAIT_FOR_HEALTH" == "1" ]]; then
   echo "Readiness URL: $HEALTH_URL"
 fi
 echo
 
 if [[ "$MODE" == "attach" ]]; then
-  remote_cmd="set -euo pipefail; cd $REMOTE_DIR_Q; $(remote_sync_main_cmd); source venv/bin/activate; exec ./ops/deploy.sh"
+  remote_cmd="set -euo pipefail; cd $REMOTE_DIR_Q; $(remote_sync_main_cmd); deploy_command=$DEPLOY_COMMAND_Q; exec bash -lc \"\$deploy_command\""
   ssh_run "$remote_cmd"
   exit $?
 fi
@@ -164,16 +173,16 @@ remote_cmd=$(cat <<REMOTE
 set -euo pipefail
 cd $REMOTE_DIR_Q
 $(remote_sync_main_cmd)
-source venv/bin/activate
+deploy_command=$DEPLOY_COMMAND_Q
 mkdir -p logs
 log_path="\$PWD/logs/illo-remote-deploy.log"
 pid_path="\$PWD/logs/illo-remote-deploy.pid"
 health_url=$HEALTH_URL_Q
 health_timeout=$HEALTH_TIMEOUT_Q
 deploy_done=0
-echo "Starting ./ops/deploy.sh in the background..."
+echo "Starting \$deploy_command in the background..."
 : >"\$log_path"
-nohup bash -c 'source venv/bin/activate && exec ./ops/deploy.sh' >"\$log_path" 2>&1 < /dev/null &
+nohup bash -lc "\$deploy_command" >"\$log_path" 2>&1 < /dev/null &
 deploy_pid=\$!
 echo "\$deploy_pid" > "\$pid_path"
 echo "Remote deploy process: \$deploy_pid"

--- a/tests/test_deploy_remote.py
+++ b/tests/test_deploy_remote.py
@@ -19,7 +19,10 @@ def test_remote_deploy_defaults_to_streaming_readiness():
     assert 'cd "$PWD"' not in content
     assert "git checkout -f -B main origin/main" in content
     assert "git reset --hard origin/main" in content
-    assert "source venv/bin/activate && exec ./ops/deploy.sh" in content
+    assert "source venv/bin/activate" not in content
+    assert 'DEPLOY_COMMAND="${ILLO_DEPLOY_COMMAND:-deploy/scripts/upgrade.sh --build --no-pull}"' in content
+    assert "--command CMD" in content
+    assert 'bash -lc "\\$deploy_command"' in content
     assert "Deploy process finished; waiting for readiness" in content
     assert 'if [ "\\$deploy_done" = "0" ] && ! kill -0 "\\$deploy_pid"' in content
     assert "exec ./illo start" not in content

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -138,8 +138,12 @@ def test_illo_exposes_dev_start_and_deploy_aliases():
     assert "deploy" in content
     assert "dev-start|dev|development)" in content
     assert 'deploy_command "${@:2}"' in content
+    assert '"$ROOT/deploy/scripts/upgrade.sh" "${@:2}"' in content
+    assert 'deploy_compose ps "${@:2}"' in content
+    assert '"$ROOT/deploy/scripts/doctor.sh" "${@:2}"' in content
     assert "native)" in content
-    assert '"$ROOT/ops/deploy.sh" "$@"' in content
+    assert 'deploy_command native "${@:2}"' in content
+    assert '"$ROOT/ops/deploy.sh" "${@:2}"' in content
 
 
 def test_compose_deploy_stays_private_without_builtin_public_ingress():


### PR DESCRIPTION
## Summary
- route `./illo deploy <subcommand>` to the Compose deployment scripts documented in `docs/server-setup.md`
- keep the native/systemd path available as `./illo native` or `./illo deploy native`
- update `ops/deploy-remote.sh` to run the Compose upgrade script instead of assuming a pre-existing venv/native deploy

## Tests
- `venv/bin/pytest tests/test_deploy_remote.py tests/test_safe_deploy.py -q`

## Deploy note
The failed server deploy was caused by two separate issues: the remote wrapper assumed `venv/` existed, and the launcher routed `./illo deploy status` into the native deploy script instead of Compose. The server also needs explicit Docker permission approval before `uwear` can run the Compose stack.
