### PR TITLE
Validate generic HTTP sync domain fields

### DIFF
--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -539,8 +539,10 @@ Constellation design contract.
      (`"title"`), `{ "path": "nested.id" }`, `{ "const": "Todo" }`,
      `{ "template": "ISSUE-{number}" }`, or
      `{ "if": { "field": "completed", "equals": true }, "then": "Done",
-     "else": "Todo" }`. Use `deferred` only when the API cannot fit the
-     generic spec yet.
+     "else": "Todo" }`. Put only real Domain data fields in `sync.fields`;
+     use `sync.title` for the record title, and do not invent helper fields
+     that are not in the bound Domain object. Use `deferred` only when the API
+     cannot fit the generic spec yet.
    - Missing external credentials are not blockers for creating the app when
      the external action can be deferred. Do not call `vault_secret_prompt`
      before producing the requested app. Declare the deferred action, deliver

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -109,8 +109,10 @@ Constellation design contract.
      (`"title"`), `{ "path": "nested.id" }`, `{ "const": "Todo" }`,
      `{ "template": "ISSUE-{number}" }`, or
      `{ "if": { "field": "completed", "equals": true }, "then": "Done",
-     "else": "Todo" }`. Use `deferred` only when the API cannot fit the
-     generic spec yet.
+     "else": "Todo" }`. Put only real Domain data fields in `sync.fields`;
+     use `sync.title` for the record title, and do not invent helper fields
+     that are not in the bound Domain object. Use `deferred` only when the API
+     cannot fit the generic spec yet.
    - Missing external credentials are not blockers for creating the app when
      the external action can be deferred. Do not call `vault_secret_prompt`
      before producing the requested app. Declare the deferred action, deliver

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -20,7 +20,7 @@ from brain.systems.workspace_apps.actions import (
     WorkspaceAppActionContractError,
     WorkspaceAppActionError,
 )
-from brain.systems.user_domains.service import DomainService
+from brain.systems.user_domains.service import DomainError, DomainService
 
 
 GENERIC_HTTP_EXECUTOR_KEY = "generic.http"
