### PR TITLE
Collect local thread and workspace app fixes

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -18,6 +18,15 @@ from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.vault import get_secret, list_secrets
 
 
+_REPO_RESOURCE_KINDS = {
+    "repo",
+    "repository",
+    "github",
+    "github_repo",
+    "github_repository",
+}
+
+
 @dataclass
 class ProjectContextMaterializationResult:
     workspaces: list[dict[str, str]] = field(default_factory=list)
@@ -39,15 +48,57 @@ def _clean_text(value: Any) -> str | None:
     return None
 
 
+def _resource_kind(resource: dict[str, Any]) -> str:
+    return (_clean_text(resource.get("kind") or resource.get("type") or resource.get("resource_type")) or "").lower()
+
+
+def _looks_like_github_remote(value: str) -> bool:
+    lowered = value.lower()
+    return (
+        lowered.startswith("git@github.com:")
+        or lowered.startswith("https://github.com/")
+        or lowered.startswith("http://github.com/")
+        or lowered.startswith("github.com/")
+    )
+
+
 def _github_slug_from_resource(resource: dict[str, Any]) -> str | None:
-    for key in ("repo", "name", "uri", "url", "remote", "repo_url"):
-        value = _clean_text(resource.get(key))
-        if not value:
-            continue
-        slug = parse_github_repo_slug(value)
+    explicit_repo = _clean_text(resource.get("repo"))
+    if explicit_repo:
+        slug = parse_github_repo_slug(explicit_repo)
         if slug:
             return slug
+
+    kind = _resource_kind(resource)
+    source = (_clean_text(resource.get("source")) or "").lower()
+    is_repo_resource = kind in _REPO_RESOURCE_KINDS or source in _REPO_RESOURCE_KINDS
+
+    for key in ("uri", "url", "remote", "repo_url"):
+        value = _clean_text(resource.get(key))
+        if value and _looks_like_github_remote(value):
+            slug = parse_github_repo_slug(value)
+            if slug:
+                return slug
+
+    if is_repo_resource:
+        for key in ("name",):
+            value = _clean_text(resource.get(key))
+            if not value:
+                continue
+            slug = parse_github_repo_slug(value)
+            if slug:
+                return slug
     return None
+
+
+def project_context_has_materializable_resources(context: dict[str, Any] | None) -> bool:
+    resources = context.get("resources") if isinstance(context, dict) else None
+    if not isinstance(resources, list):
+        return False
+    return any(
+        isinstance(resource, dict) and _github_slug_from_resource(resource)
+        for resource in resources
+    )
 
 
 def _vault_key_from_resource(resource: dict[str, Any]) -> str | None:
