### PR TITLE
Fix thread stage and nav logo spacing

### DIFF
--- a/frontend/src/lib/components/layout/IllospaceLogo.svelte
+++ b/frontend/src/lib/components/layout/IllospaceLogo.svelte
@@ -50,10 +50,6 @@
     user-select: none;
   }
 
-  .illospace-logo-icon .illospace-logo-image {
-    transform: translateX(6%);
-  }
-
   .illospace-logo-on-light {
     display: none;
   }

--- a/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
@@ -1202,7 +1202,10 @@
   .thread-mode .cortex-workspace-composer {
     min-height: 102px;
     max-height: min(220px, calc(100svh - 164px));
-    padding: 16px 18px 14px;
+    padding:
+      var(--thread-composer-padding-block-start, 16px)
+      var(--thread-composer-inline-padding, 18px)
+      var(--thread-composer-padding-block-end, 14px);
     border-color: var(--constellation-thread-composer-border);
     background: var(--constellation-thread-composer-background);
     box-shadow: var(--constellation-thread-composer-shadow);

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -1245,6 +1245,8 @@
     --thread-reply-placeholder-title: rgba(240, 240, 250, 0.88);
     --thread-reply-placeholder-hint: rgba(240, 240, 250, 0.46);
     --thread-composer-clearance: clamp(22px, 2.4vh, 34px);
+    --thread-composer-inline-padding: 18px;
+    --thread-transient-rail-offset: var(--thread-composer-inline-padding);
 
     display: grid;
     grid-template-rows: auto minmax(0, 1fr) auto;
@@ -1344,6 +1346,7 @@
   .thread-column {
     width: min(100%, var(--thread-column-max));
     margin-inline: auto;
+    box-sizing: border-box;
   }
 
   .thread-panel-header {
@@ -1974,6 +1977,8 @@
     gap: 12px;
     justify-self: start;
     margin-right: auto;
+    box-sizing: border-box;
+    padding-inline-start: var(--thread-transient-rail-offset);
   }
 
   .run-queued {
@@ -3082,7 +3087,9 @@
   .thread-thinking-state {
     display: grid;
     gap: 8px;
-    padding: 2px 0;
+    box-sizing: border-box;
+    padding-block: 2px;
+    padding-inline-start: var(--thread-transient-rail-offset);
     border-radius: 0;
     border: 0;
     background: var(--thread-thinking-background);

--- a/frontend/static/brand/illo/illo-icon-dark.svg
+++ b/frontend/static/brand/illo/illo-icon-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" fill="none" role="img" aria-labelledby="illo-icon-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 37 176 176" fill="none" role="img" aria-labelledby="illo-icon-title">
   <title id="illo-icon-title">Illo icon for dark surfaces</title>
   <g transform="translate(-184 0)">
     <path

--- a/frontend/static/brand/illo/illo-icon-light.svg
+++ b/frontend/static/brand/illo/illo-icon-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" fill="none" role="img" aria-labelledby="illo-icon-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 37 176 176" fill="none" role="img" aria-labelledby="illo-icon-title">
   <title id="illo-icon-title">Illo icon for light surfaces</title>
   <g transform="translate(-184 0)">
     <path

--- a/frontend/static/brand/illo/illo-logo-dark.svg
+++ b/frontend/static/brand/illo/illo-logo-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 240" fill="none" role="img" aria-labelledby="illo-logo-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 37 335 176" fill="none" role="img" aria-labelledby="illo-logo-title">
   <title id="illo-logo-title">Illo logo for dark surfaces</title>
   <g>
     <rect x="38" y="47" width="22" height="156" rx="11" fill="#F7F3EA"/>

--- a/frontend/static/brand/illo/illo-logo-light.svg
+++ b/frontend/static/brand/illo/illo-logo-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 240" fill="none" role="img" aria-labelledby="illo-logo-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 37 335 176" fill="none" role="img" aria-labelledby="illo-logo-title">
   <title id="illo-logo-title">Illo logo for light surfaces</title>
   <g>
     <rect x="38" y="47" width="22" height="156" rx="11" fill="#0B0B0B"/>


### PR DESCRIPTION
## Summary
- Align transient thread-stage streaming/thinking content with the composer text rail.
- Make thread composer padding token-driven for consistent spacing.
- Center Illo nav logo assets for collapsed and expanded nav rail states.

## Tests
- npm run check