### PR TITLE
Reduce API rate-limit pressure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ ILLO_ENV=development
 # Required in production services. ./illo creates an ignored local default in
 # .illo/runtime.env when this is left empty.
 SECRET_KEY=
+# API request limits. RATE_LIMIT applies per principal and route; RATE_LIMIT_GLOBAL
+# caps total requests per principal in the same RATE_WINDOW.
+# RATE_LIMIT=300
+# RATE_LIMIT_GLOBAL=1200
+# RATE_WINDOW=60
 
 # Database
 DB_HOST=127.0.0.1

--- a/brain/app/api/config.py
+++ b/brain/app/api/config.py
@@ -35,6 +35,7 @@ if not _secret_from_env:
     )
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:5173").split(",")
 RATE_LIMIT = int(os.getenv("RATE_LIMIT", "300"))
+RATE_LIMIT_GLOBAL = int(os.getenv("RATE_LIMIT_GLOBAL", str(max(RATE_LIMIT, RATE_LIMIT * 4))))
 RATE_WINDOW = int(os.getenv("RATE_WINDOW", "60"))
 
 # Localhost auth fallback exists for local CLI/dev ergonomics only.

--- a/brain/app/api/deps.py
+++ b/brain/app/api/deps.py
@@ -1,6 +1,7 @@
 """FastAPI dependencies — DB session, rate limiting."""
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 import time
 from collections import defaultdict
@@ -10,7 +11,7 @@ from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from brain.platform.db import SessionFactory
-from brain.app.api.config import RATE_LIMIT, RATE_WINDOW
+from brain.app.api.config import RATE_LIMIT, RATE_LIMIT_GLOBAL, RATE_WINDOW
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -46,14 +47,69 @@ def rate_limit(request: Request) -> None:
     if _is_internal(addr):
         return
     now = time.time()
-    hits = _rate_store[addr]
-    _rate_store[addr] = [t for t in hits if now - t < RATE_WINDOW]
-    if len(_rate_store[addr]) >= RATE_LIMIT:
-        oldest = _rate_store[addr][0]
-        retry_after = max(1, int(RATE_WINDOW - (now - oldest)) + 1)
+    principal = _rate_limit_principal(request, addr)
+    route = _rate_limit_route(request)
+    buckets = (
+        (f"route:{principal}:{route}", RATE_LIMIT),
+        (f"global:{principal}", RATE_LIMIT_GLOBAL),
+    )
+
+    pruned: list[tuple[str, list[float]]] = []
+    retry_after = 0
+    for key, limit in buckets:
+        hits = [t for t in _rate_store[key] if now - t < RATE_WINDOW]
+        pruned.append((key, hits))
+        if len(hits) >= limit:
+            oldest = hits[0]
+            retry_after = max(retry_after, int(RATE_WINDOW - (now - oldest)) + 1)
+
+    if retry_after > 0:
+        for key, hits in pruned:
+            _rate_store[key] = hits
         raise HTTPException(
             status_code=429,
             detail=f"Rate limit exceeded. Retry after {retry_after}s.",
             headers={"Retry-After": str(retry_after)},
         )
-    _rate_store[addr].append(now)
+
+    for key, hits in pruned:
+        hits.append(now)
+        _rate_store[key] = hits
+
+
+def _rate_limit_principal(request: Request, addr: str) -> str:
+    user_id = _session_user_id(request)
+    if user_id:
+        return f"user:{user_id}"
+
+    auth_header = request.headers.get("Authorization", "")
+    if not isinstance(auth_header, str):
+        auth_header = ""
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+            return f"bearer:{digest}"
+
+    return f"ip:{addr}"
+
+
+def _session_user_id(request: Request) -> str | None:
+    try:
+        session = request.session if hasattr(request, "session") else None
+        user_id = session.get("user_id") if session is not None else None
+    except Exception:
+        return None
+    text = str(user_id or "").strip()
+    return text or None
+
+
+def _rate_limit_route(request: Request) -> str:
+    method = str(getattr(request, "method", "GET") or "GET").upper()
+    route = None
+    try:
+        route = getattr(request.scope.get("route"), "path", None)
+    except Exception:
+        route = None
+    path = route or getattr(getattr(request, "url", None), "path", None) or "/"
+    return f"{method} {path}"

