### PR TITLE
Resolve direct agent auth before threaded runs

### DIFF
--- a/brain/kernel/runtime/kernel.py
+++ b/brain/kernel/runtime/kernel.py
@@ -19,7 +19,7 @@ class AgentKernel:
     this class without changing callers that already pass a ``RunEnvelope``.
     """
 
-    def run(self, envelope: RunEnvelope) -> RunResult:
+    def run(self, envelope: RunEnvelope, **run_agent_overrides) -> RunResult:
         from brain.systems.runs.direct_agent import run_agent
 
         logger.info(
@@ -29,22 +29,24 @@ class AgentKernel:
             envelope.trace_id,
             envelope.session_id,
         )
-        result = run_agent(**envelope.to_run_agent_kwargs())
+        kwargs = envelope.to_run_agent_kwargs()
+        kwargs.update(run_agent_overrides)
+        result = run_agent(**kwargs)
         return RunResult.from_agent_result(envelope, result)
 
-    def invoke_agent_result(self, envelope: RunEnvelope):
+    def invoke_agent_result(self, envelope: RunEnvelope, **run_agent_overrides):
         """Run the kernel and return the AgentResult."""
-        return self.run(envelope).agent_result
+        return self.run(envelope, **run_agent_overrides).agent_result
 
 
 _DEFAULT_KERNEL = AgentKernel()
 
 
-def run_envelope(envelope: RunEnvelope) -> RunResult:
+def run_envelope(envelope: RunEnvelope, **run_agent_overrides) -> RunResult:
     """Execute a run envelope and return a structured kernel result."""
-    return _DEFAULT_KERNEL.run(envelope)
+    return _DEFAULT_KERNEL.run(envelope, **run_agent_overrides)
 
 
-def invoke_run_envelope(envelope: RunEnvelope):
+def invoke_run_envelope(envelope: RunEnvelope, **run_agent_overrides):
     """Execute a run envelope and return the AgentResult."""
-    return _DEFAULT_KERNEL.invoke_agent_result(envelope)
+    return _DEFAULT_KERNEL.invoke_agent_result(envelope, **run_agent_overrides)

--- a/brain/platform/integrations/llm.py
+++ b/brain/platform/integrations/llm.py
@@ -5,9 +5,9 @@ injection, and provider-specific logic lives here. No other module should
 create Anthropic/OpenAI clients directly.
 
 Usage:
-    from brain.platform.integrations.llm import resolve_llm_client
+    from brain.platform.integrations.llm import async_resolve_llm_client
 
-    result = resolve_llm_client(user_id="u-123")
+    result = await async_resolve_llm_client(user_id="u-123", session=session)
     response = result.call(model="openai/gpt-5.4", messages=[...], ...)
 
 To fix provider auth issues, change ONE file: this one.
@@ -149,15 +149,6 @@ class ResolvedProviderAuth:
 
 
 # ── Resolution ───────────────────────────────────────────────────
-
-def _resolve_key_from_db(
-    user_id: str | None = None,
-    org_id: str | None = None,
-    provider: str = "anthropic",
-) -> tuple[str | None, str]:
-    """Sync client resolution does not perform DB I/O; use async_resolve_llm_client."""
-    return None, "none"
-
 
 async def _async_resolve_key_from_db(
     session: AsyncSession,
@@ -369,36 +360,6 @@ def _refresh_codex_credential_if_needed(
     return refreshed
 
 
-def _persist_refreshed_openai_codex_db_credential(
-    *,
-    user_id: str | None,
-    org_id: str | None,
-    source: str,
-    cred: OpenAICodexCredential,
-) -> None:
-    if source not in {"user_default", "org_main"}:
-        return
-
-    from brain.systems.vault import update_resolved_api_key
-
-    stored_payload = json.dumps(encode_codex_auth_payload(cred))
-    updated = update_resolved_api_key(
-        user_id=user_id,
-        org_id=org_id,
-        provider="openai",
-        source=source,
-        api_key=stored_payload,
-    )
-    if not updated:
-        logger.warning(
-            "Refreshed OpenAI Codex credential could not be persisted; "
-            "no matching DB key row for source=%s user_id=%s org_id=%s",
-            source,
-            user_id,
-            org_id,
-        )
-
-
 async def _async_persist_refreshed_openai_codex_db_credential(
     *,
     session: AsyncSession,
@@ -431,13 +392,13 @@ async def _async_persist_refreshed_openai_codex_db_credential(
         )
 
 
-def _coerce_openai_db_auth(
+def _coerce_openai_stored_auth(
     raw_value: str | None,
     source: str,
     auth_mode: str | None = None,
     on_refresh: Callable[[OpenAICodexCredential], None] | None = None,
 ) -> ResolvedProviderAuth | None:
-    """Interpret a DB-stored OpenAI credential as API key or Codex auth."""
+    """Interpret a stored OpenAI credential as API key or Codex auth."""
     token = (raw_value or "").strip()
     if not token:
         return None
@@ -485,31 +446,10 @@ def _coerce_openai_db_auth(
     return None
 
 
-def _resolve_openai_auth(
-    user_id: str | None = None,
-    org_id: str | None = None,
+def _resolve_openai_local_auth(
     auth_mode: str | None = None,
 ) -> ResolvedProviderAuth | None:
-    """Resolve OpenAI auth with DB-backed user/org state first.
-
-    Machine-local Codex auth is a development fallback only unless explicitly
-    re-enabled by environment override.
-    """
-    db_value, db_source = _resolve_key_from_db(user_id=user_id, org_id=org_id, provider="openai")
-    db_auth = _coerce_openai_db_auth(
-        db_value,
-        db_source,
-        auth_mode=auth_mode,
-        on_refresh=lambda cred: _persist_refreshed_openai_codex_db_credential(
-            user_id=user_id,
-            org_id=org_id,
-            source=db_source,
-            cred=cred,
-        ),
-    )
-    if db_auth is not None:
-        return db_auth
-
+    """Resolve OpenAI auth from sync-safe local fallbacks only."""
     if auth_mode != "api_key" and _allow_local_codex_auth_fallback():
         codex_auth = load_codex_auth_json()
         if (
@@ -557,20 +497,28 @@ async def _async_resolve_openai_auth(
         nonlocal refreshed_cred
         refreshed_cred = cred
 
-    db_auth = _coerce_openai_db_auth(
+    db_auth = _coerce_openai_stored_auth(
         db_value,
         db_source,
         auth_mode,
         _capture_refresh,
     )
     if refreshed_cred is not None:
-        await _async_persist_refreshed_openai_codex_db_credential(
-            session=session,
-            user_id=user_id,
-            org_id=org_id,
-            source=db_source,
-            cred=refreshed_cred,
-        )
+        try:
+            await _async_persist_refreshed_openai_codex_db_credential(
+                session=session,
+                user_id=user_id,
+                org_id=org_id,
+                source=db_source,
+                cred=refreshed_cred,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to persist refreshed OpenAI Codex credential for source=%s: %s",
+                db_source,
+                exc,
+                exc_info=True,
+            )
     if db_auth is not None:
         return db_auth
 
@@ -608,24 +556,21 @@ def resolve_llm_client(
     provider: str | None = None,
     auth_mode: str | None = None,
 ) -> LLMClient:
-    """Resolve an LLM client from DB-stored keys.
+    """Resolve an LLM client from sync-safe local fallbacks.
 
-    Priority:
-        1. User's default key (set via Settings UI)
-        2. Org main key (set by org owner)
-        3. Environment variable (dev convenience)
-
-    Anthropic stays DB/env-only. OpenAI may additionally use a machine-local
-    Codex auth cache as an explicit development fallback.
+    User/org DB credentials require async_resolve_llm_client.
+    OpenAI may use a machine-local Codex auth cache as an explicit development
+    fallback; provider API keys may come from the environment.
 
     Raises RuntimeError if no key can be resolved.
     """