@@ -241,30 +241,35 @@ def _sync_items_to_domain(
         title_text = str(title).strip() if title is not None else None
 
         existing = existing_by_remote.get(str(remote_id)) if remote_id is not None else None
-        if existing is not None:
-            record = service.update_record(
-                context.org_id,
-                domain_id,
-                existing.id,
-                data_patch=data,
-                title=title_text,
-                actor_id=context.user_id,
-                actor_kind="workspace_app_action",
-            )
-            updated += 1
-        else:
-            record = service.create_record(
-                context.org_id,
-                domain_id,
-                object_key,
-                data=data,
-                title=title_text,
-                actor_id=context.user_id,
-                actor_kind="workspace_app_action",
-            )
-            created += 1
-            if remote_id_field and remote_id is not None:
-                existing_by_remote[str(remote_id)] = record
+        try:
+            if existing is not None:
+                record = service.update_record(
+                    context.org_id,
+                    domain_id,
+                    existing.id,
+                    data_patch=data,
+                    title=title_text,
+                    actor_id=context.user_id,
+                    actor_kind="workspace_app_action",
+                )
+                updated += 1
+            else:
+                record = service.create_record(
+                    context.org_id,
+                    domain_id,
+                    object_key,
+                    data=data,
+                    title=title_text,
+                    actor_id=context.user_id,
+                    actor_kind="workspace_app_action",
+                )
+                created += 1
+                if remote_id_field and remote_id is not None:
+                    existing_by_remote[str(remote_id)] = record
+        except DomainError as exc:
+            raise WorkspaceAppActionContractError(
+                f"connector_spec.sync produced invalid Domain data: {exc}"
+            ) from exc
         synced_records.append(service.serialize_record(record))
 
     return {

--- a/brain/systems/workspace_apps/service.py
+++ b/brain/systems/workspace_apps/service.py
@@ -164,6 +164,7 @@ def validate_domain_bindings(
     from brain.systems.user_domains.service import DomainNotFound, DomainService
 
     service = DomainService(session)
+    binding_field_keys: dict[str, set[str]] = {}
     for alias, binding in bindings.items():
         alias_text = str(alias).strip() or "<empty>"
         if not isinstance(binding, dict):
@@ -198,6 +199,7 @@ def validate_domain_bindings(
 
         fields = service.list_fields(obj.id)
         field_keys = {field.key for field in fields}
+        binding_field_keys[alias_text] = field_keys
         bindable_field_keys = set(field_keys)
         bindable_field_keys.add("title")
         declared_fields = _string_list(alias_text, binding.get("fields"), "fields")
@@ -226,6 +228,81 @@ def validate_domain_bindings(
                     alias_text,
                     f"declares unsupported operation(s): {', '.join(unknown_ops)}; allowed: {allowed}",
                 )
+    _validate_generic_http_domain_sync_fields(manifest or {}, binding_field_keys)
+
+
+def _validate_generic_http_domain_sync_fields(
+    manifest: dict[str, Any],
+    binding_field_keys: dict[str, set[str]],
+) -> None:
+    errors: list[str] = []
+    actions = _action_declarations(manifest)
+    for action_key, action in actions.items():
+        if not isinstance(action, dict) or _executor_key(action) != "generic.http":
+            continue
+        spec = action.get("connector_spec") or action.get("connector") or action.get("http")
+        if not isinstance(spec, dict):
+            continue
+        sync = spec.get("sync") or spec.get("domain_sync")
+        if not isinstance(sync, dict):
+            continue
+        binding_alias = str(sync.get("binding") or sync.get("domain_binding") or "").strip()
+        field_keys = binding_field_keys.get(binding_alias)
+        if not field_keys:
+            continue
+
+        remote_id_field = str(sync.get("remote_id_field") or sync.get("external_id_field") or "").strip()
+        if remote_id_field and remote_id_field not in field_keys:
+            errors.append(
+                f"manifest.actions.{action_key}.connector_spec.sync.remote_id_field "
+                f"must be a field on binding '{binding_alias}'"
+            )
+
+        fields_map = sync.get("fields")
+        if not isinstance(fields_map, dict):
+            continue
+        for raw_field_key in fields_map:
+            field_key = str(raw_field_key or "").strip()
+            if not field_key:
+                continue
+            if field_key == "title":
+                errors.append(
+                    f"manifest.actions.{action_key}.connector_spec.sync.fields.title is not a Domain data field; "
+                    "use connector_spec.sync.title instead"
+                )
+            elif field_key not in field_keys:
+                errors.append(
+                    f"manifest.actions.{action_key}.connector_spec.sync.fields.{field_key} "
+                    f"must be a field on binding '{binding_alias}'"
+                )
+
+    if errors:
+        raise WorkspaceAppContractError(
+            {
+                "status": "failed",
+                "contract_version": CONTRACT_VERSION,
+                "errors": errors,
+                "warnings": [],
+            }
+        )
+
+
+def _action_declarations(manifest: dict[str, Any]) -> dict[str, Any]:
+    actions = manifest.get("actions")
+    if actions is None:
+        action_plan = manifest.get("action_plan")
+        if isinstance(action_plan, dict):
+            actions = action_plan.get("actions")
+    return dict(actions) if isinstance(actions, dict) else {}
+
+
+def _executor_key(action: dict[str, Any]) -> str:
+    executor = action.get("executor")
+    if not isinstance(executor, dict):
+        return ""
+    if str(executor.get("type") or "").strip() != "registered":
+        return ""
+    return str(executor.get("key") or "").strip()
 
 
 def active_version(session: Session, app_id: str) -> WorkspaceAppVersion | None:

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -948,7 +948,7 @@ def test_workspace_app_action_generic_http_rejects_invalid_mapping_at_save(sessi
                         "sync": {
                             "binding": "todos",
                             "remote_id": "id",
-                            "remote_id_field": "external_id",
+                            "remote_id_field": "notes",
                             "fields": {"notes": {"field": "title"}},
                         },
                     },
@@ -957,6 +957,154 @@ def test_workspace_app_action_generic_http_rejects_invalid_mapping_at_save(sessi
             visual_spec=VALID_VISUAL_SPEC,
             created_by_user_id=USER_ID,
         )
+
+
+def test_workspace_app_action_generic_http_rejects_unknown_sync_field_at_save(session):
+    domain = _todo_domain(session)
+
+    with pytest.raises(
+        WorkspaceAppContractError,
+        match=r"connector_spec\.sync\.fields\.sync_status must be a field on binding 'todos'",
+    ):
+        create_app(
+            session,
+            org_id=ORG_ID,
+            key="generic-http-unknown-sync-field",
+            name="Generic HTTP Unknown Sync Field",
+            renderer_key="generated-ui-app",
+            source_kind="json",
+            source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+            manifest=_manifest_with_action(
+                domain.id,
+                {
+                    "kind": "connector",
+                    "effects": ["external.read", "domain.write"],
+                    "executor": {"type": "registered", "key": "generic.http"},
+                    "connector_spec": {
+                        "kind": "http_sync",
+                        "request": {"method": "GET", "url": "https://api.example.test/todos"},
+                        "response": {"items_path": "$"},
+                        "sync": {
+                            "binding": "todos",
+                            "remote_id": "id",
+                            "remote_id_field": "notes",
+                            "title": "title",
+                            "fields": {
+                                "notes": "id",
+                                "sync_status": {"const": "imported"},
+                            },
+                        },
+                    },
+                },
+            ),
+            visual_spec=VALID_VISUAL_SPEC,
+            created_by_user_id=USER_ID,
+        )
+
+
+def test_workspace_app_action_generic_http_wraps_domain_validation_errors(session):
+    domain = DomainService(session).create_domain(
+        ORG_ID,
+        name="Validated Tickets",
+        slug="validated-tickets",
+        objects=[
+            {
+                "key": "ticket",
+                "name": "Ticket",
+                "fields": [
+                    {"key": "external_id", "field_type": "text"},
+                    {"key": "status", "field_type": "enum", "options": ["Todo", "Done"]},
+                ],
+            }
+        ],
+        actor_id=USER_ID,
+    )
+    source = {
+        "schema_version": 1,
+        "title": "Validated Tickets",
+        "primary_binding": "tickets",
+        "views": [
+            {
+                "id": "tickets",
+                "type": "table",
+                "title": "Tickets",
+                "binding": "tickets",
+                "columns": [
+                    {"key": "title", "label": "Title"},
+                    {"key": "status", "label": "Status"},
+                ],
+            }
+        ],
+    }
+    manifest = {
+        "contract_version": 1,
+        "data_plan": {
+            "mode": "domain",
+            "bindings": {
+                "tickets": {
+                    "domain_id": domain.id,
+                    "object_key": "ticket",
+                    "fields": ["title", "external_id", "status"],
+                    "operations": ["schema", "list", "create", "update"],
+                }
+            },
+        },
+        "design_contract": {
+            "kit": "constellation-app-kit",
+            "theme_modes": ["dark", "light"],
+        },
+        "actions": {
+            "tickets.syncExternal": {
+                "kind": "connector",
+                "effects": ["external.read", "domain.write"],
+                "executor": {"type": "registered", "key": "generic.http"},
+                "connector_spec": {
+                    "kind": "http_sync",
+                    "request": {"method": "GET", "url": "https://api.example.test/tickets"},
+                    "response": {"items_path": "$"},
+                    "sync": {
+                        "binding": "tickets",
+                        "remote_id": "id",
+                        "remote_id_field": "external_id",
+                        "title": "title",
+                        "fields": {
+                            "external_id": "id",
+                            "status": "completed",
+                        },
+                    },
+                },
+            }
+        },
+    }
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-invalid-domain-data",
+        name="Generic HTTP Invalid Domain Data",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(source),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    with patch(
+        "brain.systems.workspace_apps.generic_http._request_json",
+        return_value=[{"id": 1, "title": "Invalid status", "completed": True}],
+    ):
+        with pytest.raises(
+            WorkspaceAppActionContractError,
+            match="connector_spec.sync produced invalid Domain data: Field 'status' must be one of",
+        ):
+            run_workspace_app_action(
+                session,
+                org_id=ORG_ID,
+                app_id=app.id,
+                action_key="tickets.syncExternal",
+                payload={},
+                user_id=USER_ID,
+            )
 
 
 def test_workspace_app_action_boundaries_reject_raw_secrets(session):


### PR DESCRIPTION
Summary: prevents generic.http sync specs from saving mappings to non-existent Domain data fields, wraps Domain validation failures as workspace action contract errors instead of leaking 500s, and updates the workspace app skill guidance to keep sync.fields aligned with real Domain fields. Tests: /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_app_contract.py tests/test_workspace_apps_service.py tests/test_builtin_skill_suite.py; /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_app_compiler.py; git diff --check