### PR TITLE
Fix thread utility flows and trace export

### DIFF
--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -17,6 +17,11 @@ from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
 from brain.app.api.routers.cortex._router import router
 from brain.systems.runs.cortex import cancel_runs_for_idea, queue_status
 from brain.systems.runs.cortex.permissions import RunReadScope, run_belongs_to_scope
+from brain.systems.runs.cortex.recording import (
+    agent_trace_export_filename,
+    build_agent_trace_snapshot,
+    build_agent_trace_export_zip,
+)
 from brain.systems.runs.cortex.read_models import (
     serialize_active_runs,
     serialize_recent_runs,
@@ -169,6 +174,27 @@ def run_debug(run_id: int, user: dict[str, Any] = Depends(get_current_user)):
     if result is None:
         raise HTTPException(status_code=404, detail=f"Run #{run_id} not found")
     return result
+
+
+@router.post("/run/{run_id}/trace-export.zip")
+def download_run_trace_export(run_id: int, user: dict[str, Any] = Depends(get_current_user)):
+    with UnitOfWork() as uow:
+        run = _require_run_for_user(uow.session, run_id, user)
+        snapshot = build_agent_trace_snapshot(
+            uow.session,
+            run,
+            saved_by=str(user.get("id")) if user.get("id") else None,
+        )
+        archive = build_agent_trace_export_zip(snapshot)
+        filename = agent_trace_export_filename(snapshot)
+        return Response(
+            content=archive,
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Trace-Id": str(snapshot.get("trace_id") or ""),
+            },
+        )
 
 
 @router.post("/run/{run_id}/approve")

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from io import BytesIO
+import json
 from typing import Any
+import zipfile
 
 from sqlalchemy import select
 
 from brain.systems.runs.ids import trace_id_for_run_id
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.idea import IdeaThread
 
 
 def build_run_run_summary(session, run_id: int) -> dict[str, Any]:
@@ -83,6 +88,119 @@ def load_run_recordings(session, run_id: int) -> dict[str, Any]:
     }
 
 
+AGENT_TRACE_SNAPSHOT_ARTIFACT_TYPE = "agent_trace_snapshot"
+AGENT_TRACE_SNAPSHOT_SCHEMA_VERSION = 1
+AGENT_TRACE_EXPORT_SCHEMA_VERSION = 1
+TRACE_MAX_MESSAGES = 40
+TRACE_MAX_EVENTS = 300
+TRACE_MAX_ARTIFACTS = 60
+TRACE_MAX_STRING_CHARS = 4000
+TRACE_MAX_COLLECTION_ITEMS = 80
+TRACE_MAX_DEPTH = 6
+
+
+def build_agent_trace_snapshot(
+    session,
+    run: AgentRunRow,
+    *,
+    saved_by: str | None = None,
+    max_messages: int = TRACE_MAX_MESSAGES,
+    max_events: int = TRACE_MAX_EVENTS,
+    max_artifacts: int = TRACE_MAX_ARTIFACTS,
+) -> dict[str, Any]:
+    """Build a bounded, JSON-safe trace bundle suitable for later analysis."""
+
+    related_run_ids = _related_run_ids(session, run)
+    messages = _trace_messages(session, run, max_messages=max_messages)
+    events = _trace_events(session, related_run_ids, max_events=max_events)
+    artifacts = _trace_artifacts(session, related_run_ids, max_artifacts=max_artifacts)
+    trace_id = run.trace_id or trace_id_for_run_id(run.id)
+    bundle = {
+        "schema_version": AGENT_TRACE_SNAPSHOT_SCHEMA_VERSION,
+        "trace_id": trace_id,
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+        "saved_by": saved_by,
+        "storage_policy": {
+            "mode": "bounded_snapshot",
+            "max_messages": max_messages,
+            "max_events": max_events,
+            "max_artifacts": max_artifacts,
+            "max_string_chars": TRACE_MAX_STRING_CHARS,
+            "large_values": "truncated_in_place",
+        },
+        "run": _cap_jsonable({
+            **build_run_run_summary(session, int(run.id)),
+            "parent_run_id": getattr(run, "parent_run_id", None),
+            "root_run_id": getattr(run, "root_run_id", None),
+            "input_message": getattr(run, "input_message", None),
+            "target_ref": getattr(run, "target_ref", None) or {},
+            "workspace_ref": getattr(run, "workspace_ref", None) or {},
+            "model_policy": getattr(run, "model_policy", None) or {},
+            "context_summary": getattr(run, "context_summary", None),
+            "metadata": getattr(run, "metadata_", None) or {},
+        }),
+        "thread": {
+            "idea_id": getattr(run, "thread_id", None),
+            "messages": messages,
+            "selected_message_count": len(messages),
+            "message_limit": max_messages,
+        },
+        "related_run_ids": related_run_ids,
+        "events": events,
+        "event_count": len(events),
+        "event_limit": max_events,
+        "tools": _tool_trace(events),
+        "artifacts": artifacts,
+        "artifact_count": len(artifacts),
+        "artifact_limit": max_artifacts,
+    }
+    bundle["storage_estimate"] = {
+        "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
+        "truncated": _contains_truncation(bundle),
+    }
+    return _jsonable(bundle)
+
+
+def build_agent_trace_export_zip(
+    snapshot: dict[str, Any],
+) -> bytes:
+    """Package a trace snapshot as a small shareable zip."""
+
+    trace = _jsonable(snapshot)
+    run = trace.get("run") if isinstance(trace.get("run"), dict) else {}
+    manifest = _jsonable({
+        "schema_version": AGENT_TRACE_EXPORT_SCHEMA_VERSION,
+        "export_type": "illo_agent_trace",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "trace_id": trace.get("trace_id"),
+        "run_id": run.get("run_id"),
+        "files": [
+            {"path": "trace.json", "description": "Bounded JSON trace for agent analysis."},
+            {"path": "activity.json", "description": "Compact chronological activity list derived from the trace."},
+            {"path": "manifest.json", "description": "Export metadata."},
+            {"path": "README.md", "description": "Human-readable notes about the export."},
+        ],
+        "storage_estimate": trace.get("storage_estimate") or {},
+    })
+    activity = _trace_activity_export(trace)
+    readme = _trace_export_readme(trace)
+
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True))
+        archive.writestr("trace.json", json.dumps(trace, indent=2, sort_keys=True))
+        archive.writestr("activity.json", json.dumps(activity, indent=2, sort_keys=True))
+        archive.writestr("README.md", readme)
+    return buffer.getvalue()
+
+
+def agent_trace_export_filename(snapshot: dict[str, Any]) -> str:
+    run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
+    run_id = run.get("run_id") or snapshot.get("trace_id") or "unknown"
+    safe_run_id = "".join(ch if str(ch).isalnum() or ch in {"-", "_"} else "-" for ch in str(run_id)).strip("-")
+    return f"illo-trace-run-{safe_run_id or 'unknown'}.zip"
+
+
 def persist_run_recordings(run_id: int) -> dict[str, Any] | None:
     return {"run_id": int(run_id), "persisted": False, "reason": "recordings_are_projected_from_events"}
 
@@ -91,6 +209,270 @@ def _iso(value: Any) -> str | None:
     if value is None:
         return None
     return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _related_run_ids(session, run: AgentRunRow) -> list[int]:
