### PR TITLE
Unify composer shortcut menu portal and geometry

### DIFF
--- a/docs/prd-inbound-coordination-layer.md
+++ b/docs/prd-inbound-coordination-layer.md
@@ -134,6 +134,30 @@ The PRD intentionally describes a broader product direction: external tools send
 6. **Add fine-grained Ilo action attribution** so receipt reconciliation can say which workspace tools/actions Ilo actually chose after triage, not only the terminal run status/final answer.
 7. **Add rule candidates / payload fingerprints** so repeated replay and receipt patterns can become explicit deterministic-policy suggestions.
 
+### Deployed E2E Test Ledger
+
+Date: 2026-05-19
+Environment: deployed dev server through local SSH tunnel
+Owner while testing: Reda's Codex session
+
+This section is the running ledger for post-deploy validation. Keep failures here until they are fixed, then update the row with the fix and retest result.
+
+| Test | Status | Result | Notes |
+| --- | --- | --- | --- |
+| MCP signal from Codex session | Passed with caveat | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Ilo run `214`. | The default ambiguous MCP path works. Caveat: `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and another `desired_outcome` path. Need inspect that policy before enabling real Codex hooks, or use a more specific hook origin. |
+| Webhook ambiguous signal | Passed | `POST /webhooks` returned `202` with event `849a179f-a787-4c7c-b8a2-9a5689ce1437`, `review_required`, no matched policy, Cortex idea `39798b40-84f3-42fb-ad78-88f3a0dedaab`, thread message `250`, and Ilo run `215`. | Ilo later inspected the event with `manage_inbound.get_event(include_receipts=true)` and confirmed reconciliation succeeded: event status `processed`, receipt `1b6c48ed-81e5-4940-838f-9b27f29b7504` status `processed`, run `215` completed, final answer `Triaged as no-op / resolved`, and `reconciled_at=2026-05-19T19:38:17.805159+00:00`. |
+| Webhook deterministic Domain Projection | Passed | Ilo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Ilo setup used `manage_inbound` plus Domain tools and returned dry-run success. Caveat: Ilo reported the reused connection status as `pending`, even though the token and projection path processed live webhooks. Need decide whether active tokens should imply configured/active connection state or whether `pending` is acceptable for reused personal-source connections. |
+| Replay harness and source card | Passed with expected drift | Ilo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. | Projection events replayed stable. The 2 unmatched-path events replay as `review_required` while their stored status is now `processed` because Ilo triage/reconciliation completed them; this is expected drift, but the replay UI should explain “current preflight prediction” vs “historical post-Ilo outcome” clearly. Source card also surfaced the earlier `codex.progress` quarantine, which is useful operator feedback. |
+| MCP auth hardening | Passed | Invalid token call to `/api/mcp` returned HTTP `200` with MCP JSON-RPC error code `-32001`, message `MCP authentication failed: Invalid bridge token`, and data `{ "http_status": 401, "auth": "bearer" }`. | This confirms the deployed fix prevents the old client-side deserialize failure shape. |
+
+Post-deploy conclusion:
+
+- Core deployed E2E is green across hosted MCP signal submission, webhook ambiguous triage, deterministic Domain Projection create/update/idempotency, replay/source-card inspection, and MCP auth hardening.
+- Before enabling real automatic Codex hooks broadly, inspect the active `codex.progress` policy. It currently expects `payload.checkpoint`; a generic Codex progress signal without that field is quarantined.
+- Decide how source connection status should behave for reused personal/source connections. Connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b` processed real token traffic while Ilo reported status `pending`.
+- Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Ilo reconciled outcomes.
+- Next implementation slice remains **fine-grained Ilo action attribution**: receipts should capture which workspace tools/actions Ilo used after triage, not only terminal run status/final answer.
+
 ### Trace-Based Follow-Up
 
 After deployment, Codex sent a compatibility-thread update to Ilo and inspected the exported thread trace. Ilo correctly understood the rollout and could use general workspace tools (`manage_domain`, `manage_workspace_app`, `manage_cycle`, `manage_idea`), but it did not have native inbound-admin tools yet. That confirmed the next implementation slice should be the **Ilo Configuration Tool Surface**, not another manual UI. The `manage_inbound` tool in this branch is that slice.