--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -88,6 +88,7 @@ _RETRYABLE_OPENAI_STREAM_TERMS = (
     "timeout",
     "timed out",
 )
+_RETRYABLE_PROVIDER_STATUS_CODES = {408, 409, 429, 500, 502, 503, 529}
 
 
 def _openai_stream_error_message(error: Any) -> str:
@@ -105,6 +106,25 @@ def _openai_stream_error_message(error: Any) -> str:
 def _is_retryable_openai_error_message(message: str) -> bool:
     lowered = str(message or "").lower()
     return any(term in lowered for term in _RETRYABLE_OPENAI_STREAM_TERMS)
+
+
+def _provider_error_status_code(exc: Exception) -> int | None:
+    for attr in ("status_code", "status"):
+        value = getattr(exc, attr, None)
+        try:
+            if value is not None:
+                return int(value)
+        except (TypeError, ValueError):
+            pass
+    response = getattr(exc, "response", None)
+    for attr in ("status_code", "status"):
+        value = getattr(response, attr, None)
+        try:
+            if value is not None:
+                return int(value)
+        except (TypeError, ValueError):
+            pass
+    return None
 
 
 class _TrackedStreamContext:
@@ -272,7 +292,12 @@ class AnthropicProvider(LLMProvider):
         )
 
     def is_retryable_error(self, exc: Exception) -> bool:
-        return isinstance(exc, anthropic.InternalServerError)
+        status_code = _provider_error_status_code(exc)
+        return (
+            isinstance(exc, anthropic.InternalServerError)
+            or status_code in _RETRYABLE_PROVIDER_STATUS_CODES
+            or _is_retryable_openai_error_message(str(exc))
+        )
 
     def is_api_error(self, exc: Exception) -> bool:
         return isinstance(exc, anthropic.APIError)
@@ -502,9 +527,12 @@ class OpenAIProvider(LLMProvider):
         return StreamContext(_event_generator(), finalizer=_build_final)
 
     def is_retryable_error(self, exc: Exception) -> bool:
+        status_code = _provider_error_status_code(exc)
         return (
             exc.__class__.__module__.startswith("openai")
             and exc.__class__.__name__ == "InternalServerError"
+        ) or (
+            status_code in _RETRYABLE_PROVIDER_STATUS_CODES
         ) or isinstance(exc, OpenAICodexRetryableError) or _is_retryable_openai_error_message(str(exc))
 
     def is_api_error(self, exc: Exception) -> bool:

--- a/brain/systems/runs/direct_loop/retry.py
+++ b/brain/systems/runs/direct_loop/retry.py
@@ -4,16 +4,40 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Callable
 
 from brain.platform.integrations.providers import LLMRequest
 
 logger = logging.getLogger("agent")
+_MAX_RETRY_AFTER_SECONDS = 60.0
 
 
 class _NeverCancelled:
     def is_set(self) -> bool:
         return False