+    root_run_id = getattr(run, "root_run_id", None) or getattr(run, "id", None)
+    rows = session.scalars(
+        select(AgentRunRow.id)
+        .where((AgentRunRow.id == int(root_run_id)) | (AgentRunRow.root_run_id == int(root_run_id)))
+        .order_by(AgentRunRow.created_at.asc(), AgentRunRow.id.asc())
+    ).all()
+    ids: list[int] = []
+    for value in rows:
+        candidate = getattr(value, "id", value)
+        try:
+            ids.append(int(candidate))
+        except (TypeError, ValueError):
+            continue
+    if int(run.id) not in ids:
+        ids.insert(0, int(run.id))
+    return ids
+
+
+def _trace_messages(session, run: AgentRunRow, *, max_messages: int) -> list[dict[str, Any]]:
+    rows = session.scalars(
+        select(IdeaThread)
+        .where(IdeaThread.idea_id == run.thread_id)
+        .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
+        .limit(max_messages)
+    ).all()
+    messages = []
+    for row in reversed(rows):
+        metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
+        messages.append(_cap_jsonable({
+            "id": row.id,
+            "role": row.role,
+            "created_at": _iso(row.created_at),
+            "message_type": row.message_type,
+            "content": row.content,
+            "attachments_count": len(row.attachments or []),
+            "metadata": {
+                "run_id": metadata.get("run_id"),
+                "trace_id": metadata.get("trace_id"),
+                "execution_profile": metadata.get("execution_profile"),
+                "live_agent_text": metadata.get("live_agent_text"),
+            },
+        }))
+    return messages
+
+
+def _trace_events(session, run_ids: list[int], *, max_events: int) -> list[dict[str, Any]]:
+    rows = session.scalars(
+        select(AgentRunEventRow)
+        .where(AgentRunEventRow.run_id.in_(run_ids))
+        .order_by(AgentRunEventRow.run_id.asc(), AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+        .limit(max_events)
+    ).all()
+    return [
+        _cap_jsonable({
+            "id": event.id,
+            "run_id": event.run_id,
+            "root_run_id": event.root_run_id,
+            "sequence_no": event.sequence_no,
+            "event_type": event.event_type,
+            "visibility": event.visibility,
+            "producer": event.producer,
+            "created_at": _iso(event.created_at),
+            "payload": event.payload or {},
+        })
+        for event in rows
+    ]
+
+
+def _trace_artifacts(session, run_ids: list[int], *, max_artifacts: int) -> list[dict[str, Any]]:
+    rows = session.scalars(
+        select(AgentRunArtifactRow)
+        .where(
+            AgentRunArtifactRow.run_id.in_(run_ids),
+            AgentRunArtifactRow.artifact_type != AGENT_TRACE_SNAPSHOT_ARTIFACT_TYPE,
+        )
+        .order_by(AgentRunArtifactRow.created_at.asc(), AgentRunArtifactRow.id.asc())
+        .limit(max_artifacts)
+    ).all()
+    return [
+        _cap_jsonable({
+            "id": artifact.id,
+            "run_id": artifact.run_id,
+            "root_run_id": artifact.root_run_id,
+            "artifact_type": artifact.artifact_type,
+            "title": artifact.title,
+            "uri": artifact.uri,
+            "visibility": artifact.visibility,
+            "created_at": _iso(artifact.created_at),
+            "text": artifact.text,
+            "payload": artifact.payload or {},
+        })
+        for artifact in rows
+    ]
+
+
+def _tool_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    tools = []
+    for event in events:
+        event_type = event.get("event_type")
+        if event_type not in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
+            continue
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        tools.append(_cap_jsonable({
+            "run_id": event.get("run_id"),
+            "event_id": event.get("id"),
+            "sequence_no": event.get("sequence_no"),
+            "event_type": event_type,
+            "tool_name": payload.get("tool_name") or "tool",
+            "status": "failed" if event_type == "run.tool_failed" else ("completed" if event_type == "run.tool_completed" else "started"),
+            "created_at": event.get("created_at"),
+            "args": payload.get("args"),
+            "result": payload.get("result"),
+            "error": payload.get("error"),
+        }))
+    return tools
+
+
+def _truncate_text(value: str, max_chars: int = TRACE_MAX_STRING_CHARS) -> str:
+    if len(value) <= max_chars:
+        return value
+    omitted = len(value) - max_chars
+    return f"{value[:max_chars]}... [truncated {omitted} chars]"
+
+
+def _cap_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if depth > TRACE_MAX_DEPTH:
+        return "[truncated: max depth]"
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, str):
+        return _truncate_text(value)
+    if isinstance(value, dict):
+        items = list(value.items())
+        capped = {
+            str(key): _cap_jsonable(item, depth=depth + 1)
+            for key, item in items[:TRACE_MAX_COLLECTION_ITEMS]
+        }
+        if len(items) > TRACE_MAX_COLLECTION_ITEMS:
+            capped["_truncated_items"] = len(items) - TRACE_MAX_COLLECTION_ITEMS
+        return capped
+    if isinstance(value, (list, tuple)):
+        capped = [_cap_jsonable(item, depth=depth + 1) for item in list(value)[:TRACE_MAX_COLLECTION_ITEMS]]
+        if len(value) > TRACE_MAX_COLLECTION_ITEMS:
+            capped.append({"_truncated_items": len(value) - TRACE_MAX_COLLECTION_ITEMS})
+        return capped
+    return _truncate_text(str(value))
+
+
+def _contains_truncation(value: Any) -> bool:
+    if isinstance(value, str):
+        return "[truncated" in value
+    if isinstance(value, dict):
+        return "_truncated_items" in value or any(_contains_truncation(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_truncation(item) for item in value)
+    return False
+
+
+def _trace_activity_export(snapshot: dict[str, Any]) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
+    if run:
+        items.append(_cap_jsonable({
+            "kind": "run",
+            "at": run.get("started_at") or run.get("created_at"),
+            "run_id": run.get("run_id"),
+            "trace_id": snapshot.get("trace_id"),
+            "title": f"run {run.get('status') or 'unknown'}",
+            "status": run.get("status"),
+            "profile": run.get("profile"),
+            "recipe": run.get("recipe"),
+            "input_message": run.get("input_message"),
+        }))
+
+    thread = snapshot.get("thread") if isinstance(snapshot.get("thread"), dict) else {}
+    for message in _safe_list(thread.get("messages")):
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role") or "message"
+        items.append(_cap_jsonable({
+            "kind": "message",
+            "at": message.get("created_at"),
+            "message_id": message.get("id"),
+            "role": role,
+            "title": f"message {role}",
+            "message_type": message.get("message_type"),
+            "content": message.get("content"),
+            "metadata": message.get("metadata") or {},
+        }))
+
+    for event in _safe_list(snapshot.get("events")):
+        if not isinstance(event, dict):
+            continue
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        items.append(_cap_jsonable({
+            "kind": "event",
+            "at": event.get("created_at"),
+            "run_id": event.get("run_id"),
+            "event_id": event.get("id"),
+            "sequence_no": event.get("sequence_no"),
+            "title": event.get("event_type"),
+            "event_type": event.get("event_type"),
+            "producer": event.get("producer"),
+            "visibility": event.get("visibility"),
+            "tool_name": payload.get("tool_name"),
+            "status": payload.get("status"),
+            "payload": payload,
+        }))
+
+    for artifact in _safe_list(snapshot.get("artifacts")):
+        if not isinstance(artifact, dict):
+            continue
+        items.append(_cap_jsonable({
+            "kind": "artifact",
+            "at": artifact.get("created_at"),
+            "run_id": artifact.get("run_id"),
+            "artifact_id": artifact.get("id"),
+            "title": artifact.get("title") or artifact.get("artifact_type"),
+            "artifact_type": artifact.get("artifact_type"),
+            "visibility": artifact.get("visibility"),
+            "uri": artifact.get("uri"),
+        }))
+
+    items.sort(key=lambda item: (
+        "" if item.get("at") is None else str(item.get("at")),
+        int(item.get("sequence_no") or 0),
+        str(item.get("kind") or ""),
+    ))
+    return {
+        "schema_version": AGENT_TRACE_EXPORT_SCHEMA_VERSION,
+        "trace_id": snapshot.get("trace_id"),
+        "run_id": run.get("run_id"),
+        "items": _jsonable(items),
+        "item_count": len(items),
+    }
+
+
+def _trace_export_readme(snapshot: dict[str, Any]) -> str:
+    run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
+    estimate = snapshot.get("storage_estimate") if isinstance(snapshot.get("storage_estimate"), dict) else {}
+    return "\n".join([
+        "# Illo agent trace export",
+        "",
+        "This zip is meant to be attached to a debugging conversation so another agent can inspect why Illo answered the way it did.",
+        "",
+        "Files:",
+        "- trace.json: the full bounded trace snapshot, including run metadata, recent thread messages, events, tool calls, and artifacts.",
+        "- activity.json: a compact chronological list derived from trace.json.",
+        "- manifest.json: export metadata.",
+        "",
+        "Notes:",
+        "- Large strings and deep values may be truncated in place.",
+        "- The export can include prompts, assistant output, tool arguments/results, and artifact metadata.",
+        "- This export is generated on demand and is not saved as a database artifact.",
+        "",
+        f"Trace ID: {snapshot.get('trace_id') or 'unknown'}",
+        f"Run ID: {run.get('run_id') or 'unknown'}",
+        f"Estimated JSON bytes: {estimate.get('json_bytes') or 'unknown'}",
+        f"Truncated: {bool(estimate.get('truncated'))}",
+        "",
+    ])
 
 
 def _safe_list(value: Any) -> list[Any]:
@@ -239,6 +621,10 @@ def trace_id_for_scheduler_run_id(run_id: int | str | None) -> str | None:
 
 
 __all__ = [
+    "AGENT_TRACE_SNAPSHOT_ARTIFACT_TYPE",
+    "agent_trace_export_filename",
+    "build_agent_trace_snapshot",
+    "build_agent_trace_export_zip",
     "build_run_flight_recorder",
     "build_run_run_summary",
     "load_run_recordings",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -61,6 +61,53 @@ async function fetchJson<T>(path: string, init?: ApiRequestInit): Promise<T> {
   }
 }
 
+function filenameFromContentDisposition(value: string | null): string | null {
+  if (!value) return null;
+  const encoded = value.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded.replace(/^["']|["']$/g, ''));
+    } catch {
+      return encoded.replace(/^["']|["']$/g, '');
+    }
+  }
+  return value.match(/filename="?([^";]+)"?/i)?.[1] ?? null;
+}
+
+async function fetchBlob(path: string, init?: ApiRequestInit): Promise<{ blob: Blob; filename: string | null; headers: Headers }> {
+  const {
+    headers: extraHeaders,
+    timeoutMs = DEFAULT_API_TIMEOUT_MS,
+    signal,
+    ...rest
+  } = init ?? {};
+  const controller = !signal && timeoutMs > 0 ? new AbortController() : null;
+  const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      ...rest,
+      signal: signal ?? controller?.signal,
+      headers: { 'Content-Type': 'application/json', ...(extraHeaders as Record<string, string>) },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      throw { status: res.status, detail: err.error || err.detail || res.statusText };
+    }
+    return {
+      blob: await res.blob(),
+      filename: filenameFromContentDisposition(res.headers.get('content-disposition')),
+      headers: res.headers,
+    };
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw { status: 0, detail: 'Request timed out. Check the local server and try again.' };
+    }
+    throw err;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 function withQuery(
   path: string,
   params: Record<string, string | number | boolean | null | undefined>,
@@ -772,6 +819,15 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/cancel-all`, { method: 'POST' }),
   runGraph: (id: number) => fetchJson<any>(`/api/cortex/run/${id}/graph`),
   runTools: (id: number) => fetchJson<any[]>(`/api/cortex/runs/${id}/tools`),
+  downloadRunTraceZip: async (id: number) => {
+    const result = await fetchBlob(`/api/cortex/run/${id}/trace-export.zip`, { method: 'POST' });
+    return {
+      blob: result.blob,
+      filename: result.filename || `illo-trace-run-${id}.zip`,
+      bytes: result.blob.size,
+      traceId: result.headers.get('x-trace-id'),
+    };
+  },
   skillFeedback: (id: number, data: { note: string; quality: string }) =>
     fetchJson<any>(`/api/cortex/run/${id}/skill-feedback`, { method: 'POST', body: JSON.stringify(data) }),
   markRead: (ideaId: string) =>

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -8,6 +8,7 @@ export type ThreadRunHistoryItem = Awaited<ReturnType<typeof api.runHistory>>[nu
 export type RunDecisionResponse = Awaited<ReturnType<typeof api.approveRun>>;
 export type RunTool = Awaited<ReturnType<typeof api.runTools>>[number];
 export type RunGraph = Awaited<ReturnType<typeof api.runGraph>>;
+export type RunTraceZipDownload = Awaited<ReturnType<typeof api.downloadRunTraceZip>>;
 export type RunStatus = Awaited<ReturnType<typeof api.runStatus>>;
 export type ActiveOpsRun = Awaited<ReturnType<typeof api.opsActive>>[number];
 export type RecentOpsRun = Awaited<ReturnType<typeof api.opsRecent>>[number];
@@ -33,6 +34,7 @@ type ThreadApiMethods = {
   runStatus: () => Promise<RunStatus>;
   runGraph: (id: number) => Promise<RunGraph>;
   runTools: (id: number) => Promise<RunTool[]>;
+  downloadRunTraceZip: typeof api.downloadRunTraceZip;
   skillFeedback: typeof api.skillFeedback;
   opsActive: () => Promise<ActiveOpsRun[]>;
   opsRecent: (limit?: number, includeDebug?: boolean) => Promise<RecentOpsRun[]>;
@@ -63,6 +65,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'runStatus',
   'runGraph',
   'runTools',
+  'downloadRunTraceZip',
   'skillFeedback',
   'opsActive',
   'opsRecent',
@@ -92,6 +95,7 @@ export const {
   runStatus,
   runGraph,
   runTools,
+  downloadRunTraceZip,
   skillFeedback,
   opsActive,
   opsRecent,

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -5,6 +5,7 @@
     ConstellationIcon,
     ConstellationIconButton,
   } from '$lib/components/constellation';
+  import ThreadStageRightDockTabButton from './ThreadStageRightDockTabButton.svelte';
   import type {
     ThreadStageRightDockAddMenuItem,
     ThreadStageRightDockTab,
@@ -181,8 +182,7 @@
     onTabChange?.(nextTabId);
   }
 
-  function handleTabClose(tabId: string, event: MouseEvent) {
-    event.stopPropagation();
+  function handleTabClose(tabId: string) {
     addMenuOpen = false;
     onTabClose?.(tabId);
   }
@@ -245,48 +245,14 @@
           <div class="right-dock-tabs" role="tablist" aria-label="Thread side panel tabs">
             {#each availableTabs as tab (tab.id)}
               {@const isActive = tab.id === resolvedActiveTab?.id}
-              {#if tab.closeable}
-                <span
-                  class="right-dock-tab-group"
-                  class:is-active={isActive}
-                  role="presentation"
-                >
-                  <ConstellationIconButton
-                    className="right-dock-tab-close"
-                    size="sm"
-                    label={`Close ${tab.label}`}
-                    title={`Close ${tab.label}`}
-                    onclick={(event) => handleTabClose(tab.id, event)}
-                  >
-                    <ConstellationIcon name="close" size={10} stroke={2.2} />
-                  </ConstellationIconButton>
-                  <button
-                    type="button"
-                    class="right-dock-tab"
-                    class:is-app-tab={tab.kind === 'app'}
-                    class:is-active={isActive}
-                    role="tab"
-                    aria-selected={isActive}
-                    title={tab.label}
-                    onclick={() => handleTabChange(tab.id)}
-                  >
-                    <span class="right-dock-tab-label">{tab.label}</span>
-                  </button>
-                </span>
-              {:else}
-                <button
-                  type="button"
-                  class="right-dock-tab is-standalone"
-                  class:is-app-tab={tab.kind === 'app'}
-                  class:is-active={isActive}
-                  role="tab"
-                  aria-selected={isActive}
-                  title={tab.label}
-                  onclick={() => handleTabChange(tab.id)}
-                >
-                  <span class="right-dock-tab-label">{tab.label}</span>
-                </button>
-              {/if}
+              <ThreadStageRightDockTabButton
+                label={tab.label}
+                active={isActive}
+                appTab={tab.kind === 'app'}
+                closeable={Boolean(tab.closeable)}
+                onselect={() => handleTabChange(tab.id)}
+                onclose={() => handleTabClose(tab.id)}
+              />
             {/each}
           </div>
 
@@ -513,121 +479,6 @@
 
   .right-dock-tabs::-webkit-scrollbar {
     display: none;
-  }
-
-  .right-dock-tab {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    min-height: 28px;
-    padding: 0 8px;
-    border: 0;
-    border-radius: 999px;
-    background: transparent;
-    color: var(--constellation-utility-panel-tab-text);
-    font-family: var(--constellation-font-sans, var(--font-sans, system-ui, sans-serif));
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1;
-    letter-spacing: 0;
-    text-transform: none;
-    cursor: pointer;
-    transition:
-      background-color 160ms ease,
-      color 180ms ease,
-      opacity 180ms ease;
-  }
-
-  .right-dock-tab.is-app-tab {
-    min-width: 0;
-    justify-content: flex-start;
-  }
-
-  .right-dock-tab-group {
-    --right-dock-close-space: 0px;
-    display: inline-flex;
-    min-width: 0;
-    max-width: min(190px, 30vw);
-    height: 28px;
-    align-items: center;
-    gap: 0;
-    padding: 0 6px;
-    border-radius: 999px;
-    background: transparent;
-    color: var(--constellation-utility-panel-tab-text);
-    transition:
-      background-color 160ms ease,
-      color 160ms ease;
-  }
-
-  .right-dock-tab-group:hover,
-  .right-dock-tab-group:focus-within,
-  .right-dock-tab-group.is-active {
-    background: var(--right-dock-tab-active-background);
-  }
-
-  .right-dock-tab-group:hover,
-  .right-dock-tab-group:focus-within {
-    color: var(--constellation-utility-panel-tab-hover-text);
-  }
-
-  .right-dock-tab-group.is-active {
-    color: var(--constellation-utility-panel-tab-active-text);
-  }
-
-  .right-dock-tab-label {
-    display: inline-block;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .right-dock-tab-group .right-dock-tab {
-    min-width: 0;
-    flex: 1 1 auto;
-    justify-content: flex-start;
-    min-height: 28px;
-    padding: 0 4px;
-    color: inherit;
-    background: transparent;
-  }
-
-  .right-dock-tab.is-standalone:hover,
-  .right-dock-tab.is-standalone.is-active {
-    background: var(--right-dock-tab-active-background);
-  }
-
-  .right-dock-tab-group :global(.right-dock-tab-close.constellation-icon-button-sm) {
-    position: relative;
-    z-index: 1;
-    width: 0;
-    min-width: 0;
-    height: 28px;
-    flex: 0 0 auto;
-    overflow: hidden;
-    opacity: 0;
-    pointer-events: none;
-    transform: scale(0.92);
-    transition:
-      width 150ms ease,
-      opacity 150ms ease,
-      transform 150ms ease;
-  }
-
-  .right-dock-tab-group :global(.right-dock-tab-close .constellation-icon-button-icon) {
-    width: 11px;
-    height: 11px;
-  }
-
-  .right-dock-tab-group:hover :global(.right-dock-tab-close.constellation-icon-button-sm),
-  .right-dock-tab-group:focus-within :global(.right-dock-tab-close.constellation-icon-button-sm) {
-    width: 28px;
-    margin-right: 2px;
-    opacity: 1;
-    pointer-events: auto;
-    transform: scale(1);
   }
 
   .right-dock-add {
@@ -884,15 +735,16 @@
     min-height: 0;
   }
 
-  .right-dock-activity :global(.timeline-item) {
+  .right-dock-activity :global(.activity-list) {
+    width: 100%;
+  }
+
+  .right-dock-activity :global(.activity-list-item) {
     margin: 0;
-    padding: 11px 2px 12px;
-    border-width: 0 0 1px;
-    border-radius: 0;
     background: transparent;
   }
 
-  .right-dock-activity :global(.timeline-item:last-child) {
+  .right-dock-activity :global(.activity-list-item:last-child) {
     border-bottom-color: transparent;
   }
 

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDockTabButton.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDockTabButton.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { ConstellationIcon } from '$lib/components/constellation';
+
+  let {
+    label,
+    active = false,
+    appTab = false,
+    closeable = false,
+    onselect,
+    onclose,
+  }: {
+    label: string;
+    active?: boolean;
+    appTab?: boolean;
+    closeable?: boolean;
+    onselect?: () => void;
+    onclose?: () => void;
+  } = $props();
+
+  function handleClose(event: MouseEvent) {
+    event.stopPropagation();
+    onclose?.();
+  }
+</script>
+
+{#if closeable}
+  <span
+    class="right-dock-tab-button"
+    class:is-active={active}
+    role="presentation"
+  >
+    <button
+      type="button"
+      class="right-dock-tab-button-close"
+      aria-label={`Close ${label}`}
+      title={`Close ${label}`}
+      onclick={handleClose}
+    >
+      <ConstellationIcon name="close" size={10} stroke={2.2} />
+    </button>
+    <button
+      type="button"
+      class="right-dock-tab-button-tab"
+      class:is-app-tab={appTab}
+      class:is-active={active}
+      role="tab"
+      aria-selected={active}
+      title={label}
+      onclick={onselect}
+    >
+      <span class="right-dock-tab-button-label">{label}</span>
+    </button>
+  </span>
+{:else}
+  <button
+    type="button"
+    class="right-dock-tab-button-tab is-standalone"
+    class:is-app-tab={appTab}
+    class:is-active={active}
+    role="tab"
+    aria-selected={active}
+    title={label}
+    onclick={onselect}
+  >
+    <span class="right-dock-tab-button-label">{label}</span>
+  </button>
+{/if}
+
+<style>
+  .right-dock-tab-button-tab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    min-height: 28px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--constellation-utility-panel-tab-text);
+    font-family: var(--constellation-font-sans, var(--font-sans, system-ui, sans-serif));
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: 0;
+    text-transform: none;
+    cursor: pointer;
+    transition:
+      background-color 160ms ease,
+      color 180ms ease,
+      opacity 180ms ease;
+  }
+
+  .right-dock-tab-button-tab.is-app-tab {
+    min-width: 0;
+    justify-content: flex-start;
+  }
+
+  .right-dock-tab-button {
+    display: inline-flex;
+    min-width: 0;
+    max-width: min(190px, 30vw);
+    height: 28px;
+    align-items: center;
+    gap: 0;
+    padding: 0 6px;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--constellation-utility-panel-tab-text);
+    transition:
+      background-color 160ms ease,
+      color 160ms ease;
+  }
+
+  .right-dock-tab-button:hover,
+  .right-dock-tab-button:focus-within,
+  .right-dock-tab-button.is-active {
+    background: var(--right-dock-tab-active-background);
+  }
+
+  .right-dock-tab-button:hover,
+  .right-dock-tab-button:focus-within {
+    color: var(--constellation-utility-panel-tab-hover-text);
+  }
+
+  .right-dock-tab-button.is-active {
+    color: var(--constellation-utility-panel-tab-active-text);
+  }
+
+  .right-dock-tab-button-label {
+    display: inline-block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .right-dock-tab-button .right-dock-tab-button-tab {
+    min-width: 0;
+    flex: 1 1 auto;
+    justify-content: flex-start;
+    min-height: 28px;
+    padding: 0 4px;
+    color: inherit;
+    background: transparent;
+  }
+
+  .right-dock-tab-button-tab.is-standalone:hover,
+  .right-dock-tab-button-tab.is-standalone.is-active {
+    background: var(--right-dock-tab-active-background);
+  }
+
+  .right-dock-tab-button-close {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    width: 0;
+    min-width: 0;
+    height: 18px;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: currentColor;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0.88);
+    transition:
+      width 150ms ease,
+      margin-right 150ms ease,
+      opacity 150ms ease,
+      transform 150ms ease,
+      color 150ms ease;
+  }
+
+  .right-dock-tab-button-close:hover,
+  .right-dock-tab-button-close:focus-visible {
+    color: var(--constellation-utility-panel-tab-active-text);
+    opacity: 1;
+  }
+
+  .right-dock-tab-button-close:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .right-dock-tab-button-close :global(svg) {
+    width: 10px;
+    height: 10px;
+    flex: 0 0 auto;
+  }
+
+  .right-dock-tab-button:hover .right-dock-tab-button-close,
+  .right-dock-tab-button:focus-within .right-dock-tab-button-close {
+    width: 14px;
+    margin-right: 3px;
+    opacity: 0.82;
+    pointer-events: auto;
+    transform: scale(1);
+  }
+
+  .right-dock-tab-button-tab:hover {
+    color: var(--constellation-utility-panel-tab-hover-text);
+  }
+
+  .right-dock-tab-button-tab.is-active {
+    color: var(--constellation-utility-panel-tab-active-text);
+  }
+
+  .right-dock-tab-button-tab:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 4px;
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -68,9 +68,9 @@
   import ThreadAttachmentPreviewPane from '$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte';
   import ThreadStageShell, { type ThreadPeripherySignal } from '$lib/features/threads/components/ThreadStageShell.svelte';
   import ThreadUtilityContent from '$lib/features/threads/components/ThreadUtilityContent.svelte';
-  import VaultSecretPromptPanel from '$lib/features/vault/components/VaultSecretPromptPanel.svelte';
   import WorkspaceComposerAdapter from '$lib/features/composer/components/WorkspaceComposerAdapter.svelte';
   import ThreadAppsPane from '$lib/features/workspace-apps/components/ThreadAppsPane.svelte';
+  import VaultPage from '../../../../routes/vault/+page.svelte';
   import ThreadTranscript from './ThreadTranscript.svelte';
   import ThreadStageRightDock from './ThreadStageRightDock.svelte';
   import {
@@ -153,6 +153,7 @@
   let userScrolledUp = $state(false);
   let programmaticScroll = false;
   let showTranscriptScrollCue = $state(false);
+  let transcriptScrollFrame: number | null = null;
   let projectContextError = $state('');
   let ideaProjectContextAttachments = $state<any[]>([]);
   let ideaProjectContextLoadedForIdeaId: string | null = null;
@@ -215,6 +216,9 @@
   );
   const sidePanelAddMenuItems = $derived.by(() =>
     buildThreadSidePanelAddMenuItems(sidePanelTabs, workspaceApps.visibleApps),
+  );
+  const activeVaultSecretPrompt = $derived(
+    cortex.vaultSecretPrompt?.idea_id === idea?.id ? cortex.vaultSecretPrompt : null,
   );
 
   function ideaDisplayTitle(source: { display_title?: string | null; title?: string | null }): string {
@@ -462,9 +466,26 @@
     programmaticScroll = true;
     scrollConversationToBottom(transcriptEl);
     requestAnimationFrame(() => {
+      scrollConversationToBottom(transcriptEl);
       programmaticScroll = false;
       userScrolledUp = false;
       syncTranscriptScrollCue();
+    });
+  }
+
+  function keepTranscriptPinnedToBottom() {
+    if (!transcriptEl || userScrolledUp) {
+      syncTranscriptScrollCue();
+      return;
+    }
+
+    if (transcriptScrollFrame !== null) {
+      cancelAnimationFrame(transcriptScrollFrame);
+    }
+
+    transcriptScrollFrame = requestAnimationFrame(() => {
+      transcriptScrollFrame = null;
+      scrollToBottom(true);
     });
   }
 
@@ -960,6 +981,22 @@
   });
 
   $effect(() => {
+    const element = transcriptEl;
+    if (!element || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(keepTranscriptPinnedToBottom);
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+      if (transcriptScrollFrame !== null) {
+        cancelAnimationFrame(transcriptScrollFrame);
+        transcriptScrollFrame = null;
+      }
+    };
+  });
+
+  $effect(() => {
     const element = threadStagePanelEl;
     if (!element || typeof window === 'undefined') return;
 
@@ -983,6 +1020,10 @@
 
   onDestroy(() => {
     document.removeEventListener('click', handleDocClick);
+    if (transcriptScrollFrame !== null) {
+      cancelAnimationFrame(transcriptScrollFrame);
+      transcriptScrollFrame = null;
+    }
   });
 </script>
 
@@ -1123,11 +1164,22 @@
   {/snippet}
 
   {#snippet vaultPane()}
-    <VaultSecretPromptPanel
-      prompt={cortex.vaultSecretPrompt?.idea_id === idea?.id ? cortex.vaultSecretPrompt : null}
-      onSaved={(promptId) => cortex.clearVaultSecretPrompt(promptId)}
-      onDismiss={(promptId) => cortex.clearVaultSecretPrompt(promptId)}
-    />
+    <div class="thread-vault-surface">
+      <VaultPage
+        embedded
+        initialCreatePrefill={activeVaultSecretPrompt
+          ? {
+              id: activeVaultSecretPrompt.id,
+              keyName: activeVaultSecretPrompt.key_name,
+              description: activeVaultSecretPrompt.description,
+              category: activeVaultSecretPrompt.category,
+            }
+          : null}
+        onInitialCreateSaved={(promptId) => {
+          if (promptId) cortex.clearVaultSecretPrompt(promptId);
+        }}
+      />
+    </div>
   {/snippet}
 
   {#snippet cyclesPane()}
@@ -1285,6 +1337,71 @@
   .thread-utility-surface-body > :global(*) {
     flex: 1 1 auto;
     min-height: 0;
+  }
+
+  .thread-vault-surface {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded) {
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-scene-glow),
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-scene-warmth) {
+    display: none;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-shell) {
+    width: 100%;
+    gap: 12px;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-header) {
+    padding: 2px 2px 12px;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-header-head) {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-header-actions) {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 8px;
+  }
+
+  .thread-vault-surface :global(.vault-constellation-frame.is-embedded .constellation-page-frame-header-actions > *) {
+    flex: 1 1 auto;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded) {
+    gap: 12px;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded .inventory-tools) {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded .vault-list) {
+    padding: 0 10px 10px;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded .vault-row) {
+    grid-template-columns: 1fr;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded .vault-row-side) {
+    justify-items: start;
+  }
+
+  .thread-vault-surface :global(.vault-page.is-embedded .metadata-list) {
+    grid-template-columns: 1fr;
   }
 
   .thread-stage-panel::before,

--- a/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
@@ -5,6 +5,7 @@
     activityTimeline,
     auditApply,
     auditEval,
+    downloadRunTraceZip,
     getIdea,
     ideaAudit,
     ideaAuditAnalysisResult,
@@ -16,6 +17,16 @@
   import { formatDurationMs, formatDurationSeconds, relativeTimeAgo } from '$lib/utils/datetime';
 
   type UtilityTab = 'activity' | 'details' | 'audit';
+  type ActivityListItem = {
+    _key: string;
+    timestamp: string | null;
+    title: string;
+    meta: string[];
+    error?: string;
+    state?: string;
+    runId?: number;
+    canSaveTrace?: boolean;
+  };
 
   let {
     idea,
@@ -25,7 +36,7 @@
     activeTab?: UtilityTab;
   } = $props();
 
-  let activityItems = $state<any[]>([]);
+  let activityItems = $state<ActivityListItem[]>([]);
   let activityLoading = $state(false);
   let lastActivityIdeaId = $state<string | null>(null);
   let activityRequestSeq = 0;
@@ -48,6 +59,9 @@
   let evalResults = $state<Record<number, any>>({});
   let expandedRuns = $state<Set<number>>(new Set());
   let expandedWorkers = $state<Set<string>>(new Set());
+  let traceSaving = $state<Record<number, boolean>>({});
+  let traceSaved = $state<Record<number, { bytes?: number; filename?: string }>>({});
+  let traceErrors = $state<Record<number, string>>({});
 
   let pollAborted = $state(false);
   let loadedForIdeaId = $state<string | null>(null);
@@ -83,11 +97,52 @@
     evalResults = {};
     expandedRuns = new Set();
     expandedWorkers = new Set();
+    traceSaving = {};
+    traceSaved = {};
+    traceErrors = {};
     pollAborted = false;
   }
 
   const timeAgo = relativeTimeAgo;
   const formatDuration = formatDurationSeconds;
+  const EMOJI_PATTERN = /[\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}\u{200D}]/gu;
+
+  function cleanActivityText(value: unknown, fallback = 'Activity'): string {
+    const text = String(value ?? '')
+      .replace(EMOJI_PATTERN, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return text || fallback;
+  }
+
+  function formatActivityKind(value: unknown): string {
+    return cleanActivityText(value, 'event')
+      .replace(/[._-]+/g, ' ')
+      .replace(/\brun\b/i, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase() || 'event';
+  }
+
+  function compactCost(value: unknown): string | null {
+    if (value === null || value === undefined || value === '') return null;
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return null;
+    return `$${amount.toFixed(4)}`;
+  }
+
+  function runDuration(item: any): string | null {
+    if (typeof item.duration_sec === 'number') return formatDuration(item.duration_sec);
+    if (!item.started_at || !item.completed_at) return null;
+    const seconds = Math.round((new Date(item.completed_at).getTime() - new Date(item.started_at).getTime()) / 1000);
+    return Number.isFinite(seconds) ? formatDuration(seconds) : null;
+  }
+
+  function activityMeta(parts: Array<unknown>): string[] {
+    return parts
+      .map((part) => cleanActivityText(part, ''))
+      .filter(Boolean);
+  }
 
   async function loadActivity() {
     const ideaId = idea?.id;
@@ -104,45 +159,61 @@
     if (showLoadingState) activityLoading = true;
 
     try {
-      let timelineEvents: any[] = [];
+      let timelineEvents: ActivityListItem[] = [];
       try {
         const events = await activityTimeline(ideaId);
         timelineEvents = events.map((ev: any, index: number) => ({
           _key: `timeline-${ev.id ?? ev.timestamp ?? index}-${ev.label ?? ev.type ?? ''}`,
           timestamp: ev.timestamp,
-          type: 'timeline',
-          icon: ev.icon || '',
-          label: ev.label || '',
-          dotColor: ev.type === 'agent_started' ? 'var(--thread-accent, #57CFA0)' : ev.type === 'agent_finished' ? '#6BC785' : undefined,
+          title: cleanActivityText(ev.label || ev.type, 'Activity'),
+          meta: activityMeta([formatActivityKind(ev.type)]),
+          state: cleanActivityText(ev.type, 'event'),
         }));
       } catch { /* timeline API not available */ }
 
-      let runEvents: any[] = [];
+      let runEvents: ActivityListItem[] = [];
       try {
         const runs = await runHistory(ideaId);
-        runEvents = runs.map((dp: any) => ({
-          _key: `run-${dp.id ?? dp.run_id ?? dp.created_at ?? dp.started_at ?? dp.event}`,
-          timestamp: dp.created_at,
-          type: 'run',
-          status: dp.status,
-          event: dp.event || 'run',
-          skill_used: dp.skill_used,
-          model_used: dp.model_used,
-          thinking_used: dp.thinking_used,
-          tokens_total: dp.tokens_total,
-          started_at: dp.started_at,
-          completed_at: dp.completed_at,
-          error: dp.error,
-          estimated_cost: dp.estimated_cost,
-          skill_outcome: dp.skill_outcome,
-          dotColor: dp.status === 'completed' ? '#6BC785' : dp.status === 'failed' ? '#dc2626' : 'var(--thread-accent, #57CFA0)',
-        }));
+        runEvents = runs.flatMap((dp: any, index: number) => {
+          const runId = dp.id ?? dp.run_id ?? index;
+          const status = cleanActivityText(dp.status, 'run').toLowerCase();
+          const duration = runDuration(dp);
+          const cost = compactCost(dp.estimated_cost);
+          const tokens = typeof dp.tokens_total === 'number' ? `${dp.tokens_total.toLocaleString()} tok` : null;
+          const summary: ActivityListItem = {
+            _key: `run-${runId}-${dp.updated_at ?? dp.completed_at ?? dp.created_at ?? dp.started_at}`,
+            timestamp: dp.completed_at ?? dp.failed_at ?? dp.canceled_at ?? dp.started_at ?? dp.created_at,
+            title: `Run ${status}`,
+            meta: activityMeta([dp.skill_used, dp.model_used, duration, tokens, cost]),
+            error: dp.error ? cleanActivityText(String(dp.error).slice(0, 200), '') : undefined,
+            state: status,
+            runId: Number.isFinite(Number(runId)) ? Number(runId) : undefined,
+            canSaveTrace: Number.isFinite(Number(runId)),
+          };
+          const trace = Array.isArray(dp.activity_trace) ? dp.activity_trace : [];
+          const traceEvents: ActivityListItem[] = trace.map((entry: any, traceIndex: number) => ({
+            _key: `run-${runId}-trace-${entry.sequence_no ?? entry.at ?? traceIndex}`,
+            timestamp: entry.at ?? dp.started_at ?? dp.created_at,
+            title: cleanActivityText(entry.activity || entry.text, 'Run activity'),
+            meta: activityMeta([formatActivityKind(entry.kind), entry.tool_name]),
+            error: entry.error ? cleanActivityText(String(entry.error).slice(0, 200), '') : undefined,
+            state: entry.status ?? status,
+          }));
+          return [summary, ...traceEvents];
+        });
       } catch { /* run API not available */ }
 
       if (requestId !== activityRequestSeq || idea?.id !== ideaId) return;
 
+      const seen = new Set<string>();
       activityItems = [...timelineEvents, ...runEvents]
-        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        .filter((item: ActivityListItem) => {
+          const key = `${item.timestamp || ''}|${item.title}|${item.meta.join('|')}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        })
+        .sort((a, b) => new Date(b.timestamp || 0).getTime() - new Date(a.timestamp || 0).getTime());
     } catch {
       if (activityItems.length === 0) activityItems = [];
     } finally {
@@ -198,9 +269,32 @@
     cortex.selectIdea(linkedId);
   }
 
