### PR TITLE
Fix archive menu stacking layer

### DIFF
--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -969,17 +969,6 @@
               {#if workspaceOverlay.timelineOpen && CortexTimelineComponent}
                 <CortexTimelineComponent visible={workspaceOverlay.timelineOpen} />
               {/if}
-
-              {#if cortexSurfaceReady && !cortex.panelOpen && !chatDockExpanded && !workspaceOverlay.activeWorkspaceAppId && CortexArchiveBinMenuComponent}
-                <div class="workspace-archive-bin-shell" class:dragging={workspaceOverlay.archiveDragActive}>
-                  <CortexArchiveBinMenuComponent
-                    dragging={workspaceOverlay.archiveDragActive}
-                    dropActive={workspaceOverlay.archiveDropActive}
-                    onrestore={handleRestoreArchivedThread}
-                    onrestoreapp={handleRestoreArchivedApp}
-                  />
-                </div>
-              {/if}
             </div>
           {/snippet}
 
@@ -1016,6 +1005,19 @@
                     onAutoDraftComplete={handleRuntimeReadyAutoDraftComplete}
                   />
                 {/if}
+              </div>
+            {/if}
+          {/snippet}
+
+          {#snippet overlays()}
+            {#if cortexSurfaceReady && !cortex.panelOpen && !chatDockExpanded && !workspaceOverlay.activeWorkspaceAppId && CortexArchiveBinMenuComponent}
+              <div class="workspace-archive-bin-shell" class:dragging={workspaceOverlay.archiveDragActive}>
+                <CortexArchiveBinMenuComponent
+                  dragging={workspaceOverlay.archiveDragActive}
+                  dropActive={workspaceOverlay.archiveDropActive}
+                  onrestore={handleRestoreArchivedThread}
+                  onrestoreapp={handleRestoreArchivedApp}
+                />
               </div>
             {/if}
           {/snippet}
@@ -1254,7 +1256,7 @@
     position: absolute;
     right: 22px;
     bottom: 16px;
-    z-index: 6;
+    z-index: 1;
     pointer-events: auto;
   }
 


### PR DESCRIPTION
## Summary
- Move the archive bin/menu into the workspace backdrop overlay layer so archived items render above orbit threads/ideas.
- Keep the bin pinned to the same bottom-right position while preserving drag/drop state styling.

## Validation
- `git diff --check`
- Frontend build/check not run: this runtime does not have Node/npm installed.
