### PR TITLE
Require personal onboarding and fix timestamps

### DIFF
--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -45,6 +45,22 @@ def _intro_ref(user_id: str) -> str:
     return f"{INTRO_ORIGIN_REF_PREFIX}:{user_id}"
 
 
+def _has_personal_openai_connection(status: dict[str, Any]) -> bool:
+    return bool(
+        status.get("runtime_key_available")
+        and status.get("runtime_key_source") == "user_default"
+    )
+
+
+def _require_personal_openai_connection(*, user_id: str, org_id: str) -> None:
+    status = get_provider_auth_status(user_id=user_id, org_id=org_id, provider="openai")
+    if not _has_personal_openai_connection(status):
+        raise HTTPException(
+            status_code=409,
+            detail="Connect a personal OpenAI account before starting onboarding.",
+        )
+
+
 def _find_existing_intro(session: Any, *, org_id: str, user_id: str) -> Idea | None:
     stmt = (
         select(Idea)
@@ -107,9 +123,7 @@ def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) 
     if not user_id:
         raise HTTPException(status_code=401, detail="Authentication required")
     org_id = require_org_context(user)
-    status = get_provider_auth_status(user_id=user_id, org_id=org_id, provider="openai")
-    if not status.get("runtime_key_available"):
-        raise HTTPException(status_code=409, detail="OpenAI runtime is not connected yet.")
+    _require_personal_openai_connection(user_id=user_id, org_id=org_id)
 
     with UnitOfWork() as uow:
         existing = _find_existing_intro(uow.session, org_id=org_id, user_id=user_id)
@@ -133,9 +147,7 @@ def start_runtime_ready_intro(user: dict[str, Any] = Depends(get_current_user)) 
     if not user_id:
         raise HTTPException(status_code=401, detail="Authentication required")
     org_id = require_org_context(user)
-    status = get_provider_auth_status(user_id=user_id, org_id=org_id, provider="openai")
-    if not status.get("runtime_key_available"):
-        raise HTTPException(status_code=409, detail="OpenAI runtime is not connected yet.")
+    _require_personal_openai_connection(user_id=user_id, org_id=org_id)
 
     with UnitOfWork() as uow:
         existing = _find_existing_intro(uow.session, org_id=org_id, user_id=user_id)

--- a/frontend/src/lib/components/chat/ChatDock.svelte
+++ b/frontend/src/lib/components/chat/ChatDock.svelte
@@ -461,18 +461,9 @@
       const createdAt = parseServerDate(timestamp);
       if (!createdAt) return timestamp;
       const now = new Date();
-      const diffMs = now.getTime() - createdAt.getTime();
+      const diffMs = Math.max(0, now.getTime() - createdAt.getTime());
       const diffMinutes = Math.floor(diffMs / 60000);
       const diffHours = Math.floor(diffMs / 3600000);
-
-      if (diffMs < 0) {
-        return createdAt.toLocaleString([], {
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-        });
-      }
 
       if (diffMs < 60000) return 'just now';
       if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;

--- a/frontend/src/lib/features/cortex/components/ArchiveBinMenu.svelte
+++ b/frontend/src/lib/features/cortex/components/ArchiveBinMenu.svelte
@@ -5,6 +5,7 @@
   import { ConstellationIcon, ConstellationIconButton } from '$lib/components/constellation';
   import { cortex, type Idea } from '$lib/stores/cortex.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
+  import { relativeTimeAgo } from '$lib/utils/datetime';
 
   let {
     dragging = false,
@@ -25,15 +26,7 @@
   const recentArchivedApps = $derived(workspaceApps.archivedApps.slice(0, 12));
 
   function timeAgo(value: string | null | undefined): string {
-    if (!value) return 'recently';
-    const diffSeconds = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 1000));
-    if (diffSeconds < 60) return `${diffSeconds}s ago`;
-    const minutes = Math.floor(diffSeconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
+    return relativeTimeAgo(value) || 'recently';
   }
 
   function threadTitle(idea: Idea): string {

--- a/frontend/src/lib/features/cortex/components/ListView.svelte
+++ b/frontend/src/lib/features/cortex/components/ListView.svelte
@@ -7,6 +7,7 @@
     normalizeHexColor,
     presenceToneForColor,
   } from '$lib/utils/constellationPresence';
