### PR TITLE
Enable project-bound Git auth for agent commands

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import base64 as _base64
+from dataclasses import dataclass as _dataclass
+
 from brain.systems.runs.tool_catalog.handlers.common import *
+
 
 def _resolve_path(path: str, working_dir: str | None = None) -> str:
     """Resolve a path relative to workspace root. Enforces containment.
@@ -34,6 +38,92 @@ _BLOCKED_PATTERNS = [
     _re.compile(r"chmod\s+-R\s+777\s+/"),
     _re.compile(r":\(\)\s*\{\s*:\|:&\s*\}"),  # fork bomb
 ]
+
+_GITHUB_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+@_dataclass(frozen=True)
+class _ProjectExecutionEnv:
+    env: dict[str, str] | None
+    injected_env: list[str]
+    git_auth_hosts: list[str]
+    sensitive_values: list[str]
+
+
+def _github_token_from_project_env(project_env: dict[str, str]) -> str | None:
+    for env_name in _GITHUB_TOKEN_ENV_NAMES:
+        token = (project_env.get(env_name) or "").strip()
+        if token:
+            return token
+    return None
+
+
+def _append_git_config_env(env: dict[str, str], key: str, value: str) -> None:
+    try:
+        count = int(env.get("GIT_CONFIG_COUNT", "0") or "0")
+    except ValueError:
+        count = 0
+    env[f"GIT_CONFIG_KEY_{count}"] = key
+    env[f"GIT_CONFIG_VALUE_{count}"] = value
+    env["GIT_CONFIG_COUNT"] = str(count + 1)
+
+
+def _configure_project_bound_git_auth(
+    env: dict[str, str],
+    project_env: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Let plain git use a project-bound GitHub token without persisting config."""
+    token = _github_token_from_project_env(project_env)
+    if not token:
+        return [], []
+
+    credential = f"x-access-token:{token}"
+    encoded = _base64.b64encode(credential.encode("utf-8")).decode("ascii")
+    auth_header = f"AUTHORIZATION: basic {encoded}"
+    _append_git_config_env(env, "http.https://github.com/.extraheader", auth_header)
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    env.setdefault("GCM_INTERACTIVE", "never")
+    return ["github.com"], [token, credential, encoded, auth_header]
+
+
+def _redact_sensitive_output(text: str, sensitive_values: list[str]) -> str:
+    redacted = text
+    values = sorted(
+        {value for value in sensitive_values if value},
+        key=len,
+        reverse=True,
+    )
+    for value in values:
+        redacted = redacted.replace(value, "[secret redacted]")
+    return redacted
+
+
+def _prepare_project_execution_env() -> _ProjectExecutionEnv:
+    project_env = _current_project_bound_env()
+    if not project_env:
+        return _ProjectExecutionEnv(
+            env=None,
+            injected_env=[],
+            git_auth_hosts=[],
+            sensitive_values=[],
+        )
+
+    run_env = os.environ.copy()
+    run_env.update(project_env)
+    git_auth_hosts, git_sensitive_values = _configure_project_bound_git_auth(run_env, project_env)
+    return _ProjectExecutionEnv(
+        env=run_env,
+        injected_env=sorted(project_env),
+        git_auth_hosts=git_auth_hosts,
+        sensitive_values=list(project_env.values()) + git_sensitive_values,
+    )
+
+
+def _annotate_project_execution_result(result: dict, project_execution: _ProjectExecutionEnv) -> None:
+    if project_execution.injected_env:
+        result["injected_env"] = project_execution.injected_env
+    if project_execution.git_auth_hosts:
+        result["git_auth_configured"] = project_execution.git_auth_hosts
 
 
 def _current_project_bound_env() -> dict[str, str]:
