### PR TITLE
Harden inbound ingress and add attention-event triage tools

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -718,7 +718,13 @@ async def _mcp_endpoint(
     request: Request,
     db: AsyncSession,
 ):
-    payload = await request.json()
+    try:
+        payload = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}},
+            status_code=400,
+        )
     try:
         principal = await _authenticate_mcp_principal(request, db)
     except external_agents.ExternalAgentAuthError as exc:

--- a/brain/app/api/routers/webhooks.py
+++ b/brain/app/api/routers/webhooks.py
@@ -17,6 +17,15 @@ from brain.systems.inbound import service as inbound
 
 router = APIRouter(tags=["webhooks"], dependencies=[Depends(rate_limit)])
 
+PROVIDER_DELIVERY_ID_HEADERS = (
+    "x-atlassian-webhook-identifier",
+    "x-atlassian-webhook-id",
+    "x-github-delivery",
+    "x-linear-delivery",
+    "x-webhook-delivery",
+    "x-webhook-id",
+)
+
 
 @router.post("/webhooks", status_code=202)
 async def receive_webhook(
@@ -35,12 +44,14 @@ async def receive_webhook(
         )
         envelope = body.model_dump()
         header_idempotency_key = _clean_optional(x_illo_idempotency_key)
-        if header_idempotency_key and len(header_idempotency_key) > 160:
-            raise HTTPException(
-                status_code=422,
-                detail="X-Illo-Idempotency-Key must be 160 characters or fewer",
+        provider_delivery = _provider_delivery_id(request)
+        if header_idempotency_key:
+            _validate_idempotency_key(
+                header_idempotency_key,
+                field_name="X-Illo-Idempotency-Key",
             )
-        envelope["idempotency_key"] = envelope.get("idempotency_key") or header_idempotency_key
+        provider_idempotency_key = _provider_idempotency_key(provider_delivery)
+        envelope["idempotency_key"] = envelope.get("idempotency_key") or header_idempotency_key or provider_idempotency_key
         return await inbound.submit_inbound_envelope(
             db,
             connection=principal,
@@ -50,6 +61,7 @@ async def receive_webhook(
                 "path": str(request.url.path),
                 "method": request.method,
                 "client_host": request.client.host if request.client else None,
+                "provider_delivery": provider_delivery,
             },
         )
     except Exception as exc:
@@ -59,3 +71,27 @@ async def receive_webhook(
 def _clean_optional(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _provider_delivery_id(request: Request) -> dict[str, str] | None:
+    for header in PROVIDER_DELIVERY_ID_HEADERS:
+        value = _clean_optional(request.headers.get(header))
+        if value:
+            return {"header": header, "value": value}
+    return None
+
+
+def _provider_idempotency_key(provider_delivery: dict[str, str] | None) -> str | None:
+    if not provider_delivery:
+        return None
+    key = f"{provider_delivery['header']}:{provider_delivery['value']}"
+    _validate_idempotency_key(key, field_name=provider_delivery["header"])
+    return key
+
+
+def _validate_idempotency_key(value: str, *, field_name: str) -> None:
+    if len(value) > 160:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{field_name} must produce an idempotency key of 160 characters or fewer",
+        )

--- a/brain/systems/inbound/admin.py
+++ b/brain/systems/inbound/admin.py
@@ -6,7 +6,7 @@ from collections import Counter
 from datetime import datetime
 from typing import Any, Mapping, Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.external_agent import (
@@ -25,6 +25,11 @@ from brain.systems.inbound import service as inbound_service
 
 DEFAULT_SIGNAL_TOKEN_SCOPES = (external_agents.SCOPE_SIGNAL_SUBMIT,)
 READ_LIMIT_MAX = 100
+ATTENTION_EVENT_STATUSES = (
+    inbound_service.STATUS_FAILED,
+    inbound_service.STATUS_QUARANTINED,
+    inbound_service.STATUS_REVIEW_REQUIRED,
+)
 
 
 class InboundAdminError(RuntimeError):
@@ -511,6 +516,43 @@ async def list_events(
     return list((await session.scalars(stmt)).all())
 
 
+async def list_attention_events(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    connection_id: str | None = None,
+    policy_id: str | None = None,
+    origin: str | None = None,
+    limit: int | None = 25,
+    include_payload: bool = False,
+) -> dict[str, Any]:
+    """List inbound events that need Illo/operator attention."""
+
+    stmt = (
+        select(InboundEventRow)
+        .where(InboundEventRow.org_id == str(org_id))
+        .where(
+            or_(
+                InboundEventRow.status.in_(ATTENTION_EVENT_STATUSES),
+                InboundEventRow.error.is_not(None),
+            )
+        )
+        .order_by(InboundEventRow.created_at.desc(), InboundEventRow.id.desc())
+        .limit(_limit(limit))
+    )
+    if connection_id:
+        stmt = stmt.where(InboundEventRow.connection_id == str(connection_id))
+    if policy_id:
+        stmt = stmt.where(InboundEventRow.policy_id == str(policy_id))
+    if origin:
+        stmt = stmt.where(InboundEventRow.origin == str(origin))
+    rows = list((await session.scalars(stmt)).all())
+    return {
+        "events": [serialize_event(row, include_payload=include_payload) for row in rows],
+        "summary": _attention_summary(rows),
+    }
+
+
 async def require_event_for_org(
     session: AsyncSession,
     *,
@@ -955,7 +997,8 @@ def _source_card_traffic(events: Sequence[InboundEventRow]) -> dict[str, Any]:
         "statuses": _counter_rows(status_counts),
         "payload_shapes": _counter_rows(shape_counts, limit=30),
         "observed_outcomes": _source_card_observed_outcomes(events),
-        "recent_failures": [_source_card_event_summary(row) for row in events if _event_needs_attention(row)][:10],
+        "recent_attention": [_source_card_event_summary(row) for row in events if _event_needs_attention(row)][:10],
+        "recent_failures": [_source_card_event_summary(row) for row in events if _event_failed(row)][:10],
         "recent_events": [_source_card_event_summary(row) for row in events[:10]],
     }
 
@@ -1028,6 +1071,17 @@ def _counter_rows(counter: Counter[str], *, limit: int = 10) -> list[dict[str, A
     ]
 
 
+def _attention_summary(events: Sequence[InboundEventRow]) -> dict[str, Any]:
+    return {
+        "event_count": len(events),
+        "statuses": _counter_rows(Counter(str(row.status or "unknown") for row in events)),
+        "origins": _counter_rows(Counter(str(row.origin or "unknown") for row in events)),
+        "connections": _counter_rows(Counter(str(row.connection_id) for row in events)),
+        "oldest_created_at": _iso(min((row.created_at for row in events), default=None)),
+        "newest_created_at": _iso(max((row.created_at for row in events), default=None)),
+    }
+
+
 def _payload_shape_paths(value: Any, *, prefix: str = "payload", depth: int = 0) -> list[str]:
     if depth >= 4:
         return [prefix]
@@ -1052,10 +1106,13 @@ def _payload_shape_paths(value: Any, *, prefix: str = "payload", depth: int = 0)
 
 
 def _event_needs_attention(row: InboundEventRow) -> bool:
+    return row.status in ATTENTION_EVENT_STATUSES or bool(row.error)
+
+
+def _event_failed(row: InboundEventRow) -> bool:
     return row.status in {
         inbound_service.STATUS_FAILED,
         inbound_service.STATUS_QUARANTINED,
-        inbound_service.STATUS_REVIEW_REQUIRED,
     } or bool(row.error)
 
 

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -305,6 +305,11 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
             "optional": ["connection_id", "policy_id", "status", "origin", "include_payload", "limit"],
             "effect": "read inbound event logs",
         },
+        "list_attention_events": {
+            "required": [],
+            "optional": ["connection_id", "policy_id", "origin", "include_payload", "limit"],
+            "effect": "read stuck or attention-needed inbound events across review_required, quarantined, failed, or errored statuses",
+        },
         "get_event": {
             "required": ["event_id"],
             "optional": ["include_receipts", "limit"],

--- a/brain/systems/runs/tool_catalog/handlers/inbound.py
+++ b/brain/systems/runs/tool_catalog/handlers/inbound.py
@@ -352,6 +352,18 @@ async def _handle_manage_inbound(
                     ]
                 })
 
+            if action == "list_attention_events":
+                result = await inbound_admin.list_attention_events(
+                    session,
+                    org_id=org_id,
+                    connection_id=connection_id,
+                    policy_id=policy_id,
+                    origin=origin,
+                    limit=limit,
+                    include_payload=include_payload,
+                )
+                return _dump(result)
+
             if action == "get_event":
                 if not event_id:
                     return _error("get_event requires: event_id")

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -688,6 +688,7 @@ def action_policy_for_tool(
         "list_projections",
         "get_projection",
         "list_events",
+        "list_attention_events",
         "get_event",
         "list_receipts",
         "dry_run_match",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -852,6 +852,7 @@ INBOUND_TOOLS = [
                         "create_projection",
                         "update_projection",
                         "list_events",
+                        "list_attention_events",
                         "get_event",
                         "list_receipts",
                         "dry_run_match",

--- a/docs/prd-inbound-coordination-layer.md
+++ b/docs/prd-inbound-coordination-layer.md
@@ -1,6 +1,6 @@
 # PRD: Inbound Coordination Layer for IloSpace
 
-Status: living PRD; foundation shipped in PR #113, Illo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`; E2E follow-up fixes implemented in the current branch
+Status: living PRD; foundation shipped in PR #113, Illo-admin configuration tool and Phase 2 triage handoff implemented in `codex/illo-inbound-admin-tools`; triage reconciliation and token compatibility backfill implemented in `codex/inbound-token-reconcile`; stored-event replay harness and source cards implemented in `codex/inbound-replay-harness`; E2E follow-up fixes shipped; ship-to-all-users readiness hardening is in progress in `codex/inbound-readiness-hardening`
 Date: 2026-05-18  
 Owner: product/architecture discussion  
 
@@ -110,6 +110,20 @@ The PRD intentionally describes a broader product direction: external tools send
   - `venv/bin/python -m pytest tests/test_inbound_admin_tools.py`: `9 passed`.
   - `venv/bin/python -m pytest tests/test_external_agents_service.py tests/test_external_agent_routes.py`: `31 passed, 1 skipped`.
 
+### Implemented In Readiness Hardening Branch
+
+- Hosted MCP now catches malformed JSON request bodies and returns a structured JSON-RPC invalid request response (`-32600`, HTTP 400) instead of a generic 500.
+- Malformed MCP bodies are rejected before bridge-token authentication and before any inbound event can be stored.
+- Generic webhook ingress now maps common provider delivery-id headers (`X-GitHub-Delivery`, Atlassian/Jira-style delivery ids, Linear-style delivery ids, and generic webhook id headers) into inbound idempotency keys when callers do not provide an explicit IloSpace idempotency key.
+- Explicit `X-Illo-Idempotency-Key` still wins over provider delivery headers, while provider delivery metadata remains in ingress context for debugging.
+- Added `manage_inbound(action="list_attention_events")` so Illo can quickly inspect stuck or operator-relevant events across `review_required`, `quarantined`, `failed`, or errored rows.
+- Source cards now split `recent_attention` from `recent_failures`: `review_required` events remain visible as attention-needed context, while true failures/quarantines/errors stay in the failure list.
+- Added a connection-scope spoofing regression test proving a payload that claims another connection id cannot match another connection's source policy.
+- Product decision after E2E: a simulated provider-shaped webhook is sufficient for this readiness phase. A real Jira account is not required before the next rollout as long as token auth, delivery-id idempotency, spoof resistance, and recovery visibility are covered.
+- Verification for this slice so far:
+  - `venv/bin/python -m pytest tests/test_inbound_webhooks.py::test_webhook_provider_delivery_header_becomes_idempotency_key tests/test_inbound_webhooks.py::test_explicit_webhook_idempotency_header_wins_over_provider_delivery tests/test_inbound_webhooks.py::test_payload_cannot_spoof_another_connections_source_policy tests/test_inbound_admin_tools.py::test_illo_can_list_attention_events_for_recovery tests/test_inbound_admin_tools.py::test_source_card_summarizes_connection_and_persists_manual_context tests/test_external_agent_routes.py::test_hosted_mcp_malformed_json_returns_invalid_request_without_auth`: `6 passed`.
+  - `venv/bin/python -m pytest tests/test_external_agent_routes.py tests/test_inbound_webhooks.py tests/test_inbound_admin_tools.py tests/test_tools.py`: `81 passed`.
+
 ### Partially Shipped
 
 - **Decision receipts/effects**: inbound processing stores receipts/effects and now reconciles terminal Illo triage run status/final answer plus compact observed-outcome attribution back onto the event and receipt. Richer review workflows around those outcomes are still future work.
@@ -191,19 +205,158 @@ This section is the running ledger for post-deploy validation. Keep failures her
 
 | Test | Status | Result | Notes |
 | --- | --- | --- | --- |
-| MCP signal from Codex session | Passed; follow-up fix implemented | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Illo run `214`. | The default ambiguous MCP path works. The deployed caveat was that `origin=codex.progress` first matched existing policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276` and quarantined event `bb114da0-d013-4f38-8fe3-7a39bdbc6007` because the policy schema expected `payload.checkpoint` and top-level `desired_outcome`. Fix implemented in code: MCP Codex signals now backfill `payload.checkpoint`, and schema validation can read `desired_outcome`. Needs post-deploy retest against the live policy. |
+| MCP signal from Codex session | Passed after post-deploy retest | Hosted MCP accepted the active Codex token and stored events. Unique-origin signal `e778f9f5-7298-4845-bbe7-86ec27894c8d` returned `review_required`, created Cortex idea `4f03ebb8-2980-46bf-b3aa-33657660e233`, thread message `249`, and Illo run `214`. Post-fix `codex.progress` retest event `61eeea43-4ade-4806-a720-9ed5287dbd6c` matched policy `856ae76a-2974-4b6c-8fc0-d3fd5d557276`, generated `payload.checkpoint`, preserved top-level `desired_outcome=team_update`, queued Illo run `238`, and reconciled to `processed`. | The previous `codex.progress` quarantine caveat is fixed in production. The default ambiguous MCP path still works, and the live policy path no longer requires callers to duplicate checkpoint or desired-outcome fields manually. |
 | Webhook ambiguous signal | Passed | `POST /webhooks` returned `202` with event `849a179f-a787-4c7c-b8a2-9a5689ce1437`, `review_required`, no matched policy, Cortex idea `39798b40-84f3-42fb-ad78-88f3a0dedaab`, thread message `250`, and Illo run `215`. | Illo later inspected the event with `manage_inbound.get_event(include_receipts=true)` and confirmed reconciliation succeeded: event status `processed`, receipt `1b6c48ed-81e5-4940-838f-9b27f29b7504` status `processed`, run `215` completed, final answer `Triaged as no-op / resolved`, and `reconciled_at=2026-05-19T19:38:17.805159+00:00`. |
-| Webhook deterministic Domain Projection | Passed; follow-up fix implemented | Illo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Illo setup used `manage_inbound` plus Domain tools and returned dry-run success. The deployed caveat was that Illo reported the reused connection status as `pending` despite live token traffic. Fix implemented in code: successful token authentication marks `pending` connections as `configured`, updates `last_seen_at`, updates token `last_used_at`, and clears `last_error`. Needs post-deploy retest. |
-| Replay harness and source card | Passed with expected drift | Illo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. | Projection events replayed stable. The 2 unmatched-path events replay as `review_required` while their stored status is now `processed` because Illo triage/reconciliation completed them; this is expected drift, but the replay UI should explain “current preflight prediction” vs “historical post-Illo outcome” clearly. Source card also surfaced the earlier `codex.progress` quarantine, which is useful operator feedback. |
+| Webhook deterministic Domain Projection | Passed after post-deploy retest | Illo configured policy `5e3f3b57-3765-4c04-93da-adea55541c80` and projection `63115940-b7a2-4139-92d3-495fce54ea3e` on connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`, domain `11`, object key `ticket`. Webhook create event `82405008-04a3-469a-bb05-857bcc989809` processed and created Domain record `220`. Idempotency event `7d7a3de8-db39-4e9d-bd06-fc55900e2af3` replayed with `idempotent_replay=true` and reused record `221`. Update event `fce1281f-7bf0-4806-84c3-cf8c2b23d345` processed and updated record `221` to version `2`. | Illo setup used `manage_inbound` plus Domain tools and returned dry-run success. The connection-status caveat is fixed in production: live Codex and Jira traffic now marks connections `configured`, updates `last_seen_at`, updates token `last_used_at`, and clears `last_error`. |
+| Realistic Jira workflow configured by Illo | Passed | Headless Illo configured connection `303d8e60-b200-4a1b-9d18-b8b62279ab8e`, token `5f55c2a4-9825-4ea2-b7cf-036c68c5a297`, policy `707c62e9-cced-4d91-8154-b9df52a2cde7`, and Domain `12` / object `ticket` for `Jira Routing E2E 2026-05-19`. Dry-run for `jira.issue_created` matched the policy and predicted `review_required`. | Illo deliberately chose no deterministic projection because the workflow needed synthesis, possible solutions, owner routing, Cortex follow-up creation, and unknown-repo caution. That is the right behavior for this test; projection-only remains valid for simpler storage workflows. |
+| Jira known backend ticket | Passed | Webhook event `47f82afa-4e0c-4215-a53f-c2659713d328` for `JIRA-E2E-BE-001` returned `review_required`, queued Illo run `234`, reconciled to `processed`, created Domain record `222`, set `routing_status=routed`, stored analysis and possible solutions, and set `assignee_email=axel@uwear.ai`. Illo also created Axel-owned Cortex follow-up `ce8a3ad2-d56a-451f-88cd-edf6db35fa7f`. Duplicate replay with the same idempotency key returned `idempotent_replay=true` and reused the same event. | This proves the user-instructed Jira policy can route known repo tickets and that idempotency works on the live webhook endpoint. |
+| Jira repeated known-source frontend ticket | Passed | Webhook event `4f822245-18fd-420d-936d-cb2896ed6551` for `JIRA-E2E-FE-002` returned `review_required`, queued Illo run `235`, reconciled to `processed`, created Domain record `223`, set `routing_status=routed`, stored analysis and possible solutions, and set `assignee_email=axel@uwear.ai`. Illo created Axel-owned Cortex follow-up `797fc37c-df5f-4de0-9b98-e56b855e9e86`. | This covers “Illo receives something from a source it already knows” after the policy was configured. |
+| Jira known source with unknown repo | Passed | Webhook event `e1ef4c65-6276-43fe-8ca3-6c83b5243011` for `JIRA-E2E-UNK-003` returned `review_required`, queued Illo run `236`, reconciled to `processed`, created Domain record `224`, set `routing_status=needs-routing`, stored analysis and possible next steps, and left assignee blank. | Illo followed the instruction not to guess ownership for `unknown-ai/unknown-service`. |
+| Completely new origin through existing source token | Passed | Webhook event `285cc518-098a-4ac5-8c04-74b4dd9ee4a9` used origin `linear.issue_created`, matched no policy, queued Illo run `237`, reconciled to `processed`, and Illo resolved it as a safe no-op / informational test signal without applying the Jira routing policy. | This proves no-policy fallback enters Illo triage safely and does not over-apply a known Jira rule to a new origin. |
+| Replay harness and source card | Passed with expected drift; post-fix source-card retest passed | Illo used `manage_inbound.replay_events`, `refresh_source_card`, `get_source_card`, and `list_events` for connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b`. Replay covered 5 requested events, was read-only (`mutates_workspace=false`), and predicted `processed: 3`, `review_required: 2`. Source card refreshed at `2026-05-19T19:45:23.608441+00:00` with tags `post-deploy-e2e`, `mcp`, `webhook`, `domain-projection`. Post-fix retest refreshed Jira connection `303d8e60-b200-4a1b-9d18-b8b62279ab8e` at `2026-05-19T23:36:23.539482+00:00` and Codex connection `5b046c7e-4fc9-4a38-8b3f-0a3c4fdc638b` at `2026-05-19T23:36:23.597820+00:00`. | Source cards now summarize observed outcomes from completed Illo runs. Jira card showed `jira.issue_created`/`linear.issue_created`, all sampled events `processed`, and observed tools including `manage_domain`, `manage_idea`, `manage_inbound`, and `read_team_members`. Codex card explained the new `codex.progress` outcome and preserved the earlier quarantine as recent operator feedback. Minor follow-up: the card's `recent_failures` label can include `review_required` rows with no error, which is useful context but may read too harshly. |
 | MCP auth hardening | Passed | Invalid token call to `/api/mcp` returned HTTP `200` with MCP JSON-RPC error code `-32001`, message `MCP authentication failed: Invalid bridge token`, and data `{ "http_status": 401, "auth": "bearer" }`. | This confirms the deployed fix prevents the old client-side deserialize failure shape. |
+| MCP malformed JSON body | Failed in deployed E2E; fixed in readiness branch | A malformed `POST /api/mcp` body returned generic `{"error":"Internal server error"}` and API logs showed `JSONDecodeError: Extra data`. A valid retry immediately after passed. Current branch fixes this to return JSON-RPC `Invalid Request` (`-32600`) with HTTP 400, before auth and before event creation. | Needs post-deploy retest after `codex/inbound-readiness-hardening` ships. |
 
 Post-deploy conclusion:
 
-- Core deployed E2E is green across hosted MCP signal submission, webhook ambiguous triage, deterministic Domain Projection create/update/idempotency, replay/source-card inspection, and MCP auth hardening.
-- The active `codex.progress` policy caveat has a code fix: Codex MCP signals now generate a checkpoint payload and schema validation can read top-level `desired_outcome`. Retest after deploy before enabling automatic hooks broadly.
-- The reused source connection `pending` caveat has a code fix: successful authenticated token traffic now marks pending connections configured and updates seen/used timestamps. Retest after deploy.
-- Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Illo reconciled outcomes.
-- Minimal Illo action attribution and source-card observed outcome summaries are implemented in code and covered by local tests. Retest after deploy with a live completed Illo triage run.
+- Core deployed E2E is green across hosted MCP signal submission, webhook ambiguous triage, deterministic Domain Projection create/update/idempotency, realistic Illo-configured Jira routing, replay/source-card inspection, source-card observed outcomes, token status reconciliation, and MCP auth hardening.
+- The active `codex.progress` policy caveat is fixed in production: live event `61eeea43-4ade-4806-a720-9ed5287dbd6c` generated checkpoint data, preserved top-level `desired_outcome`, matched the policy, queued Illo, and reconciled to `processed`.
+- The reused source connection `pending` caveat is fixed in production: live Codex and Jira token traffic marked connections `configured`, updated `last_seen_at`, updated token `last_used_at`, and cleared `last_error`.
+- Realistic Jira routing shows the intended product shape: Illo can configure the source, choose an Illo-handled policy instead of projection when reasoning is needed, create Domain records, summarize/solution issues, route known repos to Axel, avoid guessing unknown repos, and safely no-op a completely new origin.
+- Improve replay/source-card language later so humans can distinguish current deterministic replay predictions from historical post-Illo reconciled outcomes, and consider renaming or splitting source-card `recent_failures` so `review_required` context does not look like an error.
+- Hosted MCP malformed JSON handling is fixed in the readiness branch and needs post-deploy retest.
+
+### Phase: Ship-To-All-Users Readiness Gate
+
+Status: next phase after deployed architecture validation.
+
+The realistic Jira/MCP E2E proves the foundation and product direction. It is enough confidence to keep building on this architecture. It is not yet enough confidence to enable the feature for all users without guardrails. This phase defines what would make the team comfortable saying, "we can ship this broadly tomorrow."
+
+The bar is not "Illo always chooses the perfect action." The bar is:
+
+- bad input fails cleanly;
+- source identity and user/org authority are enforced;
+- repeated known events are cheap and stable;
+- ambiguous or new events enter Illo safely;
+- Illo can configure, inspect, replay, and explain the system through tools;
+- operators can see what happened when something gets stuck;
+- rollback is simple if a source behaves badly.
+
+#### Required Before Broad Rollout
+
+1. **Fix user-caused request failures**
+   - Hosted MCP malformed JSON must return a structured JSON-RPC invalid request response, not a generic 500.
+   - Webhook and MCP invalid body, missing auth, bad token, missing scope, schema failure, and oversized payload responses should be predictable and documented.
+   - These failures should not create half-written workspace state.
+
+2. **Test a provider-shaped webhook contract**
+   - Use a realistic Jira/GitHub/Linear-style webhook delivery shape, including a provider delivery id header.
+   - Map provider delivery id into the inbound idempotency key.
+   - Prove origin cannot be spoofed by payload content alone.
+   - Keep raw secrets out of events, source cards, receipts, Domain records, and Illo answers.
+   - A real Jira account is not required for this rollout gate; source-token auth plus provider-shaped delivery-id simulation is enough.
+
+3. **Run the product behavior matrix**
+   - User asks Illo to configure a workflow before events arrive.
+   - A known source sends repeated known events.
+   - A known source sends an unknown repo/project/owner.
+   - A completely new origin/source sends an event.
+   - A simple storage workflow uses deterministic Domain Projection.
+   - A complex workflow deliberately bypasses projection and lets Illo synthesize, route, and decide.
+   - A Codex-style MCP progress signal follows the same envelope and receipt path.
+
+4. **Verify permissions and authority**
+   - Every connection resolves to an org and authority user.
+   - Illo configuration tools enforce that authority.
+   - Cross-org token use fails.
+   - A signal-only connection cannot call direct workspace mutation tools.
+   - Direct thread tools remain compatibility surfaces, not the default automatic hook path.
+
+5. **Make stuck work visible and recoverable**
+   - Illo can list stuck `review_required`, `quarantined`, and `failed` events.
+   - Illo can inspect the event, receipt, policy, source card, and relevant run.
+   - Illo can retry/replay safely when retry is appropriate.
+   - Operators can distinguish current replay prediction from historical post-Illo outcome.
+
+6. **Harden source-card language**
+   - Rename or split `recent_failures` so `review_required` rows without errors do not look like system failures.
+   - Source cards should keep observed outcomes as context, not as automatic rule promotion.
+   - Source cards should make it obvious when a source is healthy, ambiguous, failing validation, or waiting on Illo.
+
+7. **Add a minimal rollout and rollback plan**
+   - Start with a small internal/beta allowlist.
+   - Keep source tokens scoped to `signal:submit` by default.
+   - Document how to revoke one token, disable one connection, disable one policy, and pause inbound processing for one source.
+   - Confirm disabling a source stops new handling without deleting historical events.
+
+8. **Write the operator runbook**
+   - How to ask Illo to create a connection, mint a token, configure a policy, configure a Domain Projection, dry-run a sample, inspect logs, replay events, and refresh a source card.
+   - How to debug "webhook arrived but nothing happened."
+   - How to debug "Illo created the wrong thing."
+   - How to rotate or revoke a leaked token.
+
+#### Confidence Tests For This Phase
+
+| Test | Required Result |
+| --- | --- |
+| Malformed MCP JSON | Returns structured JSON-RPC invalid request response, no 500, no event created. |
+| Provider-shaped webhook auth | Valid token-authenticated delivery accepted; invalid token rejected; no origin spoofing through payload-only changes. |
+| Jira delivery id replay | Duplicate provider delivery id returns idempotent replay and does not create duplicate Domain records or ideas. |
+| Illo-configured projection | Illo configures a simple Jira-to-Domain storage flow; event creates/updates a record without per-event Illo reasoning. |
+| Illo-handled routing | Illo configures a complex Jira routing flow; event creates Domain record, analysis, solution notes, and clear ownership outcome. |
+| Unknown repo | Illo marks `needs-routing` or asks for clarification without guessing an owner. |
+| Unknown origin | No-policy event enters Illo triage safely and does not borrow an unrelated policy. |
+| Cross-org token attempt | Request is rejected and no event/workspace mutation is created. |
+| Signal-only token direct mutation attempt | Request is rejected; compatibility tools do not become automatic-hook guidance. |
+| Stuck run recovery | Failed or expired Illo run is visible from `manage_inbound`, and replay/inspection gives enough context for a human or Illo to recover. |
+| Source card after traffic | Source card explains sampled origins, statuses, payload shapes, observed outcomes, and real failures without exposing raw secrets. |
+| Disable connection/policy | New deliveries stop being handled; historical events remain inspectable. |
+
+#### Minimal Operator Runbook
+
+This runbook is intentionally Illo-chat-first. It documents the operations Illo should perform with `manage_inbound` on behalf of an authorized user.
+
+1. **Create or inspect a source**
+   - Ask Illo to `list_connections` for similar sources.
+   - If none exists, ask Illo to `create_connection` with `display_name`, `agent_kind`, and `transport=webhook` or `hosted_mcp`.
+   - Ask Illo to `mint_token` with default `signal:submit` scope.
+
+2. **Configure routing**
+   - Ask Illo to `create_policy` with origin patterns and natural-language instructions.
+   - For simple storage, ask Illo to create or reuse a Domain and then `create_projection`.
+   - For reasoning workflows, skip projection and let matching events enter Illo triage.
+   - Ask Illo to `dry_run_match` with a sample payload before sending real traffic.
+
+3. **Send a simulated provider delivery**
+   - Send `POST /webhooks` with bearer token auth.
+   - Include a stable provider delivery header such as `X-GitHub-Delivery: simulated-delivery-1`.
+   - Do not include a direct workspace target in the payload; the source sends facts, and Illo/IloSpace decide what to do.
+
+4. **Inspect and recover**
+   - Ask Illo to `list_attention_events` to find events that are `review_required`, `quarantined`, `failed`, or otherwise errored.
+   - Ask Illo to `get_event(include_receipts=true)` for any concerning event.
+   - Ask Illo to `replay_events` when checking whether current policy/projection config would handle the historical event differently.
+   - Ask Illo to `refresh_source_card` after meaningful traffic so future sessions can understand what the source sends and how it was handled.
+
+5. **Rollback**
+   - Revoke a leaked or bad token with `revoke_token`.
+   - Disable a bad policy with `update_policy(enabled=false)`.
+   - Disable a bad projection with `update_projection(enabled=false)`.
+   - Disable the connection with `update_connection(status="disabled")` when the whole source should stop being handled.
+   - Historical events remain inspectable after rollback.
+
+#### Non-Blockers For First Broad Rollout
+
+- A full manual configuration UI. Configuration can remain Illo-chat-first.
+- Automatic promotion from observed outcomes into deterministic rules. Illo should review and configure those intentionally.
+- Perfect provider coverage. One provider-shaped simulated webhook plus the generic webhook path is enough for the next rollout.
+- A large closed taxonomy of possible Illo outcomes. Open summaries and tags remain the right model.
+
+#### Current Readiness Call
+
+Current state is **architecture validated, not broad-rollout ready**.
+
+The current readiness branch handles malformed MCP JSON, provider-shaped delivery-id idempotency, source-card attention/failure wording, connection-scope spoofing regression coverage, stuck-event listing for Illo recovery, and the minimal operator runbook. The remaining broad-rollout work is a final live smoke using a simulated provider delivery plus one Codex MCP signal, and then an intentional beta rollout decision.
 
 ### Trace-Based Follow-Up
 

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -443,6 +443,30 @@ async def test_hosted_mcp_invalid_token_returns_json_rpc_error():
     assert body["error"]["data"] == {"http_status": 401, "auth": "bearer"}
 
 
+async def test_hosted_mcp_malformed_json_returns_invalid_request_without_auth():
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+    ) as authenticate:
+        response = await _request(
+            "POST",
+            "/api/mcp",
+            headers={
+                "Authorization": "Bearer bridge-token",
+                "Content-Type": "application/json",
+            },
+            content='{"jsonrpc":"2.0","id":7}{"extra":true}',
+        )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "Invalid Request"},
+    }
+    authenticate.assert_not_called()
+
+
 async def test_hosted_mcp_filters_tools_by_bridge_token_scope():
     principal = external_agents.AgentBridgePrincipal(
         connection_id="conn-1",

--- a/tests/test_inbound_admin_tools.py
+++ b/tests/test_inbound_admin_tools.py
@@ -324,6 +324,72 @@ async def test_configured_projection_processes_signal_and_illo_can_inspect_logs(
     assert receipts["receipts"][0]["event_id"] == result["event_id"]
 
 
+async def test_illo_can_list_attention_events_for_recovery(
+    seeded_session,
+    patch_unit_of_work,
+):
+    with bind_agent_context(AgentExecutionContext(user_id=USER_ID, org_id=ORG_ID)):
+        connection = _decode(
+            await _handle_manage_inbound(
+                action="create_connection",
+                display_name="Webhook recovery source",
+                agent_kind="custom",
+                transport="webhook",
+            )
+        )["connection"]
+
+    def event(status: str, *, origin: str, error: str | None = None) -> InboundEventRow:
+        return InboundEventRow(
+            org_id=ORG_ID,
+            connection_id=connection["id"],
+            kind="signal",
+            origin=origin,
+            raw_payload={"case": origin},
+            normalized_payload={},
+            envelope={},
+            ingress_context={"surface": "webhook"},
+            source_actor={"connection_id": connection["id"]},
+            status=status,
+            action_type="ilo_required" if status == inbound_service.STATUS_REVIEW_REQUIRED else None,
+            error=error,
+        )
+
+    seeded_session.add_all(
+        [
+            event(inbound_service.STATUS_PROCESSED, origin="custom.ok"),
+            event(inbound_service.STATUS_REVIEW_REQUIRED, origin="custom.needs_illo"),
+            event(inbound_service.STATUS_QUARANTINED, origin="custom.bad_schema", error="missing key"),
+            event(inbound_service.STATUS_FAILED, origin="custom.failed_run", error="Illo run failed"),
+            event(inbound_service.STATUS_PROCESSED, origin="custom.processed_with_error", error="late warning"),
+        ]
+    )
+    await seeded_session.flush()
+
+    with bind_agent_context(AgentExecutionContext(user_id=USER_ID, org_id=ORG_ID)):
+        attention = _decode(
+            await _handle_manage_inbound(
+                action="list_attention_events",
+                connection_id=connection["id"],
+                include_payload=False,
+                limit=10,
+            )
+        )
+
+    statuses = {row["status"] for row in attention["events"]}
+    origins = {row["origin"] for row in attention["events"]}
+    assert len(attention["events"]) == 4
+    assert inbound_service.STATUS_REVIEW_REQUIRED in statuses
+    assert inbound_service.STATUS_QUARANTINED in statuses
+    assert inbound_service.STATUS_FAILED in statuses
+    assert "custom.processed_with_error" in origins
+    assert "custom.ok" not in origins
+    assert "raw_payload" not in attention["events"][0]
+    assert attention["summary"]["event_count"] == 4
+    assert {"value": inbound_service.STATUS_REVIEW_REQUIRED, "count": 1} in attention["summary"]["statuses"]
+    assert {"value": inbound_service.STATUS_QUARANTINED, "count": 1} in attention["summary"]["statuses"]
+    assert {"value": inbound_service.STATUS_FAILED, "count": 1} in attention["summary"]["statuses"]
+
+
 async def test_dry_run_uses_same_projection_order_as_runtime(
     seeded_session,
     patch_unit_of_work,
@@ -758,6 +824,22 @@ async def test_source_card_summarizes_connection_and_persists_manual_context(
         issue={"summary": "Missing key"},
         idempotency_key="jira:missing-key",
     )
+    seeded_session.add(
+        InboundEventRow(
+            org_id=ORG_ID,
+            connection_id=connection["id"],
+            kind="signal",
+            origin="jira.issue_needs_triage",
+            raw_payload={},
+            normalized_payload={},
+            envelope={},
+            ingress_context={"surface": "webhook"},
+            source_actor={"connection_id": connection["id"]},
+            status=inbound_service.STATUS_REVIEW_REQUIRED,
+            action_type="ilo_required",
+        )
+    )
+    await seeded_session.flush()
 
     with bind_agent_context(AgentExecutionContext(user_id=USER_ID, org_id=ORG_ID)):
         before = _decode(
@@ -798,13 +880,22 @@ async def test_source_card_summarizes_connection_and_persists_manual_context(
     assert refreshed["configured_rules"]["policies"][0]["has_instructions"] is True
     assert refreshed["configured_rules"]["policies"][0]["schema_required_paths"] == ["payload.issue.key"]
     assert refreshed["configured_rules"]["projections"][0]["id"] == projection["id"]
-    assert refreshed["traffic"]["event_count_sampled"] == 2
+    assert refreshed["traffic"]["event_count_sampled"] == 3
     assert {"value": "jira.issue_created", "count": 1} in refreshed["traffic"]["common_origins"]
     assert {"value": inbound_service.STATUS_PROCESSED, "count": 1} in refreshed["traffic"]["statuses"]
     assert {"value": inbound_service.STATUS_QUARANTINED, "count": 1} in refreshed["traffic"]["statuses"]
+    assert {"value": inbound_service.STATUS_REVIEW_REQUIRED, "count": 1} in refreshed["traffic"]["statuses"]
     assert {"value": "payload.issue.key", "count": 1} in refreshed["traffic"]["payload_shapes"]
     assert {"value": "payload.issue.summary", "count": 2} in refreshed["traffic"]["payload_shapes"]
+    assert {
+        inbound_service.STATUS_QUARANTINED,
+        inbound_service.STATUS_REVIEW_REQUIRED,
+    }.issubset({row["status"] for row in refreshed["traffic"]["recent_attention"]})
     assert refreshed["traffic"]["recent_failures"][0]["status"] == inbound_service.STATUS_QUARANTINED
+    assert all(
+        row["status"] != inbound_service.STATUS_REVIEW_REQUIRED
+        for row in refreshed["traffic"]["recent_failures"]
+    )
     assert source_card["generated_at"] == refreshed["generated_at"]
     assert after["persisted_source_card"]["generated_at"] == refreshed["generated_at"]
     assert after["source_card"]["purpose"] == refreshed["purpose"]

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -183,6 +183,19 @@ async def _post_mcp(session, *, headers: dict[str, str] | None = None, json_body
         app.dependency_overrides.update(overrides)
 
 
+async def _post_mcp_raw(session, *, headers: dict[str, str] | None = None, content: str):
+    overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = lambda: session
+    app.dependency_overrides[rate_limit] = lambda: None
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post("/mcp", headers=headers or {}, content=content)
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(overrides)
+
+
 async def _assert_queued_triage(session, outcome: dict, *, reason: str) -> dict:
     assert outcome["reason"] == reason
     triage = outcome["triage"]
@@ -397,6 +410,25 @@ async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
     assert all(receipt.outcome["triage"]["status"] == "queued" for receipt in receipts)
     assert all(receipt.target["kind"] == "cortex_idea" for receipt in receipts)
     assert all(receipt.tool_use["type"] == "illo_triage" for receipt in receipts)
+
+
+async def test_malformed_mcp_json_fails_without_creating_event(session):
+    response = await _post_mcp_raw(
+        session,
+        headers={
+            "Authorization": f"Bearer {RAW_TOKEN}",
+            "Content-Type": "application/json",
+        },
+        content='{"jsonrpc":"2.0","id":2}{"extra":true}',
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "Invalid Request"},
+    }
+    assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 0
 
 
 async def test_mcp_codex_progress_signal_satisfies_default_checkpoint_policy(session):
@@ -670,6 +702,73 @@ async def test_webhook_rejects_overlong_idempotency_header(session):
     assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 0
 
 
+async def test_webhook_provider_delivery_header_becomes_idempotency_key(session):
+    await _seed_connection(session)
+
+    first = await _post_webhook(
+        session,
+        headers={
+            "Authorization": f"Bearer {RAW_TOKEN}",
+            "X-GitHub-Delivery": "delivery-123",
+        },
+        json={
+            "origin": "github.issue_created",
+            "payload": {"issue": {"key": "GH-1"}},
+        },
+    )
+    replay = await _post_webhook(
+        session,
+        headers={
+            "Authorization": f"Bearer {RAW_TOKEN}",
+            "X-GitHub-Delivery": "delivery-123",
+        },
+        json={
+            "origin": "github.issue_created",
+            "payload": {"issue": {"key": "GH-1"}},
+        },
+    )
+
+    first_body = first.json()
+    replay_body = replay.json()
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert first.status_code == 202
+    assert replay.status_code == 202
+    assert first_body["idempotent_replay"] is False
+    assert replay_body["idempotent_replay"] is True
+    assert replay_body["event_id"] == first_body["event_id"]
+    assert event.idempotency_key == "x-github-delivery:delivery-123"
+    assert event.ingress_context["provider_delivery"] == {
+        "header": "x-github-delivery",
+        "value": "delivery-123",
+    }
+    assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 1
+
+
+async def test_explicit_webhook_idempotency_header_wins_over_provider_delivery(session):
+    await _seed_connection(session)
+
+    response = await _post_webhook(
+        session,
+        headers={
+            "Authorization": f"Bearer {RAW_TOKEN}",
+            "X-Illo-Idempotency-Key": "explicit-key",
+            "X-GitHub-Delivery": "delivery-ignored",
+        },
+        json={
+            "origin": "github.issue_created",
+            "payload": {"issue": {"key": "GH-2"}},
+        },
+    )
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert response.status_code == 202
+    assert event.idempotency_key == "explicit-key"
+    assert event.ingress_context["provider_delivery"] == {
+        "header": "x-github-delivery",
+        "value": "delivery-ignored",
+    }
+
+
 async def test_webhook_rejects_empty_kind_before_inbound_processing(session):
     await _seed_connection(session)
 
@@ -778,6 +877,51 @@ async def test_source_policy_matching_uses_connection_scope_and_priority(session
         session,
         result["ilo_outcome"],
         reason="matched_policy_without_projection",
+    )
+
+
+async def test_payload_cannot_spoof_another_connections_source_policy(session):
+    principal = await _seed_connection(session)
+    other_connection_id = "55555555-5555-4555-8555-555555555555"
+    await _seed_connection(
+        session,
+        connection_id=other_connection_id,
+        token_id="66666666-6666-4666-8666-666666666666",
+        raw_token="illo_conn_other",
+    )
+    other_policy = await inbound.create_source_policy(
+        session,
+        org_id=ORG_ID,
+        connection_id=other_connection_id,
+        name="Other connection Jira policy",
+        origin_patterns=["jira.ticket_*"],
+        priority=1,
+    )
+
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "origin": "jira.ticket_created",
+            "payload": {
+                "source": {"connection_id": other_connection_id},
+                "issue": {"key": "PROJ-SPOOF"},
+            },
+            "idempotency_key": "jira:PROJ-SPOOF:create",
+        },
+        ingress_context={"surface": "test"},
+    )
+
+    assert result["status"] == "review_required"
+    assert result["matched_policy_id"] is None
+    assert result["matched_policy_id"] != str(other_policy.id)
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert event.connection_id == CONNECTION_ID
+    assert event.raw_payload["source"]["connection_id"] == other_connection_id
+    await _assert_queued_triage(
+        session,
+        result["ilo_outcome"],
+        reason="no_matching_source_policy",
     )
 
 


### PR DESCRIPTION
## Summary
- Hardened hosted MCP to return a structured JSON-RPC `Invalid Request` response for malformed bodies instead of a generic 500.
- Improved webhook ingress idempotency by deriving keys from common provider delivery headers when an explicit `X-Illo-Idempotency-Key` is not present.
- Added `manage_inbound.list_attention_events` plus tool-catalog wiring so operators can inspect failed, quarantined, review-required, or errored inbound events.
- Split source-card summaries into `recent_attention` and `recent_failures` to make operator context clearer.
- Updated the inbound coordination PRD with the ship-to-all-users readiness gate and current validation notes.

## Testing
- `venv/bin/python -m pytest tests/test_inbound_webhooks.py::test_webhook_provider_delivery_header_becomes_idempotency_key tests/test_inbound_webhooks.py::test_explicit_webhook_idempotency_header_wins_over_provider_delivery tests/test_inbound_webhooks.py::test_payload_cannot_spoof_another_connections_source_policy tests/test_inbound_admin_tools.py::test_illo_can_list_attention_events_for_recovery tests/test_inbound_admin_tools.py::test_source_card_summarizes_connection_and_persists_manual_context tests/test_external_agent_routes.py::test_hosted_mcp_malformed_json_returns_invalid_request_without_auth`
- `venv/bin/python -m pytest tests/test_external_agent_routes.py tests/test_inbound_webhooks.py tests/test_inbound_admin_tools.py tests/test_tools.py`