### PR TITLE
Add thread conversation trace export

### DIFF
--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -21,6 +21,7 @@ from brain.systems.runs.cortex.recording import (
     agent_trace_export_filename,
     build_agent_trace_snapshot,
     build_agent_trace_export_zip,
+    build_thread_trace_snapshot,
 )
 from brain.systems.runs.cortex.read_models import (
     serialize_active_runs,
@@ -183,6 +184,27 @@ def download_run_trace_export(run_id: int, user: dict[str, Any] = Depends(get_cu
         snapshot = build_agent_trace_snapshot(
             uow.session,
             run,
+            saved_by=str(user.get("id")) if user.get("id") else None,
+        )
+        archive = build_agent_trace_export_zip(snapshot)
+        filename = agent_trace_export_filename(snapshot)
+        return Response(
+            content=archive,
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Trace-Id": str(snapshot.get("trace_id") or ""),
+            },
+        )
+
+
+@router.post("/ideas/{idea_id}/trace-export.zip")
+def download_thread_trace_export(idea_id: str, user: dict[str, Any] = Depends(get_current_user)):
+    with UnitOfWork() as uow:
+        _require_idea_for_run_history(uow.session, idea_id, user)
+        snapshot = build_thread_trace_snapshot(
+            uow.session,
+            idea_id,
             saved_by=str(user.get("id")) if user.get("id") else None,
         )
         archive = build_agent_trace_export_zip(snapshot)

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -94,6 +94,10 @@ AGENT_TRACE_EXPORT_SCHEMA_VERSION = 1
 TRACE_MAX_MESSAGES = 40
 TRACE_MAX_EVENTS = 300
 TRACE_MAX_ARTIFACTS = 60
+THREAD_TRACE_MAX_MESSAGES = 500
+THREAD_TRACE_MAX_RUNS = 100
+THREAD_TRACE_MAX_EVENTS = 1200
+THREAD_TRACE_MAX_ARTIFACTS = 240
 TRACE_MAX_STRING_CHARS = 4000
 TRACE_MAX_COLLECTION_ITEMS = 80
 TRACE_MAX_DEPTH = 6
@@ -161,6 +165,77 @@ def build_agent_trace_snapshot(
     return _jsonable(bundle)
 
 
+def build_thread_trace_snapshot(
+    session,
+    idea_id: str,
+    *,
+    saved_by: str | None = None,
+    max_messages: int = THREAD_TRACE_MAX_MESSAGES,
+    max_runs: int = THREAD_TRACE_MAX_RUNS,
+    max_events: int = THREAD_TRACE_MAX_EVENTS,
+    max_artifacts: int = THREAD_TRACE_MAX_ARTIFACTS,
+) -> dict[str, Any]:
+    """Build a bounded export for analyzing a whole Cortex thread conversation."""
+
+    runs = _thread_runs(session, idea_id, max_runs=max_runs)
+    run_ids = [int(run.id) for run in runs if _is_int_like(getattr(run, "id", None))]
+    messages = _trace_thread_messages(session, idea_id, max_messages=max_messages)
+    events = _trace_events(session, run_ids, max_events=max_events)
+    artifacts = _trace_artifacts(session, run_ids, max_artifacts=max_artifacts)
+    trace_id = f"thread:{idea_id}"
+    bundle = {
+        "schema_version": AGENT_TRACE_SNAPSHOT_SCHEMA_VERSION,
+        "export_scope": "thread",
+        "trace_id": trace_id,
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+        "saved_by": saved_by,
+        "storage_policy": {
+            "mode": "bounded_thread_snapshot",
+            "max_messages": max_messages,
+            "max_runs": max_runs,
+            "max_events": max_events,
+            "max_artifacts": max_artifacts,
+            "max_string_chars": TRACE_MAX_STRING_CHARS,
+            "large_values": "truncated_in_place",
+        },
+        "thread": {
+            "idea_id": idea_id,
+            "messages": messages,
+            "selected_message_count": len(messages),
+            "message_limit": max_messages,
+        },
+        "runs": [
+            _cap_jsonable({
+                **build_run_run_summary(session, int(run.id)),
+                "parent_run_id": getattr(run, "parent_run_id", None),
+                "root_run_id": getattr(run, "root_run_id", None),
+                "input_message": getattr(run, "input_message", None),
+                "target_ref": getattr(run, "target_ref", None) or {},
+                "workspace_ref": getattr(run, "workspace_ref", None) or {},
+                "model_policy": getattr(run, "model_policy", None) or {},
+                "context_summary": getattr(run, "context_summary", None),
+                "metadata": getattr(run, "metadata_", None) or {},
+            })
+            for run in runs
+        ],
+        "run_count": len(runs),
+        "run_limit": max_runs,
+        "related_run_ids": run_ids,
+        "events": events,
+        "event_count": len(events),
+        "event_limit": max_events,
+        "tools": _tool_trace(events),
+        "artifacts": artifacts,
+        "artifact_count": len(artifacts),
+        "artifact_limit": max_artifacts,
+    }
+    bundle["storage_estimate"] = {
+        "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
+        "truncated": _contains_truncation(bundle),
+    }
+    return _jsonable(bundle)
+
+
 def build_agent_trace_export_zip(
     snapshot: dict[str, Any],
 ) -> bytes:
@@ -168,12 +243,15 @@ def build_agent_trace_export_zip(
 
     trace = _jsonable(snapshot)
     run = trace.get("run") if isinstance(trace.get("run"), dict) else {}
+    thread = trace.get("thread") if isinstance(trace.get("thread"), dict) else {}
+    is_thread_export = trace.get("export_scope") == "thread"
     manifest = _jsonable({
         "schema_version": AGENT_TRACE_EXPORT_SCHEMA_VERSION,
-        "export_type": "illo_agent_trace",
+        "export_type": "illo_thread_trace" if is_thread_export else "illo_agent_trace",
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "trace_id": trace.get("trace_id"),
         "run_id": run.get("run_id"),
+        "idea_id": thread.get("idea_id"),
         "files": [
             {"path": "trace.json", "description": "Bounded JSON trace for agent analysis."},
             {"path": "activity.json", "description": "Compact chronological activity list derived from the trace."},
@@ -195,9 +273,14 @@ def build_agent_trace_export_zip(
 
 
 def agent_trace_export_filename(snapshot: dict[str, Any]) -> str:
+    if snapshot.get("export_scope") == "thread":
+        thread = snapshot.get("thread") if isinstance(snapshot.get("thread"), dict) else {}
+        idea_id = thread.get("idea_id") or snapshot.get("trace_id") or "unknown"
+        safe_idea_id = _safe_filename_part(idea_id)
+        return f"illo-thread-trace-{safe_idea_id or 'unknown'}.zip"
     run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
     run_id = run.get("run_id") or snapshot.get("trace_id") or "unknown"
-    safe_run_id = "".join(ch if str(ch).isalnum() or ch in {"-", "_"} else "-" for ch in str(run_id)).strip("-")
+    safe_run_id = _safe_filename_part(run_id)
     return f"illo-trace-run-{safe_run_id or 'unknown'}.zip"
 
 
@@ -230,10 +313,23 @@ def _related_run_ids(session, run: AgentRunRow) -> list[int]:
     return ids
 
 
+def _thread_runs(session, idea_id: str, *, max_runs: int) -> list[AgentRunRow]:
+    return session.scalars(
+        select(AgentRunRow)
+        .where(AgentRunRow.thread_id == str(idea_id))
+        .order_by(AgentRunRow.created_at.asc(), AgentRunRow.id.asc())
+        .limit(max_runs)
+    ).all()
+
+
 def _trace_messages(session, run: AgentRunRow, *, max_messages: int) -> list[dict[str, Any]]:
+    return _trace_thread_messages(session, str(run.thread_id), max_messages=max_messages)
+
+
+def _trace_thread_messages(session, idea_id: str, *, max_messages: int) -> list[dict[str, Any]]:
     rows = session.scalars(
         select(IdeaThread)
-        .where(IdeaThread.idea_id == run.thread_id)
+        .where(IdeaThread.idea_id == str(idea_id))
         .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
         .limit(max_messages)
     ).all()
@@ -258,6 +354,8 @@ def _trace_messages(session, run: AgentRunRow, *, max_messages: int) -> list[dic
 
 
 def _trace_events(session, run_ids: list[int], *, max_events: int) -> list[dict[str, Any]]:
+    if not run_ids:
+        return []
     rows = session.scalars(
         select(AgentRunEventRow)
         .where(AgentRunEventRow.run_id.in_(run_ids))
@@ -281,6 +379,8 @@ def _trace_events(session, run_ids: list[int], *, max_events: int) -> list[dict[
 
 
 def _trace_artifacts(session, run_ids: list[int], *, max_artifacts: int) -> list[dict[str, Any]]:
+    if not run_ids:
+        return []
     rows = session.scalars(
         select(AgentRunArtifactRow)
         .where(
@@ -373,7 +473,10 @@ def _contains_truncation(value: Any) -> bool:
 def _trace_activity_export(snapshot: dict[str, Any]) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
     run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
-    if run:
+    runs = _safe_list(snapshot.get("runs")) or ([run] if run else [])
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
         items.append(_cap_jsonable({
             "kind": "run",
             "at": run.get("started_at") or run.get("created_at"),
@@ -443,7 +546,9 @@ def _trace_activity_export(snapshot: dict[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": AGENT_TRACE_EXPORT_SCHEMA_VERSION,
         "trace_id": snapshot.get("trace_id"),
-        "run_id": run.get("run_id"),
+        "run_id": run.get("run_id") if isinstance(run, dict) else None,
+        "run_ids": [item.get("run_id") for item in runs if isinstance(item, dict) and item.get("run_id")],
+        "idea_id": thread.get("idea_id"),
         "items": _jsonable(items),
         "item_count": len(items),
     }
@@ -451,14 +556,22 @@ def _trace_activity_export(snapshot: dict[str, Any]) -> dict[str, Any]:
 
 def _trace_export_readme(snapshot: dict[str, Any]) -> str:
     run = snapshot.get("run") if isinstance(snapshot.get("run"), dict) else {}
+    thread = snapshot.get("thread") if isinstance(snapshot.get("thread"), dict) else {}
     estimate = snapshot.get("storage_estimate") if isinstance(snapshot.get("storage_estimate"), dict) else {}
+    is_thread_export = snapshot.get("export_scope") == "thread"
+    title = "Illo thread trace export" if is_thread_export else "Illo agent trace export"
+    scope_note = (
+        "This zip is meant to be attached to a debugging conversation so another agent can inspect the full thread conversation and its related runs."
+        if is_thread_export
+        else "This zip is meant to be attached to a debugging conversation so another agent can inspect why Illo answered the way it did."
+    )
     return "\n".join([
-        "# Illo agent trace export",
+        f"# {title}",
         "",
-        "This zip is meant to be attached to a debugging conversation so another agent can inspect why Illo answered the way it did.",
+        scope_note,
         "",
         "Files:",
-        "- trace.json: the full bounded trace snapshot, including run metadata, recent thread messages, events, tool calls, and artifacts.",
+        "- trace.json: the full bounded trace snapshot, including thread messages, run metadata, events, tool calls, and artifacts.",
         "- activity.json: a compact chronological list derived from trace.json.",
         "- manifest.json: export metadata.",
         "",
@@ -468,6 +581,7 @@ def _trace_export_readme(snapshot: dict[str, Any]) -> str:
         "- This export is generated on demand and is not saved as a database artifact.",
         "",
         f"Trace ID: {snapshot.get('trace_id') or 'unknown'}",
+        f"Idea ID: {thread.get('idea_id') or 'unknown'}",
         f"Run ID: {run.get('run_id') or 'unknown'}",
         f"Estimated JSON bytes: {estimate.get('json_bytes') or 'unknown'}",
         f"Truncated: {bool(estimate.get('truncated'))}",
@@ -487,6 +601,18 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     return str(value)
+
+
+def _safe_filename_part(value: Any) -> str:
+    return "".join(ch if str(ch).isalnum() or ch in {"-", "_"} else "-" for ch in str(value)).strip("-")
+
+
+def _is_int_like(value: Any) -> bool:
+    try:
+        int(value)
+        return True
+    except (TypeError, ValueError):
+        return False
 
 
 def _get_payload(source: Any, name: str, default: Any = None) -> Any:

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -94,7 +94,7 @@ AGENT_TRACE_EXPORT_SCHEMA_VERSION = 1
 TRACE_MAX_MESSAGES = 40
 TRACE_MAX_EVENTS = 300
 TRACE_MAX_ARTIFACTS = 60
-THREAD_TRACE_MAX_MESSAGES = 500
+THREAD_TRACE_MAX_MESSAGES = None
 THREAD_TRACE_MAX_RUNS = 100
 THREAD_TRACE_MAX_EVENTS = 1200
 THREAD_TRACE_MAX_ARTIFACTS = 240
@@ -170,7 +170,7 @@ def build_thread_trace_snapshot(
     idea_id: str,
     *,
     saved_by: str | None = None,
-    max_messages: int = THREAD_TRACE_MAX_MESSAGES,
+    max_messages: int | None = THREAD_TRACE_MAX_MESSAGES,
     max_runs: int = THREAD_TRACE_MAX_RUNS,
     max_events: int = THREAD_TRACE_MAX_EVENTS,
     max_artifacts: int = THREAD_TRACE_MAX_ARTIFACTS,
@@ -192,6 +192,7 @@ def build_thread_trace_snapshot(
         "storage_policy": {
             "mode": "bounded_thread_snapshot",
             "max_messages": max_messages,
+            "messages": "all_thread_messages" if max_messages is None else "latest_thread_messages",
             "max_runs": max_runs,
             "max_events": max_events,
             "max_artifacts": max_artifacts,
@@ -326,15 +327,21 @@ def _trace_messages(session, run: AgentRunRow, *, max_messages: int) -> list[dic
     return _trace_thread_messages(session, str(run.thread_id), max_messages=max_messages)
 
 
-def _trace_thread_messages(session, idea_id: str, *, max_messages: int) -> list[dict[str, Any]]:
-    rows = session.scalars(
-        select(IdeaThread)
-        .where(IdeaThread.idea_id == str(idea_id))
-        .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
-        .limit(max_messages)
-    ).all()
+def _trace_thread_messages(session, idea_id: str, *, max_messages: int | None) -> list[dict[str, Any]]:
+    query = select(IdeaThread).where(IdeaThread.idea_id == str(idea_id))
+    if max_messages is None:
+        rows = session.scalars(
+            query.order_by(IdeaThread.created_at.asc(), IdeaThread.id.asc())
+        ).all()
+    else:
+        limited_rows = session.scalars(
+            query
+            .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
+            .limit(max_messages)
+        ).all()
+        rows = list(reversed(limited_rows))
     messages = []
-    for row in reversed(rows):
+    for row in rows:
         metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
         messages.append(_cap_jsonable({
             "id": row.id,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -819,6 +819,15 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/cancel-all`, { method: 'POST' }),
   runGraph: (id: number) => fetchJson<any>(`/api/cortex/run/${id}/graph`),
   runTools: (id: number) => fetchJson<any[]>(`/api/cortex/runs/${id}/tools`),
+  downloadThreadTraceZip: async (ideaId: string) => {
+    const result = await fetchBlob(`/api/cortex/ideas/${ideaId}/trace-export.zip`, { method: 'POST', timeoutMs: 60_000 });
+    return {
+      blob: result.blob,
+      filename: result.filename || `illo-thread-trace-${ideaId}.zip`,
+      bytes: result.blob.size,
+      traceId: result.headers.get('x-trace-id'),
+    };
+  },
   downloadRunTraceZip: async (id: number) => {
     const result = await fetchBlob(`/api/cortex/run/${id}/trace-export.zip`, { method: 'POST' });
     return {

--- a/frontend/src/lib/components/chat/ChatDock.svelte
+++ b/frontend/src/lib/components/chat/ChatDock.svelte
@@ -953,6 +953,18 @@
     return memberConversation(member)?.unread_count ?? 0;
   }
 
+  function unreadAccentStyle(color: string | null | undefined) {
+    const accent = normalizeHexColor(color);
+    return accent ? `--chat-unread-accent:${accent};` : undefined;
+  }
+
+  function roomUnreadAccentStyle() {
+    const lastMessage = roomConversation?.last_message;
+    return unreadAccentStyle(
+      resolvedParticipantColor(lastMessage?.sender_user_id, lastMessage?.sender_color),
+    );
+  }
+
   function isMemberConversationActive(member: TeamMember) {
     if (member.preview) {
       return chat.mode === 'dms' && String(selectedPreviewDmId) === String(member.id);
@@ -1041,7 +1053,9 @@
             {/each}
           </span>
           {#if roomConversation?.unread_count}
-            <span class="chat-channel-unread">{roomConversation.unread_count}</span>
+            <span class="chat-channel-unread" style={roomUnreadAccentStyle()}>
+              {roomConversation.unread_count}
+            </span>
           {/if}
           <span class="chat-channel-copy">
             <span>Team</span>
@@ -1071,7 +1085,9 @@
                 <small>{member.preview ? 'Preview' : 'Direct message'}</small>
               </span>
               {#if memberUnreadCount(member)}
-                <span class="chat-channel-unread">{memberUnreadCount(member)}</span>
+                <span class="chat-channel-unread" style={unreadAccentStyle(memberColor(member))}>
+                  {memberUnreadCount(member)}
+                </span>
               {/if}
             </button>
           {/each}
@@ -1732,7 +1748,8 @@
   --chat-empty-icon-text: rgba(234, 239, 250, 0.8);
   --chat-heading-text: rgba(244, 246, 252, 0.95);
   --chat-description-text: rgba(240, 240, 250, 0.56);
-  --chat-unread-background: color-mix(in srgb, var(--constellation-color-amber, #57CFA0) 90%, transparent);
+  --chat-unread-accent: var(--thread-accent, var(--constellation-color-user-accent, #57CFA0));
+  --chat-unread-background: color-mix(in srgb, var(--chat-unread-accent) 90%, transparent);
   --chat-unread-text: rgba(12, 10, 8, 0.92);
   --chat-unread-ring: rgba(9, 12, 19, 0.96);
   --chat-thread-border: rgba(255, 255, 255, 0.08);
@@ -1871,7 +1888,7 @@
   --chat-empty-icon-text: rgba(45, 57, 73, 0.8);
   --chat-heading-text: rgba(17, 24, 35, 0.92);
   --chat-description-text: rgba(78, 91, 108, 0.58);
-  --chat-unread-background: color-mix(in srgb, var(--constellation-color-amber, #57CFA0) 88%, transparent);
+  --chat-unread-background: color-mix(in srgb, var(--chat-unread-accent) 88%, transparent);
   --chat-unread-text: rgba(28, 20, 12, 0.9);
   --chat-unread-ring: rgba(247, 250, 253, 0.94);
   --chat-thread-border: rgba(24, 35, 49, 0.08);

--- a/frontend/src/lib/components/chat/ChatMessageRow.svelte
+++ b/frontend/src/lib/components/chat/ChatMessageRow.svelte
@@ -76,6 +76,11 @@
     })),
   );
 
+  function unreadChipStyle(color: string | null | undefined) {
+    const accent = normalizeHexColor(color);
+    return accent ? `--chat-unread-chip-accent:${accent};` : undefined;
+  }
+
   function openThread() {
     if (!item.thread) return;
     item.thread.onOpen?.(item.thread.id);
@@ -175,7 +180,11 @@
           </ConstellationPill>
 
           {#if item.thread.unreadCount}
-            <ChatUnreadChip count={item.thread.unreadCount} compact />
+            <ChatUnreadChip
+              count={item.thread.unreadCount}
+              compact
+              style={unreadChipStyle(item.thread.accentColor ?? item.accentColor)}
+            />
           {/if}
         </div>
 

--- a/frontend/src/lib/components/chat/ChatUnreadChip.svelte
+++ b/frontend/src/lib/components/chat/ChatUnreadChip.svelte
@@ -5,12 +5,14 @@
     compact = false,
     muted = false,
     className = '',
+    style = '',
   }: {
     count?: number;
     label?: string;
     compact?: boolean;
     muted?: boolean;
     className?: string;
+    style?: string;
   } = $props();
 
   const resolvedCount = $derived(Math.max(0, count));
@@ -23,7 +25,7 @@
 </script>
 
 {#if resolvedCount > 0 || label}
-  <span class={rootClass} aria-label={`${resolvedCount} unread`}>
+  <span class={rootClass} {style} aria-label={`${resolvedCount} unread`}>
     {text}
   </span>
 {/if}
@@ -36,8 +38,14 @@
     justify-content: center;
     padding: 4px 8px;
     border-radius: 999px;
-    background: linear-gradient(180deg, rgba(141, 183, 255, 0.2), rgba(141, 183, 255, 0.12));
-    border: 1px solid rgba(141, 183, 255, 0.26);
+    --chat-unread-chip-accent: var(--thread-accent, var(--constellation-color-user-accent, #57CFA0));
+    background:
+      linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--chat-unread-chip-accent) 24%, transparent),
+        color-mix(in srgb, var(--chat-unread-chip-accent) 14%, transparent)
+      );
+    border: 1px solid color-mix(in srgb, var(--chat-unread-chip-accent) 30%, transparent);
     color: rgba(230, 238, 255, 0.96);
     font-family: var(--constellation-font-mono);
     font-size: 9px;
@@ -45,7 +53,7 @@
     letter-spacing: 0.14em;
     line-height: 1;
     text-transform: uppercase;
-    box-shadow: 0 0 14px rgba(141, 183, 255, 0.14);
+    box-shadow: 0 0 14px color-mix(in srgb, var(--chat-unread-chip-accent) 18%, transparent);
   }
 
   .chat-unread-chip.is-compact {

--- a/frontend/src/lib/components/chat/chatTypes.ts
+++ b/frontend/src/lib/components/chat/chatTypes.ts
@@ -30,6 +30,7 @@ export type ChatAttachmentItem = {
 export type ChatThreadReference = {
   id: string;
   label?: string;
+  accentColor?: string;
   replyCount?: number;
   unreadCount?: number;
   lastReplyLabel?: string;

--- a/frontend/src/lib/components/constellation/astrePrimitiveStyle.ts
+++ b/frontend/src/lib/components/constellation/astrePrimitiveStyle.ts
@@ -124,19 +124,11 @@ function resolveLightAstreAccent(accent: string | null, seed: number) {
   if (!accent) return LIGHT_ASTRE_USER_PALETTE[seed % LIGHT_ASTRE_USER_PALETTE.length];
 
   const { h, s, l } = rgbToHsl(hexToRgb(accent));
-  const isWaterRange = h >= 164 && h <= 240;
-  const isEarthRange = h >= 10 && h <= 48;
-  const isVerySoft = s < 0.42 || l > 0.62;
-
-  if (isEarthRange || isWaterRange || isVerySoft) {
-    return LIGHT_ASTRE_USER_PALETTE[(seed + 2) % LIGHT_ASTRE_USER_PALETTE.length];
-  }
-
   return rgbToHex(
     hslToRgb({
       h,
-      s: clamp(Math.max(s * 1.22, 0.62), 0.58, 0.84),
-      l: clamp(l, 0.38, 0.5),
+      s: clamp(Math.max(s * 1.18, 0.46), 0.42, 0.9),
+      l: clamp(l, 0.34, 0.52),
     }),
   );
 }
@@ -198,7 +190,7 @@ export function buildAstrePrimitiveStyle({
     `inset 0 18px 30px color-mix(in srgb, white 46%, ${normalizedAccent} 4%)`,
     `inset 0 -24px 34px color-mix(in srgb, ${normalizedAccent} 10%, rgba(156, 109, 36, 0.1))`,
     `0 12px 30px color-mix(in srgb, ${normalizedAccent} 14%, transparent)`,
-    `0 0 54px color-mix(in srgb, var(--constellation-color-amber-core) 12%, transparent)`,
+    `0 0 54px color-mix(in srgb, ${normalizedAccent} 12%, transparent)`,
   ].join(', ');
   const lightUseBrightHover = isLightMode && emphasis;
   const lightUseCalmRest = isLightMode && !emphasis;
@@ -311,10 +303,10 @@ export function buildAstrePrimitiveStyle({
         ].join(', '),
     '--astre-rim-hot': isLightMode
       ? `color-mix(in srgb, ${normalizedAccent} 50%, rgba(255, 253, 247, 0.5))`
-      : `color-mix(in srgb, ${normalizedAccent} 52%, var(--constellation-color-amber-owner) 48%)`,
+      : `color-mix(in srgb, ${normalizedAccent} 52%, var(--constellation-color-text-primary) 48%)`,
     '--astre-rim-soft': isLightMode
       ? `color-mix(in srgb, ${normalizedAccent} 28%, rgba(255, 253, 247, 0.5))`
-      : `color-mix(in srgb, ${normalizedAccent} 34%, var(--constellation-color-amber-owner))`,
+      : `color-mix(in srgb, ${normalizedAccent} 34%, var(--constellation-color-text-primary))`,
     '--astre-rim-dim': colorAlpha(normalizedAccent, isLightMode ? 0.12 : 0.18),
     '--astre-rim-opacity': isLightMode ? (lightUseBrightHover ? 0.74 : 0.5) : 1,
   });

--- a/frontend/src/lib/features/notifications/components/NotificationsMenu.svelte
+++ b/frontend/src/lib/features/notifications/components/NotificationsMenu.svelte
@@ -28,6 +28,14 @@
     return seed.slice(0, 1).toUpperCase();
   }
 
+  function notificationActorColor(notification: AppNotification): string {
+    return notification.actor_color || (notification.source === 'chat' ? '#5ea9ff' : '#5ecfa0');
+  }
+
+  function notificationRowStyle(notification: AppNotification): string {
+    return `--notification-actor-color:${notificationActorColor(notification)}`;
+  }
+
   function toggleMenu(event: MouseEvent) {
     event.stopPropagation();
     open = !open;
@@ -143,13 +151,11 @@
             <button
               type="button"
               class="notification-row"
+              style={notificationRowStyle(notification)}
               role="menuitem"
               onclick={() => handleSelect(notification)}
             >
-              <span
-                class="notification-avatar"
-                style:background={notification.actor_color || (notification.source === 'chat' ? 'rgba(94, 169, 255, 0.22)' : 'rgba(94, 207, 160, 0.18)')}
-              >
+              <span class="notification-avatar">
                 {actorInitial(notification)}
               </span>
 
@@ -312,6 +318,7 @@
     border-radius: 16px;
     background: var(--constellation-notification-row-background);
     color: inherit;
+    --notification-actor-color: var(--constellation-color-user-accent, #57cfa0);
     text-align: left;
     cursor: pointer;
     transition:
@@ -322,7 +329,7 @@
 
   .notification-row:hover {
     transform: translateY(-1px);
-    border-color: var(--constellation-notification-row-hover-border);
+    border-color: color-mix(in srgb, var(--notification-actor-color) 24%, transparent);
     background: var(--constellation-notification-row-hover-background);
   }
 
@@ -333,9 +340,18 @@
     align-items: center;
     justify-content: center;
     border-radius: 999px;
+    background:
+      radial-gradient(circle at 36% 28%, rgba(255, 255, 255, 0.34), transparent 34%),
+      color-mix(in srgb, var(--notification-actor-color) 88%, rgba(9, 12, 19, 0.18));
     color: var(--constellation-notification-avatar-text);
     font-size: 12px;
     font-weight: 700;
+  }
+
+  :global(:root[data-color-scheme='light']) .notification-avatar {
+    background:
+      radial-gradient(circle at 36% 28%, rgba(255, 255, 255, 0.5), transparent 34%),
+      color-mix(in srgb, var(--notification-actor-color) 84%, rgba(255, 253, 247, 0.16));
   }
 
   .notification-copy {
@@ -369,7 +385,7 @@
   }
 
   .notification-occurrence {
-    color: var(--constellation-notification-occurrence);
+    color: color-mix(in srgb, var(--notification-actor-color) 84%, transparent);
     font-size: 11px;
   }
 </style>

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -7,6 +7,7 @@ export type ThreadMessage = Awaited<ReturnType<typeof api.addThreadMessage>>;
 export type ThreadRunHistoryItem = Awaited<ReturnType<typeof api.runHistory>>[number];
 export type RunDecisionResponse = Awaited<ReturnType<typeof api.approveRun>>;
 export type RunTool = Awaited<ReturnType<typeof api.runTools>>[number];
+export type ThreadTraceZipDownload = Awaited<ReturnType<typeof api.downloadThreadTraceZip>>;
 export type RunGraph = Awaited<ReturnType<typeof api.runGraph>>;
 export type RunTraceZipDownload = Awaited<ReturnType<typeof api.downloadRunTraceZip>>;
 export type RunStatus = Awaited<ReturnType<typeof api.runStatus>>;
@@ -34,6 +35,7 @@ type ThreadApiMethods = {
   runStatus: () => Promise<RunStatus>;
   runGraph: (id: number) => Promise<RunGraph>;
   runTools: (id: number) => Promise<RunTool[]>;
+  downloadThreadTraceZip: typeof api.downloadThreadTraceZip;
   downloadRunTraceZip: typeof api.downloadRunTraceZip;
   skillFeedback: typeof api.skillFeedback;
   opsActive: () => Promise<ActiveOpsRun[]>;
@@ -65,6 +67,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'runStatus',
   'runGraph',
   'runTools',
+  'downloadThreadTraceZip',
   'downloadRunTraceZip',
   'skillFeedback',
   'opsActive',
@@ -95,6 +98,7 @@ export const {
   runStatus,
   runGraph,
   runTools,
+  downloadThreadTraceZip,
   downloadRunTraceZip,
   skillFeedback,
   opsActive,

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1265,6 +1265,7 @@
     --thread-stage-panel-radius: 24px;
     --thread-stage-panel-padding-block: clamp(14px, 1.7vw, 22px);
     --thread-stage-panel-padding-inline: clamp(16px, 2vw, 24px);
+    --thread-stage-docked-header-height: 46px;
     --thread-bridge-mention-dropdown-border: rgba(124, 138, 158, 0.14);
     --thread-bridge-mention-dropdown-background:
       linear-gradient(180deg, rgba(10, 14, 22, 0.98), rgba(8, 11, 18, 1));
@@ -1645,6 +1646,15 @@
       box-sizing: border-box;
       justify-self: stretch;
       align-self: stretch;
+    }
+
+    .thread-stage-layout.with-dock .thread-stage-thread :global(.thread-panel-header) {
+      min-height: var(--thread-stage-docked-header-height);
+      padding: 0 2px 0 0;
+    }
+
+    .thread-stage-layout.with-dock .thread-stage-thread :global(.thread-header-title-row) {
+      min-height: var(--thread-stage-docked-header-height);
     }
   }
 

--- a/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
@@ -5,7 +5,7 @@
     activityTimeline,
     auditApply,
     auditEval,
-    downloadRunTraceZip,
+    downloadThreadTraceZip,
     getIdea,
     ideaAudit,
     ideaAuditAnalysisResult,
@@ -24,8 +24,6 @@
     meta: string[];
     error?: string;
     state?: string;
-    runId?: number;
-    canSaveTrace?: boolean;
   };
 
   let {
@@ -59,9 +57,9 @@
   let evalResults = $state<Record<number, any>>({});
   let expandedRuns = $state<Set<number>>(new Set());
   let expandedWorkers = $state<Set<string>>(new Set());
-  let traceSaving = $state<Record<number, boolean>>({});
-  let traceSaved = $state<Record<number, { bytes?: number; filename?: string }>>({});
-  let traceErrors = $state<Record<number, string>>({});
+  let threadTraceSaving = $state(false);
+  let threadTraceSaved = $state<{ bytes?: number; filename?: string } | null>(null);
+  let threadTraceError = $state('');
 
   let pollAborted = $state(false);
   let loadedForIdeaId = $state<string | null>(null);
@@ -97,9 +95,9 @@
     evalResults = {};
     expandedRuns = new Set();
     expandedWorkers = new Set();
-    traceSaving = {};
-    traceSaved = {};
-    traceErrors = {};
+    threadTraceSaving = false;
+    threadTraceSaved = null;
+    threadTraceError = '';
     pollAborted = false;
   }
 
@@ -187,8 +185,6 @@
             meta: activityMeta([dp.skill_used, dp.model_used, duration, tokens, cost]),
             error: dp.error ? cleanActivityText(String(dp.error).slice(0, 200), '') : undefined,
             state: status,
-            runId: Number.isFinite(Number(runId)) ? Number(runId) : undefined,
-            canSaveTrace: Number.isFinite(Number(runId)),
           };
           const trace = Array.isArray(dp.activity_trace) ? dp.activity_trace : [];
           const traceEvents: ActivityListItem[] = trace.map((entry: any, traceIndex: number) => ({
@@ -269,31 +265,29 @@
     cortex.selectIdea(linkedId);
   }
 
-  async function downloadTraceForRun(runId: number) {
-    if (!Number.isFinite(runId) || traceSaving[runId]) return;
-    traceSaving = { ...traceSaving, [runId]: true };
-    traceErrors = { ...traceErrors, [runId]: '' };
+  async function downloadThreadTrace() {
+    const ideaId = idea?.id;
+    if (!ideaId || threadTraceSaving) return;
+    threadTraceSaving = true;
+    threadTraceError = '';
     try {
-      const result = await downloadRunTraceZip(runId);
+      const result = await downloadThreadTraceZip(ideaId);
       const url = URL.createObjectURL(result.blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = result.filename || `illo-trace-run-${runId}.zip`;
+      link.download = result.filename || `illo-thread-trace-${ideaId}.zip`;
       document.body.appendChild(link);
       link.click();
       link.remove();
       window.setTimeout(() => URL.revokeObjectURL(url), 1000);
-      traceSaved = {
-        ...traceSaved,
-        [runId]: {
-          bytes: result.bytes,
-          filename: result.filename,
-        },
+      threadTraceSaved = {
+        bytes: result.bytes,
+        filename: result.filename,
       };
     } catch (e: any) {
-      traceErrors = { ...traceErrors, [runId]: e?.detail || 'Trace download failed' };
+      threadTraceError = e?.detail || 'Trace download failed';
     } finally {
-      traceSaving = { ...traceSaving, [runId]: false };
+      threadTraceSaving = false;
     }
   }
 
@@ -424,6 +418,32 @@
 </script>
 
 {#if activeTab === 'activity'}
+  <div class="activity-trace-toolbar">
+    <div class="activity-trace-copy">
+      <div class="activity-trace-title">Conversation trace</div>
+      {#if threadTraceSaved}
+        <div class="activity-trace-note">
+          {threadTraceSaved.filename || 'Trace zip'}
+          {#if threadTraceSaved.bytes}
+            &middot; {threadTraceSaved.bytes.toLocaleString()} bytes
+          {/if}
+        </div>
+      {:else if threadTraceError}
+        <div class="activity-trace-note activity-trace-note-error">{threadTraceError}</div>
+      {:else}
+        <div class="activity-trace-note">Thread transcript, runs, tools, and artifacts</div>
+      {/if}
+    </div>
+    <button
+      type="button"
+      class="activity-trace-button activity-trace-button-primary"
+      disabled={!idea?.id || threadTraceSaving}
+      onclick={downloadThreadTrace}
+    >
+      {threadTraceSaving ? 'Preparing' : threadTraceSaved ? 'Download again' : 'Download trace'}
+    </button>
+  </div>
+
   {#if activityLoading && activityItems.length === 0}
     <div class="tab-empty">Loading activity...</div>
   {:else if activityItems.length === 0}
@@ -431,7 +451,6 @@
   {:else}
     <div class="activity-list" aria-label="Thread activity">
       {#each activityItems as item (item._key)}
-        {@const savedTrace = item.runId ? traceSaved[item.runId] : null}
         <div class="activity-list-item" data-state={item.state}>
           <time class="activity-time" datetime={item.timestamp || undefined}>
             {timeAgo(item.timestamp)}
@@ -439,20 +458,6 @@
           <div class="activity-body">
             <div class="activity-title-row">
               <div class="activity-title">{item.title}</div>
-              {#if item.canSaveTrace && item.runId}
-                <button
-                  type="button"
-                  class="activity-trace-button"
-                  disabled={traceSaving[item.runId]}
-                  onclick={() => item.runId && downloadTraceForRun(item.runId)}
-                >
-                  {traceSaving[item.runId]
-                    ? 'Preparing'
-                    : savedTrace
-                      ? 'Download again'
-                      : 'Download trace'}
-                </button>
-              {/if}
             </div>
             {#if item.meta.length}
               <div class="activity-meta">
@@ -460,17 +465,6 @@
                   <span class="activity-meta-part">{meta}</span>
                 {/each}
               </div>
-            {/if}
-            {#if savedTrace}
-              <div class="activity-trace-note">
-                {savedTrace.filename || 'Trace zip'}
-                {#if savedTrace.bytes}
-                  &middot; {savedTrace.bytes.toLocaleString()} bytes
-                {/if}
-              </div>
-            {/if}
-            {#if item.runId && traceErrors[item.runId]}
-              <div class="activity-error">{traceErrors[item.runId]}</div>
             {/if}
             {#if item.error}
               <div class="activity-error">Error: {item.error}</div>
@@ -995,6 +989,32 @@
 
 
   /* Activity tab */
+  .activity-trace-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+    width: 100%;
+    margin-bottom: 10px;
+    padding: 10px 2px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  }
+
+  .activity-trace-copy {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .activity-trace-title {
+    color: rgba(239, 244, 251, 0.92);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
   .activity-list {
     display: flex;
     flex-direction: column;
@@ -1072,6 +1092,15 @@
       transform 150ms ease;
   }
 
+  .activity-trace-button-primary {
+    min-height: 28px;
+    padding: 5px 10px;
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 16%, rgba(255, 255, 255, 0.055));
+    color: rgba(239, 244, 251, 0.92);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
   .activity-trace-button:hover:not(:disabled),
   .activity-trace-button:focus-visible {
     background: color-mix(in srgb, var(--thread-accent, #57CFA0) 14%, transparent);
@@ -1116,6 +1145,10 @@
     font-size: 9px;
     line-height: 1.35;
     overflow-wrap: anywhere;
+  }
+
+  .activity-trace-note-error {
+    color: var(--negative, #D4808F);
   }
 
   .activity-error {

--- a/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
@@ -420,7 +420,7 @@
 {#if activeTab === 'activity'}
   <div class="activity-trace-toolbar">
     <div class="activity-trace-copy">
-      <div class="activity-trace-title">Conversation trace</div>
+      <div class="activity-trace-title">Whole conversation trace</div>
       {#if threadTraceSaved}
         <div class="activity-trace-note">
           {threadTraceSaved.filename || 'Trace zip'}
@@ -431,7 +431,7 @@
       {:else if threadTraceError}
         <div class="activity-trace-note activity-trace-note-error">{threadTraceError}</div>
       {:else}
-        <div class="activity-trace-note">Thread transcript, runs, tools, and artifacts</div>
+        <div class="activity-trace-note">Messages, runs, tools, and artifacts</div>
       {/if}
     </div>
     <button
@@ -440,7 +440,7 @@
       disabled={!idea?.id || threadTraceSaving}
       onclick={downloadThreadTrace}
     >
-      {threadTraceSaving ? 'Preparing' : threadTraceSaved ? 'Download again' : 'Download trace'}
+      {threadTraceSaving ? 'Preparing' : threadTraceSaved ? 'Download again' : 'Download conversation trace'}
     </button>
   </div>
 

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -174,7 +174,7 @@ def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
     session.get.side_effect = lambda model, key: {42: run, 43: child}.get(key) if model is AgentRunRow else None
     session.scalars.side_effect = [
         _result([run, child]),
-        _result([second_message, first_message]),
+        _result([first_message, second_message]),
         _result([event]),
         _result([artifact]),
     ]
@@ -183,6 +183,8 @@ def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
 
     assert snapshot["export_scope"] == "thread"
     assert snapshot["trace_id"] == "thread:idea-1"
+    assert snapshot["storage_policy"]["messages"] == "all_thread_messages"
+    assert snapshot["thread"]["message_limit"] is None
     assert snapshot["thread"]["idea_id"] == "idea-1"
     assert [message["id"] for message in snapshot["thread"]["messages"]] == [10, 11]
     assert [run["run_id"] for run in snapshot["runs"]] == [42, 43]

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -110,6 +110,89 @@ def test_agent_trace_snapshot_is_bounded_and_analysis_ready():
     assert "not copied" not in str(snapshot)
 
 
+def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
+    from brain.systems.runs.cortex.recording import (
+        agent_trace_export_filename,
+        build_thread_trace_snapshot,
+    )
+    from brain.platform.db.models.agent_run import AgentRunRow
+
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    run = _run(id=42, trace_id="run:42", input_message="Start the thread")
+    child = _run(
+        id=43,
+        trace_id="run:43",
+        parent_run_id=42,
+        root_run_id=42,
+        input_message="Worker slice",
+    )
+    first_message = SimpleNamespace(
+        id=10,
+        idea_id="idea-1",
+        role="user",
+        content="Can you analyze this whole thread?",
+        attachments=[],
+        metadata_={"run_id": 42, "trace_id": "run:42", "private": "not copied"},
+        message_type="message",
+        created_at=now,
+    )
+    second_message = SimpleNamespace(
+        id=11,
+        idea_id="idea-1",
+        role="illo",
+        content="Here is the full-thread answer.",
+        attachments=[],
+        metadata_={"run_id": 43, "trace_id": "run:43"},
+        message_type="message",
+        created_at=now,
+    )
+    event = SimpleNamespace(
+        id=99,
+        run_id=43,
+        root_run_id=42,
+        sequence_no=3,
+        event_type="run.tool_completed",
+        payload={"tool_name": "read_thread_messages", "result": "ok"},
+        producer="agent_runtime",
+        visibility="public",
+        created_at=now,
+    )
+    artifact = SimpleNamespace(
+        id=100,
+        run_id=43,
+        root_run_id=42,
+        artifact_type="reply",
+        title="Thread answer",
+        payload={"summary": "ok"},
+        text="artifact text",
+        uri=None,
+        visibility="public",
+        created_at=now,
+    )
+
+    session = MagicMock()
+    session.get.side_effect = lambda model, key: {42: run, 43: child}.get(key) if model is AgentRunRow else None
+    session.scalars.side_effect = [
+        _result([run, child]),
+        _result([second_message, first_message]),
+        _result([event]),
+        _result([artifact]),
+    ]
+
+    snapshot = build_thread_trace_snapshot(session, "idea-1", saved_by="user-1")
+
+    assert snapshot["export_scope"] == "thread"
+    assert snapshot["trace_id"] == "thread:idea-1"
+    assert snapshot["thread"]["idea_id"] == "idea-1"
+    assert [message["id"] for message in snapshot["thread"]["messages"]] == [10, 11]
+    assert [run["run_id"] for run in snapshot["runs"]] == [42, 43]
+    assert snapshot["related_run_ids"] == [42, 43]
+    assert snapshot["tools"][0]["tool_name"] == "read_thread_messages"
+    assert snapshot["artifacts"][0]["artifact_type"] == "reply"
+    assert agent_trace_export_filename(snapshot) == "illo-thread-trace-idea-1.zip"
+    assert "not copied" not in str(snapshot)
+
+
 def test_agent_trace_export_zip_contains_shareable_trace_files():
     from brain.systems.runs.cortex.recording import (
         agent_trace_export_filename,


### PR DESCRIPTION
## Summary
- add a thread-level trace export endpoint for Cortex conversations
- replace per-run activity row downloads with one conversation trace action in the activity panel
- cover thread export snapshots with focused backend tests

## Verification
- venv/bin/python -m pytest tests/test_agent_trace_snapshot.py
- npm run check