### PR TITLE
Fix async DB loop and idea list loading errors

### DIFF
--- a/brain/platform/db/repositories/ideas.py
+++ b/brain/platform/db/repositories/ideas.py
@@ -40,7 +40,9 @@ IDEA_LIST_LOAD_COLUMNS = (
     Idea.archived_at,
     Idea.user_id,
     Idea.org_id,
+    Idea.active_agents,
     Idea.agent_details,
+    Idea.attachments,
 )
 
 

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 import tempfile
 import threading
 import time
-from threading import Thread
 from typing import Any
 import uuid
 
@@ -55,7 +54,7 @@ def _run_cancel_token(run_id: int):
 _stop_event = threading.Event()
 _runner_lock = threading.Lock()
 _runner_supervisor_thread: threading.Thread | None = None
-_runner_slots: list[tuple[threading.Thread, threading.Event]] = []
+_runner_slots: list[tuple[asyncio.Task[None], asyncio.Event]] = []
 _runner_thread_index = 0
 _poll_interval_sec = 0.5
 _runner_reconcile_interval_sec = 2.0
@@ -116,8 +115,9 @@ def _runner_concurrency() -> int:
     ) or _default_runner_concurrency
 
 
-def _active_runner_threads() -> list[threading.Thread]:
-    return [thread for thread, stop_event in _runner_slots if thread.is_alive() and not stop_event.is_set()]
+def _active_runner_count() -> int:
+    with _runner_lock:
+        return sum(1 for task, stop_event in _runner_slots if not task.done() and not stop_event.is_set())
 
 
 def _int_value(value: Any) -> int | None:
@@ -517,14 +517,14 @@ async def reap_stale_active_runs(
     return reaped
 
 
-def _reap_stale_runs_if_due(*, force: bool = False) -> int:
+async def _reap_stale_runs_if_due_async(*, force: bool = False) -> int:
     global _last_stale_reconcile_monotonic
     now = time.monotonic()
     if not force and now - _last_stale_reconcile_monotonic < _stale_reconcile_interval_sec:
         return 0
     _last_stale_reconcile_monotonic = now
     try:
-        return asyncio.run(reap_stale_active_runs())
+        return await reap_stale_active_runs()
     except Exception:
         logger.exception("agent_run_stale_reconcile_failed")
         return 0
@@ -664,29 +664,32 @@ def run_queued_once(*, limit: int = 1) -> int:
     return asyncio.run(_run_queued_once_async(limit=limit))
 
 
-def _loop(slot_stop_event: threading.Event | None = None) -> None:
+async def _sleep_or_stop(delay: float, slot_stop_event: asyncio.Event | None = None) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, delay)
     while not _stop_event.is_set() and not (slot_stop_event and slot_stop_event.is_set()):
-        processed = run_queued_once()
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return
+        await asyncio.sleep(min(0.1, remaining))
+
+
+async def _loop(slot_stop_event: asyncio.Event | None = None) -> None:
+    while not _stop_event.is_set() and not (slot_stop_event and slot_stop_event.is_set()):
+        processed = await _run_queued_once_async()
         if not processed:
-            if slot_stop_event:
-                if slot_stop_event.wait(_poll_interval_sec):
-                    break
-            else:
-                _stop_event.wait(_poll_interval_sec)
+            await _sleep_or_stop(_poll_interval_sec, slot_stop_event)
 
 
 def _start_runner_slot_locked() -> None:
     global _runner_thread_index
     _runner_thread_index += 1
-    slot_stop_event = threading.Event()
-    thread = Thread(
-        target=_loop,
-        args=(slot_stop_event,),
+    slot_stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        _loop(slot_stop_event),
         name=f"agent-runner-{_runner_thread_index}",
-        daemon=True,
     )
-    _runner_slots.append((thread, slot_stop_event))
-    thread.start()
+    _runner_slots.append((task, slot_stop_event))
 
 
 def reconcile_runner_pool(*, allow_start: bool = False) -> int:
@@ -697,38 +700,55 @@ def reconcile_runner_pool(*, allow_start: bool = False) -> int:
         return desired
     with _runner_lock:
         active_slots = [
-            (thread, stop_event)
-            for thread, stop_event in _runner_slots
-            if thread.is_alive() and not stop_event.is_set()
+            (task, stop_event)
+            for task, stop_event in _runner_slots
+            if not task.done() and not stop_event.is_set()
         ]
         retiring_slots = [
-            (thread, stop_event)
-            for thread, stop_event in _runner_slots
-            if thread.is_alive() and stop_event.is_set()
+            (task, stop_event)
+            for task, stop_event in _runner_slots
+            if not task.done() and stop_event.is_set()
         ]
         _runner_slots[:] = active_slots + retiring_slots
         if len(active_slots) > desired:
