### PR TITLE
Fix builtin skill refresh and app restore guardrails

### DIFF
--- a/brain/platform/db/repositories/skill_bundles.py
+++ b/brain/platform/db/repositories/skill_bundles.py
@@ -186,6 +186,14 @@ class SkillBundleRepository(BaseRepository[SkillBundle]):
         )
         return self._session.scalars(stmt).first()
 
+    def get_version_by_digest(
+        self,
+        bundle: SkillBundle | int,
+        content_digest: str,
+    ) -> SkillBundleVersion | None:
+        """Return an existing immutable version by content digest."""
+        return self._get_version_by_digest(self._bundle_id(bundle), content_digest)
+
     # ------------------------------------------------------------------
     # Assets
     # ------------------------------------------------------------------

--- a/brain/platform/db/services/skill_bundle_io.py
+++ b/brain/platform/db/services/skill_bundle_io.py
@@ -54,6 +54,7 @@ class SkillBundleIOService:
         review_status: str = "approved",
         trust_level: str | None = None,
         source_kind: str | None = None,
+        auto_bump_conflicting_semver: bool = False,
     ) -> dict[str, Any]:
         """Import a portable bundle and return installed row identifiers."""
         parsed = load_skill_bundle(bundle_dir)
@@ -64,16 +65,39 @@ class SkillBundleIOService:
             bundle_payload["source_kind"] = source_kind
 
         bundle = self._bundles.get_or_create_bundle(**bundle_payload)
-        version_was_existing = (
-            self._bundles.get_version(bundle.id, parsed.manifest.semver) is not None
+        version_payload = parsed.to_db_version_payload(asset_root=str(parsed.root))
+        version_was_existing = False
+        version = (
+            self._bundles.get_version_by_digest(bundle.id, parsed.content_digest)
+            if auto_bump_conflicting_semver
+            else None
         )
-        version = self._bundles.create_version(
-            bundle,
-            **parsed.to_db_version_payload(asset_root=str(parsed.root)),
-            status=review_status,
-            created_by_user_id=installed_by_user_id,
-            validate_manifest=True,
-        )
+        if version is not None:
+            version_was_existing = True
+        else:
+            requested_semver = parsed.manifest.semver
+            existing_semver = self._bundles.get_version(bundle.id, requested_semver)
+            if existing_semver is not None:
+                if existing_semver.content_digest == parsed.content_digest:
+                    version = existing_semver
+                    version_was_existing = True
+                elif auto_bump_conflicting_semver:
+                    version_payload = dict(version_payload)
+                    version_payload["semver"] = self._next_semver(bundle.id, requested_semver)
+                    version_payload["provenance"] = {
+                        **dict(version_payload.get("provenance") or {}),
+                        "declared_semver": requested_semver,
+                        "auto_bumped_from_semver": requested_semver,
+                        "auto_bumped_reason": "semver_digest_conflict",
+                    }
+            if version is None:
+                version = self._bundles.create_version(
+                    bundle,
+                    **version_payload,
+                    status=review_status,
+                    created_by_user_id=installed_by_user_id,
+                    validate_manifest=True,
+                )
         self._add_missing_assets(version.id, parsed)
 
         skill = self._materialize_skill_projection(

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -208,7 +208,11 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
             "effect": "update a generated workspace app",
         },
         "archive": {"required": ["app_id or key"], "optional": [], "effect": "archive an app"},
-        "restore": {"required": ["app_id or key"], "optional": [], "effect": "restore an archived app"},
+        "restore": {
+            "required": ["app_id or key", "confirm_restore_archived"],
+            "optional": [],
+            "effect": "restore an archived app only when the user explicitly requested restore/reopen",
+        },
         "get_state": {"required": ["app_id"], "optional": ["state_key"], "effect": "read app-local state"},
         "update_state": {"required": ["app_id"], "optional": ["state_key", "data", "data_patch"], "effect": "write app-local state"},
     },

--- a/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
@@ -92,6 +92,7 @@ def _handle_manage_workspace_app(
     data_patch: dict | None = None,
     include_archived: bool = False,
     include_prototypes: bool = False,
+    confirm_restore_archived: bool = False,
 ) -> str:
     action = str(action or "").strip().lower()
     if action in {"help", "schema"}:
