### PR TITLE
Add one-time cycles and thread panel management

### DIFF
--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -11,7 +11,9 @@ from sqlalchemy.orm import Session
 from brain.app.api.auth import get_current_user
 from brain.app.api.deps import get_db, rate_limit
 from brain.app.api.schemas.cycles import CycleCreate, CycleRead, CycleRunRead, CycleUpdate
+from brain.systems.cycles.events import publish_cycle_change
 from brain.systems.cycles.service import (
+    build_one_time_schedule_expr,
     compute_next_run_at,
     cycle_defaults,
     REUSABLE_THREAD_EXECUTION_MODE,
@@ -116,8 +118,13 @@ def create_cycle(
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    schedule_expr = validate_schedule_expr(body.schedule_expr)
     timezone_name = validate_timezone_name(body.timezone)
+    if body.run_at is not None:
+        schedule_expr = build_one_time_schedule_expr(body.run_at, timezone_name)
+    elif body.schedule_expr:
+        schedule_expr = validate_schedule_expr(body.schedule_expr, timezone_name)
+    else:
+        raise HTTPException(status_code=400, detail="schedule_expr or run_at is required")
     execution_mode = validate_execution_mode(body.execution_mode)
     thinking_override = validate_thinking_override(body.thinking_override)
     try:
@@ -146,7 +153,16 @@ def create_cycle(
     )
     db.add(cycle)
     db.flush()
-    return serialize_cycle(cycle)
+    payload = serialize_cycle(cycle)
+    db.commit()
+    publish_cycle_change(
+        action="create",
+        org_id=cycle.org_id,
+        user_id=cycle.user_id,
+        cycle_id=cycle.id,
+        target_idea_id=cycle.target_idea_id,
+    )
+    return payload
 
 
 @router.get("/{cycle_id}", response_model=CycleRead)
@@ -181,10 +197,12 @@ def update_cycle(
             cycle.prompt = validate_nonempty_trimmed(updates["prompt"], "prompt")
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if "schedule_expr" in updates and updates["schedule_expr"] is not None:
-        cycle.schedule_expr = validate_schedule_expr(updates["schedule_expr"])
     if "timezone" in updates and updates["timezone"] is not None:
         cycle.timezone = validate_timezone_name(updates["timezone"])
+    if "run_at" in updates and updates["run_at"] is not None:
+        cycle.schedule_expr = build_one_time_schedule_expr(updates["run_at"], cycle.timezone)
+    if "schedule_expr" in updates and updates["schedule_expr"] is not None:
+        cycle.schedule_expr = validate_schedule_expr(updates["schedule_expr"], cycle.timezone)
     if "enabled" in updates and updates["enabled"] is not None:
         cycle.enabled = updates["enabled"]
     if "model_override" in updates:
@@ -208,7 +226,16 @@ def update_cycle(
 
     cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
     db.flush()
-    return serialize_cycle(cycle)
+    payload = serialize_cycle(cycle)
+    db.commit()
+    publish_cycle_change(
+        action="update",
+        org_id=cycle.org_id,
+        user_id=cycle.user_id,
+        cycle_id=cycle.id,
+        target_idea_id=cycle.target_idea_id,
+    )
+    return payload
 
 
 @router.delete("/{cycle_id}")
@@ -221,6 +248,14 @@ def delete_cycle(
     cycle.enabled = False
     cycle.deleted_at = datetime.now(timezone.utc)
     db.flush()
+    db.commit()
+    publish_cycle_change(
+        action="delete",
+        org_id=cycle.org_id,
+        user_id=cycle.user_id,
+        cycle_id=cycle_id,
+        target_idea_id=cycle.target_idea_id,
+    )
     return {"ok": True, "id": cycle_id}
 
 
@@ -247,5 +282,13 @@ def run_cycle(
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    _get_cycle_or_404(db, cycle_id, user)
-    return run_cycle_now(cycle_id)
+    cycle = _get_cycle_or_404(db, cycle_id, user)
+    payload = run_cycle_now(cycle_id)
+    publish_cycle_change(
+        action="run",
+        org_id=cycle.org_id,
+        user_id=cycle.user_id,
+        cycle_id=cycle_id,
+        target_idea_id=cycle.target_idea_id,
+    )
+    return payload

--- a/brain/app/api/schemas/cycles.py
+++ b/brain/app/api/schemas/cycles.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel, Field
 class CycleCreate(BaseModel):
     name: str = Field(min_length=1, max_length=500)
     prompt: str = Field(min_length=1, max_length=20000)
-    schedule_expr: str = Field(min_length=1, max_length=100)
+    schedule_expr: str | None = Field(default=None, min_length=1, max_length=100)
+    run_at: datetime | None = None
     timezone: str = Field(min_length=1, max_length=64)
     enabled: bool = True
     model_override: str | None = None
@@ -22,6 +23,7 @@ class CycleUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=500)
     prompt: str | None = Field(default=None, min_length=1, max_length=20000)
     schedule_expr: str | None = Field(default=None, min_length=1, max_length=100)
+    run_at: datetime | None = None
     timezone: str | None = Field(default=None, min_length=1, max_length=64)
     enabled: bool | None = None
     model_override: str | None = None

--- a/brain/systems/cycles/events.py
+++ b/brain/systems/cycles/events.py
@@ -1,0 +1,34 @@
+"""Realtime notifications for Cycle changes."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def publish_cycle_change(
+    *,
+    action: str,
+    org_id: str | None = None,
+    user_id: str | None = None,
+    cycle_id: int | None = None,
+    target_idea_id: str | None = None,
+) -> None:
+    payload: dict[str, Any] = {"action": action}
+    if org_id:
+        payload["org_id"] = str(org_id)
+    if user_id:
+        payload["user_id"] = str(user_id)
+    if cycle_id is not None:
+        payload["cycle_id"] = int(cycle_id)
+    if target_idea_id:
+        payload["idea_id"] = str(target_idea_id)
+        payload["target_idea_id"] = str(target_idea_id)
+
+    try:
+        from brain.systems.cortex.events import publish_safe
+
+        publish_safe("cycles_changed", payload)
+    except Exception:
+        logger.debug("cycle_change_publish_failed", exc_info=True)

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -26,6 +26,7 @@ VALID_EXECUTION_MODES = {"new_idea_per_run", REUSABLE_THREAD_EXECUTION_MODE}
 VALID_THINKING_OVERRIDES = {"none", "low", "medium", "high", "xhigh"}
 ACTIVE_RUN_STATUSES = {"queued", "running", "pending_approval"}
 TERMINAL_RUN_STATUSES = {"completed", "failed", "skipped"}
+ONE_TIME_SCHEDULE_PREFIX = "at:"
 
 
 def validate_nonempty_trimmed(value: str, field_name: str) -> str:
@@ -35,8 +36,53 @@ def validate_nonempty_trimmed(value: str, field_name: str) -> str:
     return normalized
 
 
-def validate_schedule_expr(expr: str) -> str:
+def is_one_time_schedule_expr(expr: str | None) -> bool:
+    return str(expr or "").strip().lower().startswith(ONE_TIME_SCHEDULE_PREFIX)
+
+
+def _parse_one_time_run_at(expr: str, timezone_name: str) -> datetime:
+    value = str(expr or "").strip()
+    if not is_one_time_schedule_expr(value):
+        raise ValueError("schedule_expr must start with at:")
+    raw_at = value[len(ONE_TIME_SCHEDULE_PREFIX):].strip()
+    if not raw_at:
+        raise ValueError("one-time schedule requires an ISO timestamp")
+    try:
+        run_at = datetime.fromisoformat(raw_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("one-time schedule requires an ISO timestamp") from exc
+    tz = ZoneInfo(validate_timezone_name(timezone_name))
+    if run_at.tzinfo is None:
+        run_at = run_at.replace(tzinfo=tz)
+    return run_at.astimezone(timezone.utc)
+
+
+def build_one_time_schedule_expr(run_at: str | datetime, timezone_name: str) -> str:
+    tz = ZoneInfo(validate_timezone_name(timezone_name))
+    if isinstance(run_at, datetime):
+        parsed = run_at
+    else:
+        raw_at = str(run_at or "").strip()
+        if not raw_at:
+            raise ValueError("run_at is required")
+        try:
+            parsed = datetime.fromisoformat(raw_at.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("run_at must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz)
+    local_run_at = parsed.astimezone(tz).replace(second=0, microsecond=0)
+    return f"{ONE_TIME_SCHEDULE_PREFIX}{local_run_at.isoformat()}"
+
+
+def validate_schedule_expr(expr: str, timezone_name: str | None = None) -> str:
     value = (expr or "").strip()
+    if is_one_time_schedule_expr(value):
+        tz_name = validate_timezone_name(timezone_name or "UTC")
+        return build_one_time_schedule_expr(
+            _parse_one_time_run_at(value, tz_name),
+            tz_name,
+        )
     if len(value.split()) != 5 or not croniter.is_valid(value):
         raise ValueError("schedule_expr must be a valid 5-field cron expression")
     return value
@@ -78,7 +124,11 @@ def compute_next_run_at(
     timezone_name: str,
     *,
     from_dt: datetime | None = None,
-) -> datetime:
+) -> datetime | None:
+    if is_one_time_schedule_expr(schedule_expr):
+        run_at = _parse_one_time_run_at(schedule_expr, timezone_name)
+        return None if from_dt is not None and run_at <= from_dt else run_at
+
     tz = ZoneInfo(validate_timezone_name(timezone_name))
     baseline = from_dt or datetime.now(timezone.utc)
     local_baseline = baseline.astimezone(tz)
@@ -90,6 +140,15 @@ def compute_next_run_at(
 
 
 def humanize_schedule(schedule_expr: str, timezone_name: str) -> str:
+    if is_one_time_schedule_expr(schedule_expr):
+        tz_name = validate_timezone_name(timezone_name)
+        local_run_at = _parse_one_time_run_at(schedule_expr, tz_name).astimezone(ZoneInfo(tz_name))
+        hour = local_run_at.strftime("%I").lstrip("0") or "0"
+        return (
+            f"Once at {local_run_at.strftime('%b')} {local_run_at.day}, "
+            f"{local_run_at.year} {hour}:{local_run_at.strftime('%M %p')} ({tz_name})"
+        )
+
     expr = validate_schedule_expr(schedule_expr)
     minute, hour, dom, month, dow = expr.split()
     tz = validate_timezone_name(timezone_name)
@@ -421,11 +480,14 @@ def schedule_due_cycles_once(*, limit: int = 10) -> list[int]:
             )
             uow.session.add(run)
             uow.session.flush()
-            cycle.next_run_at = compute_next_run_at(
+            next_run_at = compute_next_run_at(
                 cycle.schedule_expr,
                 cycle.timezone,
                 from_dt=scheduled_for,
             )
+            cycle.next_run_at = next_run_at
+            if is_one_time_schedule_expr(cycle.schedule_expr) and next_run_at is None:
+                cycle.enabled = False
             claimed_run_ids.append(run.id)
 
     for run_id in claimed_run_ids:

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -10,6 +10,7 @@ def _handle_manage_cycle(
     name: str | None = None,
     prompt: str | None = None,
     schedule_expr: str | None = None,
+    run_at: str | None = None,
     timezone: str | None = None,
     enabled: bool | None = None,
     model_override: str | None = None,
@@ -21,6 +22,7 @@ def _handle_manage_cycle(
     from sqlalchemy import and_, or_, select
 
     from brain.systems.cycles.service import (
+        build_one_time_schedule_expr,
         compute_next_run_at,
         cycle_defaults,
         REUSABLE_THREAD_EXECUTION_MODE,
@@ -32,6 +34,7 @@ def _handle_manage_cycle(
         validate_thinking_override,
         validate_timezone_name,
     )
+    from brain.systems.cycles.events import publish_cycle_change
     from brain.platform.db.models.cycle import Cycle
     from brain.platform.db.models.idea import Idea
     from brain.platform.db.models.org import User
@@ -82,10 +85,14 @@ def _handle_manage_cycle(
                 cycles = [serialize_cycle(cycle) for cycle in uow.session.scalars(stmt).all()]
             return json.dumps({"cycles": cycles}, default=str)
         elif action == "create":
-            if not name or not prompt or not schedule_expr or not timezone:
-                return json.dumps({"error": "create requires: name, prompt, schedule_expr, timezone"})
-            expr = validate_schedule_expr(schedule_expr)
+            if not name or not prompt or not timezone or (not schedule_expr and not run_at):
+                return json.dumps({"error": "create requires: name, prompt, timezone, and schedule_expr or run_at"})
             tz_name = validate_timezone_name(timezone)
+            expr = (
+                build_one_time_schedule_expr(run_at, tz_name)
+                if run_at
+                else validate_schedule_expr(schedule_expr or "", tz_name)
+            )
             mode = validate_execution_mode(execution_mode)
             thinking = validate_thinking_override(thinking_override)
             normalized_name = validate_nonempty_trimmed(name, "name")
@@ -116,6 +123,13 @@ def _handle_manage_cycle(
                 uow.session.add(cycle)
                 uow.session.flush()
                 payload = serialize_cycle(cycle)
+            publish_cycle_change(
+                action="create",
+                org_id=payload.get("org_id"),
+                user_id=payload.get("user_id"),
+                cycle_id=payload.get("id"),
+                target_idea_id=payload.get("target_idea_id"),
+            )
             return json.dumps({"created": payload}, default=str)
         elif action == "update":
             if not id:
@@ -136,10 +150,12 @@ def _handle_manage_cycle(
                     cycle.name = validate_nonempty_trimmed(name, "name")
                 if prompt is not None:
                     cycle.prompt = validate_nonempty_trimmed(prompt, "prompt")
-                if schedule_expr is not None:
-                    cycle.schedule_expr = validate_schedule_expr(schedule_expr)
                 if timezone is not None:
                     cycle.timezone = validate_timezone_name(timezone)
+                if run_at is not None:
+                    cycle.schedule_expr = build_one_time_schedule_expr(run_at, cycle.timezone)
+                if schedule_expr is not None:
+                    cycle.schedule_expr = validate_schedule_expr(schedule_expr, cycle.timezone)
                 if enabled is not None:
                     cycle.enabled = enabled
                 if model_override is not None:
@@ -162,6 +178,13 @@ def _handle_manage_cycle(
                 cycle.updated_at = datetime.now(dt_timezone.utc)
                 cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
                 payload = serialize_cycle(cycle)
+            publish_cycle_change(
+                action="update",
+                org_id=payload.get("org_id"),
+                user_id=payload.get("user_id"),
+                cycle_id=payload.get("id"),
+                target_idea_id=payload.get("target_idea_id"),
+            )
             return json.dumps({"updated": payload}, default=str)
         elif action == "delete":
             if not id:
@@ -174,20 +197,42 @@ def _handle_manage_cycle(
                 cycle = uow.session.scalars(stmt).first()
                 if not cycle:
                     return json.dumps({"error": f"Cycle {id} not found"})
+                cycle_org_id = cycle.org_id
+                cycle_user_id = cycle.user_id
+                cycle_target_id = cycle.target_idea_id
                 cycle.enabled = False
                 cycle.deleted_at = datetime.now(dt_timezone.utc)
+            publish_cycle_change(
+                action="delete",
+                org_id=cycle_org_id,
+                user_id=cycle_user_id,
+                cycle_id=id,
+                target_idea_id=cycle_target_id,
+            )
             return json.dumps({"deleted": {"id": id}})
         elif action == "run":
             if not id:
                 return json.dumps({"error": "run requires: id"})
             with UnitOfWork() as uow:
-                stmt = select(Cycle.id).where(
+                stmt = select(Cycle).where(
                     Cycle.id == id,
                     *_cycle_scope(),
                 )
-                if not uow.session.execute(stmt).first():
+                cycle = uow.session.scalars(stmt).first()
+                if not cycle:
                     return json.dumps({"error": f"Cycle {id} not found"})
-            return json.dumps({"run": run_cycle_now(id)}, default=str)
+                cycle_org_id = cycle.org_id
+                cycle_user_id = cycle.user_id
+                cycle_target_id = cycle.target_idea_id
+            payload = run_cycle_now(id)
+            publish_cycle_change(
+                action="run",
+                org_id=cycle_org_id,
+                user_id=cycle_user_id,
+                cycle_id=id,
+                target_idea_id=cycle_target_id,
+            )
+            return json.dumps({"run": payload}, default=str)
         else:
             return json.dumps({"error": f"Unknown action: {action}"})
     except ValueError as e:

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -442,7 +442,7 @@ BRAIN_TOOLS = [
     {
         "name": "read_cycles",
         "description": (
-            "Read workspace Cycles and Cycle runs: recurring prompts, schedules, enabled state, last/next run, "
+            "Read workspace Cycles and Cycle runs: recurring prompts, one-time reminders, schedules, enabled state, last/next run, "
             "linked thoughts, and recent run status. Use this for questions about recurring check-ins, reports, "
             "automations, or what scheduled Illo work exists. Use manage_cycle only to create, update, delete, or run one."
         ),
@@ -485,7 +485,7 @@ BRAIN_TOOLS = [
         "name": "manage_cycle",
         "description": (
             "Create, update, delete, list, or manually run workspace Cycles, which are recurring "
-            "Illo prompts/check-ins/reports. This is the action tool. For answering questions about "
+            "Illo prompts/check-ins/reports or one-time reminders. This is the action tool. For answering questions about "
             "which Cycles exist or what ran recently, prefer read_cycles first. Actions: 'create', "
             "'list', 'update', 'delete', 'run'."
         ),
@@ -502,7 +502,11 @@ BRAIN_TOOLS = [
                 "prompt": {"type": "string", "description": "Prompt Illo should run each cycle"},
                 "schedule_expr": {
                     "type": "string",
-                    "description": "5-field cron expression like '0 8 * * *'",
+                    "description": "5-field cron expression like '0 8 * * *', or a one-time expression like 'at:2026-05-08T15:30:00-04:00'",
+                },
+                "run_at": {
+                    "type": "string",
+                    "description": "ISO timestamp for a one-time reminder/run. Use instead of schedule_expr when the user asks for a reminder at a specific time.",
                 },
                 "timezone": {"type": "string", "description": "IANA timezone name"},
                 "enabled": {"type": "boolean", "description": "Whether the cycle is active"},

--- a/docs/cycles.md
+++ b/docs/cycles.md
@@ -6,6 +6,9 @@ Cycles are database-backed recurring jobs owned by the Illo scheduler.
 
 - Recurring prompts and background work live in the database as `cycles` and
   `cycle_runs`.
+- One-time reminders use the same table with a schedule expression of
+  `at:<ISO datetime>`. The scheduler runs them once, clears `next_run_at`, and
+  disables the cycle after it claims the run.
 - Built-in nightly work is registered through scheduler catalog jobs.
 - The scheduler daemon is started from `ops/illo-scheduler.service` in
   self-hosted production.

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -784,7 +784,8 @@ export const api = {
   createCycle: (data: {
     name: string;
     prompt: string;
-    schedule_expr: string;
+    schedule_expr?: string | null;
+    run_at?: string | null;
     timezone: string;
     enabled?: boolean;
     model_override?: string | null;
@@ -800,6 +801,7 @@ export const api = {
       name: string;
       prompt: string;
       schedule_expr: string;
+      run_at: string | null;
       timezone: string;
       enabled: boolean;
       model_override: string | null;

--- a/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
+++ b/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
@@ -24,6 +24,7 @@ export const CORTEX_REALTIME_EVENT_TYPES = [
   'browser_session_delta',
   'browser_session_closed',
   'browser_session_error',
+  'cycles_changed',
   'vault_secret_prompt',
   'idea_created',
   'idea_upserted',
@@ -74,6 +75,12 @@ export type CortexRealtimePayloadByType = {
   browser_session_delta: Record<string, unknown>;
   browser_session_closed: { idea_id?: string; session_id?: string };
   browser_session_error: { session_id?: string; error?: string };
+  cycles_changed: {
+    action?: string;
+    cycle_id?: string | number | null;
+    idea_id?: string | null;
+    target_idea_id?: string | null;
+  };
   vault_secret_prompt: VaultSecretPrompt | Record<string, unknown>;
   idea_created: { idea_id?: string };
   idea_upserted: { idea?: Idea };

--- a/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
+++ b/frontend/src/lib/features/cycles/components/ThreadCyclesPane.svelte
@@ -1,0 +1,844 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  import { api, type CycleRead, type CycleRunRead } from '$lib/api/client';
+  import {
+    ConstellationButton,
+    ConstellationIcon,
+    ConstellationPill,
+  } from '$lib/components/constellation';
+  import { ui } from '$lib/stores/ui.svelte';
+  import { wsClient } from '$lib/stores/ws.svelte';
+
+  type Cadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
+  type FormState = {
+    name: string;
+    prompt: string;
+    cadence: Cadence;
+    date: string;
+    time: string;
+    weekday: string;
+    monthday: string;
+    customSchedule: string;
+    enabled: boolean;
+    modelOverride: string;
+    thinkingOverride: '' | 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+    targetIdeaId: string;
+  };
+
+  let {
+    focusCycleId = null,
+    refreshSerial = null,
+  }: {
+    focusCycleId?: number | null;
+    refreshSerial?: number | null;
+  } = $props();
+
+  const DEFAULT_TIME = '09:00';
+  const DEFAULT_SCHEDULE = '0 9 * * *';
+  const ONE_TIME_PREFIX = 'at:';
+  const CADENCES: Array<{ value: Cadence; label: string }> = [
+    { value: 'once', label: 'Once' },
+    { value: 'daily', label: 'Daily' },
+    { value: 'weekdays', label: 'Weekdays' },
+    { value: 'weekly', label: 'Weekly' },
+    { value: 'monthly', label: 'Monthly' },
+    { value: 'custom', label: 'Custom' },
+  ];
+  const WEEKDAYS = [
+    { value: '0', label: 'Sun' },
+    { value: '1', label: 'Mon' },
+    { value: '2', label: 'Tue' },
+    { value: '3', label: 'Wed' },
+    { value: '4', label: 'Thu' },
+    { value: '5', label: 'Fri' },
+    { value: '6', label: 'Sat' },
+  ];
+  const THINKING_LEVELS: Array<{ value: FormState['thinkingOverride']; label: string }> = [
+    { value: '', label: 'Default' },
+    { value: 'none', label: 'None' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'XHigh' },
+  ];
+
+  let cycles = $state<CycleRead[]>([]);
+  let runs = $state<CycleRunRead[]>([]);
+  let loading = $state(true);
+  let runsLoading = $state(false);
+  let saving = $state(false);
+  let selectedCycleId = $state<number | null>(null);
+  let isDraft = $state(false);
+  let lastFocusCycleId = $state<number | null>(null);
+  let lastRefreshSerial = $state<number | null>(null);
+  let unsubscribeCyclesChanged: (() => void) | null = null;
+
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const selectedCycle = $derived.by(
+    () => cycles.find((cycle) => cycle.id === selectedCycleId) ?? null,
+  );
+  const activeCount = $derived.by(() => cycles.filter((cycle) => cycle.enabled).length);
+  const schedulePreview = $derived.by(() => labelForForm(form));
+
+  function pad2(value: number): string {
+    return String(value).padStart(2, '0');
+  }
+
+  function dateInputFromDate(date: Date): string {
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  }
+
+  function defaultRunDate(): string {
+    return dateInputFromDate(new Date(Date.now() + 86400000));
+  }
+
+  function emptyForm(): FormState {
+    return {
+      name: '',
+      prompt: '',
+      cadence: 'once',
+      date: defaultRunDate(),
+      time: DEFAULT_TIME,
+      weekday: '1',
+      monthday: '1',
+      customSchedule: DEFAULT_SCHEDULE,
+      enabled: true,
+      modelOverride: '',
+      thinkingOverride: '',
+      targetIdeaId: '',
+    };
+  }
+
+  let form = $state<FormState>(emptyForm());
+
+  function normalizeTime(value: string | null | undefined): string {
+    const match = String(value ?? '').match(/^(\d{1,2}):(\d{2})$/);
+    if (!match) return DEFAULT_TIME;
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return DEFAULT_TIME;
+    return `${pad2(hour)}:${pad2(minute)}`;
+  }
+
+  function timeFromCron(minute: string, hour: string): string | null {
+    if (!/^\d+$/.test(minute) || !/^\d+$/.test(hour)) return null;
+    const h = Number(hour);
+    const m = Number(minute);
+    if (h < 0 || h > 23 || m < 0 || m > 59) return null;
+    return `${pad2(h)}:${pad2(m)}`;
+  }
+
+  function isOneTimeSchedule(expr: string | null | undefined): boolean {
+    return String(expr ?? '').trim().toLowerCase().startsWith(ONE_TIME_PREFIX);
+  }
+
+  function oneTimeDate(expr: string | null | undefined): Date | null {
+    if (!isOneTimeSchedule(expr)) return null;
+    const raw = String(expr ?? '').trim().slice(ONE_TIME_PREFIX.length).trim();
+    if (!raw) return null;
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function parseSchedule(cycle: CycleRead | null): Pick<FormState, 'cadence' | 'date' | 'time' | 'weekday' | 'monthday' | 'customSchedule'> {
+    const expr = (cycle?.schedule_expr || DEFAULT_SCHEDULE).trim();
+    const once = oneTimeDate(expr);
+    if (once) {
+      return {
+        cadence: 'once',
+        date: dateInputFromDate(once),
+        time: normalizeTime(`${once.getHours()}:${pad2(once.getMinutes())}`),
+        weekday: '1',
+        monthday: '1',
+        customSchedule: expr,
+      };
+    }
+
+    const [minute, hour, dayOfMonth, month, dayOfWeek, ...extra] = expr.split(/\s+/);
+    const time = timeFromCron(minute, hour);
+    const base = {
+      date: defaultRunDate(),
+      time: time || DEFAULT_TIME,
+      weekday: '1',
+      monthday: '1',
+      customSchedule: expr,
+    };
+    if (!time || !dayOfMonth || !month || !dayOfWeek || extra.length) return { ...base, cadence: 'custom' };
+    if (dayOfMonth === '*' && month === '*' && dayOfWeek === '*') return { ...base, cadence: 'daily' };
+    if (dayOfMonth === '*' && month === '*' && ['1-5', '1,2,3,4,5'].includes(dayOfWeek)) {
+      return { ...base, cadence: 'weekdays' };
+    }
+    if (dayOfMonth === '*' && month === '*' && /^\d+$/.test(dayOfWeek)) {
+      return { ...base, cadence: 'weekly', weekday: dayOfWeek === '7' ? '0' : dayOfWeek };
+    }
+    if (month === '*' && dayOfWeek === '*' && /^\d+$/.test(dayOfMonth)) {
+      return { ...base, cadence: 'monthly', monthday: dayOfMonth };
+    }
+    return { ...base, cadence: 'custom' };
+  }
+
+  function fillForm(cycle: CycleRead | null) {
+    if (!cycle) {
+      form = emptyForm();
+      return;
+    }
+    const schedule = parseSchedule(cycle);
+    form = {
+      name: cycle.name,
+      prompt: cycle.prompt,
+      ...schedule,
+      enabled: cycle.enabled,
+      modelOverride: cycle.model_override || '',
+      thinkingOverride: (cycle.thinking_override as FormState['thinkingOverride']) || '',
+      targetIdeaId: cycle.target_idea_id || '',
+    };
+  }
+
+  function scheduleExprFromForm(): string {
+    const time = normalizeTime(form.time);
+    if (form.cadence === 'once') return `${ONE_TIME_PREFIX}${form.date || defaultRunDate()}T${time}:00`;
+    if (form.cadence === 'custom') return form.customSchedule.trim();
+    const [hour, minute] = time.split(':').map((value) => String(Number(value)));
+    if (form.cadence === 'weekdays') return `${minute} ${hour} * * 1-5`;
+    if (form.cadence === 'weekly') return `${minute} ${hour} * * ${form.weekday}`;
+    if (form.cadence === 'monthly') return `${minute} ${hour} ${form.monthday} * *`;
+    return `${minute} ${hour} * * *`;
+  }
+
+  function formatTime(value: string): string {
+    const [hour, minute] = normalizeTime(value).split(':').map(Number);
+    return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(
+      new Date(2026, 0, 1, hour, minute),
+    );
+  }
+
+  function formatDate(value: string): string {
+    const [year, month, day] = value.split('-').map(Number);
+    if (!year || !month || !day) return value || 'selected date';
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(year, month - 1, day));
+  }
+
+  function labelForForm(value: FormState): string {
+    const time = formatTime(value.time);
+    if (value.cadence === 'once') return `Once on ${formatDate(value.date)} at ${time}`;
+    if (value.cadence === 'weekdays') return `Weekdays at ${time}`;
+    if (value.cadence === 'weekly') return `${WEEKDAYS.find((day) => day.value === value.weekday)?.label ?? 'Weekly'} at ${time}`;
+    if (value.cadence === 'monthly') return `Monthly on day ${value.monthday} at ${time}`;
+    if (value.cadence === 'custom') return value.customSchedule || 'Custom schedule';
+    return `Daily at ${time}`;
+  }
+
+  function labelForCycle(cycle: CycleRead): string {
+    if (isOneTimeSchedule(cycle.schedule_expr)) {
+      const parsed = parseSchedule(cycle);
+      return labelForForm({ ...emptyForm(), ...parsed });
+    }
+    return cycle.schedule_human || labelForForm({ ...emptyForm(), ...parseSchedule(cycle) });
+  }
+
+  function statusTone(cycle: CycleRead): 'muted' | 'warning' | 'success' | 'danger' | 'info' {
+    const status = String(cycle.last_status || '').toLowerCase();
+    if (cycle.last_error || ['failed', 'error'].includes(status)) return 'danger';
+    if (!cycle.enabled) return isOneTimeSchedule(cycle.schedule_expr) && cycle.last_run_at ? 'info' : 'muted';
+    if (['running', 'queued', 'pending'].includes(status)) return 'warning';
+    return 'success';
+  }
+
+  function statusLabel(cycle: CycleRead): string {
+    if (cycle.last_error) return 'Needs work';
+    if (!cycle.enabled && isOneTimeSchedule(cycle.schedule_expr) && cycle.last_run_at) return 'Done';
+    if (!cycle.enabled) return 'Paused';
+    return 'Active';
+  }
+
+  function formatDateTime(value: string | null | undefined): string {
+    if (!value) return '--';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '--';
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+  }
+
+  async function loadRuns(cycleId: number | null) {
+    if (!cycleId) {
+      runs = [];
+      return;
+    }
+    runsLoading = true;
+    try {
+      runs = await api.listCycleRuns(cycleId, 8);
+    } catch {
+      runs = [];
+    } finally {
+      runsLoading = false;
+    }
+  }
+
+  async function loadCycles(preferredCycleId: number | null = selectedCycleId) {
+    loading = true;
+    try {
+      const nextCycles = await api.listCycles();
+      cycles = nextCycles;
+      const nextSelected = preferredCycleId
+        ? nextCycles.find((cycle) => cycle.id === preferredCycleId) ?? null
+        : selectedCycle ?? nextCycles[0] ?? null;
+      selectedCycleId = nextSelected?.id ?? null;
+      isDraft = !nextSelected && isDraft;
+      if (nextSelected) fillForm(nextSelected);
+      await loadRuns(nextSelected?.id ?? null);
+    } catch (err: any) {
+      ui.toast(err?.detail || 'Failed to load cycles', 'error');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function selectCycle(cycle: CycleRead) {
+    selectedCycleId = cycle.id;
+    isDraft = false;
+    fillForm(cycle);
+    await loadRuns(cycle.id);
+  }
+
+  function newCycle() {
+    selectedCycleId = null;
+    isDraft = true;
+    runs = [];
+    fillForm(null);
+  }
+
+  async function saveCycle() {
+    const scheduleExpr = scheduleExprFromForm();
+    const wasUpdate = Boolean(selectedCycleId);
+    const payload = {
+      name: form.name.trim(),
+      prompt: form.prompt.trim(),
+      schedule_expr: scheduleExpr,
+      timezone: localTimezone,
+      enabled: form.enabled,
+      model_override: form.modelOverride.trim() || null,
+      thinking_override: form.thinkingOverride || null,
+      execution_mode: 'reuse_same_idea' as const,
+      target_idea_id: form.targetIdeaId || selectedCycle?.target_idea_id || null,
+      reopen_archived: true,
+    };
+    if (!payload.name || !payload.prompt || !payload.schedule_expr) {
+      ui.toast('Name, prompt, and schedule are required', 'error');
+      return;
+    }
+    saving = true;
+    try {
+      const saved = selectedCycleId
+        ? await api.updateCycle(selectedCycleId, payload)
+        : await api.createCycle(payload);
+      selectedCycleId = saved.id;
+      isDraft = false;
+      fillForm(saved);
+      ui.toast(wasUpdate ? 'Cycle saved' : 'Cycle created', 'success');
+      await loadCycles(saved.id);
+    } catch (err: any) {
+      ui.toast(err?.detail || 'Failed to save cycle', 'error');
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function runSelectedNow() {
+    if (!selectedCycleId) return;
+    try {
+      await api.runCycle(selectedCycleId);
+      ui.toast('Cycle launched', 'success');
+      await loadCycles(selectedCycleId);
+    } catch (err: any) {
+      ui.toast(err?.detail || 'Failed to run cycle', 'error');
+    }
+  }
+
+  async function deleteSelected() {
+    if (!selectedCycleId || !selectedCycle) return;
+    if (!window.confirm(`Delete cycle "${selectedCycle.name}"?`)) return;
+    try {
+      await api.deleteCycle(selectedCycleId);
+      ui.toast('Cycle deleted', 'success');
+      selectedCycleId = null;
+      isDraft = false;
+      await loadCycles(null);
+    } catch (err: any) {
+      ui.toast(err?.detail || 'Failed to delete cycle', 'error');
+    }
+  }
+
+  $effect(() => {
+    if (!focusCycleId || focusCycleId === lastFocusCycleId) return;
+    lastFocusCycleId = focusCycleId;
+    void loadCycles(focusCycleId);
+  });
+
+  $effect(() => {
+    if (!refreshSerial || refreshSerial === lastRefreshSerial) return;
+    lastRefreshSerial = refreshSerial;
+    void loadCycles(focusCycleId || selectedCycleId);
+  });
+
+  onMount(() => {
+    void loadCycles(focusCycleId);
+    unsubscribeCyclesChanged = wsClient.on('cycles_changed', (msg) => {
+      const cycleId = Number(msg?.cycle_id || 0) || selectedCycleId;
+      void loadCycles(cycleId ?? null);
+    });
+  });
+
+  onDestroy(() => {
+    unsubscribeCyclesChanged?.();
+  });
+</script>
+
+<section class="thread-cycles-pane" aria-label="Cycles">
+  <header class="cycles-pane-header">
+    <div>
+      <span>Cycles</span>
+      <strong>{cycles.length} total / {activeCount} active</strong>
+    </div>
+    <ConstellationButton variant="quiet" size="sm" onclick={newCycle}>
+      New
+    </ConstellationButton>
+  </header>
+
+  {#if loading && cycles.length === 0}
+    <div class="cycle-pane-loading">
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+  {:else if cycles.length > 0}
+    <div class="cycle-pane-list" aria-label="Cycle list">
+      {#each cycles as cycle (cycle.id)}
+        <button
+          type="button"
+          class="cycle-pane-row"
+          class:is-selected={!isDraft && selectedCycleId === cycle.id}
+          onclick={() => selectCycle(cycle)}
+        >
+          <span>
+            <strong>{cycle.name}</strong>
+            <small>{labelForCycle(cycle)}</small>
+          </span>
+          <ConstellationPill variant={statusTone(cycle)}>{statusLabel(cycle)}</ConstellationPill>
+        </button>
+      {/each}
+    </div>
+  {:else if !isDraft}
+    <button type="button" class="cycle-pane-empty" onclick={newCycle}>
+      <ConstellationIcon name="cycles" size={18} stroke={1.8} />
+      <span>Create the first cycle</span>
+    </button>
+  {/if}
+
+  {#if isDraft || selectedCycle}
+    <div class="cycle-pane-editor">
+      <div class="cycle-pane-editor-head">
+        <span>{isDraft ? 'New cycle' : 'Selected cycle'}</span>
+        <strong>{schedulePreview}</strong>
+      </div>
+
+      <label class="cycle-pane-field">
+        <span>Name</span>
+        <input bind:value={form.name} placeholder="Reminder" />
+      </label>
+
+      <label class="cycle-pane-field">
+        <span>Prompt</span>
+        <textarea bind:value={form.prompt} rows="5" placeholder="Remind me to..."></textarea>
+      </label>
+
+      <div class="cycle-pane-cadence" role="group" aria-label="Schedule frequency">
+        {#each CADENCES as cadence}
+          <button
+            type="button"
+            class:active={form.cadence === cadence.value}
+            onclick={() => (form.cadence = cadence.value)}
+          >
+            {cadence.label}
+          </button>
+        {/each}
+      </div>
+
+      {#if form.cadence === 'custom'}
+        <label class="cycle-pane-field">
+          <span>Schedule</span>
+          <input bind:value={form.customSchedule} class="mono" placeholder="0 9 * * *" />
+        </label>
+      {:else}
+        <div class="cycle-pane-schedule-grid">
+          {#if form.cadence === 'once'}
+            <label class="cycle-pane-field">
+              <span>Date</span>
+              <input bind:value={form.date} type="date" />
+            </label>
+          {/if}
+          <label class="cycle-pane-field">
+            <span>Time</span>
+            <input bind:value={form.time} type="time" />
+          </label>
+          {#if form.cadence === 'weekly'}
+            <label class="cycle-pane-field">
+              <span>Day</span>
+              <select bind:value={form.weekday}>
+                {#each WEEKDAYS as day}
+                  <option value={day.value}>{day.label}</option>
+                {/each}
+              </select>
+            </label>
+          {:else if form.cadence === 'monthly'}
+            <label class="cycle-pane-field">
+              <span>Day</span>
+              <select bind:value={form.monthday}>
+                {#each Array.from({ length: 31 }, (_, index) => String(index + 1)) as day}
+                  <option value={day}>{day}</option>
+                {/each}
+              </select>
+            </label>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="cycle-pane-switch-row">
+        <button
+          type="button"
+          class="cycle-pane-switch"
+          class:active={form.enabled}
+          aria-pressed={form.enabled}
+          onclick={() => (form.enabled = !form.enabled)}
+        >
+          <span aria-hidden="true"></span>
+          {form.enabled ? 'Active' : 'Paused'}
+        </button>
+        <label class="cycle-pane-field">
+          <span>Reasoning</span>
+          <select bind:value={form.thinkingOverride}>
+            {#each THINKING_LEVELS as level}
+              <option value={level.value}>{level.label}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      <div class="cycle-pane-actions">
+        <ConstellationButton variant="primary" size="sm" loading={saving} onclick={saveCycle}>
+          Save
+        </ConstellationButton>
+        {#if selectedCycleId}
+          <ConstellationButton variant="quiet" size="sm" onclick={runSelectedNow}>Run now</ConstellationButton>
+          <ConstellationButton variant="destructive" size="sm" onclick={deleteSelected}>Delete</ConstellationButton>
+        {/if}
+      </div>
+
+      {#if selectedCycle}
+        <div class="cycle-pane-runs">
+          <span>Recent runs</span>
+          {#if runsLoading}
+            <small>Loading...</small>
+          {:else if runs.length === 0}
+            <small>No runs yet.</small>
+          {:else}
+            {#each runs as run (run.id)}
+              <article>
+                <strong>{formatDateTime(run.scheduled_for)}</strong>
+                <ConstellationPill variant={run.status === 'failed' ? 'danger' : run.status === 'completed' ? 'success' : 'muted'}>
+                  {run.status}
+                </ConstellationPill>
+              </article>
+            {/each}
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .thread-cycles-pane {
+    display: grid;
+    align-content: start;
+    gap: 12px;
+    width: 100%;
+    min-height: 0;
+    color: var(--constellation-color-text-primary);
+  }
+
+  .cycles-pane-header,
+  .cycle-pane-editor-head,
+  .cycle-pane-actions,
+  .cycle-pane-switch-row,
+  .cycle-pane-runs article {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .cycles-pane-header {
+    padding: 2px 2px 10px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+  }
+
+  .cycles-pane-header div,
+  .cycle-pane-editor-head {
+    display: grid;
+    min-width: 0;
+    gap: 4px;
+  }
+
+  .cycles-pane-header span,
+  .cycle-pane-editor-head span,
+  .cycle-pane-field span,
+  .cycle-pane-runs > span {
+    color: var(--constellation-color-text-muted);
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .cycles-pane-header strong,
+  .cycle-pane-editor-head strong {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+    font-weight: 520;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cycle-pane-list,
+  .cycle-pane-editor,
+  .cycle-pane-loading,
+  .cycle-pane-runs {
+    display: grid;
+    gap: 8px;
+  }
+
+  .cycle-pane-row,
+  .cycle-pane-empty {
+    width: 100%;
+    min-width: 0;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 8px;
+    background: var(--constellation-surface-nested-background);
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .cycle-pane-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    padding: 10px;
+    text-align: left;
+  }
+
+  .cycle-pane-row:hover,
+  .cycle-pane-row.is-selected {
+    border-color: var(--constellation-control-focus-ring);
+    background: var(--constellation-control-button-secondary-background-hover);
+  }
+
+  .cycle-pane-row span {
+    display: grid;
+    min-width: 0;
+    gap: 4px;
+  }
+
+  .cycle-pane-row strong,
+  .cycle-pane-row small {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cycle-pane-row strong {
+    font-size: 12px;
+    font-weight: 620;
+  }
+
+  .cycle-pane-row small,
+  .cycle-pane-runs small {
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
+  .cycle-pane-empty {
+    display: flex;
+    min-height: 86px;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--constellation-color-text-secondary);
+    font-size: 12px;
+  }
+
+  .cycle-pane-editor {
+    padding-top: 4px;
+  }
+
+  .cycle-pane-field {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .cycle-pane-field input,
+  .cycle-pane-field textarea,
+  .cycle-pane-field select {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    border: 1px solid var(--constellation-control-field-border);
+    border-radius: 8px;
+    background: var(--constellation-control-field-background);
+    color: var(--constellation-color-text-primary);
+    font: inherit;
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  .cycle-pane-field input,
+  .cycle-pane-field select {
+    min-height: 36px;
+    padding: 8px 10px;
+  }
+
+  .cycle-pane-field textarea {
+    min-height: 104px;
+    resize: vertical;
+    padding: 9px 10px;
+  }
+
+  .cycle-pane-field .mono {
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+  }
+
+  .cycle-pane-field input:focus,
+  .cycle-pane-field textarea:focus,
+  .cycle-pane-field select:focus,
+  .cycle-pane-cadence button:focus-visible,
+  .cycle-pane-row:focus-visible,
+  .cycle-pane-empty:focus-visible,
+  .cycle-pane-switch:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .cycle-pane-cadence {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .cycle-pane-cadence button {
+    min-height: 32px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 8px;
+    background: var(--constellation-surface-nested-background);
+    color: var(--constellation-color-text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+  }
+
+  .cycle-pane-cadence button.active,
+  .cycle-pane-cadence button:hover {
+    border-color: var(--constellation-control-focus-ring);
+    color: var(--constellation-color-text-primary);
+  }
+
+  .cycle-pane-schedule-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .cycle-pane-switch-row {
+    align-items: end;
+  }
+
+  .cycle-pane-switch {
+    display: inline-flex;
+    min-height: 36px;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--constellation-surface-nested-border);
+    border-radius: 8px;
+    background: var(--constellation-surface-nested-background);
+    color: var(--constellation-color-text-primary);
+    padding: 0 10px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .cycle-pane-switch > span {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--constellation-color-text-muted);
+  }
+
+  .cycle-pane-switch.active > span {
+    background: var(--constellation-color-success);
+  }
+
+  .cycle-pane-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .cycle-pane-runs {
+    border-top: 1px solid var(--constellation-surface-panel-separator);
+    padding-top: 10px;
+  }
+
+  .cycle-pane-runs article {
+    min-height: 32px;
+    border-bottom: 1px solid var(--constellation-surface-panel-separator);
+    font-size: 11px;
+  }
+
+  .cycle-pane-runs article:last-child {
+    border-bottom: 0;
+  }
+
+  .cycle-pane-loading span {
+    height: 44px;
+    border-radius: 8px;
+    background:
+      linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent),
+      var(--constellation-surface-nested-background);
+    background-size: 200% 100%;
+    animation: cycle-pane-pulse 1.4s ease-in-out infinite;
+  }
+
+  @keyframes cycle-pane-pulse {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .cycle-pane-cadence,
+    .cycle-pane-schedule-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .cycle-pane-switch-row {
+      display: grid;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -47,6 +47,7 @@
     utilityPane,
     appsPane,
     vaultPane,
+    cyclesPane,
     empty,
   }: {
     activeTabId?: string | null;
@@ -67,6 +68,7 @@
     utilityPane?: Snippet;
     appsPane?: Snippet;
     vaultPane?: Snippet;
+    cyclesPane?: Snippet;
     empty?: Snippet;
   } = $props();
 
@@ -74,6 +76,7 @@
   const hasUtilityPane = $derived(!!utilityPane);
   const hasAppsPane = $derived(!!appsPane);
   const hasVaultPane = $derived(!!vaultPane);
+  const hasCyclesPane = $derived(!!cyclesPane);
   const availableTabs = $derived(
     tabs.filter((tab) => (
       tab.kind === 'browser'
@@ -84,6 +87,8 @@
             ? hasAppsPane
             : tab.kind === 'vault'
               ? hasVaultPane
+              : tab.kind === 'cycles'
+                ? hasCyclesPane
               : true
     )),
   );
@@ -187,6 +192,7 @@
     if (kind === 'browser') return 'preview';
     if (kind === 'activity') return 'activity';
     if (kind === 'vault') return 'vault';
+    if (kind === 'cycles') return 'cycles';
     return 'code';
   }
 
@@ -345,6 +351,10 @@
         {:else if resolvedActiveTab?.kind === 'vault' && hasVaultPane}
           <section class="right-dock-pane right-dock-vault" aria-label="Vault">
             {@render vaultPane?.()}
+          </section>
+        {:else if resolvedActiveTab?.kind === 'cycles' && hasCyclesPane}
+          <section class="right-dock-pane right-dock-cycles" aria-label="Cycles">
+            {@render cyclesPane?.()}
           </section>
         {:else if hasEmptyState}
           <div class="right-dock-empty">
@@ -793,7 +803,8 @@
   }
 
   .right-dock-content[data-active-tab='activity'],
-  .right-dock-content[data-active-tab='vault'] {
+  .right-dock-content[data-active-tab='vault'],
+  .right-dock-content[data-active-tab='cycles'] {
     overflow-y: auto;
     padding: 8px 10px 10px;
     scrollbar-color: var(--constellation-utility-panel-scrollbar) transparent;
@@ -833,17 +844,23 @@
     overflow: visible;
   }
 
+  .right-dock-cycles {
+    overflow: visible;
+  }
+
   .right-dock-apps {
     overflow: hidden;
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar,
-  .right-dock-content[data-active-tab='vault']::-webkit-scrollbar {
+  .right-dock-content[data-active-tab='vault']::-webkit-scrollbar,
+  .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar {
     width: 4px;
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar-thumb,
-  .right-dock-content[data-active-tab='vault']::-webkit-scrollbar-thumb {
+  .right-dock-content[data-active-tab='vault']::-webkit-scrollbar-thumb,
+  .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar-thumb {
     border-radius: 999px;
     background: var(--constellation-utility-panel-scrollbar);
   }

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -60,6 +60,7 @@
   import { onDestroy, onMount, tick } from 'svelte';
 
   import BrowserThoughtPanel from '$lib/features/browser-sessions/components/BrowserThoughtPanel.svelte';
+  import ThreadCyclesPane from '$lib/features/cycles/components/ThreadCyclesPane.svelte';
   import ProjectContextPicker from '$lib/features/composer/components/ProjectContextPicker.svelte';
   import SkillMentionOverlay from '$lib/features/composer/components/SkillMentionOverlay.svelte';
   import SlashAutocomplete from '$lib/features/composer/components/SlashAutocomplete.svelte';
@@ -131,6 +132,7 @@
   let nextBrowserTabIndex = $state(1);
   let lastAutoOpenedBrowserSessionId = $state<string | null>(null);
   let lastAutoOpenedVaultPromptId = $state<string | null>(null);
+  let lastAutoOpenedCycleSignal = $state<number | null>(null);
   let lastAutoSelectedAppId = $state<string | null>(null);
   let teamMembers = $state<any[]>([]);
   let teamMembersLoading = false;
@@ -706,6 +708,10 @@
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'vault'));
   }
 
+  function openCyclesTab() {
+    applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'cycles'));
+  }
+
   function openAppTab(appId: string | null | undefined) {
     applySidePanelState(openAppThreadSidePanelTab(sidePanelState(), appId, workspaceApps.appById(appId ?? '')));
   }
@@ -739,6 +745,10 @@
     }
     if (item.kind === 'vault') {
       openVaultTab();
+      return;
+    }
+    if (item.kind === 'cycles') {
+      openCyclesTab();
       return;
     }
     if (item.kind === 'app') {
@@ -776,6 +786,14 @@
     if (promptId === lastAutoOpenedVaultPromptId) return;
     lastAutoOpenedVaultPromptId = promptId;
     openVaultTab();
+  });
+
+  $effect(() => {
+    const signal = cortex.cyclePanelSignal;
+    if (!signal || signal.ideaId !== idea?.id) return;
+    if (signal.serial === lastAutoOpenedCycleSignal) return;
+    lastAutoOpenedCycleSignal = signal.serial;
+    openCyclesTab();
   });
 
   let pendingInitialScrollIdeaId = $state<string | null>(null);
@@ -1001,6 +1019,13 @@
     />
   {/snippet}
 
+  {#snippet cyclesPane()}
+    <ThreadCyclesPane
+      focusCycleId={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.cycleId : null}
+      refreshSerial={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.serial : null}
+    />
+  {/snippet}
+
   <ThreadStageShell
     {entering}
     {ready}
@@ -1054,6 +1079,7 @@
               utilityPane={utilityPane}
               appsPane={appsPane}
               vaultPane={vaultPane}
+              cyclesPane={cyclesPane}
             />
           </div>
         {/if}

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -1,4 +1,4 @@
-export type ThreadStageRightDockTabKind = 'browser' | 'activity' | 'app' | 'vault';
+export type ThreadStageRightDockTabKind = 'browser' | 'activity' | 'app' | 'vault' | 'cycles';
 
 export type ThreadStageRightDockTab = {
   id: string;
@@ -48,6 +48,7 @@ export function buildThreadSidePanelAddMenuItems(
   const browserCount = tabs.filter((tab) => tab.kind === 'browser').length;
   const hasActivity = tabs.some((tab) => tab.kind === 'activity');
   const hasVault = tabs.some((tab) => tab.kind === 'vault');
+  const hasCycles = tabs.some((tab) => tab.kind === 'cycles');
   const openAppIds = new Set(
     tabs
       .filter((tab) => tab.kind === 'app' && tab.appId)
@@ -68,6 +69,15 @@ export function buildThreadSidePanelAddMenuItems(
       kind: 'vault',
       label: 'Vault',
       description: 'Add or review thread keys',
+    });
+  }
+
+  if (!hasCycles) {
+    items.push({
+      id: 'cycles',
+      kind: 'cycles',
+      label: 'Cycles',
+      description: 'Review scheduled Illo work',
     });
   }
 
@@ -140,12 +150,12 @@ export function openBrowserThreadSidePanelTab(
 
 export function openSingletonThreadSidePanelTab(
   state: ThreadSidePanelTabState,
-  kind: 'activity' | 'vault',
+  kind: 'activity' | 'vault' | 'cycles',
 ): ThreadSidePanelTabState {
   const existing = state.tabs.find((tab) => tab.kind === kind);
   if (existing) return { ...state, activeTabId: existing.id };
 
-  const label = kind === 'vault' ? 'Vault' : 'Activity';
+  const label = kind === 'vault' ? 'Vault' : kind === 'cycles' ? 'Cycles' : 'Activity';
   return {
     ...state,
     tabs: [

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -112,6 +112,13 @@ class CortexStore {
   browserDiscovery = $state<BrowserDiscoveryResult | null>(null);
   browserExtraction = $state<BrowserExtractResult | null>(null);
   vaultSecretPrompt = $state<VaultSecretPrompt | null>(null);
+  cyclePanelSignal = $state<{
+    ideaId: string;
+    toolName: string;
+    cycleId: number | null;
+    action: string | null;
+    serial: number;
+  } | null>(null);
   teamMembers = $state<TeamMember[]>([]);
   birthContext = $state<{ x: number; y: number } | null>(null);
   filters = $state<{ statuses: Set<string>; search: string; staleOnly?: boolean }>({
@@ -131,6 +138,7 @@ class CortexStore {
   private _ideasSnapshotReconcile: ReturnType<typeof setInterval> | null = null;
   private _pendingBrowserSessionRefresh: ReturnType<typeof setTimeout> | null = null;
   private _seenRunUiEvents = new Set<string>();
+  private _cyclePanelSignalSerial = 0;
   private _browserFocusLoads = new Set<string>();
   private _pendingBrowserEvents = new Map<string, {
     state?: BrowserSessionState | null;
@@ -616,6 +624,55 @@ class CortexStore {
     return String(runId) === String(rootRunId);
   }
 
+  private _nextCyclePanelSignalSerial(): number {
+    this._cyclePanelSignalSerial += 1;
+    if (!Number.isSafeInteger(this._cyclePanelSignalSerial)) this._cyclePanelSignalSerial = 1;
+    return this._cyclePanelSignalSerial;
+  }
+
+  private _triggerCyclePanelSignal(options: {
+    ideaId: string;
+    toolName: string;
+    cycleId?: unknown;
+    action?: unknown;
+  }) {
+    const ideaId = String(options.ideaId || '').trim();
+    if (!ideaId) return;
+    const cycleId = Number(options.cycleId ?? 0);
+    const action = String(options.action ?? '').trim() || null;
+    this.cyclePanelSignal = {
+      ideaId,
+      toolName: options.toolName,
+      cycleId: Number.isFinite(cycleId) && cycleId > 0 ? cycleId : null,
+      action,
+      serial: this._nextCyclePanelSignalSerial(),
+    };
+  }
+
+  private _maybeTriggerCyclePanelFromRunUiEvent(msg: any) {
+    if (msg.idea_id !== this.selectedIdeaId) return;
+    if (msg.type !== 'tool_started' && msg.type !== 'tool_finished') return;
+    const toolName = typeof msg.tool_name === 'string' ? msg.tool_name.trim() : '';
+    if (!['manage_cycle', 'read_cycles'].includes(toolName)) return;
+    this._triggerCyclePanelSignal({
+      ideaId: String(msg.idea_id),
+      toolName,
+      cycleId: msg.id ?? msg.cycle_id ?? msg.args?.id ?? msg.args?.cycle_id ?? msg.tool_input?.id,
+      action: msg.action ?? msg.args?.action ?? msg.tool_input?.action,
+    });
+  }
+
+  _handleCycleChanged(msg: any) {
+    const ideaId = String(msg?.idea_id ?? msg?.target_idea_id ?? '').trim();
+    if (!ideaId || ideaId !== this.selectedIdeaId) return;
+    this._triggerCyclePanelSignal({
+      ideaId,
+      toolName: 'cycles_changed',
+      cycleId: msg?.cycle_id,
+      action: msg?.action,
+    });
+  }
+
   private _markIdeaWorkingForRootRun(ideaId: string) {
     const current = this.ideas.find((i) => i.id === ideaId);
     if (current && ['archived', 'resolved'].includes(String(current.status || ''))) return;
@@ -630,6 +687,7 @@ class CortexStore {
     if (msg.type === 'run_started' && isRootRunEvent) {
       this._markIdeaWorkingForRootRun(msg.idea_id);
     }
+    this._maybeTriggerCyclePanelFromRunUiEvent(msg);
     if (msg.idea_id !== this.selectedIdeaId || !isRootRunEvent) return;
     const eventKey = runUiEventKey(msg);
     if (eventKey) {

--- a/frontend/src/lib/stores/cortexRealtime.ts
+++ b/frontend/src/lib/stores/cortexRealtime.ts
@@ -45,6 +45,7 @@ export interface CortexRealtimeStoreBindings {
   _stopSelectedIdeaReconcile(): void;
   _scheduleSelectedStreamRefresh(delayMs?: number): void;
   _handleRunUiEvent(msg: any): void;
+  _handleCycleChanged(msg: any): void;
   _handleBrowserSessionEvent(msg: any, frame?: BrowserFrame | null): void;
   _handleVaultSecretPrompt(msg: any): void;
   _upsertIdea(idea: Idea): void;
@@ -181,6 +182,12 @@ export function setupCortexRealtimeBindings(options: {
       }),
     );
   }
+
+  unsubs.push(
+    wsClient.on('cycles_changed', (msg) => {
+      store._handleCycleChanged(msg);
+    }),
+  );
 
   // Visual blocks — render inline in conversation stream
   unsubs.push(

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -21,7 +21,7 @@
   import { ui } from '$lib/stores/ui.svelte';
 
   type ThinkingLevel = '' | 'none' | 'low' | 'medium' | 'high' | 'xhigh';
-  type ScheduleCadence = 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
+  type ScheduleCadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
   type FilterMode = 'all' | 'active' | 'attention';
   type PillTone = 'muted' | 'warning' | 'success' | 'danger' | 'info';
 
@@ -30,6 +30,7 @@
     prompt: string;
     schedule_expr: string;
     cadence: ScheduleCadence;
+    date: string;
     time: string;
     weekday: string;
     monthday: string;
@@ -43,7 +44,7 @@
 
   type ParsedSchedule = Pick<
     CycleForm,
-    'cadence' | 'time' | 'weekday' | 'monthday' | 'custom_schedule'
+    'cadence' | 'date' | 'time' | 'weekday' | 'monthday' | 'custom_schedule'
   >;
 
   const THINKING_OPTIONS: Array<{ value: ThinkingLevel; label: string }> = [
@@ -56,6 +57,7 @@
   ];
 
   const CADENCE_OPTIONS: Array<{ value: ScheduleCadence; label: string; description: string }> = [
+    { value: 'once', label: 'Once', description: 'Single reminder' },
     { value: 'daily', label: 'Daily', description: 'Every day' },
     { value: 'weekdays', label: 'Weekdays', description: 'Monday to Friday' },
     { value: 'weekly', label: 'Weekly', description: 'One day each week' },
@@ -81,6 +83,7 @@
   const MONTHDAY_OPTIONS = Array.from({ length: 31 }, (_, index) => String(index + 1));
   const DEFAULT_SCHEDULE = '0 9 * * *';
   const DEFAULT_TIME = '09:00';
+  const ONE_TIME_PREFIX = 'at:';
 
   let cycles = $state<CycleRead[]>([]);
   let runs = $state<CycleRunRead[]>([]);
@@ -106,6 +109,7 @@
     prompt: '',
     schedule_expr: DEFAULT_SCHEDULE,
     cadence: 'daily',
+    date: defaultRunDate(),
     time: DEFAULT_TIME,
     weekday: '1',
     monthday: '1',
@@ -213,15 +217,18 @@
   }
 
   function cycleStatusDetail(cycle: CycleRead): string {
+    const isOnce = isOneTimeSchedule(cycle.schedule_expr);
     if (cycle.last_error) return 'Latest run failed';
-    if (cycle.next_run_at) return `Next ${formatDateTime(cycle.next_run_at)}`;
+    if (cycle.next_run_at) return `${isOnce ? 'Runs' : 'Next'} ${formatDateTime(cycle.next_run_at)}`;
+    if (isOnce && cycle.last_run_at) return `Ran ${timeAgo(cycle.last_run_at)}`;
     if (cycle.last_run_at) return `Last ${timeAgo(cycle.last_run_at)}`;
     return cycle.enabled ? 'No next run' : 'Paused schedule';
   }
 
   function cycleFactSummary(cycle: CycleRead): string {
     const cadence = parseSchedule(cycle.schedule_expr).cadence;
-    return `${cadence} / ${cycle.enabled ? 'active' : 'paused'} / ${threadLabel(cycle).toLowerCase()}`;
+    const state = cadence === 'once' && !cycle.enabled && cycle.last_run_at ? 'done' : cycle.enabled ? 'active' : 'paused';
+    return `${cadence} / ${state} / ${threadLabel(cycle).toLowerCase()}`;
   }
 
   function setFilter(key: string) {
@@ -232,6 +239,13 @@
 
   function previewIso(daysOffset: number, hoursOffset = 0): string {
     return new Date(Date.now() + daysOffset * 86400000 + hoursOffset * 3600000).toISOString();
+  }
+
+  function previewNextRunAtForSchedule(scheduleExpr: string, enabled = true): string | null {
+    if (!enabled) return null;
+    const onceDate = oneTimeDateFromExpression(scheduleExpr);
+    if (onceDate) return onceDate.toISOString();
+    return previewIso(1);
   }
 
   function previewCycle(
@@ -378,6 +392,44 @@
     return value.replaceAll('_', ' ');
   }
 
+  function pad2(value: number): string {
+    return String(value).padStart(2, '0');
+  }
+
+  function dateInputFromDate(date: Date): string {
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  }
+
+  function defaultRunDate(): string {
+    return dateInputFromDate(new Date(Date.now() + 86400000));
+  }
+
+  function isOneTimeSchedule(expr: string | null | undefined): boolean {
+    return String(expr ?? '').trim().toLowerCase().startsWith(ONE_TIME_PREFIX);
+  }
+
+  function oneTimeDateFromExpression(expr: string | null | undefined): Date | null {
+    if (!isOneTimeSchedule(expr)) return null;
+    const raw = String(expr ?? '').trim().slice(ONE_TIME_PREFIX.length).trim();
+    if (!raw) return null;
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function oneTimeExpressionFromForm(): string {
+    const date = form.date || defaultRunDate();
+    const time = normalizeTime(form.time);
+    return `${ONE_TIME_PREFIX}${date}T${time}:00`;
+  }
+
+  function formatDateLabel(value: string): string {
+    const [year, month, day] = value.split('-').map(Number);
+    if (!year || !month || !day) return value || 'selected date';
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(
+      new Date(year, month - 1, day),
+    );
+  }
+
   function cycleDescription(cycle: CycleRead): string {
     const prompt = cycle.prompt.trim();
     if (!prompt) return scheduleLabelForCycle(cycle);
@@ -427,12 +479,25 @@
 
   function parseSchedule(expr: string | null | undefined): ParsedSchedule {
     const source = (expr || DEFAULT_SCHEDULE).trim();
+    const onceDate = oneTimeDateFromExpression(source);
+    if (onceDate) {
+      return {
+        cadence: 'once',
+        date: dateInputFromDate(onceDate),
+        time: normalizeTime(`${onceDate.getHours()}:${pad2(onceDate.getMinutes())}`),
+        weekday: '1',
+        monthday: '1',
+        custom_schedule: source,
+      };
+    }
+
     const [minute, hour, dayOfMonth, month, dayOfWeek, ...extra] = source.split(/\s+/);
     const time = timeFromCron(minute, hour);
 
     if (!time || !dayOfMonth || !month || !dayOfWeek || extra.length) {
       return {
         cadence: 'custom',
+        date: defaultRunDate(),
         time: DEFAULT_TIME,
         weekday: '1',
         monthday: '1',
@@ -443,6 +508,7 @@
     if (dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
       return {
         cadence: 'daily',
+        date: defaultRunDate(),
         time,
         weekday: '1',
         monthday: '1',
@@ -457,6 +523,7 @@
     ) {
       return {
         cadence: 'weekdays',
+        date: defaultRunDate(),
         time,
         weekday: '1',
         monthday: '1',
@@ -469,6 +536,7 @@
       if (WEEKDAY_OPTIONS.some((option) => option.value === normalizedWeekday)) {
         return {
           cadence: 'weekly',
+          date: defaultRunDate(),
           time,
           weekday: normalizedWeekday,
           monthday: '1',
@@ -482,6 +550,7 @@
       if (day >= 1 && day <= 31) {
         return {
           cadence: 'monthly',
+          date: defaultRunDate(),
           time,
           weekday: '1',
           monthday: String(day),
@@ -492,6 +561,7 @@
 
     return {
       cadence: 'custom',
+      date: defaultRunDate(),
       time,
       weekday: '1',
       monthday: '1',
@@ -500,6 +570,7 @@
   }
 
   function scheduleExprFromForm(): string {
+    if (form.cadence === 'once') return oneTimeExpressionFromForm();
     if (form.cadence === 'custom') return form.custom_schedule.trim();
 
     const { minute, hour } = cronPartsFromTime(form.time);
@@ -511,6 +582,7 @@
 
   function scheduleLabelForForm(value: CycleForm): string {
     const time = formatTimeLabel(value.time);
+    if (value.cadence === 'once') return `Once on ${formatDateLabel(value.date)} at ${time}`;
     if (value.cadence === 'weekdays') return `Weekdays at ${time}`;
     if (value.cadence === 'weekly') return `${weekdayOption(value.weekday).plural} at ${time}`;
     if (value.cadence === 'monthly') return `Monthly on day ${value.monthday} at ${time}`;
@@ -553,11 +625,12 @@
       prompt: cycle.prompt,
       schedule_expr: cycle.schedule_expr,
       cadence: parsed.cadence,
+      date: parsed.date,
       time: parsed.time,
       weekday: parsed.weekday,
       monthday: parsed.monthday,
       custom_schedule: parsed.custom_schedule,
-      timezone: localTimezone,
+      timezone: cycle.timezone || localTimezone,
       enabled: cycle.enabled,
       model_override: cycle.model_override || '',
       thinking_override: (cycle.thinking_override as ThinkingLevel) || '',
@@ -696,7 +769,7 @@
           model_override: payload.model_override,
           thinking_override: payload.thinking_override,
           target_idea_id: payload.target_idea_id ?? existing?.target_idea_id ?? `preview-cycle-${savedId}`,
-          next_run_at: payload.enabled ? previewIso(1) : null,
+          next_run_at: previewNextRunAtForSchedule(payload.schedule_expr, payload.enabled),
           last_run_at: existing?.last_run_at ?? null,
           last_status: existing?.last_status ?? 'idle',
           last_error: null,
@@ -789,7 +862,7 @@
             ? {
                 ...item,
                 enabled: !item.enabled,
-                next_run_at: !item.enabled ? previewIso(1) : null,
+                next_run_at: !item.enabled ? previewNextRunAtForSchedule(item.schedule_expr, true) : null,
                 updated_at: new Date().toISOString(),
               }
             : item,
@@ -976,6 +1049,13 @@
 
                       {#if form.cadence !== 'custom'}
                         <div class="schedule-fields">
+                          {#if form.cadence === 'once'}
+                            <label class="cycle-field">
+                              <span class="cycle-field-label">Date</span>
+                              <input bind:value={form.date} class="cycle-input" type="date" />
+                            </label>
+                          {/if}
+
                           <label class="cycle-field">
                             <span class="cycle-field-label">Time</span>
                             <input bind:value={form.time} class="cycle-input" type="time" />
@@ -1065,7 +1145,7 @@
                                 placeholder="0 9 * * *"
                               />
                               <span class="cycle-field-hint">
-                                Use this only when Daily, Weekdays, Weekly, or Monthly does not cover the cycle.
+                                Use this only when Once, Daily, Weekdays, Weekly, or Monthly does not cover the cycle.
                               </span>
                             </label>
                           {/if}
@@ -1220,6 +1300,13 @@
 
                         {#if form.cadence !== 'custom'}
                           <div class="schedule-fields">
+                            {#if form.cadence === 'once'}
+                              <label class="cycle-field">
+                                <span class="cycle-field-label">Date</span>
+                                <input bind:value={form.date} class="cycle-input" type="date" />
+                              </label>
+                            {/if}
+
                             <label class="cycle-field">
                               <span class="cycle-field-label">Time</span>
                               <input bind:value={form.time} class="cycle-input" type="time" />
@@ -1327,7 +1414,7 @@
                                   placeholder="0 9 * * *"
                                 />
                                 <span class="cycle-field-hint">
-                                  Use this only when Daily, Weekdays, Weekly, or Monthly does not cover the cycle.
+                                  Use this only when Once, Daily, Weekdays, Weekly, or Monthly does not cover the cycle.
                                 </span>
                               </label>
                             {/if}
@@ -1752,7 +1839,7 @@
   }
 
   .cadence-grid {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 8px;
   }
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -102,6 +102,35 @@ def test_compute_next_run_at_uses_timezone():
     assert next_run == datetime(2026, 4, 22, 13, 0, tzinfo=timezone.utc)
 
 
+def test_one_time_schedule_uses_timezone_and_expires_after_run():
+    expr = service.validate_schedule_expr(
+        "at:2026-05-08T09:30:00",
+        "America/Toronto",
+    )
+
+    next_run = service.compute_next_run_at(expr, "America/Toronto")
+
+    assert expr.startswith("at:")
+    assert next_run == datetime(2026, 5, 8, 13, 30, tzinfo=timezone.utc)
+    assert (
+        service.compute_next_run_at(
+            expr,
+            "America/Toronto",
+            from_dt=next_run,
+        )
+        is None
+    )
+
+
+def test_humanize_one_time_schedule():
+    label = service.humanize_schedule(
+        "at:2026-05-08T09:30:00",
+        "America/Toronto",
+    )
+
+    assert label == "Once at May 8, 2026 9:30 AM (America/Toronto)"
+
+
 def test_cycle_defaults_reuse_same_idea_reopens_by_default():
     assert service.cycle_defaults(execution_mode="reuse_same_idea", reopen_archived=None) is True
     assert service.cycle_defaults(execution_mode="new_idea_per_run", reopen_archived=None) is True


### PR DESCRIPTION
## Summary
- add one-time `run_at` cycle scheduling for reminder-style Illo work
- publish `cycles_changed` events from cycle mutations and runs
- add a Cycles right-dock pane for thread stage, with automatic opening when Illo uses cycle tools
- update cycle management UI, API schemas/client types, docs, and coverage for one-time schedules

## Testing
- `npm run check`
- `npm run build`
- `python3 -m py_compile brain/systems/cycles/service.py brain/app/api/routers/cycles.py brain/systems/runs/tool_catalog/handlers/cycles.py brain/systems/cycles/events.py`

Note: full pytest was not available in the local environment because `pytest` / `croniter` are missing.