@@ -89,11 +179,7 @@ def _handle_exec_command(
     # Otherwise split into a list for safer execution.
     _SHELL_CHARS = {'|', '>', '<', '&&', '||', ';', '`', '$(' }
     needs_shell = any(ch in command for ch in _SHELL_CHARS)
-    project_env = _current_project_bound_env()
-    run_env = None
-    if project_env:
-        run_env = os.environ.copy()
-        run_env.update(project_env)
+    project_execution = _prepare_project_execution_env()
 
     try:
         if needs_shell:
@@ -104,7 +190,7 @@ def _handle_exec_command(
                 text=True,
                 timeout=timeout,
                 cwd=cwd,
-                env=run_env,
+                env=project_execution.env,
             )
         else:
             proc = subprocess.run(
@@ -113,14 +199,16 @@ def _handle_exec_command(
                 text=True,
                 timeout=timeout,
                 cwd=cwd,
-                env=run_env,
+                env=project_execution.env,
             )
-        stdout = proc.stdout[:_MAX_RESULT_CHARS] if proc.stdout else ""
-        stderr = proc.stderr[:_MAX_RESULT_CHARS] if proc.stderr else ""
+        stdout_raw = _redact_sensitive_output(proc.stdout or "", project_execution.sensitive_values)
+        stderr_raw = _redact_sensitive_output(proc.stderr or "", project_execution.sensitive_values)
+        stdout = stdout_raw[:_MAX_RESULT_CHARS] if stdout_raw else ""
+        stderr = stderr_raw[:_MAX_RESULT_CHARS] if stderr_raw else ""
 
-        if len(proc.stdout or "") > _MAX_RESULT_CHARS:
+        if len(stdout_raw) > _MAX_RESULT_CHARS:
             stdout += f"\n... (truncated, {len(proc.stdout):,} chars total)"
-        if len(proc.stderr or "") > _MAX_RESULT_CHARS:
+        if len(stderr_raw) > _MAX_RESULT_CHARS:
             stderr += f"\n... (truncated, {len(proc.stderr):,} chars total)"
 
         result = {
@@ -128,8 +216,7 @@ def _handle_exec_command(
             "stdout": stdout,
             "stderr": stderr,
         }
-        if project_env:
-            result["injected_env"] = sorted(project_env)
+        _annotate_project_execution_result(result, project_execution)
         # Only semantic execution outcomes belong in execution_artifacts. Generic
         # command transcripts are too noisy for provenance tools such as my_activity.
         _patched_private(
@@ -139,9 +226,11 @@ def _handle_exec_command(
         return result
     except subprocess.TimeoutExpired:
         result = {"exit_code": -1, "stdout": "", "stderr": f"Command timed out after {timeout}s", "error": "timeout"}
+        _annotate_project_execution_result(result, project_execution)
         return result
     except Exception as e:
-        result = {"exit_code": -1, "stdout": "", "stderr": str(e), "error": str(e)}
+        error = _redact_sensitive_output(str(e), project_execution.sensitive_values)
+        result = {"exit_code": -1, "stdout": "", "stderr": error, "error": error}
         return result
 
 
@@ -152,6 +241,7 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
 
     timeout = min(timeout, 300)
     cwd = _workspace or _patched_workspace_root()
+    project_execution = _prepare_project_execution_env()
 
     try:
         with tempfile.NamedTemporaryFile(
@@ -167,18 +257,24 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
                 text=True,
                 timeout=timeout,
                 cwd=cwd,
+                env=project_execution.env,
             )
-            stdout = proc.stdout[:_MAX_RESULT_CHARS] if proc.stdout else ""
-            stderr = proc.stderr[:_MAX_RESULT_CHARS] if proc.stderr else ""
+            stdout_raw = _redact_sensitive_output(proc.stdout or "", project_execution.sensitive_values)
+            stderr_raw = _redact_sensitive_output(proc.stderr or "", project_execution.sensitive_values)
+            stdout = stdout_raw[:_MAX_RESULT_CHARS] if stdout_raw else ""
+            stderr = stderr_raw[:_MAX_RESULT_CHARS] if stderr_raw else ""
 
-            if len(proc.stdout or "") > _MAX_RESULT_CHARS:
+            if len(stdout_raw) > _MAX_RESULT_CHARS:
                 stdout += f"\n... (truncated, {len(proc.stdout):,} chars total)"
+            if len(stderr_raw) > _MAX_RESULT_CHARS:
+                stderr += f"\n... (truncated, {len(proc.stderr):,} chars total)"
 
             result = {
                 "exit_code": proc.returncode,
                 "stdout": stdout,
                 "stderr": stderr,
             }
+            _annotate_project_execution_result(result, project_execution)
             _record_tool_evidence(
                 "run_script",
                 {"script": script, "description": description, "timeout": timeout, "workspace": _workspace},
@@ -196,6 +292,7 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
                 pass
     except subprocess.TimeoutExpired:
         result = {"exit_code": -1, "stdout": "", "stderr": f"Script timed out after {timeout}s", "error": "timeout"}
+        _annotate_project_execution_result(result, project_execution)
         _record_tool_evidence(
             "run_script",
             {"script": script, "description": description, "timeout": timeout, "workspace": _workspace},
@@ -203,7 +300,9 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
         )
         return result
     except Exception as e:
-        result = {"exit_code": -1, "stdout": "", "stderr": str(e), "error": str(e)}
+        error = _redact_sensitive_output(str(e), project_execution.sensitive_values)
+        result = {"exit_code": -1, "stdout": "", "stderr": error, "error": error}
+        _annotate_project_execution_result(result, project_execution)
         _record_tool_evidence(
             "run_script",
             {"script": script, "description": description, "timeout": timeout, "workspace": _workspace},

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -1,6 +1,9 @@
 """Tests for project-bound vault token availability."""
 from __future__ import annotations
 
+import base64
+from concurrent.futures import ThreadPoolExecutor
+import threading
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -287,6 +290,7 @@ def test_project_token_context_includes_github_repo_from_project_context_snapsho
 def test_exec_command_injects_project_bound_env_names_without_returning_values(monkeypatch, tmp_path):
     from brain.systems.runs.tool_catalog.handlers.files import _handle_exec_command
 
+    monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
     monkeypatch.setattr(
         "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
         lambda: {"GITHUB_TOKEN": "ghp-secret-value"},
@@ -297,5 +301,109 @@ def test_exec_command_injects_project_bound_env_names_without_returning_values(m
         result = _handle_exec_command("gh auth status", working_dir=str(tmp_path))
 
     assert result["injected_env"] == ["GITHUB_TOKEN"]
+    assert result["git_auth_configured"] == ["github.com"]
     assert "ghp-secret-value" not in str(result)
-    assert run.call_args.kwargs["env"]["GITHUB_TOKEN"] == "ghp-secret-value"
+    run_env = run.call_args.kwargs["env"]
+    encoded = base64.b64encode(b"x-access-token:ghp-secret-value").decode("ascii")
+    assert run_env["GITHUB_TOKEN"] == "ghp-secret-value"
+    assert run_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert run_env["GCM_INTERACTIVE"] == "never"
+    assert run_env["GIT_CONFIG_COUNT"] == "1"
+    assert run_env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert run_env["GIT_CONFIG_VALUE_0"] == f"AUTHORIZATION: basic {encoded}"
+
+
+def test_exec_command_redacts_project_bound_git_auth_from_output(monkeypatch, tmp_path):
+    from brain.systems.runs.tool_catalog.handlers.files import _handle_exec_command
+
+    token = "ghp-secret-value"
+    encoded = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    auth_header = f"AUTHORIZATION: basic {encoded}"
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
+        lambda: {"GH_TOKEN": token, "STRIPE_API_KEY": "sk-live-secret"},
+    )
+    proc = SimpleNamespace(
+        returncode=0,
+        stdout=f"token={token}\nheader={auth_header}\nstripe=sk-live-secret\n",
+        stderr=f"encoded={encoded}\n",
+    )
+
+    with patch("subprocess.run", return_value=proc):
+        result = _handle_exec_command("git push origin HEAD:test", working_dir=str(tmp_path))
+
+    assert token not in result["stdout"]
+    assert encoded not in result["stdout"]
+    assert "sk-live-secret" not in result["stdout"]
+    assert encoded not in result["stderr"]
+    assert result["stdout"].count("[secret redacted]") == 3
+    assert result["stderr"].count("[secret redacted]") == 1
+
+
+def test_run_script_uses_project_bound_env_and_redacts_values(monkeypatch, tmp_path):
+    from brain.systems.runs.tool_catalog.handlers.files import _handle_run_script
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
+        lambda: {"GH_TOKEN": "ghp-secret-value", "STRIPE_API_KEY": "sk-live-secret"},
+    )
+    proc = SimpleNamespace(
+        returncode=0,
+        stdout="github=ghp-secret-value\nstripe=sk-live-secret\n",
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=proc) as run:
+        result = _handle_run_script("print('ok')", _workspace=str(tmp_path))
+
+    run_env = run.call_args.kwargs["env"]
+    assert run_env["GH_TOKEN"] == "ghp-secret-value"
+    assert run_env["STRIPE_API_KEY"] == "sk-live-secret"
+    assert result["injected_env"] == ["GH_TOKEN", "STRIPE_API_KEY"]
+    assert result["git_auth_configured"] == ["github.com"]
+    assert "ghp-secret-value" not in result["stdout"]
+    assert "sk-live-secret" not in result["stdout"]
+    assert result["stdout"].count("[secret redacted]") == 2
+
+
+def test_parallel_exec_commands_keep_project_bound_env_isolated(monkeypatch, tmp_path):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import files
+
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    project_a.mkdir()
+    project_b.mkdir()
+    captured_envs: dict[str, dict[str, str]] = {}
+    lock = threading.Lock()
+
+    def project_env():
+        workspace_root = str(getattr(files._agent_context, "workspace_root", ""))
+        project_name = workspace_root.rsplit("/", 1)[-1]
+        return {"GH_TOKEN": f"token-for-{project_name}"}
+
+    def fake_run(*args, **kwargs):
+        del args
+        with lock:
+            captured_envs[str(kwargs["cwd"])] = dict(kwargs["env"])
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def run_for_project(project_root):
+        with bind_agent_context({
+            "workspace_root": str(project_root),
+            "user_id": USER_ID,
+            "org_id": ORG_ID,
+        }):
+            return files._handle_exec_command("git status", working_dir=str(project_root))
+
+    monkeypatch.setattr(files, "_current_project_bound_env", project_env)
+    with patch("subprocess.run", side_effect=fake_run):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(run_for_project, [project_a, project_b]))
+
+    assert captured_envs[str(project_a)]["GH_TOKEN"] == "token-for-project-a"
+    assert captured_envs[str(project_b)]["GH_TOKEN"] == "token-for-project-b"
+    assert captured_envs[str(project_a)]["GIT_CONFIG_VALUE_0"] != captured_envs[str(project_b)]["GIT_CONFIG_VALUE_0"]
+    assert all(result["injected_env"] == ["GH_TOKEN"] for result in results)
+    assert "token-for-project-a" not in str(results)
+    assert "token-for-project-b" not in str(results)


### PR DESCRIPTION
## Summary

- prepare a shared project-bound child-process environment for agent execution tools
- expose project-bound env vars to both `exec_command` and `run_script`
- adapt `GH_TOKEN`/`GITHUB_TOKEN` into temporary Git `http.extraheader` config so plain HTTPS `git push` can authenticate without `gh` or persisted credentials
- redact project-bound secret values and derived Git auth material from command/script stdout and stderr
- add regression coverage for Git auth injection, generic secret redaction, `run_script` env propagation, and parallel project isolation

## Diagnosis

Observed pain: agents on the team server could clone public repos but failed to push branches with:

```text
fatal: could not read Username for 'https://github.com': No such device or address
```

Suspected disease: project-bound Vault tokens were available as env vars, but generic execution did not fully bridge them into child-process auth protocols. Public `git clone` works anonymously; `git push` needs a credential, and plain Git does not read `GH_TOKEN`/`GITHUB_TOKEN` by itself.

## Proper Cure Direction

The goal is not a bespoke GitHub tool for every publishing flow. Agents should be able to use assigned project tokens through generic execution so CLIs, SDKs, scripts, APIs, and MCP processes can work without per-service Illospace tools.

This PR keeps that model and adds a protocol adapter where Git needs one: project-bound GitHub tokens are still ordinary env vars for tools such as `gh` or API clients, and they additionally become temporary Git config for child `git` commands only.

## Tactical Bridge In This PR

This PR fixes the immediate push failure for `exec_command` and extends the same project env preparation to `run_script`. It does not persist credentials into repo/global Git config, and it does not put token values into agent-visible results.

Remaining follow-up: audit other process-launch paths, especially MCP server launches, to make sure the same project-bound execution environment is used everywhere agents can spawn subprocesses.

## Validation Signals

- `exec_command` receives project-bound env names without returning secret values
- plain Git receives a temporary GitHub auth header when `GH_TOKEN` or `GITHUB_TOKEN` is bound
- arbitrary project-bound secret values are redacted from command/script output
- `run_script` receives the same project-bound env treatment
- two parallel project contexts receive isolated token values and isolated Git auth config

## Testing

- [x] `python3 -m pytest tests/test_vault_project_tokens.py -q`
- [x] `python3 -m pytest tests/test_agent.py -k "exec_command or run_script" -q`
- [x] `python3 -m pytest tests/test_tool_policy.py -q`
- [x] `python3 -m py_compile brain/systems/runs/tool_catalog/handlers/files.py`
- [x] `git diff --check`

## Public Release Hygiene

- [x] No secrets, logs, database dumps, uploads, private operator notes, or personal paths.
- [x] New environment variables are documented in `.env.example`. N/A
- [x] New public-facing behavior is documented in `README.md` or `docs/`. N/A, runtime internals only
- [x] License/notice impact has been considered. N/A
