### PR TITLE
Fix vault secret prompt recovery

### DIFF
--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1151,6 +1151,7 @@ def tool_vault_secret_prompt(
         "key_name": normalized_key,
         "description": clean_description,
         "category": normalized_category,
+        "prompt": prompt,
         "vault_url": _vault_prompt_url(
             key_name=normalized_key,
             description=clean_description,

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -56,7 +56,11 @@ import {
   type CortexRunStreamItem,
 } from '$lib/utils/cortexRunStream';
 import { normalizeHexColor } from '$lib/utils/constellationPresence';
-import { normalizeVaultSecretPromptMessage } from '$lib/utils/vaultSecretPrompt';
+import {
+  normalizeVaultSecretPromptMessage,
+  vaultSecretPromptFromRunToolEvent,
+  vaultSecretPromptFromStream,
+} from '$lib/utils/vaultSecretPrompt';
 import type {
   AgentRunOptions,
   BrowserDiscoveryResult,
@@ -150,6 +154,7 @@ class CortexStore {
   }>();
   private _vaultPromptFocusLoads = new Set<string>();
   private _pendingVaultSecretPrompts = new Map<string, VaultSecretPrompt>();
+  private _dismissedVaultSecretPromptIds = new Set<string>();
   private _teamMembersPromise: Promise<TeamMember[]> | null = null;
   private _seenIdeaRevisions = new Map<string, string>();
   private _archivedIdeaIds = new Set<string>();
@@ -365,6 +370,11 @@ class CortexStore {
   }
 
   private _applyVaultSecretPrompt(prompt: VaultSecretPrompt) {
+    if (this._dismissedVaultSecretPromptIds.has(prompt.id)) return;
+    if (this.vaultSecretPrompt?.id === prompt.id) {
+      this.panelOpen = true;
+      return;
+    }
     this.vaultSecretPrompt = prompt;
     this.panelOpen = true;
   }
@@ -395,7 +405,31 @@ class CortexStore {
     this._applyVaultSecretPrompt(prompt);
   }
 
+  private _handleVaultSecretPromptFromRunEvent(msg: any) {
+    const prompt = vaultSecretPromptFromRunToolEvent(msg) as VaultSecretPrompt | null;
+    const ideaId = prompt?.idea_id ?? null;
+    if (!prompt || !ideaId) return;
+
+    if (ideaId !== this.selectedIdeaId) {
+      this._focusThreadForVaultSecretPrompt(ideaId, prompt);
+      return;
+    }
+
+    this._applyVaultSecretPrompt(prompt);
+  }
+
+  private _maybeApplyVaultSecretPromptFromStream(ideaId: string, stream: StreamItem[]) {
+    if (this.vaultSecretPrompt?.idea_id === ideaId) return;
+    const prompt = vaultSecretPromptFromStream(
+      stream,
+      ideaId,
+      this._dismissedVaultSecretPromptIds,
+    ) as VaultSecretPrompt | null;
+    if (prompt) this._applyVaultSecretPrompt(prompt);
+  }
+
   clearVaultSecretPrompt(promptId?: string | null) {
+    if (promptId) this._dismissedVaultSecretPromptIds.add(promptId);
     if (!promptId || this.vaultSecretPrompt?.id === promptId) {
       this.vaultSecretPrompt = null;
     }
@@ -675,6 +709,9 @@ class CortexStore {
       this._markIdeaWorkingForRootRun(msg.idea_id);
     }
     this._maybeTriggerCyclePanelFromRunUiEvent(msg);
+    if (msg.type === 'tool_finished' && isRootRunEvent) {
+      this._handleVaultSecretPromptFromRunEvent(msg);
+    }
     if (msg.idea_id !== this.selectedIdeaId || !isRootRunEvent) return;
     const eventKey = runUiEventKey(msg);
     if (eventKey) {
@@ -1001,6 +1038,7 @@ class CortexStore {
     if (this.selectedIdeaId !== id || this._streamVersion !== version) return false;
     const mergedItems = this._mergeLiveStreamState(items, id);
     this.stream = mergedItems;
+    this._maybeApplyVaultSecretPromptFromStream(id, mergedItems);
     this._reconcileIdeaStatusFromStream(id, mergedItems);
     this.browserFrame = null;
     this.browserDiscovery = null;

--- a/frontend/src/lib/utils/vaultSecretPrompt.test.js
+++ b/frontend/src/lib/utils/vaultSecretPrompt.test.js
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeVaultSecretPromptMessage } from './vaultSecretPrompt.ts';
+import {
+  normalizeVaultSecretPromptMessage,
+  vaultSecretPromptFromRunToolEvent,
+  vaultSecretPromptFromStream,
+} from './vaultSecretPrompt.ts';
 
 test('normalizes vault prompt websocket payloads with nested prompt data', () => {
   assert.deepEqual(
@@ -57,4 +61,109 @@ test('accepts payload wrappers and non-string thread identifiers', () => {
 test('rejects incomplete vault prompt events', () => {
   assert.equal(normalizeVaultSecretPromptMessage({ idea_id: 'idea-1' }), null);
   assert.equal(normalizeVaultSecretPromptMessage({ prompt: { key_name: 'GITHUB_TOKEN' } }), null);
+});
+
+test('extracts vault prompts from completed tool events', () => {
+  const prompt = vaultSecretPromptFromRunToolEvent({
+    type: 'tool_finished',
+    tool_name: 'vault_secret_prompt',
+    status: 'completed',
+    idea_id: 'idea-1',
+    run_id: 42,
+    event_created_at: '2026-05-13T15:27:22Z',
+    result: JSON.stringify({
+      key_name: 'ILLO_TEST_API_KEY',
+      description: 'Temporary test secret',
+      category: 'api',
+      status: 'opened',
+    }),
+  });
+
+  assert.equal(prompt?.id, 'vault-secret-42-ILLO_TEST_API_KEY');
+  assert.equal(prompt?.idea_id, 'idea-1');
+  assert.equal(prompt?.key_name, 'ILLO_TEST_API_KEY');
+  assert.equal(prompt?.created_at, '2026-05-13T15:27:22Z');
+});
+
+test('uses stable prompt id from tool result when present', () => {
+  const prompt = vaultSecretPromptFromRunToolEvent({
+    type: 'tool_finished',
+    tool_name: 'vault_secret_prompt',
+    status: 'completed',
+    idea_id: 'idea-1',
+    run_id: 42,
+    result: JSON.stringify({
+      prompt: {
+        id: 'prompt-stable',
+        key_name: 'ANTHROPIC_API_KEY',
+        category: 'api',
+      },
+    }),
+  });
+
+  assert.equal(prompt?.id, 'prompt-stable');
+  assert.equal(prompt?.key_name, 'ANTHROPIC_API_KEY');
+});
+
+test('recovers latest vault prompt from persisted run stream', () => {
+  const prompt = vaultSecretPromptFromStream(
+    [
+      {
+        type: 'run',
+        id: '41',
+        run_id: 41,
+        idea_id: 'idea-1',
+        tool_calls: [
+          {
+            tool: 'vault_secret_prompt',
+            status: 'completed',
+            finished_at: '2026-05-13T15:00:00Z',
+            result: JSON.stringify({ key_name: 'OLD_KEY', category: 'api' }),
+          },
+        ],
+      },
+      {
+        type: 'run',
+        id: '42',
+        run_id: 42,
+        idea_id: 'idea-1',
+        tool_calls: [
+          {
+            tool: 'vault_secret_prompt',
+            status: 'completed',
+            finished_at: '2026-05-13T16:00:00Z',
+            result: JSON.stringify({ key_name: 'NEW_KEY', category: 'service' }),
+          },
+        ],
+      },
+    ],
+    'idea-1',
+  );
+
+  assert.equal(prompt?.key_name, 'NEW_KEY');
+  assert.equal(prompt?.category, 'service');
+});
+
+test('does not recover dismissed vault prompts from persisted stream', () => {
+  const prompt = vaultSecretPromptFromStream(
+    [
+      {
+        type: 'run',
+        id: '42',
+        run_id: 42,
+        idea_id: 'idea-1',
+        tool_calls: [
+          {
+            tool: 'vault_secret_prompt',
+            status: 'completed',
+            result: JSON.stringify({ key_name: 'DISMISSED_KEY', category: 'api' }),
+          },
+        ],
+      },
+    ],
+    'idea-1',
+    new Set(['vault-secret-42-DISMISSED_KEY']),
+  );
+
+  assert.equal(prompt, null);
 });

--- a/frontend/src/lib/utils/vaultSecretPrompt.ts
+++ b/frontend/src/lib/utils/vaultSecretPrompt.ts
@@ -1,5 +1,34 @@
 import type { VaultSecretPrompt } from '$lib/types/cortex';
 
+type PromptFallback = {
+  ideaId?: unknown;
+  runId?: unknown;
+  createdAt?: unknown;
+};
+
+type ToolCallLike = {
+  tool?: unknown;
+  tool_name?: unknown;
+  status?: unknown;
+  result?: unknown;
+  at?: unknown;
+  finished_at?: unknown;
+};
+
+type StreamItemLike = {
+  type?: unknown;
+  id?: unknown;
+  run_id?: unknown;
+  idea_id?: unknown;
+  thread_id?: unknown;
+  timestamp?: unknown;
+  started_at?: unknown;
+  completed_at?: unknown;
+  tool_calls?: ToolCallLike[];
+};
+
+const VAULT_SECRET_PROMPT_TOOL = 'vault_secret_prompt';
+
 function objectValue(value: any): Record<string, any> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
 }
@@ -18,7 +47,35 @@ function firstText(...values: any[]): string | null {
   return null;
 }
 
-export function normalizeVaultSecretPromptMessage(msg: any): VaultSecretPrompt | null {
+function parseJsonObject(value: unknown): Record<string, any> | null {
+  const object = objectValue(value);
+  if (object) return object;
+  const source = textValue(value);
+  if (!source) return null;
+  try {
+    const parsed = JSON.parse(source);
+    return objectValue(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function toolName(value: ToolCallLike | Record<string, any>): string | null {
+  return firstText(value.tool_name, value.tool);
+}
+
+function isVaultSecretPromptTool(value: ToolCallLike | Record<string, any>): boolean {
+  return toolName(value) === VAULT_SECRET_PROMPT_TOOL;
+}
+
+function fallbackId(ideaId: string, keyName: string, runId?: unknown): string {
+  return `vault-secret-${textValue(runId) || ideaId}-${keyName}`;
+}
+
+export function normalizeVaultSecretPromptMessage(
+  msg: any,
+  fallback: PromptFallback = {},
+): VaultSecretPrompt | null {
   const payload = objectValue(msg?.payload) ?? objectValue(msg);
   if (!payload) return null;
   const source = objectValue(payload.prompt) ?? payload;
@@ -36,17 +93,76 @@ export function normalizeVaultSecretPromptMessage(msg: any): VaultSecretPrompt |
     source.threadId,
     source.target_idea_id,
     source.targetIdeaId,
+    fallback.ideaId,
   );
   if (!keyName || !ideaId) return null;
 
   return {
-    id: firstText(source.id, payload.id) ?? `vault-secret-${ideaId}-${keyName}`,
+    id: firstText(source.id, payload.id) ?? fallbackId(ideaId, keyName, fallback.runId),
     idea_id: ideaId,
     key_name: keyName,
     description: firstText(source.description, payload.description),
     category: firstText(source.category, payload.category) ?? 'api',
     reason: firstText(source.reason, payload.reason),
     requested_by: firstText(source.requested_by, source.requestedBy, payload.requested_by, payload.requestedBy),
-    created_at: firstText(source.created_at, source.createdAt, payload.created_at, payload.createdAt),
+    created_at: firstText(source.created_at, source.createdAt, payload.created_at, payload.createdAt, fallback.createdAt),
   };
+}
+
+export function vaultSecretPromptFromToolResult(
+  result: unknown,
+  fallback: PromptFallback = {},
+): VaultSecretPrompt | null {
+  const parsed = parseJsonObject(result);
+  if (!parsed || parsed.error) return null;
+  return normalizeVaultSecretPromptMessage(parsed, fallback);
+}
+
+export function vaultSecretPromptFromRunToolEvent(msg: unknown): VaultSecretPrompt | null {
+  const payload = objectValue(msg);
+  if (!payload || !isVaultSecretPromptTool(payload)) return null;
+  if (textValue(payload.status) === 'failed') return null;
+  return vaultSecretPromptFromToolResult(payload.result, {
+    ideaId: payload.idea_id ?? payload.thread_id,
+    runId: payload.run_id ?? payload.root_run_id ?? payload.id,
+    createdAt: payload.event_created_at,
+  });
+}
+
+export function vaultSecretPromptFromStream(
+  stream: readonly StreamItemLike[],
+  ideaId: string | null | undefined,
+  ignoredPromptIds: ReadonlySet<string> = new Set(),
+): VaultSecretPrompt | null {
+  const selectedIdeaId = textValue(ideaId);
+  if (!selectedIdeaId) return null;
+
+  let latest: { prompt: VaultSecretPrompt; at: number; order: number } | null = null;
+  let order = 0;
+
+  for (const item of stream) {
+    if (textValue(item?.type) !== 'run') continue;
+    const itemIdeaId = firstText(item.idea_id, item.thread_id);
+    if (itemIdeaId && itemIdeaId !== selectedIdeaId) continue;
+
+    for (const call of item.tool_calls || []) {
+      order += 1;
+      if (!isVaultSecretPromptTool(call)) continue;
+      if (textValue(call.status) === 'failed') continue;
+
+      const prompt = vaultSecretPromptFromToolResult(call.result, {
+        ideaId: selectedIdeaId,
+        runId: item.run_id ?? item.id,
+        createdAt: call.finished_at ?? call.at ?? item.completed_at ?? item.started_at ?? item.timestamp,
+      });
+      if (!prompt || ignoredPromptIds.has(prompt.id)) continue;
+
+      const at = Date.parse(prompt.created_at || '') || Date.parse(textValue(call.finished_at) || '') || order;
+      if (!latest || at > latest.at || (at === latest.at && order > latest.order)) {
+        latest = { prompt, at, order };
+      }
+    }
+  }
+
+  return latest?.prompt ?? null;
 }

--- a/tests/test_vault_hardening.py
+++ b/tests/test_vault_hardening.py
@@ -95,6 +95,9 @@ def test_vault_secret_prompt_records_missing_and_broadcasts_thread_event():
     assert result["prompted"] is True
     assert result["status"] == "opened"
     assert result["key_name"] == "EXAMPLE_API_KEY"
+    assert result["prompt"]["id"].startswith("vault-secret-42-")
+    assert result["prompt"]["idea_id"] == "idea-1"
+    assert result["prompt"]["key_name"] == "EXAMPLE_API_KEY"
     assert "value" not in result
     assert "secret" not in result
     record_missing.assert_called_once_with(


### PR DESCRIPTION
## Summary
- recover Vault secret prompts from completed `vault_secret_prompt` tool results when the live event is missed
- include stable prompt metadata in the backend tool response for dedupe/recovery
- extend frontend/backend tests for live prompt normalization and durable prompt recovery

## Tests
- `npm test -- vaultSecretPrompt.test.js`
- `venv/bin/python -m pytest tests/test_vault_hardening.py`
- `npm run check` (0 errors, 2 existing memory UI warnings)
