### PR TITLE
Stabilize hosted MCP token auth

### DIFF
--- a/brain/app/api/routers/agent_connections.py
+++ b/brain/app/api/routers/agent_connections.py
@@ -57,6 +57,17 @@ async def create_agent_connection(
     user_id = str(user.get("id"))
 
     try:
+        existing = await external_agents.find_reusable_connection(
+            db,
+            org_id=org_id,
+            owner_user_id=user_id,
+            display_name=payload.display_name,
+            agent_kind=payload.agent_kind,
+            transport=payload.transport,
+        )
+        if existing is not None:
+            return external_agents.serialize_connection(existing)
+
         row = await external_agents.create_connection(
             db,
             org_id=org_id,

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Awaitable, Callable
 
-from fastapi import APIRouter, Depends, Header, Request, Response
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import JSONResponse
 
@@ -398,16 +398,14 @@ async def submit_inbound_envelope(
     )
 
 
-async def require_mcp_principal(
+async def _authenticate_mcp_principal(
     request: Request,
-    x_illo_bridge_token: str | None = Header(default=None, alias="X-Illo-Bridge-Token"),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession,
 ) -> external_agents.AgentBridgePrincipal:
-    token = _bearer_token(request, x_illo_bridge_token)
-    try:
-        return await external_agents.authenticate_bridge_token(db, token)
-    except Exception as exc:
-        raise_external_agent_http_error(exc)
+    return await external_agents.authenticate_bridge_token(
+        db,
+        _bearer_token(request, request.headers.get("X-Illo-Bridge-Token")),
+    )
 
 
 def _list_tools(principal: external_agents.AgentBridgePrincipal) -> list[dict[str, Any]]:
@@ -587,6 +585,29 @@ def _result(req_id: Any, payload: dict[str, Any]) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": req_id, "result": payload}
 
 
+def _error_response(req_id: Any, *, code: int, message: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": req_id, "error": error}
+
+
+def _request_id(message: Any) -> Any:
+    return message.get("id") if isinstance(message, dict) else None
+
+
+def _mcp_auth_error_response(payload: Any, message: str) -> JSONResponse:
+    data = {"http_status": 401, "auth": "bearer"}
+    if isinstance(payload, list):
+        responses = [
+            _error_response(_request_id(item), code=-32001, message=message, data=data)
+            for item in payload
+            if not isinstance(item, dict) or "id" in item
+        ]
+        return JSONResponse(responses)
+    return JSONResponse(_error_response(_request_id(payload), code=-32001, message=message, data=data))
+
+
 def _tool_result(value: dict[str, Any]) -> dict[str, Any]:
     return {
         "content": [
@@ -673,9 +694,15 @@ async def _handle_mcp_request(
 async def _mcp_endpoint(
     request: Request,
     db: AsyncSession,
-    principal: external_agents.AgentBridgePrincipal,
 ):
     payload = await request.json()
+    try:
+        principal = await _authenticate_mcp_principal(request, db)
+    except external_agents.ExternalAgentAuthError as exc:
+        return _mcp_auth_error_response(payload, f"MCP authentication failed: {exc}")
+    except external_agents.ExternalAgentPermissionError as exc:
+        return _mcp_auth_error_response(payload, f"MCP authentication failed: {exc}")
+
     if isinstance(payload, list):
         responses: list[dict[str, Any]] = []
         for item in payload:
@@ -700,15 +727,13 @@ async def _mcp_endpoint(
 async def hosted_mcp(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    principal: external_agents.AgentBridgePrincipal = Depends(require_mcp_principal),
 ):
-    return await _mcp_endpoint(request, db, principal)
+    return await _mcp_endpoint(request, db)
 
 
 @router.post("/api/mcp")
 async def hosted_api_mcp(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    principal: external_agents.AgentBridgePrincipal = Depends(require_mcp_principal),
 ):
-    return await _mcp_endpoint(request, db, principal)
+    return await _mcp_endpoint(request, db)

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -414,6 +414,34 @@ async def list_connections(
     return list((await session.scalars(stmt)).all())
 
 
+async def find_reusable_connection(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    owner_user_id: str,
+    display_name: str,
+    agent_kind: str,
+    transport: str,
+) -> ExternalAgentConnectionRow | None:
+    """Find an active personal-agent connection that represents the same install."""
+
+    stmt = (
+        select(ExternalAgentConnectionRow)
+        .where(
+            ExternalAgentConnectionRow.org_id == str(org_id),
+            ExternalAgentConnectionRow.owner_user_id == str(owner_user_id),
+            func.lower(ExternalAgentConnectionRow.display_name) == str(display_name).strip().lower(),
+            func.lower(ExternalAgentConnectionRow.agent_kind) == str(agent_kind or "custom").strip().lower(),
+            func.lower(ExternalAgentConnectionRow.transport) == str(transport or "bridge_pull").strip().lower(),
+            ExternalAgentConnectionRow.disabled_at.is_(None),
+            func.lower(ExternalAgentConnectionRow.status) != "disabled",
+        )
+        .order_by(ExternalAgentConnectionRow.created_at.desc(), ExternalAgentConnectionRow.id.desc())
+        .limit(1)
+    )
+    return (await session.scalars(stmt)).first()
+
+
 async def disable_connection(
     session: AsyncSession,
     *,
@@ -1580,6 +1608,7 @@ __all__ = [
     "create_external_task_for_idea",
     "create_headless_ask",
     "create_thread_from_agent",
+    "find_reusable_connection",
     "request_source_context",
     "fail_task",
     "generate_connection_token",

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -112,6 +112,62 @@ async def test_connection_listing_is_owner_scoped_for_members_and_org_wide_for_a
     assert captured[1] == {"org_id": "org-1", "owner_user_id": None}
 
 
+async def test_connection_create_reuses_existing_personal_agent_connection():
+    session = _AsyncSession()
+    connection = SimpleNamespace(
+        id="conn-1",
+        org_id="org-1",
+        owner_user_id="user-1",
+        display_name="Codex Desktop",
+        agent_kind="codex",
+        transport="hosted_mcp",
+        status="configured",
+        endpoint_url="http://127.0.0.1:8080/mcp",
+        remote_agent_id=None,
+        remote_session_key=None,
+        remote_agent_card={},
+        capabilities={"mcp": True},
+        last_seen_at=None,
+        last_tested_at=None,
+        last_error=None,
+        metadata_={},
+        disabled_at=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+    with patch(
+        "brain.app.api.routers.agent_connections.external_agents.find_reusable_connection",
+        return_value=connection,
+    ) as find_connection, patch(
+        "brain.app.api.routers.agent_connections.external_agents.create_connection",
+    ) as create_connection:
+        response = await _request(
+            "POST",
+            "/api/agent-connections",
+            session=session,
+            json={
+                "display_name": "Codex Desktop",
+                "agent_kind": "codex",
+                "transport": "hosted_mcp",
+                "endpoint_url": "http://127.0.0.1:8080/mcp",
+                "capabilities": {"mcp": True},
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json()["id"] == "conn-1"
+    find_connection.assert_awaited_once_with(
+        session,
+        org_id="org-1",
+        owner_user_id="user-1",
+        display_name="Codex Desktop",
+        agent_kind="codex",
+        transport="hosted_mcp",
+    )
+    create_connection.assert_not_called()
+
+
 async def test_connection_tokens_can_be_listed_for_managed_connection():
     session = _AsyncSession()
     token = SimpleNamespace(
@@ -364,6 +420,27 @@ async def test_hosted_mcp_lists_tools_for_scoped_bridge_token():
     assert "illo_create_thread" in names
     assert "illo_ask" in names
     assert "illo_search_workspace" in names
+
+
+async def test_hosted_mcp_invalid_token_returns_json_rpc_error():
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+        side_effect=external_agents.ExternalAgentAuthError("Invalid bridge token"),
+    ):
+        response = await _request(
+            "POST",
+            "/api/mcp",
+            headers={"Authorization": "Bearer revoked-token"},
+            json={"jsonrpc": "2.0", "id": 7, "method": "tools/list"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 7
+    assert body["error"]["code"] == -32001
+    assert body["error"]["message"] == "MCP authentication failed: Invalid bridge token"
+    assert body["error"]["data"] == {"http_status": 401, "auth": "bearer"}
 
 
 async def test_hosted_mcp_filters_tools_by_bridge_token_scope():

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -221,6 +221,34 @@ async def test_connection_tokens_can_be_listed_and_revoked(external_agent_sessio
 
 
 @pytest.mark.asyncio
+async def test_find_reusable_connection_matches_active_install_case_insensitively(external_agent_session):
+    disabled = ExternalAgentConnectionRow(
+        id="conn-disabled",
+        org_id="org-1",
+        owner_user_id="user-1",
+        display_name="Codex",
+        agent_kind="codex",
+        transport="hosted_mcp",
+        status="disabled",
+        disabled_at=service.utcnow(),
+    )
+    external_agent_session.add(disabled)
+    await external_agent_session.flush()
+
+    found = await service.find_reusable_connection(
+        external_agent_session,
+        org_id="org-1",
+        owner_user_id="user-1",
+        display_name="codex",
+        agent_kind="CODEX",
+        transport="HOSTED_MCP",
+    )
+
+    assert found is not None
+    assert found.id == "conn-1"
+
+
+@pytest.mark.asyncio
 async def test_signal_submit_backfill_only_updates_active_personal_agent_tokens(external_agent_session):
     now = service.utcnow()
     codex_token = ExternalAgentConnectionTokenRow(


### PR DESCRIPTION
## Summary
- return MCP-shaped JSON-RPC auth errors for invalid/revoked hosted MCP tokens instead of FastAPI detail payloads
- reuse an existing active personal-agent connection when creating another token for the same owner/name/type/transport
- add route/service regression coverage for revoked-token behavior and connection reuse

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/pytest tests/test_external_agent_routes.py tests/test_external_agents_service.py
- git diff --check
- python -m py_compile for touched backend/test files