### PR TITLE
Ignore stale empty project contexts

### DIFF
--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -37,6 +37,10 @@ from brain.systems.cortex.thread_attachments import (
     build_thread_attachment_context,
     project_context_from_text_attachments,
 )
+from brain.systems.cortex.project_context.snapshot import (
+    ProjectContextValidationError,
+    validated_project_context_snapshot,
+)
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import IdeaStateLog, IdeaThread
@@ -412,6 +416,16 @@ def _extract_project_context_from_message(
     return _merge_project_context_payloads(explicit, readable_attachments)
 
 
+def _validate_thread_project_context(project_context: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not project_context:
+        return project_context
+    try:
+        validated_project_context_snapshot(project_context, validate_local_paths=False)
+    except ProjectContextValidationError as exc:
+        raise HTTPException(status_code=422, detail={"validation_errors": exc.errors}) from exc
+    return project_context
+
+
 def _merge_project_context_into_idea(idea: Any, project_context: dict[str, Any] | None) -> None:
     if not project_context:
         return
@@ -522,6 +536,7 @@ async def add_thread_message_raw(idea_id: str, request: Request, user: dict[str,
             attachments_data,
             metadata if isinstance(metadata, dict) else None,
         )
+        project_context = _validate_thread_project_context(project_context)
         if project_context or thread_attachment_context:
             next_metadata = dict(metadata or {}) if isinstance(metadata, dict) else {}
             if project_context:

--- a/brain/systems/runs/cortex/thread_binding.py
+++ b/brain/systems/runs/cortex/thread_binding.py
@@ -7,9 +7,12 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from brain.systems.cortex.project_context.snapshot import (
+    ProjectContextValidationError,
+    validated_project_context_snapshot,
+)
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
-from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
 from brain.systems.cortex.thread_context import build_agent_visible_thread_context
 from brain.platform.db.models.idea import Idea, IdeaProjectAttachment
 
@@ -80,13 +83,15 @@ def _recipe_for_profile(profile: RunProfile, metadata: dict[str, Any] | None) ->
     return RunRecipe.DEEP if profile is RunProfile.DEEP else RunRecipe.FAST
 
 
-def _snapshot_for_project_context(project_context: dict[str, Any]) -> dict[str, Any] | None:
+def _snapshot_for_project_context(project_context: dict[str, Any]) -> tuple[dict[str, Any] | None, list[str]]:
     if not project_context:
-        return None
+        return None, []
     try:
-        return snapshot_from_project_context(project_context, validate_local_paths=False)
+        return validated_project_context_snapshot(project_context, validate_local_paths=False), []
+    except ProjectContextValidationError as exc:
+        return None, exc.errors
     except Exception:
-        return dict(project_context)
+        return None, ["Project Context could not be validated."]
 
 
 def _project_context_from_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
@@ -139,6 +144,35 @@ def _latest_attached_project_context(session: Session, idea_id: str) -> dict[str
     return dict(snapshot) if isinstance(snapshot, dict) else {}
 
 
+def _select_project_context(
+    session: Session,
+    *,
+    idea: Idea,
+    idea_id: str,
+    metadata: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None, list[dict[str, Any]]]:
+    validation_errors: list[dict[str, Any]] = []
+    for source, candidate in (
+        ("metadata", _project_context_from_metadata(metadata)),
+        ("idea", _project_context_from_idea(idea)),
+    ):
+        if not candidate:
+            continue
+        snapshot, errors = _snapshot_for_project_context(candidate)
+        if snapshot:
+            return candidate, snapshot, validation_errors
+        validation_errors.append({"source": source, "errors": errors})
+
+    candidate = _latest_attached_project_context(session, idea_id)
+    if candidate:
+        snapshot, errors = _snapshot_for_project_context(candidate)
+        if snapshot:
+            return candidate, snapshot, validation_errors
+        validation_errors.append({"source": "latest_attachment", "errors": errors})
+
+    return {}, None, validation_errors
+
+
 def build_run_request(
     session: Session,
     *,
@@ -158,24 +192,29 @@ def build_run_request(
     metadata = annotate_metadata_with_slash_skill_commands(metadata, message)
     profile = _profile_from_metadata(metadata)
     recipe = _recipe_for_profile(profile, metadata)
-    project_context = (
-        _project_context_from_metadata(metadata)
-        or _project_context_from_idea(idea)
-        or _latest_attached_project_context(session, idea_id)
+    project_context, project_context_snapshot, project_context_validation_errors = _select_project_context(
+        session,
+        idea=idea,
+        idea_id=idea_id,
+        metadata=metadata,
     )
-    project_context_snapshot = _snapshot_for_project_context(project_context)
     target_ref = {
         "kind": "cortex_idea",
         "idea_id": idea_id,
         "event": event,
         "title": getattr(idea, "title", None),
     }
-    workspace_ref = dict(project_context or {})
-    if project_context and not isinstance(metadata.get("project_context"), dict):
-        metadata["project_context"] = project_context
+    workspace_ref = dict(project_context) if project_context_snapshot else {}
+    if project_context_validation_errors:
+        metadata["project_context_validation_errors"] = project_context_validation_errors
     if project_context_snapshot:
+        metadata["project_context"] = project_context
+        metadata.pop("project_context_snapshot", None)
         target_ref["project_context_snapshot"] = project_context_snapshot
         workspace_ref["project_context_snapshot"] = project_context_snapshot
+    else:
+        metadata.pop("project_context", None)
+        metadata.pop("project_context_snapshot", None)
     if not isinstance(metadata.get("thread_context"), dict):
         thread_context = build_agent_visible_thread_context(
             session,

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1359,6 +1359,74 @@ def test_thread_binding_inherits_project_context_from_idea():
     assert request.workspace_ref["project_context_snapshot"]["resources"][0]["path"] == "projects/yc-application"
 
 
+def test_thread_binding_skips_invalid_metadata_project_context_for_valid_idea_context():
+    from brain.systems.runs.cortex.thread_binding import build_run_request
+
+    idea = SimpleNamespace(
+        id="idea-1",
+        org_id="org-1",
+        user_id="u1",
+        title="Thread",
+        agent_details={
+            "project_context": {
+                "name": "Illospace",
+                "resources": [{"type": "repo", "name": "Illospace/illospace"}],
+            },
+        },
+    )
+    session = SimpleNamespace(get=lambda model, idea_id: idea)
+
+    request = build_run_request(
+        session,
+        idea_id="idea-1",
+        event="thread_reply",
+        message="Try again",
+        user_id="u1",
+        metadata={"project_context": {"name": "Stale empty project", "resources": []}},
+    )
+
+    assert request.metadata["project_context"]["name"] == "Illospace"
+    assert request.target_ref["project_context_snapshot"]["resources"][0]["name"] == "Illospace/illospace"
+    assert request.metadata["project_context_validation_errors"] == [
+        {
+            "source": "metadata",
+            "errors": ["project_context_snapshot.resources must contain at least one resource."],
+        }
+    ]
+
+
+def test_thread_binding_drops_invalid_legacy_project_context_when_no_valid_fallback():
+    from brain.systems.runs.cortex.thread_binding import build_run_request
+
+    idea = SimpleNamespace(
+        id="idea-1",
+        org_id="org-1",
+        user_id="u1",
+        title="Thread",
+        agent_details={"project_context": {"name": "Legacy empty project", "resources": []}},
+    )
+    session = SimpleNamespace(get=lambda model, idea_id: idea)
+
+    request = build_run_request(
+        session,
+        idea_id="idea-1",
+        event="thread_reply",
+        message="Try again",
+        user_id="u1",
+        metadata={},
+    )
+
+    assert "project_context" not in request.metadata
+    assert "project_context_snapshot" not in request.target_ref
+    assert request.workspace_ref == {}
+    assert request.metadata["project_context_validation_errors"] == [
+        {
+            "source": "idea",
+            "errors": ["project_context_snapshot.resources must contain at least one resource."],
+        }
+    ]
+
+
 def test_thread_binding_falls_back_to_latest_project_attachment():
     from brain.systems.runs.cortex.thread_binding import build_run_request
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -88,6 +88,20 @@ def test_project_context_extraction_from_thread_payload():
     assert _extract_project_context_from_message([], {"project_context": snapshot}) == snapshot
 
 
+def test_thread_project_context_validation_rejects_empty_context():
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.cortex._idea_ops import _validate_thread_project_context
+
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_thread_project_context({"name": "Legacy empty project", "resources": []})
+
+    assert excinfo.value.status_code == 422
+    assert excinfo.value.detail["validation_errors"] == [
+        "project_context_snapshot.resources must contain at least one resource."
+    ]
+
+
 def test_project_context_extraction_promotes_readable_thread_upload(tmp_path, monkeypatch):
     from brain.app.api.routers.cortex import _idea_ops
     from brain.systems.cortex import thread_attachments


### PR DESCRIPTION
## Summary
- Reject newly submitted thread Project Context payloads that cannot produce a usable snapshot.
- When building run requests, choose the first valid Project Context from metadata, idea state, or latest attachment instead of preserving stale invalid data.
- Strip invalid legacy Project Context payloads from run metadata/workspace refs and record validation errors for debugging.

## Why
The production thread "Repeated Onboarding Message Bug" inherited an old `Illo-Axel` Project Context whose `resources` array was empty. The profile/attachment was created before the stricter Docker workspace validation shipped, so retries kept selecting `current-thread-project` and failed immediately with:

`Project Context has no resources to materialize.`

This is a legacy-data poisoning path, not a `/app` read-only workspace issue.

## Tests
- `pytest tests/test_agent_run_runtime.py tests/test_api_cortex.py tests/test_project_context_materializer.py tests/test_workspace_root_config.py -q`
- `pytest tests/test_agent_run_runtime.py tests/test_api_cortex.py tests/test_project_context_materializer.py tests/test_workspace_root_config.py tests/test_vault_project_tokens.py tests/test_tools.py tests/test_environment_registry.py tests/test_agent.py tests/test_tool_registry.py tests/test_tool_policy.py -q`
