### PR TITLE
Fix log-backed Cortex timeline and title issues

### DIFF
--- a/brain/app/api/routers/cortex/_analytics.py
+++ b/brain/app/api/routers/cortex/_analytics.py
@@ -104,23 +104,6 @@ async def activity_timeline(idea_id: str, user: dict[str, Any] = Depends(get_cur
                 "timestamp": ts.isoformat() if isinstance(ts, datetime) else ts,
             })
 
-        details = list(idea.agent_details or [])
-        for agent in details:
-            if agent.get("started_at"):
-                events.append({
-                    "type": "agent_started",
-                    "label": f"Agent started: \"{agent.get('label', '?')}\" ({agent.get('skill', '?')})",
-                    "timestamp": agent["started_at"],
-                })
-            if agent.get("finished_at"):
-                result_snippet = (agent.get("result") or agent.get("error") or "")[:60]
-                events.append({
-                    "type": "agent_finished",
-                    "label": f"Agent {agent.get('status', 'done')}: \"{agent.get('label', '?')}\""
-                             + (f" - {result_snippet}" if result_snippet else ""),
-                    "timestamp": agent["finished_at"],
-                })
-
         stmt = (
             select(
                 AgentRunEventRow.payload,

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -430,12 +430,7 @@ def _validate_thread_project_context(project_context: dict[str, Any] | None) -> 
 def _merge_project_context_into_idea(idea: Any, project_context: dict[str, Any] | None) -> None:
     if not project_context:
         return
-    if isinstance(idea.agent_details, dict):
-        existing = dict(idea.agent_details or {})
-    else:
-        existing = {}
-        if idea.agent_details not in (None, [], {}):
-            existing["legacy_agent_details"] = copy.deepcopy(idea.agent_details)
+    existing = dict(idea.agent_details or {}) if isinstance(idea.agent_details, dict) else {}
     existing["project_context"] = project_context
     idea.agent_details = existing
 

--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -43,7 +43,7 @@ from brain.platform.db.repositories.ideas import IdeaConnectionRepository
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.async_io import ensure_dir, run_subprocess, write_bytes
 from brain.systems.cortex.title_generation import (
-    generate_display_title,
+    async_generate_display_title,
 )
 from brain.systems.cortex.upload_preview import (
     build_upload_preview,
@@ -608,7 +608,7 @@ async def generate_title(request: Request, user: dict[str, Any] = Depends(get_cu
     text_content = data.get("text", "").strip()
     if not text_content:
         raise HTTPException(status_code=400, detail="text is required")
-    title = generate_display_title(
+    title = await async_generate_display_title(
         text_content,
         user_id=user.get("id"),
         org_id=user.get("org_id"),
@@ -632,7 +632,7 @@ async def backfill_titles(user: dict[str, Any] = Depends(get_current_user)):
 
     count = 0
     for idea_id, idea_title in ideas_to_process:
-        title = generate_display_title(str(idea_title or ""), user_id=user_id, org_id=org_id)
+        title = await async_generate_display_title(str(idea_title or ""), user_id=user_id, org_id=org_id)
         if not title:
             continue
         async with UnitOfWork() as uow:

--- a/brain/systems/cortex/title_generation.py
+++ b/brain/systems/cortex/title_generation.py
@@ -1,6 +1,7 @@
 """Cortex display-title generation."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -155,6 +156,47 @@ def _generate_with_provider_title_model(
         return None
 
 
+async def _async_generate_with_provider_title_model(
+    raw_text: str,
+    *,
+    provider: str,
+    model: str,
+    user_id: str | None,
+    org_id: str | None,
+) -> str | None:
+    try:
+        from brain.platform.integrations.llm import async_resolve_llm_client
+        from brain.platform.integrations.providers import LLMRequest, get_provider
+
+        llm = await async_resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+        )
+        provider_client = get_provider(llm.provider, llm.client)
+        response = await asyncio.to_thread(
+            provider_client.create,
+            LLMRequest(
+                model=_strip_provider_prefix(model),
+                max_output_tokens=TITLE_MAX_TOKENS,
+                messages=[{"role": "user", "content": _title_generation_user_prompt(raw_text)}],
+                system=TITLE_GENERATION_SYSTEM_PROMPT,
+                reasoning_effort=TITLE_REASONING_EFFORT,
+                extra_headers=llm.build_request_headers() or None,
+                operation_type="title_generation",
+            ),
+        )
+        text_parts = [
+            block.text
+            for block in getattr(response, "content", None) or []
+            if getattr(block, "type", None) == "text" and getattr(block, "text", None)
+        ]
+        return normalize_generated_title("\n".join(text_parts))
+    except Exception as exc:
+        logger.warning("Provider title generation failed: %s", exc)
+        return None
+
+
 def generate_display_title(
     raw_text: str,
     *,
@@ -185,6 +227,46 @@ def generate_display_title(
 
     return _generate_with_provider_title_model(
         raw_text,
+        model=_provider_model_spec(provider, model),
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+
+async def async_generate_display_title(
+    raw_text: str,
+    *,
+    user_id: str | None = None,
+    org_id: str | None = None,
+) -> str | None:
+    """Async display-title generation that can resolve DB-backed provider auth."""
+    if not (raw_text or "").strip():
+        return None
+
+    try:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+        from brain.platform.providers.model_policy import async_get_model_for_tier, async_resolve_default_provider
+
+        async with UnitOfWork() as uow:
+            provider = await async_resolve_default_provider(uow.session, user_id=user_id, org_id=org_id)
+            model = await async_get_model_for_tier(
+                uow.session,
+                TITLE_MODEL_TIER,
+                provider=provider,
+                include_provider_prefix=False,
+                user_id=user_id,
+                org_id=org_id,
+            )
+    except Exception as exc:
+        logger.warning("Title model resolution failed: %s", exc)
+        return None
+
+    if is_local_title_model(model):
+        return await asyncio.to_thread(_generate_with_local_title_model, raw_text)
+
+    return await _async_generate_with_provider_title_model(
+        raw_text,
+        provider=provider,
         model=_provider_model_spec(provider, model),
         user_id=user_id,
         org_id=org_id,
@@ -291,7 +373,7 @@ async def generate_and_store_idea_display_title(
     if skipped_reason or not source_title:
         return StoredDisplayTitle(idea_id=str(idea_id), skipped_reason=skipped_reason or "empty_title")
 
-    title = generate_display_title(source_title, user_id=user_id, org_id=org_id)
+    title = await async_generate_display_title(source_title, user_id=user_id, org_id=org_id)
     if not title:
         return StoredDisplayTitle(idea_id=str(idea_id), skipped_reason="generation_failed")
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -228,6 +228,17 @@ def test_project_context_merge_into_idea_agent_details():
     assert idea.agent_details["project_context"] == snapshot
 
 
+def test_project_context_merge_drops_non_dict_agent_details():
+    from brain.app.api.routers.cortex._idea_ops import _merge_project_context_into_idea
+
+    idea = _make_idea(agent_details=[{"old": True}])
+    snapshot = {"validation_status": "client_validated", "resources": [{"path": "brain"}]}
+
+    _merge_project_context_into_idea(idea, snapshot)
+
+    assert idea.agent_details == {"project_context": snapshot}
+
+
 async def test_notify_metadata_preserves_thread_project_context():
     from brain.app.api.routers.cortex._ideas import _effective_notify_metadata
 

--- a/tests/test_cortex_orm.py
+++ b/tests/test_cortex_orm.py
@@ -303,6 +303,39 @@ class TestGenerateTitleLowTier:
         mock_get_client.return_value.generate.assert_not_called()
         mock_simple_text_completion.assert_not_called()
 
+    async def test_async_uses_configured_api_low_tier_model_with_user_context(self):
+        from brain.systems.cortex.title_generation import async_generate_display_title
+
+        fake_uow = MagicMock()
+        fake_uow.__aenter__ = AsyncMock(return_value=fake_uow)
+        fake_uow.__aexit__ = AsyncMock(return_value=False)
+        fake_uow.session = MagicMock()
+
+        with patch("brain.platform.db.repositories.unit_of_work.UnitOfWork", return_value=fake_uow), \
+             patch("brain.platform.providers.model_policy.async_resolve_default_provider", AsyncMock(return_value="openai")) as mock_resolve_default_provider, \
+             patch("brain.platform.providers.model_policy.async_get_model_for_tier", AsyncMock(return_value="gpt-5-mini")) as mock_get_model_for_tier, \
+             patch("brain.systems.cortex.title_generation._async_generate_with_provider_title_model", AsyncMock(return_value="Provider Title")) as mock_generate_with_provider, \
+             patch("brain.platform.integrations.completions.simple_text_completion") as mock_simple_text_completion:
+            assert await async_generate_display_title("some raw text", user_id="user-1", org_id="org-1") == "Provider Title"
+
+        mock_resolve_default_provider.assert_awaited_once_with(fake_uow.session, user_id="user-1", org_id="org-1")
+        mock_get_model_for_tier.assert_awaited_once_with(
+            fake_uow.session,
+            "low",
+            provider="openai",
+            include_provider_prefix=False,
+            user_id="user-1",
+            org_id="org-1",
+        )
+        mock_generate_with_provider.assert_awaited_once_with(
+            "some raw text",
+            provider="openai",
+            model="openai/gpt-5-mini",
+            user_id="user-1",
+            org_id="org-1",
+        )
+        mock_simple_text_completion.assert_not_called()
+
 
 class TestTitleRoutes:
     async def test_generate_title_threads_authenticated_user_context(self):
@@ -314,11 +347,11 @@ class TestTitleRoutes:
 
         user = {"id": "user-1", "org_id": "org-1"}
 
-        with patch("brain.app.api.routers.cortex._misc.generate_display_title", return_value="Threaded Title") as mock_generate_title:
+        with patch("brain.app.api.routers.cortex._misc.async_generate_display_title", AsyncMock(return_value="Threaded Title")) as mock_generate_title:
             result = await generate_title(FakeRequest(), user=user)
 
         assert result == {"title": "Threaded Title"}
-        mock_generate_title.assert_called_once_with(
+        mock_generate_title.assert_awaited_once_with(
             "Summarize this thought",
             user_id="user-1",
             org_id="org-1",
@@ -346,12 +379,12 @@ class TestTitleRoutes:
         update_result = MagicMock(rowcount=1)
         mock_uow_cls.side_effect = [FakeUow(list_result), FakeUow(update_result)]
 
-        with patch("brain.app.api.routers.cortex._misc.generate_display_title", return_value="Generated Title") as mock_generate_title, \
+        with patch("brain.app.api.routers.cortex._misc.async_generate_display_title", AsyncMock(return_value="Generated Title")) as mock_generate_title, \
              patch("brain.app.api.routers.cortex._misc._publish_generated_display_title") as mock_publish:
             result = await backfill_titles(user={"id": "user-1", "org_id": "org-1"})
 
         assert result == {"ok": True, "generated": 1, "total": 1}
-        mock_generate_title.assert_called_once_with(
+        mock_generate_title.assert_awaited_once_with(
             "Raw idea",
             user_id="user-1",
             org_id="org-1",
@@ -429,7 +462,7 @@ class TestStoredIdeaTitleGeneration:
         write_uow.session.execute = AsyncMock(return_value=write_result)
         mock_uow_cls.side_effect = [read_uow, write_uow]
 
-        with patch("brain.systems.cortex.title_generation.generate_display_title", return_value="Generated Title") as mock_generate:
+        with patch("brain.systems.cortex.title_generation.async_generate_display_title", AsyncMock(return_value="Generated Title")) as mock_generate:
             result = await generate_and_store_idea_display_title(
                 "idea-1",
                 raw_title="Raw idea",
@@ -439,7 +472,7 @@ class TestStoredIdeaTitleGeneration:
 
         assert result.updated is True
         assert result.title == "Generated Title"
-        mock_generate.assert_called_once_with(
+        mock_generate.assert_awaited_once_with(
             "Raw idea",
             user_id="user-1",
             org_id="org-1",
@@ -459,7 +492,7 @@ class TestStoredIdeaTitleGeneration:
         read_uow.session.get = AsyncMock(return_value=idea)
         mock_uow_cls.return_value = read_uow
 
-        with patch("brain.systems.cortex.title_generation.generate_display_title") as mock_generate:
+        with patch("brain.systems.cortex.title_generation.async_generate_display_title") as mock_generate:
             result = await generate_and_store_idea_display_title(
                 "idea-1",
                 raw_title="Raw idea",
@@ -490,7 +523,7 @@ class TestStoredIdeaTitleGeneration:
         write_uow.session.execute = AsyncMock(return_value=write_result)
         mock_uow_cls.side_effect = [read_uow, write_uow]
 
-        with patch("brain.systems.cortex.title_generation.generate_display_title", return_value="Generated Title"):
+        with patch("brain.systems.cortex.title_generation.async_generate_display_title", AsyncMock(return_value="Generated Title")):
             result = await generate_and_store_idea_display_title(
                 "idea-1",
                 raw_title="Raw idea",


### PR DESCRIPTION
## Summary
- remove the legacy `agent_details` agent-event timeline path; activity timeline now relies on run/event tables for tool and run activity
- drop non-dict `agent_details` when attaching project context instead of preserving it under a legacy compatibility key
- move async Cortex title generation paths onto async provider/model/auth resolution so DB-backed OpenAI credentials are visible

## Logs Checked
- API: recurring 500 on `/api/cortex/ideas/{id}/activity-timeline` with `AttributeError: str object has no attribute get`
- Web: matching proxied 500 for the same endpoint
- API: `Provider title generation failed: No OpenAI auth found` despite the affected idea owner resolving OpenAI auth through the async DB/vault path
- Worker, scheduler, updater, postgres: no actionable errors in the 90-minute sweep
- Restart counts: all observed containers at 0

## Root Cause
- activity timeline still had a historical `agent_details`-as-agent-list path, but current `agent_details` is a metadata object used for things like project context
- project-context merge was also preserving old non-dict `agent_details` under a compatibility key, which kept the old shape alive
- title generation was async/background work calling the sync completion resolver; after async-first DB boundaries, the sync resolver intentionally cannot do DB I/O, so it could not see user/org OpenAI credentials

## Tests
- `pytest tests/test_completions.py tests/test_cortex_orm.py tests/test_api_cortex.py tests/test_cortex_split.py tests/test_async_db_boundaries.py -q`
- `git diff --check origin/main...HEAD`
- `rg -n "legacy_agent_details" brain tests || true`