### PR TITLE
Persist memory runtime settings in Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ restore, upgrades, logs, and status.
 - In production, add model/provider credentials from Illospace System/Access so
   they are encrypted and stored in Postgres. Environment provider keys remain a
   development fallback, not the recommended self-hosted server path.
+- Memory provider settings are saved as runtime DB settings. Embedding API keys
+  are encrypted with `VAULT_MASTER_KEY`; the app does not rewrite `.env` after
+  first boot.
 - `./illo setup` creates ignored checkout-local defaults for `SECRET_KEY` and
   `VAULT_MASTER_KEY` in `.illo/runtime.env` when they are not provided, so a
   self-hosted preview can boot cleanly.

--- a/brain/systems/memory/embeddings.py
+++ b/brain/systems/memory/embeddings.py
@@ -3,9 +3,8 @@
 Routes to the configured backend (gpu, cpu, or api).
 All other modules import embedding functions from here.
 
-Config (brain/kernel/config.py / env vars):
-    EMBEDDING_BACKEND = "gpu" | "cpu" | "api"
-    EMBEDDING_DIM     = vector dimensions (must match DB)
+Runtime config is DB-backed once an admin saves memory settings. Process
+configuration only seeds first-boot non-secret defaults.
 """
 
 from __future__ import annotations
@@ -17,11 +16,7 @@ import time
 
 import numpy as np
 
-from brain.kernel.config import (
-    EMBEDDING_BACKEND,
-    EMBEDDING_DIM,
-    MEMORY_EMOTIONAL_EMBEDDING_DIM,
-)
+from brain.kernel.config import MEMORY_EMOTIONAL_EMBEDDING_DIM
 
 logger = logging.getLogger("brain.systems.memory.embeddings")
 
@@ -146,9 +141,7 @@ def wait_for_embedding_backend_ready(
     Returns True when embeddings are ready to serve requests. For non-GPU
     backends, this is always True because those backends are loaded inline.
     """
-    import brain.kernel.config as _cfg
-
-    if _cfg.EMBEDDING_BACKEND != "gpu":
+    if _runtime_embedding_config().backend != "gpu":
         return True
 
     if client is None:
@@ -168,18 +161,41 @@ def wait_for_embedding_backend_ready(
 # ---------------------------------------------------------------------------
 
 _cpu_model = None
+_cpu_model_name = None
 _cpu_lock = threading.Lock()
 
 
+def _runtime_embedding_config():
+    try:
+        from brain.systems.runtime_settings.memory import get_embedding_runtime_config
+
+        return get_embedding_runtime_config()
+    except Exception:
+        logger.debug("Could not load DB-backed embedding runtime config; using process config", exc_info=True)
+        import brain.kernel.config as _cfg
+        from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+        return EmbeddingRuntimeConfig(
+            backend=str(_cfg.EMBEDDING_BACKEND),
+            provider=str(_cfg.EMBEDDING_API_PROVIDER),
+            api_model=str(_cfg.EMBEDDING_API_MODEL),
+            cpu_model=str(_cfg.EMBEDDING_CPU_MODEL),
+            dimensions=int(_cfg.EMBEDDING_DIM),
+            reranker=str(getattr(_cfg, "MEMORY_RERANKER", "weighted")),
+            api_key="",
+        )
+
+
 def _get_cpu_model():
-    global _cpu_model
-    if _cpu_model is None:
+    global _cpu_model, _cpu_model_name
+    model_name = _runtime_embedding_config().cpu_model
+    if _cpu_model is None or _cpu_model_name != model_name:
         with _cpu_lock:
-            if _cpu_model is None:
+            if _cpu_model is None or _cpu_model_name != model_name:
                 from sentence_transformers import SentenceTransformer
-                from brain.kernel.config import EMBEDDING_CPU_MODEL
-                logger.info("Loading CPU embedding model: %s", EMBEDDING_CPU_MODEL)
-                _cpu_model = SentenceTransformer(EMBEDDING_CPU_MODEL)
+                logger.info("Loading CPU embedding model: %s", model_name)
+                _cpu_model = SentenceTransformer(model_name)
+                _cpu_model_name = model_name
     return _cpu_model
 
 
@@ -206,15 +222,17 @@ def _prepare_gemini_text(text: str, mode: str, model: str) -> str:
 
 def _embed_api_gemini(texts: list[str], mode: str) -> np.ndarray:
     import httpx
-    from brain.kernel.config import EMBEDDING_API_KEY, EMBEDDING_API_MODEL
+    runtime = _runtime_embedding_config()
+    api_key = runtime.api_key
+    embedding_dim = runtime.dimensions
 
-    if not EMBEDDING_API_KEY:
+    if not api_key:
         raise RuntimeError(
             "Gemini embedding credentials are not configured. "
-            "Add them in System/Access or use a development-only EMBEDDING_API_KEY."
+            "Add them in System/Access."
         )
 
-    model = EMBEDDING_API_MODEL or "gemini-embedding-2"
+    model = runtime.api_model or "gemini-embedding-2"
     task_type = "RETRIEVAL_QUERY" if mode == "query" else "RETRIEVAL_DOCUMENT"
     url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:embedContent"
 
@@ -222,7 +240,7 @@ def _embed_api_gemini(texts: list[str], mode: str) -> np.ndarray:
     for text in texts:
         payload = {
             "content": {"parts": [{"text": _prepare_gemini_text(text, mode, model)}]},
-            "output_dimensionality": EMBEDDING_DIM,
+            "output_dimensionality": embedding_dim,
         }
         if model != "gemini-embedding-2":
             payload["taskType"] = task_type
@@ -230,7 +248,7 @@ def _embed_api_gemini(texts: list[str], mode: str) -> np.ndarray:
             url,
             headers={
                 "Content-Type": "application/json",
-                "x-goog-api-key": EMBEDDING_API_KEY,
+                "x-goog-api-key": api_key,
             },
             json=payload,
             timeout=30,
@@ -248,23 +266,23 @@ def _embed_api_gemini(texts: list[str], mode: str) -> np.ndarray:
 
 def _embed_api_openai(texts: list[str], mode: str) -> np.ndarray:
     import httpx
-    from brain.kernel.config import EMBEDDING_API_KEY, EMBEDDING_API_MODEL
+    runtime = _runtime_embedding_config()
 
-    api_key = EMBEDDING_API_KEY or ""
+    api_key = runtime.api_key or ""
     if not api_key:
         raise RuntimeError(
             "OpenAI embedding credentials are not configured. "
-            "Add them in System/Access or use a development-only EMBEDDING_API_KEY."
+            "Add them in System/Access."
         )
 
-    model = EMBEDDING_API_MODEL or "text-embedding-3-small"
+    model = runtime.api_model or "text-embedding-3-small"
     resp = httpx.post(
         "https://api.openai.com/v1/embeddings",
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_key}",
         },