+  import { parseServerDate } from '$lib/utils/datetime';
 
   const STATUS_COLORS: Record<string, string> = {
     idle: '#57CFA0',
@@ -21,11 +22,13 @@
   };
 
   function timeAgo(ts: string) {
-    const diff = Date.now() - new Date(ts).getTime();
+    const parsed = parseServerDate(ts);
+    if (!parsed) return '';
+    const diff = Math.max(0, Date.now() - parsed.getTime());
     if (diff < 60_000) return 'just now';
     if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
     if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-    return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
 
   function teamMemberFor(userId: string | null | undefined) {

--- a/frontend/src/lib/features/cortex/components/OpsOverlay.svelte
+++ b/frontend/src/lib/features/cortex/components/OpsOverlay.svelte
@@ -3,6 +3,7 @@
   import { cortex } from '$lib/stores/cortex.svelte';
   import { cancelRun as cancelRunRequest, opsActive, opsRecent } from '$lib/features/threads/api/threadApi';
   import { wsClient } from '$lib/stores/ws.svelte';
+  import { parseServerDate, parseServerTimeMs } from '$lib/utils/datetime';
   import { onMount, onDestroy, tick, untrack } from 'svelte';
 
   let { visible = false, onclose }: { visible: boolean; onclose: () => void } = $props();
@@ -38,7 +39,9 @@
   // ── Helpers ───────────────────────────────────────────────
   function liveElapsed(isoStr: string | null): string {
     if (!isoStr) return '--:--';
-    const sec = Math.max(0, Math.floor((now - new Date(isoStr).getTime()) / 1000));
+    const timeMs = parseServerTimeMs(isoStr);
+    if (!timeMs) return '--:--';
+    const sec = Math.max(0, Math.floor((now - timeMs) / 1000));
     const h = Math.floor(sec / 3600);
     const m = Math.floor((sec % 3600) / 60);
     const s = sec % 60;
@@ -48,8 +51,9 @@
 
   function timeAgo(isoStr: string | null): string {
     if (!isoStr) return '';
-    const diff = now - new Date(isoStr).getTime();
-    const s = Math.floor(diff / 1000);
+    const timeMs = parseServerTimeMs(isoStr);
+    if (!timeMs) return '';
+    const s = Math.max(0, Math.floor((now - timeMs) / 1000));
     if (s < 60) return `${s}s ago`;
     const m = Math.floor(s / 60);
     if (m < 60) return `${m}m ago`;
@@ -70,7 +74,7 @@
 
   function traceTime(isoStr: string): string {
     try {
-      return new Date(isoStr).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+      return parseServerDate(isoStr)?.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }) ?? '';
     } catch { return ''; }
   }
 
@@ -79,12 +83,18 @@
     const trace = d.activity_trace || [];
     if (trace.length === 0) return { pct: 50, label: 'unknown', color: '#888' };
     const lastEntry = trace[trace.length - 1];
-    const lastTime = new Date(lastEntry.at).getTime();
+    const lastTime = parseServerTimeMs(lastEntry.at);
+    if (!lastTime) return { pct: 50, label: 'unknown', color: '#888' };
     const staleSec = (now - lastTime) / 1000;
     if (staleSec < 30) return { pct: 100, label: 'active', color: '#34d399' };
     if (staleSec < 120) return { pct: 75, label: 'working', color: '#E8A94B' };
     if (staleSec < 300) return { pct: 40, label: 'slow', color: '#fb923c' };
     return { pct: 15, label: 'stalled', color: '#f87171' };
+  }
+
+  function isElapsedLong(isoStr: string | null | undefined): boolean {
+    const timeMs = parseServerTimeMs(isoStr);
+    return Boolean(timeMs && now - timeMs > 600000);
   }
 
   function runGraphProgress(d: any): { done: number; total: number; pct: number } {
@@ -347,7 +357,7 @@
 
                 <!-- Elapsed + cost -->
                 <div class="lane-metrics">
-                  <div class="lane-elapsed" class:elapsed-long={now - new Date(d.started_at || d.created_at).getTime() > 600000}>
+                  <div class="lane-elapsed" class:elapsed-long={isElapsedLong(d.started_at || d.created_at)}>
                     {liveElapsed(d.started_at || d.created_at)}
                   </div>
                   {#if d.estimated_cost}

--- a/frontend/src/lib/features/notifications/components/NotificationsMenu.svelte
+++ b/frontend/src/lib/features/notifications/components/NotificationsMenu.svelte
@@ -4,6 +4,7 @@
   import type { AppNotification } from '$lib/api/client';
   import { ConstellationIconButton } from '$lib/components/constellation';
   import { notifications } from '$lib/stores/notifications.svelte';
+  import { relativeTimeAgo } from '$lib/utils/datetime';
 
   let {
     onSelect,
@@ -15,14 +16,7 @@
   let rootEl: HTMLDivElement | undefined = $state();
 
   function timeAgo(value: string): string {
-    const diffSeconds = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 1000));
-    if (diffSeconds < 60) return `${diffSeconds}s ago`;
-    const minutes = Math.floor(diffSeconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
+    return relativeTimeAgo(value) || '0s ago';
   }
 
   function sourceLabel(source: string): string {

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -15,6 +15,7 @@ import {
   shouldShowRunInTranscript,
 } from '$lib/utils/cortexRunPresentation';
 import { streamItemRunId } from '$lib/utils/cortexRunStream';
+import { parseServerDate, parseServerTimeMs, relativeTimeAgo } from '$lib/utils/datetime';
 import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
 import { buildRunEvidenceDebug } from '$lib/utils/runEvidenceDebug';
 import type { Idea, StreamItem } from '$lib/types/cortex';
@@ -85,16 +86,7 @@ export function visibleThreadStreamItems(stream: readonly StreamItem[]): StreamI
 }
 
 export function timeAgo(isoStr: string | undefined, nowMs = Date.now()): string {
-  if (!isoStr) return '';
-  const diff = nowMs - new Date(isoStr).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  return relativeTimeAgo(isoStr, nowMs);
 }
 
 export function formatDuration(sec: number | undefined): string {
@@ -109,7 +101,9 @@ export function formatDuration(sec: number | undefined): string {
 
 export function elapsedLabel(isoStr: string | undefined, nowMs = Date.now()): string {
   if (!isoStr) return '';
-  const seconds = Math.floor((nowMs - new Date(isoStr).getTime()) / 1000);
+  const startMs = parseServerTimeMs(isoStr);
+  if (!startMs) return '';
+  const seconds = Math.max(0, Math.floor((nowMs - startMs) / 1000));
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
@@ -119,7 +113,7 @@ export function elapsedLabel(isoStr: string | undefined, nowMs = Date.now()): st
 export function formatRunClock(isoStr: string | undefined): string {
   if (!isoStr) return '';
   try {
-    return new Date(isoStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return parseServerDate(isoStr)?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) ?? '';
   } catch {
     return '';
   }

--- a/frontend/src/lib/utils/datetime.test.js
+++ b/frontend/src/lib/utils/datetime.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseServerTimeMs, relativeTimeAgo } from './datetime.ts';
+
+test('treats timezone-less server timestamps as UTC', () => {
+  assert.equal(
+    parseServerTimeMs('2026-05-09T14:34:54.552702'),
+    Date.parse('2026-05-09T14:34:54.552702Z'),
+  );
+});
+
+test('formats relative timestamps without going negative for clock skew', () => {
+  const nowMs = Date.parse('2026-05-09T14:34:54Z');
+
+  assert.equal(relativeTimeAgo('2026-05-09T14:34:24', nowMs), '30s ago');
+  assert.equal(relativeTimeAgo('2026-05-09T14:35:24', nowMs), '0s ago');
+});
+
+test('returns an empty label for invalid timestamps', () => {
+  assert.equal(relativeTimeAgo('not-a-date'), '');
+});

--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -15,11 +15,11 @@ export function parseServerTimeMs(timestamp: string | null | undefined): number 
   return parseServerDate(timestamp)?.getTime() ?? 0;
 }
 
-export function relativeTimeAgo(timestamp: string | null | undefined): string {
+export function relativeTimeAgo(timestamp: string | null | undefined, nowMs = Date.now()): string {
   const parsed = parseServerDate(timestamp);
   if (!parsed) return '';
 
-  const diff = Date.now() - parsed.getTime();
+  const diff = Math.max(0, nowMs - parsed.getTime());
   const seconds = Math.floor(diff / 1000);
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);

--- a/frontend/src/lib/utils/runtimeOnboarding.ts
+++ b/frontend/src/lib/utils/runtimeOnboarding.ts
@@ -1,0 +1,17 @@
+type RuntimeConnectionLike = {
+  status?: string | null;
+  source?: string | null;
+};
+
+type RuntimeSettingsLike = {
+  connection?: RuntimeConnectionLike | null;
+} | null | undefined;
+
+export function hasPersonalOpenAIRuntimeConnection(runtime: RuntimeSettingsLike) {
+  const connection = runtime?.connection;
+  return connection?.status === 'connected' && connection?.source === 'user_default';
+}
+
+export function requiresPersonalOpenAIOnboarding(runtime: RuntimeSettingsLike) {
+  return !hasPersonalOpenAIRuntimeConnection(runtime);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import { auth } from '$lib/stores/auth.svelte';
   import { theme } from '$lib/stores/theme.svelte';
   import { wsClient } from '$lib/stores/ws.svelte';
+  import { requiresPersonalOpenAIOnboarding } from '$lib/utils/runtimeOnboarding';
   import { onMount, onDestroy } from 'svelte';
   import { dev } from '$app/environment';
   import { goto } from '$app/navigation';
@@ -83,7 +84,7 @@
 
         try {
           const runtime = await api.runtimeSettings();
-          if (runtime?.connection?.setup_required && !isSystemPage) {
+          if (requiresPersonalOpenAIOnboarding(runtime) && !isSystemPage) {
             goto('/onboarding');
           }
         } catch {

--- a/frontend/src/routes/costs/+page.svelte
+++ b/frontend/src/routes/costs/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, tick } from 'svelte';
   import { api } from '$lib/api/client';
   import { ui } from '$lib/stores/ui.svelte';
+  import { relativeTimeAgo } from '$lib/utils/datetime';
 
   let data = $state<any>(null);
   let loading = $state(true);
@@ -50,14 +51,7 @@
   }
 
   function timeAgo(ts: string): string {
-    const diff = Date.now() - new Date(ts).getTime();
-    const mins = Math.floor(diff / 60000);
-    if (mins < 1) return 'just now';
-    if (mins < 60) return `${mins}m ago`;
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
+    return relativeTimeAgo(ts) || 'just now';
   }
 
   function drawDailyChart() {

--- a/frontend/src/routes/cycles/+page.svelte
+++ b/frontend/src/routes/cycles/+page.svelte
@@ -19,6 +19,7 @@
   } from '$lib/components/constellation';
   import AiPromptComposer from '$lib/features/composer/components/AiPromptComposer.svelte';
   import { ui } from '$lib/stores/ui.svelte';
+  import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
 
   type ThinkingLevel = '' | 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   type ScheduleCadence = 'once' | 'daily' | 'weekdays' | 'weekly' | 'monthly' | 'custom';
@@ -363,8 +364,8 @@
 
   function formatDateTime(value: string | null | undefined): string {
     if (!value) return '--';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '--';
+    const date = parseServerDate(value);
+    if (!date) return '--';
     return new Intl.DateTimeFormat(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
@@ -372,15 +373,7 @@
   }
 
   function timeAgo(value: string | null | undefined): string {
-    if (!value) return '--';
-    const deltaMs = Date.now() - new Date(value).getTime();
-    if (Number.isNaN(deltaMs)) return '--';
-    const mins = Math.floor(deltaMs / 60000);
-    if (mins < 1) return 'just now';
-    if (mins < 60) return `${mins}m ago`;
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}h ago`;
-    return `${Math.floor(hours / 24)}d ago`;
+    return relativeTimeAgo(value) || '--';
   }
 
   function sentenceCase(value: string | null | undefined): string {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -12,6 +12,7 @@
   import IllospaceLogo from '$lib/components/layout/IllospaceLogo.svelte';
   import { api } from '$lib/api/client';
   import { auth } from '$lib/stores/auth.svelte';
+  import { requiresPersonalOpenAIOnboarding } from '$lib/utils/runtimeOnboarding';
 
   type View = 'login' | 'register' | 'pending';
   type PublicOrg = { id: string; name: string; slug: string };
@@ -234,7 +235,7 @@
         return;
       }
       const runtime = await api.runtimeSettings();
-      if (runtime?.connection?.setup_required) {
+      if (requiresPersonalOpenAIOnboarding(runtime)) {
         await goto('/onboarding');
         return;
       }

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -16,6 +16,7 @@
     navigateOpenAIOAuthPopup,
     openOpenAIOAuthPopup,
   } from '$lib/utils/oauthPopup';
+  import { hasPersonalOpenAIRuntimeConnection } from '$lib/utils/runtimeOnboarding';
   import type { EmbedderKey, RuntimeOption, RuntimeSettings } from '../system/types';
 
   type OnboardingStatus = 'loading' | 'missing' | 'connecting' | 'connected' | 'error';
@@ -116,7 +117,7 @@
   }
 
   function runtimeHasOnboardingOpenAIConnection(runtime: RuntimeSettings) {
-    return Boolean(runtime?.connection?.status === 'connected' && ['user_default', 'org_main'].includes(runtime.connection.source || ''));
+    return hasPersonalOpenAIRuntimeConnection(runtime);
   }
 
   function selectEmbedder(embedder: EmbedderKey) {

--- a/frontend/src/routes/team/+page.svelte
+++ b/frontend/src/routes/team/+page.svelte
@@ -21,6 +21,7 @@
   import { auth } from '$lib/stores/auth.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import { buildPresenceSeedStyle } from '$lib/utils/constellationPresence';
+  import { parseServerDate } from '$lib/utils/datetime';
 
   interface TeamMember {
     id: number;
@@ -142,7 +143,9 @@
 
   function timeAgo(iso: string | undefined): string {
     if (!iso) return 'unknown';
-    const ms = Date.now() - new Date(iso).getTime();
+    const createdAt = parseServerDate(iso);
+    if (!createdAt) return 'unknown';
+    const ms = Math.max(0, Date.now() - createdAt.getTime());
     const days = Math.floor(ms / 86400000);
 
     if (days < 1) {

--- a/frontend/src/routes/vault/+page.svelte
+++ b/frontend/src/routes/vault/+page.svelte
@@ -14,6 +14,7 @@
     ConstellationSegmentedToggle,
   } from '$lib/components/constellation';
   import { ui } from '$lib/stores/ui.svelte';
+  import { parseServerDate, relativeTimeAgo } from '$lib/utils/datetime';
 
   interface Secret {
     id: number;
@@ -897,21 +898,13 @@
   }
 
   function timeAgo(iso: string | undefined): string {
-    if (!iso) return 'never';
-    const ms = Date.now() - new Date(iso).getTime();
-    const days = Math.floor(ms / 86400000);
-    if (days < 1) {
-      const hrs = Math.floor(ms / 3600000);
-      if (hrs < 1) return `${Math.floor(ms / 60000)}m ago`;
-      return `${hrs}h ago`;
-    }
-    return `${days}d ago`;
+    return relativeTimeAgo(iso) || 'never';
   }
 
   function relativeTime(iso: string | undefined): string {
     if (!iso) return 'never';
-    const time = new Date(iso).getTime();
-    if (Number.isNaN(time)) return 'unknown';
+    const time = parseServerDate(iso)?.getTime();
+    if (!time) return 'unknown';
     const ms = time - Date.now();
     if (ms <= 0) return timeAgo(iso);
     const mins = Math.ceil(ms / 60000);

--- a/tests/test_onboarding_runtime_intro.py
+++ b/tests/test_onboarding_runtime_intro.py
@@ -10,6 +10,10 @@ def _uow_with_session(session):
     return uow
 
 
+def _personal_openai_status():
+    return {"runtime_key_available": True, "runtime_key_source": "user_default"}
+
+
 def test_runtime_ready_intro_reuses_existing_thread():
     from brain.app.api.routers.onboarding import start_runtime_ready_intro
 
@@ -23,7 +27,7 @@ def test_runtime_ready_intro_reuses_existing_thread():
         return_value=_uow_with_session(session),
     ), patch(
         "brain.app.api.routers.onboarding.get_provider_auth_status",
-        return_value={"runtime_key_available": True},
+        return_value=_personal_openai_status(),
     ), patch("brain.app.api.routers.onboarding.route_trigger") as route_trigger:
         result = start_runtime_ready_intro(
             {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
@@ -52,7 +56,7 @@ def test_runtime_ready_intro_recovers_failed_existing_thread():
         return_value=_uow_with_session(session),
     ), patch(
         "brain.app.api.routers.onboarding.get_provider_auth_status",
-        return_value={"runtime_key_available": True},
+        return_value=_personal_openai_status(),
     ), patch(
         "brain.app.api.routers.onboarding.route_trigger",
         return_value=TriggerRouteResult(ok=True, route="run", run_id=77),
@@ -92,7 +96,7 @@ def test_runtime_ready_intro_creates_thread_and_run():
         return_value=_uow_with_session(session),
     ), patch(
         "brain.app.api.routers.onboarding.get_provider_auth_status",
-        return_value={"runtime_key_available": True},
+        return_value=_personal_openai_status(),
     ), patch(
         "brain.app.api.routers.onboarding.route_trigger",
         return_value=TriggerRouteResult(ok=True, route="run", run_id=42),
@@ -134,4 +138,26 @@ def test_runtime_ready_intro_requires_openai_runtime():
             )
 
     assert exc.value.status_code == 409
-    assert "OpenAI runtime is not connected" in exc.value.detail
+    assert "personal OpenAI account" in exc.value.detail
+
+
+def test_runtime_ready_intro_rejects_workspace_openai_runtime():
+    import pytest
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.onboarding import runtime_ready_intro_draft, start_runtime_ready_intro
+
+    user = {"id": "user-1", "org_id": "org-1", "role": "member", "name": "Alice"}
+    with patch(
+        "brain.app.api.routers.onboarding.get_provider_auth_status",
+        return_value={"runtime_key_available": True, "runtime_key_source": "org_main"},
+    ):
+        with pytest.raises(HTTPException) as exc:
+            runtime_ready_intro_draft(user)
+        assert exc.value.status_code == 409
+        assert "personal OpenAI account" in exc.value.detail
+
+        with pytest.raises(HTTPException) as exc:
+            start_runtime_ready_intro(user)
+        assert exc.value.status_code == 409
+        assert "personal OpenAI account" in exc.value.detail

--- a/tests/test_openai_oauth_ui_contract.py
+++ b/tests/test_openai_oauth_ui_contract.py
@@ -28,3 +28,16 @@ def test_system_oauth_start_keeps_page_open_when_popup_is_blocked():
     source = (ROOT / "frontend/src/routes/system/+page.svelte").read_text()
 
     assert "window.location.assign(oauthUrl)" not in source
+
+
+def test_onboarding_routes_require_personal_openai_connection():
+    helper = (ROOT / "frontend/src/lib/utils/runtimeOnboarding.ts").read_text()
+    login = (ROOT / "frontend/src/routes/login/+page.svelte").read_text()
+    layout = (ROOT / "frontend/src/routes/+layout.svelte").read_text()
+    onboarding = (ROOT / "frontend/src/routes/onboarding/+page.svelte").read_text()
+
+    assert "connection?.source === 'user_default'" in helper
+    assert "requiresPersonalOpenAIOnboarding(runtime)" in login
+    assert "requiresPersonalOpenAIOnboarding(runtime)" in layout
+    assert "hasPersonalOpenAIRuntimeConnection(runtime)" in onboarding
+    assert "org_main'].includes" not in onboarding


### PR DESCRIPTION
Summary:
- Require each approved user to complete onboarding with their own user_default OpenAI connection.
- Stop org/workspace runtime connections from satisfying the onboarding gate.
- Reject onboarding intro start/draft requests unless the runtime source is personal.
- Parse server timestamps as UTC before formatting relative time labels, preventing negative "ago" values across the transcript and related UI.

Tests:
- venv/bin/python3 -m pytest tests/test_onboarding_runtime_intro.py tests/test_openai_oauth_ui_contract.py -q
- npm test
- npm run check