### PR TITLE
Add Illo-authored teammate handoffs and thread coordination

### DIFF
--- a/brain/app/api/routers/agent_bridge.py
+++ b/brain/app/api/routers/agent_bridge.py
@@ -126,6 +126,17 @@ async def _run_trigger_if_requested(
 ):
     if not metadata.get("trigger_illo"):
         return None
+    metadata = dict(metadata)
+    metadata.setdefault(
+        "request_source",
+        external_agents.request_source_context(
+            principal,
+            surface="mcp_personal_agent" if metadata.get("mcp_tool") else "personal_agent_bridge",
+            visibility="visible_team_thread",
+            permission="visible_coordination_trigger",
+            tool_name=str(metadata.get("mcp_tool") or "") or None,
+        ),
+    )
     from brain.app.triggers.adapters.internal import build_cortex_notify_trigger
     from brain.app.triggers.router import async_route_trigger
 

--- a/brain/platform/integrations/anthropic_adapter.py
+++ b/brain/platform/integrations/anthropic_adapter.py
@@ -23,12 +23,6 @@ _OAUTH_BETA_FLAGS_FALLBACK = [
 _DEBUG_DIR = Path("/tmp/anthropic-debug")
 
 
-# OAuth tokens require this identity prefix in the system prompt to access
-# sonnet/opus models. Without it, the API returns 400 for non-haiku models.
-# Source: https://github.com/badlogic/pi-mono (pi-ai anthropic provider)
-OAUTH_SYSTEM_PROMPT_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
-
-
 @dataclass(frozen=True)
 class AnthropicAuthAdapter:
     client: anthropic.Anthropic

--- a/brain/platform/integrations/llm.py
+++ b/brain/platform/integrations/llm.py
@@ -28,11 +28,7 @@ from pathlib import Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel.common.env import env_flag as _shared_env_flag
-from brain.platform.integrations.anthropic_adapter import (
-    OAUTH_SYSTEM_PROMPT_PREFIX,
-    build_auth_adapter,
-    get_oauth_betas,
-)
+from brain.platform.integrations.anthropic_adapter import build_auth_adapter, get_oauth_betas
 from brain.platform.integrations.openai_cache import (
     build_openai_extra_headers,
     normalize_openai_request_kwargs,
@@ -99,10 +95,9 @@ class LLMClient:
     provider: str                     # "anthropic" or "openai"
     source: str                       # "user_default", "org_main", "env", "none"
     auth_mode: str | None             # "api_key", "chatgpt", etc.
-    is_oauth: bool                    # True for setup-tokens (sk-ant-oat*)
-    extra_headers: dict[str, str]     # Per-request headers (OAuth betas)
+    is_oauth: bool                    # True for provider OAuth-style credentials.
+    extra_headers: dict[str, str]     # Per-request headers.
     token_prefix: str = ""            # First 18 chars (for logging)
-    system_prompt_prefix: str = ""    # Required prefix for OAuth (Claude Code identity)
 
     def get_extra_headers(self) -> dict[str, str]:
         """Get current extra headers. Re-reads active betas for OAuth clients
@@ -237,7 +232,6 @@ def _build_openai_client(token: str, source: str = "") -> LLMClient:
         is_oauth=False,
         extra_headers={},
         token_prefix=token[:18] if token else "",
-        system_prompt_prefix="",
     )
 
 
@@ -284,7 +278,6 @@ def _build_anthropic_client(token: str) -> LLMClient:
         is_oauth=adapter.is_oauth,
         extra_headers=extra_headers,
         token_prefix=token[:18] if token else "",
-        system_prompt_prefix=OAUTH_SYSTEM_PROMPT_PREFIX if adapter.is_oauth else "",
     )
 
 
@@ -311,7 +304,6 @@ def _build_openai_codex_client(auth: ResolvedProviderAuth) -> LLMClient:
             "originator": originator,
         },
         token_prefix=auth.token[:18] if auth.token else "",
-        system_prompt_prefix="",
     )
 
 
@@ -618,7 +610,6 @@ def resolve_llm_client(
         is_oauth=result.is_oauth,
         extra_headers=result.extra_headers,
         token_prefix=result.token_prefix,
-        system_prompt_prefix=result.system_prompt_prefix,
     )
 
 
@@ -704,7 +695,6 @@ async def async_resolve_llm_client(
             is_oauth=result.is_oauth,
             extra_headers=result.extra_headers,
             token_prefix=result.token_prefix,
-            system_prompt_prefix=result.system_prompt_prefix,
         )
 
     if session is not None:

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -1110,6 +1110,28 @@ def principalish_user_name(session: Session, user_id: str) -> str:
     return user.name if user is not None and user.name else "Someone"
 
 
+def request_source_context(
+    principal: AgentBridgePrincipal,
+    *,
+    surface: str,
+    visibility: str,
+    permission: str,
+    tool_name: str | None = None,
+) -> dict[str, Any]:
+    context = {
+        "surface": surface,
+        "acting_user_id": principal.owner_user_id,
+        "personal_agent": principal.connection_display_name,
+        "personal_agent_kind": principal.agent_kind,
+        "connection_id": principal.connection_id,
+        "visibility": visibility,
+        "permission": permission,
+    }
+    if tool_name:
+        context["tool"] = tool_name
+    return context
+
+
 def create_thread_from_agent(
     session: Session,
     principal: AgentBridgePrincipal,
@@ -1322,6 +1344,17 @@ def create_headless_ask(
     metadata: Mapping[str, Any] | None = None,
 ) -> ExternalAgentTaskRow:
     task_id = str(uuid.uuid4())
+    metadata = dict(metadata or {})
+    metadata.setdefault(
+        "request_source",
+        request_source_context(
+            principal,
+            surface="mcp_personal_agent" if metadata.get("mcp_tool") else "personal_agent_bridge",
+            visibility="headless_private",
+            permission="private_workspace_context",
+            tool_name=str(metadata.get("mcp_tool") or "") or None,
+        ),
+    )
     task = ExternalAgentTaskRow(
         id=task_id,
         org_id=principal.org_id,
@@ -1333,7 +1366,7 @@ def create_headless_ask(
         input_parts=[{"type": "ask_illo", "question": str(question), "context": dict(context or {})}],
         status="queued",
         idempotency_key=f"ask:{task_id}",
-        metadata_={**dict(metadata or {}), "headless": True},
+        metadata_={**metadata, "headless": True},
     )
     session.add(task)
     session.flush()
@@ -1354,6 +1387,7 @@ def create_headless_ask(
             workspace_ref={"source": "external_agent_bridge", "mode": "headless"},
             model_policy={"tier": "standard", "thinking": "medium"},
             metadata={
+                **metadata,
                 "origin": "external_agent_headless_ask",
                 "external_agent_connection_id": principal.connection_id,
                 "external_agent_task_id": task_id,
@@ -1440,6 +1474,7 @@ __all__ = [
     "create_external_task_for_idea",
     "create_headless_ask",
     "create_thread_from_agent",
+    "request_source_context",
     "fail_task",
     "generate_connection_token",
     "get_headless_ask",

--- a/brain/systems/personality/soul.py
+++ b/brain/systems/personality/soul.py
@@ -47,6 +47,9 @@ Competence is warmth.
 
 Treat the workspace as one living place that may include one person or many.
 You are not the user's voice. Be careful on shared surfaces.
+Requests may come directly from a workspace member or through a connected
+personal agent acting for that member. Treat personal-agent requests as
+human-originated intent with an agent intermediary.
 Help people coordinate, preserve decisions, and keep momentum.
 Private things stay private.
 

--- a/brain/systems/personality/soul.py
+++ b/brain/systems/personality/soul.py
@@ -49,6 +49,16 @@ Treat the workspace as one living place that may include one person or many.
 You are not the user's voice. Be careful on shared surfaces.
 Help people coordinate, preserve decisions, and keep momentum.
 Private things stay private.
+
+## Coordination
+
+When a request involves other workspace members, treat it as workspace
+coordination, not only as a reply to the current user.
+
+Choose the lightest visible coordination surface that fits the work:
+- reply in the current thread when the current audience is enough;
+- name or mention teammates in the current thread when they should share the same context;
+- create teammate-owned threads when each person needs their own action, follow-up, or handoff.
 """
 
 SOUL_MAX_CHARS = int(os.getenv("ILLO_SOUL_MAX_CHARS", "6000"))

--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 from typing import Any
 
 from brain.systems.runs.skill_commands import parse_slash_skill_names
@@ -25,6 +26,14 @@ def _skill_names_from_metadata(metadata: dict[str, Any], message: str) -> list[s
     return names
 
 
+def _request_source_from_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    for key in ("request_source", "request_source_context"):
+        value = metadata.get(key)
+        if isinstance(value, dict):
+            return {str(k): v for k, v in value.items() if v not in (None, "", [], {})}
+    return {}
+
+
 @dataclass(frozen=True)
 class RunContext:
     thread_id: str
@@ -35,6 +44,7 @@ class RunContext:
     memory: list[str] = field(default_factory=list)
     skills: list[str] = field(default_factory=list)
     handoff: dict[str, Any] = field(default_factory=dict)
+    request_source: dict[str, Any] = field(default_factory=dict)
 
     def prompt_context(self) -> str:
         parts: list[str] = []
@@ -48,6 +58,11 @@ class RunContext:
             parts.append(f"Workspace: {self.workspace_ref}")
         if self.handoff:
             parts.append(f"Handoff: {self.handoff}")
+        if self.request_source:
+            parts.append(
+                "Request Source:\n"
+                + json.dumps(self.request_source, sort_keys=True, indent=2, default=str)
+            )
         if self.skills:
             skill_tokens = ", ".join(f"/{name.lstrip('/')}" for name in self.skills)
             parts.append(
@@ -81,6 +96,7 @@ class RunContextLoader:
             target_ref=dict(target_ref or {}),
             workspace_ref=dict(workspace_ref or {}),
             thread_context=dict(thread_context) if isinstance(thread_context, dict) else {},
+            request_source=_request_source_from_metadata(metadata),
             skills=_skill_names_from_metadata(metadata, message),
         )
 

--- a/brain/systems/runs/direct_loop/request.py
+++ b/brain/systems/runs/direct_loop/request.py
@@ -22,7 +22,7 @@ def normalize_model_name(model: str) -> str:
     return model
 
 
-def build_system_blocks(llm, system_prompt: str, cache: bool) -> list[dict] | None:
+def build_system_blocks(_llm, system_prompt: str, cache: bool) -> list[dict] | None:
     """Build the system parameter with optional caching.
 
     The cache flag is accepted for direct-agent helper parity. The
@@ -31,8 +31,6 @@ def build_system_blocks(llm, system_prompt: str, cache: bool) -> list[dict] | No
     """
 
     blocks = []
-    if llm.system_prompt_prefix:
-        blocks.append({"type": "text", "text": llm.system_prompt_prefix})
     if system_prompt:
         blocks.append({"type": "text", "text": system_prompt})
     return blocks or None

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -21,18 +21,17 @@ logger = logging.getLogger(__name__)
 
 FAST_AGENT_INSTRUCTIONS = """## Fast Mode
 
-You are Illo Brain in Fast mode: one high-intelligence agent working directly with the user.
+This run is the interactive single-agent path. Handle the user's request in one
+continuous conversation when it can be answered, inspected, or completed with
+short feedback loops.
 
-Operating rules:
-- Move quickly, but keep senior engineering hygiene.
-- Use the isolated workspace from the runtime when it is available.
-- Preserve user changes and avoid unrelated refactors.
-- Skills are optional accelerators. Load one when the user explicitly names it or when it clearly pays for itself.
-- A `/skill` mention is an explicit skill command. Treat it as a signal that the user is interested in that skill and it may be relevant context; load the card, summary, or procedure only if useful.
-- For onboarding/setup introductions, inspect the workspace first and distinguish configured context from things Illo can help set up next.
-- Do not describe low-level implementation tools such as browser primitives, shell commands, file readers, or raw tool names as product capabilities.
-- Do not build a coordinator run graph in Fast. Escalate to Deep only when autonomy, parallel workers, assignments, or long verification are genuinely useful.
-- Stream useful progress through activity updates and answer in normal conversational prose.
+Runtime rules:
+- Treat the provided Target, Workspace, Context, attachments, memory, and live steering as the current run state.
+- Use later live steering to adjust the current run without discarding useful progress.
+- Prefer the smallest complete action that satisfies the request now; leave larger follow-up work explicit.
+- Keep progress updates brief and meaningful when work takes more than a moment.
+- Do not simulate a Deep coordinator graph inside Fast. If the request needs parallel workers, long verification, or durable delegation, make that boundary explicit and prepare a clean handoff.
+- Before finalizing, reconcile the answer with the evidence visible in this run and name any concrete blocker or uncertainty.
 """
 
 _FAST_HIDDEN_TOOL_NAMES = {"cortex_reply", "cortex_visual_reply"}

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -198,7 +198,7 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         "create": {
             "required": ["title"],
             "optional": ["thread_message", "description", "status", "start_run", "parent_id", "user_id"],
-            "effect": "create a Cortex thought",
+            "effect": "create a Cortex thought with an Illo-authored seed message; user_id assigns the owner",
         },
         "update": {
             "required": ["idea_id unless a current thread is bound", "at least one changed field"],

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -54,6 +54,24 @@ def _idea_actor(*, org_id: str | None, actor_user_id: str | None) -> dict[str, A
     }
 
 
+def _caller_is_service_actor(actor: dict[str, Any]) -> bool:
+    from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
+
+    return bool(_caller_is_service_principal(actor))
+
+
+def _actor_org_context(actor: dict[str, Any]) -> str:
+    from brain.app.api.authorization import require_org_context
+
+    return str(require_org_context(actor))
+
+
+async def _require_idea_for_actor(session, idea_id: str, actor: dict[str, Any]):
+    from brain.app.api.routers.cortex._helpers import _a_require_idea_for_user
+
+    return await _a_require_idea_for_user(session, idea_id, actor)
+
+
 def _target_idea_id(idea_id: str | None, thread_id: str | None, context_idea_id: str | None) -> str | None:
     return str(idea_id or thread_id or context_idea_id).strip() or None
 
@@ -274,16 +292,14 @@ async def _restore_idea(idea, *, session) -> tuple[str, str]:
 
 
 async def _apply_owner_handoff(idea, *, next_owner_id: str, actor: dict[str, Any], session) -> None:
-    from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
     from brain.app.api.routers.cortex._ideas import _freeze_display_author_for_handoff
-    from brain.app.api.authorization import require_org_context
     from brain.platform.db.models.org import User
 
     target_user = await session.scalar(select(User).where(User.id == str(next_owner_id)))
     if target_user is None:
         raise HTTPException(status_code=404, detail="Target owner not found")
-    if not _caller_is_service_principal(actor):
-        org_id = require_org_context(actor)
+    if not _caller_is_service_actor(actor):
+        org_id = _actor_org_context(actor)
         if str(target_user.org_id) != str(org_id):
             raise HTTPException(status_code=403, detail="Target owner is outside this org")
     if str(next_owner_id) != str(getattr(idea, "user_id", "")):
@@ -298,8 +314,6 @@ async def _validated_create_owner_id(
     fallback_owner_id: str,
     actor: dict[str, Any],
 ) -> str:
-    from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
-    from brain.app.api.authorization import require_org_context
     from brain.platform.db.models.org import User
 
     owner_id = str(requested_owner_id or fallback_owner_id)
@@ -309,8 +323,8 @@ async def _validated_create_owner_id(
     target_user = await session.scalar(select(User).where(User.id == owner_id))
     if target_user is None:
         raise HTTPException(status_code=404, detail="Target owner not found")
-    if not _caller_is_service_principal(actor):
-        org_id = require_org_context(actor)
+    if not _caller_is_service_actor(actor):
+        org_id = _actor_org_context(actor)
         if str(target_user.org_id) != str(org_id):
             raise HTTPException(status_code=403, detail="Target owner is outside this org")
     return owner_id
@@ -405,7 +419,6 @@ async def _handle_manage_idea(
     if normalized_action in {"help", "schema"}:
         return _manage_tool_guide("manage_idea", operation)
 
-    from brain.app.api.routers.cortex._helpers import _a_require_idea_for_user
     from brain.systems.cortex.events import publish_safe
     from brain.platform.db.models.idea import Idea
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -512,7 +525,7 @@ async def _handle_manage_idea(
             else:
                 if not target_idea_id:
                     return json.dumps({"error": f"{normalized_action or 'action'} requires: idea_id when no current Cortex thread is bound"})
-                idea = await _a_require_idea_for_user(uow.session, target_idea_id, actor)
+                idea = await _require_idea_for_actor(uow.session, target_idea_id, actor)
 
                 if normalized_action == "get":
                     return json.dumps({"idea": await _serialize_idea(idea, uow.session)}, default=str)

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -115,6 +115,7 @@ async def _seed_created_idea_thread(
     idea,
     seed_content: str,
     actor_user_id: str | None,
+    owner_user_id: str | None,
     parent_id: str | None,
     origin_ref: str | None,
 ) -> Any | None:
@@ -125,12 +126,15 @@ async def _seed_created_idea_thread(
     source_run_id = _current_tool_run_id()
     thread_msg = IdeaThread(
         idea_id=str(idea.id),
-        role="user",
+        role="illo",
         content=seed_content,
-        user_id=actor_user_id,
-        message_type="trigger",
+        user_id=None,
+        message_type="agent_response",
         metadata_={
             "source": "manage_idea.create",
+            "author": "illo",
+            "requested_by_user_id": actor_user_id,
+            "owner_user_id": owner_user_id,
             "created_by_run_id": source_run_id,
             "parent_idea_id": parent_id,
             "origin_ref": origin_ref,
@@ -283,8 +287,33 @@ async def _apply_owner_handoff(idea, *, next_owner_id: str, actor: dict[str, Any
         if str(target_user.org_id) != str(org_id):
             raise HTTPException(status_code=403, detail="Target owner is outside this org")
     if str(next_owner_id) != str(getattr(idea, "user_id", "")):
-            await _freeze_display_author_for_handoff(idea, session)
+        await _freeze_display_author_for_handoff(idea, session)
     idea.user_id = str(next_owner_id)
+
+
+async def _validated_create_owner_id(
+    *,
+    session,
+    requested_owner_id: str | None,
+    fallback_owner_id: str,
+    actor: dict[str, Any],
+) -> str:
+    from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
+    from brain.app.api.authorization import require_org_context
+    from brain.platform.db.models.org import User
+
+    owner_id = str(requested_owner_id or fallback_owner_id)
+    if owner_id == str(fallback_owner_id):
+        return owner_id
+
+    target_user = await session.scalar(select(User).where(User.id == owner_id))
+    if target_user is None:
+        raise HTTPException(status_code=404, detail="Target owner not found")
+    if not _caller_is_service_principal(actor):
+        org_id = require_org_context(actor)
+        if str(target_user.org_id) != str(org_id):
+            raise HTTPException(status_code=403, detail="Target owner is outside this org")
+    return owner_id
 
 
 async def _apply_idea_updates(
@@ -366,7 +395,7 @@ async def _handle_manage_idea(
     orbit_anchor_id: str | None = None,
     parent_id: str | None = None,
     user_id: str | None = None,
-    origin: str = "user_created",
+    origin: str = "illo_created",
     origin_ref: str | None = None,
     search: str | None = None,
     include_archived: bool = False,
@@ -412,14 +441,20 @@ async def _handle_manage_idea(
                 if should_start_run is None:
                     should_start_run = requested_status in _RUN_ADMISSION_CREATE_STATUSES
                 initial_status = "emerged" if should_start_run or requested_status in _RUN_ADMISSION_CREATE_STATUSES else requested_status
+                owner_user_id = await _validated_create_owner_id(
+                    session=uow.session,
+                    requested_owner_id=user_id,
+                    fallback_owner_id=actor_user_id,
+                    actor=actor,
+                )
                 idea = Idea(
                     title=title,
                     description=description,
                     status=initial_status,
-                    origin=origin or "user_created",
+                    origin=origin or "illo_created",
                     origin_ref=origin_ref,
                     parent_id=parent_id,
-                    user_id=actor_user_id,
+                    user_id=owner_user_id,
                     org_id=org_id,
                 )
                 if salience_score is not None:
@@ -449,12 +484,10 @@ async def _handle_manage_idea(
                     idea=idea,
                     seed_content=seed_content,
                     actor_user_id=actor_user_id,
+                    owner_user_id=owner_user_id,
                     parent_id=parent_id,
                     origin_ref=origin_ref,
                 )
-                if user_id is not None:
-                    await _apply_owner_handoff(idea, next_owner_id=user_id, actor=actor, session=uow.session)
-                    await uow.session.flush()
                 run_result = None
                 if should_start_run:
                     run_result = await _admit_created_idea_run(

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -185,7 +185,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "output_budget_chars": 14_000,
         "evidence_emitter": True,
         "context_route": {
-            "description": "Read the workspace roster and optional nearby activity for people. Use for who is here, roles, ownership, and named teammate activity.",
+            "description": "Read the workspace roster and optional nearby activity for people. Use for who is here, roles, ownership, named teammate activity, and teammate coordination that needs exact user ids.",
             "domains": ["team members", "workspace roster", "people", "roles", "ownership", "who is working on what"],
             "scopes": ["narrow", "broad"],
         },
@@ -243,7 +243,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "idea_management",
         "reversibility": "reversible_by_archive",
         "action_manifest": True,
-        "expected_effect": "read or mutate Cortex thoughts, threads, and ideas",
+        "expected_effect": "read or mutate Cortex thoughts, threads, ideas, and Illo-authored teammate handoffs",
         "output_budget_chars": 14_000,
     },
     "post_chat_message": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -487,8 +487,7 @@ BRAIN_TOOLS = [
         "description": (
             "Read the workspace roster and, by default, nearby activity for those people. Use for questions about "
             "who is in the workspace, roles, ownership, or what a named teammate appears to be working on. "
-            "Use before coordinating with, greeting, tagging, or handing work to named teammates when you need "
-            "their exact user ids. "
+            "Use when teammate coordination requires exact member ids, names, roles, or ownership. "
             "This is read-only and should be used before answering teammate-activity questions from memory."
         ),
         "input_schema": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -487,6 +487,8 @@ BRAIN_TOOLS = [
         "description": (
             "Read the workspace roster and, by default, nearby activity for those people. Use for questions about "
             "who is in the workspace, roles, ownership, or what a named teammate appears to be working on. "
+            "Use before coordinating with, greeting, tagging, or handing work to named teammates when you need "
+            "their exact user ids. "
             "This is read-only and should be used before answering teammate-activity questions from memory."
         ),
         "input_schema": {
@@ -782,6 +784,9 @@ CORTEX_IDEA_TOOLS = [
             "Create, list, get, update, archive, restore, or mark-read Cortex thoughts. "
             "When a created thought should start working immediately, set start_run=true "
             "or use status=queued/working so a starter message and AgentRun are created. "
+            "For teammate coordination or handoffs, use action=create with user_id set to the teammate owner. "
+            "The first thread_message you provide is authored by Illo; user_id controls ownership/assignment, "
+            "not message authorship. "
             "Use this for requests about thoughts, threads, idea threads, or ideas, such as "
             "'archive this thread', 'rename this thought', 'mark this resolved', or "
             "'restore that idea'. This is the action/exact-thread tool. For recent team-wide thread "
@@ -823,7 +828,7 @@ CORTEX_IDEA_TOOLS = [
                 "title": {"type": "string", "description": "Raw idea title for create/update."},
                 "thread_message": {
                     "type": "string",
-                    "description": "Optional first thread message for a newly created idea. Defaults to description, then title.",
+                    "description": "Optional first Illo-authored thread message for a newly created idea. Defaults to description, then title.",
                 },
                 "start_run": {
                     "type": "boolean",
@@ -866,8 +871,8 @@ CORTEX_IDEA_TOOLS = [
                 },
                 "orbit_anchor_id": {"type": "string", "description": "Optional orbit anchor target id."},
                 "parent_id": {"type": "string", "description": "Optional parent idea id for create."},
-                "user_id": {"type": "string", "description": "Optional owner id for explicit thread handoff."},
-                "origin": {"type": "string", "description": "Origin for create.", "default": "user_created"},
+                "user_id": {"type": "string", "description": "Optional owner/assignee id for explicit thread handoff. This does not author messages as that user."},
+                "origin": {"type": "string", "description": "Origin for create.", "default": "illo_created"},
                 "origin_ref": {"type": "string", "description": "Optional origin reference for create."},
                 "search": {"type": "string", "description": "Optional title/description filter for list."},
                 "include_archived": {"type": "boolean", "default": False},

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1303,6 +1303,7 @@
     --thread-stage-panel-padding-block: clamp(14px, 1.7vw, 22px);
     --thread-stage-panel-padding-inline: clamp(16px, 2vw, 24px);
     --thread-stage-docked-header-height: 46px;
+    --thread-stage-stacked-dock-height: clamp(220px, 34svh, 360px);
     --thread-bridge-mention-dropdown-border: rgba(124, 138, 158, 0.14);
     --thread-bridge-mention-dropdown-background:
       linear-gradient(180deg, rgba(10, 14, 22, 0.98), rgba(8, 11, 18, 1));
@@ -1703,9 +1704,19 @@
       --thread-stage-panel-padding-inline: clamp(12px, 2.4vw, 20px);
     }
 
+    .thread-stage-layout.with-dock {
+      grid-template-rows: minmax(0, 1fr) minmax(220px, var(--thread-stage-stacked-dock-height));
+      row-gap: 10px;
+    }
+
     .thread-stage-dock {
-      position: absolute;
-      inset: clamp(132px, 20vh, 168px) clamp(16px, 3vw, 22px) clamp(106px, 15vh, 128px);
+      position: relative;
+      inset: auto;
+      width: 100%;
+      min-height: 0;
+      padding-top: 10px;
+      border-top: 1px solid var(--constellation-utility-panel-header-border);
+      box-sizing: border-box;
     }
   }
 
@@ -1715,6 +1726,7 @@
       --thread-stage-panel-radius: 20px;
       --thread-stage-panel-padding-block: 12px;
       --thread-stage-panel-padding-inline: 12px;
+      --thread-stage-stacked-dock-height: clamp(200px, 32svh, 320px);
     }
   }
 </style>

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -36,7 +36,6 @@ def _mock_llm_client(mock_anthropic_client, provider="anthropic"):
     llm.is_oauth = False
     llm.extra_headers = {}
     llm.token_prefix = "sk-ant-api03-test" if provider == "anthropic" else "sk-openai-test"
-    llm.system_prompt_prefix = ""
     llm.get_extra_headers.return_value = {}
     llm.auth_mode = "api_key"
 

--- a/tests/test_agent_auth_fallback.py
+++ b/tests/test_agent_auth_fallback.py
@@ -318,7 +318,6 @@ def test_llm_client_build_request_headers_merges_and_normalizes_openai_session()
             "originator": "illo-brain",
         },
         token_prefix="",
-        system_prompt_prefix="",
     )
 
     headers = llm.build_request_headers(

--- a/tests/test_agent_claude_cli_backend.py
+++ b/tests/test_agent_claude_cli_backend.py
@@ -12,7 +12,6 @@ def _make_llm_mock(is_oauth: bool, client: MagicMock):
     llm.is_oauth = is_oauth
     llm.extra_headers = {"anthropic-beta": "oauth-2025-04-20"} if is_oauth else {}
     llm.token_prefix = "sk-ant-oat01-real" if is_oauth else "sk-ant-api03-test"
-    llm.system_prompt_prefix = "You are Claude Code, Anthropic's official CLI for Claude." if is_oauth else ""
     llm.get_extra_headers.return_value = dict(llm.extra_headers)
     return llm
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -386,6 +386,9 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert captured["spec"].run_id == 42
     assert captured["spec"].idea_id is None
     assert captured["spec"].workspace_root == "/tmp/work"
+    assert "interactive single-agent path" in captured["spec"].system_prompt
+    assert "Move quickly, but keep senior engineering hygiene." not in captured["spec"].system_prompt
+    assert "A `/skill` mention is an explicit skill command." not in captured["spec"].system_prompt
     assert _stream_has(runtime.stream.messages, "run.text_delta", {"delta": "README contents", "run_id": 42})
     assert any(event.event_type == "run.activity" and event.payload["label"] == "Reading files" for event in runtime.store.events)
     assert any(event.event_type == "run.tool_completed" and event.payload["tool_name"] == "read_file" for event in runtime.store.events)

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -112,12 +112,9 @@ def test_request_runtime_preserves_cache_policy_and_facade_wrappers():
     )
     from brain.systems.runs.direct_loop import request as runtime_request
 
-    llm = SimpleNamespace(system_prompt_prefix="prefix")
+    llm = SimpleNamespace()
     system = _build_system_blocks(llm, "Be precise", cache=True)
-    assert system == [
-        {"type": "text", "text": "prefix"},
-        {"type": "text", "text": "Be precise"},
-    ]
+    assert system == [{"type": "text", "text": "Be precise"}]
     assert _apply_anthropic_cache_breakpoint(system, True)[-1]["cache_control"] == {"type": "ephemeral"}
     anthropic_system = _apply_provider_system_cache_policy("anthropic", "Be precise", True)
     assert anthropic_system == [{"type": "text", "text": "Be precise", "cache_control": {"type": "ephemeral"}}]
@@ -282,7 +279,6 @@ def test_run_agent_retries_once_after_context_overflow_with_checkpoint(monkeypat
         is_oauth=False,
         extra_headers={},
         token_prefix="sk-test",
-        system_prompt_prefix="",
         auth_mode="api_key",
         get_extra_headers=lambda: {},
         build_request_headers=lambda **_kwargs: {},
@@ -368,7 +364,6 @@ def test_run_agent_uses_thread_handoff_but_persists_raw_archive(monkeypatch):
         is_oauth=False,
         extra_headers={},
         token_prefix="sk-test",
-        system_prompt_prefix="",
         auth_mode="api_key",
         get_extra_headers=lambda: {},
         build_request_headers=lambda **_kwargs: {},

--- a/tests/test_agent_soul.py
+++ b/tests/test_agent_soul.py
@@ -30,6 +30,8 @@ def test_default_soul_is_team_workspace_specific(monkeypatch, tmp_path):
     assert "an agent inside a workspace used by a team" in soul.content
     assert "Default to concise" in soul.content
     assert "You are not the user's voice" in soul.content
+    assert "connected\npersonal agent acting for that member" in soul.content
+    assert "not only as a reply to the current user" in soul.content
     assert "teammate-owned threads" in soul.content
 
 

--- a/tests/test_agent_soul.py
+++ b/tests/test_agent_soul.py
@@ -30,6 +30,7 @@ def test_default_soul_is_team_workspace_specific(monkeypatch, tmp_path):
     assert "an agent inside a workspace used by a team" in soul.content
     assert "Default to concise" in soul.content
     assert "You are not the user's voice" in soul.content
+    assert "teammate-owned threads" in soul.content
 
 
 def test_manage_soul_replace_writes_bounded_soul(monkeypatch, tmp_path):

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -472,11 +472,19 @@ async def test_manage_idea_create_seeds_new_thread_message(monkeypatch):
         )
 
     thread_rows = [obj for obj in added if obj.__class__.__name__ == "IdeaThread"]
+    idea_rows = [obj for obj in added if obj.__class__.__name__ == "Idea"]
     assert payload["created"] is True
     assert payload["thread_message_id"] == 42
     assert payload["run_started"] is False
+    assert idea_rows[0].origin == "illo_created"
+    assert thread_rows[0].role == "illo"
+    assert thread_rows[0].user_id is None
+    assert thread_rows[0].message_type == "agent_response"
     assert thread_rows[0].content == "Inspect vault and AWS credential handoff path."
     assert thread_rows[0].metadata_["source"] == "manage_idea.create"
+    assert thread_rows[0].metadata_["author"] == "illo"
+    assert thread_rows[0].metadata_["requested_by_user_id"] == "user-1"
+    assert thread_rows[0].metadata_["owner_user_id"] == "user-1"
     assert thread_rows[0].metadata_["created_by_run_id"] == 7
     assert published == [("idea_created", {"idea_id": "idea-created", "title": "Check vault state"})]
 
@@ -537,7 +545,10 @@ async def test_manage_idea_create_can_handoff_owner(monkeypatch):
     assert payload["created"] is True
     assert payload["idea"]["user_id"] == "target-user"
     assert idea_rows[0].user_id == "target-user"
-    assert thread_rows[0].user_id == "user-1"
+    assert thread_rows[0].role == "illo"
+    assert thread_rows[0].user_id is None
+    assert thread_rows[0].metadata_["requested_by_user_id"] == "user-1"
+    assert thread_rows[0].metadata_["owner_user_id"] == "target-user"
 
 
 async def test_manage_idea_create_queued_admits_run_instead_of_empty_queue(monkeypatch):

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -11,7 +11,6 @@ class _FakeLLM:
     auth_mode = "api_key"
     token_prefix = "sk-test"
     is_oauth = False
-    system_prompt_prefix = ""
 
     def build_request_headers(self, **_kwargs):
         return {}

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -380,6 +380,10 @@ async def test_hosted_mcp_create_thread_routes_trigger_when_requested():
     assert trigger.event_type == "cortex.thread_reply"
     assert trigger.target["idea_id"] == "idea-1"
     assert "Please coordinate with JB and Axel" in trigger.payload["run_message"]
+    request_source = trigger.payload["metadata"]["request_source"]
+    assert request_source["surface"] == "mcp_personal_agent"
+    assert request_source["personal_agent"] == "Hermes"
+    assert request_source["visibility"] == "visible_team_thread"
     assert order[:2] == ["commit", "broadcast:thread_message"]
 
 

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -150,6 +150,10 @@ def test_headless_ask_blocks_thread_mutation_tools():
     blocked_tools = captured_requests[0].metadata["tool_policy"]["blocked_tools"]
     assert "manage_idea" in blocked_tools
     assert "post_chat_message" in blocked_tools
+    request_source = captured_requests[0].metadata["request_source"]
+    assert request_source["surface"] == "personal_agent_bridge"
+    assert request_source["personal_agent"] == "Hermes"
+    assert request_source["visibility"] == "headless_private"
 
 
 def test_create_thread_from_agent_notifies_teammate_with_unified_notification():

--- a/tests/test_slash_skill_commands.py
+++ b/tests/test_slash_skill_commands.py
@@ -44,3 +44,27 @@ def test_run_context_prompts_agent_about_slash_skill_command():
     assert "Slash skill command(s): /debug" in prompt
     assert "user is interested in those skills" in prompt
     assert "prefer loading the skill card or summary before the full procedure" in prompt
+
+
+def test_run_context_includes_structured_request_source():
+    from brain.systems.runs.context import RunContextLoader
+
+    context = RunContextLoader().load(
+        thread_id="idea-1",
+        message="coordinate this",
+        metadata={
+            "request_source": {
+                "surface": "mcp_personal_agent",
+                "acting_user_id": "user-1",
+                "personal_agent": "Hermes",
+                "visibility": "visible_team_thread",
+                "permission": "visible_coordination_trigger",
+            }
+        },
+    )
+
+    prompt = context.prompt_context()
+    assert "Request Source:" in prompt
+    assert '"surface": "mcp_personal_agent"' in prompt
+    assert '"personal_agent": "Hermes"' in prompt
+    assert '"visibility": "visible_team_thread"' in prompt


### PR DESCRIPTION
## Summary
- Treat workspace coordination as a first-class flow, including exact-user-id handoffs and teammate-owned threads
- Seed newly created ideas with Illo-authored thread messages while keeping ownership separate from message authorship
- Update thread stage dock layout for a stacked, in-flow presentation on smaller screens
- Expand tests to cover the new create/handoff semantics and soul guidance

## Testing
- Updated unit tests for soul text and Cortex idea creation/handoff behavior
- Not run (not requested)