### PR TITLE
Fix project context Git auth for agent commands

### DIFF
--- a/brain/systems/runs/project_execution_env.py
+++ b/brain/systems/runs/project_execution_env.py
@@ -22,21 +22,66 @@ class ProjectExecutionEnv:
     sensitive_values: list[str]
 
 
+def _current_context_run_id() -> int | str | None:
+    run = getattr(_agent_context, "run", None)
+    return getattr(run, "run_id", None) or getattr(run, "id", None) or getattr(_agent_context, "run_id", None)
+
+
+def _run_payload_context(run: object) -> dict | None:
+    target_payload = dict(
+        getattr(run, "target_metadata", None)
+        or getattr(run, "target_ref", None)
+        or {}
+    )
+    workspace_payload = dict(getattr(run, "workspace_ref", None) or {})
+    snapshot = target_payload.get("project_context_snapshot") or workspace_payload.get("project_context_snapshot")
+    if isinstance(snapshot, dict):
+        target_payload["project_context_snapshot"] = snapshot
+
+    workspace_root = (
+        workspace_payload.get("resolved_workspace_root")
+        or workspace_payload.get("workspace_root")
+    )
+    workspaces = workspace_payload.get("workspaces")
+    if (not isinstance(workspace_root, str) or not workspace_root.strip()) and isinstance(workspaces, list):
+        workspace_root = next(
+            (
+                item["path"].strip()
+                for item in workspaces
+                if isinstance(item, dict) and isinstance(item.get("path"), str) and item["path"].strip()
+            ),
+            None,
+        )
+
+    if not target_payload and not workspace_root:
+        return None
+
+    workspace_root = workspace_root.strip() if isinstance(workspace_root, str) and workspace_root.strip() else None
+    defaults = {"workspace_root": workspace_root, "workspace_hint": workspace_root} if workspace_root else {}
+    return {"binding": {"raw_target_metadata": target_payload}, "execution_defaults": defaults}
+
+
 def _current_run_target_context() -> dict | None:
     """Load the current run target context, if the tool call is running inside one."""
-    run = getattr(_agent_context, "run", None)
-    run_id = getattr(run, "run_id", None)
+    run_id = _current_context_run_id()
     if not run_id:
         return None
 
     try:
+        from brain.platform.db.models.run import AgentRun
         from brain.platform.db.repositories.unit_of_work import UnitOfWork
         from brain.systems.environment import load_run_target_context
 
         with UnitOfWork() as uow:
-            return load_run_target_context(uow.session, run_id)
+            context = load_run_target_context(uow.session, int(run_id))
+            if context:
+                return context
+            run = uow.session.get(AgentRun, int(run_id))
+            if run:
+                return _run_payload_context(run)
     except Exception:
         return None
+    return None
 
 
 def _current_workspace_root_hint() -> str | None:

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -288,6 +288,62 @@ def test_project_token_context_includes_github_repo_from_project_context_snapsho
     assert context["target_registry_id"] == 7
 
 
+def test_project_bound_env_uses_materialized_project_context_without_run_binding(
+    patch_uow,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs import project_execution_env
+
+    github = _secret(session, "GITHUB_TOKEN", "ghp-test", access_level="ask")
+    _binding(session, github, project_slug="example-org/example-repo", env_name="GH_TOKEN")
+
+    workspace_root = tmp_path / "example-repo"
+    run = SimpleNamespace(
+        target_ref={"kind": "cortex_idea"},
+        workspace_ref={
+            "workspace_root": str(workspace_root),
+            "project_context_snapshot": {
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "repo": "example-org/example-repo",
+                        "uri": "https://github.com/example-org/example-repo",
+                    }
+                ]
+            },
+        },
+    )
+
+    class FakeSession:
+        def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr("brain.systems.environment.load_run_target_context", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", lambda: FakeUow())
+
+    with bind_agent_context({
+        "run_id": 123,
+        "user_id": USER_ID,
+        "org_id": ORG_ID,
+        "workspace_root": str(workspace_root),
+    }):
+        env = project_execution_env.current_project_bound_env()
+
+    assert env == {"GH_TOKEN": "ghp-test"}
+
+
 def test_exec_command_injects_project_bound_env_names_without_returning_values(monkeypatch, tmp_path):
     from brain.systems.runs.tool_catalog.handlers.files import _handle_exec_command
 


### PR DESCRIPTION
## Summary
- Make project-bound token resolution use the active thread-local run id set by the agent runtime.
- When no run_target_bindings row exists, fall back to the materialized Project Context snapshot already stored on AgentRun.workspace_ref.
- Keep the fix limited to runtime env resolution so exec_command receives GH_TOKEN/Git extraheader auth after a successful Project Context clone.

## Validation
- pytest tests/test_vault_project_tokens.py -q
- 15 passed