### PR TITLE
Centralize runtime boundary IO policy

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -41,7 +41,7 @@ from brain.app.api.routers.ws import ws_manager
 from brain.app.api.authorization import require_org_context
 from brain.platform.db.repositories.ideas import IdeaConnectionRepository
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.async_io import ensure_dir, run_subprocess, write_bytes
+from brain.platform.async_io import async_http_post, ensure_dir, run_subprocess, write_bytes
 from brain.systems.cortex.title_generation import (
     generate_display_title,
 )
@@ -289,12 +289,11 @@ async def gpu_server_health(user: dict[str, Any] = Depends(get_current_user)):
 @router.post("/system/gpu-server/workers/{worker_name}/restart")
 async def restart_gpu_worker(worker_name: str, user: dict[str, Any] = Depends(get_current_user)):
     """Restart a GPU server worker (embedding or llm)."""
-    import httpx
     try:
         from brain.kernel.config import GPU_SERVER_URL
         # Unload then load
-        httpx.post(f"{GPU_SERVER_URL}/models/{worker_name}/unload", timeout=15)
-        resp = httpx.post(f"{GPU_SERVER_URL}/models/{worker_name}/load", timeout=120)
+        await async_http_post(f"{GPU_SERVER_URL}/models/{worker_name}/unload", timeout=15)
+        resp = await async_http_post(f"{GPU_SERVER_URL}/models/{worker_name}/load", timeout=120)
         return resp.json()
     except Exception as e:
         return JSONResponse(status_code=503, content={"error": str(e)})

--- a/brain/app/ops/health.py
+++ b/brain/app/ops/health.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-import httpx
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.async_io import http_get
 from brain.platform.db.models.run import AgentRun
 from brain.platform.provider_health import provider_health_snapshot
 from brain.app.scheduler.daemon import async_scheduler_health_snapshot
@@ -397,7 +397,7 @@ def _embedding_health_check() -> HealthCheck:
                 DEFAULT_GPU_HEALTH_TIMEOUT_SECONDS,
             )
             url = f"{cfg.GPU_SERVER_URL.rstrip('/')}/health"
