### PR TITLE
Support generic HTTP now mappings

### DIFF
--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -537,7 +537,8 @@ Constellation design contract.
      non-GET methods with `external.write`, and add `domain.write` only when
      `sync` mutates the Domain. Sync mappings may use plain string paths
      (`"title"`), `{ "path": "nested.id" }`, `{ "const": "Todo" }`,
-     `{ "template": "ISSUE-{number}" }`, or
+     `{ "template": "ISSUE-{number}" }`, `{ "now": true }` for the current
+     UTC ISO timestamp, or
      `{ "if": { "field": "completed", "equals": true }, "then": "Done",
      "else": "Todo" }`. Put only real Domain data fields in `sync.fields`;
      use `sync.title` for the record title, and do not invent helper fields

--- a/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/build-workspace-app/SKILL.md
@@ -107,7 +107,8 @@ Constellation design contract.
      non-GET methods with `external.write`, and add `domain.write` only when
      `sync` mutates the Domain. Sync mappings may use plain string paths
      (`"title"`), `{ "path": "nested.id" }`, `{ "const": "Todo" }`,
-     `{ "template": "ISSUE-{number}" }`, or
+     `{ "template": "ISSUE-{number}" }`, `{ "now": true }` for the current
+     UTC ISO timestamp, or
      `{ "if": { "field": "completed", "equals": true }, "then": "Done",
      "else": "Todo" }`. Put only real Domain data fields in `sync.fields`;
      use `sync.title` for the record title, and do not invent helper fields

--- a/brain/systems/workspace_apps/contracts.py
+++ b/brain/systems/workspace_apps/contracts.py
@@ -44,7 +44,8 @@ GENERATED_UI_CHART_TYPES = {"bar", "line", "pie", "scatter"}
 GENERIC_HTTP_EXECUTOR_KEY = "generic.http"
 GENERIC_HTTP_KINDS = {"http_request", "http_sync"}
 GENERIC_HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
