### PR TITLE
Keep OpenAI OAuth in a popup

### DIFF
--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -38,7 +38,7 @@ INTRO_RUN_SETTLED_STATUSES = {
     RunStatus.COMPLETED.value,
 }
 
-INTRO_PROMPT = "Illo works well solo. Introduce yourself and help me finish setting up this workspace."
+INTRO_PROMPT = "Hi Illo, what can you help me with?"
 
 
 def _intro_ref(user_id: str) -> str:

--- a/frontend/src/lib/components/constellation/ConstellationWorkspaceBackdrop.svelte
+++ b/frontend/src/lib/components/constellation/ConstellationWorkspaceBackdrop.svelte
@@ -1,5 +1,16 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { Snippet } from 'svelte';
+
+  type GradientStop = readonly [number, string];
+  type NebulaPatch = {
+    x: number;
+    y: number;
+    radius: number;
+    scaleX: number;
+    scaleY: number;
+    stops: GradientStop[];
+  };
 
   type Props = {
     className?: string;
@@ -16,6 +27,198 @@
     canvasUtility?: Snippet;
     overlays?: Snippet;
   };
+
+  let deepFieldCanvas: HTMLCanvasElement | null = null;
+
+  const DEEP_FIELD_SEED = 0x9e3779b9;
+
+  function seededRandom(seed: number) {
+    let value = seed;
+    return () => {
+      value += 0x6d2b79f5;
+      let next = value;
+      next = Math.imul(next ^ (next >>> 15), next | 1);
+      next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+      return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function drawNebulaPatch(context: CanvasRenderingContext2D, patch: NebulaPatch) {
+    context.save();
+    context.translate(patch.x, patch.y);
+    context.scale(patch.scaleX, patch.scaleY);
+
+    const gradient = context.createRadialGradient(0, 0, 0, 0, 0, patch.radius);
+    for (const [offset, color] of patch.stops) {
+      gradient.addColorStop(offset, color);
+    }
+
+    context.fillStyle = gradient;
+    context.fillRect(-patch.radius, -patch.radius, patch.radius * 2, patch.radius * 2);
+    context.restore();
+  }
+
+  function drawDeepField(canvasElement: HTMLCanvasElement) {
+    const rect = canvasElement.getBoundingClientRect();
+    const width = Math.max(1, Math.round(rect.width));
+    const height = Math.max(1, Math.round(rect.height));
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    const pixelWidth = Math.round(width * pixelRatio);
+    const pixelHeight = Math.round(height * pixelRatio);
+    const context = canvasElement.getContext('2d');
+
+    if (!context) {
+      return;
+    }
+
+    if (canvasElement.width !== pixelWidth || canvasElement.height !== pixelHeight) {
+      canvasElement.width = pixelWidth;
+      canvasElement.height = pixelHeight;
+    }
+
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.clearRect(0, 0, width, height);
+    context.globalCompositeOperation = 'screen';
+
+    const rand = seededRandom(DEEP_FIELD_SEED + width * 31 + height * 17);
+    const span = Math.max(width, height);
+    const patches: NebulaPatch[] = [
+      {
+        x: width * 0.18,
+        y: height * 0.26,
+        radius: span * 0.48,
+        scaleX: 1.55,
+        scaleY: 0.78,
+        stops: [
+          [0, 'rgba(58, 95, 154, 0.18)'],
+          [0.34, 'rgba(37, 70, 124, 0.1)'],
+          [1, 'rgba(37, 70, 124, 0)'],
+        ],
+      },
+      {
+        x: width * 0.72,
+        y: height * 0.3,
+        radius: span * 0.42,
+        scaleX: 1.22,
+        scaleY: 0.68,
+        stops: [
+          [0, 'rgba(82, 74, 136, 0.12)'],
+          [0.42, 'rgba(52, 64, 122, 0.07)'],
+          [1, 'rgba(52, 64, 122, 0)'],
+        ],
+      },
+      {
+        x: width * 0.52,
+        y: height * 0.86,
+        radius: span * 0.52,
+        scaleX: 1.82,
+        scaleY: 0.52,
+        stops: [
+          [0, 'rgba(31, 104, 126, 0.12)'],
+          [0.46, 'rgba(18, 72, 104, 0.075)'],
+          [1, 'rgba(18, 72, 104, 0)'],
+        ],
+      },
+      {
+        x: width * 0.92,
+        y: height * 0.76,
+        radius: span * 0.34,
+        scaleX: 1.16,
+        scaleY: 0.92,
+        stops: [
+          [0, 'rgba(124, 92, 78, 0.08)'],
+          [0.5, 'rgba(94, 72, 90, 0.045)'],
+          [1, 'rgba(94, 72, 90, 0)'],
+        ],
+      },
+    ];
+
+    context.filter = 'blur(18px) saturate(1.08)';
+    for (const patch of patches) {
+      drawNebulaPatch(context, patch);
+    }
+    context.filter = 'none';
+
+    const dustCount = clamp(Math.round((width * height) / 850), 260, 2600);
+    for (let i = 0; i < dustCount; i += 1) {
+      const x = rand() * width;
+      const y = rand() * height;
+      const alpha = 0.01 + rand() * 0.035;
+      const size = 0.24 + rand() * 0.72;
+      const hueRoll = rand();
+      const color =
+        hueRoll > 0.9
+          ? `rgba(255, 207, 162, ${alpha * 0.7})`
+          : hueRoll > 0.62
+            ? `rgba(111, 174, 226, ${alpha})`
+            : `rgba(226, 238, 255, ${alpha})`;
+
+      context.fillStyle = color;
+      context.fillRect(x, y, size, size);
+    }
+
+    const starCount = clamp(Math.round((width * height) / 5400), 150, 520);
+    for (let i = 0; i < starCount; i += 1) {
+      const x = rand() * width;
+      const y = rand() * height;
+      const bright = Math.pow(rand(), 3);
+      const radius = 0.32 + bright * 1.42;
+      const alpha = 0.18 + bright * 0.62 + (rand() > 0.988 ? 0.18 : 0);
+      const tint = rand();
+      const core =
+        tint > 0.92
+          ? [255, 222, 180]
+          : tint > 0.58
+            ? [160, 204, 255]
+            : [235, 244, 255];
+
+      if (radius > 0.76) {
+        const halo = context.createRadialGradient(x, y, 0, x, y, radius * 5.4);
+        halo.addColorStop(0, `rgba(${core[0]}, ${core[1]}, ${core[2]}, ${alpha * 0.28})`);
+        halo.addColorStop(0.32, `rgba(${core[0]}, ${core[1]}, ${core[2]}, ${alpha * 0.08})`);
+        halo.addColorStop(1, `rgba(${core[0]}, ${core[1]}, ${core[2]}, 0)`);
+        context.fillStyle = halo;
+        context.beginPath();
+        context.arc(x, y, radius * 5.4, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      context.fillStyle = `rgba(${core[0]}, ${core[1]}, ${core[2]}, ${Math.min(alpha, 0.86)})`;
+      context.beginPath();
+      context.arc(x, y, radius, 0, Math.PI * 2);
+      context.fill();
+    }
+  }
+
+  onMount(() => {
+    let frame = 0;
+    const scheduleDraw = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        if (deepFieldCanvas) {
+          drawDeepField(deepFieldCanvas);
+        }
+      });
+    };
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' && deepFieldCanvas ? new ResizeObserver(scheduleDraw) : null;
+
+    scheduleDraw();
+    if (deepFieldCanvas && resizeObserver) {
+      resizeObserver.observe(deepFieldCanvas);
+    }
+    window.addEventListener('resize', scheduleDraw);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleDraw);
+    };
+  });
 
   let {
     className = '',
@@ -62,7 +265,7 @@
   <div class="constellation-workspace-backdrop-underlay" aria-hidden="true">
     <div class="constellation-workspace-backdrop-surface"></div>
     <div class="constellation-workspace-backdrop-tide"></div>
-    <div class="constellation-workspace-backdrop-deep-field"></div>
+    <canvas bind:this={deepFieldCanvas} class="constellation-workspace-backdrop-deep-field"></canvas>
     <svg
       class="constellation-workspace-backdrop-waves"
       viewBox="0 0 1440 900"
@@ -185,9 +388,6 @@
     --constellation-workspace-caustics-size: var(--constellation-workspace-theme-caustics-size, auto);
     --constellation-workspace-caustics-blend-mode: var(--constellation-workspace-theme-caustics-blend-mode, normal);
     --constellation-workspace-deep-field-opacity: var(--constellation-workspace-theme-deep-field-opacity, 0);
-    --constellation-workspace-deep-field-nebula: var(--constellation-workspace-theme-deep-field-nebula, none);
-    --constellation-workspace-deep-field-stars: var(--constellation-workspace-theme-deep-field-stars, none);
-    --constellation-workspace-deep-field-dust: var(--constellation-workspace-theme-deep-field-dust, none);
     --constellation-workspace-water-animation-state: var(
       --constellation-workspace-theme-water-animation-state,
       paused
@@ -314,46 +514,12 @@
 
   .constellation-workspace-backdrop-deep-field {
     inset: 0;
-    overflow: hidden;
+    display: block;
+    width: 100%;
+    height: 100%;
     opacity: var(--constellation-workspace-deep-field-opacity);
     mix-blend-mode: screen;
-    background: var(--constellation-workspace-deep-field-nebula);
-  }
-
-  .constellation-workspace-backdrop-deep-field::before,
-  .constellation-workspace-backdrop-deep-field::after {
-    content: '';
-    position: absolute;
-    inset: -4%;
-    pointer-events: none;
-  }
-
-  .constellation-workspace-backdrop-deep-field::before {
-    background-image: var(--constellation-workspace-deep-field-stars);
-    background-position:
-      18px 28px,
-      92px 10px,
-      160px 140px,
-      0 0;
-    background-size:
-      154px 154px,
-      263px 263px,
-      391px 391px,
-      520px 520px;
-    opacity: 0.82;
-  }
-
-  .constellation-workspace-backdrop-deep-field::after {
-    background-image: var(--constellation-workspace-deep-field-dust);
-    background-position:
-      12% 18%,
-      76% 24%,
-      50% 82%;
-    background-size:
-      420px 320px,
-      520px 380px,
-      680px 440px;
-    opacity: 0.74;
+    background: transparent;
   }
 
   .constellation-workspace-backdrop-waves {
@@ -435,6 +601,12 @@
     width: 420px;
     height: 320px;
     background: var(--constellation-workspace-scene-warmth);
+  }
+
+  :global(:root:not([data-color-scheme='light'])) .constellation-workspace-backdrop::before,
+  :global(:root:not([data-color-scheme='light'])) .constellation-workspace-backdrop-scene-glow,
+  :global(:root:not([data-color-scheme='light'])) .constellation-workspace-backdrop-scene-warmth {
+    display: none;
   }
 
   .constellation-workspace-backdrop-canvas {

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -1232,7 +1232,7 @@
   }
 
   :global(.constellation-workspace-backdrop.cortex-workspace-backdrop.is-direct-thread) {
-    --constellation-workspace-theme-deep-field-opacity: 0;
+    --constellation-workspace-theme-deep-field-opacity: 0.82;
   }
 
   .workspace-composer-shell {

--- a/frontend/src/lib/styles/constellation.css
+++ b/frontend/src/lib/styles/constellation.css
@@ -378,30 +378,30 @@
   --constellation-presence-seed-user-owner-accent-strength: 18%;
 
   --constellation-workspace-theme-background:
-    radial-gradient(ellipse 66% 44% at 20% 18%, rgba(83, 116, 170, 0.16), transparent 68%),
-    radial-gradient(ellipse 58% 40% at 80% 22%, rgba(112, 87, 150, 0.1), transparent 68%),
-    radial-gradient(ellipse 74% 52% at 50% 76%, rgba(48, 104, 108, 0.075), transparent 72%),
-    radial-gradient(ellipse 88% 64% at 46% 46%, rgba(255, 255, 255, 0.028), transparent 78%),
-    linear-gradient(180deg, #0e1523 0%, #121929 48%, #0b111d 100%);
-  --constellation-workspace-theme-star-color-a: rgba(240, 240, 250, 0.38);
-  --constellation-workspace-theme-star-color-b: rgba(141, 183, 255, 0.22);
-  --constellation-workspace-theme-star-color-c: rgba(213, 161, 77, 0.16);
-  --constellation-workspace-theme-star-opacity: 0.3;
-  --constellation-workspace-theme-deep-field-opacity: 0.86;
+    radial-gradient(ellipse 54% 32% at 18% 16%, rgba(77, 115, 190, 0.13), transparent 70%),
+    radial-gradient(ellipse 46% 28% at 80% 20%, rgba(118, 84, 162, 0.09), transparent 72%),
+    radial-gradient(ellipse 62% 36% at 52% 82%, rgba(36, 100, 102, 0.07), transparent 76%),
+    radial-gradient(ellipse 92% 68% at 50% 46%, rgba(7, 12, 24, 0.24), transparent 68%),
+    linear-gradient(180deg, #02050c 0%, #07101d 46%, #02040a 100%);
+  --constellation-workspace-theme-star-color-a: rgba(240, 240, 250, 0.26);
+  --constellation-workspace-theme-star-color-b: rgba(122, 177, 255, 0.24);
+  --constellation-workspace-theme-star-color-c: rgba(255, 208, 154, 0.14);
+  --constellation-workspace-theme-star-opacity: 0.2;
+  --constellation-workspace-theme-deep-field-opacity: 0.96;
   --constellation-workspace-theme-deep-field-nebula:
-    radial-gradient(ellipse 64% 24% at 18% 26%, rgba(141, 183, 255, 0.085), transparent 72%),
-    radial-gradient(ellipse 52% 22% at 76% 22%, rgba(173, 126, 210, 0.07), transparent 72%),
-    radial-gradient(ellipse 74% 28% at 52% 80%, rgba(87, 207, 160, 0.042), transparent 76%),
-    radial-gradient(ellipse 84% 32% at 42% 50%, rgba(240, 240, 250, 0.026), transparent 78%);
+    radial-gradient(ellipse 58% 20% at 16% 28%, rgba(115, 168, 255, 0.105), transparent 74%),
+    radial-gradient(ellipse 46% 18% at 78% 24%, rgba(176, 124, 226, 0.078), transparent 74%),
+    radial-gradient(ellipse 70% 24% at 50% 82%, rgba(62, 191, 157, 0.048), transparent 78%),
+    radial-gradient(ellipse 80% 28% at 42% 50%, rgba(240, 240, 250, 0.022), transparent 80%);
   --constellation-workspace-theme-deep-field-stars:
-    radial-gradient(circle at center, rgba(240, 240, 250, 0.66) 0 0.68px, transparent 0.9px),
-    radial-gradient(circle at center, rgba(141, 183, 255, 0.38) 0 0.82px, transparent 1.02px),
-    radial-gradient(circle at center, rgba(255, 225, 189, 0.24) 0 0.76px, transparent 1px),
-    radial-gradient(circle at center, rgba(240, 240, 250, 0.18) 0 1.1px, transparent 1.35px);
+    radial-gradient(circle at center, rgba(240, 240, 250, 0.72) 0 0.58px, transparent 0.88px),
+    radial-gradient(circle at center, rgba(122, 177, 255, 0.44) 0 0.78px, transparent 1.04px),
+    radial-gradient(circle at center, rgba(255, 218, 176, 0.28) 0 0.72px, transparent 1px),
+    radial-gradient(circle at center, rgba(240, 240, 250, 0.16) 0 1.05px, transparent 1.38px);
   --constellation-workspace-theme-deep-field-dust:
-    radial-gradient(ellipse 56% 18% at 18% 30%, rgba(141, 183, 255, 0.11), transparent 74%),
-    radial-gradient(ellipse 44% 16% at 74% 24%, rgba(213, 161, 77, 0.068), transparent 72%),
-    radial-gradient(ellipse 62% 18% at 52% 78%, rgba(240, 240, 250, 0.05), transparent 76%);
+    radial-gradient(ellipse 52% 16% at 18% 30%, rgba(122, 177, 255, 0.12), transparent 76%),
+    radial-gradient(ellipse 42% 14% at 74% 24%, rgba(218, 157, 89, 0.064), transparent 74%),
+    radial-gradient(ellipse 58% 16% at 52% 78%, rgba(240, 240, 250, 0.042), transparent 78%);
   --constellation-workspace-theme-scene-glow:
     radial-gradient(ellipse 76% 52% at 28% 24%, rgba(141, 183, 255, 0.14), transparent 76%),
     radial-gradient(ellipse 56% 42% at 60% 34%, rgba(240, 240, 250, 0.05), transparent 74%);

--- a/frontend/src/lib/styles/constellation.css
+++ b/frontend/src/lib/styles/constellation.css
@@ -386,28 +386,10 @@
   --constellation-workspace-theme-star-color-a: rgba(240, 240, 250, 0.26);
   --constellation-workspace-theme-star-color-b: rgba(122, 177, 255, 0.24);
   --constellation-workspace-theme-star-color-c: rgba(255, 208, 154, 0.14);
-  --constellation-workspace-theme-star-opacity: 0.2;
+  --constellation-workspace-theme-star-opacity: 0;
   --constellation-workspace-theme-deep-field-opacity: 0.96;
-  --constellation-workspace-theme-deep-field-nebula:
-    radial-gradient(ellipse 58% 20% at 16% 28%, rgba(115, 168, 255, 0.105), transparent 74%),
-    radial-gradient(ellipse 46% 18% at 78% 24%, rgba(176, 124, 226, 0.078), transparent 74%),
-    radial-gradient(ellipse 70% 24% at 50% 82%, rgba(62, 191, 157, 0.048), transparent 78%),
-    radial-gradient(ellipse 80% 28% at 42% 50%, rgba(240, 240, 250, 0.022), transparent 80%);
-  --constellation-workspace-theme-deep-field-stars:
-    radial-gradient(circle at center, rgba(240, 240, 250, 0.72) 0 0.58px, transparent 0.88px),
-    radial-gradient(circle at center, rgba(122, 177, 255, 0.44) 0 0.78px, transparent 1.04px),
-    radial-gradient(circle at center, rgba(255, 218, 176, 0.28) 0 0.72px, transparent 1px),
-    radial-gradient(circle at center, rgba(240, 240, 250, 0.16) 0 1.05px, transparent 1.38px);
-  --constellation-workspace-theme-deep-field-dust:
-    radial-gradient(ellipse 52% 16% at 18% 30%, rgba(122, 177, 255, 0.12), transparent 76%),
-    radial-gradient(ellipse 42% 14% at 74% 24%, rgba(218, 157, 89, 0.064), transparent 74%),
-    radial-gradient(ellipse 58% 16% at 52% 78%, rgba(240, 240, 250, 0.042), transparent 78%);
-  --constellation-workspace-theme-scene-glow:
-    radial-gradient(ellipse 76% 52% at 28% 24%, rgba(141, 183, 255, 0.14), transparent 76%),
-    radial-gradient(ellipse 56% 42% at 60% 34%, rgba(240, 240, 250, 0.05), transparent 74%);
-  --constellation-workspace-theme-scene-warmth:
-    radial-gradient(ellipse 82% 56% at 72% 72%, rgba(213, 161, 77, 0.07), transparent 78%),
-    radial-gradient(ellipse 64% 48% at 42% 82%, rgba(87, 207, 160, 0.045), transparent 76%);
+  --constellation-workspace-theme-scene-glow: none;
+  --constellation-workspace-theme-scene-warmth: none;
 
   --constellation-screen-frame-scene-glow:
     radial-gradient(circle at 34% 28%, rgba(141, 183, 255, 0.12), transparent 36%),
@@ -886,9 +868,6 @@
   --constellation-workspace-theme-star-color-c: rgba(255, 255, 255, 0.22);
   --constellation-workspace-theme-star-opacity: 0.34;
   --constellation-workspace-theme-deep-field-opacity: 0;
-  --constellation-workspace-theme-deep-field-nebula: none;
-  --constellation-workspace-theme-deep-field-stars: none;
-  --constellation-workspace-theme-deep-field-dust: none;
   --constellation-workspace-theme-scene-glow:
     radial-gradient(ellipse 72% 54% at 36% 28%, rgba(72, 159, 210, 0.18), transparent 76%),
     radial-gradient(ellipse 56% 42% at 66% 34%, rgba(255, 255, 255, 0.24), transparent 78%);

--- a/frontend/src/lib/utils/oauthPopup.ts
+++ b/frontend/src/lib/utils/oauthPopup.ts
@@ -1,0 +1,31 @@
+const OPENAI_OAUTH_POPUP_TARGET = 'illo-openai-oauth';
+const OPENAI_OAUTH_POPUP_FEATURES = 'popup,width=540,height=760';
+
+export function openOpenAIOAuthPopup(): Window | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.open('about:blank', OPENAI_OAUTH_POPUP_TARGET, OPENAI_OAUTH_POPUP_FEATURES);
+  } catch {
+    return null;
+  }
+}
+
+export function navigateOpenAIOAuthPopup(popup: Window | null, url: string): boolean {
+  if (!url) return false;
+  try {
+    if (!popup || popup.closed) return false;
+    popup.location.href = url;
+    popup.focus();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function closeOAuthPopup(popup: Window | null) {
+  try {
+    if (popup && !popup.closed) popup.close();
+  } catch {
+    // Best-effort cleanup for a popup that may have crossed origins.
+  }
+}

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -11,6 +11,11 @@
     ConstellationTextInput,
   } from '$lib/components/constellation';
   import IllospaceLogo from '$lib/components/layout/IllospaceLogo.svelte';
+  import {
+    closeOAuthPopup,
+    navigateOpenAIOAuthPopup,
+    openOpenAIOAuthPopup,
+  } from '$lib/utils/oauthPopup';
   import type { EmbedderKey, RuntimeOption, RuntimeSettings } from '../system/types';
 
   type OnboardingStatus = 'loading' | 'missing' | 'connecting' | 'connected' | 'error';
@@ -235,6 +240,7 @@
   }
 
   async function startOpenAI() {
+    const popup = openOpenAIOAuthPopup();
     status = 'connecting';
     notice = null;
     try {
@@ -244,15 +250,19 @@
       oauthCallbackAvailable = result.callback_available ?? true;
       oauthCallbackMode = result.callback_mode || 'local_bridge';
 
-      if (oauthUrl && typeof window !== 'undefined') {
-        const popup = window.open('about:blank', 'illo-openai-oauth', 'popup,width=540,height=760');
-        if (popup) {
-          popup.location.href = oauthUrl;
-          popup.focus();
-        } else {
-          window.location.assign(oauthUrl);
+      if (oauthUrl) {
+        const opened = navigateOpenAIOAuthPopup(popup, oauthUrl);
+        if (!opened) {
+          notice = {
+            tone: 'warning',
+            title: 'Popup blocked.',
+            detail: 'Allow popups for this site, then choose Connect OpenAI again. The main window will stay here.',
+          };
+          status = 'missing';
           return;
         }
+      } else {
+        closeOAuthPopup(popup);
       }
 
       notice = oauthCallbackAvailable
@@ -270,6 +280,7 @@
             detail: result.callback_detail || 'Finish sign-in, then paste the callback URL below.',
           };
     } catch (error) {
+      closeOAuthPopup(popup);
       status = 'missing';
       notice = errorNotice('Could not start OpenAI sign-in.', error, 'Try again.');
     }

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -10,6 +10,11 @@
     ConstellationNotice,
     ConstellationPageFrame,
   } from '$lib/components/constellation';
+  import {
+    closeOAuthPopup,
+    navigateOpenAIOAuthPopup,
+    openOpenAIOAuthPopup,
+  } from '$lib/utils/oauthPopup';
 
   import AccessCard from './AccessCard.svelte';
   import MemoryCard from './MemoryCard.svelte';
@@ -192,6 +197,7 @@
 
   async function startCodexSignIn(callbackMode: unknown = 'auto') {
     const requestedCallbackMode = normalizeCodexSignInCallbackMode(callbackMode);
+    const popup = openOpenAIOAuthPopup();
     savingConnection = true;
     notice = null;
     try {
@@ -200,14 +206,18 @@
       oauthState = result.state || '';
       oauthCallbackAvailable = result.callback_available ?? true;
       oauthCallbackMode = result.callback_mode || 'local_bridge';
-      if (oauthUrl && typeof window !== 'undefined') {
-        const popup = window.open('about:blank', 'illo-openai-oauth', 'popup,width=540,height=760');
-        if (!popup) {
-          window.location.assign(oauthUrl);
+      if (oauthUrl) {
+        const opened = navigateOpenAIOAuthPopup(popup, oauthUrl);
+        if (!opened) {
+          notice = {
+            tone: 'warning',
+            title: 'Popup blocked.',
+            detail: 'Allow popups for this site, then choose Sign in again. The main window will stay here.',
+          };
           return;
         }
-        popup.location.href = oauthUrl;
-        popup.focus();
+      } else {
+        closeOAuthPopup(popup);
       }
       notice = oauthCallbackAvailable
         ? {
@@ -224,6 +234,7 @@
             detail: result.callback_detail || 'The automatic callback bridge is unavailable. Use the manual callback fallback if the window cannot return here.',
           };
     } catch (error) {
+      closeOAuthPopup(popup);
       notice = errorNotice('Could not start Codex sign-in.', error, 'Try again from the System tab.');
     } finally {
       savingConnection = false;

--- a/tests/test_onboarding_runtime_intro.py
+++ b/tests/test_onboarding_runtime_intro.py
@@ -111,7 +111,7 @@ def test_runtime_ready_intro_creates_thread_and_run():
     assert idea.display_title == "Welcome to Illo"
     route_trigger.assert_called_once()
     trigger = route_trigger.call_args.args[0]
-    assert "Illo works well solo" in trigger.payload["thread_message"]
+    assert trigger.payload["thread_message"] == "Hi Illo, what can you help me with?"
     assert trigger.payload["metadata"]["prompt_visibility"] == "hidden"
     assert trigger.payload["metadata"]["provider"] == "openai"
     assert trigger.payload["metadata"]["model"] == "openai/gpt-5.5"


### PR DESCRIPTION
## Summary
- reserve the OpenAI/Codex OAuth popup synchronously from the user click
- navigate the reserved popup after the backend returns the OAuth URL
- keep the main app window in place when popup creation is blocked
- share popup open/navigate/cleanup helpers across onboarding and System settings

## Testing
- `npm run check`
- `npm run build`

Note: both commands still report the existing memory-page warnings unrelated to this change.
