### PR TITLE
Fix cycle save validation errors returning 500

### DIFF
--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -198,16 +198,24 @@ async def update_cycle(
         await _validate_target_idea(db, updates["target_idea_id"], user)
 
     try:
+        next_timezone = cycle.timezone
+        if "timezone" in updates and updates["timezone"] is not None:
+            next_timezone = validate_timezone_name(updates["timezone"])
+
+        next_schedule_expr = cycle.schedule_expr
+        if "run_at" in updates and updates["run_at"] is not None:
+            next_schedule_expr = build_one_time_schedule_expr(updates["run_at"], next_timezone)
+        elif "schedule_expr" in updates and updates["schedule_expr"] is not None:
+            next_schedule_expr = validate_schedule_expr(updates["schedule_expr"], next_timezone)
+
+        next_run_at = compute_next_run_at(next_schedule_expr, next_timezone)
+
         if "name" in updates and updates["name"] is not None:
             cycle.name = validate_nonempty_trimmed(updates["name"], "name")
         if "prompt" in updates and updates["prompt"] is not None:
             cycle.prompt = validate_nonempty_trimmed(updates["prompt"], "prompt")
-        if "timezone" in updates and updates["timezone"] is not None:
-            cycle.timezone = validate_timezone_name(updates["timezone"])
-        if "run_at" in updates and updates["run_at"] is not None:
-            cycle.schedule_expr = build_one_time_schedule_expr(updates["run_at"], cycle.timezone)
-        if "schedule_expr" in updates and updates["schedule_expr"] is not None:
-            cycle.schedule_expr = validate_schedule_expr(updates["schedule_expr"], cycle.timezone)
+        cycle.timezone = next_timezone
+        cycle.schedule_expr = next_schedule_expr
         if "enabled" in updates and updates["enabled"] is not None:
             cycle.enabled = updates["enabled"]
         if "model_override" in updates:
@@ -229,7 +237,7 @@ async def update_cycle(
         cycle.execution_mode = REUSABLE_THREAD_EXECUTION_MODE
         cycle.reopen_archived = True
 
-        cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
+        cycle.next_run_at = next_run_at
     except ValueError as exc:
         raise _bad_request(exc) from exc
     await db.flush()

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -57,6 +57,10 @@ def _cycle_scope_conditions(user: dict[str, Any]) -> list[Any]:
     return [Cycle.user_id == str(user["id"]), Cycle.deleted_at.is_(None)]
 
 
+def _bad_request(exc: ValueError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
+
+
 def _target_idea_scope_conditions(idea_id: str, user: dict[str, Any]) -> list[Any]:
     conditions: list[Any] = [Idea.id == idea_id]
     if _is_service_principal(user):
@@ -121,20 +125,21 @@ async def create_cycle(
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    timezone_name = validate_timezone_name(body.timezone)
-    if body.run_at is not None:
-        schedule_expr = build_one_time_schedule_expr(body.run_at, timezone_name)
-    elif body.schedule_expr:
-        schedule_expr = validate_schedule_expr(body.schedule_expr, timezone_name)
-    else:
-        raise HTTPException(status_code=400, detail="schedule_expr or run_at is required")
-    execution_mode = validate_execution_mode(body.execution_mode)
-    thinking_override = validate_thinking_override(body.thinking_override)
     try:
+        timezone_name = validate_timezone_name(body.timezone)
+        if body.run_at is not None:
+            schedule_expr = build_one_time_schedule_expr(body.run_at, timezone_name)
+        elif body.schedule_expr:
+            schedule_expr = validate_schedule_expr(body.schedule_expr, timezone_name)
+        else:
+            raise HTTPException(status_code=400, detail="schedule_expr or run_at is required")
+        execution_mode = validate_execution_mode(body.execution_mode)
+        thinking_override = validate_thinking_override(body.thinking_override)
         name = validate_nonempty_trimmed(body.name, "name")
         prompt = validate_nonempty_trimmed(body.prompt, "prompt")
+        next_run_at = compute_next_run_at(schedule_expr, timezone_name)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise _bad_request(exc) from exc
     await _validate_target_idea(db, body.target_idea_id, user)
     cycle = Cycle(
         user_id=user["id"],
@@ -152,7 +157,7 @@ async def create_cycle(
             execution_mode=execution_mode,
             reopen_archived=body.reopen_archived,
         ),
-        next_run_at=compute_next_run_at(schedule_expr, timezone_name),
+        next_run_at=next_run_at,
     )
     db.add(cycle)
     await db.flush()
@@ -192,44 +197,41 @@ async def update_cycle(
     if "target_idea_id" in updates:
         await _validate_target_idea(db, updates["target_idea_id"], user)
 
-    if "name" in updates and updates["name"] is not None:
-        try:
+    try:
+        if "name" in updates and updates["name"] is not None:
             cycle.name = validate_nonempty_trimmed(updates["name"], "name")
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if "prompt" in updates and updates["prompt"] is not None:
-        try:
+        if "prompt" in updates and updates["prompt"] is not None:
             cycle.prompt = validate_nonempty_trimmed(updates["prompt"], "prompt")
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if "timezone" in updates and updates["timezone"] is not None:
-        cycle.timezone = validate_timezone_name(updates["timezone"])
-    if "run_at" in updates and updates["run_at"] is not None:
-        cycle.schedule_expr = build_one_time_schedule_expr(updates["run_at"], cycle.timezone)
-    if "schedule_expr" in updates and updates["schedule_expr"] is not None:
-        cycle.schedule_expr = validate_schedule_expr(updates["schedule_expr"], cycle.timezone)
-    if "enabled" in updates and updates["enabled"] is not None:
-        cycle.enabled = updates["enabled"]
-    if "model_override" in updates:
-        cycle.model_override = (updates["model_override"] or "").strip() or None
-    if "thinking_override" in updates:
-        cycle.thinking_override = validate_thinking_override(updates["thinking_override"])
-    if "execution_mode" in updates and updates["execution_mode"] is not None:
-        cycle.execution_mode = validate_execution_mode(updates["execution_mode"])
-    if "target_idea_id" in updates:
-        cycle.target_idea_id = updates["target_idea_id"]
-    if "reopen_archived" in updates and updates["reopen_archived"] is not None:
-        cycle.reopen_archived = updates["reopen_archived"]
-    elif "execution_mode" in updates and "reopen_archived" not in updates:
-        cycle.reopen_archived = cycle_defaults(
-            execution_mode=cycle.execution_mode,
-            reopen_archived=None,
-        )
+        if "timezone" in updates and updates["timezone"] is not None:
+            cycle.timezone = validate_timezone_name(updates["timezone"])
+        if "run_at" in updates and updates["run_at"] is not None:
+            cycle.schedule_expr = build_one_time_schedule_expr(updates["run_at"], cycle.timezone)
+        if "schedule_expr" in updates and updates["schedule_expr"] is not None:
+            cycle.schedule_expr = validate_schedule_expr(updates["schedule_expr"], cycle.timezone)
+        if "enabled" in updates and updates["enabled"] is not None:
+            cycle.enabled = updates["enabled"]
+        if "model_override" in updates:
+            cycle.model_override = (updates["model_override"] or "").strip() or None
+        if "thinking_override" in updates:
+            cycle.thinking_override = validate_thinking_override(updates["thinking_override"])
+        if "execution_mode" in updates and updates["execution_mode"] is not None:
+            cycle.execution_mode = validate_execution_mode(updates["execution_mode"])
+        if "target_idea_id" in updates:
+            cycle.target_idea_id = updates["target_idea_id"]
+        if "reopen_archived" in updates and updates["reopen_archived"] is not None:
+            cycle.reopen_archived = updates["reopen_archived"]
+        elif "execution_mode" in updates and "reopen_archived" not in updates:
+            cycle.reopen_archived = cycle_defaults(
+                execution_mode=cycle.execution_mode,
+                reopen_archived=None,
+            )
 
-    cycle.execution_mode = REUSABLE_THREAD_EXECUTION_MODE
-    cycle.reopen_archived = True
+        cycle.execution_mode = REUSABLE_THREAD_EXECUTION_MODE
+        cycle.reopen_archived = True
 
-    cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
+        cycle.next_run_at = compute_next_run_at(cycle.schedule_expr, cycle.timezone)
+    except ValueError as exc:
+        raise _bad_request(exc) from exc
     await db.flush()
     payload = serialize_cycle(cycle)
     event = {

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -86,6 +86,18 @@ async def _handle_manage_cycle_async(
     if not user_id:
         return json.dumps({"error": "manage_cycle requires a user-scoped cortex run"})
 
+    def _optional_text(value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _optional_update_text(value: str | None) -> str | None:
+        # Tool-call optional string fields often arrive as empty strings. Treat blanks
+        # as omitted for update-only fields so a schedule update is not derailed by
+        # an unrelated default like run_at="" or name="".
+        return _optional_text(value)
+
     def _cycle_scope():
         scope = [Cycle.deleted_at.is_(None)]
         if org_id:
@@ -126,18 +138,23 @@ async def _handle_manage_cycle_async(
                 cycles = [serialize_cycle(cycle) for cycle in result.all()]
             return json.dumps({"cycles": cycles}, default=str)
         elif action == "create":
-            if not name or not prompt or not timezone or (not schedule_expr and not run_at):
+            create_name = _optional_text(name)
+            create_prompt = _optional_text(prompt)
+            create_timezone = _optional_text(timezone)
+            create_run_at = _optional_text(run_at)
+            create_schedule_expr = _optional_text(schedule_expr)
+            if not create_name or not create_prompt or not create_timezone or (not create_schedule_expr and not create_run_at):
                 return json.dumps({"error": "create requires: name, prompt, timezone, and schedule_expr or run_at"})
-            tz_name = validate_timezone_name(timezone)
+            tz_name = validate_timezone_name(create_timezone)
             expr = (
-                build_one_time_schedule_expr(run_at, tz_name)
-                if run_at
-                else validate_schedule_expr(schedule_expr or "", tz_name)
+                build_one_time_schedule_expr(create_run_at, tz_name)
+                if create_run_at
+                else validate_schedule_expr(create_schedule_expr or "", tz_name)
             )
             mode = validate_execution_mode(execution_mode)
             thinking = validate_thinking_override(thinking_override)
-            normalized_name = validate_nonempty_trimmed(name, "name")
-            normalized_prompt = validate_nonempty_trimmed(prompt, "prompt")
+            normalized_name = validate_nonempty_trimmed(create_name, "name")
+            normalized_prompt = validate_nonempty_trimmed(create_prompt, "prompt")
             async with UnitOfWork() as uow:
                 if target_idea_id:
                     stmt = select(Idea.id).where(*_idea_scope(target_idea_id))
@@ -176,6 +193,15 @@ async def _handle_manage_cycle_async(
         elif action == "update":
             if not id:
                 return json.dumps({"error": "update requires: id"})
+            update_name = _optional_update_text(name)
+            update_prompt = _optional_update_text(prompt)
+            update_timezone = _optional_update_text(timezone)
+            update_run_at = _optional_update_text(run_at)
+            update_schedule_expr = _optional_update_text(schedule_expr)
+            update_model_override = model_override if model_override is not None else None
+            update_thinking_override = _optional_update_text(thinking_override)
+            update_execution_mode = _optional_update_text(execution_mode)
+            update_target_idea_id = _optional_update_text(target_idea_id)
             async with UnitOfWork() as uow:
                 stmt = select(Cycle).where(
                     Cycle.id == id,
@@ -185,34 +211,34 @@ async def _handle_manage_cycle_async(
                 cycle = result.first()
                 if not cycle:
                     return json.dumps({"error": f"Cycle {id} not found"})
-                if target_idea_id:
-                    idea_stmt = select(Idea.id).where(*_idea_scope(target_idea_id))
+                if update_target_idea_id:
+                    idea_stmt = select(Idea.id).where(*_idea_scope(update_target_idea_id))
                     result = await uow.session.execute(idea_stmt)
                     if not result.first():
                         return json.dumps({"error": "target_idea_id must belong to the current workspace"})
-                if name is not None:
-                    cycle.name = validate_nonempty_trimmed(name, "name")
-                if prompt is not None:
-                    cycle.prompt = validate_nonempty_trimmed(prompt, "prompt")
-                if timezone is not None:
-                    cycle.timezone = validate_timezone_name(timezone)
-                if run_at is not None:
-                    cycle.schedule_expr = build_one_time_schedule_expr(run_at, cycle.timezone)
-                if schedule_expr is not None:
-                    cycle.schedule_expr = validate_schedule_expr(schedule_expr, cycle.timezone)
+                if update_name is not None:
+                    cycle.name = validate_nonempty_trimmed(update_name, "name")
+                if update_prompt is not None:
+                    cycle.prompt = validate_nonempty_trimmed(update_prompt, "prompt")
+                if update_timezone is not None:
+                    cycle.timezone = validate_timezone_name(update_timezone)
+                if update_run_at is not None:
+                    cycle.schedule_expr = build_one_time_schedule_expr(update_run_at, cycle.timezone)
+                if update_schedule_expr is not None:
+                    cycle.schedule_expr = validate_schedule_expr(update_schedule_expr, cycle.timezone)
                 if enabled is not None:
                     cycle.enabled = enabled
-                if model_override is not None:
-                    cycle.model_override = (model_override or "").strip() or None
-                if thinking_override is not None:
-                    cycle.thinking_override = validate_thinking_override(thinking_override)
-                if execution_mode is not None:
-                    cycle.execution_mode = validate_execution_mode(execution_mode)
+                if update_model_override is not None:
+                    cycle.model_override = (update_model_override or "").strip() or None
+                if update_thinking_override is not None:
+                    cycle.thinking_override = validate_thinking_override(update_thinking_override)
+                if update_execution_mode is not None:
+                    cycle.execution_mode = validate_execution_mode(update_execution_mode)
                 if target_idea_id is not None:
-                    cycle.target_idea_id = target_idea_id
+                    cycle.target_idea_id = update_target_idea_id
                 if reopen_archived is not None:
                     cycle.reopen_archived = reopen_archived
-                elif execution_mode is not None:
+                elif update_execution_mode is not None:
                     cycle.reopen_archived = cycle_defaults(
                         execution_mode=cycle.execution_mode,
                         reopen_archived=None,

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -60,6 +60,30 @@ class _AllResult:
         return list(self._values)
 
 
+
+class _RouterCycleResult:
+    def __init__(self, cycle):
+        self._cycle = cycle
+
+    def first(self):
+        return self._cycle
+
+
+class _RouterCycleSession:
+    def __init__(self, cycle):
+        self._cycle = cycle
+        self.flushed = False
+
+    def scalars(self, statement):
+        return _RouterCycleResult(self._cycle)
+
+    def execute(self, statement):
+        return _FirstResult((self._cycle.target_idea_id,))
+
+    def flush(self):
+        self.flushed = True
+
+
 class _ExecuteCycleSession:
     def __init__(self, *, run, cycle, idea, owner=None, expected_run_id=None):
         self._scalar_values = [run, cycle, idea]
@@ -282,6 +306,59 @@ def _cycle_for_serialization(*, schedule_expr: str, timezone_name: str) -> Cycle
     cycle.updated_at = now
     return cycle
 
+
+
+@pytest.mark.asyncio
+async def test_cycle_update_recomputes_schedule_with_new_timezone_before_saving():
+    cycle = _cycle_for_serialization(
+        schedule_expr="0 9 * * *",
+        timezone_name="UTC",
+    )
+    db = _RouterCycleSession(cycle)
+
+    body = cycles_router.CycleUpdate(
+        schedule_expr="0 9 * * 1",
+        timezone="America/Toronto",
+    )
+    response = await cycles_router.update_cycle(
+        cycle.id,
+        body,
+        db=db,
+        user={"id": cycle.user_id, "org_id": None},
+    )
+
+    assert response["schedule_expr"] == "0 9 * * 1"
+    assert response["timezone"] == "America/Toronto"
+    assert response["next_run_at"].tzinfo is not None
+    assert cycle.schedule_expr == "0 9 * * 1"
+    assert cycle.timezone == "America/Toronto"
+    assert db.flushed is True
+
+
+@pytest.mark.asyncio
+async def test_cycle_update_validation_failure_does_not_mutate_or_flush():
+    cycle = _cycle_for_serialization(
+        schedule_expr="0 9 * * *",
+        timezone_name="America/Toronto",
+    )
+    db = _RouterCycleSession(cycle)
+
+    body = cycles_router.CycleUpdate(
+        schedule_expr="0 9 * * 1",
+        timezone="Mars/Base",
+    )
+    with pytest.raises(cycles_router.HTTPException) as caught:
+        await cycles_router.update_cycle(
+            cycle.id,
+            body,
+            db=db,
+            user={"id": cycle.user_id, "org_id": None},
+        )
+
+    assert caught.value.status_code == 400
+    assert cycle.timezone == "America/Toronto"
+    assert cycle.schedule_expr == "0 9 * * *"
+    assert db.flushed is False
 
 def test_serialize_cycle_does_not_raise_for_legacy_bad_timezone():
     cycle = _cycle_for_serialization(

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -250,6 +250,14 @@ def test_validate_nonempty_trimmed_rejects_blank_text():
         service.validate_nonempty_trimmed("   ", "name")
 
 
+def test_cycle_router_bad_request_returns_400():
+    with pytest.raises(cycles_router.HTTPException) as caught:
+        raise cycles_router._bad_request(ValueError("Unknown timezone: Mars/Base"))
+
+    assert caught.value.status_code == 400
+    assert caught.value.detail == "Unknown timezone: Mars/Base"
+
+
 def _cycle_for_serialization(*, schedule_expr: str, timezone_name: str) -> Cycle:
     now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
     cycle = Cycle()


### PR DESCRIPTION
## Summary
- Map Cycle create/update validation failures to HTTP 400 instead of leaking as 500s
- Compute create `next_run_at` inside the validation boundary
- Add a regression check for the router's 400 conversion helper

## Validation
- `python -m py_compile brain/app/api/routers/cycles.py tests/test_cycles_service.py`
- `git diff --check`
- `python -m pytest tests/test_cycles_service.py -q` could not run in this runtime because pytest is not installed
