### PR TITLE
Defer direct agent handoff summaries

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -31,8 +31,9 @@ import logging
 import os
 import time
 import uuid
+from collections.abc import Awaitable
 from contextlib import suppress
-from typing import Callable
+from typing import Any, Callable
 
 from brain.platform.integrations.llm import (
     async_resolve_llm_client,
@@ -1125,6 +1126,7 @@ def _make_result(
     output: str, success: bool, session_id: str, tokens: _TokenAccumulator,
     start_time: float, tool_calls: list[str], error: str | None = None,
     worker_results: list | None = None,
+    post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
 ) -> AgentResult:
     """Construct an AgentResult with common fields."""
     return _runtime_make_result(
@@ -1136,6 +1138,7 @@ def _make_result(
         tool_calls,
         error=error,
         worker_results=worker_results,
+        post_completion_tasks=post_completion_tasks,
     )
 
 
@@ -1291,6 +1294,7 @@ async def run_agent_async(
     load_session_handoff: Callable[..., dict | None] | None = None,
     save_session: Callable[..., None] | None = None,
     save_session_handoff: Callable[..., None] | None = None,
+    defer_thread_handoff: bool = True,
 ) -> AgentResult:
     """Run an agent loop with tool use from async runtime code.
 
@@ -1757,16 +1761,23 @@ async def run_agent_async(
             persist_session=persist_session,
             save_session=save_session,
         )
+        post_completion_tasks = ()
         if persist_session and raw_archive_messages is not None:
-            await _update_thread_handoff_after_run_async(
-                session_id=session_id,
-                archive_messages=persistable_messages,
-                previous_handoff=thread_handoff,
-                semantic_compactor=thread_handoff_compactor,
-                run_id=run_id,
-                user_id=None,
-                save_session_handoff=save_session_handoff,
-            )
+            def handoff_update():
+                return _update_thread_handoff_after_run_async(
+                    session_id=session_id,
+                    archive_messages=persistable_messages,
+                    previous_handoff=thread_handoff,
+                    semantic_compactor=thread_handoff_compactor,
+                    run_id=run_id,
+                    user_id=None,
+                    save_session_handoff=save_session_handoff,
+                )
+
+            if defer_thread_handoff:
+                post_completion_tasks = (handoff_update,)
+            else:
+                await handoff_update()
 
         logger.info(
             "Agent %s: completed in %ds (turns=%d, input=%d, output=%d, tools=%d)",
@@ -1785,7 +1796,15 @@ async def run_agent_async(
                 len(state.tool_calls_made),
                 len(state.messages),
             )
-        return _make_result(output, True, session_id, state.tokens, start_time, state.tool_calls_made)
+        return _make_result(
+            output,
+            True,
+            session_id,
+            state.tokens,
+            start_time,
+            state.tool_calls_made,
+            post_completion_tasks=post_completion_tasks,
+        )
 
     except Exception as e:
         if state.provider and state.provider.is_api_error(e):
@@ -1915,6 +1934,7 @@ def run_agent(
         "load_session_handoff": load_session_handoff or _async_from_sync(globals()["_load_session_handoff"]),
         "save_session": save_session or _async_from_sync(globals()["_save_session"]),
         "save_session_handoff": save_session_handoff or _async_from_sync(globals()["_save_session_handoff"]),
+        "defer_thread_handoff": False,
     }
     with asyncio.Runner() as runner:
         return runner.run(run_agent_async(**kwargs))

--- a/brain/systems/runs/direct_loop/result.py
+++ b/brain/systems/runs/direct_loop/result.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -40,6 +42,7 @@ class AgentResult:
     tool_calls: list[str] = field(default_factory=list)
     worker_results: list = field(default_factory=list)
     error: str | None = None
+    post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
 
 
 def make_result(
@@ -51,6 +54,7 @@ def make_result(
     tool_calls: list[str],
     error: str | None = None,
     worker_results: list | None = None,
+    post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
 ) -> AgentResult:
     """Construct an AgentResult with common runtime fields."""
 
@@ -66,4 +70,5 @@ def make_result(
         tool_calls=tool_calls,
         error=error,
         worker_results=worker_results or [],
+        post_completion_tasks=post_completion_tasks,
     )

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 import inspect
+import logging
 from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +20,9 @@ from brain.systems.runs.stream import RunStream
 from brain.systems.runs.steering import SteeringInbox, SteeringMessage
 from brain.systems.runs.tools import AsyncRunToolExecutor
 
+logger = logging.getLogger(__name__)
+_post_completion_tasks: set[asyncio.Task[None]] = set()
+
 
 class AsyncRunRecipeHandler(Protocol):
     def execute(self, runtime: "RunRuntime") -> "RunRecipeResult | Awaitable[RunRecipeResult]":
@@ -29,6 +34,23 @@ class RunRecipeResult:
     output: str
     status: RunStatus = RunStatus.COMPLETED
     artifacts: tuple = ()
+    post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
+
+
+async def _run_post_completion_task(run_id: int, task: Callable[[], Awaitable[Any]]) -> None:
+    try:
+        await task()
+    except Exception:
+        logger.exception("agent_run_post_completion_task_failed run_id=%s", run_id)
+
+
+def _schedule_post_completion_task(run_id: int, task: Callable[[], Awaitable[Any]]) -> None:
+    post_completion_task = asyncio.create_task(
+        _run_post_completion_task(run_id, task),
+        name=f"agent-run-{run_id}-post-completion",
+    )
+    _post_completion_tasks.add(post_completion_task)
+    post_completion_task.add_done_callback(_post_completion_tasks.discard)
 
 
 def _stream_payload(event, row, run: Any | None = None) -> dict[str, Any]:
@@ -269,7 +291,10 @@ class AsyncAgentRunEngine:
             return await self.fail(run.id, result.output or "recipe_failed")
         if result_status == RunStatus.CANCELED:
             return await self.cancel(run.id, reason=result.output or None)
-        return await self.complete(run.id, output=result.output, status=result_status)
+        completed = await self.complete(run.id, output=result.output, status=result_status)
+        for task in result.post_completion_tasks:
+            _schedule_post_completion_task(run.id, task)
+        return completed
 
     async def complete(
         self,

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -177,7 +177,11 @@ class FastRecipe(BaseRunRecipe):
             status = RunStatus.CANCELED
         if getattr(result, "error", None) and not output:
             output = str(result.error)
-        return RunRecipeResult(output=output, status=status)
+        return RunRecipeResult(
+            output=output,
+            status=status,
+            post_completion_tasks=tuple(getattr(result, "post_completion_tasks", ()) or ()),
+        )
 
 
 __all__ = ["FastRecipe"]

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -148,11 +148,13 @@ class WorkerRecipe(BaseRunRecipe):
             logger.exception("worker_recipe_failed", extra={"run_id": runtime.run.id})
             output = f"Worker failed: {exc}"
             status = RunStatus.FAILED
+            post_completion_tasks = ()
         else:
             output = str(getattr(result, "output", "") or "").strip()
             status = RunStatus.COMPLETED if getattr(result, "success", False) else RunStatus.FAILED
             if getattr(result, "error", None) and not output:
                 output = str(result.error)
+            post_completion_tasks = tuple(getattr(result, "post_completion_tasks", ()) or ())
         if output and not streamed_output:
             await runtime.text_delta(output)
         worker_result = worker_result_artifact(
@@ -163,7 +165,12 @@ class WorkerRecipe(BaseRunRecipe):
             tool_records=tool_records,
             root_run_id=runtime.run.root_run_id,
         )
-        return RunRecipeResult(output=output, status=status, artifacts=(worker_result,))
+        return RunRecipeResult(
+            output=output,
+            status=status,
+            artifacts=(worker_result,),
+            post_completion_tasks=post_completion_tasks,
+        )
 
 
 def worker_assignment_from_runtime(runtime: RunRuntime) -> WorkerAssignment:

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import Callable, AsyncIterator
 from datetime import datetime, timedelta, timezone
@@ -104,6 +105,41 @@ async def test_claim_and_completion_are_idempotent(session_factory):
 
     events = await _event_types(session, first.id)
     assert events.count("run.completed") == 1
+
+
+async def test_post_completion_tasks_run_after_terminal_completion(session_factory):
+    session = session_factory()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    event_types_at_start: list[str] = []
+    statuses_at_start: list[str | None] = []
+
+    class PostCompletionRecipe:
+        async def execute(self, runtime: RunRuntime) -> RunRecipeResult:
+            async def after_completion() -> None:
+                event_types_at_start.extend(await _event_types(session, runtime.run.id))
+                row = await session.get(AgentRunRow, runtime.run.id)
+                statuses_at_start.append(row.status if row is not None else None)
+                started.set()
+                await release.wait()
+                finished.set()
+
+            return RunRecipeResult(output="done", post_completion_tasks=(after_completion,))
+
+    run = await asyncio.wait_for(
+        AsyncAgentRunEngine(session, recipes={"fast": PostCompletionRecipe()}).run(
+            AgentRunRequest(thread_id="thread-1", message="hello")
+        ),
+        timeout=1,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    release.set()
+    await asyncio.wait_for(finished.wait(), timeout=1)
+
+    assert run.status == RunStatus.COMPLETED
+    assert "run.completed" in event_types_at_start
+    assert statuses_at_start == [RunStatus.COMPLETED.value]
 
 
 async def test_deferred_queued_run_waits_for_target_terminal(session_factory):

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -38,6 +38,9 @@ async def test_run_agent_async_basic_completion_uses_async_session_hooks(monkeyp
     provider_calls = []
     hook_calls = []
     loop_id = id(asyncio.get_running_loop())
+    handoff_started = asyncio.Event()
+    handoff_release = asyncio.Event()
+    handoff_completed = asyncio.Event()
 
     class FakeProvider:
         def create(self, request):
@@ -62,22 +65,28 @@ async def test_run_agent_async_basic_completion_uses_async_session_hooks(monkeyp
         hook_calls.append(("save_session", id(asyncio.get_running_loop()), session_id, len(messages), token_args, user_id))
 
     async def save_session_handoff(session_id, payload, *, user_id=None):
+        handoff_started.set()
+        await handoff_release.wait()
         hook_calls.append(("save_session_handoff", id(asyncio.get_running_loop()), session_id, payload, user_id))
+        handoff_completed.set()
 
     monkeypatch.setattr(direct_agent, "get_provider", lambda *_args, **_kwargs: FakeProvider())
 
     run_agent_async = getattr(direct_agent, "run_agent_async")
-    result = await run_agent_async(
-        message="Say hello",
-        model="claude-sonnet-4-6",
-        tools=[],
-        persist_session=True,
-        session_id="async-session",
-        resolved_llm=_FakeLLM(),
-        load_session=load_session,
-        load_session_handoff=load_session_handoff,
-        save_session=save_session,
-        save_session_handoff=save_session_handoff,
+    result = await asyncio.wait_for(
+        run_agent_async(
+            message="Say hello",
+            model="claude-sonnet-4-6",
+            tools=[],
+            persist_session=True,
+            session_id="async-session",
+            resolved_llm=_FakeLLM(),
+            load_session=load_session,
+            load_session_handoff=load_session_handoff,
+            save_session=save_session,
+            save_session_handoff=save_session_handoff,
+        ),
+        timeout=1,
     )
 
     assert result.success
@@ -88,8 +97,15 @@ async def test_run_agent_async_basic_completion_uses_async_session_hooks(monkeyp
         "load_session",
         "load_session_handoff",
         "save_session",
-        "save_session_handoff",
     ]
+    assert len(result.post_completion_tasks) == 1
+    handoff_task = asyncio.create_task(result.post_completion_tasks[0]())
+    await asyncio.wait_for(handoff_started.wait(), timeout=1)
+    assert not handoff_completed.is_set()
+    handoff_release.set()
+    await asyncio.wait_for(handoff_completed.wait(), timeout=1)
+    await handoff_task
+    assert hook_calls[-1][0] == "save_session_handoff"
 
 
 async def test_run_agent_async_honors_async_cancellation_without_sync_polling(monkeypatch):


### PR DESCRIPTION
## Summary
- return direct-agent handoff summarization as deferred post-completion work instead of awaiting it on the user-visible path
- schedule post-completion tasks from the run engine only after the final answer, `run.completed`, and terminal status are persisted
- keep the sync compatibility wrapper waiting for handoff so short-lived sync event loops do not cancel pending work
- keep background task references until completion and log failures without failing an already-completed user run

## Validation
- `pytest -q tests/test_direct_agent_async_contract.py tests/test_agent_run_state_machine.py::test_post_completion_tasks_run_after_terminal_completion tests/test_agent_runtime_modules.py::test_run_agent_uses_thread_handoff_but_persists_raw_archive`
- `python3 scripts/async_io_debt_metrics.py --json --top 20`
- `python3 scripts/direct_agent_async_metrics.py --target complete`
- `git diff --check`
