### PR TITLE
Enable Compose runtime self-updates

### DIFF
--- a/brain/systems/runtime_settings/self_update.py
+++ b/brain/systems/runtime_settings/self_update.py
@@ -4,7 +4,7 @@ import json
 import os
 import shlex
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -22,10 +22,15 @@ _LOG_NAME = "illo-self-update.log"
 _META_NAME = "illo-self-update.json"
 _PID_NAME = "illo-self-update.pid"
 _START_LOCK_NAME = "illo-self-update.starting"
+_REQUEST_RUNNING_STATUSES = {"queued", "starting", "running"}
 
 
 def get_runtime_update_status() -> RuntimeUpdateRead:
     root = _repo_root()
+    request_file = _request_file()
+    if request_file is not None:
+        return _request_update_status(request_file)
+
     state_dir = _state_dir(root)
     available, detail = _availability(root)
     metadata = _read_metadata(state_dir)
@@ -46,6 +51,10 @@ def get_runtime_update_status() -> RuntimeUpdateRead:
 
 def start_runtime_update(*, requested_by: str | None = None) -> RuntimeUpdateRead:
     root = _repo_root()
+    request_file = _request_file()
+    if request_file is not None:
+        return _start_request_update(request_file, requested_by=requested_by)
+
     available, detail = _availability(root)
     if not available:
         raise HTTPException(status_code=409, detail=detail or "Illospace self-update is unavailable.")
@@ -137,6 +146,121 @@ def _state_dir(root: Path) -> Path:
     return Path(cfg.BRAIN_LOG_DIR).resolve()
 
 
+def _request_file() -> Path | None:
+    raw = os.getenv("ILLO_SELF_UPDATE_REQUEST_FILE", "").strip()
+    return Path(raw).resolve() if raw else None
+
+
+def _request_status_file(request_file: Path) -> Path:
+    raw = os.getenv("ILLO_SELF_UPDATE_STATUS_FILE", "").strip()
+    return Path(raw).resolve() if raw else request_file.with_name("status.json")
+
+
+def _request_log_path(request_file: Path) -> Path:
+    raw = os.getenv("ILLO_SELF_UPDATE_LOG_PATH", "").strip()
+    if raw:
+        return Path(raw).resolve()
+    return Path(cfg.BRAIN_LOG_DIR).resolve() / _LOG_NAME
+
+
+def _request_heartbeat_file(request_file: Path) -> Path | None:
+    raw = os.getenv("ILLO_SELF_UPDATE_HEARTBEAT_FILE", "").strip()
+    return Path(raw).resolve() if raw else None
+
+
+def _request_availability(request_file: Path) -> tuple[bool, str | None]:
+    try:
+        request_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return False, f"Illospace update queue is unavailable: {exc}"
+    if not os.access(request_file.parent, os.W_OK):
+        return False, f"Illospace update queue is not writable: {request_file.parent}"
+    heartbeat_file = _request_heartbeat_file(request_file)
+    if heartbeat_file is not None:
+        heartbeat = _read_json(heartbeat_file)
+        updated_at = _parse_datetime(heartbeat.get("updated_at"))
+        if updated_at is None:
+            return False, "Illospace update is waiting for the Compose updater sidecar."
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) - updated_at > timedelta(seconds=60):
+            return False, "Illospace update is unavailable because the Compose updater sidecar heartbeat is stale."
+    return True, "Queues the update for the Compose updater sidecar."
+
+
+def _request_update_status(request_file: Path) -> RuntimeUpdateRead:
+    available, availability_detail = _request_availability(request_file)
+    status_data = _read_json(_request_status_file(request_file))
+    raw_status = str(status_data.get("status") or "").strip().lower()
+    running = raw_status in _REQUEST_RUNNING_STATUSES or request_file.exists()
+    detail = status_data.get("detail") if isinstance(status_data.get("detail"), str) else None
+
+    return RuntimeUpdateRead(
+        status="running" if running else "idle",
+        available=available,
+        pid=None,
+        started_at=_parse_datetime(status_data.get("started_at") or status_data.get("requested_at")),
+        active_agent_runs=_active_agent_run_count(),
+        log_path=str(_request_log_path(request_file)),
+        detail=detail or availability_detail,
+    )
+
+
+def _start_request_update(request_file: Path, *, requested_by: str | None) -> RuntimeUpdateRead:
+    available, detail = _request_availability(request_file)
+    if not available:
+        raise HTTPException(status_code=409, detail=detail or "Illospace self-update is unavailable.")
+
+    existing = _request_update_status(request_file)
+    if existing.status == "running":
+        return RuntimeUpdateRead(
+            **{
+                **existing.model_dump(),
+                "detail": "Illospace update is already running.",
+            }
+        )
+
+    lock_path = request_file.with_name(f".{request_file.name}.starting")
+    lock_fd = _acquire_start_lock(lock_path)
+    if lock_fd is None:
+        return RuntimeUpdateRead(
+            **{
+                **_request_update_status(request_file).model_dump(),
+                "status": "running",
+                "detail": "Illospace update is starting.",
+            }
+        )
+
+    try:
+        started_at = datetime.now(timezone.utc)
+        payload = {
+            "requested_at": started_at.isoformat(),
+            "requested_by": requested_by,
+        }
+        _write_json_atomic(request_file, payload)
+        _write_json_atomic(
+            _request_status_file(request_file),
+            {
+                **payload,
+                "started_at": started_at.isoformat(),
+                "status": "queued",
+                "detail": "Illospace update queued for the Compose updater sidecar.",
+            },
+        )
+        active_runs = _active_agent_run_count()
+        return RuntimeUpdateRead(
+            status="running",
+            available=True,
+            pid=None,
+            started_at=started_at,
+            active_agent_runs=active_runs,
+            log_path=str(_request_log_path(request_file)),
+            detail="Illospace update queued for the Compose updater sidecar.",
+        )
+    finally:
+        _release_start_lock(lock_fd, lock_path)
+
+
 def _availability(root: Path) -> tuple[bool, str | None]:
     if os.getenv("ILLO_SELF_UPDATE_COMMAND", "").strip():
         return True, "Self-update uses the configured update command."