-    if not user_id and not org_id:
+    if user_id or org_id:
         import traceback
         caller = "".join(traceback.format_stack(limit=4)[:-1])
         logger.warning(
-            "resolve_llm_client called without user_id or org_id — "
-            "will fall back to env key. Thread user_id from the caller.\n%s",
+            "resolve_llm_client called with user/org context, but sync auth "
+            "resolution only supports local fallbacks. Use async_resolve_llm_client "
+            "for user/org credentials.\n%s",
             caller,
         )
 
@@ -642,16 +587,12 @@ def resolve_llm_client(
         raise NotImplementedError(f"Provider '{provider}' not yet supported. Add it here.")
 
     if provider == "openai":
-        resolved_auth = _resolve_openai_auth(
-            user_id=user_id,
-            org_id=org_id,
-            auth_mode=auth_mode,
-        )
+        resolved_auth = _resolve_openai_local_auth(auth_mode=auth_mode)
         if not resolved_auth:
             shared_hint = (
-                "Add a user-scoped OpenAI/Codex credential in Illo."
+                "user-scoped OpenAI/Codex credentials require async_resolve_llm_client."
                 if os.environ.get("ILLO_ENV", "development") == "production"
-                else "Add a user-scoped OpenAI/Codex credential in Illo, or set OPENAI_API_KEY in dev. Machine-local Codex login is only a local fallback."
+                else "user-scoped OpenAI/Codex credentials require async_resolve_llm_client; set OPENAI_API_KEY in dev or enable the machine-local Codex fallback."
             )
             raise RuntimeError(
                 f"No OpenAI auth found. {shared_hint}"
@@ -660,16 +601,11 @@ def resolve_llm_client(
             return _build_openai_codex_client(resolved_auth)
         return _build_openai_client(resolved_auth.token, resolved_auth.source)
 
-    # 1+2. DB keys (user default → org main → org vault → env fallback inside resolve_api_key)
-    key, source = _resolve_key_from_db(user_id=user_id, org_id=org_id, provider=provider)
-
-    # 3. Env fallback (for dev — no DB key yet)
-    if not key:
-        key, source = _resolve_key_from_env(provider=provider)
+    key, source = _resolve_key_from_env(provider=provider)
 
     if not key:
         raise RuntimeError(
-            f"No API key found for {provider}. Add one in Settings. Environment keys are only a development fallback."
+            f"No API key found for {provider}. User/org credentials require async_resolve_llm_client; environment keys are only a development fallback."
         )
 
     result = _build_anthropic_client(key)

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -408,16 +408,20 @@ def _init_llm(
     model: str,
     *,
     org_id: str | None = None,
+    resolved_llm=None,
 ):
     """Resolve LLM client, provider, and extra headers."""
-    default_provider = resolve_default_provider(user_id=user_id, org_id=org_id)
-    requested_provider = infer_provider_from_model(model, default=default_provider)
-    llm = resolve_llm_client(
-        user_id=user_id,
-        org_id=org_id,
-        provider=requested_provider,
-        auth_mode=_required_openai_auth_mode(model) if requested_provider == "openai" else None,
-    )
+    if resolved_llm is None:
+        default_provider = resolve_default_provider(user_id=user_id, org_id=org_id)
+        requested_provider = infer_provider_from_model(model, default=default_provider)
+        llm = resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=requested_provider,
+            auth_mode=_required_openai_auth_mode(model) if requested_provider == "openai" else None,
+        )
+    else:
+        llm = resolved_llm
     provider = get_provider(llm.provider, llm.client)
     extra_headers = llm.build_request_headers(session_id=session_id)
     logger.info(
@@ -1305,6 +1309,7 @@ def run_agent(
     live_guidance_loader: "Callable[[], list[str]] | None" = None,
     user_id: str | None = None,
     skip_harvest: bool = False,
+    resolved_llm=None,
     metadata: dict | None = None,
 ) -> AgentResult:
     """Run an agent loop with tool use.
@@ -1431,6 +1436,7 @@ def run_agent(
             session_id,
             model,
             org_id=metadata.get("org_id"),
+            resolved_llm=resolved_llm,
         )
         state.provider_name = llm.provider
         if semantic_compactor is None:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -173,7 +173,7 @@ from brain.systems.sessions.harvest import (  # noqa: F401
 
 
 # ── Client ───────────────────────────────────────────────────
-# All client creation goes through brain.platform.integrations.llm.resolve_llm_client().
+# LLM clients are normally resolved before this blocking loop enters.
 # No singleton, no ALLOW_* flags, no filesystem credential files.
 
 def _normalize_model(model: str) -> str:

--- a/brain/systems/runs/predict_rlm_backend.py
+++ b/brain/systems/runs/predict_rlm_backend.py
@@ -21,7 +21,7 @@ from brain.platform.async_io import run_blocking
 from brain.systems.runs.events import async_record_tool_call
 from brain.platform.db.models.org import Org, User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.integrations.llm import _resolve_key_from_db, _resolve_key_from_env, resolve_llm_client
+from brain.platform.integrations.llm import _resolve_key_from_env, resolve_llm_client
 from brain.platform.integrations.providers import LLMRequest, _merge_streamed_output_into_response, get_provider
 from brain.systems.runs.direct_agent import (
     AgentResult,
@@ -854,9 +854,7 @@ def _build_predict_rlm_lm(
         )
 
     if provider == "anthropic":
-        token, _ = _resolve_key_from_db(user_id=user_id, org_id=org_id, provider="anthropic")
-        if not token:
-            token, _ = _resolve_key_from_env(provider="anthropic")
+        token, _ = _resolve_key_from_env(provider="anthropic")
         if not token:
             raise RuntimeError(
                 "PredictRLM requires an Anthropic API key. "

--- a/brain/systems/runs/recipes/threaded_invocation.py
+++ b/brain/systems/runs/recipes/threaded_invocation.py
@@ -7,6 +7,25 @@ import inspect
 from typing import Any
 
 from brain.platform.async_io import run_blocking
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.platform.integrations.llm import async_resolve_llm_client
+from brain.platform.providers.model_policy import (
+    MODEL_TIERS,
+    async_get_model_for_tier,
+    infer_provider_from_model,
+    normalize_model_tier,
+)
+
+
+def _required_openai_auth_mode(model: str | None) -> str | None:
+    if not model:
+        return None
+    value = str(model)
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            value = value[len(prefix):]
+            break
+    return "chatgpt" if value.lower() == "gpt-5.5" else None
 
 
 def sync_on_loop(loop: asyncio.AbstractEventLoop, async_fn):
@@ -31,10 +50,65 @@ def thread_sync_tool_handlers(loop: asyncio.AbstractEventLoop, handlers: dict[st
 
 
 async def invoke_direct_agent_threaded(invoke_direct_agent, spec):
-    result = await run_blocking(invoke_direct_agent, spec)
+    if _is_default_direct_agent_invocation(invoke_direct_agent):
+        spec, resolved_model, resolved_llm = await _resolve_direct_agent_runtime(spec)
+        result = await run_blocking(_invoke_direct_agent_with_resolved_llm, spec, resolved_model, resolved_llm)
+    else:
+        result = await run_blocking(invoke_direct_agent, spec)
     if inspect.isawaitable(result):
         result = await result
     return result
 
 
-__all__ = ["invoke_direct_agent_threaded", "sync_on_loop", "thread_sync_tool_handlers"]
+def _is_default_direct_agent_invocation(invoke_direct_agent) -> bool:
+    return (
+        getattr(invoke_direct_agent, "__module__", "") == "brain.systems.runs.invocation"
+        and getattr(invoke_direct_agent, "__name__", "") == "invoke_direct_agent"
+    )
+
+
+async def _resolve_direct_agent_runtime(spec):
+    user_id = getattr(spec, "user_id", None)
+    metadata = getattr(spec, "metadata", None) or {}
+    org_id = metadata.get("org_id") if isinstance(metadata, dict) else None
+    if not user_id and not org_id:
+        return spec, None, None
+
+    async with UnitOfWork() as uow:
+        model = getattr(spec, "model", None)
+        tier = normalize_model_tier(str(model), default=None) if model else None
+        if not model or tier in MODEL_TIERS:
+            model = await async_get_model_for_tier(
+                uow.session,
+                tier or "medium",
+                include_provider_prefix=True,
+                user_id=user_id,
+                org_id=org_id,
+            )
+        provider = infer_provider_from_model(str(model))
+        llm = await async_resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+            auth_mode=_required_openai_auth_mode(str(model)) if provider == "openai" else None,
+            session=uow.session,
+        )
+    return spec, str(model), llm
+
+
+def _invoke_direct_agent_with_resolved_llm(spec, resolved_model, resolved_llm):
+    from brain.kernel.runtime.kernel import invoke_run_envelope
+
+    overrides = {}
+    if resolved_model:
+        overrides["model"] = resolved_model
+    if resolved_llm is not None:
+        overrides["resolved_llm"] = resolved_llm
+    return invoke_run_envelope(spec.to_run_envelope(), **overrides)
+
+
+__all__ = [
+    "invoke_direct_agent_threaded",
+    "sync_on_loop",
+    "thread_sync_tool_handlers",
+]

--- a/brain/systems/runs/recipes/threaded_invocation.py
+++ b/brain/systems/runs/recipes/threaded_invocation.py
@@ -1,4 +1,4 @@
-"""Helpers for running the legacy direct-agent loop from async recipes."""
+"""Helpers for running the blocking direct-agent loop from async recipes."""
 
 from __future__ import annotations
 

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -207,7 +207,7 @@
       "import": "brain.systems.vault",
       "source_layer": "brain.platform",
       "target_layer": "brain.systems",
-      "allowed_occurrences": 3,
+      "allowed_occurrences": 2,
       "owner": "architecture-boundaries",
       "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
       "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -114,6 +114,27 @@ class TestProviderInference:
         assert mock_resolve.call_args.kwargs["provider"] == "openai"
         assert mock_resolve.call_args.kwargs["auth_mode"] == "chatgpt"
 
+    @patch("brain.systems.runs.direct_agent.get_provider")
+    @patch("brain.systems.runs.direct_agent.resolve_llm_client")
+    def test_init_llm_reuses_pre_resolved_client(self, mock_resolve, mock_get_provider):
+        from brain.systems.runs.direct_agent import _init_llm
+
+        llm = SimpleNamespace(
+            provider="openai",
+            client=object(),
+            source="user_default",
+            auth_mode="chatgpt",
+            token_prefix="access-token",
+            is_oauth=False,
+            build_request_headers=MagicMock(return_value={}),
+        )
+        mock_get_provider.return_value = MagicMock()
+
+        _init_llm("user-1", "sess-1", "openai/gpt-5.5", resolved_llm=llm)
+
+        mock_resolve.assert_not_called()
+        mock_get_provider.assert_called_once_with("openai", llm.client)
+
 
 class TestLiveGuidance:
     def test_append_live_guidance_adds_user_message(self):

--- a/tests/test_agent_auth_fallback.py
+++ b/tests/test_agent_auth_fallback.py
@@ -2,43 +2,39 @@
 import json
 import os
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-def test_sync_db_key_resolution_is_disabled_without_async_session():
-    from brain.platform.integrations.llm import _resolve_key_from_db
+@pytest.mark.asyncio
+async def test_async_resolve_llm_client_uses_stored_anthropic_key():
+    """User/org credentials are only resolved through the async auth path."""
+    from brain.platform.integrations.llm import async_resolve_llm_client
 
-    assert _resolve_key_from_db(user_id="user-1", provider="anthropic") == (None, "none")
-
-
-def test_resolve_llm_client_uses_db_key():
-    """Explicit Anthropic requests still use Anthropic DB keys."""
-    from brain.platform.integrations.llm import resolve_llm_client
-
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=("sk-ant-api03-test-key", "user_default")), \
+    mock_resolve = AsyncMock(return_value=("sk-ant-api03-test-key", "user_default"))
+    with patch("brain.platform.integrations.llm._async_resolve_key_from_db", mock_resolve), \
          patch("brain.platform.integrations.llm._build_anthropic_client") as mock_build:
         mock_build.return_value = MagicMock(
             client=MagicMock(), provider="anthropic", source="",
-            is_oauth=False, extra_headers={}, token_prefix="sk-ant-api03-test",
+            auth_mode="api_key", is_oauth=False, extra_headers={}, token_prefix="sk-ant-api03-test",
             get_extra_headers=MagicMock(return_value={}),
         )
-        result = resolve_llm_client(user_id="user-1", provider="anthropic")
+        result = await async_resolve_llm_client(user_id="user-1", provider="anthropic", session=object())
 
     assert result.source == "user_default"
     mock_build.assert_called_once_with("sk-ant-api03-test-key")
+    mock_resolve.assert_awaited_once()
 
 
 def test_resolve_llm_client_falls_back_to_env():
-    """When no DB key exists, explicit Anthropic requests fall back to Anthropic env auth."""
+    """The sync resolver only uses local/env fallback auth."""
     from brain.platform.integrations.llm import resolve_llm_client
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
-         patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-ant-api03-env-key", "env")), \
+    with patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-ant-api03-env-key", "env")), \
          patch("brain.platform.integrations.llm._build_anthropic_client") as mock_build:
         mock_build.return_value = MagicMock(
             client=MagicMock(), provider="anthropic", source="",
-            is_oauth=False, extra_headers={}, token_prefix="sk-ant-api03-env-",
+            auth_mode="api_key", is_oauth=False, extra_headers={}, token_prefix="sk-ant-api03-env-",
             get_extra_headers=MagicMock(return_value={}),
         )
         result = resolve_llm_client(user_id="user-1", provider="anthropic")
@@ -50,8 +46,7 @@ def test_resolve_llm_client_raises_when_no_key():
     """RuntimeError when no key can be found anywhere."""
     from brain.platform.integrations.llm import resolve_llm_client
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
-         patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=(None, "none")), \
+    with patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=(None, "none")), \
          patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None):
         with pytest.raises(RuntimeError, match="No API key found"):
             resolve_llm_client(user_id="user-1", provider="anthropic")
@@ -61,18 +56,18 @@ def test_resolve_llm_client_detects_oauth_token():
     """Setup tokens (sk-ant-oat*) are detected and get OAuth headers."""
     from brain.platform.integrations.llm import resolve_llm_client
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=("sk-ant-oat01-setup-token", "org_main")), \
+    with patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-ant-oat01-setup-token", "env")), \
          patch("brain.platform.integrations.llm._build_anthropic_client") as mock_build:
         mock_build.return_value = MagicMock(
             client=MagicMock(), provider="anthropic", source="",
-            is_oauth=True, extra_headers={"anthropic-beta": "oauth-2025-04-20"},
+            auth_mode="api_key", is_oauth=True, extra_headers={"anthropic-beta": "oauth-2025-04-20"},
             token_prefix="sk-ant-oat01-setu",
             get_extra_headers=MagicMock(return_value={"anthropic-beta": "oauth-2025-04-20"}),
         )
         result = resolve_llm_client(user_id="user-1", provider="anthropic")
 
     assert result.is_oauth is True
-    assert result.source == "org_main"
+    assert result.source == "env"
 
 
 def test_resolve_llm_client_default_provider_coerces_anthropic_to_openai():
@@ -81,20 +76,20 @@ def test_resolve_llm_client_default_provider_coerces_anthropic_to_openai():
 
     with patch("brain.platform.providers.model_policy.resolve_default_provider", return_value="anthropic"), \
          patch(
-             "brain.platform.integrations.llm._resolve_openai_auth",
-             return_value=ResolvedProviderAuth(token="sk-openai-test", source="user_default", auth_mode="api_key"),
+             "brain.platform.integrations.llm._resolve_openai_local_auth",
+             return_value=ResolvedProviderAuth(token="sk-openai-test", source="env", auth_mode="api_key"),
          ), \
          patch("brain.platform.integrations.llm._build_openai_client") as mock_build, \
          patch("brain.platform.integrations.llm._build_anthropic_client") as mock_anthropic_build:
         mock_build.return_value = MagicMock(
-            client=MagicMock(), provider="openai", source="user_default",
+            client=MagicMock(), provider="openai", source="env",
             auth_mode="api_key", is_oauth=False, extra_headers={}, token_prefix="sk-openai-test",
             get_extra_headers=MagicMock(return_value={}),
         )
         result = resolve_llm_client(user_id="user-1")
 
     assert result.provider == "openai"
-    mock_build.assert_called_once_with("sk-openai-test", "user_default")
+    mock_build.assert_called_once_with("sk-openai-test", "env")
     mock_anthropic_build.assert_not_called()
 
 
@@ -118,7 +113,6 @@ def test_resolve_openai_client_uses_codex_cache_when_available():
         "ILLO_ALLOW_LOCAL_CODEX_AUTH_FALLBACK": "1",
     }
     with patch.dict(os.environ, env, clear=False), \
-         patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
          patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=codex_auth), \
          patch("brain.platform.integrations.llm.OpenAICodexClient", return_value=mock_client) as mock_codex_cls:
         result = resolve_llm_client(user_id="user-1", provider="openai")
@@ -132,9 +126,10 @@ def test_resolve_openai_client_uses_codex_cache_when_available():
     assert mock_codex_cls.call_args.kwargs["timeout"] == 123.0
 
 
-def test_resolve_openai_client_refreshes_expired_codex_db_credential():
+@pytest.mark.asyncio
+async def test_async_resolve_openai_client_refreshes_expired_codex_credential():
     """Expired ChatGPT/Codex access tokens should refresh before client construction."""
-    from brain.platform.integrations.llm import resolve_llm_client
+    from brain.platform.integrations.llm import async_resolve_llm_client
     from brain.platform.integrations.openai_codex_auth import (
         OpenAICodexCredential,
         encode_codex_auth_payload,
@@ -156,14 +151,16 @@ def test_resolve_openai_client_refreshes_expired_codex_db_credential():
     )
     mock_client = MagicMock()
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(expired_payload, "user_default")), \
+    mock_resolve = AsyncMock(return_value=(expired_payload, "user_default"))
+    mock_persist = AsyncMock()
+    with patch("brain.platform.integrations.llm._async_resolve_key_from_db", mock_resolve), \
          patch("brain.platform.integrations.llm.refresh_codex_access_token", return_value=refreshed) as mock_refresh, \
-         patch("brain.platform.integrations.llm._persist_refreshed_openai_codex_db_credential") as mock_persist, \
+         patch("brain.platform.integrations.llm._async_persist_refreshed_openai_codex_db_credential", mock_persist), \
          patch("brain.platform.integrations.llm.OpenAICodexClient", return_value=mock_client) as mock_codex_cls:
-        result = resolve_llm_client(user_id="user-1", provider="openai")
+        result = await async_resolve_llm_client(user_id="user-1", provider="openai", session=object())
 
     mock_refresh.assert_called_once_with("refresh-token-123")
-    mock_persist.assert_called_once()
+    mock_persist.assert_awaited_once()
     assert mock_persist.call_args.kwargs["user_id"] == "user-1"
     assert mock_persist.call_args.kwargs["source"] == "user_default"
     assert mock_persist.call_args.kwargs["cred"].access_token == "fresh-access"
@@ -175,9 +172,10 @@ def test_resolve_openai_client_refreshes_expired_codex_db_credential():
     assert mock_codex_cls.call_args.args[0] == "fresh-access"
 
 
-def test_resolve_openai_client_continues_when_refreshed_credential_persist_fails():
+@pytest.mark.asyncio
+async def test_async_resolve_openai_client_continues_when_refreshed_credential_persist_fails():
     """A successful token refresh should not fail the current model call if DB writeback hiccups."""
-    from brain.platform.integrations.llm import resolve_llm_client
+    from brain.platform.integrations.llm import async_resolve_llm_client
     from brain.platform.integrations.openai_codex_auth import (
         OpenAICodexCredential,
         encode_codex_auth_payload,
@@ -199,14 +197,13 @@ def test_resolve_openai_client_continues_when_refreshed_credential_persist_fails
     )
     mock_client = MagicMock()
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(expired_payload, "user_default")), \
+    mock_resolve = AsyncMock(return_value=(expired_payload, "user_default"))
+    mock_persist = AsyncMock(side_effect=RuntimeError("db unavailable"))
+    with patch("brain.platform.integrations.llm._async_resolve_key_from_db", mock_resolve), \
          patch("brain.platform.integrations.llm.refresh_codex_access_token", return_value=refreshed), \
-         patch(
-             "brain.platform.integrations.llm._persist_refreshed_openai_codex_db_credential",
-             side_effect=RuntimeError("db unavailable"),
-         ), \
+         patch("brain.platform.integrations.llm._async_persist_refreshed_openai_codex_db_credential", mock_persist), \
          patch("brain.platform.integrations.llm.OpenAICodexClient", return_value=mock_client) as mock_codex_cls:
-        result = resolve_llm_client(user_id="user-1", provider="openai")
+        result = await async_resolve_llm_client(user_id="user-1", provider="openai", session=object())
 
     assert result.token_prefix == "fresh-access"[:18]
     assert mock_codex_cls.call_args.args[0] == "fresh-access"
@@ -226,7 +223,6 @@ def test_resolve_openai_client_does_not_use_codex_cache_in_production_by_default
     )
 
     with patch.dict(os.environ, {"ILLO_ENV": "production"}, clear=False), \
-         patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
          patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=codex_auth), \
          patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=(None, "none")):
         with pytest.raises(RuntimeError, match="user-scoped OpenAI/Codex credential"):
@@ -248,7 +244,6 @@ def test_resolve_openai_client_can_reenable_codex_cache_with_explicit_override()
     )
 
     with patch.dict(os.environ, {"ILLO_ENV": "production", "ILLO_ALLOW_LOCAL_CODEX_AUTH_FALLBACK": "1"}, clear=False), \
-         patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
          patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=codex_auth), \
          patch("brain.platform.integrations.llm.OpenAICodexClient", return_value=mock_client):
         result = resolve_llm_client(user_id="user-1", provider="openai")
@@ -261,8 +256,7 @@ def test_resolve_openai_client_falls_back_to_env_api_key_when_no_codex_cache():
     """OpenAI env API keys still work when no Codex auth is available."""
     from brain.platform.integrations.llm import resolve_llm_client
 
-    with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
-         patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None), \
+    with patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None), \
          patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-openai-test", "env")), \
          patch("brain.platform.integrations.llm._import_openai_sdk") as mock_sdk:
         mock_sdk.return_value.OpenAI.return_value = MagicMock()

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -380,6 +380,54 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert any(_artifact_type(artifact) == "file_observation" for artifact in runtime.store.artifacts)
 
 
+async def test_direct_agent_threaded_resolves_llm_before_blocking(monkeypatch):
+    from brain.systems.runs.invocation import build_direct_agent_invocation
+    from brain.systems.runs.recipes import threaded_invocation
+
+    class FakeUnitOfWork:
+        session = object()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    resolved_llm = SimpleNamespace(provider="openai", client=object())
+    calls = {}
+
+    async def fake_model_for_tier(session, tier, **kwargs):
+        calls["model_for_tier"] = {"session": session, "tier": tier, **kwargs}
+        return "openai/gpt-5.5"
+
+    async def fake_resolve_llm_client(**kwargs):
+        calls["resolve_llm_client"] = kwargs
+        return resolved_llm
+
+    monkeypatch.setattr(threaded_invocation, "UnitOfWork", FakeUnitOfWork)
+    monkeypatch.setattr(threaded_invocation, "async_get_model_for_tier", fake_model_for_tier)
+    monkeypatch.setattr(threaded_invocation, "async_resolve_llm_client", fake_resolve_llm_client)
+
+    spec = build_direct_agent_invocation(
+        message="hello",
+        model="high",
+        user_id="user-1",
+        metadata={"org_id": "org-1"},
+    )
+
+    resolved_spec, resolved_model, resolved = await threaded_invocation._resolve_direct_agent_runtime(spec)
+
+    assert resolved_spec is spec
+    assert resolved_model == "openai/gpt-5.5"
+    assert resolved is resolved_llm
+    assert calls["model_for_tier"]["session"] is FakeUnitOfWork.session
+    assert calls["model_for_tier"]["tier"] == "high"
+    assert calls["model_for_tier"]["include_provider_prefix"] is True
+    assert calls["resolve_llm_client"]["provider"] == "openai"
+    assert calls["resolve_llm_client"]["auth_mode"] == "chatgpt"
+    assert calls["resolve_llm_client"]["session"] is FakeUnitOfWork.session
+
+
 def test_fast_onboarding_tool_surface_uses_standard_fast_surface(monkeypatch):
     from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
 

--- a/tests/test_predict_rlm_backend.py
+++ b/tests/test_predict_rlm_backend.py
@@ -670,8 +670,8 @@ def test_build_predict_rlm_lm_uses_anthropic_api_key_auth(monkeypatch):
                 captured["cache"] = cache
 
     monkeypatch.setattr(
-        "brain.systems.runs.predict_rlm_backend._resolve_key_from_db",
-        lambda **kwargs: ("sk-ant-test", "user_default"),
+        "brain.systems.runs.predict_rlm_backend._resolve_key_from_env",
+        lambda **kwargs: ("sk-ant-test", "env"),
     )
     monkeypatch.setitem(sys.modules, "dspy", FakeDSPY)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -870,10 +870,9 @@ class TestModelMap:
 # ── LLM Client (OpenAI path) ─────────────────────────────────────
 
 class TestLLMClientOpenAI:
-    @patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none"))
     @patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-test-key", "env"))
     @patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None)
-    def test_resolve_openai_client(self, mock_codex, mock_env, mock_db):
+    def test_resolve_openai_client(self, mock_codex, mock_env):
         from brain.platform.integrations.llm import resolve_llm_client
         mock_openai = MagicMock()
         mock_openai.OpenAI.return_value = MagicMock()
@@ -883,11 +882,10 @@ class TestLLMClientOpenAI:
             assert result.is_oauth is False
             assert result.source == "env"
 
-    @patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none"))
     @patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=("sk-test-key", "env"))
     @patch("brain.platform.integrations.llm._import_openai_sdk", side_effect=RuntimeError("missing openai"))
     @patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None)
-    def test_resolve_openai_missing_sdk_raises_cleanly(self, mock_codex, mock_sdk, mock_env, mock_db):
+    def test_resolve_openai_missing_sdk_raises_cleanly(self, mock_codex, mock_sdk, mock_env):
         from brain.platform.integrations.llm import resolve_llm_client
 
         with pytest.raises(RuntimeError, match="missing openai"):
@@ -895,11 +893,10 @@ class TestLLMClientOpenAI:
 
     def test_resolve_openai_no_key_raises(self):
         from brain.platform.integrations.llm import resolve_llm_client
-        with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")):
-            with patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=(None, "none")):
-                with patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None):
-                    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
-                        resolve_llm_client(provider="openai")
+        with patch("brain.platform.integrations.llm._resolve_key_from_env", return_value=(None, "none")):
+            with patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=None):
+                with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+                    resolve_llm_client(provider="openai")
 
     def test_resolve_openai_from_codex_cache(self):
         from brain.platform.integrations.llm import resolve_llm_client
@@ -913,8 +910,7 @@ class TestLLMClientOpenAI:
         )
         mock_client = MagicMock()
 
-        with patch("brain.platform.integrations.llm._resolve_key_from_db", return_value=(None, "none")), \
-             patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=codex_auth), \
+        with patch("brain.platform.integrations.llm.load_codex_auth_json", return_value=codex_auth), \
              patch("brain.platform.integrations.llm.OpenAICodexClient", return_value=mock_client):
             result = resolve_llm_client(provider="openai")
 


### PR DESCRIPTION
## Summary
- pre-resolve direct-agent model/auth through the async DB-backed resolver before async recipes enter the blocking direct-agent loop
- pass the resolved LLM client through the invocation envelope so the sync loop does not try DB-backed auth resolution
- keep direct sync callers on the existing sync resolver path

## Log Evidence
- Worker run `140` failed immediately after `Reading context` with `No OpenAI auth found. Add a user-scoped OpenAI/Codex credential in Illo.`
- The same user/org resolved successfully through `async_resolve_llm_client` on the worker: provider `openai`, source `user_default`, auth mode `chatgpt`, client `OpenAICodexClient`.
- API `/api/cortex/generate-title` returned 200, confirming this was not the title-generation path fixed in #66.

## Root Cause
- Fast/deep/worker direct-agent recipes cross from async runtime into a blocking direct-agent loop.
- The direct-agent loop still initialized its provider with `resolve_llm_client`, whose sync DB resolver intentionally performs no DB I/O after the async-first migration.
- So user-scoped OpenAI/Codex auth existed, but only the async resolver could see it.

## Tests
- `pytest tests/test_agent.py tests/test_agent_run_runtime.py tests/test_runtime_envelope.py tests/test_agent_auth_fallback.py tests/test_providers.py tests/test_async_db_boundaries.py -q`
- `git diff --check`