### PR TITLE
Fix agent run worker async boundaries

### DIFF
--- a/brain/systems/runs/cancel.py
+++ b/brain/systems/runs/cancel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 import time
 from typing import Callable
@@ -46,13 +45,7 @@ class RunCancelToken:
         return self._canceled
 
     def is_set(self) -> bool:
-        if self._canceled:
-            return True
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(self.a_is_set())
-        return False
+        return self._canceled
 
 
 __all__ = ["RunCancelToken"]

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -676,7 +676,11 @@ async def _sleep_or_stop(delay: float, slot_stop_event: asyncio.Event | None = N
 
 async def _loop(slot_stop_event: asyncio.Event | None = None) -> None:
     while not _stop_event.is_set() and not (slot_stop_event and slot_stop_event.is_set()):
-        processed = await _run_queued_once_async()
+        try:
+            processed = await _run_queued_once_async()
+        except Exception:
+            logger.exception("agent_run_runner_slot_failed")
+            processed = 0
         if not processed:
             await _sleep_or_stop(_poll_interval_sec, slot_stop_event)
 
@@ -699,6 +703,15 @@ def reconcile_runner_pool(*, allow_start: bool = False) -> int:
     ):
         return desired
     with _runner_lock:
+        for task, stop_event in _runner_slots:
+            if task.done() and not task.cancelled() and not stop_event.is_set():
+                exc = task.exception()
+                if exc is not None:
+                    logger.error(
+                        "agent_run_runner_slot_crashed",
+                        extra={"task": task.get_name()},
+                        exc_info=(type(exc), exc, exc.__traceback__),
+                    )
         active_slots = [
             (task, stop_event)
             for task, stop_event in _runner_slots
@@ -729,9 +742,9 @@ async def _supervisor_async_loop() -> None:
     try:
         while not _stop_event.is_set():
             try:
+                reconcile_runner_pool(allow_start=True)
                 await _reap_stale_runs_if_due_async(force=first_reconcile)
                 first_reconcile = False
-                reconcile_runner_pool(allow_start=True)
             except Exception:
                 logger.exception("agent_run_runner_reconcile_failed")
             await _sleep_or_stop(_runner_reconcile_interval_sec)

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -810,6 +810,7 @@ def _update_thread_handoff_after_run(
     semantic_compactor=None,
     run_id: int | None = None,
     user_id: str | None = None,
+    save_session_handoff: Callable[..., None] | None = None,
 ) -> dict | None:
     """Incrementally summarize the raw archive for the next persistent run."""
     from brain.systems.context.thread_handoff import ThreadHandoff, build_thread_handoff
@@ -828,7 +829,7 @@ def _update_thread_handoff_after_run(
         run_id=run_id,
     )
     payload = handoff.to_payload()
-    _save_session_handoff(session_id, payload, user_id=user_id)
+    (save_session_handoff or _save_session_handoff)(session_id, payload, user_id=user_id)
     if fallback_error:
         logger.debug("Agent %s: post-run handoff fallback used: %s", session_id, fallback_error)
     logger.info(
@@ -1311,6 +1312,10 @@ def run_agent(
     skip_harvest: bool = False,
     resolved_llm=None,
     metadata: dict | None = None,
+    load_session: Callable[..., tuple[list[dict], str | None]] | None = None,
+    load_session_handoff: Callable[..., dict | None] | None = None,
+    save_session: Callable[..., None] | None = None,
+    save_session_handoff: Callable[..., None] | None = None,
 ) -> AgentResult:
     """Run an agent loop with tool use.
 
@@ -1457,11 +1462,16 @@ def run_agent(
             )
 
         # Load existing raw session archive, then use durable handoff + recent messages as active context.
-        loaded_messages, stored_system = _load_session(session_id) if persist_session else ([], None)
+        load_session = load_session or _load_session
+        load_session_handoff = load_session_handoff or _load_session_handoff
+        save_session = save_session or _save_session
+        save_session_handoff = save_session_handoff or _save_session_handoff
+
+        loaded_messages, stored_system = load_session(session_id) if persist_session else ([], None)
         if stored_system and not system_prompt:
             system_prompt = stored_system
         raw_archive_messages = copy.deepcopy(loaded_messages) if persist_session else None
-        thread_handoff = _load_session_handoff(session_id) if persist_session else None
+        thread_handoff = load_session_handoff(session_id) if persist_session else None
 
         # Build system + reasoning config
         system = _build_system_blocks(llm, system_prompt, cache_system_prompt)
@@ -1774,7 +1784,7 @@ def run_agent(
             persist_session=persist_session,
             memory_org_for_user=_memory_org_for_user,
             auto_encode_if_needed=_auto_encode_if_needed,
-            save_session=_save_session,
+            save_session=save_session,
         )
         if persist_session and raw_archive_messages is not None:
             _update_thread_handoff_after_run(
@@ -1784,6 +1794,7 @@ def run_agent(
                 semantic_compactor=thread_handoff_compactor,
                 run_id=run_id,
                 user_id=None,
+                save_session_handoff=save_session_handoff,
             )
 
         logger.info(

--- a/brain/systems/runs/recipes/threaded_invocation.py
+++ b/brain/systems/runs/recipes/threaded_invocation.py
@@ -15,6 +15,12 @@ from brain.platform.providers.model_policy import (
     infer_provider_from_model,
     normalize_model_tier,
 )
+from brain.systems.sessions import (
+    async_load_session,
+    async_load_session_handoff,
+    async_save_session,
+    async_save_session_handoff,
+)
 
 
 def _required_openai_auth_mode(model: str | None) -> str | None:
@@ -51,8 +57,15 @@ def thread_sync_tool_handlers(loop: asyncio.AbstractEventLoop, handlers: dict[st
 
 async def invoke_direct_agent_threaded(invoke_direct_agent, spec):
     if _is_default_direct_agent_invocation(invoke_direct_agent):
+        loop = asyncio.get_running_loop()
         spec, resolved_model, resolved_llm = await _resolve_direct_agent_runtime(spec)
-        result = await run_blocking(_invoke_direct_agent_with_resolved_llm, spec, resolved_model, resolved_llm)
+        result = await run_blocking(
+            _invoke_direct_agent_with_resolved_llm,
+            spec,
+            resolved_model,
+            resolved_llm,
+            _direct_agent_loop_overrides(loop, spec),
+        )
     else:
         result = await run_blocking(invoke_direct_agent, spec)
     if inspect.isawaitable(result):
@@ -96,10 +109,43 @@ async def _resolve_direct_agent_runtime(spec):
     return spec, str(model), llm
 
 
-def _invoke_direct_agent_with_resolved_llm(spec, resolved_model, resolved_llm):
+class _LoopBoundCancelEvent:
+    def __init__(self, loop: asyncio.AbstractEventLoop, cancel_event: Any):
+        self._loop = loop
+        self._cancel_event = cancel_event
+
+    async def a_is_set(self) -> bool:
+        checker = getattr(self._cancel_event, "a_is_set", None)
+        if checker is None:
+            checker = getattr(self._cancel_event, "is_set", None)
+        if checker is None:
+            return False
+        result = checker()
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    def is_set(self) -> bool:
+        return bool(sync_on_loop(self._loop, self.a_is_set)())
+
+
+def _direct_agent_loop_overrides(loop: asyncio.AbstractEventLoop, spec) -> dict[str, Any]:
+    overrides: dict[str, Any] = {
+        "load_session": sync_on_loop(loop, async_load_session),
+        "load_session_handoff": sync_on_loop(loop, async_load_session_handoff),
+        "save_session": sync_on_loop(loop, async_save_session),
+        "save_session_handoff": sync_on_loop(loop, async_save_session_handoff),
+    }
+    cancel_event = getattr(spec, "cancel_event", None)
+    if cancel_event is not None:
+        overrides["cancel_event"] = _LoopBoundCancelEvent(loop, cancel_event)
+    return overrides
+
+
+def _invoke_direct_agent_with_resolved_llm(spec, resolved_model, resolved_llm, run_agent_overrides=None):
     from brain.kernel.runtime.kernel import invoke_run_envelope
 
-    overrides = {}
+    overrides = dict(run_agent_overrides or {})
     if resolved_model:
         overrides["model"] = resolved_model
     if resolved_llm is not None:

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 
@@ -16,6 +17,19 @@ def test_runner_concurrency_is_configurable(monkeypatch):
 
     monkeypatch.setenv("ILLO_AGENT_RUNNER_CONCURRENCY", "nope")
     assert runner._runner_concurrency() == 4
+
+
+def test_run_cancel_token_sync_check_does_not_open_db_loop():
+    from brain.systems.runs.cancel import RunCancelToken
+
+    def fail_uow():
+        raise AssertionError("sync cancellation checks must not open DB sessions")
+
+    token = RunCancelToken(42, uow_factory=fail_uow)
+
+    assert token.is_set() is False
+    token._canceled = True
+    assert token.is_set() is True
 
 
 def test_start_runner_starts_configured_worker_pool(monkeypatch):
@@ -108,6 +122,69 @@ def test_runner_pool_uses_one_event_loop(monkeypatch):
 
     assert len(loops) == 3
     assert len(set(loops)) == 1
+
+
+async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    stale_started = asyncio.Event()
+    release_stale = asyncio.Event()
+    slot_entered = asyncio.Event()
+    release_slot = asyncio.Event()
+
+    async def blocked_reap(**_kwargs):
+        stale_started.set()
+        await release_stale.wait()
+        return 0
+
+    async def fake_loop(_slot_stop_event=None):
+        slot_entered.set()
+        await release_slot.wait()
+
+    runner.stop_runner()
+    runner._stop_event.clear()
+    monkeypatch.setattr(runner, "_runner_concurrency", lambda: 1)
+    monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", blocked_reap)
+    monkeypatch.setattr(runner, "_loop", fake_loop)
+    supervisor = asyncio.create_task(runner._supervisor_async_loop())
+    try:
+        await asyncio.wait_for(stale_started.wait(), timeout=1)
+        await asyncio.wait_for(slot_entered.wait(), timeout=1)
+    finally:
+        runner._stop_event.set()
+        release_stale.set()
+        release_slot.set()
+        await asyncio.wait_for(supervisor, timeout=1)
+        runner.stop_runner()
+
+
+async def test_runner_slot_logs_and_survives_queue_errors(monkeypatch, caplog):
+    from brain.systems.runs.cortex import runner
+
+    calls = 0
+    slot_stop_event = asyncio.Event()
+
+    async def fake_run_queued_once():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("claim failed")
+        slot_stop_event.set()
+        return 0
+
+    runner.stop_runner()
+    runner._stop_event.clear()
+    monkeypatch.setattr(runner, "_run_queued_once_async", fake_run_queued_once)
+    monkeypatch.setattr(runner, "_poll_interval_sec", 0)
+    caplog.set_level(logging.ERROR, logger=runner.__name__)
+    try:
+        await asyncio.wait_for(runner._loop(slot_stop_event), timeout=1)
+    finally:
+        slot_stop_event.set()
+        runner.stop_runner()
+
+    assert calls == 2
+    assert "agent_run_runner_slot_failed" in caplog.text
 
 
 async def _noop_reap(**_kwargs):

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -428,6 +428,63 @@ async def test_direct_agent_threaded_resolves_llm_before_blocking(monkeypatch):
     assert calls["resolve_llm_client"]["session"] is FakeUnitOfWork.session
 
 
+async def test_direct_agent_threaded_routes_db_callbacks_to_runner_loop(monkeypatch):
+    from brain.systems.runs.invocation import build_direct_agent_invocation
+    from brain.systems.runs.recipes import threaded_invocation
+
+    loop = asyncio.get_running_loop()
+    seen = []
+
+    async def fake_load_session(session_id, user_id=None):
+        seen.append(("load", id(asyncio.get_running_loop()), session_id, user_id))
+        return ([{"role": "user", "content": "stored"}], "system")
+
+    async def fake_load_handoff(session_id, user_id=None):
+        seen.append(("load_handoff", id(asyncio.get_running_loop()), session_id, user_id))
+        return {"message_count": 1}
+
+    async def fake_save_session(session_id, messages, system_prompt, *token_args, user_id=None):
+        seen.append((
+            "save",
+            id(asyncio.get_running_loop()),
+            session_id,
+            len(messages),
+            system_prompt,
+            token_args,
+            user_id,
+        ))
+
+    async def fake_save_handoff(session_id, payload, *, user_id=None):
+        seen.append(("save_handoff", id(asyncio.get_running_loop()), session_id, payload, user_id))
+
+    async def fake_cancelled():
+        seen.append(("cancel", id(asyncio.get_running_loop())))
+        return True
+
+    monkeypatch.setattr(threaded_invocation, "async_load_session", fake_load_session)
+    monkeypatch.setattr(threaded_invocation, "async_load_session_handoff", fake_load_handoff)
+    monkeypatch.setattr(threaded_invocation, "async_save_session", fake_save_session)
+    monkeypatch.setattr(threaded_invocation, "async_save_session_handoff", fake_save_handoff)
+
+    spec = build_direct_agent_invocation(
+        message="hello",
+        cancel_event=SimpleNamespace(a_is_set=fake_cancelled),
+    )
+    overrides = threaded_invocation._direct_agent_loop_overrides(loop, spec)
+
+    def call_from_agent_thread():
+        assert overrides["load_session"]("session-1") == ([{"role": "user", "content": "stored"}], "system")
+        assert overrides["load_session_handoff"]("session-1") == {"message_count": 1}
+        overrides["save_session"]("session-1", [{"role": "user", "content": "x"}], "system", 1, 2, 3, 4)
+        overrides["save_session_handoff"]("session-1", {"message_count": 2})
+        assert overrides["cancel_event"].is_set() is True
+
+    await asyncio.to_thread(call_from_agent_thread)
+
+    assert {entry[1] for entry in seen} == {id(loop)}
+    assert [entry[0] for entry in seen] == ["load", "load_handoff", "save", "save_handoff", "cancel"]
+
+
 def test_fast_onboarding_tool_surface_uses_standard_fast_surface(monkeypatch):
     from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
 


### PR DESCRIPTION
## Summary
- start agent-runner queue slots before stale-run maintenance so worker startup cannot be blocked by reconciliation
- keep runner slots alive and logged when a queue pass crashes
- route threaded direct-agent session persistence and cancel checks back to the runner event loop
- remove the sync DB fallback from RunCancelToken.is_set()

## Root cause from logs
- production is on c4fe677 from current main
- worker logs only startup while run 145 remains queued with only run.created, so the worker was alive but not claiming
- manual drain completed run 144 but produced asyncpg cross-event-loop errors from sync session/cancel side effects
- current runner also awaited stale-run reconciliation before creating queue slots; a blocked maintenance pass could leave the worker started but unable to consume queued runs

## Tests
- TDD regression: tests/test_agent_run_runner.py::test_supervisor_starts_runner_slots_before_stale_reconcile_finishes failed before the runner-order fix and passes now
- git diff --check
- pytest tests/test_agent_run_runner.py tests/test_agent_run_runtime.py tests/test_agent_split.py tests/test_agent_runtime_modules.py tests/test_async_io_debt_metrics.py tests/test_agent.py -q
- python3 scripts/async_io_debt_metrics.py --json --top 20