-        json={"model": model, "input": texts, "dimensions": EMBEDDING_DIM},
+        json={"model": model, "input": texts, "dimensions": runtime.dimensions},
         timeout=30,
     )
     if resp.status_code != 200:
@@ -274,8 +292,8 @@ def _embed_api_openai(texts: list[str], mode: str) -> np.ndarray:
 
 
 def _embed_api(texts: list[str], mode: str) -> np.ndarray:
-    from brain.kernel.config import EMBEDDING_API_PROVIDER
-    if EMBEDDING_API_PROVIDER == "openai":
+    runtime = _runtime_embedding_config()
+    if runtime.provider == "openai":
         return _embed_api_openai(texts, mode)
     return _embed_api_gemini(texts, mode)
 
@@ -293,9 +311,7 @@ _BACKENDS = {
 
 def embed_batch(texts: list[str], mode: str = "document") -> np.ndarray:
     """Embed multiple texts. Returns (N, dims) numpy array."""
-    # Read backend dynamically so hot-reload from settings works
-    import brain.kernel.config as _cfg
-    backend = _cfg.EMBEDDING_BACKEND
+    backend = _runtime_embedding_config().backend
     fn = _BACKENDS.get(backend)
     if not fn:
         raise ValueError(f"Unknown EMBEDDING_BACKEND: {backend!r}. Use gpu, cpu, or api.")
@@ -377,14 +393,20 @@ def make_emotional_embedding(
 def server_health() -> dict | None:
     """Return embedding backend health info."""
     try:
-        if EMBEDDING_BACKEND == "gpu":
+        runtime = _runtime_embedding_config()
+        backend = runtime.backend
+        if backend == "gpu":
             from brain.platform.gpu_client import get_client
             return get_client().health()
-        elif EMBEDDING_BACKEND == "cpu":
+        elif backend == "cpu":
             model = _get_cpu_model()
             return {"status": "ok", "backend": "cpu", "model": model.get_config_dict().get("model_name_or_path", "?")}
-        elif EMBEDDING_BACKEND == "api":
-            from brain.kernel.config import EMBEDDING_API_PROVIDER, EMBEDDING_API_MODEL
-            return {"status": "ok", "backend": "api", "provider": EMBEDDING_API_PROVIDER, "model": EMBEDDING_API_MODEL}
+        elif backend == "api":
+            return {
+                "status": "ok",
+                "backend": "api",
+                "provider": runtime.provider,
+                "model": runtime.api_model,
+            }
     except Exception:
         return None

--- a/brain/systems/runtime_settings/memory.py
+++ b/brain/systems/runtime_settings/memory.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import base64
+import json
 import logging
-import os
 import time
-from pathlib import Path
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 from fastapi import HTTPException
+from sqlalchemy import select
 
 from brain.kernel import config as cfg
 from brain.platform.db.models.org import User
+from brain.platform.db.models.vault import VaultConfig
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
 from .embedding_registry import (
@@ -25,7 +28,14 @@ from .schemas import RuntimeMemoryCheckRead, RuntimeMemoryRead, RuntimeMemoryUpd
 
 logger = logging.getLogger(__name__)
 
-ENV_PATH = Path(__file__).resolve().parents[3] / ".env"
+RUNTIME_MEMORY_SETTINGS_KEY = "runtime_memory"
+RUNTIME_MEMORY_SECRET_PREFIX = "runtime_memory_api_key_"
+RUNTIME_SETTINGS_UNAVAILABLE_DETAIL = (
+    "Runtime memory settings could not be saved. Check that Postgres is available and try again."
+)
+VAULT_NOT_CONFIGURED_DETAIL = (
+    "Vault master key is not configured. Set VAULT_MASTER_KEY before saving memory API keys."
+)
 EMBEDDING_MODEL_OPTIONS = embedding_model_options()
 EMBEDDER_OPTIONS = embedder_options()
 RERANKER_OPTIONS = [
@@ -33,23 +43,162 @@ RERANKER_OPTIONS = [
 ]
 
 
-def _update_env_var(key: str, value: str | None) -> None:
-    lines: list[str] = []
-    if ENV_PATH.exists():
-        lines = ENV_PATH.read_text().splitlines()
+@dataclass(frozen=True)
+class EmbeddingRuntimeConfig:
+    backend: str
+    provider: str
+    api_model: str
+    cpu_model: str
+    dimensions: int
+    reranker: str = "weighted"
+    api_key: str = ""
 
-    written = False
-    updated: list[str] = []
-    for line in lines:
-        if line.startswith(f"{key}="):
-            if value is not None:
-                updated.append(f"{key}={value}")
-            written = True
-        else:
-            updated.append(line)
-    if not written and value is not None:
-        updated.append(f"{key}={value}")
-    ENV_PATH.write_text("\n".join(updated) + ("\n" if updated else ""))
+    def stored_settings(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "provider": self.provider,
+            "api_model": self.api_model,
+            "cpu_model": self.cpu_model,
+            "dimensions": self.dimensions,
+            "reranker": self.reranker,
+        }
+
+
+def _provider_key(provider: str | None) -> str:
+    provider = (provider or "").strip().lower()
+    if provider in {"google", "gemini"}:
+        return "gemini"
+    if provider == "openai":
+        return "openai"
+    return provider
+
+
+def _runtime_secret_config_key(provider: str | None) -> str:
+    return f"{RUNTIME_MEMORY_SECRET_PREFIX}{_provider_key(provider)}"
+
+
+def _read_runtime_config_value(key: str) -> str | None:
+    try:
+        with UnitOfWork() as uow:
+            config = uow.session.scalars(select(VaultConfig).where(VaultConfig.key == key)).first()
+            return config.value if config else None
+    except Exception:
+        logger.debug("Could not read runtime memory config key %s", key, exc_info=True)
+        return None
+
+
+def _write_runtime_config_value(key: str, value: str) -> None:
+    try:
+        with UnitOfWork() as uow:
+            config = uow.session.scalars(select(VaultConfig).where(VaultConfig.key == key)).first()
+            if config:
+                config.value = value
+            else:
+                uow.session.add(VaultConfig(key=key, value=value))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Could not persist runtime memory config key %s: %s", key, exc)
+        raise HTTPException(status_code=503, detail=RUNTIME_SETTINGS_UNAVAILABLE_DETAIL) from exc
+
+
+def _read_persisted_runtime_settings() -> dict[str, Any]:
+    raw = _read_runtime_config_value(RUNTIME_MEMORY_SETTINGS_KEY)
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Ignoring invalid runtime memory settings JSON")
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): value for key, value in data.items() if value is not None}
+
+
+def _persist_runtime_settings(config: EmbeddingRuntimeConfig) -> None:
+    _write_runtime_config_value(RUNTIME_MEMORY_SETTINGS_KEY, json.dumps(config.stored_settings(), sort_keys=True))
+
+
+def _persist_embedding_api_key(provider: str, api_key: str) -> None:
+    if not api_key:
+        return
+    try:
+        from brain.systems.vault import _encrypt
+
+        encrypted = base64.b64encode(_encrypt(api_key)).decode("ascii")
+    except RuntimeError as exc:
+        if "VAULT_MASTER_KEY is required" in str(exc):
+            raise HTTPException(status_code=503, detail=VAULT_NOT_CONFIGURED_DETAIL) from exc
+        raise
+    _write_runtime_config_value(_runtime_secret_config_key(provider), encrypted)
+
+
+def _read_persisted_embedding_api_key(provider: str) -> str | None:
+    raw = _read_runtime_config_value(_runtime_secret_config_key(provider))
+    if not raw:
+        return None
+    try:
+        from brain.systems.vault import _decrypt
+
+        return _decrypt(base64.b64decode(raw.encode("ascii"))).strip() or None
+    except RuntimeError as exc:
+        if "VAULT_MASTER_KEY is required" in str(exc):
+            logger.warning("Memory API key is encrypted, but VAULT_MASTER_KEY is not configured")
+            return None
+        raise
+    except Exception:
+        logger.warning("Could not decrypt persisted %s memory API key", provider, exc_info=True)
+        return None
+
+
+def _stored_str(settings: dict[str, Any], key: str, default: Any) -> str:
+    value = settings.get(key)
+    if value in (None, ""):
+        value = default
+    return str(value if value is not None else "")
+
+
+def _stored_int(settings: dict[str, Any], key: str, default: int) -> int:
+    try:
+        return int(settings.get(key) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _default_runtime_config() -> EmbeddingRuntimeConfig:
+    provider = _provider_key(getattr(cfg, "EMBEDDING_API_PROVIDER", "gemini"))
+    api_model = str(getattr(cfg, "EMBEDDING_API_MODEL", "") or default_embedding_model(provider) or "gemini-embedding-2")
+    return EmbeddingRuntimeConfig(
+        backend=str(getattr(cfg, "EMBEDDING_BACKEND", "api") or "api").lower(),
+        provider=provider,
+        api_model=api_model,
+        cpu_model=str(getattr(cfg, "EMBEDDING_CPU_MODEL", "") or "all-MiniLM-L6-v2"),
+        dimensions=int(getattr(cfg, "EMBEDDING_DIM", 0) or embedding_dimensions(provider, api_model)),
+        reranker=str(getattr(cfg, "MEMORY_RERANKER", "") or "weighted"),
+    )
+
+
+def get_embedding_runtime_config(*, include_secret: bool = True) -> EmbeddingRuntimeConfig:
+    """Return the installation memory runtime config.
+
+    Persisted DB settings win. Process env/config only seed the initial
+    non-secret defaults before an admin saves runtime settings in Illospace.
+    Provider API keys are read only from the encrypted runtime store.
+    """
+    defaults = _default_runtime_config()
+    settings = _read_persisted_runtime_settings()
+    provider = _provider_key(_stored_str(settings, "provider", defaults.provider))
+    config = EmbeddingRuntimeConfig(
+        backend=_stored_str(settings, "backend", defaults.backend).lower(),
+        provider=provider,
+        api_model=_stored_str(settings, "api_model", defaults.api_model),
+        cpu_model=_stored_str(settings, "cpu_model", defaults.cpu_model),
+        dimensions=_stored_int(settings, "dimensions", defaults.dimensions),
+        reranker=_stored_str(settings, "reranker", defaults.reranker) or "weighted",
+        api_key=_read_persisted_embedding_api_key(provider) if include_secret else "",
+    )
+    return config
 
 
 def _sync_gpu_embedding_worker(backend: str) -> None:
@@ -65,23 +214,28 @@ def _sync_gpu_embedding_worker(backend: str) -> None:
         logger.info("Could not sync embedding worker after settings update: %s", exc)
 
 
-def _apply_embedding_runtime_settings(updates: dict[str, str], *, sync_worker: bool = True) -> None:
-    for key, value in updates.items():
-        _update_env_var(key, value)
-        os.environ[key] = value
-        if key == "EMBEDDING_DIM":
-            setattr(cfg, key, int(value))
-        else:
-            setattr(cfg, key, value)
-
+def _clear_embedding_runtime_caches() -> None:
     try:
         from brain.systems.memory import embeddings as emb_mod
 
         emb_mod._cpu_model = None
+        emb_mod._cpu_model_name = None
     except Exception:
         pass
+
+
+def _save_embedding_runtime_config(
+    config: EmbeddingRuntimeConfig,
+    *,
+    api_key: str | None = None,
+    sync_worker: bool = True,
+) -> None:
+    if api_key:
+        _persist_embedding_api_key(config.provider, api_key)
+    _persist_runtime_settings(config)
+    _clear_embedding_runtime_caches()
     if sync_worker:
-        _sync_gpu_embedding_worker(updates.get("EMBEDDING_BACKEND", str(cfg.EMBEDDING_BACKEND)))
+        _sync_gpu_embedding_worker(config.backend)
 
 
 def _standard_openai_api_key(token: str | None) -> str | None:
@@ -102,23 +256,15 @@ def _standard_openai_api_key(token: str | None) -> str | None:
 
 
 def _current_api_provider() -> str:
-    return (os.getenv("EMBEDDING_API_PROVIDER") or cfg.EMBEDDING_API_PROVIDER or "gemini").lower()
+    return get_embedding_runtime_config(include_secret=False).provider
 
 
 def _installation_embedding_api_key(provider: str) -> str | None:
-    provider = (provider or "").lower()
-    key = ""
-    if _current_api_provider() == provider:
-        key = os.getenv("EMBEDDING_API_KEY") or cfg.EMBEDDING_API_KEY
-    if not key and provider == "openai":
-        key = os.getenv("OPENAI_API_KEY", "")
-    elif not key and provider == "gemini":
-        key = os.getenv("GEMINI_API_KEY", "") or os.getenv("GOOGLE_API_KEY", "")
-
+    key = _read_persisted_embedding_api_key(_provider_key(provider)) or ""
     key = (key or "").strip()
     if not key:
         return None
-    if provider == "openai":
+    if _provider_key(provider) == "openai":
         return _standard_openai_api_key(key)
     return key
 
@@ -128,14 +274,17 @@ def configure_openai_embedding_api_key(api_key: str) -> None:
     key = _standard_openai_api_key(api_key)
     if not key:
         return
-    _apply_embedding_runtime_settings(
-        {
-            "EMBEDDING_BACKEND": "api",
-            "EMBEDDING_DIM": str(embedding_dimensions("openai", "text-embedding-3-small")),
-            "EMBEDDING_API_PROVIDER": "openai",
-            "EMBEDDING_API_MODEL": "text-embedding-3-small",
-            "EMBEDDING_API_KEY": key,
-        }
+    current = get_embedding_runtime_config(include_secret=False)
+    _save_embedding_runtime_config(
+        EmbeddingRuntimeConfig(
+            backend="api",
+            provider="openai",
+            api_model="text-embedding-3-small",
+            cpu_model=current.cpu_model,
+            dimensions=embedding_dimensions("openai", "text-embedding-3-small"),
+            reranker=current.reranker,
+        ),
+        api_key=key,
     )
 
 
@@ -145,14 +294,17 @@ def configure_gemini_embedding_api_key(api_key: str) -> None:
     if not key:
         return
     model = default_embedding_model("gemini") or "gemini-embedding-2"
-    _apply_embedding_runtime_settings(
-        {
-            "EMBEDDING_BACKEND": "api",
-            "EMBEDDING_DIM": str(embedding_dimensions("gemini", model)),
-            "EMBEDDING_API_PROVIDER": "gemini",
-            "EMBEDDING_API_MODEL": model,
-            "EMBEDDING_API_KEY": key,
-        }
+    current = get_embedding_runtime_config(include_secret=False)
+    _save_embedding_runtime_config(
+        EmbeddingRuntimeConfig(
+            backend="api",
+            provider="gemini",
+            api_model=model,
+            cpu_model=current.cpu_model,
+            dimensions=embedding_dimensions("gemini", model),
+            reranker=current.reranker,
+        ),
+        api_key=key,
     )
 
 
@@ -167,17 +319,15 @@ def _embedder_from_backend_provider(backend: str, provider: str | None) -> str:
 
 
 def get_embedding_info(user: User | None = None) -> dict[str, Any]:
-    backend = (os.getenv("EMBEDDING_BACKEND") or cfg.EMBEDDING_BACKEND or "gpu").lower()
-    provider = (os.getenv("EMBEDDING_API_PROVIDER") or cfg.EMBEDDING_API_PROVIDER or "gemini").lower()
-    api_model = os.getenv("EMBEDDING_API_MODEL") or cfg.EMBEDDING_API_MODEL
-    cpu_model = os.getenv("EMBEDDING_CPU_MODEL") or cfg.EMBEDDING_CPU_MODEL
-    dim = int(os.getenv("EMBEDDING_DIM") or cfg.EMBEDDING_DIM)
-    api_key_set = bool(_installation_embedding_api_key(provider))
+    runtime = get_embedding_runtime_config()
+    backend = runtime.backend.lower()
+    provider = runtime.provider.lower()
+    api_key_set = bool(runtime.api_key)
     info: dict[str, Any] = {
         "backend": backend,
         "provider": provider,
-        "model": api_model if backend == "api" else cpu_model if backend == "cpu" else "local-gpu",
-        "dimensions": dim,
+        "model": runtime.api_model if backend == "api" else runtime.cpu_model if backend == "cpu" else "local-gpu",
+        "dimensions": runtime.dimensions,
         "api_key_set": api_key_set,
     }
     if backend == "gpu":
@@ -252,7 +402,8 @@ def _indexed_vector_count() -> int:
 
 def get_runtime_memory(user: User) -> RuntimeMemoryRead:
     info = get_embedding_info(user)
-    reranker = os.getenv("MEMORY_RERANKER") or getattr(cfg, "MEMORY_RERANKER", "weighted") or "weighted"
+    runtime = get_embedding_runtime_config(include_secret=False)
+    reranker = runtime.reranker or "weighted"
     if reranker != "weighted":
         reranker = "weighted"
     embedder = _embedder_from_info(info)
@@ -306,35 +457,36 @@ def update_runtime_memory(user: User, update: RuntimeMemoryUpdate) -> RuntimeMem
             ),
         )
 
+    runtime = get_embedding_runtime_config(include_secret=False)
     if embedder_spec.backend == "api":
         backend = "api"
         provider = embedder_spec.provider or "openai"
-        cpu_model = os.getenv("EMBEDDING_CPU_MODEL") or cfg.EMBEDDING_CPU_MODEL
+        cpu_model = runtime.cpu_model
         model = api_model or embedder_spec.default_model
     elif embedder == "local_cpu":
         backend = "cpu"
-        provider = os.getenv("EMBEDDING_API_PROVIDER") or cfg.EMBEDDING_API_PROVIDER
-        model = os.getenv("EMBEDDING_API_MODEL") or cfg.EMBEDDING_API_MODEL
-        cpu_model = os.getenv("EMBEDDING_CPU_MODEL") or cfg.EMBEDDING_CPU_MODEL
+        provider = runtime.provider
+        model = runtime.api_model
+        cpu_model = runtime.cpu_model
     else:
         backend = "gpu"
-        provider = os.getenv("EMBEDDING_API_PROVIDER") or cfg.EMBEDDING_API_PROVIDER
-        model = os.getenv("EMBEDDING_API_MODEL") or cfg.EMBEDDING_API_MODEL
-        cpu_model = os.getenv("EMBEDDING_CPU_MODEL") or cfg.EMBEDDING_CPU_MODEL
+        provider = runtime.provider
+        model = runtime.api_model
+        cpu_model = runtime.cpu_model
 
     dimensions = embedding_dimensions(embedder, model)
-    updates = {
-        "EMBEDDING_BACKEND": backend,
-        "EMBEDDING_DIM": str(dimensions),
-        "EMBEDDING_API_PROVIDER": provider or "openai",
-        "EMBEDDING_API_MODEL": model or "text-embedding-3-small",
-        "EMBEDDING_CPU_MODEL": cpu_model or "all-MiniLM-L6-v2",
-        "MEMORY_RERANKER": update.reranker,
-    }
+    next_config = EmbeddingRuntimeConfig(
+        backend=backend,
+        provider=_provider_key(provider or "openai"),
+        api_model=model or "text-embedding-3-small",
+        cpu_model=cpu_model or "all-MiniLM-L6-v2",
+        dimensions=dimensions,
+        reranker=update.reranker,
+    )
+    api_key = None
     if embedder_spec.backend == "api":
         api_key = _installation_embedding_api_key(provider)
-        updates["EMBEDDING_API_KEY"] = api_key or ""
-    _apply_embedding_runtime_settings(updates)
+    _save_embedding_runtime_config(next_config, api_key=api_key)
 
     return get_runtime_memory(user)
 
@@ -347,7 +499,7 @@ def check_runtime_memory(user: User) -> RuntimeMemoryCheckRead:
         vector = embed_query("illo brain memory setup check")
         shape = getattr(vector, "shape", None)
         dimensions = int(shape[0] if shape else len(vector))
-        expected = int(os.getenv("EMBEDDING_DIM") or cfg.EMBEDDING_DIM)
+        expected = get_embedding_runtime_config(include_secret=False).dimensions
         duration_ms = int(round((time.perf_counter() - started) * 1000))
         if dimensions != expected:
             return RuntimeMemoryCheckRead(
@@ -364,7 +516,7 @@ def check_runtime_memory(user: User) -> RuntimeMemoryCheckRead:
         )
     except Exception as exc:
         detail = str(exc)
-        provider = (os.getenv("EMBEDDING_API_PROVIDER") or cfg.EMBEDDING_API_PROVIDER or "").lower()
+        provider = get_embedding_runtime_config(include_secret=False).provider.lower()
         if "EMBEDDING_API_KEY" in detail:
             if provider in {"gemini", "google"}:
                 detail = "Gemini memory needs a Google AI Studio API key. Add a Gemini key in Access or choose Local CPU."

--- a/deploy/compose/.env.production.example
+++ b/deploy/compose/.env.production.example
@@ -50,7 +50,9 @@ ILLO_OPENAI_OAUTH_SERVER_CALLBACK=1
 # from the System/Access screens. They are encrypted with VAULT_MASTER_KEY and
 # stored in Postgres, not in this Compose env file.
 
-# Embeddings. API mode is the lowest-friction team-server default.
+# Embeddings. API mode is the lowest-friction team-server default. The selected
+# memory provider/model can be changed later in Illospace and is persisted in
+# Postgres; provider API keys should still be entered through System/Access.
 EMBEDDING_BACKEND=api
 EMBEDDING_API_PROVIDER=gemini
 EMBEDDING_API_MODEL=gemini-embedding-2

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -50,6 +50,10 @@ ssh -L 8080:127.0.0.1:8080 <ssh-user>@<server>
 Open `http://localhost:8080`, create the owner account, and add provider
 credentials in System/Access.
 
+Memory setup is also runtime-managed: choosing OpenAI/Gemini memory saves the
+non-secret embedding settings in Postgres and encrypts the embedding API key
+with `VAULT_MASTER_KEY`. The Compose app image and `/app/.env` are not mutated.
+
 OpenAI/Codex sign-in uses OpenAI's registered localhost callback. In this
 Compose deployment, the API runs inside a container, so the browser's
 `localhost:1455` is your workstation, not the API container. Illospace therefore

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -188,7 +188,8 @@ check_db_provider_credentials() {
   if count="$(compose exec -T postgres psql -U "${DB_USER:-}" -d "${DB_NAME:-}" -tAc "
 SELECT
   COALESCE((SELECT count(*) FROM user_api_keys WHERE is_active), 0) +
-  COALESCE((SELECT count(*) FROM org_api_keys), 0);
+  COALESCE((SELECT count(*) FROM org_api_keys), 0) +
+  COALESCE((SELECT count(*) FROM vault_config WHERE key LIKE 'runtime_memory_api_key_%' AND value <> ''), 0);
 " 2>/dev/null | tr -d '[:space:]')"; then
     if [[ "$count" =~ ^[0-9]+$ ]] && [ "$count" -gt 0 ]; then
       pass "DB-backed provider credentials are configured ($count key record(s))"

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -57,6 +57,10 @@ provider credentials should be added from the Illospace System/Access screens
 after first boot so they are encrypted with `VAULT_MASTER_KEY` and stored in
 Postgres.
 
+The memory setup screen follows the same rule. OpenAI/Gemini embedding choices
+are saved as runtime DB settings, and embedding API keys are encrypted in
+Postgres rather than written back to `/app/.env`.
+
 ## Private Access
 
 The Compose stack does not install public TLS or domain ingress. The browser

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -158,7 +158,7 @@ class TestEmbeddingsClient:
     def test_server_health_calls_gpu_client(self):
         from brain.systems.memory.embeddings import server_health
         with patch("brain.platform.gpu_client.get_client") as mock_get, \
-             patch("brain.systems.memory.embeddings.EMBEDDING_BACKEND", "gpu"):
+             patch("brain.kernel.config.EMBEDDING_BACKEND", "gpu"):
             mock_client = MagicMock()
             mock_client.health.return_value = {"status": "ok"}
             mock_get.return_value = mock_client
@@ -168,7 +168,7 @@ class TestEmbeddingsClient:
     def test_server_health_returns_none_on_failure(self):
         from brain.systems.memory.embeddings import server_health
         with patch("brain.platform.gpu_client.get_client") as mock_get, \
-             patch("brain.systems.memory.embeddings.EMBEDDING_BACKEND", "gpu"):
+             patch("brain.kernel.config.EMBEDDING_BACKEND", "gpu"):
             mock_get.return_value.health.side_effect = RuntimeError("down")
             result = server_health()
             assert result is None

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -327,19 +327,30 @@ def test_get_llm_info_exposes_provider_health(monkeypatch):
 
 
 def test_runtime_memory_reports_installation_scope_and_installation_keys(monkeypatch):
+    import base64
+    import json
     from types import SimpleNamespace
 
     import brain.kernel.config as cfg
     import brain.systems.runtime_settings.memory as memory_settings
+    import brain.systems.vault as vault
 
-    monkeypatch.setenv("EMBEDDING_BACKEND", "api")
-    monkeypatch.setenv("EMBEDDING_API_PROVIDER", "gemini")
-    monkeypatch.setenv("EMBEDDING_API_KEY", "gemini-key")
-    monkeypatch.setenv("EMBEDDING_API_MODEL", "gemini-embedding-2")
-    monkeypatch.setenv("EMBEDDING_DIM", "768")
+    stored_config = {
+        memory_settings.RUNTIME_MEMORY_SETTINGS_KEY: json.dumps({
+            "backend": "api",
+            "provider": "gemini",
+            "api_model": "gemini-embedding-2",
+            "cpu_model": "all-MiniLM-L6-v2",
+            "dimensions": 768,
+            "reranker": "weighted",
+        }),
+        memory_settings._runtime_secret_config_key("gemini"): base64.b64encode(b"encrypted:gemini-key").decode(),
+    }
+
     monkeypatch.setattr(cfg, "EMBEDDING_BACKEND", "api", raising=False)
     monkeypatch.setattr(cfg, "EMBEDDING_API_PROVIDER", "gemini", raising=False)
-    monkeypatch.setattr(cfg, "EMBEDDING_API_KEY", "gemini-key", raising=False)
+    monkeypatch.setattr(memory_settings, "_read_runtime_config_value", lambda key: stored_config.get(key))
+    monkeypatch.setattr(vault, "_decrypt", lambda token: token.decode().removeprefix("encrypted:"))
     monkeypatch.setattr(memory_settings, "_indexed_vector_count", lambda: 0)
 
     data = memory_settings.get_runtime_memory(SimpleNamespace(id="user-1", org_id="org-1"))
@@ -348,6 +359,16 @@ def test_runtime_memory_reports_installation_scope_and_installation_keys(monkeyp
     assert data.embedder == "gemini"
     assert data.embedding_model == "gemini-embedding-2"
     assert data.api_key_statuses == {"openai": False, "gemini": True}
+
+
+def test_runtime_memory_does_not_use_env_api_keys(monkeypatch):
+    import brain.systems.runtime_settings.memory as memory_settings
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-env-key")
+    monkeypatch.setenv("EMBEDDING_API_KEY", "embedding-env-key")
+    monkeypatch.setattr(memory_settings, "_read_runtime_config_value", lambda key: None)
+
+    assert memory_settings._installation_embedding_api_key("gemini") is None
 
 
 def test_update_runtime_memory_blocks_embedder_change_when_installation_vectors_exist(monkeypatch):
@@ -387,15 +408,107 @@ def test_update_runtime_memory_writes_installation_reranker(monkeypatch):
     monkeypatch.setattr(cfg, "EMBEDDING_BACKEND", "cpu", raising=False)
     monkeypatch.setattr(cfg, "EMBEDDING_DIM", 384, raising=False)
     monkeypatch.setattr(memory_settings, "_indexed_vector_count", lambda: 0)
-    monkeypatch.setattr(memory_settings, "_apply_embedding_runtime_settings", lambda updates: captured.update(updates))
+    monkeypatch.setattr(
+        memory_settings,
+        "_save_embedding_runtime_config",
+        lambda config, **kwargs: captured.update(config.stored_settings()),
+    )
 
     memory_settings.update_runtime_memory(
         SimpleNamespace(id="user-1", org_id="org-1"),
         RuntimeMemoryUpdate(embedder="local_cpu", embedding_model=None, reranker="weighted"),
     )
 
-    assert captured["EMBEDDING_BACKEND"] == "cpu"
-    assert captured["MEMORY_RERANKER"] == "weighted"
+    assert captured["backend"] == "cpu"
+    assert captured["reranker"] == "weighted"
+
+
+def test_openai_memory_key_persists_in_encrypted_runtime_store(monkeypatch):
+    import base64
+    import json
+
+    import brain.systems.runtime_settings.memory as memory_settings
+    import brain.systems.vault as vault
+
+    stored_config = {}
+
+    monkeypatch.setattr(memory_settings, "_read_runtime_config_value", lambda key: stored_config.get(key))
+    monkeypatch.setattr(memory_settings, "_write_runtime_config_value", lambda key, value: stored_config.__setitem__(key, value))
+    monkeypatch.setattr(memory_settings, "_sync_gpu_embedding_worker", lambda backend: None)
+    monkeypatch.setattr(vault, "_encrypt", lambda value: f"encrypted:{value}".encode())
+    monkeypatch.setattr(vault, "_decrypt", lambda token: token.decode().removeprefix("encrypted:"))
+
+    memory_settings.configure_openai_embedding_api_key("sk-test-memory")
+
+    runtime = json.loads(stored_config[memory_settings.RUNTIME_MEMORY_SETTINGS_KEY])
+    assert runtime["backend"] == "api"
+    assert runtime["provider"] == "openai"
+    assert runtime["api_model"] == "text-embedding-3-small"
+    assert runtime["dimensions"] == 768
+    assert "api_key" not in runtime
+
+    encrypted = stored_config[memory_settings._runtime_secret_config_key("openai")]
+    assert encrypted != "sk-test-memory"
+    assert base64.b64decode(encrypted).decode() == "encrypted:sk-test-memory"
+    assert memory_settings._installation_embedding_api_key("openai") == "sk-test-memory"
+
+
+def test_openai_memory_key_reports_missing_vault_master_key(monkeypatch):
+    import pytest
+
+    import brain.systems.runtime_settings.memory as memory_settings
+    import brain.systems.vault as vault
+
+    def missing_key(_value):
+        raise RuntimeError("VAULT_MASTER_KEY is required. Refusing to auto-generate a vault key.")
+
+    monkeypatch.setattr(vault, "_encrypt", missing_key)
+
+    with pytest.raises(memory_settings.HTTPException) as exc:
+        memory_settings.configure_openai_embedding_api_key("sk-test-memory")
+
+    assert exc.value.status_code == 503
+    assert "VAULT_MASTER_KEY" in exc.value.detail
+
+
+def test_embedding_api_reads_persisted_runtime_config(monkeypatch):
+    import numpy as np
+
+    import brain.systems.memory.embeddings as embeddings
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    captured = {}
+
+    class Response:
+        status_code = 200
+        text = "{}"
+
+        def json(self):
+            return {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
+
+    def post(url, *, headers, json, timeout):
+        captured.update({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return Response()
+
+    monkeypatch.setattr(
+        embeddings,
+        "_runtime_embedding_config",
+        lambda: EmbeddingRuntimeConfig(
+            backend="api",
+            provider="openai",
+            api_model="text-embedding-3-small",
+            cpu_model="all-MiniLM-L6-v2",
+            dimensions=768,
+            api_key="sk-db-memory",
+        ),
+    )
+    monkeypatch.setattr("httpx.post", post)
+
+    vector = embeddings._embed_api_openai(["hello"], "query")
+
+    assert isinstance(vector, np.ndarray)
+    assert captured["headers"]["Authorization"] == "Bearer sk-db-memory"
+    assert captured["json"]["dimensions"] == 768
 
 
 def test_connect_gemini_api_key_requires_installation_admin(monkeypatch):


### PR DESCRIPTION
## Summary
- stop memory setup from writing embedding settings/API keys to /app/.env
- persist non-secret memory runtime settings as typed DB config and encrypt embedding API keys with VAULT_MASTER_KEY
- make API/worker/scheduler embedding calls read the DB-backed runtime config directly, without mutating process env/config globals
- remove memory API-key env fallback; provider keys for memory come from the encrypted runtime store
- update Compose docs/doctor checks for the DB-backed memory credential path

## Validation
- python3 -m pytest tests/test_runtime_settings.py tests/test_memory.py tests/test_runtime_settings_oauth_start_route.py tests/test_openai_user_auth_connect.py -q
- bash -n deploy/scripts/doctor.sh && python3 -m py_compile brain/systems/runtime_settings/memory.py brain/systems/memory/embeddings.py && git diff --check
- throwaway Compose project with rebuilt API image: configured OpenAI memory key inside non-root API container, verified /app/.env was not created, verified runtime_memory_api_key_openai was encrypted in Postgres