### PR TITLE
Centralize project-bound execution env

### DIFF
--- a/brain/systems/runs/project_execution_env.py
+++ b/brain/systems/runs/project_execution_env.py
@@ -1,0 +1,238 @@
+"""Project-bound environment setup for agent-owned child processes."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+import logging
+import os
+
+from brain.systems.runs.execution_context import _agent_context
+
+logger = logging.getLogger("agent")
+
+_GITHUB_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+@dataclass(frozen=True)
+class ProjectExecutionEnv:
+    env: dict[str, str] | None
+    injected_env: list[str]
+    git_auth_hosts: list[str]
+    sensitive_values: list[str]
+
+
+def _current_run_target_context() -> dict | None:
+    """Load the current run target context, if the tool call is running inside one."""
+    run = getattr(_agent_context, "run", None)
+    run_id = getattr(run, "run_id", None)
+    if not run_id:
+        return None
+
+    try:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+        from brain.systems.environment import load_run_target_context
+
+        with UnitOfWork() as uow:
+            return load_run_target_context(uow.session, run_id)
+    except Exception:
+        return None
+
+
+def _current_workspace_root_hint() -> str | None:
+    """Return the safest current workspace root hint available to helper wrappers."""
+    workspace_root = getattr(_agent_context, "workspace_root", None)
+    if isinstance(workspace_root, str) and workspace_root.strip():
+        return workspace_root
+
+    context = _current_run_target_context()
+    if not context:
+        return None
+
+    defaults = context.get("execution_defaults") or {}
+    workspace_hint = defaults.get("workspace_root") or defaults.get("workspace_hint")
+    if isinstance(workspace_hint, str) and workspace_hint.strip():
+        return workspace_hint
+    return None
+
+
+def _canonical_project_token_slug(value: object, *, require_repo_like: bool = False) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        from brain.systems.cortex.project_context.github import parse_github_repo_slug
+
+        github_slug = parse_github_repo_slug(raw)
+    except Exception:
+        github_slug = None
+    if github_slug:
+        return github_slug.lower()
+    if require_repo_like:
+        return None
+    return raw.lower()
+
+
+def _project_context_token_slugs(raw_target: dict) -> list[str]:
+    snapshot = raw_target.get("project_context_snapshot")
+    if not isinstance(snapshot, dict):
+        return []
+    resources = snapshot.get("resources")
+    if not isinstance(resources, list):
+        return []
+
+    slugs: list[str] = []
+
+    def add(value: object, *, require_repo_like: bool = False) -> None:
+        slug = _canonical_project_token_slug(value, require_repo_like=require_repo_like)
+        if slug and slug not in slugs:
+            slugs.append(slug)
+
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        git = resource.get("git") if isinstance(resource.get("git"), dict) else {}
+        add(resource.get("repo"))
+        add(resource.get("name"), require_repo_like=not ("/" in str(resource.get("name") or "")))
+        for key in ("uri", "url", "html_url", "remote", "remote_url"):
+            add(resource.get(key), require_repo_like=True)
+        for key in ("repo", "remote", "remote_url", "url"):
+            add(git.get(key), require_repo_like=True)
+    return slugs
+
+
+def _current_project_token_context() -> dict:
+    """Return the project identity used for project-bound vault tokens."""
+    context = _current_run_target_context() or {}
+    binding = context.get("binding") or {}
+    registry = context.get("registry") or binding.get("target_registry") or {}
+    raw_target = binding.get("raw_target_metadata") or {}
+
+    target_registry_id = registry.get("id") or binding.get("target_registry_id")
+    project_slugs: list[str] = []
+
+    def add_slug(value: object, *, require_repo_like: bool = False) -> None:
+        slug = _canonical_project_token_slug(value, require_repo_like=require_repo_like)
+        if slug and slug not in project_slugs:
+            project_slugs.append(slug)
+
+    add_slug(registry.get("slug"))
+    for key in ("project_slug", "slug", "repo", "name"):
+        add_slug(raw_target.get(key))
+    for slug in _project_context_token_slugs(raw_target):
+        add_slug(slug)
+
+    workspace_root = getattr(_agent_context, "workspace_root", None) or _current_workspace_root_hint()
+    if isinstance(workspace_root, str) and workspace_root.strip():
+        add_slug(os.path.basename(os.path.realpath(workspace_root)))
+
+    try:
+        target_registry_id = int(target_registry_id) if target_registry_id is not None else None
+    except (TypeError, ValueError):
+        target_registry_id = None
+
+    return {
+        "project_slug": project_slugs[0] if project_slugs else None,
+        "project_slugs": project_slugs,
+        "target_registry_id": target_registry_id,
+    }
+
+
+def current_project_bound_env() -> dict[str, str]:
+    """Resolve project-bound vault tokens for command env injection."""
+    user_id = getattr(_agent_context, "user_id", None)
+    if not user_id:
+        return {}
+    project_context = _current_project_token_context()
+    if not project_context.get("project_slug") and project_context.get("target_registry_id") is None:
+        return {}
+    try:
+        from brain.systems.vault import resolve_project_bound_env_tokens
+
+        resolved = resolve_project_bound_env_tokens(
+            user_id=user_id,
+            org_id=getattr(_agent_context, "org_id", None),
+            project_slug=project_context.get("project_slug"),
+            project_slugs=project_context.get("project_slugs"),
+            target_registry_id=project_context.get("target_registry_id"),
+        )
+        return {str(key): str(value) for key, value in resolved.items() if key and value is not None}
+    except Exception:
+        logger.debug("project_bound_vault_env_resolution_failed", exc_info=True)
+        return {}
+
+
+def prepare_project_execution_env() -> ProjectExecutionEnv:
+    project_env = current_project_bound_env()
+    if not project_env:
+        return ProjectExecutionEnv(
+            env=None,
+            injected_env=[],
+            git_auth_hosts=[],
+            sensitive_values=[],
+        )
+
+    run_env = os.environ.copy()
+    run_env.update(project_env)
+    git_auth_hosts, git_sensitive_values = _configure_project_bound_git_auth(run_env, project_env)
+    return ProjectExecutionEnv(
+        env=run_env,
+        injected_env=sorted(project_env),
+        git_auth_hosts=git_auth_hosts,
+        sensitive_values=list(project_env.values()) + git_sensitive_values,
+    )
+
+
+def annotate_project_execution_result(result: dict, project_execution: ProjectExecutionEnv) -> None:
+    if project_execution.injected_env:
+        result["injected_env"] = project_execution.injected_env
+    if project_execution.git_auth_hosts:
+        result["git_auth_configured"] = project_execution.git_auth_hosts
+
+
+def redact_sensitive_output(text: str, sensitive_values: list[str]) -> str:
+    redacted = text
+    values = sorted(
+        {value for value in sensitive_values if value},
+        key=len,
+        reverse=True,
+    )
+    for value in values:
+        redacted = redacted.replace(value, "[secret redacted]")
+    return redacted
+
+
+def _github_token_from_project_env(project_env: dict[str, str]) -> str | None:
+    for env_name in _GITHUB_TOKEN_ENV_NAMES:
+        token = (project_env.get(env_name) or "").strip()
+        if token:
+            return token
+    return None
+
+
+def _append_git_config_env(env: dict[str, str], key: str, value: str) -> None:
+    try:
+        count = int(env.get("GIT_CONFIG_COUNT", "0") or "0")
+    except ValueError:
+        count = 0
+    env[f"GIT_CONFIG_KEY_{count}"] = key
+    env[f"GIT_CONFIG_VALUE_{count}"] = value
+    env["GIT_CONFIG_COUNT"] = str(count + 1)
+
+
+def _configure_project_bound_git_auth(
+    env: dict[str, str],
+    project_env: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Let plain git use a project-bound GitHub token without persisting config."""
+    token = _github_token_from_project_env(project_env)
+    if not token:
+        return [], []
+
+    credential = f"x-access-token:{token}"
+    encoded = base64.b64encode(credential.encode("utf-8")).decode("ascii")
+    auth_header = f"AUTHORIZATION: basic {encoded}"
+    _append_git_config_env(env, "http.https://github.com/.extraheader", auth_header)
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    env.setdefault("GCM_INTERACTIVE", "never")
+    return ["github.com"], [token, credential, encoded, auth_header]

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -29,6 +29,13 @@ from brain.systems.runs.execution_context import (
     _agent_context,
     bind_agent_context,
 )
