### PR TITLE
Add runtime self-update handoff

### DIFF
--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -70,17 +70,27 @@ def _require_embedding_backend_ready() -> None:
     )
 
 
+def _cycle_scheduler_enabled() -> bool:
+    raw = os.getenv("ILLO_WORKER_DISABLE_CYCLE_SCHEDULER", "").strip().lower()
+    return raw not in {"1", "true", "yes", "on"}
+
+
 def main() -> None:
     logger.info("starting agent-run worker")
     _require_embedding_backend_ready()
-    start_cycle_scheduler()
+    cycle_scheduler_enabled = _cycle_scheduler_enabled()
+    if cycle_scheduler_enabled:
+        start_cycle_scheduler()
+    else:
+        logger.info("cycle scheduler disabled for this worker")
     start_runner()
     try:
         while _running:
             time.sleep(_poll_interval())
     finally:
         stop_runner(drain_timeout_seconds=_shutdown_drain_timeout_seconds())
-        stop_cycle_scheduler()
+        if cycle_scheduler_enabled:
+            stop_cycle_scheduler()
         logger.info("agent-run worker stopped")
 
 

--- a/brain/systems/runtime_settings/router.py
+++ b/brain/systems/runtime_settings/router.py
@@ -29,8 +29,10 @@ from .schemas import (
     RuntimeModelsRead,
     RuntimeModelsUpdate,
     RuntimeSettingsRead,
+    RuntimeUpdateRead,
 )
 from .service import can_manage_runtime_settings, get_runtime_settings
+from .self_update import get_runtime_update_status, start_runtime_update
 
 router = APIRouter(prefix="/api/runtime-settings", tags=["runtime-settings"], dependencies=[Depends(rate_limit)])
 _OPENAI_OAUTH_CALLBACK_START_MODES = {"auto", "server", "local_bridge"}
