### PR TITLE
Persist visible Illo replies for completed runs

### DIFF
--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -29,8 +29,8 @@ from brain.systems.cortex.project_context.materializer import (
     materialize_project_context_workspaces,
     project_context_has_materializable_resources,
 )
-from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
-from brain.platform.db.models.idea import Idea, IdeaStateLog
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.idea import Idea, IdeaStateLog, IdeaThread
 
 logger = logging.getLogger(__name__)
 UnitOfWork = None
@@ -212,6 +212,65 @@ _TERMINAL_RUN_IDEA_STATUS = {
 _PROTECTED_IDEA_STATUSES = {"archived", "resolved"}
 
 
+def _message_belongs_to_run(message: IdeaThread, run_id: int) -> bool:
+    metadata = getattr(message, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return False
+    return str(metadata.get("run_id") or "") == str(run_id)
+
+
+async def _post_run_final_answer_to_thread_once_async(
+    session,
+    *,
+    run: AgentRunRow,
+    idea: Idea,
+) -> IdeaThread | None:
+    """Mirror a completed root run's final answer into the visible thread."""
+    artifact = (
+        await session.scalars(
+            select(AgentRunArtifactRow)
+            .where(
+                AgentRunArtifactRow.run_id == int(run.id),
+                AgentRunArtifactRow.artifact_type == "final_answer",
+            )
+            .order_by(AgentRunArtifactRow.created_at.desc(), AgentRunArtifactRow.id.desc())
+            .limit(1)
+        )
+    ).first()
+    text = str(getattr(artifact, "text", None) or "").strip()
+    if not text:
+        return None
+
+    recent_responses = (
+        await session.scalars(
+            select(IdeaThread)
+            .where(
+                IdeaThread.idea_id == str(idea.id),
+                IdeaThread.role.in_(("illo", "assistant")),
+                IdeaThread.message_type == "agent_response",
+            )
+        )
+    ).all()
+    if any(_message_belongs_to_run(message, int(run.id)) for message in recent_responses):
+        return None
+
+    message = IdeaThread(
+        idea_id=str(idea.id),
+        role="illo",
+        content=text,
+        user_id=None,
+        message_type="agent_response",
+        metadata_={
+            "run_id": int(run.id),
+            "artifact_id": getattr(artifact, "id", None),
+            "source": "agent_run_final_answer",
+        },
+    )
+    session.add(message)
+    await session.flush()
+    return message
+
+
 async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
     run = await session.get(AgentRunRow, int(run_id))
     if run is None or run.parent_run_id is not None:
@@ -227,7 +286,10 @@ async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict
     if idea is None:
         return None
     old_status = str(idea.status or "")
-    if old_status in _PROTECTED_IDEA_STATUSES or old_status == target_status:
+    if old_status in _PROTECTED_IDEA_STATUSES:
+        return None
+    await _post_run_final_answer_to_thread_once_async(session, run=run, idea=idea)
+    if old_status == target_status:
         return None
 
     idea.status = target_status

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -27,6 +27,17 @@ class _AwaitableValue:
         return getattr(self.value, name)
 
 
+class _ScalarRows:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return list(self.rows)
+
+
 class _Store:
     def __init__(self):
         self.events = []
@@ -1620,12 +1631,19 @@ async def test_thread_binding_applies_explicit_model_override():
 async def test_runner_settles_root_run_idea_status():
     from brain.systems.runs.cortex.runner import _settle_idea_for_terminal_root_run_async
     from brain.platform.db.models.agent_run import AgentRunRow
-    from brain.platform.db.models.idea import Idea, IdeaStateLog
+    from brain.platform.db.models.idea import Idea, IdeaStateLog, IdeaThread
 
     idea_id = str(uuid.uuid4())
     run = SimpleNamespace(id=42, parent_run_id=None, thread_id=idea_id, status="completed")
     idea = SimpleNamespace(id=idea_id, status="active", updated_at=None)
+    final_artifact = SimpleNamespace(
+        id=99,
+        run_id=42,
+        artifact_type="final_answer",
+        text="Done. I created the teammate handoffs.",
+    )
     added = []
+    scalar_calls = 0
 
     class FakeSession:
         async def get(self, model, key):
@@ -1637,6 +1655,13 @@ async def test_runner_settles_root_run_idea_status():
 
         def add(self, obj):
             added.append(obj)
+
+        async def scalars(self, stmt):
+            nonlocal scalar_calls
+            scalar_calls += 1
+            if scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([])
 
         async def flush(self):
             pass
@@ -1651,6 +1676,54 @@ async def test_runner_settles_root_run_idea_status():
         "run_id": 42,
     }
     assert any(isinstance(obj, IdeaStateLog) for obj in added)
+    response = next(obj for obj in added if isinstance(obj, IdeaThread))
+    assert response.idea_id == idea_id
+    assert response.role == "illo"
+    assert response.message_type == "agent_response"
+    assert response.content == "Done. I created the teammate handoffs."
+    assert response.metadata_ == {
+        "run_id": 42,
+        "artifact_id": 99,
+        "source": "agent_run_final_answer",
+    }
+
+
+async def test_runner_does_not_duplicate_final_answer_thread_message():
+    from brain.systems.runs.cortex.runner import _settle_idea_for_terminal_root_run_async
+    from brain.platform.db.models.agent_run import AgentRunRow
+    from brain.platform.db.models.idea import Idea, IdeaThread
+
+    idea_id = str(uuid.uuid4())
+    run = SimpleNamespace(id=45, parent_run_id=None, thread_id=idea_id, status="completed")
+    idea = SimpleNamespace(id=idea_id, status="unread_reply", updated_at=None)
+    final_artifact = SimpleNamespace(id=100, run_id=45, artifact_type="final_answer", text="Already visible")
+    existing_message = SimpleNamespace(metadata_={"run_id": 45})
+    added = []
+    scalar_calls = 0
+
+    class FakeSession:
+        async def get(self, model, key):
+            if model is AgentRunRow and int(key) == 45:
+                return run
+            if model is Idea and str(key) == idea_id:
+                return idea
+            return None
+
+        def add(self, obj):
+            added.append(obj)
+
+        async def scalars(self, stmt):
+            nonlocal scalar_calls
+            scalar_calls += 1
+            if scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([existing_message])
+
+        async def flush(self):
+            pass
+
+    assert await _settle_idea_for_terminal_root_run_async(FakeSession(), 45) is None
+    assert not any(isinstance(obj, IdeaThread) for obj in added)
 
 
 async def test_runner_does_not_settle_child_run_idea_status():


### PR DESCRIPTION
## Summary
- Persist completed root run final answers as normal visible Illo thread replies
- Keep duplicate protection so repeated settlement does not create multiple replies for the same run
- Cover the MCP coordination case where Illo acknowledges in the parent thread, then creates JB/Axel-owned child threads

## Why
The hosted MCP flow successfully triggered Illo and created child handoff threads, but the parent thread only showed the user's trigger message. Illo's acknowledgement was stored as an AgentRun final-answer artifact, leaving the UI in an unread state with no visible reply.

## Tests
- venv/bin/python -m pytest tests/test_agent_run_runtime.py tests/test_api_cortex.py -k 'runner or unified_stream'
- venv/bin/python -m pytest tests/test_external_agent_routes.py tests/test_external_agents_service.py -q
- git diff --check