### PR TITLE
Add handoff summary side panel tab

### DIFF
--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -17,6 +17,7 @@ from brain.app.api.routers.cortex._helpers import _caller_is_service_principal
 from brain.app.api.routers.cortex._router import router
 from brain.systems.runs.cortex import queue_status_async
 from brain.systems.runs.cortex.permissions import RunReadScope, run_belongs_to_scope
+from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
 from brain.systems.runs.cortex.recording import (
     agent_trace_export_filename,
     build_agent_trace_snapshot_async,
@@ -173,6 +174,13 @@ async def run_history(
                 raise HTTPException(status_code=404, detail="Idea not found")
 
     return await serialize_run_history_async(idea_id, include_debug=include_debug, uow_factory=UnitOfWork)
+
+
+@router.get("/ideas/{idea_id}/handoff-summary")
+async def thread_handoff_summary(idea_id: str, user: dict[str, Any] = Depends(get_current_user)):
+    async with UnitOfWork() as uow:
+        await _require_idea_for_run_history(uow.session, idea_id, user)
+        return await latest_thread_handoff_summary(uow.session, idea_id)
 
 
 @router.get("/run/{run_id}/debug")

--- a/brain/systems/runs/cortex/handoff_summary.py
+++ b/brain/systems/runs/cortex/handoff_summary.py
@@ -1,0 +1,108 @@
+"""Read models for durable agent handoff summaries attached to Cortex threads."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent import AgentSession
+from brain.platform.db.models.agent_run import AgentRunRow
+
+_RUN_SESSION_RE = re.compile(r"^agent-run-(?P<run_id>\d+)(?:-|$)")
+
+
+async def latest_thread_handoff_summary(
+    session: AsyncSession,
+    idea_id: str,
+) -> dict[str, Any]:
+    """Return the newest durable handoff summary for runs in one thread."""
+    run_result = await session.scalars(
+        select(AgentRunRow.id)
+        .where(AgentRunRow.thread_id == str(idea_id))
+        .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
+    )
+    run_ids = [int(run_id) for run_id in run_result.all()]
+    if not run_ids:
+        return {"found": False}
+
+    candidates_by_session_id = {
+        session_id: run_id
+        for run_id in run_ids
+        for session_id in _candidate_session_ids(run_id)
+    }
+    session_result = await session.scalars(
+        select(AgentSession).where(AgentSession.session_id.in_(list(candidates_by_session_id)))
+    )
+    summaries = [
+        agent_session
+        for agent_session in session_result.all()
+        if _handoff_payload(agent_session.handoff_summary)
+    ]
+    if not summaries:
+        return {"found": False}
+
+    latest = max(summaries, key=_handoff_sort_key)
+    payload = _handoff_payload(latest.handoff_summary) or {}
+    run_id = candidates_by_session_id.get(latest.session_id) or _run_id_from_session_id(latest.session_id)
+    updated_at = _coerce_datetime(latest.handoff_updated_at or latest.updated_at or latest.created_at)
+
+    return {
+        "found": True,
+        "run_id": run_id,
+        "session_id": latest.session_id,
+        "updated_at": updated_at.isoformat() if updated_at else None,
+        "message_count": int(
+            latest.handoff_message_count
+            or payload.get("message_count")
+            or 0
+        ),
+        "summary": payload,
+    }
+
+
+def _candidate_session_ids(run_id: int) -> tuple[str, str]:
+    return (f"agent-run-{run_id}", f"agent-run-{run_id}-worker")
+
+
+def _handoff_payload(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value if value else None
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) and parsed else None
+    return None
+
+
+def _handoff_sort_key(session: AgentSession) -> tuple[datetime, str]:
+    when = _coerce_datetime(session.handoff_updated_at or session.updated_at or session.created_at)
+    return (when or datetime.min.replace(tzinfo=timezone.utc), session.session_id)
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def _run_id_from_session_id(session_id: str) -> int | None:
+    match = _RUN_SESSION_RE.match(str(session_id or ""))
+    if not match:
+        return None
+    return int(match.group("run_id"))
+
+
+__all__ = ["latest_thread_handoff_summary"]

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -821,6 +821,8 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/cancel-all`, { method: 'POST' }),
   runGraph: (id: number) => fetchJson<any>(`/api/cortex/run/${id}/graph`),
   runTools: (id: number) => fetchJson<any[]>(`/api/cortex/runs/${id}/tools`),
+  threadHandoffSummary: (ideaId: string) =>
+    fetchJson<any>(`/api/cortex/ideas/${ideaId}/handoff-summary`),
   downloadThreadTraceZip: async (ideaId: string) => {
     const result = await fetchBlob(`/api/cortex/ideas/${ideaId}/trace-export.zip`, { method: 'POST', timeoutMs: 60_000 });
     return {

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -8,6 +8,7 @@ export type ThreadRunHistoryItem = Awaited<ReturnType<typeof api.runHistory>>[nu
 export type RunDecisionResponse = Awaited<ReturnType<typeof api.approveRun>>;
 export type RunTool = Awaited<ReturnType<typeof api.runTools>>[number];
 export type ThreadTraceZipDownload = Awaited<ReturnType<typeof api.downloadThreadTraceZip>>;
+export type ThreadHandoffSummary = Awaited<ReturnType<typeof api.threadHandoffSummary>>;
 export type RunGraph = Awaited<ReturnType<typeof api.runGraph>>;
 export type RunTraceZipDownload = Awaited<ReturnType<typeof api.downloadRunTraceZip>>;
 export type RunStatus = Awaited<ReturnType<typeof api.runStatus>>;
@@ -32,6 +33,7 @@ type ThreadApiMethods = {
   runStatus: () => Promise<RunStatus>;
   runGraph: (id: number) => Promise<RunGraph>;
   runTools: (id: number) => Promise<RunTool[]>;
+  threadHandoffSummary: typeof api.threadHandoffSummary;
   downloadThreadTraceZip: typeof api.downloadThreadTraceZip;
   downloadRunTraceZip: typeof api.downloadRunTraceZip;
   skillFeedback: typeof api.skillFeedback;
@@ -61,6 +63,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'runStatus',
   'runGraph',
   'runTools',
+  'threadHandoffSummary',
   'downloadThreadTraceZip',
   'downloadRunTraceZip',
   'skillFeedback',
@@ -89,6 +92,7 @@ export const {
   runStatus,
   runGraph,
   runTools,
+  threadHandoffSummary,
   downloadThreadTraceZip,
   downloadRunTraceZip,
   skillFeedback,

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -15,6 +15,7 @@
   type DockWidth = number | string;
   const DEFAULT_TABS: ThreadStageRightDockTab[] = [
     { id: 'activity', label: 'Activity', kind: 'activity', closeable: true },
+    { id: 'handoff-summary', label: 'Handoff', kind: 'handoff-summary', closeable: true },
   ];
 
   function clamp(value: number, min: number, max: number) {
@@ -90,15 +91,17 @@
           ? hasPreviewPane
           : tab.kind === 'activity'
             ? hasUtilityPane
-            : tab.kind === 'app'
-              ? hasAppsPane
-              : tab.kind === 'vault'
-                ? hasVaultPane
-                : tab.kind === 'cycles'
-                  ? hasCyclesPane
-                  : tab.kind === 'code-review'
-                    ? hasCodeReviewPane
-                    : true
+            : tab.kind === 'handoff-summary'
+              ? hasUtilityPane
+              : tab.kind === 'app'
+                ? hasAppsPane
+                : tab.kind === 'vault'
+                  ? hasVaultPane
+                  : tab.kind === 'cycles'
+                    ? hasCyclesPane
+                    : tab.kind === 'code-review'
+                      ? hasCodeReviewPane
+                      : true
     )),
   );
   const resolvedActiveTab = $derived(
@@ -200,6 +203,7 @@
     if (kind === 'browser') return 'preview';
     if (kind === 'preview') return 'document';
     if (kind === 'activity') return 'activity';
+    if (kind === 'handoff-summary') return 'document';
     if (kind === 'vault') return 'vault';
     if (kind === 'cycles') return 'cycles';
     if (kind === 'code-review') return 'code';
@@ -315,6 +319,10 @@
           </section>
         {:else if resolvedActiveTab?.kind === 'activity' && hasUtilityPane}
           <section class="right-dock-pane right-dock-activity" aria-label="Activity">
+            {@render utilityPane?.()}
+          </section>
+        {:else if resolvedActiveTab?.kind === 'handoff-summary' && hasUtilityPane}
+          <section class="right-dock-pane right-dock-handoff-summary" aria-label="Handoff summary">
             {@render utilityPane?.()}
           </section>
         {:else if resolvedActiveTab?.kind === 'app' && hasAppsPane}

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -824,6 +824,10 @@
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'activity'));
   }
 
+  function openHandoffSummaryTab() {
+    applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'handoff-summary'));
+  }
+
   function openVaultTab() {
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'vault'));
   }
@@ -874,6 +878,10 @@
     }
     if (item.kind === 'activity') {
       addActivityTab();
+      return;
+    }
+    if (item.kind === 'handoff-summary') {
+      openHandoffSummaryTab();
       return;
     }
     if (item.kind === 'vault') {
@@ -1179,7 +1187,10 @@
   {#snippet utilityPane()}
     <div class="thread-utility-surface">
       <div class="thread-utility-surface-body">
-        <ThreadUtilityContent {idea} activeTab="activity" />
+        <ThreadUtilityContent
+          {idea}
+          activeTab={activeSidePanelTab?.kind === 'handoff-summary' ? 'handoff-summary' : 'activity'}
+        />
       </div>
     </div>
   {/snippet}

--- a/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadUtilityContent.svelte
@@ -12,11 +12,12 @@
     ideaAuditAnalyze,
     ideaConnections as loadIdeaConnections,
     runHistory,
+    threadHandoffSummary,
   } from '$lib/features/threads/api/threadApi';
   import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
   import { formatDurationMs, formatDurationSeconds, relativeTimeAgo } from '$lib/utils/datetime';
 
-  type UtilityTab = 'activity' | 'details' | 'audit';
+  type UtilityTab = 'activity' | 'handoff-summary' | 'details' | 'audit';
   type ActivityListItem = {
     _key: string;
     timestamp: string | null;
@@ -60,6 +61,10 @@
   let threadTraceSaving = $state(false);
   let threadTraceSaved = $state<{ bytes?: number; filename?: string } | null>(null);
   let threadTraceError = $state('');
+  let handoffSummaryData = $state<any>(null);
+  let handoffSummaryLoading = $state(false);
+  let handoffSummaryError = $state('');
+  let handoffRequestSeq = 0;
 
   let pollAborted = $state(false);
   let loadedForIdeaId = $state<string | null>(null);
@@ -98,6 +103,10 @@
     threadTraceSaving = false;
     threadTraceSaved = null;
     threadTraceError = '';
+    handoffSummaryData = null;
+    handoffSummaryLoading = false;
+    handoffSummaryError = '';
+    handoffRequestSeq += 1;
     pollAborted = false;
   }
 
@@ -140,6 +149,57 @@
     return parts
       .map((part) => cleanActivityText(part, ''))
       .filter(Boolean);
+  }
+
+  function handoffCheckpoint(source: any): any {
+    const summary = source?.summary;
+    return summary?.checkpoint && typeof summary.checkpoint === 'object'
+      ? summary.checkpoint
+      : summary && typeof summary === 'object'
+        ? summary
+        : {};
+  }
+
+  function handoffText(value: unknown): string {
+    return String(value ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  function handoffList(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => handoffText(item))
+        .filter(Boolean);
+    }
+    const text = handoffText(value);
+    return text ? [text] : [];
+  }
+
+  function handoffSections(checkpoint: any): Array<{ label: string; items: string[] }> {
+    return [
+      { label: 'Current Plan', items: handoffList(checkpoint.current_plan) },
+      { label: 'Completed', items: handoffList(checkpoint.completed_work) },
+      { label: 'Decisions', items: handoffList(checkpoint.decisions) },
+      { label: 'Files & Objects', items: handoffList(checkpoint.files_or_objects_touched) },
+      { label: 'Constraints', items: handoffList(checkpoint.user_constraints) },
+      { label: 'Open Questions', items: handoffList(checkpoint.open_questions) },
+      { label: 'Risks', items: handoffList(checkpoint.risks_or_unknowns) },
+      { label: 'Important Tool Results', items: handoffList(checkpoint.important_tool_results) },
+    ].filter((section) => section.items.length > 0);
+  }
+
+  function handoffHasVisibleCheckpoint(checkpoint: any): boolean {
+    return Boolean(
+      handoffText(checkpoint.active_objective)
+      || handoffText(checkpoint.recent_user_intent)
+      || handoffText(checkpoint.verification_status)
+      || handoffSections(checkpoint).length,
+    );
+  }
+
+  function handoffSourceLabel(value: unknown): string {
+    return handoffText(value)
+      .replace(/_/g, ' ')
+      .replace(/\bllm\b/i, 'LLM');
   }
 
   async function loadActivity() {
@@ -293,8 +353,32 @@
 
   function loadUtilityTab(tab: UtilityTab) {
     if (tab === 'activity') loadActivity();
+    else if (tab === 'handoff-summary') loadHandoffSummary();
     else if (tab === 'details') loadDetails();
     else if (tab === 'audit') loadAudit();
+  }
+
+  async function loadHandoffSummary() {
+    const ideaId = idea?.id;
+    if (!ideaId) return;
+
+    const requestId = ++handoffRequestSeq;
+    handoffSummaryLoading = true;
+    handoffSummaryError = '';
+
+    try {
+      const result = await threadHandoffSummary(ideaId);
+      if (requestId !== handoffRequestSeq || idea?.id !== ideaId) return;
+      handoffSummaryData = result;
+    } catch (e: any) {
+      if (requestId !== handoffRequestSeq || idea?.id !== ideaId) return;
+      handoffSummaryData = null;
+      handoffSummaryError = e?.detail || 'Failed to load handoff summary.';
+    } finally {
+      if (requestId === handoffRequestSeq && idea?.id === ideaId) {
+        handoffSummaryLoading = false;
+      }
+    }
   }
 
   async function loadAudit() {
@@ -473,6 +557,71 @@
           </div>
         </div>
       {/each}
+    </div>
+  {/if}
+{:else if activeTab === 'handoff-summary'}
+  {#if handoffSummaryLoading}
+    <div class="tab-empty">Loading handoff...</div>
+  {:else if handoffSummaryError}
+    <div class="tab-empty">{handoffSummaryError}</div>
+  {:else if !handoffSummaryData?.found}
+    <div class="tab-empty">No handoff summary yet.</div>
+  {:else}
+    {@const checkpoint = handoffCheckpoint(handoffSummaryData)}
+    <div class="handoff-summary-pane" aria-label="Latest handoff summary">
+      <div class="handoff-summary-toolbar">
+        <div class="activity-trace-copy">
+          <div class="activity-trace-title">Latest handoff summary</div>
+          <div class="activity-trace-note">
+            {handoffSummaryData.run_id ? `Run #${handoffSummaryData.run_id}` : 'Run'}
+            {#if handoffSummaryData.message_count}
+              &middot; {handoffSummaryData.message_count.toLocaleString()} messages
+            {/if}
+            {#if handoffSummaryData.updated_at}
+              &middot; {timeAgo(handoffSummaryData.updated_at)}
+            {/if}
+            {#if handoffSummaryData.summary?.source}
+              &middot; {handoffSourceLabel(handoffSummaryData.summary.source)}
+            {/if}
+          </div>
+        </div>
+      </div>
+
+      {#if handoffHasVisibleCheckpoint(checkpoint)}
+        {#if handoffText(checkpoint.active_objective)}
+          <section class="handoff-summary-section handoff-summary-section-primary">
+            <h4 class="details-section-title">Active Objective</h4>
+            <p class="handoff-summary-lead">{handoffText(checkpoint.active_objective)}</p>
+          </section>
+        {/if}
+
+        {#if handoffText(checkpoint.recent_user_intent)}
+          <section class="handoff-summary-section">
+            <h4 class="details-section-title">Recent User Intent</h4>
+            <p class="handoff-summary-text">{handoffText(checkpoint.recent_user_intent)}</p>
+          </section>
+        {/if}
+
+        {#each handoffSections(checkpoint) as section (section.label)}
+          <section class="handoff-summary-section">
+            <h4 class="details-section-title">{section.label}</h4>
+            <ul class="handoff-summary-list">
+              {#each section.items as item}
+                <li>{item}</li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+
+        {#if handoffText(checkpoint.verification_status)}
+          <section class="handoff-summary-section">
+            <h4 class="details-section-title">Verification</h4>
+            <p class="handoff-summary-text">{handoffText(checkpoint.verification_status)}</p>
+          </section>
+        {/if}
+      {:else}
+        <div class="tab-empty">The stored handoff is empty.</div>
+      {/if}
     </div>
   {/if}
 {:else if activeTab === 'details'}
@@ -1208,6 +1357,83 @@
     line-height: 1.4;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  /* ── Handoff summary tab ─────────────────────────────── */
+  .handoff-summary-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+    width: 100%;
+    padding-bottom: 12px;
+  }
+
+  .handoff-summary-toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+    width: 100%;
+    padding: 2px 2px 12px;
+    border-bottom: 1px solid var(--panel-utility-divider-border);
+  }
+
+  .handoff-summary-section {
+    min-width: 0;
+    padding: 12px 13px 13px;
+    border: 1px solid var(--panel-utility-card-border);
+    border-radius: 16px;
+    background: var(--panel-utility-card-background);
+  }
+
+  .handoff-summary-section-primary {
+    border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 18%, var(--panel-utility-card-border));
+  }
+
+  .handoff-summary-lead,
+  .handoff-summary-text {
+    margin: 0;
+    color: var(--panel-utility-primary-text);
+    font-size: 12px;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .handoff-summary-lead {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .handoff-summary-list {
+    display: grid;
+    gap: 7px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .handoff-summary-list li {
+    position: relative;
+    padding-left: 13px;
+    color: var(--panel-utility-primary-text);
+    font-size: 12px;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .handoff-summary-list li::before {
+    content: '';
+    position: absolute;
+    top: 0.67em;
+    left: 0;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 68%, transparent);
   }
 
   /* ── Details tab ─────────────────────────────────────── */

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -1,4 +1,12 @@
-export type ThreadStageRightDockTabKind = 'browser' | 'activity' | 'app' | 'vault' | 'cycles' | 'preview' | 'code-review';
+export type ThreadStageRightDockTabKind =
+  | 'browser'
+  | 'activity'
+  | 'handoff-summary'
+  | 'app'
+  | 'vault'
+  | 'cycles'
+  | 'preview'
+  | 'code-review';
 
 export type ThreadStageRightDockTab = {
   id: string;
@@ -31,7 +39,10 @@ export type ThreadSidePanelTabState = {
 };
 
 export function createDefaultThreadSidePanelTabs(): ThreadStageRightDockTab[] {
-  return [{ id: 'activity', label: 'Activity', kind: 'activity', closeable: true }];
+  return [
+    { id: 'activity', label: 'Activity', kind: 'activity', closeable: true },
+    { id: 'handoff-summary', label: 'Handoff', kind: 'handoff-summary', closeable: true },
+  ];
 }
 
 export function activeThreadSidePanelTab(
@@ -47,6 +58,7 @@ export function buildThreadSidePanelAddMenuItems(
 ): ThreadStageRightDockAddMenuItem[] {
   const browserCount = tabs.filter((tab) => tab.kind === 'browser').length;
   const hasActivity = tabs.some((tab) => tab.kind === 'activity');
+  const hasHandoffSummary = tabs.some((tab) => tab.kind === 'handoff-summary');
   const hasVault = tabs.some((tab) => tab.kind === 'vault');
   const hasCycles = tabs.some((tab) => tab.kind === 'cycles');
   const hasCodeReview = tabs.some((tab) => tab.kind === 'code-review');
@@ -97,6 +109,15 @@ export function buildThreadSidePanelAddMenuItems(
       kind: 'activity',
       label: 'Activity',
       description: 'Open run activity',
+    });
+  }
+
+  if (!hasHandoffSummary) {
+    items.push({
+      id: 'handoff-summary',
+      kind: 'handoff-summary',
+      label: 'Handoff',
+      description: 'Open durable agent summary',
     });
   }
 
@@ -160,7 +181,7 @@ export function openBrowserThreadSidePanelTab(
 
 export function openSingletonThreadSidePanelTab(
   state: ThreadSidePanelTabState,
-  kind: 'activity' | 'vault' | 'cycles' | 'preview' | 'code-review',
+  kind: 'activity' | 'handoff-summary' | 'vault' | 'cycles' | 'preview' | 'code-review',
 ): ThreadSidePanelTabState {
   const existing = state.tabs.find((tab) => tab.kind === kind);
   if (existing) return { ...state, activeTabId: existing.id };
@@ -173,6 +194,8 @@ export function openSingletonThreadSidePanelTab(
         ? 'Preview'
         : kind === 'code-review'
           ? 'Review files'
+          : kind === 'handoff-summary'
+            ? 'Handoff'
           : 'Activity';
   return {
     ...state,

--- a/frontend/src/lib/utils/threadSidePanelController.test.js
+++ b/frontend/src/lib/utils/threadSidePanelController.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildThreadSidePanelAddMenuItems,
+  createDefaultThreadSidePanelTabs,
+  openSingletonThreadSidePanelTab,
+} from '../features/threads/controllers/threadSidePanelController.ts';
+
+test('default thread side panel opens Activity beside Handoff', () => {
+  const tabs = createDefaultThreadSidePanelTabs();
+
+  assert.deepEqual(tabs.map((tab) => tab.kind), ['activity', 'handoff-summary']);
+  assert.deepEqual(tabs.map((tab) => tab.label), ['Activity', 'Handoff']);
+});
+
+test('handoff summary is restored from the side panel add menu when closed', () => {
+  const tabs = [{ id: 'activity', label: 'Activity', kind: 'activity', closeable: true }];
+
+  const menuItems = buildThreadSidePanelAddMenuItems(tabs, []);
+  assert.ok(menuItems.some((item) => item.kind === 'handoff-summary' && item.label === 'Handoff'));
+
+  const next = openSingletonThreadSidePanelTab(
+    { tabs, activeTabId: 'activity', nextBrowserTabIndex: 1 },
+    'handoff-summary',
+  );
+
+  assert.equal(next.activeTabId, 'handoff-summary');
+  assert.ok(next.tabs.some((tab) => tab.kind === 'handoff-summary' && tab.label === 'Handoff'));
+});

--- a/tests/test_thread_handoff_summary.py
+++ b/tests/test_thread_handoff_summary.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+from brain.platform.db.models.agent import AgentSession
+from brain.platform.db.models.agent_run import AgentRunRow
+
+
+IDEA_ID = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    sqlite3.register_adapter(dict, lambda value: json.dumps(value))
+    sqlite3.register_adapter(list, lambda value: json.dumps(value))
+    return await async_sqlite_session_factory(
+        [
+            AgentRunRow.__table__,
+            AgentSession.__table__,
+        ],
+        connect_listener=_register_sqlite_functions,
+    )
+
+
+async def test_latest_thread_handoff_summary_returns_newest_thread_session(session):
+    from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
+
+    now = datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)
+    older_handoff = _handoff_payload("Older objective", message_count=4)
+    newest_handoff = _handoff_payload("Ship the handoff summary tab", message_count=8)
+    unrelated_handoff = _handoff_payload("Do not leak this thread", message_count=12)
+
+    session.add_all(
+        [
+            _run(11, IDEA_ID, now - timedelta(minutes=30)),
+            _run(12, IDEA_ID, now - timedelta(minutes=10)),
+            _run(13, "other-idea", now),
+            _agent_session(
+                "agent-run-11",
+                older_handoff,
+                handoff_updated_at=now - timedelta(minutes=20),
+            ),
+            _agent_session(
+                "agent-run-12-worker",
+                newest_handoff,
+                handoff_updated_at=now - timedelta(minutes=5),
+            ),
+            _agent_session(
+                "agent-run-13",
+                unrelated_handoff,
+                handoff_updated_at=now,
+            ),
+        ]
+    )
+    await session.flush()
+
+    summary = await latest_thread_handoff_summary(session, IDEA_ID)
+
+    assert summary["found"] is True
+    assert summary["run_id"] == 12
+    assert summary["session_id"] == "agent-run-12-worker"
+    assert summary["message_count"] == 8
+    assert summary["summary"]["checkpoint"]["active_objective"] == "Ship the handoff summary tab"
+
+
+async def test_latest_thread_handoff_summary_reports_empty_thread(session):
+    from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
+
+    session.add(_run(21, IDEA_ID, datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)))
+    session.add(
+        AgentSession(
+            session_id="agent-run-21",
+            messages=[],
+            handoff_summary=None,
+            handoff_message_count=0,
+        )
+    )
+    await session.flush()
+
+    summary = await latest_thread_handoff_summary(session, IDEA_ID)
+
+    assert summary == {"found": False}
+
+
+def _handoff_payload(active_objective: str, *, message_count: int) -> dict:
+    return {
+        "schema_version": 1,
+        "source": "deterministic_fallback",
+        "message_count": message_count,
+        "previous_message_count": 0,
+        "checkpoint": {
+            "schema_version": 1,
+            "source": "deterministic_fallback",
+            "active_objective": active_objective,
+            "user_constraints": ["Keep it read-only."],
+            "completed_work": ["Found the Activity panel."],
+            "current_plan": ["Expose the summary beside Activity."],
+            "files_or_objects_touched": ["frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte"],
+            "decisions": [],
+            "failed_attempts": [],
+            "important_tool_results": [],
+            "open_questions": [],
+            "verification_status": "Not verified yet.",
+            "recent_user_intent": active_objective,
+            "risks_or_unknowns": [],
+            "metadata": {},
+        },
+        "metadata": {"session_id": "agent-run-12-worker"},
+        "digest": "digest",
+    }
+
+
+def _run(run_id: int, thread_id: str, created_at: datetime) -> AgentRunRow:
+    return AgentRunRow(
+        id=run_id,
+        thread_id=thread_id,
+        profile="fast",
+        recipe="fast",
+        status="completed",
+        input_message="work",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={},
+        created_at=created_at,
+        started_at=created_at,
+        completed_at=created_at + timedelta(minutes=1),
+    )
+
+
+def _agent_session(
+    session_id: str,
+    handoff_summary: dict,
+    *,
+    handoff_updated_at: datetime,
+) -> AgentSession:
+    return AgentSession(
+        session_id=session_id,
+        messages=[],
+        handoff_summary=handoff_summary,
+        handoff_message_count=handoff_summary["message_count"],
+        handoff_updated_at=handoff_updated_at,
+        created_at=handoff_updated_at,
+        updated_at=handoff_updated_at,
+    )
+
+
+def _register_sqlite_functions(dbapi_conn, connection_record):
+    _ = connection_record
+    dbapi_conn.create_function("NOW", 0, lambda: datetime.now(timezone.utc).isoformat())
+    dbapi_conn.create_function("gen_random_uuid", 0, lambda: str(uuid.uuid4()))
+
+
+def _patch_sqlite_for_pg_types() -> None:
+    for name in ("visit_JSONB", "visit_ARRAY", "visit_UUID", "visit_VECTOR", "visit_Vector"):
+        if not hasattr(SQLiteTypeCompiler, name):
+            setattr(SQLiteTypeCompiler, name, lambda self, type_, **kw: "TEXT")
+    SQLiteTypeCompiler.visit_BIGINT = lambda self, type_, **kw: "INTEGER"
+
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_thread_handoff_summary_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+        return result
+
+    patched._thread_handoff_summary_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched


### PR DESCRIPTION
## Summary
- add a backend read model and API endpoint for the latest agent handoff summary on a thread
- add frontend API wiring and a default Handoff tab beside Activity in the thread side panel
- render structured handoff checkpoint sections with loading, empty, and error states

## Tests
- pytest tests/test_thread_handoff_summary.py -q
- pytest tests/test_cortex_split.py -q
- npm test
- npm run check
- npm run build
- python3 -m py_compile brain/systems/runs/cortex/handoff_summary.py brain/app/api/routers/cortex/_run.py

## Local preview
- verified in the in-app browser as Axel on http://127.0.0.1:5175/cortex?idea=5a445033-aed8-463d-8562-0e51762a2cf0