-GENERIC_HTTP_MAPPING_KEYS = ("const", "path", "template", "if")
+GENERIC_HTTP_MAPPING_KEYS = ("const", "path", "template", "if", "now")
+GENERIC_HTTP_MAPPING_DESCRIPTION = "const, path, template, now, or if/then/else"
 RECORD_LIKE_STATE_KEYS = {
     "records",
     "items",
@@ -358,16 +359,18 @@ def _validate_generic_http_mapping_expr(
     if isinstance(expr, Mapping):
         present = [key for key in GENERIC_HTTP_MAPPING_KEYS if key in expr]
         if not present:
-            errors.append(f"{field_path} mapping expressions must use const, path, template, or if/then/else")
+            errors.append(f"{field_path} mapping expressions must use {GENERIC_HTTP_MAPPING_DESCRIPTION}")
             return
         if len(present) > 1:
-            errors.append(f"{field_path} mapping expression must use only one of const, path, template, or if")
+            errors.append(f"{field_path} mapping expression must use only one of const, path, template, now, or if")
             return
         key = present[0]
         if key == "path" and not isinstance(expr.get("path"), str):
             errors.append(f"{field_path}.path must be a string")
         elif key == "template" and not isinstance(expr.get("template"), str):
             errors.append(f"{field_path}.template must be a string")
+        elif key == "now" and expr.get("now") is not True:
+            errors.append(f"{field_path}.now must be true")
         elif key == "if":
             _validate_generic_http_condition(f"{field_path}.if", expr.get("if"), errors)
             if "then" not in expr:

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import ipaddress
 import re
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
 
@@ -324,11 +325,15 @@ def _mapped_value(expr: Any, item: Mapping[str, Any]) -> Any:
             return _extract_path(item, str(expr.get("path") or ""))
         if "template" in expr:
             return _render_template(str(expr.get("template") or ""), item)
+        if "now" in expr:
+            if expr.get("now") is True:
+                return _utc_now_iso()
+            raise WorkspaceAppActionContractError("mapping expression.now must be true")
         if "if" in expr:
             condition = _mapping(expr.get("if"), "mapping expression.if")
             branch = expr.get("then") if _condition_matches(condition, item) else expr.get("else")
             return _literal_or_mapped_value(branch, item)
-        raise WorkspaceAppActionContractError("mapping expressions must use const, path, template, or if/then/else")
+        raise WorkspaceAppActionContractError("mapping expressions must use const, path, template, now, or if/then/else")
     if expr is None:
         return None
     return _extract_path(item, str(expr))
@@ -405,6 +410,10 @@ def _render_template(template: str, payload: Mapping[str, Any]) -> str:
         return "" if value is None else str(value)
 
     return _TEMPLATE_RE.sub(replace, template)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _validate_url(url: str) -> None:

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -878,6 +878,96 @@ def test_workspace_app_action_generic_http_supports_templates_and_conditionals(s
     assert second.data["status"] == "Done"
 
 
+def test_workspace_app_action_generic_http_supports_now_mapping(session):
+    domain = DomainService(session).create_domain(
+        ORG_ID,
+        name="Timestamped Tickets",
+        slug="timestamped-tickets",
+        objects=[
+            {
+                "key": "ticket",
+                "name": "Ticket",
+                "fields": [
+                    {"key": "external_id", "field_type": "text"},
+                    {"key": "synced_at", "field_type": "datetime"},
+                ],
+            }
+        ],
+        actor_id=USER_ID,
+    )
+    manifest = {
+        "contract_version": 1,
+        "data_plan": {
+            "mode": "domain",
+            "bindings": {
+                "tickets": {
+                    "domain_id": domain.id,
+                    "object_key": "ticket",
+                    "fields": ["title", "external_id", "synced_at"],
+                    "operations": ["schema", "list", "create", "update"],
+                }
+            },
+        },
+        "design_contract": {
+            "kit": "constellation-app-kit",
+            "theme_modes": ["dark", "light"],
+        },
+        "actions": {
+            "tickets.syncExternal": {
+                "kind": "connector",
+                "effects": ["external.read", "domain.write"],
+                "executor": {"type": "registered", "key": "generic.http"},
+                "connector_spec": {
+                    "kind": "http_sync",
+                    "request": {"method": "GET", "url": "https://jsonplaceholder.typicode.com/todos"},
+                    "response": {"items_path": "$"},
+                    "sync": {
+                        "binding": "tickets",
+                        "remote_id": "id",
+                        "remote_id_field": "external_id",
+                        "title": "title",
+                        "fields": {
+                            "synced_at": {"now": True},
+                        },
+                    },
+                },
+            }
+        },
+    }
+    app = create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-now-sync",
+        name="Generic HTTP Now Sync",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    with patch(
+        "brain.systems.workspace_apps.generic_http._request_json",
+        return_value=[{"id": "todo-1", "title": "Synced todo"}],
+    ), patch("brain.systems.workspace_apps.generic_http._utc_now_iso", return_value="2026-05-13T21:20:05Z"):
+        result = run_workspace_app_action(
+            session,
+            org_id=ORG_ID,
+            app_id=app.id,
+            action_key="tickets.syncExternal",
+            payload={},
+            user_id=USER_ID,
+        )
+
+    assert result["ok"] is True
+    assert result["result"]["created"] == 1
+    record = DomainService(session).list_records(ORG_ID, domain.id, object_key="ticket", limit=1)[0]
+    assert record.title == "Synced todo"
+    assert record.data["external_id"] == "todo-1"
+    assert record.data["synced_at"] == "2026-05-13T21:20:05Z"
+
+
 def test_workspace_app_action_generic_http_request_returns_compact_response(session):
     domain = _todo_domain(session)
     manifest = _manifest_with_action(
@@ -926,7 +1016,7 @@ def test_workspace_app_action_generic_http_request_returns_compact_response(sess
 def test_workspace_app_action_generic_http_rejects_invalid_mapping_at_save(session):
     domain = _todo_domain(session)
 
-    with pytest.raises(WorkspaceAppContractError, match="mapping expressions must use const, path, template, or if/then/else"):
+    with pytest.raises(WorkspaceAppContractError, match="mapping expressions must use const, path, template, now, or if/then/else"):
         create_app(
             session,
             org_id=ORG_ID,


### PR DESCRIPTION
## Summary
- add `{"now": true}` as a supported generic HTTP sync mapping expression
- resolve `now` at action execution time as a UTC ISO timestamp
- document the mapping in the built-in workspace-app skill and mirror
- add a regression covering app save validation plus runtime Domain sync into a datetime field

## Why
The latest Illo trace showed a remaining retry after it naturally generated `synced_at: {"now": true}` for a JSONPlaceholder sync action. The app eventually recovered, but this support removes that avoidable contract bump without weakening arbitrary object mappings.

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_apps_service.py -k generic_http
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_workspace_app_compiler.py tests/test_workspace_app_contract.py tests/test_workspace_apps_service.py tests/test_builtin_skill_suite.py