--- a/frontend/src/lib/features/composer/components/MentionAutocomplete.svelte
+++ b/frontend/src/lib/features/composer/components/MentionAutocomplete.svelte
@@ -12,6 +12,7 @@
     type MentionAutocompleteOption,
     type MentionDropdownPlacement,
   } from '$lib/features/composer/domain/mentionAutocomplete';
+  import { shortcutMenuPortal } from '$lib/features/composer/domain/shortcutMenu';
 
   type NormalizedMentionOption = Required<Pick<MentionAutocompleteOption, 'name' | 'hint'>> &
     MentionAutocompleteOption & {
@@ -57,16 +58,6 @@
     }
     return Array.from(rows.values());
   });
-
-  function portalToBody(node: HTMLElement) {
-    if (typeof document === 'undefined') return {};
-    document.body.appendChild(node);
-    return {
-      destroy() {
-        node.remove();
-      },
-    };
-  }
 
   function updateMenuGeometry() {
     if (typeof window === 'undefined' || !textarea) {
@@ -218,7 +209,7 @@
     class="mention-dropdown"
     class:placement-below={effectivePlacement === 'below'}
     style={dropdownStyle}
-    use:portalToBody
+    use:shortcutMenuPortal
   >
     <div class="mention-dropdown-label">Mention someone</div>
     {#each matches as m, i (m.name)}
@@ -244,15 +235,14 @@
 <style>
   .mention-dropdown {
     position: fixed;
-    top: var(--mention-dropdown-top, 0);
+    top: var(--mention-dropdown-top, auto);
     right: auto;
-    bottom: auto;
+    bottom: var(--mention-dropdown-bottom, auto);
     left: var(--mention-dropdown-left, 12px);
     width: min(var(--mention-dropdown-width, 260px), calc(100vw - 24px));
     max-height: var(--mention-dropdown-max-height, 260px);
     box-sizing: border-box;
     overflow-y: auto;
-    transform: translateY(-100%);
     background: var(--constellation-select-chip-menu-background, rgba(12, 15, 22, 0.96));
     backdrop-filter: blur(20px);
     border: 1px solid var(--constellation-select-chip-menu-border, rgba(255, 255, 255, 0.08));
@@ -264,10 +254,6 @@
     opacity: 1;
     animation: none;
     scrollbar-color: var(--constellation-utility-panel-scrollbar, rgba(255, 255, 255, 0.14)) transparent;
-  }
-
-  .mention-dropdown.placement-below {
-    transform: none;
   }
 
   .mention-dropdown-label {

--- a/frontend/src/lib/features/composer/components/SlashAutocomplete.svelte
+++ b/frontend/src/lib/features/composer/components/SlashAutocomplete.svelte
@@ -1,19 +1,17 @@
 <script module lang="ts">
   import { slashCommands } from '$lib/features/cortex/api/cortexApi';
+  import {
+    anchoredShortcutMenuGeometry,
+    shortcutMenuCssVariables,
+    shortcutMenuPortal,
+    type ShortcutMenuGeometry,
+  } from '$lib/features/composer/domain/shortcutMenu';
 
   interface SlashCommand {
     name: string;
     description: string;
     tier?: string;
     model_tier?: string;
-  }
-
-  interface MenuGeometry {
-    maxHeight: number;
-    left: number;
-    width: number;
-    top: number | null;
-    bottom: number | null;
   }
 
   let slashCommandsPromise: Promise<SlashCommand[]> | null = null;
@@ -33,8 +31,9 @@
     return slashCommandsPromise;
   }
 
-  function defaultMenuGeometry(): MenuGeometry {
+  function defaultMenuGeometry(): ShortcutMenuGeometry {
     return {
+      placement: 'above',
       maxHeight: MENU_MAX_HEIGHT,
       left: 0,
       width: 0,
@@ -43,9 +42,6 @@
     };
   }
 
-  function menuCssLength(value: number | null) {
-    return value === null ? 'auto' : `${value}px`;
-  }
 </script>
 
 <script lang="ts">
@@ -70,37 +66,15 @@
   let loaded = $state(false);
   let loadError = $state<string | null>(null);
   let effectivePlacement = $state<'above' | 'below'>('above');
-  let menuGeometry = $state<MenuGeometry>(defaultMenuGeometry());
+  let menuGeometry = $state<ShortcutMenuGeometry>(defaultMenuGeometry());
   let geometryFrame: number | null = null;
 
   const shouldShowMenu = $derived(
     visible && active && (loading || Boolean(loadError) || loaded || filtered.length > 0),
   );
   const dropdownStyle = $derived(
-    [
-      `--slash-dropdown-max-height: ${menuGeometry.maxHeight}px`,
-      `--slash-dropdown-left: ${menuGeometry.left}px`,
-      `--slash-dropdown-width: ${menuGeometry.width}px`,
-      `--slash-dropdown-top: ${menuCssLength(menuGeometry.top)}`,
-      `--slash-dropdown-bottom: ${menuCssLength(menuGeometry.bottom)}`,
-    ].join(';'),
+    shortcutMenuCssVariables(menuGeometry, 'slash'),
   );
-
-  function portalToBody(node: HTMLElement) {
-    if (typeof document === 'undefined') return {};
-
-    const parent = node.parentNode;
-    const marker = document.createComment('slash-autocomplete-portal');
-    parent?.insertBefore(marker, node);
-    document.body.appendChild(node);
-
-    return {
-      destroy() {
-        marker.parentNode?.insertBefore(node, marker);
-        marker.remove();
-      },
-    };
-  }
 
   function updateMenuGeometry() {
     if (typeof window === 'undefined' || !anchor) {
@@ -110,30 +84,15 @@
     }
 
     const rect = anchor.getBoundingClientRect();
-    const spaceAbove = Math.max(0, rect.top - MENU_VIEWPORT_GAP);
-    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - MENU_VIEWPORT_GAP);
-
-    let nextPlacement = placement;
-    if (placement === 'above' && spaceAbove < MENU_PREFERRED_HEIGHT && spaceBelow > spaceAbove) {
-      nextPlacement = 'below';
-    } else if (placement === 'below' && spaceBelow < MENU_PREFERRED_HEIGHT && spaceAbove > spaceBelow) {
-      nextPlacement = 'above';
-    }
-
-    const availableSpace = nextPlacement === 'above' ? spaceAbove : spaceBelow;
-    const viewportWidth = Math.max(window.innerWidth, rect.width + MENU_VIEWPORT_GAP * 2);
-    const width = Math.max(0, Math.min(rect.width, viewportWidth - MENU_VIEWPORT_GAP * 2));
-    const maxLeft = Math.max(MENU_VIEWPORT_GAP, viewportWidth - MENU_VIEWPORT_GAP - width);
-    const left = Math.min(Math.max(rect.left, MENU_VIEWPORT_GAP), maxLeft);
-
-    effectivePlacement = nextPlacement;
-    menuGeometry = {
-      maxHeight: Math.max(MENU_MIN_HEIGHT, Math.min(MENU_MAX_HEIGHT, availableSpace - MENU_ANCHOR_GAP)),
-      left,
-      width,
-      top: nextPlacement === 'below' ? rect.bottom + MENU_ANCHOR_GAP : null,
-      bottom: nextPlacement === 'above' ? window.innerHeight - rect.top + MENU_ANCHOR_GAP : null,
-    };
+    menuGeometry = anchoredShortcutMenuGeometry(rect, window.innerWidth, window.innerHeight, {
+      placement,
+      preferredHeight: MENU_PREFERRED_HEIGHT,
+      minHeight: MENU_MIN_HEIGHT,
+      maxHeight: MENU_MAX_HEIGHT,
+      viewportGap: MENU_VIEWPORT_GAP,
+      anchorGap: MENU_ANCHOR_GAP,
+    });
+    effectivePlacement = menuGeometry.placement;
   }
 
   function queueMenuGeometryUpdate() {
@@ -261,8 +220,8 @@
   }
 
   function select(cmd: SlashCommand) {
+    clear();
     oninput('/' + cmd.name + ' ');
-    filtered = [];
   }
 
   function commandDescription(cmd: SlashCommand) {
@@ -272,7 +231,7 @@
 
 {#if shouldShowMenu}
   <div
-    use:portalToBody
+    use:shortcutMenuPortal
     class="slash-dropdown"
     class:placement-below={effectivePlacement === 'below'}
     style={dropdownStyle}

--- a/frontend/src/lib/features/composer/domain/mentionAutocomplete.ts
+++ b/frontend/src/lib/features/composer/domain/mentionAutocomplete.ts
@@ -1,3 +1,8 @@
+import {
+  anchoredShortcutMenuGeometry,
+  shortcutMenuCssVariables,
+} from '$lib/features/composer/domain/shortcutMenu';
+
 export type MentionAutocompleteOption = {
   id?: string;
   name: string;
@@ -17,17 +22,11 @@ export type MentionDropdownGeometry = {
 
 const MENTION_HANDLE_SPLIT_RE = /[._+\-\s]+/;
 const MENTION_HANDLE_INVALID_RE = /[^a-z0-9._-]+/g;
-const DROPDOWN_VIEWPORT_GAP = 12;
-const DROPDOWN_GAP = 8;
 const DROPDOWN_PREFERRED_HEIGHT = 180;
 const DROPDOWN_MIN_HEIGHT = 96;
 const DROPDOWN_MAX_HEIGHT = 260;
 const DROPDOWN_MIN_WIDTH = 220;
 const DROPDOWN_MAX_WIDTH = 320;
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
-}
 
 export function normalizeMentionHandle(value: string | null | undefined) {
   return (value ?? '')
@@ -55,29 +54,17 @@ export function mentionDropdownGeometry(
   viewportWidth: number,
   viewportHeight: number,
 ): MentionDropdownGeometry {
-  const width = clamp(rect.width, DROPDOWN_MIN_WIDTH, DROPDOWN_MAX_WIDTH);
-  const maxLeft = Math.max(DROPDOWN_VIEWPORT_GAP, viewportWidth - width - DROPDOWN_VIEWPORT_GAP);
-  const left = clamp(rect.left, DROPDOWN_VIEWPORT_GAP, maxLeft);
-  const spaceAbove = Math.max(0, rect.top - DROPDOWN_VIEWPORT_GAP);
-  const spaceBelow = Math.max(0, viewportHeight - rect.bottom - DROPDOWN_VIEWPORT_GAP);
-  const placement =
-    spaceAbove < DROPDOWN_PREFERRED_HEIGHT && spaceBelow > spaceAbove ? 'below' : 'above';
-  const availableSpace = placement === 'above' ? spaceAbove : spaceBelow;
-  const top = placement === 'above' ? rect.top - DROPDOWN_GAP : rect.bottom + DROPDOWN_GAP;
-  const maxHeight = clamp(
-    availableSpace - DROPDOWN_GAP,
-    DROPDOWN_MIN_HEIGHT,
-    DROPDOWN_MAX_HEIGHT,
-  );
+  const geometry = anchoredShortcutMenuGeometry(rect, viewportWidth, viewportHeight, {
+    preferredHeight: DROPDOWN_PREFERRED_HEIGHT,
+    minHeight: DROPDOWN_MIN_HEIGHT,
+    maxHeight: DROPDOWN_MAX_HEIGHT,
+    minWidth: DROPDOWN_MIN_WIDTH,
+    maxWidth: DROPDOWN_MAX_WIDTH,
+  });
 
   return {
-    placement,
-    style: [
-      `--mention-dropdown-left:${left}px`,
-      `--mention-dropdown-top:${top}px`,
-      `--mention-dropdown-width:${width}px`,
-      `--mention-dropdown-max-height:${maxHeight}px`,
-    ].join(';'),
+    placement: geometry.placement,
+    style: shortcutMenuCssVariables(geometry, 'mention'),
   };
 }
 

--- a/frontend/src/lib/features/composer/domain/shortcutMenu.ts
+++ b/frontend/src/lib/features/composer/domain/shortcutMenu.ts
@@ -1,0 +1,97 @@
+export type ShortcutMenuPlacement = 'above' | 'below';
+
+export type ShortcutMenuGeometry = {
+  placement: ShortcutMenuPlacement;
+  left: number;
+  width: number;
+  maxHeight: number;
+  top: number | null;
+  bottom: number | null;
+};
+
+export type ShortcutMenuGeometryOptions = {
+  placement?: ShortcutMenuPlacement;
+  preferredHeight?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  viewportGap?: number;
+  anchorGap?: number;
+  minWidth?: number;
+  maxWidth?: number;
+};
+
+type AnchorRect = Pick<DOMRect, 'top' | 'bottom' | 'left' | 'width'>;
+
+const DEFAULT_PREFERRED_HEIGHT = 180;
+const DEFAULT_MIN_HEIGHT = 96;
+const DEFAULT_MAX_HEIGHT = 260;
+const DEFAULT_VIEWPORT_GAP = 12;
+const DEFAULT_ANCHOR_GAP = 8;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function cssLength(value: number | null) {
+  return value === null ? 'auto' : `${value}px`;
+}
+
+export function shortcutMenuPortal(node: HTMLElement) {
+  if (typeof document === 'undefined') return {};
+  document.body.appendChild(node);
+
+  return {
+    destroy() {
+      node.remove();
+    },
+  };
+}
+
+export function anchoredShortcutMenuGeometry(
+  rect: AnchorRect,
+  viewportWidth: number,
+  viewportHeight: number,
+  options: ShortcutMenuGeometryOptions = {},
+): ShortcutMenuGeometry {
+  const viewportGap = options.viewportGap ?? DEFAULT_VIEWPORT_GAP;
+  const anchorGap = options.anchorGap ?? DEFAULT_ANCHOR_GAP;
+  const preferredHeight = options.preferredHeight ?? DEFAULT_PREFERRED_HEIGHT;
+  const minHeight = options.minHeight ?? DEFAULT_MIN_HEIGHT;
+  const maxHeight = options.maxHeight ?? DEFAULT_MAX_HEIGHT;
+  const availableWidth = Math.max(0, viewportWidth - viewportGap * 2);
+  const maxWidth = Math.min(options.maxWidth ?? availableWidth, availableWidth);
+  const minWidth = Math.min(options.minWidth ?? 0, maxWidth);
+  const width = clamp(rect.width, minWidth, maxWidth);
+  const maxLeft = Math.max(viewportGap, viewportWidth - viewportGap - width);
+  const left = clamp(rect.left, viewportGap, maxLeft);
+  const spaceAbove = Math.max(0, rect.top - viewportGap);
+  const spaceBelow = Math.max(0, viewportHeight - rect.bottom - viewportGap);
+
+  let placement = options.placement ?? 'above';
+  if (placement === 'above' && spaceAbove < preferredHeight && spaceBelow > spaceAbove) {
+    placement = 'below';
+  } else if (placement === 'below' && spaceBelow < preferredHeight && spaceAbove > spaceBelow) {
+    placement = 'above';
+  }
+
+  const availableSpace = placement === 'above' ? spaceAbove : spaceBelow;
+
+  return {
+    placement,
+    left,
+    width,
+    maxHeight: clamp(availableSpace - anchorGap, minHeight, maxHeight),
+    top: placement === 'below' ? rect.bottom + anchorGap : null,
+    bottom: placement === 'above' ? viewportHeight - rect.top + anchorGap : null,
+  };
+}
+
+export function shortcutMenuCssVariables(geometry: ShortcutMenuGeometry, prefix: string) {
+  return [
+    `--${prefix}-dropdown-left:${geometry.left}px`,
+    `--${prefix}-dropdown-width:${geometry.width}px`,
+    `--${prefix}-dropdown-max-height:${geometry.maxHeight}px`,
+    `--${prefix}-dropdown-top:${cssLength(geometry.top)}`,
+    `--${prefix}-dropdown-bottom:${cssLength(geometry.bottom)}`,
+  ].join(';');
+}

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -70,6 +70,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'getIdea',
   'ideaConnections',
   'activityTimeline',
+  'generateTitle',
   'uploadFile',
   'previewUpload',
   'listIdeaProjectContext',

--- a/frontend/src/lib/utils/shortcutMenu.test.js
+++ b/frontend/src/lib/utils/shortcutMenu.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  anchoredShortcutMenuGeometry,
+  shortcutMenuCssVariables,
+} from '../features/composer/domain/shortcutMenu.ts';
+
+const utilsDir = dirname(fileURLToPath(import.meta.url));
+const srcDir = resolve(utilsDir, '..', '..');
+
+function readSource(relativePath) {
+  return readFileSync(resolve(srcDir, relativePath), 'utf8');
+}
+
+test('shortcut menu geometry flips below when there is not enough room above', () => {
+  const geometry = anchoredShortcutMenuGeometry(
+    { top: 24, bottom: 72, left: 20, width: 300 },
+    480,
+    600,
+    { placement: 'above', preferredHeight: 160, minHeight: 96, maxHeight: 220 },
+  );
+
+  assert.equal(geometry.placement, 'below');
+  assert.equal(geometry.top, 80);
+  assert.equal(geometry.bottom, null);
+  assert.equal(geometry.left, 20);
+  assert.equal(geometry.width, 300);
+});
+
+test('shortcut menu css variables always encode top and bottom closure states', () => {
+  const style = shortcutMenuCssVariables(
+    {
+      placement: 'above',
+      left: 12,
+      width: 320,
+      maxHeight: 180,
+      top: null,
+      bottom: 64,
+    },
+    'shortcut',
+  );
+
+  assert.match(style, /--shortcut-dropdown-top:auto/);
+  assert.match(style, /--shortcut-dropdown-bottom:64px/);
+});
+
+test('composer shortcut menus share the same body portal action', () => {
+  const slashSource = readSource('lib/features/composer/components/SlashAutocomplete.svelte');
+  const mentionSource = readSource('lib/features/composer/components/MentionAutocomplete.svelte');
+  const portalSource = readSource('lib/features/composer/domain/shortcutMenu.ts');
+
+  assert.match(slashSource, /use:shortcutMenuPortal/);
+  assert.match(mentionSource, /use:shortcutMenuPortal/);
+  assert.match(portalSource, /document\.body\.appendChild\(node\)/);
+  assert.match(portalSource, /destroy\(\)\s*\{\s*node\.remove\(\);\s*\}/);
+  assert.doesNotMatch(slashSource, /insertBefore\(node/);
+  assert.doesNotMatch(mentionSource, /insertBefore\(node/);
+});

--- a/frontend/src/lib/utils/slashCommand.test.js
+++ b/frontend/src/lib/utils/slashCommand.test.js
@@ -84,10 +84,18 @@ test('findFirstSlashCommandToken sees inline commands beyond the end cursor case
 test('slash autocomplete is anchored to the viewport instead of composer overflow boxes', () => {
   const source = readSource('lib/features/composer/components/SlashAutocomplete.svelte');
 
-  assert.match(source, /document\.body\.appendChild\(node\)/);
+  assert.match(source, /shortcutMenuPortal/);
   assert.match(source, /position:\s*fixed;/);
   assert.match(source, /--slash-dropdown-left/);
   assert.match(source, /--slash-dropdown-width/);
+});
+
+test('slash autocomplete uses the shared shortcut menu portal', () => {
+  const source = readSource('lib/features/composer/components/SlashAutocomplete.svelte');
+
+  assert.match(source, /use:shortcutMenuPortal/);
+  assert.doesNotMatch(source, /function\s+portalToBody/);
+  assert.doesNotMatch(source, /document\.createComment\(/);
 });
 
 test('thread composer editor does not clip overlay hosts', () => {

--- a/frontend/src/lib/utils/threadApiExports.test.js
+++ b/frontend/src/lib/utils/threadApiExports.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+const threadApiSource = readFileSync(
+  new URL('../features/threads/api/threadApi.ts', import.meta.url),
+  'utf8',
+);
+
+function threadApiPickerNames(source) {
+  const sourceFile = ts.createSourceFile('threadApi.ts', source, ts.ScriptTarget.Latest, true);
+  const names = new Set();
+
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'pickTypedApiMethods'
+    ) {
+      const [firstArg] = node.arguments;
+      if (firstArg && ts.isArrayLiteralExpression(firstArg)) {
+        for (const element of firstArg.elements) {
+          if (ts.isStringLiteralLike(element)) names.add(element.text);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return names;
+}
+
+function threadApiDestructuredExports(source) {
+  const sourceFile = ts.createSourceFile('threadApi.ts', source, ts.ScriptTarget.Latest, true);
+  const names = [];
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isIdentifier(node.initializer) &&
+      node.initializer.text === 'threadApi' &&
+      ts.isObjectBindingPattern(node.name)
+    ) {
+      for (const element of node.name.elements) {
+        if (ts.isIdentifier(element.name)) names.push(element.name.text);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return names;
+}
+
+test('thread API picker includes every destructured runtime export', () => {
+  const pickedNames = threadApiPickerNames(threadApiSource);
+  const exportedNames = threadApiDestructuredExports(threadApiSource);
+
+  assert.deepEqual(
+    exportedNames.filter((name) => !pickedNames.has(name)),
+    [],
+  );
+});


### PR DESCRIPTION
## Summary
- Extract a shared shortcut menu helper for portal mounting and anchored geometry.
- Update slash commands and @mentions to use the same positioning/portal behavior.
- Close the slash menu immediately on selection so it no longer lingers or shifts after input changes.
- Add regression tests for shared shortcut menu behavior and thread API export coverage.

## Testing
- `npm test` passed.
- `npm run check` passed.
- `npm run build` passed.
- Local browser verification confirmed `/` opens the menu, Backspace closes it, and selecting a command inserts text and dismisses the menu.