-            for _thread, stop_event in active_slots[desired:]:
+            for _task, stop_event in active_slots[desired:]:
                 stop_event.set()
             active_slots = active_slots[:desired]
         while len(active_slots) < desired:
             _start_runner_slot_locked()
             active_slots = [
-                (thread, stop_event)
-                for thread, stop_event in _runner_slots
-                if thread.is_alive() and not stop_event.is_set()
+                (task, stop_event)
+                for task, stop_event in _runner_slots
+                if not task.done() and not stop_event.is_set()
             ]
     return desired
 
 
+async def _supervisor_async_loop() -> None:
+    first_reconcile = True
+    try:
+        while not _stop_event.is_set():
+            try:
+                await _reap_stale_runs_if_due_async(force=first_reconcile)
+                first_reconcile = False
+                reconcile_runner_pool(allow_start=True)
+            except Exception:
+                logger.exception("agent_run_runner_reconcile_failed")
+            await _sleep_or_stop(_runner_reconcile_interval_sec)
+    finally:
+        with _runner_lock:
+            slots = list(_runner_slots)
+        for _task, stop_event in slots:
+            stop_event.set()
+        live_tasks = [task for task, _stop_event in slots if not task.done()]
+        if live_tasks:
+            await asyncio.gather(*live_tasks, return_exceptions=True)
+        with _runner_lock:
+            _runner_slots.clear()
+
+
 def _supervisor_loop() -> None:
-    while not _stop_event.is_set():
-        try:
-            _reap_stale_runs_if_due()
-            reconcile_runner_pool(allow_start=True)
-        except Exception:
-            logger.exception("agent_run_runner_reconcile_failed")
-        _stop_event.wait(_runner_reconcile_interval_sec)
+    asyncio.run(_supervisor_async_loop())
 
 
 def start_runner() -> None:
@@ -736,9 +756,8 @@ def start_runner() -> None:
     if _runner_supervisor_thread and _runner_supervisor_thread.is_alive():
         return
     _stop_event.clear()
