### PR TITLE
Add project profile privacy controls

### DIFF
--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import Depends, File, Form, HTTPException, Request, UploadFile
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.api.auth import get_current_user
@@ -166,18 +166,17 @@ async def _resolve_project_access_users(
         await db.scalars(
             select(User).where(
                 User.org_id == org_id,
-                or_(func.lower(User.name).in_(lookup_keys), func.lower(User.email).in_(lookup_keys)),
+                func.lower(User.name).in_(lookup_keys),
             )
         )
     ).all()
     found_keys: set[str] = set()
     by_key: dict[str, User] = {}
     for user in users:
-        for value in (user.name, user.email):
-            key = str(value or "").strip().lower()
-            if key and key in lookup_keys:
-                found_keys.add(key)
-                by_key.setdefault(key, user)
+        key = str(user.name or "").strip().lower()
+        if key and key in lookup_keys:
+            found_keys.add(key)
+            by_key.setdefault(key, user)
     missing = [username for username in cleaned if username.lower() not in found_keys]
     if missing:
         raise HTTPException(status_code=422, detail={"unknown_users": missing})

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -170,22 +170,24 @@ async def _resolve_project_access_users(
             )
         )
     ).all()
-    found_keys: set[str] = set()
-    by_key: dict[str, User] = {}
+    users_by_key: dict[str, list[User]] = {}
     for user in users:
         key = str(user.name or "").strip().lower()
         if key and key in lookup_keys:
-            found_keys.add(key)
-            by_key.setdefault(key, user)
-    missing = [username for username in cleaned if username.lower() not in found_keys]
+            users_by_key.setdefault(key, []).append(user)
+    missing = [username for username in cleaned if username.lower() not in users_by_key]
     if missing:
         raise HTTPException(status_code=422, detail={"unknown_users": missing})
+    ambiguous = [username for username in cleaned if len(users_by_key.get(username.lower(), [])) > 1]
+    if ambiguous:
+        raise HTTPException(status_code=422, detail={"ambiguous_users": ambiguous})
     ordered: list[User] = []
     seen_ids: set[str] = set()
     for username in cleaned:
-        matched = by_key.get(username.lower())
-        if not matched:
+        matches = users_by_key.get(username.lower()) or []
+        if not matches:
             continue