-  function statusIcon(s: string): string {
-    const icons: Record<string, string> = { completed: '✅', failed: '❌', timeout: '⏱️', running: '⚙️', queued: '📋' };
-    return icons[s] || '❔';
+  async function downloadTraceForRun(runId: number) {
+    if (!Number.isFinite(runId) || traceSaving[runId]) return;
+    traceSaving = { ...traceSaving, [runId]: true };
+    traceErrors = { ...traceErrors, [runId]: '' };
+    try {
+      const result = await downloadRunTraceZip(runId);
+      const url = URL.createObjectURL(result.blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = result.filename || `illo-trace-run-${runId}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+      traceSaved = {
+        ...traceSaved,
+        [runId]: {
+          bytes: result.bytes,
+          filename: result.filename,
+        },
+      };
+    } catch (e: any) {
+      traceErrors = { ...traceErrors, [runId]: e?.detail || 'Trace download failed' };
+    } finally {
+      traceSaving = { ...traceSaving, [runId]: false };
+    }
   }
 
   function loadUtilityTab(tab: UtilityTab) {
@@ -335,44 +429,56 @@
   {:else if activityItems.length === 0}
     <div class="tab-empty">No activity yet.</div>
   {:else}
-    {#each activityItems as item (item._key)}
-      <div class="timeline-item">
-        <div class="timeline-dot" style="background: {item.dotColor || 'var(--text-3)'};"></div>
-        <div style="flex: 1;">
-          {#if item.type === 'run'}
-            <div class="timeline-text">
-              {statusIcon(item.status)} {item.event}
-              {#if item.skill_used}
-                <span class="dbadge" style="background: #6366f1;">{item.skill_used}</span>
-              {/if}
-              {#if item.model_used}
-                <span class="dbadge" style="background: #0891b2;">{item.model_used}</span>
-              {/if}
-            </div>
-            <div class="timeline-time">
-              {timeAgo(item.timestamp)}
-              {#if item.started_at}
-                &middot; {formatDuration(item.started_at && item.completed_at
-                  ? Math.round((new Date(item.completed_at).getTime() - new Date(item.started_at).getTime()) / 1000)
-                  : undefined)}
-              {/if}
-              {#if item.tokens_total}
-                &middot; {item.tokens_total.toLocaleString()} tok
-              {/if}
-              {#if item.estimated_cost}
-                &middot; ${Number(item.estimated_cost).toFixed(4)}
+    <div class="activity-list" aria-label="Thread activity">
+      {#each activityItems as item (item._key)}
+        {@const savedTrace = item.runId ? traceSaved[item.runId] : null}
+        <div class="activity-list-item" data-state={item.state}>
+          <time class="activity-time" datetime={item.timestamp || undefined}>
+            {timeAgo(item.timestamp)}
+          </time>
+          <div class="activity-body">
+            <div class="activity-title-row">
+              <div class="activity-title">{item.title}</div>
+              {#if item.canSaveTrace && item.runId}
+                <button
+                  type="button"
+                  class="activity-trace-button"
+                  disabled={traceSaving[item.runId]}
+                  onclick={() => item.runId && downloadTraceForRun(item.runId)}
+                >
+                  {traceSaving[item.runId]
+                    ? 'Preparing'
+                    : savedTrace
+                      ? 'Download again'
+                      : 'Download trace'}
+                </button>
               {/if}
             </div>
-            {#if item.error}
-              <div class="timeline-error">Error: {item.error.substring(0, 200)}</div>
+            {#if item.meta.length}
+              <div class="activity-meta">
+                {#each item.meta as meta}
+                  <span class="activity-meta-part">{meta}</span>
+                {/each}
+              </div>
             {/if}
-          {:else}
-            <div class="timeline-text">{item.icon} {item.label}</div>
-            <div class="timeline-time">{timeAgo(item.timestamp)}</div>
-          {/if}
+            {#if savedTrace}
+              <div class="activity-trace-note">
+                {savedTrace.filename || 'Trace zip'}
+                {#if savedTrace.bytes}
+                  &middot; {savedTrace.bytes.toLocaleString()} bytes
+                {/if}
+              </div>
+            {/if}
+            {#if item.runId && traceErrors[item.runId]}
+              <div class="activity-error">{traceErrors[item.runId]}</div>
+            {/if}
+            {#if item.error}
+              <div class="activity-error">Error: {item.error}</div>
+            {/if}
+          </div>
         </div>
-      </div>
-    {/each}
+      {/each}
+    </div>
   {/if}
 {:else if activeTab === 'details'}
   {#if detailsLoading}
@@ -888,51 +994,137 @@
   }
 
 
-  /* ── Timeline (Activity tab) ─────────────────────────── */
-  .timeline-item {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    gap: 12px;
-    padding: 14px 14px 15px;
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.04);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
-    font-size: 12px;
-    margin-bottom: 10px;
-  }
-
-  .timeline-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--text-3);
-    margin-top: 7px;
-    flex-shrink: 0;
-    box-shadow: none;
-  }
-
-  .timeline-text {
-    color: rgba(239, 244, 251, 0.88);
+  /* Activity tab */
+  .activity-list {
     display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-wrap: wrap;
-    line-height: 1.5;
+    flex-direction: column;
+    width: 100%;
+    min-width: 0;
   }
 
-  .timeline-time {
-    color: rgba(231, 238, 247, 0.44);
+  .activity-list-item {
+    display: grid;
+    grid-template-columns: 48px minmax(0, 1fr);
+    gap: 10px;
+    width: 100%;
+    min-width: 0;
+    padding: 8px 2px 9px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 12px;
+  }
+
+  .activity-list-item:last-child {
+    border-bottom-color: transparent;
+  }
+
+  .activity-time {
+    min-width: 0;
+    color: rgba(231, 238, 247, 0.48);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.35;
+    letter-spacing: 0.02em;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .activity-body {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .activity-title-row {
+    min-width: 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .activity-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: rgba(239, 244, 251, 0.9);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.35;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .activity-trace-button {
+    flex: 0 0 auto;
+    min-height: 20px;
+    padding: 2px 7px;
+    border: 0;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(231, 238, 247, 0.66);
+    font: inherit;
     font-size: 10px;
-    margin-top: 6px;
-    font-family: var(--font-mono);
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
+    line-height: 1.4;
+    cursor: pointer;
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      transform 150ms ease;
   }
 
-  .timeline-error {
+  .activity-trace-button:hover:not(:disabled),
+  .activity-trace-button:focus-visible {
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 14%, transparent);
+    color: rgba(239, 244, 251, 0.9);
+  }
+
+  .activity-trace-button:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--thread-accent, #57CFA0) 35%, transparent);
+    outline-offset: 2px;
+  }
+
+  .activity-trace-button:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+
+  .activity-trace-button:disabled {
+    cursor: default;
+    opacity: 0.62;
+  }
+
+  .activity-meta {
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 8px;
+    color: rgba(231, 238, 247, 0.52);
+    font-size: 10px;
+    line-height: 1.35;
+  }
+
+  .activity-meta-part {
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .activity-trace-note {
+    min-width: 0;
+    color: rgba(231, 238, 247, 0.48);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+  }
+
+  .activity-error {
+    min-width: 0;
     color: var(--negative, #D4808F);
     font-size: 11px;
-    margin-top: 8px;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   /* ── Details tab ─────────────────────────────────────── */
@@ -1740,7 +1932,9 @@
   }
 
   .tab-empty,
-  .timeline-time,
+  .activity-time,
+  .activity-meta,
+  .activity-trace-note,
   .details-empty,
   .details-meta,
   .link-meta,
@@ -1760,7 +1954,7 @@
     color: var(--panel-utility-muted-text);
   }
 
-  .timeline-text,
+  .activity-title,
   .details-desc,
   .details-meta strong,
   .link-item,
@@ -1782,7 +1976,6 @@
     color: var(--panel-utility-primary-hover-text);
   }
 
-  .timeline-item,
   .details-section,
   .audit-card,
   .audit-efficiency,
@@ -1797,6 +1990,7 @@
   }
 
   .link-item,
+  .activity-list-item,
   .metrics-section,
   .metrics-row,
   .audit-eval-row + .audit-eval-row,

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -169,13 +169,14 @@
   // ── Constants (from cortex-core.js) ────────────────────────
   const ILLO_AGENT_ROLES = ['illo', 'agent', 'assistant'];
 
-  // Ownership accent color stays subtle; position remains the primary ownership cue.
+  // Ownership accents follow the orbit anchor: the astre/pin a thread belongs to.
   function ownerColor(d: any): string {
-    const explicitAuthorColor = normalizeHexColor(d.author_color);
-    if (explicitAuthorColor) return explicitAuthorColor;
-
-    const explicitUserColor = normalizeHexColor(d.user_color);
-    if (explicitUserColor) return explicitUserColor;
+    const anchorKey = itemOrbitAnchorKey(d);
+    const anchor = orbitAnchorLookup?.byId?.get(anchorKey)
+      ?? orbitAnchorLookup?.byAnchorKey?.get(anchorKey)
+      ?? attractorLookup?.byId?.get(anchorKey);
+    const anchorColor = normalizeHexColor(anchor?.color);
+    if (anchorColor) return anchorColor;
 
     const currentUserColor = d.user_id === auth.user?.id
       ? normalizeHexColor(auth.user?.color)
@@ -186,6 +187,9 @@
       const attractorColor = normalizeHexColor(attractorLookup.byId.get(d.user_id)!.color);
       if (attractorColor) return attractorColor;
     }
+
+    const explicitUserColor = normalizeHexColor(d.user_color);
+    if (explicitUserColor) return explicitUserColor;
 
     return '#f0f0fa';
   }

--- a/frontend/src/routes/vault/+page.svelte
+++ b/frontend/src/routes/vault/+page.svelte
@@ -79,6 +79,12 @@
 
   type FilterMode = 'all' | 'attention' | 'grants';
   type PillTone = 'muted' | 'warning' | 'success' | 'danger' | 'info';
+  type VaultInitialCreatePrefill = {
+    id?: string | null;
+    keyName?: string | null;
+    description?: string | null;
+    category?: string | null;
+  };
   type VaultRow =
     | { id: string; kind: 'secret'; secret: Secret }
     | { id: string; kind: 'grant'; grant: AgentGrant }
@@ -98,6 +104,16 @@
     { key: 'available', label: 'Agent Available' },
     { key: 'manual', label: 'Manual Only' },
   ];
+
+  let {
+    embedded = false,
+    initialCreatePrefill = null,
+    onInitialCreateSaved,
+  }: {
+    embedded?: boolean;
+    initialCreatePrefill?: VaultInitialCreatePrefill | null;
+    onInitialCreateSaved?: (prefillId?: string | null) => void;
+  } = $props();
 
   let secrets = $state<Secret[]>([]);
   let missing = $state<MissingSecret[]>([]);
@@ -130,6 +146,7 @@
   let formSaving = $state(false);
   let showPassword = $state(false);
   let initialCreatePrefillApplied = $state(false);
+  let appliedInitialCreatePrefillSignature = $state<string | null>(null);
 
   // Edit form
   let showEditModal = $state(false);
@@ -165,6 +182,12 @@
   let copiedKey = $state('');
 
   const isVaultPreview = $derived(dev && $page.url.searchParams.get('preview') === '1');
+  const frameClassName = $derived(
+    ['vault-constellation-frame', embedded ? 'is-embedded' : ''].filter(Boolean).join(' '),
+  );
+  const frameContentClassName = $derived(
+    ['vault-page', embedded ? 'is-embedded' : ''].filter(Boolean).join(' '),
+  );
   const vaultSessionStorageKey = $derived(
     auth.user?.id ? `${VAULT_SESSION_STORAGE_PREFIX}:${String(auth.user.id)}` : '',
   );
@@ -235,6 +258,11 @@
 
   onDestroy(() => {
     Object.values(revealTimers).forEach(clearTimeout);
+  });
+
+  $effect(() => {
+    if (!initialCreatePrefill?.keyName || loading || vaultLocked) return;
+    maybeApplyInitialCreatePrefill();
   });
 
   function previewIso(daysAgo: number, hoursAgo = 0): string {
@@ -740,7 +768,24 @@
   }
 
   function maybeApplyInitialCreatePrefill() {
-    if (initialCreatePrefillApplied || vaultLocked) return;
+    if (vaultLocked) return;
+    const propKeyName = (initialCreatePrefill?.keyName || '').trim();
+    if (propKeyName) {
+      const signature = JSON.stringify([
+        propKeyName,
+        initialCreatePrefill?.description ?? '',
+        initialCreatePrefill?.category ?? '',
+      ]);
+      if (appliedInitialCreatePrefillSignature === signature) return;
+      appliedInitialCreatePrefillSignature = signature;
+      openCreate(propKeyName, {
+        description: initialCreatePrefill?.description,
+        category: initialCreatePrefill?.category,
+      });
+      return;
+    }
+
+    if (initialCreatePrefillApplied) return;
     const params = $page.url.searchParams;
     const keyName = (params.get('add_secret') || params.get('key_name') || '').trim();
     if (!keyName) return;
@@ -749,6 +794,12 @@
       description: params.get('description'),
       category: params.get('category'),
     });
+  }
+
+  function notifyInitialCreateSaved(keyName: string) {
+    const prefillKeyName = (initialCreatePrefill?.keyName || '').trim();
+    if (!prefillKeyName || prefillKeyName !== keyName.trim()) return;
+    onInitialCreateSaved?.(initialCreatePrefill?.id ?? null);
   }
 
   async function submitCreate() {
@@ -776,6 +827,7 @@
       missing = missing.filter((item) => item.key_name !== keyName);
       selectedRowId = `secret:${keyName}`;
       showCreateModal = false;
+      notifyInitialCreateSaved(keyName);
       ui.toast('Preview secret added', 'success');
       return;
     }
@@ -790,6 +842,7 @@
       }, vaultToken);
       ui.toast('Secret created', 'success');
       showCreateModal = false;
+      notifyInitialCreateSaved(formKeyName.trim());
       await loadData();
     } catch (err: any) {
       handleVaultError(err, 'Create failed');
@@ -1047,6 +1100,7 @@
     eyebrow="Constellation Vault"
     title="Vault"
     subtitle="Protected secrets, missing runtime keys, and shared access."
+    className={frameClassName}
   >
     <div class="vault-constellation-lock-panel">
       <ConstellationPanel tone="warning">
@@ -1083,7 +1137,8 @@
     eyebrow="Constellation Vault"
     title="Vault"
     subtitle={loading ? 'Loading protected secrets, missing keys, and lock state.' : `${secrets.length} secrets · ${categoryCount} categories tracked.`}
-    contentClassName="vault-page"
+    className={frameClassName}
+    contentClassName={frameContentClassName}
   >
     {#snippet actions()}
       {#if hasPin}

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import zipfile
+
+
+def _result(rows):
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+def _run(**overrides):
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    values = {
+        "id": 42,
+        "trace_id": "run:42",
+        "thread_id": "idea-1",
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "parent_run_id": None,
+        "root_run_id": None,
+        "profile": "fast",
+        "recipe": "direct",
+        "status": "completed",
+        "input_message": "Explain the activity panel",
+        "target_ref": {"event": "thread_reply"},
+        "workspace_ref": {"cwd": "/repo"},
+        "model_policy": {"model": "openai:gpt-5.4"},
+        "context_summary": "Used recent thread context.",
+        "metadata_": {"source": "test"},
+        "created_at": now,
+        "updated_at": now,
+        "started_at": now,
+        "paused_at": None,
+        "completed_at": now,
+        "failed_at": None,
+        "canceled_at": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_agent_trace_snapshot_is_bounded_and_analysis_ready():
+    from brain.systems.runs.cortex.recording import build_agent_trace_snapshot
+    from brain.platform.db.models.agent_run import AgentRunRow
+
+    run = _run()
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    message = SimpleNamespace(
+        id=9,
+        idea_id="idea-1",
+        role="illo",
+        content="Final answer " + ("x" * 5000),
+        attachments=[],
+        metadata_={"run_id": 42, "trace_id": "run:42", "private": "not copied"},
+        message_type="message",
+        created_at=now,
+    )
+    event = SimpleNamespace(
+        id=99,
+        run_id=42,
+        root_run_id=42,
+        sequence_no=3,
+        event_type="run.tool_completed",
+        payload={"tool_name": "read_file", "args": {"path": "README.md"}, "result": "y" * 5000},
+        producer="agent_runtime",
+        visibility="public",
+        created_at=now,
+    )
+    artifact = SimpleNamespace(
+        id=100,
+        run_id=42,
+        root_run_id=42,
+        artifact_type="reply",
+        title="Final reply",
+        payload={"large": "z" * 5000},
+        text="artifact text",
+        uri=None,
+        visibility="public",
+        created_at=now,
+    )
+
+    session = MagicMock()
+    session.get.side_effect = lambda model, key: run if model is AgentRunRow and key == 42 else None
+    session.scalars.side_effect = [
+        _result([42]),
+        _result([message]),
+        _result([event]),
+        _result([artifact]),
+    ]
+
+    snapshot = build_agent_trace_snapshot(session, run, saved_by="user-1")
+
+    assert snapshot["schema_version"] == 1
+    assert snapshot["trace_id"] == "run:42"
+    assert snapshot["thread"]["messages"][0]["metadata"] == {
+        "run_id": 42,
+        "trace_id": "run:42",
+        "execution_profile": None,
+        "live_agent_text": None,
+    }
+    assert snapshot["tools"][0]["tool_name"] == "read_file"
+    assert snapshot["artifacts"][0]["artifact_type"] == "reply"
+    assert snapshot["storage_estimate"]["truncated"] is True
+    assert "not copied" not in str(snapshot)
+
+
+def test_agent_trace_export_zip_contains_shareable_trace_files():
+    from brain.systems.runs.cortex.recording import (
+        agent_trace_export_filename,
+        build_agent_trace_export_zip,
+    )
+
+    snapshot = {
+        "schema_version": 1,
+        "trace_id": "run:42",
+        "run": {
+            "run_id": 42,
+            "status": "completed",
+            "started_at": "2026-05-12T12:00:00+00:00",
+            "input_message": "Why did Illo answer that?",
+        },
+        "thread": {
+            "messages": [
+                {
+                    "id": 1,
+                    "role": "user",
+                    "created_at": "2026-05-12T12:00:01+00:00",
+                    "message_type": "message",
+                    "content": "Original prompt",
+                    "metadata": {"run_id": 42, "trace_id": "run:42"},
+                }
+            ]
+        },
+        "events": [
+            {
+                "id": 2,
+                "run_id": 42,
+                "sequence_no": 1,
+                "event_type": "run.tool_completed",
+                "created_at": "2026-05-12T12:00:02+00:00",
+                "payload": {"tool_name": "read_file", "result": "ok"},
+            }
+        ],
+        "artifacts": [],
+        "storage_estimate": {"json_bytes": 512, "truncated": False},
+    }
+
+    archive_bytes = build_agent_trace_export_zip(snapshot)
+
+    assert agent_trace_export_filename(snapshot) == "illo-trace-run-42.zip"
+    with zipfile.ZipFile(BytesIO(archive_bytes)) as archive:
+        assert set(archive.namelist()) == {"README.md", "activity.json", "manifest.json", "trace.json"}
+        manifest = json.loads(archive.read("manifest.json"))
+        trace = json.loads(archive.read("trace.json"))
+        activity = json.loads(archive.read("activity.json"))
+        readme = archive.read("README.md").decode("utf-8")
+
+    assert "artifact_id" not in manifest
+    assert manifest["trace_id"] == "run:42"
+    assert trace["run"]["input_message"] == "Why did Illo answer that?"
+    assert activity["item_count"] == 3
+    assert "trace.json" in readme
+    assert "not saved as a database artifact" in readme


### PR DESCRIPTION
## Summary
- add a bounded run trace snapshot/export zip path with backend coverage and frontend API helpers
- refresh the thread utility/right-dock flow, including tab button extraction and trace export actions
- embed Vault in the thread side panel and keep the transcript pinned when the composer grows so the latest message stays visible

## Tests
- npm run check
- venv/bin/python -m pytest tests/test_agent_trace_snapshot.py

## Notes
- `npm run check` passes with the existing memory-page warnings still present.
