### PR TITLE
Remove retired legacy no-op surfaces

### DIFF
--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -786,17 +786,6 @@ async def update_presence(request: Request, user: dict[str, Any] = Depends(get_c
     return {"viewers": viewers}
 
 
-# ── Retired legacy agent status ────────────────────────────────
-
-@router.post("/ideas/{idea_id}/agent-status")
-async def update_agent_status(idea_id: str, request: Request, user: dict[str, Any] = Depends(get_current_user)):
-    _ = (idea_id, request, user)
-    raise HTTPException(
-        status_code=410,
-        detail="Legacy agent-status updates are retired; use AgentRun events and projections.",
-    )
-
-
 # ── Unified stream ─────────────────────────────────────────────
 
 async def unified_stream_payload(

--- a/brain/jobs/pipelines/nightly_context_eval.py
+++ b/brain/jobs/pipelines/nightly_context_eval.py
@@ -30,17 +30,6 @@ def gather_recent_context_policy_eval_sources(
     return []
 
 
-def persist_context_policy_candidate_decisions(
-    evaluation_payload: Mapping[str, Any],
-    *,
-    user_id: str | None = None,
-    org_id: str | None = None,
-    visibility: str = "private",
-) -> list[dict[str, Any]]:
-    """Legacy no-op: policy-update candidate storage was removed."""
-    return []
-
-
 def run_nightly_context_policy_eval(
     *,
     target_date: date | None = None,
@@ -81,14 +70,7 @@ def run_nightly_context_policy_eval(
     persisted: list[dict[str, Any]] = []
     persist_error = None
     if persist_candidates:
-        try:
-            persisted = persist_context_policy_candidate_decisions(
-                evaluation,
-                user_id=user_id,
-                org_id=org_id,
-            )
-        except Exception as exc:
-            persist_error = str(exc)
+        persist_error = "candidate persistence is unavailable"
 
     payload = {
         "pipeline": "nightly_context_eval",

--- a/brain/systems/cortex/reply.py
+++ b/brain/systems/cortex/reply.py
@@ -60,12 +60,6 @@ def reply_to_cortex(idea_id: str, content: str, attachments: list | None = None,
         raise RuntimeError(f"Failed to post reply to cortex thread {idea_id}: {e}") from e
 
 
-def update_agent_status(idea_id: str, action: str, label: str, **kwargs) -> dict:
-    """Retired compatibility stub for the pre-AgentRun status endpoint."""
-    _ = (idea_id, action, label, kwargs)
-    raise RuntimeError("Legacy agent-status updates are retired; use AgentRun events and projections.")
-
-
 def main():
     global DASHBOARD_URL
     parser = argparse.ArgumentParser(description="Post Illo's response to a Cortex idea thread")
@@ -74,10 +68,6 @@ def main():
     parser.add_argument("--dashboard-url", default=None, help=f"Dashboard URL (default: {DASHBOARD_URL})")
     parser.add_argument("--restart-dashboard", action="store_true",
                         help="Restart illo-dashboard service after posting reply")
-    parser.add_argument("--agent-started", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--agent-completed", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--label", default=None, help=argparse.SUPPRESS)
-    parser.add_argument("--skill", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     if args.dashboard_url:
@@ -86,16 +76,11 @@ def main():
     metadata = None  # reserved for future use via CLI args
 
     try:
-        if args.agent_started:
-            update_agent_status(args.idea_id, "started", args.label or "", skill=args.skill or "")
-        elif args.agent_completed:
-            update_agent_status(args.idea_id, "completed", args.label or "", result=args.content or "")
-        else:
-            if not args.content:
-                print("Error: --content is required", file=sys.stderr)
-                sys.exit(1)
-            result = reply_to_cortex(args.idea_id, args.content, metadata=metadata)
-            print(json.dumps(result, indent=2))
+        if not args.content:
+            print("Error: --content is required", file=sys.stderr)
+            sys.exit(1)
+        result = reply_to_cortex(args.idea_id, args.content, metadata=metadata)
+        print(json.dumps(result, indent=2))
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/brain/systems/learning/queue.py
+++ b/brain/systems/learning/queue.py
@@ -575,17 +575,6 @@ class AfterRunLearningQueueService:
         )
 
 
-def queue_after_run_learning_for_run(
-    run_id: int,
-    *,
-    policy: LearningBudgetPolicy | None = None,
-    ledger: LearningBudgetLedger | None = None,
-) -> AfterRunLearningQueueResult | None:
-    """Legacy no-op: after-run learning persistence has been removed."""
-    logger.debug("after-run learning queue disabled for run %s", run_id)
-    return None
-
-
 def build_eval_case_from_trajectory(trajectory: Mapping[str, Any]) -> dict[str, Any]:
     """Build the compact eval-case payload from an already-built trajectory."""
     trajectory = _mapping(trajectory)
@@ -960,5 +949,4 @@ __all__ = [
     "AfterRunLearningSource",
     "AfterRunSkillReference",
     "build_eval_case_from_trajectory",
-    "queue_after_run_learning_for_run",
 ]

--- a/brain/systems/quality/guardian.py
+++ b/brain/systems/quality/guardian.py
@@ -215,30 +215,3 @@ async def get_scout_checklist() -> str:
         md += "\n"
 
     return md
-
-def list_policy_promotions(
-    status: str | None = None,
-    promotion_type: str | None = None,
-) -> list[dict]:
-    """Legacy no-op: policy promotion persistence has been removed."""
-    return []
-
-
-def policy_promotion_activation_report(promotion_id: int) -> dict | None:
-    """Legacy no-op: policy promotion persistence has been removed."""
-    return None
-
-
-def activate_policy_promotion(promotion_id: int, *, reviewer_id: str | None = None) -> dict | None:
-    """Legacy no-op: policy promotion persistence has been removed."""
-    return None
-
-
-def rollback_policy_promotion(
-    promotion_id: int,
-    *,
-    reason: str,
-    reviewer_id: str | None = None,
-) -> dict | None:
-    """Legacy no-op: policy promotion persistence has been removed."""
-    return None

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -810,14 +810,13 @@ async def client():
 
 
 @pytest.mark.asyncio
-async def test_legacy_agent_status_endpoint_is_retired(client):
+async def test_agent_status_endpoint_is_removed(client):
     resp = await client.post(
         "/api/cortex/ideas/idea-1/agent-status",
         json={"action": "started", "label": "legacy-worker"},
     )
 
-    assert resp.status_code == 410
-    assert "AgentRun events" in resp.json()["detail"]
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_context_policy_evals.py
+++ b/tests/test_context_policy_evals.py
@@ -161,3 +161,19 @@ def test_nightly_context_eval_pipeline_is_shadow_only_for_provided_sources():
     assert result["active_policy_changed"] is False
     assert result["runtime_flags_mutated"] is False
     assert result["evaluation"]["replayable_case_count"] == 1
+
+
+def test_nightly_context_eval_reports_unavailable_candidate_persistence():
+    from brain.jobs.pipelines.nightly_context_eval import run_nightly_context_policy_eval
+
+    result = run_nightly_context_policy_eval(
+        target_date=NOW.date(),
+        sources=[_case()],
+        load_recent=False,
+        persist_candidates=True,
+        now=NOW,
+    )
+
+    assert result["persist_candidates"] is True
+    assert result["persisted_candidates"] == []
+    assert result["persist_error"] == "candidate persistence is unavailable"


### PR DESCRIPTION
## Summary
- remove retired Cortex agent-status API and CLI compatibility paths
- delete policy-promotion and after-run learning no-op wrappers whose backing persistence was already removed
- report unavailable context-policy candidate persistence directly instead of routing through a no-op helper

## Validation
- python3 -m pytest tests/test_api_cortex.py tests/test_after_run_learning_queue.py tests/test_context_policy_evals.py tests/test_guardian.py
- python3 -m compileall -q brain/app/api/routers/cortex/_idea_ops.py brain/jobs/pipelines/nightly_context_eval.py brain/systems/cortex/reply.py brain/systems/learning/queue.py brain/systems/quality/guardian.py
- python3 scripts/async_db_debt_metrics.py --json --top 10

## Legacy audit delta
- removes 9 legacy-marked functions/stubs
- removes the retired /api/cortex/ideas/{idea_id}/agent-status route
- keeps async DB debt at zero, with the existing required SQLAlchemy run_sync exemption