+
+
+def _retry_after_seconds(headers: dict[str, str]) -> float | None:
+    value = None
+    for key, candidate in headers.items():
+        if str(key).lower() == "retry-after":
+            value = str(candidate).strip()
+            break
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+            if retry_at.tzinfo is None:
+                retry_at = retry_at.replace(tzinfo=timezone.utc)
+            seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
+        except Exception:
+            return None
+    return max(0.0, min(seconds, _MAX_RETRY_AFTER_SECONDS))
 
 
 def api_call_with_retry(
@@ -67,8 +91,9 @@ def api_call_with_retry(
                 raise
             resp = getattr(exc, "response", None)
             headers = dict(getattr(resp, "headers", {}) or {}) if resp else {}
+            retry_after = _retry_after_seconds(headers)
             logger.warning(
-                "Agent %s turn %d: API 500 (attempt %d/%d), req=%s",
+                "Agent %s turn %d: provider retryable error (attempt %d/%d), req=%s",
                 session_id,
                 turn,
                 api_attempt + 1,
@@ -94,7 +119,7 @@ def api_call_with_retry(
                     call_start = time.time()
                     continue
                 raise
-            delay = retry_delays[api_attempt]
+            delay = retry_after if retry_after is not None else retry_delays[api_attempt]
             api_attempt += 1
             if on_stream_activity:
                 on_stream_activity(f"API hiccup — retrying in {delay}s…")

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -71,6 +71,9 @@ import type {
   VaultSecretPrompt,
 } from '$lib/types/cortex';
 
+const ACTIVE_IDEA_SNAPSHOT_RECONCILE_MS = 8_000;
+const SELECTED_THREAD_RECONCILE_MS = 5_000;
+
 export type {
   AgentRunOptions,
   BrowserDiscoveryResult,
@@ -470,7 +473,7 @@ class CortexStore {
         return;
       }
       this._refreshIdeasSnapshot();
-    }, 1500);
+    }, ACTIVE_IDEA_SNAPSHOT_RECONCILE_MS);
   }
 
   private _stopIdeasSnapshotReconcile() {
@@ -1587,7 +1590,7 @@ class CortexStore {
         return;
       }
       this._refreshSelectedStream();
-    }, 1200);
+    }, SELECTED_THREAD_RECONCILE_MS);
   }
 
   private _stopSelectedIdeaReconcile() {

--- a/frontend/src/lib/stores/workspaceApps.svelte.ts
+++ b/frontend/src/lib/stores/workspaceApps.svelte.ts
@@ -330,6 +330,7 @@ class WorkspaceAppsStore {
   }
 
   scheduleFollowupRefreshes(delaysMs: number[]) {
+    if (this._followupRefreshTimers.size > 0) return;
     delaysMs.forEach((delayMs) => {
       const timer = setTimeout(() => {
         this._followupRefreshTimers.delete(timer);

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -660,6 +660,52 @@ def test_retry_runtime_streams_when_live_callbacks_are_present():
     assert response == "streamed-response"
     assert streamed and streamed[0][2] is False
 
+
+def test_retry_runtime_respects_retry_after_header(monkeypatch):
+    from brain.systems.runs.direct_loop import retry as retry_module
+    from brain.systems.runs.direct_loop.retry import api_call_with_retry
+
+    class RetryableProviderError(Exception):
+        response = SimpleNamespace(headers={"Retry-After": "0.25", "x-request-id": "req-1"})
+
+    attempts = 0
+    sleeps = []
+
+    def create(_request):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RetryableProviderError("rate limit")
+        return "ok"
+
+    provider = SimpleNamespace(
+        create=create,
+        is_retryable_error=lambda exc: isinstance(exc, RetryableProviderError),
+    )
+    monkeypatch.setattr(retry_module.time, "sleep", lambda delay: sleeps.append(delay))
+
+    response = api_call_with_retry(
+        provider,
+        request=SimpleNamespace(),
+        llm=SimpleNamespace(is_oauth=False, build_request_headers=lambda **_: {}),
+        cancel_event=None,
+        on_stream_activity=None,
+        on_stream_delta=None,
+        session_id="session-1",
+        turn=0,
+        tokens=SimpleNamespace(),
+        start_time=0,
+        tool_calls_made=[],
+        call_start=0,
+        retry_delays=(10,),
+        streaming_call=lambda *args, **kwargs: "unused",
+        make_cancelled_result=lambda *args, **kwargs: "cancelled",
+        degrade_betas=lambda: False,
+    )
+
+    assert response == "ok"
+    assert sleeps == [0.25]
+
 def test_streaming_runtime_surfaces_public_reflection_not_raw_reasoning(monkeypatch):
     from brain.platform.integrations.transports.base import LLMResponse, StreamContext, StreamEvent, Usage
     from brain.systems.runs.direct_loop import streaming as runtime_streaming

--- a/tests/test_api_deps.py
+++ b/tests/test_api_deps.py
@@ -1,7 +1,9 @@
 import pytest
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from fastapi import HTTPException
+from brain.app.api.config import RATE_LIMIT, RATE_LIMIT_GLOBAL
 from brain.app.api.deps import rate_limit, _rate_store, _is_internal
 
 
@@ -34,9 +36,51 @@ def test_rate_limit_allows_localhost():
 
 def test_rate_limit_blocks_excess():
     now = time.time()
-    _rate_store["10.0.0.1"] = [now] * 300
-    mock_request = MagicMock()
-    mock_request.client.host = "10.0.0.1"
+    mock_request = _request("10.0.0.1", path="/api/cortex/bootstrap")
+    _rate_store["route:ip:10.0.0.1:GET /api/cortex/bootstrap"] = [now] * RATE_LIMIT
     with pytest.raises(HTTPException) as exc_info:
         rate_limit(mock_request)
     assert exc_info.value.status_code == 429
+
+
+def test_rate_limit_uses_authenticated_user_not_shared_ip():
+    now = time.time()
+    _rate_store["route:user:user-a:GET /api/cortex/bootstrap"] = [now] * RATE_LIMIT
+
+    blocked = _request("10.0.0.1", path="/api/cortex/bootstrap", user_id="user-a")
+    allowed = _request("10.0.0.1", path="/api/cortex/bootstrap", user_id="user-b")
+
+    with pytest.raises(HTTPException):
+        rate_limit(blocked)
+    rate_limit(allowed)
+
+
+def test_rate_limit_uses_route_buckets_before_global_bucket():
+    now = time.time()
+    _rate_store["route:user:user-a:GET /api/cortex/bootstrap"] = [now] * RATE_LIMIT
+
+    request = _request("10.0.0.1", path="/api/cortex/ideas", user_id="user-a")
+
+    rate_limit(request)
+
+
+def test_rate_limit_global_bucket_still_caps_authenticated_users():
+    now = time.time()
+    _rate_store["global:user:user-a"] = [now] * RATE_LIMIT_GLOBAL
+    request = _request("10.0.0.1", path="/api/cortex/ideas", user_id="user-a")
+
+    with pytest.raises(HTTPException) as exc_info:
+        rate_limit(request)
+
+    assert exc_info.value.status_code == 429
+
+
+def _request(addr: str, *, path: str = "/api/test", method: str = "GET", user_id: str | None = None):
+    request = MagicMock()
+    request.client = SimpleNamespace(host=addr)
+    request.method = method
+    request.headers = {}
+    request.session = {"user_id": user_id} if user_id else {}
+    request.scope = {"route": SimpleNamespace(path=path)}
+    request.url = SimpleNamespace(path=path)
+    return request

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -309,6 +309,24 @@ class TestAnthropicProvider:
         p.stream(LLMRequest(model="claude-sonnet-4-6", messages=[], max_output_tokens=100))
         client.messages.stream.assert_called_once()
 
+    def test_rate_limit_status_is_retryable(self):
+        client = MagicMock()
+        p = AnthropicProvider(client)
+
+        class ProviderStatusError(Exception):
+            status_code = 429
+
+        assert p.is_retryable_error(ProviderStatusError("rate limit exceeded"))
+
+    def test_client_error_status_is_not_retryable(self):
+        client = MagicMock()
+        p = AnthropicProvider(client)
+
+        class ProviderStatusError(Exception):
+            status_code = 400
+
+        assert not p.is_retryable_error(ProviderStatusError("bad request"))
+
 
 # ── OpenAIProvider ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- split API rate limiting into authenticated principal + route buckets with a wider global safety cap
- slow Cortex fallback snapshot polling and coalesce workspace-app follow-up refresh bursts
- classify provider 429/overload responses as retryable and honor Retry-After up to a bounded cap

## Tests
- pytest tests/test_api_deps.py tests/test_providers.py tests/test_agent_runtime_modules.py::test_retry_runtime_respects_retry_after_header tests/test_agent_runtime_modules.py::test_retry_runtime_streams_when_live_callbacks_are_present -q
- npm run check

Note: npm run check still reports two pre-existing warnings in MemoryGraph.svelte and memory/+page.svelte.