@@ -106,6 +107,7 @@ def _handle_manage_workspace_app(
     state_key = _optional_text(state_key) or "default"
     include_archived = _optional_bool(include_archived)
     include_prototypes = _optional_bool(include_prototypes)
+    confirm_restore_archived = _optional_bool(confirm_restore_archived)
     anchor_user_id, uuid_error = _optional_uuid(anchor_user_id, "anchor_user_id")
     if uuid_error:
         return json.dumps(uuid_error)
@@ -266,6 +268,16 @@ def _handle_manage_workspace_app(
             if action == "restore":
                 if not app_id and not key:
                     return json.dumps({"error": "restore requires: app_id or key"})
+                if not confirm_restore_archived:
+                    return json.dumps(
+                        {
+                            "error": (
+                                "restore requires confirm_restore_archived=true. "
+                                "Use restore only when the user explicitly asks to restore an archived app; "
+                                "for build/create requests, create a new app or update an active app instead."
+                            )
+                        }
+                    )
                 app = restore_app(uow.session, org_id=org_id, app_id=app_id, key=key)
                 serialized = serialize_app(uow.session, app)
                 uow.commit()

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -174,8 +174,11 @@ BRAIN_TOOLS = [
         "description": (
             "Open a guided Vault form in the current Cortex thread for a user-supplied secret. "
             "Use before asking the user to paste an API key in chat, when a task needs a missing credential "
-            "or a newly created skill/API integration needs a named key. This tool never reads or stores the "
-            "secret value itself; the user enters the value into Vault UI."
+            "or a newly created skill/API integration needs a named key. Do not use this before producing "
+            "the main requested deliverable when the credential is only needed for a deferred connector or "
+            "future sync; build the app or artifact first, declare the deferred action, and mention setup as "
+            "a follow-up. This tool never reads or stores the secret value itself; the user enters the value "
+            "into Vault UI."
         ),
         "input_schema": {
             "type": "object",
@@ -471,6 +474,8 @@ BRAIN_TOOLS = [
         "description": (
             "Read generated workspace apps/dashboards and optional app-local state. Use this for questions about "
             "what apps exist, what dashboards are available, or what UI state an app currently stores. "
+            "For build/create requests, leave include_archived=false unless the user explicitly asks to inspect "
+            "archived apps; archived apps should not be reused or restored by default. "
             "Use manage_workspace_app only when creating, updating, archiving, restoring, or changing app state."
         ),
         "input_schema": {
@@ -482,7 +487,11 @@ BRAIN_TOOLS = [
                 "start_at": {"type": "string", "description": "ISO timestamp for custom lower bound."},
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
-                "include_archived": {"type": "boolean", "default": False},
+                "include_archived": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include archived apps only when the user explicitly asks about archived/restorable apps.",
+                },
                 "include_state": {"type": "boolean", "description": "Include app-local state rows.", "default": True},
             },
         },
@@ -754,7 +763,12 @@ CORTEX_IDEA_TOOLS = [
                         "done",
                         "archived",
                     ],
-                    "description": "Next status for create, update, or set_status.",
+                    "description": (
+                        "Next status for create, update, or set_status. Use needs_input only when the "
+                        "requested deliverable cannot be produced without user input; missing credentials "
+                        "for deferred integrations are a follow-up limitation, not a reason to block an "
+                        "otherwise buildable app."
+                    ),
                 },
                 "salience_score": {"type": "number", "description": "Optional salience score."},
                 "position_x": {"type": "number", "description": "Optional Cortex canvas x position."},
@@ -898,6 +912,8 @@ WORKSPACE_APP_TOOLS = [
             "host-rendered structured UIs, including tables, lists, cards, metrics, charts, forms, details, "
             "board/kanban views, and manifest action buttons. Use renderer_key='sandboxed-html-app' and source_kind='html' "
             "only for bespoke interactions or custom blocks that cannot be represented by structured views. "
+            "Use action='restore' only when the user explicitly asks to restore an archived app; for build/create "
+            "requests, create a new app or update an active app instead of resurrecting archived drafts. "
             "Recordful apps must use manage_domain first; app-local "
             "state is only for UI preferences, filters, drafts, and ephemeral interface state. "
             "For awareness questions about what apps exist or current app state, prefer read_workspace_apps first. "
@@ -1010,6 +1026,14 @@ WORKSPACE_APP_TOOLS = [
                 "data_patch": {"type": "object", "description": "Shallow state patch for update_state."},
                 "include_archived": {"type": "boolean", "default": False},
                 "include_prototypes": {"type": "boolean", "default": False},
+                "confirm_restore_archived": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Required for action='restore'. Set true only when the user explicitly asked "
+                        "to restore or reopen an archived app."
+                    ),
+                },
             },
             "required": ["action"],
         },

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -447,6 +447,10 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
+   - Archived apps are not candidates for new build/create requests. Only
+     restore an archived app when the user explicitly asks to restore or
+     reopen that archived app; otherwise create a fresh app or update an
+     active app.
 3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
@@ -505,6 +509,11 @@ Constellation design contract.
      product connector has not been registered yet. Use
      `executor: { "type": "registered", "key": "..." }` only for approved
      server-owned executors.
+   - Missing external credentials are not blockers for creating the app when
+     the external action can be deferred. Do not call `vault_secret_prompt`
+     before producing the requested app. Declare the deferred action, deliver
+     the usable manual/Domain-backed surface, and mention connector setup as a
+     follow-up limitation.
    - Allowed action effects are `domain.read`, `domain.write`,
      `app_state.read`, `app_state.write`, `external.read`,
      `external.write`, `workflow.trigger`, and `agent.run`.
@@ -521,7 +530,9 @@ Constellation design contract.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.
-9. Tell the user what app was created and what data it stores.
+9. Tell the user what app was created and what data it stores. Set a thread to
+   `needs_input` only when the main requested app cannot be produced without
+   more information; missing credentials for deferred sync do not qualify.
 
 ## App Contract
 
@@ -1070,6 +1081,7 @@ def _ensure_builtin_skill_bundles() -> None:
                     review_status="approved",
                     trust_level=ILLO_CORE_TRUST_LEVEL,
                     source_kind=ILLO_CORE_SOURCE_KIND,
+                    auto_bump_conflicting_semver=True,
                 )
         except Exception as exc:
             logger.warning(

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -33,6 +33,10 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
+   - Archived apps are not candidates for new build/create requests. Only
+     restore an archived app when the user explicitly asks to restore or
+     reopen that archived app; otherwise create a fresh app or update an
+     active app.
 3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
@@ -91,6 +95,11 @@ Constellation design contract.
      product connector has not been registered yet. Use
      `executor: { "type": "registered", "key": "..." }` only for approved
      server-owned executors.
+   - Missing external credentials are not blockers for creating the app when
+     the external action can be deferred. Do not call `vault_secret_prompt`
+     before producing the requested app. Declare the deferred action, deliver
+     the usable manual/Domain-backed surface, and mention connector setup as a
+     follow-up limitation.
    - Allowed action effects are `domain.read`, `domain.write`,
      `app_state.read`, `app_state.write`, `external.read`,
      `external.write`, `workflow.trigger`, and `agent.run`.
@@ -107,7 +116,9 @@ Constellation design contract.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.
-9. Tell the user what app was created and what data it stores.
+9. Tell the user what app was created and what data it stores. Set a thread to
+   `needs_input` only when the main requested app cannot be produced without
+   more information; missing credentials for deferred sync do not qualify.
 
 ## App Contract
 

--- a/tests/test_skill_bundle_io_service.py
+++ b/tests/test_skill_bundle_io_service.py
@@ -16,10 +16,16 @@ from brain.platform.db.models.skill_bundle import (
     SkillInstallation,
     SkillOverlay,
 )
-from brain.platform.db.repositories.skill_bundles import SkillBundleRepository
+from brain.platform.db.repositories.skill_bundles import (
+    SkillBundleRepository,
+    SkillBundleVersionConflict,
+)
 from brain.platform.db.repositories.skills import SkillRepository
 from brain.platform.db.services.skill_bundle_io import SkillBundleIOService
 from brain.systems.skills.bundles import SkillBundleError, load_skill_bundle
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+USER_ID = "33333333-3333-4333-8333-333333333333"
 
 
 def _patch_sqlite_for_pg_types():
@@ -29,6 +35,8 @@ def _patch_sqlite_for_pg_types():
         SQLiteTypeCompiler.visit_ARRAY = lambda self, type_, **kw: "TEXT"
     if not hasattr(SQLiteTypeCompiler, "visit_VECTOR"):
         SQLiteTypeCompiler.visit_VECTOR = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_uuid = lambda self, type_, **kw: "TEXT"
 
     original = SQLiteDDLCompiler.get_column_default_string
 
@@ -110,9 +118,9 @@ def test_import_bundle_materializes_skill_installation_and_assets(service, sessi
     result = service.import_bundle(
         tmp_path,
         namespace="illo_core",
-        org_id="org-1",
-        user_id="user-1",
-        installed_by_user_id="user-1",
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        installed_by_user_id=USER_ID,
         trust_level="illo_core",
     )
 
@@ -148,7 +156,7 @@ default_thinking_tier = "xhigh"
 """,
     )
 
-    result = service.import_bundle(tmp_path, namespace="illo_core", org_id="org-1")
+    result = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
 
     skill = session.get(Skill, result["skill"]["id"])
     assert skill.model_tier == "high"
@@ -162,7 +170,7 @@ def test_import_bundle_keeps_hosted_source_distinct_from_agent_draft(
 ):
     _write_bundle(tmp_path, source="self_hosted", visibility="private_local")
 
-    result = service.import_bundle(tmp_path, namespace="self_hosted", org_id="org-1")
+    result = service.import_bundle(tmp_path, namespace="self_hosted", org_id=ORG_ID)
 
     skill = session.get(Skill, result["skill"]["id"])
     bundle = session.get(SkillBundle, result["bundle"]["id"])
@@ -176,8 +184,8 @@ def test_import_bundle_keeps_hosted_source_distinct_from_agent_draft(
 def test_import_bundle_is_idempotent_for_same_version(service, session, tmp_path):
     _write_bundle(tmp_path)
 
-    first = service.import_bundle(tmp_path, namespace="illo_core", org_id="org-1")
-    second = service.import_bundle(tmp_path, namespace="illo_core", org_id="org-1")
+    first = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
+    second = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
 
     assert second["version"]["existing"] is True
     assert second["version"]["id"] == first["version"]["id"]
@@ -207,7 +215,7 @@ default_model_tier = "turbo"
     (tmp_path / "SKILL.md").write_text("# Develop\n", encoding="utf-8")
 
     with pytest.raises(SkillBundleError, match="default_model_tier"):
-        service.import_bundle(tmp_path, namespace="self_hosted", org_id="org-1")
+        service.import_bundle(tmp_path, namespace="self_hosted", org_id=ORG_ID)
 
     assert session.query(SkillBundle).count() == 0
     assert session.query(SkillBundleVersion).count() == 0
@@ -220,10 +228,10 @@ def test_import_bundle_updates_existing_install_with_rollback_pointer(
     tmp_path,
 ):
     _write_bundle(tmp_path, version="1.0.0", procedure="# Develop\nv1\n")
-    first = service.import_bundle(tmp_path, namespace="illo_core", org_id="org-1")
+    first = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
 
     _write_bundle(tmp_path, version="1.1.0", procedure="# Develop\nv2\n")
-    second = service.import_bundle(tmp_path, namespace="illo_core", org_id="org-1")
+    second = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
 
     skill = session.get(Skill, second["skill"]["id"])
     installation = session.get(SkillInstallation, second["installation"]["id"])
@@ -233,6 +241,55 @@ def test_import_bundle_updates_existing_install_with_rollback_pointer(
     assert installation.rollback_bundle_version_id == first["version"]["id"]
     assert skill.procedure == "# Develop\nv2\n"
     assert skill.version == 2
+
+
+def test_import_bundle_can_auto_bump_core_bundle_when_semver_stays_stale(
+    service,
+    session,
+    tmp_path,
+):
+    _write_bundle(tmp_path, version="1.0.0", procedure="# Develop\nv1\n")
+    first = service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
+
+    _write_bundle(tmp_path, version="1.0.0", procedure="# Develop\nv2\n")
+    second = service.import_bundle(
+        tmp_path,
+        namespace="illo_core",
+        org_id=ORG_ID,
+        auto_bump_conflicting_semver=True,
+    )
+    third = service.import_bundle(
+        tmp_path,
+        namespace="illo_core",
+        org_id=ORG_ID,
+        auto_bump_conflicting_semver=True,
+    )
+
+    skill = session.get(Skill, second["skill"]["id"])
+    installation = session.get(SkillInstallation, second["installation"]["id"])
+    version = session.get(SkillBundleVersion, second["version"]["id"])
+
+    assert second["version"]["id"] != first["version"]["id"]
+    assert second["version"]["semver"] == "1.0.1"
+    assert second["version"]["existing"] is False
+    assert third["version"]["id"] == second["version"]["id"]
+    assert third["version"]["existing"] is True
+    assert version.provenance["declared_semver"] == "1.0.0"
+    assert version.provenance["auto_bumped_from_semver"] == "1.0.0"
+    assert installation.rollback_bundle_version_id == first["version"]["id"]
+    assert skill.procedure == "# Develop\nv2\n"
+    assert skill.bundle_version_id == second["version"]["id"]
+    assert skill.version == 2
+
+
+def test_import_bundle_rejects_stale_semver_without_auto_bump(service, tmp_path):
+    _write_bundle(tmp_path, version="1.0.0", procedure="# Develop\nv1\n")
+    service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
+
+    _write_bundle(tmp_path, version="1.0.0", procedure="# Develop\nv2\n")
+
+    with pytest.raises(SkillBundleVersionConflict, match="different digest"):
+        service.import_bundle(tmp_path, namespace="illo_core", org_id=ORG_ID)
 
 
 def test_export_skill_bundle_writes_loadable_files(service, session, tmp_path):

--- a/tests/test_skill_bundle_repository.py
+++ b/tests/test_skill_bundle_repository.py
@@ -29,6 +29,8 @@ def _patch_sqlite_for_pg_types():
         SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
     if not hasattr(SQLiteTypeCompiler, "visit_ARRAY"):
         SQLiteTypeCompiler.visit_ARRAY = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_uuid = lambda self, type_, **kw: "TEXT"
 
     original = SQLiteDDLCompiler.get_column_default_string
 
@@ -108,6 +110,13 @@ def test_create_version_rejects_conflicting_semver_digest(repo):
             semver="1.0.0",
             content_digest="sha256:bbb",
         )
+
+
+def test_get_version_by_digest_returns_existing_version(repo):
+    bundle, version = _create_bundle_version(repo, digest="sha256:aaa")
+
+    assert repo.get_version_by_digest(bundle, "sha256:aaa").id == version.id
+    assert repo.get_version_by_digest(bundle.id, "sha256:missing") is None
 
 
 def test_add_and_list_assets(repo):

--- a/tests/test_workspace_app_contract.py
+++ b/tests/test_workspace_app_contract.py
@@ -643,7 +643,13 @@ def test_manage_workspace_app_publishes_change_after_restore():
     ), patch("brain.systems.workspace_apps.service.serialize_app", return_value=serialized), patch(
         "brain.systems.workspace_apps.events.publish_workspace_app_change"
     ) as publish:
-        result = json.loads(_handle_manage_workspace_app(action="restore", app_id="app-1"))
+        result = json.loads(
+            _handle_manage_workspace_app(
+                action="restore",
+                app_id="app-1",
+                confirm_restore_archived=True,
+            )
+        )
 
     assert result["app"] == serialized
     publish.assert_called_once_with(
@@ -651,3 +657,18 @@ def test_manage_workspace_app_publishes_change_after_restore():
         action="restore",
         app=serialized,
     )
+
+
+def test_manage_workspace_app_restore_requires_explicit_confirmation():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.workspace_apps._workspace_app_context",
+        return_value=("11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"),
+    ), patch("brain.platform.db.repositories.unit_of_work.UnitOfWork", return_value=_FakeUow()), patch(
+        "brain.systems.workspace_apps.service.restore_app",
+    ) as restore_app:
+        result = json.loads(_handle_manage_workspace_app(action="restore", app_id="app-1"))
+
+    assert "confirm_restore_archived=true" in result["error"]
+    restore_app.assert_not_called()


### PR DESCRIPTION
## Summary

- auto-bump changed `illo_core` builtin skill bundles when declared semver is stale, then update the active system installation instead of serving stale skill text
- require explicit `confirm_restore_archived=true` before `manage_workspace_app(action="restore")`
- update workspace-app/vault/idea tool guidance so archived app restore, vault prompts, and `needs_input` do not hijack buildable app requests

## Tests

- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_skill_bundle_repository.py tests/test_skill_bundle_io_service.py tests/test_workspace_app_contract.py`
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_app_compiler.py tests/test_workspace_apps_service.py tests/test_builtin_skill_suite.py tests/test_tool_registry.py`