+        matched = matches[0]
         matched_id = str(matched.id)
         if matched_id in seen_ids:
             continue

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import Depends, File, Form, HTTPException, Request, UploadFile
-from sqlalchemy import select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.api.auth import get_current_user
@@ -20,6 +20,11 @@ from brain.systems.cortex.project_context.github import (
     parse_github_repo_slug,
 )
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
+from brain.systems.cortex.project_context.access import (
+    can_manage_project_profile,
+    normalize_project_visibility,
+    project_profile_visible_predicate,
+)
 from brain.systems.cortex.project_context.resources import normalize_project_resource
 from brain.systems.cortex.project_context.schemas import (
     GitHubConnectRead,
@@ -46,7 +51,7 @@ from brain.systems.cortex.project_context.uploads import (
     save_project_context_uploads,
 )
 from brain.systems.cortex.project_context import vault as project_context_vault
-from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
+from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile, ProjectProfileAccess
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.models.org import User
 
@@ -79,8 +84,28 @@ def _profile_scope_stmt(org_id: str | None):
     return stmt.where(ProjectProfile.org_id == org_id)
 
 
-def _profile_lookup_stmt(profile_id: str, org_id: str | None, *, include_inactive: bool = False):
+def _actor_user_id(user: dict[str, Any] | None) -> str | None:
+    user_id = str((user or {}).get("id") or "").strip()
+    return user_id or None
+
+
+def _profile_visible_stmt(org_id: str | None, user: dict[str, Any] | None):
+    stmt = _profile_scope_stmt(org_id)
+    if _caller_is_service_principal(user):
+        return stmt
+    return stmt.where(project_profile_visible_predicate(ProjectProfile, ProjectProfileAccess, _actor_user_id(user)))
+
+
+def _profile_lookup_stmt(
+    profile_id: str,
+    org_id: str | None,
+    user: dict[str, Any] | None,
+    *,
+    include_inactive: bool = False,
+):
     stmt = _profile_scope_stmt(org_id).where(ProjectProfile.id == profile_id)
+    if not _caller_is_service_principal(user):
+        stmt = stmt.where(project_profile_visible_predicate(ProjectProfile, ProjectProfileAccess, _actor_user_id(user)))
     if not include_inactive:
         stmt = stmt.where(ProjectProfile.active.is_(True))
     return stmt
@@ -90,13 +115,160 @@ async def _get_project_profile(
     db: AsyncSession,
     profile_id: str,
     org_id: str | None,
+    user: dict[str, Any] | None,
     *,
     include_inactive: bool = False,
 ) -> ProjectProfile:
-    profile = await db.scalar(_profile_lookup_stmt(profile_id, org_id, include_inactive=include_inactive))
+    profile = await db.scalar(_profile_lookup_stmt(profile_id, org_id, user, include_inactive=include_inactive))
     if profile is None:
         raise HTTPException(status_code=404, detail="Project profile not found")
     return profile
+
+
+def _require_project_profile_manager(profile: ProjectProfile, user: dict[str, Any] | None) -> None:
+    if not can_manage_project_profile(profile, user):
+        raise HTTPException(status_code=403, detail="Only the project owner can change this project")
+
+
+def _request_visibility(value: str | None) -> str:
+    try:
+        return normalize_project_visibility(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def _clean_shared_usernames(usernames: list[str] | None) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for username in usernames or []:
+        value = str(username or "").strip()
+        key = value.lower()
+        if not value or key in seen:
+            continue
+        cleaned.append(value)
+        seen.add(key)
+    return cleaned
+
+
+async def _resolve_project_access_users(
+    db: AsyncSession,
+    org_id: str | None,
+    usernames: list[str] | None,
+) -> list[User]:
+    cleaned = _clean_shared_usernames(usernames)
+    if not cleaned:
+        return []
+    if not org_id:
+        raise HTTPException(status_code=422, detail="Project sharing requires an org-scoped user")
+
+    lookup_keys = {item.lower() for item in cleaned}
+    users = (
+        await db.scalars(
+            select(User).where(
+                User.org_id == org_id,
+                or_(func.lower(User.name).in_(lookup_keys), func.lower(User.email).in_(lookup_keys)),
+            )
+        )
+    ).all()
+    found_keys: set[str] = set()
+    by_key: dict[str, User] = {}
+    for user in users:
+        for value in (user.name, user.email):
+            key = str(value or "").strip().lower()
+            if key and key in lookup_keys:
+                found_keys.add(key)
+                by_key.setdefault(key, user)
+    missing = [username for username in cleaned if username.lower() not in found_keys]
+    if missing:
+        raise HTTPException(status_code=422, detail={"unknown_users": missing})
+    ordered: list[User] = []
+    seen_ids: set[str] = set()
+    for username in cleaned:
+        matched = by_key.get(username.lower())
+        if not matched:
+            continue
+        matched_id = str(matched.id)
+        if matched_id in seen_ids:
+            continue
+        ordered.append(matched)
+        seen_ids.add(matched_id)
+    return ordered
+
+
+async def _sync_project_access_list(
+    db: AsyncSession,
+    profile: ProjectProfile,
+    *,
+    org_id: str | None,
+    shared_usernames: list[str] | None,
+    actor_user_id: str | None,
+) -> None:
+    users = await _resolve_project_access_users(db, org_id, shared_usernames)
+    owner_user_id = str(profile.user_id or "")
+    target_user_ids = [
+        str(user.id)
+        for user in users
+        if str(user.id) != owner_user_id
+    ]
+    target_user_ids = list(dict.fromkeys(target_user_ids))
+
+    if target_user_ids:
+        await db.execute(
+            delete(ProjectProfileAccess).where(
+                ProjectProfileAccess.project_profile_id == profile.id,
+                ProjectProfileAccess.shared_with_user_id.not_in(target_user_ids),
+            )
+        )
+    else:
+        await db.execute(
+            delete(ProjectProfileAccess).where(ProjectProfileAccess.project_profile_id == profile.id)
+        )
+
+    existing_ids = {
+        str(row.shared_with_user_id)
+        for row in (
+            await db.scalars(
+                select(ProjectProfileAccess).where(ProjectProfileAccess.project_profile_id == profile.id)
+            )
+        ).all()
+    }
+    for user_id in target_user_ids:
+        if user_id in existing_ids:
+            continue
+        db.add(
+            ProjectProfileAccess(
+                project_profile_id=profile.id,
+                shared_with_user_id=user_id,
+                shared_by_user_id=actor_user_id,
+            )
+        )
+
+
+async def _access_map_for_profiles(
+    db: AsyncSession,
+    profiles: list[ProjectProfile],
+) -> dict[str, list[dict[str, Any]]]:
+    profile_ids = [str(profile.id) for profile in profiles if profile.id]
+    if not profile_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(ProjectProfileAccess, User)
+            .join(User, User.id == ProjectProfileAccess.shared_with_user_id)
+            .where(ProjectProfileAccess.project_profile_id.in_(profile_ids))
+            .order_by(User.name.asc())
+        )
+    ).all()
+    access_by_profile: dict[str, list[dict[str, Any]]] = {profile_id: [] for profile_id in profile_ids}
+    for access, shared_user in rows:
+        access_by_profile.setdefault(str(access.project_profile_id), []).append({
+            "user_id": str(shared_user.id),
+            "name": shared_user.name,
+            "email": shared_user.email,
+            "shared_by_user_id": str(access.shared_by_user_id) if access.shared_by_user_id else None,
+            "created_at": access.created_at,
+        })
+    return access_by_profile
 
 
 async def _require_idea_for_user(
@@ -176,11 +348,16 @@ async def list_project_profiles(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    stmt = _profile_scope_stmt(org_id)
+    stmt = _profile_visible_stmt(org_id, user)
     if not include_inactive:
         stmt = stmt.where(ProjectProfile.active.is_(True))
     stmt = stmt.order_by(ProjectProfile.created_at.desc())
-    return [profile_to_read(profile) for profile in (await db.scalars(stmt)).all()]
+    profiles = (await db.scalars(stmt)).all()
+    access_by_profile = await _access_map_for_profiles(db, list(profiles))
+    return [
+        profile_to_read(profile, access_by_profile.get(str(profile.id), []))
+        for profile in profiles
+    ]
 
 
 @router.post("/project-context/profiles", response_model=ProjectProfileRead, status_code=201)
@@ -190,6 +367,7 @@ async def create_project_profile(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
+    visibility = _request_visibility(body.visibility)
     _validated_snapshot_or_422(body.project_context)
     existing_stmt = _profile_scope_stmt(org_id).where(ProjectProfile.slug == body.slug)
     existing = await db.scalar(existing_stmt)
@@ -202,13 +380,23 @@ async def create_project_profile(
         name=body.name,
         description=body.description,
         project_context=body.project_context,
+        visibility=visibility,
         default_environment_binding_id=body.default_environment_binding_id,
         metadata_=body.metadata,
     )
     db.add(profile)
+    await db.flush()
+    await _sync_project_access_list(
+        db,
+        profile,
+        org_id=org_id,
+        shared_usernames=body.shared_usernames,
+        actor_user_id=_actor_user_id(user),
+    )
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.get("/project-context/profiles/{profile_id}", response_model=ProjectProfileRead)
@@ -218,8 +406,9 @@ async def get_project_profile(
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    profile = await _get_project_profile(db, profile_id, _profile_org_id(user), include_inactive=include_inactive)
-    return profile_to_read(profile)
+    profile = await _get_project_profile(db, profile_id, _profile_org_id(user), user, include_inactive=include_inactive)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.patch("/project-context/profiles/{profile_id}", response_model=ProjectProfileRead)
@@ -230,7 +419,8 @@ async def update_project_profile(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     fields = body.model_fields_set
     if "slug" in fields and body.slug and body.slug != profile.slug:
         existing = await db.scalar(
@@ -249,6 +439,8 @@ async def update_project_profile(
     if "project_context" in fields and body.project_context is not None:
         _validated_snapshot_or_422(body.project_context)
         profile.project_context = body.project_context
+    if "visibility" in fields and body.visibility is not None:
+        profile.visibility = _request_visibility(body.visibility)
     if "default_environment_binding_id" in fields:
         profile.default_environment_binding_id = body.default_environment_binding_id
     if "active" in fields and body.active is not None:
@@ -256,9 +448,18 @@ async def update_project_profile(
     if "metadata" in fields:
         profile.metadata_ = body.metadata or {}
     db.add(profile)
+    if "shared_usernames" in fields and body.shared_usernames is not None:
+        await _sync_project_access_list(
+            db,
+            profile,
+            org_id=org_id,
+            shared_usernames=body.shared_usernames,
+            actor_user_id=_actor_user_id(user),
+        )
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.delete("/project-context/profiles/{profile_id}", response_model=ProjectProfileRead)
@@ -268,12 +469,14 @@ async def archive_project_profile(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     profile.active = False
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.post("/project-context/profiles/{profile_id}/resources", response_model=ProjectProfileRead, status_code=201)
@@ -284,7 +487,8 @@ async def add_project_resources(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     resources = _project_resources(profile)
     existing_ids = {str(resource.get("id")) for resource in resources if resource.get("id")}
     for raw in body.resources:
@@ -295,7 +499,8 @@ async def add_project_resources(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.patch("/project-context/profiles/{profile_id}/resources/{resource_id}", response_model=ProjectProfileRead)
@@ -307,7 +512,8 @@ async def update_project_resource(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     resources = _project_resources(profile)
     for index, resource in enumerate(resources):
         if _resource_identity(resource) != resource_id and str(resource.get("id") or "") != resource_id:
@@ -322,7 +528,8 @@ async def update_project_resource(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.delete("/project-context/profiles/{profile_id}/resources/{resource_id}", response_model=ProjectProfileRead)
@@ -333,7 +540,8 @@ async def remove_project_resource(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     resources = _project_resources(profile)
     next_resources = [
         resource
@@ -346,7 +554,8 @@ async def remove_project_resource(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.post("/project-context/profiles/{profile_id}/resources/reorder", response_model=ProjectProfileRead)
@@ -357,7 +566,8 @@ async def reorder_project_resources(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = _profile_org_id(user)
-    profile = await _get_project_profile(db, profile_id, org_id, include_inactive=True)
+    profile = await _get_project_profile(db, profile_id, org_id, user, include_inactive=True)
+    _require_project_profile_manager(profile, user)
     resources = _project_resources(profile)
     by_id = {str(resource.get("id") or _resource_identity(resource)): resource for resource in resources}
     requested = [str(resource_id) for resource_id in body.resource_ids]
@@ -367,7 +577,8 @@ async def reorder_project_resources(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
-    return profile_to_read(profile)
+    access_by_profile = await _access_map_for_profiles(db, [profile])
+    return profile_to_read(profile, access_by_profile.get(str(profile.id), []))
 
 
 @router.post("/project-context/github/connect", response_model=GitHubConnectRead)
@@ -510,7 +721,7 @@ async def attach_idea_project_context(
     profile: ProjectProfile | None = None
     if body.project_profile_id:
         org_id = _profile_org_id(user)
-        profile = await _get_project_profile(db, body.project_profile_id, org_id)
+        profile = await _get_project_profile(db, body.project_profile_id, org_id, user)
         project_context = dict(profile.project_context or {})
     if not project_context:
         raise HTTPException(status_code=422, detail="project_profile_id or project_context is required")

--- a/brain/platform/db/alembic/versions/0005_project_profile_privacy.py
+++ b/brain/platform/db/alembic/versions/0005_project_profile_privacy.py
@@ -1,0 +1,117 @@
+"""Add project profile privacy controls.
+
+Revision ID: 0005_project_profile_privacy
+Revises: 0004_external_agent_connections
+Create Date: 2026-05-18
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0005_project_profile_privacy"
+down_revision = "0004_external_agent_connections"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(sa.inspect(op.get_bind()).get_table_names(schema="public"))
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return column_name in {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns(table_name, schema="public")
+    }
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {
+        index["name"]
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name, schema="public")
+    }
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    inspector = sa.inspect(op.get_bind())
+    constraints = inspector.get_check_constraints(table_name, schema="public")
+    return constraint_name in {constraint["name"] for constraint in constraints}
+
+
+def upgrade() -> None:
+    if not _column_exists("project_profiles", "visibility"):
+        op.add_column(
+            "project_profiles",
+            sa.Column("visibility", sa.String(length=20), nullable=False, server_default="public"),
+        )
+        op.alter_column("project_profiles", "visibility", server_default="private")
+
+    if not _index_exists("project_profiles", "ix_project_profiles_org_visibility"):
+        op.create_index(
+            "ix_project_profiles_org_visibility",
+            "project_profiles",
+            ["org_id", "visibility"],
+        )
+    if not _constraint_exists("project_profiles", "ck_project_profiles_visibility"):
+        op.create_check_constraint(
+            "ck_project_profiles_visibility",
+            "project_profiles",
+            "visibility IN ('private', 'public')",
+        )
+
+    if not _table_exists("project_profile_access"):
+        op.create_table(
+            "project_profile_access",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "project_profile_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("project_profiles.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "shared_with_user_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "shared_by_user_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+            sa.UniqueConstraint(
+                "project_profile_id",
+                "shared_with_user_id",
+                name="uq_project_profile_access_profile_user",
+            ),
+        )
+        op.create_index(
+            "ix_project_profile_access_user",
+            "project_profile_access",
+            ["shared_with_user_id"],
+        )
+
+
+def downgrade() -> None:
+    if _table_exists("project_profile_access"):
+        op.drop_index("ix_project_profile_access_user", table_name="project_profile_access")
+        op.drop_table("project_profile_access")
+    if _index_exists("project_profiles", "ix_project_profiles_org_visibility"):
+        op.drop_index("ix_project_profiles_org_visibility", table_name="project_profiles")
+    if _constraint_exists("project_profiles", "ck_project_profiles_visibility"):
+        op.drop_constraint("ck_project_profiles_visibility", "project_profiles", type_="check")
+    if _column_exists("project_profiles", "visibility"):
+        op.drop_column("project_profiles", "visibility")

--- a/brain/platform/db/models/idea.py
+++ b/brain/platform/db/models/idea.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -35,6 +36,7 @@ __all__ = [
     "UserMention",
     "VisualBlock",
     "ProjectProfile",
+    "ProjectProfileAccess",
     "IdeaProjectAttachment",
 ]
 
@@ -265,6 +267,9 @@ class ProjectProfile(Base, CreatedAtMixin):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     project_context: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    visibility: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="private", default="private"
+    )
     default_environment_binding_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("environment_bindings.id", ondelete="SET NULL"), nullable=True
     )
@@ -275,7 +280,35 @@ class ProjectProfile(Base, CreatedAtMixin):
 
     __table_args__ = (
         UniqueConstraint("org_id", "slug", name="uq_project_profiles_org_slug"),
+        CheckConstraint("visibility IN ('private', 'public')", name="ck_project_profiles_visibility"),
         Index("ix_project_profiles_org_active", "org_id", "active"),
+        Index("ix_project_profiles_org_visibility", "org_id", "visibility"),
+    )
+
+
+class ProjectProfileAccess(Base, CreatedAtMixin):
+    """User access grant for private Project Context profiles."""
+
+    __tablename__ = "project_profile_access"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_profile_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("project_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    shared_with_user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    shared_by_user_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "project_profile_id",
+            "shared_with_user_id",
+            name="uq_project_profile_access_profile_user",
+        ),
+        Index("ix_project_profile_access_user", "shared_with_user_id"),
     )
 
 

--- a/brain/systems/cortex/project_context/access.py
+++ b/brain/systems/cortex/project_context/access.py
@@ -1,0 +1,71 @@
+"""Project Context profile visibility policy."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from sqlalchemy import exists, or_
+
+
+PROJECT_VISIBILITY_PUBLIC = "public"
+PROJECT_VISIBILITY_PRIVATE = "private"
+VALID_PROJECT_VISIBILITIES = {PROJECT_VISIBILITY_PUBLIC, PROJECT_VISIBILITY_PRIVATE}
+
+
+def normalize_project_visibility(value: str | None, *, default: str = PROJECT_VISIBILITY_PRIVATE) -> str:
+    visibility = str(value or default).strip().lower()
+    if visibility not in VALID_PROJECT_VISIBILITIES:
+        allowed = ", ".join(sorted(VALID_PROJECT_VISIBILITIES))
+        raise ValueError(f"Invalid project visibility {visibility!r}; expected one of: {allowed}")
+    return visibility
+
+
+def project_profile_visibility(profile: Any, *, default: str = PROJECT_VISIBILITY_PUBLIC) -> str:
+    try:
+        value = getattr(profile, "visibility")
+    except Exception:
+        value = None
+    try:
+        return normalize_project_visibility(value, default=default)
+    except ValueError:
+        return default
+
+
+def project_profile_visible_predicate(ProjectProfile: Any, ProjectProfileAccess: Any, user_id: str | None):
+    conditions = [ProjectProfile.visibility == PROJECT_VISIBILITY_PUBLIC]
+    if user_id:
+        conditions.extend([
+            ProjectProfile.user_id == user_id,
+            exists().where(
+                ProjectProfileAccess.project_profile_id == ProjectProfile.id,
+                ProjectProfileAccess.shared_with_user_id == user_id,
+            ),
+        ])
+    return or_(*conditions)
+
+
+def is_project_profile_visible(
+    profile: Any,
+    *,
+    user_id: str | None,
+    shared_user_ids: Iterable[str] = (),
+) -> bool:
+    visibility = project_profile_visibility(profile)
+    if visibility == PROJECT_VISIBILITY_PUBLIC:
+        return True
+    if not user_id:
+        return False
+    if str(getattr(profile, "user_id", "") or "") == str(user_id):
+        return True
+    return str(user_id) in {str(item) for item in shared_user_ids}
+
+
+def can_manage_project_profile(profile: Any, user: dict[str, Any] | None) -> bool:
+    if not user:
+        return False
+    if str(user.get("principal_type") or "").lower() == "service" or str(user.get("id") or "").startswith("service:"):
+        return True
+    user_id = str(user.get("id") or "")
+    if user_id and str(getattr(profile, "user_id", "") or "") == user_id:
+        return True
+    role = str(user.get("role") or "").lower()
+    return not getattr(profile, "user_id", None) and role in {"owner", "admin"}

--- a/brain/systems/cortex/project_context/profiles.py
+++ b/brain/systems/cortex/project_context/profiles.py
@@ -1,11 +1,14 @@
 """Project Context persistence read-model adapters."""
 from __future__ import annotations
 
+from typing import Any
+
+from brain.systems.cortex.project_context.access import project_profile_visibility
 from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentRead, ProjectProfileRead
 from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
 
 
-def profile_to_read(profile: ProjectProfile) -> ProjectProfileRead:
+def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None = None) -> ProjectProfileRead:
     return ProjectProfileRead.model_validate({
         "id": profile.id,
         "org_id": profile.org_id,
@@ -14,6 +17,8 @@ def profile_to_read(profile: ProjectProfile) -> ProjectProfileRead:
         "name": profile.name,
         "description": profile.description,
         "project_context": profile.project_context,
+        "visibility": project_profile_visibility(profile),
+        "access": access or [],
         "default_environment_binding_id": profile.default_environment_binding_id,
         "active": True if profile.active is None else profile.active,
         "metadata": profile.metadata_ or {},

--- a/brain/systems/cortex/project_context/schemas.py
+++ b/brain/systems/cortex/project_context/schemas.py
@@ -16,7 +16,7 @@ class ProjectProfileCreate(BaseModel):
     description: str | None = None
     project_context: dict[str, Any]
     visibility: str = Field(default=PROJECT_VISIBILITY_PRIVATE)
-    shared_usernames: list[str] = Field(default_factory=list)
+    shared_usernames: list[str] = Field(default_factory=list, description="User names to grant access to a private project.")
     default_environment_binding_id: int | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -27,7 +27,7 @@ class ProjectProfileUpdate(BaseModel):
     description: str | None = None
     project_context: dict[str, Any] | None = None
     visibility: str | None = None
-    shared_usernames: list[str] | None = None
+    shared_usernames: list[str] | None = Field(default=None, description="User names to grant access to a private project.")
     default_environment_binding_id: int | None = None
     active: bool | None = None
     metadata: dict[str, Any] | None = None

--- a/brain/systems/cortex/project_context/schemas.py
+++ b/brain/systems/cortex/project_context/schemas.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from brain.systems.cortex.project_context.access import PROJECT_VISIBILITY_PRIVATE
 from brain.systems.cortex.project_context.resources import ProjectResource, normalize_project_resource
 
 
@@ -14,6 +15,8 @@ class ProjectProfileCreate(BaseModel):
     name: str = Field(..., min_length=1)
     description: str | None = None
     project_context: dict[str, Any]
+    visibility: str = Field(default=PROJECT_VISIBILITY_PRIVATE)
+    shared_usernames: list[str] = Field(default_factory=list)
     default_environment_binding_id: int | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -23,9 +26,19 @@ class ProjectProfileUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1)
     description: str | None = None
     project_context: dict[str, Any] | None = None
+    visibility: str | None = None
+    shared_usernames: list[str] | None = None
     default_environment_binding_id: int | None = None
     active: bool | None = None
     metadata: dict[str, Any] | None = None
+
+
+class ProjectProfileAccessRead(BaseModel):
+    user_id: str
+    name: str
+    email: str | None = None
+    shared_by_user_id: str | None = None
+    created_at: datetime | None = None
 
 
 class ProjectProfileRead(BaseModel):
@@ -38,6 +51,8 @@ class ProjectProfileRead(BaseModel):
     name: str
     description: str | None = None
     project_context: dict[str, Any]
+    visibility: str = PROJECT_VISIBILITY_PRIVATE
+    access: list[ProjectProfileAccessRead] = Field(default_factory=list)
     default_environment_binding_id: int | None = None
     active: bool = True
     metadata_: dict[str, Any] | None = Field(default=None, alias="metadata")

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -216,12 +216,12 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         "get": {"required": ["project_id"], "optional": ["include_inactive"], "effect": "read one project profile"},
         "create": {
             "required": ["slug", "name"],
-            "optional": ["description", "project_context", "resources", "metadata", "default_environment_binding_id"],
+            "optional": ["description", "project_context", "resources", "visibility", "shared_usernames", "metadata", "default_environment_binding_id"],
             "effect": "create a reusable project context profile",
         },
         "update": {
             "required": ["project_id"],
-            "optional": ["slug", "name", "description", "project_context", "resources", "metadata"],
+            "optional": ["slug", "name", "description", "project_context", "resources", "visibility", "shared_usernames", "metadata"],
             "effect": "update a project context profile",
         },
         "archive": {"required": ["project_id"], "optional": [], "effect": "archive a project profile"},

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -27,25 +27,35 @@ def _attachment_read(attachment) -> dict[str, Any]:
     return attachment_to_read(attachment).model_dump(mode="json", by_alias=True)
 
 
-def _profile_stmt(org_id: str, *, include_inactive: bool = False):
+def _profile_stmt(org_id: str, user_id: str | None, *, include_inactive: bool = False):
     from sqlalchemy import select
-    from brain.platform.db.models.idea import ProjectProfile
+    from brain.platform.db.models.idea import ProjectProfile, ProjectProfileAccess
+    from brain.systems.cortex.project_context.access import project_profile_visible_predicate
 
     stmt = select(ProjectProfile).where(ProjectProfile.org_id == org_id)
+    stmt = stmt.where(project_profile_visible_predicate(ProjectProfile, ProjectProfileAccess, user_id))
     if not include_inactive:
         stmt = stmt.where(ProjectProfile.active.is_(True))
     return stmt
 
 
-async def _get_profile(session, org_id: str, profile_id: str, *, include_inactive: bool = False):
+async def _get_profile(session, org_id: str, user_id: str | None, profile_id: str, *, include_inactive: bool = False):
     from brain.platform.db.models.idea import ProjectProfile
 
-    profile = await session.get(ProjectProfile, profile_id)
-    if profile is None or str(profile.org_id or "") != str(org_id):
-        raise ValueError("Project profile not found")
-    if not include_inactive and profile.active is False:
+    profile = await session.scalar(
+        _profile_stmt(org_id, user_id, include_inactive=include_inactive)
+        .where(ProjectProfile.id == profile_id)
+    )
+    if profile is None:
         raise ValueError("Project profile not found")
     return profile
+
+
+def _require_manage_access(profile, actor: dict[str, Any]) -> None:
+    from brain.systems.cortex.project_context.access import can_manage_project_profile
+
+    if not can_manage_project_profile(profile, actor):
+        raise ValueError("Only the project owner can change this project")
 
 
 def _validated_project_context(project_context: dict[str, Any]) -> dict[str, Any]:
@@ -135,6 +145,8 @@ async def _handle_manage_project(
     resource_id: str | None = None,
     resource_ids: list[str] | None = None,
     metadata: dict | None = None,
+    visibility: str | None = None,
+    shared_usernames: list[str] | None = None,
     default_environment_binding_id: int | None = None,
     environment_binding_id: int | None = None,
     idea_id: str | None = None,
@@ -147,6 +159,8 @@ async def _handle_manage_project(
     from sqlalchemy import select
 
     from brain.app.api.routers.cortex._project_context import _require_idea_for_user
+    from brain.app.api.routers.cortex._project_context import _sync_project_access_list
+    from brain.systems.cortex.project_context.access import normalize_project_visibility
     from brain.systems.cortex.project_context.resources import normalize_project_resource
     from brain.systems.cortex.project_context.snapshot import (
         ProjectContextValidationError,
@@ -169,20 +183,22 @@ async def _handle_manage_project(
     try:
         async with UnitOfWork() as uow:
             if action == "list":
-                stmt = _profile_stmt(org_id, include_inactive=include_inactive).order_by(ProjectProfile.created_at.desc())
+                stmt = _profile_stmt(org_id, user_id, include_inactive=include_inactive).order_by(ProjectProfile.created_at.desc())
                 profiles = (await uow.session.scalars(stmt)).all()
                 return json.dumps({"projects": [_profile_read(profile) for profile in profiles]}, default=str)
 
             if action == "get":
                 if not selected_profile_id:
                     return json.dumps({"error": "get requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=include_inactive)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=include_inactive)
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "create":
                 if not slug or not name:
                     return json.dumps({"error": "create requires: slug, name"})
-                existing = await uow.session.scalar(_profile_stmt(org_id, include_inactive=True).where(ProjectProfile.slug == slug))
+                existing = await uow.session.scalar(
+                    select(ProjectProfile).where(ProjectProfile.org_id == org_id, ProjectProfile.slug == slug)
+                )
                 if existing is not None:
                     return json.dumps({"error": "Project profile slug already exists"})
                 context = _context_from_inputs(project_context=project_context, resources=resources, name=name)
@@ -193,17 +209,27 @@ async def _handle_manage_project(
                     name=name,
                     description=description,
                     project_context=context,
+                    visibility=normalize_project_visibility(visibility),
                     default_environment_binding_id=default_environment_binding_id,
                     metadata_=metadata or {},
                 )
                 uow.session.add(profile)
+                await uow.session.flush()
+                await _sync_project_access_list(
+                    uow.session,
+                    profile,
+                    org_id=org_id,
+                    shared_usernames=shared_usernames,
+                    actor_user_id=user_id,
+                )
                 await uow.commit()
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "update":
                 if not selected_profile_id:
                     return json.dumps({"error": "update requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 if slug and slug != profile.slug:
                     existing = await uow.session.scalar(
                         select(ProjectProfile).where(
@@ -225,6 +251,16 @@ async def _handle_manage_project(
                         resources=resources,
                         name=profile.name,
                     )
+                if visibility is not None:
+                    profile.visibility = normalize_project_visibility(visibility)
+                if shared_usernames is not None:
+                    await _sync_project_access_list(
+                        uow.session,
+                        profile,
+                        org_id=org_id,
+                        shared_usernames=shared_usernames,
+                        actor_user_id=user_id,
+                    )
                 if default_environment_binding_id is not None:
                     profile.default_environment_binding_id = default_environment_binding_id
                 if metadata is not None:
@@ -236,7 +272,8 @@ async def _handle_manage_project(
             if action in {"archive", "delete"}:
                 if not selected_profile_id:
                     return json.dumps({"error": f"{action} requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 profile.active = False
                 uow.session.add(profile)
                 await uow.commit()
@@ -248,7 +285,8 @@ async def _handle_manage_project(
                 incoming = resources or ([resource] if isinstance(resource, dict) else [])
                 if not incoming:
                     return json.dumps({"error": "add_resource requires: resource or resources"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 existing_ids = {str(item.get("id")) for item in current if item.get("id")}
                 for raw in incoming:
@@ -263,7 +301,8 @@ async def _handle_manage_project(
             if action == "update_resource":
                 if not selected_profile_id or not resource_id or not isinstance(resource, dict):
                     return json.dumps({"error": "update_resource requires: project_id, resource_id, resource"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 for index, existing in enumerate(current):
                     if _resource_matches(existing, resource_id):
@@ -281,7 +320,8 @@ async def _handle_manage_project(
             if action == "remove_resource":
                 if not selected_profile_id or not resource_id:
                     return json.dumps({"error": "remove_resource requires: project_id, resource_id"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 next_resources = [item for item in current if not _resource_matches(item, resource_id)]
                 if len(next_resources) == len(current):
@@ -294,7 +334,8 @@ async def _handle_manage_project(
             if action == "reorder_resources":
                 if not selected_profile_id or not resource_ids:
                     return json.dumps({"error": "reorder_resources requires: project_id, resource_ids"})
-                profile = await _get_profile(uow.session, org_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 by_id = {str(item.get("id")): item for item in current if item.get("id")}
                 requested = [str(item) for item in resource_ids]
@@ -313,7 +354,7 @@ async def _handle_manage_project(
                 profile = None
                 context = project_context
                 if selected_profile_id:
-                    profile = await _get_profile(uow.session, org_id, selected_profile_id)
+                    profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id)
                     context = dict(profile.project_context or {})
                 if not context:
                     return json.dumps({"error": "attach_to_thread requires: project_id or project_context"})

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -158,8 +158,7 @@ async def _handle_manage_project(
 
     from sqlalchemy import select
 
-    from brain.app.api.routers.cortex._project_context import _require_idea_for_user
-    from brain.app.api.routers.cortex._project_context import _sync_project_access_list
+    from brain.app.api.routers.cortex._project_context import _require_idea_for_user, _sync_project_access_list
     from brain.systems.cortex.project_context.access import normalize_project_visibility
     from brain.systems.cortex.project_context.resources import normalize_project_resource
     from brain.systems.cortex.project_context.snapshot import (

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -649,13 +649,15 @@ async def _query_project_profiles(
         payload["warnings"].append({"source": "project_profiles", "error": "org_id required"})
         payload["sources"]["project_profiles"] = []
         return
-    from brain.platform.db.models.idea import ProjectProfile
+    from brain.platform.db.models.idea import ProjectProfile, ProjectProfileAccess
     from brain.platform.db.models.org import User
+    from brain.systems.cortex.project_context.access import project_profile_visible_predicate
 
     stmt = (
         select(ProjectProfile, User)
         .outerjoin(User, User.id == ProjectProfile.user_id)
         .where(ProjectProfile.org_id == org_id)
+        .where(project_profile_visible_predicate(ProjectProfile, ProjectProfileAccess, user_id))
         .order_by(ProjectProfile.created_at.desc())
         .limit(limit)
     )
@@ -685,6 +687,7 @@ async def _query_project_profiles(
             "name": profile.name,
             "description": _snippet(profile.description),
             "active": bool(profile.active),
+            "visibility": getattr(profile, "visibility", "public") or "public",
             "user_id": str(profile.user_id) if profile.user_id is not None else None,
             "user_name": user.name if user else None,
             "org_id": str(profile.org_id) if profile.org_id is not None else None,

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -982,7 +982,7 @@ PROJECT_TOOLS = [
                 },
                 "shared_usernames": {
                     "type": "array",
-                    "description": "User names or emails to grant access to a private project.",
+                    "description": "User names to grant access to a private project.",
                     "items": {"type": "string"},
                 },
                 "default_environment_binding_id": {"type": "integer", "description": "Optional default environment binding id."},

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -975,6 +975,16 @@ PROJECT_TOOLS = [
                     "items": {"type": "string"},
                 },
                 "metadata": {"type": "object", "description": "Optional metadata for profile or attachment provenance."},
+                "visibility": {
+                    "type": "string",
+                    "enum": ["private", "public"],
+                    "description": "Project visibility. New projects default to private; public projects are visible to the org.",
+                },
+                "shared_usernames": {
+                    "type": "array",
+                    "description": "User names or emails to grant access to a private project.",
+                    "items": {"type": "string"},
+                },
                 "default_environment_binding_id": {"type": "integer", "description": "Optional default environment binding id."},
                 "environment_binding_id": {"type": "integer", "description": "Optional per-thread attachment environment binding id."},
                 "idea_id": {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -731,7 +731,16 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   listProjectContextProfiles: () =>
     fetchJson<any[]>('/api/cortex/project-context/profiles'),
-  createProjectContextProfile: (data: { slug: string; name: string; description?: string | null; project_context: any; default_environment_binding_id?: number | null; metadata?: Record<string, any> }) =>
+  createProjectContextProfile: (data: {
+    slug: string;
+    name: string;
+    description?: string | null;
+    project_context: any;
+    visibility?: 'private' | 'public';
+    shared_usernames?: string[];
+    default_environment_binding_id?: number | null;
+    metadata?: Record<string, any>;
+  }) =>
     fetchJson<any>('/api/cortex/project-context/profiles', { method: 'POST', body: JSON.stringify(data) }),
   connectProjectContextGitHub: (data: { vault_key: string }, vaultToken?: string | null) =>
     fetchJson<any>('/api/cortex/project-context/github/connect', {

--- a/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
+++ b/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
@@ -23,6 +23,7 @@
     resourceLocator,
     slugify,
     type ProjectContextProfile,
+    type ProjectVisibility,
   } from './project-context/projectContextProfiles';
 
   let {
@@ -58,6 +59,8 @@
   let creatingProject = $state(false);
   let newProjectName = $state('');
   let newProjectDescription = $state('');
+  let newProjectVisibility = $state<ProjectVisibility>('private');
+  let newProjectSharedUsernames = $state('');
   let selectedResources = $state<ProjectContextResource[]>([]);
   let projectSaving = $state(false);
   let projectSaveError = $state('');
@@ -231,6 +234,8 @@
     selectedResources = [];
     newProjectName = '';
     newProjectDescription = '';
+    newProjectVisibility = 'private';
+    newProjectSharedUsernames = '';
     projectSaveError = '';
   }
 
@@ -246,7 +251,18 @@
     const detail = err?.detail;
     const validationErrors = detail?.validation_errors;
     if (Array.isArray(validationErrors) && validationErrors.length) return String(validationErrors[0]);
+    if (Array.isArray(detail?.unknown_users) && detail.unknown_users.length) {
+      return `Unknown users: ${detail.unknown_users.join(', ')}`;
+    }
     return projectContextErrorDetail(err, 'Could not save project.');
+  }
+
+  function sharedUsernamesForSave(): string[] {
+    if (newProjectVisibility !== 'private') return [];
+    return newProjectSharedUsernames
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
   }
 
   async function saveProjectProfile() {
@@ -268,6 +284,8 @@
           name,
           description: description || null,
           project_context: projectContext,
+          visibility: newProjectVisibility,
+          shared_usernames: sharedUsernamesForSave(),
           metadata: { source: 'cortex-ui-project-picker' },
         });
         profile = mapServerProjectProfile(created);
@@ -286,6 +304,8 @@
       selectedResources = [];
       newProjectName = '';
       newProjectDescription = '';
+      newProjectVisibility = 'private';
+      newProjectSharedUsernames = '';
     } catch (err: any) {
       projectSaveError = errorCopy(err);
     } finally {
@@ -445,6 +465,8 @@
           <ProjectContextCreateForm
             bind:name={newProjectName}
             bind:description={newProjectDescription}
+            bind:visibility={newProjectVisibility}
+            bind:sharedUsernames={newProjectSharedUsernames}
             resources={selectedResources}
             validation={activeProjectValidation}
             saveError={projectSaveError}

--- a/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
+++ b/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
@@ -254,6 +254,9 @@
     if (Array.isArray(detail?.unknown_users) && detail.unknown_users.length) {
       return `Unknown users: ${detail.unknown_users.join(', ')}`;
     }
+    if (Array.isArray(detail?.ambiguous_users) && detail.ambiguous_users.length) {
+      return `Ambiguous users: ${detail.ambiguous_users.join(', ')}`;
+    }
     return projectContextErrorDetail(err, 'Could not save project.');
   }
 

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { ConstellationIcon } from '$lib/components/constellation';
   import { listTeamMembers } from '$lib/features/cortex/api/cortexApi';
   import { auth } from '$lib/stores/auth.svelte';
@@ -52,6 +53,7 @@
   let teamUsersError = $state('');
   let shareSearch = $state('');
   let sharePickerOpen = $state(false);
+  let sharePickerEl: HTMLDivElement | null = $state(null);
 
   function openConnector(nextMode: ConnectorMode) {
     connectorMode = nextMode;
@@ -155,11 +157,25 @@
     }
   }
 
+  function handleDocumentPointerDown(event: PointerEvent) {
+    if (!sharePickerOpen || !sharePickerEl) return;
+    const target = event.target;
+    if (target instanceof Node && sharePickerEl.contains(target)) return;
+    sharePickerOpen = false;
+  }
+
   $effect(() => {
     if (visibility === 'private') return;
     sharedUsernames = '';
     shareSearch = '';
     sharePickerOpen = false;
+  });
+
+  onMount(() => {
+    document.addEventListener('pointerdown', handleDocumentPointerDown, true);
+    return () => {
+      document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+    };
   });
 </script>
 
@@ -203,7 +219,7 @@
 </div>
 
 {#if visibility === 'private'}
-  <div class="project-access-picker">
+  <div bind:this={sharePickerEl} class="project-access-picker" class:open={sharePickerOpen}>
     {#if selectedShareUsers.length}
       <div class="project-access-selected" aria-label="Shared users">
         {#each selectedShareUsers as selectedName}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -5,11 +5,13 @@
   import ProjectContextGitHubConnector from './ProjectContextGitHubConnector.svelte';
   import ProjectContextLocalConnector from './ProjectContextLocalConnector.svelte';
   import ProjectContextResourcePills from './ProjectContextResourcePills.svelte';
-  import type { ConnectorMode } from './projectContextProfiles';
+  import type { ConnectorMode, ProjectVisibility } from './projectContextProfiles';
 
   let {
     name = $bindable(''),
     description = $bindable(''),
+    visibility = $bindable<ProjectVisibility>('private'),
+    sharedUsernames = $bindable(''),
     resources = [],
     validation = { valid: true, errors: [] },
     saveError = '',
@@ -22,6 +24,8 @@
   }: {
     name?: string;
     description?: string;
+    visibility?: ProjectVisibility;
+    sharedUsernames?: string;
     resources?: ProjectContextResource[];
     validation?: { valid: boolean; errors: string[] };
     saveError?: string;
@@ -65,6 +69,36 @@
     bind:value={description}
   />
 </div>
+
+<div class="project-visibility-row" role="group" aria-label="Project visibility">
+  <button
+    type="button"
+    class:selected={visibility === 'private'}
+    aria-pressed={visibility === 'private'}
+    onclick={() => { visibility = 'private'; }}
+  >
+    <ConstellationIcon name="lock" size={14} stroke={1.8} />
+    <span>Private</span>
+  </button>
+  <button
+    type="button"
+    class:selected={visibility === 'public'}
+    aria-pressed={visibility === 'public'}
+    onclick={() => { visibility = 'public'; }}
+  >
+    <ConstellationIcon name="team" size={14} stroke={1.8} />
+    <span>Public</span>
+  </button>
+</div>
+
+{#if visibility === 'private'}
+  <input
+    class="project-access-input"
+    aria-label="Shared usernames"
+    placeholder="Share with usernames or emails"
+    bind:value={sharedUsernames}
+  />
+{/if}
 
 {#if connectorMode === 'menu'}
   <ProjectContextConnectorMenu onOpen={openConnector} />

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import { ConstellationIcon } from '$lib/components/constellation';
+  import { listTeamMembers } from '$lib/features/cortex/api/cortexApi';
+  import { auth } from '$lib/stores/auth.svelte';
   import type { ProjectContextResource } from '$lib/utils/projectContext';
   import ProjectContextConnectorMenu from './ProjectContextConnectorMenu.svelte';
   import ProjectContextGitHubConnector from './ProjectContextGitHubConnector.svelte';
   import ProjectContextLocalConnector from './ProjectContextLocalConnector.svelte';
   import ProjectContextResourcePills from './ProjectContextResourcePills.svelte';
   import type { ConnectorMode, ProjectVisibility } from './projectContextProfiles';
+
+  type ShareableUser = {
+    id?: string;
+    user_id?: string;
+    name?: string;
+  };
 
   let {
     name = $bindable(''),
@@ -38,10 +46,47 @@
   } = $props();
 
   let connectorMode = $state<ConnectorMode>('menu');
+  let teamUsers = $state<ShareableUser[]>([]);
+  let teamUsersLoaded = false;
+  let teamUsersLoading = $state(false);
+  let teamUsersError = $state('');
+  let shareSearch = $state('');
+  let sharePickerOpen = $state(false);
 
   function openConnector(nextMode: ConnectorMode) {
     connectorMode = nextMode;
   }
+
+  function userId(user: ShareableUser): string {
+    return String(user.id ?? user.user_id ?? '').trim();
+  }
+
+  function userName(user: ShareableUser): string {
+    return String(user.name ?? '').trim();
+  }
+
+  function selectedShareNames(): string[] {
+    return sharedUsernames
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  function selectedShareNameSet(): Set<string> {
+    return new Set(selectedShareNames().map((item) => item.toLowerCase()));
+  }
+
+  const selectedShareUsers = $derived(selectedShareNames());
+  const filteredShareUsers = $derived.by(() => {
+    const needle = shareSearch.trim().toLowerCase();
+    const selected = selectedShareNameSet();
+    const currentUserId = String(auth.user?.id ?? '');
+    return teamUsers
+      .filter((user) => userName(user) && userId(user) !== currentUserId)
+      .filter((user) => !selected.has(userName(user).toLowerCase()))
+      .filter((user) => !needle || userName(user).toLowerCase().includes(needle))
+      .sort((a, b) => userName(a).localeCompare(userName(b)));
+  });
 
   const connectorTitle = $derived(
     connectorMode === 'github'
@@ -50,6 +95,72 @@
         ? 'Files or folders'
         : '',
   );
+
+  async function loadShareUsers() {
+    if (teamUsersLoading || teamUsersLoaded) return;
+    teamUsersLoading = true;
+    teamUsersError = '';
+    try {
+      teamUsers = await listTeamMembers();
+      teamUsersLoaded = true;
+    } catch {
+      teamUsers = [];
+      teamUsersLoaded = true;
+      teamUsersError = 'Could not load users.';
+    } finally {
+      teamUsersLoading = false;
+    }
+  }
+
+  function openSharePicker() {
+    sharePickerOpen = true;
+    void loadShareUsers();
+  }
+
+  function addShareUser(user: ShareableUser) {
+    const name = userName(user);
+    if (!name) return;
+    const selected = selectedShareNames();
+    if (!selected.some((item) => item.toLowerCase() === name.toLowerCase())) {
+      sharedUsernames = [...selected, name].join(', ');
+    }
+    shareSearch = '';
+    sharePickerOpen = true;
+  }
+
+  function removeShareUser(name: string) {
+    sharedUsernames = selectedShareNames()
+      .filter((item) => item.toLowerCase() !== name.toLowerCase())
+      .join(', ');
+    sharePickerOpen = true;
+  }
+
+  function handleShareKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      sharePickerOpen = false;
+      return;
+    }
+    if (event.key === 'Enter') {
+      const first = filteredShareUsers[0];
+      if (!first) return;
+      event.preventDefault();
+      addShareUser(first);
+      return;
+    }
+    if (event.key === 'Backspace' && !shareSearch.trim()) {
+      const selected = selectedShareNames();
+      if (!selected.length) return;
+      event.preventDefault();
+      sharedUsernames = selected.slice(0, -1).join(', ');
+    }
+  }
+
+  $effect(() => {
+    if (visibility === 'private') return;
+    sharedUsernames = '';
+    shareSearch = '';
+    sharePickerOpen = false;
+  });
 </script>
 
 <div class="project-create-intro">
@@ -92,12 +203,51 @@
 </div>
 
 {#if visibility === 'private'}
-  <input
-    class="project-access-input"
-    aria-label="Shared usernames"
-    placeholder="Share with usernames or emails"
-    bind:value={sharedUsernames}
-  />
+  <div class="project-access-picker">
+    {#if selectedShareUsers.length}
+      <div class="project-access-selected" aria-label="Shared users">
+        {#each selectedShareUsers as selectedName}
+          <button type="button" onclick={() => removeShareUser(selectedName)}>
+            <span>{selectedName}</span>
+            <ConstellationIcon name="x" size={12} stroke={2} />
+          </button>
+        {/each}
+      </div>
+    {/if}
+    <input
+      class="project-access-input"
+      aria-label="Shared users"
+      placeholder="Share with users"
+      bind:value={shareSearch}
+      onfocus={openSharePicker}
+      oninput={openSharePicker}
+      onkeydown={handleShareKeydown}
+    />
+    {#if sharePickerOpen}
+      <div class="project-access-menu" role="listbox" aria-label="Users">
+        {#if teamUsersLoading}
+          <div class="project-access-empty">Loading users...</div>
+        {:else if teamUsersError}
+          <div class="project-access-empty">{teamUsersError}</div>
+        {:else if filteredShareUsers.length}
+          {#each filteredShareUsers as user (userId(user) || userName(user))}
+            <button
+              type="button"
+              role="option"
+              aria-selected="false"
+              onpointerdown={(event) => event.preventDefault()}
+              onclick={() => addShareUser(user)}
+            >
+              <ConstellationIcon name="team" size={14} stroke={1.8} />
+              <span>{userName(user)}</span>
+            </button>
+          {/each}
+        {:else}
+          <div class="project-access-empty">No users found.</div>
+        {/if}
+      </div>
+    {/if}
+  </div>
 {/if}
 
 {#if connectorMode === 'menu'}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { ConstellationIcon } from '$lib/components/constellation';
   import { listTeamMembers } from '$lib/features/cortex/api/cortexApi';
   import { auth } from '$lib/stores/auth.svelte';
@@ -139,7 +138,7 @@
 
   function handleShareKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
-      sharePickerOpen = false;
+      closeSharePicker();
       return;
     }
     if (event.key === 'Enter') {
@@ -157,11 +156,19 @@
     }
   }
 
-  function handleDocumentPointerDown(event: PointerEvent) {
-    if (!sharePickerOpen || !sharePickerEl) return;
-    const target = event.target;
-    if (target instanceof Node && sharePickerEl.contains(target)) return;
+  function closeSharePicker() {
     sharePickerOpen = false;
+  }
+
+  function isInsideSharePicker(event: Event): boolean {
+    const target = event.target;
+    return target instanceof Node && !!sharePickerEl?.contains(target);
+  }
+
+  function handleShareFocusOut(event: FocusEvent) {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && sharePickerEl?.contains(nextTarget)) return;
+    closeSharePicker();
   }
 
   $effect(() => {
@@ -171,10 +178,29 @@
     sharePickerOpen = false;
   });
 
-  onMount(() => {
+  $effect(() => {
+    if (!sharePickerOpen) return;
+
+    function handleDocumentPointerDown(event: PointerEvent) {
+      if (!isInsideSharePicker(event)) closeSharePicker();
+    }
+
+    function handleDocumentMouseDown(event: MouseEvent) {
+      if (!isInsideSharePicker(event)) closeSharePicker();
+    }
+
+    function handleDocumentKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') closeSharePicker();
+    }
+
     document.addEventListener('pointerdown', handleDocumentPointerDown, true);
+    document.addEventListener('mousedown', handleDocumentMouseDown, true);
+    document.addEventListener('keydown', handleDocumentKeyDown);
+
     return () => {
       document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+      document.removeEventListener('mousedown', handleDocumentMouseDown, true);
+      document.removeEventListener('keydown', handleDocumentKeyDown);
     };
   });
 </script>
@@ -219,7 +245,12 @@
 </div>
 
 {#if visibility === 'private'}
-  <div bind:this={sharePickerEl} class="project-access-picker" class:open={sharePickerOpen}>
+  <div
+    bind:this={sharePickerEl}
+    class="project-access-picker"
+    class:open={sharePickerOpen}
+    onfocusout={handleShareFocusOut}
+  >
     {#if selectedShareUsers.length}
       <div class="project-access-selected" aria-label="Shared users">
         {#each selectedShareUsers as selectedName}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
@@ -48,6 +48,16 @@
     selectedProfileId = profile.id;
     onSelect?.();
   }
+
+  function profileMeta(profile: ProjectContextProfile): string {
+    if (profile.id === 'none') return profile.description;
+    const visibility = profile.visibility === 'public' ? 'Public' : 'Private';
+    const sharedCount = profile.visibility === 'private' ? (profile.access?.length ?? 0) : 0;
+    const access = sharedCount > 0 ? `${visibility} · ${sharedCount} shared` : visibility;
+    return [access, profile.description || `${profile.resources.length} resource${profile.resources.length === 1 ? '' : 's'}`]
+      .filter(Boolean)
+      .join(' · ');
+  }
 </script>
 
 <div class="project-context-search-control">
@@ -73,16 +83,14 @@
         aria-selected={isSelected}
         onclick={() => selectProject(profile)}
       >
-        <ConstellationIcon name="folder" size={17} stroke={1.8} />
+        <ConstellationIcon
+          name={profile.id === 'none' ? 'folder' : profile.visibility === 'public' ? 'team' : 'lock'}
+          size={17}
+          stroke={1.8}
+        />
         <span class="project-context-profile-option-copy">
           <strong>{profile.name}</strong>
-          {#if profile.description && profile.id !== 'none'}
-            <small>{profile.description}</small>
-          {:else if profile.resources.length}
-            <small>{profile.resources.length} resource{profile.resources.length === 1 ? '' : 's'}</small>
-          {:else if profile.id !== 'none'}
-            <small>No resources attached</small>
-          {/if}
+          <small>{profileMeta(profile)}</small>
         </span>
         {#if isSelected}
           <span class="project-context-profile-check" aria-hidden="true">

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -587,6 +587,18 @@
     margin-top: 0;
   }
 
+  .project-access-picker {
+    position: relative;
+    display: grid;
+    gap: 6px;
+  }
+
+  .project-access-selected {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
   .project-create-intro {
     display: grid;
     gap: 3px;
@@ -698,6 +710,31 @@
     cursor: pointer;
   }
 
+  .project-access-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 4;
+    display: grid;
+    gap: 1px;
+    max-height: 152px;
+    overflow: auto;
+    box-sizing: border-box;
+    padding: 4px;
+    border: 1px solid var(--project-context-popover-border);
+    border-radius: 9px;
+    background: var(--project-context-popover-background);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+  }
+
+  .project-access-empty {
+    padding: 8px;
+    color: var(--project-context-muted-text);
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
   .project-connector-grid {
     display: grid;
     gap: 8px;
@@ -713,6 +750,8 @@
 
   .connector-back-button,
   .project-visibility-row button,
+  .project-access-selected button,
+  .project-access-menu button,
   .project-context-secondary,
   .project-context-primary,
   .github-connect-row button,
@@ -752,6 +791,35 @@
     border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 26%, var(--project-context-button-border));
     background: var(--project-context-button-active-background);
     color: var(--project-context-button-active-text);
+  }
+
+  .project-access-selected button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 26px;
+    padding: 5px 7px;
+    border-radius: 999px;
+    background: var(--project-context-pill-background);
+    color: var(--project-context-pill-text);
+  }
+
+  .project-access-menu button {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 7px;
+    min-height: 30px;
+    border: 0;
+    border-radius: 7px;
+    padding: 7px 8px;
+    background: transparent;
+    text-align: left;
+  }
+
+  .project-access-menu button:hover {
+    background: var(--project-context-option-hover-background);
+    color: var(--project-context-option-hover-text);
   }
 
   .connector-view-title {

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -13,6 +13,7 @@
     --project-context-chip-invalid-background: rgba(212, 128, 143, 0.12);
     --project-context-popover-border: var(--composer-menu-border, rgba(240, 240, 250, 0.09));
     --project-context-popover-background: var(--composer-menu-background, rgba(9, 12, 18, 0.98));
+    --project-context-access-menu-background: #0b1118;
     --project-context-popover-shadow: var(
       --composer-menu-shadow,
       0 18px 42px rgba(0, 0, 0, 0.32),
@@ -73,6 +74,7 @@
   :root[data-color-scheme='light'] .project-context-composer {
     --project-context-popover-border: var(--composer-menu-border, rgba(49, 63, 76, 0.12));
     --project-context-popover-background: var(--composer-menu-background, rgba(255, 253, 247, 0.98));
+    --project-context-access-menu-background: #fffdf8;
     --project-context-popover-shadow: var(--composer-menu-shadow, 0 18px 38px rgba(54, 70, 82, 0.13));
     --project-context-option-hover-background: var(--composer-menu-option-hover-background, rgba(49, 63, 76, 0.055));
     --project-context-option-active-background: var(--composer-menu-option-active-background, rgba(49, 63, 76, 0.075));
@@ -589,8 +591,13 @@
 
   .project-access-picker {
     position: relative;
+    z-index: 1;
     display: grid;
     gap: 6px;
+  }
+
+  .project-access-picker.open {
+    z-index: 24;
   }
 
   .project-access-selected {
@@ -715,7 +722,7 @@
     top: calc(100% + 4px);
     left: 0;
     right: 0;
-    z-index: 4;
+    z-index: 25;
     display: grid;
     gap: 1px;
     max-height: 152px;
@@ -724,8 +731,9 @@
     padding: 4px;
     border: 1px solid var(--project-context-popover-border);
     border-radius: 9px;
-    background: var(--project-context-popover-background);
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+    background: var(--project-context-access-menu-background);
+    box-shadow: var(--project-context-popover-shadow);
+    color: var(--project-context-option-text);
   }
 
   .project-access-empty {
@@ -814,6 +822,7 @@
     border-radius: 7px;
     padding: 7px 8px;
     background: transparent;
+    color: var(--project-context-option-text);
     text-align: left;
   }
 

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -385,6 +385,14 @@
       0 28px 72px rgba(0, 0, 0, 0.42),
       0 0 0 1px rgba(255, 255, 255, 0.02) inset;
     --project-context-modal-divider: rgba(240, 240, 250, 0.075);
+    --project-context-popover-border: rgba(240, 240, 250, 0.1);
+    --project-context-popover-shadow:
+      0 18px 42px rgba(0, 0, 0, 0.38),
+      0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+    --project-context-access-menu-background: #0b1118;
+    --project-context-option-text: rgba(249, 244, 232, 0.9);
+    --project-context-option-hover-background: rgba(240, 240, 250, 0.075);
+    --project-context-option-hover-text: rgba(249, 244, 232, 0.96);
     --project-context-title: rgba(249, 244, 232, 0.95);
     --project-context-command-border: rgba(255, 255, 255, 0.08);
     --project-context-command-background: rgba(255, 255, 255, 0.035);
@@ -451,6 +459,14 @@
     --project-context-modal-background: rgba(255, 253, 247, 0.99);
     --project-context-modal-shadow: 0 28px 68px rgba(54, 70, 82, 0.17);
     --project-context-modal-divider: rgba(126, 92, 52, 0.09);
+    --project-context-popover-border: rgba(126, 92, 52, 0.14);
+    --project-context-popover-shadow:
+      0 18px 38px rgba(54, 70, 82, 0.2),
+      0 0 0 1px rgba(126, 92, 52, 0.05) inset;
+    --project-context-access-menu-background: #fffefb;
+    --project-context-option-text: #18212a;
+    --project-context-option-hover-background: rgba(49, 63, 76, 0.07);
+    --project-context-option-hover-text: #18212a;
     --project-context-title: #18212a;
     --project-context-command-border: rgba(49, 63, 76, 0.11);
     --project-context-command-background: rgba(248, 250, 248, 0.72);
@@ -729,11 +745,17 @@
     overflow: auto;
     box-sizing: border-box;
     padding: 4px;
-    border: 1px solid var(--project-context-popover-border);
+    border: 1px solid var(--project-context-popover-border, rgba(126, 92, 52, 0.14));
     border-radius: 9px;
-    background: var(--project-context-access-menu-background);
-    box-shadow: var(--project-context-popover-shadow);
-    color: var(--project-context-option-text);
+    background-color: #0b1118;
+    background: var(--project-context-access-menu-background, #fffefb);
+    background-clip: padding-box;
+    box-shadow: var(--project-context-popover-shadow, 0 18px 38px rgba(54, 70, 82, 0.2));
+    color: var(--project-context-option-text, #18212a);
+  }
+
+  :root[data-color-scheme='light'] .project-access-menu {
+    background-color: #fffefb;
   }
 
   .project-access-empty {
@@ -822,7 +844,7 @@
     border-radius: 7px;
     padding: 7px 8px;
     background: transparent;
-    color: var(--project-context-option-text);
+    color: var(--project-context-option-text, #18212a);
     text-align: left;
   }
 

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -580,6 +580,13 @@
     margin-bottom: 0;
   }
 
+  .project-visibility-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    margin-top: 0;
+  }
+
   .project-create-intro {
     display: grid;
     gap: 3px;
@@ -600,6 +607,7 @@
 
   .project-context-field select,
   .project-create-fields input,
+  .project-access-input,
   .connector-panel input,
   .connector-panel select {
     width: 100%;
@@ -620,12 +628,14 @@
 
   .project-context-field select:focus,
   .project-create-fields input:focus,
+  .project-access-input:focus,
   .connector-panel input:focus,
   .connector-panel select:focus {
     border-color: color-mix(in srgb, var(--project-context-field-value) 28%, var(--project-context-field-border));
   }
 
   .project-create-fields input::placeholder,
+  .project-access-input::placeholder,
   .connector-panel input::placeholder {
     color: var(--project-context-muted-text);
   }
@@ -702,6 +712,7 @@
   }
 
   .connector-back-button,
+  .project-visibility-row button,
   .project-context-secondary,
   .project-context-primary,
   .github-connect-row button,
@@ -727,6 +738,20 @@
     gap: 3px;
     min-height: 28px;
     padding: 6px 9px 6px 7px;
+  }
+
+  .project-visibility-row button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 34px;
+  }
+
+  .project-visibility-row button.selected {
+    border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 26%, var(--project-context-button-border));
+    background: var(--project-context-button-active-background);
+    color: var(--project-context-button-active-text);
   }
 
   .connector-view-title {

--- a/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
@@ -6,9 +6,18 @@ export type ProjectContextProfile = {
   description: string;
   resources: ProjectContextResource[];
   serverProfileId?: string;
+  visibility?: ProjectVisibility;
+  access?: ProjectProfileAccess[];
 };
 
 export type ConnectorMode = 'menu' | 'github' | 'local';
+export type ProjectVisibility = 'private' | 'public';
+
+export type ProjectProfileAccess = {
+  user_id: string;
+  name: string;
+  email?: string | null;
+};
 
 const RESOURCE_TYPE_LABELS: Record<string, string> = {
   repo: 'GitHub',
@@ -42,6 +51,8 @@ export function mapServerProjectProfile(profile: any): ProjectContextProfile {
     serverProfileId: profile.id,
     name: profile.name,
     description: profile.description ?? 'Saved project profile',
+    visibility: profile.visibility === 'public' ? 'public' : 'private',
+    access: Array.isArray(profile.access) ? profile.access : [],
     resources: Array.isArray(profile.project_context?.resources)
       ? profile.project_context.resources
       : [],

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -24,6 +24,8 @@ BROAD_DESTRUCTIVE_SQL_PATTERNS = (
 )
 REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0003_schema_simplification.py",
+    # Downgrade removes only the access table introduced by the same migration.
+    "0005_project_profile_privacy.py",
 }
 
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1575,6 +1575,24 @@ async def test_resolve_project_access_users_reports_unknown_names():
     assert excinfo.value.detail == {"unknown_users": ["missing"]}
 
 
+async def test_resolve_project_access_users_rejects_ambiguous_names():
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.cortex._project_context import _resolve_project_access_users
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = [
+        SimpleNamespace(id="user-2", org_id="org-1", name="Alex", email="alex@example.com"),
+        SimpleNamespace(id="user-3", org_id="org-1", name="alex", email="alex2@example.com"),
+    ]
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _resolve_project_access_users(_AsyncSession(session), "org-1", ["Alex"])
+
+    assert excinfo.value.status_code == 422
+    assert excinfo.value.detail == {"ambiguous_users": ["Alex"]}
+
+
 @pytest.mark.asyncio
 async def test_create_project_profile_rejects_empty_project_context(client, mock_session_factory):
     from brain.app.api.routers.cortex import _project_context as pc_mod

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1528,7 +1528,7 @@ def test_project_profile_create_defaults_private():
     assert payload.shared_usernames == []
 
 
-async def test_resolve_project_access_users_accepts_names_and_emails():
+async def test_resolve_project_access_users_accepts_names_only():
     from brain.app.api.routers.cortex._project_context import _resolve_project_access_users
 
     session = MagicMock()
@@ -1539,10 +1539,25 @@ async def test_resolve_project_access_users_accepts_names_and_emails():
     users = await _resolve_project_access_users(
         _AsyncSession(session),
         "org-1",
-        ["alex", "alex@example.com"],
+        ["alex"],
     )
 
     assert [user.id for user in users] == ["user-2"]
+
+
+async def test_resolve_project_access_users_rejects_emails():
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.cortex._project_context import _resolve_project_access_users
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = []
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _resolve_project_access_users(_AsyncSession(session), "org-1", ["alex@example.com"])
+
+    assert excinfo.value.status_code == 422
+    assert excinfo.value.detail == {"unknown_users": ["alex@example.com"]}
 
 
 async def test_resolve_project_access_users_reports_unknown_names():

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1479,6 +1479,87 @@ def test_project_context_snapshot_attachment_revalidates_existing_status():
     ]
 
 
+def test_project_profile_visibility_policy_matches_drive_model():
+    from brain.systems.cortex.project_context.access import is_project_profile_visible
+
+    public_profile = SimpleNamespace(user_id="owner-1", visibility="public")
+    private_profile = SimpleNamespace(user_id="owner-1", visibility="private")
+
+    assert is_project_profile_visible(public_profile, user_id="user-2")
+    assert is_project_profile_visible(private_profile, user_id="owner-1")
+    assert is_project_profile_visible(private_profile, user_id="user-2", shared_user_ids=["user-2"])
+    assert not is_project_profile_visible(private_profile, user_id="user-3", shared_user_ids=["user-2"])
+
+
+def test_project_profile_read_includes_visibility_and_access():
+    from brain.systems.cortex.project_context.profiles import profile_to_read
+
+    profile = SimpleNamespace(
+        id="project-1",
+        org_id="org-1",
+        user_id="owner-1",
+        slug="yc",
+        name="YC",
+        description=None,
+        project_context={"resources": [{"kind": "folder", "path": "yc"}]},
+        visibility="private",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=None,
+    )
+
+    payload = profile_to_read(profile, [{"user_id": "user-2", "name": "Alex", "email": "alex@example.com"}])
+
+    assert payload.visibility == "private"
+    assert payload.access[0].name == "Alex"
+
+
+def test_project_profile_create_defaults_private():
+    from brain.systems.cortex.project_context.schemas import ProjectProfileCreate
+
+    payload = ProjectProfileCreate(
+        slug="yc",
+        name="YC",
+        project_context={"resources": [{"kind": "folder", "path": "yc"}]},
+    )
+
+    assert payload.visibility == "private"
+    assert payload.shared_usernames == []
+
+
+async def test_resolve_project_access_users_accepts_names_and_emails():
+    from brain.app.api.routers.cortex._project_context import _resolve_project_access_users
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = [
+        SimpleNamespace(id="user-2", org_id="org-1", name="Alex", email="alex@example.com")
+    ]
+
+    users = await _resolve_project_access_users(
+        _AsyncSession(session),
+        "org-1",
+        ["alex", "alex@example.com"],
+    )
+
+    assert [user.id for user in users] == ["user-2"]
+
+
+async def test_resolve_project_access_users_reports_unknown_names():
+    from fastapi import HTTPException
+
+    from brain.app.api.routers.cortex._project_context import _resolve_project_access_users
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = []
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _resolve_project_access_users(_AsyncSession(session), "org-1", ["missing"])
+
+    assert excinfo.value.status_code == 422
+    assert excinfo.value.detail == {"unknown_users": ["missing"]}
+
+
 @pytest.mark.asyncio
 async def test_create_project_profile_rejects_empty_project_context(client, mock_session_factory):
     from brain.app.api.routers.cortex import _project_context as pc_mod

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -58,6 +58,7 @@ EXPECTED_TABLES = {
     "org_provider_model_mappings",
     "orgs",
     "project_narratives",
+    "project_profile_access",
     "project_profiles",
     "provider_health_snapshots",
     "resource_leases",


### PR DESCRIPTION
## Summary
- add private/public visibility to Project Context profiles, with existing projects migrated as public and new projects defaulting private
- add a project access table for private-profile shares by username/email and enforce owner/shared/public visibility across API and agent tools
- add composer UI controls for choosing visibility and entering private access usernames when creating a project

## Tests
- python3 -m pytest tests/test_api_cortex.py tests/test_models_all.py tests/test_tool_registry.py
- python3 -m pytest tests/test_tools.py -k project
- npm run check
- git diff --check