@@ -174,8 +298,12 @@ def _active_agent_run_count() -> int:
 
 
 def _read_metadata(state_dir: Path) -> dict[str, Any]:
+    return _read_json(state_dir / _META_NAME)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
     try:
-        data = json.loads((state_dir / _META_NAME).read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
     return data if isinstance(data, dict) else {}
@@ -224,6 +352,13 @@ def _write_log_header(log_path: Path, started_at: datetime, *, requested_by: str
         handle.write(f"=== Illospace self-update requested at {started_at.isoformat()} ===\n".encode("utf-8"))
         if requested_by:
             handle.write(f"Requested by: {requested_by}\n".encode("utf-8"))
+
+
+def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
 
 
 def _acquire_start_lock(path: Path) -> int | None:

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -10,6 +10,7 @@ public ingress, TLS automation, or cloud-specific infrastructure.
 - `api`: FastAPI backend
 - `worker`: standalone AgentRun worker
 - `scheduler`: recurring job daemon
+- `updater`: owner-triggered self-update sidecar with access to the host repo and Docker socket
 - `migrate`: one-shot Alembic migration job
 - `postgres`: Postgres 16 with pgvector
 
@@ -128,6 +129,11 @@ Build during upgrade when release images are unavailable:
 ```bash
 ./illo deploy upgrade --build --no-pull
 ```
+
+Owners/admins can also start the same update flow from System/Update Illospace.
+In Compose, the API queues the request in the private data volume and the
+`updater` sidecar runs `./illo update --mode compose` from the host checkout.
+The sidecar mounts the Docker socket, so keep this stack on trusted hosts only.
 
 ## Advanced Paths
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -27,6 +27,10 @@ x-illo-env: &illo-env
   AGENT_CHECKLIST_PATH: /data/private/agent-context/pre-flight-checklist.md
   BRAIN_LOG_DIR: /data/private/logs
   CORTEX_EVENT_FANOUT_ENABLED: "1"
+  ILLO_SELF_UPDATE_REQUEST_FILE: /data/private/self-update/request.json
+  ILLO_SELF_UPDATE_STATUS_FILE: /data/private/self-update/status.json
+  ILLO_SELF_UPDATE_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+  ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
 
 x-backend-service: &backend-service
   image: ${ILLO_API_IMAGE:-ghcr.io/illospace/api:latest}
@@ -117,6 +121,31 @@ services:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+
+  updater:
+    image: ${ILLO_UPDATER_IMAGE:-ghcr.io/illospace/updater:latest}
+    build:
+      context: ../..
+      dockerfile: deploy/docker/updater.Dockerfile
+    restart: unless-stopped
+    environment:
+      ILLO_SELF_UPDATE_REPO: /repo
+      ILLO_SELF_UPDATE_REQUEST_FILE: /data/private/self-update/request.json
+      ILLO_SELF_UPDATE_STATUS_FILE: /data/private/self-update/status.json
+      ILLO_SELF_UPDATE_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+      ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
+      ILLO_COMPOSE_ENV_FILE: /repo/deploy/compose/.env
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-illospace}
+    volumes:
+      - illo_private:/data/private
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../..:/repo
+    healthcheck:
+      test: ["CMD", "illo-self-update-healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
 
   web:
     image: ${ILLO_WEB_IMAGE:-ghcr.io/illospace/web:latest}

--- a/deploy/docker/updater.Dockerfile
+++ b/deploy/docker/updater.Dockerfile
@@ -1,0 +1,16 @@
+FROM docker:27-cli
+
+RUN apk add --no-cache \
+    bash \
+    coreutils \
+    docker-cli-compose \
+    git \
+    jq
+
+WORKDIR /repo
+
+COPY deploy/scripts/self-update-daemon.sh /usr/local/bin/illo-self-update-daemon
+COPY deploy/scripts/self-update-healthcheck.sh /usr/local/bin/illo-self-update-healthcheck
+RUN chmod +x /usr/local/bin/illo-self-update-daemon /usr/local/bin/illo-self-update-healthcheck
+
+CMD ["illo-self-update-daemon"]

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -210,7 +210,7 @@ if [ "$runtime_checks" = "0" ]; then
 elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" && compose ps --services --status running >"$tmp_running" 2>/dev/null; then
   running="$(cat "$tmp_running")"
   if printf '%s\n' "$running" | grep -qx api; then
-    for service in postgres api web worker scheduler; do
+    for service in postgres api web worker scheduler updater; do
       if printf '%s\n' "$running" | grep -qx "$service"; then
         health="$(container_health "$service" || true)"
         case "$health" in

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${ILLO_SELF_UPDATE_REPO:-/repo}"
+REQUEST_FILE="${ILLO_SELF_UPDATE_REQUEST_FILE:-/data/private/self-update/request.json}"
+STATUS_FILE="${ILLO_SELF_UPDATE_STATUS_FILE:-/data/private/self-update/status.json}"
+HEARTBEAT_FILE="${ILLO_SELF_UPDATE_HEARTBEAT_FILE:-/data/private/self-update/heartbeat.json}"
+LOG_PATH="${ILLO_SELF_UPDATE_LOG_PATH:-/data/private/logs/illo-self-update.log}"
+POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
+RUNNING_FILE="${REQUEST_FILE}.running"
+
+json_write() {
+  local path="$1"
+  shift
+  mkdir -p "$(dirname "$path")"
+  jq -n "$@" > "${path}.tmp"
+  mv "${path}.tmp" "$path"
+}
+
+write_status() {
+  local status="$1"
+  local detail="$2"
+  local requested_at="${3:-}"
+  local requested_by="${4:-}"
+  local exit_code="${5:-}"
+  json_write "$STATUS_FILE" \
+    --arg status "$status" \
+    --arg detail "$detail" \
+    --arg requested_at "$requested_at" \
+    --arg requested_by "$requested_by" \
+    --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg exit_code "$exit_code" \
+    '{
+      status: $status,
+      detail: $detail,
+      requested_at: (if $requested_at | length > 0 then $requested_at else null end),
+      started_at: (if $requested_at | length > 0 then $requested_at else null end),
+      requested_by: (if $requested_by | length > 0 then $requested_by else null end),
+      updated_at: $updated_at,
+      exit_code: (if $exit_code | length > 0 then ($exit_code | tonumber) else null end)
+    }'
+}
+
+write_heartbeat() {
+  json_write "$HEARTBEAT_FILE" \
+    --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    '{status: "ready", updated_at: $updated_at}'
+}
+
+process_request() {
+  local requested_at requested_by exit_code
+  if ! mv "$REQUEST_FILE" "$RUNNING_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  requested_at="$(jq -r '.requested_at // ""' "$RUNNING_FILE" 2>/dev/null || true)"
+  requested_by="$(jq -r '.requested_by // ""' "$RUNNING_FILE" 2>/dev/null || true)"
+  write_status "running" "Illospace update is running." "$requested_at" "$requested_by"
+
+  mkdir -p "$(dirname "$LOG_PATH")"
+  {
+    echo
+    echo "=== Illospace Compose self-update started at $(date -u +"%Y-%m-%dT%H:%M:%SZ") ==="
+    [ -z "$requested_by" ] || echo "Requested by: $requested_by"
+    cd "$REPO"
+    ILLO_UPDATE_MODE=compose ILLO_COMPOSE_SKIP_UPDATER_RESTART=1 bash ./illo update --mode compose
+  } >> "$LOG_PATH" 2>&1
+  exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    write_status "idle" "Illospace update completed." "$requested_at" "$requested_by" "$exit_code"
+  else
+    write_status "idle" "Illospace update failed with exit code $exit_code. Check the update log." "$requested_at" "$requested_by" "$exit_code"
+  fi
+  rm -f "$RUNNING_FILE"
+}
+
+mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")"
+write_status "idle" "Compose updater sidecar is ready." "" ""
+
+while true; do
+  write_heartbeat
+  if [ -f "$REQUEST_FILE" ]; then
+    set +e
+    process_request
+    exit_code=$?
+    set -e
+    if [ "$exit_code" -ne 0 ]; then
+      write_status "idle" "Illospace update failed with exit code $exit_code. Check the update log." "" "" "$exit_code"
+      rm -f "$RUNNING_FILE"
+    fi
+  fi
+  sleep "$POLL_SECONDS"
+done

--- a/deploy/scripts/self-update-healthcheck.sh
+++ b/deploy/scripts/self-update-healthcheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HEARTBEAT_FILE="${ILLO_SELF_UPDATE_HEARTBEAT_FILE:-/data/private/self-update/heartbeat.json}"
+MAX_AGE_SECONDS="${ILLO_SELF_UPDATE_HEARTBEAT_MAX_AGE_SECONDS:-60}"
+
+[ -f "$HEARTBEAT_FILE" ] || exit 1
+
+updated_at="$(jq -r '.updated_at // empty' "$HEARTBEAT_FILE" 2>/dev/null)"
+[ -n "$updated_at" ] || exit 1
+
+heartbeat_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null)" || exit 1
+now_epoch="$(date -u +%s)"
+
+[ $((now_epoch - heartbeat_epoch)) -le "$MAX_AGE_SECONDS" ]

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -9,6 +9,7 @@ ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$COMPOSE_DIR/.env}"
 
 BUILD=0
 PULL=1
