### PR TITLE
Normalize workspace app domain operations

### DIFF
--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1080,6 +1080,8 @@ WORKSPACE_APP_TOOLS = [
                         "\"operations\":[\"schema\",\"list\",\"query\",\"create\",\"update\",\"archive\","
                         "\"aggregate\",\"bulkUpdate\",\"history\",\"listRelations\",\"createRelation\","
                         "\"archiveRelation\"]}}}} and access them with window.illo.domain('todos'). "
+                        "Domain binding operations are exact SDK method names; do not use capability labels "
+                        "such as read, write, or crud in manifest.data_plan.bindings.*.operations. "
                         "The app runtime exposes manifest-bound Domain CRUD, aggregate, bulkUpdate, "
                         "history, relation helpers, polling-backed subscribe, app state, and "
                         "window.illo.actions.run(actionKey, payload) for manifest-declared server-side actions. "

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -561,6 +561,9 @@ Constellation design contract.
 6. When using Domains, save a manifest with `data_plan.mode="domain"` and
    one binding per SDK alias. Each binding must include `domain_id` and
    `object_key`; include `domain_slug`, `fields`, and `operations` when known.
+   Domain binding `operations` are method names, not capability labels: use
+   exact values like `schema`, `list`, `get`, `query`, `create`, `update`, and
+   `archive`. Do not write `read`, `write`, or `crud` in the manifest.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -131,6 +131,9 @@ Constellation design contract.
 6. When using Domains, save a manifest with `data_plan.mode="domain"` and
    one binding per SDK alias. Each binding must include `domain_id` and
    `object_key`; include `domain_slug`, `fields`, and `operations` when known.
+   Domain binding `operations` are method names, not capability labels: use
+   exact values like `schema`, `list`, `get`, `query`, `create`, `update`, and
+   `archive`. Do not write `read`, `write`, or `crud` in the manifest.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.

--- a/brain/systems/workspace_apps/compiler.py
+++ b/brain/systems/workspace_apps/compiler.py
@@ -13,6 +13,7 @@ from typing import Any, Mapping
 from brain.systems.workspace_apps.contracts import (
     APP_KIT_NAME,
     CONTRACT_VERSION,
+    DOMAIN_OPERATIONS,
     STRUCTURED_UI_RENDERER_KEY,
     STRUCTURED_UI_SOURCE_KIND,
 )
@@ -42,6 +43,31 @@ _VIEW_TYPE_ALIASES = {
     "card": "cards",
     "kanban": "board",
     "board-view": "board",
+}
+COMMON_DOMAIN_BINDING_OPERATIONS = [
+    "schema",
+    "list",
+    "get",
+    "query",
+    "create",
+    "update",
+    "archive",
+]
+_OPERATION_CANONICAL_BY_COMPACT = {
+    re.sub(r"[^a-z0-9]+", "", operation.lower()): operation for operation in DOMAIN_OPERATIONS
+}
+_OPERATION_ALIAS_EXPANSIONS = {
+    "read": ("schema", "list", "get", "query"),
+    "readonly": ("schema", "list", "get", "query"),
+    "write": ("create", "update"),
+    "writes": ("create", "update"),
+    "mutate": ("create", "update"),
+    "mutation": ("create", "update"),
+    "upsert": ("create", "update"),
+    "delete": ("archive",),
+    "remove": ("archive",),
+    "destroy": ("archive",),
+    "crud": tuple(COMMON_DOMAIN_BINDING_OPERATIONS),
 }
 
 
@@ -323,6 +349,8 @@ def _compile_manifest(
         ):
             next_plan["scope"] = DEFAULT_APP_LOCAL_SCOPE
             _record(repairs, "manifest.data_plan.scope", "defaulted app-local scope to UI state")
+        if next_plan.get("mode") == "domain":
+            _normalize_domain_bindings(next_plan, repairs=repairs)
         next_manifest["data_plan"] = next_plan
 
     design_contract = next_manifest.get("design_contract")
@@ -341,6 +369,80 @@ def _compile_manifest(
             _record(repairs, "manifest.design_contract.theme_modes", "ensured dark and light theme modes")
         next_manifest["design_contract"] = next_design
     return next_manifest
+
+
+def _normalize_domain_bindings(
+    data_plan: dict[str, Any],
+    *,
+    repairs: list[dict[str, Any]],
+) -> None:
+    bindings = data_plan.get("bindings")
+    if not isinstance(bindings, Mapping):
+        return
+
+    next_bindings: dict[str, Any] = {}
+    changed_bindings = False
+    for alias, raw_binding in bindings.items():
+        if not isinstance(raw_binding, Mapping):
+            next_bindings[alias] = raw_binding
+            continue
+
+        binding = dict(raw_binding)
+        operations, operations_changed = _normalize_domain_operations(binding.get("operations"))
+        if operations:
+            if operations != binding.get("operations"):
+                binding["operations"] = operations
+                _record(
+                    repairs,
+                    f"manifest.data_plan.bindings.{alias}.operations",
+                    "normalized Domain binding operations",
+                )
+                changed_bindings = True
+            elif operations_changed:
+                changed_bindings = True
+        next_bindings[alias] = binding
+
+    if changed_bindings:
+        data_plan["bindings"] = next_bindings
+
+
+def _normalize_domain_operations(value: Any) -> tuple[list[str], bool]:
+    if isinstance(value, str):
+        raw_items = [item for item in re.split(r"[\s,|/]+", value) if item]
+        changed = True
+    elif isinstance(value, list):
+        raw_items = value
+        changed = False
+    else:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+
+    if not raw_items:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+
+    operations: list[str] = []
+    for raw_item in raw_items:
+        canonical = _domain_operation_expansion(raw_item)
+        if canonical != [str(raw_item)]:
+            changed = True
+        for operation in canonical:
+            if operation not in operations:
+                operations.append(operation)
+
+    if not operations:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+    return operations, changed
+
+
+def _domain_operation_expansion(value: Any) -> list[str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return []
+    compact = re.sub(r"[^a-z0-9]+", "", raw.lower())
+    if compact in _OPERATION_ALIAS_EXPANSIONS:
+        return list(_OPERATION_ALIAS_EXPANSIONS[compact])
+    if compact in _OPERATION_CANONICAL_BY_COMPACT:
+        return [_OPERATION_CANONICAL_BY_COMPACT[compact]]
+    return [raw]
 
 
 def _compile_visual_spec(

--- a/tests/test_workspace_app_compiler.py
+++ b/tests/test_workspace_app_compiler.py
@@ -123,6 +123,75 @@ def test_compiler_infers_domain_backed_table_from_single_binding():
     assert _validation_report(compiled)["status"] == "passed"
 
 
+def test_compiler_repairs_domain_binding_operation_aliases():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="Ticket Board",
+        source_code=json.dumps({"description": "Track tickets"}),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": 1,
+                        "object_key": "ticket",
+                        "fields": ["title", "status"],
+                        "operations": ["read", "write", "bulk_update", "list-relations"],
+                    }
+                },
+            },
+        },
+    )
+
+    assert compiled.manifest["data_plan"]["bindings"]["tickets"]["operations"] == [
+        "schema",
+        "list",
+        "get",
+        "query",
+        "create",
+        "update",
+        "bulkUpdate",
+        "listRelations",
+    ]
+    assert {
+        repair["field"]: repair["message"] for repair in compiled.repairs
+    }["manifest.data_plan.bindings.tickets.operations"] == "normalized Domain binding operations"
+    assert _validation_report(compiled)["status"] == "passed"
+
+
+def test_compiler_defaults_missing_domain_binding_operations():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="Ticket Board",
+        source_code=json.dumps({"description": "Track tickets"}),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": 1,
+                        "object_key": "ticket",
+                        "fields": ["title", "status"],
+                    }
+                },
+            },
+        },
+    )
+
+    assert compiled.manifest["data_plan"]["bindings"]["tickets"]["operations"] == [
+        "schema",
+        "list",
+        "get",
+        "query",
+        "create",
+        "update",
+        "archive",
+    ]
+    assert _validation_report(compiled)["status"] == "passed"
+
+
 def test_compiler_accepts_domain_backed_board_view():
     compiled = compile_workspace_app_input(
         action="create",

--- a/tests/test_workspace_app_contract.py
+++ b/tests/test_workspace_app_contract.py
@@ -574,6 +574,96 @@ def test_manage_workspace_app_extracts_embedded_contract_fields_on_update():
     assert "manifest" not in json.loads(kwargs["source_code"])
 
 
+def test_manage_workspace_app_update_repairs_domain_ops_with_generic_http_action():
+    from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
+
+    manifest = json.loads(json.dumps(VALID_DOMAIN_MANIFEST))
+    manifest["data_plan"]["bindings"]["tasks"]["operations"] = ["read", "write"]
+    manifest["actions"] = {
+        "tasks.syncExternal": {
+            "kind": "connector",
+            "effects": ["external.read", "domain.write"],
+            "executor": {"type": "registered", "key": "generic.http"},
+            "connector_spec": {
+                "kind": "http_sync",
+                "request": {
+                    "method": "GET",
+                    "url": "https://jsonplaceholder.typicode.com/todos",
+                },
+                "response": {"items_path": ""},
+                "sync": {
+                    "binding": "tasks",
+                    "remote_id": "id",
+                    "title": "title",
+                    "fields": {
+                        "status": {
+                            "if": {"path": "completed", "equals": True},
+                            "then": "Done",
+                            "else": "Todo",
+                        }
+                    },
+                },
+            },
+        }
+    }
+    source_code = json.dumps(
+        {
+            **json.loads(VALID_GENERATED_UI_SOURCE),
+            "actions": [{"key": "tasks.syncExternal", "label": "Sync"}],
+        }
+    )
+    app = object()
+    serialized = {"id": "app-1", "key": "tasks", "name": "Task Tracker"}
+
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.workspace_apps._workspace_app_context",
+        return_value=("11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"),
+    ), patch("brain.platform.db.repositories.unit_of_work.UnitOfWork", return_value=_FakeUow()), patch(
+        "brain.systems.workspace_apps.service.update_app",
+        return_value=app,
+    ) as update_app, patch("brain.systems.workspace_apps.service.serialize_app", return_value=serialized), patch(
+        "brain.systems.workspace_apps.events.publish_workspace_app_change"
+    ):
+        result = json.loads(
+            _handle_manage_workspace_app(
+                action="update",
+                app_id="app-1",
+                renderer_key="generated-ui-app",
+                source_kind="json",
+                source_code=source_code,
+                manifest=manifest,
+            )
+        )
+
+    assert result["app"] == serialized
+    assert result["compiler_repairs"] == [
+        {
+            "field": "manifest.data_plan.bindings.tasks.operations",
+            "message": "normalized Domain binding operations",
+        }
+    ]
+    kwargs = update_app.call_args.kwargs
+    assert kwargs["manifest"]["data_plan"]["bindings"]["tasks"]["operations"] == [
+        "schema",
+        "list",
+        "get",
+        "query",
+        "create",
+        "update",
+    ]
+    assert kwargs["manifest"]["actions"]["tasks.syncExternal"]["executor"]["key"] == "generic.http"
+    assert (
+        build_contract_validation_report(
+            renderer_key=kwargs["renderer_key"],
+            source_kind=kwargs["source_kind"],
+            source_code=kwargs["source_code"],
+            manifest=kwargs["manifest"],
+            visual_spec=VALID_THUMBNAIL,
+        )["status"]
+        == "passed"
+    )
+
+
 def test_manage_workspace_app_update_normalizes_empty_optional_fields():
     from brain.systems.runs.tool_catalog.handlers.workspace_apps import _handle_manage_workspace_app
 


### PR DESCRIPTION
## Summary
- normalize common Domain binding operation aliases like read/write/crud into canonical SDK operations during workspace app input compilation
- default missing Domain binding operations to the common app CRUD/read surface
- update the workspace-app skill and tool description to tell Illo not to emit capability labels in manifest operations
- add a continuation regression for updating an existing generated-ui app with a generic.http sync action while repairing sloppy Domain operations

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_app_compiler.py tests/test_workspace_app_contract.py tests/test_workspace_apps_service.py
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_builtin_skill_suite.py
