### PR TITLE
Add architecture boundary guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build start test test-all install install-browser
+.PHONY: dev build start test test-all architecture-check install install-browser
 
 ## Install all dependencies
 install:
@@ -30,6 +30,10 @@ start:
 ## Run fast tests only (no Docker, no DB)
 test:
 	python3 -m pytest tests/ -m "not requires_db" -q
+
+## Run backend architecture boundary guardrails
+architecture-check:
+	python3 -m pytest tests/test_architecture_boundaries.py -q
 
 ## Run full test suite with Docker test DB
 test-all:

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -1,0 +1,506 @@
+{
+  "version": 1,
+  "description": "Temporary allowlist for existing architecture boundary violations. New violations fail tests; removed violations require deleting or lowering their entries.",
+  "entries": [
+    {
+      "source": "brain/app/api/routers/cortex_intel.py",
+      "import": "brain.jobs.pipelines.cortex_emerge",
+      "source_layer": "brain.app",
+      "target_layer": "brain.jobs",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "App code invokes job pipeline behavior directly; expose a system use case or explicit job facade."
+    },
+    {
+      "source": "brain/app/api/routers/cortex_intel.py",
+      "import": "brain.jobs.pipelines.cortex_optimize",
+      "source_layer": "brain.app",
+      "target_layer": "brain.jobs",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "App code invokes job pipeline behavior directly; expose a system use case or explicit job facade."
+    },
+    {
+      "source": "brain/jobs/pipelines/experiment_tracking.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.jobs",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Job code reuses app or CLI behavior; move reusable behavior into systems."
+    },
+    {
+      "source": "brain/jobs/pipelines/nightly_assess.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.jobs",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Job code reuses app or CLI behavior; move reusable behavior into systems."
+    },
+    {
+      "source": "brain/jobs/pipelines/nightly_dream.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.jobs",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Job code reuses app or CLI behavior; move reusable behavior into systems."
+    },
+    {
+      "source": "brain/kernel/runtime/kernel.py",
+      "import": "brain.systems.runs.direct_agent",
+      "source_layer": "brain.kernel",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Kernel runtime delegates into a system implementation; extract a neutral invocation contract."
+    },
+    {
+      "source": "brain/platform/browser/service.py",
+      "import": "brain.app.web.research",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code depends on an app adapter; move reusable behavior to platform or a neutral contract."
+    },
+    {
+      "source": "brain/platform/browser/service.py",
+      "import": "brain.systems.cortex.events",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/browser/service.py",
+      "import": "brain.systems.cortex.resources.telemetry",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/browser/service.py",
+      "import": "brain.systems.cortex.upload_preview",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/browser/service.py",
+      "import": "brain.systems.runs.events",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/repositories/memories.py",
+      "import": "brain.systems.memory.embeddings",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 3,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/repositories/memories.py",
+      "import": "brain.systems.memory.retrieval_pools",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/repositories/memories.py",
+      "import": "brain.systems.memory.truth_maintenance",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/repositories/skill_bundles.py",
+      "import": "brain.systems.skills.bundles",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/repositories/unit_of_work.py",
+      "import": "brain.systems.user_domains.service",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/schemas/skills.py",
+      "import": "brain.systems.skills.bundles",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/services/skill_bundle_io.py",
+      "import": "brain.systems.skills.bundles",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/db/services/skill_io.py",
+      "import": "brain.systems.skills.gate",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/integrations/github_connector.py",
+      "import": "brain.systems.cortex.project_context.github",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/integrations/llm.py",
+      "import": "brain.systems.vault",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 2,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/telemetry/postmortem.py",
+      "import": "brain.systems.feedback.heuristics",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 2,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/platform/telemetry/postmortem.py",
+      "import": "brain.systems.learning",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
+    },
+    {
+      "source": "brain/systems/agency/core.py",
+      "import": "brain.app.scheduler.executor",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/cognition/frame.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/cognition/frame.py",
+      "import": "brain.app.mcp.server",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 2,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/cortex/encode.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/cortex/thread_attachments.py",
+      "import": "brain.app.api.routers.cortex._helpers",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/cycles/service.py",
+      "import": "brain.app.api.routers.cortex._helpers",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/feedback/predict.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/memory/encoder.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/memory/lessons.py",
+      "import": "brain.app.cli.agent_cli",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/memory/retrieval.py",
+      "import": "brain.jobs.pipelines.agent_cli",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.jobs",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code calls an offline job module; move shared behavior into systems or platform."
+    },
+    {
+      "source": "brain/systems/prompts/builder.py",
+      "import": "brain.app.cli.skills",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/quality/review.py",
+      "import": "brain.app.hooks.brain_context",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/direct_loop/session_effects.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/event_log.py",
+      "import": "brain.app.api.ws.run_events",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/chat.py",
+      "import": "brain.app.api.routers.chat",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/chat.py",
+      "import": "brain.app.api.services.chat",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/composition.py",
+      "import": "brain.app.mcp.server",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/ideas.py",
+      "import": "brain.app.api.authorization",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/ideas.py",
+      "import": "brain.app.api.routers.cortex._helpers",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 2,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/ideas.py",
+      "import": "brain.app.api.routers.cortex._ideas",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 3,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/projects.py",
+      "import": "brain.app.api.routers.cortex._helpers",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runs/tool_catalog/handlers/web.py",
+      "import": "brain.app.web",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 2,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runtime_settings/auth.py",
+      "import": "brain.app.api.routers.cortex._key_utils",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runtime_settings/router.py",
+      "import": "brain.app.api.auth",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/runtime_settings/router.py",
+      "import": "brain.app.api.deps",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/sessions/harvest.py",
+      "import": "brain.app.cli.memory",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    },
+    {
+      "source": "brain/systems/tools/handlers.py",
+      "import": "brain.app.mcp.server",
+      "source_layer": "brain.systems",
+      "target_layer": "brain.app",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
+      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
+    }
+  ]
+}

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -1,0 +1,214 @@
+"""Guardrails for backend architecture dependency boundaries."""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ALLOWLIST_PATH = ROOT / "tests" / "fixtures" / "architecture-boundary-allowlist.json"
+
+LAYERS = (
+    "brain.app",
+    "brain.jobs",
+    "brain.systems",
+    "brain.platform",
+    "brain.kernel",
+)
+
+ALLOWED_IMPORTS = {
+    "brain.app": {"brain.app", "brain.systems", "brain.platform", "brain.kernel"},
+    "brain.jobs": {"brain.jobs", "brain.systems", "brain.platform", "brain.kernel"},
+    "brain.systems": {"brain.systems", "brain.platform", "brain.kernel"},
+    "brain.platform": {"brain.platform", "brain.kernel"},
+    "brain.kernel": {"brain.kernel"},
+}
+
+
+class BoundaryImport(NamedTuple):
+    source: str
+    imported: str
+    source_layer: str
+    target_layer: str
+
+
+def test_architecture_layer_imports_match_allowlist() -> None:
+    """Fail when new cross-layer imports appear or stale allowlist debt remains."""
+
+    actual = _boundary_violations()
+    allowed = _allowlist()
+
+    unexpected = sorted(set(actual) - set(allowed))
+    stale = sorted(set(allowed) - set(actual))
+    mismatched_counts = sorted(
+        (violation, actual[violation], allowed[violation])
+        for violation in set(actual) & set(allowed)
+        if actual[violation] != allowed[violation]
+    )
+
+    assert not unexpected and not stale and not mismatched_counts, _format_failure(
+        unexpected=unexpected,
+        stale=stale,
+        mismatched_counts=mismatched_counts,
+    )
+
+
+def test_architecture_boundary_allowlist_has_remediation_metadata() -> None:
+    data = _load_allowlist_data()
+    entries = data.get("entries")
+
+    assert data.get("version") == 1
+    assert isinstance(entries, list)
+    assert entries == sorted(entries, key=_entry_sort_key)
+
+    for entry in entries:
+        assert isinstance(entry.get("source"), str) and entry["source"].endswith(".py")
+        assert isinstance(entry.get("import"), str) and entry["import"].startswith("brain.")
+        assert entry.get("source_layer") in LAYERS
+        assert entry.get("target_layer") in LAYERS
+        assert isinstance(entry.get("allowed_occurrences"), int)
+        assert entry["allowed_occurrences"] > 0
+        assert entry.get("owner") == "architecture-boundaries"
+        assert entry.get("reason")
+        assert entry.get("planned_removal")
+
+
+def _boundary_violations() -> Counter[BoundaryImport]:
+    violations: Counter[BoundaryImport] = Counter()
+    for path in _brain_python_files():
+        source = path.relative_to(ROOT).as_posix()
+        module_parts = list(path.relative_to(ROOT).with_suffix("").parts)
+        source_layer = _layer_for(".".join(module_parts))
+        if source_layer is None:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=source)
+        for node in ast.walk(tree):
+            for imported in _resolve_import(module_parts, node):
+                target_layer = _layer_for(imported)
+                if target_layer is None or target_layer in ALLOWED_IMPORTS[source_layer]:
+                    continue
+                violations[
+                    BoundaryImport(
+                        source=source,
+                        imported=imported,
+                        source_layer=source_layer,
+                        target_layer=target_layer,
+                    )
+                ] += 1
+    return violations
+
+
+def _allowlist() -> Counter[BoundaryImport]:
+    entries = _load_allowlist_data()["entries"]
+    allowed: Counter[BoundaryImport] = Counter()
+    for entry in entries:
+        allowed[
+            BoundaryImport(
+                source=entry["source"],
+                imported=entry["import"],
+                source_layer=entry["source_layer"],
+                target_layer=entry["target_layer"],
+            )
+        ] = entry["allowed_occurrences"]
+    return allowed
+
+
+def _load_allowlist_data() -> dict:
+    return json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+
+
+def _brain_python_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "brain"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return [
+            ROOT / line
+            for line in result.stdout.splitlines()
+            if line.endswith(".py")
+        ]
+    return [
+        path
+        for path in (ROOT / "brain").rglob("*.py")
+        if "__pycache__" not in path.parts
+        and "uploads" not in path.parts
+        and not any(part.startswith(".") for part in path.relative_to(ROOT).parts)
+    ]
+
+
+def _resolve_import(module_parts: list[str], node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if not isinstance(node, ast.ImportFrom):
+        return []
+    if node.level == 0:
+        return [node.module] if node.module else []
+
+    base = module_parts[:-1]
+    keep = len(base) - (node.level - 1)
+    if keep < 0:
+        return []
+    resolved = base[:keep]
+    if node.module:
+        resolved.extend(node.module.split("."))
+    return [".".join(resolved)] if resolved else []
+
+
+def _layer_for(module_name: str) -> str | None:
+    return next(
+        (
+            layer
+            for layer in LAYERS
+            if module_name == layer or module_name.startswith(layer + ".")
+        ),
+        None,
+    )
+
+
+def _format_failure(
+    *,
+    unexpected: list[BoundaryImport],
+    stale: list[BoundaryImport],
+    mismatched_counts: list[tuple[BoundaryImport, int, int]],
+) -> str:
+    lines = [
+        "Architecture boundary allowlist is out of sync.",
+        "See tests/fixtures/architecture-boundary-allowlist.json.",
+    ]
+    if unexpected:
+        lines.append("Unexpected new violations:")
+        lines.extend(f"  - {_format_violation(item)}" for item in unexpected)
+    if stale:
+        lines.append("Stale allowlist entries:")
+        lines.extend(f"  - {_format_violation(item)}" for item in stale)
+    if mismatched_counts:
+        lines.append("Changed violation counts:")
+        lines.extend(
+            f"  - {_format_violation(item)} actual={actual} allowed={allowed}"
+            for item, actual, allowed in mismatched_counts
+        )
+    return "\n".join(lines)
+
+
+def _format_violation(violation: BoundaryImport) -> str:
+    return (
+        f"{violation.source}: {violation.source_layer} -> "
+        f"{violation.target_layer} via {violation.imported}"
+    )
+
+
+def _entry_sort_key(entry: dict) -> tuple[str, str, str, str]:
+    return (
+        entry.get("source", ""),
+        entry.get("import", ""),
+        entry.get("source_layer", ""),
+        entry.get("target_layer", ""),
+    )


### PR DESCRIPTION
## Summary

- add a backend architecture boundary pytest guardrail
- add a test fixture allowlist for existing cross-layer import debt
- add a Make target for running the guardrail locally

## Testing

- python3 -m pytest tests/test_architecture_boundaries.py -q
- git diff --check main...HEAD

## Notes

Documentation from the audit stays local and is intentionally not part of this PR.
