### PR TITLE
Add project visibility access badges

### DIFF
--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
@@ -118,15 +118,23 @@
                 <span
                   class="project-context-profile-access-stack"
                   title={accessSummary.tooltip}
+                  data-tooltip={accessSummary.tooltip}
                   aria-label={accessSummary.ariaLabel}
                 >
                   {#each accessSummary.visibleMembers as member, index (projectAccessMemberKey(member, index))}
-                    <span class="project-context-profile-access-avatar" aria-hidden="true">
+                    <span
+                      class="project-context-profile-access-avatar"
+                      aria-hidden="true"
+                    >
                       {projectAccessInitial(member)}
                     </span>
                   {/each}
                   {#if accessSummary.overflowCount > 0}
-                    <span class="project-context-profile-access-avatar overflow" aria-hidden="true">
+                    <span
+                      class="project-context-profile-access-avatar overflow"
+                      title={accessSummary.tooltip}
+                      aria-hidden="true"
+                    >
                       +{accessSummary.overflowCount}
                     </span>
                   {/if}

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextSavedProjectSelector.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
   import { ConstellationIcon } from '$lib/components/constellation';
+  import { auth } from '$lib/stores/auth.svelte';
+  import {
+    projectAccessInitial,
+    projectAccessMemberKey,
+    projectAccessMemberName,
+    summarizeProjectAccess,
+    type ProjectAccessMember,
+  } from '$lib/utils/projectProfileAccess';
   import type { ProjectContextProfile } from './projectContextProfiles';
 
   let {
@@ -28,6 +36,8 @@
       const searchable = [
         profile.name,
         profile.description,
+        profile.id === 'none' ? '' : profile.visibility === 'public' ? 'public' : 'private',
+        ...(profile.id === 'none' ? [] : (profile.access ?? []).map(projectAccessMemberName)),
         ...profile.resources.flatMap((resource) => [
           resource.label,
           resource.name,
@@ -51,12 +61,17 @@
 
   function profileMeta(profile: ProjectContextProfile): string {
     if (profile.id === 'none') return profile.description;
-    const visibility = profile.visibility === 'public' ? 'Public' : 'Private';
-    const sharedCount = profile.visibility === 'private' ? (profile.access?.length ?? 0) : 0;
-    const access = sharedCount > 0 ? `${visibility} · ${sharedCount} shared` : visibility;
-    return [access, profile.description || `${profile.resources.length} resource${profile.resources.length === 1 ? '' : 's'}`]
-      .filter(Boolean)
-      .join(' · ');
+    return profile.description || `${profile.resources.length} resource${profile.resources.length === 1 ? '' : 's'}`;
+  }
+
+  function profileOwner(profile: ProjectContextProfile): ProjectAccessMember | null {
+    const currentUser = auth.user;
+    if (!currentUser || !profile.userId || String(profile.userId) !== String(currentUser.id)) return null;
+    return {
+      user_id: String(currentUser.id),
+      name: currentUser.name,
+      email: currentUser.email,
+    };
   }
 </script>
 
@@ -75,6 +90,7 @@
   {:else if filteredProfiles.length}
     {#each filteredProfiles as profile}
       {@const isSelected = profile.id === selectedProfile?.id || profile.id === selectedProfileId}
+      {@const accessSummary = summarizeProjectAccess(profile, undefined, profileOwner(profile))}
       <button
         type="button"
         class="project-context-profile-option"
@@ -89,7 +105,41 @@
           stroke={1.8}
         />
         <span class="project-context-profile-option-copy">
-          <strong>{profile.name}</strong>
+          <span class="project-context-profile-option-title">
+            <strong>{profile.name}</strong>
+            {#if profile.id !== 'none'}
+              {#if accessSummary.isPublic}
+                <span
+                  class="project-context-profile-visibility-pill public"
+                  title={accessSummary.tooltip}
+                  aria-label={accessSummary.ariaLabel}
+                >Public</span>
+              {:else if accessSummary.members.length}
+                <span
+                  class="project-context-profile-access-stack"
+                  title={accessSummary.tooltip}
+                  aria-label={accessSummary.ariaLabel}
+                >
+                  {#each accessSummary.visibleMembers as member, index (projectAccessMemberKey(member, index))}
+                    <span class="project-context-profile-access-avatar" aria-hidden="true">
+                      {projectAccessInitial(member)}
+                    </span>
+                  {/each}
+                  {#if accessSummary.overflowCount > 0}
+                    <span class="project-context-profile-access-avatar overflow" aria-hidden="true">
+                      +{accessSummary.overflowCount}
+                    </span>
+                  {/if}
+                </span>
+              {:else}
+                <span
+                  class="project-context-profile-visibility-pill private"
+                  title={accessSummary.tooltip}
+                  aria-label={accessSummary.ariaLabel}
+                >Private</span>
+              {/if}
+            {/if}
+          </span>
           <small>{profileMeta(profile)}</small>
         </span>
         {#if isSelected}

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -336,11 +336,50 @@
   }
 
   .project-context-profile-access-stack {
+    position: relative;
     display: inline-flex;
     flex: 0 0 auto;
     align-items: center;
     margin-left: auto;
-    padding-left: 2px;
+    margin-block: -4px;
+    padding: 4px 0 4px 2px;
+  }
+
+  .project-context-profile-access-stack::after {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 7px);
+    z-index: 30;
+    width: max-content;
+    max-width: min(260px, calc(100vw - 48px));
+    box-sizing: border-box;
+    border: 1px solid var(--project-context-section-divider);
+    border-radius: 7px;
+    padding: 6px 8px;
+    background: var(--project-context-popover-background);
+    box-shadow: var(--shadow-lg);
+    color: var(--project-context-card-text);
+    content: attr(data-tooltip);
+    font-family: var(--constellation-font-sans);
+    font-size: 11px;
+    font-weight: 560;
+    letter-spacing: 0;
+    line-height: 1.25;
+    opacity: 0;
+    pointer-events: none;
+    text-transform: none;
+    transform: translateY(3px);
+    transition:
+      opacity 120ms ease,
+      transform 120ms ease;
+    white-space: normal;
+  }
+
+  .project-context-profile-access-stack:hover::after,
+  .project-context-profile-access-stack:focus-visible::after,
+  .project-context-profile-access-stack:focus-within::after {
+    opacity: 1;
+    transform: translateY(0);
   }
 
   .project-context-profile-access-avatar {

--- a/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextPicker.css
@@ -292,6 +292,92 @@
     min-width: 0;
   }
 
+  .project-context-profile-option-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .project-context-profile-option-title strong {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .project-context-profile-visibility-pill {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    min-height: 17px;
+    box-sizing: border-box;
+    border: 1px solid var(--project-context-pill-border);
+    border-radius: 999px;
+    padding: 0 7px;
+    background: var(--project-context-pill-background);
+    color: var(--project-context-pill-text);
+    font-family: var(--constellation-font-mono);
+    font-size: 8.5px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .project-context-profile-visibility-pill.public {
+    border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 32%, var(--project-context-pill-border));
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 12%, transparent);
+    color: color-mix(in srgb, var(--thread-accent, #57CFA0) 58%, var(--project-context-card-text));
+  }
+
+  .project-context-profile-visibility-pill.private {
+    opacity: 0.84;
+  }
+
+  .project-context-profile-access-stack {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    margin-left: auto;
+    padding-left: 2px;
+  }
+
+  .project-context-profile-access-avatar {
+    position: relative;
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    border: 1px solid color-mix(in srgb, var(--thread-accent, #57CFA0) 24%, var(--project-context-pill-border));
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 14%, var(--project-context-popover-background));
+    color: var(--project-context-card-text);
+    font-family: var(--constellation-font-mono);
+    font-size: 8px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    text-transform: uppercase;
+    box-shadow: 0 0 0 1px var(--project-context-popover-background);
+  }
+
+  .project-context-profile-access-avatar + .project-context-profile-access-avatar {
+    margin-left: -4px;
+  }
+
+  .project-context-profile-access-avatar.overflow {
+    width: auto;
+    min-width: 18px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: var(--project-context-pill-background);
+    color: var(--project-context-pill-text);
+    font-size: 7.5px;
+  }
+
   .project-context-profile-option-copy strong,
   .project-context-profile-option-copy small {
     overflow: hidden;

--- a/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
+++ b/frontend/src/lib/features/composer/components/project-context/projectContextProfiles.ts
@@ -6,6 +6,7 @@ export type ProjectContextProfile = {
   description: string;
   resources: ProjectContextResource[];
   serverProfileId?: string;
+  userId?: string;
   visibility?: ProjectVisibility;
   access?: ProjectProfileAccess[];
 };
@@ -17,6 +18,8 @@ export type ProjectProfileAccess = {
   user_id: string;
   name: string;
   email?: string | null;
+  shared_by_user_id?: string | null;
+  created_at?: string | null;
 };
 
 const RESOURCE_TYPE_LABELS: Record<string, string> = {
@@ -49,6 +52,7 @@ export function mapServerProjectProfile(profile: any): ProjectContextProfile {
   return {
     id: `server:${profile.id}`,
     serverProfileId: profile.id,
+    userId: profile.user_id,
     name: profile.name,
     description: profile.description ?? 'Saved project profile',
     visibility: profile.visibility === 'public' ? 'public' : 'private',

--- a/frontend/src/lib/utils/projectProfileAccess.test.js
+++ b/frontend/src/lib/utils/projectProfileAccess.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  projectAccessInitial,
+  projectAccessMemberName,
+  summarizeProjectAccess,
+} from './projectProfileAccess.ts';
+
+test('summarizes public project access as a public badge', () => {
+  const summary = summarizeProjectAccess({
+    visibility: 'public',
+    access: [{ user_id: 'user-1', name: 'Ada Lovelace' }],
+  });
+
+  assert.equal(summary.isPublic, true);
+  assert.deepEqual(summary.visibleMembers, []);
+  assert.equal(summary.overflowCount, 0);
+  assert.equal(summary.tooltip, 'Public project');
+  assert.equal(summary.ariaLabel, 'Public project');
+});
+
+test('summarizes private project access with three visible members and full-list tooltip', () => {
+  const summary = summarizeProjectAccess({
+    visibility: 'private',
+    access: [
+      { user_id: 'user-1', name: 'Ada Lovelace' },
+      { user_id: 'user-2', name: 'Ben Bitdiddle' },
+      { user_id: 'user-3', name: 'Cora Count' },
+      { user_id: 'user-4', name: 'Dana Scully' },
+    ],
+  });
+
+  assert.equal(summary.isPublic, false);
+  assert.deepEqual(summary.visibleMembers.map(projectAccessMemberName), [
+    'Ada Lovelace',
+    'Ben Bitdiddle',
+    'Cora Count',
+  ]);
+  assert.equal(summary.overflowCount, 1);
+  assert.equal(summary.tooltip, 'Shared with Ada Lovelace, Ben Bitdiddle, Cora Count, Dana Scully');
+  assert.equal(summary.ariaLabel, 'Private project shared with Ada Lovelace, Ben Bitdiddle, Cora Count, Dana Scully');
+});
+
+test('dedupes private access members, includes owner first, and falls back to a private badge when empty', () => {
+  const summary = summarizeProjectAccess(
+    {
+      visibility: 'private',
+      access: [
+        { user_id: 'user-1', name: 'Ada Lovelace' },
+        { user_id: 'user-1', name: 'Ada Lovelace' },
+        { user_id: 'user-2', name: 'Ben Bitdiddle' },
+        { name: '  ' },
+      ],
+    },
+    undefined,
+    { user_id: 'owner-1', name: 'Grace Hopper' },
+  );
+
+  assert.deepEqual(summary.members.map(projectAccessMemberName), [
+    'Grace Hopper',
+    'Ada Lovelace',
+    'Ben Bitdiddle',
+  ]);
+  assert.equal(summary.overflowCount, 0);
+
+  const emptySummary = summarizeProjectAccess({ visibility: 'private', access: [] });
+  assert.equal(emptySummary.tooltip, 'Private project');
+  assert.equal(emptySummary.ariaLabel, 'Private project');
+});
+
+test('builds round-letter initials from member names or email fallback', () => {
+  assert.equal(projectAccessInitial({ name: 'Ada Lovelace' }), 'A');
+  assert.equal(projectAccessInitial({ email: 'grace@example.com' }), 'G');
+  assert.equal(projectAccessInitial(null), '?');
+});

--- a/frontend/src/lib/utils/projectProfileAccess.ts
+++ b/frontend/src/lib/utils/projectProfileAccess.ts
@@ -1,0 +1,88 @@
+export type ProjectAccessMember = {
+  user_id?: string | null;
+  name?: string | null;
+  email?: string | null;
+};
+
+export type ProjectAccessSummary = {
+  isPublic: boolean;
+  members: ProjectAccessMember[];
+  visibleMembers: ProjectAccessMember[];
+  overflowCount: number;
+  tooltip: string;
+  ariaLabel: string;
+};
+
+export const PROJECT_ACCESS_BADGE_LIMIT = 3;
+
+export function projectAccessMemberName(member: ProjectAccessMember | null | undefined): string {
+  return String(member?.name ?? member?.email ?? '').trim();
+}
+
+export function projectAccessMemberKey(member: ProjectAccessMember, index = 0): string {
+  const key = String(member.user_id ?? member.email ?? projectAccessMemberName(member)).trim();
+  return key || `member-${index}`;
+}
+
+export function projectAccessInitial(memberOrName: ProjectAccessMember | string | null | undefined): string {
+  const name = typeof memberOrName === 'string'
+    ? memberOrName
+    : projectAccessMemberName(memberOrName);
+  const initial = Array.from(name.trim())[0];
+  return initial ? initial.toUpperCase() : '?';
+}
+
+export function projectAccessMembers(access: ProjectAccessMember[] | null | undefined): ProjectAccessMember[] {
+  const seen = new Set<string>();
+  const members: ProjectAccessMember[] = [];
+
+  for (const member of access ?? []) {
+    const name = projectAccessMemberName(member);
+    if (!name) continue;
+
+    const key = String(member.user_id ?? member.email ?? name).trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+
+    seen.add(key);
+    members.push(member);
+  }
+
+  return members;
+}
+
+export function summarizeProjectAccess(
+  profile: { visibility?: string | null; access?: ProjectAccessMember[] | null },
+  limit = PROJECT_ACCESS_BADGE_LIMIT,
+  owner?: ProjectAccessMember | null,
+): ProjectAccessSummary {
+  const isPublic = profile.visibility === 'public';
+  if (isPublic) {
+    return {
+      isPublic: true,
+      members: [],
+      visibleMembers: [],
+      overflowCount: 0,
+      tooltip: 'Public project',
+      ariaLabel: 'Public project',
+    };
+  }
+
+  const members = projectAccessMembers([
+    ...(owner ? [owner] : []),
+    ...(profile.access ?? []),
+  ]);
+  const safeLimit = Math.max(0, limit);
+  const visibleMembers = members.slice(0, safeLimit);
+  const overflowCount = Math.max(0, members.length - visibleMembers.length);
+  const memberNames = members.map(projectAccessMemberName);
+  const memberList = memberNames.join(', ');
+
+  return {
+    isPublic: false,
+    members,
+    visibleMembers,
+    overflowCount,
+    tooltip: memberList ? `Shared with ${memberList}` : 'Private project',
+    ariaLabel: memberList ? `Private project shared with ${memberList}` : 'Private project',
+  };
+}


### PR DESCRIPTION
## Summary
- Show a compact Public pill for public saved projects.
- Show round initial badges for private project members, capped at three with a +N overflow marker.
- Add full member-list hover/title text and searchable access names.

## Validation
- `git diff --check`
- Could not run frontend tests/checks because Node/npm are not installed in this workspace.
- Could not run pytest because pytest is not installed in this workspace.