@@ -156,7 +207,7 @@ def _should_use_existing_resource_path(existing_path: str | None, workspace_root
     if not existing_path:
         return None
     path = Path(existing_path).expanduser()
-    if not path.exists():
+    if not path.exists() or not path.is_dir():
         return None
     if _path_is_relative_to(path, workspace_root):
         return path

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from io import BytesIO
 import json
+from pathlib import PurePath
 from typing import Any
 import zipfile
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from brain.systems.runs.ids import trace_id_for_run_id
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import IdeaThread
 
 
@@ -98,6 +100,8 @@ THREAD_TRACE_MAX_MESSAGES = None
 THREAD_TRACE_MAX_RUNS = 100
 THREAD_TRACE_MAX_EVENTS = 1200
 THREAD_TRACE_MAX_ARTIFACTS = 240
+TRACE_MAX_CYCLES = 50
+TRACE_MAX_CYCLE_RUNS = 200
 TRACE_MAX_STRING_CHARS = 4000
 TRACE_MAX_COLLECTION_ITEMS = 80
 TRACE_MAX_DEPTH = 6
@@ -115,9 +119,18 @@ def build_agent_trace_snapshot(
     """Build a bounded, JSON-safe trace bundle suitable for later analysis."""
 
     related_run_ids = _related_run_ids(session, run)
+    related_runs = _runs_by_id(session, related_run_ids)
+    if not related_runs:
+        related_runs = [run]
     messages = _trace_messages(session, run, max_messages=max_messages)
     events = _trace_events(session, related_run_ids, max_events=max_events)
     artifacts = _trace_artifacts(session, related_run_ids, max_artifacts=max_artifacts)
+    cycle_state = _trace_cycle_state(
+        session,
+        idea_id=str(run.thread_id) if getattr(run, "thread_id", None) else None,
+        runs=related_runs,
+    )
+    diagnostics = _trace_diagnostics(related_runs, events, artifacts, cycle_state)
     trace_id = run.trace_id or trace_id_for_run_id(run.id)
     bundle = {
         "schema_version": AGENT_TRACE_SNAPSHOT_SCHEMA_VERSION,
@@ -157,6 +170,8 @@ def build_agent_trace_snapshot(
         "artifacts": artifacts,
         "artifact_count": len(artifacts),
         "artifact_limit": max_artifacts,
+        "cycles": cycle_state,
+        "diagnostics": diagnostics,
     }
     bundle["storage_estimate"] = {
         "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
@@ -182,6 +197,8 @@ def build_thread_trace_snapshot(
     messages = _trace_thread_messages(session, idea_id, max_messages=max_messages)
     events = _trace_events(session, run_ids, max_events=max_events)
     artifacts = _trace_artifacts(session, run_ids, max_artifacts=max_artifacts)
+    cycle_state = _trace_cycle_state(session, idea_id=idea_id, runs=runs)
+    diagnostics = _trace_diagnostics(runs, events, artifacts, cycle_state)
     trace_id = f"thread:{idea_id}"
     bundle = {
         "schema_version": AGENT_TRACE_SNAPSHOT_SCHEMA_VERSION,
@@ -229,6 +246,8 @@ def build_thread_trace_snapshot(
         "artifacts": artifacts,
         "artifact_count": len(artifacts),
         "artifact_limit": max_artifacts,
+        "cycles": cycle_state,
+        "diagnostics": diagnostics,
     }
     bundle["storage_estimate"] = {
         "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
@@ -253,6 +272,15 @@ def build_agent_trace_export_zip(
         "trace_id": trace.get("trace_id"),
         "run_id": run.get("run_id"),
         "idea_id": thread.get("idea_id"),
+        "diagnostics": {
+            "cycle_count": ((trace.get("cycles") or {}).get("cycle_count") if isinstance(trace.get("cycles"), dict) else None),
+            "cycle_run_count": ((trace.get("cycles") or {}).get("cycle_run_count") if isinstance(trace.get("cycles"), dict) else None),
+            "delivery_signal_count": (
+                len(((trace.get("diagnostics") or {}).get("delivery_signals") or []))
+                if isinstance(trace.get("diagnostics"), dict)
+                else None
+            ),
+        },
         "files": [
             {"path": "trace.json", "description": "Bounded JSON trace for agent analysis."},
             {"path": "activity.json", "description": "Compact chronological activity list derived from the trace."},
@@ -323,6 +351,16 @@ def _thread_runs(session, idea_id: str, *, max_runs: int) -> list[AgentRunRow]:
     ).all()
 
 
+def _runs_by_id(session, run_ids: list[int]) -> list[AgentRunRow]:
+    if not run_ids:
+        return []
+    return session.scalars(
+        select(AgentRunRow)
+        .where(AgentRunRow.id.in_(run_ids))
+        .order_by(AgentRunRow.created_at.asc(), AgentRunRow.id.asc())
+    ).all()
+
+
 def _trace_messages(session, run: AgentRunRow, *, max_messages: int) -> list[dict[str, Any]]:
     return _trace_thread_messages(session, str(run.thread_id), max_messages=max_messages)
 
@@ -363,12 +401,15 @@ def _trace_thread_messages(session, idea_id: str, *, max_messages: int | None) -
 def _trace_events(session, run_ids: list[int], *, max_events: int) -> list[dict[str, Any]]:
     if not run_ids:
         return []
-    rows = session.scalars(
-        select(AgentRunEventRow)
-        .where(AgentRunEventRow.run_id.in_(run_ids))
-        .order_by(AgentRunEventRow.run_id.asc(), AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
-        .limit(max_events)
-    ).all()
+    per_run_limit = max(10, max_events // max(len(run_ids), 1))
+    rows: list[Any] = []
+    for run_id in run_ids:
+        rows.extend(session.scalars(
+            select(AgentRunEventRow)
+            .where(AgentRunEventRow.run_id == int(run_id))
+            .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+            .limit(per_run_limit)
+        ).all())
     return [
         _cap_jsonable({
             "id": event.id,
@@ -388,15 +429,19 @@ def _trace_events(session, run_ids: list[int], *, max_events: int) -> list[dict[
 def _trace_artifacts(session, run_ids: list[int], *, max_artifacts: int) -> list[dict[str, Any]]:
     if not run_ids:
         return []
-    rows = session.scalars(
-        select(AgentRunArtifactRow)
-        .where(
-            AgentRunArtifactRow.run_id.in_(run_ids),
-            AgentRunArtifactRow.artifact_type != AGENT_TRACE_SNAPSHOT_ARTIFACT_TYPE,
-        )
-        .order_by(AgentRunArtifactRow.created_at.asc(), AgentRunArtifactRow.id.asc())
-        .limit(max_artifacts)
-    ).all()
+    per_run_limit = max(5, max_artifacts // max(len(run_ids), 1))
+    rows: list[Any] = []
+    for run_id in run_ids:
+        run_rows = session.scalars(
+            select(AgentRunArtifactRow)
+            .where(
+                AgentRunArtifactRow.run_id == int(run_id),
+                AgentRunArtifactRow.artifact_type != AGENT_TRACE_SNAPSHOT_ARTIFACT_TYPE,
+            )
+            .order_by(AgentRunArtifactRow.created_at.desc(), AgentRunArtifactRow.id.desc())
+            .limit(per_run_limit)
+        ).all()
+        rows.extend(reversed(run_rows))
     return [
         _cap_jsonable({
             "id": artifact.id,
@@ -412,6 +457,340 @@ def _trace_artifacts(session, run_ids: list[int], *, max_artifacts: int) -> list
         })
         for artifact in rows
     ]
+
+
+def _trace_cycle_state(
+    session,
+    *,
+    idea_id: str | None,
+    runs: list[AgentRunRow],
+    max_cycles: int = TRACE_MAX_CYCLES,
+    max_cycle_runs: int = TRACE_MAX_CYCLE_RUNS,
+) -> dict[str, Any]:
+    """Include Cycle control-plane rows that explain scheduled-run lifecycle state."""
+
+    run_ids = [
+        int(run.id)
+        for run in runs
+        if _is_int_like(getattr(run, "id", None))
+    ]
+    cycle_ids: set[int] = set()
+    cycle_run_ids: set[int] = set()
+    for run in runs:
+        metadata = getattr(run, "metadata_", None)
+        if not isinstance(metadata, dict):
+            continue
+        _add_int(cycle_ids, metadata.get("cycle_id"))
+        _add_int(cycle_run_ids, metadata.get("cycle_run_id"))
+        envelope = metadata.get("launch_envelope")
+        if isinstance(envelope, dict):
+            _add_int(cycle_ids, envelope.get("cycle_id"))
+            _add_int(cycle_run_ids, envelope.get("cycle_run_id"))
+
+    try:
+        cycle_rows = _query_cycles(session, idea_id=idea_id, cycle_ids=cycle_ids, limit=max_cycles)
+        for cycle in cycle_rows:
+            _add_int(cycle_ids, getattr(cycle, "id", None))
+
+        cycle_run_rows = _query_cycle_runs(
+            session,
+            idea_id=idea_id,
+            run_ids=run_ids,
+            cycle_ids=cycle_ids,
+            cycle_run_ids=cycle_run_ids,
+            limit=max_cycle_runs,
+        )
+        for cycle_run in cycle_run_rows:
+            _add_int(cycle_ids, getattr(cycle_run, "cycle_id", None))
+            _add_int(cycle_run_ids, getattr(cycle_run, "id", None))
+
+        missing_cycle_ids = {
+            cycle_id
+            for cycle_id in cycle_ids
+            if cycle_id not in {int(cycle.id) for cycle in cycle_rows if _is_int_like(getattr(cycle, "id", None))}
+        }
+        if missing_cycle_ids:
+            cycle_rows.extend(_query_cycles(session, idea_id=None, cycle_ids=missing_cycle_ids, limit=max_cycles))
+    except Exception as exc:
+        return {
+            "schema_version": 1,
+            "cycles": [],
+            "cycle_runs": [],
+            "cycle_ids": sorted(cycle_ids),
+            "cycle_run_ids": sorted(cycle_run_ids),
+            "error": str(exc),
+        }
+
+    cycles = [_cap_jsonable(_cycle_payload(cycle)) for cycle in cycle_rows]
+    cycle_runs = [_cap_jsonable(_cycle_run_payload(cycle_run)) for cycle_run in cycle_run_rows]
+    return {
+        "schema_version": 1,
+        "cycles": cycles,
+        "cycle_runs": cycle_runs,
+        "cycle_count": len(cycles),
+        "cycle_run_count": len(cycle_runs),
+        "cycle_ids": sorted({int(cycle["id"]) for cycle in cycles if _is_int_like(cycle.get("id"))}),
+        "cycle_run_ids": sorted({int(run["id"]) for run in cycle_runs if _is_int_like(run.get("id"))}),
+    }
+
+
+def _query_cycles(
+    session,
+    *,
+    idea_id: str | None,
+    cycle_ids: set[int],
+    limit: int,
+) -> list[Cycle]:
+    conditions = []
+    if idea_id:
+        conditions.append(Cycle.target_idea_id == str(idea_id))
+    if cycle_ids:
+        conditions.append(Cycle.id.in_(sorted(cycle_ids)))
+    if not conditions:
+        return []
+    return list(session.scalars(
+        select(Cycle)
+        .where(or_(*conditions))
+        .order_by(Cycle.updated_at.desc(), Cycle.id.asc())
+        .limit(limit)
+    ).all())
+
+
+def _query_cycle_runs(
+    session,
+    *,
+    idea_id: str | None,
+    run_ids: list[int],
+    cycle_ids: set[int],
+    cycle_run_ids: set[int],
+    limit: int,
+) -> list[CycleRun]:
+    conditions = []
+    if idea_id:
+        conditions.append(CycleRun.idea_id == str(idea_id))
+    if run_ids:
+        conditions.append(CycleRun.run_id.in_(run_ids))
+    if cycle_ids:
+        conditions.append(CycleRun.cycle_id.in_(sorted(cycle_ids)))
+    if cycle_run_ids:
+        conditions.append(CycleRun.id.in_(sorted(cycle_run_ids)))
+    if not conditions:
+        return []
+    rows = session.scalars(
+        select(CycleRun)
+        .where(or_(*conditions))
+        .order_by(CycleRun.created_at.desc(), CycleRun.id.desc())
+        .limit(limit)
+    ).all()
+    return list(reversed(rows))
+
+
+def _cycle_payload(cycle: Cycle) -> dict[str, Any]:
+    return {
+        "id": cycle.id,
+        "user_id": cycle.user_id,
+        "org_id": cycle.org_id,
+        "name": cycle.name,
+        "prompt": cycle.prompt,
+        "schedule_expr": cycle.schedule_expr,
+        "timezone": cycle.timezone,
+        "enabled": cycle.enabled,
+        "model_override": cycle.model_override,
+        "thinking_override": cycle.thinking_override,
+        "execution_mode": cycle.execution_mode,
+        "target_idea_id": cycle.target_idea_id,
+        "reopen_archived": cycle.reopen_archived,
+        "next_run_at": _iso(cycle.next_run_at),
+        "last_run_at": _iso(cycle.last_run_at),
+        "last_status": cycle.last_status,
+        "last_error": cycle.last_error,
+        "deleted_at": _iso(cycle.deleted_at),
+        "created_at": _iso(getattr(cycle, "created_at", None)),
+        "updated_at": _iso(getattr(cycle, "updated_at", None)),
+    }
+
+
+def _cycle_run_payload(cycle_run: CycleRun) -> dict[str, Any]:
+    return {
+        "id": cycle_run.id,
+        "cycle_id": cycle_run.cycle_id,
+        "scheduled_for": _iso(cycle_run.scheduled_for),
+        "started_at": _iso(cycle_run.started_at),
+        "completed_at": _iso(cycle_run.completed_at),
+        "status": cycle_run.status,
+        "error": cycle_run.error,
+        "skip_reason": cycle_run.skip_reason,
+        "idea_id": cycle_run.idea_id,
+        "run_id": cycle_run.run_id,
+        "prompt_snapshot": cycle_run.prompt_snapshot,
+        "created_at": _iso(getattr(cycle_run, "created_at", None)),
+    }
+
+
+def _trace_diagnostics(
+    runs: list[AgentRunRow],
+    events: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    cycle_state: dict[str, Any],
+) -> dict[str, Any]:
+    workspace = _workspace_diagnostics(runs)
+    delivery = _delivery_signals(events, artifacts)
+    status = _run_status_diagnostics(runs, events)
+    return _cap_jsonable({
+        "schema_version": 1,
+        "workspace": workspace,
+        "delivery_signals": delivery,
+        "run_status": status,
+        "cycle_summary": {
+            "cycle_count": cycle_state.get("cycle_count"),
+            "cycle_run_count": cycle_state.get("cycle_run_count"),
+            "cycle_ids": cycle_state.get("cycle_ids") or [],
+            "cycle_run_ids": cycle_state.get("cycle_run_ids") or [],
+            "error": cycle_state.get("error"),
+        },
+    })
+
+
+def _workspace_diagnostics(runs: list[AgentRunRow]) -> list[dict[str, Any]]:
+    diagnostics = []
+    for run in runs:
+        workspace_ref = getattr(run, "workspace_ref", None)
+        if not isinstance(workspace_ref, dict):
+            workspace_ref = {}
+        roots = _workspace_root_candidates(workspace_ref)
+        resources = []
+        for resource in _safe_list(workspace_ref.get("resources")):
+            if not isinstance(resource, dict):
+                continue
+            path = resource.get("path")
+            resources.append({
+                "id": resource.get("id"),
+                "kind": resource.get("kind") or resource.get("type"),
+                "label": resource.get("label") or resource.get("name"),
+                "path": path,
+                "looks_like_file": _looks_like_file_path(path),
+            })
+        suspicious_roots = [
+            root for root in roots
+            if _looks_like_file_path(root.get("path"))
+        ]
+        diagnostics.append({
+            "run_id": getattr(run, "id", None),
+            "workspace_roots": roots,
+            "suspicious_file_roots": suspicious_roots,
+            "resources": resources,
+            "resource_count": len(resources),
+        })
+    return diagnostics
+
+
+def _workspace_root_candidates(workspace_ref: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates = []
+    for key in ("resolved_workspace_root", "workspace_root", "worktree_path", "path", "local_path"):
+        value = workspace_ref.get(key)
+        if isinstance(value, str) and value.strip():
+            candidates.append({"source": key, "path": value.strip(), "looks_like_file": _looks_like_file_path(value)})
+    materialization = workspace_ref.get("project_context_materialization")
+    if isinstance(materialization, dict):
+        for item in _safe_list(materialization.get("workspaces")):
+            if isinstance(item, dict) and isinstance(item.get("path"), str) and item["path"].strip():
+                path = item["path"].strip()
+                candidates.append({
+                    "source": "project_context_materialization.workspaces",
+                    "name": item.get("name"),
+                    "path": path,
+                    "looks_like_file": _looks_like_file_path(path),
+                })
+    snapshot = workspace_ref.get("project_context_snapshot")
+    if isinstance(snapshot, dict):
+        scope = snapshot.get("permission_scope")
+        if isinstance(scope, dict):
+            for path in _safe_list(scope.get("allowed_paths")):
+                if isinstance(path, str) and path.strip():
+                    candidates.append({
+                        "source": "project_context_snapshot.permission_scope.allowed_paths",
+                        "path": path.strip(),
+                        "looks_like_file": _looks_like_file_path(path),
+                    })
+    return candidates
+
+
+def _delivery_signals(events: list[dict[str, Any]], artifacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    signals = []
+    keywords = (
+        "mattermost", "webhook", "http", "post", "payload too large", "too large",
+        "16k", "not a directory", "path escapes workspace", "exec_command", "run_script",
+        "browser failed", "delivery",
+    )
+    for event in events:
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        text = json.dumps(payload, default=str).lower()
+        if any(keyword in text for keyword in keywords):
+            signals.append({
+                "source": "event",
+                "at": event.get("created_at"),
+                "run_id": event.get("run_id"),
+                "event_type": event.get("event_type"),
+                "tool_name": payload.get("tool_name"),
+                "status": payload.get("status"),
+                "payload": payload,
+            })
+    for artifact in artifacts:
+        text = " ".join([
+            str(artifact.get("title") or ""),
+            str(artifact.get("artifact_type") or ""),
+            str(artifact.get("text") or ""),
+            json.dumps(artifact.get("payload") or {}, default=str),
+        ]).lower()
+        if any(keyword in text for keyword in keywords):
+            signals.append({
+                "source": "artifact",
+                "at": artifact.get("created_at"),
+                "run_id": artifact.get("run_id"),
+                "artifact_id": artifact.get("id"),
+                "title": artifact.get("title"),
+                "artifact_type": artifact.get("artifact_type"),
+                "text": artifact.get("text"),
+                "payload": artifact.get("payload") or {},
+            })
+    return signals
+
+
+def _run_status_diagnostics(runs: list[AgentRunRow], events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    changes_by_run: dict[int, list[dict[str, Any]]] = {}
+    for event in events:
+        if event.get("event_type") != "run.status_changed" or not _is_int_like(event.get("run_id")):
+            continue
+        run_id = int(event["run_id"])
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        changes_by_run.setdefault(run_id, []).append({
+            "at": event.get("created_at"),
+            "from_status": payload.get("from_status"),
+            "to_status": payload.get("to_status"),
+        })
+    rows = []
+    for run in runs:
+        run_id = int(run.id) if _is_int_like(getattr(run, "id", None)) else None
+        rows.append({
+            "run_id": run_id,
+            "status": getattr(run, "status", None),
+            "created_at": _iso(getattr(run, "created_at", None)),
+            "started_at": _iso(getattr(run, "started_at", None)),
+            "completed_at": _iso(getattr(run, "completed_at", None)),
+            "failed_at": _iso(getattr(run, "failed_at", None)),
+            "canceled_at": _iso(getattr(run, "canceled_at", None)),
+            "status_changes": changes_by_run.get(run_id or -1, []),
+        })
+    return rows
+
+
+def _looks_like_file_path(path: Any) -> bool:
+    return isinstance(path, str) and bool(PurePath(path).suffix)
+
+
+def _add_int(values: set[int], value: Any) -> None:
+    if _is_int_like(value):
+        values.add(int(value))
 
 
 def _tool_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -545,6 +924,56 @@ def _trace_activity_export(snapshot: dict[str, Any]) -> dict[str, Any]:
             "uri": artifact.get("uri"),
         }))
 
+    cycles = snapshot.get("cycles") if isinstance(snapshot.get("cycles"), dict) else {}
+    for cycle in _safe_list(cycles.get("cycles")):
+        if not isinstance(cycle, dict):
+            continue
+        items.append(_cap_jsonable({
+            "kind": "cycle",
+            "at": cycle.get("updated_at") or cycle.get("created_at"),
+            "cycle_id": cycle.get("id"),
+            "title": cycle.get("name") or "cycle",
+            "status": cycle.get("last_status"),
+            "enabled": cycle.get("enabled"),
+            "schedule_expr": cycle.get("schedule_expr"),
+            "timezone": cycle.get("timezone"),
+            "next_run_at": cycle.get("next_run_at"),
+            "last_run_at": cycle.get("last_run_at"),
+            "last_error": cycle.get("last_error"),
+        }))
+    for cycle_run in _safe_list(cycles.get("cycle_runs")):
+        if not isinstance(cycle_run, dict):
+            continue
+        items.append(_cap_jsonable({
+            "kind": "cycle_run",
+            "at": cycle_run.get("created_at") or cycle_run.get("scheduled_for"),
+            "cycle_run_id": cycle_run.get("id"),
+            "cycle_id": cycle_run.get("cycle_id"),
+            "run_id": cycle_run.get("run_id"),
+            "title": f"cycle_run {cycle_run.get('status') or 'unknown'}",
+            "status": cycle_run.get("status"),
+            "scheduled_for": cycle_run.get("scheduled_for"),
+            "started_at": cycle_run.get("started_at"),
+            "completed_at": cycle_run.get("completed_at"),
+            "error": cycle_run.get("error"),
+            "skip_reason": cycle_run.get("skip_reason"),
+        }))
+
+    diagnostics = snapshot.get("diagnostics") if isinstance(snapshot.get("diagnostics"), dict) else {}
+    for signal in _safe_list(diagnostics.get("delivery_signals")):
+        if not isinstance(signal, dict):
+            continue
+        items.append(_cap_jsonable({
+            "kind": "diagnostic",
+            "at": signal.get("at"),
+            "run_id": signal.get("run_id"),
+            "title": "delivery signal",
+            "source": signal.get("source"),
+            "tool_name": signal.get("tool_name"),
+            "status": signal.get("status"),
+            "signal": signal,
+        }))
+
     items.sort(key=lambda item: (
         "" if item.get("at") is None else str(item.get("at")),
         int(item.get("sequence_no") or 0),
@@ -578,13 +1007,14 @@ def _trace_export_readme(snapshot: dict[str, Any]) -> str:
         scope_note,
         "",
         "Files:",
-        "- trace.json: the full bounded trace snapshot, including thread messages, run metadata, events, tool calls, and artifacts.",
-        "- activity.json: a compact chronological list derived from trace.json.",
+        "- trace.json: the full bounded trace snapshot, including thread messages, run metadata, events, tool calls, artifacts, Cycle rows, CycleRun rows, and diagnostics.",
+        "- activity.json: a compact chronological list derived from trace.json, including Cycle/CycleRun and delivery diagnostic items.",
         "- manifest.json: export metadata.",
         "",
         "Notes:",
         "- Large strings and deep values may be truncated in place.",
         "- The export can include prompts, assistant output, tool arguments/results, and artifact metadata.",
+        "- Diagnostics highlight workspace roots, file-only resources, run status transitions, Cycle lifecycle state, and delivery/webhook failure signals.",
         "- This export is generated on demand and is not saved as a database artifact.",
         "",
         f"Trace ID: {snapshot.get('trace_id') or 'unknown'}",

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -27,7 +27,10 @@ from brain.systems.runs.store import AgentRunStore
 from brain.systems.runs.stream import RunStream
 from brain.systems.runs.ui_events import run_event_to_ui_message
 from brain.systems.cortex.events import publish_live_safe, publish_safe
-from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+from brain.systems.cortex.project_context.materializer import (
+    materialize_project_context_workspaces,
+    project_context_has_materializable_resources,
+)
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.idea import Idea, IdeaStateLog
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -230,11 +233,14 @@ def _run_has_project_context(run: AgentRunRow | None) -> bool:
         return False
     target_ref = run.target_ref if isinstance(run.target_ref, dict) else {}
     workspace_ref = run.workspace_ref if isinstance(run.workspace_ref, dict) else {}
-    return bool(
-        isinstance(target_ref.get("project_context_snapshot"), dict)
-        or isinstance(workspace_ref.get("project_context_snapshot"), dict)
-        or isinstance(workspace_ref.get("resources"), list)
-    )
+    for context in (
+        target_ref.get("project_context_snapshot"),
+        workspace_ref.get("project_context_snapshot"),
+        {"resources": workspace_ref.get("resources")},
+    ):
+        if isinstance(context, dict) and project_context_has_materializable_resources(context):
+            return True
+    return False
 
 
 def _project_context_root(run_id: int, *, thread_id: str | None = None) -> str:

--- a/brain/systems/runs/recipes/shared.py
+++ b/brain/systems/runs/recipes/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from pathlib import PurePath
 from typing import Any
 
@@ -22,6 +23,21 @@ def _looks_like_file_path(path: str) -> bool:
     return bool(PurePath(path).suffix)
 
 
+def _workspace_directory_path(path: str | None) -> str | None:
+    if not isinstance(path, str) or not path.strip():
+        return None
+    candidate = path.strip()
+    local_path = Path(candidate).expanduser()
+    try:
+        if local_path.exists():
+            return candidate if local_path.is_dir() else None
+    except OSError:
+        return None
+    if _looks_like_file_path(candidate):
+        return None
+    return candidate
+
+
 def _resource_workspace_path(resource: dict[str, Any]) -> str | None:
     path = resource.get("path")
     if not isinstance(path, str) or not path.strip():
@@ -30,8 +46,8 @@ def _resource_workspace_path(resource: dict[str, Any]) -> str | None:
     if resource_kind in {"file", "attachment"}:
         return None
     if resource_kind in {"repo", "repository", "directory", "folder", "workspace"}:
-        return path.strip()
-    return None if _looks_like_file_path(path) else path.strip()
+        return _workspace_directory_path(path)
+    return _workspace_directory_path(path)
 
 
 def workspace_root_from_ref(workspace_ref: dict[str, Any]) -> str | None:
@@ -43,8 +59,9 @@ def workspace_root_from_ref(workspace_ref: dict[str, Any]) -> str | None:
     """
     for key in _WORKSPACE_ROOT_KEYS:
         value = workspace_ref.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+        path = _workspace_directory_path(value)
+        if path:
+            return path
 
     snapshot = workspace_ref.get("project_context_snapshot")
     if isinstance(snapshot, dict):
@@ -58,13 +75,15 @@ def workspace_root_from_ref(workspace_ref: dict[str, Any]) -> str | None:
         scope = snapshot.get("permission_scope")
         if isinstance(scope, dict):
             path = _single_allowed_path(scope)
-            if path and not _looks_like_file_path(path):
+            path = _workspace_directory_path(path)
+            if path:
                 return path
 
     scope = workspace_ref.get("project_context_permission_scope")
     if isinstance(scope, dict):
         path = _single_allowed_path(scope)
-        if path and not _looks_like_file_path(path):
+        path = _workspace_directory_path(path)
+        if path:
             return path
 
     return None

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -427,12 +427,16 @@ def _normalize_workspace_entry(entry) -> dict[str, str] | None:
     """Normalize a workspace entry into {name, path}."""
     if isinstance(entry, str) and entry.strip():
         expanded = os.path.realpath(os.path.expanduser(entry.strip()))
+        if os.path.exists(expanded) and not os.path.isdir(expanded):
+            return None
         return {"name": os.path.basename(expanded), "path": expanded}
     if isinstance(entry, dict):
         raw_path = str(entry.get("path", "")).strip()
         if not raw_path:
             return None
         expanded = os.path.realpath(os.path.expanduser(raw_path))
+        if os.path.exists(expanded) and not os.path.isdir(expanded):
+            return None
         name = str(entry.get("name") or os.path.basename(expanded)).strip()
         return {"name": name, "path": expanded}
     return None
@@ -463,10 +467,10 @@ def _select_workspace(
 ) -> str | None:
     """Resolve an explicit workspace selector against the allowed workspace set."""
     registry = _build_workspace_registry(workspace_root, allowed_workspaces)
-    default_root = registry[0]["path"] if registry else workspace_root
+    default_root = registry[0]["path"] if registry else None
     if not workspace:
         return default_root
-    if not registry and not workspace_root:
+    if not registry:
         return None
 
     requested = workspace.strip()

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -59,6 +59,8 @@ def _handle_exec_command(
             return result
 
     timeout = min(timeout, 300)  # Cap at 5 minutes
+    if _workspace and os.path.exists(_workspace) and not os.path.isdir(_workspace):
+        _workspace = None
     if _workspace:
         try:
             cwd = _resolve_path(working_dir, _workspace) if working_dir else _workspace
@@ -133,6 +135,8 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
     import tempfile
 
     timeout = min(timeout, 300)
+    if _workspace and os.path.exists(_workspace) and not os.path.isdir(_workspace):
+        _workspace = None
     cwd = _workspace or _patched_workspace_root()
     project_execution = _prepare_project_execution_env()
 

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1080,6 +1080,8 @@ WORKSPACE_APP_TOOLS = [
                         "\"operations\":[\"schema\",\"list\",\"query\",\"create\",\"update\",\"archive\","
                         "\"aggregate\",\"bulkUpdate\",\"history\",\"listRelations\",\"createRelation\","
                         "\"archiveRelation\"]}}}} and access them with window.illo.domain('todos'). "
+                        "Domain binding operations are exact SDK method names; do not use capability labels "
+                        "such as read, write, or crud in manifest.data_plan.bindings.*.operations. "
                         "The app runtime exposes manifest-bound Domain CRUD, aggregate, bulkUpdate, "
                         "history, relation helpers, polling-backed subscribe, app state, and "
                         "window.illo.actions.run(actionKey, payload) for manifest-declared server-side actions. "

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -561,6 +561,9 @@ Constellation design contract.
 6. When using Domains, save a manifest with `data_plan.mode="domain"` and
    one binding per SDK alias. Each binding must include `domain_id` and
    `object_key`; include `domain_slug`, `fields`, and `operations` when known.
+   Domain binding `operations` are method names, not capability labels: use
+   exact values like `schema`, `list`, `get`, `query`, `create`, `update`, and
+   `archive`. Do not write `read`, `write`, or `crud` in the manifest.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -131,6 +131,9 @@ Constellation design contract.
 6. When using Domains, save a manifest with `data_plan.mode="domain"` and
    one binding per SDK alias. Each binding must include `domain_id` and
    `object_key`; include `domain_slug`, `fields`, and `operations` when known.
+   Domain binding `operations` are method names, not capability labels: use
+   exact values like `schema`, `list`, `get`, `query`, `create`, `update`, and
+   `archive`. Do not write `read`, `write`, or `crud` in the manifest.
 7. Save with `manage_workspace_app(action="create" | "update")`.
 8. Verify contract validation, rendered behavior, persistence, dark/light theme
    fit, and thumbnail facade before telling the user the app is done.

--- a/brain/systems/workspace_apps/compiler.py
+++ b/brain/systems/workspace_apps/compiler.py
@@ -13,6 +13,7 @@ from typing import Any, Mapping
 from brain.systems.workspace_apps.contracts import (
     APP_KIT_NAME,
     CONTRACT_VERSION,
+    DOMAIN_OPERATIONS,
     STRUCTURED_UI_RENDERER_KEY,
     STRUCTURED_UI_SOURCE_KIND,
 )
@@ -42,6 +43,31 @@ _VIEW_TYPE_ALIASES = {
     "card": "cards",
     "kanban": "board",
     "board-view": "board",
+}
+COMMON_DOMAIN_BINDING_OPERATIONS = [
+    "schema",
+    "list",
+    "get",
+    "query",
+    "create",
+    "update",
+    "archive",
+]
+_OPERATION_CANONICAL_BY_COMPACT = {
+    re.sub(r"[^a-z0-9]+", "", operation.lower()): operation for operation in DOMAIN_OPERATIONS
+}
+_OPERATION_ALIAS_EXPANSIONS = {
+    "read": ("schema", "list", "get", "query"),
+    "readonly": ("schema", "list", "get", "query"),
+    "write": ("create", "update"),
+    "writes": ("create", "update"),
+    "mutate": ("create", "update"),
+    "mutation": ("create", "update"),
+    "upsert": ("create", "update"),
+    "delete": ("archive",),
+    "remove": ("archive",),
+    "destroy": ("archive",),
+    "crud": tuple(COMMON_DOMAIN_BINDING_OPERATIONS),
 }
 
 
@@ -323,6 +349,8 @@ def _compile_manifest(
         ):
             next_plan["scope"] = DEFAULT_APP_LOCAL_SCOPE
             _record(repairs, "manifest.data_plan.scope", "defaulted app-local scope to UI state")
+        if next_plan.get("mode") == "domain":
+            _normalize_domain_bindings(next_plan, repairs=repairs)
         next_manifest["data_plan"] = next_plan
 
     design_contract = next_manifest.get("design_contract")
@@ -341,6 +369,80 @@ def _compile_manifest(
             _record(repairs, "manifest.design_contract.theme_modes", "ensured dark and light theme modes")
         next_manifest["design_contract"] = next_design
     return next_manifest
+
+
+def _normalize_domain_bindings(
+    data_plan: dict[str, Any],
+    *,
+    repairs: list[dict[str, Any]],
+) -> None:
+    bindings = data_plan.get("bindings")
+    if not isinstance(bindings, Mapping):
+        return
+
+    next_bindings: dict[str, Any] = {}
+    changed_bindings = False
+    for alias, raw_binding in bindings.items():
+        if not isinstance(raw_binding, Mapping):
+            next_bindings[alias] = raw_binding
+            continue
+
+        binding = dict(raw_binding)
+        operations, operations_changed = _normalize_domain_operations(binding.get("operations"))
+        if operations:
+            if operations != binding.get("operations"):
+                binding["operations"] = operations
+                _record(
+                    repairs,
+                    f"manifest.data_plan.bindings.{alias}.operations",
+                    "normalized Domain binding operations",
+                )
+                changed_bindings = True
+            elif operations_changed:
+                changed_bindings = True
+        next_bindings[alias] = binding
+
+    if changed_bindings:
+        data_plan["bindings"] = next_bindings
+
+
+def _normalize_domain_operations(value: Any) -> tuple[list[str], bool]:
+    if isinstance(value, str):
+        raw_items = [item for item in re.split(r"[\s,|/]+", value) if item]
+        changed = True
+    elif isinstance(value, list):
+        raw_items = value
+        changed = False
+    else:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+
+    if not raw_items:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+
+    operations: list[str] = []
+    for raw_item in raw_items:
+        canonical = _domain_operation_expansion(raw_item)
+        if canonical != [str(raw_item)]:
+            changed = True
+        for operation in canonical:
+            if operation not in operations:
+                operations.append(operation)
+
+    if not operations:
+        return list(COMMON_DOMAIN_BINDING_OPERATIONS), True
+    return operations, changed
+
+
+def _domain_operation_expansion(value: Any) -> list[str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return []
+    compact = re.sub(r"[^a-z0-9]+", "", raw.lower())
+    if compact in _OPERATION_ALIAS_EXPANSIONS:
+        return list(_OPERATION_ALIAS_EXPANSIONS[compact])
+    if compact in _OPERATION_CANONICAL_BY_COMPACT:
+        return [_OPERATION_CANONICAL_BY_COMPACT[compact]]
+    return [raw]
 
 
 def _compile_visual_spec(

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -235,6 +235,32 @@
     return item.status === 'running' ? `Using ${tool}` : `Used ${tool}`;
   }
 
+  function getRunLiveCueWorkIndex(item: CortexThreadStageRunItem) {
+    const workItems = item.workItems ?? [];
+    for (let index = workItems.length - 1; index >= 0; index -= 1) {
+      const workItem = workItems[index];
+      if (workItem.kind === 'tool' && workItem.status === 'running') return index;
+    }
+    return -1;
+  }
+
+  function getRunLiveCueLabel(item: CortexThreadStageRunItem, cueIndex = getRunLiveCueWorkIndex(item)) {
+    if (cueIndex >= 0) {
+      const workItem = item.workItems?.[cueIndex];
+      if (workItem?.kind === 'tool') return getTimelineToolLabel(workItem);
+    }
+
+    return THINKING_STATUS_LABEL;
+  }
+
+  function shouldRenderLiveWorkItem(workIndex: number, cueIndex: number) {
+    return workIndex !== cueIndex;
+  }
+
+  function hasVisibleLiveWorkItems(item: CortexThreadStageRunItem, cueIndex: number) {
+    return Boolean(item.workItems?.some((_workItem, workIndex) => shouldRenderLiveWorkItem(workIndex, cueIndex)));
+  }
+
   function getTimelineToolTitle(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
     const parts = [item.tool, item.status, item.time].filter(Boolean);
     return parts.join(' · ');
@@ -262,6 +288,20 @@
       'run-work-thought',
       /^Reflecting:/i.test(text.trim()) ? 'run-work-reflection' : '',
     ].filter(Boolean).join(' ');
+  }
+
+  function getThinkingStatusLabel(item: CortexThreadStageThinkingItem) {
+    const latestStep = item.steps?.at(-1)?.label?.trim();
+    return latestStep || item.label || THINKING_STATUS_LABEL;
+  }
+
+  function getThinkingSteps(item: CortexThreadStageThinkingItem) {
+    const steps = [...(item.steps ?? [])];
+    const latestStep = steps.at(-1);
+    if (latestStep?.label?.trim() && latestStep.label.trim() === getThinkingStatusLabel(item)) {
+      return steps.slice(0, -1);
+    }
+    return steps;
   }
 
   function getMessageClass(item: CortexThreadStageMessageItem) {
@@ -654,28 +694,34 @@
             {@const runKey = getRunKey(item, index)}
             {@const liveWorkStream = isRunLiveWorkStream(item)}
             {#if liveWorkStream}
+              {@const liveCueWorkIndex = getRunLiveCueWorkIndex(item)}
+              {@const liveCueLabel = getRunLiveCueLabel(item, liveCueWorkIndex)}
               <section class="run-live-work-stream" aria-label="Live run work">
                 {#if item.workItems && item.workItems.length > 0}
-                  <div class="run-work-timeline" aria-label="Run work timeline">
-                    {#each item.workItems as workItem, workIndex (`live-${workItem.kind}-${workItem.at ?? workItem.time ?? 'work'}-${workIndex}`)}
-                      {#if workItem.kind === 'tool'}
-                        <div class={`run-work-item run-work-tool run-work-tool-${workItem.status ?? 'used'}`} title={getTimelineToolTitle(workItem)}>
-                          <span class="run-work-tool-icon" aria-hidden="true">
-                            <ConstellationIcon name="tool" size={13} stroke={1.7} />
-                          </span>
+                  {#if hasVisibleLiveWorkItems(item, liveCueWorkIndex)}
+                    <div class="run-work-timeline" aria-label="Run work timeline">
+                      {#each item.workItems as workItem, workIndex (`live-${workItem.kind}-${workItem.at ?? workItem.time ?? 'work'}-${workIndex}`)}
+                        {#if shouldRenderLiveWorkItem(workIndex, liveCueWorkIndex)}
+                          {#if workItem.kind === 'tool'}
+                            <div class={`run-work-item run-work-tool run-work-tool-${workItem.status ?? 'used'}`} title={getTimelineToolTitle(workItem)}>
+                              <span class="run-work-tool-icon" aria-hidden="true">
+                                <ConstellationIcon name="tool" size={13} stroke={1.7} />
+                              </span>
 
-                          <span class="run-work-tool-copy">
-                            <span class="run-work-tool-label">{getTimelineToolLabel(workItem)}</span>
-                            {#if shouldShowTimelineToolArgs(workItem)}
-                              <code class="run-work-tool-args">{workItem.args}</code>
-                            {/if}
-                          </span>
-                        </div>
-                      {:else}
-                        <div class={getWorkThoughtClass(workItem.text)}>{@html getWorkThoughtHtml(workItem.text)}</div>
-                      {/if}
-                    {/each}
-                  </div>
+                              <span class="run-work-tool-copy">
+                                <span class="run-work-tool-label">{getTimelineToolLabel(workItem)}</span>
+                                {#if shouldShowTimelineToolArgs(workItem)}
+                                  <code class="run-work-tool-args">{workItem.args}</code>
+                                {/if}
+                              </span>
+                            </div>
+                          {:else}
+                            <div class={getWorkThoughtClass(workItem.text)}>{@html getWorkThoughtHtml(workItem.text)}</div>
+                          {/if}
+                        {/if}
+                      {/each}
+                    </div>
+                  {/if}
                 {:else if item.liveLines && item.liveLines.length > 0}
                   <div class="run-work-timeline" aria-label="Run work timeline">
                     {#each item.liveLines as line, lineIndex (`live-line-${typeof line === 'string' ? line : line.text}-${lineIndex}`)}
@@ -685,8 +731,8 @@
                   </div>
                 {/if}
 
-                <div class="run-live-work-cue" aria-live="polite" aria-label={THINKING_STATUS_LABEL}>
-                  <span class="thinking-status-label">{THINKING_STATUS_LABEL}</span>
+                <div class="run-live-work-cue" aria-live="polite" aria-label={liveCueLabel}>
+                  <span class="thinking-status-label">{liveCueLabel}</span>
                   <span class="thinking-status-dots" aria-hidden="true">
                     <span>.</span>
                     <span>.</span>
@@ -1032,9 +1078,11 @@
             </details>
             {/if}
           {:else if item.kind === 'thinking'}
-            <section class="thread-thinking-state" aria-live="polite" aria-label={item.label ?? THINKING_STATUS_LABEL}>
+            {@const thinkingStatusLabel = getThinkingStatusLabel(item)}
+            {@const thinkingSteps = getThinkingSteps(item)}
+            <section class="thread-thinking-state" aria-live="polite" aria-label={thinkingStatusLabel}>
               <div class="thread-thinking-header">
-                <span class="thinking-status-label">{THINKING_STATUS_LABEL}</span>
+                <span class="thinking-status-label">{thinkingStatusLabel}</span>
                 <span class="thinking-status-dots" aria-hidden="true">
                   <span>.</span>
                   <span>.</span>
@@ -1046,9 +1094,9 @@
                 {/if}
               </div>
 
-              {#if item.steps && item.steps.length > 0}
+              {#if thinkingSteps.length > 0}
                 <div class="thread-thinking-steps">
-                  {#each item.steps as step, stepIndex (`${step.time ?? 'step'}-${stepIndex}`)}
+                  {#each thinkingSteps as step, stepIndex (`${step.time ?? 'step'}-${stepIndex}`)}
                     <div class="thread-thinking-step">
                       {#if step.time}
                         <span class="thread-thinking-step-time">{step.time}</span>

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -19,6 +19,7 @@ import { streamItemRunId } from '$lib/utils/cortexRunStream';
 import { parseServerDate, parseServerTimeMs, relativeTimeAgo } from '$lib/utils/datetime';
 import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
 import { buildRunEvidenceDebug } from '$lib/utils/runEvidenceDebug';
+import { orderQueuedThreadStreamItems } from '$lib/utils/threadStreamOrdering';
 import type { Idea, StreamItem } from '$lib/types/cortex';
 import type {
   CortexThreadStageAttachmentItem,
@@ -345,7 +346,7 @@ export function buildThreadTranscriptItems({
   onDenyRun,
 }: BuildThreadTranscriptOptions): CortexThreadStageTranscriptItem[] {
   const items: CortexThreadStageTranscriptItem[] = [];
-  const visibleItems = visibleThreadStreamItems(stream);
+  const visibleItems = orderQueuedThreadStreamItems(visibleThreadStreamItems(stream));
   const activeRunIds = new Set(
     visibleItems
       .filter((streamItem) => streamItem.type === 'run' && isActiveRun(streamItem))

--- a/frontend/src/lib/utils/cortexRunPresentation.test.js
+++ b/frontend/src/lib/utils/cortexRunPresentation.test.js
@@ -114,6 +114,75 @@ test('drops duplicate tool activity prose when a structured tool call exists', (
   assert.equal(items[0].tool, 'exec_command');
 });
 
+test('drops persisted tool activity prose even when work log omits tool metadata', () => {
+  const items = runWorkTimelineItems({
+    work_log: [
+      {
+        time: '2026-05-03T22:00:01.000Z',
+        text: 'Using skill_asset: examples/domain-backed-app.md',
+        kind: 'run.activity',
+      },
+      { time: '2026-05-03T22:00:02.000Z', text: 'Using skill_asset', kind: 'run.tool_started' },
+    ],
+    tool_calls: [
+      {
+        tool: 'skill_asset',
+        args: '{"path":"examples/domain-backed-app.md"}',
+        at: '2026-05-03T22:00:02.000Z',
+        status: 'completed',
+      },
+    ],
+  });
+
+  assert.deepEqual(items.map((item) => item.kind), ['tool']);
+  assert.equal(items[0].tool, 'skill_asset');
+});
+
+test('compacts progressive reflection snippets into the latest thought', () => {
+  const items = runWorkTimelineItems({
+    work_log: [
+      {
+        time: '2026-05-03T22:00:01.000Z',
+        text: 'Assessing API usage guidelines',
+        kind: 'run.activity',
+      },
+      {
+        time: '2026-05-03T22:00:04.000Z',
+        text: 'Assessing API usage guidelines and checking whether the app can fetch public JSON directly',
+        kind: 'run.activity',
+      },
+    ],
+  });
+
+  assert.deepEqual(items.map((item) => item.kind), ['thought']);
+  assert.equal(
+    items[0].text,
+    'Assessing API usage guidelines and checking whether the app can fetch public JSON directly',
+  );
+});
+
+test('compacts adjacent duplicate tool rows with the same arguments', () => {
+  const items = runWorkTimelineItems({
+    tool_calls: [
+      {
+        tool: 'skill_asset',
+        args: '{"path":"examples/domain-backed-app.md"}',
+        at: '2026-05-03T22:00:01.000Z',
+        status: 'completed',
+      },
+      {
+        tool: 'skill_asset',
+        args: '{"path":"examples/domain-backed-app.md"}',
+        at: '2026-05-03T22:00:02.000Z',
+        status: 'completed',
+      },
+    ],
+  });
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].tool, 'skill_asset');
+});
+
 test('keeps the latest persisted activity when the trace is newest first', () => {
   const steps = runActivitySteps({
     activity_trace: [

--- a/frontend/src/lib/utils/cortexRunPresentation.ts
+++ b/frontend/src/lib/utils/cortexRunPresentation.ts
@@ -316,10 +316,21 @@ function workEntryTool(entry: any): string {
   return 'tool';
 }
 
-function isDuplicateToolActivity(entry: any, kind: string, text: string): boolean {
+function toolNameFromActivityText(text: string): string {
+  const match = text.match(/^Using\s+([^:\s]+)(?::|\s|$)/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+function isDuplicateToolActivity(
+  entry: any,
+  kind: string,
+  text: string,
+  structuredToolNames: ReadonlySet<string>,
+): boolean {
   if (kind !== 'run.activity' && kind !== 'step_started') return false;
-  if (!entry?.tool_name) return false;
-  return /^Using\s+/i.test(text);
+  if (!/^Using\s+/i.test(text)) return false;
+  const toolName = String(entry?.tool_name || toolNameFromActivityText(text)).trim();
+  return Boolean(toolName && (entry?.tool_name || structuredToolNames.has(toolName)));
 }
 
 function workTimelineTimeMs(at: string | undefined): number | null {
@@ -338,6 +349,73 @@ function timelineToolKey(tool: string, at: string | undefined): string {
   return `${tool}:${at ?? ''}`;
 }
 
+function normalizedTimelineText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[`*_#>\[\]()]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function volatileThoughtKey(text: string): string {
+  const normalized = normalizedTimelineText(text);
+  if (normalized.startsWith('thinking through the request')) return 'thinking';
+  if (normalized.startsWith('writing response')) return 'writing';
+  if (normalized.startsWith('streaming')) return 'streaming';
+  return '';
+}
+
+function thoughtsAreProgressive(left: AgentRunWorkThoughtItem, right: AgentRunWorkThoughtItem): boolean {
+  const leftText = normalizedTimelineText(left.text).replace(/[.…]+$/g, '');
+  const rightText = normalizedTimelineText(right.text).replace(/[.…]+$/g, '');
+  if (!leftText || !rightText) return false;
+  const volatileLeft = volatileThoughtKey(left.text);
+  if (volatileLeft && volatileLeft === volatileThoughtKey(right.text)) return true;
+  const shortest = Math.min(leftText.length, rightText.length);
+  return shortest >= 24 && (leftText.startsWith(rightText) || rightText.startsWith(leftText));
+}
+
+function toolDisplayKey(item: AgentRunWorkToolItem): string {
+  return [
+    item.tool.toLowerCase(),
+    item.args || '',
+  ].join(':');
+}
+
+function timelineItemsAreRedundant(
+  left: AgentRunWorkTimelineItem,
+  right: AgentRunWorkTimelineItem,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === 'tool' && right.kind === 'tool') {
+    return toolDisplayKey(left) === toolDisplayKey(right);
+  }
+  if (left.kind === 'thought' && right.kind === 'thought') {
+    return thoughtsAreProgressive(left, right);
+  }
+  return false;
+}
+
+function mergeRedundantTimelineItems<T extends AgentRunWorkTimelineItem & { order: number; key: string }>(
+  records: T[],
+): T[] {
+  const compacted: T[] = [];
+  for (const record of records) {
+    const previous = compacted[compacted.length - 1];
+    if (previous && timelineItemsAreRedundant(previous, record)) {
+      compacted[compacted.length - 1] =
+        previous.kind === 'thought'
+          && record.kind === 'thought'
+          && previous.text.length > record.text.length
+          ? previous
+          : record;
+      continue;
+    }
+    compacted.push(record);
+  }
+  return compacted;
+}
+
 export function runWorkTimelineItems(
   source: any,
   {
@@ -353,6 +431,11 @@ export function runWorkTimelineItems(
   const workEntries = runWorkLogEntries(source);
   const toolStartOrder = new Map<string, number>();
   const toolCallKeys = new Set<string>();
+  const structuredToolNames = new Set<string>(
+    (source?.tool_calls || [])
+      .map((call: any) => String(call?.tool || call?.tool_name || '').trim())
+      .filter(Boolean),
+  );
 
   workEntries.forEach((entry, index) => {
     const kind = workEntryKind(entry);
@@ -375,7 +458,7 @@ export function runWorkTimelineItems(
 
     const text = workEntryText(entry);
     if (!text) continue;
-    if (isDuplicateToolActivity(entry, kind, text)) continue;
+    if (isDuplicateToolActivity(entry, kind, text, structuredToolNames)) continue;
     const at = workEntryTime(entry);
     pushRecord({
       kind: 'thought',
@@ -437,7 +520,7 @@ export function runWorkTimelineItems(
     }
   }
 
-  return records
+  const orderedRecords = records
     .sort((left, right) => {
       const leftMs = workTimelineTimeMs(left.at);
       const rightMs = workTimelineTimeMs(right.at);
@@ -445,7 +528,9 @@ export function runWorkTimelineItems(
       if (leftMs !== null && rightMs === null) return -1;
       if (leftMs === null && rightMs !== null) return 1;
       return left.order - right.order;
-    })
+    });
+
+  return mergeRedundantTimelineItems(orderedRecords)
     .slice(-limit)
     .map(({ order: _order, key: _key, ...item }) => item);
 }

--- a/frontend/src/lib/utils/threadStreamOrdering.test.js
+++ b/frontend/src/lib/utils/threadStreamOrdering.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { orderQueuedThreadStreamItems } from './threadStreamOrdering.ts';
+
+test('places queued follow-up messages after the run reply they are waiting for', () => {
+  const ordered = orderQueuedThreadStreamItems([
+    { type: 'message', id: 'prompt-1', role: 'user', content: 'Build the app' },
+    { type: 'run', id: 'run-1', run_id: 1, status: 'completed' },
+    {
+      type: 'message',
+      id: 'queued-message',
+      role: 'user',
+      content: 'Add JSONPlaceholder sync',
+      metadata: { queued_after_run: true, queued_after_run_id: 1 },
+    },
+    {
+      type: 'run',
+      id: 'run-2',
+      run_id: 2,
+      status: 'completed',
+      metadata: { queued_after_run_id: 1, thread_message_id: 'queued-message' },
+    },
+    {
+      type: 'message',
+      id: 'run-1-final',
+      role: 'illo',
+      content: 'Built it.',
+      metadata: { run_id: 1 },
+    },
+    {
+      type: 'message',
+      id: 'run-2-final',
+      role: 'illo',
+      content: 'Wired the sync button.',
+      metadata: { run_id: 2 },
+    },
+  ]);
+
+  assert.deepEqual(ordered.map((item) => item.id), [
+    'prompt-1',
+    'run-1',
+    'run-1-final',
+    'queued-message',
+    'run-2',
+    'run-2-final',
+  ]);
+});
+
+test('keeps queued follow-ups after the active run card until a final reply exists', () => {
+  const ordered = orderQueuedThreadStreamItems([
+    { type: 'message', id: 'prompt-1', role: 'user', content: 'Build the app' },
+    {
+      type: 'message',
+      id: 'queued-message',
+      role: 'user',
+      content: 'Add JSONPlaceholder sync',
+      metadata: { queued_after_run: true, queued_after_run_id: 1 },
+    },
+    { type: 'run', id: 'run-1', run_id: 1, status: 'running' },
+    {
+      type: 'run',
+      id: 'run-2',
+      run_id: 2,
+      status: 'queued',
+      metadata: { queued_after_run_id: 1, thread_message_id: 'queued-message' },
+    },
+  ]);
+
+  assert.deepEqual(ordered.map((item) => item.id), [
+    'prompt-1',
+    'run-1',
+    'queued-message',
+    'run-2',
+  ]);
+});
+
+test('preserves unanchored queued messages in timestamp order', () => {
+  const ordered = orderQueuedThreadStreamItems([
+    { type: 'message', id: 'prompt-1', role: 'user', content: 'Build the app' },
+    {
+      type: 'message',
+      id: 'queued-message',
+      role: 'user',
+      content: 'Add JSONPlaceholder sync',
+      metadata: { queued_after_run: true, queued_after_run_id: 99 },
+    },
+    { type: 'run', id: 'run-1', run_id: 1, status: 'completed' },
+  ]);
+
+  assert.deepEqual(ordered.map((item) => item.id), ['prompt-1', 'queued-message', 'run-1']);
+});

--- a/frontend/src/lib/utils/threadStreamOrdering.ts
+++ b/frontend/src/lib/utils/threadStreamOrdering.ts
@@ -1,0 +1,96 @@
+export type ThreadStreamOrderingItem = {
+  type?: string;
+  id?: string | number | null;
+  role?: string | null;
+  content?: string | null;
+  run_id?: string | number | null;
+  metadata?: Record<string, any> | null;
+};
+
+function keyFor(value: unknown): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  return String(value);
+}
+
+function metadataFor(item: ThreadStreamOrderingItem): Record<string, any> {
+  return item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
+}
+
+function queuedAfterRunId(item: ThreadStreamOrderingItem): string | null {
+  const metadata = metadataFor(item);
+  return keyFor(metadata.queued_after_run_id);
+}
+
+function itemRunId(item: ThreadStreamOrderingItem): string | null {
+  const metadata = metadataFor(item);
+  return keyFor(item.run_id ?? metadata.run_id ?? (item.type === 'run' ? item.id : null));
+}
+
+function isAgentRunReply(item: ThreadStreamOrderingItem): boolean {
+  const role = item.role === 'assistant' || item.role === 'illo';
+  if (item.type !== 'message' || !role) return false;
+  if (metadataFor(item).live_agent_text) return false;
+  return Boolean(String(item.content || '').trim() && itemRunId(item));
+}
+
+export function orderQueuedThreadStreamItems<T extends ThreadStreamOrderingItem>(items: readonly T[]): T[] {
+  const blocksByAnchor = new Map<string, T[]>();
+  const anchorIds = new Set<string>();
+
+  for (const item of items) {
+    const anchorId = queuedAfterRunId(item);
+    if (!anchorId) continue;
+    anchorIds.add(anchorId);
+    blocksByAnchor.set(anchorId, [...(blocksByAnchor.get(anchorId) ?? []), item]);
+  }
+
+  if (blocksByAnchor.size === 0) return [...items];
+
+  const lastRunReplyIndexByAnchor = new Map<string, number>();
+  const anchorsWithTarget = new Set<string>();
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    const runId = itemRunId(item);
+    if (!runId || !anchorIds.has(runId)) continue;
+    anchorsWithTarget.add(runId);
+    if (isAgentRunReply(item)) lastRunReplyIndexByAnchor.set(runId, index);
+  }
+
+  const movedAnchors = new Set(
+    [...anchorIds].filter((anchorId) => anchorsWithTarget.has(anchorId)),
+  );
+  if (movedAnchors.size === 0) return [...items];
+
+  const flushedAnchors = new Set<string>();
+  const flush = (anchorId: string, output: T[]) => {
+    if (flushedAnchors.has(anchorId)) return;
+    const block = blocksByAnchor.get(anchorId);
+    if (!block?.length) return;
+    output.push(...block);
+    flushedAnchors.add(anchorId);
+  };
+
+  const ordered: T[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    const anchorId = queuedAfterRunId(item);
+    if (anchorId && movedAnchors.has(anchorId)) continue;
+
+    ordered.push(item);
+
+    const runId = itemRunId(item);
+    if (!runId || !movedAnchors.has(runId)) continue;
+    if (
+      (isAgentRunReply(item) && lastRunReplyIndexByAnchor.get(runId) === index)
+      || (item.type === 'run' && !lastRunReplyIndexByAnchor.has(runId))
+    ) {
+      flush(runId, ordered);
+    }
+  }
+
+  for (const anchorId of movedAnchors) {
+    flush(anchorId, ordered);
+  }
+
+  return ordered;
+}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1374,6 +1374,16 @@ class TestExecToolHandlers:
         assert result["exit_code"] == -1
         assert "escapes workspace" in result["stderr"]
 
+    def test_exec_command_ignores_file_workspace_root(self, tmp_path):
+        from brain.systems.runs.direct_agent import _handle_exec_command
+
+        attachment = tmp_path / "agent.md"
+        attachment.write_text("# Sales agent\n")
+
+        result = _handle_exec_command("echo ok", _workspace=str(attachment))
+        assert result["exit_code"] == 0
+        assert result["stdout"].strip() == "ok"
+
 
 class TestFinalReplyReview:
     @patch("brain.systems.runs.direct_agent.get_provider")

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -445,6 +445,8 @@ def test_workspace_root_from_ref_uses_thread_project_context_snapshot():
     assert (
         workspace_root_from_ref(
             {
+                "workspace_root": "/tmp/ideas/idea-1/uploads/agent.md",
+                "resolved_workspace_root": "/tmp/ideas/idea-1/uploads/agent.md",
                 "project_context_snapshot": {
                     "resources": [{"kind": "file", "path": "/tmp/ideas/idea-1/uploads/agent.md"}],
                     "permission_scope": {"allowed_paths": ["/tmp/ideas/idea-1/uploads/agent.md"]},

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -45,11 +45,70 @@ def _run(**overrides):
     return SimpleNamespace(**values)
 
 
+def _cycle(**overrides):
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    values = {
+        "id": 7,
+        "user_id": "user-1",
+        "org_id": "org-1",
+        "name": "Weekly sales cycle",
+        "prompt": "Run the weekly report",
+        "schedule_expr": "0 9 * * 1",
+        "timezone": "America/Toronto",
+        "enabled": True,
+        "model_override": None,
+        "thinking_override": "none",
+        "execution_mode": "reuse_same_idea",
+        "target_idea_id": "idea-1",
+        "reopen_archived": True,
+        "next_run_at": now,
+        "last_run_at": now,
+        "last_status": "completed",
+        "last_error": None,
+        "deleted_at": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _cycle_run(**overrides):
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    values = {
+        "id": 8,
+        "cycle_id": 7,
+        "scheduled_for": now,
+        "started_at": now,
+        "completed_at": now,
+        "status": "completed",
+        "error": None,
+        "skip_reason": None,
+        "idea_id": "idea-1",
+        "run_id": 42,
+        "prompt_snapshot": "Run the weekly report",
+        "created_at": now,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
 def test_agent_trace_snapshot_is_bounded_and_analysis_ready():
     from brain.systems.runs.cortex.recording import build_agent_trace_snapshot
     from brain.platform.db.models.agent_run import AgentRunRow
 
-    run = _run()
+    run = _run(
+        workspace_ref={
+            "workspace_root": "/app/brain/uploads/agent.md",
+            "resources": [{"id": "attachment-1", "kind": "file", "path": "/app/brain/uploads/agent.md"}],
+        },
+        metadata_={
+            "source": "cycle",
+            "cycle_id": 7,
+            "cycle_run_id": 8,
+            "launch_envelope": {"cycle_id": 7, "cycle_run_id": 8},
+        },
+    )
     now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
     message = SimpleNamespace(
         id=9,
@@ -89,9 +148,12 @@ def test_agent_trace_snapshot_is_bounded_and_analysis_ready():
     session.get.side_effect = lambda model, key: run if model is AgentRunRow and key == 42 else None
     session.scalars.side_effect = [
         _result([42]),
+        _result([run]),
         _result([message]),
         _result([event]),
         _result([artifact]),
+        _result([_cycle()]),
+        _result([_cycle_run()]),
     ]
 
     snapshot = build_agent_trace_snapshot(session, run, saved_by="user-1")
@@ -106,6 +168,8 @@ def test_agent_trace_snapshot_is_bounded_and_analysis_ready():
     }
     assert snapshot["tools"][0]["tool_name"] == "read_file"
     assert snapshot["artifacts"][0]["artifact_type"] == "reply"
+    assert snapshot["cycles"]["cycle_runs"][0]["run_id"] == 42
+    assert snapshot["diagnostics"]["workspace"][0]["suspicious_file_roots"][0]["path"] == "/app/brain/uploads/agent.md"
     assert snapshot["storage_estimate"]["truncated"] is True
     assert "not copied" not in str(snapshot)
 
@@ -175,8 +239,12 @@ def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
     session.scalars.side_effect = [
         _result([run, child]),
         _result([first_message, second_message]),
+        _result([]),
         _result([event]),
+        _result([]),
         _result([artifact]),
+        _result([_cycle()]),
+        _result([_cycle_run(run_id=43)]),
     ]
 
     snapshot = build_thread_trace_snapshot(session, "idea-1", saved_by="user-1")
@@ -191,6 +259,9 @@ def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
     assert snapshot["related_run_ids"] == [42, 43]
     assert snapshot["tools"][0]["tool_name"] == "read_thread_messages"
     assert snapshot["artifacts"][0]["artifact_type"] == "reply"
+    assert snapshot["cycles"]["cycle_count"] == 1
+    assert snapshot["cycles"]["cycle_run_count"] == 1
+    assert snapshot["diagnostics"]["cycle_summary"]["cycle_run_ids"] == [8]
     assert agent_trace_export_filename(snapshot) == "illo-thread-trace-idea-1.zip"
     assert "not copied" not in str(snapshot)
 
@@ -233,6 +304,15 @@ def test_agent_trace_export_zip_contains_shareable_trace_files():
             }
         ],
         "artifacts": [],
+        "cycles": {
+            "cycles": [{"id": 7, "name": "Weekly sales cycle", "last_status": "completed"}],
+            "cycle_runs": [{"id": 8, "cycle_id": 7, "run_id": 42, "status": "completed"}],
+            "cycle_count": 1,
+            "cycle_run_count": 1,
+        },
+        "diagnostics": {
+            "delivery_signals": [{"source": "artifact", "run_id": 42, "title": "webhook failed"}],
+        },
         "storage_estimate": {"json_bytes": 512, "truncated": False},
     }
 
@@ -248,7 +328,10 @@ def test_agent_trace_export_zip_contains_shareable_trace_files():
 
     assert "artifact_id" not in manifest
     assert manifest["trace_id"] == "run:42"
+    assert manifest["diagnostics"]["cycle_run_count"] == 1
     assert trace["run"]["input_message"] == "Why did Illo answer that?"
-    assert activity["item_count"] == 3
+    assert activity["item_count"] == 6
+    assert any(item["kind"] == "cycle_run" for item in activity["items"])
     assert "trace.json" in readme
+    assert "CycleRun" in readme
     assert "not saved as a database artifact" in readme

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1,6 +1,69 @@
 from types import SimpleNamespace
 
 
+def test_thread_attachment_file_is_not_materialized_as_github_workspace():
+    from brain.systems.cortex.project_context.materializer import _github_slug_from_resource
+
+    assert _github_slug_from_resource({
+        "kind": "file",
+        "name": "agent.md",
+        "path": "/app/brain/uploads/94fe1c1fe9134e6aaa7b4f9844c7a6a6.md",
+        "source": "thread_attachment",
+        "uri": "/static/uploads/94fe1c1fe9134e6aaa7b4f9844c7a6a6.md",
+    }) is None
+
+
+def test_runner_skips_materialization_for_thread_attachment_files(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=51,
+        user_id="user-1",
+        org_id="org-1",
+        thread_id="idea-4",
+        target_ref={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "attachment-1",
+                        "kind": "file",
+                        "name": "agent.md",
+                        "path": "/app/brain/uploads/agent.md",
+                        "source": "thread_attachment",
+                        "uri": "/static/uploads/agent.md",
+                    }
+                ],
+            }
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def fail_materialize(*_args, **_kwargs):
+        raise AssertionError("file-only attachments should not be materialized as workspaces")
+
+    monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(runner, "materialize_project_context_workspaces", fail_materialize)
+
+    context_ready, status_payload = runner._materialize_project_context(51)
+
+    assert context_ready is True
+    assert status_payload is None
+
+
 def test_materialize_github_project_context_uses_vault_key_without_persisting_token(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context import materializer
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
@@ -520,7 +583,17 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
         user_id="user-1",
         org_id="org-1",
         thread_id="idea-3",
-        target_ref={"project_context_snapshot": {"resources": []}},
+        target_ref={
+            "project_context_snapshot": {
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "repo": "example-org/missing-repo",
+                        "uri": "https://github.com/example-org/missing-repo",
+                    }
+                ]
+            }
+        },
         workspace_ref={},
     )
 

--- a/tests/test_workspace_app_compiler.py
+++ b/tests/test_workspace_app_compiler.py
@@ -123,6 +123,75 @@ def test_compiler_infers_domain_backed_table_from_single_binding():
     assert _validation_report(compiled)["status"] == "passed"
 
 
+def test_compiler_repairs_domain_binding_operation_aliases():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="Ticket Board",
+        source_code=json.dumps({"description": "Track tickets"}),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": 1,
+                        "object_key": "ticket",
+                        "fields": ["title", "status"],
+                        "operations": ["read", "write", "bulk_update", "list-relations"],
+                    }
+                },
+            },
+        },
+    )
+
+    assert compiled.manifest["data_plan"]["bindings"]["tickets"]["operations"] == [
+        "schema",
+        "list",
+        "get",
+        "query",
+        "create",
+        "update",
+        "bulkUpdate",
+        "listRelations",
+    ]
+    assert {
+        repair["field"]: repair["message"] for repair in compiled.repairs
+    }["manifest.data_plan.bindings.tickets.operations"] == "normalized Domain binding operations"
+    assert _validation_report(compiled)["status"] == "passed"
+
+
+def test_compiler_defaults_missing_domain_binding_operations():
+    compiled = compile_workspace_app_input(
+        action="create",
+        name="Ticket Board",
+        source_code=json.dumps({"description": "Track tickets"}),
+        manifest={
+            "contract_version": 1,
+            "data_plan": {
+                "mode": "domain",
+                "bindings": {
+                    "tickets": {
+                        "domain_id": 1,
+                        "object_key": "ticket",
+                        "fields": ["title", "status"],
+                    }
+                },
+            },
+        },
+    )
+
+    assert compiled.manifest["data_plan"]["bindings"]["tickets"]["operations"] == [
+        "schema",
+        "list",
+        "get",
+        "query",
+        "create",
+        "update",
+        "archive",
+    ]
+    assert _validation_report(compiled)["status"] == "passed"
+
+
 def test_compiler_accepts_domain_backed_board_view():
     compiled = compile_workspace_app_input(
         action="create",


### PR DESCRIPTION
## Summary
- add cycle/control-plane diagnostics to thread trace exports
- improve live thread work rendering and fix queued follow-up transcript ordering
- normalize workspace app Domain binding operation aliases/defaults and clarify prompts

## Tests
- `venv/bin/pytest tests/test_agent_trace_snapshot.py tests/test_workspace_app_compiler.py`
- `npm test`
- `npm run check` (0 errors; existing warnings in memory UI remain)
