### PR TITLE
Reduce workspace app generation friction

### DIFF
--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -408,6 +408,33 @@ async def list_archived_ideas(
     return await _run_db(db, _list)
 
 
+@router.delete("/ideas/archived")
+async def empty_archived_ideas(
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    def _delete(sync_db: Session) -> tuple[int, str | None]:
+        repo = IdeaRepository(sync_db)
+        if _caller_is_service_principal(user):
+            deleted = repo.hard_delete_archived()
+            sync_db.commit()
+            return deleted, None
+
+        org_id = require_org_context(user)
+        deleted = repo.hard_delete_archived_for_org(org_id)
+        sync_db.commit()
+        return deleted, str(org_id)
+
+    deleted, event_org_id = await _run_db(db, _delete)
+    if deleted:
+        await ws_manager.broadcast_product_event(
+            "idea_archive_emptied",
+            {"deleted": deleted},
+            org_id=event_org_id,
+        )
+    return {"deleted": deleted}
+
+
 @router.post("/ideas", response_model=IdeaRead, status_code=201)
 async def create_idea(
     body: IdeaCreate,

--- a/brain/app/api/routers/workspace_apps.py
+++ b/brain/app/api/routers/workspace_apps.py
@@ -277,25 +277,28 @@ async def update_workspace_app_state(
 
 
 @router.post("/{app_id}/actions/run", response_model=WorkspaceAppActionRunRead)
-def run_workspace_app_declared_action(
+async def run_workspace_app_declared_action(
     app_id: str,
     body: WorkspaceAppActionRun,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = require_org_context(user)
-    try:
-        result = run_workspace_app_action(
-            db,
-            org_id=org_id,
-            app_id=app_id,
-            action_key=body.action_key,
-            payload=body.payload,
-            user_id=_user_id(user),
-        )
-        db.commit()
-        return result
-    except WorkspaceAppActionError as exc:
-        _raise_action_http(exc)
-    except WorkspaceAppError as exc:
-        _raise_http(exc)
+    def _run(sync_db: Session):
+        try:
+            result = run_workspace_app_action(
+                sync_db,
+                org_id=org_id,
+                app_id=app_id,
+                action_key=body.action_key,
+                payload=body.payload,
+                user_id=_user_id(user),
+            )
+            sync_db.commit()
+            return result
+        except WorkspaceAppActionError as exc:
+            _raise_action_http(exc)
+        except WorkspaceAppError as exc:
+            _raise_http(exc)
+
+    return await run_db(db, _run)

--- a/brain/app/api/routers/workspace_apps.py
+++ b/brain/app/api/routers/workspace_apps.py
@@ -34,6 +34,7 @@ from brain.systems.workspace_apps.service import (
     WorkspaceAppNotFound,
     archive_app,
     create_app,
+    delete_archived_apps,
     get_app,
     get_state,
     list_archived_apps,
@@ -99,6 +100,23 @@ async def list_archived_workspace_apps(
 ):
     org_id = require_org_context(user)
     return await run_db(db, lambda sync_db: serialize_apps(sync_db, list_archived_apps(sync_db, org_id, limit=limit)))
+
+
+@router.delete("/archived")
+async def empty_archived_workspace_apps(
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    org_id = require_org_context(user)
+
+    def _delete(sync_db: Session):
+        deleted = delete_archived_apps(sync_db, org_id=org_id)
+        sync_db.commit()
+        if deleted:
+            publish_workspace_app_change(org_id=org_id, action="empty_archive")
+        return {"deleted": deleted}
+
+    return await run_db(db, _delete)
 
 
 @router.post("", response_model=WorkspaceAppRead, status_code=201, include_in_schema=False)

--- a/brain/platform/db/repositories/ideas.py
+++ b/brain/platform/db/repositories/ideas.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Any
 from typing import Sequence
 
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import aliased, load_only
 
@@ -117,6 +117,47 @@ class IdeaRepository(BaseRepository[Idea]):
         if limit:
             stmt = stmt.limit(limit)
         return self._session.scalars(stmt).all()
+
+    def hard_delete_archived(self) -> int:
+        idea_ids = list(
+            self._session.scalars(
+                select(Idea.id).where(Idea.archived_at.is_not(None))
+            ).all()
+        )
+        return self._hard_delete_by_ids(idea_ids)
+
+    def hard_delete_archived_for_org(self, org_id: str) -> int:
+        org_user_ids = select(User.id).where(User.org_id == str(org_id))
+        idea_ids = list(
+            self._session.scalars(
+                select(Idea.id).where(
+                    Idea.archived_at.is_not(None),
+                    or_(
+                        Idea.org_id == org_id,
+                        and_(Idea.org_id.is_(None), Idea.user_id.in_(org_user_ids)),
+                    ),
+                )
+            ).all()
+        )
+        return self._hard_delete_by_ids(idea_ids)
+
+    def _hard_delete_by_ids(self, idea_ids: Sequence[str]) -> int:
+        ids = [str(idea_id) for idea_id in idea_ids if idea_id]
+        if not ids:
+            return 0
+        self._session.execute(
+            update(Idea)
+            .where(Idea.parent_id.in_(ids))
+            .values(parent_id=None)
+            .execution_options(synchronize_session=False)
+        )
+        self._session.execute(
+            delete(Idea)
+            .where(Idea.id.in_(ids))
+            .execution_options(synchronize_session=False)
+        )
+        self._session.flush()
+        return len(ids)
 
     def list_by_status(self, status: str) -> Sequence[Idea]:
         stmt = (

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -195,8 +195,16 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         },
     },
     "manage_workspace_app": {
-        "list": {"required": [], "optional": ["include_archived", "include_prototypes"], "effect": "read workspace apps"},
-        "get": {"required": ["app_id or key"], "optional": ["include_archived"], "effect": "read one workspace app"},
+        "list": {
+            "required": [],
+            "optional": ["include_archived", "confirm_include_archived", "include_prototypes"],
+            "effect": "read active workspace apps; archived reads require explicit user intent",
+        },
+        "get": {
+            "required": ["app_id or key"],
+            "optional": ["include_archived", "confirm_include_archived"],
+            "effect": "read one active workspace app; archived reads require explicit user intent",
+        },
         "create": {
             "required": ["name"],
             "optional": ["key", "description", "renderer_key", "source_kind", "source_code", "manifest", "visual_spec", "initial_state"],

--- a/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_apps.py
@@ -92,7 +92,9 @@ def _handle_manage_workspace_app(
     data_patch: dict | None = None,
     include_archived: bool = False,
     include_prototypes: bool = False,
+    confirm_include_archived: bool = False,
     confirm_restore_archived: bool = False,
+    **_ignored: Any,
 ) -> str:
     action = str(action or "").strip().lower()
     if action in {"help", "schema"}:
@@ -107,10 +109,22 @@ def _handle_manage_workspace_app(
     state_key = _optional_text(state_key) or "default"
     include_archived = _optional_bool(include_archived)
     include_prototypes = _optional_bool(include_prototypes)
+    confirm_include_archived = _optional_bool(confirm_include_archived)
     confirm_restore_archived = _optional_bool(confirm_restore_archived)
     anchor_user_id, uuid_error = _optional_uuid(anchor_user_id, "anchor_user_id")
     if uuid_error:
         return json.dumps(uuid_error)
+
+    if action in {"list", "get"} and include_archived and not confirm_include_archived:
+        return json.dumps(
+            {
+                "error": (
+                    "include_archived=true for list/get requires confirm_include_archived=true. "
+                    "Use archived reads only when the user explicitly asks to inspect archived apps; "
+                    "for build/create requests, look at active apps or create a fresh app instead."
+                )
+            }
+        )
 
     manifest, mapping_error = _optional_mapping(manifest, "manifest")
     if mapping_error:

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -2060,8 +2060,20 @@ def _handle_read_workspace_apps(
     end_at: str | None = None,
     limit: int = 20,
     include_archived: bool = False,
+    confirm_include_archived: bool = False,
     include_state: bool = True,
 ) -> str:
+    if include_archived and not confirm_include_archived:
+        return json.dumps(
+            {
+                "error": (
+                    "include_archived=true requires confirm_include_archived=true. "
+                    "Archived apps are only for explicit archived-app inspection; "
+                    "new app builds should search active apps or create a fresh app."
+                )
+            },
+            default=str,
+        )
     payload = _query_workspace_data_for_agent(
         sources=["apps"] if include_state else ["workspace_apps"],
         query=query or "workspace apps",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -473,8 +473,9 @@ BRAIN_TOOLS = [
         "description": (
             "Read generated workspace apps/dashboards and optional app-local state. Use this for questions about "
             "what apps exist, what dashboards are available, or what UI state an app currently stores. "
-            "For build/create requests, leave include_archived=false unless the user explicitly asks to inspect "
-            "archived apps; archived apps should not be reused or restored by default. "
+            "For build/create requests, leave include_archived=false; archived apps are not candidates for "
+            "new app discovery. Only inspect archived apps when the user explicitly asks about archived or "
+            "restorable apps, and then set confirm_include_archived=true. "
             "Use manage_workspace_app only when creating, updating, archiving, restoring, or changing app state."
         ),
         "input_schema": {
@@ -490,6 +491,11 @@ BRAIN_TOOLS = [
                     "type": "boolean",
                     "default": False,
                     "description": "Include archived apps only when the user explicitly asks about archived/restorable apps.",
+                },
+                "confirm_include_archived": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Required with include_archived=true; confirms the user explicitly asked to inspect archived apps.",
                 },
                 "include_state": {"type": "boolean", "description": "Include app-local state rows.", "default": True},
             },
@@ -911,6 +917,8 @@ WORKSPACE_APP_TOOLS = [
             "host-rendered structured UIs, including tables, lists, cards, metrics, charts, forms, details, "
             "board/kanban views, and manifest action buttons. Use renderer_key='sandboxed-html-app' and source_kind='html' "
             "only for bespoke interactions or custom blocks that cannot be represented by structured views. "
+            "For list/get discovery, keep include_archived=false unless the user explicitly asks to inspect archived apps; "
+            "archived apps are not candidates for new build/create requests. "
             "Use action='restore' only when the user explicitly asks to restore an archived app; for build/create "
             "requests, create a new app or update an active app instead of resurrecting archived drafts. "
             "Recordful apps must use manage_domain first; app-local "
@@ -983,6 +991,9 @@ WORKSPACE_APP_TOOLS = [
                         "\"theme_modes\":[\"dark\",\"light\"]}}. Do not use alternate keys like "
                         "system, design_system, uses_app_kit_classes, or supports_color_scheme in "
                         "manifest.design_contract; put descriptive labels in metadata instead. "
+                        "Domain records expose a virtual top-level title; bindings may include \"title\" "
+                        "for display/card labels even when the object's field definitions do not contain "
+                        "a data field named title. "
                         "Use bindings such as {\"data_plan\":{\"mode\":\"domain\","
                         "\"bindings\":{\"todos\":{\"domain_id\":1,\"domain_slug\":\"todo-notes\","
                         "\"object_key\":\"todo_item\",\"fields\":[\"title\",\"notes\",\"completed\"],"
@@ -1025,6 +1036,14 @@ WORKSPACE_APP_TOOLS = [
                 "data_patch": {"type": "object", "description": "Shallow state patch for update_state."},
                 "include_archived": {"type": "boolean", "default": False},
                 "include_prototypes": {"type": "boolean", "default": False},
+                "confirm_include_archived": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Required with action='list' or action='get' and include_archived=true. "
+                        "Set true only when the user explicitly asked to inspect archived apps."
+                    ),
+                },
                 "confirm_restore_archived": {
                     "type": "boolean",
                     "default": False,

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -452,10 +452,11 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
-   - Archived apps are not candidates for new build/create requests. Only
-     restore an archived app when the user explicitly asks to restore or
-     reopen that archived app; otherwise create a fresh app or update an
-     active app.
+   - Archived apps are not candidates for new build/create requests. Do not
+     inspect archived apps while building a new app unless the user explicitly
+     asks about archived/restorable apps. Only restore an archived app when the
+     user explicitly asks to restore or reopen that archived app; otherwise
+     create a fresh app or update an active app.
 3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
@@ -600,6 +601,9 @@ Constellation design contract.
 - The persisted manifest must end with `contract_version: 1`, `data_plan`, and
   `design_contract`. The compiler supplies simple app-local UI-state defaults;
   provide explicit Domain bindings for recordful apps.
+- Domain records have a virtual top-level `title` separate from object data
+  fields. You may use `title` in generated UI columns, board cards, and binding
+  `fields` even when the Domain object's field list has no `title` data field.
 - The design contract shape is strict. Use exactly
   `design_contract: { "kit": "constellation-app-kit", "theme_modes": ["dark", "light"] }`.
   Do not replace `kit` with `system`, `design_system`, or

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -515,6 +515,17 @@ Constellation design contract.
      product connector has not been registered yet. Use
      `executor: { "type": "registered", "key": "..." }` only for approved
      server-owned executors.
+   - For ordinary REST/JSON APIs described by user-provided docs, prefer the
+     built-in `generic.http` executor over provider-specific code. Declare
+     `executor: { "type": "registered", "key": "generic.http" }` plus a
+     `connector_spec` with `request`, optional Vault/project-bound `auth`,
+     optional `response.items_path`, and optional `sync` mapping into a Domain
+     binding. Use `kind: "http_sync"` when the response should upsert Domain
+     records, and `kind: "http_request"` for create/update/delete calls that
+     only need to return the external response. Pair GET with `external.read`,
+     non-GET methods with `external.write`, and add `domain.write` only when
+     `sync` mutates the Domain. Use `deferred` only when the API cannot fit the
+     generic spec yet.
    - Missing external credentials are not blockers for creating the app when
      the external action can be deferred. Do not call `vault_secret_prompt`
      before producing the requested app. Declare the deferred action, deliver
@@ -628,7 +639,33 @@ Constellation design contract.
         "mode": "upsert",
         "external_id_field": "external_id"
       },
-      "executor": {"type": "deferred"}
+      "executor": {"type": "registered", "key": "generic.http"},
+      "connector_spec": {
+        "kind": "http_sync",
+        "request": {
+          "method": "GET",
+          "url": "https://api.example.com/repos/{owner}/{repo}/issues"
+        },
+        "auth": {
+          "type": "bearer",
+          "source": "project_env",
+          "env": "GITHUB_TOKEN",
+          "project_slug": "{owner}/{repo}"
+        },
+        "response": {"items_path": "$"},
+        "sync": {
+          "binding": "tickets",
+          "remote_id": "id",
+          "remote_id_field": "external_id",
+          "title": "title",
+          "fields": {
+            "external_id": "id",
+            "number": "number",
+            "url": "html_url",
+            "status": {"const": "Todo"}
+          }
+        }
+      }
     }
   }
 }

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -96,6 +96,17 @@ Constellation design contract.
      product connector has not been registered yet. Use
      `executor: { "type": "registered", "key": "..." }` only for approved
      server-owned executors.
+   - For ordinary REST/JSON APIs described by user-provided docs, prefer the
+     built-in `generic.http` executor over provider-specific code. Declare
+     `executor: { "type": "registered", "key": "generic.http" }` plus a
+     `connector_spec` with `request`, optional Vault/project-bound `auth`,
+     optional `response.items_path`, and optional `sync` mapping into a Domain
+     binding. Use `kind: "http_sync"` when the response should upsert Domain
+     records, and `kind: "http_request"` for create/update/delete calls that
+     only need to return the external response. Pair GET with `external.read`,
+     non-GET methods with `external.write`, and add `domain.write` only when
+     `sync` mutates the Domain. Use `deferred` only when the API cannot fit the
+     generic spec yet.
    - Missing external credentials are not blockers for creating the app when
      the external action can be deferred. Do not call `vault_secret_prompt`
      before producing the requested app. Declare the deferred action, deliver
@@ -209,7 +220,33 @@ Constellation design contract.
         "mode": "upsert",
         "external_id_field": "external_id"
       },
-      "executor": {"type": "deferred"}
+      "executor": {"type": "registered", "key": "generic.http"},
+      "connector_spec": {
+        "kind": "http_sync",
+        "request": {
+          "method": "GET",
+          "url": "https://api.example.com/repos/{owner}/{repo}/issues"
+        },
+        "auth": {
+          "type": "bearer",
+          "source": "project_env",
+          "env": "GITHUB_TOKEN",
+          "project_slug": "{owner}/{repo}"
+        },
+        "response": {"items_path": "$"},
+        "sync": {
+          "binding": "tickets",
+          "remote_id": "id",
+          "remote_id_field": "external_id",
+          "title": "title",
+          "fields": {
+            "external_id": "id",
+            "number": "number",
+            "url": "html_url",
+            "status": {"const": "Todo"}
+          }
+        }
+      }
     }
   }
 }

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -33,10 +33,11 @@ Constellation design contract.
      view/control surface over that data.
    - Use app-local state through `manage_workspace_app` only for UI
      preferences, filters, draft input, view settings, and ephemeral state.
-   - Archived apps are not candidates for new build/create requests. Only
-     restore an archived app when the user explicitly asks to restore or
-     reopen that archived app; otherwise create a fresh app or update an
-     active app.
+   - Archived apps are not candidates for new build/create requests. Do not
+     inspect archived apps while building a new app unless the user explicitly
+     asks about archived/restorable apps. Only restore an archived app when the
+     user explicitly asks to restore or reopen that archived app; otherwise
+     create a fresh app or update an active app.
 3. Prefer a host-rendered structured UI spec for common app patterns:
    `renderer_key="generated-ui-app"`, `source_kind="json"`, and
    `source_code` as JSON with `schema_version: 1`, `title`, optional
@@ -181,6 +182,9 @@ Constellation design contract.
 - The persisted manifest must end with `contract_version: 1`, `data_plan`, and
   `design_contract`. The compiler supplies simple app-local UI-state defaults;
   provide explicit Domain bindings for recordful apps.
+- Domain records have a virtual top-level `title` separate from object data
+  fields. You may use `title` in generated UI columns, board cards, and binding
+  `fields` even when the Domain object's field list has no `title` data field.
 - The design contract shape is strict. Use exactly
   `design_contract: { "kit": "constellation-app-kit", "theme_modes": ["dark", "light"] }`.
   Do not replace `kit` with `system`, `design_system`, or

--- a/brain/systems/workspace_apps/actions.py
+++ b/brain/systems/workspace_apps/actions.py
@@ -52,6 +52,7 @@ class WorkspaceAppActionContext:
 WorkspaceAppActionExecutor = Callable[[WorkspaceAppActionContext, dict[str, Any]], Mapping[str, Any] | None]
 
 _EXECUTORS: dict[str, WorkspaceAppActionExecutor] = {}
+_BUILTIN_EXECUTOR_KEYS = {"generic.http"}
 _SECRET_KEY_RE = re.compile(
     r"(?:^|[_-])(?:token|secret|password|api[_-]?key|authorization|bearer|client[_-]?secret|private[_-]?key)(?:$|[_-])",
     re.IGNORECASE,
@@ -165,7 +166,7 @@ def run_workspace_app_action(
     if executor_type != "registered" or not executor_key:
         raise WorkspaceAppActionExecutorMissing(_missing_executor_message(normalized_key))
 
-    registered = _EXECUTORS.get(executor_key)
+    registered = _EXECUTORS.get(executor_key) or _builtin_executor(executor_key)
     if registered is None:
         raise WorkspaceAppActionExecutorMissing(
             f"Workspace action '{normalized_key}' uses executor '{executor_key}', but no approved executor is registered."
@@ -196,6 +197,14 @@ def _missing_executor_message(action_key: str) -> str:
         f"Workspace action '{action_key}' is declared, but no server-side action executor is registered yet. "
         "Use Domain APIs in-app, or add an approved connector/action executor for external systems."
     )
+
+
+def _builtin_executor(key: str) -> WorkspaceAppActionExecutor | None:
+    if key not in _BUILTIN_EXECUTOR_KEYS:
+        return None
+    from brain.systems.workspace_apps.generic_http import execute_generic_http_action
+
+    return execute_generic_http_action
 
 
 def _connector_keys(declaration: Mapping[str, Any]) -> list[str]:

--- a/brain/systems/workspace_apps/compiler.py
+++ b/brain/systems/workspace_apps/compiler.py
@@ -438,13 +438,19 @@ def _normalize_views(
         if not str(view.get("title") or "").strip():
             view["title"] = app_name if index == 0 else f"View {index + 1}"
             changed = True
-        if view.get("type") in {"table", "list", "cards", "detail", "form"} and not (
-            isinstance(view.get("columns"), list) or isinstance(view.get("fields"), list)
-        ):
-            columns = _infer_columns(view=view, spec=spec, manifest=manifest)
-            if columns:
-                view["columns"] = columns
-                changed = True
+        if view.get("type") in {"table", "list", "cards", "detail", "form"}:
+            columns_key = "columns" if "columns" in view or "fields" not in view else "fields"
+            raw_columns = view.get(columns_key)
+            if isinstance(raw_columns, list):
+                columns, columns_changed = _normalize_columns(raw_columns)
+                if columns_changed:
+                    view[columns_key] = columns
+                    changed = True
+            elif not isinstance(view.get("columns"), list) and not isinstance(view.get("fields"), list):
+                columns = _infer_columns(view=view, spec=spec, manifest=manifest)
+                if columns:
+                    view["columns"] = columns
+                    changed = True
         if view.get("type") == "board" and not (view.get("group_by") or view.get("groupBy")):
             group_by = _infer_board_group_by(view=view, spec=spec, manifest=manifest)
             if group_by:
@@ -457,6 +463,40 @@ def _normalize_views(
                 changed = True
         next_views.append(view)
     return next_views, changed
+
+
+def _normalize_columns(raw_columns: list[Any]) -> tuple[list[Any], bool]:
+    changed = False
+    columns: list[Any] = []
+    for raw_column in raw_columns:
+        normalized = _normalize_column(raw_column)
+        if normalized != raw_column:
+            changed = True
+        columns.append(normalized)
+    return columns, changed
+
+
+def _normalize_column(raw_column: Any) -> Any:
+    if isinstance(raw_column, str):
+        key = raw_column.strip()
+        return {"key": key, "label": _label(key)} if key else raw_column
+    if not isinstance(raw_column, Mapping):
+        return raw_column
+
+    column = dict(raw_column)
+    key = str(
+        column.get("key")
+        or column.get("field")
+        or column.get("field_key")
+        or column.get("fieldKey")
+        or column.get("id")
+        or ""
+    ).strip()
+    if key and not str(column.get("key") or "").strip():
+        column["key"] = key
+    if key and not str(column.get("label") or "").strip():
+        column["label"] = _label(key)
+    return column
 
 
 def _infer_view(

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -1,0 +1,414 @@
+"""Generic HTTP connector executor for generated workspace app actions.
+
+This is an intentionally narrow interpreter, not arbitrary generated code. Apps
+declare a connector spec in the manifest; the server executes bounded HTTP
+requests, resolves approved Vault/project-bound credentials, and maps response
+items into Domain records.
+"""
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from brain.systems.workspace_apps.actions import (
+    WorkspaceAppActionContext,
+    WorkspaceAppActionContractError,
+    WorkspaceAppActionError,
+)
+from brain.systems.user_domains.service import DomainService
+
+
+GENERIC_HTTP_EXECUTOR_KEY = "generic.http"
+_ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+_TEMPLATE_RE = re.compile(r"\{([a-zA-Z_][\w.-]*)\}")
+_MAX_ITEMS = 200
+
+
+def execute_generic_http_action(
+    context: WorkspaceAppActionContext,
+    payload: dict[str, Any],
+) -> Mapping[str, Any]:
+    spec = _connector_spec(context.declaration)
+    request_spec = _mapping(spec.get("request"), "connector_spec.request")
+    kind = str(spec.get("kind") or spec.get("type") or "http_sync").strip()
+    _validate_request_effects(context, request_spec)
+
+    response = _request_json(request_spec, spec=spec, context=context, payload=payload)
+    raw_sync_spec = spec.get("sync") or spec.get("domain_sync")
+    if raw_sync_spec is not None:
+        sync_spec = _mapping(raw_sync_spec, "connector_spec.sync")
+        items = _items_from_response(response, spec.get("response"))
+        return _sync_items_to_domain(context, sync_spec, items)
+    if kind == "http_sync":
+        raise WorkspaceAppActionContractError("connector_spec.sync is required when kind is 'http_sync'")
+    return {"response": _compact_response(response)}
+
+
+def _connector_spec(declaration: Mapping[str, Any]) -> dict[str, Any]:
+    raw = declaration.get("connector_spec") or declaration.get("connector") or declaration.get("http")
+    spec = _mapping(raw, "connector_spec")
+    kind = str(spec.get("kind") or spec.get("type") or "http_sync").strip()
+    if kind not in {"http_request", "http_sync"}:
+        raise WorkspaceAppActionContractError("connector_spec.kind must be 'http_request' or 'http_sync'")
+    return spec
+
+
+def _validate_request_effects(context: WorkspaceAppActionContext, request_spec: Mapping[str, Any]) -> None:
+    effects = {str(effect).strip() for effect in context.declaration.get("effects", [])}
+    method = str(request_spec.get("method") or "GET").strip().upper()
+    needed = "external.read" if method == "GET" else "external.write"
+    if needed not in effects:
+        raise WorkspaceAppActionContractError(f"connector_spec.request.method {method} requires effect '{needed}'")
+
+
+def _request_json(
+    request_spec: Mapping[str, Any],
+    *,
+    spec: Mapping[str, Any],
+    context: WorkspaceAppActionContext,
+    payload: Mapping[str, Any],
+) -> Any:
+    method = str(request_spec.get("method") or "GET").strip().upper()
+    if method not in _ALLOWED_METHODS:
+        raise WorkspaceAppActionContractError(
+            "connector_spec.request.method must be one of: " + ", ".join(sorted(_ALLOWED_METHODS))
+        )
+    url = _render_template(str(request_spec.get("url") or ""), payload)
+    _validate_url(url)
+
+    headers = _render_string_mapping(request_spec.get("headers"), payload)
+    params = _render_string_mapping(request_spec.get("params"), payload)
+    body = _render_json_value(request_spec.get("json"), payload)
+    _apply_auth(headers, spec.get("auth"), context=context, payload=payload)
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(20.0, connect=5.0), follow_redirects=False) as client:
+            response = client.request(
+                method,
+                url,
+                headers=headers or None,
+                params=params or None,
+                json=body if body is not None and method != "GET" else None,
+            )
+    except httpx.HTTPError as exc:
+        raise WorkspaceAppActionError("External connector request failed.") from exc
+
+    if not response.is_success:
+        raise WorkspaceAppActionError(f"External connector returned HTTP {response.status_code}.")
+    if not response.content:
+        return {}
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise WorkspaceAppActionError("External connector response was not valid JSON.") from exc
+
+
+def _apply_auth(
+    headers: dict[str, str],
+    auth_spec: Any,
+    *,
+    context: WorkspaceAppActionContext,
+    payload: Mapping[str, Any],
+) -> None:
+    if auth_spec in (None, {}, "none"):
+        return
+    auth = _mapping(auth_spec, "connector_spec.auth")
+    auth_type = str(auth.get("type") or "bearer").strip()
+    if auth_type == "none":
+        return
+
+    token = _resolve_secret(auth, context=context, payload=payload)
+    if not token:
+        raise WorkspaceAppActionContractError("Connector auth could not resolve an approved Vault credential.")
+
+    if auth_type == "bearer":
+        headers["Authorization"] = f"Bearer {token}"
+        return
+    if auth_type == "header":
+        header_name = str(auth.get("header") or auth.get("name") or "").strip()
+        if not header_name or header_name.lower() == "authorization":
+            raise WorkspaceAppActionContractError("header auth requires a non-Authorization header name")
+        headers[header_name] = token
+        return
+    raise WorkspaceAppActionContractError("connector_spec.auth.type must be 'none', 'bearer', or 'header'")
+
+
+def _resolve_secret(
+    auth: Mapping[str, Any],
+    *,
+    context: WorkspaceAppActionContext,
+    payload: Mapping[str, Any],
+) -> str | None:
+    source = str(auth.get("source") or "vault_key").strip()
+    if source == "vault_key":
+        key = _render_template(str(auth.get("vault_key") or auth.get("key") or ""), payload)
+        if not key:
+            raise WorkspaceAppActionContractError("vault_key auth requires connector_spec.auth.vault_key")
+        if not context.user_id:
+            raise WorkspaceAppActionContractError("Vault-backed connector auth requires a human user")
+        from brain.systems.vault import get_secret
+
+        return get_secret(
+            key,
+            context.user_id,
+            org_id=context.org_id,
+            allow_shared=True,
+            accessed_by="workspace_app_connector",
+        )
+    if source in {"project_env", "project_vault_binding"}:
+        env_name = str(auth.get("env") or auth.get("env_name") or "GITHUB_TOKEN").strip()
+        project_slug = _render_template(str(auth.get("project_slug") or payload.get("project_slug") or ""), payload)
+        project_slugs = [project_slug] if project_slug else []
+        for candidate in auth.get("project_slugs") or payload.get("project_slugs") or []:
+            rendered = _render_template(str(candidate), payload)
+            if rendered:
+                project_slugs.append(rendered)
+        if not env_name or not project_slugs:
+            raise WorkspaceAppActionContractError("project_env auth requires env and project_slug")
+        if not context.user_id:
+            raise WorkspaceAppActionContractError("Project-bound connector auth requires a human user")
+        from brain.systems.vault import resolve_project_bound_env_tokens
+
+        env = resolve_project_bound_env_tokens(
+            user_id=context.user_id,
+            org_id=context.org_id,
+            project_slug=project_slugs[0],
+            project_slugs=project_slugs,
+        )
+        return env.get(env_name)
+    raise WorkspaceAppActionContractError("connector_spec.auth.source must be 'vault_key' or 'project_env'")
+
+
+def _sync_items_to_domain(
+    context: WorkspaceAppActionContext,
+    sync_spec: Mapping[str, Any],
+    items: list[Any],
+) -> dict[str, Any]:
+    effects = {str(effect).strip() for effect in context.declaration.get("effects", [])}
+    if "domain.write" not in effects:
+        raise WorkspaceAppActionContractError("connector_spec.sync requires effect 'domain.write'")
+
+    binding_alias = str(sync_spec.get("binding") or sync_spec.get("domain_binding") or "").strip()
+    if not binding_alias:
+        raise WorkspaceAppActionContractError("connector_spec.sync.binding is required")
+    binding = _domain_binding(context.version.manifest or {}, binding_alias)
+    if not binding:
+        raise WorkspaceAppActionContractError(f"Domain binding '{binding_alias}' is not declared")
+
+    domain_id = _positive_int(binding.get("domain_id"), f"binding '{binding_alias}'.domain_id")
+    object_key = str(binding.get("object_key") or "").strip()
+    if not object_key:
+        raise WorkspaceAppActionContractError(f"binding '{binding_alias}'.object_key is required")
+
+    service = DomainService(context.session)
+    remote_id_expr = sync_spec.get("remote_id") or sync_spec.get("external_id") or "id"
+    remote_id_field = str(sync_spec.get("remote_id_field") or sync_spec.get("external_id_field") or "").strip()
+    fields_map = _mapping(sync_spec.get("fields"), "connector_spec.sync.fields")
+    title_expr = sync_spec.get("title") or sync_spec.get("title_path")
+    limit = min(_positive_int(sync_spec.get("limit") or _MAX_ITEMS, "connector_spec.sync.limit"), _MAX_ITEMS)
+
+    existing_by_remote: dict[str, Any] = {}
+    if remote_id_field:
+        for record in service.list_records(context.org_id, domain_id, object_key=object_key, limit=500):
+            value = (record.data or {}).get(remote_id_field)
+            if value is not None:
+                existing_by_remote[str(value)] = record
+
+    created = 0
+    updated = 0
+    skipped = 0
+    synced_records: list[dict[str, Any]] = []
+
+    for item in items[:limit]:
+        if not isinstance(item, Mapping):
+            skipped += 1
+            continue
+        remote_id = _mapped_value(remote_id_expr, item)
+        data = {
+            str(field_key): _mapped_value(field_expr, item)
+            for field_key, field_expr in fields_map.items()
+            if str(field_key).strip()
+        }
+        data = {key: value for key, value in data.items() if value is not None}
+        if remote_id_field and remote_id is not None:
+            data.setdefault(remote_id_field, str(remote_id))
+        title = _mapped_value(title_expr, item) if title_expr is not None else None
+        title_text = str(title).strip() if title is not None else None
+
+        existing = existing_by_remote.get(str(remote_id)) if remote_id is not None else None
+        if existing is not None:
+            record = service.update_record(
+                context.org_id,
+                domain_id,
+                existing.id,
+                data_patch=data,
+                title=title_text,
+                actor_id=context.user_id,
+                actor_kind="workspace_app_action",
+            )
+            updated += 1
+        else:
+            record = service.create_record(
+                context.org_id,
+                domain_id,
+                object_key,
+                data=data,
+                title=title_text,
+                actor_id=context.user_id,
+                actor_kind="workspace_app_action",
+            )
+            created += 1
+            if remote_id_field and remote_id is not None:
+                existing_by_remote[str(remote_id)] = record
+        synced_records.append(service.serialize_record(record))
+
+    return {
+        "synced": created + updated,
+        "created": created,
+        "updated": updated,
+        "skipped": skipped,
+        "records": synced_records,
+    }
+
+
+def _items_from_response(response: Any, response_spec: Any) -> list[Any]:
+    if isinstance(response_spec, Mapping):
+        path = response_spec.get("items_path") or response_spec.get("path") or ""
+        value = _extract_path(response, str(path)) if path else response
+    else:
+        value = response
+    if isinstance(value, list):
+        return value
+    if isinstance(value, Mapping):
+        for key in ("items", "data", "results", "records"):
+            candidate = value.get(key)
+            if isinstance(candidate, list):
+                return candidate
+    raise WorkspaceAppActionContractError("Connector response did not contain a list of items")
+
+
+def _compact_response(value: Any, *, depth: int = 0) -> Any:
+    if depth >= 4:
+        return None
+    if isinstance(value, Mapping):
+        compact: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= 50:
+                compact["__truncated__"] = True
+                break
+            compact[str(key)] = _compact_response(item, depth=depth + 1)
+        return compact
+    if isinstance(value, list):
+        compact_items = [_compact_response(item, depth=depth + 1) for item in value[:50]]
+        if len(value) > 50:
+            compact_items.append({"__truncated__": True})
+        return compact_items
+    return value
+
+
+def _mapped_value(expr: Any, item: Mapping[str, Any]) -> Any:
+    if isinstance(expr, Mapping):
+        if "const" in expr:
+            return expr.get("const")
+        if "path" in expr:
+            return _extract_path(item, str(expr.get("path") or ""))
+        raise WorkspaceAppActionContractError("mapping expressions must use const or path")
+    if expr is None:
+        return None
+    return _extract_path(item, str(expr))
+
+
+def _extract_path(source: Any, path: str) -> Any:
+    clean = path.strip()
+    if clean in {"", "$", "."}:
+        return source
+    clean = clean.removeprefix("$.").removeprefix(".")
+    current = source
+    for part in clean.split("."):
+        if part.endswith("[]"):
+            key = part[:-2]
+            value = _extract_path(current, key) if key else current
+            return value if isinstance(value, list) else []
+        if isinstance(current, Mapping):
+            current = current.get(part)
+        elif isinstance(current, list):
+            try:
+                current = current[int(part)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return current
+
+
+def _render_string_mapping(value: Any, payload: Mapping[str, Any]) -> dict[str, str]:
+    if value is None:
+        return {}
+    raw = _mapping(value, "request mapping")
+    return {str(key): _render_template(str(item), payload) for key, item in raw.items()}
+
+
+def _render_json_value(value: Any, payload: Mapping[str, Any]) -> Any:
+    if isinstance(value, str):
+        return _render_template(value, payload)
+    if isinstance(value, Mapping):
+        return {key: _render_json_value(item, payload) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_render_json_value(item, payload) for item in value]
+    return value
+
+
+def _render_template(template: str, payload: Mapping[str, Any]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        value = _extract_path(payload, match.group(1))
+        return "" if value is None else str(value)
+
+    return _TEMPLATE_RE.sub(replace, template)
+
+
+def _validate_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise WorkspaceAppActionContractError("connector_spec.request.url must be an https URL")
+    host = parsed.hostname.lower()
+    if host in {"localhost", "metadata.google.internal"} or host.endswith(".local"):
+        raise WorkspaceAppActionContractError("connector_spec.request.url cannot target local/internal hosts")
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+        raise WorkspaceAppActionContractError("connector_spec.request.url cannot target private/internal addresses")
+
+
+def _domain_binding(manifest: Mapping[str, Any], alias: str) -> Mapping[str, Any] | None:
+    data_plan = manifest.get("data_plan")
+    bindings = data_plan.get("bindings") if isinstance(data_plan, Mapping) else None
+    if not isinstance(bindings, Mapping):
+        return None
+    binding = bindings.get(alias)
+    return binding if isinstance(binding, Mapping) else None
+
+
+def _mapping(value: Any, field: str) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise WorkspaceAppActionContractError(f"{field} must be an object")
+
+
+def _positive_int(value: Any, field: str) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise WorkspaceAppActionContractError(f"{field} must be a positive integer") from exc
+    if number <= 0:
+        raise WorkspaceAppActionContractError(f"{field} must be a positive integer")
+    return number
+
+
+__all__ = ["GENERIC_HTTP_EXECUTOR_KEY", "execute_generic_http_action"]

--- a/brain/systems/workspace_apps/service.py
+++ b/brain/systems/workspace_apps/service.py
@@ -5,7 +5,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
 from brain.platform.db.models.workspace_app import WorkspaceApp, WorkspaceAppState, WorkspaceAppVersion
@@ -642,6 +642,44 @@ def archive_app(
     app.archived_at = datetime.now(timezone.utc)
     session.flush()
     return {"archived": {"id": app.id, "key": app.key}}
+
+
+def delete_archived_apps(
+    session: Session,
+    org_id: str,
+    *,
+    include_prototypes: bool = False,
+) -> int:
+    stmt = (
+        select(WorkspaceApp)
+        .where(WorkspaceApp.org_id == org_id, WorkspaceApp.archived_at.is_not(None))
+    )
+    apps = list(session.scalars(stmt).all())
+    app_ids = [
+        str(app.id)
+        for app in apps
+        if include_prototypes or not _is_prototype_app(app)
+    ]
+    if not app_ids:
+        return 0
+
+    session.execute(
+        delete(WorkspaceAppState)
+        .where(WorkspaceAppState.app_id.in_(app_ids))
+        .execution_options(synchronize_session=False)
+    )
+    session.execute(
+        delete(WorkspaceAppVersion)
+        .where(WorkspaceAppVersion.app_id.in_(app_ids))
+        .execution_options(synchronize_session=False)
+    )
+    session.execute(
+        delete(WorkspaceApp)
+        .where(WorkspaceApp.id.in_(app_ids))
+        .execution_options(synchronize_session=False)
+    )
+    session.flush()
+    return len(app_ids)
 
 
 def restore_app(

--- a/brain/systems/workspace_apps/service.py
+++ b/brain/systems/workspace_apps/service.py
@@ -198,9 +198,11 @@ def validate_domain_bindings(
 
         fields = service.list_fields(obj.id)
         field_keys = {field.key for field in fields}
+        bindable_field_keys = set(field_keys)
+        bindable_field_keys.add("title")
         declared_fields = _string_list(alias_text, binding.get("fields"), "fields")
         if declared_fields is not None:
-            unknown = sorted(set(declared_fields) - field_keys)
+            unknown = sorted(set(declared_fields) - bindable_field_keys)
             if unknown:
                 raise _binding_error(alias_text, f"declares missing field(s): {', '.join(unknown)}")
             required = sorted(

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -713,6 +713,8 @@ export const api = {
     fetchJson<any[]>(status ? `/api/cortex/ideas?status=${encodeURIComponent(status)}` : '/api/cortex/ideas'),
   listArchivedIdeas: (limit = 12) =>
     fetchJson<any[]>(withQuery('/api/cortex/ideas/archived', { limit })),
+  emptyArchivedIdeas: () =>
+    fetchJson<{ deleted: number }>('/api/cortex/ideas/archived', { method: 'DELETE' }),
   getIdea: (id: string) => fetchJson<any>(`/api/cortex/ideas/${id}`),
   createIdea: (data: any) =>
     fetchJson<any>('/api/cortex/ideas', { method: 'POST', body: JSON.stringify(data) }),
@@ -1027,6 +1029,8 @@ export const api = {
   getWorkspaceApp: (appId: string) => fetchJson<WorkspaceAppRead>(`/api/workspace-apps/${appId}`),
   listArchivedWorkspaceApps: (limit = 12) =>
     fetchJson<WorkspaceAppRead[]>(withQuery('/api/workspace-apps/archived', { limit })),
+  emptyArchivedWorkspaceApps: () =>
+    fetchJson<{ deleted: number }>('/api/workspace-apps/archived', { method: 'DELETE' }),
   updateWorkspaceApp: (appId: string, data: WorkspaceAppUpdateInput) =>
     fetchJson<WorkspaceAppRead>(`/api/workspace-apps/${appId}`, { method: 'PATCH', body: JSON.stringify(data) }),
   archiveWorkspaceApp: (appId: string) =>

--- a/frontend/src/lib/features/cortex/components/ArchiveBinMenu.svelte
+++ b/frontend/src/lib/features/cortex/components/ArchiveBinMenu.svelte
@@ -4,6 +4,7 @@
   import type { WorkspaceAppRead } from '$lib/api/client';
   import { ConstellationIcon, ConstellationIconButton } from '$lib/components/constellation';
   import { cortex, type Idea } from '$lib/stores/cortex.svelte';
+  import { ui } from '$lib/stores/ui.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import { relativeTimeAgo } from '$lib/utils/datetime';
 
@@ -20,10 +21,12 @@
   } = $props();
 
   let open = $state(false);
+  let emptying = $state(false);
   let rootEl: HTMLDivElement | undefined = $state();
 
   const recentArchived = $derived(cortex.archivedIdeas.slice(0, 12));
   const recentArchivedApps = $derived(workspaceApps.archivedApps.slice(0, 12));
+  const visibleArchivedCount = $derived(recentArchived.length + recentArchivedApps.length);
 
   function timeAgo(value: string | null | undefined): string {
     return relativeTimeAgo(value) || 'recently';
@@ -56,6 +59,35 @@
     event.stopPropagation();
     open = false;
     await onrestoreapp?.(app, event);
+  }
+
+  async function handleEmptyBin(event: MouseEvent) {
+    event.stopPropagation();
+    if (emptying || visibleArchivedCount === 0) return;
+
+    const confirmed = typeof window !== 'undefined' && window.confirm(
+      'Permanently delete all archived threads and apps in the trash bin? This cannot be undone.',
+    );
+    if (!confirmed) return;
+
+    emptying = true;
+    try {
+      const [threadResult, appResult] = await Promise.all([
+        cortex.emptyArchivedIdeas(),
+        workspaceApps.emptyArchived(),
+      ]);
+      const deleted = Number(threadResult?.deleted || 0) + Number(appResult?.deleted || 0);
+      const suffix = deleted === 1 ? 'item' : 'items';
+      ui.toast(
+        deleted > 0 ? `Trash bin emptied. ${deleted} ${suffix} deleted.` : 'Trash bin is already empty.',
+        'success',
+      );
+      open = false;
+    } catch (err: any) {
+      ui.toast(err?.detail || 'Failed to empty trash bin', 'error');
+    } finally {
+      emptying = false;
+    }
   }
 
   function handleDocumentClick(event: MouseEvent) {
@@ -102,6 +134,18 @@
           <strong>Archived</strong>
           <span>Recent threads and apps</span>
         </div>
+        <button
+          type="button"
+          class="cortex-archive-empty-action"
+          disabled={visibleArchivedCount === 0 || emptying}
+          title="Empty trash bin"
+          aria-label="Empty trash bin"
+          role="menuitem"
+          onclick={handleEmptyBin}
+        >
+          <ConstellationIcon name="trash" size={12} stroke={2} />
+          <span>{emptying ? 'Emptying' : 'Empty'}</span>
+        </button>
       </div>
 
       {#if (cortex.archivedIdeasLoading || workspaceApps.archivedLoading) && recentArchived.length === 0 && recentArchivedApps.length === 0}
@@ -334,6 +378,45 @@
   .cortex-archive-copy span {
     color: var(--constellation-notification-subtitle);
     font-size: 12px;
+  }
+
+  .cortex-archive-empty-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-width: 78px;
+    min-height: 30px;
+    padding: 0 10px;
+    border-radius: 10px;
+    border: 1px solid color-mix(in srgb, var(--constellation-button-destructive-border) 82%, transparent);
+    background: color-mix(in srgb, var(--constellation-button-destructive-background) 74%, transparent);
+    color: var(--constellation-button-destructive-text);
+    font-family: var(--constellation-font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      transform 160ms ease,
+      border-color 160ms ease,
+      background-color 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .cortex-archive-empty-action:hover:not(:disabled),
+  .cortex-archive-empty-action:focus-visible {
+    transform: translateY(-1px);
+    border-color: var(--constellation-button-destructive-border-hover);
+    background: var(--constellation-button-destructive-background-hover);
+    outline: none;
+  }
+
+  .cortex-archive-empty-action:disabled {
+    opacity: 0.44;
+    cursor: not-allowed;
   }
 
   .cortex-archive-empty {

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
@@ -24,6 +24,7 @@
     options?: Array<string | { label?: string; value?: any }>;
     width?: string;
   };
+  type GeneratedUiColumnInput = GeneratedUiColumn | string;
 
   type GeneratedUiBoardGroup = string | { label?: string; value?: any };
   type GeneratedUiBoardCard = {
@@ -63,8 +64,8 @@
     binding?: string;
     data_binding?: string;
     object_key?: string;
-    columns?: GeneratedUiColumn[];
-    fields?: GeneratedUiColumn[];
+    columns?: GeneratedUiColumnInput[];
+    fields?: GeneratedUiColumnInput[];
     groups?: GeneratedUiBoardGroup[];
     board_columns?: GeneratedUiBoardGroup[];
     boardColumns?: GeneratedUiBoardGroup[];
@@ -77,7 +78,7 @@
     group_by?: string;
     card?: GeneratedUiBoardCard;
     allow_create?: boolean;
-    create?: boolean | { fields?: GeneratedUiColumn[] };
+    create?: boolean | { fields?: GeneratedUiColumnInput[] };
     empty_state?: string;
   };
 
@@ -368,7 +369,9 @@
 
   function columnsForView(view: GeneratedUiView, rows: Record<string, any>[]): GeneratedUiColumn[] {
     const configured = view.columns || view.fields;
-    if (Array.isArray(configured) && configured.length) return configured.filter((column) => !!column?.key);
+    if (Array.isArray(configured) && configured.length) {
+      return configured.map(normalizeColumn).filter((column): column is GeneratedUiColumn => !!column?.key);
+    }
     const bindingFields = bindingForView(view)?.fields;
     if (Array.isArray(bindingFields) && bindingFields.length) {
       return bindingFields
@@ -386,7 +389,9 @@
   function createFieldsForView(view: GeneratedUiView, rows: Record<string, any>[]): GeneratedUiColumn[] {
     const binding = bindingForView(view);
     if (view.create && typeof view.create === 'object' && Array.isArray(view.create.fields)) {
-      return view.create.fields.filter((field) => !!field?.key && bindingAllowsField(binding, field.key));
+      return view.create.fields
+        .map(normalizeColumn)
+        .filter((field): field is GeneratedUiColumn => !!field?.key && bindingAllowsField(binding, field.key));
     }
     return columnsForView(view, rows).filter((field) => (
       !['id', 'version'].includes(field.key)
@@ -399,6 +404,16 @@
       .replace(/^_+/, '')
       .replace(/[_-]+/g, ' ')
       .replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+
+  function normalizeColumn(raw: GeneratedUiColumnInput): GeneratedUiColumn | null {
+    if (typeof raw === 'string') {
+      const key = raw.trim();
+      return key ? { key, label: labelFromKey(key) } : null;
+    }
+    if (!raw || typeof raw !== 'object') return null;
+    const key = String(raw.key || '').trim();
+    return key ? { ...raw, key, label: raw.label || labelFromKey(key) } : null;
   }
 
   function cellValue(row: Record<string, any>, column: GeneratedUiColumn): any {
@@ -457,10 +472,10 @@
     busyCell = { ...busyCell, [cacheKey]: true };
     try {
       const value = coerceOptionValue(rawValue, column);
-      const updated = await updateDomainRecord(domainId, record.id, {
-        data_patch: { [column.key]: value },
-        expected_version: record.version,
-      });
+      const payload = column.key === 'title'
+        ? { title: String(value ?? ''), expected_version: record.version }
+        : { data_patch: { [column.key]: value }, expected_version: record.version };
+      const updated = await updateDomainRecord(domainId, record.id, payload);
       recordsByAlias = {
         ...recordsByAlias,
         [alias]: (recordsByAlias[alias] || []).map((candidate) => (
@@ -604,9 +619,10 @@
     const draft = draftByView[id] || {};
     busyCreate = { ...busyCreate, [id]: true };
     try {
+      const { title, ...data } = draft;
       const created = await createDomainRecord(domainId, objectKey, {
-        data: draft,
-        title: draft.title || undefined,
+        data,
+        title: title || undefined,
       });
       recordsByAlias = {
         ...recordsByAlias,

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -762,6 +762,14 @@ class CortexStore {
     }
   }
 
+  async emptyArchivedIdeas() {
+    const result = await api.emptyArchivedIdeas();
+    this.archivedIdeas = [];
+    this.archivedIdeaCountsByUser = {};
+    this._archivedIdeaIds = new Set<string>();
+    return result;
+  }
+
   applyUserProfileUpdate(update: {
     userId: string;
     name?: string | null;

--- a/frontend/src/lib/stores/workspaceApps.svelte.ts
+++ b/frontend/src/lib/stores/workspaceApps.svelte.ts
@@ -140,6 +140,21 @@ class WorkspaceAppsStore {
     }
   }
 
+  async emptyArchived() {
+    const archivedIds = new Set(this.archivedApps.map((app) => app.id));
+    const result = await api.emptyArchivedWorkspaceApps();
+    this.archivedApps = [];
+    if (archivedIds.size > 0) {
+      this.stateCache = Object.fromEntries(
+        Object.entries(this.stateCache).filter(([cacheKey]) => {
+          const [appId] = cacheKey.split(':', 1);
+          return !archivedIds.has(appId);
+        }),
+      );
+    }
+    return result;
+  }
+
   async restore(appId: string | null | undefined) {
     if (!appId) return null;
     const restored = await api.restoreWorkspaceApp(appId);
@@ -377,6 +392,11 @@ class WorkspaceAppsStore {
     const action = String(msg?.action || '').toLowerCase();
     const appId = msg?.app_id || msg?.app?.id;
     const key = msg?.key || msg?.app?.key;
+    if (action === 'empty_archive') {
+      this.archivedApps = [];
+      this.scheduleRefresh(650);
+      return;
+    }
     if (action === 'archive' || action === 'delete' || action === 'remove') {
       this._removeApp(appId, key);
     } else if (msg?.app) {

--- a/frontend/src/lib/utils/generatedWorkspaceAppContract.ts
+++ b/frontend/src/lib/utils/generatedWorkspaceAppContract.ts
@@ -47,6 +47,7 @@ export function bindingAllowsField(
 ): boolean {
   const key = String(fieldKey || '').trim();
   if (!key) return false;
+  if (key === 'title') return true;
   const fields = Array.isArray(binding?.fields) ? binding.fields.map(String) : [];
   return fields.length === 0 || fields.includes(key);
 }

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -223,36 +223,6 @@
       "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
     },
     {
-      "source": "brain/platform/telemetry/postmortem.py",
-      "import": "brain.systems.learning",
-      "source_layer": "brain.platform",
-      "target_layer": "brain.systems",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
-    },
-    {
-      "source": "brain/systems/agency/core.py",
-      "import": "brain.app.scheduler.executor",
-      "source_layer": "brain.systems",
-      "target_layer": "brain.app",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
-    },
-    {
-      "source": "brain/systems/cognition/frame.py",
-      "import": "brain.app.cli.memory",
-      "source_layer": "brain.systems",
-      "target_layer": "brain.app",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
-    },
-    {
       "source": "brain/systems/cognition/frame.py",
       "import": "brain.app.mcp.server",
       "source_layer": "brain.systems",
@@ -331,16 +301,6 @@
       "owner": "architecture-boundaries",
       "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
       "reason": "System code calls an offline job module; move shared behavior into systems or platform."
-    },
-    {
-      "source": "brain/systems/prompts/builder.py",
-      "import": "brain.app.cli.skills",
-      "source_layer": "brain.systems",
-      "target_layer": "brain.app",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
     },
     {
       "source": "brain/systems/quality/review.py",

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -968,6 +968,31 @@ async def test_list_archived_ideas(client, mock_session_factory):
 
 
 @pytest.mark.asyncio
+async def test_empty_archived_ideas(client, mock_session_factory):
+    broadcasts = []
+
+    async def _broadcast(event_type, data, **kwargs):
+        broadcasts.append((event_type, data, kwargs))
+
+    with patch(
+        "brain.app.api.routers.cortex._ideas.IdeaRepository"
+    ) as MockRepo, patch(
+        "brain.app.api.routers.cortex._ideas.ws_manager.broadcast_product_event",
+        side_effect=_broadcast,
+    ):
+        MockRepo.return_value.hard_delete_archived_for_org.return_value = 3
+        resp = await client.delete("/api/cortex/ideas/archived")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deleted": 3}
+    MockRepo.return_value.hard_delete_archived_for_org.assert_called_once_with("test-org")
+    mock_session_factory.commit.assert_called()
+    assert broadcasts == [
+        ("idea_archive_emptied", {"deleted": 3}, {"org_id": "test-org"}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_idea(client, mock_session_factory):
     idea = _make_idea(title="New Idea")
     broadcasts = []

--- a/tests/test_repo_ideas.py
+++ b/tests/test_repo_ideas.py
@@ -184,6 +184,33 @@ class TestIdeaRepository:
         repo.archive(idea.id)
         assert idea.archived_at is not None
 
+    def test_hard_delete_archived_for_org_removes_only_org_archive(self, repo, session):
+        _seed_org_user(session)
+        archived = _make_idea(session, org_id=ORG_1, archived_at=datetime.now(timezone.utc))
+        child = _make_idea(session, org_id=ORG_1, parent_id=archived.id)
+        active = _make_idea(session, org_id=ORG_1)
+        other_org_archived = _make_idea(
+            session,
+            id=str(uuid.uuid4()),
+            user_id=USER_2,
+            org_id=ORG_2,
+            archived_at=datetime.now(timezone.utc),
+        )
+        archived_id = archived.id
+        child_id = child.id
+        active_id = active.id
+        other_org_archived_id = other_org_archived.id
+
+        deleted = repo.hard_delete_archived_for_org(ORG_1)
+        session.flush()
+        session.expire_all()
+
+        assert deleted == 1
+        assert session.get(Idea, archived_id) is None
+        assert session.get(Idea, child_id).parent_id is None
+        assert session.get(Idea, active_id) is not None
+        assert session.get(Idea, other_org_archived_id) is not None
+
 
 # ---------------------------------------------------------------------------
 # IdeaThreadRepository

--- a/tests/test_workspace_app_compiler.py
+++ b/tests/test_workspace_app_compiler.py
@@ -184,6 +184,36 @@ def test_compiler_accepts_domain_backed_board_view():
     assert _validation_report(compiled)["status"] == "passed"
 
 
+def test_compiler_normalizes_generated_ui_string_columns():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="Ticket Board",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(
+            {
+                "schema_version": 1,
+                "title": "Ticket Board",
+                "views": [
+                    {
+                        "type": "table",
+                        "title": "Tickets",
+                        "columns": ["title", "status", {"field": "assignee"}],
+                    }
+                ],
+            }
+        ),
+    )
+
+    source = json.loads(compiled.source_code)
+    assert source["views"][0]["columns"] == [
+        {"key": "title", "label": "Title"},
+        {"key": "status", "label": "Status"},
+        {"field": "assignee", "key": "assignee", "label": "Assignee"},
+    ]
+    assert _validation_report(compiled)["status"] == "passed"
+
+
 def test_compiler_does_not_silently_repair_recordful_app_local_state():
     compiled = compile_workspace_app_input(
         action="create",

--- a/tests/test_workspace_app_contract.py
+++ b/tests/test_workspace_app_contract.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from brain.systems.workspace_apps.contracts import build_contract_validation_report
+from brain.systems.workspace_apps.actions import WorkspaceAppActionExecutorMissing
 from brain.systems.workspace_apps.service import WorkspaceAppContractError, _validate_contract_state_payload_or_raise
 
 
@@ -314,6 +315,14 @@ class _FakeUow:
         return None
 
 
+class _FakeAsyncDb:
+    def __init__(self):
+        self.sync_session = MagicMock()
+
+    async def run_sync(self, fn):
+        return fn(self.sync_session)
+
+
 def test_manage_workspace_app_surfaces_contract_errors():
     from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
 
@@ -330,6 +339,60 @@ def test_manage_workspace_app_surfaces_contract_errors():
 
     assert result["contract_validation"]["status"] == "failed"
     assert "Workspace app contract validation failed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_app_action_route_uses_sync_session_bridge():
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.workspace_apps import run_workspace_app_declared_action
+    from brain.app.api.schemas.workspace_apps import WorkspaceAppActionRun
+
+    db = _FakeAsyncDb()
+
+    with patch(
+        "brain.app.api.routers.workspace_apps.run_workspace_app_action",
+        side_effect=WorkspaceAppActionExecutorMissing("missing executor"),
+    ) as run_action:
+        with pytest.raises(HTTPException) as exc:
+            await run_workspace_app_declared_action(
+                "app-1",
+                WorkspaceAppActionRun(action_key="tickets.syncExternal", payload={}),
+                db=db,
+                user={"id": "user-1", "org_id": "org-1"},
+            )
+
+    assert exc.value.status_code == 501
+    assert exc.value.detail == "missing executor"
+    assert run_action.call_args.args[0] is db.sync_session
+
+
+def test_manage_workspace_app_schema_ignores_extra_tool_args():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    result = json.loads(
+        _handle_manage_workspace_app(
+            action="schema",
+            operation="create",
+            limit=10,
+        )
+    )
+
+    assert result["tool"] == "manage_workspace_app"
+    assert result["operation"] == "create"
+
+
+def test_manage_workspace_app_archived_lookup_requires_confirmation():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.workspace_apps._workspace_app_context",
+        return_value=("11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"),
+    ), patch("brain.platform.db.repositories.unit_of_work.UnitOfWork") as uow:
+        result = json.loads(_handle_manage_workspace_app(action="get", app_id="app-1", include_archived=True))
+
+    assert "confirm_include_archived=true" in result["error"]
+    uow.assert_not_called()
 
 
 def test_manage_workspace_app_extracts_embedded_contract_fields_from_source_code():

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -338,6 +338,75 @@ def test_invalid_domain_bindings_block_save(session, overrides, message):
         )
 
 
+def test_domain_binding_allows_virtual_record_title_field(session):
+    domain = DomainService(session).create_domain(
+        ORG_ID,
+        name="Ticket Board",
+        slug="ticket-board",
+        objects=[
+            {
+                "key": "ticket",
+                "name": "Ticket",
+                "fields": [
+                    {"key": "status", "field_type": "enum", "options": ["Backlog", "Done"], "required": True},
+                    {"key": "priority", "field_type": "text"},
+                ],
+            }
+        ],
+        actor_id=USER_ID,
+    )
+
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="ticket-board",
+        name="Ticket Board",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(
+            {
+                "schema_version": 1,
+                "title": "Ticket Board",
+                "primary_binding": "tickets",
+                "views": [
+                    {
+                        "id": "tickets",
+                        "type": "table",
+                        "title": "Tickets",
+                        "binding": "tickets",
+                        "columns": [
+                            {"key": "title", "label": "Title"},
+                            {"key": "status", "label": "Status"},
+                            {"key": "priority", "label": "Priority"},
+                        ],
+                    }
+                ],
+            }
+        ),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": domain.id,
+                        "object_key": "ticket",
+                        "fields": ["title", "status", "priority"],
+                        "operations": ["schema", "list", "create", "update"],
+                    }
+                },
+            },
+            "design_contract": {
+                "kit": "constellation-app-kit",
+                "theme_modes": ["dark", "light"],
+            },
+        },
+        visual_spec=VALID_VISUAL_SPEC,
+    )
+
+    assert active_version(session, app.id) is not None
+
+
 def test_domain_binding_blocks_archived_or_cross_org_domain(session):
     domain = _todo_domain(session)
     domain.archived_at = datetime.now(timezone.utc)

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import json
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -27,6 +28,7 @@ from brain.systems.workspace_apps.service import (
     active_version,
     archive_app,
     create_app,
+    delete_archived_apps,
     list_archived_apps,
     restore_app,
     update_app,
@@ -538,6 +540,44 @@ def test_archive_and_restore_app_leave_domain_records_intact(session):
     assert restored.archived_at is None
 
 
+def test_delete_archived_apps_permanently_removes_app_versions_and_state(session):
+    domain = _todo_domain(session)
+    archived = create_app(
+        session,
+        org_id=ORG_ID,
+        key="trash-me",
+        name="Trash Me",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=_manifest(domain.id),
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+        initial_state={"view": "table"},
+    )
+    active = create_app(
+        session,
+        org_id=ORG_ID,
+        key="keep-me",
+        name="Keep Me",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=_manifest(domain.id),
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+    archive_app(session, org_id=ORG_ID, app_id=archived.id)
+
+    deleted = delete_archived_apps(session, org_id=ORG_ID)
+
+    assert deleted == 1
+    assert session.query(WorkspaceApp).filter_by(id=archived.id).count() == 0
+    assert session.query(WorkspaceAppVersion).filter_by(app_id=archived.id).count() == 0
+    assert session.query(WorkspaceAppState).filter_by(app_id=archived.id).count() == 0
+    assert session.query(WorkspaceApp).filter_by(id=active.id).count() == 1
+
+
 def test_workspace_app_action_requires_registered_executor(session):
     domain = _todo_domain(session)
     app = create_app(
@@ -611,6 +651,159 @@ def test_workspace_app_action_registered_executor_runs(session):
     assert result["effects"] == ["domain.read", "domain.write", "external.read", "external.write"]
     assert result["connector_keys"] == ["ticketing"]
     assert result["result"] == {"synced": True, "ticketId": 42}
+
+
+def test_workspace_app_action_generic_http_syncs_domain_records(session):
+    domain = DomainService(session).create_domain(
+        ORG_ID,
+        name="Tickets",
+        slug="tickets",
+        objects=[
+            {
+                "key": "ticket",
+                "name": "Ticket",
+                "fields": [
+                    {"key": "external_id", "field_type": "text"},
+                    {"key": "number", "field_type": "number"},
+                    {"key": "status", "field_type": "enum", "options": ["Todo", "Done"]},
+                    {"key": "url", "field_type": "url"},
+                ],
+            }
+        ],
+        actor_id=USER_ID,
+    )
+    service = DomainService(session)
+    existing = service.create_record(
+        ORG_ID,
+        domain.id,
+        "ticket",
+        title="Old issue",
+        data={"external_id": "123", "number": 123, "status": "Todo", "url": "https://example.test/old"},
+        actor_id=USER_ID,
+    )
+    manifest = {
+        "contract_version": 1,
+        "data_plan": {
+            "mode": "domain",
+            "bindings": {
+                "tickets": {
+                    "domain_id": domain.id,
+                    "object_key": "ticket",
+                    "fields": ["title", "external_id", "number", "status", "url"],
+                    "operations": ["schema", "list", "create", "update"],
+                }
+            },
+        },
+        "design_contract": {
+            "kit": "constellation-app-kit",
+            "theme_modes": ["dark", "light"],
+        },
+        "actions": {
+            "tickets.syncExternal": {
+                "kind": "connector",
+                "effects": ["external.read", "domain.write"],
+                "executor": {"type": "registered", "key": "generic.http"},
+                "connector_spec": {
+                    "kind": "http_sync",
+                    "request": {"method": "GET", "url": "https://api.example.test/issues"},
+                    "response": {"items_path": "$"},
+                    "sync": {
+                        "binding": "tickets",
+                        "remote_id": "id",
+                        "remote_id_field": "external_id",
+                        "title": "title",
+                        "fields": {
+                            "number": "number",
+                            "status": {"const": "Done"},
+                            "url": "html_url",
+                        },
+                    },
+                },
+            }
+        },
+    }
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-ticket-sync",
+        name="Generic HTTP Ticket Sync",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    with patch(
+        "brain.systems.workspace_apps.generic_http._request_json",
+        return_value=[
+            {"id": 123, "number": 123, "title": "Updated issue", "html_url": "https://example.test/123"},
+            {"id": 456, "number": 456, "title": "New issue", "html_url": "https://example.test/456"},
+        ],
+    ):
+        result = run_workspace_app_action(
+            session,
+            org_id=ORG_ID,
+            app_id=app.id,
+            action_key="tickets.syncExternal",
+            payload={},
+            user_id=USER_ID,
+        )
+
+    assert result["ok"] is True
+    assert result["result"]["created"] == 1
+    assert result["result"]["updated"] == 1
+    session.refresh(existing)
+    assert existing.title == "Updated issue"
+    assert existing.data["status"] == "Done"
+    records = service.list_records(ORG_ID, domain.id, object_key="ticket", limit=10)
+    assert {record.title for record in records} == {"Updated issue", "New issue"}
+
+
+def test_workspace_app_action_generic_http_request_returns_compact_response(session):
+    domain = _todo_domain(session)
+    manifest = _manifest_with_action(
+        domain.id,
+        {
+            "kind": "connector",
+            "effects": ["external.write"],
+            "executor": {"type": "registered", "key": "generic.http"},
+            "connector_spec": {
+                "kind": "http_request",
+                "request": {
+                    "method": "POST",
+                    "url": "https://api.example.test/issues",
+                    "json": {"title": "{title}"},
+                },
+            },
+        },
+    )
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-create-issue",
+        name="Generic HTTP Create Issue",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    with patch("brain.systems.workspace_apps.generic_http._request_json", return_value={"id": "abc", "ok": True}):
+        result = run_workspace_app_action(
+            session,
+            org_id=ORG_ID,
+            app_id=app.id,
+            action_key="tickets.syncExternal",
+            payload={"title": "Ship it"},
+            user_id=USER_ID,
+        )
+
+    assert result["ok"] is True
+    assert result["result"] == {"response": {"id": "abc", "ok": True}}
 
 
 def test_workspace_app_action_boundaries_reject_raw_secrets(session):


### PR DESCRIPTION
## Summary
- tolerate extra manage_workspace_app tool args and require explicit confirmation before archived app reads
- normalize generated-ui string/field columns before contract validation
- treat Domain record title as a virtual bindable field and handle title create/update in the generated UI renderer
- keep the built-in workspace app skill and filesystem bundle in sync with archived-read/title guidance

## Tests
- venv/bin/pytest tests/test_workspace_app_compiler.py tests/test_workspace_app_contract.py tests/test_workspace_apps_service.py tests/test_builtin_skill_suite.py
- npm --prefix frontend run check
- git diff --check