### PR TITLE
Add coordinator soul synthesis and onboarding prompt

### DIFF
--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy import select
 
 from brain.app.api.auth import get_current_user
@@ -14,6 +14,7 @@ from brain.app.triggers.router import route_trigger
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
 from brain.systems.services.runtime_introspection import get_provider_auth_status
 from brain.systems.runs.status import RunStatus
 
@@ -97,6 +98,23 @@ def _route_intro_run(session: Any, *, idea: Idea, user: dict[str, Any]) -> Any:
     return route_trigger(trigger, session=session)
 
 
+def _queue_intro_display_title(
+    background_tasks: BackgroundTasks,
+    *,
+    idea_id: str,
+    user_id: str,
+    org_id: str,
+    raw_title: str,
+) -> None:
+    background_tasks.add_task(
+        generate_and_store_idea_display_title,
+        idea_id,
+        raw_title=raw_title,
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+
 @router.post("/runtime-ready-intro-draft")
 def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) -> dict[str, Any]:
     """Return the visible composer draft for the runtime-ready intro flow."""
@@ -122,7 +140,10 @@ def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) 
 
 
 @router.post("/runtime-ready-intro")
-def start_runtime_ready_intro(user: dict[str, Any] = Depends(get_current_user)) -> dict[str, Any]:
+def start_runtime_ready_intro(
+    background_tasks: BackgroundTasks,
+    user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
     """Create or reuse the Cortex intro thread after model runtime setup."""
     user_id = str(user.get("id") or "")
     if not user_id:
@@ -174,6 +195,13 @@ def start_runtime_ready_intro(user: dict[str, Any] = Depends(get_current_user)) 
         uow.session.flush()
 
         result = _route_intro_run(uow.session, idea=idea, user=user)
+        _queue_intro_display_title(
+            background_tasks,
+            idea_id=str(idea.id),
+            user_id=user_id,
+            org_id=org_id,
+            raw_title=idea.title,
+        )
 
         return {
             "ok": True,

--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -25,8 +25,8 @@ router = APIRouter(
 
 INTRO_ORIGIN = "onboarding"
 INTRO_ORIGIN_REF_PREFIX = "runtime-ready-intro"
-INTRO_TITLE = "Illo, help me finish setting up this workspace."
-INTRO_DISPLAY_TITLE = "Welcome to Illo"
+INTRO_PROMPT = "Hey Illo, help me understand what you can do to help me."
+INTRO_TITLE = INTRO_PROMPT
 INTRO_DESCRIPTION = "Runtime is connected. Illo can finish setup from here."
 INTRO_MODEL = "openai/gpt-5.5"
 INTRO_RUN_SETTLED_STATUSES = {
@@ -37,9 +37,6 @@ INTRO_RUN_SETTLED_STATUSES = {
     RunStatus.VERIFYING.value,
     RunStatus.COMPLETED.value,
 }
-
-INTRO_PROMPT = "Hi Illo, what can you help me with?"
-
 
 def _intro_ref(user_id: str) -> str:
     return f"{INTRO_ORIGIN_REF_PREFIX}:{user_id}"
@@ -118,8 +115,6 @@ def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) 
             "idea_id": str(existing.id) if existing is not None else None,
             "should_play": existing is None,
             "prompt": INTRO_PROMPT,
-            "title": INTRO_TITLE,
-            "display_title": INTRO_DISPLAY_TITLE,
             "origin": INTRO_ORIGIN,
             "origin_ref": _intro_ref(user_id),
             "run_metadata": _intro_metadata("visible_composer"),
@@ -160,7 +155,6 @@ def start_runtime_ready_intro(user: dict[str, Any] = Depends(get_current_user)) 
 
         idea = Idea(
             title=INTRO_TITLE,
-            display_title=INTRO_DISPLAY_TITLE,
             description=INTRO_DESCRIPTION,
             status="active",
             origin=INTRO_ORIGIN,

--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -141,8 +141,8 @@ def runtime_ready_intro_draft(user: dict[str, Any] = Depends(get_current_user)) 
 
 @router.post("/runtime-ready-intro")
 def start_runtime_ready_intro(
-    background_tasks: BackgroundTasks,
     user: dict[str, Any] = Depends(get_current_user),
+    background_tasks: BackgroundTasks = None,
 ) -> dict[str, Any]:
     """Create or reuse the Cortex intro thread after model runtime setup."""
     user_id = str(user.get("id") or "")
@@ -195,13 +195,14 @@ def start_runtime_ready_intro(
         uow.session.flush()
 
         result = _route_intro_run(uow.session, idea=idea, user=user)
-        _queue_intro_display_title(
-            background_tasks,
-            idea_id=str(idea.id),
-            user_id=user_id,
-            org_id=org_id,
-            raw_title=idea.title,
-        )
+        if background_tasks is not None:
+            _queue_intro_display_title(
+                background_tasks,
+                idea_id=str(idea.id),
+                user_id=user_id,
+                org_id=org_id,
+                raw_title=idea.title,
+            )
 
         return {
             "ok": True,

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -29,10 +29,14 @@ _WORKSPACE_ACTIVITY_PHRASES = (
 )
 _WORKSPACE_OVERVIEW_PHRASES = (
     "finish setting up this workspace",
+    "help me understand this workspace",
+    "help me understand what you can do to help me",
     "help me finish setting up this workspace",
     "introduce yourself",
+    "what can you do to help me",
     "what can you see",
     "what do you know about this workspace",
+    "what you should know about the team",
     "what is this workspace",
     "workspace overview",
     "workspace setup",

--- a/brain/systems/runs/recipes/deep.py
+++ b/brain/systems/runs/recipes/deep.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from collections.abc import Mapping
 from typing import Any, Iterable
 
+from brain.platform.providers.model_policy import get_model_for_tier
+from brain.systems.personality import soul_prompt_section
 from brain.systems.runs.assignments import AcceptanceCriteria, EvidenceRequirement, WorkerAssignment
 from brain.systems.runs.domain import AgentRun, AgentRunArtifact, ArtifactType, RunProfile, RunRecipe
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
 from brain.systems.runs.events import run_event
 from brain.systems.runs.graph import DeepPlan, RunEdge, RunNode
+from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent
 from brain.systems.runs.recipes.base import BaseRunRecipe
 from brain.systems.runs.recipes.phase_barrier import (
     apply_phase_barrier_decision,
@@ -20,12 +24,26 @@ from brain.systems.runs.recipes.phase_barrier import (
     review_completed_phase,
 )
 from brain.systems.runs.recipes.scout import ScoutHandoff, scout_request
+from brain.systems.runs.recipes.shared import workspace_root_from_ref
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.verification.evidence import verification_evidence, worker_evidence_from_artifacts
 from brain.systems.runs.verification.gates import VerificationResult, verify_worker_evidence
 from brain.systems.runs.verification.policy import VerificationMode, verification_mode_for_run
 
 logger = logging.getLogger(__name__)
+
+
+DEEP_COORDINATOR_SYNTHESIS_INSTRUCTIONS = """## Deep Coordinator Mode
+
+You are Illo Brain in Deep mode: the coordinator who owns the final answer to the user after scoped workers finish.
+
+Rules:
+- Answer the user's original request directly in natural conversational prose.
+- Use worker results as evidence. Do not invent changes, commands, files, or verification that are not in the synthesis payload.
+- Surface the useful outcome first, then mention verification, blockers, or uncertainty when they matter.
+- Do not expose internal JSON, run graph mechanics, or worker chatter unless it helps the user understand the result.
+- Keep it concise and concrete.
+"""
 
 
 def _root_run_id(runtime: RunRuntime) -> int:
@@ -502,8 +520,79 @@ class DeepRecipe(BaseRunRecipe):
         node: RunNode,
         node_results: dict[str, dict[str, Any]],
     ) -> dict[str, Any]:
-        output = self._synthesize_output(node_results)
+        output = self._synthesize_with_coordinator(runtime, node_results)
         return {"node_id": node.id, "node_kind": _node_kind(node), "status": RunStatus.COMPLETED.value, "output": output}
+
+    def _synthesize_with_coordinator(self, runtime: RunRuntime, node_results: dict[str, dict[str, Any]]) -> str:
+        fallback = self._synthesize_output(node_results)
+        model, thinking = _coordinator_model_and_thinking(runtime)
+        system_prompt = soul_prompt_section() + "\n\n" + DEEP_COORDINATOR_SYNTHESIS_INSTRUCTIONS
+        payload = _coordinator_synthesis_payload(runtime, node_results)
+        runtime.store.append_event(
+            run_event(
+                runtime.run.id,
+                "run.coordinator_synthesis_started",
+                {"worker_count": len(payload.get("workers") or [])},
+                root_run_id=_root_run_id(runtime),
+                producer="deep",
+            )
+        )
+        try:
+            spec = build_direct_agent_invocation(
+                message=json.dumps(payload, indent=2, default=str),
+                system_prompt=system_prompt,
+                session_id=f"agent-run-{runtime.run.id}-synthesis",
+                model=str(model),
+                thinking=str(thinking),
+                tools=[],
+                tool_handlers={},
+                persist_session=False,
+                max_turns=2,
+                workspace_root=workspace_root_from_ref(runtime.request.workspace_ref),
+                user_id=runtime.request.user_id,
+                run_id=runtime.run.id,
+                idea_id=None,
+                tool_call_source="coordinator",
+                brain_context_preloaded=True,
+                skip_harvest=True,
+                metadata={
+                    "org_id": runtime.request.org_id,
+                    "profile": str(runtime.request.normalized_profile.value),
+                    "recipe": "deep_synthesis",
+                    "root_run_id": runtime.run.root_run_id,
+                    "provider_operation_type": "coordinator",
+                },
+            )
+            result = invoke_direct_agent(spec)
+            success = bool(getattr(result, "success", False))
+            output = str(getattr(result, "output", "") or "").strip()
+            if not success or not output:
+                output = fallback
+            runtime.store.append_event(
+                run_event(
+                    runtime.run.id,
+                    "run.coordinator_synthesis_completed",
+                    {
+                        "used_fallback": output == fallback,
+                        "success": success,
+                    },
+                    root_run_id=_root_run_id(runtime),
+                    producer="deep",
+                )
+            )
+            return output
+        except Exception as exc:
+            logger.warning("deep_coordinator_synthesis_failed run_id=%s error=%s", runtime.run.id, exc)
+            runtime.store.append_event(
+                run_event(
+                    runtime.run.id,
+                    "run.coordinator_synthesis_failed",
+                    {"error": str(exc)},
+                    root_run_id=_root_run_id(runtime),
+                    producer="deep",
+                )
+            )
+            return fallback
 
     def _synthesize_output(self, node_results: dict[str, dict[str, Any]]) -> str:
         scout = _scout_from_payload(node_results.get("scout"))
@@ -681,6 +770,76 @@ def _child_output(artifacts: list[Any]) -> str:
         elif artifact_type == "worker_result" and text:
             latest_worker = text
     return latest_final or latest_worker
+
+
+def _coordinator_model_and_thinking(runtime: RunRuntime) -> tuple[str, str]:
+    model_policy = dict(runtime.request.model_policy or {})
+    model = model_policy.get("coordinator_model") or model_policy.get("model")
+    if not model:
+        model = get_model_for_tier(
+            model_policy.get("coordinator_tier") or model_policy.get("tier") or "high",
+            include_provider_prefix=True,
+            user_id=runtime.request.user_id,
+            org_id=runtime.request.org_id,
+        )
+    thinking = model_policy.get("coordinator_thinking") or model_policy.get("thinking") or "high"
+    return str(model), str(thinking)
+
+
+def _coordinator_synthesis_payload(runtime: RunRuntime, node_results: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    scout = _scout_from_payload(node_results.get("scout"))
+    worker_results = [result for result in node_results.values() if result.get("assignment")]
+    workers: list[dict[str, Any]] = []
+    for result in worker_results:
+        assignment_payload = result.get("assignment") if isinstance(result.get("assignment"), dict) else {}
+        assignment = WorkerAssignment.from_payload(
+            {"id": str(result.get("node_id") or "worker"), **dict(assignment_payload)}
+        )
+        workers.append(
+            {
+                "node_id": result.get("node_id"),
+                "run_id": result.get("run_id") or result.get("child_run_id"),
+                "role": assignment.role,
+                "status": result.get("status"),
+                "objective": assignment.objective,
+                "output": _truncate(str(result.get("output") or ""), limit=4000),
+                "warning": result.get("warning"),
+                "evidence": _synthesis_artifact_summaries(result.get("artifacts")),
+            }
+        )
+    verification = dict(node_results.get("verify") or {})
+    return {
+        "task": runtime.request.message,
+        "run_id": runtime.run.id,
+        "scout": scout.to_payload(),
+        "verification": {
+            "status": verification.get("status"),
+            "passed": verification.get("passed"),
+            "warning": verification.get("warning"),
+            "details": verification.get("details") or {},
+        },
+        "workers": workers,
+    }
+
+
+def _synthesis_artifact_summaries(value: Any) -> list[dict[str, Any]]:
+    artifacts = value if isinstance(value, list) else []
+    summaries: list[dict[str, Any]] = []
+    for artifact in artifacts[:8]:
+        if not isinstance(artifact, Mapping):
+            continue
+        payload = artifact.get("payload") if isinstance(artifact.get("payload"), Mapping) else {}
+        summaries.append(
+            {
+                "artifact_type": artifact.get("artifact_type"),
+                "title": artifact.get("title"),
+                "has_text": bool(artifact.get("has_text")),
+                "text": _truncate(str(artifact.get("text") or ""), limit=1600),
+                "payload": _truncate(json.dumps(payload, sort_keys=True, default=str), limit=1600) if payload else "",
+                "uri": artifact.get("uri"),
+            }
+        )
+    return summaries
 
 
 def _artifact_type(artifact: Any) -> str:

--- a/brain/systems/runs/recipes/deep.py
+++ b/brain/systems/runs/recipes/deep.py
@@ -26,7 +26,11 @@ from brain.systems.runs.recipes.phase_barrier import (
 from brain.systems.runs.recipes.scout import ScoutHandoff, scout_request
 from brain.systems.runs.recipes.shared import workspace_root_from_ref
 from brain.systems.runs.status import RunStatus
-from brain.systems.runs.verification.evidence import verification_evidence, worker_evidence_from_artifacts
+from brain.systems.runs.verification.evidence import (
+    artifact_payloads,
+    verification_evidence,
+    worker_evidence_from_artifacts,
+)
 from brain.systems.runs.verification.gates import VerificationResult, verify_worker_evidence
 from brain.systems.runs.verification.policy import VerificationMode, verification_mode_for_run
 
@@ -566,14 +570,16 @@ class DeepRecipe(BaseRunRecipe):
             result = invoke_direct_agent(spec)
             success = bool(getattr(result, "success", False))
             output = str(getattr(result, "output", "") or "").strip()
+            used_fallback = False
             if not success or not output:
                 output = fallback
+                used_fallback = True
             runtime.store.append_event(
                 run_event(
                     runtime.run.id,
                     "run.coordinator_synthesis_completed",
                     {
-                        "used_fallback": output == fallback,
+                        "used_fallback": used_fallback,
                         "success": success,
                     },
                     root_run_id=_root_run_id(runtime),
@@ -596,15 +602,11 @@ class DeepRecipe(BaseRunRecipe):
 
     def _synthesize_output(self, node_results: dict[str, dict[str, Any]]) -> str:
         scout = _scout_from_payload(node_results.get("scout"))
-        worker_results = [result for result in node_results.values() if result.get("assignment")]
+        worker_rows = _worker_synthesis_rows(node_results)
         lines = ["Deep completed using native AgentRun workers.", "", f"Scout: {scout.summary}", "", "Worker results:"]
-        for result in worker_results:
-            assignment_payload = result.get("assignment") if isinstance(result.get("assignment"), dict) else {}
-            assignment = WorkerAssignment.from_payload(
-                {"id": str(result.get("node_id") or "worker"), **dict(assignment_payload)}
-            )
-            detail = _truncate(str(result.get("output") or "")) or str(result.get("warning") or "No worker output recorded.")
-            lines.append(f"- {assignment.role} (run {result.get('run_id')}, {result.get('status')}): {detail}")
+        for row in worker_rows:
+            detail = _truncate(str(row.get("output") or "")) or str(row.get("warning") or "No worker output recorded.")
+            lines.append(f"- {row.get('role')} (run {row.get('run_id')}, {row.get('status')}): {detail}")
         return "\n".join(lines).strip()
 
     def _verification_result(self, payload: dict[str, Any] | None) -> VerificationResult | None:
@@ -788,25 +790,6 @@ def _coordinator_model_and_thinking(runtime: RunRuntime) -> tuple[str, str]:
 
 def _coordinator_synthesis_payload(runtime: RunRuntime, node_results: dict[str, dict[str, Any]]) -> dict[str, Any]:
     scout = _scout_from_payload(node_results.get("scout"))
-    worker_results = [result for result in node_results.values() if result.get("assignment")]
-    workers: list[dict[str, Any]] = []
-    for result in worker_results:
-        assignment_payload = result.get("assignment") if isinstance(result.get("assignment"), dict) else {}
-        assignment = WorkerAssignment.from_payload(
-            {"id": str(result.get("node_id") or "worker"), **dict(assignment_payload)}
-        )
-        workers.append(
-            {
-                "node_id": result.get("node_id"),
-                "run_id": result.get("run_id") or result.get("child_run_id"),
-                "role": assignment.role,
-                "status": result.get("status"),
-                "objective": assignment.objective,
-                "output": _truncate(str(result.get("output") or ""), limit=4000),
-                "warning": result.get("warning"),
-                "evidence": _synthesis_artifact_summaries(result.get("artifacts")),
-            }
-        )
     verification = dict(node_results.get("verify") or {})
     return {
         "task": runtime.request.message,
@@ -818,16 +801,41 @@ def _coordinator_synthesis_payload(runtime: RunRuntime, node_results: dict[str, 
             "warning": verification.get("warning"),
             "details": verification.get("details") or {},
         },
-        "workers": workers,
+        "workers": _worker_synthesis_rows(node_results),
     }
 
 
-def _synthesis_artifact_summaries(value: Any) -> list[dict[str, Any]]:
-    artifacts = value if isinstance(value, list) else []
-    summaries: list[dict[str, Any]] = []
-    for artifact in artifacts[:8]:
-        if not isinstance(artifact, Mapping):
+def _worker_synthesis_rows(node_results: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for result in node_results.values():
+        if not result.get("assignment"):
             continue
+        assignment = _assignment_from_worker_result(result)
+        rows.append(
+            {
+                "node_id": result.get("node_id"),
+                "run_id": result.get("run_id") or result.get("child_run_id"),
+                "role": assignment.role,
+                "status": result.get("status"),
+                "objective": assignment.objective,
+                "output": _truncate(str(result.get("output") or ""), limit=4000),
+                "warning": result.get("warning"),
+                "evidence": _synthesis_artifact_summaries(result.get("artifacts")),
+            }
+        )
+    return rows
+
+
+def _assignment_from_worker_result(result: Mapping[str, Any]) -> WorkerAssignment:
+    assignment_payload = result.get("assignment") if isinstance(result.get("assignment"), Mapping) else {}
+    return WorkerAssignment.from_payload(
+        {"id": str(result.get("node_id") or "worker"), **dict(assignment_payload)}
+    )
+
+
+def _synthesis_artifact_summaries(value: Any) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for artifact in artifact_payloads(value)[:8]:
         payload = artifact.get("payload") if isinstance(artifact.get("payload"), Mapping) else {}
         summaries.append(
             {

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -35,11 +35,16 @@ Operating rules:
 - Stream useful progress through activity updates and answer in normal conversational prose.
 """
 
+_FAST_HIDDEN_TOOL_NAMES = {"cortex_reply", "cortex_visual_reply"}
 _ONBOARDING_HIDDEN_TOOL_PREFIXES = ("browser_",)
 
 
 def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
-    tools = build_agent_tools("worker")
+    tools = [
+        tool
+        for tool in build_agent_tools("coordinator")
+        if str(tool.get("name") or "") not in _FAST_HIDDEN_TOOL_NAMES
+    ]
     metadata = runtime.request.metadata if isinstance(runtime.request.metadata, dict) else {}
     is_onboarding_intro = (
         metadata.get("origin") == "onboarding"

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -16,7 +16,6 @@ from brain.systems.runs.tools import RunToolExecutor, ToolRecord, ToolScope, wra
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent
 from brain.platform.providers.model_policy import get_model_for_tier
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
-from brain.systems.personality import soul_prompt_section
 
 logger = logging.getLogger(__name__)
 
@@ -203,9 +202,7 @@ def build_worker_prompt(
     evidence_so_far: Any = None,
 ) -> str:
     return (
-        soul_prompt_section()
-        + "\n\n"
-        + WORKER_AGENT_INSTRUCTIONS
+        WORKER_AGENT_INSTRUCTIONS
         + _json_block("Worker Assignment", assignment.to_payload())
         + _json_block("Target", target_ref)
         + _json_block("Workspace", workspace_ref)

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -1901,6 +1901,7 @@ def _handle_read_workspace_overview(
     payload["answering_guidance"] = [
         "Distinguish what already exists in this workspace from what Illo can help set up.",
         "Use setup_gaps to avoid overclaiming configured project context, Domains, apps, or Cycles.",
+        "If the overview is empty or sparse, ask the user for a few team, project, and workflow details so Illo can fill in workspace context and help better.",
     ]
     return json.dumps(payload, default=str)
 

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping
 
 from sqlalchemy import String, and_, cast, func, or_, select
 
+from brain.systems.runs.tool_definitions import WORKSPACE_OVERVIEW_SPARSE_GUIDANCE
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
 
 _ZERO_UUID = "00000000-0000-0000-0000-000000000000"
@@ -1901,7 +1902,7 @@ def _handle_read_workspace_overview(
     payload["answering_guidance"] = [
         "Distinguish what already exists in this workspace from what Illo can help set up.",
         "Use setup_gaps to avoid overclaiming configured project context, Domains, apps, or Cycles.",
-        "If the overview is empty or sparse, ask the user for a few team, project, and workflow details so Illo can fill in workspace context and help better.",
+        WORKSPACE_OVERVIEW_SPARSE_GUIDANCE,
     ]
     return json.dumps(payload, default=str)
 

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -176,7 +176,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "output_budget_chars": 22_000,
         "evidence_emitter": True,
         "context_route": {
-            "description": "Read a curated overview of the workspace: team members, active thoughts, recent runs/messages, Project Context, Domains, apps, Cycles, and setup gaps. Use first for onboarding, setup, and broad 'what can you see?' questions.",
+            "description": "Read a curated overview of the workspace: team members, active thoughts, recent runs/messages, Project Context, Domains, apps, Cycles, and setup gaps. Use first for onboarding, setup, and broad 'what can you see?' questions. If it is empty or sparse, ask the user for team, project, and workflow details so Illo can fill in workspace context and help better.",
             "domains": ["workspace overview", "workspace setup", "onboarding", "available context", "workspace awareness"],
             "scopes": ["broad"],
         },
@@ -543,7 +543,7 @@ for _browser_name, _metadata in _BROWSER_METADATA.items():
 def _definition_sources() -> list[tuple[str, tuple[str, ...], list[Mapping[str, Any]]]]:
     sources: list[tuple[str, tuple[str, ...], list[Mapping[str, Any]]]] = [
         ("brain", ("coordinator", "worker"), BRAIN_TOOLS),
-        ("soul", ("coordinator", "worker"), SOUL_TOOLS),
+        ("soul", ("coordinator",), SOUL_TOOLS),
         ("domains", ("coordinator", "worker"), DOMAIN_TOOLS),
         ("ideas", ("coordinator", "worker"), CORTEX_IDEA_TOOLS),
         ("chat", ("coordinator", "worker"), CHAT_TOOLS),

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -38,6 +38,7 @@ from brain.systems.runs.tool_definitions import (
     PROJECT_TOOLS,
     SOUL_TOOLS,
     SESSION_TOOLS,
+    WORKSPACE_OVERVIEW_SPARSE_GUIDANCE,
     WORKSPACE_APP_TOOLS,
 )
 from brain.systems.runs.tool_catalog.metadata import (
@@ -176,7 +177,12 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "output_budget_chars": 22_000,
         "evidence_emitter": True,
         "context_route": {
-            "description": "Read a curated overview of the workspace: team members, active thoughts, recent runs/messages, Project Context, Domains, apps, Cycles, and setup gaps. Use first for onboarding, setup, and broad 'what can you see?' questions. If it is empty or sparse, ask the user for team, project, and workflow details so Illo can fill in workspace context and help better.",
+            "description": (
+                "Read a curated overview of the workspace: team members, active thoughts, recent runs/messages, "
+                "Project Context, Domains, apps, Cycles, and setup gaps. Use first for onboarding, setup, and broad "
+                "'what can you see?' questions. "
+                + WORKSPACE_OVERVIEW_SPARSE_GUIDANCE
+            ),
             "domains": ["workspace overview", "workspace setup", "onboarding", "available context", "workspace awareness"],
             "scopes": ["broad"],
         },

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -33,6 +33,11 @@ _WORKSPACE_ALL_TIME_WINDOW_SCHEMA = {
     "description": "Relative time window. Use all for current/existing workspace state, or custom with start_at/end_at.",
 }
 
+WORKSPACE_OVERVIEW_SPARSE_GUIDANCE = (
+    "If the overview is empty or sparse, ask the user for a few team, project, "
+    "and workflow details so Illo can fill in workspace context and help better."
+)
+
 
 # ── Brain Tools ───────────────────────────────────────────────
 # Available to all agents (coordinator + workers)
@@ -336,8 +341,8 @@ BRAIN_TOOLS = [
             "answering broad setup questions, or explaining what context is available. Returns team members, "
             "active/recent Cortex thoughts, recent agent runs/messages, Project Context profiles and attachments, "
             "Domains/records, workspace apps, Cycles, and setup gaps. Use this first for 'what is this workspace?', "
-            "'what can you see?', and onboarding setup guidance. If the overview is empty or sparse, ask the "
-            "user for a few team, project, and workflow details so Illo can fill in workspace context and help better."
+            "'what can you see?', and onboarding setup guidance. "
+            f"{WORKSPACE_OVERVIEW_SPARSE_GUIDANCE}"
         ),
         "input_schema": {
             "type": "object",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -336,7 +336,8 @@ BRAIN_TOOLS = [
             "answering broad setup questions, or explaining what context is available. Returns team members, "
             "active/recent Cortex thoughts, recent agent runs/messages, Project Context profiles and attachments, "
             "Domains/records, workspace apps, Cycles, and setup gaps. Use this first for 'what is this workspace?', "
-            "'what can you see?', and onboarding setup guidance."
+            "'what can you see?', and onboarding setup guidance. If the overview is empty or sparse, ask the "
+            "user for a few team, project, and workflow details so Illo can fill in workspace context and help better."
         ),
         "input_schema": {
             "type": "object",
@@ -1625,7 +1626,6 @@ LIFECYCLE_TOOLS = [
 # is AgentRun-owned, not model-visible.
 WORKER_TOOLS = (
     BRAIN_TOOLS
-    + SOUL_TOOLS
     + DOMAIN_TOOLS
     + CORTEX_IDEA_TOOLS
     + CHAT_TOOLS

--- a/brain/systems/runs/verification/evidence.py
+++ b/brain/systems/runs/verification/evidence.py
@@ -34,12 +34,18 @@ def worker_evidence_from_artifacts(
         "output": output,
         "artifact_count": len(artifacts),
         "assignment": assignment.to_payload(),
-        "artifacts": [_artifact_payload(artifact) for artifact in artifacts],
+        "artifacts": artifact_payloads(artifacts),
         "warning": None if status == "completed" else f"worker ended with status {status}",
     }
 
 
-def _artifact_payload(artifact: Any) -> dict[str, Any]:
+def artifact_payloads(artifacts: Any) -> list[dict[str, Any]]:
+    if not isinstance(artifacts, (list, tuple)):
+        return []
+    return [artifact_payload(artifact) for artifact in artifacts]
+
+
+def artifact_payload(artifact: Any) -> dict[str, Any]:
     if isinstance(artifact, dict):
         artifact_type = artifact.get("artifact_type") or artifact.get("type")
         payload = artifact.get("payload")
@@ -64,4 +70,4 @@ def _artifact_payload(artifact: Any) -> dict[str, Any]:
     }
 
 
-__all__ = ["verification_evidence", "worker_evidence_from_artifacts"]
+__all__ = ["artifact_payload", "artifact_payloads", "verification_evidence", "worker_evidence_from_artifacts"]

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1073,8 +1073,8 @@ export const api = {
       idea_id?: string | null;
       should_play: boolean;
       prompt: string;
-      title: string;
-      display_title: string;
+      title?: string | null;
+      display_title?: string | null;
       origin: string;
       origin_ref: string;
       run_metadata?: Record<string, any> | null;

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -196,6 +196,14 @@ def _stub_phase_reviews(monkeypatch, decisions_by_node=None):
         return SimpleNamespace(output=json.dumps(decision), success=True)
 
     monkeypatch.setattr("brain.systems.runs.recipes.phase_barrier.invoke_direct_agent", fake_phase_review)
+    _stub_deep_synthesis(monkeypatch)
+
+
+def _stub_deep_synthesis(monkeypatch, output="Deep completed using native AgentRun workers."):
+    def fake_deep_synthesis(spec):
+        return SimpleNamespace(output=output, success=True)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.deep.invoke_direct_agent", fake_deep_synthesis)
 
 
 def _runtime(recipe: str = "fast", *, message: str = "Read the README", store=None, workspace_ref=None):
@@ -373,6 +381,32 @@ def test_fast_onboarding_tool_surface_hides_browser_primitives(monkeypatch):
     assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == ["read_workspace_overview"]
 
 
+def test_fast_tool_surface_is_direct_coordinator_without_staged_reply_tools(monkeypatch):
+    from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
+
+    roles = []
+
+    def fake_build_agent_tools(role):
+        roles.append(role)
+        return [
+            {"name": "manage_soul"},
+            {"name": "cortex_reply"},
+            {"name": "cortex_visual_reply"},
+            {"name": "read_workspace_overview"},
+        ]
+
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", fake_build_agent_tools)
+
+    runtime = SimpleNamespace(request=SimpleNamespace(metadata={}))
+
+    assert roles == []
+    assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == [
+        "manage_soul",
+        "read_workspace_overview",
+    ]
+    assert roles == ["coordinator"]
+
+
 def test_runtime_drain_steering_can_use_isolated_durable_drain():
     from brain.systems.runs.steering import SteeringMessage
 
@@ -531,6 +565,63 @@ def test_deep_recipe_uses_native_child_runs(monkeypatch):
         and event.payload.get("completed_node_id") in {"investigate", "execute"}
     ]
     assert max(worker_completion_positions) < min(worker_review_positions)
+
+
+def test_deep_coordinator_synthesis_uses_soul_and_owns_final_answer(monkeypatch):
+    from brain.systems.runs.domain import AgentRunArtifact
+    from brain.systems.runs.recipes.deep import DeepRecipe
+    from brain.systems.runs.status import RunStatus
+
+    _stub_phase_reviews(monkeypatch)
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.deep.soul_prompt_section",
+        lambda: "## Agent Soul\nUse the coordinator voice.",
+    )
+    captured = {}
+
+    def fake_deep_synthesis(spec):
+        captured["spec"] = spec
+        return SimpleNamespace(output="Coordinator final answer.", success=True)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.deep.invoke_direct_agent", fake_deep_synthesis)
+
+    class _ChildEngine:
+        def __init__(self, session, **kwargs):
+            self.store = session
+
+        def run_existing(self, run_id):
+            run = self.store.runs[run_id]
+            artifact_type = "worker_result" if str(getattr(run.recipe, "value", run.recipe)) == "worker" else "final_answer"
+            self.store.append_artifact(
+                AgentRunArtifact(
+                    run_id=run_id,
+                    root_run_id=42,
+                    artifact_type=artifact_type,
+                    title="Worker result" if artifact_type == "worker_result" else "Scout result",
+                    text=f"child {run_id} evidence",
+                )
+            )
+            return SimpleNamespace(status=RunStatus.COMPLETED, id=run.id)
+
+    request_message = "Implement the README cleanup and verify the result."
+    store = _Store()
+    runtime = _runtime("deep", message=request_message, store=store)
+    runtime.engine = _ChildEngine(store)
+
+    result = DeepRecipe().execute(runtime)
+
+    assert result.output == "Coordinator final answer."
+    spec = captured["spec"]
+    assert spec.tool_call_source == "coordinator"
+    assert spec.tools == []
+    assert spec.persist_session is False
+    assert "## Agent Soul\nUse the coordinator voice." in spec.system_prompt
+    assert "## Deep Coordinator Mode" in spec.system_prompt
+    payload = json.loads(spec.message)
+    assert payload["task"] == request_message
+    assert "child 101 evidence" in spec.message
+    assert any(event.event_type == "run.coordinator_synthesis_started" for event in store.events)
+    assert any(event.event_type == "run.coordinator_synthesis_completed" for event in store.events)
 
 
 def test_deep_recipe_failed_verification_returns_failed_status(monkeypatch):

--- a/tests/test_agent_soul.py
+++ b/tests/test_agent_soul.py
@@ -92,12 +92,18 @@ def test_manage_soul_blocks_prompt_override(monkeypatch, tmp_path):
 
 
 def test_manage_soul_tool_has_handler_and_read_is_not_action():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_catalog.registry import action_policy_for_tool, get_tool_registration
     from brain.systems.runs.tool_handlers import _get_tool_handlers
 
     registration = get_tool_registration("manage_soul")
+    coordinator_names = {tool["name"] for tool in COORDINATOR_TOOLS}
+    worker_names = {tool["name"] for tool in WORKER_TOOLS}
 
     assert registration is not None
+    assert [role.value for role in registration.availability] == ["coordinator"]
+    assert "manage_soul" in coordinator_names
+    assert "manage_soul" not in worker_names
     assert registration.permission == "manage_soul"
     assert registration.side_effect_class == "soul_management"
     assert "manage_soul" in _get_tool_handlers()

--- a/tests/test_onboarding_runtime_intro.py
+++ b/tests/test_onboarding_runtime_intro.py
@@ -29,8 +29,8 @@ def test_runtime_ready_intro_reuses_existing_thread():
         return_value={"runtime_key_available": True},
     ), patch("brain.app.api.routers.onboarding.route_trigger") as route_trigger:
         result = start_runtime_ready_intro(
-            background_tasks,
-            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks=background_tasks,
         )
 
     assert result == {
@@ -64,8 +64,8 @@ def test_runtime_ready_intro_recovers_failed_existing_thread():
         return_value=TriggerRouteResult(ok=True, route="run", run_id=77),
     ) as route_trigger:
         result = start_runtime_ready_intro(
-            background_tasks,
-            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks=background_tasks,
         )
 
     assert result["created"] is False
@@ -107,8 +107,8 @@ def test_runtime_ready_intro_creates_thread_and_run():
         return_value=TriggerRouteResult(ok=True, route="run", run_id=42),
     ) as route_trigger:
         result = start_runtime_ready_intro(
-            background_tasks,
-            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks=background_tasks,
         )
 
     idea = next(obj for obj in added if isinstance(obj, Idea))
@@ -144,15 +144,13 @@ def test_runtime_ready_intro_requires_openai_runtime():
 
     from brain.app.api.routers.onboarding import start_runtime_ready_intro
 
-    background_tasks = BackgroundTasks()
     with patch(
         "brain.app.api.routers.onboarding.get_provider_auth_status",
         return_value={"runtime_key_available": False},
     ):
         with pytest.raises(HTTPException) as exc:
             start_runtime_ready_intro(
-                background_tasks,
-                user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+                {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
             )
 
     assert exc.value.status_code == 409

--- a/tests/test_onboarding_runtime_intro.py
+++ b/tests/test_onboarding_runtime_intro.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from fastapi import BackgroundTasks
+
 
 def _uow_with_session(session):
     uow = MagicMock()
@@ -13,6 +15,7 @@ def _uow_with_session(session):
 def test_runtime_ready_intro_reuses_existing_thread():
     from brain.app.api.routers.onboarding import start_runtime_ready_intro
 
+    background_tasks = BackgroundTasks()
     session = MagicMock()
     existing = SimpleNamespace(id="idea-existing")
     completed_run = SimpleNamespace(status="completed")
@@ -26,7 +29,8 @@ def test_runtime_ready_intro_reuses_existing_thread():
         return_value={"runtime_key_available": True},
     ), patch("brain.app.api.routers.onboarding.route_trigger") as route_trigger:
         result = start_runtime_ready_intro(
-            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks,
+            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
         )
 
     assert result == {
@@ -36,12 +40,14 @@ def test_runtime_ready_intro_reuses_existing_thread():
         "run_id": None,
     }
     route_trigger.assert_not_called()
+    assert background_tasks.tasks == []
 
 
 def test_runtime_ready_intro_recovers_failed_existing_thread():
     from brain.app.api.routers.onboarding import start_runtime_ready_intro
     from brain.app.triggers.contracts import TriggerRouteResult
 
+    background_tasks = BackgroundTasks()
     session = MagicMock()
     existing = SimpleNamespace(id="idea-existing")
     failed_run = SimpleNamespace(status="failed")
@@ -58,13 +64,15 @@ def test_runtime_ready_intro_recovers_failed_existing_thread():
         return_value=TriggerRouteResult(ok=True, route="run", run_id=77),
     ) as route_trigger:
         result = start_runtime_ready_intro(
-            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks,
+            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
         )
 
     assert result["created"] is False
     assert result["idea_id"] == "idea-existing"
     assert result["run_id"] == 77
     route_trigger.assert_called_once()
+    assert background_tasks.tasks == []
 
 
 def test_runtime_ready_intro_creates_thread_and_run():
@@ -72,6 +80,7 @@ def test_runtime_ready_intro_creates_thread_and_run():
     from brain.app.triggers.contracts import TriggerRouteResult
     from brain.platform.db.models.idea import Idea
 
+    background_tasks = BackgroundTasks()
     session = MagicMock()
     session.scalars.return_value.first.return_value = None
     added = []
@@ -98,7 +107,8 @@ def test_runtime_ready_intro_creates_thread_and_run():
         return_value=TriggerRouteResult(ok=True, route="run", run_id=42),
     ) as route_trigger:
         result = start_runtime_ready_intro(
-            {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+            background_tasks,
+            user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
         )
 
     idea = next(obj for obj in added if isinstance(obj, Idea))
@@ -117,6 +127,15 @@ def test_runtime_ready_intro_creates_thread_and_run():
     assert trigger.payload["metadata"]["provider"] == "openai"
     assert trigger.payload["metadata"]["model"] == "openai/gpt-5.5"
     assert "thread_message_id" not in trigger.payload["metadata"]
+    assert len(background_tasks.tasks) == 1
+    task = background_tasks.tasks[0]
+    assert task.func.__name__ == "generate_and_store_idea_display_title"
+    assert task.args == ("idea-1",)
+    assert task.kwargs == {
+        "raw_title": INTRO_PROMPT,
+        "user_id": "user-1",
+        "org_id": "org-1",
+    }
 
 
 def test_runtime_ready_intro_requires_openai_runtime():
@@ -125,13 +144,15 @@ def test_runtime_ready_intro_requires_openai_runtime():
 
     from brain.app.api.routers.onboarding import start_runtime_ready_intro
 
+    background_tasks = BackgroundTasks()
     with patch(
         "brain.app.api.routers.onboarding.get_provider_auth_status",
         return_value={"runtime_key_available": False},
     ):
         with pytest.raises(HTTPException) as exc:
             start_runtime_ready_intro(
-                {"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
+                background_tasks,
+                user={"id": "user-1", "org_id": "org-1", "role": "owner", "name": "Alice"},
             )
 
     assert exc.value.status_code == 409

--- a/tests/test_onboarding_runtime_intro.py
+++ b/tests/test_onboarding_runtime_intro.py
@@ -68,7 +68,7 @@ def test_runtime_ready_intro_recovers_failed_existing_thread():
 
 
 def test_runtime_ready_intro_creates_thread_and_run():
-    from brain.app.api.routers.onboarding import INTRO_ORIGIN, start_runtime_ready_intro
+    from brain.app.api.routers.onboarding import INTRO_ORIGIN, INTRO_PROMPT, start_runtime_ready_intro
     from brain.app.triggers.contracts import TriggerRouteResult
     from brain.platform.db.models.idea import Idea
 
@@ -108,10 +108,11 @@ def test_runtime_ready_intro_creates_thread_and_run():
     assert result["run_id"] == 42
     assert idea.origin == INTRO_ORIGIN
     assert idea.origin_ref == "runtime-ready-intro:user-1"
-    assert idea.display_title == "Welcome to Illo"
+    assert idea.title == INTRO_PROMPT
+    assert idea.display_title is None
     route_trigger.assert_called_once()
     trigger = route_trigger.call_args.args[0]
-    assert trigger.payload["thread_message"] == "Hi Illo, what can you help me with?"
+    assert trigger.payload["thread_message"] == INTRO_PROMPT
     assert trigger.payload["metadata"]["prompt_visibility"] == "hidden"
     assert trigger.payload["metadata"]["provider"] == "openai"
     assert trigger.payload["metadata"]["model"] == "openai/gpt-5.5"

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -121,7 +121,7 @@ def test_workspace_activity_question_requires_workspace_data():
 def test_onboarding_intro_requires_workspace_overview():
     from brain.systems.runs.introspection import required_introspection_tool
 
-    tool, message = required_introspection_tool("Illo, introduce yourself and help me finish setting up this workspace.")
+    tool, message = required_introspection_tool("Hey Illo, help me understand what you can do to help me.")
 
     assert tool == "read_workspace_overview"
     assert message is not None

--- a/tests/test_worker_roles.py
+++ b/tests/test_worker_roles.py
@@ -98,5 +98,6 @@ class TestWorkerScope:
         )
 
         assert "Worker Assignment" in prompt
+        assert "Agent Soul" not in prompt
         assert "Review the AgentRun child artifacts" in prompt
         assert "brain/systems/runs/store.py" in prompt


### PR DESCRIPTION
## Summary
- add a Deep coordinator synthesis pass that uses the Illo soul prompt for the final answer
- keep worker prompts/tool surfaces scoped away from soul management while Fast uses the coordinator tool surface without staged reply tools
- update onboarding intro copy and workspace overview guidance so sparse workspace context naturally prompts follow-up questions

## Verification
- ./venv/bin/pytest tests/test_agent_run_runtime.py tests/test_agent_soul.py tests/test_worker_roles.py tests/test_onboarding_runtime_intro.py tests/test_tool_registry.py
- npm run check