@@ -126,3 +128,15 @@ def save_runtime_memory(payload: RuntimeMemoryUpdate, user: User = Depends(_runt
 def check_memory(user: User = Depends(_runtime_user)) -> RuntimeMemoryCheckRead:
     _require_settings_admin(user)
     return check_runtime_memory(user)
+
+
+@router.get("/update", response_model=RuntimeUpdateRead)
+def read_runtime_update(user: User = Depends(_runtime_user)) -> RuntimeUpdateRead:
+    _require_settings_admin(user)
+    return get_runtime_update_status()
+
+
+@router.post("/update", response_model=RuntimeUpdateRead)
+def start_illospace_update(user: User = Depends(_runtime_user)) -> RuntimeUpdateRead:
+    _require_settings_admin(user)
+    return start_runtime_update(requested_by=str(user.id))

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -9,6 +10,7 @@ ModelTier = Literal["low", "medium", "high"]
 ConnectionStatus = Literal["connected", "missing", "error"]
 EmbedderKey = Literal["local_gpu", "local_cpu", "openai", "gemini"]
 RerankerKey = Literal["weighted"]
+RuntimeUpdateStatus = Literal["idle", "running"]
 
 
 class RuntimeOption(BaseModel):
@@ -59,6 +61,16 @@ class RuntimeMemoryCheckRead(BaseModel):
 
 class RuntimePermissionsRead(BaseModel):
     can_manage_settings: bool
+
+
+class RuntimeUpdateRead(BaseModel):
+    status: RuntimeUpdateStatus
+    available: bool
+    pid: int | None = None
+    started_at: datetime | None = None
+    active_agent_runs: int = 0
+    log_path: str | None = None
+    detail: str | None = None
 
 
 class RuntimeSettingsRead(BaseModel):

--- a/brain/systems/runtime_settings/self_update.py
+++ b/brain/systems/runtime_settings/self_update.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+
+from brain.kernel import config as cfg
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+from .schemas import RuntimeUpdateRead
+
+_ACTIVE_AGENT_RUN_STATUSES = ("starting", "running", "verifying")
+_LOG_NAME = "illo-self-update.log"
+_META_NAME = "illo-self-update.json"
+_PID_NAME = "illo-self-update.pid"
+_START_LOCK_NAME = "illo-self-update.starting"
+
+
+def get_runtime_update_status() -> RuntimeUpdateRead:
+    root = _repo_root()
+    state_dir = _state_dir(root)
+    available, detail = _availability(root)
+    metadata = _read_metadata(state_dir)
+    pid = _coerce_pid(metadata.get("pid")) or _read_pid(state_dir / _PID_NAME)
+    running = bool(pid and _pid_running(pid))
+    started_at = _parse_datetime(metadata.get("started_at"))
+
+    return RuntimeUpdateRead(
+        status="running" if running else "idle",
+        available=available,
+        pid=pid if running else None,
+        started_at=started_at,
+        active_agent_runs=_active_agent_run_count(),
+        log_path=str(state_dir / _LOG_NAME),
+        detail=detail,
+    )
+
+
+def start_runtime_update(*, requested_by: str | None = None) -> RuntimeUpdateRead:
+    root = _repo_root()
+    available, detail = _availability(root)
+    if not available:
+        raise HTTPException(status_code=409, detail=detail or "Illospace self-update is unavailable.")
+
+    state_dir = _state_dir(root)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    existing = get_runtime_update_status()
+    if existing.status == "running":
+        return RuntimeUpdateRead(
+            **{
+                **existing.model_dump(),
+                "detail": "Illospace update is already running.",
+            }
+        )
+
+    lock_path = state_dir / _START_LOCK_NAME
+    lock_fd = _acquire_start_lock(lock_path)
+    if lock_fd is None:
+        return RuntimeUpdateRead(
+            **{
+                **get_runtime_update_status().model_dump(),
+                "status": "running",
+                "detail": "Illospace update is starting.",
+            }
+        )
+
+    try:
+        command = _update_command(root)
+        started_at = datetime.now(timezone.utc)
+        log_path = state_dir / _LOG_NAME
+        _write_log_header(log_path, started_at, requested_by=requested_by)
+        env = os.environ.copy()
+        env["ILLO_SELF_UPDATE_REQUESTED_AT"] = started_at.isoformat()
+        if requested_by:
+            env["ILLO_SELF_UPDATE_REQUESTED_BY"] = requested_by
+
+        with log_path.open("ab") as handle:
+            process = subprocess.Popen(
+                command,
+                cwd=str(root),
+                stdin=subprocess.DEVNULL,
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+                close_fds=True,
+                start_new_session=True,
+                env=env,
+            )
+
+        metadata = {
+            "pid": process.pid,
+            "started_at": started_at.isoformat(),
+            "requested_by": requested_by,
+            "root": str(root),
+        }
+        (state_dir / _META_NAME).write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+        (state_dir / _PID_NAME).write_text(f"{process.pid}\n", encoding="utf-8")
+
+        active_runs = _active_agent_run_count()
+        detail = "Illospace update started."
+        if active_runs:
+            detail = (
+                f"Illospace update started. {active_runs} active AgentRun(s) "
+                "will drain before the worker restarts on the new code."
+            )
+        return RuntimeUpdateRead(
+            status="running",
+            available=True,
+            pid=process.pid,
+            started_at=started_at,
+            active_agent_runs=active_runs,
+            log_path=str(log_path),
+            detail=detail,
+        )
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not start Illospace update: {exc}") from exc
+    finally:
+        _release_start_lock(lock_fd, lock_path)
+
+
+def _repo_root() -> Path:
+    return Path(os.getenv("ILLO_SELF_UPDATE_ROOT") or cfg.BRAIN_DIR).resolve()
+
+
+def _state_dir(root: Path) -> Path:
+    raw = os.getenv("ILLO_SELF_UPDATE_STATE_DIR")
+    if raw:
+        path = Path(raw)
+        return path if path.is_absolute() else root / path
+    return Path(cfg.BRAIN_LOG_DIR).resolve()
+
+
+def _availability(root: Path) -> tuple[bool, str | None]:
+    if os.getenv("ILLO_SELF_UPDATE_COMMAND", "").strip():
+        return True, "Self-update uses the configured update command."
+    launcher = root / "illo"
+    if not launcher.exists():
+        return False, "Illospace update is unavailable because the ./illo launcher is missing."
+    if not (root / ".git").exists():
+        return False, "Illospace update is unavailable from this runtime because it is not running from a git checkout."
+    return True, "Uses ./illo update to choose native/systemd or Docker Compose safely."
+
+
+def _update_command(root: Path) -> list[str]:
+    override = os.getenv("ILLO_SELF_UPDATE_COMMAND", "").strip()
+    if override:
+        try:
+            command = shlex.split(override)
+        except ValueError as exc:
+            raise HTTPException(status_code=500, detail=f"Invalid ILLO_SELF_UPDATE_COMMAND: {exc}") from exc
+        if command:
+            return command
+    return ["bash", str(root / "illo"), "update"]
+
+
+def _active_agent_run_count() -> int:
+    try:
+        with UnitOfWork() as uow:
+            count = uow.session.scalar(
+                select(func.count())
+                .select_from(AgentRunRow)
+                .where(AgentRunRow.status.in_(_ACTIVE_AGENT_RUN_STATUSES))
+            )
+        return int(count or 0)
+    except Exception:
+        return 0
+
+
+def _read_metadata(state_dir: Path) -> dict[str, Any]:
+    try:
+        data = json.loads((state_dir / _META_NAME).read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_pid(path: Path) -> int | None:
+    try:
+        return _coerce_pid(path.read_text(encoding="utf-8").strip())
+    except Exception:
+        return None
+
+
+def _coerce_pid(value: Any) -> int | None:
+    try:
+        pid = int(value)
+    except Exception:
+        return None
+    return pid if pid > 0 else None
+
+
+def _pid_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _write_log_header(log_path: Path, started_at: datetime, *, requested_by: str | None) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("ab") as handle:
+        handle.write(b"\n")
+        handle.write(f"=== Illospace self-update requested at {started_at.isoformat()} ===\n".encode("utf-8"))
+        if requested_by:
+            handle.write(f"Requested by: {requested_by}\n".encode("utf-8"))
+
+
+def _acquire_start_lock(path: Path) -> int | None:
+    try:
+        return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        return None
+
+
+def _release_start_lock(fd: int, path: Path) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -46,6 +46,82 @@ compose() {
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
 }
 
+active_agent_run_count() {
+  local count
+  if count="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "
+SELECT count(*) FROM agent_runs WHERE status IN ('\''starting'\'', '\''running'\'', '\''verifying'\'');
+"' 2>/dev/null | tr -d '[:space:]')"; then
+    if [[ "$count" =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "$count"
+      return 0
+    fi
+  fi
+  printf 'unknown\n'
+}
+
+worker_container_id() {
+  compose ps -q worker 2>/dev/null || true
+}
+
+start_worker_handoff() {
+  compose run \
+    -d \
+    --no-deps \
+    -e ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1 \
+    -e ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS="${ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS:-infinity}" \
+    worker
+}
+
+container_running() {
+  local id="$1"
+  [ -n "$id" ] || return 1
+  [ "$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null || echo false)" = "true" ]
+}
+
+wait_for_worker_exit() {
+  local id="$1"
+  local wait_seconds="${ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
+  local deadline=$((SECONDS + wait_seconds))
+  while container_running "$id"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Worker did not drain within ${wait_seconds}s; leaving it on the old image to avoid killing active AgentRuns." >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+update_worker_after_drain() {
+  local active_runs="$1"
+  local worker_id handoff_id
+  worker_id="$(worker_container_id)"
+
+  if [ -z "$worker_id" ]; then
+    echo "Worker container is not running; starting worker on the new image."
+    compose up -d --no-deps worker
+    return 0
+  fi
+
+  handoff_id="$(start_worker_handoff)"
+  echo "Worker: started handoff worker ${handoff_id:-unknown} on the new image for new AgentRuns."
+  echo "Worker: ${active_runs} active AgentRun(s); signaling drain before replacing worker."
+  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
+  docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
+  if ! wait_for_worker_exit "$worker_id"; then
+    docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
+    return 0
+  fi
+  compose up -d --no-deps worker
+  if [ -n "$handoff_id" ]; then
+    echo "Worker: regular worker is on the new image; draining handoff worker $handoff_id."
+    docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
+    (
+      docker wait "$handoff_id" >/dev/null 2>&1 || true
+      docker rm "$handoff_id" >/dev/null 2>&1 || true
+    ) &
+  fi
+}
+
 if [ "$PULL" = "1" ]; then
   compose pull postgres api web || {
     echo "Image pull failed. If release images are not published yet, rerun with --build." >&2
@@ -59,6 +135,13 @@ fi
 
 compose up -d postgres
 compose run --rm migrate
-compose up -d --remove-orphans
+ACTIVE_RUNS="$(active_agent_run_count)"
+if [ "$ACTIVE_RUNS" = "0" ]; then
+  compose up -d --remove-orphans
+else
+  echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
+  compose up -d --no-deps api scheduler web
+  update_worker_after_drain "$ACTIVE_RUNS"
+fi
 
 "$SCRIPT_DIR/doctor.sh"

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1120,6 +1120,9 @@ export const api = {
   // System
   systemInfo: () => fetchJson<any>('/api/system'),
   runtimeSettings: () => fetchJson<any>('/api/runtime-settings'),
+  runtimeUpdateStatus: () => fetchJson<any>('/api/runtime-settings/update'),
+  startRuntimeUpdate: () =>
+    fetchJson<any>('/api/runtime-settings/update', { method: 'POST' }),
   connectRuntimeOpenAIKey: (data: { api_key: string }) =>
     fetchJson<any>('/api/runtime-settings/connection/openai/api-key', { method: 'POST', body: JSON.stringify(data) }),
   connectRuntimeOpenAIEmbeddingKey: (data: { api_key: string }) =>

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -30,6 +30,7 @@
     PillTone,
     RuntimeOption,
     RuntimeSettings,
+    RuntimeUpdateStatus,
     StartupGuideStep,
     StartupStepKey,
   } from './types';
@@ -57,6 +58,8 @@
   let notice = $state<NoticeState | null>(null);
   let geminiApiKey = $state('');
   let savingGeminiKey = $state(false);
+  let updateStatus = $state<RuntimeUpdateStatus | null>(null);
+  let startingUpdate = $state(false);
   let startingIntro = $state(false);
   let setupEmbedderPromptSkipped = $state(false);
   let modelDraft = $state<Record<ModelTier, string>>({ low: '', medium: '', high: '' });
@@ -78,6 +81,7 @@
   const showEmbedderKeyPrompt = $derived(setupMode && canManageSettings && !hasEmbeddingApiKey && !setupEmbedderPromptSkipped);
   const startupGuideSteps = $derived(buildStartupGuideSteps());
   const showStartupGuide = $derived(shouldShowStartupGuide());
+  const updateRunning = $derived(startingUpdate || updateStatus?.status === 'running');
 
   onMount(() => {
     loadSettings();
@@ -114,11 +118,43 @@
     loading = true;
     loadError = '';
     try {
-      hydrate(await api.runtimeSettings());
+      const next = await api.runtimeSettings();
+      hydrate(next);
+      if (next.permissions?.can_manage_settings) {
+        void loadUpdateStatus();
+      }
     } catch (error) {
       loadError = error instanceof Error ? error.message : 'System setup failed to load.';
     } finally {
       loading = false;
+    }
+  }
+
+  async function loadUpdateStatus() {
+    if (!settings?.permissions?.can_manage_settings) return;
+    try {
+      updateStatus = await api.runtimeUpdateStatus();
+    } catch {
+      updateStatus = null;
+    }
+  }
+
+  async function startIllospaceUpdate() {
+    if (!canManageSettings || updateStatus?.available === false) return;
+    startingUpdate = true;
+    notice = null;
+    try {
+      const nextStatus = (await api.startRuntimeUpdate()) as RuntimeUpdateStatus;
+      updateStatus = nextStatus;
+      notice = {
+        tone: 'info',
+        title: 'Illospace update started.',
+        detail: nextStatus.detail || updateNoticeDetail(nextStatus),
+      };
+    } catch (error) {
+      notice = errorNotice('Update did not start.', error, 'Check the server update log and try again.');
+    } finally {
+      startingUpdate = false;
     }
   }
 
@@ -662,6 +698,14 @@
     target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
+  function updateNoticeDetail(status: RuntimeUpdateStatus | null) {
+    const activeRuns = status?.active_agent_runs ?? 0;
+    if (activeRuns > 0) {
+      return `${activeRuns} active AgentRun${activeRuns === 1 ? '' : 's'} will finish before the worker restarts on the new code.`;
+    }
+    return 'The server is fetching origin/main and applying the update.';
+  }
+
   function errorNotice(title: string, error: unknown, fallback: string): NoticeState {
     const detail =
       error instanceof Error
@@ -688,6 +732,20 @@
   contentClassName="system-page"
 >
   {#snippet actions()}
+    {#if canManageSettings}
+      <ConstellationButton
+        variant="secondary"
+        onclick={startIllospaceUpdate}
+        loading={updateRunning}
+        loadingLabel={startingUpdate ? 'Starting' : 'Updating'}
+        disabled={updateStatus?.available === false}
+      >
+        {#snippet leadingVisual()}
+          <ConstellationIcon name="git-branch" size={14} />
+        {/snippet}
+        Update Illospace
+      </ConstellationButton>
+    {/if}
     <ConstellationButton variant="quiet" onclick={loadSettings} loading={loading} loadingLabel="Loading">
       {#snippet leadingVisual()}
         <ConstellationIcon name="refresh" size={14} />

--- a/frontend/src/routes/system/types.ts
+++ b/frontend/src/routes/system/types.ts
@@ -46,6 +46,16 @@ export interface RuntimeSettings {
   };
 }
 
+export interface RuntimeUpdateStatus {
+  status: 'idle' | 'running';
+  available: boolean;
+  pid?: number | null;
+  started_at?: string | null;
+  active_agent_runs: number;
+  log_path?: string | null;
+  detail?: string | null;
+}
+
 export interface MemoryCheck {
   status: 'ok' | 'error';
   detail: string;

--- a/illo
+++ b/illo
@@ -2511,6 +2511,114 @@ deploy_command() {
   esac
 }
 
+# ── Self-update CLI ────────────────────────────────────────
+
+update_usage() {
+  echo ""
+  echo -e "${BOLD}Usage:${NC} ./illo update [--mode auto|native|compose]"
+  echo ""
+  echo "Fetch origin/main and update the running server without interrupting active AgentRuns."
+  echo ""
+  echo "Modes:"
+  echo -e "  ${GREEN}auto${NC}      Prefer native/systemd when active, otherwise Compose when a stack is present"
+  echo -e "  ${GREEN}native${NC}    Run ops/deploy.sh, which drains cortex-worker while AgentRuns are active"
+  echo -e "  ${GREEN}compose${NC}   Fast-forward to origin/main, rebuild images, migrate, and restart Compose"
+  echo ""
+}
+
+update_git_sync_main() {
+  echo "=== Syncing checkout to origin/main ==="
+  git fetch origin main
+  git checkout main
+  git pull --ff-only origin main
+}
+
+update_native_services_active() {
+  systemd_user_ready || return 1
+  run_logged_timeout 5 systemctl --user is-active --quiet illo-api.service >/dev/null 2>&1 && return 0
+  run_logged_timeout 5 systemctl --user is-active --quiet cortex-worker.service >/dev/null 2>&1 && return 0
+  return 1
+}
+
+update_compose_stack_present() {
+  [ -f "$(deploy_compose_env_file)" ] || return 1
+  command -v docker >/dev/null 2>&1 || return 1
+  docker compose version >/dev/null 2>&1 || return 1
+  deploy_compose ps -q api >/dev/null 2>&1 || return 1
+  [ -n "$(deploy_compose ps -q api 2>/dev/null || true)" ]
+}
+
+update_detect_mode() {
+  if update_native_services_active; then
+    echo "native"
+    return 0
+  fi
+  if update_compose_stack_present; then
+    echo "compose"
+    return 0
+  fi
+  echo "local"
+}
+
+update_command() {
+  local mode="${ILLO_UPDATE_MODE:-${ILLO_SELF_UPDATE_MODE:-auto}}"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --mode)
+        mode="${2:?--mode requires a value}"
+        shift 2
+        ;;
+      -h|--help)
+        update_usage
+        return 0
+        ;;
+      *)
+        err "Unknown update option: $1"
+        update_usage
+        return 2
+        ;;
+    esac
+  done
+
+  case "$mode" in
+    auto)
+      mode="$(update_detect_mode)"
+      ;;
+    native|systemd)
+      mode="native"
+      ;;
+    compose|docker)
+      mode="compose"
+      ;;
+    local|dev)
+      mode="local"
+      ;;
+    *)
+      err "Unknown update mode: $mode"
+      update_usage
+      return 2
+      ;;
+  esac
+
+  case "$mode" in
+    native)
+      dim "Update mode: native/systemd"
+      exec "$ROOT/ops/deploy.sh"
+      ;;
+    compose)
+      dim "Update mode: Docker Compose"
+      update_git_sync_main || return 1
+      deploy_command upgrade --build --no-pull
+      ;;
+    local)
+      err "Self-update is not enabled for local/dev runs."
+      dim "Run git pull manually for local development, or set ILLO_UPDATE_MODE=native|compose when this checkout owns a server."
+      return 1
+      ;;
+  esac
+}
+
 # ── CLI ────────────────────────────────────────────────────
 
 usage() {
@@ -2521,6 +2629,7 @@ usage() {
   echo -e "  ${GREEN}dev${NC}          Start development mode with frontend hot reload"
   echo -e "  ${GREEN}setup${NC}        Run setup only"
   echo -e "  ${GREEN}deploy${NC}       Manage the recommended Compose team-server deploy"
+  echo -e "  ${GREEN}update${NC}       Update a running server from origin/main"
   echo -e "  ${GREEN}doctor${NC}       Validate local configuration"
   echo -e "  ${GREEN}uninstall${NC}    Remove local runtime, config, and Illo Docker DB"
   echo -e "  ${GREEN}test${NC}         Run tests"
@@ -2541,6 +2650,9 @@ case "${1:-}" in
     ;;
   deploy)
     deploy_command "${@:2}"
+    ;;
+  update)
+    update_command "${@:2}"
     ;;
   doctor)
     check_prereqs

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -228,6 +228,48 @@ restart_user_service_if_present() {
   return 1
 }
 
