### PR TITLE
Improve project context auth and inbound signal handling

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -52,7 +52,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "Submit a progress or status signal from a personal tool into IloSpace. "
                 "This is the default tool for automatic hooks and routine work updates: "
                 "send what happened, plus hints like repo, branch, task, and files touched. "
-                "Do not choose a thread, project, or teammate target here; IloSpace and Ilo "
+                "Do not choose a thread, project, or teammate target here; IloSpace and Illo "
                 "decide whether to store, route, summarize, ask, or ignore the signal. "
                 "Use direct thread tools only when the user explicitly asks for a visible "
                 "thread/message in a known destination."
@@ -155,8 +155,8 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "with teammates, publish findings into Illo, or start a team-visible "
                 "discussion. For automatic hooks and routine progress, prefer "
                 f"{SIGNAL_TOOL_NAME} so IloSpace can route the signal. Set trigger_illo "
-                "only when the user wants Ilo to actively respond or the message explicitly "
-                "mentions Ilo."
+                "only when the user wants Illo to actively respond or the message explicitly "
+                "mentions Illo."
             ),
             {
                 "title": {"type": "string", "description": "Thread title visible in Illo."},
@@ -317,6 +317,27 @@ def _signal_hints(arguments: dict[str, Any]) -> dict[str, Any]:
     return hints
 
 
+def _signal_payload(arguments: dict[str, Any], *, summary: str, origin: str, hints: dict[str, Any]) -> dict[str, Any]:
+    payload = _clean_dict(arguments.get("payload"))
+    source_tool = str(hints.get("source_tool") or arguments.get("source_tool") or "").strip().lower()
+    if "checkpoint" not in payload and (origin == "codex.progress" or source_tool == "codex"):
+        payload["checkpoint"] = {
+            key: value
+            for key, value in {
+                "summary": summary,
+                "source_tool": hints.get("source_tool") or "codex",
+                "repo": hints.get("repo"),
+                "branch": hints.get("branch"),
+                "task_title": hints.get("task_title"),
+                "files_touched": hints.get("files_touched"),
+                "session_id": hints.get("session_id"),
+                "run_id": hints.get("run_id"),
+            }.items()
+            if value not in (None, "", [])
+        }
+    return payload
+
+
 def _build_signal_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
     forbidden = sorted(_FORBIDDEN_SIGNAL_TARGET_FIELDS.intersection(arguments))
     if forbidden:
@@ -327,12 +348,14 @@ def _build_signal_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
     summary = _clean_optional_string(arguments.get("summary"))
     if not summary:
         raise ValueError(f"{SIGNAL_TOOL_NAME} requires a non-empty summary")
+    origin = _clean_optional_string(arguments.get("origin")) or "codex.progress"
+    hints = _signal_hints(arguments)
     return {
         "kind": "signal",
-        "origin": _clean_optional_string(arguments.get("origin")) or "codex.progress",
-        "payload": _clean_dict(arguments.get("payload")),
+        "origin": origin,
+        "payload": _signal_payload(arguments, summary=summary, origin=origin, hints=hints),
         "summary": summary,
-        "hints": _signal_hints(arguments),
+        "hints": hints,
         "desired_outcome": _clean_optional_string(arguments.get("desired_outcome")),
         "idempotency_key": _clean_optional_string(arguments.get("idempotency_key")),
     }

--- a/brain/platform/db/models/inbound.py
+++ b/brain/platform/db/models/inbound.py
@@ -332,7 +332,7 @@ class InboundEventRow(Base, CreatedAtMixin):
 
 
 class InboundDecisionReceiptRow(Base, CreatedAtMixin):
-    """Durable receipt for deterministic or Ilo-handled inbound decisions."""
+    """Durable receipt for deterministic or Illo-handled inbound decisions."""
 
     __tablename__ = "inbound_decision_receipts"
     __table_args__ = (

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -131,26 +131,36 @@ async def _maybe_await(value):
 
 
 async def _github_secret_names(user_id: str, org_id: str | None) -> list[str]:
+    def append_names(secrets: Any, *, github_like_only: bool = False) -> None:
+        for secret in (secrets if isinstance(secrets, list) else []):
+            name = _clean_text(secret.get("key_name") if isinstance(secret, dict) else None)
+            if not name or name in seen:
+                continue
+            if github_like_only and "github" not in name.lower() and name.upper() not in {"GH_TOKEN"}:
+                continue
+            seen.add(name)
+            names.append(name)
+
+    names: list[str] = []
+    seen: set[str] = set()
     try:
         candidates = await _maybe_await(list_secrets(user_id, category="github", org_id=org_id))
     except Exception:
         candidates = []
-    names: list[str] = []
-    seen: set[str] = set()
-    for secret in candidates:
-        name = _clean_text(secret.get("key_name") if isinstance(secret, dict) else None)
-        if not name or name in seen:
-            continue
-        seen.add(name)
-        names.append(name)
+    append_names(candidates)
+    try:
+        general_candidates = await _maybe_await(list_secrets(user_id, org_id=org_id))
+    except Exception:
+        general_candidates = []
+    append_names(general_candidates, github_like_only=True)
     return names[:5]
 
 
 async def _token_candidates(resource: dict[str, Any], user_id: str | None, org_id: str | None) -> list[tuple[str | None, str | None]]:
     explicit_key = _vault_key_from_resource(resource)
-    candidates: list[tuple[str | None, str | None]] = [] if explicit_key else [(None, None)]
+    candidates: list[tuple[str | None, str | None]] = []
     if not user_id:
-        return candidates or [(None, None)]
+        return [(None, None)]
 
     key_names = []
     if explicit_key:
@@ -174,8 +184,7 @@ async def _token_candidates(resource: dict[str, Any], user_id: str | None, org_i
             token = None
         if token:
             candidates.append((key_name, token.strip()))
-    if explicit_key:
-        candidates.append((None, None))
+    candidates.append((None, None))
     return candidates
 
 

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -609,7 +609,12 @@ async def authenticate_bridge_token(
     scopes = frozenset(str(scope) for scope in _json_list(row.scopes))
     if required_scope and "*" not in scopes and required_scope not in scopes:
         raise ExternalAgentPermissionError(f"Bridge token is missing scope: {required_scope}")
-    row.last_used_at = utcnow()
+    now = utcnow()
+    row.last_used_at = now
+    connection.last_seen_at = now
+    connection.last_error = None
+    if str(connection.status or "").strip().lower() == "pending":
+        connection.status = "configured"
     return AgentBridgePrincipal(
         connection_id=str(row.connection_id),
         org_id=str(row.org_id),

--- a/brain/systems/inbound/admin.py
+++ b/brain/systems/inbound/admin.py
@@ -1,4 +1,4 @@
-"""Ilo-facing administration helpers for inbound coordination."""
+"""Illo-facing administration helpers for inbound coordination."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ READ_LIMIT_MAX = 100
 
 
 class InboundAdminError(RuntimeError):
-    """Raised when an Ilo-facing inbound admin operation is invalid."""
+    """Raised when an Illo-facing inbound admin operation is invalid."""
 
 
 def _iso(value: Any) -> str | None:
@@ -954,9 +954,71 @@ def _source_card_traffic(events: Sequence[InboundEventRow]) -> dict[str, Any]:
         "common_origins": _counter_rows(origin_counts),
         "statuses": _counter_rows(status_counts),
         "payload_shapes": _counter_rows(shape_counts, limit=30),
+        "observed_outcomes": _source_card_observed_outcomes(events),
         "recent_failures": [_source_card_event_summary(row) for row in events if _event_needs_attention(row)][:10],
         "recent_events": [_source_card_event_summary(row) for row in events[:10]],
     }
+
+
+def _source_card_observed_outcomes(events: Sequence[InboundEventRow]) -> dict[str, Any]:
+    by_origin: dict[str, dict[str, Any]] = {}
+    tag_counts: Counter[str] = Counter()
+    tool_counts: Counter[str] = Counter()
+    total = 0
+    for row in events:
+        attribution = _event_attribution(row)
+        if not attribution:
+            continue
+        total += 1
+        origin = str(row.origin or "unknown")
+        bucket = by_origin.setdefault(
+            origin,
+            {
+                "origin": origin,
+                "count": 0,
+                "tags": Counter(),
+                "tool_names": Counter(),
+                "summaries": [],
+                "recent_event_ids": [],
+            },
+        )
+        bucket["count"] += 1
+        bucket["recent_event_ids"].append(str(row.id))
+        summary = str(attribution.get("summary") or "").strip()
+        if summary and summary not in bucket["summaries"] and len(bucket["summaries"]) < 5:
+            bucket["summaries"].append(summary)
+        for tag in _stripped_strings(_json_list(attribution.get("tags"))):
+            tag_counts[tag] += 1
+            bucket["tags"][tag] += 1
+        for tool_name in _stripped_strings(_json_list(attribution.get("tool_names"))):
+            tool_counts[tool_name] += 1
+            bucket["tool_names"][tool_name] += 1
+
+    origins = []
+    for bucket in sorted(by_origin.values(), key=lambda item: (-int(item["count"]), item["origin"]))[:10]:
+        origins.append(
+            {
+                "origin": bucket["origin"],
+                "count": bucket["count"],
+                "tags": _counter_rows(bucket["tags"]),
+                "tool_names": _counter_rows(bucket["tool_names"]),
+                "summaries": bucket["summaries"],
+                "recent_event_ids": bucket["recent_event_ids"][:10],
+            }
+        )
+    return {
+        "event_count_sampled": total,
+        "common_tags": _counter_rows(tag_counts),
+        "tool_names": _counter_rows(tool_counts),
+        "by_origin": origins,
+    }
+
+
+def _event_attribution(row: InboundEventRow) -> dict[str, Any]:
+    action_result = _json_dict(row.action_result)
+    triage = _json_dict(action_result.get("triage"))
+    attribution = _json_dict(triage.get("attribution"))
+    return attribution or _json_dict(action_result.get("attribution"))
 
 
 def _counter_rows(counter: Counter[str], *, limit: int = 10) -> list[dict[str, Any]]:

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -1,0 +1,294 @@
+"""Minimal attribution for completed inbound Illo triage runs."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunEventRow
+from brain.systems.runs.status import RunStatus
+from brain.systems.runs.tool_catalog.registry import action_policy_for_tool, get_tool_registration
+
+
+_TOOL_COMPLETED_EVENT = "run.tool_completed"
+_MAX_TARGET_REFS = 20
+
+_DIRECT_REF_KINDS = {
+    "idea_id": "idea",
+    "thread_id": "thread",
+    "thread_message_id": "thread_message",
+    "message_id": "message",
+    "domain_id": "domain",
+    "record_id": "domain_record",
+    "connection_id": "external_source_connection",
+    "policy_id": "inbound_source_policy",
+    "projection_id": "inbound_domain_projection",
+    "token_id": "external_source_token",
+    "event_id": "inbound_event",
+    "run_id": "agent_run",
+}
+
+_OBJECT_REF_KINDS = {
+    "idea": "idea",
+    "thread": "thread",
+    "thread_message": "thread_message",
+    "message": "message",
+    "domain": "domain",
+    "record": "domain_record",
+    "connection": "external_source_connection",
+    "policy": "inbound_source_policy",
+    "projection": "inbound_domain_projection",
+    "token": "external_source_token",
+    "event": "inbound_event",
+    "run": "agent_run",
+}
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _json_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _parse_result(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text or text[0] not in "[{":
+        return value
+    try:
+        return json.loads(text)
+    except Exception:
+        return value
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").strip()
+
+
+def _tool_name(payload: Mapping[str, Any]) -> str | None:
+    value = payload.get("tool_name") or payload.get("tool")
+    text = str(value or "").strip()
+    return text or None
+
+
+def _tool_args(payload: Mapping[str, Any]) -> dict[str, Any]:
+    args = payload.get("args")
+    return dict(args) if isinstance(args, dict) else {}
+
+
+def _tool_result(payload: Mapping[str, Any]) -> Any:
+    return _parse_result(payload.get("result"))
+
+
+def _tool_is_read_only(tool_name: str, args: Mapping[str, Any]) -> bool:
+    try:
+        policy = action_policy_for_tool(tool_name, kwargs=dict(args))
+    except Exception:
+        policy = None
+    if policy is None:
+        return True
+    registration = get_tool_registration(tool_name)
+    return _enum_value(getattr(registration, "side_effect_class", "")) == "read_only"
+
+
+def _add_ref(refs: list[dict[str, str]], seen: set[tuple[str, str]], *, kind: str, value: Any, source: str) -> None:
+    if len(refs) >= _MAX_TARGET_REFS:
+        return
+    text = str(value or "").strip()
+    if not text:
+        return
+    key = (kind, text)
+    if key in seen:
+        return
+    seen.add(key)
+    refs.append({"kind": kind, "id": text, "source": source})
+
+
+def _collect_refs(value: Any, refs: list[dict[str, str]], seen: set[tuple[str, str]], *, source: str) -> None:
+    if len(refs) >= _MAX_TARGET_REFS:
+        return
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_text = str(key)
+            if key_text in _DIRECT_REF_KINDS:
+                _add_ref(refs, seen, kind=_DIRECT_REF_KINDS[key_text], value=child, source=source)
+            if key_text in _OBJECT_REF_KINDS and isinstance(child, Mapping):
+                _add_ref(refs, seen, kind=_OBJECT_REF_KINDS[key_text], value=child.get("id"), source=source)
+            if isinstance(child, Mapping | list):
+                _collect_refs(child, refs, seen, source=source)
+    elif isinstance(value, list):
+        for child in value[:10]:
+            _collect_refs(child, refs, seen, source=source)
+
+
+def _target_refs(tool_events: list[AgentRunEventRow]) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for row in tool_events:
+        payload = _json_dict(row.payload)
+        source = _tool_name(payload) or "tool_result"
+        _collect_refs(_tool_result(payload), refs, seen, source=source)
+    return refs
+
+
+def _operation_tag(args: Mapping[str, Any], result: Any) -> str | None:
+    result_data = _json_dict(result)
+    operation = str(result_data.get("operation") or args.get("action") or "").strip().lower()
+    if not operation:
+        return None
+    if operation.endswith("ed"):
+        return operation
+    if operation.startswith("create"):
+        return "created"
+    if operation.startswith("update"):
+        return "updated"
+    if operation.startswith("delete") or operation.startswith("remove"):
+        return "deleted"
+    if operation.startswith("archive"):
+        return "archived"
+    if operation.startswith("restore"):
+        return "restored"
+    if operation.startswith("mint"):
+        return "minted"
+    if operation.startswith("revoke"):
+        return "revoked"
+    if operation.startswith("refresh"):
+        return "refreshed"
+    if operation.startswith("post"):
+        return "posted"
+    return operation.replace("_", "-")
+
+
+def _tool_tag(tool_name: str) -> str:
+    registration = get_tool_registration(tool_name)
+    side_effect = _enum_value(getattr(registration, "side_effect_class", ""))
+    if side_effect:
+        return side_effect
+    return tool_name.replace("_", "-")
+
+
+def _tags(
+    tool_events: list[AgentRunEventRow],
+    *,
+    mutating_tools: list[str],
+    read_only_seen: bool,
+    status: RunStatus,
+) -> list[str]:
+    tags: list[str] = []
+    if status != RunStatus.COMPLETED:
+        tags.append(status.value)
+    if read_only_seen:
+        tags.append("inspected")
+    for row in tool_events:
+        payload = _json_dict(row.payload)
+        tool_name = _tool_name(payload)
+        if not tool_name or tool_name not in mutating_tools:
+            continue
+        args = _tool_args(payload)
+        result = _tool_result(payload)
+        tags.append(_tool_tag(tool_name))
+        operation = _operation_tag(args, result)
+        if operation:
+            tags.append(operation)
+    if not mutating_tools:
+        tags.append("no_workspace_change")
+    return _unique(tags)
+
+
+def _summary(
+    *,
+    status: RunStatus,
+    tool_names: list[str],
+    mutating_tools: list[str],
+    refs: list[dict[str, str]],
+    tags: list[str],
+) -> str:
+    if status != RunStatus.COMPLETED:
+        return f"Illo triage ended with status {status.value}."
+    if not tool_names:
+        return "Illo resolved the signal without a workspace tool action."
+    if not mutating_tools:
+        return "Illo inspected workspace context and resolved the signal without a workspace mutation."
+
+    target_kinds = _unique([str(ref.get("kind") or "") for ref in refs])[:3]
+    target_text = ", ".join(target_kinds) if target_kinds else "workspace state"
+    tool_text = ", ".join(mutating_tools[:3])
+    operation = next((tag for tag in tags if tag in {"created", "updated", "deleted", "archived", "restored", "minted", "revoked", "refreshed", "posted"}), "updated")
+    return f"Illo {operation} {target_text} using {tool_text}."
+
+
+async def summarize_inbound_run_attribution(
+    session: AsyncSession,
+    *,
+    run_id: int,
+    status: RunStatus,
+) -> dict[str, Any]:
+    """Build compact observed-outcome attribution from completed tool events."""
+
+    tool_events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id == int(run_id),
+                    AgentRunEventRow.event_type == _TOOL_COMPLETED_EVENT,
+                )
+                .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+            )
+        ).all()
+    )
+    tool_names = _unique(
+        [
+            tool_name
+            for row in tool_events
+            if (tool_name := _tool_name(_json_dict(row.payload))) is not None
+        ]
+    )
+    mutating_tools: list[str] = []
+    read_only_seen = False
+    for row in tool_events:
+        payload = _json_dict(row.payload)
+        tool_name = _tool_name(payload)
+        if not tool_name:
+            continue
+        if _tool_is_read_only(tool_name, _tool_args(payload)):
+            read_only_seen = True
+        else:
+            mutating_tools.append(tool_name)
+    mutating_tools = _unique(mutating_tools)
+    refs = _target_refs(tool_events)
+    tags = _tags(tool_events, mutating_tools=mutating_tools, read_only_seen=read_only_seen, status=status)
+    return {
+        "summary": _summary(
+            status=status,
+            tool_names=tool_names,
+            mutating_tools=mutating_tools,
+            refs=refs,
+            tags=tags,
+        ),
+        "tags": tags,
+        "tool_names": tool_names,
+        "target_refs": refs,
+        "run_event_ids": [int(row.id) for row in tool_events if row.id is not None],
+    }
+
+
+__all__ = ["summarize_inbound_run_attribution"]

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -16,6 +16,17 @@ from brain.systems.runs.tool_catalog.registry import action_policy_for_tool, get
 
 _TOOL_COMPLETED_EVENT = "run.tool_completed"
 _MAX_TARGET_REFS = 20
+_SUMMARY_OPERATION_TAGS = {
+    "created",
+    "updated",
+    "deleted",
+    "archived",
+    "restored",
+    "minted",
+    "revoked",
+    "refreshed",
+    "posted",
+}
 
 _DIRECT_REF_KINDS = {
     "idea_id": "idea",
@@ -50,10 +61,6 @@ _OBJECT_REF_KINDS = {
 
 def _json_dict(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
-
-
-def _json_list(value: Any) -> list[Any]:
-    return list(value) if isinstance(value, list) else []
 
 
 def _unique(values: list[str]) -> list[str]:
@@ -231,7 +238,7 @@ def _summary(
     target_kinds = _unique([str(ref.get("kind") or "") for ref in refs])[:3]
     target_text = ", ".join(target_kinds) if target_kinds else "workspace state"
     tool_text = ", ".join(mutating_tools[:3])
-    operation = next((tag for tag in tags if tag in {"created", "updated", "deleted", "archived", "restored", "minted", "revoked", "refreshed", "posted"}), "updated")
+    operation = next((tag for tag in tags if tag in _SUMMARY_OPERATION_TAGS), "updated")
     return f"Illo {operation} {target_text} using {tool_text}."
 
 
@@ -263,6 +270,7 @@ async def summarize_inbound_run_attribution(
         ]
     )
     mutating_tools: list[str] = []
+    mutating_tool_events: list[AgentRunEventRow] = []
     read_only_seen = False
     for row in tool_events:
         payload = _json_dict(row.payload)
@@ -273,20 +281,23 @@ async def summarize_inbound_run_attribution(
             read_only_seen = True
         else:
             mutating_tools.append(tool_name)
+            mutating_tool_events.append(row)
     mutating_tools = _unique(mutating_tools)
     refs = _target_refs(tool_events)
+    mutating_refs = _target_refs(mutating_tool_events)
     tags = _tags(tool_events, mutating_tools=mutating_tools, read_only_seen=read_only_seen, status=status)
     return {
         "summary": _summary(
             status=status,
             tool_names=tool_names,
             mutating_tools=mutating_tools,
-            refs=refs,
+            refs=mutating_refs,
             tags=tags,
         ),
         "tags": tags,
         "tool_names": tool_names,
         "target_refs": refs,
+        "mutated_target_refs": mutating_refs,
         "run_event_ids": [int(row.id) for row in tool_events if row.id is not None],
     }
 

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -1,4 +1,4 @@
-"""Reconcile inbound decision receipts after Ilo triage runs finish."""
+"""Reconcile inbound decision receipts after Illo triage runs finish."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.systems.inbound.attribution import summarize_inbound_run_attribution
 from brain.systems.runs.domain import AgentRun, ArtifactType
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 
@@ -133,7 +134,7 @@ async def reconcile_inbound_triage_run(
     """Close the decision receipt loop for an inbound triage run.
 
     Triage admission starts with an inbound event in ``review_required``. Once the
-    admitted Ilo run reaches a terminal state, the event and receipt should show
+    admitted Illo run reaches a terminal state, the event and receipt should show
     the final run outcome instead of only the queued handoff.
     """
 
@@ -162,6 +163,7 @@ async def reconcile_inbound_triage_run(
     now = datetime.now(timezone.utc)
     terminal_at = _run_datetime(row, status)
     final_answer = await _latest_final_answer(session, run_id)
+    attribution = await summarize_inbound_run_attribution(session, run_id=run_id, status=status)
     terminal_status = _receipt_terminal_status(status)
     triage_terminal = _triage_terminal_payload(
         run_id=run_id,
@@ -177,6 +179,7 @@ async def reconcile_inbound_triage_run(
         **triage,
         **triage_terminal,
         "result": _triage_result(status, final_answer),
+        "attribution": attribution,
     }
 
     tool_use = _json_dict(receipt.tool_use)
@@ -189,6 +192,7 @@ async def reconcile_inbound_triage_run(
             reconciled_at=now,
             terminal_at=terminal_at,
         ),
+        "attribution": attribution,
     }
 
     event.status = terminal_status
@@ -200,7 +204,7 @@ async def reconcile_inbound_triage_run(
     if status == RunStatus.COMPLETED:
         event.error = None
     else:
-        event.error = final_answer or f"Ilo triage run ended with status {status.value}"
+        event.error = final_answer or f"Illo triage run ended with status {status.value}"
 
     await session.flush()
     return receipt

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -696,7 +696,7 @@ def _validate_schema_config(schema_config: Mapping[str, Any], envelope: Mapping[
             if path:
                 required_paths.append(str(path))
     root = _path_root(envelope)
-    missing = [path for path in required_paths if _extract_path(root, str(path)) is _MISSING]
+    missing = [path for path in required_paths if _required_path_missing(_extract_path(root, str(path)))]
     if missing:
         raise InboundValidationError(f"Missing required inbound field(s): {', '.join(sorted(missing))}")
 
@@ -1058,6 +1058,12 @@ class _Missing:
 
 
 _MISSING = _Missing()
+
+
+def _required_path_missing(value: Any) -> bool:
+    if value is _MISSING or value is None:
+        return True
+    return isinstance(value, str) and not value.strip()
 
 
 def _path_root(envelope: Mapping[str, Any]) -> dict[str, Any]:

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -86,7 +86,7 @@ async def create_source_policy(
     metadata: Mapping[str, Any] | None = None,
     enabled: bool = True,
 ) -> InboundSourcePolicyRow:
-    """Create an Ilo-configurable source policy record."""
+    """Create an Illo-configurable source policy record."""
 
     policy = InboundSourcePolicyRow(
         org_id=str(org_id),
@@ -787,11 +787,11 @@ async def _queue_illo_triage(
 
     origin = str(normalized.get("origin") or event.origin)
     source_name = context.display_name or context.source_kind or "external source"
-    title = _truncate(f"Inbound signal needs Ilo triage: {origin}", 180)
+    title = _truncate(f"Inbound signal needs Illo triage: {origin}", 180)
     idea = Idea(
         title=title,
         description=_truncate(
-            f"{source_name} sent an inbound signal that needs Ilo to decide the workspace outcome.",
+            f"{source_name} sent an inbound signal that needs Illo to decide the workspace outcome.",
             500,
         ),
         status="emerged",
@@ -893,7 +893,7 @@ def _triage_thread_message(
 ) -> str:
     origin = str(normalized.get("origin") or event.origin)
     lines = [
-        "An inbound signal needs Ilo triage.",
+        "An inbound signal needs Illo triage.",
         "",
         f"Reason: {reason}",
         f"Inbound event: {event.id}",
@@ -1066,6 +1066,7 @@ def _path_root(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "payload": dict(envelope.get("payload") or {}),
         "hints": dict(envelope.get("hints") or {}),
         "summary": envelope.get("summary"),
+        "desired_outcome": envelope.get("desired_outcome"),
         "origin": envelope.get("origin"),
     }
 

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -812,8 +812,8 @@ DOMAIN_TOOLS = [
 ]
 
 # ── Inbound Coordination Tools ────────────────────────────────
-# Ilo-facing configuration for external source signals. External systems submit
-# to /webhooks or hosted MCP; Ilo configures that lane through this tool.
+# Illo-facing configuration for external source signals. External systems submit
+# to /webhooks or hosted MCP; Illo configures that lane through this tool.
 
 INBOUND_TOOLS = [
     {
@@ -821,10 +821,10 @@ INBOUND_TOOLS = [
         "description": (
             "Configure and inspect the inbound coordination layer on behalf of the current user: "
             "external source connections, scoped signal tokens, origin policies, Domain Projections, "
-            "event logs, and decision receipts. Use this when a user asks Ilo to set up or adjust "
+            "event logs, and decision receipts. Use this when a user asks Illo to set up or adjust "
             "webhooks, MCP personal-tool signals, Jira/GitHub/Stripe-style sources, routing rules, "
             "or deterministic storage into Domains. External tools should submit signals through "
-            "hosted MCP or POST /webhooks; this tool is Ilo's chat-based admin/configuration surface. "
+            "hosted MCP or POST /webhooks; this tool is Illo's chat-based admin/configuration surface. "
             "Use action='help' or action='schema' with operation before mutating unfamiliar configs."
         ),
         "input_schema": {
@@ -914,7 +914,7 @@ INBOUND_TOOLS = [
                 },
                 "instructions": {
                     "type": "string",
-                    "description": "Natural-language instructions for Ilo when this policy needs agent handling.",
+                    "description": "Natural-language instructions for Illo when this policy needs agent handling.",
                 },
                 "schema_config": {
                     "type": "object",
@@ -984,7 +984,7 @@ INBOUND_TOOLS = [
                 "include_receipts": {"type": "boolean", "default": False},
                 "source_purpose": {
                     "type": "string",
-                    "description": "Optional human/Ilo-authored purpose to store on a refreshed source card.",
+                    "description": "Optional human/Illo-authored purpose to store on a refreshed source card.",
                 },
                 "source_notes": {
                     "type": "string",

--- a/docs/mcp-personal-tool-signals.md
+++ b/docs/mcp-personal-tool-signals.md
@@ -6,7 +6,7 @@ Parent PRD: `docs/prd-inbound-coordination-layer.md`
 ## Purpose
 
 Personal tools such as Codex, Claude Code, OpenCode, and local scripts should
-submit work progress to IloSpace as signals. They should not decide which Ilo
+submit work progress to IloSpace as signals. They should not decide which Illo
 thread, project, pin, or teammate should receive the update.
 
 The default hosted MCP tool is:
@@ -26,7 +26,19 @@ publishing only.
 {
   "kind": "signal",
   "origin": "codex.progress",
-  "payload": {},
+  "payload": {
+    "checkpoint": {
+      "summary": "Implemented the MCP submit-signal tool and tests.",
+      "source_tool": "codex",
+      "repo": "illospace-project",
+      "branch": "codex/mcp-submit-signal",
+      "task_title": "MCP personal-tool signal lane",
+      "files_touched": [
+        "brain/app/api/routers/agent_mcp.py",
+        "tests/test_external_agent_routes.py"
+      ]
+    }
+  },
   "summary": "Implemented the MCP submit-signal tool and tests.",
   "hints": {
     "source_tool": "codex",
@@ -69,6 +81,11 @@ has happened, such as:
 - a handoff summary is needed before stopping work.
 
 Hooks should avoid sending noise for every command, file read, or tiny edit.
+
+For `origin = codex.progress`, the hosted MCP adapter now backfills
+`payload.checkpoint` from the top-level summary and hints when callers do not
+provide one. This keeps simple hooks compatible with policies that require a
+Codex checkpoint while preserving any explicit payload fields the caller sends.
 
 ## Example Arguments
 

--- a/docs/prd-inbound-coordination-layer.md
+++ b/docs/prd-inbound-coordination-layer.md
@@ -1,6 +1,6 @@
 # PRD: Inbound Coordination Layer for IloSpace
 
-Status: living PRD; foundation shipped in PR #113, Illo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`
+Status: living PRD; foundation shipped in PR #113, Illo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`; E2E follow-up fixes implemented in the current branch
 Date: 2026-05-18  
 Owner: product/architecture discussion  
 
@@ -96,20 +96,33 @@ The PRD intentionally describes a broader product direction: external tools send
 - `get_source_card` is read-only in action policy metadata. `refresh_source_card` mutates only connection metadata and remains a high-risk audited action under the existing `manage_inbound` mutation gate.
 - Tests prove Illo can refresh a source card with purpose/notes/tags, persist it on the connection, summarize policies/projections/events/failures, and later read the persisted card.
 
+### Shipped In E2E Follow-Up Fix Slice
+
+- Hosted MCP `illo_submit_signal` now backfills `payload.checkpoint` for `origin=codex.progress`/Codex sources when callers only provide a top-level summary and hints. Explicit caller payload fields are preserved.
+- Inbound schema validation now supports top-level `desired_outcome` paths, so policies can require `desired_outcome` without forcing callers to duplicate it inside `payload`.
+- Successful bridge-token authentication now updates token `last_used_at`, connection `last_seen_at`, clears `last_error`, and moves a `pending` connection to `configured`. This resolves the deployed E2E caveat where a connection processed live traffic while still appearing pending.
+- Terminal Illo triage reconciliation now records compact observed-outcome attribution on the Decision Receipt tool use and copies it into the inbound event triage result.
+- Attribution uses existing `agent_run_events` only. It stores a deterministic summary, open-ended tags, tool names, target references, and run event ids; it does not store raw tool args/results or add a new table.
+- Source cards now aggregate observed outcome summaries, tags, tool names, and recent event ids by origin. This informs Illo about historical handling without auto-promoting rules or constraining future actions.
+- User-visible inbound/MCP strings touched in this slice use **Illo** for the agent name.
+- Verification for this slice:
+  - `venv/bin/python -m pytest tests/test_inbound_webhooks.py tests/test_external_agent_routes.py::test_hosted_mcp_submit_signal_builds_shared_envelope`: `17 passed`.
+  - `venv/bin/python -m pytest tests/test_inbound_admin_tools.py`: `9 passed`.
+  - `venv/bin/python -m pytest tests/test_external_agents_service.py tests/test_external_agent_routes.py`: `31 passed, 1 skipped`.
+
 ### Partially Shipped
 
-- **Decision receipts/effects**: inbound processing stores receipts/effects and now reconciles terminal Illo triage run status/final answer back onto the event and receipt. Rich action-level capture is still future work because Illo's later tool calls are not yet attributed back to the inbound event.
-- **Source policies**: deterministic policy matching exists, Illo can configure it, and Illo can replay historical events against current policy config. Observed handling summaries and source-card pattern memory are still future work.
+- **Decision receipts/effects**: inbound processing stores receipts/effects and now reconciles terminal Illo triage run status/final answer plus compact observed-outcome attribution back onto the event and receipt. Richer review workflows around those outcomes are still future work.
+- **Source policies**: deterministic policy matching exists, Illo can configure it, Illo can replay historical events against current policy config, and source cards can summarize observed outcomes. Source-card pattern memory is still informational only and does not change routing behavior.
 - **Domain Projection**: deterministic configured projection works and Illo can create/edit it, but projection targets still require an existing Domain/schema.
-- **Illo Action Runtime**: ambiguous events now enter Illo's normal Cortex run path, and run completion reconciles the inbound receipt. Fine-grained observed outcome attribution is still future work.
+- **Illo Action Runtime**: ambiguous events now enter Illo's normal Cortex run path, run completion reconciles the inbound receipt, and minimal observed outcome attribution captures what Illo did or inspected.
 - **MCP token scopes**: newly minted/default bridge tokens include `signal:submit`, and a compatibility migration/backfill grants it to old active personal-agent tokens. Arbitrary non-agent webhook/custom tokens still require explicit configuration.
 - **Observability**: Illo can inspect stored events and receipts, run read-only replay, and maintain connection-level source cards through `manage_inbound`. There is not yet a first-class inbound monitor or UI.
 
 ### Not Yet Shipped
 
 - Illo-facing tools for durable replay jobs and richer observed outcome review.
-- Fine-grained final action reconciliation after an Illo triage run completes: attributing the observed outcome, open tags, tool names, and target references back to the inbound event beyond the run's final answer/status.
-- Source-card pattern memory from repeated Decision Receipts, without automatically changing routing behavior.
+- Richer observed-outcome review workflows and source-card pattern memory from repeated Decision Receipts, without automatically changing routing behavior.
 - Persisted replay reports with named replay runs, saved diffs, and promotion candidates.
 - Source-card promotion into a richer monitor/domain/app view with trend history, ownership workflows, and suggested rule changes.
 - Native monitoring Cycle/app/Domain setup for inbound webhook/MCP activity.
@@ -131,10 +144,12 @@ The PRD intentionally describes a broader product direction: external tools send
    - Let the run processor act and inspect what Illo decides.
 4. **Deploy the token backfill/reconciliation slice** and confirm the existing Codex MCP token can call `illo_submit_signal` without rotation.
 5. **Deploy the replay harness + source-card slice** and ask Illo to replay a few real inbound events, refresh the source card for the tested MCP/webhook connection, and explain what it learned.
-6. **Add fine-grained Illo action attribution** so receipt reconciliation can say what Illo observed or did after triage, not only the terminal run status/final answer. This should store a deterministic plain-language summary, open-ended tags, tool names, and target references.
-7. **Add source-card observed outcome summaries** so Illo can see how similar events have been handled before. These summaries should inform Illo, not automatically promote deterministic rules or constrain Illo's future choices.
+6. **Deploy and retest the E2E follow-up fixes**: Codex MCP signal against the existing `codex.progress` policy, pending-to-configured connection state after live token traffic, and source-card observed outcome summaries after a completed Illo triage run.
+7. **Design the next observability layer** only after the deployed retest: persisted replay reports, richer source monitors, or a lightweight inbound activity app.
 
 ### Next Implementation Slice: Minimal Illo Action Attribution
+
+Status: implemented in the E2E follow-up fix slice; keep this section as the decision record for the implementation.
 
 The next implementation slice should be intentionally small. Attribution exists to improve Illo's awareness, not to constrain Illo's future choices or create a second decision-maker inside the deterministic layer.
 
@@ -176,19 +191,19 @@ This section is the running ledger for post-deploy validation. Keep failures her
 
 | Test | Status | Result | Notes |
 | --- | --- | --- | --- |
-| MCP signal from Codex session | Passed with caveat | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Illo run `214`. | The default ambiguous MCP path works. Caveat: `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and another `desired_outcome` path. Need inspect that policy before enabling real Codex hooks, or use a more specific hook origin. |
+| MCP signal from Codex session | Passed; follow-up fix implemented | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Illo run `214`. | The default ambiguous MCP path works. The deployed caveat was that `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and top-level `desired_outcome`. Fix implemented in code: MCP Codex signals now backfill `payload.checkpoint`, and schema validation can read `desired_outcome`. Needs post-deploy retest against the live policy. |
 | Webhook ambiguous signal | Passed | `POST /webhooks` returned `202` with event `849a179f-a787-4c7c-b8a2-9a5689ce1437`, `review_required`, no matched policy, Cortex idea `39798b40-84f3-42fb-ad78-88f3a0dedaab`, thread message `250`, and Illo run `215`. | Illo later inspected the event with `manage_inbound.get_event(include_receipts=true)` and confirmed reconciliation succeeded: event status `processed`, receipt `1b6c48ed-81e5-4940-838f-9b27f29b7504` status `processed`, run `215` completed, final answer `Triaged as no-op / resolved`, and `reconciled_at=2026-05-19T19:38:17.805159+00:00`. |
-| Webhook deterministic Domain Projection | Passed | Illo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Illo setup used `manage_inbound` plus Domain tools and returned dry-run success. Caveat: Illo reported the reused connection status as `pending`, even though the token and projection path processed live webhooks. Need decide whether active tokens should imply configured/active connection state or whether `pending` is acceptable for reused personal-source connections. |
+| Webhook deterministic Domain Projection | Passed; follow-up fix implemented | Illo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Illo setup used `manage_inbound` plus Domain tools and returned dry-run success. The deployed caveat was that Illo reported the reused connection status as `pending` despite live token traffic. Fix implemented in code: successful token authentication marks `pending` connections as `configured`, updates `last_seen_at`, updates token `last_used_at`, and clears `last_error`. Needs post-deploy retest. |
 | Replay harness and source card | Passed with expected drift | Illo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. | Projection events replayed stable. The 2 unmatched-path events replay as `review_required` while their stored status is now `processed` because Illo triage/reconciliation completed them; this is expected drift, but the replay UI should explain “current preflight prediction” vs “historical post-Illo outcome” clearly. Source card also surfaced the earlier `codex.progress` quarantine, which is useful operator feedback. |
 | MCP auth hardening | Passed | Invalid token call to `/api/mcp` returned HTTP `200` with MCP JSON-RPC error code `-32001`, message `MCP authentication failed: Invalid bridge token`, and data `{ "http_status": 401, "auth": "bearer" }`. | This confirms the deployed fix prevents the old client-side deserialize failure shape. |
 
 Post-deploy conclusion:
 
 - Core deployed E2E is green across hosted MCP signal submission, webhook ambiguous triage, deterministic Domain Projection create/update/idempotency, replay/source-card inspection, and MCP auth hardening.
-- Before enabling real automatic Codex hooks broadly, inspect the active `codex.progress` policy. It currently expects `payload.checkpoint`; a generic Codex progress signal without that field is quarantined.
-- Decide how source connection status should behave for reused personal/source connections. Connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b` processed real token traffic while Illo reported status `pending`.
+- The active `codex.progress` policy caveat has a code fix: Codex MCP signals now generate a checkpoint payload and schema validation can read top-level `desired_outcome`. Retest after deploy before enabling automatic hooks broadly.
+- The reused source connection `pending` caveat has a code fix: successful authenticated token traffic now marks pending connections configured and updates seen/used timestamps. Retest after deploy.
 - Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Illo reconciled outcomes.
-- Next implementation slice remains **fine-grained Illo action attribution**: receipts should capture a minimal observed outcome summary, open tags, tool names, and target references after triage, not only terminal run status/final answer.
+- Minimal Illo action attribution and source-card observed outcome summaries are implemented in code and covered by local tests. Retest after deploy with a live completed Illo triage run.
 
 ### Trace-Based Follow-Up
 

--- a/docs/prd-inbound-coordination-layer.md
+++ b/docs/prd-inbound-coordination-layer.md
@@ -1,14 +1,14 @@
 # PRD: Inbound Coordination Layer for IloSpace
 
-Status: living PRD; foundation shipped in PR #113, Ilo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`
+Status: living PRD; foundation shipped in PR #113, Illo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`
 Date: 2026-05-18  
 Owner: product/architecture discussion  
 
 ## Implementation Status After PR #113 And Admin Tool Slice
 
-PR #113 merged the first foundation slice. The follow-up admin tool slice adds the missing Ilo-facing configuration surface for the deterministic inbound lane. Phase 2 adds the first active Ilo triage handoff for ambiguous inbound signals. The replay harness slice lets Ilo evaluate historical inbound events against current policy/projection configuration without mutating workspace state. The source-card slice gives Ilo a durable, connection-level summary of what a source is for, how it is configured, what it sends, and where it is failing. Together, they still do **not** complete the entire PRD.
+PR #113 merged the first foundation slice. The follow-up admin tool slice adds the missing Illo-facing configuration surface for the deterministic inbound lane. Phase 2 adds the first active Illo triage handoff for ambiguous inbound signals. The replay harness slice lets Illo evaluate historical inbound events against current policy/projection configuration without mutating workspace state. The source-card slice gives Illo a durable, connection-level summary of what a source is for, how it is configured, what it sends, and where it is failing. Together, they still do **not** complete the entire PRD.
 
-The PRD intentionally describes a broader product direction: external tools send signals into IloSpace, IloSpace records and preflights them, and Ilo can configure every integration behavior by chatting with the user. The merged work delivered the shared ingress foundation and two concrete ingress lanes. The admin tool slice makes the shipped deterministic lane configurable by Ilo, without adding a manual configuration UI.
+The PRD intentionally describes a broader product direction: external tools send signals into IloSpace, IloSpace records and preflights them, and Illo can configure every integration behavior by chatting with the user. The merged work delivered the shared ingress foundation and two concrete ingress lanes. The admin tool slice makes the shipped deterministic lane configurable by Illo, without adding a manual configuration UI.
 
 ### Shipped In PR #113
 
@@ -28,36 +28,36 @@ The PRD intentionally describes a broader product direction: external tools send
 
 ### Shipped In `codex/illo-inbound-admin-tools`
 
-- Ilo-facing `manage_inbound` tool registered for coordinator and worker agents.
+- Illo-facing `manage_inbound` tool registered for coordinator and worker agents.
 - Chat-configurable External Source Connections with user/org authority context.
 - Least-privilege token minting for inbound signal sources, defaulting to `signal:submit`.
 - Source token metadata listing/get and token revocation without re-exposing raw token secrets.
 - Source policy creation/update/list/get with origin patterns, envelope kinds, instructions, schema config, allowed actions, thresholds, review mode, metadata, and enabled/priority controls.
 - Domain Projection creation/update/list/get for deterministic writes into existing IloSpace Domains.
 - Policy/projection safety check that a projection policy belongs to the same connection.
-- Automatic `domain_projection.upsert` permission on the policy when Ilo creates a projection for that policy.
+- Automatic `domain_projection.upsert` permission on the policy when Illo creates a projection for that policy.
 - Inbound event listing/get with optional raw payload and normalized envelope details.
 - Decision receipt listing/get through event detail inspection.
-- Dry-run matching so Ilo can test a sample origin/payload against the current policy/projection config without storing an event.
+- Dry-run matching so Illo can test a sample origin/payload against the current policy/projection config without storing an event.
 - Action manifest/read-only policy metadata so read operations stay inspectable and mutating config/token operations remain high-risk audited actions.
-- Tests proving Ilo can configure a connection, mint a scoped token, create policy/projection config, dry-run routing, process a real inbound envelope through that config, and inspect logs/receipts.
+- Tests proving Illo can configure a connection, mint a scoped token, create policy/projection config, dry-run routing, process a real inbound envelope through that config, and inspect logs/receipts.
 
 ### Shipped In Phase 2 Triage Handoff
 
-- Review-required inbound outcomes now create an inbound-origin Cortex Idea and seed a thread message for Ilo.
+- Review-required inbound outcomes now create an inbound-origin Cortex Idea and seed a thread message for Illo.
 - The triage thread message carries the signal reason, source identity, origin, summary, desired outcome, policy instructions when present, hints, and a bounded payload preview.
-- The inbound service admits an Ilo Cortex run through the shared `work_intake` API instead of writing to the run store directly.
+- The inbound service admits an Illo Cortex run through the shared `work_intake` API instead of writing to the run store directly.
 - Decision receipts for ambiguous events now persist the triage target (`cortex_idea`) and tool-use handoff (`illo_triage`) with run id when admission succeeds.
 - Webhook and MCP signals share the same triage path when no source policy matches.
-- Matched policies without a deterministic projection, and policies whose projection action is not allowed, route into Ilo triage instead of stopping as passive store-only review.
-- Projection validation failures configured as `review_required` route into Ilo triage; `quarantined` and `failed` outcomes remain terminal.
+- Matched policies without a deterministic projection, and policies whose projection action is not allowed, route into Illo triage instead of stopping as passive store-only review.
+- Projection validation failures configured as `review_required` route into Illo triage; `quarantined` and `failed` outcomes remain terminal.
 - Tests prove ambiguous webhook/MCP signals queue triage runs, create thread context, persist receipt target/tool-use metadata, and preserve the work-intake architecture boundary.
 
 ### Latest Progress In This Branch
 
-- Added final-result reconciliation for inbound triage runs when Ilo reaches a terminal run status.
-- Inbound events that were handed to Ilo now move from `review_required` to `processed` after a completed Ilo run, or `failed` after a failed/canceled/expired run.
-- Decision receipts now retain the original triage handoff and also record run status, reconciliation timestamp, completion timestamp when available, and final answer text when Ilo produced one.
+- Added final-result reconciliation for inbound triage runs when Illo reaches a terminal run status.
+- Inbound events that were handed to Illo now move from `review_required` to `processed` after a completed Illo run, or `failed` after a failed/canceled/expired run.
+- Decision receipts now retain the original triage handoff and also record run status, reconciliation timestamp, completion timestamp when available, and final answer text when Illo produced one.
 - Added a compatibility service and Alembic migration to grant `signal:submit` to old active personal-agent bridge tokens that predate PR #113.
 - Backfill is restricted to active personal-agent-like connections (`hosted_mcp`, `bridge_pull`, or known personal-agent kinds such as Codex/Hermes/OpenClaw/OpenCode/Claude Code), and does not widen arbitrary webhook/custom tokens.
 - Migration downgrade deliberately does not remove `signal:submit`, because post-upgrade user grants cannot be distinguished from automatic backfill safely.
@@ -77,39 +77,39 @@ The PRD intentionally describes a broader product direction: external tools send
 
 ### Shipped In Replay Harness Slice
 
-- Added `manage_inbound(action="replay_events")` as an Ilo-facing read-only replay operation.
+- Added `manage_inbound(action="replay_events")` as an Illo-facing read-only replay operation.
 - Replay can inspect one event by `event_id` or a batch of stored events filtered by connection, policy, status, origin, and limit.
 - Replay reuses the same policy/projection preview logic as `dry_run_match`, but the input comes from stored inbound event envelopes instead of a new sample payload.
 - Replay returns original decision metadata, current replay prediction, change flags for policy/projection/status drift, and an aggregate summary.
 - Replay can optionally include stored raw/normalized payloads for inspection, but omits payloads by default.
 - Replay does not call `submit_inbound_envelope`, does not create decision receipts, does not mutate inbound event state, and does not write Domain records.
-- `replay_events` is marked as a read-only `manage_inbound` action in action policy metadata, so Ilo can use it without a high-risk mutation approval path.
+- `replay_events` is marked as a read-only `manage_inbound` action in action policy metadata, so Illo can use it without a high-risk mutation approval path.
 - Tests prove replay can compare processed historical events against changed policy config without mutating Domain records or event state, and can include payloads for single-event inspection.
 
 ### Shipped In Source Cards Slice
 
-- Added `manage_inbound(action="get_source_card")` as a read-only Ilo-facing summary of one inbound source connection.
-- Added `manage_inbound(action="refresh_source_card")` so Ilo can persist the latest source card on the connection metadata.
-- Source cards summarize connection identity/capabilities, Ilo-authored purpose/notes/tags, configured policies, Domain Projections, sampled origins, sampled statuses, payload shape paths, recent events, and recent failures.
-- Source cards reuse existing connection metadata instead of adding a new table in this slice. This keeps the slice small and avoids schema churn while preserving a durable summary Ilo can read later.
+- Added `manage_inbound(action="get_source_card")` as a read-only Illo-facing summary of one inbound source connection.
+- Added `manage_inbound(action="refresh_source_card")` so Illo can persist the latest source card on the connection metadata.
+- Source cards summarize connection identity/capabilities, Illo-authored purpose/notes/tags, configured policies, Domain Projections, sampled origins, sampled statuses, payload shape paths, recent events, and recent failures.
+- Source cards reuse existing connection metadata instead of adding a new table in this slice. This keeps the slice small and avoids schema churn while preserving a durable summary Illo can read later.
 - Payload values are not stored in the card; the card stores payload shape paths and event ids/statuses. Raw payload inspection remains behind event/replay reads with `include_payload`.
 - `get_source_card` is read-only in action policy metadata. `refresh_source_card` mutates only connection metadata and remains a high-risk audited action under the existing `manage_inbound` mutation gate.
-- Tests prove Ilo can refresh a source card with purpose/notes/tags, persist it on the connection, summarize policies/projections/events/failures, and later read the persisted card.
+- Tests prove Illo can refresh a source card with purpose/notes/tags, persist it on the connection, summarize policies/projections/events/failures, and later read the persisted card.
 
 ### Partially Shipped
 
-- **Decision receipts/effects**: inbound processing stores receipts/effects and now reconciles terminal Ilo triage run status/final answer back onto the event and receipt. Rich action-level capture is still future work because Ilo's later tool calls are not yet attributed back to the inbound event.
-- **Source policies**: deterministic policy matching exists, Ilo can configure it, and Ilo can replay historical events against current policy config. Learned rule promotion and payload fingerprinting are still future work.
-- **Domain Projection**: deterministic configured projection works and Ilo can create/edit it, but projection targets still require an existing Domain/schema.
-- **Ilo Action Runtime**: ambiguous events now enter Ilo's normal Cortex run path, and run completion reconciles the inbound receipt. Fine-grained action-result capture and learned-rule promotion are still future work.
+- **Decision receipts/effects**: inbound processing stores receipts/effects and now reconciles terminal Illo triage run status/final answer back onto the event and receipt. Rich action-level capture is still future work because Illo's later tool calls are not yet attributed back to the inbound event.
+- **Source policies**: deterministic policy matching exists, Illo can configure it, and Illo can replay historical events against current policy config. Observed handling summaries and source-card pattern memory are still future work.
+- **Domain Projection**: deterministic configured projection works and Illo can create/edit it, but projection targets still require an existing Domain/schema.
+- **Illo Action Runtime**: ambiguous events now enter Illo's normal Cortex run path, and run completion reconciles the inbound receipt. Fine-grained observed outcome attribution is still future work.
 - **MCP token scopes**: newly minted/default bridge tokens include `signal:submit`, and a compatibility migration/backfill grants it to old active personal-agent tokens. Arbitrary non-agent webhook/custom tokens still require explicit configuration.
-- **Observability**: Ilo can inspect stored events and receipts, run read-only replay, and maintain connection-level source cards through `manage_inbound`. There is not yet a first-class inbound monitor or UI.
+- **Observability**: Illo can inspect stored events and receipts, run read-only replay, and maintain connection-level source cards through `manage_inbound`. There is not yet a first-class inbound monitor or UI.
 
 ### Not Yet Shipped
 
-- Ilo-facing tools for durable replay jobs, rule candidates, learned payload fingerprints, and automatic rule promotion.
-- Fine-grained final action reconciliation after an Ilo triage run completes: attributing actual workspace tool calls, no-op decisions, questions, summaries, or scheduled follow-ups back to the inbound event beyond the run's final answer/status.
-- Rule learner / payload fingerprint promotion from repeated Decision Receipts into deterministic policy.
+- Illo-facing tools for durable replay jobs and richer observed outcome review.
+- Fine-grained final action reconciliation after an Illo triage run completes: attributing the observed outcome, open tags, tool names, and target references back to the inbound event beyond the run's final answer/status.
+- Source-card pattern memory from repeated Decision Receipts, without automatically changing routing behavior.
 - Persisted replay reports with named replay runs, saved diffs, and promotion candidates.
 - Source-card promotion into a richer monitor/domain/app view with trend history, ownership workflows, and suggested rule changes.
 - Native monitoring Cycle/app/Domain setup for inbound webhook/MCP activity.
@@ -117,22 +117,54 @@ The PRD intentionally describes a broader product direction: external tools send
 
 ### Recommended Next Slice
 
-1. **Merge and deploy `manage_inbound`** so Ilo can actually configure the inbound layer in production chat.
-2. **Run one real Ilo-driven configuration smoke test**:
-   - Ask Ilo to create or inspect a source connection.
-   - Ask Ilo to mint a `signal:submit` token.
-   - Ask Ilo to create a policy and Domain Projection for a known test payload.
+1. **Merge and deploy `manage_inbound`** so Illo can actually configure the inbound layer in production chat.
+2. **Run one real Illo-driven configuration smoke test**:
+   - Ask Illo to create or inspect a source connection.
+   - Ask Illo to mint a `signal:submit` token.
+   - Ask Illo to create a policy and Domain Projection for a known test payload.
    - Send a webhook or MCP signal through the configured lane.
-   - Ask Ilo to inspect the event and receipt.
+   - Ask Illo to inspect the event and receipt.
 3. **Run one real ambiguous-signal smoke test**:
    - Send a webhook or MCP signal that has no matching deterministic policy.
    - Confirm the inbound event stores `review_required`.
-   - Confirm a Cortex Idea/thread/run is created for Ilo triage.
-   - Let the run processor act and inspect what Ilo decides.
+   - Confirm a Cortex Idea/thread/run is created for Illo triage.
+   - Let the run processor act and inspect what Illo decides.
 4. **Deploy the token backfill/reconciliation slice** and confirm the existing Codex MCP token can call `illo_submit_signal` without rotation.
-5. **Deploy the replay harness + source-card slice** and ask Ilo to replay a few real inbound events, refresh the source card for the tested MCP/webhook connection, and explain what it learned.
-6. **Add fine-grained Ilo action attribution** so receipt reconciliation can say which workspace tools/actions Ilo actually chose after triage, not only the terminal run status/final answer.
-7. **Add rule candidates / payload fingerprints** so repeated replay and receipt patterns can become explicit deterministic-policy suggestions.
+5. **Deploy the replay harness + source-card slice** and ask Illo to replay a few real inbound events, refresh the source card for the tested MCP/webhook connection, and explain what it learned.
+6. **Add fine-grained Illo action attribution** so receipt reconciliation can say what Illo observed or did after triage, not only the terminal run status/final answer. This should store a deterministic plain-language summary, open-ended tags, tool names, and target references.
+7. **Add source-card observed outcome summaries** so Illo can see how similar events have been handled before. These summaries should inform Illo, not automatically promote deterministic rules or constrain Illo's future choices.
+
+### Next Implementation Slice: Minimal Illo Action Attribution
+
+The next implementation slice should be intentionally small. Attribution exists to improve Illo's awareness, not to constrain Illo's future choices or create a second decision-maker inside the deterministic layer.
+
+Decisions for this slice:
+
+- Attribution is **outcome-first**, but not taxonomy-first. Store a deterministic plain-language `summary`, open-ended `tags`, `tool_names`, and `target_refs`.
+- Do **not** introduce a closed `outcome_class` enum. If Illo does something novel, the summary still works and tags can evolve naturally.
+- Use existing `agent_run_events` as the source of truth for observed tool calls. Do not add a new attribution table in this slice.
+- Run attribution only during terminal inbound triage reconciliation. Do not stream partial attribution while Illo is still working.
+- Infer attribution in the backend from run events and final status. Do not call another LLM just to label the result.
+- Store the canonical compact attribution on the matching Decision Receipt, and copy the same compact object into the inbound event's triage result for easier event/source-card reads.
+- Treat no-op and inspected-only outcomes as successful observed outcomes when Illo intentionally resolves a signal without mutating workspace state.
+- Source cards should aggregate observed outcome summaries by origin and tool names, using open-ended tags. They should say what happened before, not recommend or auto-promote a rule.
+- Hard lists are acceptable for backend mechanics and safety, such as statuses, action names, projection write modes, and validation failure statuses. Hard lists are not acceptable as boundaries on Illo's possible intent, meaning, outcomes, or future choices.
+
+Minimal attribution shape:
+
+```json
+{
+  "summary": "Illo created a ticket record for E2E-123 in the E2E Projection Domain.",
+  "tags": ["domain_record", "created"],
+  "tool_names": ["manage_domain"],
+  "target_refs": [
+    {"kind": "domain_record", "domain_id": 11, "record_id": 220}
+  ],
+  "run_event_ids": [1234]
+}
+```
+
+The `run_event_ids` field is a trace back to the runtime event log. The attribution payload should not duplicate full tool arguments, full tool results, raw inbound payloads, or long model answers.
 
 ### Deployed E2E Test Ledger
 
@@ -144,36 +176,36 @@ This section is the running ledger for post-deploy validation. Keep failures her
 
 | Test | Status | Result | Notes |
 | --- | --- | --- | --- |
-| MCP signal from Codex session | Passed with caveat | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Ilo run `214`. | The default ambiguous MCP path works. Caveat: `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and another `desired_outcome` path. Need inspect that policy before enabling real Codex hooks, or use a more specific hook origin. |
-| Webhook ambiguous signal | Passed | `POST /webhooks` returned `202` with event `849a179f-a787-4c7c-b8a2-9a5689ce1437`, `review_required`, no matched policy, Cortex idea `39798b40-84f3-42fb-ad78-88f3a0dedaab`, thread message `250`, and Ilo run `215`. | Ilo later inspected the event with `manage_inbound.get_event(include_receipts=true)` and confirmed reconciliation succeeded: event status `processed`, receipt `1b6c48ed-81e5-4940-838f-9b27f29b7504` status `processed`, run `215` completed, final answer `Triaged as no-op / resolved`, and `reconciled_at=2026-05-19T19:38:17.805159+00:00`. |
-| Webhook deterministic Domain Projection | Passed | Ilo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Ilo setup used `manage_inbound` plus Domain tools and returned dry-run success. Caveat: Ilo reported the reused connection status as `pending`, even though the token and projection path processed live webhooks. Need decide whether active tokens should imply configured/active connection state or whether `pending` is acceptable for reused personal-source connections. |
-| Replay harness and source card | Passed with expected drift | Ilo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. | Projection events replayed stable. The 2 unmatched-path events replay as `review_required` while their stored status is now `processed` because Ilo triage/reconciliation completed them; this is expected drift, but the replay UI should explain “current preflight prediction” vs “historical post-Ilo outcome” clearly. Source card also surfaced the earlier `codex.progress` quarantine, which is useful operator feedback. |
+| MCP signal from Codex session | Passed with caveat | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Illo run `214`. | The default ambiguous MCP path works. Caveat: `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and another `desired_outcome` path. Need inspect that policy before enabling real Codex hooks, or use a more specific hook origin. |
+| Webhook ambiguous signal | Passed | `POST /webhooks` returned `202` with event `849a179f-a787-4c7c-b8a2-9a5689ce1437`, `review_required`, no matched policy, Cortex idea `39798b40-84f3-42fb-ad78-88f3a0dedaab`, thread message `250`, and Illo run `215`. | Illo later inspected the event with `manage_inbound.get_event(include_receipts=true)` and confirmed reconciliation succeeded: event status `processed`, receipt `1b6c48ed-81e5-4940-838f-9b27f29b7504` status `processed`, run `215` completed, final answer `Triaged as no-op / resolved`, and `reconciled_at=2026-05-19T19:38:17.805159+00:00`. |
+| Webhook deterministic Domain Projection | Passed | Illo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Illo setup used `manage_inbound` plus Domain tools and returned dry-run success. Caveat: Illo reported the reused connection status as `pending`, even though the token and projection path processed live webhooks. Need decide whether active tokens should imply configured/active connection state or whether `pending` is acceptable for reused personal-source connections. |
+| Replay harness and source card | Passed with expected drift | Illo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. | Projection events replayed stable. The 2 unmatched-path events replay as `review_required` while their stored status is now `processed` because Illo triage/reconciliation completed them; this is expected drift, but the replay UI should explain “current preflight prediction” vs “historical post-Illo outcome” clearly. Source card also surfaced the earlier `codex.progress` quarantine, which is useful operator feedback. |
 | MCP auth hardening | Passed | Invalid token call to `/api/mcp` returned HTTP `200` with MCP JSON-RPC error code `-32001`, message `MCP authentication failed: Invalid bridge token`, and data `{ "http_status": 401, "auth": "bearer" }`. | This confirms the deployed fix prevents the old client-side deserialize failure shape. |
 
 Post-deploy conclusion:
 
 - Core deployed E2E is green across hosted MCP signal submission, webhook ambiguous triage, deterministic Domain Projection create/update/idempotency, replay/source-card inspection, and MCP auth hardening.
 - Before enabling real automatic Codex hooks broadly, inspect the active `codex.progress` policy. It currently expects `payload.checkpoint`; a generic Codex progress signal without that field is quarantined.
-- Decide how source connection status should behave for reused personal/source connections. Connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b` processed real token traffic while Ilo reported status `pending`.
-- Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Ilo reconciled outcomes.
-- Next implementation slice remains **fine-grained Ilo action attribution**: receipts should capture which workspace tools/actions Ilo used after triage, not only terminal run status/final answer.
+- Decide how source connection status should behave for reused personal/source connections. Connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b` processed real token traffic while Illo reported status `pending`.
+- Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Illo reconciled outcomes.
+- Next implementation slice remains **fine-grained Illo action attribution**: receipts should capture a minimal observed outcome summary, open tags, tool names, and target references after triage, not only terminal run status/final answer.
 
 ### Trace-Based Follow-Up
 
-After deployment, Codex sent a compatibility-thread update to Ilo and inspected the exported thread trace. Ilo correctly understood the rollout and could use general workspace tools (`manage_domain`, `manage_workspace_app`, `manage_cycle`, `manage_idea`), but it did not have native inbound-admin tools yet. That confirmed the next implementation slice should be the **Ilo Configuration Tool Surface**, not another manual UI. The `manage_inbound` tool in this branch is that slice.
+After deployment, Codex sent a compatibility-thread update to Illo and inspected the exported thread trace. Illo correctly understood the rollout and could use general workspace tools (`manage_domain`, `manage_workspace_app`, `manage_cycle`, `manage_idea`), but it did not have native inbound-admin tools yet. That confirmed the next implementation slice should be the **Illo Configuration Tool Surface**, not another manual UI. The `manage_inbound` tool in this branch is that slice.
 
 ## Naming And Scope
 
 This PRD uses the following vocabulary deliberately:
 
 - **IloSpace** means the whole workspace, codebase, product, and team coordination system.
-- **Ilo** means the agent that lives inside IloSpace: the LLM-powered coordinator that can reason, use skills, and call tools.
+- **Illo** means the agent that lives inside IloSpace: the LLM-powered coordinator that can reason, use skills, and call tools.
 - **External Source Connection** means any outside tool, app, agent, webhook source, IDE, script, or personal worker connected to IloSpace.
 - **Inbound Signal** means something an external source tells IloSpace happened.
 - **External Task** means work IloSpace asks an external source to do.
-- **Ilo Outcome** means the result of Ilo handling a signal. It may be a tool call, a workspace mutation, a stored note, a summary, a question to a human, a no-op, a scheduled follow-up, or another action Ilo can perform with its available skills and tools.
+- **Illo Outcome** means the result of Illo handling a signal. It may be a tool call, a workspace mutation, a stored note, a summary, a question to a human, a no-op, a scheduled follow-up, or another action Illo can perform with its available skills and tools.
 
-Current implementation and repo docs may still use the existing `Illospace` / `Illo` spelling and `illo_*` API/tool prefixes. This PRD is about product architecture and uses the requested conceptual distinction: **IloSpace is the system; Ilo is the agent**.
+Current implementation and repo docs may still use the existing `Illospace` / `Illo` spelling and `illo_*` API/tool prefixes. This PRD is about product architecture and uses the requested conceptual distinction: **IloSpace is the system; Illo is the agent**.
 
 ## Problem Statement
 
@@ -181,14 +213,14 @@ Teams increasingly work through many personal and external tools: Codex, Hermes,
 
 That creates the wrong burden. External tools are good at doing local work, observing their own state, and sending factual updates. They are not the right place to decide how team context should be organized across IloSpace threads, ideas, pins, projects, notifications, and agent runs.
 
-At the same time, routing every incoming event through a full Ilo reasoning loop would be too slow, expensive, and noisy. A Jira webhook that always sends the same issue event should not make Ilo repeatedly rediscover what Jira is, what the payload means, and where it probably belongs. Repeated judgment should become reusable system knowledge.
+At the same time, routing every incoming event through a full Illo reasoning loop would be too slow, expensive, and noisy. A Jira webhook that always sends the same issue event should not make Illo repeatedly rediscover what Jira is, what the payload means, and where it probably belongs. Repeated judgment should become reusable system knowledge.
 
 The product needs a bare but strong foundation for inbound coordination:
 
 - external tools submit signals and intent into IloSpace;
 - IloSpace records, authenticates, normalizes, dedupes, and applies known policy deterministically;
-- Ilo handles ambiguity and chooses what to do using its skills and tools when the deterministic layer cannot safely shortcut;
-- repeated Ilo handling decisions become decision receipts, learned patterns, and eventually deterministic rules;
+- Illo handles ambiguity and chooses what to do using its skills and tools when the deterministic layer cannot safely shortcut;
+- repeated Illo handling decisions become decision receipts and observed handling patterns that Illo can use as context before it chooses whether to configure deterministic shortcuts;
 - personal agents can still receive tasks from IloSpace without being conflated with simple inbound webhook sources.
 
 ## Solution
@@ -202,8 +234,8 @@ Connections can have capabilities such as:
 - submit inbound signals;
 - receive external tasks from IloSpace;
 - report task events and task results;
-- ask Ilo for private workspace context;
-- submit explicit requests for Ilo to consider, when strongly scoped and explicitly targeted.
+- ask Illo for private workspace context;
+- submit explicit requests for Illo to consider, when strongly scoped and explicitly targeted.
 
 The default inbound API/MCP/webhook primitive should be signal submission, not direct workspace mutation. External tools should generally say:
 
@@ -211,25 +243,25 @@ The default inbound API/MCP/webhook primitive should be signal submission, not d
 
 They should not generally say:
 
-> “Post this to that thread and trigger Ilo.”
+> “Post this to that thread and trigger Illo.”
 
-IloSpace should route incoming envelopes through deterministic preflight first. If the signal has an explicit task binding, explicit approved target, source rule, idempotency match, known payload fingerprint, or learned pattern, IloSpace can resolve the envelope without invoking Ilo. If the signal is ambiguous, Ilo handles it directly: it reasons over the signal, uses its available tools and skills, chooses whether anything should happen, and records a Decision Receipt. Over time, repeated receipts can promote into source rules or learned patterns so future events bypass or minimize Ilo reasoning.
+IloSpace should route incoming envelopes through deterministic preflight first. If the signal has an explicit task binding, explicit approved target, source rule, or idempotency match, IloSpace can resolve the envelope without invoking Illo. If the signal is ambiguous, Illo handles it directly: it reasons over the signal, uses its available tools and skills, chooses whether anything should happen, and records a Decision Receipt. Over time, repeated receipts become observed handling patterns that help Illo understand the source faster. Illo may then choose to configure a deterministic shortcut using its tools, but the system should not silently promote rules behind Illo's back.
 
 Existing Hermes/OpenClaw work remains valuable. It becomes the first implemented specialization of this broader model: a personal-agent connection that can receive outbound tasks and report results. Jira/GitHub/Figma-style sources are connections that mostly submit inbound signals. Codex can be either: a normal session may only submit signals, while a long-running Codex daemon could also receive tasks.
 
-## Ilo-First Configuration Principle
+## Illo-First Configuration Principle
 
-All configuration must be possible through Ilo. Users should configure inbound integrations, source policies, schemas, instructions, thresholds, tool-use/outcome permissions, replay tests, and rule promotion by chatting with Ilo.
+All configuration must be possible through Illo. Users should configure inbound integrations, source policies, schemas, instructions, thresholds, deterministic preflight actions, replay tests, and observed-pattern review by chatting with Illo.
 
-V1 should not build an integration builder UI, schema builder UI, drag/drop priority UI, or manual settings dashboard. The implementation should build durable configuration services and expose them to Ilo as tools. A UI may emerge later on top of the same services, but it is not the product surface for this PRD.
+V1 should not build an integration builder UI, schema builder UI, drag/drop priority UI, or manual settings dashboard. The implementation should build durable configuration services and expose them to Illo as tools. A UI may emerge later on top of the same services, but it is not the product surface for this PRD.
 
-Observability is allowed and useful, but it is not configuration. V1 may expose server-style logs, event details, dry-run results, replay results, and current config snapshots so humans can inspect what happened. Changes still go through Ilo.
+Observability is allowed and useful, but it is not configuration. V1 may expose server-style logs, event details, dry-run results, replay results, and current config snapshots so humans can inspect what happened. Changes still go through Illo.
 
 The product principle is:
 
-> If a human could configure it, Ilo must have a tool to configure it.
+> If a human could configure it, Illo must have a tool to configure it.
 
-Ilo configuration and inbound handling should always have an authority principal. Even when the event comes from MCP, a webhook, or an external agent, the connection should resolve to the user who configured it, requested it, or owns that personal connection. Ilo acts on behalf of that user, and backend permission checks use that user/org context.
+Illo configuration and inbound handling should always have an authority principal. Even when the event comes from MCP, a webhook, or an external agent, the connection should resolve to the user who configured it, requested it, or owns that personal connection. Illo acts on behalf of that user, and backend permission checks use that user/org context.
 
 ## V1 Alignment And Parallel Work Split
 
@@ -237,7 +269,7 @@ The webhook integration workstream and the MCP/personal-tool workstream should l
 
 The shared rule is:
 
-> Different ingress, same envelope, same deterministic preflight, same Ilo action runtime.
+> Different ingress, same envelope, same deterministic preflight, same Illo action runtime.
 
 ### Shared Foundation Workstream
 
@@ -247,12 +279,12 @@ The foundation owns:
 
 - External Source Connection identity, auth, org/workspace scope, source type, capabilities, and status.
 - Inbound Envelope persistence for raw payload, normalized payload, idempotency, status, source metadata, and processing result.
-- Source Policy lookup for allowed envelope kinds, instructions, origin patterns, tool-use/outcome permissions, thresholds, review mode, and schema expectations.
-- Deterministic policy evaluation before Ilo reasoning.
-- Ilo action runtime interface that lets Ilo handle ambiguous signals using its available tools and skills.
-- Decision Receipt persistence for outcome, confidence, target, tool use, reasoning summary, features used, and reusable-pattern candidate.
+- Source Policy lookup for allowed envelope kinds, instructions, origin patterns, deterministic preflight actions, thresholds, review mode, and schema expectations.
+- Deterministic policy evaluation before Illo reasoning.
+- Illo action runtime interface that lets Illo handle ambiguous signals using its available tools and skills.
+- Decision Receipt persistence for outcome, confidence, target, tool use, reasoning summary, features used, and observed outcome summary.
 - Tool/runtime guardrails for permissions, review/quarantine outcomes, dry-run, and safe execution.
-- Ilo configuration tools for every configurable field in the foundation.
+- Illo configuration tools for every configurable field in the foundation.
 
 The foundation should expose one internal service interface that both product surfaces call:
 
@@ -296,10 +328,10 @@ Webhook V1 owns:
 - Authenticated integration connection or integration token.
 - Minimal external payload: `origin` and `payload`, plus optional idempotency/header metadata.
 - Origin pattern matching with explicit priority/order.
-- Incoming schema configuration model that Ilo can populate through tools and the backend can compile to internal JSON Schema or equivalent validation.
-- Integration instructions for Ilo handling.
-- Allowed outcomes/tool use and auto-execute thresholds.
-- Optional Domain Projection configuration, created by Ilo, for sources that should store structured records without requiring Ilo reasoning on every event.
+- Incoming schema configuration model that Illo can populate through tools and the backend can compile to internal JSON Schema or equivalent validation.
+- Integration instructions for Illo handling.
+- Deterministic preflight actions and auto-execute thresholds.
+- Optional Domain Projection configuration, created by Illo, for sources that should store structured records without requiring Illo reasoning on every event.
 - Dry-run/test payload flow.
 - Event logs.
 - Replay.
@@ -313,19 +345,19 @@ POST /webhooks                -> webhook ingress
 origin + payload              -> Inbound Envelope
 origin_patterns + priority    -> deterministic source policy matching
 integration_events            -> Inbound Envelope/Event Store
-LLM strict plan               -> Ilo outcome / receipt
-allowed_outcomes/tool_use + thresholds  -> tool/runtime guardrails
+LLM strict plan               -> Illo outcome / receipt
+deterministic actions + thresholds      -> tool/runtime guardrails
 event logs + replay           -> receipt/replay/audit tooling
 ```
 
 For V1 webhook outcomes:
 
-- Ilo may open a Cortex thread above threshold when source policy permits it.
-- Ilo may create memory above threshold when source policy permits it, but the result must preserve source provenance and remain easy to inspect/delete.
-- Ad hoc Domain writes proposed by Ilo while handling an ambiguous payload must start in review/dry-run, because Ilo is inventing or choosing structured writes at event time.
-- Configured Domain Projections may auto-create or auto-update records when Ilo has already created or selected the Domain, object type, field mapping, external id strategy, principal, and policy. In that path, each event still stores a raw inbound event first, then deterministic validation/upsert writes into the Domain if the projection contract passes.
+- Deterministic preflight may open a Cortex thread above threshold when source policy permits that specific shortcut.
+- Deterministic preflight may create memory above threshold when source policy permits that specific shortcut, but the result must preserve source provenance and remain easy to inspect/delete.
+- Ad hoc Domain writes proposed by Illo while handling an ambiguous payload must start in review/dry-run, because Illo is inventing or choosing structured writes at event time.
+- Configured Domain Projections may auto-create or auto-update records when Illo has already created or selected the Domain, object type, field mapping, external id strategy, principal, and policy. In that path, each event still stores a raw inbound event first, then deterministic validation/upsert writes into the Domain if the projection contract passes.
 
-Webhook integrations have a **source actor identity** and an **authority principal**. The source actor identifies the external system that sent the event. The authority principal is the user who configured, requested, or owns that source connection. Ilo acts and permissions are checked under the authority principal, while provenance still shows the external source actor. Both must be scoped to one IloSpace workspace/org and must never imply cross-org global write access.
+Webhook integrations have a **source actor identity** and an **authority principal**. The source actor identifies the external system that sent the event. The authority principal is the user who configured, requested, or owns that source connection. Illo acts and permissions are checked under the authority principal, while provenance still shows the external source actor. Both must be scoped to one IloSpace workspace/org and must never imply cross-org global write access.
 
 ### MCP / Personal Tool Signal Workstream
 
@@ -344,7 +376,7 @@ MCP V1 owns:
 The MCP lane should treat direct `create_thread` / `post_thread_message` style tools as advanced or compatibility tools, not the default path. The default path is:
 
 ```text
-Personal tool -> hosted MCP submit signal -> Inbound Envelope -> Source Policy -> deterministic preflight or Ilo action runtime -> Ilo Outcome
+Personal tool -> hosted MCP submit signal -> Inbound Envelope -> Source Policy -> deterministic preflight or Illo action runtime -> Illo Outcome
 ```
 
 The MCP lane should not block on webhook observability surfaces. It only needs the shared foundation service and a connection/token with `can_submit_signals`.
@@ -387,8 +419,8 @@ Both must produce:
 - an authenticated External Source Connection;
 - a stored Inbound Envelope/Event;
 - a matched Source Policy or default policy;
-- a deterministic decision or Ilo Decision Receipt;
-- an Ilo Outcome or review/quarantine outcome;
+- a deterministic decision or Illo Decision Receipt;
+- an Illo Outcome or review/quarantine outcome;
 - provenance visible in logs and any workspace projection.
 
 ## Two-PR Parallel Ownership Plan
@@ -400,7 +432,7 @@ The shared contract must be agreed before coding:
 - `submit_inbound_envelope(connection, envelope, ingress_context) -> InboundProcessingResult`
 - envelope shape, result shape, status enum, source actor, authority principal, idempotency behavior, and provenance expectations;
 - table/model names for external source connections, inbound events, source policies, Domain Projections, and Decision Receipts;
-- rule that all configuration is done through Ilo tools, not a manual configuration UI.
+- rule that all configuration is done through Illo tools, not a manual configuration UI.
 
 If one PR lands the shared contract first, the other PR should rebase onto it. If both PRs are developed at the same time, Reda's MCP PR may mock the shared service in tests, but the mock is only a test boundary. Production behavior must call the real shared service after the PRs are merged.
 
@@ -416,8 +448,8 @@ JB implementation scope:
 - Webhook authentication / integration token handling.
 - Origin pattern matching and priority/order evaluation.
 - Raw payload storage, normalized payload storage, idempotency, status transitions, and replayable event state.
-- Ilo-configurable source policy fields needed for webhooks.
-- Ilo-configurable Domain Projection fields: Domain id, object key, external id field, field mapping, upsert mode, validation behavior, review/quarantine behavior, and authority principal.
+- Illo-configurable source policy fields needed for webhooks.
+- Illo-configurable Domain Projection fields: Domain id, object key, external id field, field mapping, upsert mode, validation behavior, review/quarantine behavior, and authority principal.
 - Domain Projection engine that writes into existing IloSpace Domains after validation and idempotency.
 - Webhook logs, dry-run, replay, and server-side observability needed for debugging.
 
@@ -474,8 +506,8 @@ The original split expected these tests to be blocked until the webhook/MCP foun
 - Real MCP `illo_submit_signal` persists through JB's real `submit_inbound_envelope` service: shipped in PR #113 and covered by tests.
 - Webhook and MCP inputs produce the same internal record types and status transitions: shipped in PR #113 and covered by tests.
 - `origin = jira.ticket_created` and `origin = codex.progress` both exercise the same Inbound Event store and Decision Receipt path: shipped in PR #113 and covered by tests.
-- Ilo can configure a source policy / Domain Projection, then a webhook event uses that configuration without per-event Ilo reasoning: implemented in `codex/illo-inbound-admin-tools` and covered by tests.
-- Ilo can replay stored webhook/MCP-created inbound events through current policy/projection config without mutating workspace state: implemented in `codex/inbound-replay-harness` and covered by tests.
+- Illo can configure a source policy / Domain Projection, then a webhook event uses that configuration without per-event Illo reasoning: implemented in `codex/illo-inbound-admin-tools` and covered by tests.
+- Illo can replay stored webhook/MCP-created inbound events through current policy/projection config without mutating workspace state: implemented in `codex/inbound-replay-harness` and covered by tests.
 - Provenance shows both source actor and authority principal for webhook and MCP lanes.
 
 ## Architecture Diagrams
@@ -492,7 +524,7 @@ flowchart LR
     subgraph IloSpace["IloSpace system"]
         Ingress["Unified ingress<br/>MCP / webhook / REST"]
         Policy["Deterministic preflight<br/>auth, scope, dedupe, rules, fingerprints"]
-        Agent["Ilo action runtime<br/>LLM + skills + tools"]
+        Agent["Illo action runtime<br/>LLM + skills + tools"]
         Projection["Configured projection<br/>Domain upsert / store-only"]
         Guard["Tool/runtime guardrails<br/>permissions, dry-run, review, audit"]
         Workspace["IloSpace state<br/>Domains, memory, threads, projects, tasks, logs"]
@@ -531,8 +563,8 @@ flowchart TD
     Tasks --> T3["Future Codex daemon task"]
 
     TaskEvents --> R1["started / blocked / completed / failed"]
-    Context --> C1["private Ilo context answer"]
-    Requests --> E1["Ilo considers request under policy"]
+    Context --> C1["private Illo context answer"]
+    Requests --> E1["Illo considers request under policy"]
 ```
 
 ### 3. Inbound Signal Flow
@@ -543,7 +575,7 @@ sequenceDiagram
     participant Ingress as IloSpace Ingress
     participant Store as Signal Store
     participant Policy as Deterministic Preflight
-    participant Ilo as Ilo Action Runtime
+    participant Illo as Illo Action Runtime
     participant Projection as Domain Projection
     participant Guard as Tool / Runtime Guardrails
     participant Workspace as IloSpace Workspace
@@ -559,14 +591,14 @@ sequenceDiagram
     else explicit binding or known rule
         Policy->>Guard: shortcut decision
     else ambiguous signal
-        Policy->>Ilo: hand signal to Ilo
-        Ilo->>Workspace: read context through tools
-        Ilo->>Guard: use tools / choose outcome
-        Ilo->>Store: write decision receipt
+        Policy->>Illo: hand signal to Illo
+        Illo->>Workspace: read context through tools
+        Illo->>Guard: use tools / choose outcome
+        Illo->>Store: write decision receipt
     end
 
     Guard->>Workspace: apply permitted tool effects or record review
-    Policy->>Store: update fingerprints and rule candidates
+    Policy->>Store: update observed outcome summaries
 ```
 
 ### 3B. Configured Domain Projection Flow
@@ -574,16 +606,16 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant User as User
-    participant Ilo as Ilo
+    participant Illo as Illo
     participant Config as Connection / Policy Config
     participant Webhook as External Source
     participant Store as Inbound Event Store
     participant Projection as Domain Projection
     participant Domain as IloSpace Domain
 
-    User->>Ilo: "Set up Jira tickets in IloSpace"
-    Ilo->>Domain: create or select Tickets Domain and Ticket object
-    Ilo->>Config: create connection, policy, schema, and field mapping
+    User->>Illo: "Set up Jira tickets in IloSpace"
+    Illo->>Domain: create or select Tickets Domain and Ticket object
+    Illo->>Config: create connection, policy, schema, and field mapping
     Webhook->>Store: submit jira.ticket_created payload
     Store->>Projection: matched configured projection
     Projection->>Projection: validate schema, map fields, dedupe by external id
@@ -599,8 +631,8 @@ flowchart LR
         Idea["Thread / idea / project context"]
         Task["ExternalTask<br/>IloSpace asks outside worker"]
         Signal["InboundSignal<br/>outside source tells IloSpace something"]
-        Handler["Deterministic preflight or Ilo"]
-        Outcome["Ilo Outcome"]
+        Handler["Deterministic preflight or Illo"]
+        Outcome["Illo Outcome"]
     end
 
     subgraph PersonalAgent["Personal agent / worker"]
@@ -632,24 +664,25 @@ flowchart TD
     C -->|"yes"| X
     C -->|"no"| D{"Source rule matches?"}
     D -->|"yes"| X
-    D -->|"no"| E{"Known payload fingerprint<br/>with high-confidence route?"}
-    E -->|"yes"| X
+    D -->|"no"| E{"Similar observed handling<br/>is available?"}
+    E -->|"yes"| G["Illo handling with<br/>observed source memory"]
     E -->|"no"| F{"Candidate route set is small?"}
-    F -->|"yes"| G["Light Ilo handling<br/>small context / candidate set"]
-    F -->|"no"| H["Full Ilo handling<br/>reason, use tools, decide outcome"]
+    F -->|"yes"| K["Illo handling with<br/>small context"]
+    F -->|"no"| H["Full Illo handling<br/>reason, use tools, decide outcome"]
     G --> I["Decision receipt"]
+    K --> I
     H --> I
     I --> X
-    I --> J["Rule / fingerprint candidate<br/>for future fast path"]
+    I --> J["Observed handling summary<br/>for future Illo context"]
 ```
 
 ### 6. Parallel Workstreams
 
 ```mermaid
 flowchart TD
-    Foundation["Shared Foundation<br/>External Source Connection<br/>Inbound Envelope Store<br/>Source Policy<br/>Ilo Config Tools<br/>Deterministic Preflight<br/>Ilo Action Runtime"]
+    Foundation["Shared Foundation<br/>External Source Connection<br/>Inbound Envelope Store<br/>Source Policy<br/>Illo Config Tools<br/>Deterministic Preflight<br/>Illo Action Runtime"]
 
-    Webhook["Webhook Integrations V1<br/>POST /webhooks<br/>origin rules<br/>Ilo-configured schema<br/>instructions<br/>logs/replay"]
+    Webhook["Webhook Integrations V1<br/>POST /webhooks<br/>origin rules<br/>Illo-configured schema<br/>instructions<br/>logs/replay"]
 
     MCP["MCP / Personal Tool V1<br/>hosted submit signal tool<br/>Codex hook guidance<br/>personal tool examples"]
 
@@ -659,7 +692,7 @@ flowchart TD
     MCP -->|"same envelope"| Foundation
     Agents -->|"later: task_event/task_result envelope"| Foundation
 
-    Foundation --> Action["Ilo Outcome<br/>tool call, store, summarize,<br/>ask human, no-op, review, quarantine"]
+    Foundation --> Action["Illo Outcome<br/>tool call, store, summarize,<br/>ask human, no-op, review, quarantine"]
 ```
 
 ## User Stories
@@ -672,45 +705,45 @@ flowchart TD
 6. As a teammate using Jira, I want Jira issue events to enter IloSpace as signals, so that relevant project activity can be routed into team context.
 7. As a teammate using GitHub, I want pull request and issue activity to enter IloSpace as signals, so that engineering changes can be connected to threads, projects, and pins.
 8. As a designer using Figma, I want design updates to enter IloSpace as signals, so that design work can be coordinated with engineering and product threads.
-9. As an authorized teammate chatting with Ilo, I want Ilo to register an External Source Connection, so that each outside source has identity, auth, scopes, and capabilities without me using a settings UI.
-10. As an authorized teammate chatting with Ilo, I want Ilo to configure whether a connection can submit signals, receive tasks, report task events, ask for context, or submit explicit requests for Ilo to consider, so that each source has the minimum required power.
-11. As an authorized teammate chatting with Ilo, I want Ilo to configure source-specific webhook policies, so that common payloads can be normalized and routed cheaply.
-12. As an authorized teammate chatting with Ilo, I want Ilo to create scoped, revocable, auditable connection tokens, so that external sources never need broad internal service credentials.
-13. As an authorized teammate chatting with Ilo, I want Ilo to surface repeated source behavior and proposed rules, so that IloSpace becomes faster and cheaper over time.
-14. As an authorized teammate chatting with Ilo, I want Ilo to approve, reject, or modify proposed routing rules according to my instructions and permissions, so that learned automation stays understandable and governed.
-15. As an authorized teammate chatting with Ilo, I want Ilo to inspect a connection’s recent signals, task events, failures, and decisions, so that I can debug integrations conversationally.
-16. As an authorized teammate chatting with Ilo, I want low-confidence or sensitive outcomes to require human confirmation through Ilo, so that external automation cannot silently create messy or risky workspace state.
-17. As Ilo, I want incoming signals to include raw payload, normalized fields, hints, source identity, and policy context, so that I can handle ambiguity only when deterministic preflight is insufficient.
-18. As Ilo, I want every ambiguous handling decision to produce a receipt, so that future signals can reuse prior judgment without repeating full reasoning.
-19. As Ilo, I want deterministic rules and payload fingerprints to handle common cases, so that my LLM reasoning is reserved for ambiguity.
-20. As Ilo, I want deterministic preflight to narrow candidate context when possible, so that I can handle the signal with less context and fewer tokens.
-21. As Ilo, I want to create a new idea/thread when no suitable home exists, so that novel signals are not forced into the wrong context.
-22. As Ilo, I want to post to an existing thread when the signal clearly belongs there, so that team progress stays attached to prior discussion.
-23. As Ilo, I want to link signals to projects and pins, so that broader subjects can accumulate activity across many threads.
-24. As Ilo, I want to ignore or privately store low-value signals, so that the workspace does not become noisy.
-25. As Ilo, I want to trigger an agent run only when the signal calls for active reasoning or action, so that not every update becomes work.
+9. As an authorized teammate chatting with Illo, I want Illo to register an External Source Connection, so that each outside source has identity, auth, scopes, and capabilities without me using a settings UI.
+10. As an authorized teammate chatting with Illo, I want Illo to configure whether a connection can submit signals, receive tasks, report task events, ask for context, or submit explicit requests for Illo to consider, so that each source has the minimum required power.
+11. As an authorized teammate chatting with Illo, I want Illo to configure source-specific webhook policies, so that common payloads can be normalized and routed cheaply.
+12. As an authorized teammate chatting with Illo, I want Illo to create scoped, revocable, auditable connection tokens, so that external sources never need broad internal service credentials.
+13. As an authorized teammate chatting with Illo, I want Illo to surface repeated source behavior as observed patterns, so that IloSpace becomes faster and cheaper without hiding how decisions are made.
+14. As an authorized teammate chatting with Illo, I want Illo to decide when an observed pattern should become deterministic configuration, so that shortcuts remain understandable and governed.
+15. As an authorized teammate chatting with Illo, I want Illo to inspect a connection’s recent signals, task events, failures, and decisions, so that I can debug integrations conversationally.
+16. As an authorized teammate chatting with Illo, I want low-confidence or sensitive outcomes to require human confirmation through Illo, so that external automation cannot silently create messy or risky workspace state.
+17. As Illo, I want incoming signals to include raw payload, normalized fields, hints, source identity, and policy context, so that I can handle ambiguity only when deterministic preflight is insufficient.
+18. As Illo, I want every ambiguous handling decision to produce a receipt, so that future signals can reuse prior judgment without repeating full reasoning.
+19. As Illo, I want source cards to show how similar events were handled before, so that I can reason with prior context instead of rediscovering every repeated pattern.
+20. As Illo, I want deterministic preflight to narrow candidate context when possible, so that I can handle the signal with less context and fewer tokens.
+21. As Illo, I want to create a new idea/thread when no suitable home exists, so that novel signals are not forced into the wrong context.
+22. As Illo, I want to post to an existing thread when the signal clearly belongs there, so that team progress stays attached to prior discussion.
+23. As Illo, I want to link signals to projects and pins, so that broader subjects can accumulate activity across many threads.
+24. As Illo, I want to ignore or privately store low-value signals, so that the workspace does not become noisy.
+25. As Illo, I want to trigger an agent run only when the signal calls for active reasoning or action, so that not every update becomes work.
 26. As a teammate reading a thread, I want external updates to show their source and provenance, so that I understand where the information came from.
 27. As a teammate reading a thread, I want task results from Hermes/OpenClaw/future workers to appear in the right thread automatically, so that delegated work closes the loop.
 28. As a teammate reading a project, I want related external signals to be linked or summarized, so that project context includes work happening outside IloSpace.
-29. As a teammate, I want the system to distinguish factual signal submission from explicit requests to Ilo, so that personal agents do not accidentally take over coordination decisions.
-30. As a teammate, I want to explicitly ask Ilo through an external tool for a known outcome when needed, so that precise human-directed requests are still possible without making the external tool own coordination.
-31. As a coding agent, I want a simple `submit signal` tool, so that I do not need to search the workspace, pick a thread, and decide whether to trigger Ilo.
+29. As a teammate, I want the system to distinguish factual signal submission from explicit requests to Illo, so that personal agents do not accidentally take over coordination decisions.
+30. As a teammate, I want to explicitly ask Illo through an external tool for a known outcome when needed, so that precise human-directed requests are still possible without making the external tool own coordination.
+31. As a coding agent, I want a simple `submit signal` tool, so that I do not need to search the workspace, pick a thread, and decide whether to trigger Illo.
 32. As a coding agent, I want tool descriptions to make the default behavior clear, so that I submit intent instead of mutating workspace state directly.
 33. As a webhook integration, I want a stable ingestion endpoint, so that events can enter IloSpace without pretending to be personal agents.
 34. As a webhook integration, I want payload normalization recipes, so that repeated payload shapes become typed signals.
 35. As a webhook integration, I want idempotency and replay protection, so that retries do not create duplicate updates.
 36. As a system operator, I want raw payload storage with redaction policy, so that integrations are auditable without leaking unnecessary sensitive data.
 37. As a system operator, I want rate limits per connection and source type, so that noisy external systems cannot overwhelm IloSpace.
-38. As a system operator, I want source policy to define default visibility, allowed tool use/outcome boundaries, and escalation behavior, so that each integration has predictable guardrails.
+38. As a system operator, I want source policy to define default visibility, deterministic preflight actions, and escalation behavior, so that each integration has predictable guardrails without limiting Illo's normal tool capabilities.
 39. As a system operator, I want routing receipts to be searchable, so that I can understand why IloSpace posted, created, linked, ignored, or asked for help.
 40. As a product builder, I want the existing Hermes/OpenClaw task lifecycle to remain intact, so that current personal-agent work does not need to be rewritten.
 41. As a product builder, I want inbound signals to be separate from external tasks, so that Jira/GitHub/Figma events do not pollute the task lifecycle model.
 42. As a product builder, I want shared auth and connection concepts across signals and tasks, so that the foundation stays simple even as capabilities differ.
-43. As a product builder, I want direct workspace mutation tools to be internal Ilo tools, so that the default external MCP does not teach agents to route or mutate workspace state by themselves.
-44. As a product builder, I want explicit external requests to be interpreted by Ilo and guarded by policy, so that precise user intent remains possible without bypassing coordination.
-45. As a product builder, I want learned rules to be generated from receipts rather than hidden memory calls, so that the system’s learning is durable and inspectable.
+43. As a product builder, I want direct workspace mutation tools to be internal Illo tools, so that the default external MCP does not teach agents to route or mutate workspace state by themselves.
+44. As a product builder, I want explicit external requests to be interpreted by Illo and guarded by policy, so that precise user intent remains possible without bypassing coordination.
+45. As a product builder, I want observed source patterns to be generated from receipts rather than hidden memory calls, so that Illo's context is durable and inspectable.
 46. As a product builder, I want a replay harness for old signals and receipts, so that routing policy changes can be tested against real historical examples.
-47. As a product builder, I want source cards that summarize connection behavior, common payloads, rules, and examples, so that integration behavior is understandable at a glance.
+47. As a product builder, I want source cards that summarize connection behavior, common payloads, configured rules, and observed outcomes, so that integration behavior is understandable at a glance.
 48. As a teammate, I want IloSpace to coordinate among personal agents rather than compete with them, so that I can keep my preferred tools while the team gains shared context.
 49. As a webhook integration builder, I want my `POST /webhooks` implementation to call the same inbound envelope service as MCP signal submission, so that the webhook lane does not drift into a separate architecture.
 50. As an MCP integration builder, I want my hosted MCP tool to call the same inbound envelope service as webhooks, so that Codex-style progress updates and Jira-style webhook events become comparable system inputs.
@@ -720,23 +753,23 @@ flowchart TD
 54. As a security-minded admin, I want integration actors to remain scoped to one workspace/org, so that “system actor” never means cross-org global write access.
 55. As a coding agent, I want the hosted MCP tool to accept repo, branch, task, and file hints, so that IloSpace can route progress without forcing me to choose a thread.
 56. As an operator, I want the first shared milestone to prove webhook and MCP inputs produce the same internal records, so that the foundation is real and not just conceptual.
-57. As an authorized teammate, I want to configure integrations by chatting with Ilo rather than filling out forms, so that IloSpace stays agent-native instead of becoming another settings dashboard.
-58. As Ilo, I want tools for every configurable integration field, so that I can create and update connections, policies, schemas, thresholds, tool-use permissions, tests, replays, and rule promotions on behalf of authorized users.
+57. As an authorized teammate, I want to configure integrations by chatting with Illo rather than filling out forms, so that IloSpace stays agent-native instead of becoming another settings dashboard.
+58. As Illo, I want tools for every configurable integration field, so that I can create and update connections, policies, schemas, thresholds, deterministic preflight actions, tests, replays, and observed pattern summaries on behalf of authorized users.
 59. As a teammate, I want observability surfaces to be read-only by default, so that I can inspect events and logs without confusing logs with the configuration experience.
-60. As an authorized teammate chatting with Ilo, I want Ilo to create or select a Domain and configure a source-to-Domain projection, so that repeated Jira/GitHub/Stripe-style events can be stored as structured records without invoking Ilo on every event.
+60. As an authorized teammate chatting with Illo, I want Illo to create or select a Domain and configure a source-to-Domain projection, so that repeated Jira/GitHub/Stripe-style events can be stored as structured records without invoking Illo on every event.
 61. As a teammate, I want every projected Domain record to keep source provenance and inbound event linkage, so that I can trace a record back to the external payload and replay or audit the import.
 
 ## Implementation Decisions
 
 - Add a generalized External Source Connection concept that is capability-based, not product-name-based. Hermes, OpenClaw, Codex, Jira, GitHub, Figma, and custom scripts are all connections with different capabilities.
-- Build configuration services first, then expose those services to Ilo as tools. Do not make a manual configuration UI the V1 product surface.
-- Every configurable field must have an Ilo-accessible tool path: connections, capabilities, source policies, origin patterns, instructions, schema fields, tool-use permissions, thresholds, dry-run inputs, replay, rule candidates, and source status.
+- Build configuration services first, then expose those services to Illo as tools. Do not make a manual configuration UI the V1 product surface.
+- Every configurable field must have an Illo-accessible tool path: connections, capabilities, source policies, origin patterns, instructions, schema fields, deterministic preflight actions, thresholds, dry-run inputs, replay, observed source summaries, and source status.
 - Treat logs, dry-run output, replay output, and config snapshots as observability surfaces, not the primary configuration surface.
 - Use one shared inbound service for webhook, MCP, and future inbound lanes. Do not build a webhook-only service that cannot be reused by the hosted MCP tool.
 - Implement the shared foundation before or alongside the first webhook/MCP slices. Both product lanes should call `submit_inbound_envelope` or an equivalent service boundary.
 - Treat the colleague’s webhook proposal as the first configured-source implementation of the broader inbound architecture.
 - Treat the Codex/MCP proposal as the first personal-tool signal implementation of the broader inbound architecture.
-- Separate source actor identity from authority principal. A webhook may be provenance-attributed to Jira, GitHub, or Stripe, but Ilo handling and tool permission checks must resolve to the user who configured, requested, or owns the connection.
+- Separate source actor identity from authority principal. A webhook may be provenance-attributed to Jira, GitHub, or Stripe, but Illo handling and tool permission checks must resolve to the user who configured, requested, or owns the connection.
 - Require authenticated source identity for public webhook ingress. The `origin` string is routing metadata, not proof of identity.
 - Preserve the existing personal-agent task model for outbound delegation. It is the right shape for long-running remote work with status, artifacts, and completion.
 - Do not stretch the external task lifecycle to represent arbitrary inbound webhook or progress events. Add a separate inbound signal model.
@@ -745,19 +778,19 @@ flowchart TD
 - Treat `request` as an external source asking IloSpace to consider doing something, without assuming the source gets to mutate the workspace directly.
 - Treat `task_event` and `task_result` as deterministic updates tied to an existing External Task created by IloSpace.
 - Add a default MCP/API/webhook entrypoint for signal submission. The preferred public tool should be conceptually named `submit signal`, even if the final code-level prefix follows existing naming conventions.
-- Keep direct workspace mutation tools as internal Ilo tools, not the default external integration surface. Automatic hooks and general personal-agent MCP guidance should prefer signal/request submission.
-- Route all inbound envelopes through IloSpace. The system may bypass Ilo reasoning through deterministic preflight, but external sources should not perform fuzzy routing themselves.
-- Add a deterministic preflight layer before Ilo reasoning. It handles auth, scopes, validation, dedupe, idempotency, redaction, explicit task binding, explicit approved targets, source rules, payload fingerprints, and learned high-confidence patterns.
-- Add Ilo handling only for ambiguous cases or cases where policy requires agent judgment.
-- Add Decision Receipts as durable records of agent or policy decisions. Receipts should include signal id, outcome, target when relevant, tool use, confidence, reasoning summary, features used, whether a human was asked, and whether the decision is reusable.
-- Add learned pattern support from repeated receipts. When many similar signals are routed the same way, IloSpace can propose a deterministic rule.
-- Add source policies for each connection. Policies define allowed envelope types, default visibility, allowed outcomes/tool use, Ilo handling instructions, deterministic rules, confirmation thresholds, redaction behavior, and cost policy.
+- Keep direct workspace mutation tools as internal Illo tools, not the default external integration surface. Automatic hooks and general personal-agent MCP guidance should prefer signal/request submission.
+- Route all inbound envelopes through IloSpace. The system may bypass Illo reasoning through deterministic preflight, but external sources should not perform fuzzy routing themselves.
+- Add a deterministic preflight layer before Illo reasoning. It handles auth, scopes, validation, dedupe, idempotency, redaction, explicit task binding, explicit approved targets, and Illo-configured source rules.
+- Add Illo handling only for ambiguous cases or cases where policy requires agent judgment.
+- Add Decision Receipts as durable records of agent or policy decisions. Receipts should include signal id, outcome, target when relevant, tool use, confidence, reasoning summary, features used, whether a human was asked, and a minimal observed outcome summary.
+- Add observed pattern support from repeated receipts. When many similar signals are handled similarly, IloSpace should make that pattern visible to Illo as context. Illo remains the actor that decides whether to configure a deterministic shortcut.
+- Add source policies for each connection. Policies define allowed envelope types, default visibility, deterministic preflight actions, Illo handling instructions, confirmation thresholds, redaction behavior, and cost policy. They do not define the global boundary of what Illo may do with its normal tools.
 - Add Domain Projection policies for configured structured ingestion. A projection binds a source/origin pattern to a Domain, object type, field mapping, external id strategy, upsert mode, validation mode, owner principal, and review/quarantine behavior.
-- Add payload fingerprints that hash stable source/event/schema/features rather than full payload content. Fingerprints should support fast recognition of repeated payload shapes.
-- Add source cards as an operator-facing summary of each connection: what it sends, common payloads, known rules, examples, recent errors, and current capabilities.
-- The first source-card slice stores a generated card inside connection metadata, with Ilo-authored purpose/notes/tags and computed policy/projection/event summaries. This avoids a new table until source cards need history, ownership, or workflow.
+- Add payload shape summaries that describe stable source/event/schema/features rather than full payload content. Shape summaries should help Illo recognize repeated source behavior, not automatically change routing.
+- Add source cards as an operator-facing summary of each connection: what it sends, common payloads, configured rules, observed outcomes, examples, recent errors, and current capabilities.
+- The first source-card slice stores a generated card inside connection metadata, with Illo-authored purpose/notes/tags and computed policy/projection/event summaries. This avoids a new table until source cards need history, ownership, or workflow.
 - Add a replay harness that can run historical signals against current policy and handling settings without mutating the workspace.
-- The first replay slice is a synchronous, read-only Ilo tool over stored event envelopes. It previews current policy/projection outcomes and reports drift, but durable replay jobs, saved reports, and rule-promotion candidates remain later work.
+- The first replay slice is a synchronous, read-only Illo tool over stored event envelopes. It previews current policy/projection outcomes and reports drift, but durable replay jobs, saved reports, and richer observed outcome reports remain later work.
 - Keep personal-agent connection tokens and scoped auth as the template for future connection security. Do not use broad internal service tokens for external sources.
 - Add connection capabilities rather than separate tables per source type wherever practical. Capabilities should make Codex, Hermes, OpenClaw, Jira, GitHub, and Figma differ by behavior, not by bespoke architecture.
 - For personal agents that can receive tasks, the existing outbound bridge model remains valid: IloSpace creates an External Task; the worker claims or receives it; task events and results return as bound inbound envelopes.
@@ -765,27 +798,27 @@ flowchart TD
 - For Codex, support both modes conceptually: ordinary sessions submit signals; future long-running Codex workers may receive tasks.
 - For Jira/GitHub/Figma, start with inbound-only signal connections and source policies.
 - For webhook V1, support origin matching with explicit priority/order. The first active integration/policy whose rules match the authenticated source and origin wins.
-- For webhook V1, support an Ilo-configurable schema field model that compiles to internal validation. Do not require users to hand-author raw JSON Schema and do not require a schema-builder UI in V1.
+- For webhook V1, support an Illo-configurable schema field model that compiles to internal validation. Do not require users to hand-author raw JSON Schema and do not require a schema-builder UI in V1.
 - For webhook V1, support dry-run and replay before expecting broad auto-execution.
-- For webhook V1, define initial guardrails for Ilo tool use around opening Cortex threads, creating memory, ad hoc Domain write review, and configured Domain Projection execution. These are seed permissions for the Jira/webhook slice, not the global taxonomy of everything Ilo can do.
+- For webhook V1, define initial guardrails for Illo tool use around opening Cortex threads, creating memory, ad hoc Domain write review, and configured Domain Projection execution. These are seed permissions for the Jira/webhook slice, not the global taxonomy of everything Illo can do.
 - For MCP V1, add one default signal submission tool and update tool descriptions/guidance so coding agents understand that fuzzy routing belongs to IloSpace.
 - For MCP V1, keep direct thread tools as compatibility/advanced tools only if still needed. They must not be the recommended path for automatic progress hooks.
 - For explicit user-directed commands, allow deterministic execution only when the target and permission are explicit. Example: a result tied to an existing task id can be posted back deterministically because IloSpace already knows the destination.
-- Do not require every inbound signal to trigger a visible workspace update. Possible outcomes include store only, ignore as noise, ask human, use a tool, summarize, schedule follow-up, or trigger an Ilo run. This list is illustrative, not a boundary on Ilo's capabilities.
-- Make provenance visible in workspace projections. Thread messages or linked records created from external signals should show source connection, source object, and whether Ilo or deterministic preflight made the decision.
-- Keep IloSpace’s current product trigger system downstream of signal handling. Inbound signals are pre-trigger raw material; only selected Ilo outcomes should become triggers for agent runs.
+- Do not require every inbound signal to trigger a visible workspace update. Possible outcomes include store only, ignore as noise, ask human, use a tool, summarize, schedule follow-up, or trigger an Illo run. This list is illustrative, not a boundary on Illo's capabilities.
+- Make provenance visible in workspace projections. Thread messages or linked records created from external signals should show source connection, source object, and whether Illo or deterministic preflight made the decision.
+- Keep IloSpace’s current product trigger system downstream of signal handling. Inbound signals are pre-trigger raw material; only selected Illo outcomes should become triggers for agent runs.
 
 ### Proposed Deep Modules
 
 - **Connection Registry**: owns external source identity, auth, scopes, capabilities, status, and source card metadata.
-- **Ilo Configuration Tool Surface**: gives Ilo tools for every configurable connection, source policy, schema, action, threshold, dry-run, replay, and rule-promotion operation.
+- **Illo Configuration Tool Surface**: gives Illo tools for every configurable connection, source policy, schema, deterministic preflight action, threshold, dry-run, replay, and observed-pattern operation.
 - **Inbound Envelope Store**: owns raw payloads, normalized signals, idempotency, redaction, and replayable state.
 - **Signal Normalizer**: converts source-specific payloads into a stable inbound signal shape.
-- **Policy Engine**: performs deterministic preflight decisions and decides whether Ilo handling is needed.
+- **Policy Engine**: performs deterministic preflight decisions and decides whether Illo handling is needed.
 - **Domain Projection Engine**: validates configured source payloads, maps fields, dedupes by external id, and writes structured records into existing IloSpace Domains with provenance.
-- **Ilo Action Runtime**: lets Ilo perform LLM-based interpretation and tool use only when policy cannot safely decide.
-- **Decision Receipt Store**: records outcomes, features, confidence, targets when relevant, tool use, and reusable-pattern candidates.
-- **Rule Learner**: turns repeated receipts into proposed or auto-promoted deterministic rules.
+- **Illo Action Runtime**: lets Illo perform LLM-based interpretation and tool use only when policy cannot safely decide.
+- **Decision Receipt Store**: records outcomes, features, confidence, targets when relevant, tool use, and minimal observed outcome summaries.
+- **Observed Outcome Summarizer**: derives compact summaries, open tags, tool names, and target references from completed Illo runs so source cards can show how similar events were handled before.
 - **Tool Runtime Guardrails**: enforces permissions, dry-run, review, audit, and action safety around any tool effects.
 - **Replay Harness**: replays historical envelopes through policy and handling simulation for regression testing.
 
@@ -798,13 +831,13 @@ Build the backend foundation used by both webhook and MCP ingress.
 Deliverables:
 
 - Connection capability model.
-- Ilo configuration tools for connection and policy creation/update.
+- Illo configuration tools for connection and policy creation/update.
 - Inbound envelope/event persistence.
 - Source policy representation.
 - Domain Projection representation for structured event storage.
 - Internal `submit_inbound_envelope` service.
 - Deterministic policy gate.
-- Ilo action runtime interface.
+- Illo action runtime interface.
 - Decision receipt persistence.
 - Tool/runtime guardrails with review/quarantine outcomes.
 - Tests proving the same service can process a webhook-style and MCP-style envelope.
@@ -818,14 +851,14 @@ Deliverables:
 - Public webhook ingress with authenticated source identity.
 - Minimal payload shape: `origin` and `payload`.
 - Origin pattern matching with priority.
-- Ilo-configurable schema fields and backend validation.
-- Ilo-configurable Domain Projection for events that should become structured records.
+- Illo-configurable schema fields and backend validation.
+- Illo-configurable Domain Projection for events that should become structured records.
 - Integration instructions.
-- Allowed outcomes/tool use and auto-execute thresholds.
+- Deterministic preflight actions and auto-execute thresholds.
 - Event logs, dry-run, replay.
 - Read-only observability for event logs, dry-run results, replay results, and config snapshots.
-- Source cards for source purpose, configured rules, sampled payload shapes, recent failures, and source health summary.
-- Jira-like fixture proving ticket handling into a configured Tickets Domain, review, or an Ilo-created thread depending on policy.
+- Source cards for source purpose, configured rules, sampled payload shapes, observed outcomes, recent failures, and source health summary.
+- Jira-like fixture proving ticket handling into a configured Tickets Domain, review, or an Illo-created thread depending on policy.
 
 #### Package C: MCP / Personal Tool Signals V1
 
@@ -853,14 +886,14 @@ Deliverables:
 
 ## Testing Decisions
 
-- Tests should focus on observable behavior: accepted/rejected envelopes, stored raw payloads, normalized signal shape, deterministic preflight decisions, receipts, Ilo outcomes, task updates, and permission failures.
-- Avoid tests that assert internal prompt wording or implementation details of Ilo’s LLM reasoning.
+- Tests should focus on observable behavior: accepted/rejected envelopes, stored raw payloads, normalized signal shape, deterministic preflight decisions, receipts, Illo outcomes, task updates, and permission failures.
+- Avoid tests that assert internal prompt wording or implementation details of Illo’s LLM reasoning.
 - Add contract tests for the signal submission API/MCP/webhook entrypoints: auth, scope checks, idempotency, validation, redaction, and response shape.
-- Add model/service tests for connection capabilities: a connection with only signal capability cannot claim tasks or bypass Ilo with direct workspace mutation.
-- Add policy engine tests for deterministic bypass: explicit task result, explicit approved target, source rule, known fingerprint, unknown signal requiring Ilo handling.
-- Add decision receipt tests: ambiguous signals produce receipts with outcome, confidence, target/tool use when relevant, and reusable-pattern metadata.
-- Add rule learner tests: repeated similar receipts produce a proposed rule; low-confidence or conflicting receipts do not.
-- Add tool/runtime guardrail tests: policy/Ilo decisions create or update the correct workspace projection without requiring the external source to call direct mutation tools.
+- Add model/service tests for connection capabilities: a connection with only signal capability cannot claim tasks or bypass Illo with direct workspace mutation.
+- Add policy engine tests for deterministic bypass: explicit task result, explicit approved target, source rule, known fingerprint, unknown signal requiring Illo handling.
+- Add decision receipt tests: ambiguous signals produce receipts with outcome, confidence, target/tool use when relevant, and minimal observed outcome metadata.
+- Add observed outcome summarizer tests: completed Illo triage runs produce compact summaries, open tags, tool names, and target references without a hard outcome enum or automatic rule promotion.
+- Add tool/runtime guardrail tests: deterministic preflight and Illo decisions create or update the correct workspace projection without requiring the external source to call direct mutation tools.
 - Add external task compatibility tests: existing Hermes/OpenClaw task claim, event, artifact, complete, and fail flows still work.
 - Add regression tests around hosted MCP tool descriptions: default guidance should steer general clients toward signal submission, not direct thread mutation.
 - Add webhook integration tests for at least one Jira-like source payload: raw payload stored, normalized signal created, idempotency applied, and routing policy evaluated.
@@ -868,11 +901,11 @@ Deliverables:
 - Add shared-path tests proving webhook and MCP inputs both produce Inbound Envelope/Event records and Decision Receipts/results through the same foundation service.
 - Add security tests proving a claimed `origin` alone cannot impersonate another source.
 - Add org/workspace scope tests proving integration actors are system actors inside one org/workspace, not global cross-org actors.
-- Add tool-gating tests proving ad hoc domain record creation stays review/dry-run in V1 unless an explicit Ilo-configured Domain Projection exists.
+- Add tool-gating tests proving ad hoc domain record creation stays review/dry-run in V1 unless an explicit Illo-configured Domain Projection exists.
 - Add Domain Projection tests proving a configured Jira-like ticket event can create/update a Domain record deterministically after raw event storage, validation, idempotency, and permission checks.
 - Add replay harness tests: a fixture set of historical signals can be evaluated without mutating workspace state.
 - Use existing external-agent service and route tests as prior art for scoped token auth, task lifecycle, hosted MCP, and bridge route behavior.
-- Use existing trigger/work-intake tests as prior art for downstream run admission after an Ilo outcome requires an agent run.
+- Use existing trigger/work-intake tests as prior art for downstream run admission after an Illo outcome requires an agent run.
 
 ## Out of Scope
 
@@ -880,25 +913,25 @@ Deliverables:
 - Building a full public A2A protocol implementation.
 - Building source-specific deep integrations for every app in the first pass.
 - Renaming all existing code identifiers from current `illo_*` naming.
-- Guaranteeing fully autonomous rule promotion without operator visibility.
+- Letting a background learner change routing behavior without Illo explicitly deciding to configure that behavior.
 - Building a manual configuration UI for source policy fields in the first implementation.
 - Making UI the configuration surface for integrations.
 - Making all external tools always-on personal agents.
 - Letting external sources perform fuzzy workspace routing directly.
 - Treating Jira/GitHub/Figma events as external tasks.
 - Making every inbound signal visible to the team.
-- Making every inbound signal trigger an Ilo run.
+- Making every inbound signal trigger an Illo run.
 
 ## Further Notes
 
 The most important product principle is:
 
-> External tools submit signals and intent. IloSpace owns coordination. Ilo handles ambiguity. Deterministic policy handles the repeated and obvious.
+> External tools submit signals and intent. IloSpace owns coordination. Illo handles ambiguity. Deterministic policy handles the repeated and obvious.
 
 This lets IloSpace become the team coordination layer without competing with personal agents. Hermes, OpenClaw, Codex, Figma, Jira, GitHub, and future tools can keep doing their local work. IloSpace turns their outputs into shared context, durable memory, team-visible progress, and actionable coordination.
 
-The existing personal-agent MVP already proved useful pieces: scoped connection tokens, external task lifecycle, task events, artifacts, hosted MCP, bridge-first delegation, and public/private interaction modes. The new inbound coordination layer should reuse those lessons while introducing the missing primitive: a durable Inbound Signal that Ilo can handle through deterministic preflight or agent reasoning.
+The existing personal-agent MVP already proved useful pieces: scoped connection tokens, external task lifecycle, task events, artifacts, hosted MCP, bridge-first delegation, and public/private interaction modes. The new inbound coordination layer should reuse those lessons while introducing the missing primitive: a durable Inbound Signal that Illo can handle through deterministic preflight or agent reasoning.
 
-Direct thread creation/posting should be treated as internal Ilo tool use, not the default external surface shown to hooks, webhooks, or autonomous personal agents. The default external surface should be signal/request submission into IloSpace.
+Direct thread creation/posting should be treated as internal Illo tool use, not the default external surface shown to hooks, webhooks, or autonomous personal agents. The default external surface should be signal/request submission into IloSpace.
 
-The architecture should intentionally support a future where IloSpace has many repeated information flows. Ilo should not spend tokens rediscovering the same payload forever. Ilo handling should leave receipts; receipts should produce patterns; patterns should become rules; rules should make the next signal cheaper.
+The architecture should intentionally support a future where IloSpace has many repeated information flows. Illo should not spend tokens rediscovering the same payload forever. Illo handling should leave receipts; receipts should produce observed patterns; observed patterns should make future handling cheaper by giving Illo better context. When a deterministic shortcut is useful, Illo should configure it explicitly through its tools.

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -1414,9 +1414,14 @@
   }
 
   .thread-panel-header {
+    --thread-header-status-halo-clearance: 8px;
     display: grid;
     overflow: visible;
-    padding: 0 2px 14px 0;
+    padding:
+      var(--thread-header-status-halo-clearance)
+      2px
+      14px
+      var(--thread-header-status-halo-clearance);
   }
 
   .thread-header-title-row {
@@ -3049,7 +3054,11 @@
 
   @media (max-width: 720px) {
     .thread-panel-header {
-      padding: 0 0 8px;
+      padding:
+        var(--thread-header-status-halo-clearance)
+        0
+        8px
+        var(--thread-header-status-halo-clearance);
     }
 
     .run-compact-summary {

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -533,7 +533,17 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
     assert captured["envelope"] == {
         "kind": "signal",
         "origin": "codex.progress",
-        "payload": {"tests": "targeted"},
+        "payload": {
+            "tests": "targeted",
+            "checkpoint": {
+                "summary": "Implemented the submit signal tool.",
+                "source_tool": "codex",
+                "repo": "illospace-project",
+                "branch": "codex/mcp-submit-signal",
+                "task_title": "MCP signal lane",
+                "files_touched": ["brain/app/api/routers/agent_mcp.py"],
+            },
+        },
         "summary": "Implemented the submit signal tool.",
         "hints": {
             "source_tool": "codex",

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -35,7 +35,9 @@ from brain.platform.db.models.inbound import (
 )
 from brain.platform.db.models.org import Org, User
 from brain.systems.external_agents import service as external_agents
+from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound import service as inbound
+from brain.systems.runs.events import run_event
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.user_domains.service import AsyncDomainService
@@ -113,6 +115,7 @@ async def _seed_connection(
     token_id: str = TOKEN_ID,
     raw_token: str = RAW_TOKEN,
     scopes: list[str] | None = None,
+    status: str = "online",
 ) -> external_agents.AgentBridgePrincipal:
     if await session.get(Org, ORG_ID) is None:
         session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
@@ -125,7 +128,7 @@ async def _seed_connection(
         display_name="Jira webhook",
         agent_kind="jira",
         transport="webhook",
-        status="online",
+        status=status,
         remote_agent_card={},
         capabilities={"submit_signals": True},
         auth_metadata={},
@@ -199,7 +202,7 @@ async def _assert_queued_triage(session, outcome: dict, *, reason: str) -> dict:
     assert thread_message is not None
     assert thread_message.idea_id == triage["idea_id"]
     assert thread_message.role == "user"
-    assert "An inbound signal needs Ilo triage." in thread_message.content
+    assert "An inbound signal needs Illo triage." in thread_message.content
     assert run is not None
     assert run.thread_id == triage["idea_id"]
     assert run.status == "queued"
@@ -291,6 +294,28 @@ async def test_post_webhook_stores_event_even_without_policy(session):
     assert triage["event_id"] == str(event.id)
 
 
+async def test_authenticated_source_traffic_marks_pending_connection_configured(session):
+    await _seed_connection(session, status="pending")
+
+    response = await _post_webhook(
+        session,
+        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
+        json={
+            "origin": "jira.ticket_created",
+            "payload": {"issue": {"key": "PROJ-1"}},
+            "idempotency_key": "jira:PROJ-1:created",
+        },
+    )
+
+    connection = await session.get(ExternalAgentConnectionRow, CONNECTION_ID)
+    token = await session.get(ExternalAgentConnectionTokenRow, TOKEN_ID)
+    assert response.status_code == 202
+    assert connection.status == "configured"
+    assert connection.last_seen_at is not None
+    assert connection.last_error is None
+    assert token.last_used_at is not None
+
+
 async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
     await _seed_connection(session)
 
@@ -374,8 +399,53 @@ async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
     assert all(receipt.tool_use["type"] == "illo_triage" for receipt in receipts)
 
 
+async def test_mcp_codex_progress_signal_satisfies_default_checkpoint_policy(session):
+    await _seed_connection(session)
+    policy = await inbound.create_source_policy(
+        session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        name="Codex progress checkpoints",
+        origin_patterns=["codex.progress"],
+        schema_config={"required_paths": ["payload.checkpoint", "desired_outcome"]},
+    )
+
+    response = await _post_mcp(
+        session,
+        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
+        json_body={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "illo_submit_signal",
+                "arguments": {
+                    "summary": "Implemented inbound follow-up fixes.",
+                    "source_tool": "codex",
+                    "repo": "illospace-project",
+                    "branch": "codex/inbound-followups",
+                    "task_title": "E2E followups",
+                    "files_touched": ["brain/app/api/routers/agent_mcp.py"],
+                    "desired_outcome": "team_update",
+                    "idempotency_key": "codex:e2e-followups:1",
+                },
+            },
+        },
+    )
+
+    body = json.loads(response.json()["result"]["content"][0]["text"])
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert response.status_code == 200
+    assert body["status"] == "review_required"
+    assert body["matched_policy_id"] == str(policy.id)
+    assert body["error"] is None
+    assert event.status == "review_required"
+    assert event.raw_payload["checkpoint"]["summary"] == "Implemented inbound follow-up fixes."
+    assert event.normalized_payload["desired_outcome"] == "team_update"
+
+
 async def test_inbound_triage_receipt_reconciles_when_illo_run_completes(session):
-    final_answer = "Ilo reviewed the inbound signal and decided no workspace mutation is needed."
+    final_answer = "Illo reviewed the inbound signal and decided no workspace mutation is needed."
     triage = await _queue_unmatched_webhook_triage(
         session,
         origin="jira.ticket_created",
@@ -383,7 +453,7 @@ async def test_inbound_triage_receipt_reconciles_when_illo_run_completes(session
         idempotency_key="jira:PROJ-1:created",
     )
     event = (await session.scalars(select(InboundEventRow))).one()
-    event.error = "schema validation required Ilo triage"
+    event.error = "schema validation required Illo triage"
     await session.flush()
     await _finish_triage_run(session, triage, status=RunStatus.COMPLETED, final_answer=final_answer)
 
@@ -403,10 +473,69 @@ async def test_inbound_triage_receipt_reconciles_when_illo_run_completes(session
     assert receipt.outcome["triage"]["run_status"] == "completed"
     assert receipt.tool_use["status"] == "completed"
     assert receipt.tool_use["type"] == "illo_triage"
+    assert receipt.tool_use["attribution"]["tags"] == ["no_workspace_change"]
+    assert event.action_result["triage"]["attribution"]["summary"] == (
+        "Illo resolved the signal without a workspace tool action."
+    )
+
+
+async def test_inbound_triage_receipt_records_tool_attribution(session):
+    triage = await _queue_unmatched_webhook_triage(
+        session,
+        origin="jira.ticket_created",
+        issue_key="PROJ-3",
+        idempotency_key="jira:PROJ-3:created",
+    )
+    store = AsyncAgentRunStore(session)
+    run_id = int(triage["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    tool_event = await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "manage_domain",
+                "args": {"action": "create_record"},
+                "result": json.dumps(
+                    {
+                        "operation": "created",
+                        "record": {"id": 220, "domain_id": 11},
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
+    await store.append_final_answer_once(run_id, "Created the projected ticket record.", root_run_id=run_id)
+    await store.set_status(run_id, RunStatus.COMPLETED)
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    attribution = receipt.tool_use["attribution"]
+    assert attribution == event.action_result["triage"]["attribution"]
+    assert attribution["summary"] == "Illo created domain_record, domain using manage_domain."
+    assert attribution["tool_names"] == ["manage_domain"]
+    assert "domain_management" in attribution["tags"]
+    assert "created" in attribution["tags"]
+    assert attribution["run_event_ids"] == [tool_event.id]
+    assert {"kind": "domain_record", "id": "220", "source": "manage_domain"} in attribution["target_refs"]
+    assert {"kind": "domain", "id": "11", "source": "manage_domain"} in attribution["target_refs"]
+
+    source_card = await inbound_admin.get_source_card(
+        session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+    )
+    observed = source_card["source_card"]["traffic"]["observed_outcomes"]
+    assert observed["event_count_sampled"] == 1
+    assert {"value": "manage_domain", "count": 1} in observed["tool_names"]
+    assert {"value": "domain_management", "count": 1} in observed["common_tags"]
+    assert observed["by_origin"][0]["summaries"] == [attribution["summary"]]
 
 
 async def test_inbound_triage_receipt_reconciles_when_illo_run_fails(session):
-    final_answer = "Ilo triage failed before it could decide on the signal."
+    final_answer = "Illo triage failed before it could decide on the signal."
     triage = await _queue_unmatched_webhook_triage(
         session,
         origin="jira.ticket_updated",

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -444,6 +444,47 @@ async def test_mcp_codex_progress_signal_satisfies_default_checkpoint_policy(ses
     assert event.normalized_payload["desired_outcome"] == "team_update"
 
 
+async def test_mcp_codex_progress_signal_requires_non_empty_desired_outcome(session):
+    await _seed_connection(session)
+    await inbound.create_source_policy(
+        session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        name="Codex progress checkpoints",
+        origin_patterns=["codex.progress"],
+        schema_config={"required_paths": ["payload.checkpoint", "desired_outcome"]},
+    )
+
+    response = await _post_mcp(
+        session,
+        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
+        json_body={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "illo_submit_signal",
+                "arguments": {
+                    "summary": "Implemented inbound follow-up fixes.",
+                    "source_tool": "codex",
+                    "repo": "illospace-project",
+                    "branch": "codex/inbound-followups",
+                    "task_title": "E2E followups",
+                    "files_touched": ["brain/app/api/routers/agent_mcp.py"],
+                    "idempotency_key": "codex:e2e-followups:missing-outcome",
+                },
+            },
+        },
+    )
+
+    body = json.loads(response.json()["result"]["content"][0]["text"])
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert response.status_code == 200
+    assert body["status"] == "quarantined"
+    assert "desired_outcome" in body["error"]
+    assert event.status == "quarantined"
+
+
 async def test_inbound_triage_receipt_reconciles_when_illo_run_completes(session):
     final_answer = "Illo reviewed the inbound signal and decided no workspace mutation is needed."
     triage = await _queue_unmatched_webhook_triage(
@@ -490,6 +531,23 @@ async def test_inbound_triage_receipt_records_tool_attribution(session):
     run_id = int(triage["run_id"])
     await store.set_status(run_id, RunStatus.STARTING)
     await store.set_status(run_id, RunStatus.RUNNING)
+    read_event = await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "manage_inbound",
+                "args": {"action": "get_event"},
+                "result": json.dumps(
+                    {
+                        "event_id": "999",
+                        "status": "review_required",
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
     tool_event = await store.append_event(
         run_event(
             run_id,
@@ -515,12 +573,17 @@ async def test_inbound_triage_receipt_records_tool_attribution(session):
     attribution = receipt.tool_use["attribution"]
     assert attribution == event.action_result["triage"]["attribution"]
     assert attribution["summary"] == "Illo created domain_record, domain using manage_domain."
-    assert attribution["tool_names"] == ["manage_domain"]
+    assert attribution["tool_names"] == ["manage_inbound", "manage_domain"]
     assert "domain_management" in attribution["tags"]
     assert "created" in attribution["tags"]
-    assert attribution["run_event_ids"] == [tool_event.id]
+    assert "inspected" in attribution["tags"]
+    assert attribution["run_event_ids"] == [read_event.id, tool_event.id]
+    assert {"kind": "inbound_event", "id": "999", "source": "manage_inbound"} in attribution["target_refs"]
     assert {"kind": "domain_record", "id": "220", "source": "manage_domain"} in attribution["target_refs"]
     assert {"kind": "domain", "id": "11", "source": "manage_domain"} in attribution["target_refs"]
+    assert {"kind": "inbound_event", "id": "999", "source": "manage_inbound"} not in attribution["mutated_target_refs"]
+    assert {"kind": "domain_record", "id": "220", "source": "manage_domain"} in attribution["mutated_target_refs"]
+    assert {"kind": "domain", "id": "11", "source": "manage_domain"} in attribution["mutated_target_refs"]
 
     source_card = await inbound_admin.get_source_card(
         session,

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -156,6 +156,93 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
     assert "test-private-token" not in str(run.target_metadata)
 
 
+async def test_materialize_github_project_context_finds_general_github_token(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=52,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_metadata={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "github_repo",
+                        "name": "example-org/private-repo",
+                        "uri": "https://github.com/example-org/private-repo",
+                    },
+                ],
+            },
+        },
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def fake_list_secrets(user_id, category=None, *, org_id=None):
+        assert user_id == "user-1"
+        assert org_id == "org-1"
+        if category == "github":
+            return []
+        assert category is None
+        return [
+            {"key_name": "STRIPE_SECRET", "category": "general"},
+            {"key_name": "GITHUB_TOKEN", "category": "general"},
+        ]
+
+    def fake_get_secret(key_name, **kwargs):
+        assert key_name == "GITHUB_TOKEN"
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["org_id"] == "org-1"
+        assert kwargs["accessed_by"] == "api"
+        return "general-github-token"
+
+    clone_calls = []
+
+    def fake_clone(slug, destination, *, token, branch):
+        clone_calls.append({"slug": slug, "token": token, "branch": branch})
+        destination.mkdir(parents=True)
+        return {"path": str(destination), "branch": branch or "main", "commit": "abc123"}
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "list_secrets", fake_list_secrets)
+    monkeypatch.setattr(materializer, "get_secret", fake_get_secret)
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(
+        52,
+        workspace_root=str(tmp_path),
+        user_id="user-1",
+        org_id="org-1",
+    )
+
+    assert result.ok
+    assert clone_calls == [
+        {
+            "slug": "example-org/private-repo",
+            "token": "general-github-token",
+            "branch": None,
+        }
+    ]
+    assert "general-github-token" not in str(run.metadata_)
+    assert "general-github-token" not in str(run.target_metadata)
+
+
 async def test_materialize_github_project_context_fails_closed_when_clone_unavailable(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context import materializer
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces


### PR DESCRIPTION
## Summary
- fix Project Context GitHub materialization so general vault keys like GITHUB_TOKEN are discovered and tried before anonymous clone
- add inbound/MCP follow-ups for Codex checkpoint payloads, desired_outcome validation, bridge-token seen/configured state, and observed triage attribution
- keep the existing thread status dot clipping fix on this branch

## Tests
- venv/bin/python -m pytest tests/test_external_agent_routes.py tests/test_inbound_webhooks.py tests/test_project_context_materializer.py