-    _reap_stale_runs_if_due(force=True)
-    concurrency = reconcile_runner_pool(allow_start=True)
-    _runner_supervisor_thread = Thread(
+    concurrency = _runner_concurrency()
+    _runner_supervisor_thread = threading.Thread(
         target=_supervisor_loop,
         name="agent-runner-supervisor",
         daemon=True,
@@ -750,29 +769,14 @@ def start_runner() -> None:
 def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
     global _runner_supervisor_thread
     _stop_event.set()
-    with _runner_lock:
-        for _thread, stop_event in _runner_slots:
-            stop_event.set()
 
     deadline = None
     if drain_timeout_seconds is not None:
         deadline = time.monotonic() + max(0.0, float(drain_timeout_seconds))
 
-    for thread in [thread for thread, _stop in list(_runner_slots)]:
-        remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
-        if thread.is_alive():
-            thread.join(timeout=remaining)
-            if deadline is not None and time.monotonic() >= deadline:
-                break
     if _runner_supervisor_thread and _runner_supervisor_thread.is_alive():
         remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
         _runner_supervisor_thread.join(timeout=remaining)
-    with _runner_lock:
-        _runner_slots[:] = [
-            (thread, stop_event)
-            for thread, stop_event in _runner_slots
-            if thread.is_alive()
-        ]
     if not (_runner_supervisor_thread and _runner_supervisor_thread.is_alive()):
         _runner_supervisor_thread = None
 
@@ -784,10 +788,10 @@ async def queue_status_async(*, consumer_running: bool | None = None, org_id: st
             stmt = stmt.where(AgentRunRow.org_id == org_id)
         result = await uow.session.execute(stmt)
         counts = {str(status): int(count) for status, count in result.all()}
-    active_threads = _active_runner_threads()
+    active_runner_count = _active_runner_count()
     return {
-        "runner_running": bool(active_threads),
-        "runner_concurrency": len(active_threads),
+        "runner_running": bool(active_runner_count),
+        "runner_concurrency": active_runner_count,
         "runner_configured_concurrency": _runner_concurrency(),
         "event_consumer_running": consumer_running,
         "counts": counts,

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 
@@ -24,15 +25,16 @@ def test_start_runner_starts_configured_worker_pool(monkeypatch):
     entered = 0
     entered_lock = threading.Lock()
 
-    def fake_loop(_slot_stop_event=None):
+    async def fake_loop(_slot_stop_event=None):
         nonlocal entered
         with entered_lock:
             entered += 1
-        release.wait(timeout=1)
+        await asyncio.to_thread(release.wait, 1)
 
     runner.stop_runner()
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 3)
     monkeypatch.setattr(runner, "_loop", fake_loop)
+    monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
     try:
         runner.start_runner()
         for _ in range(100):
@@ -40,9 +42,7 @@ def test_start_runner_starts_configured_worker_pool(monkeypatch):
                 if entered == 3:
                     break
             time.sleep(0.01)
-        active_names = [thread.name for thread in runner._active_runner_threads()]
-        assert len(active_names) == 3
-        assert all(name.startswith("agent-runner-") for name in active_names)
+        assert runner._active_runner_count() == 3
         with entered_lock:
             assert entered == 3
     finally:
@@ -57,14 +57,15 @@ def test_stop_runner_can_drain_active_slots(monkeypatch):
     entered = threading.Event()
     finished = threading.Event()
 
-    def fake_loop(_slot_stop_event=None):
+    async def fake_loop(_slot_stop_event=None):
         entered.set()
-        release.wait(timeout=1)
+        await asyncio.to_thread(release.wait, 1)
         finished.set()
 
     runner.stop_runner()
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 1)
     monkeypatch.setattr(runner, "_loop", fake_loop)
+    monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
     try:
         runner.start_runner()
         assert entered.wait(timeout=1)
@@ -79,3 +80,35 @@ def test_stop_runner_can_drain_active_slots(monkeypatch):
     finally:
         release.set()
         runner.stop_runner()
+
+
+def test_runner_pool_uses_one_event_loop(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    loops: list[int] = []
+    release = threading.Event()
+
+    async def fake_loop(_slot_stop_event=None):
+        loops.append(id(asyncio.get_running_loop()))
+        await asyncio.to_thread(release.wait, 1)
+
+    runner.stop_runner()
+    monkeypatch.setattr(runner, "_runner_concurrency", lambda: 3)
+    monkeypatch.setattr(runner, "_loop", fake_loop)
+    monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
+    try:
+        runner.start_runner()
+        for _ in range(100):
+            if len(loops) == 3:
+                break
+            time.sleep(0.01)
+    finally:
+        release.set()
+        runner.stop_runner()
+
+    assert len(loops) == 3
+    assert len(set(loops)) == 1
+
+
+async def _noop_reap(**_kwargs):
+    return 0

--- a/tests/test_cortex_orm.py
+++ b/tests/test_cortex_orm.py
@@ -82,6 +82,15 @@ def _make_skill(**kwargs):
 
 # ── Helper tests ───────────────────────────────────────────────
 
+def test_idea_list_load_columns_cover_idea_read_response_fields():
+    from brain.platform.db.repositories.ideas import IDEA_LIST_LOAD_COLUMNS
+
+    columns = {column.key for column in IDEA_LIST_LOAD_COLUMNS}
+
+    assert "active_agents" in columns
+    assert "attachments" in columns
+
+
 class TestRowToDict:
     def test_orm_object(self):
         from brain.app.api.routers.cortex import _row_to_dict


### PR DESCRIPTION
## Summary
- include active_agents and attachments in idea list load_only columns so /api/cortex/ideas can serialize IdeaRead without async lazy loads
- run the AgentRun worker pool as async tasks on one long-lived runner event loop instead of spawning per-slot threads that repeatedly call asyncio.run()
- keep runtime DB pooling intact; the fix removes the unsafe loop topology rather than disabling pools

## Server Logs
- GET /api/cortex/ideas was 500ing with MissingGreenlet while Pydantic read active_agents/attachments
- agent-runner threads crashed with asyncpg Futures attached to a different event loop, followed by Event loop is closed during pool cleanup

## Tests
- pytest tests/test_api_cortex.py tests/test_agent_run_runner.py tests/test_db_engine.py tests/test_cortex_orm.py tests/test_async_db_boundaries.py tests/test_async_unit_of_work.py tests/test_agent_run_state_machine.py tests/test_pipeline.py -q
- pytest tests/test_chat_api_routes.py tests/test_notifications_api.py -q
- git diff --check