+from brain.systems.runs.project_execution_env import (
+    _canonical_project_token_slug,
+    _current_project_token_context,
+    _current_run_target_context,
+    _current_workspace_root_hint,
+    _project_context_token_slugs,
+)
 from brain.systems.runs.tool_catalog.registry import (
     action_manifest_tool_names,
     parallel_safe_tool_names,
@@ -427,122 +434,6 @@ def _select_workspace(
 
     options = ", ".join(sorted(item["name"] for item in registry)) or "(none)"
     raise ValueError(f"Workspace '{workspace}' is not accessible in this run. Available: {options}")
-
-
-def _current_run_target_context() -> dict | None:
-    """Load the current run target context, if the tool call is running inside one."""
-    run = getattr(_agent_context, "run", None)
-    run_id = getattr(run, "run_id", None)
-    if not run_id:
-        return None
-
-    try:
-        from brain.platform.db.repositories.unit_of_work import UnitOfWork
-        from brain.systems.environment import load_run_target_context
-
-        with UnitOfWork() as uow:
-            return load_run_target_context(uow.session, run_id)
-    except Exception:
-        return None
-
-
-def _current_workspace_root_hint() -> str | None:
-    """Return the safest current workspace root hint available to helper wrappers."""
-    workspace_root = getattr(_agent_context, "workspace_root", None)
-    if isinstance(workspace_root, str) and workspace_root.strip():
-        return workspace_root
-
-    context = _current_run_target_context()
-    if not context:
-        return None
-
-    defaults = context.get("execution_defaults") or {}
-    workspace_hint = defaults.get("workspace_root") or defaults.get("workspace_hint")
-    if isinstance(workspace_hint, str) and workspace_hint.strip():
-        return workspace_hint
-    return None
-
-
-def _canonical_project_token_slug(value: object, *, require_repo_like: bool = False) -> str | None:
-    raw = str(value or "").strip()
-    if not raw:
-        return None
-    try:
-        from brain.systems.cortex.project_context.github import parse_github_repo_slug
-
-        github_slug = parse_github_repo_slug(raw)
-    except Exception:
-        github_slug = None
-    if github_slug:
-        return github_slug.lower()
-    if require_repo_like:
-        return None
-    return raw.lower()
-
-
-def _project_context_token_slugs(raw_target: dict) -> list[str]:
-    snapshot = raw_target.get("project_context_snapshot")
-    if not isinstance(snapshot, dict):
-        return []
-    resources = snapshot.get("resources")
-    if not isinstance(resources, list):
-        return []
-
-    slugs: list[str] = []
-
-    def add(value: object, *, require_repo_like: bool = False) -> None:
-        slug = _canonical_project_token_slug(value, require_repo_like=require_repo_like)
-        if slug and slug not in slugs:
-            slugs.append(slug)
-
-    for resource in resources:
-        if not isinstance(resource, dict):
-            continue
-        git = resource.get("git") if isinstance(resource.get("git"), dict) else {}
-        add(resource.get("repo"))
-        add(resource.get("name"), require_repo_like=not ("/" in str(resource.get("name") or "")))
-        for key in ("uri", "url", "html_url", "remote", "remote_url"):
-            add(resource.get(key), require_repo_like=True)
-        for key in ("repo", "remote", "remote_url", "url"):
-            add(git.get(key), require_repo_like=True)
-    return slugs
-
-
-def _current_project_token_context() -> dict:
-    """Return the project identity used for project-bound vault tokens."""
-    context = _current_run_target_context() or {}
-    binding = context.get("binding") or {}
-    registry = context.get("registry") or binding.get("target_registry") or {}
-    raw_target = binding.get("raw_target_metadata") or {}
-
-    target_registry_id = registry.get("id") or binding.get("target_registry_id")
-    project_slugs: list[str] = []
-
-    def add_slug(value: object, *, require_repo_like: bool = False) -> None:
-        slug = _canonical_project_token_slug(value, require_repo_like=require_repo_like)
-        if slug and slug not in project_slugs:
-            project_slugs.append(slug)
-
-    add_slug(registry.get("slug"))
-    for key in ("project_slug", "slug", "repo", "name"):
-        add_slug(raw_target.get(key))
-    for slug in _project_context_token_slugs(raw_target):
-        add_slug(slug)
-
-    workspace_root = getattr(_agent_context, "workspace_root", None) or _current_workspace_root_hint()
-    if isinstance(workspace_root, str) and workspace_root.strip():
-        add_slug(os.path.basename(os.path.realpath(workspace_root)))
-
-    try:
-        target_registry_id = int(target_registry_id) if target_registry_id is not None else None
-    except (TypeError, ValueError):
-        target_registry_id = None
-
-    return {
-        "project_slug": project_slugs[0] if project_slugs else None,
-        "project_slugs": project_slugs,
-        "target_registry_id": target_registry_id,
-    }
 
 
 def _get_current_run_id() -> str | None:

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import base64 as _base64
-from dataclasses import dataclass as _dataclass
-
 from brain.systems.runs.tool_catalog.handlers.common import *
+from brain.systems.runs.project_execution_env import (
+    annotate_project_execution_result as _annotate_project_execution_result,
+    prepare_project_execution_env as _prepare_project_execution_env,
+    redact_sensitive_output as _redact_sensitive_output,
+)
 
 
 def _resolve_path(path: str, working_dir: str | None = None) -> str:
@@ -38,115 +40,6 @@ _BLOCKED_PATTERNS = [
     _re.compile(r"chmod\s+-R\s+777\s+/"),
     _re.compile(r":\(\)\s*\{\s*:\|:&\s*\}"),  # fork bomb
 ]
-
-_GITHUB_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
-
-
-@_dataclass(frozen=True)
-class _ProjectExecutionEnv:
-    env: dict[str, str] | None
-    injected_env: list[str]
-    git_auth_hosts: list[str]
-    sensitive_values: list[str]
-
-
-def _github_token_from_project_env(project_env: dict[str, str]) -> str | None:
-    for env_name in _GITHUB_TOKEN_ENV_NAMES:
-        token = (project_env.get(env_name) or "").strip()
-        if token:
-            return token
-    return None
-
-
-def _append_git_config_env(env: dict[str, str], key: str, value: str) -> None:
-    try:
-        count = int(env.get("GIT_CONFIG_COUNT", "0") or "0")
-    except ValueError:
-        count = 0
-    env[f"GIT_CONFIG_KEY_{count}"] = key
-    env[f"GIT_CONFIG_VALUE_{count}"] = value
-    env["GIT_CONFIG_COUNT"] = str(count + 1)
-
-
-def _configure_project_bound_git_auth(
-    env: dict[str, str],
-    project_env: dict[str, str],
-) -> tuple[list[str], list[str]]:
-    """Let plain git use a project-bound GitHub token without persisting config."""
-    token = _github_token_from_project_env(project_env)
-    if not token:
-        return [], []
-
-    credential = f"x-access-token:{token}"
-    encoded = _base64.b64encode(credential.encode("utf-8")).decode("ascii")
-    auth_header = f"AUTHORIZATION: basic {encoded}"
-    _append_git_config_env(env, "http.https://github.com/.extraheader", auth_header)
-    env.setdefault("GIT_TERMINAL_PROMPT", "0")
-    env.setdefault("GCM_INTERACTIVE", "never")
-    return ["github.com"], [token, credential, encoded, auth_header]
-
-
-def _redact_sensitive_output(text: str, sensitive_values: list[str]) -> str:
-    redacted = text
-    values = sorted(
-        {value for value in sensitive_values if value},
-        key=len,
-        reverse=True,
-    )
-    for value in values:
-        redacted = redacted.replace(value, "[secret redacted]")
-    return redacted
-
-
-def _prepare_project_execution_env() -> _ProjectExecutionEnv:
-    project_env = _current_project_bound_env()
-    if not project_env:
-        return _ProjectExecutionEnv(
-            env=None,
-            injected_env=[],
-            git_auth_hosts=[],
-            sensitive_values=[],
-        )
-
-    run_env = os.environ.copy()
-    run_env.update(project_env)
-    git_auth_hosts, git_sensitive_values = _configure_project_bound_git_auth(run_env, project_env)
-    return _ProjectExecutionEnv(
-        env=run_env,
-        injected_env=sorted(project_env),
-        git_auth_hosts=git_auth_hosts,
-        sensitive_values=list(project_env.values()) + git_sensitive_values,
-    )
-
-
-def _annotate_project_execution_result(result: dict, project_execution: _ProjectExecutionEnv) -> None:
-    if project_execution.injected_env:
-        result["injected_env"] = project_execution.injected_env
-    if project_execution.git_auth_hosts:
-        result["git_auth_configured"] = project_execution.git_auth_hosts
-
-
-def _current_project_bound_env() -> dict[str, str]:
-    """Resolve project-bound vault tokens for command env injection."""
-    user_id = getattr(_agent_context, "user_id", None)
-    if not user_id:
-        return {}
-    project_context = _current_project_token_context()
-    if not project_context.get("project_slug") and project_context.get("target_registry_id") is None:
-        return {}
-    try:
-        from brain.systems.vault import resolve_project_bound_env_tokens
-
-        return resolve_project_bound_env_tokens(
-            user_id=user_id,
-            org_id=getattr(_agent_context, "org_id", None),
-            project_slug=project_context.get("project_slug"),
-            project_slugs=project_context.get("project_slugs"),
-            target_registry_id=project_context.get("target_registry_id"),
-        )
-    except Exception:
-        logger.debug("project_bound_vault_env_resolution_failed", exc_info=True)
-        return {}
 
 
 def _handle_exec_command(

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -26,6 +26,11 @@ import time
 import numpy as np
 
 from brain.kernel import config as brain_config
+from brain.systems.runs.project_execution_env import (
+    annotate_project_execution_result,
+    prepare_project_execution_env,
+    redact_sensitive_output,
+)
 
 logger = logging.getLogger("agent.tools")
 
@@ -533,13 +538,19 @@ def handle_test_runner(target: str, pattern: str | None = None, verbose: bool = 
     if verbose:
         cmd.append("-v")
 
+    project_execution = prepare_project_execution_env()
+
     try:
         proc = subprocess.run(
             cmd, capture_output=True, text=True,
             timeout=120, cwd=workspace_root or WORKSPACE_ROOT,
+            env=project_execution.env,
         )
 
-        output = proc.stdout + proc.stderr
+        output = redact_sensitive_output(
+            (proc.stdout or "") + (proc.stderr or ""),
+            project_execution.sensitive_values,
+        )
         result = {
             "exit_code": proc.returncode,
             "success": proc.returncode == 0,
@@ -571,12 +582,18 @@ def handle_test_runner(target: str, pattern: str | None = None, verbose: bool = 
 
             result["failures"] = failures[:5]  # Cap at 5
 
+        annotate_project_execution_result(result, project_execution)
         return result
 
     except subprocess.TimeoutExpired:
-        return {"exit_code": -1, "success": False, "error": "Tests timed out after 120s"}
+        result = {"exit_code": -1, "success": False, "error": "Tests timed out after 120s"}
+        annotate_project_execution_result(result, project_execution)
+        return result
     except Exception as e:
-        return {"exit_code": -1, "success": False, "error": str(e)}
+        error = redact_sensitive_output(str(e), project_execution.sensitive_values)
+        result = {"exit_code": -1, "success": False, "error": error}
+        annotate_project_execution_result(result, project_execution)
+        return result
 
 
 def handle_project_context(path: str | None = None, workspace_root: str | None = None) -> dict:

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -258,9 +258,10 @@ def test_project_bound_env_tokens_match_project_slug_aliases(patch_uow, session)
 
 def test_project_token_context_includes_github_repo_from_project_context_snapshot(monkeypatch):
     from brain.systems.runs.tool_catalog.handlers import common
+    from brain.systems.runs import project_execution_env
 
     monkeypatch.setattr(
-        common,
+        project_execution_env,
         "_current_run_target_context",
         lambda: {
             "registry": {"id": 7, "slug": "example-repo"},
@@ -292,7 +293,7 @@ def test_exec_command_injects_project_bound_env_names_without_returning_values(m
 
     monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
     monkeypatch.setattr(
-        "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
+        "brain.systems.runs.project_execution_env.current_project_bound_env",
         lambda: {"GITHUB_TOKEN": "ghp-secret-value"},
     )
     proc = SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -320,7 +321,7 @@ def test_exec_command_redacts_project_bound_git_auth_from_output(monkeypatch, tm
     encoded = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
     auth_header = f"AUTHORIZATION: basic {encoded}"
     monkeypatch.setattr(
-        "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
+        "brain.systems.runs.project_execution_env.current_project_bound_env",
         lambda: {"GH_TOKEN": token, "STRIPE_API_KEY": "sk-live-secret"},
     )
     proc = SimpleNamespace(
@@ -344,7 +345,7 @@ def test_run_script_uses_project_bound_env_and_redacts_values(monkeypatch, tmp_p
     from brain.systems.runs.tool_catalog.handlers.files import _handle_run_script
 
     monkeypatch.setattr(
-        "brain.systems.runs.tool_catalog.handlers.files._current_project_bound_env",
+        "brain.systems.runs.project_execution_env.current_project_bound_env",
         lambda: {"GH_TOKEN": "ghp-secret-value", "STRIPE_API_KEY": "sk-live-secret"},
     )
     proc = SimpleNamespace(
@@ -368,6 +369,7 @@ def test_run_script_uses_project_bound_env_and_redacts_values(monkeypatch, tmp_p
 
 def test_parallel_exec_commands_keep_project_bound_env_isolated(monkeypatch, tmp_path):
     from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs import project_execution_env
     from brain.systems.runs.tool_catalog.handlers import files
 
     project_a = tmp_path / "project-a"
@@ -396,7 +398,7 @@ def test_parallel_exec_commands_keep_project_bound_env_isolated(monkeypatch, tmp
         }):
             return files._handle_exec_command("git status", working_dir=str(project_root))
 
-    monkeypatch.setattr(files, "_current_project_bound_env", project_env)
+    monkeypatch.setattr(project_execution_env, "current_project_bound_env", project_env)
     with patch("subprocess.run", side_effect=fake_run):
         with ThreadPoolExecutor(max_workers=2) as executor:
             results = list(executor.map(run_for_project, [project_a, project_b]))
@@ -407,3 +409,37 @@ def test_parallel_exec_commands_keep_project_bound_env_isolated(monkeypatch, tmp
     assert all(result["injected_env"] == ["GH_TOKEN"] for result in results)
     assert "token-for-project-a" not in str(results)
     assert "token-for-project-b" not in str(results)
+
+
+def test_test_runner_uses_project_bound_env_and_redacts_values(monkeypatch, tmp_path):
+    from brain.systems.runs import project_execution_env
+    from brain.systems.tools.handlers import handle_test_runner
+
+    token = "ghp-secret-value"
+    encoded = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    monkeypatch.setattr(
+        project_execution_env,
+        "current_project_bound_env",
+        lambda: {"GH_TOKEN": token, "SERVICE_TOKEN": "service-secret"},
+    )
+    proc = SimpleNamespace(
+        returncode=1,
+        stdout=(
+            f"FAILED tests/test_example.py::test_token - {token}\n"
+            f"=========================== FAILURES ===========================\n"
+            f"service-secret\n"
+        ),
+        stderr=f"encoded={encoded}\n",
+    )
+
+    with patch("subprocess.run", return_value=proc) as run:
+        result = handle_test_runner("tests/test_example.py", workspace_root=str(tmp_path))
+
+    run_env = run.call_args.kwargs["env"]
+    assert run_env["GH_TOKEN"] == token
+    assert run_env["SERVICE_TOKEN"] == "service-secret"
+    assert result["injected_env"] == ["GH_TOKEN", "SERVICE_TOKEN"]
+    assert result["git_auth_configured"] == ["github.com"]
+    assert token not in str(result)
+    assert encoded not in str(result)
+    assert "service-secret" not in str(result)


### PR DESCRIPTION
## Summary
- move project-bound child-process env setup into a shared runtime helper
- keep exec_command and run_script on the shared helper instead of file-local token logic
- apply the same env injection, Git auth adaptation, metadata, and redaction to test_runner

## Validation
- python3 -m py_compile brain/systems/runs/project_execution_env.py brain/systems/runs/tool_catalog/handlers/common.py brain/systems/runs/tool_catalog/handlers/files.py brain/systems/tools/handlers.py
- python3 -m pytest tests/test_vault_project_tokens.py -q
- python3 -m pytest tests/test_tools.py -q
- python3 -m pytest tests/test_agent.py -k "exec_command or run_script" -q
- python3 -m pytest tests/test_tool_policy.py -q
- git diff --cached --check