### PR TITLE
Fix workspace app ownership and sync title mapping

### DIFF
--- a/brain/systems/runs/cortex/thread_binding.py
+++ b/brain/systems/runs/cortex/thread_binding.py
@@ -125,6 +125,21 @@ def _metadata_int(metadata: dict[str, Any], *keys: str) -> int | None:
     return None
 
 
+def _trigger_actor_user_id(metadata: dict[str, Any], *, org_id: str | None = None) -> str | None:
+    trigger = metadata.get("illo_trigger")
+    if not isinstance(trigger, dict):
+        return None
+    actor = trigger.get("actor")
+    if not isinstance(actor, dict):
+        return None
+    if actor.get("internal") is True:
+        return None
+    if org_id and str(actor.get("org_id") or "") not in {"", str(org_id)}:
+        return None
+    actor_id = str(actor.get("id") or "").strip()
+    return actor_id or None
+
+
 async def _a_latest_attached_project_context(session: Any, idea_id: str) -> dict[str, Any]:
     if not hasattr(session, "scalars"):
         return {}
@@ -228,9 +243,14 @@ async def a_build_run_request(
         )
         if thread_context:
             metadata["thread_context"] = thread_context
+    owner_user_id = (
+        _trigger_actor_user_id(metadata, org_id=str(getattr(idea, "org_id", "") or "") or None)
+        or user_id
+        or getattr(idea, "user_id", None)
+    )
     return AgentRunRequest(
         org_id=str(getattr(idea, "org_id", "") or "") or None,
-        user_id=user_id or getattr(idea, "user_id", None),
+        user_id=owner_user_id,
         thread_id=idea_id,
         message=message,
         profile=profile,

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -217,6 +217,10 @@ async def _sync_items_to_domain(
     title_expr = sync_spec.get("title") or sync_spec.get("title_path")
     limit = min(_positive_int(sync_spec.get("limit") or _MAX_ITEMS, "connector_spec.sync.limit"), _MAX_ITEMS)
 
+    object_type = await service.get_object_type(domain_id, object_key)
+    field_keys = {str(field.key) for field in await service.list_fields(object_type.id)}
+    title_field_key = str(getattr(object_type, "title_field", "") or "").strip()
+
     existing_by_remote: dict[str, Any] = {}
     if remote_id_field:
         for record in await service.list_records(context.org_id, domain_id, object_key=object_key, limit=500):
@@ -244,6 +248,10 @@ async def _sync_items_to_domain(
             data.setdefault(remote_id_field, str(remote_id))
         title = _mapped_value(title_expr, item) if title_expr is not None else None
         title_text = str(title).strip() if title is not None else None
+        if title_text:
+            for field_key in ("title", title_field_key):
+                if field_key and field_key in field_keys and field_key not in data:
+                    data[field_key] = title_text
 
         existing = existing_by_remote.get(str(remote_id)) if remote_id is not None else None
         try:

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1445,6 +1445,34 @@ async def test_thread_binding_keeps_fast_high_intelligence_by_default():
     assert request.metadata["event"] == "thread_reply"
 
 
+async def test_thread_binding_prefers_cortex_trigger_actor_over_payload_user_id():
+    from brain.systems.runs.cortex.thread_binding import a_build_run_request
+
+    session = _async_thread_binding_session(
+        SimpleNamespace(id="idea-1", org_id="org-1", user_id="u1", title="Thread")
+    )
+
+    request = await a_build_run_request(
+        session,
+        idea_id="idea-1",
+        event="idea_created",
+        message="Build a workspace app",
+        user_id="service-user",
+        metadata={
+            "illo_trigger": {
+                "actor": {
+                    "id": "u1",
+                    "org_id": "org-1",
+                    "internal": False,
+                    "principal_type": "human",
+                }
+            }
+        },
+    )
+
+    assert request.user_id == "u1"
+
+
 async def test_thread_binding_records_slash_skill_interest():
     from brain.systems.runs.cortex.thread_binding import a_build_run_request
 

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -896,6 +896,105 @@ async def test_workspace_app_action_generic_http_supports_templates_and_conditio
     assert second.data["status"] == "Done"
 
 
+async def test_workspace_app_action_generic_http_populates_required_title_field_from_sync_title(session):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="Required Title Tickets",
+        slug="required-title-tickets",
+        objects=[
+            {
+                "key": "ticket",
+                "name": "Ticket",
+                "fields": [
+                    {"key": "external_id", "field_type": "text", "required": True},
+                    {"key": "title", "field_type": "text", "required": True},
+                    {"key": "status", "field_type": "enum", "options": ["Todo", "Done"]},
+                    {"key": "link", "field_type": "url"},
+                    {"key": "synced_at", "field_type": "datetime"},
+                ],
+            }
+        ],
+        actor_id=USER_ID,
+    )
+    manifest = {
+        "contract_version": 1,
+        "data_plan": {
+            "mode": "domain",
+            "bindings": {
+                "tickets": {
+                    "domain_id": domain.id,
+                    "object_key": "ticket",
+                    "fields": ["title", "external_id", "status", "link", "synced_at"],
+                    "operations": ["schema", "list", "create", "update"],
+                }
+            },
+        },
+        "design_contract": {
+            "kit": "constellation-app-kit",
+            "theme_modes": ["dark", "light"],
+        },
+        "actions": {
+            "tickets.syncExternal": {
+                "kind": "connector",
+                "effects": ["external.read", "domain.write"],
+                "executor": {"type": "registered", "key": "generic.http"},
+                "connector_spec": {
+                    "kind": "http_sync",
+                    "request": {"method": "GET", "url": "https://jsonplaceholder.typicode.com/todos"},
+                    "response": {"items_path": "$"},
+                    "sync": {
+                        "binding": "tickets",
+                        "remote_id": "id",
+                        "remote_id_field": "external_id",
+                        "title": "title",
+                        "fields": {
+                            "status": {
+                                "if": {"path": "completed", "equals": True},
+                                "then": "Done",
+                                "else": "Todo",
+                            },
+                            "link": {"template": "https://jsonplaceholder.typicode.com/todos/{id}"},
+                            "synced_at": {"now": True},
+                        },
+                    },
+                },
+            }
+        },
+    }
+    app = await a_create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-required-title-sync",
+        name="Generic HTTP Required Title Sync",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    with patch(
+        "brain.systems.workspace_apps.generic_http._request_json",
+        return_value=[{"id": 1, "title": "delectus aut autem", "completed": False}],
+    ), patch("brain.systems.workspace_apps.generic_http._utc_now_iso", return_value="2026-05-15T14:30:00Z"):
+        result = await async_run_workspace_app_action(
+            session,
+            org_id=ORG_ID,
+            app_id=app.id,
+            action_key="tickets.syncExternal",
+            payload={},
+            user_id=USER_ID,
+        )
+
+    assert result["ok"] is True
+    records = await service.list_records(ORG_ID, domain.id, object_key="ticket", limit=10)
+    assert len(records) == 1
+    assert records[0].title == "delectus aut autem"
+    assert records[0].data["title"] == "delectus aut autem"
+
+
 async def test_workspace_app_action_generic_http_supports_now_mapping(session):
     service = AsyncDomainService(session)
     domain = await service.create_domain(


### PR DESCRIPTION
## Summary
- Prefer the human Cortex trigger actor when building AgentRun ownership, so generated workspace apps are created under the requester instead of a stale/service user.
- Populate a real Domain title field from `connector_spec.sync.title` during generic HTTP sync when that field exists and was not explicitly mapped.
- Add regression coverage for the wrong-owner run context and the required-title sync failure seen in the latest Illo trace.

## Tests
- `uv run pytest tests/test_agent_run_runtime.py::test_thread_binding_prefers_cortex_trigger_actor_over_payload_user_id tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_populates_required_title_field_from_sync_title -q`
- `uv run pytest tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_syncs_domain_records tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_supports_templates_and_conditionals tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_supports_now_mapping tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_rejects_invalid_mapping_at_save tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_rejects_unknown_sync_field_at_save tests/test_workspace_apps_service.py::test_workspace_app_action_generic_http_wraps_domain_validation_errors -q`
- `uv run python -m compileall brain/systems/runs/cortex/thread_binding.py brain/systems/workspace_apps/generic_http.py`

## Notes
- A broader local run of `tests/test_cortex_thread_context.py` still hits the existing SQLite UUID fixture issue once `aiosqlite` is installed locally; the failure happens while loading the test Idea row before this branch's changed logic runs.