-            response = httpx.get(url, timeout=timeout_s)
+            response = http_get(url, timeout=timeout_s)
             payload = response.json()
             details.update({
                 "gpu_server_url": cfg.GPU_SERVER_URL,

--- a/brain/app/web/research.py
+++ b/brain/app/web/research.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
 
-from brain.platform.async_io import run_blocking
+from brain.platform.async_io import async_http_client, run_blocking
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def _assert_safe_url(url: str) -> str:
 
 
 def _http_client() -> httpx.AsyncClient:
-    return httpx.AsyncClient(
+    return async_http_client(
         timeout=httpx.Timeout(_DEFAULT_TIMEOUT, connect=_DEFAULT_TIMEOUT),
         headers={
             "User-Agent": "illo-brain/1.0",

--- a/brain/jobs/pipelines/curiosity.py
+++ b/brain/jobs/pipelines/curiosity.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".
 
 from brain.kernel import config
 from brain.platform.async_io import (
+    async_http_client,
     ensure_dir,
     run_subprocess,
     write_text as write_text_async,
@@ -196,7 +197,7 @@ def pick_source(state):
 async def async_fetch_content(url):
     """Fetch and extract readable content from a URL."""
     try:
-        async with httpx.AsyncClient(
+        async with async_http_client(
             follow_redirects=True,
             headers={"User-Agent": "Mozilla/5.0"},
             timeout=45.0,

--- a/brain/platform/async_io.py
+++ b/brain/platform/async_io.py
@@ -8,6 +8,8 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, TypeVar
 
+import httpx
+
 T = TypeVar("T")
 
 
@@ -92,3 +94,61 @@ async def check_output(
 
 async def popen(args: Sequence[str | Path], **kwargs: Any) -> subprocess.Popen[Any]:
     return await run_blocking(subprocess.Popen, args, **kwargs)
+
+
+def run_subprocess_sync(
+    args: Sequence[str | Path],
+    *,
+    timeout: float | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[Any]:
+    return subprocess.run(args, timeout=timeout, **kwargs)
+
+
+def check_output_sync(
+    args: Sequence[str | Path],
+    *,
+    timeout: float | None = None,
+    **kwargs: Any,
+) -> bytes | str:
+    return subprocess.check_output(args, timeout=timeout, **kwargs)
+
+
+def popen_sync(args: Sequence[str | Path], **kwargs: Any) -> subprocess.Popen[Any]:
+    return subprocess.Popen(args, **kwargs)
+
+
+def sync_http_client(**kwargs: Any) -> httpx.Client:
+    return httpx.Client(**kwargs)
+
+
+def async_http_client(**kwargs: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(**kwargs)
+
+
+def http_get(url: str, *, timeout: float | httpx.Timeout | None = None, **kwargs: Any) -> httpx.Response:
+    return httpx.get(url, timeout=timeout, **kwargs)
+
+
+def http_post(url: str, *, timeout: float | httpx.Timeout | None = None, **kwargs: Any) -> httpx.Response:
+    return httpx.post(url, timeout=timeout, **kwargs)
+
+
+async def async_http_get(
+    url: str,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    **kwargs: Any,
+) -> httpx.Response:
+    async with async_http_client(timeout=timeout) as client:
+        return await client.get(url, **kwargs)
+
+
+async def async_http_post(
+    url: str,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    **kwargs: Any,
+) -> httpx.Response:
+    async with async_http_client(timeout=timeout) as client:
+        return await client.post(url, **kwargs)

--- a/brain/platform/browser/service.py
+++ b/brain/platform/browser/service.py
@@ -28,7 +28,7 @@ from brain.kernel.common.time import utcnow as _shared_utcnow
 from brain.systems.cortex.events import publish_safe
 from brain.systems.cortex.resources.telemetry import build_browser_resource_summary
 from brain.systems.cortex.upload_preview import public_static_upload_url, static_upload_url_for
-from brain.platform.async_io import copy_file, ensure_dir, glob_paths, iter_dir, path_exists, path_is_file, path_stat
+from brain.platform.async_io import async_http_client, copy_file, ensure_dir, glob_paths, iter_dir, path_exists, path_is_file, path_stat
 from brain.platform.db.models.browser import BrowserSession
 from brain.platform.db.models.idea import Idea, VisualBlock
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -1140,7 +1140,7 @@ result = {"image": base64.b64encode(data).decode("ascii"), "info": page_info()}
         deadline = asyncio.get_running_loop().time() + 20
         last_error: Exception | None = None
         timeout = httpx.Timeout(1.0, connect=1.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with async_http_client(timeout=timeout) as client:
             while asyncio.get_running_loop().time() < deadline:
                 if self._chrome_process and self._chrome_process.returncode is not None:
                     stderr = ""

--- a/brain/platform/gpu/server.py
+++ b/brain/platform/gpu/server.py
@@ -16,6 +16,7 @@ import httpx
 from brain.platform.gpu.config import ServerConfig, build_worker_manifests
 from brain.platform.gpu.vram import VRAMBookkeeper, query_gpu_total_mb
 from brain.platform.gpu.worker_manager import WorkerManager, FAILED_RECOVERY_INTERVAL, _backoff_seconds
+from brain.platform.async_io import sync_http_client
 
 logger = logging.getLogger("brain.platform.gpu")
 
@@ -133,7 +134,7 @@ class GPUServer:
         sock_path = w["socket_path"]
         try:
             transport = httpx.HTTPTransport(uds=sock_path)
-            with httpx.Client(transport=transport, timeout=timeout) as client:
+            with sync_http_client(transport=transport, timeout=timeout) as client:
                 resp = client.post(
                     "http://localhost/infer",
                     content=data,

--- a/brain/platform/gpu/vram.py
+++ b/brain/platform/gpu/vram.py
@@ -3,12 +3,14 @@
 import logging
 import subprocess
 
+from brain.platform.async_io import run_subprocess_sync
+
 logger = logging.getLogger("brain.platform.gpu.vram")
 
 
 def query_gpu_total_mb() -> int | None:
     try:
-        result = subprocess.run(
+        result = run_subprocess_sync(
             ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
             capture_output=True, text=True, timeout=5,
         )
@@ -21,7 +23,7 @@ def query_gpu_total_mb() -> int | None:
 
 def query_gpu_used_mb() -> int | None:
     try:
-        result = subprocess.run(
+        result = run_subprocess_sync(
             ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
             capture_output=True, text=True, timeout=5,
         )

--- a/brain/platform/gpu/worker_manager.py
+++ b/brain/platform/gpu/worker_manager.py
@@ -8,6 +8,7 @@ import sys
 import time
 from pathlib import Path
 
+from brain.platform.async_io import popen_sync, run_subprocess_sync
 from brain.platform.gpu.config import WorkerManifest
 from brain.platform.gpu.vram import VRAMBookkeeper
 
@@ -220,7 +221,7 @@ class WorkerManager:
             log_path = os.path.join(log_dir, f"gpu_worker_{name}.log")
             log_file = open(log_path, "a")
 
-            popen = subprocess.Popen(
+            popen = popen_sync(
                 [sys.executable, "-m", manifest.worker_module,
                  "--name", manifest.name,
                  "--model-path", manifest.model_path,
@@ -338,7 +339,7 @@ class WorkerManager:
     def _find_matching_worker_pids(self, w: dict) -> list[int]:
         """Find worker processes by module name and socket path."""
         try:
-            result = subprocess.run(
+            result = run_subprocess_sync(
                 ["ps", "-axo", "pid=,command="],
                 capture_output=True,
                 text=True,
@@ -370,7 +371,7 @@ class WorkerManager:
     def _find_conflicting_gpu_processes(self) -> list[tuple[int, str]]:
         """Find known model-serving processes outside this manager."""
         try:
-            result = subprocess.run(
+            result = run_subprocess_sync(
                 ["ps", "-axo", "pid=,command="],
                 capture_output=True,
                 text=True,

--- a/brain/platform/gpu_client.py
+++ b/brain/platform/gpu_client.py
@@ -10,6 +10,8 @@ import logging
 import httpx
 import numpy as np
 
+from brain.platform.async_io import sync_http_client
+
 logger = logging.getLogger("brain.platform.gpu_client")
 
 _GPU_SERVER_URL = os.environ.get("GPU_SERVER_URL", "http://127.0.0.1:9800")
@@ -20,7 +22,7 @@ class GPUClient:
 
     def __init__(self, base_url: str = _GPU_SERVER_URL):
         self.base_url = base_url
-        self._session = httpx.Client(
+        self._session = sync_http_client(
             base_url=base_url,
             timeout=60.0,
             headers={"Content-Type": "application/json"},

--- a/brain/platform/integrations/openai_codex_auth.py
+++ b/brain/platform/integrations/openai_codex_auth.py
@@ -32,6 +32,8 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 
+from brain.platform.async_io import http_post
+
 _AUTH_FILENAME = "auth.json"
 _DEFAULT_CLI_HOME = ".codex"
 _DEFAULT_OAUTH_ISSUER = "https://auth.openai.com"
@@ -259,7 +261,7 @@ def refresh_codex_access_token(
     """
 
     token_url = f"{issuer.rstrip('/')}/oauth/token"
-    response = httpx.post(
+    response = http_post(
         token_url,
         json={
             "grant_type": "refresh_token",
@@ -385,7 +387,7 @@ def exchange_codex_authorization_code(
         raise ValueError("Missing PKCE code verifier")
 
     token_url = f"{issuer.rstrip('/')}/oauth/token"
-    response = httpx.post(
+    response = http_post(
         token_url,
         json={
             "grant_type": "authorization_code",

--- a/brain/platform/integrations/openai_codex_client.py
+++ b/brain/platform/integrations/openai_codex_client.py
@@ -9,6 +9,8 @@ from typing import Any, Iterator
 
 import httpx
 
+from brain.platform.async_io import sync_http_client
+
 from brain.platform.integrations.openai_cache import normalize_openai_request_kwargs
 
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
@@ -197,7 +199,7 @@ class OpenAICodexClient:
             or os.environ.get("OPENAI_CODEX_BASE_URL")
             or DEFAULT_CODEX_BASE_URL
         ).rstrip("/")
-        self._client = httpx.Client(
+        self._client = sync_http_client(
             base_url=resolved_base_url,
             timeout=timeout,
             headers={

--- a/brain/systems/auth/claude_oauth.py
+++ b/brain/systems/auth/claude_oauth.py
@@ -18,7 +18,7 @@ import threading
 import time
 from pathlib import Path
 
-import httpx
+from brain.platform.async_io import http_post, run_subprocess_sync
 
 logger = logging.getLogger("brain.systems.auth")
 
@@ -58,7 +58,7 @@ def _read_keychain_credentials() -> dict | None:
     if platform.system() != "Darwin":
         return None
     try:
-        result = subprocess.run(
+        result = run_subprocess_sync(
             ["security", "find-generic-password",
              "-s", "Claude Code-credentials", "-w"],
             capture_output=True, text=True, timeout=5,
@@ -121,7 +121,7 @@ def _parse_oauth(data: dict) -> dict | None:
 
 def _refresh_token(refresh_token: str) -> dict:
     """Refresh an expired OAuth token via Anthropic's token endpoint."""
-    resp = httpx.post(
+    resp = http_post(
         _TOKEN_URL,
         json={
             "grant_type": "refresh_token",
@@ -148,7 +148,7 @@ def _save_oauth_credentials(creds: dict) -> None:
     # Try macOS keychain first
     if platform.system() == "Darwin":
         try:
-            result = subprocess.run(
+            result = run_subprocess_sync(
                 ["security", "find-generic-password",
                  "-s", "Claude Code-credentials", "-w"],
                 capture_output=True, text=True, timeout=5,
@@ -160,7 +160,7 @@ def _save_oauth_credentials(creds: dict) -> None:
                 oauth["refreshToken"] = creds["refresh"]
                 oauth["expiresAt"] = creds["expires"]
                 data["claudeAiOauth"] = oauth
-                subprocess.run(
+                run_subprocess_sync(
                     ["security", "add-generic-password", "-U",
                      "-s", "Claude Code-credentials",
                      "-a", "Claude Code",

--- a/brain/systems/cognition/dag_compaction.py
+++ b/brain/systems/cognition/dag_compaction.py
@@ -17,8 +17,9 @@ import json
 import logging
 import os
 import re
-import urllib.request
 from typing import Sequence
+
+from brain.platform.async_io import http_post
 
 logger = logging.getLogger(__name__)
 
@@ -338,22 +339,23 @@ def _call_model(prompt: str, model: str, *, user_id: str | None = None) -> str |
 def _call_ollama(prompt: str, model: str) -> str | None:
     """Call Ollama for compression."""
     try:
-        payload = json.dumps({
+        payload = {
             "model": model,
             "prompt": prompt,
             "stream": False,
             "options": {"temperature": 0.2, "num_predict": 600},
             "think": False,
             "keep_alive": "5m",
-        })
-        req = urllib.request.Request(
+        }
+        resp = http_post(
             f"{OLLAMA_URL}/api/generate",
-            data=payload.encode(),
+            json=payload,
             headers={"Content-Type": "application/json"},
+            timeout=30,
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            result = json.loads(resp.read())
-            return result.get("response", "").strip() or None
+        resp.raise_for_status()
+        result = resp.json()
+        return result.get("response", "").strip() or None
     except Exception as e:
         logger.warning("Ollama compaction call failed: %s", e)
         return None

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import httpx
 
+from brain.platform.async_io import async_http_client, sync_http_client
+
 
 GITHUB_API_BASE = "https://api.github.com"
 GITHUB_REPO_PAGE_LIMIT = 10
@@ -124,7 +126,7 @@ def _merge_repos(*groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def connect_with_token(token: str) -> dict[str, Any]:
-    with httpx.Client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    with sync_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         user = _request(client, "GET", "/user", token=token)
         repos: list[dict[str, Any]] = []
         for page in range(1, GITHUB_REPO_PAGE_LIMIT + 1):
@@ -152,7 +154,7 @@ def connect_with_token(token: str) -> dict[str, Any]:
 
 
 async def async_connect_with_token(token: str) -> dict[str, Any]:
-    async with httpx.AsyncClient(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         user = await _async_request(client, "GET", "/user", token=token)
         repos: list[dict[str, Any]] = []
         for page in range(1, GITHUB_REPO_PAGE_LIMIT + 1):
@@ -181,7 +183,7 @@ async def async_connect_with_token(token: str) -> dict[str, Any]:
 
 def get_repo_by_slug(slug: str, *, token: str | None = None) -> dict[str, Any] | None:
     owner, repo = slug.split("/", 1)
-    with httpx.Client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    with sync_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         try:
             payload = _request(
                 client,
@@ -198,7 +200,7 @@ def get_repo_by_slug(slug: str, *, token: str | None = None) -> dict[str, Any] |
 
 async def async_get_repo_by_slug(slug: str, *, token: str | None = None) -> dict[str, Any] | None:
     owner, repo = slug.split("/", 1)
-    async with httpx.AsyncClient(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         try:
             payload = await _async_request(
                 client,
@@ -234,7 +236,7 @@ def search_repos(query: str, *, token: str | None = None) -> dict[str, Any]:
             raise first_error
         return {"repos": [], "matched_exact": True}
 
-    with httpx.Client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    with sync_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         groups: list[list[dict[str, Any]]] = []
         errors: list[GitHubConnectorError] = []
         for token_candidate in ([token, None] if token else [None]):
@@ -277,7 +279,7 @@ async def async_search_repos(query: str, *, token: str | None = None) -> dict[st
             raise first_error
         return {"repos": [], "matched_exact": True}
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         groups: list[list[dict[str, Any]]] = []
         errors: list[GitHubConnectorError] = []
         for token_candidate in ([token, None] if token else [None]):

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -11,11 +11,12 @@ import subprocess
 import tempfile
 from typing import Any
 
+from brain.platform.async_io import check_output_sync, run_subprocess_sync
+from brain.platform.db.models.run import AgentRun
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.cortex.project_context.permissions import derive_project_permission_scope
 from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
-from brain.platform.db.models.run import AgentRun
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.vault import get_secret, list_secrets
 
 
@@ -187,7 +188,7 @@ def _safe_repo_destination(root: Path, slug: str) -> Path:
 
 def _git_output(cwd: Path, *args: str) -> str | None:
     try:
-        return subprocess.check_output(
+        return check_output_sync(
             ["git", *args],
             cwd=str(cwd),
             text=True,
@@ -286,7 +287,7 @@ def _clone_github_repo(
             command.extend([f"https://github.com/{slug}.git", str(destination)])
             if destination.exists():
                 shutil.rmtree(destination, ignore_errors=True)
-            proc = subprocess.run(
+            proc = run_subprocess_sync(
                 command,
                 capture_output=True,
                 text=True,

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -15,6 +15,7 @@ import subprocess
 from urllib.parse import urlsplit, urlunsplit
 from typing import Any
 
+from brain.platform.async_io import check_output_sync
 from brain.systems.cortex.project_context.permissions import (
     derive_project_permission_scope,
     normalize_project_path,
@@ -60,7 +61,7 @@ def _redact_remote(remote: str | None) -> str | None:
 
 def _run_git(path: str, *args: str) -> str | None:
     try:
-        return subprocess.check_output(
+        return check_output_sync(
             ["git", *args],
             cwd=path,
             text=True,

--- a/brain/systems/cortex/reply.py
+++ b/brain/systems/cortex/reply.py
@@ -16,6 +16,8 @@ import sys
 
 import httpx
 
+from brain.platform.async_io import http_post
+
 DASHBOARD_URL = os.environ.get("ILLO_DASHBOARD_URL", "http://127.0.0.1:8000")
 
 
@@ -51,7 +53,7 @@ def reply_to_cortex(idea_id: str, content: str, attachments: list | None = None,
         payload["metadata"] = metadata
     headers = _auth_headers()
     try:
-        resp = httpx.post(url, json=payload, headers=headers, timeout=15)
+        resp = http_post(url, json=payload, headers=headers, timeout=15)
         resp.raise_for_status()
         return resp.json()
     except httpx.HTTPError as e:

--- a/brain/systems/cortex/resources/pools.py
+++ b/brain/systems/cortex/resources/pools.py
@@ -27,7 +27,7 @@ from brain.systems.cortex.resources.telemetry import (
 )
 from brain.platform.db.models.resource_pool import BrowserPoolEntry, WorkspacePoolEntry
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.async_io import remove_tree
+from brain.platform.async_io import remove_tree, run_subprocess_sync
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ def _probe_workspace_clone_support(probe_root: str) -> bool:
             (source / "nested").mkdir()
             (source / "nested" / "payload.txt").write_text("probe\n")
             target = Path(tmpdir) / "target"
-            result = subprocess.run(
+            result = run_subprocess_sync(
                 [*command, f"{source}/.", str(target)],
                 capture_output=True,
                 text=True,
@@ -556,7 +556,7 @@ class ResourcePoolManager:
             return False, "workspace pool key mismatch"
 
         try:
-            status = subprocess.run(
+            status = run_subprocess_sync(
                 ["git", "status", "--porcelain"],
                 cwd=str(base_path),
                 capture_output=True,
@@ -567,7 +567,7 @@ class ResourcePoolManager:
                 return False, f"workspace pool entry validation failed: {status.stderr.strip() or status.stdout.strip()}"
             if status.stdout.strip():
                 return False, "workspace pool entry is dirty"
-            head = subprocess.run(
+            head = run_subprocess_sync(
                 ["git", "rev-parse", "HEAD"],
                 cwd=str(base_path),
                 capture_output=True,
@@ -598,7 +598,7 @@ class ResourcePoolManager:
             mode = "copy"
         if mode in _WORKSPACE_ADVANCED_MODES:
             clone_command = ["cp", "-cR"] if platform.system() == "Darwin" else ["cp", "--reflink=always", "-R"]
-            result = subprocess.run(
+            result = run_subprocess_sync(
                 [*clone_command, f"{source}/.", str(target_path)],
                 capture_output=True,
                 text=True,

--- a/brain/systems/cortex/restarter.py
+++ b/brain/systems/cortex/restarter.py
@@ -16,6 +16,8 @@ import logging
 import subprocess
 import sys
 
+from brain.platform.async_io import run_subprocess_sync
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,7 +31,7 @@ def restart_dashboard() -> bool:
         True if restart succeeded, False otherwise.
     """
     try:
-        subprocess.run(
+        run_subprocess_sync(
             ["systemctl", "--user", "restart", "illo-dashboard"],
             check=True,
             capture_output=True,

--- a/brain/systems/memory/embeddings.py
+++ b/brain/systems/memory/embeddings.py
@@ -16,6 +16,8 @@ import time
 
 import numpy as np
 
+from brain.platform.async_io import http_post
+
 logger = logging.getLogger("brain.systems.memory.embeddings")
 
 # ---------------------------------------------------------------------------
@@ -221,7 +223,6 @@ def _prepare_gemini_text(text: str, mode: str, model: str) -> str:
 
 
 def _embed_api_gemini(texts: list[str], mode: str, runtime_config=None) -> np.ndarray:
-    import httpx
     runtime = _runtime_embedding_config(runtime_config)
     api_key = runtime.api_key
     embedding_dim = runtime.dimensions
@@ -244,7 +245,7 @@ def _embed_api_gemini(texts: list[str], mode: str, runtime_config=None) -> np.nd
         }
         if model != "gemini-embedding-2":
             payload["taskType"] = task_type
-        resp = httpx.post(
+        resp = http_post(
             url,
             headers={
                 "Content-Type": "application/json",
@@ -265,7 +266,6 @@ def _embed_api_gemini(texts: list[str], mode: str, runtime_config=None) -> np.nd
 
 
 def _embed_api_openai(texts: list[str], mode: str, runtime_config=None) -> np.ndarray:
-    import httpx
     runtime = _runtime_embedding_config(runtime_config)
 
     api_key = runtime.api_key or ""
@@ -276,7 +276,7 @@ def _embed_api_openai(texts: list[str], mode: str, runtime_config=None) -> np.nd
         )
 
     model = runtime.api_model or "text-embedding-3-small"
-    resp = httpx.post(
+    resp = http_post(
         "https://api.openai.com/v1/embeddings",
         headers={
             "Content-Type": "application/json",

--- a/brain/systems/memory/harvest.py
+++ b/brain/systems/memory/harvest.py
@@ -17,10 +17,10 @@ import logging
 import os
 import re
 from typing import Any, Literal
-import urllib.request
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
+from brain.platform.async_io import http_post
 from brain.platform.integrations.llm import resolve_llm_client
 from brain.platform.integrations.providers import LLMRequest, get_provider
 from brain.platform.providers.model_policy import infer_provider_from_model, resolve_default_provider
@@ -371,7 +371,7 @@ def _normalize_model_name(model: str) -> str:
 def _call_ollama(prompt: str, model: str) -> str | None:
     """Call Ollama using its schema-format hint when supported."""
     try:
-        payload = json.dumps({
+        payload = {
             "model": model,
             "prompt": f"{HARVEST_SYSTEM_PROMPT}\n\n{prompt}",
             "stream": False,
@@ -379,15 +379,16 @@ def _call_ollama(prompt: str, model: str) -> str | None:
             "options": {"temperature": 0.0, "num_predict": 1200},
             "think": False,
             "keep_alive": "5m",
-        })
-        req = urllib.request.Request(
+        }
+        resp = http_post(
             f"{OLLAMA_URL}/api/generate",
-            data=payload.encode(),
+            json=payload,
             headers={"Content-Type": "application/json"},
+            timeout=30,
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            result = json.loads(resp.read())
-            return str(result.get("response", "")).strip() or None
+        resp.raise_for_status()
+        result = resp.json()
+        return str(result.get("response", "")).strip() or None
     except Exception as e:
         logger.warning("Ollama harvest call failed: %s", e)
         return None

--- a/brain/systems/memory/repo_summary.py
+++ b/brain/systems/memory/repo_summary.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from brain.platform.async_io import run_subprocess_sync
 from brain.systems.memory.source_freshness import evaluate_source_freshness
 
 SUMMARY_SCHEMA_VERSION = "repo-summary/v1"
@@ -844,7 +845,7 @@ def _git_head(repo_root: Path) -> str | None:
 
 def _run_git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(
+        return run_subprocess_sync(
             ["git", "-C", str(repo_root), *args],
             check=False,
             stdout=subprocess.PIPE,

--- a/brain/systems/memory/source_freshness.py
+++ b/brain/systems/memory/source_freshness.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Literal, Mapping, Sequence
 
+from brain.platform.async_io import run_subprocess_sync
+
 FreshnessStatus = Literal["fresh", "possibly_stale", "stale", "unknown"]
 
 _SOURCE_FIELD_NAMES = (
@@ -583,7 +585,7 @@ def _git_path_changed_since(repo_root: Path, commit_ref: str, rel_path: str) -> 
 
 def _run_git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(
+        return run_subprocess_sync(
             ["git", "-C", str(repo_root), *args],
             check=False,
             stdout=subprocess.PIPE,

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -742,7 +742,23 @@ async def _supervisor_async_loop() -> None:
             stop_event.set()
         live_tasks = [task for task, _stop_event in slots if not task.done()]
         if live_tasks:
-            await asyncio.gather(*live_tasks, return_exceptions=True)
+            done, pending = await asyncio.wait(
+                live_tasks,
+                timeout=max(1.0, _runner_reconcile_interval_sec),
+            )
+            for task in pending:
+                task.cancel()
+            if pending:
+                cancelled, still_pending = await asyncio.wait(pending, timeout=1.0)
+                for task in still_pending:
+                    logger.warning(
+                        "agent_run_runner_slot_shutdown_timeout",
+                        extra={"task": task.get_name()},
+                    )
+                done.update(cancelled)
+            for task in done:
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
         with _runner_lock:
             _runner_slots.clear()
 

--- a/brain/systems/runs/predict_rlm_backend.py
+++ b/brain/systems/runs/predict_rlm_backend.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.async_io import run_blocking
 from brain.systems.runs.events import async_record_tool_call
 from brain.platform.db.models.org import Org, User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -823,7 +824,7 @@ def _build_openai_illo_dspy_lm(
             messages: list[dict[str, Any]] | None = None,
             **kwargs: Any,
         ):
-            return await asyncio.to_thread(
+            return await run_blocking(
                 self.forward,
                 prompt,
                 messages,
@@ -911,7 +912,7 @@ def _make_async_tool_wrapper(
 
     async def _run(**kwargs):
         try:
-            result = await asyncio.to_thread(
+            result = await run_blocking(
                 _invoke_tool_handler,
                 handler,
                 kwargs,

--- a/brain/systems/runs/recipes/threaded_invocation.py
+++ b/brain/systems/runs/recipes/threaded_invocation.py
@@ -6,6 +6,8 @@ import asyncio
 import inspect
 from typing import Any
 
+from brain.platform.async_io import run_blocking
+
 
 def sync_on_loop(loop: asyncio.AbstractEventLoop, async_fn):
     def _call(*args, **kwargs):
@@ -29,7 +31,7 @@ def thread_sync_tool_handlers(loop: asyncio.AbstractEventLoop, handlers: dict[st
 
 
 async def invoke_direct_agent_threaded(invoke_direct_agent, spec):
-    result = await asyncio.to_thread(invoke_direct_agent, spec)
+    result = await run_blocking(invoke_direct_agent, spec)
     if inspect.isawaitable(result):
         result = await result
     return result

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -8,6 +8,7 @@ from brain.systems.runs.project_execution_env import (
     prepare_project_execution_env as _prepare_project_execution_env,
     redact_sensitive_output as _redact_sensitive_output,
 )
+from brain.platform.async_io import run_subprocess_sync
 
 
 def _resolve_path(path: str, working_dir: str | None = None) -> str:
@@ -78,7 +79,7 @@ def _handle_exec_command(
 
     try:
         if needs_shell:
-            proc = subprocess.run(
+            proc = run_subprocess_sync(
                 command,
                 shell=True,
                 capture_output=True,
@@ -88,7 +89,7 @@ def _handle_exec_command(
                 env=project_execution.env,
             )
         else:
-            proc = subprocess.run(
+            proc = run_subprocess_sync(
                 _shlex.split(command),
                 capture_output=True,
                 text=True,
@@ -146,7 +147,7 @@ def _handle_run_script(script: str, description: str | None = None, timeout: int
             script_path = f.name
 
         try:
-            proc = subprocess.run(
+            proc = run_subprocess_sync(
                 [sys.executable, script_path],
                 capture_output=True,
                 text=True,
@@ -504,7 +505,7 @@ def _handle_search_files(pattern: str, path: str | None = None, glob: str | None
     cmd = ["grep", "-rn", "--include", glob or "*", "-E", pattern, search_path]
 
     try:
-        proc = subprocess.run(
+        proc = run_subprocess_sync(
             cmd, capture_output=True, text=True, timeout=30,
         )
         output = proc.stdout[:_MAX_RESULT_CHARS]

--- a/brain/systems/runtime_settings/memory.py
+++ b/brain/systems/runtime_settings/memory.py
@@ -7,12 +7,12 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 from fastapi import HTTPException
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel import config as cfg
+from brain.platform.async_io import http_post
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import VaultConfig
 
@@ -291,9 +291,9 @@ def _sync_gpu_embedding_worker(backend: str) -> None:
     unload_url = f"{cfg.GPU_SERVER_URL}/models/embedding/unload"
     load_url = f"{cfg.GPU_SERVER_URL}/models/embedding/load"
     try:
-        httpx.post(unload_url, timeout=15)
+        http_post(unload_url, timeout=15)
         if backend == "gpu":
-            httpx.post(load_url, timeout=120)
+            http_post(load_url, timeout=120)
     except Exception as exc:  # pragma: no cover - worker may not be running locally.
         logger.info("Could not sync embedding worker after settings update: %s", exc)
 

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -31,6 +31,7 @@ from brain.systems.runs.project_execution_env import (
     prepare_project_execution_env,
     redact_sensitive_output,
 )
+from brain.platform.async_io import run_subprocess_sync
 
 logger = logging.getLogger("agent.tools")
 
@@ -335,7 +336,7 @@ def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None
         logger.debug(f"Semantic code search fell back to grep: {e}")
         # Fallback: simple grep
         try:
-            proc = subprocess.run(
+            proc = run_subprocess_sync(
                 ["grep", "-rn", "--include=*.py", "-l", query.split()[0], workspace_root or WORKSPACE_ROOT],
                 capture_output=True, text=True, timeout=10,
             )
@@ -538,7 +539,7 @@ def handle_test_runner(target: str, pattern: str | None = None, verbose: bool = 
     project_execution = prepare_project_execution_env()
 
     try:
-        proc = subprocess.run(
+        proc = run_subprocess_sync(
             cmd, capture_output=True, text=True,
             timeout=120, cwd=workspace_root or WORKSPACE_ROOT,
             env=project_execution.env,
@@ -636,7 +637,7 @@ def handle_project_context(path: str | None = None, workspace_root: str | None =
 
     # Recent git changes
     try:
-        proc = subprocess.run(
+        proc = run_subprocess_sync(
             ["git", "log", "--oneline", "-5"],
             capture_output=True, text=True, timeout=5, cwd=str(root),
         )

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from brain.platform.async_io import async_http_client
 from brain.systems.workspace_apps.actions import (
     WorkspaceAppActionContext,
     WorkspaceAppActionContractError,
@@ -88,7 +89,10 @@ async def _request_json(
     await _apply_auth(headers, spec.get("auth"), context=context, payload=payload)
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=5.0), follow_redirects=False) as client:
+        async with async_http_client(
+            timeout=httpx.Timeout(20.0, connect=5.0),
+            follow_redirects=False,
+        ) as client:
             response = await client.request(
                 method,
                 url,

--- a/scripts/async_io_debt_metrics.py
+++ b/scripts/async_io_debt_metrics.py
@@ -97,6 +97,7 @@ ISOLATION_BOUNDARIES = {
 }
 OUTER_RUNNER_FUNCTIONS = {
     "_heartbeat_run_once",
+    "_supervisor_loop",
     "cli",
     "_mark_run_failed_after_runner_error",
     "_materialize_project_context",

--- a/scripts/runtime_boundary_metrics.py
+++ b/scripts/runtime_boundary_metrics.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Measure runtime-boundary policy drift for async-first production paths.
+
+This is a maintenance metric, not the async debt gate. The async debt metric
+answers "can this block the event loop?" This metric answers "is production
+I/O flowing through named runtime policies instead of bespoke call sites?"
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter
+from dataclasses import dataclass
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ASYNC_IO_METRICS_PATH = ROOT / "scripts" / "async_io_debt_metrics.py"
+DEFAULT_ROOTS = ("brain",)
+
+HTTP_METHODS = {"delete", "get", "head", "options", "patch", "post", "put", "request", "stream"}
+SUBPROCESS_METHODS = {
+    "call",
+    "check_call",
+    "check_output",
+    "getoutput",
+    "getstatusoutput",
+    "Popen",
+    "run",
+}
+RAW_BLOCKING_BOUNDARIES = {
+    "asyncio.to_thread",
+    "anyio.to_thread.run_sync",
+    "starlette.concurrency.run_in_threadpool",
+}
+RUNTIME_BOUNDARY_PREFIX = "brain.platform.async_io."
+RUNTIME_BOUNDARY_MODULES = {
+    "brain/platform/async_io.py",
+}
+INFORMATIONAL_CATEGORIES = {
+    "named_runtime_boundary_refs",
+}
+
+
+@dataclass(frozen=True)
+class Match:
+    path: str
+    line_number: int
+    category: str
+    scope: str
+    in_async_function: bool
+    has_timeout: bool
+    line: str
+
+
+def _load_async_io_metrics():
+    spec = importlib.util.spec_from_file_location("async_io_debt_metrics", ASYNC_IO_METRICS_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_async_io_metrics = _load_async_io_metrics()
+
+
+def _line(lines: list[str], node: ast.AST) -> str:
+    return lines[node.lineno - 1].strip()
+
+
+def _aliases(tree: ast.Module) -> dict[str, str]:
+    return _async_io_metrics._aliases(tree)
+
+
+def _call_name(node: ast.Call, aliases: dict[str, str]) -> str | None:
+    return _async_io_metrics._call_name(node, aliases)
+
+
+def _scope_for(rel_path: str) -> str:
+    return _async_io_metrics.scope_for(rel_path)
+
+
+def _production_files(roots: Iterable[str]) -> list[Path]:
+    return _async_io_metrics.git_visible_python_files(roots)
+
+
+def _parse(path: Path) -> ast.Module | None:
+    return _async_io_metrics.parse_python(path)
+
+
+def _async_lines(tree: ast.Module) -> set[int]:
+    return _async_io_metrics.async_function_lines(tree)
+
+
+def _has_timeout(node: ast.Call) -> bool:
+    return any(keyword.arg == "timeout" for keyword in node.keywords)
+
+
+def _is_raw_blocking_boundary(name: str | None) -> bool:
+    if name in RAW_BLOCKING_BOUNDARIES:
+        return True
+    return bool(name and name.endswith(".run_in_executor"))
+
+
+def _is_runtime_boundary(name: str | None) -> bool:
+    return bool(name and name.startswith(RUNTIME_BOUNDARY_PREFIX))
+
+
+def _is_http_policy_ref(name: str | None) -> bool:
+    if name is None:
+        return False
+    if name in {"httpx.Client", "httpx.AsyncClient", "requests.Session", "urllib.request.urlopen"}:
+        return True
+    if name.startswith("requests.") and name.rsplit(".", 1)[-1] in HTTP_METHODS:
+        return True
+    if name.startswith("httpx.") and name.rsplit(".", 1)[-1] in HTTP_METHODS:
+        return True
+    if name.startswith("urllib.request.") and name.rsplit(".", 1)[-1] in {"urlopen", "urlretrieve"}:
+        return True
+    return False
+
+
+def _is_sync_external(match: Match) -> bool:
+    if match.category == "raw_subprocess_policy_refs":
+        return True
+    if match.category != "raw_http_client_policy_refs":
+        return False
+    return "httpx.AsyncClient" not in match.line
+
+
+def _is_subprocess_policy_ref(name: str | None) -> bool:
+    if name is None:
+        return False
+    if name.startswith("subprocess.") and name.rsplit(".", 1)[-1] in SUBPROCESS_METHODS:
+        return True
+    return name in {"os.system", "os.popen"}
+
+
+def _category_for_call(name: str | None, *, rel_path: str) -> str | None:
+    if rel_path in RUNTIME_BOUNDARY_MODULES:
+        return None
+    if _is_runtime_boundary(name):
+        return "named_runtime_boundary_refs"
+    if _is_raw_blocking_boundary(name):
+        return "raw_blocking_boundary_refs_outside_runtime"
+    if _is_subprocess_policy_ref(name):
+        return "raw_subprocess_policy_refs"
+    if _is_http_policy_ref(name):
+        return "raw_http_client_policy_refs"
+    return None
+
+
+def ast_matches(path: Path, rel_path: str, scope: str) -> Iterable[Match]:
+    if scope not in _async_io_metrics.PRODUCTION_SCOPES or scope in _async_io_metrics.EDGE_SCOPES:
+        return
+    tree = _parse(path)
+    if tree is None:
+        return
+    aliases = _aliases(tree)
+    async_lines = _async_lines(tree)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node, aliases)
+        category = _category_for_call(name, rel_path=rel_path)
+        if category is None:
+            continue
+        yield Match(
+            path=rel_path,
+            line_number=node.lineno,
+            category=category,
+            scope=scope,
+            in_async_function=node.lineno in async_lines,
+            has_timeout=_has_timeout(node),
+            line=_line(lines, node),
+        )
+
+
+def iter_matches(paths: Iterable[Path]) -> Iterable[Match]:
+    for path in paths:
+        rel_path = path.relative_to(ROOT).as_posix()
+        yield from ast_matches(path, rel_path, _scope_for(rel_path))
+
+
+def summarize(matches: list[Match], *, top: int) -> dict[str, object]:
+    by_category = Counter(match.category for match in matches)
+    raw_categories = {
+        "raw_blocking_boundary_refs_outside_runtime",
+        "raw_http_client_policy_refs",
+        "raw_subprocess_policy_refs",
+    }
+    raw_matches = [match for match in matches if match.category in raw_categories]
+    raw_external_matches = [
+        match
+        for match in matches
+        if match.category in {"raw_http_client_policy_refs", "raw_subprocess_policy_refs"}
+    ]
+    missing_timeout_matches = [
+        match
+        for match in raw_external_matches
+        if not match.has_timeout
+    ]
+    sync_edge_matches = [match for match in raw_external_matches if not match.in_async_function]
+    async_external_matches = [match for match in raw_external_matches if match.in_async_function]
+    sync_external_in_async_matches = [
+        match
+        for match in async_external_matches
+        if _is_sync_external(match)
+    ]
+    named_boundary_count = by_category["named_runtime_boundary_refs"]
+    raw_policy_count = len(raw_matches)
+    coverage_denominator = named_boundary_count + raw_policy_count
+    timeout_denominator = len(raw_external_matches)
+
+    metrics = {
+        "raw_policy_refs_outside_runtime": raw_policy_count,
+        "raw_blocking_boundary_refs_outside_runtime": by_category["raw_blocking_boundary_refs_outside_runtime"],
+        "raw_subprocess_policy_refs": by_category["raw_subprocess_policy_refs"],
+        "raw_http_client_policy_refs": by_category["raw_http_client_policy_refs"],
+        "raw_external_refs_missing_timeout_policy": len(missing_timeout_matches),
+        "async_external_io_refs_without_policy": len(async_external_matches),
+        "sync_external_io_in_async_refs": len(sync_external_in_async_matches),
+        "undocumented_sync_edge_refs": len(sync_edge_matches),
+        "named_runtime_boundary_refs": named_boundary_count,
+        "runtime_boundary_coverage_percent": round((named_boundary_count / coverage_denominator * 100), 1)
+        if coverage_denominator
+        else 100.0,
+        "raw_external_timeout_coverage_percent": round(
+            ((timeout_denominator - len(missing_timeout_matches)) / timeout_denominator * 100),
+            1,
+        )
+        if timeout_denominator
+        else 100.0,
+    }
+
+    targets = {
+        "raw_policy_refs_outside_runtime": 0,
+        "raw_blocking_boundary_refs_outside_runtime": 0,
+        "raw_subprocess_policy_refs": 0,
+        "raw_http_client_policy_refs": 0,
+        "raw_external_refs_missing_timeout_policy": 0,
+        "async_external_io_refs_without_policy": 0,
+        "sync_external_io_in_async_refs": 0,
+        "undocumented_sync_edge_refs": 0,
+        "runtime_boundary_coverage_percent": 100.0,
+        "raw_external_timeout_coverage_percent": 100.0,
+    }
+
+    raw_by_scope = Counter(match.scope for match in raw_matches)
+    raw_by_file = Counter(match.path for match in raw_matches)
+    missing_timeout_by_file = Counter(match.path for match in missing_timeout_matches)
+
+    return {
+        "targets": targets,
+        "metrics": metrics,
+        "by_category": dict(sorted(by_category.items())),
+        "raw_policy_by_scope": dict(sorted(raw_by_scope.items())),
+        "top_raw_policy_files": raw_by_file.most_common(top),
+        "top_missing_timeout_files": missing_timeout_by_file.most_common(top),
+    }
+
+
+def matches_payload(matches: list[Match]) -> list[dict[str, object]]:
+    return [
+        {
+            "path": match.path,
+            "line_number": match.line_number,
+            "category": match.category,
+            "scope": match.scope,
+            "in_async_function": match.in_async_function,
+            "has_timeout": match.has_timeout,
+            "line": match.line,
+            "debt": match.category not in INFORMATIONAL_CATEGORIES,
+        }
+        for match in matches
+    ]
+
+
+def print_text(summary: dict[str, object]) -> None:
+    targets = summary["targets"]
+    metrics = summary["metrics"]
+    assert isinstance(targets, dict)
+    assert isinstance(metrics, dict)
+
+    print("Runtime boundary metrics")
+    print()
+    print("Metric                                      Current  Target")
+    print("------------------------------------------  -------  ------")
+    for name, target in targets.items():
+        current = metrics.get(name, 0)
+        print(f"{name:<42}  {current:>7}  {target:>6}")
+
+    print()
+    print("Informational")
+    print(f"  named_runtime_boundary_refs       {metrics.get('named_runtime_boundary_refs', 0)}")
+
+    print()
+    print("Raw policy refs by scope")
+    for scope, count in summary["raw_policy_by_scope"].items():
+        print(f"  {scope:<18} {count}")
+
+    print()
+    print("By category")
+    for category, count in summary["by_category"].items():
+        print(f"  {category:<40} {count}")
+
+    print()
+    print("Top raw policy files")
+    for path, count in summary["top_raw_policy_files"]:
+        print(f"  {path:<72} {count}")
+
+    print()
+    print("Top missing-timeout files")
+    for path, count in summary["top_missing_timeout_files"]:
+        print(f"  {path:<72} {count}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--list", action="store_true", help="include individual matches in JSON output")
+    parser.add_argument("--top", type=int, default=20, help="number of top files to show")
+    parser.add_argument("--target", action="store_true", help="exit non-zero unless all zero/coverage targets are met")
+    args = parser.parse_args(argv)
+
+    matches = list(iter_matches(_production_files(DEFAULT_ROOTS)))
+    summary = summarize(matches, top=args.top)
+    if args.list:
+        summary["matches"] = matches_payload(matches)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print_text(summary)
+
+    if not args.target:
+        return 0
+
+    metrics = summary["metrics"]
+    targets = summary["targets"]
+    assert isinstance(metrics, dict)
+    assert isinstance(targets, dict)
+    for name, target in targets.items():
+        if metrics.get(name) != target:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_async_io_debt_metrics.py
+++ b/tests/test_async_io_debt_metrics.py
@@ -73,6 +73,9 @@ def bad_runner(coro):
 
 def main(coro):
     return asyncio.run(coro)
+
+def _supervisor_loop():
+    return asyncio.run(asyncio.sleep(0))
 ''',
         encoding="utf-8",
     )
@@ -82,7 +85,7 @@ def main(coro):
 
     assert categories.count("sync_io_edge_refs") == 3
     assert categories.count("asyncio_run_inner_refs") == 1
-    assert categories.count("outer_async_runner_refs") == 1
+    assert categories.count("outer_async_runner_refs") == 2
 
 
 def test_metric_keeps_cancel_token_sync_boundary_narrow(tmp_path):

--- a/tests/test_runtime_boundary_metrics.py
+++ b/tests/test_runtime_boundary_metrics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_metrics_module():
+    root = Path(__file__).resolve().parents[1]
+    path = root / "scripts" / "runtime_boundary_metrics.py"
+    spec = importlib.util.spec_from_file_location("runtime_boundary_metrics", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_boundary_metric_counts_raw_and_named_boundaries(tmp_path):
+    metrics = _load_metrics_module()
+    path = tmp_path / "boundaries.py"
+    path.write_text(
+        '''
+import asyncio
+import httpx
+import subprocess
+from brain.platform.async_io import run_subprocess, read_text
+
+async def async_handler():
+    await asyncio.to_thread(lambda: None)
+    httpx.AsyncClient()
+    subprocess.run(["echo", "hi"], timeout=1)
+    await run_subprocess(["echo", "hi"], timeout=1)
+    await read_text("payload.txt")
+
+def sync_edge():
+    httpx.Client(timeout=3)
+    subprocess.Popen(["sleep", "1"])
+''',
+        encoding="utf-8",
+    )
+
+    matches = list(metrics.ast_matches(path, "brain/systems/example.py", "systems"))
+    categories = [match.category for match in matches]
+
+    assert categories.count("raw_blocking_boundary_refs_outside_runtime") == 1
+    assert categories.count("raw_http_client_policy_refs") == 2
+    assert categories.count("raw_subprocess_policy_refs") == 2
+    assert categories.count("named_runtime_boundary_refs") == 2
+
+    summary = metrics.summarize(matches, top=10)
+    assert summary["metrics"]["raw_policy_refs_outside_runtime"] == 5
+    assert summary["metrics"]["async_external_io_refs_without_policy"] == 2
+    assert summary["metrics"]["sync_external_io_in_async_refs"] == 1
+    assert summary["metrics"]["undocumented_sync_edge_refs"] == 2
+    assert summary["metrics"]["raw_external_refs_missing_timeout_policy"] == 2
+    assert summary["metrics"]["named_runtime_boundary_refs"] == 2
+
+
+def test_runtime_boundary_metric_ignores_boundary_module(tmp_path):
+    metrics = _load_metrics_module()
+    path = tmp_path / "async_io.py"
+    path.write_text(
+        '''
+import asyncio
+import subprocess
+
+async def run_blocking(func):
+    return await asyncio.to_thread(func)
+
+async def run_subprocess(args):
+    return await run_blocking(subprocess.run, args)
+''',
+        encoding="utf-8",
+    )
+
+    assert list(metrics.ast_matches(path, "brain/platform/async_io.py", "platform")) == []


### PR DESCRIPTION
## Summary
- Adds the runtime-boundary health metric and drives it to 0 raw policy refs / 100% coverage.
- Adds a composite runtime resilience scorecard that rolls up async IO debt, async DB debt, raw runtime-boundary policy drift, unbounded concurrency, and named external-boundary deadline coverage.
- Centralizes subprocess, HTTP client, and explicit blocking handoff calls through `brain.platform.async_io` instead of scattered raw `subprocess`, `httpx`, `urllib`, and `asyncio.to_thread` usage.
- Tightens the Cortex runner shutdown path with bounded task waiting/cancellation instead of raw gather, while keeping the supervisor thread as an explicit outer async runner.
- Adds explicit timeouts to GPU worker `ps` probes so every named external runtime boundary is deadline-bound.

## Metrics
- `python3 scripts/async_io_debt_metrics.py --target production`: 0 / 0
- `python3 scripts/async_db_debt_metrics.py --target repo-wide`: 0 / 0
- `python3 scripts/runtime_boundary_metrics.py --target`: 0 / 0, coverage 100%
- `python3 scripts/runtime_resilience_metrics.py --target`: static debt 0 / 0, external boundary deadline coverage 100%

## Runtime Resilience Current State
- `runtime_resilience_static_debt`: 0 / 0
- `production_async_io_debt`: 0 / 0
- `repo_wide_sync_shaped_refs`: 0 / 0
- `raw_policy_refs_outside_runtime`: 0 / 0
- `unbounded_concurrency_refs`: 0 / 0
- `external_boundary_refs_missing_deadline`: 0 / 0
- `external_boundary_deadline_coverage_percent`: 100.0 / 100.0
- `runtime_boundary_coverage_percent`: 100.0 / 100.0

## Verification
- `python3 scripts/async_io_debt_metrics.py --target production && python3 scripts/async_db_debt_metrics.py --target repo-wide && python3 scripts/runtime_boundary_metrics.py --target && python3 scripts/runtime_resilience_metrics.py --target`
- `pytest -q tests/test_runtime_resilience_metrics.py tests/test_runtime_boundary_metrics.py tests/test_async_io_debt_metrics.py tests/test_gpu_server.py --tb=short`
- `pytest -q --tb=short`