+worker_service_main_pid() {
+  systemctl --user show cortex-worker --property=MainPID --value 2>/dev/null || true
+}
+
+start_worker_handoff() {
+  mkdir -p "$ROOT/logs"
+  (
+    cd "$ROOT"
+    env \
+      PYTHONPATH="$ROOT" \
+      ILLO_ENV="${ILLO_ENV:-production}" \
+      ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1 \
+      ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS="${ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS:-infinity}" \
+      "$PYTHON_BIN" -m brain.systems.cortex.worker
+  ) >> "$ROOT/logs/cortex-worker-handoff.log" 2>&1 &
+  echo "$!"
+}
+
+monitor_worker_handoff() {
+  local old_pid="$1"
+  local handoff_pid="$2"
+  (
+    local timeout_seconds="${ILLO_WORKER_HANDOFF_TIMEOUT_SECONDS:-86400}"
+    local deadline=$((SECONDS + timeout_seconds))
+    local current_pid active
+    echo "Handoff: temporary worker $handoff_pid is serving new AgentRuns while cortex-worker drains."
+    while kill -0 "$handoff_pid" >/dev/null 2>&1 && [ "$SECONDS" -lt "$deadline" ]; do
+      active="$(systemctl --user is-active cortex-worker 2>/dev/null || true)"
+      current_pid="$(worker_service_main_pid)"
+      if [ "$active" = "active" ] && [ -n "$current_pid" ] && [ "$current_pid" != "0" ] && [ "$current_pid" != "$old_pid" ]; then
+        echo "Handoff: cortex-worker restarted as $current_pid; draining temporary worker $handoff_pid."
+        kill -TERM "$handoff_pid" >/dev/null 2>&1 || true
+        exit 0
+      fi
+      sleep 5
+    done
+    if kill -0 "$handoff_pid" >/dev/null 2>&1; then
+      echo "Handoff: timeout waiting for cortex-worker restart; temporary worker remains active."
+    fi
+  ) >> "$ROOT/logs/cortex-worker-handoff.log" 2>&1 &
+}
+
 disable_user_service_if_present() {
   local service_name="$1"
   if have_user_service "$service_name"; then
@@ -307,7 +349,12 @@ restart_or_drain_worker() {
 
   echo "Worker:    $active_runs active AgentRun(s); signaling drain instead of restart"
   echo "           It will stop claiming new runs and restart on the new version after active runs finish."
+  local old_pid handoff_pid
+  old_pid="$(worker_service_main_pid)"
+  handoff_pid="$(start_worker_handoff)"
+  echo "Worker:    started temporary handoff worker $handoff_pid for new AgentRuns"
   systemctl --user kill --kill-who=main --signal=TERM cortex-worker || true
+  monitor_worker_handoff "$old_pid" "$handoff_pid"
 }
 
 should_run_local_embedder() {
@@ -380,8 +427,9 @@ PY
 }
 
 echo "=== Pulling latest code ==="
+git fetch origin main
 git checkout main
-git pull origin main
+git pull --ff-only origin main
 
 if [ ! -x "$PYTHON_BIN" ]; then
   echo "=== Creating virtual environment ==="

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -41,3 +41,11 @@ def test_shutdown_drain_timeout_accepts_numeric_override(monkeypatch):
     monkeypatch.setenv("ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS", "42.5")
 
     assert _shutdown_drain_timeout_seconds() == 42.5
+
+
+def test_cycle_scheduler_can_be_disabled_for_handoff_worker(monkeypatch):
+    from brain.systems.cortex.worker import _cycle_scheduler_enabled
+
+    monkeypatch.setenv("ILLO_WORKER_DISABLE_CYCLE_SCHEDULER", "1")
+
+    assert _cycle_scheduler_enabled() is False

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -520,3 +520,94 @@ def test_connect_gemini_api_key_requires_installation_admin(monkeypatch):
         connect_gemini_api_key(SimpleNamespace(id="user-1", org_id="org-1", role="member"), "gemini-key")
 
     assert getattr(exc.value, "status_code", None) == 403
+
+
+def test_start_runtime_update_launches_detached_safe_deploy(monkeypatch, tmp_path):
+    import brain.systems.runtime_settings.self_update as self_update
+
+    root = tmp_path / "repo"
+    state_dir = tmp_path / "state"
+    launcher = root / "illo"
+    (root / ".git").mkdir(parents=True)
+    launcher.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    popen_calls = []
+
+    class Proc:
+        pid = 4242
+
+    def fake_popen(command, **kwargs):
+        popen_calls.append((command, kwargs))
+        return Proc()
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+    monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 2)
+    monkeypatch.setattr(self_update, "_pid_running", lambda _pid: False)
+    monkeypatch.setattr(self_update.subprocess, "Popen", fake_popen)
+
+    status = self_update.start_runtime_update(requested_by="owner-1")
+
+    assert status.status == "running"
+    assert status.available is True
+    assert status.pid == 4242
+    assert status.active_agent_runs == 2
+    assert "active AgentRun" in (status.detail or "")
+    command, kwargs = popen_calls[0]
+    assert command == ["bash", str(launcher), "update"]
+    assert kwargs["cwd"] == str(root)
+    assert kwargs["stdin"] is self_update.subprocess.DEVNULL
+    assert kwargs["stderr"] is self_update.subprocess.STDOUT
+    assert kwargs["close_fds"] is True
+    assert kwargs["start_new_session"] is True
+    assert (state_dir / "illo-self-update.pid").read_text(encoding="utf-8").strip() == "4242"
+
+
+def test_start_runtime_update_reuses_running_update(monkeypatch, tmp_path):
+    import brain.systems.runtime_settings.self_update as self_update
+
+    root = tmp_path / "repo"
+    state_dir = tmp_path / "state"
+    (root / ".git").mkdir(parents=True)
+    (root / "illo").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    state_dir.mkdir()
+    (state_dir / "illo-self-update.json").write_text(
+        '{"pid": 5150, "started_at": "2026-05-11T12:00:00+00:00"}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+    monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 1)
+    monkeypatch.setattr(self_update, "_pid_running", lambda pid: pid == 5150)
+    monkeypatch.setattr(
+        self_update.subprocess,
+        "Popen",
+        MagicMock(side_effect=AssertionError("should not launch a duplicate update")),
+    )
+
+    status = self_update.start_runtime_update(requested_by="owner-1")
+
+    assert status.status == "running"
+    assert status.pid == 5150
+    assert status.detail == "Illospace update is already running."
+
+
+def test_start_runtime_update_rejects_non_checkout_without_override(monkeypatch, tmp_path):
+    import brain.systems.runtime_settings.self_update as self_update
+
+    root = tmp_path / "repo"
+    state_dir = tmp_path / "state"
+    root.mkdir()
+    (root / "illo").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+
+    with pytest.raises(Exception) as exc:
+        self_update.start_runtime_update(requested_by="owner-1")
+
+    assert getattr(exc.value, "status_code", None) == 409
+    assert "not running from a git checkout" in exc.value.detail

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -57,6 +57,9 @@ def test_ops_deploy_drains_worker_instead_of_restarting_active_runs():
 
     assert "active_agent_run_count" in content
     assert "restart_or_drain_worker" in content
+    assert "start_worker_handoff" in content
+    assert "monitor_worker_handoff" in content
+    assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in content
     assert "systemctl --user kill --kill-who=main --signal=TERM cortex-worker" in content
     assert "active AgentRun(s); signaling drain instead of restart" in content
 
@@ -186,9 +189,22 @@ def test_illo_exposes_native_default_dev_mode_and_compose_deploy():
     assert 'run_dev' in content
     assert "deploy" in content
     assert 'deploy_command "${@:2}"' in content
+    assert 'update_command "${@:2}"' in content
     assert "--no-next" in content
     assert "worker-status" not in content
     assert "worker-drain" not in content
+
+
+def test_illo_update_auto_selects_native_or_compose_server_mode():
+    illo_path = Path(__file__).resolve().parents[1] / "illo"
+    content = illo_path.read_text()
+
+    assert "update_detect_mode" in content
+    assert "update_native_services_active" in content
+    assert "update_compose_stack_present" in content
+    assert 'exec "$ROOT/ops/deploy.sh"' in content
+    assert "deploy_command upgrade --build --no-pull" in content
+    assert "Self-update is not enabled for local/dev runs." in content
 
 
 def test_compose_deploy_stays_private_without_builtin_public_ingress():
@@ -201,3 +217,19 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     assert service_names == ["postgres", "migrate", "api", "worker", "scheduler", "web"]
     assert "127.0.0.1:${ILLO_WEB_PORT:-8080}:8080" in compose
     assert "deploy " + "publish" not in launcher
+
+
+def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
+    upgrade = (Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "upgrade.sh").read_text()
+
+    assert "active_agent_run_count" in upgrade
+    assert "status IN" in upgrade
+    assert "compose up -d --no-deps api scheduler web" in upgrade
+    assert "start_worker_handoff" in upgrade
+    assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in upgrade
+    assert "started handoff worker" in upgrade
+    assert "docker update --restart=no" in upgrade
+    assert 'docker kill -s TERM "$worker_id"' in upgrade
+    assert "wait_for_worker_exit" in upgrade
+    assert "compose up -d --no-deps worker" in upgrade
+    assert "avoid killing active AgentRuns" in upgrade


### PR DESCRIPTION
## Summary
- add an admin-only Runtime Settings update endpoint and System page "Update Illospace" button
- route runtime updates through `./illo update`, which chooses native/systemd or Docker Compose from the running environment
- add worker handoff for native and Compose deploys so active AgentRuns drain on the old worker while new AgentRuns are claimed by a new handoff/new worker
- rebuild/update the frontend in both native and Compose deploy paths

## Important behavior
- Existing active agents are not hot-swapped mid-run; they keep running on the old worker and drain naturally.
- New agents can start immediately on the new handoff/new worker while old runs continue.
- Frontend updates are included: native deploy builds `frontend/build`; Compose update rebuilds/restarts the `web` image.
- Database migrations still need to remain backward-compatible while old workers drain.

## Test plan
- `pytest tests/test_runtime_settings.py tests/test_safe_deploy.py tests/test_cortex_worker.py tests/test_alembic_config.py::test_deploy_script_uses_alembic -q`
- `bash -n deploy/scripts/upgrade.sh illo ops/deploy.sh`
- `python3 -m py_compile brain/systems/runtime_settings/self_update.py brain/systems/runtime_settings/router.py brain/systems/runtime_settings/schemas.py brain/systems/cortex/worker.py`
- `npm run check` (passes with 0 errors and 2 existing warnings in memory UI files)
