### PR TITLE
Fix Docker project workspaces

### DIFF
--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -19,7 +19,6 @@ from brain.systems.cortex.project_context.github import (
     parse_github_repo_slug,
     search_repos,
 )
-from brain.systems.cortex.project_context.permissions import derive_project_permission_scope
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
 from brain.systems.cortex.project_context.resources import normalize_project_resource
 from brain.systems.cortex.project_context.schemas import (
@@ -38,7 +37,10 @@ from brain.systems.cortex.project_context.schemas import (
     ProjectResourcesCreate,
     ProjectResourcesReorder,
 )
-from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
+from brain.systems.cortex.project_context.snapshot import (
+    ProjectContextValidationError,
+    validated_project_context_snapshot,
+)
 from brain.systems.cortex.project_context.uploads import (
     ProjectContextUploadError,
     save_project_context_uploads,
@@ -95,10 +97,11 @@ def _get_project_profile(
     return profile
 
 
-def _validate_project_context(project_context: dict[str, Any]) -> None:
-    snapshot = snapshot_from_project_context(project_context)
-    if snapshot.get("status") == "invalid":
-        raise HTTPException(status_code=422, detail={"validation_errors": snapshot.get("validation_errors") or []})
+def _validated_snapshot_or_422(project_context: dict[str, Any]) -> dict[str, Any]:
+    try:
+        return validated_project_context_snapshot(project_context)
+    except ProjectContextValidationError as exc:
+        raise HTTPException(status_code=422, detail={"validation_errors": exc.errors}) from exc
 
 
 def _resource_identity(resource: dict[str, Any]) -> str:
@@ -132,7 +135,7 @@ def _project_resources(profile: ProjectProfile) -> list[dict[str, Any]]:
 def _replace_project_resources(profile: ProjectProfile, resources: list[dict[str, Any]]) -> None:
     context = dict(profile.project_context or {})
     context["resources"] = resources
-    _validate_project_context(context)
+    _validated_snapshot_or_422(context)
     profile.project_context = context
 
 
@@ -157,7 +160,7 @@ def create_project_profile(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    _validate_project_context(body.project_context)
+    _validated_snapshot_or_422(body.project_context)
     existing_stmt = _profile_scope_stmt(org_id).where(ProjectProfile.slug == body.slug)
     existing = db.scalar(existing_stmt)
     if existing is not None:
@@ -214,7 +217,7 @@ def update_project_profile(
     if "description" in fields:
         profile.description = body.description
     if "project_context" in fields and body.project_context is not None:
-        _validate_project_context(body.project_context)
+        _validated_snapshot_or_422(body.project_context)
         profile.project_context = body.project_context
     if "default_environment_binding_id" in fields:
         profile.default_environment_binding_id = body.default_environment_binding_id
@@ -481,16 +484,13 @@ def attach_idea_project_context(
         project_context = dict(profile.project_context or {})
     if not project_context:
         raise HTTPException(status_code=422, detail="project_profile_id or project_context is required")
-    snapshot = snapshot_from_project_context(project_context)
-    if snapshot.get("status") == "invalid":
-        raise HTTPException(status_code=422, detail={"validation_errors": snapshot.get("validation_errors") or []})
-    permission_scope = snapshot.get("permission_scope") or derive_project_permission_scope(snapshot)
+    snapshot = _validated_snapshot_or_422(project_context)
     attachment = IdeaProjectAttachment(
         idea_id=idea_id,
         project_profile_id=profile.id if profile else body.project_profile_id,
         attached_by=str(user.get("id")) if user.get("id") else None,
         snapshot=snapshot,
-        permission_scope=permission_scope,
+        permission_scope=snapshot.get("permission_scope") or {},
         status=str(snapshot.get("status") or "validated"),
         validation_errors=snapshot.get("validation_errors") or [],
         environment_binding_id=body.environment_binding_id

--- a/brain/kernel/config.py
+++ b/brain/kernel/config.py
@@ -31,7 +31,20 @@ except ImportError:
 # Paths
 # ---------------------------------------------------------------------------
 BRAIN_DIR = Path(__file__).resolve().parents[2]  # repository root
-WORKSPACE_ROOT = Path(os.getenv("WORKSPACE_ROOT", BRAIN_DIR.parent))
+
+
+def resolve_workspace_root(*, default: Path | None = None) -> Path:
+    """Return the configured agent workspace root.
+
+    `WORKSPACE_ROOT` is the deploy contract. `ILLO_WORKSPACE_ROOT` is accepted
+    as a compatibility fallback for older local shells.
+    """
+
+    configured = os.getenv("WORKSPACE_ROOT") or os.getenv("ILLO_WORKSPACE_ROOT")
+    return Path(configured) if configured else (default or BRAIN_DIR.parent)
+
+
+WORKSPACE_ROOT = resolve_workspace_root()
 
 # Runtime-private agent state. Keep operator prompts, generated journals, logs,
 # uploads, and local brain exports out of the public source tree by default.

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -26,7 +26,11 @@ class ProjectContextMaterializationResult:
 
     @property
     def ok(self) -> bool:
-        return not self.errors
+        return bool(self.workspaces) and not self.errors
+
+    def fail(self, message: str) -> "ProjectContextMaterializationResult":
+        self.errors.append(message)
+        return self
 
 
 def _clean_text(value: Any) -> str | None:
@@ -396,22 +400,24 @@ def materialize_project_context_workspaces(
     """Clone Project Context repos and expose them through AgentRun.workspace_ref."""
 
     result = ProjectContextMaterializationResult()
-    if not run_id or not workspace_root:
-        return result
+    if not run_id:
+        return result.fail("Project Context materialization requires a run id.")
+    if not workspace_root:
+        return result.fail("Project Context materialization requires a workspace root.")
 
     root = Path(workspace_root).expanduser()
     with UnitOfWork() as uow:
         run = uow.session.get(AgentRun, run_id)
         if not run:
-            return result
+            return result.fail(f"Agent run {run_id} was not found.")
         metadata = dict(getattr(run, "metadata_", None) or {})
         snapshot = _snapshot_from_run(run)
         if not isinstance(snapshot, dict):
-            return result
+            return result.fail("Project Context snapshot is missing.")
         snapshot = dict(snapshot)
         resources = [dict(item) for item in snapshot.get("resources") or [] if isinstance(item, dict)]
         if not resources:
-            return result
+            return result.fail("Project Context has no resources to materialize.")
         snapshot["resources"] = resources
         user_id = user_id or (str(run.user_id) if getattr(run, "user_id", None) else None)
         org_id = org_id or _clean_text(getattr(run, "org_id", None)) or _clean_text(metadata.get("org_id"))
@@ -434,7 +440,7 @@ def materialize_project_context_workspaces(
             result.errors.append(error)
 
     if not result.resources_checked:
-        return result
+        return result.fail("Project Context resources do not include a supported repository.")
 
     result.workspaces = workspaces
     status = "materialized" if not result.errors else "failed"

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -26,11 +26,18 @@ _RESOURCE_LOCATOR_KEYS = ("path", "uri", "name")
 _BROWSER_ONLY_URI_SCHEMES = {"browser", "browser-file", "browser-folder"}
 
 
+class ProjectContextValidationError(ValueError):
+    """Raised when an explicit Project Context cannot produce a usable snapshot."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("Invalid project context: " + "; ".join(errors))
+
+
 def _clean_scalar(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
-
 
 
 def _redact_remote(remote: str | None) -> str | None:
@@ -49,6 +56,7 @@ def _redact_remote(remote: str | None) -> str | None:
     if "://" not in remote and "@" in remote and ":" in remote.split("@", 1)[-1]:
         return f"***@{remote.split('@', 1)[-1]}"
     return remote
+
 
 def _run_git(path: str, *args: str) -> str | None:
     try:
@@ -176,9 +184,7 @@ def validate_project_context_snapshot(
     if not isinstance(resources, list):
         return "invalid", ["project_context_snapshot.resources must be a list."]
     if not resources:
-        if _clean_scalar(snapshot.get("name")) or _clean_scalar(snapshot.get("id")):
-            return "validated", []
-        return "invalid", ["project_context_snapshot.resources must contain at least one resource unless the project has a name or id."]
+        return "invalid", ["project_context_snapshot.resources must contain at least one resource."]
 
     errors: list[str] = []
     seen_ids: set[str] = set()
@@ -241,6 +247,17 @@ def validate_project_context_snapshot(
     return ("invalid" if errors else "validated", errors)
 
 
+def _finalize_snapshot(snapshot: dict[str, Any], *, validate_local_paths: bool) -> dict[str, Any]:
+    status, errors = validate_project_context_snapshot(snapshot, validate_local_paths=validate_local_paths)
+    snapshot["status"] = status
+    if errors:
+        snapshot["validation_errors"] = errors
+    else:
+        snapshot.pop("validation_errors", None)
+    snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
+    return snapshot
+
+
 def build_project_context_snapshot(
     metadata: Mapping[str, Any] | None,
     *,
@@ -278,14 +295,7 @@ def build_project_context_snapshot(
                 snapshot[key] = value
         if run_id is not None:
             snapshot["run_id"] = run_id
-        if resources or any(k in snapshot for k in ("id", "name")):
-            status, errors = validate_project_context_snapshot(snapshot, validate_local_paths=validate_local_paths)
-            snapshot["status"] = status
-            if errors:
-                snapshot["validation_errors"] = errors
-            snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
-            return snapshot
-        return None
+        return _finalize_snapshot(snapshot, validate_local_paths=validate_local_paths)
 
     target = metadata.get("target")
     if isinstance(target, Mapping):
@@ -299,12 +309,7 @@ def build_project_context_snapshot(
             }
             if run_id is not None:
                 snapshot["run_id"] = run_id
-            status, errors = validate_project_context_snapshot(snapshot, validate_local_paths=validate_local_paths)
-            snapshot["status"] = status
-            if errors:
-                snapshot["validation_errors"] = errors
-            snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
-            return snapshot
+            return _finalize_snapshot(snapshot, validate_local_paths=validate_local_paths)
     return None
 
 
@@ -319,16 +324,18 @@ def snapshot_from_project_context(
         {"project_context": project_context},
         validate_local_paths=validate_local_paths,
     )
-    if snapshot is None:
-        snapshot = dict(project_context)
-        status, errors = validate_project_context_snapshot(
-            snapshot,
-            validate_local_paths=validate_local_paths,
-        )
-        snapshot["status"] = status
-        if errors:
-            snapshot["validation_errors"] = errors
-    snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
+    return snapshot if snapshot is not None else _finalize_snapshot(dict(project_context), validate_local_paths=validate_local_paths)
+
+
+def validated_project_context_snapshot(
+    project_context: Mapping[str, Any],
+    *,
+    validate_local_paths: bool = True,
+) -> dict[str, Any]:
+    snapshot = snapshot_from_project_context(project_context, validate_local_paths=validate_local_paths)
+    if snapshot.get("status") == "invalid":
+        errors = [str(error) for error in (snapshot.get("validation_errors") or [])]
+        raise ProjectContextValidationError(errors or ["Project Context is invalid."])
     return snapshot
 
 
@@ -347,15 +354,7 @@ def attach_project_context_snapshot(
         validate_local_paths=validate_local_paths,
     )
     if snapshot is None and isinstance(metadata, Mapping) and isinstance(metadata.get("project_context_snapshot"), Mapping):
-        snapshot = dict(metadata["project_context_snapshot"])
-        if "status" not in snapshot:
-            status, errors = validate_project_context_snapshot(
-                snapshot,
-                validate_local_paths=validate_local_paths,
-            )
-            snapshot["status"] = status
-            if errors:
-                snapshot["validation_errors"] = errors
+        snapshot = _finalize_snapshot(dict(metadata["project_context_snapshot"]), validate_local_paths=validate_local_paths)
     if snapshot:
         payload["project_context_snapshot"] = snapshot
     return payload

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -16,6 +16,7 @@ import uuid
 
 from sqlalchemy import func, select
 
+from brain.kernel import config as brain_config
 from brain.systems.runs.cancel import RunCancelToken
 from brain.systems.runs.engine import AgentRunEngine
 from brain.systems.runs.events import activity_event, run_event
@@ -212,8 +213,7 @@ def _run_has_project_context(run: AgentRunRow | None) -> bool:
 
 
 def _project_context_root(run_id: int, *, thread_id: str | None = None) -> str:
-    configured = os.environ.get("ILLO_PROJECT_CONTEXT_WORKSPACE_ROOT")
-    base = Path(configured).expanduser() if configured else Path(tempfile.gettempdir()) / "illo-agent-runs"
+    base = brain_config.resolve_workspace_root(default=Path(tempfile.gettempdir()) / "illo-agent-runs").expanduser()
     if thread_id:
         safe_thread_id = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in str(thread_id))[:120]
         if safe_thread_id:
@@ -467,11 +467,11 @@ def _reap_stale_runs_if_due(*, force: bool = False) -> int:
         return 0
 
 
-def _materialize_project_context(run_id: int) -> None:
+def _materialize_project_context(run_id: int) -> tuple[bool, dict[str, Any] | None]:
     with UnitOfWork() as uow:
         run = uow.session.get(AgentRunRow, int(run_id))
         if not _run_has_project_context(run):
-            return
+            return True, None
         _record_project_activity(
             uow.session,
             int(run_id),
@@ -495,13 +495,40 @@ def _materialize_project_context(run_id: int) -> None:
             workspaces=result.workspaces,
             errors=result.errors[:3],
         )
+    if not result.ok:
+        details = "; ".join(result.errors[:3]) or "No project workspace was materialized."
+        message = f"Project Context unavailable: {details}"
+        return False, _mark_run_failed_after_runner_error(
+            int(run_id),
+            message,
+            final_answer=(
+                "I could not start this run because the selected Project Context did not "
+                f"provide a usable workspace. {details}"
+            ),
+        )
+    return True, None
 
 
-def _mark_run_failed_after_runner_error(run_id: int, error: str) -> dict[str, Any] | None:
+def _mark_run_failed_after_runner_error(
+    run_id: int,
+    error: str,
+    *,
+    final_answer: str | None = None,
+) -> dict[str, Any] | None:
     with UnitOfWork() as uow:
         store = AgentRunStore(uow.session)
         row = store.require_run(int(run_id))
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
+            if final_answer:
+                store.append_final_answer_once(int(run_id), final_answer, root_run_id=row.root_run_id)
+                store.append_event(
+                    run_event(
+                        int(run_id),
+                        "run.text_completed",
+                        {"text": final_answer},
+                        root_run_id=row.root_run_id,
+                    )
+                )
             store.append_event(run_event(int(run_id), "run.failed", {"error": error}, root_run_id=row.root_run_id))
             store.set_status(int(run_id), RunStatus.FAILED, reason=error[:500])
         return _settle_idea_for_terminal_root_run(uow.session, int(run_id))
@@ -514,7 +541,12 @@ def run_queued_once(*, limit: int = 1) -> int:
     for run_id in ids:
         try:
             with _run_heartbeat(int(run_id)):
-                _materialize_project_context(int(run_id))
+                context_ready, status_payload = _materialize_project_context(int(run_id))
+                if not context_ready:
+                    if status_payload:
+                        publish_safe("status_change", status_payload)
+                    processed += 1
+                    continue
                 status_payload = None
                 with UnitOfWork() as uow:
                     _engine_for_session(uow.session).run_existing(int(run_id))

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -48,10 +48,7 @@ _MODEL_TIER_ALIASES: dict[str, str] = {}
 _REASONING_EFFORTS = {"none", "low", "medium", "high", "xhigh"}
 
 # Workspace root — configurable, defaults to project root
-WORKSPACE_ROOT = os.environ.get(
-    "ILLO_WORKSPACE_ROOT",
-    str(brain_config.BRAIN_DIR),
-)
+WORKSPACE_ROOT = str(brain_config.resolve_workspace_root(default=brain_config.BRAIN_DIR))
 
 # Max output size for tool results (from budget config)
 _MAX_RESULT_CHARS = int(os.environ.get("BUDGET_MAX_TOOL_RESULT_CHARS", "10000"))

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -137,9 +137,7 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
     project_execution = _prepare_project_execution_env()
 
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", dir=cwd, delete=False, prefix="_illo_script_"
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, prefix="_illo_script_") as f:
             f.write(script)
             script_path = f.name
 

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -48,12 +48,16 @@ def _get_profile(session, org_id: str, profile_id: str, *, include_inactive: boo
     return profile
 
 
-def _validate_project_context(project_context: dict[str, Any]) -> dict[str, Any]:
-    from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
+def _validated_project_context(project_context: dict[str, Any]) -> dict[str, Any]:
+    from brain.systems.cortex.project_context.snapshot import (
+        ProjectContextValidationError,
+        validated_project_context_snapshot,
+    )
 
-    snapshot = snapshot_from_project_context(project_context)
-    if snapshot.get("status") == "invalid":
-        raise ValueError("Invalid project context: " + "; ".join(snapshot.get("validation_errors") or []))
+    try:
+        validated_project_context_snapshot(project_context)
+    except ProjectContextValidationError as exc:
+        raise ValueError(str(exc)) from exc
     return project_context
 
 
@@ -81,7 +85,7 @@ def _context_from_inputs(
             for index, resource in enumerate(resources)
             if isinstance(resource, dict)
         ]
-    return _validate_project_context(context)
+    return _validated_project_context(context)
 
 
 def _project_resources(profile) -> list[dict[str, Any]]:
@@ -92,7 +96,7 @@ def _project_resources(profile) -> list[dict[str, Any]]:
 def _store_resources(profile, resources: list[dict[str, Any]]) -> None:
     context = dict(profile.project_context or {})
     context["resources"] = resources
-    profile.project_context = _validate_project_context(context)
+    profile.project_context = _validated_project_context(context)
 
 
 def _unique_resource_id(resource: dict[str, Any], existing_ids: set[str], index: int) -> str:
@@ -143,9 +147,11 @@ def _handle_manage_project(
     from sqlalchemy import select
 
     from brain.app.api.routers.cortex._helpers import _require_idea_for_user
-    from brain.systems.cortex.project_context.permissions import derive_project_permission_scope
     from brain.systems.cortex.project_context.resources import normalize_project_resource
-    from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
+    from brain.systems.cortex.project_context.snapshot import (
+        ProjectContextValidationError,
+        validated_project_context_snapshot,
+    )
     from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
@@ -310,16 +316,16 @@ def _handle_manage_project(
                     context = dict(profile.project_context or {})
                 if not context:
                     return json.dumps({"error": "attach_to_thread requires: project_id or project_context"})
-                snapshot = snapshot_from_project_context(context)
-                if snapshot.get("status") == "invalid":
-                    return json.dumps({"error": "Invalid project context", "validation_errors": snapshot.get("validation_errors") or []})
-                permission_scope = snapshot.get("permission_scope") or derive_project_permission_scope(snapshot)
+                try:
+                    snapshot = validated_project_context_snapshot(context)
+                except ProjectContextValidationError as exc:
+                    return json.dumps({"error": "Invalid project context", "validation_errors": exc.errors})
                 attachment = IdeaProjectAttachment(
                     idea_id=target_idea_id,
                     project_profile_id=profile.id if profile else selected_profile_id,
                     attached_by=user_id,
                     snapshot=snapshot,
-                    permission_scope=permission_scope,
+                    permission_scope=snapshot.get("permission_scope") or {},
                     status=str(snapshot.get("status") or "validated"),
                     validation_errors=snapshot.get("validation_errors") or [],
                     environment_binding_id=environment_binding_id

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -37,10 +37,7 @@ logger = logging.getLogger("agent.tools")
 
 # ── Workspace ────────────────────────────────────────────────
 
-WORKSPACE_ROOT = os.environ.get(
-    "ILLO_WORKSPACE_ROOT",
-    str(brain_config.BRAIN_DIR),
-)
+WORKSPACE_ROOT = str(brain_config.resolve_workspace_root(default=brain_config.BRAIN_DIR))
 
 
 def _resolve_path(path: str, workspace_root: str | None = None) -> str:

--- a/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
+++ b/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
@@ -84,6 +84,9 @@
   );
   const activeProjectValidation = $derived(validateProjectContextResources(activeProjectResources));
   const activeProjectContextSnapshot = $derived(buildProjectContextAttachment());
+  const activeProjectStateValidation = $derived(
+    activeProjectContextSnapshot ? activeProjectValidation : { valid: true, errors: [] },
+  );
   const chipLabel = $derived(
     creatingProject
       ? (newProjectName.trim() || 'New Project')
@@ -92,6 +95,7 @@
   const canSaveProject = $derived(
     creatingProject
       && newProjectName.trim().length > 0
+      && selectedResources.length > 0
       && activeProjectValidation.valid
       && !projectSaving,
   );
@@ -292,8 +296,8 @@
   $effect(() => {
     onStateChange?.({
       snapshot: activeProjectContextSnapshot,
-      valid: activeProjectValidation.valid,
-      error: activeProjectValidation.errors[0] ?? null,
+      valid: activeProjectStateValidation.valid,
+      error: activeProjectStateValidation.errors[0] ?? null,
       resourceCount: activeProjectResources.length,
     });
   });
@@ -379,7 +383,7 @@
   <button
     class="project-context-chip"
     class:active={projectContextOpen || creatingProject}
-    class:invalid={!activeProjectValidation.valid}
+    class:invalid={!activeProjectStateValidation.valid}
     type="button"
     disabled={disabled}
     aria-expanded={projectContextOpen}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -50,7 +50,7 @@
 
 <div class="project-create-intro">
   <strong>Projects are saved context containers.</strong>
-  <span>Create one empty, or add resources now. A resource can be a GitHub repo or local files and folders.</span>
+  <span>Add a GitHub repo or backend-readable files before saving.</span>
 </div>
 
 <div class="project-create-fields">
@@ -101,7 +101,7 @@
     onRemove={onRemoveResource}
   />
 {:else}
-  <p class="project-context-muted project-empty-note">No resources yet. Saving now creates an empty project you can use as a named container.</p>
+  <p class="project-context-muted project-empty-note">No resources yet. Add a GitHub repo, file, or folder before saving.</p>
 {/if}
 
 {#if !validation.valid}
@@ -114,6 +114,6 @@
 <div class="project-context-actions">
   <button class="project-context-secondary" type="button" onclick={onCancel}>Cancel</button>
   <button class="project-context-primary" type="button" onclick={onSave} disabled={!canSave}>
-    {saving ? 'Saving...' : (resources.length ? 'Save project' : 'Create empty project')}
+    {saving ? 'Saving...' : 'Save project'}
   </button>
 </div>

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
@@ -81,7 +81,7 @@
           {:else if profile.resources.length}
             <small>{profile.resources.length} resource{profile.resources.length === 1 ? '' : 's'}</small>
           {:else if profile.id !== 'none'}
-            <small>Empty project — add resources when you create or attach context</small>
+            <small>No resources attached</small>
           {/if}
         </span>
         {#if isSelected}

--- a/frontend/src/lib/utils/projectContext.test.js
+++ b/frontend/src/lib/utils/projectContext.test.js
@@ -69,6 +69,7 @@ test('normalizes connector resources before project save or run', () => {
 });
 
 test('flags duplicate or empty resources before run', () => {
+    assert.equal(validateProjectContextResources([]).valid, false);
     assert.equal(validateProjectContextResources([{ path: 'frontend' }, { path: 'frontend' }]).valid, false);
     assert.equal(validateProjectContextResources([{ path: 'frontend' }, { repo: 'example-org/example-repo' }]).valid, true);
     assert.equal(validateProjectContextResources([{ uri: 'browser-file://spec.md', name: 'spec.md' }]).valid, false);

--- a/frontend/src/lib/utils/projectContext.ts
+++ b/frontend/src/lib/utils/projectContext.ts
@@ -136,6 +136,9 @@ export function normalizeProjectContextResources(resources: ProjectContextResour
 
 export function validateProjectContextResources(resources: ProjectContextResource[]): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
+  if (!resources.length) {
+    errors.push('Project context needs at least one repo, folder, file, or doc.');
+  }
   const seen = new Set<string>();
   for (const resource of normalizeProjectContextResources(resources)) {
     const key = (resource.path ?? resource.repo ?? resource.uri ?? resource.name ?? resource.label ?? '').trim();

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1275,8 +1275,28 @@ def test_project_context_validation_rejects_missing_local_path_when_enforced(tmp
     assert any("does not exist" in error for error in snapshot["validation_errors"])
 
 
+def test_project_context_snapshot_attachment_revalidates_existing_status():
+    from brain.systems.cortex.project_context.snapshot import attach_project_context_snapshot
+
+    payload = attach_project_context_snapshot(
+        {},
+        {
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [],
+            },
+        },
+    )
+
+    snapshot = payload["project_context_snapshot"]
+    assert snapshot["status"] == "invalid"
+    assert snapshot["validation_errors"] == [
+        "project_context_snapshot.resources must contain at least one resource."
+    ]
+
+
 @pytest.mark.asyncio
-async def test_create_empty_project_profile(client, mock_session_factory):
+async def test_create_project_profile_rejects_empty_project_context(client, mock_session_factory):
     from brain.app.api.routers.cortex import _project_context as pc_mod
 
     with (
@@ -1297,10 +1317,10 @@ async def test_create_empty_project_profile(client, mock_session_factory):
             json={"slug": "empty-project", "name": "Empty Project", "project_context": {"name": "Empty Project", "resources": []}},
         )
 
-    assert response.status_code == 201
-    payload = response.json()
-    assert payload["name"] == "Empty Project"
-    assert payload["project_context"]["resources"] == []
+    assert response.status_code == 422
+    assert response.json()["detail"]["validation_errors"] == [
+        "project_context_snapshot.resources must contain at least one resource."
+    ]
 
 
 async def test_create_project_profile_validates_project_context(client, mock_session_factory):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -418,10 +418,149 @@ def test_materialize_refuses_to_overwrite_non_matching_thread_checkout(tmp_path,
     assert run.target_status == "invalid"
 
 
+def test_materialize_empty_project_context_is_not_ready(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=48,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = materialize_project_context_workspaces(48, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert not result.ok
+    assert result.workspaces == []
+    assert result.errors == ["Project Context has no resources to materialize."]
+    assert "workspace_root" not in run.workspace_ref
+
+
+def test_materialize_missing_project_context_snapshot_reports_error(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=50,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={"kind": "cortex_idea"},
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = materialize_project_context_workspaces(50, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert not result.ok
+    assert result.errors == ["Project Context snapshot is missing."]
+
+
 def test_project_context_root_is_scoped_by_thread(monkeypatch, tmp_path):
     from brain.systems.runs.cortex.runner import _project_context_root
 
-    monkeypatch.setenv("ILLO_PROJECT_CONTEXT_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
 
     assert _project_context_root(101, thread_id="idea/with spaces") == str(tmp_path / "ideas" / "idea-with-spaces")
     assert _project_context_root(101, thread_id=None) == str(tmp_path / "run-101")
+
+
+def test_project_context_root_uses_workspace_root_in_deploy(monkeypatch, tmp_path):
+    from brain.systems.runs.cortex.runner import _project_context_root
+
+    monkeypatch.delenv("ILLO_WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+
+    assert _project_context_root(102, thread_id="idea-2") == str(tmp_path / "ideas" / "idea-2")
+
+
+def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=49,
+        user_id="user-1",
+        org_id="org-1",
+        thread_id="idea-3",
+        target_ref={"project_context_snapshot": {"resources": []}},
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    captured = {}
+
+    monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(runner, "_record_project_activity", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "materialize_project_context_workspaces",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            workspaces=[],
+            errors=["Project Context has no resources to materialize."],
+        ),
+    )
+
+    def fake_mark_failed(run_id, error, *, final_answer=None):
+        captured.update({"run_id": run_id, "error": error, "final_answer": final_answer})
+        return {"idea_id": "idea-3", "new_status": "failed"}
+
+    monkeypatch.setattr(runner, "_mark_run_failed_after_runner_error", fake_mark_failed)
+
+    context_ready, status_payload = runner._materialize_project_context(49)
+
+    assert context_ready is False
+    assert status_payload == {"idea_id": "idea-3", "new_status": "failed"}
+    assert captured["run_id"] == 49
+    assert "Project Context unavailable" in captured["error"]
+    assert "did not provide a usable workspace" in captured["final_answer"]

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -367,6 +367,20 @@ def test_run_script_uses_project_bound_env_and_redacts_values(monkeypatch, tmp_p
     assert result["stdout"].count("[secret redacted]") == 2
 
 
+def test_run_script_keeps_temp_script_outside_workspace(tmp_path):
+    from brain.systems.runs.tool_catalog.handlers.files import _handle_run_script
+
+    proc = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", return_value=proc) as run:
+        result = _handle_run_script("print('ok')", _workspace=str(tmp_path))
+
+    script_path = run.call_args.args[0][1]
+    assert result["exit_code"] == 0
+    assert run.call_args.kwargs["cwd"] == str(tmp_path)
+    assert not str(script_path).startswith(str(tmp_path))
+
+
 def test_parallel_exec_commands_keep_project_bound_env_isolated(monkeypatch, tmp_path):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs import project_execution_env

--- a/tests/test_workspace_root_config.py
+++ b/tests/test_workspace_root_config.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+def test_resolve_workspace_root_prefers_deploy_env(monkeypatch, tmp_path):
+    from brain.kernel import config
+
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path / "workspace"))
+    monkeypatch.setenv("ILLO_WORKSPACE_ROOT", str(tmp_path / "illo"))
+
+    assert config.resolve_workspace_root() == tmp_path / "workspace"
+
+
+def test_resolve_workspace_root_accepts_legacy_illo_env(monkeypatch, tmp_path):
+    from brain.kernel import config
+
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("ILLO_WORKSPACE_ROOT", str(tmp_path / "illo"))
+
+    assert config.resolve_workspace_root() == tmp_path / "illo"
+
+
+def test_resolve_workspace_root_uses_default_without_env(monkeypatch, tmp_path):
+    from brain.kernel import config
+
+    monkeypatch.delenv("ILLO_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+
+    assert config.resolve_workspace_root(default=Path(tmp_path)) == tmp_path


### PR DESCRIPTION
## Summary
- make WORKSPACE_ROOT the single Docker workspace contract, with ILLO_WORKSPACE_ROOT only as a local compatibility fallback
- centralize Project Context snapshot finalization and validation so API routes, agent tools, and attachment paths share one invariant
- materialize Project Context repos under the resolved workspace root and fail runs before model execution when no usable workspace exists
- reject empty Project Context snapshots/profiles instead of marking named-but-empty projects as validated, including stale snapshots that already claim validated status
- prevent the UI from creating empty projects and mark legacy empty saved profiles invalid when selected
- keep run_script temp files outside project workspaces while preserving command cwd

## Tests
- python3 -m py_compile brain/systems/cortex/project_context/snapshot.py brain/app/api/routers/cortex/_project_context.py brain/systems/runs/tool_catalog/handlers/projects.py brain/systems/cortex/project_context/materializer.py
- pytest tests/test_workspace_root_config.py tests/test_project_context_materializer.py tests/test_vault_project_tokens.py tests/test_tools.py tests/test_api_cortex.py tests/test_environment_registry.py tests/test_agent_run_runtime.py tests/test_agent.py tests/test_tool_registry.py tests/test_tool_policy.py -q
- npm test
- npm run check

## Full-suite note
- pytest -q was also attempted locally. It still has unrelated failures on current main/local setup: DB-backed chat tests cannot connect to Postgres on 127.0.0.1:5432, and several theme contract tests reference old frontend component paths that no longer exist.