### PR TITLE
Implement universal thread context ingress

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -25,7 +25,7 @@ from brain.systems.inbound.service import submit_inbound_envelope as _submit_inb
 
 router = APIRouter(tags=["agent-mcp"], dependencies=[Depends(rate_limit)])
 
-SIGNAL_TOOL_NAME = "illo_submit_signal"
+CONTEXT_TOOL_NAME = "illo_submit_context"
 
 
 ToolHandler = Callable[
@@ -46,44 +46,50 @@ def _tool_schema(description: str, properties: dict[str, Any], required: list[st
 
 
 MCP_TOOLS: dict[str, dict[str, Any]] = {
-    SIGNAL_TOOL_NAME: {
+    CONTEXT_TOOL_NAME: {
         **_tool_schema(
             (
-                "Submit a progress or status signal from a personal tool into IloSpace. "
-                "This is the default tool for automatic hooks and routine work updates: "
-                "send what happened, plus hints like repo, branch, task, and files touched. "
-                "Do not choose a thread, project, or teammate target here; IloSpace and Illo "
-                "decide whether to store, route, summarize, ask, or ignore the signal. "
-                "Use direct thread tools only when the user explicitly asks for a visible "
-                "thread/message in a known destination."
+                "Submit ordered context from a personal agent to Illo, the user's team agent. "
+                "Use this when the user wants Illo or the team to have the current AI thread, "
+                "trace, artifacts, files, links, diffs, or other source material. The personal "
+                "agent supplies context and provenance; Illo coordinates the team workspace. "
+                "Do not encode a workflow such as decision request here. Use correlation when "
+                "attaching to a known Thread; otherwise IlloSpace may create one and return a link."
             ),
             {
-                "summary": {
+                "intent": {
                     "type": "string",
-                    "description": "Concise human-readable progress summary from the personal tool.",
+                    "description": "Natural-language reason this context is being submitted.",
                 },
                 "origin": {
                     "type": "string",
-                    "description": "Stable source event name, for example codex.progress.",
-                    "default": "codex.progress",
+                    "description": "Stable source event name, for example codex.context.",
+                    "default": "codex.context",
                 },
-                "payload": {
+                "parts": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Ordered source context parts: text, json, link, file, trace, conversation, diff, screenshot, or artifact.",
+                    "default": [],
+                },
+                "source": {
                     "type": "object",
-                    "description": "Optional structured event payload from the personal tool.",
+                    "description": "Optional provenance about the personal agent, repo, branch, model, session, or external source.",
                     "default": {},
                 },
-                "hints": {
+                "constraints": {
                     "type": "object",
-                    "description": "Optional routing/context hints. These are not direct workspace targets.",
+                    "description": "Optional boundaries such as privacy, urgency, visibility, or notification preferences.",
                     "default": {},
                 },
-                "desired_outcome": {
-                    "type": "string",
-                    "description": "Optional intent for IloSpace, such as team_update, store_only, or ask_illo.",
+                "correlation": {
+                    "type": "object",
+                    "description": "Optional correlation such as thread_id, external_session_id, or previous submission reference.",
+                    "default": {},
                 },
                 "idempotency_key": {
                     "type": "string",
-                    "description": "Optional stable key so repeated hook submissions do not duplicate work.",
+                    "description": "Optional stable key so repeated submissions do not duplicate work.",
                 },
                 "source_tool": {
                     "type": "string",
@@ -103,7 +109,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "run_id": {"type": "string", "description": "Optional personal-tool run id."},
                 "metadata": {"type": "object", "description": "Optional machine-readable metadata.", "default": {}},
             },
-            ["summary"],
+            ["intent"],
         ),
         "scope": external_agents.SCOPE_SIGNAL_SUBMIT,
         "mutates_inbound": True,
@@ -154,7 +160,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "personal-agent work. Use only when the user explicitly asks to share work "
                 "with teammates, publish findings into Illo, or start a team-visible "
                 "discussion. For automatic hooks and routine progress, prefer "
-                f"{SIGNAL_TOOL_NAME} so IloSpace can route the signal. Set trigger_illo "
+                f"{CONTEXT_TOOL_NAME} so IloSpace can route the context. Set trigger_illo "
                 "only when the user wants Illo to actively respond or the message explicitly "
                 "mentions Illo."
             ),
@@ -191,7 +197,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "Advanced compatibility tool for posting a visible update into an existing "
                 "Illo thread. Use only when the user explicitly names or provides the thread "
                 "destination. For automatic hooks and routine progress, prefer "
-                f"{SIGNAL_TOOL_NAME} so IloSpace can route the signal."
+                f"{CONTEXT_TOOL_NAME} so IloSpace can route the context."
             ),
             {
                 "idea_id": {"type": "string", "description": "Existing Illo idea/thread id."},
@@ -286,7 +292,7 @@ def _tool_metadata(arguments: dict[str, Any], *, tool_name: str, trigger_illo: b
     return metadata
 
 
-_FORBIDDEN_SIGNAL_TARGET_FIELDS = frozenset(
+_FORBIDDEN_CONTEXT_TARGET_FIELDS = frozenset(
     {
         "idea_id",
         "thread_id",
@@ -305,63 +311,69 @@ def _clean_optional_string(value: Any) -> str | None:
     return text or None
 
 
-def _signal_hints(arguments: dict[str, Any]) -> dict[str, Any]:
-    hints = _clean_dict(arguments.get("hints"))
+def _context_source(arguments: dict[str, Any]) -> dict[str, Any]:
+    source = _clean_dict(arguments.get("source"))
     for key in ("source_tool", "repo", "branch", "task_title", "session_id", "run_id"):
         value = _clean_optional_string(arguments.get(key))
         if value:
-            hints.setdefault(key, value)
+            source.setdefault(key, value)
     files_touched = _clean_string_list(arguments.get("files_touched"))
     if files_touched:
-        hints.setdefault("files_touched", files_touched)
-    return hints
+        source.setdefault("files_touched", files_touched)
+    return source
 
 
-def _signal_payload(arguments: dict[str, Any], *, summary: str, origin: str, hints: dict[str, Any]) -> dict[str, Any]:
-    payload = _clean_dict(arguments.get("payload"))
-    source_tool = str(hints.get("source_tool") or arguments.get("source_tool") or "").strip().lower()
-    if "checkpoint" not in payload and (origin == "codex.progress" or source_tool == "codex"):
-        payload["checkpoint"] = {
-            key: value
-            for key, value in {
-                "summary": summary,
-                "source_tool": hints.get("source_tool") or "codex",
-                "repo": hints.get("repo"),
-                "branch": hints.get("branch"),
-                "task_title": hints.get("task_title"),
-                "files_touched": hints.get("files_touched"),
-                "session_id": hints.get("session_id"),
-                "run_id": hints.get("run_id"),
-            }.items()
-            if value not in (None, "", [])
-        }
-    return payload
+def _clean_context_parts(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{CONTEXT_TOOL_NAME} parts must be an array")
+    parts: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, dict):
+            parts.append(dict(item))
+        elif str(item or "").strip():
+            parts.append({"type": "text", "text": str(item)})
+    return parts
 
 
-def _build_signal_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
-    forbidden = sorted(_FORBIDDEN_SIGNAL_TARGET_FIELDS.intersection(arguments))
+def _build_context_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
+    forbidden = sorted(_FORBIDDEN_CONTEXT_TARGET_FIELDS.intersection(arguments))
     if forbidden:
         raise ValueError(
-            f"{SIGNAL_TOOL_NAME} accepts context hints, not direct workspace targets. "
-            f"Remove top-level field(s): {', '.join(forbidden)}"
+            f"{CONTEXT_TOOL_NAME} accepts context and optional correlation, not direct workspace targets. "
+            f"Move Thread ids under correlation and remove top-level field(s): {', '.join(forbidden)}"
         )
-    summary = _clean_optional_string(arguments.get("summary"))
-    if not summary:
-        raise ValueError(f"{SIGNAL_TOOL_NAME} requires a non-empty summary")
-    origin = _clean_optional_string(arguments.get("origin")) or "codex.progress"
-    hints = _signal_hints(arguments)
+    intent = _clean_optional_string(arguments.get("intent") or arguments.get("summary"))
+    if not intent:
+        raise ValueError(f"{CONTEXT_TOOL_NAME} requires a non-empty intent")
+    origin = _clean_optional_string(arguments.get("origin")) or "codex.context"
+    source = _context_source(arguments)
+    constraints = _clean_dict(arguments.get("constraints"))
+    correlation = _clean_dict(arguments.get("correlation"))
+    parts = _clean_context_parts(arguments.get("parts"))
+    payload = {
+        "intent": intent,
+        "parts": parts,
+        "source": source,
+        "constraints": constraints,
+        "correlation": correlation,
+    }
     return {
-        "kind": "signal",
+        "kind": "context",
         "origin": origin,
-        "payload": _signal_payload(arguments, summary=summary, origin=origin, hints=hints),
-        "summary": summary,
-        "hints": hints,
-        "desired_outcome": _clean_optional_string(arguments.get("desired_outcome")),
+        "payload": payload,
+        "summary": _clean_optional_string(arguments.get("summary")) or intent,
+        "intent": intent,
+        "parts": parts,
+        "source": source,
+        "constraints": constraints,
+        "correlation": correlation,
         "idempotency_key": _clean_optional_string(arguments.get("idempotency_key")),
     }
 
 
-def _signal_connection(principal: external_agents.AgentBridgePrincipal) -> dict[str, Any]:
+def _context_connection(principal: external_agents.AgentBridgePrincipal) -> dict[str, Any]:
     return {
         "id": principal.connection_id,
         "org_id": principal.org_id,
@@ -370,11 +382,11 @@ def _signal_connection(principal: external_agents.AgentBridgePrincipal) -> dict[
         "display_name": principal.connection_display_name,
         "agent_kind": principal.agent_kind,
         "source_type": "personal_tool",
-        "capabilities": ["submit_signals"],
+        "capabilities": ["submit_context"],
     }
 
 
-def _signal_source_actor(principal: external_agents.AgentBridgePrincipal) -> dict[str, Any]:
+def _context_source_actor(principal: external_agents.AgentBridgePrincipal) -> dict[str, Any]:
     return {
         "kind": "external_source_connection",
         "connection_id": principal.connection_id,
@@ -383,14 +395,14 @@ def _signal_source_actor(principal: external_agents.AgentBridgePrincipal) -> dic
     }
 
 
-def _signal_ingress_context(
+def _context_ingress_context(
     principal: external_agents.AgentBridgePrincipal,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "surface": "mcp_personal_tool",
-        "tool_name": SIGNAL_TOOL_NAME,
-        "source_actor": _signal_source_actor(principal),
+        "tool_name": CONTEXT_TOOL_NAME,
+        "source_actor": _context_source_actor(principal),
         "authority_principal": {
             "kind": "user",
             "user_id": principal.owner_user_id,
@@ -400,7 +412,7 @@ def _signal_ingress_context(
             "token_id": principal.token_id,
             "scopes": sorted(principal.scopes),
         },
-        "metadata": _tool_metadata(arguments, tool_name=SIGNAL_TOOL_NAME),
+        "metadata": _tool_metadata(arguments, tool_name=CONTEXT_TOOL_NAME),
     }
 
 
@@ -446,18 +458,31 @@ def _list_tools(principal: external_agents.AgentBridgePrincipal) -> list[dict[st
     return tools
 
 
-async def _tool_submit_signal(
+def _context_tool_response(result: dict[str, Any]) -> dict[str, Any]:
+    outcome = dict(result.get("ilo_outcome") or {})
+    return {
+        **result,
+        "thread_id": outcome.get("thread_id"),
+        "url": outcome.get("url"),
+        "message": outcome.get("message"),
+        "operation": outcome.get("operation"),
+        "context_submission_id": outcome.get("context_submission_id"),
+    }
+
+
+async def _tool_submit_context(
     db: AsyncSession,
     principal: external_agents.AgentBridgePrincipal,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    envelope = _build_signal_envelope(arguments)
-    return await submit_inbound_envelope(
+    envelope = _build_context_envelope(arguments)
+    result = await submit_inbound_envelope(
         db,
-        connection=_signal_connection(principal),
+        connection=_context_connection(principal),
         envelope=envelope,
-        ingress_context=_signal_ingress_context(principal, arguments),
+        ingress_context=_context_ingress_context(principal, arguments),
     )
+    return _context_tool_response(result)
 
 
 async def _tool_search_workspace(
@@ -593,7 +618,7 @@ async def _add_thread_trigger_result_if_needed(
 
 
 TOOL_HANDLERS: dict[str, ToolHandler] = {
-    SIGNAL_TOOL_NAME: _tool_submit_signal,
+    CONTEXT_TOOL_NAME: _tool_submit_context,
     "illo_search_workspace": _tool_search_workspace,
     "illo_get_thread": _tool_get_thread,
     "illo_get_team_members": _tool_get_team_members,

--- a/brain/app/api/routers/cortex/__init__.py
+++ b/brain/app/api/routers/cortex/__init__.py
@@ -9,6 +9,7 @@ from brain.app.api.routers.cortex._router import router  # noqa: F401
 import brain.app.api.routers.cortex._ideas  # noqa: F401
 import brain.app.api.routers.cortex._run  # noqa: F401
 import brain.app.api.routers.cortex._idea_ops  # noqa: F401
+import brain.app.api.routers.cortex._discussion  # noqa: F401
 import brain.app.api.routers.cortex._analytics  # noqa: F401
 import brain.app.api.routers.cortex._misc  # noqa: F401
 import brain.app.api.routers.cortex._bootstrap  # noqa: F401

--- a/brain/app/api/routers/cortex/_discussion.py
+++ b/brain/app/api/routers/cortex/_discussion.py
@@ -1,0 +1,155 @@
+"""Thread Discussion endpoints."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.app.api.auth import get_current_user
+from brain.app.api.deps import get_db
+from brain.app.api.routers.cortex._helpers import _a_require_idea_for_user as _require_idea_for_user
+from brain.app.api.routers.cortex._router import router
+from brain.app.api.routers.ws import ws_manager
+from brain.app.mentions import classify_mention_intent
+from brain.platform.db.models.idea import ThreadDiscussionComment
+from brain.platform.db.models.org import User
+
+
+class DiscussionCommentCreate(BaseModel):
+    body: str = Field(min_length=1, max_length=20_000)
+    attachments: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+
+
+def _comment_payload(
+    comment: ThreadDiscussionComment,
+    *,
+    author_name: str | None = None,
+    author_color: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": comment.id,
+        "thread_id": str(comment.thread_id),
+        "org_id": str(comment.org_id),
+        "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
+        "author_kind": comment.author_kind,
+        "author_name": author_name,
+        "author_color": author_color,
+        "body": comment.body,
+        "attachments": comment.attachments or [],
+        "metadata": comment.metadata_ or {},
+        "created_at": comment.created_at.isoformat() if comment.created_at else None,
+    }
+
+
+def _thread_org_id(idea: Any, user: dict[str, Any]) -> str:
+    return str(getattr(idea, "org_id", None) or user.get("org_id") or "")
+
+
+async def _discussion_comment_payloads(
+    db: AsyncSession,
+    *,
+    thread_id: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(ThreadDiscussionComment, User.name.label("author_name"), User.color.label("author_color"))
+        .outerjoin(User, ThreadDiscussionComment.author_user_id == User.id)
+        .where(ThreadDiscussionComment.thread_id == str(thread_id))
+        .order_by(ThreadDiscussionComment.created_at.asc(), ThreadDiscussionComment.id.asc())
+        .limit(max(1, min(int(limit or 100), 300)))
+    )
+    return [
+        _comment_payload(row[0], author_name=row.author_name, author_color=row.author_color)
+        for row in (await db.execute(stmt)).all()
+    ]
+
+
+async def _trigger_illo_from_discussion(
+    db: AsyncSession,
+    *,
+    idea: Any,
+    comment: ThreadDiscussionComment,
+    user: dict[str, Any],
+) -> dict[str, Any]:
+    from brain.app.triggers.adapters.internal import build_cortex_notify_trigger
+    from brain.app.triggers.router import async_route_trigger
+
+    metadata = {
+        **dict(comment.metadata_ or {}),
+        "source": "thread_discussion",
+        "discussion_comment_id": comment.id,
+        "thread_message": comment.body,
+    }
+    trigger = build_cortex_notify_trigger(
+        event="thread_reply",
+        idea_id=str(idea.id),
+        idea=idea,
+        user=user,
+        thread_message=comment.body,
+        metadata=metadata,
+        effective_metadata=metadata,
+        priority=0,
+    )
+    return (await async_route_trigger(trigger, session=db)).to_response()
+
+
+@router.get("/ideas/{idea_id}/discussion")
+async def list_thread_discussion(
+    idea_id: str,
+    limit: int = 100,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    await _require_idea_for_user(db, idea_id, user)
+    return await _discussion_comment_payloads(db, thread_id=idea_id, limit=limit)
+
+
+@router.post("/ideas/{idea_id}/discussion", status_code=201)
+async def create_thread_discussion_comment(
+    idea_id: str,
+    body: DiscussionCommentCreate,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    idea = await _require_idea_for_user(db, idea_id, user)
+    text = body.body.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Discussion comment body is required")
+
+    attachments = body.attachments if isinstance(body.attachments, list) else []
+    org_id = _thread_org_id(idea, user)
+    comment = ThreadDiscussionComment(
+        thread_id=str(idea.id),
+        org_id=org_id,
+        author_user_id=str(user.get("id")) if user.get("id") else None,
+        author_kind="user",
+        body=text,
+        attachments=attachments,
+        metadata_=dict(body.metadata or {}),
+    )
+    db.add(comment)
+    await db.flush()
+
+    trigger = None
+    if classify_mention_intent(text, invoke_without_mentions=False).should_invoke_illo:
+        trigger = await _trigger_illo_from_discussion(db, idea=idea, comment=comment, user=user)
+
+    payload = _comment_payload(
+        comment,
+        author_name=user.get("name"),
+        author_color=user.get("color"),
+    )
+    await db.commit()
+    await ws_manager.broadcast_product_event(
+        "thread_discussion_comment",
+        {"idea_id": str(idea.id), "comment": payload},
+        org_id=org_id,
+    )
+    return {
+        "comment": payload,
+        "trigger": trigger,
+    }

--- a/brain/app/api/routers/workspace_pins.py
+++ b/brain/app/api/routers/workspace_pins.py
@@ -125,7 +125,7 @@ async def update_workspace_pin(
     body: WorkspacePinUpdate,
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
-    ):
+) -> WorkspacePinRead:
     org_id = require_org_context(user)
     pin = await _get_pin_for_org(db, org_id, pin_id)
     _require_pin_author(pin, user)
@@ -145,6 +145,7 @@ async def update_workspace_pin(
         pin.pin_metadata = dict(updates["metadata"])
 
     await db.flush()
+    await db.refresh(pin)
     payload = _serialize_pin(pin)
     await ws_manager.broadcast_to_org(org_id, "workspace_pin_updated", {"pin": payload.model_dump(mode="json")})
     return payload
@@ -155,7 +156,7 @@ async def delete_workspace_pin(
     pin_id: str,
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
-    ):
+):
     org_id = require_org_context(user)
     pin = await _get_pin_for_org(db, org_id, pin_id)
     _require_pin_author(pin, user)

--- a/brain/platform/db/alembic/versions/0010_thread_context_and_discussion.py
+++ b/brain/platform/db/alembic/versions/0010_thread_context_and_discussion.py
@@ -1,0 +1,121 @@
+"""Add Thread context submissions and Discussion comments.
+
+Revision ID: 0010_thread_context_and_discussion
+Revises: 0009_org_owned_provider_credentials
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0010_thread_context_and_discussion"
+down_revision = "0009_org_owned_provider_credentials"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(table_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return table_name in inspector.get_table_names(schema="public")
+
+
+def upgrade() -> None:
+    if not _table_exists("thread_context_submissions"):
+        op.create_table(
+            "thread_context_submissions",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=False),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "thread_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("ideas.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "org_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("orgs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "source_connection_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("external_agent_connections.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "submitted_by_user_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "inbound_event_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("inbound_events.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("intent", sa.Text(), nullable=True),
+            sa.Column("source", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("constraints", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("correlation", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("parts", postgresql.JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+            sa.Column("routing_result", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        )
+        op.create_index(
+            "ix_thread_context_submissions_thread_created",
+            "thread_context_submissions",
+            ["thread_id", "created_at", "id"],
+        )
+        op.create_index(
+            "ix_thread_context_submissions_inbound_event",
+            "thread_context_submissions",
+            ["inbound_event_id"],
+        )
+
+    if not _table_exists("thread_discussion_comments"):
+        op.create_table(
+            "thread_discussion_comments",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "thread_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("ideas.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "org_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("orgs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "author_user_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("author_kind", sa.String(length=20), nullable=False, server_default="user"),
+            sa.Column("body", sa.Text(), nullable=False),
+            sa.Column("attachments", postgresql.JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+            sa.Column("metadata", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        )
+        op.create_index(
+            "ix_thread_discussion_comments_thread_created",
+            "thread_discussion_comments",
+            ["thread_id", "created_at", "id"],
+        )
+
+
+def downgrade() -> None:
+    return None

--- a/brain/platform/db/models/idea.py
+++ b/brain/platform/db/models/idea.py
@@ -35,6 +35,8 @@ __all__ = [
     "IdeaThread",
     "UserMention",
     "VisualBlock",
+    "ThreadContextSubmission",
+    "ThreadDiscussionComment",
     "ProjectProfile",
     "ProjectProfileAccess",
     "IdeaProjectAttachment",
@@ -189,6 +191,68 @@ class IdeaThread(Base, CreatedAtMixin):
     user_id: Mapped[Optional[str]] = mapped_column(
         UUID(as_uuid=False), ForeignKey("users.id"), nullable=True
     )
+
+
+class ThreadContextSubmission(Base, CreatedAtMixin):
+    """Immutable context submitted by a personal agent and attached to a Thread."""
+
+    __tablename__ = "thread_context_submissions"
+    __table_args__ = (
+        Index("ix_thread_context_submissions_thread_created", "thread_id", "created_at", "id"),
+        Index("ix_thread_context_submissions_inbound_event", "inbound_event_id"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+        default=lambda: str(uuid.uuid4()),
+    )
+    thread_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("ideas.id", ondelete="CASCADE"), nullable=False
+    )
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False
+    )
+    source_connection_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("external_agent_connections.id", ondelete="SET NULL"), nullable=True
+    )
+    submitted_by_user_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    inbound_event_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("inbound_events.id", ondelete="SET NULL"), nullable=True
+    )
+    intent: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    source: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), default=dict)
+    constraints: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), default=dict)
+    correlation: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), default=dict)
+    parts: Mapped[list] = mapped_column(JSONB, server_default=text("'[]'::jsonb"), default=list)
+    routing_result: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), default=dict)
+
+
+class ThreadDiscussionComment(Base, CreatedAtMixin):
+    """Attached team discussion comment for a Thread."""
+
+    __tablename__ = "thread_discussion_comments"
+    __table_args__ = (
+        Index("ix_thread_discussion_comments_thread_created", "thread_id", "created_at", "id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    thread_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("ideas.id", ondelete="CASCADE"), nullable=False
+    )
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False
+    )
+    author_user_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    author_kind: Mapped[str] = mapped_column(String(20), nullable=False, server_default="user", default="user")
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    attachments: Mapped[list] = mapped_column(JSONB, server_default=text("'[]'::jsonb"), default=list)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, server_default=text("'{}'::jsonb"), default=dict)
 
 
 class UserMention(Base, CreatedAtMixin):

--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -336,6 +336,14 @@ def _without_openai_reasoning_summary(kwargs: dict[str, Any]) -> dict[str, Any]:
     return retry_kwargs
 
 
+def _is_complete_openai_reasoning_summary_event(event_type: str) -> bool:
+    return event_type in {
+        "response.reasoning_summary_text.done",
+        "response.reasoning_summary_part.done",
+        "response.output_item.done",
+    }
+
+
 class OpenAIProvider(LLMProvider):
     """OpenAI provider using the native Responses API."""
 
@@ -446,7 +454,11 @@ class OpenAIProvider(LLMProvider):
                             raise OpenAICodexRetryableError(message)
                         raise RuntimeError(message)
 
-                    reasoning_summary_delta = _extract_openai_reasoning_summary_from_event(event)
+                    reasoning_summary_delta = (
+                        _extract_openai_reasoning_summary_from_event(event)
+                        if _is_complete_openai_reasoning_summary_event(event_type)
+                        else ""
+                    )
                     if reasoning_summary_delta:
                         yield StreamEvent(type="reflection", text=reasoning_summary_delta)
                         continue

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.domain import DomainRecord
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
-from brain.platform.db.models.idea import Idea, IdeaThread
+from brain.platform.db.models.idea import Idea, IdeaThread, ThreadContextSubmission
 from brain.platform.db.models.inbound import (
     InboundDecisionReceiptRow,
     InboundDomainProjectionKeyRow,
@@ -35,6 +35,10 @@ STATUS_FAILED = "failed"
 ACTION_STORE_ONLY = "store_only"
 ACTION_DOMAIN_PROJECTION_UPSERT = "domain_projection.upsert"
 ACTION_ILO_REQUIRED = "ilo_required"
+ACTION_THREAD_CREATED = "thread.created"
+ACTION_THREAD_ATTACHED = "thread.attached"
+ACTION_CONTEXT_ACCEPTED = "accepted"
+CONTEXT_ENVELOPE_KIND = "context"
 
 DOMAIN_PROJECTION_ACTIONS = frozenset(
     {ACTION_DOMAIN_PROJECTION_UPSERT, "domain_projection", "create_domain_record"}
@@ -188,6 +192,14 @@ async def submit_inbound_envelope(
     policy: InboundSourcePolicyRow | None = None
     projection: InboundDomainProjectionRow | None = None
     try:
+        if normalized["kind"] == CONTEXT_ENVELOPE_KIND:
+            return await _process_context_envelope(
+                session,
+                context=context,
+                event=event,
+                normalized=normalized,
+            )
+
         policy = await match_source_policy(
             session,
             org_id=context.org_id,
@@ -429,9 +441,44 @@ def _normalize_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "desired_outcome": _clean_optional(data.get("desired_outcome")),
         "idempotency_key": _clean_optional(data.get("idempotency_key")),
     }
+    if kind == CONTEXT_ENVELOPE_KIND:
+        normalized.update(_normalize_context_fields(data, normalized["payload"]))
     if normalized["idempotency_key"] and len(str(normalized["idempotency_key"])) > 160:
         raise InboundValidationError("idempotency_key must be 160 characters or fewer")
     return normalized
+
+
+def _normalize_context_fields(data: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    intent = _clean_optional(data.get("intent")) or _clean_optional(payload.get("intent"))
+    source = data.get("source", payload.get("source", {}))
+    constraints = data.get("constraints", payload.get("constraints", {}))
+    correlation = data.get("correlation", payload.get("correlation", {}))
+    parts = data.get("parts", payload.get("parts", []))
+    if source is None:
+        source = {}
+    if constraints is None:
+        constraints = {}
+    if correlation is None:
+        correlation = {}
+    if parts is None:
+        parts = []
+    if not isinstance(source, dict):
+        raise InboundValidationError("source must be an object")
+    if not isinstance(constraints, dict):
+        raise InboundValidationError("constraints must be an object")
+    if not isinstance(correlation, dict):
+        raise InboundValidationError("correlation must be an object")
+    if not isinstance(parts, list):
+        raise InboundValidationError("parts must be an array")
+    if not intent and not parts and not _clean_optional(data.get("summary")):
+        raise InboundValidationError("context envelope requires intent, summary, or parts")
+    return {
+        "intent": intent,
+        "source": dict(source),
+        "constraints": dict(constraints),
+        "correlation": dict(correlation),
+        "parts": list(parts),
+    }
 
 
 async def _find_idempotent_event(
@@ -963,6 +1010,221 @@ def _triage_tool_use(triage: Mapping[str, Any]) -> dict[str, Any]:
         "status": triage.get("status"),
         **({"run_id": triage.get("run_id")} if triage.get("run_id") is not None else {}),
     }
+
+
+async def _process_context_envelope(
+    session: AsyncSession,
+    *,
+    context: _ConnectionContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Attach submitted personal-agent context to a Thread without LLM routing."""
+
+    if not context.owner_user_id:
+        return await _complete_event(
+            session,
+            event,
+            policy=None,
+            status=STATUS_PROCESSED,
+            action_type=ACTION_CONTEXT_ACCEPTED,
+            action_result={
+                "operation": "stored",
+                "reason": "missing_authority_user",
+                "event_id": str(event.id),
+            },
+            confidence=1.0,
+            target={"kind": "inbound_event", "event_id": str(event.id)},
+            tool_use={"type": ACTION_CONTEXT_ACCEPTED},
+            reasoning_summary="Context was accepted as an inbound event because no authority user was available.",
+        )
+
+    correlation = dict(normalized.get("correlation") or {})
+    thread = await _correlated_thread(session, context=context, correlation=correlation)
+    operation = "attached"
+    action_type = ACTION_THREAD_ATTACHED
+    if thread is None:
+        thread = await _create_context_thread(session, context=context, event=event, normalized=normalized)
+        operation = "created"
+        action_type = ACTION_THREAD_CREATED
+
+    source = dict(normalized.get("source") or {})
+    constraints = dict(normalized.get("constraints") or {})
+    parts = list(normalized.get("parts") or [])
+    intent = _clean_optional(normalized.get("intent")) or _clean_optional(normalized.get("summary"))
+
+    submission = ThreadContextSubmission(
+        thread_id=str(thread.id),
+        org_id=context.org_id,
+        source_connection_id=context.connection_id,
+        submitted_by_user_id=context.owner_user_id,
+        inbound_event_id=str(event.id),
+        intent=intent,
+        source=source,
+        constraints=constraints,
+        correlation=correlation,
+        parts=_json_safe(parts),
+        routing_result={},
+    )
+    session.add(submission)
+    await session.flush()
+
+    thread_message = IdeaThread(
+        idea_id=str(thread.id),
+        role="user",
+        content=_context_timeline_preview(
+            context=context,
+            normalized=normalized,
+            submission_id=str(submission.id),
+        ),
+        attachments=[],
+        metadata_={
+            "source": "inbound.context",
+            "event_id": str(event.id),
+            "context_submission_id": str(submission.id),
+            "origin": normalized.get("origin"),
+            "operation": operation,
+            "connection_id": context.connection_id,
+            "source_connection_display_name": context.display_name,
+            "source_kind": context.source_kind,
+            "part_count": len(parts),
+        },
+        message_type="context_submission",
+        user_id=context.owner_user_id,
+    )
+    session.add(thread_message)
+    await session.flush()
+
+    action_result = {
+        "operation": operation,
+        "thread_id": str(thread.id),
+        "url": _thread_url(thread),
+        "context_submission_id": str(submission.id),
+        "thread_message_id": thread_message.id,
+        "event_id": str(event.id),
+        "message": (
+            "Context accepted and attached to an existing Thread."
+            if operation == "attached"
+            else "Context accepted and a Thread was created."
+        ),
+    }
+    submission.routing_result = dict(action_result)
+    return await _complete_event(
+        session,
+        event,
+        policy=None,
+        status=STATUS_PROCESSED,
+        action_type=action_type,
+        action_result=action_result,
+        confidence=1.0,
+        target={"kind": "cortex_idea", "idea_id": str(thread.id)},
+        tool_use={"type": "illo_submit_context", "operation": operation},
+        reasoning_summary=(
+            "Context ingress was routed deterministically by explicit correlation."
+            if operation == "attached"
+            else "Context ingress created a Thread immediately so the personal agent can return a link."
+        ),
+        reusable_pattern_candidate={
+            "kind": CONTEXT_ENVELOPE_KIND,
+            "origin": normalized.get("origin"),
+            "source_kind": context.source_kind,
+        },
+    )
+
+
+async def _correlated_thread(
+    session: AsyncSession,
+    *,
+    context: _ConnectionContext,
+    correlation: Mapping[str, Any],
+) -> Idea | None:
+    thread_id = _clean_optional(correlation.get("thread_id") or correlation.get("idea_id"))
+    if not thread_id:
+        return None
+    thread = await session.get(Idea, thread_id)
+    if thread is None or str(thread.org_id) != str(context.org_id):
+        raise InboundValidationError("correlation.thread_id does not match an accessible Thread")
+    return thread
+
+
+async def _create_context_thread(
+    session: AsyncSession,
+    *,
+    context: _ConnectionContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+) -> Idea:
+    intent = _clean_optional(normalized.get("intent")) or _clean_optional(normalized.get("summary"))
+    source_name = context.display_name or context.source_kind or "personal agent"
+    title = _truncate(intent or f"Context from {source_name}", 180)
+    idea = Idea(
+        title=title,
+        description=_truncate(f"{source_name} submitted context to Illo.", 500),
+        status="emerged",
+        origin="inbound_context",
+        origin_ref=f"inbound_event:{event.id}",
+        user_id=str(context.owner_user_id),
+        org_id=context.org_id,
+        agent_details={
+            "context_ingress": {
+                "event_id": str(event.id),
+                "origin": normalized.get("origin"),
+                "connection_id": context.connection_id,
+                "source_kind": context.source_kind,
+            }
+        },
+    )
+    session.add(idea)
+    await session.flush()
+    return idea
+
+
+def _context_timeline_preview(
+    *,
+    context: _ConnectionContext,
+    normalized: Mapping[str, Any],
+    submission_id: str,
+) -> str:
+    source_name = context.display_name or context.source_kind or "personal agent"
+    parts = list(normalized.get("parts") or [])
+    lines = [
+        f"Context submitted from {source_name}.",
+        "",
+        f"Submission: {submission_id}",
+    ]
+    if normalized.get("intent"):
+        lines.append(f"Intent: {normalized.get('intent')}")
+    if normalized.get("summary") and normalized.get("summary") != normalized.get("intent"):
+        lines.append(f"Summary: {normalized.get('summary')}")
+    if normalized.get("origin"):
+        lines.append(f"Origin: {normalized.get('origin')}")
+    if parts:
+        lines.extend(["", f"Context parts: {len(parts)}"])
+        for index, part in enumerate(parts[:8], start=1):
+            lines.append(f"{index}. {_context_part_preview(part)}")
+        if len(parts) > 8:
+            lines.append(f"... plus {len(parts) - 8} more part(s).")
+    if normalized.get("source"):
+        lines.extend(["", f"Source: {_json_preview(normalized.get('source'), limit=600)}"])
+    return _truncate("\n".join(lines), MAX_TRIAGE_MESSAGE_CHARS)
+
+
+def _context_part_preview(part: Any) -> str:
+    if not isinstance(part, dict):
+        return _truncate(part, 180)
+    part_type = _clean_optional(part.get("type") or part.get("kind")) or "part"
+    title = _clean_optional(part.get("title") or part.get("name") or part.get("label"))
+    text = _clean_optional(part.get("text") or part.get("content") or part.get("url") or part.get("uri"))
+    bits = [part_type]
+    if title:
+        bits.append(title)
+    if text:
+        bits.append(_truncate(text, 140))
+    return " - ".join(bits)
+
+
+def _thread_url(thread: Idea) -> str:
+    return f"/cortex?idea={thread.id}"
 
 
 async def _complete_event(

--- a/brain/systems/runs/direct_loop/streaming.py
+++ b/brain/systems/runs/direct_loop/streaming.py
@@ -4,19 +4,51 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import re
 import time
 from typing import Callable
 
 from brain.platform.async_io import run_blocking
 
 
-def _public_reflection_excerpt(text: str, *, limit: int = 140) -> str:
+def _public_reflection_excerpt(text: str, *, limit: int = 320) -> str:
     """Compact a provider-supplied reasoning summary for live activity."""
     cleaned = " ".join((text or "").split())
+    if not _reflection_is_publishable(cleaned):
+        return ""
     if len(cleaned) <= limit:
         return cleaned
+    boundary = _last_sentence_boundary(cleaned, limit=limit)
+    if boundary is not None:
+        return cleaned[:boundary].strip()
     shortened = cleaned[:limit].rsplit(" ", 1)[0].rstrip(".,;:")
     return f"{shortened}…"
+
+
+def _reflection_is_publishable(text: str) -> bool:
+    if not text:
+        return False
+    bold_match = re.match(r"^\*\*([^*]+)\*\*\s*([\s\S]*)$", text)
+    if bold_match:
+        tail = (bold_match.group(2) or "").strip()
+        if not tail or len(tail) < 24 or tail in {"I", "I'm", "I’m", "The"}:
+            return False
+        return True
+    words = text.split()
+    if len(words) >= 3 and text.rstrip().endswith((".", "?", "!", "…")):
+        return True
+    return len(text) >= 80
+
+
+def _last_sentence_boundary(text: str, *, limit: int) -> int | None:
+    window = text[:limit]
+    for mark in (". ", "? ", "! "):
+        index = window.rfind(mark)
+        if index >= 80:
+            return index + 1
+    if window.rstrip().endswith((".", "?", "!")):
+        return len(window.rstrip())
+    return None
 
 
 def _approx_token_count(chars: int) -> int:
@@ -50,6 +82,7 @@ def streaming_call(
         thinking_chars = 0
         text_chars = 0
         reflection_text = ""
+        published_reflection = False
         phase = "waiting"
         for event in stream:
             if cancel_event.is_set():
@@ -84,11 +117,12 @@ def streaming_call(
                 phase = "writing"
             now = time.time()
             if on_stream_activity and now - last_progress >= 3:
-                last_progress = now
                 label = ""
                 if phase == "reflection":
-                    excerpt = _public_reflection_excerpt(reflection_text)
-                    label = excerpt
+                    if not published_reflection:
+                        label = _public_reflection_excerpt(reflection_text)
+                        if label:
+                            published_reflection = True
                 elif phase == "thinking":
                     elapsed = int(now - call_start)
                     thinking_tokens = _approx_token_count(thinking_chars)
@@ -104,6 +138,7 @@ def streaming_call(
                 else:
                     label = f"Streaming… ({int(now - call_start)}s)"
                 if label and label != last_activity_label:
+                    last_progress = now
                     last_activity_label = label
                     on_stream_activity(label)
         return stream.get_final_message()

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -68,6 +68,17 @@ def _json_block(title: str, value: Any) -> str:
     return f"\n\n## {title}\n```json\n{json.dumps(value, indent=2, default=str)}\n```"
 
 
+def _initial_acknowledgement(message: str) -> str:
+    normalized = " ".join(str(message or "").lower().split())
+    if any(term in normalized for term in ("fix", "broken", "bug", "issue", "error")):
+        return "Got it - I'll inspect the issue, make the smallest safe fix, and verify it."
+    if any(term in normalized for term in ("project", "folder", "copy", "repo", "repository")):
+        return "Got it - I'll check the project context, make the requested change carefully, and verify it."
+    if any(term in normalized for term in ("look", "inspect", "check", "understand", "tell me what")):
+        return "Got it - I'll inspect the context first, then tell you what I find."
+    return "Got it - I'll inspect the request and take the safest next step."
+
+
 def _thread_attachment_context(runtime: RunRuntime) -> dict[str, Any] | None:
     metadata_context = runtime.request.metadata.get("thread_attachment_context")
     if isinstance(metadata_context, dict):
@@ -90,6 +101,7 @@ class FastRecipe(BaseRunRecipe):
             workspace_ref=runtime.request.workspace_ref,
             metadata=runtime.request.metadata,
         )
+        await runtime.activity(_initial_acknowledgement(context.message or runtime.request.message))
         await runtime.activity("Reading context")
         workspace_root = _workspace_root(runtime.request.workspace_ref)
         model_policy = dict(runtime.request.model_policy or {})

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -29,6 +29,8 @@ Runtime rules:
 - Treat the provided Target, Workspace, Context, attachments, memory, and live steering as the current run state.
 - Use later live steering to adjust the current run without discarding useful progress.
 - Prefer the smallest complete action that satisfies the request now; leave larger follow-up work explicit.
+- Before your first tool call on work that needs inspection, edits, or more than a moment, write one brief task-specific assistant sentence that says what you are about to do.
+- Make that opening natural to the request; do not use canned acknowledgements.
 - Keep progress updates brief and meaningful when work takes more than a moment.
 - Do not simulate a Deep coordinator graph inside Fast. If the request needs parallel workers, long verification, or durable delegation, make that boundary explicit and prepare a clean handoff.
 - Before finalizing, reconcile the answer with the evidence visible in this run and name any concrete blocker or uncertainty.
@@ -68,17 +70,6 @@ def _json_block(title: str, value: Any) -> str:
     return f"\n\n## {title}\n```json\n{json.dumps(value, indent=2, default=str)}\n```"
 
 
-def _initial_acknowledgement(message: str) -> str:
-    normalized = " ".join(str(message or "").lower().split())
-    if any(term in normalized for term in ("fix", "broken", "bug", "issue", "error")):
-        return "Got it - I'll inspect the issue, make the smallest safe fix, and verify it."
-    if any(term in normalized for term in ("project", "folder", "copy", "repo", "repository")):
-        return "Got it - I'll check the project context, make the requested change carefully, and verify it."
-    if any(term in normalized for term in ("look", "inspect", "check", "understand", "tell me what")):
-        return "Got it - I'll inspect the context first, then tell you what I find."
-    return "Got it - I'll inspect the request and take the safest next step."
-
-
 def _thread_attachment_context(runtime: RunRuntime) -> dict[str, Any] | None:
     metadata_context = runtime.request.metadata.get("thread_attachment_context")
     if isinstance(metadata_context, dict):
@@ -101,7 +92,6 @@ class FastRecipe(BaseRunRecipe):
             workspace_ref=runtime.request.workspace_ref,
             metadata=runtime.request.metadata,
         )
-        await runtime.activity(_initial_acknowledgement(context.message or runtime.request.message))
         await runtime.activity("Reading context")
         workspace_root = _workspace_root(runtime.request.workspace_ref)
         model_policy = dict(runtime.request.model_policy or {})

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -31,6 +31,24 @@ def _current_run_id() -> int | None:
         return None
 
 
+def _current_thread_id() -> str | None:
+    thread_id = getattr(_agent_context, "idea_id", None) or getattr(_agent_context, "thread_id", None)
+    if thread_id:
+        return str(thread_id)
+    run = getattr(_agent_context, "run", None)
+    thread_id = getattr(run, "thread_id", None)
+    if thread_id:
+        return str(thread_id)
+    execution_metadata = getattr(_agent_context, "execution_metadata", None)
+    if isinstance(execution_metadata, dict):
+        target_ref = execution_metadata.get("target_ref")
+        if isinstance(target_ref, dict):
+            candidate = target_ref.get("idea_id") or target_ref.get("thread_id")
+            if candidate:
+                return str(candidate)
+    return None
+
+
 def _coerce_optional_int(value: Any) -> int | None:
     if value in (None, ""):
         return None
@@ -109,4 +127,61 @@ async def _handle_post_chat_message(
     return json.dumps({"ok": True, "message": message_payload}, default=str)
 
 
-__all__ = ["_handle_post_chat_message"]
+async def _handle_read_thread_discussion(
+    thread_id: str | None = None,
+    limit: int = 50,
+) -> str:
+    """Read Discussion comments intentionally from the current Thread."""
+    from sqlalchemy import select
+
+    from brain.platform.db.models.idea import ThreadDiscussionComment
+    from brain.platform.db.models.org import User
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    target_thread_id = str(thread_id or _current_thread_id() or "").strip()
+    if not target_thread_id:
+        return json.dumps({"error": "read_thread_discussion requires a Thread id or an active Thread run"})
+    org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
+    if not org_id:
+        return json.dumps({"error": "read_thread_discussion requires an org-scoped run"})
+    capped_limit = max(1, min(int(limit or 50), 200))
+
+    async with UnitOfWork() as uow:
+        stmt = (
+            select(ThreadDiscussionComment, User.name.label("author_name"), User.color.label("author_color"))
+            .outerjoin(User, ThreadDiscussionComment.author_user_id == User.id)
+            .where(ThreadDiscussionComment.thread_id == target_thread_id)
+            .where(ThreadDiscussionComment.org_id == org_id)
+            .order_by(ThreadDiscussionComment.created_at.desc(), ThreadDiscussionComment.id.desc())
+            .limit(capped_limit)
+        )
+        rows = list((await uow.session.execute(stmt)).all())
+
+    comments = []
+    for row in reversed(rows):
+        comment = row[0]
+        comments.append(
+            {
+                "id": comment.id,
+                "thread_id": str(comment.thread_id),
+                "author_kind": comment.author_kind,
+                "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
+                "author_name": row.author_name,
+                "author_color": row.author_color,
+                "body": comment.body,
+                "attachments": comment.attachments or [],
+                "metadata": comment.metadata_ or {},
+                "created_at": comment.created_at.isoformat() if comment.created_at else None,
+            }
+        )
+    return json.dumps(
+        {
+            "thread_id": target_thread_id,
+            "count": len(comments),
+            "comments": comments,
+        },
+        default=str,
+    )
+
+
+__all__ = ["_handle_post_chat_message", "_handle_read_thread_discussion"]

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -30,7 +30,10 @@ from brain.systems.runs.tool_catalog.handlers.cortex_reply import (
     _handle_cortex_reply,
     _handle_cortex_visual_reply,
 )
-from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_chat_message
+from brain.systems.runs.tool_catalog.handlers.chat import (
+    _handle_post_chat_message,
+    _handle_read_thread_discussion,
+)
 from brain.systems.runs.tool_catalog.handlers.cycles import _handle_manage_cycle
 from brain.systems.runs.tool_catalog.handlers.domains import _handle_manage_domain
 from brain.systems.runs.tool_catalog.handlers.inbound import _handle_manage_inbound
@@ -200,6 +203,10 @@ def _get_tool_handlers(
         "post_chat_message": lambda **kw: _patched_private(
             "_handle_post_chat_message",
             _handle_post_chat_message,
+        )(**kw),
+        "read_thread_discussion": lambda **kw: _patched_private(
+            "_handle_read_thread_discussion",
+            _handle_read_thread_discussion,
         )(**kw),
         "manage_cycle": lambda **kw: _patched_private("_handle_manage_cycle", _handle_manage_cycle)(**kw),
         "manage_domain": lambda **kw: _patched_private("_handle_manage_domain", _handle_manage_domain)(**kw),

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -273,6 +273,14 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "post an Illo-authored message to the native team room",
         "output_budget_chars": 8_000,
     },
+    "read_thread_discussion": {
+        "permission": "read_workspace",
+        "risk_class": "low",
+        "side_effect_class": "read_only",
+        "reversibility": "none",
+        "expected_effect": "read Discussion comments attached to the current Thread",
+        "output_budget_chars": 12_000,
+    },
     "manage_project": {
         "permission": "write_project",
         "risk_class": "medium",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1140,6 +1140,28 @@ CHAT_TOOLS = [
             },
             "required": ["body"],
         },
+    },
+    {
+        "name": "read_thread_discussion",
+        "description": (
+            "Read the Discussion comments attached to the current Thread. "
+            "Use this only when team comments may contain relevant context, or when the user asks "
+            "about the Discussion. Discussion is not automatically included in every run prompt."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "thread_id": {
+                    "type": "string",
+                    "description": "Optional Thread id. Defaults to the current Thread for this run.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum comments to return, from newest back then ordered chronologically.",
+                    "default": 50,
+                },
+            },
+        },
     }
 ]
 

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -49,6 +49,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_cortex_reply",
     "_handle_cortex_visual_reply",
     "_handle_post_chat_message",
+    "_handle_read_thread_discussion",
     "_handle_read_thread_messages",
     "_handle_manage_cycle",
     "_handle_manage_domain",

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Start here when you want to understand, run, or extend Illo Brain.
 - [Cycles](cycles.md) - scheduler-owned recurring jobs.
 - [Security Model](security-model.md) - secrets, tool execution, browser sessions, and data boundaries.
 - [Personal Agent Connections MVP](personal-agent-connections-mvp.md) - implementation plan for connecting Illo with Hermes and OpenClaw.
+- [Universal Thread Context Ingress PRD](prd-universal-thread-context-ingress.md) - product plan for personal agents submitting context into Illo and Universal Threads.
 - [Dependency Licensing](dependency-licensing.md) - Apache 2.0 project policy and third-party review notes.
 
 Planning notes, runtime journals, memory exports, logs, and operator notes belong

--- a/docs/mcp-personal-tool-signals.md
+++ b/docs/mcp-personal-tool-signals.md
@@ -1,7 +1,12 @@
 # MCP Personal Tool Signals
 
-Status: implementation note for Reda's MCP lane
+Status: historical implementation note; superseded for new work by
+`docs/prd-universal-thread-context-ingress.md`
 Parent PRD: `docs/prd-inbound-coordination-layer.md`
+
+Current canonical ingress tool for personal agents is `illo_submit_context`.
+This document describes the earlier `illo_submit_signal` lane that proved the
+inbound coordination foundation and still explains legacy scope/history.
 
 ## Purpose
 

--- a/docs/prd-universal-thread-context-ingress.md
+++ b/docs/prd-universal-thread-context-ingress.md
@@ -1,0 +1,427 @@
+# PRD: Universal Thread Context Ingress
+
+Status: thin vertical slice implemented in this branch; still a living PRD
+Date: 2026-05-21
+Owner: product/architecture discussion
+Related docs:
+
+- `docs/prd-inbound-coordination-layer.md`
+- `docs/mcp-personal-tool-signals.md`
+- `docs/personal-agent-connections-mvp.md`
+
+## Problem Statement
+
+Illospace is becoming the bridge between a person's private AI agents and the
+team workspace where shared judgment happens.
+
+Today, a user can work with a personal agent such as Codex, and that agent can
+submit small progress signals to Illo through MCP. That proves the transport and
+inbound coordination foundation, but it does not yet express the larger product
+shape: a personal agent should be able to hand rich context to Illo, the team
+agent, and let Illo decide what durable workspace object should exist.
+
+The motivating example is:
+
+1. Reda works with Codex.
+2. Reda reaches a moment where team context or team judgment matters and says
+   something like "let's ask the team."
+3. Codex sends Illo the relevant context. This may include the full user/agent
+   conversation, tool trace, files, links, prompt history, or other artifacts.
+4. Illo receives the context as the team agent. Illo records it through the
+   inbound coordination layer and decides how it belongs in the workspace.
+5. When a Thread is created or updated, Codex gets back a link so Reda can jump
+   into Illospace.
+6. The existing Thread stage renders the AI work. A right-panel Discussion lets
+   teammates comment on the Thread without turning Illospace into another Slack.
+7. If the team needs Illo, they summon it with `@illo`. Illo's substantive work
+   continues in the main Thread, not inside the comment surface.
+
+The product gap is not a missing special case called "decision request." The
+gap is a universal context ingress contract and a Universal Thread model broad
+enough to hold AI traces, Illo runs, imported context, artifacts, discussion,
+and outcomes without forcing every submission into a narrow workflow.
+
+## Solution
+
+Introduce **Universal Thread** as the product-facing collaboration object and
+introduce `illo_submit_context` as the canonical personal-agent-to-Illo ingress
+primitive.
+
+The relationship model is:
+
+- A personal agent acts for an individual user.
+- Illo acts as the team agent for the user's Illospace team.
+- A personal agent sends context to Illo. It does not own team routing,
+  workspace placement, team notifications, or durable collaboration state.
+- Illo receives the context through the existing inbound coordination layer and
+  decides what durable workspace object, if any, should exist.
+- The frontend renders persisted Thread state generically. It does not encode
+  workflow policy.
+
+The two high-level MCP primitives are:
+
+- `illo_ask`: private query to Illo for information Illo already has or can
+  reason over. This is not team-visible by default and may run asynchronously
+  behind `illo_get_ask`.
+- `illo_submit_context`: universal ingress for new context from a personal
+  agent to Illo. It acknowledges receipt quickly, records the context through
+  inbound coordination, and returns any immediately available Thread URL.
+
+Universal Thread product vocabulary:
+
+- **Thread**: the canonical durable object for human/AI/team collaboration.
+  "Idea" is legacy/internal naming that may remain in the database and APIs
+  during the MVP.
+- **AI Timeline**: the main existing Thread conversation/stage. It contains
+  Illo runs, AI messages, imported trace previews, tool/activity entries,
+  artifacts, and generated outputs.
+- **Discussion**: a right-panel comment surface attached to the Thread. It is
+  scoped, human-first, and not a Slack replacement. Illo may comment there, but
+  AI work happens in the AI Timeline.
+- **Context**: imported external context parts such as raw Codex traces,
+  prompt/conversation excerpts, files, links, screenshots, tool logs, diffs, or
+  structured JSON.
+- **Outcome**: optional durable result/status/decision marker when the Thread
+  reaches one.
+
+MVP proof loop:
+
+```text
+personal agent submits context
+-> inbound coordination records/routes it
+-> Illo may create or update a Thread
+-> existing Thread UI renders submitted context
+-> Discussion exists as an attached comment surface
+-> @illo from Discussion can continue work in the main Thread
+```
+
+MVP scope is governed by this proof loop. Anything not required to prove the
+loop is out of scope unless explicitly pulled in.
+
+## User Stories
+
+1. As a user working with Codex, I want to send my current agent conversation to
+   Illo, so that my team can inspect the exact context instead of a lossy
+   summary.
+2. As a user working with Codex, I want Codex to receive an Illo Thread link
+   after submission, so that I can jump into the team workspace.
+3. As a teammate, I want to open the Illo Thread and see the submitted context,
+   so that I understand what the personal agent was doing.
+4. As a teammate, I want to inspect the raw imported context when needed, so
+   that I can debug prompt drift, bad assumptions, or confusing agent behavior.
+5. As a teammate, I want a compact preview of imported context by default, so
+   that a full trace does not overwhelm the Thread.
+6. As a teammate, I want to discuss an imported AI thread in a right-panel
+   Discussion, so that comments stay attached to the relevant AI work.
+7. As a teammate, I want Discussion to feel like a comment section, so that
+   Illospace does not compete with Slack as a general chat tool.
+8. As a teammate, I want to summon Illo with `@illo` from Discussion, so that
+   Illo only participates when explicitly needed.
+9. As a teammate, I want Illo's substantive work to appear in the main Thread,
+   so that AI work remains in the AI Timeline rather than buried in comments.
+10. As Illo, I want a tool to inspect Discussion when useful, so that I can read
+    team comments intentionally without polluting every run prompt.
+11. As Illo, I want submitted context to arrive through the existing inbound
+    coordination layer, so that webhooks, MCP, and personal agents share one
+    routing foundation.
+12. As a personal agent, I want one universal context submission tool, so that I
+    do not need to choose among many scenario-specific Illo tools.
+13. As a personal agent, I want the MCP tool description to explain my
+    relationship to Illo, so that I know I submit context while Illo coordinates
+    the team workspace.
+14. As a personal agent, I want to include ordered context parts, so that I can
+    send text, JSON, links, artifacts, traces, diffs, or files without inventing
+    a new tool for each type.
+15. As a personal agent, I want `illo_submit_context` to acknowledge quickly, so
+    that long Illo reasoning does not risk MCP timeout failures.
+16. As a personal agent, I want `illo_ask` to remain a private query primitive,
+    so that I can ask Illo for existing workspace knowledge without creating a
+    visible Thread.
+17. As a user, I want submitted context to be immutable once recorded, so that
+    the team can trust the original source material.
+18. As a user, I want Illo to generate summaries or previews as derived views,
+    so that raw context remains available while the default view stays readable.
+19. As a user, I want multiple context submissions to be attachable to the same
+    Thread, so that follow-up Codex sessions or later traces can stay with the
+    same shared work.
+20. As a user, I want a submitted context result to say what happened in plain
+    terms, so that Codex can report whether Illo accepted, created, or attached
+    the context.
+21. As a product builder, I want Universal Thread rendering to be source-agnostic,
+    so that Codex, Claude Code, OpenClaw, Hermes, and future agents can all use
+    the same Thread surface.
+22. As a product builder, I want the MVP to reuse existing Thread infrastructure,
+    so that we can learn from usage before redesigning the whole page.
+23. As a product builder, I want "Thread" to become the user-facing language, so
+    that legacy "idea" terminology does not leak into the product direction.
+24. As an operator, I want every submitted context envelope recorded durably, so
+    that routing decisions, idempotency, and debugging remain inspectable.
+25. As an operator, I want context submissions without a Thread to remain inbound
+    events, so that the Thread model is not polluted by source events that Illo
+    chose not to surface.
+26. As a future Slack integration user, I want Slack previews to link back to the
+    Illo Thread, so that Slack distributes awareness without becoming the source
+    of collaboration truth.
+27. As a teammate, I want Thread Discussion notifications to be scoped and
+    intentional, so that only relevant mentions, subscriptions, or activity
+    produce noise.
+28. As Illo, I want `@illo this is what we decided, carry on` to create a
+    Thread-linked run, so that team decisions can steer the main AI work.
+29. As a user, I want Codex to send full context when I ask, so that Illo and the
+    team are not forced to rely on a summary written by the same agent that may
+    be confused.
+30. As a product builder, I want the frontend to render persisted state, so that
+    routing policy stays in the inbound/backend layer rather than scattered
+    through UI conditionals.
+
+## Implementation Decisions
+
+- Use the existing inbound coordination layer as the routing boundary. This PRD
+  is an evolution from inbound signals to inbound context, not a second routing
+  system.
+- Add or rename the canonical MCP ingress tool to `illo_submit_context`. Because
+  the product has not launched, there is no compatibility requirement to keep
+  `illo_submit_signal` as the primary name.
+- Keep `illo_ask` as a separate private query primitive. `illo_submit_context`
+  is for new context entering Illo; `illo_ask` is for retrieving or reasoning
+  over context Illo already has.
+- Define the context envelope as generic and source-agnostic:
+  - `intent`: natural-language reason the personal agent is submitting context.
+  - `parts`: ordered context parts.
+  - `source`: provenance about the personal agent, user, session, model, repo,
+    branch, or external origin.
+  - `constraints`: optional boundaries such as privacy, urgency, visibility, or
+    notification preferences.
+  - `correlation`: optional existing Thread URL/id, external session id, or
+    previous submission reference.
+  - `idempotency_key`: optional stable dedupe key.
+- Treat part types as content types, not product workflows. Examples include
+  `text`, `json`, `link`, `file`, `trace`, `conversation`, `diff`,
+  `screenshot`, and `artifact`.
+- Extend inbound envelope handling to accept a new kind such as `context`. The
+  existing inbound event table and decision receipt table remain the audit and
+  result spine.
+- Add routing results that can describe Thread outcomes generically, such as
+  `thread.created`, `thread.attached`, `accepted`, `stored`, or
+  `needs_clarification`.
+- Keep `illo_submit_context` async-safe. The tool should acknowledge quickly,
+  return any immediately available `thread_id` and `url`, and let longer Illo
+  reasoning continue through normal Thread/AgentRun state.
+- Reuse the existing `ideas` table as the physical Thread table for MVP. "Idea"
+  remains a legacy storage/API name until a later rename.
+- Introduce a Thread read/domain model that presents `ideas` as Threads to new
+  product surfaces, docs, and MCP descriptions.
+- Add a `thread_context_submissions` table for immutable submitted context that
+  attaches to a Thread when Illo creates or selects one.
+- Store submitted context parts as JSONB on `thread_context_submissions` for MVP.
+  Normalize into child rows only after real querying/rendering needs appear.
+- Suggested `thread_context_submissions` fields:
+  - `id`
+  - `thread_id`
+  - `org_id`
+  - `source_connection_id`
+  - `submitted_by_user_id`
+  - `inbound_event_id`
+  - `intent`
+  - `source`
+  - `constraints`
+  - `correlation`
+  - `parts`
+  - `routing_result`
+  - `created_at`
+- Persist every context submission first as an inbound event. If it creates or
+  attaches to a Thread, also persist it as a `thread_context_submissions` row.
+  If no Thread exists, keep it as an inbound event/source record only.
+- Preserve raw submitted trace/context as the canonical source artifact. Any
+  summaries, previews, extracted decisions, or timeline cards are derived views.
+- Allow multiple context submissions to attach to the same Thread when
+  correlation is explicit or Illo confidently routes them there.
+- Do not inject Discussion into every Illo run prompt. Discussion is available
+  through an explicit Illo tool when needed.
+- Include the triggering `@illo` Discussion comment as the trigger when a user
+  summons Illo from Discussion.
+- Add an Illo-visible tool for reading Thread Discussion. The tool should make
+  scope explicit, for example latest messages, messages since a timestamp, full
+  discussion, or messages mentioning Illo.
+- Keep Illo's substantive continuation in the main Thread/AI Timeline. Discussion
+  may receive small comments or acknowledgements, but the AI work belongs in the
+  Thread.
+- Keep the existing Thread stage as the MVP frontend surface. Add Discussion as
+  a possible right-panel tab/surface.
+- Render submitted context as generic preview blocks in the existing Thread
+  timeline. Start with compact expandable previews; do not try to perfect raw
+  trace visualization before usage teaches the right shape.
+- Make Universal Thread rendering source-agnostic. Source labels and provenance
+  are metadata, not separate UI architectures.
+- Treat Slack as a distribution surface later. A Slack unfurl should preview and
+  link to the Illo Thread, not mirror the Discussion as a competing chat.
+- Update product language in new docs, tool descriptions, and frontend copy to
+  use Thread, AI Timeline, Discussion, Context, and Outcome. Existing code may
+  continue to say idea during the transition.
+
+## Implementation Notes From First Slice
+
+This implementation pass delivered the first thin vertical slice of the proof
+loop and left a few product/technical decisions explicit for future review:
+
+- `illo_submit_context` replaces `illo_submit_signal` in hosted and local MCP
+  tool catalogs. No compatibility alias was kept because the product has not
+  launched and the canonical primitive should not carry the old "signal"
+  framing.
+- The hosted MCP tool still uses the existing `signal:submit` token scope for
+  this slice. That avoids bridge-token churn and keeps the authorization path
+  small, but the scope name is now legacy implementation debt. A later cleanup
+  should rename or alias it to a context-oriented scope once token migration is
+  worth paying for.
+- Context ingress is deterministic in the MVP hot path. If the caller supplies
+  `correlation.thread_id` or `correlation.idea_id`, the context attaches to that
+  Thread when it belongs to the user's org. Otherwise, when the source has an
+  owner user, IlloSpace creates a new Thread immediately and returns its link.
+  If there is no owner user, the context remains a stored inbound event. This
+  keeps MCP acknowledgement quick and avoids a long Illo routing run inside the
+  tool call.
+- The deterministic context path still enters through
+  `submit_inbound_envelope`; it is not a parallel ingress stack. Context simply
+  gets its own envelope normalization and routing branch before the older signal
+  source-policy flow.
+- `thread_context_submissions` now stores immutable submitted context rows
+  attached to Threads when a Thread exists. Parts remain JSONB for now, matching
+  the PRD's bias toward preserving raw submitted material before optimizing for
+  querying every possible trace shape.
+- Context previews in the AI Timeline are compact `IdeaThread` messages tagged
+  as context submissions. The rich raw-trace inspector is intentionally not
+  solved yet; the durable submission row is the source of truth for expanding
+  that UI later.
+- Discussion is implemented as `thread_discussion_comments`, a dedicated
+  Thread-attached comment table, not the existing general chat/room system. This
+  keeps Discussion closer to a comment section and avoids polluting team chat
+  with per-Thread collaboration surfaces.
+- Discussion is available as a right-panel tab on the existing Thread stage.
+  The backend broadcasts a `thread_discussion_comment` websocket event, but the
+  first frontend pass reloads Discussion on panel open and after posting rather
+  than subscribing live. Live subscription is a straightforward follow-up, not a
+  requirement for proving the loop.
+- `@illo` in Discussion routes through the existing Cortex notify/run path and
+  links the run to the main Thread. Discussion comments do not automatically
+  enter every Illo prompt. The existing mention classifier invokes Illo for
+  unmentioned main Thread replies, so Discussion explicitly disables that
+  default and requires an actual Illo mention.
+- Illo now has an explicit `read_thread_discussion` tool. This preserves the
+  product boundary that Discussion can be inspected when useful without becoming
+  ambient prompt context for every run.
+- Slack previews, a full ideas-to-threads backend rename, a new Thread page, and
+  detailed raw-trace visualization were left out under the positive proof-loop
+  scope rule.
+
+## Testing Decisions And Coverage
+
+Good tests should validate external behavior and durable contracts rather than
+implementation details. The important behaviors are:
+
+- Context envelopes are accepted, normalized, stored, and idempotently replayed.
+- `illo_submit_context` uses the same inbound coordination service as webhooks
+  and hosted MCP.
+- Inbound events preserve source actor, authority user, ingress metadata,
+  envelope kind, intent, source, constraints, correlation, and parts.
+- Routing can create a Thread and return a simple URL/id result.
+- Routing can attach a second context submission to an existing Thread.
+- Routing can store a context submission without a Thread while preserving the
+  inbound event/receipt.
+- Raw submitted context remains available after derived previews are generated.
+- Discussion comments do not automatically trigger Illo.
+- `@illo` in Discussion triggers an Illo run linked to the Thread.
+- Illo can explicitly inspect Discussion through a tool.
+- Illo continuation appears in the main Thread/AI Timeline.
+- The existing Thread UI continues to open, stream, reply, and render normal
+  Illo messages after context preview blocks are added.
+
+Recommended test modules:
+
+- Inbound service tests for `kind=context` normalization, idempotency, receipts,
+  and routing results.
+- Hosted MCP route tests for `illo_submit_context` schema, scope checks, and
+  quick acknowledgement shape.
+- Context submission persistence tests for immutable JSONB envelope storage.
+- Thread service/read-model tests for rendering context submission previews.
+- Discussion API/service tests for right-panel comment behavior and mention
+  triggering.
+- Agent tool tests for explicit Discussion inspection.
+- Frontend component tests or Playwright smoke tests for opening an existing
+  Thread with a submitted context preview and Discussion panel available.
+
+Coverage added in this implementation pass:
+
+- Inbound tests for `kind=context` thread creation, context submission
+  persistence, compact timeline preview creation, explicit Thread correlation,
+  and idempotent replay.
+- Hosted MCP route tests for the `illo_submit_context` tool schema, shared
+  envelope construction, commit/rollback boundaries, scope checks, and rejection
+  of direct workspace target fields outside `correlation`.
+- Local MCP package tests for the `illo_submit_context` catalog and client
+  payload.
+- Model metadata coverage for `thread_context_submissions` and
+  `thread_discussion_comments`.
+- Discussion API coverage for normal comments not triggering Illo, explicit
+  `@illo` comments triggering the main Thread run path, and commit-before-
+  broadcast ordering.
+- Frontend typecheck coverage for the Discussion tab/pane and context timeline
+  tag changes.
+
+Useful prior art in the codebase:
+
+- Existing inbound webhook/MCP tests for `submit_inbound_envelope`.
+- Existing external agent route tests for hosted MCP and `illo_ask`.
+- Existing Cortex Thread tests for opening, posting, notifying, and run history.
+- Existing chat tests for threaded room comments, mentions, and notifications.
+- Existing trace export tests for bounded trace projections.
+
+## MVP Scope Principle
+
+The MVP is a thin vertical foundation for the universal context-to-Thread loop.
+Anything that does not directly support that loop is out of scope unless
+explicitly pulled in.
+
+The loop is:
+
+```text
+personal agent submits context
+-> inbound coordination records/routes it
+-> Illo may create or update a Thread
+-> existing Thread UI renders submitted context
+-> Discussion exists as an attached comment surface
+-> @illo from Discussion can continue work in the main Thread
+```
+
+Examples of work excluded by this principle include, but are not limited to:
+
+- full backend rename from ideas to threads;
+- a brand-new Thread page layout;
+- Slack replacement behavior or general-purpose team chat expansion;
+- hardcoded decision-request workflows;
+- hardcoded Codex-only routing or UI behavior beyond source/provenance labels;
+- automatic Illo participation in Discussion without an explicit summon;
+- perfect visualization for every possible raw trace shape;
+- complex personal-agent polling/handoff contracts beyond quick acknowledgement
+  and optional Thread URL;
+- many special-case MCP tools for individual submission scenarios.
+
+These examples are not a closed list. The positive proof loop is the scope
+boundary.
+
+## Further Notes
+
+This PRD deliberately narrows product mechanics while broadening the product
+primitive. The important abstraction is not a larger list of situations where
+Codex may write to Illo. The important abstraction is universal context ingress:
+a personal agent submits ordered context parts, provenance, intent, constraints,
+and correlation to Illo; Illo coordinates that context inside the team
+workspace.
+
+The current inbound coordination system already contains much of the necessary
+architecture: event storage, idempotency, connection identity, policy matching,
+decision receipts, Illo triage, and source-card observability. This PRD should
+be implemented by evolving that system, not bypassing it.
+
+The product language should move steadily toward Thread. The legacy "idea"
+language was an older internal name and should not define the future user
+mental model.

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -201,6 +201,31 @@ export interface ChatUnreadThread {
   latest_unread_at: string;
 }
 
+export interface ThreadDiscussionComment {
+  id: number;
+  thread_id: string;
+  org_id: string;
+  author_user_id: string | null;
+  author_kind: string;
+  author_name: string | null;
+  author_color: string | null;
+  body: string;
+  attachments: any[];
+  metadata: Record<string, any> | null;
+  created_at: string | null;
+}
+
+export interface ThreadDiscussionCreateInput {
+  body: string;
+  attachments?: any[];
+  metadata?: Record<string, any> | null;
+}
+
+export interface ThreadDiscussionCreateResult {
+  comment: ThreadDiscussionComment;
+  trigger: any | null;
+}
+
 export interface AppNotification {
   id: number;
   source: string;
@@ -737,6 +762,13 @@ export const api = {
   listThreads: (ideaId: string) => fetchJson<any[]>(`/api/cortex/ideas/${ideaId}/threads`),
   createThread: (ideaId: string, content: string) =>
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/threads`, { method: 'POST', body: JSON.stringify({ content }) }),
+  listThreadDiscussion: (ideaId: string, limit = 100) =>
+    fetchJson<ThreadDiscussionComment[]>(withQuery(`/api/cortex/ideas/${ideaId}/discussion`, { limit })),
+  postThreadDiscussionComment: (ideaId: string, data: ThreadDiscussionCreateInput) =>
+    fetchJson<ThreadDiscussionCreateResult>(`/api/cortex/ideas/${ideaId}/discussion`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
 
   // Cortex (continued)
   updateIdea: (id: string, data: any) =>

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -21,6 +21,9 @@ export type ThreadActivityTimelineItem = Awaited<ReturnType<typeof api.activityT
 export type IdeaAudit = Awaited<ReturnType<typeof api.ideaAudit>>;
 export type IdeaAuditAnalysisResult = Awaited<ReturnType<typeof api.ideaAuditAnalysisResult>>;
 export type GeneratedThreadTitle = Awaited<ReturnType<typeof api.generateTitle>>;
+export type ThreadDiscussionComment = Awaited<ReturnType<typeof api.listThreadDiscussion>>[number];
+export type ThreadDiscussionCreateInput = Parameters<typeof api.postThreadDiscussionComment>[1];
+export type ThreadDiscussionCreateResult = Awaited<ReturnType<typeof api.postThreadDiscussionComment>>;
 
 type ThreadApiMethods = {
   unifiedStream: (ideaId: string, includeDebug?: boolean) => Promise<StreamItem[]>;
@@ -39,6 +42,8 @@ type ThreadApiMethods = {
   skillFeedback: typeof api.skillFeedback;
   getIdea: (id: string) => Promise<Idea>;
   ideaConnections: (ideaId: string) => Promise<Connection[]>;
+  listThreadDiscussion: typeof api.listThreadDiscussion;
+  postThreadDiscussionComment: typeof api.postThreadDiscussionComment;
   activityTimeline: typeof api.activityTimeline;
   generateTitle: typeof api.generateTitle;
   uploadFile: (file: File) => Promise<UploadedThreadFile>;
@@ -69,6 +74,8 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'skillFeedback',
   'getIdea',
   'ideaConnections',
+  'listThreadDiscussion',
+  'postThreadDiscussionComment',
   'activityTimeline',
   'generateTitle',
   'uploadFile',
@@ -99,6 +106,8 @@ export const {
   skillFeedback,
   getIdea,
   ideaConnections,
+  listThreadDiscussion,
+  postThreadDiscussionComment,
   activityTimeline,
   generateTitle,
   uploadFile,

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  import {
+    listThreadDiscussion,
+    postThreadDiscussionComment,
+    type ThreadDiscussionComment,
+  } from '$lib/features/threads/api/threadApi';
+
+  let {
+    ideaId = null,
+  }: {
+    ideaId?: string | null;
+  } = $props();
+
+  let comments = $state<ThreadDiscussionComment[]>([]);
+  let body = $state('');
+  let loading = $state(false);
+  let posting = $state(false);
+  let error = $state('');
+  let loadedForIdeaId = $state<string | null>(null);
+
+  $effect(() => {
+    if (!ideaId) {
+      comments = [];
+      loadedForIdeaId = null;
+      return;
+    }
+    if (loadedForIdeaId === ideaId) return;
+    void loadComments(ideaId);
+  });
+
+  async function loadComments(targetIdeaId = ideaId) {
+    if (!targetIdeaId) return;
+    loading = true;
+    error = '';
+    try {
+      comments = await listThreadDiscussion(targetIdeaId);
+      loadedForIdeaId = targetIdeaId;
+    } catch (err: any) {
+      error = err?.detail || 'Failed to load Discussion.';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function submitComment(event: SubmitEvent) {
+    event.preventDefault();
+    const text = body.trim();
+    if (!ideaId || !text || posting) return;
+    posting = true;
+    error = '';
+    try {
+      const result = await postThreadDiscussionComment(ideaId, {
+        body: text,
+        metadata: { source: 'thread_discussion_panel' },
+      });
+      comments = [...comments, result.comment];
+      body = '';
+    } catch (err: any) {
+      error = err?.detail || 'Failed to post comment.';
+    } finally {
+      posting = false;
+    }
+  }
+
+  function authorLabel(comment: ThreadDiscussionComment) {
+    if (comment.author_name) return comment.author_name;
+    if (comment.author_kind === 'illo') return 'Illo';
+    return 'Teammate';
+  }
+
+  function timeLabel(value: string | null) {
+    if (!value) return '';
+    try {
+      return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  }
+</script>
+
+<div class="thread-discussion-pane">
+  <div class="discussion-list" aria-label="Thread Discussion">
+    {#if loading && comments.length === 0}
+      <div class="discussion-empty">Loading Discussion...</div>
+    {:else if error && comments.length === 0}
+      <div class="discussion-empty discussion-error">{error}</div>
+    {:else if comments.length === 0}
+      <div class="discussion-empty">No Discussion yet.</div>
+    {:else}
+      {#each comments as comment (comment.id)}
+        <article class="discussion-comment">
+          <div class="discussion-comment-meta">
+            <span class="discussion-author">{authorLabel(comment)}</span>
+            {#if timeLabel(comment.created_at)}
+              <time datetime={comment.created_at || undefined}>{timeLabel(comment.created_at)}</time>
+            {/if}
+          </div>
+          <div class="discussion-body">{comment.body}</div>
+        </article>
+      {/each}
+    {/if}
+  </div>
+
+  <form class="discussion-composer" onsubmit={submitComment}>
+    {#if error && comments.length > 0}
+      <div class="discussion-inline-error">{error}</div>
+    {/if}
+    <textarea
+      bind:value={body}
+      placeholder="Comment on this Thread..."
+      rows="3"
+      disabled={posting || !ideaId}
+    ></textarea>
+    <button type="submit" disabled={posting || !body.trim() || !ideaId}>
+      {posting ? 'Posting...' : 'Post'}
+    </button>
+  </form>
+</div>
+
+<style>
+  .thread-discussion-pane {
+    min-height: 100%;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto;
+    color: var(--constellation-utility-panel-tab-active-text);
+  }
+
+  .discussion-list {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    overflow-y: auto;
+    scrollbar-color: var(--constellation-utility-panel-scrollbar) transparent;
+  }
+
+  .discussion-list::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  .discussion-list::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: var(--constellation-utility-panel-scrollbar);
+  }
+
+  .discussion-empty {
+    padding: 22px 12px;
+    color: var(--constellation-utility-panel-tab-text);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .discussion-error,
+  .discussion-inline-error {
+    color: #ff9a9a;
+  }
+
+  .discussion-comment {
+    display: grid;
+    gap: 5px;
+    padding: 10px 11px;
+    border: 1px solid var(--constellation-utility-panel-header-border);
+    border-radius: 8px;
+    background: var(--constellation-control-field-background);
+  }
+
+  .discussion-comment-meta {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    color: var(--constellation-utility-panel-tab-text);
+    font-size: 11px;
+  }
+
+  .discussion-author {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--constellation-utility-panel-tab-active-text);
+    font-weight: 690;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .discussion-body {
+    color: var(--constellation-utility-panel-tab-active-text);
+    font-size: 13px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .discussion-composer {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-top: 1px solid var(--constellation-utility-panel-header-border);
+  }
+
+  .discussion-composer textarea {
+    width: 100%;
+    min-width: 0;
+    resize: vertical;
+    max-height: 160px;
+    padding: 9px 10px;
+    border: 1px solid var(--constellation-control-field-border);
+    border-radius: 8px;
+    background: var(--constellation-control-field-background);
+    color: var(--constellation-utility-panel-tab-active-text);
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .discussion-composer textarea:focus {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .discussion-composer button {
+    justify-self: end;
+    min-height: 32px;
+    padding: 0 12px;
+    border: 1px solid var(--constellation-control-button-secondary-border);
+    border-radius: 8px;
+    background: var(--constellation-control-button-secondary-background);
+    color: var(--constellation-control-button-secondary-text);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 720;
+    cursor: pointer;
+  }
+
+  .discussion-composer button:hover:not(:disabled),
+  .discussion-composer button:focus-visible {
+    border-color: var(--constellation-control-focus-ring);
+  }
+
+  .discussion-composer button:disabled,
+  .discussion-composer textarea:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  .discussion-inline-error {
+    font-size: 12px;
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -14,6 +14,7 @@
 
   type DockWidth = number | string;
   const DEFAULT_TABS: ThreadStageRightDockTab[] = [
+    { id: 'discussion', label: 'Discussion', kind: 'discussion', closeable: true },
     { id: 'activity', label: 'Activity', kind: 'activity', closeable: true },
     { id: 'handoff-summary', label: 'Handoff', kind: 'handoff-summary', closeable: true },
   ];
@@ -46,6 +47,7 @@
     className,
     browserPane,
     previewPane,
+    discussionPane,
     utilityPane,
     appsPane,
     vaultPane,
@@ -68,6 +70,7 @@
     className?: string;
     browserPane?: Snippet;
     previewPane?: Snippet;
+    discussionPane?: Snippet;
     utilityPane?: Snippet;
     appsPane?: Snippet;
     vaultPane?: Snippet;
@@ -78,32 +81,13 @@
 
   const hasBrowserPane = $derived(!!browserPane);
   const hasPreviewPane = $derived(!!previewPane);
+  const hasDiscussionPane = $derived(!!discussionPane);
   const hasUtilityPane = $derived(!!utilityPane);
   const hasAppsPane = $derived(!!appsPane);
   const hasVaultPane = $derived(!!vaultPane);
   const hasCyclesPane = $derived(!!cyclesPane);
   const hasCodeReviewPane = $derived(!!codeReviewPane);
-  const availableTabs = $derived(
-    tabs.filter((tab) => (
-      tab.kind === 'browser'
-        ? hasBrowserPane
-        : tab.kind === 'preview'
-          ? hasPreviewPane
-          : tab.kind === 'activity'
-            ? hasUtilityPane
-            : tab.kind === 'handoff-summary'
-              ? hasUtilityPane
-              : tab.kind === 'app'
-                ? hasAppsPane
-                : tab.kind === 'vault'
-                  ? hasVaultPane
-                  : tab.kind === 'cycles'
-                    ? hasCyclesPane
-                    : tab.kind === 'code-review'
-                      ? hasCodeReviewPane
-                      : true
-    )),
-  );
+  const availableTabs = $derived(tabs.filter(tabHasPane));
   const resolvedActiveTab = $derived(
     availableTabs.find((tab) => tab.id === activeTabId) ?? availableTabs[0] ?? null,
   );
@@ -202,12 +186,37 @@
   function iconForMenuKind(kind: ThreadStageRightDockTabKind) {
     if (kind === 'browser') return 'preview';
     if (kind === 'preview') return 'document';
+    if (kind === 'discussion') return 'reply-thread';
     if (kind === 'activity') return 'activity';
     if (kind === 'handoff-summary') return 'document';
     if (kind === 'vault') return 'vault';
     if (kind === 'cycles') return 'cycles';
     if (kind === 'code-review') return 'code';
     return 'code';
+  }
+
+  function tabHasPane(tab: ThreadStageRightDockTab) {
+    switch (tab.kind) {
+      case 'browser':
+        return hasBrowserPane;
+      case 'preview':
+        return hasPreviewPane;
+      case 'discussion':
+        return hasDiscussionPane;
+      case 'activity':
+      case 'handoff-summary':
+        return hasUtilityPane;
+      case 'app':
+        return hasAppsPane;
+      case 'vault':
+        return hasVaultPane;
+      case 'cycles':
+        return hasCyclesPane;
+      case 'code-review':
+        return hasCodeReviewPane;
+      default:
+        return true;
+    }
   }
 
   function handleDocumentClick(event: MouseEvent) {
@@ -316,6 +325,10 @@
         {:else if resolvedActiveTab?.kind === 'preview' && hasPreviewPane}
           <section class="right-dock-pane right-dock-preview" aria-label="Preview">
             {@render previewPane?.()}
+          </section>
+        {:else if resolvedActiveTab?.kind === 'discussion' && hasDiscussionPane}
+          <section class="right-dock-pane right-dock-discussion" aria-label="Discussion">
+            {@render discussionPane?.()}
           </section>
         {:else if resolvedActiveTab?.kind === 'activity' && hasUtilityPane}
           <section class="right-dock-pane right-dock-activity" aria-label="Activity">
@@ -616,6 +629,7 @@
   }
 
   .right-dock-content[data-active-tab='activity'],
+  .right-dock-content[data-active-tab='discussion'],
   .right-dock-content[data-active-tab='handoff-summary'],
   .right-dock-content[data-active-tab='vault'],
   .right-dock-content[data-active-tab='cycles'] {
@@ -654,6 +668,10 @@
     overflow: visible;
   }
 
+  .right-dock-discussion {
+    overflow: hidden;
+  }
+
   .right-dock-handoff-summary {
     overflow: visible;
   }
@@ -671,6 +689,7 @@
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar,
+  .right-dock-content[data-active-tab='discussion']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='handoff-summary']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='vault']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar {
@@ -678,6 +697,7 @@
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar-thumb,
+  .right-dock-content[data-active-tab='discussion']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='handoff-summary']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='vault']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar-thumb {

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -68,6 +68,7 @@
   import SlashAutocomplete from '$lib/features/composer/components/SlashAutocomplete.svelte';
   import ThreadAttachmentPreviewPane from '$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte';
   import ThreadCodeReviewPane from '$lib/features/threads/components/ThreadCodeReviewPane.svelte';
+  import ThreadDiscussionPane from '$lib/features/threads/components/ThreadDiscussionPane.svelte';
   import ThreadStageShell, { type ThreadPeripherySignal } from '$lib/features/threads/components/ThreadStageShell.svelte';
   import ThreadUtilityContent from '$lib/features/threads/components/ThreadUtilityContent.svelte';
   import WorkspaceComposerAdapter from '$lib/features/composer/components/WorkspaceComposerAdapter.svelte';
@@ -828,6 +829,10 @@
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'activity'));
   }
 
+  function openDiscussionTab() {
+    applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'discussion'));
+  }
+
   function openHandoffSummaryTab() {
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), 'handoff-summary'));
   }
@@ -882,6 +887,10 @@
     }
     if (item.kind === 'activity') {
       addActivityTab();
+      return;
+    }
+    if (item.kind === 'discussion') {
+      openDiscussionTab();
       return;
     }
     if (item.kind === 'handoff-summary') {
@@ -1215,6 +1224,10 @@
     <ThreadAttachmentPreviewPane attachment={dockPreviewAttachment} />
   {/snippet}
 
+  {#snippet discussionPane()}
+    <ThreadDiscussionPane ideaId={idea?.id ?? null} />
+  {/snippet}
+
   {#snippet appsPane()}
     <ThreadAppsPane
       apps={workspaceApps.visibleApps}
@@ -1315,6 +1328,7 @@
               onAddMenuItem={handleSidePanelAddMenuItem}
               browserPane={browserPane}
               previewPane={previewPane}
+              discussionPane={discussionPane}
               utilityPane={utilityPane}
               appsPane={appsPane}
               vaultPane={vaultPane}

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -1,5 +1,6 @@
 export type ThreadStageRightDockTabKind =
   | 'browser'
+  | 'discussion'
   | 'activity'
   | 'handoff-summary'
   | 'app'
@@ -40,6 +41,7 @@ export type ThreadSidePanelTabState = {
 
 export function createDefaultThreadSidePanelTabs(): ThreadStageRightDockTab[] {
   return [
+    { id: 'discussion', label: 'Discussion', kind: 'discussion', closeable: true },
     { id: 'activity', label: 'Activity', kind: 'activity', closeable: true },
     { id: 'handoff-summary', label: 'Handoff', kind: 'handoff-summary', closeable: true },
   ];
@@ -57,6 +59,7 @@ export function buildThreadSidePanelAddMenuItems(
   visibleApps: readonly ThreadSidePanelAppLike[],
 ): ThreadStageRightDockAddMenuItem[] {
   const browserCount = tabs.filter((tab) => tab.kind === 'browser').length;
+  const hasDiscussion = tabs.some((tab) => tab.kind === 'discussion');
   const hasActivity = tabs.some((tab) => tab.kind === 'activity');
   const hasHandoffSummary = tabs.some((tab) => tab.kind === 'handoff-summary');
   const hasVault = tabs.some((tab) => tab.kind === 'vault');
@@ -82,6 +85,15 @@ export function buildThreadSidePanelAddMenuItems(
       kind: 'vault',
       label: 'Vault',
       description: 'Add or review thread keys',
+    });
+  }
+
+  if (!hasDiscussion) {
+    items.push({
+      id: 'discussion',
+      kind: 'discussion',
+      label: 'Discussion',
+      description: 'Open thread comments',
     });
   }
 
@@ -181,7 +193,7 @@ export function openBrowserThreadSidePanelTab(
 
 export function openSingletonThreadSidePanelTab(
   state: ThreadSidePanelTabState,
-  kind: 'activity' | 'handoff-summary' | 'vault' | 'cycles' | 'preview' | 'code-review',
+  kind: 'discussion' | 'activity' | 'handoff-summary' | 'vault' | 'cycles' | 'preview' | 'code-review',
 ): ThreadSidePanelTabState {
   const existing = state.tabs.find((tab) => tab.kind === kind);
   if (existing) return { ...state, activeTabId: existing.id };
@@ -196,6 +208,8 @@ export function openSingletonThreadSidePanelTab(
           ? 'Review files'
           : kind === 'handoff-summary'
             ? 'Handoff'
+            : kind === 'discussion'
+              ? 'Discussion'
           : 'Activity';
   return {
     ...state,

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -378,7 +378,7 @@ export function buildThreadTranscriptItems({
         role: isAgent ? 'illo' : 'user',
         author: isAgent ? 'Illo' : item.user_name || 'You',
         timestamp: timeAgo(item.timestamp, nowMs),
-        tag: item.metadata?.fast_steer ? 'Steering' : item.metadata?.queued_after_run ? 'Queued' : undefined,
+        tag: messageTag(item),
         tone: isAgent ? 'spectral' : accentTone(userAccent),
         accentColor: userAccent ?? undefined,
         coreColor: userAccent ? mixHex(userAccent, userShellColor, themeMode === 'light' ? 0.16 : 0.68) : undefined,
@@ -512,4 +512,11 @@ export function buildThreadTranscriptItems({
   }
 
   return items;
+}
+
+function messageTag(item: StreamItem): string | undefined {
+  if (item.metadata?.context_submission_id || item.message_type === 'context_submission') return 'Context';
+  if (item.metadata?.fast_steer) return 'Steering';
+  if (item.metadata?.queued_after_run) return 'Queued';
+  return undefined;
 }

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -15,7 +15,7 @@ import {
   isFastRun,
   shouldShowRunInTranscript,
 } from '$lib/utils/cortexRunPresentation';
-import { streamItemRunId } from '$lib/utils/cortexRunStream';
+import { shouldRenderLiveAgentTextItem, streamItemRunId } from '$lib/utils/cortexRunStream';
 import { parseServerDate, parseServerTimeMs, relativeTimeAgo } from '$lib/utils/datetime';
 import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
 import { buildRunEvidenceDebug } from '$lib/utils/runEvidenceDebug';
@@ -347,16 +347,10 @@ export function buildThreadTranscriptItems({
 }: BuildThreadTranscriptOptions): CortexThreadStageTranscriptItem[] {
   const items: CortexThreadStageTranscriptItem[] = [];
   const visibleItems = orderQueuedThreadStreamItems(visibleThreadStreamItems(stream));
-  const activeRunIds = new Set(
-    visibleItems
-      .filter((streamItem) => streamItem.type === 'run' && isActiveRun(streamItem))
-      .map((streamItem) => streamItemRunId(streamItem) ?? String(streamItem.id)),
-  );
 
   for (const item of visibleItems) {
     if (item.type === 'message') {
-      const messageRunId = streamItemRunId(item);
-      if (item.metadata?.live_agent_text && messageRunId && activeRunIds.has(messageRunId)) continue;
+      if (!shouldRenderLiveAgentTextItem(item, visibleItems)) continue;
 
       const isAgent = item.role === 'assistant' || item.role === 'illo';
       const userAccent = isAgent ? null : resolveUserAccent(item, idea, currentUser);

--- a/frontend/src/lib/utils/cortexRunStream.test.js
+++ b/frontend/src/lib/utils/cortexRunStream.test.js
@@ -7,6 +7,7 @@ import {
   applyRunCompletedToStream,
   mergeLiveStreamState,
   runUiEventKey,
+  shouldRenderLiveAgentTextItem,
 } from './cortexRunStream.ts';
 import { mergeRunProgressSnapshot } from './cortexRunPresentation.ts';
 
@@ -100,6 +101,28 @@ test('appends, extends, and resets live text deltas', () => {
   assert.equal(second[0].content, 'Hello');
   assert.equal(second[0].metadata.live_agent_text, true);
   assert.deepEqual(reset, []);
+});
+
+test('keeps live agent text visible until a settled run reply exists', () => {
+  const run = { type: 'run', id: '12', run_id: 12, status: 'running' };
+  const live = {
+    type: 'message',
+    id: 'live-run-12',
+    role: 'illo',
+    content: 'I will inspect the trace first.',
+    metadata: { run_id: 12, live_agent_text: true },
+  };
+  const settled = {
+    type: 'message',
+    id: 'm12',
+    role: 'illo',
+    content: 'Here is what I found.',
+    metadata: { run_id: 12 },
+  };
+
+  assert.equal(shouldRenderLiveAgentTextItem(live, [run, live]), true);
+  assert.equal(shouldRenderLiveAgentTextItem(live, [run, live, settled]), false);
+  assert.equal(shouldRenderLiveAgentTextItem(settled, [run, live, settled]), true);
 });
 
 test('creates and updates run activity with tool call state', () => {

--- a/frontend/src/lib/utils/cortexRunStream.ts
+++ b/frontend/src/lib/utils/cortexRunStream.ts
@@ -66,6 +66,24 @@ export function isLivePartialReply(item: Partial<CortexRunStreamItem> | null | u
   return Boolean(item?.metadata?.live_agent_text);
 }
 
+function isSettledAgentRunReply(item: Partial<CortexRunStreamItem>, runId: string): boolean {
+  if (item.type !== 'message' || isLivePartialReply(item)) return false;
+  const isAgentMessage = item.role === 'assistant' || item.role === 'illo';
+  return isAgentMessage && streamItemRunId(item) === runId && Boolean(String(item.content || '').trim());
+}
+
+export function shouldRenderLiveAgentTextItem(
+  item: Partial<CortexRunStreamItem> | null | undefined,
+  visibleItems: readonly Partial<CortexRunStreamItem>[] = [],
+): boolean {
+  if (!isLivePartialReply(item)) return true;
+  const runId = streamItemRunId(item);
+  if (!runId) return true;
+  return !visibleItems.some((candidate) => {
+    return candidate !== item && isSettledAgentRunReply(candidate, runId);
+  });
+}
+
 export function runUiEventKey(msg: any): string | null {
   const eventId = msg?.run_event_id ?? msg?.event_id ?? msg?.event_cursor;
   if (eventId === null || eventId === undefined || eventId === '' || Number(eventId) <= 0) return null;

--- a/frontend/src/lib/utils/threadSidePanelController.test.js
+++ b/frontend/src/lib/utils/threadSidePanelController.test.js
@@ -7,11 +7,11 @@ import {
   openSingletonThreadSidePanelTab,
 } from '../features/threads/controllers/threadSidePanelController.ts';
 
-test('default thread side panel opens Activity beside Handoff', () => {
+test('default thread side panel opens Discussion beside Activity and Handoff', () => {
   const tabs = createDefaultThreadSidePanelTabs();
 
-  assert.deepEqual(tabs.map((tab) => tab.kind), ['activity', 'handoff-summary']);
-  assert.deepEqual(tabs.map((tab) => tab.label), ['Activity', 'Handoff']);
+  assert.deepEqual(tabs.map((tab) => tab.kind), ['discussion', 'activity', 'handoff-summary']);
+  assert.deepEqual(tabs.map((tab) => tab.label), ['Discussion', 'Activity', 'Handoff']);
 });
 
 test('handoff summary is restored from the side panel add menu when closed', () => {

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -443,6 +443,11 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert "interactive single-agent path" in captured["spec"].system_prompt
     assert "Move quickly, but keep senior engineering hygiene." not in captured["spec"].system_prompt
     assert "A `/skill` mention is an explicit skill command." not in captured["spec"].system_prompt
+    assert any(
+        event.event_type == "run.activity"
+        and event.payload["label"] == "Got it - I'll inspect the request and take the safest next step."
+        for event in runtime.store.events
+    )
     assert _stream_has(runtime.stream.messages, "run.text_delta", {"delta": "README contents", "run_id": 42})
     assert any(event.event_type == "run.activity" and event.payload["label"] == "Reading files" for event in runtime.store.events)
     assert any(event.event_type == "run.tool_completed" and event.payload["tool_name"] == "read_file" for event in runtime.store.events)

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -441,13 +441,9 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert captured["spec"].idea_id is None
     assert captured["spec"].workspace_root == "/tmp/work"
     assert "interactive single-agent path" in captured["spec"].system_prompt
+    assert "write one brief task-specific assistant sentence" in captured["spec"].system_prompt
     assert "Move quickly, but keep senior engineering hygiene." not in captured["spec"].system_prompt
     assert "A `/skill` mention is an explicit skill command." not in captured["spec"].system_prompt
-    assert any(
-        event.event_type == "run.activity"
-        and event.payload["label"] == "Got it - I'll inspect the request and take the safest next step."
-        for event in runtime.store.events
-    )
     assert _stream_has(runtime.stream.messages, "run.text_delta", {"delta": "README contents", "run_id": 42})
     assert any(event.event_type == "run.activity" and event.payload["label"] == "Reading files" for event in runtime.store.events)
     assert any(event.event_type == "run.tool_completed" and event.payload["tool_name"] == "read_file" for event in runtime.store.events)

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -788,6 +788,16 @@ def test_streaming_runtime_surfaces_public_reflection_not_raw_reasoning(monkeypa
     assert deltas == ["Visible answer"]
 
 
+def test_public_reflection_excerpt_skips_title_only_fragments():
+    from brain.systems.runs.direct_loop.streaming import _public_reflection_excerpt
+
+    assert _public_reflection_excerpt("**Understanding project setup** I") == ""
+    assert _public_reflection_excerpt("**Understanding project setup** The") == ""
+    assert _public_reflection_excerpt(
+        "**Understanding project setup** I need to check the project context before changing resources."
+    ).startswith("**Understanding project setup**")
+
+
 def test_streaming_runtime_dedupes_stable_reflection_excerpt(monkeypatch):
     from brain.platform.integrations.transports.base import LLMResponse, StreamContext, StreamEvent, Usage
     from brain.systems.runs.direct_loop import streaming as runtime_streaming
@@ -828,6 +838,45 @@ def test_streaming_runtime_dedupes_stable_reflection_excerpt(monkeypatch):
     assert response is final
     assert len(activities) == 1
     assert activities[0].startswith("**Formulating a PR**")
+
+
+def test_streaming_runtime_waits_for_useful_reflection_fragment(monkeypatch):
+    from brain.platform.integrations.transports.base import LLMResponse, StreamContext, StreamEvent, Usage
+    from brain.systems.runs.direct_loop import streaming as runtime_streaming
+
+    final = LLMResponse(content=[], stop_reason="end_turn", usage=Usage())
+    events = iter([
+        StreamEvent(type="reflection", text="**Understanding project setup** I"),
+        StreamEvent(
+            type="reflection",
+            text=" need to check the project context before changing resources.",
+        ),
+    ])
+    provider = SimpleNamespace(stream=lambda _request: StreamContext(events, final_message=final))
+    cancel_event = SimpleNamespace(is_set=lambda: False)
+    activities = []
+    times = iter([0, 4, 8])
+
+    monkeypatch.setattr(runtime_streaming.time, "time", lambda: next(times))
+
+    response = runtime_streaming.streaming_call(
+        provider,
+        request=SimpleNamespace(),
+        cancel_event=cancel_event,
+        on_stream_activity=activities.append,
+        on_stream_delta=None,
+        session_id="session-1",
+        tokens=SimpleNamespace(),
+        start_time=0,
+        tool_calls_made=[],
+        call_start=0,
+        make_cancelled_result=lambda *args, **kwargs: None,
+    )
+
+    assert response is final
+    assert activities == [
+        "**Understanding project setup** I need to check the project context before changing resources."
+    ]
 
 
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1236,6 +1236,78 @@ async def test_create_thread_message_commits_before_broadcast(client, mock_sessi
 
 
 @pytest.mark.asyncio
+async def test_create_thread_discussion_comment_commits_before_broadcast_without_trigger(client, mock_session_factory):
+    idea = _make_idea(id="some-id", org_id="test-org")
+    order: list[str] = []
+
+    def _add(obj):
+        obj.id = 1
+        obj.created_at = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+
+    mock_session_factory.add.side_effect = _add
+    mock_session_factory.commit.side_effect = lambda: order.append("commit")
+
+    async def _broadcast(*_args, **_kwargs):
+        order.append("broadcast")
+
+    with (
+        patch("brain.app.api.routers.cortex._discussion._require_idea_for_user", AsyncMock(return_value=idea)),
+        patch("brain.app.api.routers.cortex._discussion.ws_manager.broadcast_product_event", side_effect=_broadcast),
+        patch("brain.app.triggers.router.async_route_trigger", AsyncMock()) as route_trigger,
+    ):
+        resp = await client.post(
+            "/api/cortex/ideas/some-id/discussion",
+            json={"body": "This direction looks right."},
+        )
+
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert payload["comment"]["body"] == "This direction looks right."
+    assert payload["trigger"] is None
+    route_trigger.assert_not_awaited()
+    assert "commit" in order
+    assert "broadcast" in order
+    assert order.index("commit") < order.index("broadcast")
+
+
+@pytest.mark.asyncio
+async def test_create_thread_discussion_illo_mention_routes_main_thread_trigger(client, mock_session_factory):
+    idea = _make_idea(id="some-id", title="Shared Thread", org_id="test-org")
+    trigger_response = {"status": "queued", "run_id": "run-1"}
+
+    def _add(obj):
+        obj.id = 7
+        obj.created_at = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+
+    mock_session_factory.add.side_effect = _add
+
+    async def _route_trigger(trigger, *, session):
+        return SimpleNamespace(to_response=lambda: trigger_response)
+
+    with (
+        patch("brain.app.api.routers.cortex._discussion._require_idea_for_user", AsyncMock(return_value=idea)),
+        patch("brain.app.api.routers.cortex._discussion.ws_manager.broadcast_product_event", AsyncMock()),
+        patch("brain.app.triggers.adapters.internal.build_cortex_notify_trigger", return_value=SimpleNamespace(event_type="cortex.thread_reply")) as build_trigger,
+        patch("brain.app.triggers.router.async_route_trigger", side_effect=_route_trigger) as route_trigger,
+    ):
+        resp = await client.post(
+            "/api/cortex/ideas/some-id/discussion",
+            json={"body": "@illo this is what we decided, carry on"},
+        )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["trigger"] == trigger_response
+    build_trigger.assert_called_once()
+    _, kwargs = build_trigger.call_args
+    assert kwargs["event"] == "thread_reply"
+    assert kwargs["idea_id"] == "some-id"
+    assert kwargs["thread_message"] == "@illo this is what we decided, carry on"
+    assert kwargs["metadata"]["source"] == "thread_discussion"
+    assert kwargs["metadata"]["discussion_comment_id"] == 7
+    route_trigger.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_update_idea_status_commits_before_broadcast(client, mock_session_factory):
     idea = _make_idea(id="status-idea", status="emerged", org_id="test-org")
     order: list[str] = []

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -416,7 +416,7 @@ async def test_hosted_mcp_lists_tools_for_scoped_bridge_token():
 
     assert response.status_code == 200
     names = {tool["name"] for tool in response.json()["result"]["tools"]}
-    assert "illo_submit_signal" in names
+    assert "illo_submit_context" in names
     assert "illo_create_thread" in names
     assert "illo_ask" in names
     assert "illo_search_workspace" in names
@@ -493,7 +493,7 @@ async def test_hosted_mcp_filters_tools_by_bridge_token_scope():
     assert names == {"illo_search_workspace", "illo_get_thread", "illo_get_team_members"}
 
 
-async def test_hosted_mcp_submit_signal_builds_shared_envelope():
+async def test_hosted_mcp_submit_context_builds_shared_envelope():
     session = _AsyncSession()
     captured: dict[str, object] = {}
 
@@ -502,7 +502,18 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
         captured["connection"] = connection
         captured["envelope"] = envelope
         captured["ingress_context"] = ingress_context
-        return {"status": "processed", "event_id": "evt-1", "confidence": 0.9}
+        return {
+            "status": "processed",
+            "event_id": "evt-1",
+            "confidence": 0.9,
+            "ilo_outcome": {
+                "operation": "created",
+                "thread_id": "idea-1",
+                "url": "/cortex?idea=idea-1",
+                "message": "Context accepted and a Thread was created.",
+                "context_submission_id": "sub-1",
+            },
+        }
 
     with patch(
         "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
@@ -521,17 +532,16 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
                 "id": 11,
                 "method": "tools/call",
                 "params": {
-                    "name": "illo_submit_signal",
+                    "name": "illo_submit_context",
                     "arguments": {
-                        "summary": "Implemented the submit signal tool.",
-                        "origin": "codex.progress",
+                        "intent": "Ask the team to review the implementation context.",
+                        "origin": "codex.context",
                         "source_tool": "codex",
                         "repo": "illospace-project",
-                        "branch": "codex/mcp-submit-signal",
-                        "task_title": "MCP signal lane",
+                        "branch": "codex/mcp-submit-context",
+                        "task_title": "MCP context lane",
                         "files_touched": ["brain/app/api/routers/agent_mcp.py"],
-                        "payload": {"tests": "targeted"},
-                        "desired_outcome": "team_update",
+                        "parts": [{"type": "text", "text": "Implemented the submit context tool."}],
                         "idempotency_key": "codex:run-1",
                         "metadata": {"hook": "post-message"},
                     },
@@ -541,7 +551,11 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
 
     assert response.status_code == 200
     payload = json.loads(response.json()["result"]["content"][0]["text"])
-    assert payload == {"status": "processed", "event_id": "evt-1", "confidence": 0.9}
+    assert payload["status"] == "processed"
+    assert payload["event_id"] == "evt-1"
+    assert payload["thread_id"] == "idea-1"
+    assert payload["url"] == "/cortex?idea=idea-1"
+    assert payload["context_submission_id"] == "sub-1"
     submit.assert_awaited_once()
     assert captured["db"] is session
     assert captured["connection"] == {
@@ -552,31 +566,36 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
         "display_name": "Hermes",
         "agent_kind": "hermes",
         "source_type": "personal_tool",
-        "capabilities": ["submit_signals"],
+        "capabilities": ["submit_context"],
     }
     assert captured["envelope"] == {
-        "kind": "signal",
-        "origin": "codex.progress",
+        "kind": "context",
+        "origin": "codex.context",
         "payload": {
-            "tests": "targeted",
-            "checkpoint": {
-                "summary": "Implemented the submit signal tool.",
+            "intent": "Ask the team to review the implementation context.",
+            "parts": [{"type": "text", "text": "Implemented the submit context tool."}],
+            "source": {
                 "source_tool": "codex",
                 "repo": "illospace-project",
-                "branch": "codex/mcp-submit-signal",
-                "task_title": "MCP signal lane",
+                "branch": "codex/mcp-submit-context",
+                "task_title": "MCP context lane",
                 "files_touched": ["brain/app/api/routers/agent_mcp.py"],
             },
+            "constraints": {},
+            "correlation": {},
         },
-        "summary": "Implemented the submit signal tool.",
-        "hints": {
+        "summary": "Ask the team to review the implementation context.",
+        "intent": "Ask the team to review the implementation context.",
+        "parts": [{"type": "text", "text": "Implemented the submit context tool."}],
+        "source": {
             "source_tool": "codex",
             "repo": "illospace-project",
-            "branch": "codex/mcp-submit-signal",
-            "task_title": "MCP signal lane",
+            "branch": "codex/mcp-submit-context",
+            "task_title": "MCP context lane",
             "files_touched": ["brain/app/api/routers/agent_mcp.py"],
         },
-        "desired_outcome": "team_update",
+        "constraints": {},
+        "correlation": {},
         "idempotency_key": "codex:run-1",
     }
     ingress_context = captured["ingress_context"]
@@ -588,15 +607,15 @@ async def test_hosted_mcp_submit_signal_builds_shared_envelope():
         "org_id": "org-1",
     }
     assert ingress_context["metadata"]["hook"] == "post-message"
-    assert ingress_context["metadata"]["mcp_tool"] == "illo_submit_signal"
+    assert ingress_context["metadata"]["mcp_tool"] == "illo_submit_context"
 
 
-async def test_hosted_mcp_submit_signal_commits_before_later_batch_rollback():
+async def test_hosted_mcp_submit_context_commits_before_later_batch_rollback():
     order: list[str] = []
     session = _AsyncSession(order)
 
     async def fake_submit(_db, *, connection, envelope, ingress_context):
-        order.append("signal-write")
+        order.append("context-write")
         return {"status": "processed", "event_id": "evt-1", "connection_id": connection["id"]}
 
     with patch(
@@ -620,8 +639,8 @@ async def test_hosted_mcp_submit_signal_commits_before_later_batch_rollback():
                     "id": 21,
                     "method": "tools/call",
                     "params": {
-                        "name": "illo_submit_signal",
-                        "arguments": {"summary": "Signal should be durable before batch failure."},
+                        "name": "illo_submit_context",
+                        "arguments": {"intent": "Context should be durable before batch failure."},
                     },
                 },
                 {
@@ -638,13 +657,13 @@ async def test_hosted_mcp_submit_signal_commits_before_later_batch_rollback():
 
     assert response.status_code == 200
     first, second = response.json()
-    signal_result = json.loads(first["result"]["content"][0]["text"])
-    assert signal_result["event_id"] == "evt-1"
+    context_result = json.loads(first["result"]["content"][0]["text"])
+    assert context_result["event_id"] == "evt-1"
     assert second["result"]["isError"] is True
-    assert order == ["signal-write", "commit", "rollback"]
+    assert order == ["context-write", "commit", "rollback"]
 
 
-async def test_hosted_mcp_submit_signal_requires_signal_scope():
+async def test_hosted_mcp_submit_context_requires_signal_scope():
     principal = external_agents.AgentBridgePrincipal(
         connection_id="conn-1",
         org_id="org-1",
@@ -671,8 +690,8 @@ async def test_hosted_mcp_submit_signal_requires_signal_scope():
                 "id": 12,
                 "method": "tools/call",
                 "params": {
-                    "name": "illo_submit_signal",
-                    "arguments": {"summary": "Progress happened."},
+                    "name": "illo_submit_context",
+                    "arguments": {"intent": "Share context with Illo."},
                 },
             },
         )
@@ -684,7 +703,7 @@ async def test_hosted_mcp_submit_signal_requires_signal_scope():
     submit.assert_not_called()
 
 
-async def test_hosted_mcp_submit_signal_rejects_direct_workspace_targets():
+async def test_hosted_mcp_submit_context_rejects_direct_workspace_targets():
     with patch(
         "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
         return_value=_principal(),
@@ -701,9 +720,9 @@ async def test_hosted_mcp_submit_signal_rejects_direct_workspace_targets():
                 "id": 13,
                 "method": "tools/call",
                 "params": {
-                    "name": "illo_submit_signal",
+                    "name": "illo_submit_context",
                     "arguments": {
-                        "summary": "Please post this progress.",
+                        "intent": "Please post this context.",
                         "idea_id": "idea-1",
                     },
                 },

--- a/tests/test_illo_personal_agent_mcp.py
+++ b/tests/test_illo_personal_agent_mcp.py
@@ -27,7 +27,7 @@ def test_tool_catalog_contains_behavior_guidance():
     tools = {tool["name"]: tool for tool in response["result"]["tools"]}
 
     assert {
-        "illo_submit_signal",
+        "illo_submit_context",
         "illo_search_workspace",
         "illo_get_thread",
         "illo_create_thread",
@@ -36,7 +36,7 @@ def test_tool_catalog_contains_behavior_guidance():
         "illo_get_ask",
         "illo_get_team_members",
     } == set(tools)
-    assert "default tool for automatic hooks" in tools["illo_submit_signal"]["description"]
+    assert "team agent" in tools["illo_submit_context"]["description"]
     assert "before creating a new thread" in tools["illo_search_workspace"]["description"]
     assert "without creating a visible thread" in tools["illo_ask"]["description"]
     assert "Advanced compatibility tool" in tools["illo_create_thread"]["description"]
@@ -54,10 +54,11 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
     client = module.IlloBridgeClient(module.IlloBridgeConfig("https://illo.test", "bridge-token", 12))
 
     client.search_workspace("roadmap", limit=5)
-    client.submit_signal(
-        "Implemented signal submission",
+    client.submit_context(
+        "Ask the team to review the implementation context",
+        parts=[{"type": "text", "text": "Implemented context submission"}],
         repo="illospace-project",
-        branch="codex/mcp-submit-signal",
+        branch="codex/mcp-submit-context",
         files_touched=[" brain/app/api/routers/agent_mcp.py ", ""],
         metadata={"source": "test"},
     )
@@ -87,11 +88,14 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
     assert {call["token"] for call in calls} == {"bridge-token"}
     assert {call["timeout"] for call in calls} == {12}
     assert calls[0]["payload"] == {"query": "roadmap", "limit": 5}
-    signal_payload = calls[1]["payload"]
-    assert signal_payload["method"] == "tools/call"
-    assert signal_payload["params"]["name"] == "illo_submit_signal"
-    assert signal_payload["params"]["arguments"]["summary"] == "Implemented signal submission"
-    assert signal_payload["params"]["arguments"]["files_touched"] == [
+    context_payload = calls[1]["payload"]
+    assert context_payload["method"] == "tools/call"
+    assert context_payload["params"]["name"] == "illo_submit_context"
+    assert context_payload["params"]["arguments"]["intent"] == "Ask the team to review the implementation context"
+    assert context_payload["params"]["arguments"]["parts"] == [
+        {"type": "text", "text": "Implemented context submission"}
+    ]
+    assert context_payload["params"]["arguments"]["files_touched"] == [
         "brain/app/api/routers/agent_mcp.py"
     ]
     assert calls[4]["payload"]["teammate_user_ids"] == ["user-1"]

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -25,7 +25,7 @@ from brain.platform.db.models.external_agent import (
     ExternalAgentConnectionRow,
     ExternalAgentConnectionTokenRow,
 )
-from brain.platform.db.models.idea import Idea, IdeaStateLog, IdeaThread
+from brain.platform.db.models.idea import Idea, IdeaStateLog, IdeaThread, ThreadContextSubmission
 from brain.platform.db.models.inbound import (
     InboundDecisionReceiptRow,
     InboundDomainProjectionKeyRow,
@@ -104,6 +104,7 @@ async def session(async_sqlite_session_factory):
             InboundDomainProjectionKeyRow.__table__,
             InboundEventRow.__table__,
             InboundDecisionReceiptRow.__table__,
+            ThreadContextSubmission.__table__,
         ]
     )
 
@@ -130,7 +131,7 @@ async def _seed_connection(
         transport="webhook",
         status=status,
         remote_agent_card={},
-        capabilities={"submit_signals": True},
+        capabilities={"submit_context": True},
         auth_metadata={},
         metadata_={},
     )
@@ -329,7 +330,7 @@ async def test_authenticated_source_traffic_marks_pending_connection_configured(
     assert token.last_used_at is not None
 
 
-async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
+async def test_webhook_and_mcp_context_share_inbound_event_path(session):
     await _seed_connection(session)
 
     webhook_response = await _post_webhook(
@@ -349,17 +350,16 @@ async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
             "id": 1,
             "method": "tools/call",
             "params": {
-                "name": "illo_submit_signal",
+                "name": "illo_submit_context",
                 "arguments": {
-                    "summary": "Implemented inbound coordination.",
-                    "origin": "codex.progress",
+                    "intent": "Ask the team to review inbound coordination.",
+                    "origin": "codex.context",
                     "source_tool": "codex",
                     "repo": "illospace-project",
                     "branch": "codex/inbound-coordination-e2e",
                     "task_title": "Unify inbound PRs",
                     "files_touched": ["brain/app/api/routers/agent_mcp.py"],
-                    "payload": {"tests": "e2e"},
-                    "desired_outcome": "team_update",
+                    "parts": [{"type": "text", "text": "Implemented inbound coordination."}],
                     "idempotency_key": "codex:e2e:1",
                     "metadata": {"hook": "post-message"},
                 },
@@ -371,33 +371,31 @@ async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
     assert mcp_response.status_code == 200
     mcp_payload = json.loads(mcp_response.json()["result"]["content"][0]["text"])
     assert webhook_response.json()["status"] == "review_required"
-    assert mcp_payload["status"] == "review_required"
+    assert mcp_payload["status"] == "processed"
     assert mcp_payload["matched_policy_id"] is None
+    assert mcp_payload["thread_id"]
+    assert mcp_payload["url"] == f"/cortex?idea={mcp_payload['thread_id']}"
     webhook_triage = await _assert_queued_triage(
         session,
         webhook_response.json()["ilo_outcome"],
         reason="no_matching_source_policy",
     )
-    mcp_triage = await _assert_queued_triage(
-        session,
-        mcp_payload["ilo_outcome"],
-        reason="no_matching_source_policy",
-    )
 
     events = (await session.scalars(select(InboundEventRow).order_by(InboundEventRow.created_at))).all()
-    assert [event.origin for event in events] == ["jira.ticket_created", "codex.progress"]
-    assert [event.status for event in events] == ["review_required", "review_required"]
-    assert [event.action_type for event in events] == ["ilo_required", "ilo_required"]
+    assert [event.origin for event in events] == ["jira.ticket_created", "codex.context"]
+    assert [event.status for event in events] == ["review_required", "processed"]
+    assert [event.action_type for event in events] == ["ilo_required", "thread.created"]
     assert all(event.connection_id == CONNECTION_ID for event in events)
     assert all(event.authority_user_id == USER_ID for event in events)
     assert events[0].ingress_context["surface"] == "webhook"
     assert events[1].ingress_context["surface"] == "mcp_personal_tool"
-    assert events[1].normalized_payload["summary"] == "Implemented inbound coordination."
-    assert events[1].normalized_payload["hints"]["source_tool"] == "codex"
-    assert events[1].normalized_payload["hints"]["files_touched"] == [
+    assert events[1].normalized_payload["intent"] == "Ask the team to review inbound coordination."
+    assert events[1].normalized_payload["source"]["source_tool"] == "codex"
+    assert events[1].normalized_payload["source"]["files_touched"] == [
         "brain/app/api/routers/agent_mcp.py"
     ]
-    assert [webhook_triage["event_id"], mcp_triage["event_id"]] == [str(event.id) for event in events]
+    assert webhook_triage["event_id"] == str(events[0].id)
+    assert mcp_payload["event_id"] == str(events[1].id)
 
     receipts = (
         await session.scalars(
@@ -406,10 +404,12 @@ async def test_webhook_and_mcp_signals_share_inbound_event_path(session):
     ).all()
     assert len(receipts) == 2
     assert [receipt.event_id for receipt in receipts] == [str(event.id) for event in events]
-    assert all(receipt.outcome["reason"] == "no_matching_source_policy" for receipt in receipts)
-    assert all(receipt.outcome["triage"]["status"] == "queued" for receipt in receipts)
+    assert receipts[0].outcome["reason"] == "no_matching_source_policy"
+    assert receipts[0].outcome["triage"]["status"] == "queued"
+    assert receipts[1].outcome["operation"] == "created"
     assert all(receipt.target["kind"] == "cortex_idea" for receipt in receipts)
-    assert all(receipt.tool_use["type"] == "illo_triage" for receipt in receipts)
+    assert receipts[0].tool_use["type"] == "illo_triage"
+    assert receipts[1].tool_use["type"] == "illo_submit_context"
 
 
 async def test_malformed_mcp_json_fails_without_creating_event(session):
@@ -431,52 +431,7 @@ async def test_malformed_mcp_json_fails_without_creating_event(session):
     assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 0
 
 
-async def test_mcp_codex_progress_signal_satisfies_default_checkpoint_policy(session):
-    await _seed_connection(session)
-    policy = await inbound.create_source_policy(
-        session,
-        org_id=ORG_ID,
-        connection_id=CONNECTION_ID,
-        name="Codex progress checkpoints",
-        origin_patterns=["codex.progress"],
-        schema_config={"required_paths": ["payload.checkpoint", "desired_outcome"]},
-    )
-
-    response = await _post_mcp(
-        session,
-        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
-        json_body={
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/call",
-            "params": {
-                "name": "illo_submit_signal",
-                "arguments": {
-                    "summary": "Implemented inbound follow-up fixes.",
-                    "source_tool": "codex",
-                    "repo": "illospace-project",
-                    "branch": "codex/inbound-followups",
-                    "task_title": "E2E followups",
-                    "files_touched": ["brain/app/api/routers/agent_mcp.py"],
-                    "desired_outcome": "team_update",
-                    "idempotency_key": "codex:e2e-followups:1",
-                },
-            },
-        },
-    )
-
-    body = json.loads(response.json()["result"]["content"][0]["text"])
-    event = (await session.scalars(select(InboundEventRow))).one()
-    assert response.status_code == 200
-    assert body["status"] == "review_required"
-    assert body["matched_policy_id"] == str(policy.id)
-    assert body["error"] is None
-    assert event.status == "review_required"
-    assert event.raw_payload["checkpoint"]["summary"] == "Implemented inbound follow-up fixes."
-    assert event.normalized_payload["desired_outcome"] == "team_update"
-
-
-async def test_mcp_codex_progress_signal_requires_non_empty_desired_outcome(session):
+async def test_mcp_context_ignores_signal_policy_and_creates_thread(session):
     await _seed_connection(session)
     await inbound.create_source_policy(
         session,
@@ -495,9 +450,49 @@ async def test_mcp_codex_progress_signal_requires_non_empty_desired_outcome(sess
             "id": 2,
             "method": "tools/call",
             "params": {
-                "name": "illo_submit_signal",
+                "name": "illo_submit_context",
                 "arguments": {
-                    "summary": "Implemented inbound follow-up fixes.",
+                    "intent": "Ask the team to review inbound follow-up fixes.",
+                    "origin": "codex.context",
+                    "source_tool": "codex",
+                    "repo": "illospace-project",
+                    "branch": "codex/inbound-followups",
+                    "task_title": "E2E followups",
+                    "files_touched": ["brain/app/api/routers/agent_mcp.py"],
+                    "parts": [{"type": "text", "text": "Implemented inbound follow-up fixes."}],
+                    "idempotency_key": "codex:e2e-followups:1",
+                },
+            },
+        },
+    )
+
+    body = json.loads(response.json()["result"]["content"][0]["text"])
+    event = (await session.scalars(select(InboundEventRow))).one()
+    assert response.status_code == 200
+    assert body["status"] == "processed"
+    assert body["thread_id"]
+    assert body["url"] == f"/cortex?idea={body['thread_id']}"
+    assert body["matched_policy_id"] is None
+    assert body["error"] is None
+    assert event.status == "processed"
+    assert event.kind == "context"
+    assert event.raw_payload["intent"] == "Ask the team to review inbound follow-up fixes."
+    assert event.normalized_payload["source"]["source_tool"] == "codex"
+
+
+async def test_mcp_context_requires_non_empty_intent(session):
+    await _seed_connection(session)
+
+    response = await _post_mcp(
+        session,
+        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
+        json_body={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "illo_submit_context",
+                "arguments": {
                     "source_tool": "codex",
                     "repo": "illospace-project",
                     "branch": "codex/inbound-followups",
@@ -509,12 +504,11 @@ async def test_mcp_codex_progress_signal_requires_non_empty_desired_outcome(sess
         },
     )
 
-    body = json.loads(response.json()["result"]["content"][0]["text"])
-    event = (await session.scalars(select(InboundEventRow))).one()
+    body = response.json()["result"]
     assert response.status_code == 200
-    assert body["status"] == "quarantined"
-    assert "desired_outcome" in body["error"]
-    assert event.status == "quarantined"
+    assert body["isError"] is True
+    assert "intent" in body["content"][0]["text"]
+    assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 0
 
 
 async def test_inbound_triage_receipt_reconciles_when_illo_run_completes(session):
@@ -659,7 +653,7 @@ async def test_inbound_triage_receipt_reconciles_when_illo_run_fails(session):
     assert receipt.tool_use["status"] == "failed"
 
 
-async def test_mcp_signal_rejects_overlong_origin_before_inbound_processing(session):
+async def test_mcp_context_rejects_overlong_origin_before_inbound_processing(session):
     await _seed_connection(session)
 
     response = await _post_mcp(
@@ -670,9 +664,9 @@ async def test_mcp_signal_rejects_overlong_origin_before_inbound_processing(sess
             "id": 2,
             "method": "tools/call",
             "params": {
-                "name": "illo_submit_signal",
+                "name": "illo_submit_context",
                 "arguments": {
-                    "summary": "This should not reach persistence.",
+                    "intent": "This should not reach persistence.",
                     "origin": "x" * 241,
                 },
             },
@@ -823,6 +817,94 @@ async def test_idempotent_insert_integrity_error_returns_existing_replay(session
     assert replay["idempotent_replay"] is True
     assert replay["event_id"] == first["event_id"]
     assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 1
+
+
+async def test_context_envelope_creates_thread_submission_and_preview(session):
+    principal = await _seed_connection(session)
+
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "context",
+            "origin": "codex.context",
+            "intent": "Ask the team to review the agent trace",
+            "parts": [
+                {"type": "conversation", "title": "Codex thread", "text": "User asked; Codex replied."},
+                {"type": "diff", "title": "Implementation diff", "text": "+ new behavior"},
+            ],
+            "source": {"source_tool": "codex", "repo": "illospace-project"},
+            "idempotency_key": "codex:context:1",
+        },
+        ingress_context={"surface": "test"},
+    )
+
+    assert result["status"] == "processed"
+    assert result["matched_policy_id"] is None
+    assert result["ilo_outcome"]["operation"] == "created"
+    thread_id = result["ilo_outcome"]["thread_id"]
+    assert result["ilo_outcome"]["url"] == f"/cortex?idea={thread_id}"
+
+    idea = await session.get(Idea, thread_id)
+    assert idea is not None
+    assert idea.origin == "inbound_context"
+    assert idea.title == "Ask the team to review the agent trace"
+
+    submission = (await session.scalars(select(ThreadContextSubmission))).one()
+    assert submission.thread_id == thread_id
+    assert submission.intent == "Ask the team to review the agent trace"
+    assert submission.source["source_tool"] == "codex"
+    assert submission.parts[0]["type"] == "conversation"
+    assert submission.routing_result["thread_id"] == thread_id
+
+    preview = (await session.scalars(select(IdeaThread).where(IdeaThread.idea_id == thread_id))).one()
+    assert preview.message_type == "context_submission"
+    assert "Context submitted from Jira webhook." in preview.content
+    assert preview.metadata_["context_submission_id"] == str(submission.id)
+
+
+async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempotently(session):
+    principal = await _seed_connection(session)
+    thread = Idea(
+        id="77777777-7777-4777-8777-777777777777",
+        title="Existing shared thread",
+        status="emerged",
+        origin="user_created",
+        user_id=USER_ID,
+        org_id=ORG_ID,
+    )
+    session.add(thread)
+    await session.flush()
+
+    first = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "context",
+            "origin": "codex.context",
+            "intent": "Attach follow-up trace",
+            "parts": [{"type": "trace", "text": "tool calls"}],
+            "correlation": {"thread_id": str(thread.id)},
+            "idempotency_key": "codex:context:attach",
+        },
+    )
+    replay = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "context",
+            "origin": "codex.context",
+            "intent": "Attach follow-up trace",
+            "parts": [{"type": "trace", "text": "tool calls"}],
+            "correlation": {"thread_id": str(thread.id)},
+            "idempotency_key": "codex:context:attach",
+        },
+    )
+
+    assert first["ilo_outcome"]["operation"] == "attached"
+    assert first["ilo_outcome"]["thread_id"] == str(thread.id)
+    assert replay["idempotent_replay"] is True
+    assert await session.scalar(select(func.count()).select_from(ThreadContextSubmission)) == 1
 
 
 async def test_source_policy_matching_uses_connection_scope_and_priority(session):

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -93,6 +93,8 @@ EXPECTED_TABLES = {
     "summary_lineage",
     "tags",
     "target_registry",
+    "thread_context_submissions",
+    "thread_discussion_comments",
     "user_codex_connections",
     "user_mentions",
     "users",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -380,6 +380,49 @@ class TestOpenAIProvider:
         assert result.stop_reason == "end_turn"
         assert result.content[0].text == "Hi"
 
+    def test_stream_emits_only_complete_reasoning_summary_reflections(self):
+        client = MagicMock()
+        mock_resp = MagicMock()
+        output_message = MagicMock()
+        output_message.type = "message"
+        output_message.role = "assistant"
+        output_text = MagicMock()
+        output_text.type = "output_text"
+        output_text.text = "Answer"
+        output_message.content = [output_text]
+        mock_resp.output = [output_message]
+        mock_resp.usage.input_tokens = 10
+        mock_resp.usage.output_tokens = 5
+        mock_resp.usage.input_tokens_details.cached_tokens = 0
+        mock_resp.incomplete_details = None
+        client.responses.create.return_value = iter([
+            {"type": "response.reasoning_summary_text.delta", "delta": "**Understanding setup** I"},
+            {
+                "type": "response.reasoning_summary_text.done",
+                "text": "**Understanding setup** I checked the project context before changing anything.",
+            },
+            {"type": "response.output_text.delta", "delta": "Answer"},
+            {"type": "response.completed", "response": mock_resp},
+        ])
+
+        p = OpenAIProvider(client)
+        with p.stream(LLMRequest(
+            model="openai/gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="high",
+        )) as stream:
+            events = list(stream)
+            result = stream.get_final_message()
+
+        assert [(event.type, event.text) for event in events] == [
+            (
+                "reflection",
+                "**Understanding setup** I checked the project context before changing anything.",
+            ),
+            ("text", "Answer"),
+        ]
+        assert result.content[0].text == "Answer"
+
     def test_stream_strips_provider_prefix(self):
         client = MagicMock()
         mock_resp = MagicMock()

--- a/tools/illo-personal-agent-mcp/README.md
+++ b/tools/illo-personal-agent-mcp/README.md
@@ -77,7 +77,7 @@ Local repo config before package publish:
 
 ## Tools
 
-- `illo_submit_signal`: default path for automatic hooks and routine progress updates from Codex-style personal tools. Sends a signal envelope with summary, origin, payload, hints, desired outcome, and idempotency key so IloSpace can decide where it belongs.
+- `illo_submit_context`: default path for personal agents sending new context to Illo. Sends an intent, ordered context parts, provenance, constraints, correlation, and idempotency key so Illo can place the context in the team workspace.
 - `illo_search_workspace`: search existing Illo ideas/threads before creating duplicates.
 - `illo_get_thread`: inspect visible context for an existing Illo thread.
 - `illo_create_thread`: advanced compatibility tool for explicitly requested visible team threads.
@@ -89,28 +89,44 @@ Local repo config before package publish:
 Behavior guidance lives in tool descriptions so MCP clients can use this package
 without a separate skill or prompt file.
 
-## Codex-Style Progress Signal
+## Context Submission
 
-Automatic hooks should prefer `illo_submit_signal` instead of searching for a
-thread and posting directly. A typical payload:
+Personal agents should prefer `illo_submit_context` when they need to hand new
+conversation, trace, file, diff, link, or artifact context to Illo. A typical
+payload:
 
 ```json
 {
-  "summary": "Implemented the MCP submit-signal tool and added tests.",
-  "origin": "codex.progress",
+  "intent": "Share the Codex thread so the team can inspect the exact context and decide what to do next.",
+  "origin": "codex.context",
   "source_tool": "codex",
   "repo": "illospace-project",
-  "branch": "codex/mcp-submit-signal",
-  "task_title": "MCP personal-tool signal lane",
+  "branch": "codex/universal-thread-context",
+  "task_title": "Universal Thread context ingress",
   "files_touched": [
     "brain/app/api/routers/agent_mcp.py",
     "tests/test_external_agent_routes.py"
   ],
-  "desired_outcome": "team_update",
-  "idempotency_key": "codex:mcp-submit-signal:2026-05-18T18:30Z"
+  "parts": [
+    {
+      "type": "conversation",
+      "title": "Codex conversation",
+      "content": "Full or bounded conversation text goes here."
+    },
+    {
+      "type": "diff",
+      "title": "Current code diff",
+      "content": "Diff or artifact reference goes here."
+    }
+  ],
+  "correlation": {
+    "thread_id": "optional-existing-illo-thread-id"
+  },
+  "idempotency_key": "codex:universal-thread-context:2026-05-21T18:30Z"
 }
 ```
 
-The signal may include context hints, but it should not choose an Ilo thread,
-project, pin, or teammate target. IloSpace owns routing and Ilo handles
-ambiguity.
+The submission may include `correlation.thread_id` when the user explicitly
+means to attach context to an existing Thread. It should not choose projects,
+pins, teammates, or workflow-specific outcomes. Illo owns coordination in the
+team workspace.

--- a/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
+++ b/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
@@ -17,7 +17,7 @@ from typing import Any, Callable
 
 logger = logging.getLogger("illo_personal_agent_mcp")
 DEFAULT_TIMEOUT_SECONDS = 60.0
-SIGNAL_TOOL_NAME = "illo_submit_signal"
+CONTEXT_TOOL_NAME = "illo_submit_context"
 
 
 class IlloBridgeError(RuntimeError):
@@ -153,14 +153,15 @@ class IlloBridgeClient:
     def get_team_members(self) -> dict[str, Any]:
         return self._request("GET", "/api/agent-bridge/workspace/team-members")
 
-    def submit_signal(
+    def submit_context(
         self,
-        summary: str,
+        intent: str,
         *,
-        origin: str = "codex.progress",
-        payload: dict[str, Any] | None = None,
-        hints: dict[str, Any] | None = None,
-        desired_outcome: str | None = None,
+        origin: str = "codex.context",
+        parts: list[dict[str, Any]] | None = None,
+        source: dict[str, Any] | None = None,
+        constraints: dict[str, Any] | None = None,
+        correlation: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
         source_tool: str = "codex",
         repo: str | None = None,
@@ -173,11 +174,12 @@ class IlloBridgeClient:
     ) -> dict[str, Any]:
         arguments = _drop_empty(
             {
-                "summary": str(summary),
-                "origin": str(origin or "codex.progress"),
-                "payload": dict(payload or {}),
-                "hints": dict(hints or {}),
-                "desired_outcome": desired_outcome,
+                "intent": str(intent),
+                "origin": str(origin or "codex.context"),
+                "parts": list(parts or []),
+                "source": dict(source or {}),
+                "constraints": dict(constraints or {}),
+                "correlation": dict(correlation or {}),
                 "idempotency_key": idempotency_key,
                 "source_tool": source_tool,
                 "repo": repo,
@@ -194,9 +196,9 @@ class IlloBridgeClient:
             "/api/mcp",
             payload={
                 "jsonrpc": "2.0",
-                "id": SIGNAL_TOOL_NAME,
+                "id": CONTEXT_TOOL_NAME,
                 "method": "tools/call",
-                "params": {"name": SIGNAL_TOOL_NAME, "arguments": arguments},
+                "params": {"name": CONTEXT_TOOL_NAME, "arguments": arguments},
             },
         )
         return _decode_mcp_tool_result(response)
@@ -286,12 +288,13 @@ def tool_illo_get_team_members() -> dict[str, Any]:
     return _client().get_team_members()
 
 
-def tool_illo_submit_signal(
-    summary: str,
-    origin: str = "codex.progress",
-    payload: dict[str, Any] | None = None,
-    hints: dict[str, Any] | None = None,
-    desired_outcome: str | None = None,
+def tool_illo_submit_context(
+    intent: str,
+    origin: str = "codex.context",
+    parts: list[dict[str, Any]] | None = None,
+    source: dict[str, Any] | None = None,
+    constraints: dict[str, Any] | None = None,
+    correlation: dict[str, Any] | None = None,
     idempotency_key: str | None = None,
     source_tool: str = "codex",
     repo: str | None = None,
@@ -302,12 +305,13 @@ def tool_illo_submit_signal(
     run_id: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return _client().submit_signal(
-        summary=summary,
+    return _client().submit_context(
+        intent=intent,
         origin=origin,
-        payload=payload,
-        hints=hints,
-        desired_outcome=desired_outcome,
+        parts=parts,
+        source=source,
+        constraints=constraints,
+        correlation=correlation,
         idempotency_key=idempotency_key,
         source_tool=source_tool,
         repo=repo,
@@ -372,27 +376,43 @@ ToolFunction = Callable[..., dict[str, Any]]
 
 
 TOOLS: dict[str, dict[str, Any]] = {
-    SIGNAL_TOOL_NAME: {
-        "function": tool_illo_submit_signal,
+    CONTEXT_TOOL_NAME: {
+        "function": tool_illo_submit_context,
         "description": (
-            "Submit a progress or status signal from a personal tool into IloSpace. "
-            "This is the default tool for automatic hooks and routine work updates: "
-            "send what happened, plus hints like repo, branch, task, and files touched. "
-            "Do not choose a thread, project, or teammate target here; IloSpace and Ilo "
-            "decide whether to store, route, summarize, ask, or ignore the signal."
+            "Submit ordered context from a personal agent to Illo, the user's team agent. "
+            "Use this when the user wants Illo or the team to have the current AI thread, "
+            "trace, artifacts, files, links, diffs, or other source material. The personal "
+            "agent supplies context and provenance; Illo coordinates the team workspace."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "summary": {"type": "string", "description": "Concise progress summary."},
-                "origin": {"type": "string", "description": "Stable event name.", "default": "codex.progress"},
-                "payload": {"type": "object", "description": "Optional structured payload.", "default": {}},
-                "hints": {
+                "intent": {
+                    "type": "string",
+                    "description": "Natural-language reason this context is being submitted.",
+                },
+                "origin": {"type": "string", "description": "Stable event name.", "default": "codex.context"},
+                "parts": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Ordered source context parts.",
+                    "default": [],
+                },
+                "source": {
                     "type": "object",
-                    "description": "Optional routing/context hints, not direct workspace targets.",
+                    "description": "Optional provenance about the personal agent, repo, branch, model, or session.",
                     "default": {},
                 },
-                "desired_outcome": {"type": "string", "description": "Optional intent for IloSpace."},
+                "constraints": {
+                    "type": "object",
+                    "description": "Optional privacy, urgency, visibility, or notification boundaries.",
+                    "default": {},
+                },
+                "correlation": {
+                    "type": "object",
+                    "description": "Optional thread_id, external_session_id, or prior submission reference.",
+                    "default": {},
+                },
                 "idempotency_key": {"type": "string", "description": "Optional dedupe key."},
                 "source_tool": {"type": "string", "description": "Personal tool name.", "default": "codex"},
                 "repo": {"type": "string", "description": "Repository or workspace hint."},
@@ -408,7 +428,7 @@ TOOLS: dict[str, dict[str, Any]] = {
                 "run_id": {"type": "string", "description": "Optional tool run id."},
                 "metadata": {"type": "object", "description": "Optional metadata.", "default": {}},
             },
-            "required": ["summary"],
+            "required": ["intent"],
         },
     },
     "illo_search_workspace": {
@@ -449,7 +469,7 @@ TOOLS: dict[str, dict[str, Any]] = {
             "personal-agent work. Use only when the user explicitly asks to share work "
             "with teammates, publish findings into Illo, or start a team-visible "
             "discussion. For automatic hooks and routine progress, prefer "
-            f"{SIGNAL_TOOL_NAME} so IloSpace can route the signal. Set trigger_illo "
+            f"{CONTEXT_TOOL_NAME} so IloSpace can route the context. Set trigger_illo "
             "only when the user wants Ilo to actively respond or the message explicitly "
             "mentions Ilo."
         ),
@@ -486,7 +506,7 @@ TOOLS: dict[str, dict[str, Any]] = {
             "Advanced compatibility tool for posting a visible update into an existing "
             "Illo thread. Use only when the user explicitly names or provides the thread "
             "destination. For automatic hooks and routine progress, prefer "
-            f"{SIGNAL_TOOL_NAME} so IloSpace can route the signal."
+            f"{CONTEXT_TOOL_NAME} so IloSpace can route the context."
         ),
         "inputSchema": {
             "type": "object",


### PR DESCRIPTION
## Summary

- add `illo_submit_context` as the hosted/local MCP context-ingress primitive
- persist inbound context submissions and deterministic Thread create/attach results
- add Thread Discussion storage, API, right-panel UI, `@illo` continuation, and Illo `read_thread_discussion`
- update the PRD/docs with implementation decisions, tradeoffs, and verification coverage

## Notes

- The MVP keeps the existing `signal:submit` bridge-token scope for `illo_submit_context`; the PRD documents this as temporary naming debt.
- Context previews are compact timeline entries backed by durable `thread_context_submissions`, not a full raw trace inspector yet.
- Discussion is a Thread-attached comment surface, not the general chat room system.
- The unrelated local `brain/app/api/routers/workspace_pins.py` edit was left uncommitted.

## Verification

- `venv/bin/python -m pytest tests/test_inbound_webhooks.py tests/test_external_agent_routes.py tests/test_illo_personal_agent_mcp.py tests/test_models_all.py tests/test_api_cortex.py::test_create_thread_discussion_comment_commits_before_broadcast_without_trigger tests/test_api_cortex.py::test_create_thread_discussion_illo_mention_routes_main_thread_trigger`
- `npm run check`
- `git diff --cached --check`
