### PR TITLE
Improve one-shot workspace app generation

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
 from brain.systems.runs.tool_catalog.handlers.common import *
 from brain.systems.workspace_apps.compiler import (
     compile_workspace_app_input,
@@ -15,6 +20,56 @@ def _workspace_app_context() -> tuple[str | None, str | None]:
     org_id = getattr(_agent_context, "org_id", None) or execution_metadata.get("org_id")
     user_id = getattr(_agent_context, "user_id", None) or execution_metadata.get("user_id")
     return org_id, user_id
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_uuid(value: Any, field: str) -> tuple[str | None, dict[str, str] | None]:
+    text = _optional_text(value)
+    if text is None:
+        return None, None
+    try:
+        return str(uuid.UUID(text)), None
+    except (TypeError, ValueError, AttributeError):
+        return None, {"error": f"{field} must be a valid UUID when provided"}
+
+
+def _optional_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", ""}:
+        return False
+    return default
+
+
+def _optional_mapping(value: Any, field: str) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, Mapping):
+        return dict(value), None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None, None
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            return None, {"error": f"{field} must be an object or valid JSON object string: {exc.msg}"}
+        if isinstance(parsed, Mapping):
+            return dict(parsed), None
+    return None, {"error": f"{field} must be an object when provided"}
 
 
 def _handle_manage_workspace_app(
@@ -41,6 +96,38 @@ def _handle_manage_workspace_app(
     action = str(action or "").strip().lower()
     if action in {"help", "schema"}:
         return _manage_tool_guide("manage_workspace_app", operation)
+
+    app_id = _optional_text(app_id)
+    key = _optional_text(key)
+    name = _optional_text(name)
+    description = _optional_text(description)
+    renderer_key = _optional_text(renderer_key)
+    source_kind = _optional_text(source_kind)
+    state_key = _optional_text(state_key) or "default"
+    include_archived = _optional_bool(include_archived)
+    include_prototypes = _optional_bool(include_prototypes)
+    anchor_user_id, uuid_error = _optional_uuid(anchor_user_id, "anchor_user_id")
+    if uuid_error:
+        return json.dumps(uuid_error)
+
+    manifest, mapping_error = _optional_mapping(manifest, "manifest")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    visual_spec, mapping_error = _optional_mapping(visual_spec, "visual_spec")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    metadata, mapping_error = _optional_mapping(metadata, "metadata")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    initial_state, mapping_error = _optional_mapping(initial_state, "initial_state")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    data, mapping_error = _optional_mapping(data, "data")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    data_patch, mapping_error = _optional_mapping(data_patch, "data_patch")
+    if mapping_error:
+        return json.dumps(mapping_error)
 
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
     from brain.systems.workspace_apps.service import (

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -894,11 +894,11 @@ WORKSPACE_APP_TOOLS = [
         "description": (
             "Create, list, update, archive, and persist state for generated workspace apps. "
             "This is the action tool to create or change a persistent programmable UI surface or dashboard "
-            "inside Cortex. Use renderer_key='generated-ui-app' and source_kind='json' for simple "
-            "host-rendered structured UIs. Use renderer_key='sandboxed-html-app' and source_kind='html' "
-            "as the first-class full-code runtime for custom layouts, interactions, charts, drag/drop, "
-            "canvas, or app logic that should still follow Illospace App Kit tokens/classes. Do not infer "
-            "that a workflow needs a use-case-specific template or built-in view type. Recordful apps must use manage_domain first; app-local "
+            "inside Cortex. Use renderer_key='generated-ui-app' and source_kind='json' for common "
+            "host-rendered structured UIs, including tables, lists, cards, metrics, charts, forms, details, "
+            "board/kanban views, and manifest action buttons. Use renderer_key='sandboxed-html-app' and source_kind='html' "
+            "only for bespoke interactions or custom blocks that cannot be represented by structured views. "
+            "Recordful apps must use manage_domain first; app-local "
             "state is only for UI preferences, filters, drafts, and ephemeral interface state. "
             "For awareness questions about what apps exist or current app state, prefer read_workspace_apps first. "
             "New generated apps must pass the workspace app contract before they are persisted. Use action='help' "
@@ -949,8 +949,10 @@ WORKSPACE_APP_TOOLS = [
                     "type": "string",
                     "description": (
                         "Generated app source. For generated-ui-app, provide a JSON string with "
-                        "schema_version=1, title, optional description, and views. For sandboxed html, "
-                        "provide a responsive HTML/CSS/JS body or document. Canonical calls pass "
+                        "schema_version=1, title, optional description, optional top-level actions "
+                        "referencing manifest.actions, and views. For sandboxed html, "
+                        "provide a responsive HTML/CSS/JS body or document only when structured views are insufficient. "
+                        "Canonical calls pass "
                         "manifest, visual_spec, and metadata as separate tool args; the app compiler "
                         "also normalizes wrapped generated-app envelopes when needed."
                     ),
@@ -998,10 +1000,6 @@ WORKSPACE_APP_TOOLS = [
                     ),
                 },
                 "metadata": {"type": "object", "description": "App metadata for provenance and runtime notes."},
-                "anchor_user_id": {
-                    "type": "string",
-                    "description": "Optional user id whose astre should anchor the app object.",
-                },
                 "initial_state": {"type": "object", "description": "Initial app-local state for create."},
                 "state_key": {
                     "type": "string",

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -447,18 +447,23 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
-3. Prefer a host-rendered structured UI spec for simple apps:
+3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
-   `description`, `primary_binding`, and `views`.
-   Use view types `table`, `list`, `cards`, `chart`, `metrics`, `detail`, or
-   `form`. Use editable `status`/`select`/`boolean` columns only when the
-   Domain binding allows `update`.
+   `description`, `primary_binding`, optional `actions`, and `views`.
+   Use view types `table`, `list`, `cards`, `board`, `chart`, `metrics`,
+   `detail`, or `form`. Use `board` for kanban/status-column workflows such
+   as ticket trackers, CRM pipelines, approval queues, sourcing funnels, and
+   work progression. Use editable `status`/`select`/`boolean` columns only
+   when the Domain binding allows `update`.
+   Surface manifest-declared server actions with top-level `actions`, e.g.
+   `[{ "key": "tickets.syncExternal", "label": "Sync GitHub" }]`; do not
+   switch to HTML just to add an action button.
 4. Use `renderer_key="sandboxed-html-app"` and `source_kind="html"` as the
-   first-class full-code app runtime when the user needs custom layout,
-   interaction, charts, drag/drop, canvas, or richer composition than the
-   structured renderer should carry. This is still a native Illospace app:
-   use App Kit classes, design tokens, the manifest, and the host bridge.
+   full-code app runtime only when the requested interaction cannot be
+   represented with structured views or a composed structured workflow. This
+   is still a native Illospace app: use App Kit classes, design tokens, the
+   manifest, and the host bridge.
 5. For full-code apps, use the host bridge:
    - `window.illo.domain(alias)` for bound Domain records and generic workspace
      data primitives.
@@ -546,6 +551,35 @@ Constellation design contract.
   generated UI spec and pass `manifest`, `visual_spec`, and `metadata` as
   separate tool arguments. The app compiler tolerates wrapped envelopes and
   fills safe defaults, but it will not invent durable data models.
+- Use native `board` views for kanban/status-column apps before considering
+  sandboxed HTML. Minimal example:
+
+```json
+{
+  "schema_version": 1,
+  "title": "GitHub Ticket Tracker",
+  "primary_binding": "tickets",
+  "actions": [
+    {"key": "tickets.syncExternal", "label": "Sync GitHub"}
+  ],
+  "views": [
+    {
+      "id": "ticket-board",
+      "type": "board",
+      "title": "Tickets",
+      "binding": "tickets",
+      "group_by": "status",
+      "groups": ["Backlog", "Todo", "In Progress", "In Review", "Done"],
+      "card": {
+        "title": "title",
+        "subtitle": "repo",
+        "badges": ["priority", "milestone"]
+      },
+      "allow_create": true
+    }
+  ]
+}
+```
 - Legacy generated HTML must use fluid layout and container-aware sizing.
 - The persisted manifest must end with `contract_version: 1`, `data_plan`, and
   `design_contract`. The compiler supplies simple app-local UI-state defaults;
@@ -580,7 +614,9 @@ Constellation design contract.
 }
 ```
 
-  The app can call `window.illo.actions.run("tickets.importExternal", payload)`.
+  Generated UI apps can surface this with top-level `actions`, e.g.
+  `[{ "key": "tickets.importExternal", "label": "Import" }]`. Full-code
+  apps can call `window.illo.actions.run("tickets.importExternal", payload)`.
   The server validates the declaration and only runs registered executors.
 - Use the Illo App Kit classes (`illo-app`, `illo-panel`, `illo-toolbar`,
   `illo-input`, `illo-button`, `illo-list`, `illo-row`, `illo-tabs`,

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -33,18 +33,23 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
-3. Prefer a host-rendered structured UI spec for simple apps:
+3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
-   `description`, `primary_binding`, and `views`.
-   Use view types `table`, `list`, `cards`, `chart`, `metrics`, `detail`, or
-   `form`. Use editable `status`/`select`/`boolean` columns only when the
-   Domain binding allows `update`.
+   `description`, `primary_binding`, optional `actions`, and `views`.
+   Use view types `table`, `list`, `cards`, `board`, `chart`, `metrics`,
+   `detail`, or `form`. Use `board` for kanban/status-column workflows such
+   as ticket trackers, CRM pipelines, approval queues, sourcing funnels, and
+   work progression. Use editable `status`/`select`/`boolean` columns only
+   when the Domain binding allows `update`.
+   Surface manifest-declared server actions with top-level `actions`, e.g.
+   `[{ "key": "tickets.syncExternal", "label": "Sync GitHub" }]`; do not
+   switch to HTML just to add an action button.
 4. Use `renderer_key="sandboxed-html-app"` and `source_kind="html"` as the
-   first-class full-code app runtime when the user needs custom layout,
-   interaction, charts, drag/drop, canvas, or richer composition than the
-   structured renderer should carry. This is still a native Illospace app:
-   use App Kit classes, design tokens, the manifest, and the host bridge.
+   full-code app runtime only when the requested interaction cannot be
+   represented with structured views or a composed structured workflow. This
+   is still a native Illospace app: use App Kit classes, design tokens, the
+   manifest, and the host bridge.
 5. For full-code apps, use the host bridge:
    - `window.illo.domain(alias)` for bound Domain records and generic workspace
      data primitives.
@@ -132,6 +137,35 @@ Constellation design contract.
   generated UI spec and pass `manifest`, `visual_spec`, and `metadata` as
   separate tool arguments. The app compiler tolerates wrapped envelopes and
   fills safe defaults, but it will not invent durable data models.
+- Use native `board` views for kanban/status-column apps before considering
+  sandboxed HTML. Minimal example:
+
+```json
+{
+  "schema_version": 1,
+  "title": "GitHub Ticket Tracker",
+  "primary_binding": "tickets",
+  "actions": [
+    {"key": "tickets.syncExternal", "label": "Sync GitHub"}
+  ],
+  "views": [
+    {
+      "id": "ticket-board",
+      "type": "board",
+      "title": "Tickets",
+      "binding": "tickets",
+      "group_by": "status",
+      "groups": ["Backlog", "Todo", "In Progress", "In Review", "Done"],
+      "card": {
+        "title": "title",
+        "subtitle": "repo",
+        "badges": ["priority", "milestone"]
+      },
+      "allow_create": true
+    }
+  ]
+}
+```
 - Legacy generated HTML must use fluid layout and container-aware sizing.
 - The persisted manifest must end with `contract_version: 1`, `data_plan`, and
   `design_contract`. The compiler supplies simple app-local UI-state defaults;
@@ -166,7 +200,9 @@ Constellation design contract.
 }
 ```
 
-  The app can call `window.illo.actions.run("tickets.importExternal", payload)`.
+  Generated UI apps can surface this with top-level `actions`, e.g.
+  `[{ "key": "tickets.importExternal", "label": "Import" }]`. Full-code
+  apps can call `window.illo.actions.run("tickets.importExternal", payload)`.
   The server validates the declaration and only runs registered executors.
 - Use the Illo App Kit classes (`illo-app`, `illo-panel`, `illo-toolbar`,
   `illo-input`, `illo-button`, `illo-list`, `illo-row`, `illo-tabs`,

--- a/brain/systems/workspace_apps/compiler.py
+++ b/brain/systems/workspace_apps/compiler.py
@@ -40,6 +40,8 @@ _VIEW_TYPE_ALIASES = {
     "stats": "metrics",
     "grid": "cards",
     "card": "cards",
+    "kanban": "board",
+    "board-view": "board",
 }
 
 
@@ -174,6 +176,20 @@ def contract_repair_guidance(report: Mapping[str, Any] | None) -> dict[str, Any]
             "failure_kind": "data_model_requires_domain",
             "retryable": True,
             "suggested_repair": "Create or bind a Domain for durable records; keep app-local state to UI preferences, filters, drafts, or ephemeral state.",
+        }
+    if (
+        "illo app kit" in text
+        or "hardcode visual colors" in text
+        or "fixed body background" in text
+        or "letter spacing" in text
+        or "illo-panel" in text
+        or "illo-button" in text
+        or "illo-select" in text
+    ):
+        return {
+            "failure_kind": "html_app_contract",
+            "retryable": True,
+            "suggested_repair": "Repair the sandboxed HTML source: use App Kit classes on controls, use host/App Kit CSS variables instead of hardcoded colors, avoid fixed body backgrounds, and keep layout fluid across dock and overlay widths.",
         }
     if "generated ui" in text or "source_code" in text:
         return {
@@ -429,6 +445,16 @@ def _normalize_views(
             if columns:
                 view["columns"] = columns
                 changed = True
+        if view.get("type") == "board" and not (view.get("group_by") or view.get("groupBy")):
+            group_by = _infer_board_group_by(view=view, spec=spec, manifest=manifest)
+            if group_by:
+                view["group_by"] = group_by
+                changed = True
+        if view.get("type") == "board" and not isinstance(view.get("card"), Mapping):
+            card = _infer_board_card(view=view, spec=spec, manifest=manifest)
+            if card:
+                view["card"] = card
+                changed = True
         next_views.append(view)
     return next_views, changed
 
@@ -464,6 +490,8 @@ def _infer_view(
 
 
 def _infer_view_type(view: Mapping[str, Any]) -> str:
+    if view.get("group_by") or view.get("groupBy") or view.get("card") or view.get("groups"):
+        return "board"
     if isinstance(view.get("metrics"), list):
         return "metrics"
     if view.get("chart_type") or view.get("chart"):
@@ -506,6 +534,59 @@ def _infer_columns(
     if isinstance(fields, list):
         return [{"key": str(field), "label": _label(str(field))} for field in fields if str(field).strip()]
     return []
+
+
+def _infer_board_group_by(
+    *,
+    view: Mapping[str, Any],
+    spec: Mapping[str, Any],
+    manifest: Mapping[str, Any] | None,
+) -> str | None:
+    candidates: list[str] = []
+    for source in (view, spec):
+        for key in ("group_by", "groupBy", "status_field", "statusField"):
+            value = str(source.get(key) or "").strip()
+            if value:
+                candidates.append(value)
+    rows = _row_candidates(view) or _row_candidates(spec) or []
+    for row in rows[:8]:
+        if not isinstance(row, Mapping):
+            continue
+        for key in ("status", "state", "stage", "phase", "column"):
+            if key in row:
+                candidates.append(key)
+    alias = view.get("binding") or view.get("data_binding") or spec.get("primary_binding") or _primary_binding_alias(spec, manifest)
+    binding = _domain_binding(manifest, str(alias)) if alias else None
+    fields = binding.get("fields") if isinstance(binding, Mapping) else None
+    if isinstance(fields, list):
+        normalized = [str(field).strip() for field in fields if str(field).strip()]
+        for key in ("status", "state", "stage", "phase", "column"):
+            if key in normalized:
+                candidates.append(key)
+        if normalized:
+            candidates.append(normalized[0])
+    return candidates[0] if candidates else None
+
+
+def _infer_board_card(
+    *,
+    view: Mapping[str, Any],
+    spec: Mapping[str, Any],
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    fields = _infer_columns(view=view, spec=spec, manifest=manifest)
+    keys = [field["key"] for field in fields if field.get("key")]
+    if not keys:
+        return None
+    title = "title" if "title" in keys else keys[0]
+    subtitle = next((key for key in ("repo", "repository", "project", "milestone") if key in keys), None)
+    badges = [key for key in ("priority", "status", "labels", "label", "milestone") if key in keys and key != title]
+    card: dict[str, Any] = {"title": title}
+    if subtitle:
+        card["subtitle"] = subtitle
+    if badges:
+        card["badges"] = badges[:3]
+    return card
 
 
 def _primary_binding_alias(spec: Mapping[str, Any], manifest: Mapping[str, Any] | None) -> str | None:

--- a/brain/systems/workspace_apps/contracts.py
+++ b/brain/systems/workspace_apps/contracts.py
@@ -39,7 +39,7 @@ ACTION_EFFECTS = {
 }
 ACTION_EXECUTOR_TYPES = {"registered", "deferred"}
 APP_LOCAL_SCOPES = {"ui_state", "preferences", "filters", "draft", "ephemeral"}
-GENERATED_UI_VIEW_TYPES = {"table", "list", "cards", "chart", "metrics", "detail", "form"}
+GENERATED_UI_VIEW_TYPES = {"table", "list", "cards", "board", "chart", "metrics", "detail", "form"}
 GENERATED_UI_CHART_TYPES = {"bar", "line", "pie", "scatter"}
 RECORD_LIKE_STATE_KEYS = {
     "records",
@@ -139,7 +139,7 @@ def build_contract_validation_report(
     if normalized_renderer == "sandboxed-html-app" and normalized_source_kind == "html":
         _validate_html_source(source_code or "", errors)
     if _is_structured_ui_renderer(normalized_renderer, normalized_source_kind):
-        _validate_generated_ui_source(source_code or "", errors)
+        _validate_generated_ui_source(source_code or "", errors, manifest=manifest_dict)
 
     return {
         "status": "passed" if not errors else "failed",
@@ -331,7 +331,12 @@ def _is_structured_ui_renderer(renderer_key: str, source_kind: str) -> bool:
     }
 
 
-def _validate_generated_ui_source(source: str, errors: list[str]) -> None:
+def _validate_generated_ui_source(
+    source: str,
+    errors: list[str],
+    *,
+    manifest: Mapping[str, Any] | None = None,
+) -> None:
     if not source.strip():
         errors.append("source_code is required for generated-ui apps")
         return
@@ -349,6 +354,8 @@ def _validate_generated_ui_source(source: str, errors: list[str]) -> None:
         errors.append("generated UI schema_version must be 1 when provided")
     if not str(spec.get("title") or "").strip():
         errors.append("generated UI spec.title is required")
+
+    _validate_generated_ui_actions(spec, errors, manifest=manifest)
 
     views = spec.get("views")
     if not isinstance(views, list) or not views:
@@ -375,6 +382,10 @@ def _validate_generated_ui_source(source: str, errors: list[str]) -> None:
                         errors.append(
                             f"generated UI spec.views[{index}].columns[{col_index}] must include a key"
                         )
+        if view_type == "board":
+            group_by = raw_view.get("group_by", raw_view.get("groupBy"))
+            if group_by is not None and not str(group_by or "").strip():
+                errors.append(f"generated UI spec.views[{index}].group_by must be non-empty when provided")
         if view_type == "chart":
             chart_type = str(raw_view.get("chart_type") or raw_view.get("chart") or "bar").strip()
             if chart_type not in GENERATED_UI_CHART_TYPES:
@@ -382,6 +393,50 @@ def _validate_generated_ui_source(source: str, errors: list[str]) -> None:
                     f"generated UI spec.views[{index}].chart_type must be one of: "
                     f"{', '.join(sorted(GENERATED_UI_CHART_TYPES))}"
                 )
+
+
+def _validate_generated_ui_actions(
+    spec: Mapping[str, Any],
+    errors: list[str],
+    *,
+    manifest: Mapping[str, Any] | None = None,
+) -> None:
+    actions = spec.get("actions")
+    if actions is None:
+        return
+    if not isinstance(actions, list):
+        errors.append("generated UI spec.actions must be a list when provided")
+        return
+    declared_action_keys = _declared_action_keys(manifest or {})
+    for index, raw_action in enumerate(actions):
+        key = ""
+        if isinstance(raw_action, str):
+            key = raw_action.strip()
+        elif isinstance(raw_action, Mapping):
+            key = str(raw_action.get("key") or raw_action.get("action_key") or "").strip()
+            payload = raw_action.get("payload")
+            if payload is not None and not isinstance(payload, Mapping):
+                errors.append(f"generated UI spec.actions[{index}].payload must be an object when provided")
+            if _forbidden_secret_paths(raw_action):
+                errors.append(f"generated UI spec.actions[{index}] must not contain raw credentials or secret values")
+        else:
+            errors.append(f"generated UI spec.actions[{index}] must be an action key or object")
+            continue
+        if not key or not re.match(r"^[a-zA-Z][\w.-]*$", key):
+            errors.append(f"generated UI spec.actions[{index}].key must be a stable action identifier")
+        elif key not in declared_action_keys:
+            errors.append(
+                f"generated UI spec.actions[{index}].key must reference a manifest.actions declaration"
+            )
+
+
+def _declared_action_keys(manifest: Mapping[str, Any]) -> set[str]:
+    actions = manifest.get("actions")
+    if actions is None:
+        actions = _as_mapping(manifest.get("action_plan")).get("actions")
+    if not isinstance(actions, Mapping):
+        return set()
+    return {str(key or "").strip() for key in actions.keys() if str(key or "").strip()}
 
 
 class _AppKitHtmlParser(HTMLParser):

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
@@ -4,6 +4,7 @@
   import {
     createDomainRecord,
     listDomainRecords,
+    runWorkspaceAppAction,
     updateDomainRecord,
     type DomainRecordRead,
     type WorkspaceAppRead,
@@ -24,6 +25,36 @@
     width?: string;
   };
 
+  type GeneratedUiBoardGroup = string | { label?: string; value?: any };
+  type GeneratedUiBoardCard = {
+    title?: string;
+    subtitle?: string;
+    description?: string;
+    badges?: string[];
+    meta?: string[];
+    assignee?: string;
+    href?: string;
+  };
+
+  type GeneratedUiAction = string | {
+    key?: string;
+    action_key?: string;
+    label?: string;
+    title?: string;
+    description?: string;
+    payload?: Record<string, any>;
+    disabled?: boolean;
+    hidden?: boolean;
+  };
+
+  type NormalizedGeneratedUiAction = {
+    key: string;
+    label: string;
+    description?: string;
+    payload: Record<string, any>;
+    disabled: boolean;
+  };
+
   type GeneratedUiView = {
     id?: string;
     type?: string;
@@ -34,12 +65,17 @@
     object_key?: string;
     columns?: GeneratedUiColumn[];
     fields?: GeneratedUiColumn[];
+    groups?: GeneratedUiBoardGroup[];
+    board_columns?: GeneratedUiBoardGroup[];
+    boardColumns?: GeneratedUiBoardGroup[];
+    groupBy?: string;
     rows?: Record<string, any>[];
     records?: Record<string, any>[];
     metrics?: Array<{ key?: string; label?: string; value?: any; op?: string; field?: string; equals?: any }>;
     chart_type?: string;
     chart?: string;
     group_by?: string;
+    card?: GeneratedUiBoardCard;
     allow_create?: boolean;
     create?: boolean | { fields?: GeneratedUiColumn[] };
     empty_state?: string;
@@ -51,6 +87,7 @@
     title?: string;
     description?: string;
     primary_binding?: string;
+    actions?: GeneratedUiAction[];
     views?: GeneratedUiView[];
     rows?: Record<string, any>[];
     records?: Record<string, any>[];
@@ -85,6 +122,9 @@
   let draftByView = $state<Record<string, Record<string, any>>>({});
   let busyCell = $state<Record<string, boolean>>({});
   let busyCreate = $state<Record<string, boolean>>({});
+  let busyAction = $state<Record<string, boolean>>({});
+  let actionNotice = $state<string | null>(null);
+  let actionError = $state<string | null>(null);
   let uiStateBase = $state<Record<string, any>>({});
   let uiStateLoadSignature = $state('');
   let uiStateLoaded = $state(false);
@@ -100,6 +140,8 @@
     spec?.primary_binding || Object.keys(domainBindings)[0] || null,
   );
   const views = $derived(normalizeViews(spec));
+  const hasBoardView = $derived(views.some((view) => view.type === 'board'));
+  const structuredActions = $derived(generatedActionsForSpec(spec, manifest));
   const bindingSignature = $derived(
     JSON.stringify(Object.entries(domainBindings).map(([alias, binding]) => [
       alias,
@@ -153,6 +195,56 @@
     if (!source) return [];
     if (Array.isArray(source.views) && source.views.length) return source.views;
     return [{ id: 'records', type: 'table', title: source.title || app.name }];
+  }
+
+  function manifestActionDeclarations(appManifest: Record<string, any>): Record<string, any> {
+    const direct = appManifest.actions;
+    if (isRecord(direct)) return direct;
+    const actionPlan = appManifest.action_plan;
+    if (isRecord(actionPlan) && isRecord(actionPlan.actions)) return actionPlan.actions;
+    return {};
+  }
+
+  function generatedActionsForSpec(
+    source: GeneratedUiSpec | null,
+    appManifest: Record<string, any>,
+  ): NormalizedGeneratedUiAction[] {
+    const declarations = manifestActionDeclarations(appManifest);
+    const configured = Array.isArray(source?.actions) && source.actions.length
+      ? source.actions
+      : Object.keys(declarations);
+    return configured
+      .map((raw) => normalizeGeneratedAction(raw, declarations))
+      .filter((action): action is NormalizedGeneratedUiAction => Boolean(action));
+  }
+
+  function normalizeGeneratedAction(
+    raw: GeneratedUiAction,
+    declarations: Record<string, any>,
+  ): NormalizedGeneratedUiAction | null {
+    const rawObject = isRecord(raw) ? raw : null;
+    const key = String(
+      typeof raw === 'string' ? raw : rawObject?.key || rawObject?.action_key || '',
+    ).trim();
+    if (!key) return null;
+    const declaration = declarations[key];
+    if (!isRecord(declaration)) return null;
+    const ui = isRecord(declaration.ui) ? declaration.ui : {};
+    if (rawObject?.hidden || ui.hidden === true) return null;
+    const label = String(rawObject?.label || rawObject?.title || ui.label || declaration.label || actionLabelFromKey(key)).trim();
+    return {
+      key,
+      label: label || actionLabelFromKey(key),
+      description: String(rawObject?.description || declaration.description || '').trim() || undefined,
+      payload: isRecord(rawObject?.payload) ? rawObject.payload : {},
+      disabled: rawObject?.disabled === true || ui.disabled === true,
+    };
+  }
+
+  function actionLabelFromKey(key: string): string {
+    const parts = key.split('.');
+    const tail = parts[parts.length - 1] || key;
+    return labelFromKey(tail.replace(/([a-z])([A-Z])/g, '$1 $2'));
   }
 
   function viewId(view: GeneratedUiView, index: number): string {
@@ -277,6 +369,13 @@
   function columnsForView(view: GeneratedUiView, rows: Record<string, any>[]): GeneratedUiColumn[] {
     const configured = view.columns || view.fields;
     if (Array.isArray(configured) && configured.length) return configured.filter((column) => !!column?.key);
+    const bindingFields = bindingForView(view)?.fields;
+    if (Array.isArray(bindingFields) && bindingFields.length) {
+      return bindingFields
+        .filter((key) => typeof key === 'string' && key.trim())
+        .slice(0, 8)
+        .map((key) => ({ key, label: labelFromKey(key) }));
+    }
     const first = rows[0] || {};
     return Object.keys(first)
       .filter((key) => !key.startsWith('__') && !['id', 'version', 'object_key'].includes(key))
@@ -371,6 +470,126 @@
     } finally {
       const { [cacheKey]: _removed, ...nextBusy } = busyCell;
       busyCell = nextBusy;
+    }
+  }
+
+  function boardGroupKey(view: GeneratedUiView): string {
+    return String(view.group_by || view.groupBy || 'status').trim() || 'status';
+  }
+
+  function normalizeBoardGroup(group: GeneratedUiBoardGroup): { label: string; value: any } {
+    if (typeof group === 'string') return { label: group, value: group };
+    const value = group?.value ?? group?.label ?? '';
+    return { label: group?.label || formatValue(value), value };
+  }
+
+  function boardGroups(view: GeneratedUiView, rows: Record<string, any>[]): Array<{ label: string; value: any }> {
+    const configured = view.groups || view.board_columns || view.boardColumns;
+    if (Array.isArray(configured) && configured.length) {
+      return configured.map(normalizeBoardGroup).filter((group) => String(group.value ?? '').trim());
+    }
+    const key = boardGroupKey(view);
+    const values = Array.from(new Set(rows.map((row) => row[key]).filter((value) => value !== null && value !== undefined && value !== '')));
+    if (values.length) return values.map((value) => ({ label: formatValue(value), value }));
+    return ['Backlog', 'Todo', 'In Progress', 'In Review', 'Done'].map((value) => ({ label: value, value }));
+  }
+
+  function rowsForBoardGroup(rows: Record<string, any>[], groupKey: string, groupValue: any): Record<string, any>[] {
+    return rows.filter((row) => String(row[groupKey] ?? '') === String(groupValue ?? ''));
+  }
+
+  function boardCard(view: GeneratedUiView): GeneratedUiBoardCard {
+    return view.card || {};
+  }
+
+  function boardCardTitle(view: GeneratedUiView, row: Record<string, any>, columns: GeneratedUiColumn[]): string {
+    const card = boardCard(view);
+    const key = card.title || 'title';
+    return formatValue(row[key] ?? row.title ?? row.name ?? row[columns[0]?.key]);
+  }
+
+  function boardCardSubtitle(view: GeneratedUiView, row: Record<string, any>): string {
+    const key = boardCard(view).subtitle;
+    return key ? formatValue(row[key]) : '';
+  }
+
+  function boardCardBadgeKeys(view: GeneratedUiView, columns: GeneratedUiColumn[]): string[] {
+    const configured = boardCard(view).badges;
+    if (Array.isArray(configured) && configured.length) return configured;
+    const preferred = ['priority', 'status', 'state', 'milestone', 'labels', 'label'];
+    const keys = columns.map((column) => column.key);
+    return preferred.filter((key) => keys.includes(key)).slice(0, 3);
+  }
+
+  function boardRowId(row: Record<string, any>): string {
+    return String(row.__record?.id ?? row.id ?? row.title ?? JSON.stringify(row));
+  }
+
+  function canMoveBoardCard(view: GeneratedUiView, groupKey: string, row: Record<string, any>): boolean {
+    const binding = bindingForView(view);
+    return Boolean(
+      row.__record
+      && bindingAllowsOperation(binding, 'update')
+      && bindingAllowsField(binding, groupKey)
+    );
+  }
+
+  function startBoardDrag(event: DragEvent, view: GeneratedUiView, index: number, row: Record<string, any>, groupKey: string) {
+    if (!event.dataTransfer || !canMoveBoardCard(view, groupKey, row)) return;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('application/x-illo-board-card', JSON.stringify({
+      viewId: viewId(view, index),
+      rowId: boardRowId(row),
+      groupKey,
+    }));
+  }
+
+  async function dropBoardCard(
+    event: DragEvent,
+    view: GeneratedUiView,
+    index: number,
+    rows: Record<string, any>[],
+    nextGroupValue: any,
+  ) {
+    event.preventDefault();
+    const raw = event.dataTransfer?.getData('application/x-illo-board-card');
+    if (!raw) return;
+    try {
+      const payload = JSON.parse(raw);
+      if (payload.viewId !== viewId(view, index)) return;
+      const row = rows.find((candidate) => boardRowId(candidate) === payload.rowId);
+      const groupKey = String(payload.groupKey || boardGroupKey(view));
+      if (!row || !canMoveBoardCard(view, groupKey, row)) return;
+      await updateCell(view, row, {
+        key: groupKey,
+        label: labelFromKey(groupKey),
+        type: typeof nextGroupValue === 'boolean' ? 'boolean' : 'status',
+        editable: true,
+        options: boardGroups(view, rows),
+      }, String(nextGroupValue ?? ''));
+    } catch {
+      return;
+    }
+  }
+
+  async function runGeneratedAction(action: NormalizedGeneratedUiAction) {
+    if (busyAction[action.key] || action.disabled) return;
+    busyAction = { ...busyAction, [action.key]: true };
+    actionNotice = null;
+    actionError = null;
+    try {
+      const result = await runWorkspaceAppAction(app.id, {
+        action_key: action.key,
+        payload: action.payload,
+      });
+      actionNotice = result.status === 'completed'
+        ? `${action.label} completed.`
+        : `${action.label}: ${result.status}`;
+      await loadBoundRecords();
+    } catch (err: any) {
+      actionError = err?.detail || err?.message || 'Workspace action failed.';
+    } finally {
+      busyAction = { ...busyAction, [action.key]: false };
     }
   }
 
@@ -519,7 +738,7 @@
   }
 </script>
 
-<section class="generated-ui generated-app-shell" class:is-dock={surface === 'dock'}>
+<section class="generated-ui generated-app-shell" class:is-dock={surface === 'dock'} class:has-board={hasBoardView}>
   <header class="generated-ui__header generated-app-shell__header">
     <div class="generated-ui__title-block">
       <span class="generated-ui__eyebrow">Generated UI</span>
@@ -530,6 +749,17 @@
     </div>
 
     <div class="generated-ui__actions">
+      {#each structuredActions as action (action.key)}
+        <button
+          type="button"
+          class="generated-ui__action-button"
+          title={action.description || action.label}
+          disabled={busyAction[action.key] || action.disabled}
+          onclick={() => runGeneratedAction(action)}
+        >
+          {busyAction[action.key] ? 'Running' : action.label}
+        </button>
+      {/each}
       <label class="generated-ui__search">
         <span>Search</span>
         <input
@@ -555,6 +785,11 @@
     {#if loadError}
       <div class="generated-ui__notice">{loadError}</div>
     {/if}
+    {#if actionError}
+      <div class="generated-ui__notice generated-ui__notice--error">{actionError}</div>
+    {:else if actionNotice}
+      <div class="generated-ui__notice">{actionNotice}</div>
+    {/if}
 
     <div class="generated-ui__body" aria-busy={loadingRecords}>
       {#each views as view, index (viewId(view, index))}
@@ -578,6 +813,53 @@
                   <span>{metric.label || labelFromKey(metric.key || metric.op || 'metric')}</span>
                   <strong>{metricValue(metric, rows)}</strong>
                 </div>
+              {/each}
+            </div>
+          {:else if view.type === 'board'}
+            {@const groupKey = boardGroupKey(view)}
+            {@const groups = boardGroups(view, rows)}
+            {@const badgeKeys = boardCardBadgeKeys(view, columns)}
+            <div class="generated-ui__board">
+              {#each groups as group}
+                {@const groupRows = rowsForBoardGroup(rows, groupKey, group.value)}
+                <section
+                  class="generated-ui__board-column"
+                  role="list"
+                  aria-label={`${group.label} ${labelFromKey(groupKey)}`}
+                  ondragover={(event) => event.preventDefault()}
+                  ondrop={(event) => dropBoardCard(event, view, index, rows, group.value)}
+                >
+                  <header>
+                    <strong>{group.label}</strong>
+                    <span>{groupRows.length}</span>
+                  </header>
+                  <div class="generated-ui__board-cards">
+                    {#each groupRows as row}
+                      <article
+                        class="generated-ui__board-card"
+                        role="listitem"
+                        draggable={canMoveBoardCard(view, groupKey, row)}
+                        ondragstart={(event) => startBoardDrag(event, view, index, row, groupKey)}
+                      >
+                        <strong>{boardCardTitle(view, row, columns)}</strong>
+                        {#if boardCardSubtitle(view, row)}
+                          <p>{boardCardSubtitle(view, row)}</p>
+                        {/if}
+                        {#if badgeKeys.length}
+                          <div>
+                            {#each badgeKeys as key}
+                              {#if row[key] !== undefined && row[key] !== null && row[key] !== ''}
+                                <span>{formatValue(row[key])}</span>
+                              {/if}
+                            {/each}
+                          </div>
+                        {/if}
+                      </article>
+                    {:else}
+                      <div class="generated-ui__board-empty">{view.empty_state || 'No records.'}</div>
+                    {/each}
+                  </div>
+                </section>
               {/each}
             </div>
           {:else if view.type === 'chart'}
@@ -742,6 +1024,10 @@
   border-radius: 18px;
 }
 
+.generated-ui.has-board {
+  width: min(1040px, calc(100vw - 28px));
+}
+
 .generated-ui.is-dock {
   width: 100%;
   max-height: none;
@@ -795,7 +1081,9 @@
 
 .generated-ui__actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
 }
 
@@ -837,6 +1125,7 @@
 }
 
 .generated-ui__icon-button,
+.generated-ui__action-button,
 .generated-ui__create button {
   display: inline-flex;
   min-height: 34px;
@@ -848,6 +1137,23 @@
   background: var(--constellation-control-button-secondary-background);
   color: var(--constellation-control-button-secondary-text);
   cursor: pointer;
+}
+
+.generated-ui__action-button {
+  max-width: 180px;
+  padding: 0 12px;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generated-ui__action-button:disabled,
+.generated-ui__icon-button:disabled,
+.generated-ui__create button:disabled {
+  cursor: default;
+  opacity: 0.62;
 }
 
 .generated-ui__icon-button {
@@ -936,6 +1242,117 @@
 .generated-ui__rows {
   display: grid;
   gap: 2px;
+}
+
+.generated-ui__board {
+  display: grid;
+  grid-auto-columns: minmax(210px, 1fr);
+  grid-auto-flow: column;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.generated-ui__board-column {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto minmax(92px, 1fr);
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--constellation-surface-panel-separator);
+  border-radius: 12px;
+  background: var(--constellation-surface-nested-background);
+}
+
+.generated-ui__board-column header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.generated-ui__board-column header strong {
+  overflow: hidden;
+  color: var(--constellation-section-title);
+  font-size: 12px;
+  font-weight: 680;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generated-ui__board-column header span {
+  flex: 0 0 auto;
+  color: var(--constellation-label-meta);
+  font-family: var(--constellation-font-mono, monospace);
+  font-size: 10px;
+}
+
+.generated-ui__board-cards {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-height: 80px;
+}
+
+.generated-ui__board-card {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--constellation-surface-panel-separator);
+  border-radius: 10px;
+  background: var(--constellation-surface-panel-background);
+}
+
+.generated-ui__board-card[draggable='true'] {
+  cursor: grab;
+}
+
+.generated-ui__board-card strong,
+.generated-ui__board-card p {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.generated-ui__board-card strong {
+  color: var(--constellation-section-title);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.generated-ui__board-card p {
+  white-space: nowrap;
+}
+
+.generated-ui__board-card div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+
+.generated-ui__board-card div span {
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--constellation-control-pill-info-border);
+  border-radius: 999px;
+  color: var(--constellation-color-text-tertiary);
+  font-size: 10px;
+  padding: 3px 6px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generated-ui__board-empty {
+  display: grid;
+  min-height: 56px;
+  place-items: center;
+  border: 1px dashed var(--constellation-surface-panel-separator);
+  border-radius: 10px;
+  color: var(--constellation-color-text-muted);
+  font-size: 11px;
 }
 
 .generated-ui__row {

--- a/tests/test_workspace_app_compiler.py
+++ b/tests/test_workspace_app_compiler.py
@@ -123,6 +123,67 @@ def test_compiler_infers_domain_backed_table_from_single_binding():
     assert _validation_report(compiled)["status"] == "passed"
 
 
+def test_compiler_accepts_domain_backed_board_view():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="GitHub Ticket Tracker",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(
+            {
+                "schema_version": 1,
+                "title": "GitHub Ticket Tracker",
+                "primary_binding": "tickets",
+                "actions": [{"key": "tickets.syncExternal", "label": "Sync GitHub"}],
+                "views": [
+                    {
+                        "id": "ticket-board",
+                        "type": "kanban",
+                        "title": "Tickets",
+                        "binding": "tickets",
+                        "groups": ["Backlog", "Todo", "In Progress", "In Review", "Done"],
+                    }
+                ],
+            }
+        ),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": 1,
+                        "object_key": "ticket",
+                        "fields": ["title", "status", "priority", "repo", "assignee"],
+                        "operations": ["schema", "list", "query", "create", "update", "archive"],
+                    }
+                },
+            },
+            "actions": {
+                "tickets.syncExternal": {
+                    "kind": "connector",
+                    "description": "Sync GitHub issues into the tickets Domain.",
+                    "effects": ["external.read", "domain.write"],
+                    "connectors": [{"key": "github", "provider": "github", "auth": "project_vault_binding"}],
+                    "executor": {"type": "deferred"},
+                }
+            },
+        },
+    )
+
+    source = json.loads(compiled.source_code)
+    assert source["actions"] == [{"key": "tickets.syncExternal", "label": "Sync GitHub"}]
+    board = source["views"][0]
+    assert board["type"] == "board"
+    assert board["group_by"] == "status"
+    assert board["card"] == {
+        "title": "title",
+        "subtitle": "repo",
+        "badges": ["priority", "status"],
+    }
+    assert _validation_report(compiled)["status"] == "passed"
+
+
 def test_compiler_does_not_silently_repair_recordful_app_local_state():
     compiled = compile_workspace_app_input(
         action="create",

--- a/tests/test_workspace_app_contract.py
+++ b/tests/test_workspace_app_contract.py
@@ -144,6 +144,55 @@ def test_structured_generated_ui_payload_is_accepted():
     assert any("views[0].type" in error for error in rejected["errors"])
 
 
+def test_structured_generated_ui_actions_must_reference_manifest_actions():
+    source = {
+        "schema_version": 1,
+        "title": "Task Tracker",
+        "primary_binding": "tasks",
+        "actions": [{"key": "tasks.syncExternal", "label": "Sync"}],
+        "views": [{"id": "tasks", "type": "board", "title": "Tasks", "binding": "tasks"}],
+    }
+    manifest = {
+        **VALID_DOMAIN_MANIFEST,
+        "actions": {
+            "tasks.syncExternal": {
+                "kind": "connector",
+                "effects": ["external.read", "domain.write"],
+                "executor": {"type": "deferred"},
+            }
+        },
+    }
+
+    accepted = _report(
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(source),
+        manifest=manifest,
+    )
+    assert accepted["status"] == "passed"
+
+    rejected = _report(
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(source),
+    )
+    assert rejected["status"] == "failed"
+    assert any("must reference a manifest.actions declaration" in error for error in rejected["errors"])
+
+    secret_source = {
+        **source,
+        "actions": [{"key": "tasks.syncExternal", "payload": {"github_token": "ghp_123456789012345678901234567890123456"}}],
+    }
+    secret_rejected = _report(
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(secret_source),
+        manifest=manifest,
+    )
+    assert secret_rejected["status"] == "failed"
+    assert any("must not contain raw credentials" in error for error in secret_rejected["errors"])
+
+
 def test_old_quick_todo_style_payload_is_rejected():
     report = _report(
         manifest={
@@ -460,6 +509,75 @@ def test_manage_workspace_app_extracts_embedded_contract_fields_on_update():
     assert kwargs["visual_spec"] == VALID_THUMBNAIL
     assert kwargs["metadata"] == {"created_from": "wrapped-source"}
     assert "manifest" not in json.loads(kwargs["source_code"])
+
+
+def test_manage_workspace_app_update_normalizes_empty_optional_fields():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    app = object()
+    serialized = {"id": "app-1", "key": "tasks", "name": "Task Tracker"}
+
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.workspace_apps._workspace_app_context",
+        return_value=("11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"),
+    ), patch("brain.platform.db.repositories.unit_of_work.UnitOfWork", return_value=_FakeUow()), patch(
+        "brain.systems.workspace_apps.service.update_app",
+        return_value=app,
+    ) as update_app, patch("brain.systems.workspace_apps.service.serialize_app", return_value=serialized), patch(
+        "brain.systems.workspace_apps.events.publish_workspace_app_change"
+    ):
+        result = json.loads(
+            _handle_manage_workspace_app(
+                action="update",
+                app_id="app-1",
+                name="",
+                description="",
+                anchor_user_id="",
+                include_archived="false",
+                manifest="",
+                visual_spec="",
+            )
+        )
+
+    assert result["app"] == serialized
+    kwargs = update_app.call_args.kwargs
+    assert kwargs["name"] is None
+    assert kwargs["description"] is None
+    assert kwargs["anchor_user_id"] is None
+    assert kwargs["manifest"] is None
+    assert kwargs["visual_spec"] is None
+
+
+def test_manage_workspace_app_update_parses_json_object_strings():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    app = object()
+    serialized = {"id": "app-1", "key": "tasks", "name": "Task Tracker"}
+    manifest = {"contract_version": 1, "data_plan": {"mode": "app_local", "scope": "ui_state"}}
+    visual_spec = {"thumbnail": {"label": "Tasks", "status": "Ready"}}
+
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.workspace_apps._workspace_app_context",
+        return_value=("11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"),
+    ), patch("brain.platform.db.repositories.unit_of_work.UnitOfWork", return_value=_FakeUow()), patch(
+        "brain.systems.workspace_apps.service.update_app",
+        return_value=app,
+    ) as update_app, patch("brain.systems.workspace_apps.service.serialize_app", return_value=serialized), patch(
+        "brain.systems.workspace_apps.events.publish_workspace_app_change"
+    ):
+        result = json.loads(
+            _handle_manage_workspace_app(
+                action="update",
+                app_id="app-1",
+                manifest=json.dumps(manifest),
+                visual_spec=json.dumps(visual_spec),
+            )
+        )
+
+    assert result["app"] == serialized
+    kwargs = update_app.call_args.kwargs
+    assert kwargs["manifest"] == manifest
+    assert kwargs["visual_spec"] == visual_spec
 
 
 def test_manage_workspace_app_publishes_change_after_create():

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -270,6 +270,48 @@ def test_valid_structured_generated_ui_app_saves(session):
     assert json.loads(version.source_code)["views"][0]["type"] == "table"
 
 
+def test_valid_structured_board_generated_ui_app_saves(session):
+    domain = _todo_domain(session)
+    board_spec = {
+        "schema_version": 1,
+        "title": "Todo Board",
+        "primary_binding": "todos",
+        "actions": [{"key": "tickets.syncExternal", "label": "Sync external"}],
+        "views": [
+            {
+                "id": "todo-board",
+                "type": "board",
+                "title": "Todo board",
+                "binding": "todos",
+                "group_by": "completed",
+                "groups": [
+                    {"label": "Open", "value": False},
+                    {"label": "Done", "value": True},
+                ],
+                "card": {"title": "title", "badges": ["notes"]},
+            }
+        ],
+    }
+
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="todo-board-ui",
+        name="Todo Board UI",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(board_spec),
+        manifest=_manifest_with_action(domain.id),
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    version = active_version(session, app.id)
+    assert version is not None
+    assert json.loads(version.source_code)["actions"][0]["key"] == "tickets.syncExternal"
+    assert json.loads(version.source_code)["views"][0]["type"] == "board"
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [


### PR DESCRIPTION
## Summary
- normalize manage_workspace_app inputs so empty optional values, UUIDs, string booleans, and JSON-string objects do not derail app updates
- add native generated-ui board/kanban support with renderer, compiler, contract, and tests
- add generated-ui action buttons bound to manifest actions, plus updated app-builder skill/tool guidance to avoid HTML detours

## Verification
- venv/bin/pytest tests/test_workspace_app_compiler.py tests/test_workspace_app_contract.py tests/test_workspace_apps_service.py
- npm run check
- git diff --check

## Notes
- The GitHub sync action remains a declared/deferred connector boundary until a registered GitHub executor is wired.