### PR TITLE
Add code review files dock panel

### DIFF
--- a/frontend/src/lib/features/threads/components/ThreadCodeReviewPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadCodeReviewPane.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { ConstellationIcon } from '$lib/components/constellation';
+  import type { CodeReviewFile } from '$lib/utils/cortexRunPresentation';
+
+  let {
+    files = [],
+    latestRunStatus = '',
+  }: {
+    files?: CodeReviewFile[];
+    latestRunStatus?: string | null;
+  } = $props();
+
+  const changedCount = $derived(files.length);
+
+  function operationLabel(file: CodeReviewFile): string {
+    const operation = String(file.operation || file.status || '').trim();
+    return operation || 'changed';
+  }
+
+  function sourceLabel(file: CodeReviewFile): string {
+    if (file.source === 'artifact') return 'artifact';
+    return file.tool || 'tool call';
+  }
+</script>
+
+<div class="code-review-pane">
+  <header class="code-review-header">
+    <div class="code-review-title-row">
+      <span class="code-review-icon" aria-hidden="true">
+        <ConstellationIcon name="code" size={16} stroke={1.8} />
+      </span>
+      <div>
+        <div class="code-review-title">Review files</div>
+        <div class="code-review-subtitle">
+          {#if changedCount}
+            {changedCount} {changedCount === 1 ? 'file' : 'files'} changed by this thread
+          {:else if latestRunStatus}
+            No changed files detected · latest run {latestRunStatus}
+          {:else}
+            No code changes detected yet
+          {/if}
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {#if changedCount}
+    <div class="code-review-list" role="list" aria-label="Files to review">
+      {#each files as file, index (file.path + '-' + index)}
+        <article class="code-review-file" role="listitem">
+          <div class="code-review-file-main">
+            <span class="code-review-file-icon" aria-hidden="true">
+              <ConstellationIcon name="file" size={15} stroke={1.8} />
+            </span>
+            <code title={file.path}>{file.path}</code>
+          </div>
+          <div class="code-review-file-meta">
+            <span>{operationLabel(file)}</span>
+            <span>{sourceLabel(file)}</span>
+            {#if file.status}
+              <span>{file.status}</span>
+            {/if}
+          </div>
+        </article>
+      {/each}
+    </div>
+  {:else}
+    <div class="code-review-empty">
+      <div class="code-review-empty-orb">
+        <ConstellationIcon name="file" size={22} stroke={1.6} />
+      </div>
+      <strong>No files to review yet</strong>
+      <p>When Illo writes or edits files, this panel opens and keeps the changed file list in one column for review.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .code-review-pane {
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    color: var(--text-1, #f4f6fa);
+  }
+
+  .code-review-header {
+    flex: 0 0 auto;
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--constellation-utility-panel-header-border, rgba(255, 255, 255, 0.09));
+  }
+
+  .code-review-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .code-review-icon {
+    width: 30px;
+    height: 30px;
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px;
+    color: var(--thread-accent, #57cfa0);
+    background: color-mix(in srgb, var(--thread-accent, #57cfa0) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--thread-accent, #57cfa0) 22%, transparent);
+  }
+
+  .code-review-title {
+    font-size: 14px;
+    font-weight: 720;
+    letter-spacing: -0.01em;
+  }
+
+  .code-review-subtitle {
+    margin-top: 2px;
+    color: var(--text-3, rgba(244, 246, 250, 0.58));
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  .code-review-list {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    display: grid;
+    align-content: start;
+    gap: 8px;
+    padding: 12px;
+    scrollbar-color: var(--constellation-utility-panel-scrollbar, rgba(255, 255, 255, 0.18)) transparent;
+  }
+
+  .code-review-file {
+    min-width: 0;
+    padding: 11px 12px;
+    border-radius: 14px;
+    border: 1px solid var(--constellation-card-border, rgba(255, 255, 255, 0.08));
+    background: rgba(255, 255, 255, 0.045);
+  }
+
+  .code-review-file-main {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .code-review-file-icon {
+    color: var(--thread-accent, #57cfa0);
+    opacity: 0.9;
+  }
+
+  .code-review-file code {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-1, #f4f6fa);
+    font-family: var(--constellation-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 12px;
+    background: transparent;
+  }
+
+  .code-review-file-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 9px;
+    padding-left: 26px;
+  }
+
+  .code-review-file-meta span {
+    padding: 2px 7px;
+    border-radius: 999px;
+    color: var(--text-3, rgba(244, 246, 250, 0.62));
+    background: rgba(255, 255, 255, 0.055);
+    font-size: 10px;
+    line-height: 1.5;
+    text-transform: lowercase;
+  }
+
+  .code-review-empty {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 28px 24px;
+    text-align: center;
+    color: var(--text-3, rgba(244, 246, 250, 0.58));
+  }
+
+  .code-review-empty strong {
+    color: var(--text-1, #f4f6fa);
+    font-size: 14px;
+  }
+
+  .code-review-empty p {
+    max-width: 280px;
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  .code-review-empty-orb {
+    width: 48px;
+    height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 18px;
+    color: var(--thread-accent, #57cfa0);
+    background: color-mix(in srgb, var(--thread-accent, #57cfa0) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--thread-accent, #57cfa0) 18%, transparent);
+  }
+
+  :global(:root[data-color-scheme='light']) .code-review-pane {
+    color: var(--text-1, #18212a);
+  }
+
+  :global(:root[data-color-scheme='light']) .code-review-file {
+    background: rgba(49, 63, 76, 0.045);
+    border-color: rgba(49, 63, 76, 0.08);
+  }
+
+  :global(:root[data-color-scheme='light']) .code-review-file-meta span {
+    background: rgba(49, 63, 76, 0.06);
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -49,6 +49,7 @@
     appsPane,
     vaultPane,
     cyclesPane,
+    codeReviewPane,
     empty,
   }: {
     activeTabId?: string | null;
@@ -70,6 +71,7 @@
     appsPane?: Snippet;
     vaultPane?: Snippet;
     cyclesPane?: Snippet;
+    codeReviewPane?: Snippet;
     empty?: Snippet;
   } = $props();
 
@@ -79,6 +81,7 @@
   const hasAppsPane = $derived(!!appsPane);
   const hasVaultPane = $derived(!!vaultPane);
   const hasCyclesPane = $derived(!!cyclesPane);
+  const hasCodeReviewPane = $derived(!!codeReviewPane);
   const availableTabs = $derived(
     tabs.filter((tab) => (
       tab.kind === 'browser'
@@ -93,7 +96,9 @@
                 ? hasVaultPane
                 : tab.kind === 'cycles'
                   ? hasCyclesPane
-                  : true
+                  : tab.kind === 'code-review'
+                    ? hasCodeReviewPane
+                    : true
     )),
   );
   const resolvedActiveTab = $derived(
@@ -197,6 +202,7 @@
     if (kind === 'activity') return 'activity';
     if (kind === 'vault') return 'vault';
     if (kind === 'cycles') return 'cycles';
+    if (kind === 'code-review') return 'code';
     return 'code';
   }
 
@@ -322,6 +328,10 @@
         {:else if resolvedActiveTab?.kind === 'cycles' && hasCyclesPane}
           <section class="right-dock-pane right-dock-cycles" aria-label="Cycles">
             {@render cyclesPane?.()}
+          </section>
+        {:else if resolvedActiveTab?.kind === 'code-review' && hasCodeReviewPane}
+          <section class="right-dock-pane right-dock-code-review" aria-label="Review changed files">
+            {@render codeReviewPane?.()}
           </section>
         {:else if hasEmptyState}
           <div class="right-dock-empty">

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -6,6 +6,7 @@
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import {
+    deriveCodeReviewFilesFromRuns,
     findActiveFastRun,
     hasLiveFastReply as streamHasLiveFastReply,
     isActiveRun,
@@ -66,6 +67,7 @@
   import SkillMentionOverlay from '$lib/features/composer/components/SkillMentionOverlay.svelte';
   import SlashAutocomplete from '$lib/features/composer/components/SlashAutocomplete.svelte';
   import ThreadAttachmentPreviewPane from '$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte';
+  import ThreadCodeReviewPane from '$lib/features/threads/components/ThreadCodeReviewPane.svelte';
   import ThreadStageShell, { type ThreadPeripherySignal } from '$lib/features/threads/components/ThreadStageShell.svelte';
   import ThreadUtilityContent from '$lib/features/threads/components/ThreadUtilityContent.svelte';
   import WorkspaceComposerAdapter from '$lib/features/composer/components/WorkspaceComposerAdapter.svelte';
@@ -137,6 +139,7 @@
   let lastAutoOpenedBrowserSessionId = $state<string | null>(null);
   let lastAutoOpenedVaultPromptId = $state<string | null>(null);
   let lastAutoOpenedCycleSignal = $state<number | null>(null);
+  let lastAutoOpenedCodeReviewSignature = $state<string | null>(null);
   let lastAutoSelectedAppId = $state<string | null>(null);
   let dockPreviewAttachment = $state<CortexThreadStageImageAttachment | CortexThreadStageFileAttachment | null>(null);
   let teamMembers = $state<any[]>([]);
@@ -220,6 +223,13 @@
   const activeVaultSecretPrompt = $derived(
     String(cortex.vaultSecretPrompt?.idea_id ?? '') === String(idea?.id ?? '') ? cortex.vaultSecretPrompt : null,
   );
+  const codeReviewFiles = $derived.by(() =>
+    deriveCodeReviewFilesFromRuns(
+      visibleStreamItems.filter((item: any) => item?.type === 'run'),
+    ),
+  );
+  const codeReviewSignature = $derived.by(() => codeReviewFiles.map((file) => file.path).join('|'));
+
 
   function ideaDisplayTitle(source: { display_title?: string | null; title?: string | null }): string {
     return source.display_title?.trim() || source.title?.trim() || 'Untitled thread';
@@ -822,6 +832,10 @@
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'cycles'));
   }
 
+  function openCodeReviewTab() {
+    applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'code-review'));
+  }
+
   function openPreviewTab(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment) {
     dockPreviewAttachment = attachment;
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'preview'));
@@ -868,6 +882,10 @@
     }
     if (item.kind === 'cycles') {
       openCyclesTab();
+      return;
+    }
+    if (item.kind === 'code-review') {
+      openCodeReviewTab();
       return;
     }
     if (item.kind === 'preview') {
@@ -919,6 +937,23 @@
     openCyclesTab();
   });
 
+  $effect(() => {
+    const currentIdeaId = idea?.id ?? null;
+    if (!currentIdeaId) {
+      lastAutoOpenedCodeReviewSignature = null;
+      return;
+    }
+    const signature = codeReviewSignature;
+    if (!signature) {
+      lastAutoOpenedCodeReviewSignature = null;
+      return;
+    }
+    const scopedSignature = `${currentIdeaId}:${signature}`;
+    if (scopedSignature === lastAutoOpenedCodeReviewSignature) return;
+    lastAutoOpenedCodeReviewSignature = scopedSignature;
+    openCodeReviewTab();
+  });
+
   let pendingInitialScrollIdeaId = $state<string | null>(null);
   let lastSelectedIdeaId = $state<string | null>(null);
 
@@ -945,6 +980,7 @@
       ideaProjectContextLoadedForIdeaId = null;
       ideaProjectContextLoadingForIdeaId = null;
       dockPreviewAttachment = null;
+      lastAutoOpenedCodeReviewSignature = null;
       if (currentIdeaId) void loadIdeaProjectContext(currentIdeaId);
     }
   });
@@ -1159,6 +1195,10 @@
     />
   {/snippet}
 
+  {#snippet codeReviewPane()}
+    <ThreadCodeReviewPane files={codeReviewFiles} latestRunStatus={latestRun?.status ?? null} />
+  {/snippet}
+
   {#snippet vaultPane()}
     <div class="thread-vault-surface">
       <VaultPage
@@ -1240,6 +1280,7 @@
               appsPane={appsPane}
               vaultPane={vaultPane}
               cyclesPane={cyclesPane}
+              codeReviewPane={codeReviewPane}
             />
           </div>
         {/if}

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -1,4 +1,4 @@
-export type ThreadStageRightDockTabKind = 'browser' | 'activity' | 'app' | 'vault' | 'cycles' | 'preview';
+export type ThreadStageRightDockTabKind = 'browser' | 'activity' | 'app' | 'vault' | 'cycles' | 'preview' | 'code-review';
 
 export type ThreadStageRightDockTab = {
   id: string;
@@ -49,6 +49,7 @@ export function buildThreadSidePanelAddMenuItems(
   const hasActivity = tabs.some((tab) => tab.kind === 'activity');
   const hasVault = tabs.some((tab) => tab.kind === 'vault');
   const hasCycles = tabs.some((tab) => tab.kind === 'cycles');
+  const hasCodeReview = tabs.some((tab) => tab.kind === 'code-review');
   const openAppIds = new Set(
     tabs
       .filter((tab) => tab.kind === 'app' && tab.appId)
@@ -78,6 +79,15 @@ export function buildThreadSidePanelAddMenuItems(
       kind: 'cycles',
       label: 'Cycles',
       description: 'Review scheduled Illo work',
+    });
+  }
+
+  if (!hasCodeReview) {
+    items.push({
+      id: 'code-review',
+      kind: 'code-review',
+      label: 'Review files',
+      description: 'See files Illo changed',
     });
   }
 
@@ -150,7 +160,7 @@ export function openBrowserThreadSidePanelTab(
 
 export function openSingletonThreadSidePanelTab(
   state: ThreadSidePanelTabState,
-  kind: 'activity' | 'vault' | 'cycles' | 'preview',
+  kind: 'activity' | 'vault' | 'cycles' | 'preview' | 'code-review',
 ): ThreadSidePanelTabState {
   const existing = state.tabs.find((tab) => tab.kind === kind);
   if (existing) return { ...state, activeTabId: existing.id };
@@ -161,7 +171,9 @@ export function openSingletonThreadSidePanelTab(
       ? 'Cycles'
       : kind === 'preview'
         ? 'Preview'
-        : 'Activity';
+        : kind === 'code-review'
+          ? 'Review files'
+          : 'Activity';
   return {
     ...state,
     tabs: [

--- a/frontend/src/lib/utils/cortexRunPresentation.test.js
+++ b/frontend/src/lib/utils/cortexRunPresentation.test.js
@@ -5,6 +5,8 @@ import {
   runActivitySteps,
   runWorkSummarySubtitle,
   runWorkSummaryTitle,
+  deriveCodeReviewFilesFromRun,
+  deriveCodeReviewFilesFromRuns,
   findActiveFastRun,
   hasLiveFastReply,
   shouldShowRunInTranscript,
@@ -247,4 +249,47 @@ test('terminal run snapshots settle without dropping live activity', () => {
   assert.equal(merged.status, 'completed');
   assert.deepEqual(merged.activity_trace.map((entry) => entry.activity), ['Using tool', 'Completed']);
   assert.equal(merged.work_summary.duration_sec, 32);
+});
+
+
+test('derives code review files from write and edit tool calls', () => {
+  const files = deriveCodeReviewFilesFromRun({
+    id: 42,
+    tool_calls: [
+      { tool: 'read_file', args: '{"path":"README.md"}', status: 'completed' },
+      { tool: 'write_file', args: '{"path":"src/new.ts","content":"x"}', status: 'completed' },
+      { tool: 'edit_file', args: '{"path":"src/existing.ts"}', status: 'completed' },
+    ],
+  });
+
+  assert.deepEqual(files.map((file) => file.path), ['src/existing.ts', 'src/new.ts']);
+  assert.equal(files[0].operation, 'changed');
+  assert.equal(files[1].operation, 'created or updated');
+});
+
+test('derives code review files from file artifacts and dedupes with tool calls', () => {
+  const files = deriveCodeReviewFilesFromRuns([
+    {
+      id: 7,
+      artifacts: [
+        {
+          artifact_type: 'file_observation',
+          payload: { type: 'file_observation', operation: 'read', path: 'src/read-only.ts' },
+        },
+        {
+          artifact_type: 'file',
+          created_at: '2026-05-03T22:00:00.000Z',
+          payload: { type: 'file', relative_path: 'src/changed.ts', status: 'edit' },
+        },
+      ],
+      tool_calls: [
+        { tool: 'edit_file', args: '{"path":"src/changed.ts"}', status: 'completed' },
+      ],
+    },
+  ]);
+
+  assert.equal(files.length, 1);
+  assert.equal(files[0].path, 'src/changed.ts');
+  assert.equal(files[0].source, 'artifact');
+  assert.equal(files[0].operation, 'edit');
 });

--- a/frontend/src/lib/utils/cortexRunPresentation.ts
+++ b/frontend/src/lib/utils/cortexRunPresentation.ts
@@ -227,6 +227,140 @@ export function findActiveFastRun(runInfo: any, items: any[] | undefined | null)
   return (items || []).find((item: any) => item?.type === 'run' && isActiveRun(item) && isFastRun(item)) ?? null;
 }
 
+
+export interface CodeReviewFile {
+  path: string;
+  operation?: string;
+  status?: string;
+  source: 'artifact' | 'tool_call';
+  tool?: string;
+  runId?: string | number;
+  at?: string;
+}
+
+const CODE_REVIEW_FILE_TOOLS = new Set(['write_file', 'edit_file', 'apply_patch']);
+const NON_REVIEW_FILE_OPERATIONS = new Set(['read', 'observe', 'observed', 'search', 'list', 'summary']);
+
+function normalizeReviewPath(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function normalizeReviewOperation(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function parseToolArgs(args: unknown): Record<string, any> {
+  if (!args) return {};
+  if (typeof args === 'object') return args as Record<string, any>;
+  if (typeof args !== 'string') return {};
+  const trimmed = args.trim();
+  if (!trimmedLooksLikeJson(trimmed)) return {};
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function trimmedLooksLikeJson(value: string): boolean {
+  return value.startsWith('{') && value.endsWith('}');
+}
+
+function reviewOperationForTool(tool: string): string {
+  if (tool === 'write_file') return 'created or updated';
+  if (tool === 'edit_file' || tool === 'apply_patch') return 'changed';
+  return 'changed';
+}
+
+function artifactPayload(artifact: any): Record<string, any> {
+  const payload = artifact?.payload;
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) return payload;
+  if (artifact && typeof artifact === 'object' && !Array.isArray(artifact)) return artifact;
+  return {};
+}
+
+function artifactReviewFile(artifact: any, runId: string | number | undefined): CodeReviewFile | null {
+  const payload = artifactPayload(artifact);
+  const type = String(payload.type ?? artifact?.artifact_type ?? '').trim();
+  if (type !== 'file' && type !== 'file_observation' && artifact?.artifact_type !== 'file_edit') return null;
+
+  const operation = normalizeReviewOperation(payload.operation ?? payload.status ?? artifact?.artifact_type);
+  if (operation && NON_REVIEW_FILE_OPERATIONS.has(operation)) return null;
+
+  const path = normalizeReviewPath(payload.relative_path ?? payload.path ?? artifact?.uri);
+  if (!path) return null;
+
+  return {
+    path,
+    operation: operation || 'changed',
+    status: normalizeReviewPath(payload.status ?? artifact?.visibility) || undefined,
+    source: 'artifact',
+    tool: normalizeReviewPath(payload.provenance?.operation ?? payload.provenance?.source) || undefined,
+    runId: runId ?? payload.run_id,
+    at: normalizeReviewPath(artifact?.created_at ?? payload.observed_at) || undefined,
+  };
+}
+
+function toolCallReviewFile(call: any, runId: string | number | undefined): CodeReviewFile | null {
+  const tool = normalizeReviewPath(call?.tool ?? call?.tool_name);
+  if (!CODE_REVIEW_FILE_TOOLS.has(tool)) return null;
+  const args = parseToolArgs(call?.args);
+  const path = normalizeReviewPath(args.path ?? args.file ?? args.file_path);
+  if (!path) return null;
+
+  return {
+    path,
+    operation: reviewOperationForTool(tool),
+    status: normalizeReviewPath(call?.status) || undefined,
+    source: 'tool_call',
+    tool,
+    runId,
+    at: normalizeReviewPath(call?.finished_at ?? call?.at) || undefined,
+  };
+}
+
+function reviewFileRank(source: CodeReviewFile['source']): number {
+  return source === 'artifact' ? 2 : 1;
+}
+
+export function deriveCodeReviewFilesFromRun(source: any): CodeReviewFile[] {
+  if (!source) return [];
+  const runId = source?.run_id ?? source?.id;
+  const byPath = new Map<string, CodeReviewFile>();
+
+  const add = (file: CodeReviewFile | null) => {
+    if (!file?.path) return;
+    const key = file.path;
+    const existing = byPath.get(key);
+    if (!existing || reviewFileRank(file.source) >= reviewFileRank(existing.source)) {
+      byPath.set(key, { ...existing, ...file });
+    }
+  };
+
+  for (const artifact of Array.isArray(source?.artifacts) ? source.artifacts : []) {
+    add(artifactReviewFile(artifact, runId));
+  }
+  for (const call of Array.isArray(source?.tool_calls) ? source.tool_calls : []) {
+    add(toolCallReviewFile(call, runId));
+  }
+
+  return Array.from(byPath.values()).sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function deriveCodeReviewFilesFromRuns(sources: Array<any | null | undefined>): CodeReviewFile[] {
+  const byPath = new Map<string, CodeReviewFile>();
+  for (const source of sources) {
+    for (const file of deriveCodeReviewFilesFromRun(source)) {
+      const existing = byPath.get(file.path);
+      if (!existing || reviewFileRank(file.source) >= reviewFileRank(existing.source)) {
+        byPath.set(file.path, { ...existing, ...file });
+      }
+    }
+  }
+  return Array.from(byPath.values()).sort((left, right) => left.path.localeCompare(right.path));
+}
+
 export interface AgentRunActivityStep {
   time?: string;
   label: string;


### PR DESCRIPTION
## Summary
- Add a Review files dock tab for Cortex threads
- Auto-open the review panel when Illo changes files during a run
- Derive reviewable files from persisted artifacts and file-edit tool calls
- Add unit coverage for changed-file extraction

## Validation
- Added unit tests for extraction logic
- Frontend test execution was not available in this runtime because node/npm are not installed