+SKIP_UPDATER_RESTART="${ILLO_COMPOSE_SKIP_UPDATER_RESTART:-0}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -44,6 +45,22 @@ fi
 
 compose() {
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+non_worker_services() {
+  if [ "$SKIP_UPDATER_RESTART" = "1" ]; then
+    printf '%s\n' api scheduler web
+  else
+    printf '%s\n' api scheduler web updater
+  fi
+}
+
+all_runtime_services() {
+  if [ "$SKIP_UPDATER_RESTART" = "1" ]; then
+    printf '%s\n' postgres api worker scheduler web
+  else
+    printf '%s\n' postgres api worker scheduler web updater
+  fi
 }
 
 active_agent_run_count() {
@@ -123,24 +140,26 @@ update_worker_after_drain() {
 }
 
 if [ "$PULL" = "1" ]; then
-  compose pull postgres api web || {
+  compose pull postgres api web updater || {
     echo "Image pull failed. If release images are not published yet, rerun with --build." >&2
     exit 1
   }
 fi
 
 if [ "$BUILD" = "1" ]; then
-  compose build api web
+  compose build api web updater
 fi
 
 compose up -d postgres
 compose run --rm migrate
 ACTIVE_RUNS="$(active_agent_run_count)"
 if [ "$ACTIVE_RUNS" = "0" ]; then
-  compose up -d --remove-orphans
+  mapfile -t runtime_services < <(all_runtime_services)
+  compose up -d --remove-orphans "${runtime_services[@]}"
 else
   echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
-  compose up -d --no-deps api scheduler web
+  mapfile -t services < <(non_worker_services)
+  compose up -d --no-deps "${services[@]}"
   update_worker_after_drain "$ACTIVE_RUNS"
 fi
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -88,10 +88,12 @@ users will not use `http://localhost:8080`.
 Expected result:
 
 - `./illo deploy status` shows `postgres`, `api`, `worker`, `scheduler`, and
-  `web` running
+  `updater`, and `web` running
 - `./illo deploy doctor` exits successfully
 - `http://localhost:8080` opens the dashboard through the SSH tunnel
 - an owner/admin can sign in and add provider credentials in System/Access
+- an owner/admin can start a code update from System/Update Illospace; the
+  Compose updater sidecar runs it from the host checkout
 
 ## Health Checks
 

--- a/illo
+++ b/illo
@@ -2445,7 +2445,7 @@ deploy_up() {
     fi
   fi
   if [ "$build" = "1" ]; then
-    deploy_compose build api web || return 1
+    deploy_compose build api web updater || return 1
   fi
   deploy_compose up -d || return 1
   if [ "$doctor" = "1" ]; then

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -542,6 +542,7 @@ def test_start_runtime_update_launches_detached_safe_deploy(monkeypatch, tmp_pat
     monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
     monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
     monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+    monkeypatch.delenv("ILLO_SELF_UPDATE_REQUEST_FILE", raising=False)
     monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 2)
     monkeypatch.setattr(self_update, "_pid_running", lambda _pid: False)
     monkeypatch.setattr(self_update.subprocess, "Popen", fake_popen)
@@ -579,6 +580,7 @@ def test_start_runtime_update_reuses_running_update(monkeypatch, tmp_path):
     monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
     monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
     monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+    monkeypatch.delenv("ILLO_SELF_UPDATE_REQUEST_FILE", raising=False)
     monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 1)
     monkeypatch.setattr(self_update, "_pid_running", lambda pid: pid == 5150)
     monkeypatch.setattr(
@@ -605,9 +607,77 @@ def test_start_runtime_update_rejects_non_checkout_without_override(monkeypatch,
     monkeypatch.setenv("ILLO_SELF_UPDATE_ROOT", str(root))
     monkeypatch.setenv("ILLO_SELF_UPDATE_STATE_DIR", str(state_dir))
     monkeypatch.delenv("ILLO_SELF_UPDATE_COMMAND", raising=False)
+    monkeypatch.delenv("ILLO_SELF_UPDATE_REQUEST_FILE", raising=False)
 
     with pytest.raises(Exception) as exc:
         self_update.start_runtime_update(requested_by="owner-1")
 
     assert getattr(exc.value, "status_code", None) == 409
     assert "not running from a git checkout" in exc.value.detail
+
+
+def test_start_runtime_update_queues_compose_sidecar_request(monkeypatch, tmp_path):
+    import json
+
+    import brain.systems.runtime_settings.self_update as self_update
+
+    request_file = tmp_path / "self-update" / "request.json"
+    status_file = tmp_path / "self-update" / "status.json"
+    log_path = tmp_path / "logs" / "illo-self-update.log"
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_REQUEST_FILE", str(request_file))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_STATUS_FILE", str(status_file))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_LOG_PATH", str(log_path))
+    monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 3)
+
+    status = self_update.start_runtime_update(requested_by="owner-1")
+
+    assert status.status == "running"
+    assert status.available is True
+    assert status.pid is None
+    assert status.active_agent_runs == 3
+    assert status.log_path == str(log_path)
+    assert "queued" in (status.detail or "")
+    request_payload = json.loads(request_file.read_text(encoding="utf-8"))
+    status_payload = json.loads(status_file.read_text(encoding="utf-8"))
+    assert request_payload["requested_by"] == "owner-1"
+    assert status_payload["status"] == "queued"
+
+
+def test_runtime_update_status_reports_compose_sidecar_available(monkeypatch, tmp_path):
+    import brain.systems.runtime_settings.self_update as self_update
+
+    request_file = tmp_path / "self-update" / "request.json"
+    status_file = tmp_path / "self-update" / "status.json"
+    status_file.parent.mkdir()
+    status_file.write_text(
+        '{"status": "idle", "detail": "Compose updater sidecar is ready."}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_REQUEST_FILE", str(request_file))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_STATUS_FILE", str(status_file))
+    monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 0)
+
+    status = self_update.get_runtime_update_status()
+
+    assert status.status == "idle"
+    assert status.available is True
+    assert status.detail == "Compose updater sidecar is ready."
+
+
+def test_runtime_update_status_waits_for_compose_sidecar_heartbeat(monkeypatch, tmp_path):
+    import brain.systems.runtime_settings.self_update as self_update
+
+    request_file = tmp_path / "self-update" / "request.json"
+    heartbeat_file = tmp_path / "self-update" / "heartbeat.json"
+
+    monkeypatch.setenv("ILLO_SELF_UPDATE_REQUEST_FILE", str(request_file))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_HEARTBEAT_FILE", str(heartbeat_file))
+    monkeypatch.setattr(self_update, "_active_agent_run_count", lambda: 0)
+
+    status = self_update.get_runtime_update_status()
+
+    assert status.status == "idle"
+    assert status.available is False
+    assert "waiting for the Compose updater sidecar" in (status.detail or "")

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -190,6 +190,7 @@ def test_illo_exposes_native_default_dev_mode_and_compose_deploy():
     assert "deploy" in content
     assert 'deploy_command "${@:2}"' in content
     assert 'update_command "${@:2}"' in content
+    assert "deploy_compose build api web updater" in content
     assert "--no-next" in content
     assert "worker-status" not in content
     assert "worker-drain" not in content
@@ -214,8 +215,14 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     services_section = compose.split("services:", 1)[1].rsplit("\nvolumes:", 1)[0]
     service_names = re.findall(r"^  ([a-z][a-z0-9_-]+):$", services_section, flags=re.MULTILINE)
 
-    assert service_names == ["postgres", "migrate", "api", "worker", "scheduler", "web"]
+    assert service_names == ["postgres", "migrate", "api", "worker", "scheduler", "updater", "web"]
     assert "127.0.0.1:${ILLO_WEB_PORT:-8080}:8080" in compose
+    assert "ILLO_SELF_UPDATE_REQUEST_FILE" in compose
+    assert "ILLO_SELF_UPDATE_HEARTBEAT_FILE" in compose
+    assert "deploy/docker/updater.Dockerfile" in compose
+    assert "illo-self-update-healthcheck" in compose
+    assert "/var/run/docker.sock:/var/run/docker.sock" in compose
+    assert "../..:/repo" in compose
     assert "deploy " + "publish" not in launcher
 
 
@@ -224,7 +231,9 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
 
     assert "active_agent_run_count" in upgrade
     assert "status IN" in upgrade
-    assert "compose up -d --no-deps api scheduler web" in upgrade
+    assert "non_worker_services" in upgrade
+    assert "api scheduler web updater" in upgrade
+    assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
     assert "start_worker_handoff" in upgrade
     assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in upgrade
     assert "started handoff worker" in upgrade


### PR DESCRIPTION
## Summary
- add a Compose updater sidecar that watches the private volume for owner/admin update requests
- have the runtime update endpoint queue Compose requests instead of requiring the API container to own a git checkout
- wire the sidecar to the host repo and Docker socket so it can run the existing `./illo update --mode compose` handoff flow
- keep the API container away from direct Docker socket access and add a heartbeat-based availability check

## Why
The first runtime update PR made the button visible for owners/admins, but Compose API containers do not include `./illo`/`.git` or own the host checkout. That made the button correctly disabled in Compose. This PR gives Compose a proper host-side updater path.

## Behavior
- Owner/admin still controls visibility.
- Compose availability requires a writable update queue and a fresh updater heartbeat.
- Clicking the button writes a request to `/data/private/self-update/request.json`.
- The updater sidecar runs `./illo update --mode compose`, preserving active AgentRuns through the existing worker handoff.

## Test plan
- `pytest tests/test_runtime_settings.py tests/test_safe_deploy.py tests/test_cortex_worker.py tests/test_alembic_config.py::test_deploy_script_uses_alembic -q`
- `bash -n deploy/scripts/upgrade.sh deploy/scripts/self-update-daemon.sh illo ops/deploy.sh deploy/scripts/doctor.sh`
- `python3 -m py_compile brain/systems/runtime_settings/self_update.py brain/systems/runtime_settings/router.py brain/systems/runtime_settings/schemas.py brain/systems/cortex/worker.py`
- `docker compose --env-file /dev/null -f deploy/compose/docker-compose.yml config` with required env placeholders
- `npm run check` (0 errors, existing memory UI warnings only)
