### PR TITLE
Add launch envelope for cycle runs

### DIFF
--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -26,6 +26,8 @@ VALID_THINKING_OVERRIDES = {"none", "low", "medium", "high", "xhigh"}
 ACTIVE_RUN_STATUSES = {"queued", "running", "pending_approval"}
 TERMINAL_RUN_STATUSES = {"completed", "failed", "skipped"}
 ONE_TIME_SCHEDULE_PREFIX = "at:"
+CYCLE_LAUNCH_ENVELOPE_VERSION = 1
+CYCLE_CONTROL_TOOLS = ("manage_cycle",)
 
 
 def validate_nonempty_trimmed(value: str, field_name: str) -> str:
@@ -159,6 +161,19 @@ def humanize_schedule(schedule_expr: str, timezone_name: str) -> str:
     if minute.isdigit() and hour.isdigit() and dom == "*" and month == "*" and dow == "*":
         dt = datetime(2000, 1, 1, int(hour), int(minute))
         return f"Every day at {dt.strftime('%-I:%M %p')} ({tz})"
+    weekday_names = {
+        "0": "Sundays",
+        "1": "Mondays",
+        "2": "Tuesdays",
+        "3": "Wednesdays",
+        "4": "Thursdays",
+        "5": "Fridays",
+        "6": "Saturdays",
+        "7": "Sundays",
+    }
+    if minute.isdigit() and hour.isdigit() and dom == "*" and month == "*" and dow in weekday_names:
+        dt = datetime(2000, 1, 1, int(hour), int(minute))
+        return f"{weekday_names[dow]} at {dt.strftime('%-I:%M %p')} ({tz})"
     if (
         minute.isdigit()
         and hour.isdigit()
@@ -321,6 +336,66 @@ def _admit_cycle_run(
     return result.run_id if result.ok else None
 
 
+def _cycle_launch_envelope(cycle: Cycle, run: CycleRun) -> dict:
+    """Return the minimal scheduler semantics around an otherwise free-form prompt."""
+
+    return {
+        "version": CYCLE_LAUNCH_ENVELOPE_VERSION,
+        "origin": "scheduled_cycle",
+        "cycle_id": cycle.id,
+        "cycle_run_id": run.id,
+        "cycle_name": cycle.name,
+        "scheduled_for": run.scheduled_for.isoformat() if run.scheduled_for else None,
+        "launch_mode": "reuse_same_thread",
+        "active_instruction_source": "cycle.prompt",
+        "prior_thread_role": "context_only",
+        "lifecycle_owner": "cycle_run",
+        "thread_visibility": "visible",
+    }
+
+
+def _cycle_run_metadata(cycle: Cycle, run: CycleRun) -> dict:
+    envelope = _cycle_launch_envelope(cycle, run)
+    return {
+        "source": "cycle",
+        "origin": "cycle",
+        "cycle_id": cycle.id,
+        "cycle_run_id": run.id,
+        "model_override": cycle.model_override,
+        "thinking_override": cycle.thinking_override,
+        "launch_envelope": envelope,
+        "contract": {
+            "kind": "scheduled_prompt",
+            "active_instruction_source": "cycle.prompt",
+            "lifecycle_owner": "cycle_run",
+        },
+        "context_policy": {
+            "current_instruction_role": "scheduled_prompt",
+            "prior_thread_role": "context_only",
+        },
+        "tool_policy": {
+            "disabled_tools": list(CYCLE_CONTROL_TOOLS),
+            "reason": "Cycle executions run the scheduled prompt; scheduler mutation belongs to explicit control-plane requests.",
+        },
+    }
+
+
+def _cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
+    envelope = _cycle_launch_envelope(cycle, run)
+    header = (
+        f"[Idea: \"{idea.title}\" | {idea.id}]\n\n"
+        "## Scheduled Prompt Launch\n"
+        f"- Origin: {envelope['origin']}\n"
+        f"- Cycle ID: {cycle.id}\n"
+        f"- Cycle run ID: {run.id}\n"
+        "- The scheduled prompt below is the current user instruction.\n"
+        "- Prior thread messages are background context only, not active commands.\n"
+        "- Do not create, update, delete, or run Cycles from this execution; scheduler changes belong to explicit control-plane turns.\n\n"
+        "## Scheduled Prompt\n"
+    )
+    return f"{header}{cycle.prompt[:2000]}"
+
+
 def _append_cycle_thread_message(
     session,
     idea: Idea,
@@ -333,6 +408,7 @@ def _append_cycle_thread_message(
         "source": "cycle",
         "cycle_id": cycle.id,
         "cycle_run_id": cycle_run.id,
+        "launch_envelope": _cycle_launch_envelope(cycle, cycle_run),
     }
     thread_msg = IdeaThread(
         idea_id=idea.id,
@@ -577,14 +653,8 @@ def execute_cycle_run(run_id: int) -> None:
         run.started_at = datetime.now(timezone.utc)
         run.status = "running"
         idea_id = idea.id
-        run_metadata = {
-            "source": "cycle",
-            "cycle_id": cycle.id,
-            "cycle_run_id": run.id,
-            "model_override": cycle.model_override,
-            "thinking_override": cycle.thinking_override,
-        }
-        run_message = f"[Idea: \"{idea.title}\" | {idea.id}]\n\n{cycle.prompt[:2000]}"
+        run_metadata = _cycle_run_metadata(cycle, run)
+        run_message = _cycle_run_message(idea, cycle, run)
         agent_run_id = _admit_cycle_run(
             uow.session,
             idea_id=idea.id,

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -214,6 +214,17 @@ def _settle_idea_for_terminal_root_run(session, run_id: int) -> dict[str, Any] |
     }
 
 
+def _finalize_cycle_run_if_needed(run_id: int, *, status: str, error: str | None = None) -> None:
+    if status not in {"completed", "failed"}:
+        return
+    try:
+        from brain.systems.cycles.service import finalize_cycle_run_from_run
+
+        finalize_cycle_run_from_run(int(run_id), status=status, error=error)
+    except Exception:
+        logger.exception("cycle_run_settlement_failed", extra={"run_id": run_id, "status": status})
+
+
 def _run_has_project_context(run: AgentRunRow | None) -> bool:
     if run is None:
         return False
@@ -569,14 +580,21 @@ def run_queued_once(*, limit: int = 1) -> int:
             with _run_heartbeat(int(run_id)):
                 context_ready, status_payload = _materialize_project_context(int(run_id))
                 if not context_ready:
+                    _finalize_cycle_run_if_needed(
+                        int(run_id),
+                        status="failed",
+                        error="Project Context unavailable",
+                    )
                     if status_payload:
                         publish_safe("status_change", status_payload)
                     processed += 1
                     continue
                 status_payload = None
                 with UnitOfWork() as uow:
-                    _engine_for_session(uow.session).run_existing(int(run_id))
+                    completed_run = _engine_for_session(uow.session).run_existing(int(run_id))
+                    completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
                     status_payload = _settle_idea_for_terminal_root_run(uow.session, int(run_id))
+                _finalize_cycle_run_if_needed(int(run_id), status=completed_status)
             if status_payload:
                 publish_safe("status_change", status_payload)
             processed += 1
@@ -584,6 +602,7 @@ def run_queued_once(*, limit: int = 1) -> int:
             logger.exception("agent_run_failed", extra={"run_id": run_id})
             try:
                 status_payload = _mark_run_failed_after_runner_error(int(run_id), "runner_failed")
+                _finalize_cycle_run_if_needed(int(run_id), status="failed", error="runner_failed")
                 if status_payload:
                     publish_safe("status_change", status_payload)
             except Exception:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -222,6 +222,35 @@ def _metadata_int(metadata: dict, key: str, default: int) -> int:
         return default
 
 
+def _disabled_tool_names(metadata: dict) -> set[str]:
+    policy = metadata.get("tool_policy")
+    if not isinstance(policy, dict):
+        return set()
+    raw_names = policy.get("disabled_tools") or policy.get("blocked_tools") or []
+    if isinstance(raw_names, str):
+        raw_names = [raw_names]
+    if not isinstance(raw_names, list):
+        return set()
+    return {str(name).strip() for name in raw_names if str(name or "").strip()}
+
+
+def _apply_tool_policy(tools: list[dict] | None, tool_handlers: dict | None, metadata: dict) -> tuple[list[dict] | None, dict | None]:
+    disabled = _disabled_tool_names(metadata)
+    if not disabled:
+        return tools, tool_handlers
+    filtered_tools = [
+        tool
+        for tool in tools or []
+        if str(tool.get("name") or "").strip() not in disabled
+    ]
+    filtered_handlers = (
+        {name: handler for name, handler in (tool_handlers or {}).items() if name not in disabled}
+        if tool_handlers is not None
+        else None
+    )
+    return filtered_tools, filtered_handlers
+
+
 def _initial_user_content(message: str, metadata: dict) -> str | list[dict]:
     """Attach immediate thread files/images to the first user turn."""
 
@@ -1315,6 +1344,7 @@ def run_agent(
         tools = BRAIN_TOOLS
     if tool_handlers is None:
         tool_handlers = _get_tool_handlers(workspace_root=workspace_root)
+    tools, tool_handlers = _apply_tool_policy(tools, tool_handlers, metadata)
 
     state = AgentLoopState(
         gates=_GateState(

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -38,11 +38,24 @@ Operating rules:
 _FAST_HIDDEN_TOOL_NAMES = {"cortex_reply", "cortex_visual_reply"}
 
 
+def _disabled_tool_names(runtime: RunRuntime) -> set[str]:
+    policy = runtime.request.metadata.get("tool_policy")
+    if not isinstance(policy, dict):
+        return set()
+    raw_names = policy.get("disabled_tools") or policy.get("blocked_tools") or []
+    if isinstance(raw_names, str):
+        raw_names = [raw_names]
+    if not isinstance(raw_names, list):
+        return set()
+    return {str(name).strip() for name in raw_names if str(name or "").strip()}
+
+
 def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
+    hidden = _FAST_HIDDEN_TOOL_NAMES | _disabled_tool_names(runtime)
     return [
         tool
         for tool in build_agent_tools("coordinator")
-        if str(tool.get("name") or "") not in _FAST_HIDDEN_TOOL_NAMES
+        if str(tool.get("name") or "") not in hidden
     ]
 
 
@@ -98,8 +111,14 @@ class FastRecipe(BaseRunRecipe):
         def _guidance() -> list[str]:
             return runtime.drain_steering()
 
+        disabled_tools = _disabled_tool_names(runtime)
+        raw_tool_handlers = build_tool_handlers(workspace_root=workspace_root)
+        if disabled_tools:
+            raw_tool_handlers = {
+                name: handler for name, handler in raw_tool_handlers.items() if name not in disabled_tools
+            }
         tool_handlers = wrap_tool_handlers(
-            build_tool_handlers(workspace_root=workspace_root),
+            raw_tool_handlers,
             executor=runtime.tool_executor(),
             run_id=runtime.run.id,
             root_run_id=runtime.run.root_run_id,

--- a/brain/systems/runs/recipes/shared.py
+++ b/brain/systems/runs/recipes/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import PurePath
 from typing import Any
 
 
@@ -15,6 +16,22 @@ def _single_allowed_path(scope: dict[str, Any]) -> str | None:
         if isinstance(path, str) and path.strip():
             return path.strip()
     return None
+
+
+def _looks_like_file_path(path: str) -> bool:
+    return bool(PurePath(path).suffix)
+
+
+def _resource_workspace_path(resource: dict[str, Any]) -> str | None:
+    path = resource.get("path")
+    if not isinstance(path, str) or not path.strip():
+        return None
+    resource_kind = str(resource.get("kind") or resource.get("type") or "").strip().lower()
+    if resource_kind in {"file", "attachment"}:
+        return None
+    if resource_kind in {"repo", "repository", "directory", "folder", "workspace"}:
+        return path.strip()
+    return None if _looks_like_file_path(path) else path.strip()
 
 
 def workspace_root_from_ref(workspace_ref: dict[str, Any]) -> str | None:
@@ -35,19 +52,19 @@ def workspace_root_from_ref(workspace_ref: dict[str, Any]) -> str | None:
         if isinstance(resources, list) and len(resources) == 1:
             resource = resources[0]
             if isinstance(resource, dict):
-                path = resource.get("path")
-                if isinstance(path, str) and path.strip():
-                    return path.strip()
+                path = _resource_workspace_path(resource)
+                if path:
+                    return path
         scope = snapshot.get("permission_scope")
         if isinstance(scope, dict):
             path = _single_allowed_path(scope)
-            if path:
+            if path and not _looks_like_file_path(path):
                 return path
 
     scope = workspace_ref.get("project_context_permission_scope")
     if isinstance(scope, dict):
         path = _single_allowed_path(scope)
-        if path:
+        if path and not _looks_like_file_path(path):
             return path
 
     return None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -270,6 +270,18 @@ class TestToolDefinitions:
             assert "input_schema" in tool, f"Tool {tool['name']} missing input_schema"
             assert tool["input_schema"]["type"] == "object"
 
+    def test_tool_policy_filters_model_tools_and_handlers(self):
+        from brain.systems.runs.direct_agent import _apply_tool_policy
+
+        tools, handlers = _apply_tool_policy(
+            [{"name": "manage_cycle"}, {"name": "web_search"}],
+            {"manage_cycle": object(), "web_search": object()},
+            {"tool_policy": {"disabled_tools": ["manage_cycle"]}},
+        )
+
+        assert tools == [{"name": "web_search"}]
+        assert sorted(handlers) == ["web_search"]
+
 
 class TestBrainGate:
     """Test the brain gate enforcement mechanism."""

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -442,6 +442,18 @@ def test_workspace_root_from_ref_uses_thread_project_context_snapshot():
             }
         }
     ) == "/tmp/ideas/idea-1/project/repo"
+    assert (
+        workspace_root_from_ref(
+            {
+                "project_context_snapshot": {
+                    "resources": [{"kind": "file", "path": "/tmp/ideas/idea-1/uploads/agent.md"}],
+                    "permission_scope": {"allowed_paths": ["/tmp/ideas/idea-1/uploads/agent.md"]},
+                },
+                "project_context_permission_scope": {"allowed_paths": ["/tmp/ideas/idea-1/uploads/agent.md"]},
+            }
+        )
+        is None
+    )
     assert workspace_root_from_ref(
         {
             "project_context_permission_scope": {
@@ -479,6 +491,56 @@ def test_fast_recipe_infers_workspace_root_from_project_context_snapshot(monkeyp
 
     assert result.status.value == "completed"
     assert captured["spec"].workspace_root == "/tmp/ideas/idea-1/project/repo"
+
+
+def test_fast_recipe_applies_runtime_tool_policy(monkeypatch):
+    from brain.systems.runs.recipes.fast import FastRecipe
+
+    captured = {}
+
+    def fake_invoke(spec):
+        captured["spec"] = spec
+        return SimpleNamespace(output="ok", success=True, error=None)
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_agent_tools",
+        lambda role: [{"name": "manage_cycle"}, {"name": "web_search"}],
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_tool_handlers",
+        lambda **kwargs: {"manage_cycle": object(), "web_search": object()},
+    )
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent", fake_invoke)
+
+    runtime = _runtime("fast")
+    runtime.request = replace(
+        runtime.request,
+        metadata={"tool_policy": {"disabled_tools": ["manage_cycle"]}},
+    )
+
+    result = FastRecipe().execute(runtime)
+
+    assert result.status.value == "completed"
+    assert [tool["name"] for tool in captured["spec"].tools] == ["web_search"]
+    assert sorted(captured["spec"].tool_handlers) == ["web_search"]
+
+
+def test_runner_delegates_cycle_settlement_for_terminal_run(monkeypatch):
+    from brain.systems.runs.cortex import runner
+    from brain.systems.cycles import service as cycle_service
+
+    calls = []
+    monkeypatch.setattr(
+        cycle_service,
+        "finalize_cycle_run_from_run",
+        lambda run_id, *, status, error=None: calls.append((run_id, status, error)),
+    )
+
+    runner._finalize_cycle_run_if_needed(99, status="completed")
+    runner._finalize_cycle_run_if_needed(100, status="running")
+    runner._finalize_cycle_run_if_needed(101, status="failed", error="boom")
+
+    assert calls == [(99, "completed", None), (101, "failed", "boom")]
 
 
 def test_deep_recipe_uses_native_child_runs(monkeypatch):

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -109,6 +109,10 @@ def test_compute_next_run_at_uses_timezone():
     assert next_run == datetime(2026, 4, 22, 13, 0, tzinfo=timezone.utc)
 
 
+def test_humanize_schedule_names_single_monday_not_weekdays():
+    assert service.humanize_schedule("0 9 * * 1", "America/Toronto") == "Mondays at 9:00 AM (America/Toronto)"
+
+
 def test_one_time_schedule_uses_timezone_and_expires_after_run():
     expr = service.validate_schedule_expr(
         "at:2026-05-08T09:30:00",
@@ -340,7 +344,13 @@ def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeypatch):
 
     session = _ExecuteCycleSession(run=run, cycle=cycle, idea=idea, expected_run_id=run.id)
     monkeypatch.setattr(service, "UnitOfWork", lambda: _ExecuteCycleUoW(session))
-    monkeypatch.setattr(service, "_admit_cycle_run", lambda *args, **kwargs: 77)
+    admissions = []
+
+    def fake_admit(*args, **kwargs):
+        admissions.append(kwargs)
+        return 77
+
+    monkeypatch.setattr(service, "_admit_cycle_run", fake_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
 
     service.execute_cycle_run(run.id)
@@ -349,6 +359,13 @@ def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeypatch):
     assert run.run_id == 77
     assert run.status == "running"
     assert cycle.last_status == "running"
+    assert admissions[0]["metadata"]["origin"] == "cycle"
+    assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
+    assert admissions[0]["metadata"]["launch_envelope"]["active_instruction_source"] == "cycle.prompt"
+    assert admissions[0]["metadata"]["context_policy"]["prior_thread_role"] == "context_only"
+    assert admissions[0]["metadata"]["tool_policy"]["disabled_tools"] == ["manage_cycle"]
+    assert "Scheduled Prompt Launch" in admissions[0]["message"]
+    assert "Prior thread messages are background context only" in admissions[0]["message"]
 
 
 def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):


### PR DESCRIPTION
Summary:
- Treat cycle executions as scheduled prompt launches with a minimal envelope: origin, lifecycle owner, prior-thread role, and thread visibility.
- Pass the envelope through AgentRun metadata and visible thread metadata, with a scheduled-prompt wrapper so prior messages are context only.
- Apply tool policy filtering so scheduled launches cannot mutate cycles, settle cycle runs when AgentRuns finish or fail, and avoid using single attached files as workspace cwd.

Tests:
- venv/bin/python -m pytest tests/test_cycles_service.py tests/test_agent_run_runtime.py tests/test_agent.py::TestToolDefinitions::test_tool_policy_filters_model_tools_and_handlers -q
- venv/bin/python -m pytest tests/test_agent_split.py tests/test_runtime_envelope.py -q