### PR TITLE
Order live Illo text chronologically in thread transcripts

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -54,7 +54,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "trace, artifacts, files, links, diffs, or other source material. The personal "
                 "agent supplies context and provenance; Illo coordinates the team workspace. "
                 "Do not encode a workflow such as decision request here. Use correlation when "
-                "attaching to a known Thread; otherwise IlloSpace may create one and return a link."
+                "attaching to a known Thread; otherwise IlloSpace may create one and return thread_url."
             ),
             {
                 "intent": {
@@ -463,7 +463,9 @@ def _context_tool_response(result: dict[str, Any]) -> dict[str, Any]:
     return {
         **result,
         "thread_id": outcome.get("thread_id"),
-        "url": outcome.get("url"),
+        "thread_url": outcome.get("thread_url") or outcome.get("url"),
+        "thread_route": outcome.get("thread_route"),
+        "url": outcome.get("url") or outcome.get("thread_url"),
         "message": outcome.get("message"),
         "operation": outcome.get("operation"),
         "context_submission_id": outcome.get("context_submission_id"),

--- a/brain/app/api/routers/cortex/_discussion.py
+++ b/brain/app/api/routers/cortex/_discussion.py
@@ -17,6 +17,9 @@ from brain.app.mentions import classify_mention_intent
 from brain.platform.db.models.idea import ThreadDiscussionComment
 from brain.platform.db.models.org import User
 
+THREAD_DISCUSSION_SURFACE = "thread_discussion"
+THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
+
 
 class DiscussionCommentCreate(BaseModel):
     body: str = Field(min_length=1, max_length=20_000)
@@ -49,6 +52,54 @@ def _thread_org_id(idea: Any, user: dict[str, Any]) -> str:
     return str(getattr(idea, "org_id", None) or user.get("org_id") or "")
 
 
+def _discussion_trigger_context(
+    *,
+    idea: Any,
+    comment: ThreadDiscussionComment,
+    user: dict[str, Any],
+) -> dict[str, Any]:
+    thread_id = str(getattr(idea, "id", "") or comment.thread_id)
+    comment_id = comment.id
+    author_user_id = str(comment.author_user_id or user.get("id") or "") or None
+    return {
+        "surface": THREAD_DISCUSSION_SURFACE,
+        "thread_id": thread_id,
+        "comment_id": comment_id,
+        "body": comment.body,
+        "author_user_id": author_user_id,
+        "response_target": {
+            "surface": THREAD_DISCUSSION_SURFACE,
+            "thread_id": thread_id,
+            "reply_to_comment_id": comment_id,
+        },
+    }
+
+
+def _discussion_trigger_metadata(
+    *,
+    comment: ThreadDiscussionComment,
+    discussion_trigger: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        **dict(comment.metadata_ or {}),
+        "source": THREAD_DISCUSSION_SURFACE,
+        "originating_surface": THREAD_DISCUSSION_SURFACE,
+        "triggering_surface": THREAD_DISCUSSION_SURFACE,
+        "source_surface": THREAD_DISCUSSION_SURFACE,
+        "discussion_comment_id": comment.id,
+        "discussion_trigger": discussion_trigger,
+        "required_response_tool": THREAD_DISCUSSION_REPLY_TOOL,
+        "final_answer_target_surface": "originating_surface",
+        "thread_message": comment.body,
+        "request_source_context": {
+            "surface": THREAD_DISCUSSION_SURFACE,
+            "thread_id": discussion_trigger["thread_id"],
+            "comment_id": comment.id,
+            "response_tool": THREAD_DISCUSSION_REPLY_TOOL,
+        },
+    }
+
+
 async def _discussion_comment_payloads(
     db: AsyncSession,
     *,
@@ -78,12 +129,8 @@ async def _trigger_illo_from_discussion(
     from brain.app.triggers.adapters.internal import build_cortex_notify_trigger
     from brain.app.triggers.router import async_route_trigger
 
-    metadata = {
-        **dict(comment.metadata_ or {}),
-        "source": "thread_discussion",
-        "discussion_comment_id": comment.id,
-        "thread_message": comment.body,
-    }
+    discussion_trigger = _discussion_trigger_context(idea=idea, comment=comment, user=user)
+    metadata = _discussion_trigger_metadata(comment=comment, discussion_trigger=discussion_trigger)
     trigger = build_cortex_notify_trigger(
         event="thread_reply",
         idea_id=str(idea.id),

--- a/brain/app/triggers/adapters/internal.py
+++ b/brain/app/triggers/adapters/internal.py
@@ -18,6 +18,35 @@ def _idea_payload(idea: Any) -> dict[str, Any]:
     }
 
 
+def _discussion_reply_run_message(
+    *,
+    idea_data: dict[str, Any],
+    idea_id: str,
+    thread_message: str,
+    metadata: dict[str, Any] | None,
+) -> str:
+    metadata = dict(metadata or {})
+    discussion_trigger = metadata.get("discussion_trigger")
+    if not isinstance(discussion_trigger, dict):
+        discussion_trigger = {}
+    comment_id = discussion_trigger.get("comment_id") or metadata.get("discussion_comment_id")
+    return "\n".join(
+        [
+            f"[Thread: \"{idea_data['title']}\" | {idea_id}]",
+            "",
+            "A teammate summoned @illo from Thread Discussion.",
+            "Originating surface: thread_discussion.",
+            "Acknowledge or answer in Discussion with post_thread_discussion_reply when a visible response fits.",
+            "Use read_thread_discussion if more Discussion context is needed.",
+            "Use AI Timeline tools such as cortex_reply only when continuing the underlying Thread work belongs there.",
+            "You may also act headlessly when no visible surface update is appropriate.",
+            "",
+            f"Triggering Discussion comment id: {comment_id}",
+            f"Triggering Discussion comment: {thread_message[:2000]}",
+        ]
+    )
+
+
 def build_cortex_notify_trigger(
     *,
     event: str,
@@ -54,8 +83,19 @@ def build_cortex_notify_trigger(
             )
         run_metadata = metadata
     else:
-        run_message = f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n{thread_message[:2000]}"
         run_metadata = effective_metadata if effective_metadata is not None else metadata
+        if (
+            isinstance(run_metadata, dict)
+            and str(run_metadata.get("originating_surface") or "") == "thread_discussion"
+        ):
+            run_message = _discussion_reply_run_message(
+                idea_data=idea_data,
+                idea_id=idea_id,
+                thread_message=thread_message,
+                metadata=run_metadata,
+            )
+        else:
+            run_message = f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n{thread_message[:2000]}"
 
     payload = {
         "idea_id": idea_id,

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -71,6 +71,7 @@ HEADLESS_ASK_BLOCKED_TOOLS = (
     "manage_idea",
     "manage_workspace_app",
     "post_chat_message",
+    "post_thread_discussion_reply",
 )
 
 TASK_TERMINAL_STATUSES = {"completed", "failed", "cancelled", "canceled"}

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -51,6 +53,7 @@ MAX_INBOUND_KIND_LENGTH = 40
 MAX_INBOUND_ORIGIN_LENGTH = 240
 MAX_TRIAGE_MESSAGE_CHARS = 8000
 MAX_TRIAGE_PAYLOAD_CHARS = 5000
+DEFAULT_PUBLIC_APP_URL = "http://localhost:8080"
 
 
 class InboundValidationError(ValueError):
@@ -1095,10 +1098,14 @@ async def _process_context_envelope(
     session.add(thread_message)
     await session.flush()
 
+    thread_url = _thread_url(thread)
+    thread_route = _thread_route(thread)
     action_result = {
         "operation": operation,
         "thread_id": str(thread.id),
-        "url": _thread_url(thread),
+        "thread_url": thread_url,
+        "thread_route": thread_route,
+        "url": thread_url,
         "context_submission_id": str(submission.id),
         "thread_message_id": thread_message.id,
         "event_id": str(event.id),
@@ -1223,8 +1230,51 @@ def _context_part_preview(part: Any) -> str:
     return " - ".join(bits)
 
 
+def _public_app_base_url() -> str:
+    raw = (
+        os.environ.get("ILLO_PUBLIC_URL")
+        or os.environ.get("ILLO_DASHBOARD_URL")
+        or DEFAULT_PUBLIC_APP_URL
+    ).strip()
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return DEFAULT_PUBLIC_APP_URL
+    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+
+
+def _thread_route_for_id(thread_id: Any) -> str:
+    return f"/cortex?idea={thread_id}"
+
+
+def _thread_url_for_route(route: str) -> str:
+    return f"{_public_app_base_url()}{route}"
+
+
+def _thread_route(thread: Idea) -> str:
+    return _thread_route_for_id(thread.id)
+
+
 def _thread_url(thread: Idea) -> str:
-    return f"/cortex?idea={thread.id}"
+    return _thread_url_for_route(_thread_route(thread))
+
+
+def _with_thread_links(outcome: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(outcome or {})
+    thread_id = _clean_optional(result.get("thread_id") or result.get("idea_id"))
+    if not thread_id:
+        return result
+    route = _clean_optional(result.get("thread_route"))
+    existing_url = _clean_optional(result.get("url"))
+    if route is None and existing_url and existing_url.startswith("/"):
+        route = existing_url
+    route = route or _thread_route_for_id(thread_id)
+    thread_url = _clean_optional(result.get("thread_url"))
+    if thread_url is None or thread_url.startswith("/"):
+        thread_url = _thread_url_for_route(route)
+    result["thread_route"] = route
+    result["thread_url"] = thread_url
+    result["url"] = thread_url
+    return result
 
 
 async def _complete_event(
@@ -1283,12 +1333,13 @@ def _finalize_event(
 
 
 def _result_from_event(event: InboundEventRow, *, idempotent_replay: bool = False) -> dict[str, Any]:
+    outcome = _with_thread_links(event.action_result or {})
     return {
         "status": event.status,
         "event_id": str(event.id),
         "matched_policy_id": str(event.policy_id) if event.policy_id else None,
         "domain_projection_id": str(event.domain_projection_id) if event.domain_projection_id else None,
-        "ilo_outcome": dict(event.action_result or {}),
+        "ilo_outcome": outcome,
         "confidence": event.confidence,
         "idempotent_replay": idempotent_replay,
         "error": event.error,

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -211,6 +211,60 @@ _TERMINAL_RUN_IDEA_STATUS = {
     "canceled": "failed",
 }
 _PROTECTED_IDEA_STATUSES = {"archived", "resolved"}
+_AI_TIMELINE_SURFACES = {"ai_timeline", "thread_timeline", "cortex_thread", "main_thread"}
+_NON_TIMELINE_FINAL_ANSWER_TARGETS = {
+    "discussion",
+    "headless",
+    "none",
+    "originating_surface",
+    "thread_discussion",
+}
+
+
+def _run_surface_value(run: AgentRunRow, key: str) -> str:
+    for container in (
+        getattr(run, "target_ref", None),
+        getattr(run, "metadata_", None),
+    ):
+        if not isinstance(container, dict):
+            continue
+        value = container.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _run_should_mirror_final_answer_to_timeline(run: AgentRunRow) -> bool:
+    target_surface = _run_surface_value(run, "final_answer_target_surface")
+    if target_surface in _AI_TIMELINE_SURFACES:
+        return True
+    if target_surface in _NON_TIMELINE_FINAL_ANSWER_TARGETS:
+        return False
+    originating_surface = _run_surface_value(run, "originating_surface")
+    return originating_surface != "thread_discussion"
+
+
+async def _run_completed_tool(session, *, run_id: int, tool_name: str) -> bool:
+    if not hasattr(session, "scalars"):
+        return False
+    try:
+        result = await session.scalars(
+            select(AgentRunEventRow)
+            .where(
+                AgentRunEventRow.run_id == int(run_id),
+                AgentRunEventRow.event_type == "run.tool_completed",
+            )
+            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+            .limit(50)
+        )
+        events = list(result.all())
+    except Exception:
+        return False
+    for event in events:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        if str(payload.get("tool_name") or payload.get("tool") or "") == tool_name:
+            return True
+    return False
 
 
 def _message_belongs_to_run(message: IdeaThread, run_id: int) -> bool:
@@ -253,6 +307,11 @@ async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Id
 async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
     run = await session.get(AgentRunRow, int(run_id))
     if run is None or run.parent_run_id is not None:
+        return None
+    if (
+        not _run_should_mirror_final_answer_to_timeline(run)
+        and not await _run_completed_tool(session, run_id=int(run_id), tool_name="cortex_reply")
+    ):
         return None
     target_status = _TERMINAL_RUN_IDEA_STATUS.get(str(run.status or ""))
     if not target_status or not run.thread_id:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1729,6 +1729,13 @@ async def run_agent_async(
 
         # Post-loop: harvest, auto-encode, save, return
         output = _extract_text(state.messages)
+        staged_reply_contents = [
+            str(content or "").strip()
+            for content in list(getattr(_agent_context, "reply_contents", []) or [])
+            if str(content or "").strip()
+        ]
+        if staged_reply_contents:
+            output = staged_reply_contents[-1]
         raw_persist_source = raw_archive_messages if raw_archive_messages is not None else state.messages
         persistable_messages = _messages_without_inline_attachment_binary(
             _sanitize_tool_pairs(copy.deepcopy(raw_persist_source), session_id)

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -53,6 +53,15 @@ def _disabled_tool_names(runtime: RunRuntime) -> set[str]:
 
 def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
     hidden = _FAST_HIDDEN_TOOL_NAMES | _disabled_tool_names(runtime)
+    target_ref = getattr(runtime.request, "target_ref", {}) or {}
+    surface = str(
+        runtime.request.metadata.get("originating_surface")
+        or target_ref.get("originating_surface")
+        or ""
+    )
+    if surface == "thread_discussion":
+        hidden = set(hidden)
+        hidden.discard("cortex_reply")
     return [
         tool
         for tool in build_agent_tools("coordinator")

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -6,17 +6,33 @@ from typing import Any
 
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
 
+THREAD_DISCUSSION_SURFACE = "thread_discussion"
+
+
+def _execution_metadata() -> dict[str, Any]:
+    metadata = getattr(_agent_context, "execution_metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _metadata_trigger(name: str) -> dict[str, Any]:
+    trigger = _execution_metadata().get(name)
+    return dict(trigger) if isinstance(trigger, dict) else {}
+
 
 def _current_chat_trigger() -> dict[str, Any]:
     trigger = getattr(_agent_context, "chat_trigger", None)
     if isinstance(trigger, dict):
         return dict(trigger)
-    execution_metadata = getattr(_agent_context, "execution_metadata", None)
-    if isinstance(execution_metadata, dict) and isinstance(
-        execution_metadata.get("chat_trigger"),
-        dict,
-    ):
-        return dict(execution_metadata["chat_trigger"])
+    return _metadata_trigger("chat_trigger")
+
+
+def _current_discussion_trigger() -> dict[str, Any]:
+    trigger = _metadata_trigger("discussion_trigger")
+    if trigger:
+        return trigger
+    target_ref = getattr(_agent_context, "target_ref", None)
+    if isinstance(target_ref, dict) and isinstance(target_ref.get("discussion_trigger"), dict):
+        return dict(target_ref["discussion_trigger"])
     return {}
 
 
@@ -39,13 +55,11 @@ def _current_thread_id() -> str | None:
     thread_id = getattr(run, "thread_id", None)
     if thread_id:
         return str(thread_id)
-    execution_metadata = getattr(_agent_context, "execution_metadata", None)
-    if isinstance(execution_metadata, dict):
-        target_ref = execution_metadata.get("target_ref")
-        if isinstance(target_ref, dict):
-            candidate = target_ref.get("idea_id") or target_ref.get("thread_id")
-            if candidate:
-                return str(candidate)
+    target_ref = _execution_metadata().get("target_ref")
+    if isinstance(target_ref, dict):
+        candidate = target_ref.get("idea_id") or target_ref.get("thread_id")
+        if candidate:
+            return str(candidate)
     return None
 
 
@@ -56,6 +70,39 @@ def _coerce_optional_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         raise ValueError("thread_root_message_id must be an integer")
+
+
+def _coerce_comment_id(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError("reply_to_comment_id must be an integer")
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _discussion_comment_payload(comment: Any) -> dict[str, Any]:
+    return {
+        "id": comment.id,
+        "thread_id": str(comment.thread_id),
+        "org_id": str(comment.org_id),
+        "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
+        "author_kind": comment.author_kind,
+        "author_name": None,
+        "author_color": None,
+        "body": comment.body,
+        "attachments": comment.attachments or [],
+        "metadata": comment.metadata_ or {},
+        "created_at": comment.created_at.isoformat() if comment.created_at else None,
+    }
 
 
 async def _publish_chat_events(publish, summaries: dict[str, dict[str, Any]]) -> None:
@@ -127,6 +174,77 @@ async def _handle_post_chat_message(
     return json.dumps({"ok": True, "message": message_payload}, default=str)
 
 
+async def _handle_post_thread_discussion_reply(
+    body: str,
+    thread_id: str | None = None,
+    reply_to_comment_id: int | None = None,
+) -> str:
+    """Post an Illo-authored reply to a Thread's Discussion surface."""
+    from brain.app.api.routers.ws import ws_manager
+    from brain.platform.db.models.idea import Idea, ThreadDiscussionComment
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    text = str(body or "").strip()
+    if not text:
+        return json.dumps({"error": "post_thread_discussion_reply requires body"})
+
+    trigger = _current_discussion_trigger()
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    target_thread_id = _first_nonempty(
+        thread_id,
+        response_target.get("thread_id"),
+        trigger.get("thread_id"),
+        _current_thread_id(),
+    )
+    if not target_thread_id:
+        return json.dumps({"error": "post_thread_discussion_reply requires a Thread id or active Thread run"})
+
+    org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
+    if not org_id:
+        return json.dumps({"error": "post_thread_discussion_reply requires an org-scoped run"})
+
+    target_reply_to_comment_id = (
+        _coerce_comment_id(reply_to_comment_id)
+        if reply_to_comment_id is not None
+        else _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
+    )
+
+    async with UnitOfWork() as uow:
+        idea = await uow.session.get(Idea, target_thread_id)
+        if idea is None:
+            return json.dumps({"error": "Thread not found"})
+        idea_org_id = str(getattr(idea, "org_id", "") or "")
+        if idea_org_id and idea_org_id != org_id:
+            return json.dumps({"error": "Thread is outside this org"})
+
+        metadata = {
+            "source": "illo_agent",
+            "surface": THREAD_DISCUSSION_SURFACE,
+            "created_by_run_id": _current_run_id(),
+        }
+        if target_reply_to_comment_id is not None:
+            metadata["reply_to_comment_id"] = target_reply_to_comment_id
+        comment = ThreadDiscussionComment(
+            thread_id=target_thread_id,
+            org_id=org_id,
+            author_user_id=None,
+            author_kind="illo",
+            body=text,
+            attachments=[],
+            metadata_=metadata,
+        )
+        uow.session.add(comment)
+        await uow.session.flush()
+        payload = _discussion_comment_payload(comment)
+
+    await ws_manager.broadcast_product_event(
+        "thread_discussion_comment",
+        {"idea_id": target_thread_id, "comment": payload},
+        org_id=org_id,
+    )
+    return json.dumps({"ok": True, "comment": payload}, default=str)
+
+
 async def _handle_read_thread_discussion(
     thread_id: str | None = None,
     limit: int = 50,
@@ -184,4 +302,8 @@ async def _handle_read_thread_discussion(
     )
 
 
-__all__ = ["_handle_post_chat_message", "_handle_read_thread_discussion"]
+__all__ = [
+    "_handle_post_chat_message",
+    "_handle_post_thread_discussion_reply",
+    "_handle_read_thread_discussion",
+]

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -180,9 +180,9 @@ async def _handle_post_thread_discussion_reply(
     reply_to_comment_id: int | None = None,
 ) -> str:
     """Post an Illo-authored reply to a Thread's Discussion surface."""
-    from brain.app.api.routers.ws import ws_manager
     from brain.platform.db.models.idea import Idea, ThreadDiscussionComment
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
+    from brain.systems.cortex.events import publish_safe
 
     text = str(body or "").strip()
     if not text:
@@ -237,10 +237,9 @@ async def _handle_post_thread_discussion_reply(
         await uow.session.flush()
         payload = _discussion_comment_payload(comment)
 
-    await ws_manager.broadcast_product_event(
+    publish_safe(
         "thread_discussion_comment",
-        {"idea_id": target_thread_id, "comment": payload},
-        org_id=org_id,
+        {"idea_id": target_thread_id, "org_id": org_id, "comment": payload},
     )
     return json.dumps({"ok": True, "comment": payload}, default=str)
 

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -32,6 +32,7 @@ from brain.systems.runs.tool_catalog.handlers.cortex_reply import (
 )
 from brain.systems.runs.tool_catalog.handlers.chat import (
     _handle_post_chat_message,
+    _handle_post_thread_discussion_reply,
     _handle_read_thread_discussion,
 )
 from brain.systems.runs.tool_catalog.handlers.cycles import _handle_manage_cycle
@@ -203,6 +204,10 @@ def _get_tool_handlers(
         "post_chat_message": lambda **kw: _patched_private(
             "_handle_post_chat_message",
             _handle_post_chat_message,
+        )(**kw),
+        "post_thread_discussion_reply": lambda **kw: _patched_private(
+            "_handle_post_thread_discussion_reply",
+            _handle_post_thread_discussion_reply,
         )(**kw),
         "read_thread_discussion": lambda **kw: _patched_private(
             "_handle_read_thread_discussion",

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -273,6 +273,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "post an Illo-authored message to the native team room",
         "output_budget_chars": 8_000,
     },
+    "post_thread_discussion_reply": {
+        "permission": "write_chat",
+        "risk_class": "medium",
+        "side_effect_class": "chat_message",
+        "reversibility": "append_only",
+        "action_manifest": True,
+        "expected_effect": "post an Illo-authored reply to Thread Discussion",
+        "output_budget_chars": 8_000,
+    },
     "read_thread_discussion": {
         "permission": "read_workspace",
         "risk_class": "low",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1142,6 +1142,34 @@ CHAT_TOOLS = [
         },
     },
     {
+        "name": "post_thread_discussion_reply",
+        "description": (
+            "Post an Illo-authored reply into the current Thread Discussion. "
+            "Use this when a run was summoned from Discussion, or when the natural "
+            "answer belongs in Discussion rather than the AI Timeline. This does not "
+            "post to the AI Timeline; use cortex_reply or other Thread tools when the "
+            "underlying AI Timeline work should visibly continue there."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "description": "Concise markdown message to post in Thread Discussion as Illo.",
+                },
+                "thread_id": {
+                    "type": "string",
+                    "description": "Optional Thread id. Defaults to the triggering/current Thread.",
+                },
+                "reply_to_comment_id": {
+                    "type": "integer",
+                    "description": "Optional Discussion comment id being acknowledged. Defaults to the triggering comment.",
+                },
+            },
+            "required": ["body"],
+        },
+    },
+    {
         "name": "read_thread_discussion",
         "description": (
             "Read the Discussion comments attached to the current Thread. "

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -49,6 +49,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_cortex_reply",
     "_handle_cortex_visual_reply",
     "_handle_post_chat_message",
+    "_handle_post_thread_discussion_reply",
     "_handle_read_thread_discussion",
     "_handle_read_thread_messages",
     "_handle_manage_cycle",

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -28,7 +28,7 @@ SENSITIVE_ARG_PARTS = ("api_key", "apikey", "authorization", "cookie", "password
 FILE_OBSERVATION_TOOLS = frozenset({"file_summary", "list_files", "read_file", "search_files", "semantic_search"})
 FILE_EDIT_TOOLS = frozenset({"apply_patch", "edit_file", "write_file"})
 COMMAND_OUTPUT_TOOLS = frozenset({"exec_command", "run_script", "test_runner"})
-CHAT_MESSAGE_TOOLS = frozenset({"post_chat_message"})
+CHAT_MESSAGE_TOOLS = frozenset({"post_chat_message", "post_thread_discussion_reply"})
 
 
 async def _maybe_await(value):

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -529,6 +529,24 @@ def _metadata_int(metadata: dict[str, Any], *keys: str) -> int | None:
     return None
 
 
+def _surface_context_for_target(metadata: dict[str, Any]) -> dict[str, Any]:
+    surface_context: dict[str, Any] = {}
+    for key in (
+        "originating_surface",
+        "triggering_surface",
+        "source_surface",
+        "required_response_tool",
+        "final_answer_target_surface",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            surface_context[key] = value.strip()
+    discussion_trigger = metadata.get("discussion_trigger")
+    if isinstance(discussion_trigger, dict):
+        surface_context["discussion_trigger"] = dict(discussion_trigger)
+    return surface_context
+
+
 async def _a_latest_attached_project_context(session: Any, idea_id: str) -> dict[str, Any]:
     if not hasattr(session, "scalars"):
         return {}
@@ -666,6 +684,7 @@ async def _agent_run_request_for_cortex(
         "event": event,
         "title": getattr(idea, "title", None),
     }
+    target_ref.update(_surface_context_for_target(metadata))
     workspace_ref = dict(project_context) if project_context_snapshot else {}
     if project_context_validation_errors:
         metadata["project_context_validation_errors"] = project_context_validation_errors

--- a/docs/prd-universal-thread-context-ingress.md
+++ b/docs/prd-universal-thread-context-ingress.md
@@ -1,6 +1,6 @@
 # PRD: Universal Thread Context Ingress
 
-Status: thin vertical slice implemented in this branch; still a living PRD
+Status: first deployed slice validated; living PRD with follow-up corrections
 Date: 2026-05-21
 Owner: product/architecture discussion
 Related docs:
@@ -29,12 +29,15 @@ The motivating example is:
    conversation, tool trace, files, links, prompt history, or other artifacts.
 4. Illo receives the context as the team agent. Illo records it through the
    inbound coordination layer and decides how it belongs in the workspace.
-5. When a Thread is created or updated, Codex gets back a link so Reda can jump
-   into Illospace.
+5. When a Thread is created or updated, Codex gets back an absolute URL so Reda
+   can jump directly into Illospace from the personal-agent chat.
 6. The existing Thread stage renders the AI work. A right-panel Discussion lets
    teammates comment on the Thread without turning Illospace into another Slack.
-7. If the team needs Illo, they summon it with `@illo`. Illo's substantive work
-   continues in the main Thread, not inside the comment surface.
+   This Discussion should feel like the same team-chat product language, not a
+   second-rate textarea attached to the page.
+7. If the team needs Illo, they summon it with `@illo`. Illo acknowledges in the
+   surface where it was summoned, receives that surface as context, and then uses
+   the right tools to act wherever the request belongs.
 
 The product gap is not a missing special case called "decision request." The
 gap is a universal context ingress contract and a Universal Thread model broad
@@ -65,7 +68,8 @@ The two high-level MCP primitives are:
   behind `illo_get_ask`.
 - `illo_submit_context`: universal ingress for new context from a personal
   agent to Illo. It acknowledges receipt quickly, records the context through
-  inbound coordination, and returns any immediately available Thread URL.
+  inbound coordination, and returns any immediately available absolute Thread
+  URL.
 
 Universal Thread product vocabulary:
 
@@ -76,8 +80,13 @@ Universal Thread product vocabulary:
   Illo runs, AI messages, imported trace previews, tool/activity entries,
   artifacts, and generated outputs.
 - **Discussion**: a right-panel comment surface attached to the Thread. It is
-  scoped, human-first, and not a Slack replacement. Illo may comment there, but
-  AI work happens in the AI Timeline.
+  scoped, human-first, and not a Slack replacement. It should reuse the same
+  message, composer, mention, empty-state, spacing, and token primitives as the
+  general team room, while remaining Thread-scoped.
+- **Surface**: a container where conversation or work happens, such as the AI
+  Timeline, Discussion, a headless ask, or a future artifact-specific pane.
+  Illo runs should know the triggering surface and should have tools to read
+  from and respond into the relevant surface.
 - **Context**: imported external context parts such as raw Codex traces,
   prompt/conversation excerpts, files, links, screenshots, tool logs, diffs, or
   structured JSON.
@@ -92,7 +101,7 @@ personal agent submits context
 -> Illo may create or update a Thread
 -> existing Thread UI renders submitted context
 -> Discussion exists as an attached comment surface
--> @illo from Discussion can continue work in the main Thread
+-> @illo from Discussion acknowledges there and can act through surface tools
 ```
 
 MVP scope is governed by this proof loop. Anything not required to prove the
@@ -103,8 +112,9 @@ loop is out of scope unless explicitly pulled in.
 1. As a user working with Codex, I want to send my current agent conversation to
    Illo, so that my team can inspect the exact context instead of a lossy
    summary.
-2. As a user working with Codex, I want Codex to receive an Illo Thread link
-   after submission, so that I can jump into the team workspace.
+2. As a user working with Codex, I want Codex to receive an absolute Illo Thread
+   URL after submission, so that I can click it directly from the personal-agent
+   chat and jump into the team workspace.
 3. As a teammate, I want to open the Illo Thread and see the submitted context,
    so that I understand what the personal agent was doing.
 4. As a teammate, I want to inspect the raw imported context when needed, so
@@ -113,12 +123,16 @@ loop is out of scope unless explicitly pulled in.
    that a full trace does not overwhelm the Thread.
 6. As a teammate, I want to discuss an imported AI thread in a right-panel
    Discussion, so that comments stay attached to the relevant AI work.
-7. As a teammate, I want Discussion to feel like a comment section, so that
-   Illospace does not compete with Slack as a general chat tool.
+7. As a teammate, I want Discussion to use the same polished team-chat design
+   primitives as the general room, so that Thread comments feel native to
+   Illospace rather than bolted on.
 8. As a teammate, I want to summon Illo with `@illo` from Discussion, so that
-   Illo only participates when explicitly needed.
-9. As a teammate, I want Illo's substantive work to appear in the main Thread,
-   so that AI work remains in the AI Timeline rather than buried in comments.
+   Illo only participates when explicitly needed and replies in the place where
+   I summoned it.
+9. As a teammate, I want Illo to understand which surface I summoned it from, so
+   that it can acknowledge in Discussion, continue AI Timeline work, answer
+   headlessly, update artifacts, or take another suitable action without the
+   product hardcoding every possible workflow.
 10. As Illo, I want a tool to inspect Discussion when useful, so that I can read
     team comments intentionally without polluting every run prompt.
 11. As Illo, I want submitted context to arrive through the existing inbound
@@ -165,8 +179,9 @@ loop is out of scope unless explicitly pulled in.
 27. As a teammate, I want Thread Discussion notifications to be scoped and
     intentional, so that only relevant mentions, subscriptions, or activity
     produce noise.
-28. As Illo, I want `@illo this is what we decided, carry on` to create a
-    Thread-linked run, so that team decisions can steer the main AI work.
+28. As Illo, I want `@illo this is what we decided, carry on` to arrive with
+    Discussion as the triggering surface, so that I can acknowledge the team
+    there and then continue the underlying work in the appropriate surface.
 29. As a user, I want Codex to send full context when I ask, so that Illo and the
     team are not forced to rely on a summary written by the same agent that may
     be confused.
@@ -205,8 +220,13 @@ loop is out of scope unless explicitly pulled in.
   `thread.created`, `thread.attached`, `accepted`, `stored`, or
   `needs_clarification`.
 - Keep `illo_submit_context` async-safe. The tool should acknowledge quickly,
-  return any immediately available `thread_id` and `url`, and let longer Illo
-  reasoning continue through normal Thread/AgentRun state.
+  return any immediately available `thread_id`, internal route/path, and
+  user-facing absolute `thread_url`, and let longer Illo reasoning continue
+  through normal Thread/AgentRun state.
+- The MCP result must not depend on the personal agent reconstructing a URL from
+  a relative route. A relative path can remain useful for clients inside
+  Illospace, but Codex and other personal agents need a complete URL they can
+  show directly to the user.
 - Reuse the existing `ideas` table as the physical Thread table for MVP. "Idea"
   remains a legacy storage/API name until a later rename.
 - Introduce a Thread read/domain model that presents `ideas` as Threads to new
@@ -237,17 +257,28 @@ loop is out of scope unless explicitly pulled in.
 - Allow multiple context submissions to attach to the same Thread when
   correlation is explicit or Illo confidently routes them there.
 - Do not inject Discussion into every Illo run prompt. Discussion is available
-  through an explicit Illo tool when needed.
-- Include the triggering `@illo` Discussion comment as the trigger when a user
-  summons Illo from Discussion.
-- Add an Illo-visible tool for reading Thread Discussion. The tool should make
-  scope explicit, for example latest messages, messages since a timestamp, full
-  discussion, or messages mentioning Illo.
-- Keep Illo's substantive continuation in the main Thread/AI Timeline. Discussion
-  may receive small comments or acknowledgements, but the AI work belongs in the
-  Thread.
+  through explicit surface tools when needed.
+- Include the triggering `@illo` Discussion comment and its surface metadata
+  when a user summons Illo from Discussion.
+- Add Illo-visible surface tools for reading from and writing to Thread
+  Discussion. The read tool should make scope explicit, for example latest
+  messages, messages since a timestamp, full discussion, or messages mentioning
+  Illo. The write tool should let Illo acknowledge or answer in Discussion
+  without pretending every response belongs in the AI Timeline.
+- Add or adapt Illo-visible tools so a run can also continue AI Timeline work,
+  inspect submitted context, operate headlessly, or update other Thread surfaces
+  when that is the natural response to the user's request.
+- Do not encode deterministic action routing such as "Discussion mentions always
+  create AI Timeline work." The product contract is that Illo knows the
+  triggering surface and has enough tools to act in the surface that fits the
+  ask.
 - Keep the existing Thread stage as the MVP frontend surface. Add Discussion as
   a possible right-panel tab/surface.
+- Discussion should be visually and interactively built from the existing team
+  room/chat primitives: message rows, composer, mention rendering, attachment
+  affordances where applicable, loading/empty states, spacing, focus behavior,
+  and design tokens. A minimal bespoke textarea/list is not acceptable for the
+  product direction.
 - Render submitted context as generic preview blocks in the existing Thread
   timeline. Start with compact expandable previews; do not try to perfect raw
   trace visualization before usage teaches the right shape.
@@ -295,23 +326,65 @@ loop and left a few product/technical decisions explicit for future review:
 - Discussion is implemented as `thread_discussion_comments`, a dedicated
   Thread-attached comment table, not the existing general chat/room system. This
   keeps Discussion closer to a comment section and avoids polluting team chat
-  with per-Thread collaboration surfaces.
+  with per-Thread collaboration surfaces. This storage choice does not mean the
+  frontend should invent a weaker Discussion UI; it should still reuse the
+  general room's chat primitives and design tokens.
 - Discussion is available as a right-panel tab on the existing Thread stage.
   The backend broadcasts a `thread_discussion_comment` websocket event, but the
   first frontend pass reloads Discussion on panel open and after posting rather
   than subscribing live. Live subscription is a straightforward follow-up, not a
   requirement for proving the loop.
 - `@illo` in Discussion routes through the existing Cortex notify/run path and
-  links the run to the main Thread. Discussion comments do not automatically
-  enter every Illo prompt. The existing mention classifier invokes Illo for
-  unmentioned main Thread replies, so Discussion explicitly disables that
-  default and requires an actual Illo mention.
+  links the run to the main Thread. The deployed behavior exposed a semantic
+  bug: Illo answered in the AI Timeline with insufficient awareness that the
+  user summoned it from Discussion. The corrected contract is surface-aware:
+  Illo should acknowledge or answer in Discussion first, then use tools to carry
+  work into the AI Timeline, run headlessly, inspect context, or act elsewhere
+  when the ask calls for it.
 - Illo now has an explicit `read_thread_discussion` tool. This preserves the
   product boundary that Discussion can be inspected when useful without becoming
-  ambient prompt context for every run.
+  ambient prompt context for every run. A matching write/reply capability is
+  needed so Illo can naturally participate in Discussion when summoned there.
+- The first deployed MCP response returned an internal route such as
+  `/cortex?idea=...`. That is not enough for the original Codex use case. The
+  corrected contract is an absolute, user-clickable Thread URL in the MCP tool
+  result, plus optional IDs/routes for programmatic clients.
 - Slack previews, a full ideas-to-threads backend rename, a new Thread page, and
   detailed raw-trace visualization were left out under the positive proof-loop
   scope rule.
+
+## Implementation Notes From Surface Correction Pass
+
+The follow-up implementation pass addressed the first deployed slice's three
+largest product gaps:
+
+- `illo_submit_context` now treats `thread_url` as the canonical user-facing
+  absolute URL. `url` remains populated for existing callers and now also points
+  to the absolute URL. `thread_route` preserves the relative `/cortex?idea=...`
+  route for internal/programmatic clients.
+- Absolute Thread URLs are built from `ILLO_PUBLIC_URL` first, then
+  `ILLO_DASHBOARD_URL`, then a local-development fallback of
+  `http://localhost:8080`. Deployed environments should set `ILLO_PUBLIC_URL`
+  to the browser-reachable Illospace origin.
+- Discussion still uses dedicated Thread-attached storage
+  (`thread_discussion_comments`) instead of becoming the general team room. The
+  frontend correction is visual/interaction reuse: the panel now owns its full
+  right-dock surface and is built from the existing chat composer, state,
+  presence, mention, scroll, and token primitives.
+- `@illo` from Discussion now creates a surface-aware run. The trigger carries
+  `originating_surface=thread_discussion`, the triggering comment, and a
+  Discussion response target.
+- Illo now has an explicit `post_thread_discussion_reply` tool, paired with
+  `read_thread_discussion`, so it can acknowledge or answer in Discussion
+  without pretending every response belongs in the AI Timeline.
+- Discussion-origin runs no longer automatically mirror final answers into the
+  AI Timeline. Illo can still use AI Timeline tools such as `cortex_reply` when
+  continuing the underlying Thread work is the right action.
+- There is intentionally no deterministic fallback that auto-posts an
+  acknowledgement if the model ignores the Discussion reply tool. That preserves
+  the "Illo has the right surface tools and decides how to act" product
+  contract, but it leaves prompt/tool-choice quality as an important behavior to
+  observe in real usage.
 
 ## Testing Decisions And Coverage
 
@@ -323,15 +396,18 @@ implementation details. The important behaviors are:
   and hosted MCP.
 - Inbound events preserve source actor, authority user, ingress metadata,
   envelope kind, intent, source, constraints, correlation, and parts.
-- Routing can create a Thread and return a simple URL/id result.
+- Routing can create a Thread and return an absolute user-facing URL plus stable
+  IDs/routes for programmatic clients.
 - Routing can attach a second context submission to an existing Thread.
 - Routing can store a context submission without a Thread while preserving the
   inbound event/receipt.
 - Raw submitted context remains available after derived previews are generated.
 - Discussion comments do not automatically trigger Illo.
-- `@illo` in Discussion triggers an Illo run linked to the Thread.
+- `@illo` in Discussion triggers a surface-aware Illo run linked to the Thread.
 - Illo can explicitly inspect Discussion through a tool.
-- Illo continuation appears in the main Thread/AI Timeline.
+- Illo can explicitly reply in Discussion through a tool.
+- Illo can continue in the AI Timeline, run headlessly, or act in another
+  Thread surface when that is the natural response to the user's ask.
 - The existing Thread UI continues to open, stream, reply, and render normal
   Illo messages after context preview blocks are added.
 
@@ -343,11 +419,14 @@ Recommended test modules:
   quick acknowledgement shape.
 - Context submission persistence tests for immutable JSONB envelope storage.
 - Thread service/read-model tests for rendering context submission previews.
-- Discussion API/service tests for right-panel comment behavior and mention
-  triggering.
-- Agent tool tests for explicit Discussion inspection.
+- Discussion API/service tests for right-panel comment behavior, mention
+  triggering, and Discussion-targeted Illo acknowledgements/replies.
+- Agent tool tests for explicit Discussion inspection and Discussion replies.
+- Surface-routing tests proving that a Discussion-originated summon carries
+  surface metadata and does not force every Illo action into the AI Timeline.
 - Frontend component tests or Playwright smoke tests for opening an existing
-  Thread with a submitted context preview and Discussion panel available.
+  Thread with a submitted context preview and Discussion panel available, using
+  the same chat primitives/tokens as the general team room.
 
 Coverage added in this implementation pass:
 
@@ -362,8 +441,9 @@ Coverage added in this implementation pass:
 - Model metadata coverage for `thread_context_submissions` and
   `thread_discussion_comments`.
 - Discussion API coverage for normal comments not triggering Illo, explicit
-  `@illo` comments triggering the main Thread run path, and commit-before-
-  broadcast ordering.
+  `@illo` comments triggering the current main Thread run path, and
+  commit-before-broadcast ordering. Follow-up coverage must update this to the
+  surface-aware reply/action contract described above.
 - Frontend typecheck coverage for the Discussion tab/pane and context timeline
   tag changes.
 
@@ -389,7 +469,7 @@ personal agent submits context
 -> Illo may create or update a Thread
 -> existing Thread UI renders submitted context
 -> Discussion exists as an attached comment surface
--> @illo from Discussion can continue work in the main Thread
+-> @illo from Discussion acknowledges there and can act through surface tools
 ```
 
 Examples of work excluded by this principle include, but are not limited to:
@@ -402,7 +482,7 @@ Examples of work excluded by this principle include, but are not limited to:
 - automatic Illo participation in Discussion without an explicit summon;
 - perfect visualization for every possible raw trace shape;
 - complex personal-agent polling/handoff contracts beyond quick acknowledgement
-  and optional Thread URL;
+  and a user-facing absolute Thread URL;
 - many special-case MCP tools for individual submission scenarios.
 
 These examples are not a closed list. The positive proof loop is the scope

--- a/frontend/src/lib/components/chat/ChatComposer.svelte
+++ b/frontend/src/lib/components/chat/ChatComposer.svelte
@@ -16,6 +16,7 @@
     modeLabel = '',
     replyContextLabel = '',
     primaryActionLabel = 'Send',
+    workingLabel = '',
     stopLabel = 'Stop',
     attachLabel = 'Attach',
     disabled = false,
@@ -158,7 +159,7 @@
     canSubmit={resolvedCanSubmit}
     attachLabel={attachLabel}
     sendLabel={primaryActionLabel}
-    stopLabel={stopLabel}
+    stopLabel={loading && !onStop && workingLabel ? workingLabel : stopLabel}
     {attachments}
     {disabled}
     onStop={onStop}

--- a/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
@@ -84,6 +84,10 @@
   const selectModeOptions = $derived(intentOptions ?? []);
   const showSecondaryIntentPicker = $derived(Boolean(secondaryIntentOptions?.length));
   const showSettingsPicker = $derived(Boolean(settingsGroups?.length));
+  const showAttachControl = $derived(Boolean(onAttach));
+  const actionDisabled = $derived(
+    disabled || (isWorking ? !onStop && !shouldSubmitWhileWorking : !resolvedCanSubmit),
+  );
   const selectedIntentValue = $derived(intentValue ?? selectedMode);
   const selectedSecondaryIntentValue = $derived(secondaryIntentValue ?? secondaryIntentOptions?.[0]?.value ?? '');
   const effectiveIntentValue = $derived(
@@ -449,15 +453,17 @@
           {@render leadingControls()}
         {:else}
           <div class="composer-default-leading">
-            <ConstellationComposerOrb
-              label={attachLabel}
-              title={attachLabel}
-              disabled={disabled}
-              variant={controlVariant}
-              onclick={handleAttach}
-            >
-              <ConstellationIcon name="attach" size={18} stroke={2} />
-            </ConstellationComposerOrb>
+            {#if showAttachControl}
+              <ConstellationComposerOrb
+                label={attachLabel}
+                title={attachLabel}
+                disabled={disabled}
+                variant={controlVariant}
+                onclick={handleAttach}
+              >
+                <ConstellationIcon name="attach" size={18} stroke={2} />
+              </ConstellationComposerOrb>
+            {/if}
 
             <div class="composer-chip-group" aria-label="Composer settings">
               {#if extraLeadingControls}
@@ -591,7 +597,7 @@
           <ConstellationComposerActionOrb
             actionState={effectiveActionState}
             label={actionLabel}
-            disabled={disabled || (!isWorking && !resolvedCanSubmit)}
+            disabled={actionDisabled}
             onclick={handleSubmitAction}
           />
         {/if}

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -1,9 +1,24 @@
 <script lang="ts">
+  import { tick } from 'svelte';
+
+  import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
+  import ChatStateView from '$lib/components/chat/ChatStateView.svelte';
+  import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
+  import {
+    CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
+    conversationIsNearBottom,
+    scrollConversationToBottom,
+    shouldShowConversationScrollCue,
+  } from '$lib/components/chat/conversationScroll';
+  import { ConstellationNotice, ConstellationPresenceSeed } from '$lib/components/constellation';
   import {
     listThreadDiscussion,
     postThreadDiscussionComment,
     type ThreadDiscussionComment,
   } from '$lib/features/threads/api/threadApi';
+  import { auth } from '$lib/stores/auth.svelte';
+  import { buildPresenceSeedStyle, normalizeHexColor, presenceToneForColor } from '$lib/utils/constellationPresence';
+  import { parseServerDate } from '$lib/utils/datetime';
 
   let {
     ideaId = null,
@@ -17,6 +32,25 @@
   let posting = $state(false);
   let error = $state('');
   let loadedForIdeaId = $state<string | null>(null);
+  let streamEl: HTMLDivElement | undefined = $state();
+  let userScrolledUp = $state(false);
+  let showScrollCue = $state(false);
+  let lastScrollIdeaId = $state<string | null>(null);
+
+  type MessageTextSegment = {
+    text: string;
+    mention: boolean;
+  };
+
+  const MESSAGE_GROUP_WINDOW_MS = 15 * 60 * 1000;
+  const MENTION_RENDER_RE = /(^|[^A-Za-z0-9_])@([A-Za-z0-9._-]+)([.,:;!?]?)/g;
+  const tailSignature = $derived(`${comments.length}:${comments.at(-1)?.id ?? 'empty'}`);
+  const composerPlaceholder = $derived(
+    ideaId ? 'Comment on this Thread...' : 'Open a Thread to comment...',
+  );
+  const composerHint = $derived(
+    posting ? 'Posting comment...' : '@illo brings Illo into this Discussion.',
+  );
 
   $effect(() => {
     if (!ideaId) {
@@ -26,6 +60,19 @@
     }
     if (loadedForIdeaId === ideaId) return;
     void loadComments(ideaId);
+  });
+
+  $effect(() => {
+    if (ideaId === lastScrollIdeaId) return;
+    lastScrollIdeaId = ideaId;
+    userScrolledUp = false;
+    showScrollCue = false;
+  });
+
+  $effect(() => {
+    tailSignature;
+    if (!streamEl || loading) return;
+    tick().then(() => scrollDiscussionToBottom());
   });
 
   async function loadComments(targetIdeaId = ideaId) {
@@ -42,9 +89,8 @@
     }
   }
 
-  async function submitComment(event: SubmitEvent) {
-    event.preventDefault();
-    const text = body.trim();
+  async function submitComment(value = body) {
+    const text = value.trim();
     if (!ideaId || !text || posting) return;
     posting = true;
     error = '';
@@ -55,11 +101,16 @@
       });
       comments = [...comments, result.comment];
       body = '';
+      userScrolledUp = false;
     } catch (err: any) {
       error = err?.detail || 'Failed to post comment.';
     } finally {
       posting = false;
     }
+  }
+
+  function handleComposerValueChange(value: string) {
+    body = value;
   }
 
   function authorLabel(comment: ThreadDiscussionComment) {
@@ -71,180 +122,465 @@
   function timeLabel(value: string | null) {
     if (!value) return '';
     try {
-      return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const createdAt = parseServerDate(value);
+      if (!createdAt) return '';
+      const now = new Date();
+      const diffMs = Math.max(0, now.getTime() - createdAt.getTime());
+      const diffMinutes = Math.floor(diffMs / 60000);
+      const diffHours = Math.floor(diffMs / 3600000);
+
+      if (diffMs < 60000) return 'just now';
+      if (diffMinutes < 60) return `${diffMinutes} min ago`;
+      if (diffHours < 24) return `${diffHours} hr ago`;
+
+      return createdAt.toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
     } catch {
       return '';
     }
   }
+
+  function isIlloComment(comment: ThreadDiscussionComment) {
+    return comment.author_kind === 'illo' || comment.author_kind === 'agent';
+  }
+
+  function isOwnComment(comment: ThreadDiscussionComment) {
+    return (
+      comment.author_user_id != null &&
+      auth.user?.id != null &&
+      String(comment.author_user_id) === String(auth.user.id)
+    );
+  }
+
+  function participantTone(comment: ThreadDiscussionComment) {
+    if (isIlloComment(comment)) return 'spectral';
+    return presenceToneForColor(comment.author_color);
+  }
+
+  function participantStyle(comment: ThreadDiscussionComment) {
+    if (isIlloComment(comment)) return undefined;
+    return buildPresenceSeedStyle(normalizeHexColor(comment.author_color)) || undefined;
+  }
+
+  function messageStyle(comment: ThreadDiscussionComment) {
+    const accent = normalizeHexColor(comment.author_color);
+    if (!accent || isIlloComment(comment)) return undefined;
+
+    return [
+      `--discussion-message-author-color:color-mix(in srgb, ${accent} 76%, var(--constellation-color-text-primary))`,
+      `--discussion-message-hover-border:color-mix(in srgb, ${accent} 20%, transparent)`,
+      `--discussion-message-hover-background:color-mix(in srgb, ${accent} 8%, transparent)`,
+      `--seed-accent:${accent}`,
+    ].join('; ');
+  }
+
+  function shouldShowMessageHeader(rows: ThreadDiscussionComment[], index: number) {
+    if (index === 0) return true;
+
+    const current = rows[index];
+    const previous = rows[index - 1];
+    if (!current || !previous) return true;
+
+    if (!sameDiscussionAuthor(current, previous)) return true;
+
+    if (!current.created_at || !previous.created_at) return false;
+
+    const currentDate = parseServerDate(current.created_at);
+    const previousDate = parseServerDate(previous.created_at);
+    if (!currentDate || !previousDate) return true;
+
+    if (!sameCalendarDay(currentDate, previousDate)) return true;
+
+    return currentDate.getTime() - previousDate.getTime() > MESSAGE_GROUP_WINDOW_MS;
+  }
+
+  function sameDiscussionAuthor(current: ThreadDiscussionComment, previous: ThreadDiscussionComment) {
+    return (
+      current.author_user_id === previous.author_user_id &&
+      current.author_kind === previous.author_kind &&
+      current.author_name === previous.author_name
+    );
+  }
+
+  function sameCalendarDay(current: Date, previous: Date) {
+    return (
+      current.getFullYear() === previous.getFullYear() &&
+      current.getMonth() === previous.getMonth() &&
+      current.getDate() === previous.getDate()
+    );
+  }
+
+  function messageTextSegments(bodyText: string): MessageTextSegment[] {
+    const segments: MessageTextSegment[] = [];
+    MENTION_RENDER_RE.lastIndex = 0;
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = MENTION_RENDER_RE.exec(bodyText)) !== null) {
+      const boundary = match[1] ?? '';
+      let token = match[2] ?? '';
+      let punctuation = match[3] ?? '';
+      const tokenTrailingPunctuation = token.match(/[.,:;!?]+$/)?.[0] ?? '';
+      if (tokenTrailingPunctuation) {
+        token = token.slice(0, -tokenTrailingPunctuation.length);
+        punctuation = `${tokenTrailingPunctuation}${punctuation}`;
+      }
+
+      const mentionStart = match.index + boundary.length;
+      if (mentionStart > cursor) {
+        segments.push({ text: bodyText.slice(cursor, mentionStart), mention: false });
+      }
+
+      const mentionText = `@${token}`;
+      segments.push({ text: mentionText, mention: true });
+      cursor = mentionStart + mentionText.length;
+
+      if (punctuation) {
+        segments.push({ text: punctuation, mention: false });
+        cursor += punctuation.length;
+      }
+    }
+
+    if (cursor < bodyText.length) {
+      segments.push({ text: bodyText.slice(cursor), mention: false });
+    }
+
+    return segments.length > 0 ? segments : [{ text: bodyText, mention: false }];
+  }
+
+  function syncScrollCue() {
+    showScrollCue = shouldShowConversationScrollCue(streamEl);
+  }
+
+  function handleStreamScroll() {
+    userScrolledUp = !conversationIsNearBottom(streamEl, CONVERSATION_SCROLL_BOTTOM_THRESHOLD);
+    syncScrollCue();
+  }
+
+  function scrollDiscussionToBottom(force = false) {
+    if (!streamEl) return;
+    if (!force && userScrolledUp) return;
+    scrollConversationToBottom(streamEl);
+    requestAnimationFrame(() => {
+      userScrolledUp = false;
+      syncScrollCue();
+    });
+  }
 </script>
 
 <div class="thread-discussion-pane">
-  <div class="discussion-list" aria-label="Thread Discussion">
-    {#if loading && comments.length === 0}
-      <div class="discussion-empty">Loading Discussion...</div>
+  <div
+    class="discussion-stream"
+    aria-label="Thread Discussion"
+    bind:this={streamEl}
+    onscroll={handleStreamScroll}
+  >
+    {#if !ideaId}
+      <ChatStateView
+        state="empty"
+        title="No Thread selected"
+        description="Open a Thread to read and write its Discussion."
+        eyebrow="Discussion"
+        compact
+        surface="plain"
+        className="discussion-state"
+      />
+    {:else if loading && comments.length === 0}
+      <ChatStateView
+        state="loading"
+        compact
+        surface="plain"
+        className="discussion-state"
+      />
     {:else if error && comments.length === 0}
-      <div class="discussion-empty discussion-error">{error}</div>
+      <ChatStateView
+        state="error"
+        title="Discussion could not load"
+        description={error}
+        tone="warning"
+        actionLabel="Try again"
+        onAction={() => void loadComments()}
+        compact
+        className="discussion-state"
+      />
     {:else if comments.length === 0}
-      <div class="discussion-empty">No Discussion yet.</div>
+      <ChatStateView
+        state="empty"
+        title="No comments yet"
+        description="Start a scoped note for teammates on this Thread."
+        eyebrow="Discussion"
+        compact
+        surface="plain"
+        className="discussion-state"
+      />
     {:else}
-      {#each comments as comment (comment.id)}
-        <article class="discussion-comment">
-          <div class="discussion-comment-meta">
-            <span class="discussion-author">{authorLabel(comment)}</span>
-            {#if timeLabel(comment.created_at)}
-              <time datetime={comment.created_at || undefined}>{timeLabel(comment.created_at)}</time>
+      <div class="discussion-message-list">
+        {#each comments as comment, index (comment.id)}
+          {@const showHeader = shouldShowMessageHeader(comments, index)}
+          {@const author = authorLabel(comment)}
+          {@const timestamp = timeLabel(comment.created_at)}
+          <article
+            class="discussion-message"
+            class:has-header={showHeader}
+            class:is-continuation={!showHeader}
+            class:is-own={isOwnComment(comment)}
+            class:is-illo={isIlloComment(comment)}
+            style={messageStyle(comment)}
+          >
+            {#if showHeader}
+              <header class="discussion-message-header">
+                <ConstellationPresenceSeed
+                  label={author}
+                  size="sm"
+                  role={isIlloComment(comment) ? 'illo' : 'user'}
+                  tone={participantTone(comment)}
+                  style={participantStyle(comment)}
+                  treatment="plain"
+                />
+
+                <div class="discussion-message-author-copy">
+                  <span>{author}</span>
+                  {#if timestamp}
+                    <time datetime={comment.created_at || undefined}>{timestamp}</time>
+                  {/if}
+                </div>
+              </header>
             {/if}
-          </div>
-          <div class="discussion-body">{comment.body}</div>
-        </article>
-      {/each}
+
+            <p class="discussion-message-body">
+              {#each messageTextSegments(comment.body) as segment, segmentIndex (segmentIndex)}
+                {#if segment.mention}
+                  <span class="discussion-mention">{segment.text}</span>
+                {:else}
+                  {segment.text}
+                {/if}
+              {/each}
+            </p>
+          </article>
+        {/each}
+      </div>
     {/if}
+
+    <ConversationScrollCue
+      visible={showScrollCue}
+      label="Jump to latest Discussion comment"
+      onclick={() => scrollDiscussionToBottom(true)}
+    />
   </div>
 
-  <form class="discussion-composer" onsubmit={submitComment}>
+  <div class="discussion-composer">
     {#if error && comments.length > 0}
-      <div class="discussion-inline-error">{error}</div>
+      <ConstellationNotice
+        title="Comment was not posted"
+        description={error}
+        tone="warning"
+        compact
+      />
     {/if}
-    <textarea
-      bind:value={body}
-      placeholder="Comment on this Thread..."
-      rows="3"
+
+    <ChatComposer
+      tone="spectral"
+      variant="thread"
+      placeholder={composerPlaceholder}
+      value={body}
+      hint={composerHint}
+      modeLabel="Discussion"
       disabled={posting || !ideaId}
-    ></textarea>
-    <button type="submit" disabled={posting || !body.trim() || !ideaId}>
-      {posting ? 'Posting...' : 'Post'}
-    </button>
-  </form>
+      loading={posting}
+      canSubmit={Boolean(ideaId) && body.trim().length > 0 && !posting}
+      primaryActionLabel="Post"
+      workingLabel="Posting"
+      onValueChange={handleComposerValueChange}
+      onSubmit={(value) => void submitComment(value)}
+    />
+  </div>
 </div>
 
 <style>
   .thread-discussion-pane {
-    min-height: 100%;
-    display: grid;
-    grid-template-rows: minmax(0, 1fr) auto;
-    color: var(--constellation-utility-panel-tab-active-text);
+    --discussion-message-hover-background: rgba(255, 255, 255, 0.025);
+    --discussion-message-hover-border: rgba(255, 255, 255, 0.03);
+    --discussion-message-body-text: var(--constellation-thread-message-illo-body);
+    --discussion-message-meta-text: var(--constellation-thread-message-illo-meta);
+    --discussion-message-author-color: var(--constellation-thread-message-author);
+    --discussion-mention-background: rgba(150, 188, 255, 0.16);
+    --discussion-mention-text: rgba(207, 224, 255, 0.98);
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    color: var(--discussion-message-body-text);
+    container-type: inline-size;
   }
 
-  .discussion-list {
+  :global(:root[data-color-scheme='light']) .thread-discussion-pane {
+    --discussion-message-hover-background: rgba(255, 255, 255, 0.42);
+    --discussion-message-hover-border: rgba(24, 35, 49, 0.04);
+    --discussion-mention-background: rgba(72, 111, 168, 0.14);
+    --discussion-mention-text: #315a91;
+  }
+
+  .discussion-stream {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
     min-height: 0;
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    padding: 12px;
-    overflow-y: auto;
+    overflow: auto;
+    padding: 14px 14px 8px;
     scrollbar-color: var(--constellation-utility-panel-scrollbar) transparent;
   }
 
-  .discussion-list::-webkit-scrollbar {
+  .discussion-stream::-webkit-scrollbar {
     width: 4px;
   }
 
-  .discussion-list::-webkit-scrollbar-thumb {
+  .discussion-stream::-webkit-scrollbar-thumb {
     border-radius: 999px;
     background: var(--constellation-utility-panel-scrollbar);
   }
 
-  .discussion-empty {
-    padding: 22px 12px;
-    color: var(--constellation-utility-panel-tab-text);
-    font-size: 13px;
-    text-align: center;
+  .thread-discussion-pane :global(.discussion-state) {
+    margin: auto 0;
+    padding: 8px 2px;
   }
 
-  .discussion-error,
-  .discussion-inline-error {
-    color: #ff9a9a;
-  }
-
-  .discussion-comment {
-    display: grid;
-    gap: 5px;
-    padding: 10px 11px;
-    border: 1px solid var(--constellation-utility-panel-header-border);
-    border-radius: 8px;
-    background: var(--constellation-control-field-background);
-  }
-
-  .discussion-comment-meta {
+  .discussion-message-list {
     display: flex;
+    flex-direction: column;
+    gap: 0;
     min-width: 0;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    color: var(--constellation-utility-panel-tab-text);
-    font-size: 11px;
+    padding-bottom: 6px;
   }
 
-  .discussion-author {
+  .discussion-message {
+    position: relative;
+    display: grid;
+    align-self: stretch;
+    gap: 7px;
+    min-width: 0;
+    padding: 10px 12px;
+    border-radius: 14px;
+    background: transparent;
+    isolation: isolate;
+  }
+
+  .discussion-message::before {
+    content: '';
+    position: absolute;
+    inset: 1px 0;
+    z-index: -1;
+    border-radius: inherit;
+    background: transparent;
+    box-shadow: inset 0 0 0 1px transparent;
+    transition:
+      background-color 140ms ease,
+      box-shadow 140ms ease;
+    pointer-events: none;
+  }
+
+  .discussion-message:hover::before,
+  .discussion-message:focus-within::before,
+  .discussion-message.is-own::before {
+    background: var(--discussion-message-hover-background);
+    box-shadow: inset 0 0 0 1px var(--discussion-message-hover-border);
+  }
+
+  .discussion-message.is-continuation {
+    gap: 0;
+    padding-top: 2px;
+  }
+
+  .discussion-message.is-continuation .discussion-message-body {
+    padding-left: 32px;
+  }
+
+  .discussion-message-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .discussion-message-author-copy {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .discussion-message-author-copy span {
     min-width: 0;
     overflow: hidden;
-    color: var(--constellation-utility-panel-tab-active-text);
-    font-weight: 690;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--discussion-message-author-color);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.15;
   }
 
-  .discussion-body {
-    color: var(--constellation-utility-panel-tab-active-text);
-    font-size: 13px;
-    line-height: 1.45;
+  .discussion-message-author-copy time {
+    color: var(--discussion-message-meta-text);
+    font-size: 11px;
+    line-height: 1.2;
+  }
+
+  .discussion-message-body {
+    margin: 0;
+    color: var(--discussion-message-body-text);
+    font-size: 14px;
+    line-height: 1.6;
     white-space: pre-wrap;
-    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .discussion-mention {
+    display: inline;
+    padding: 0 0.24em;
+    border-radius: 5px;
+    background: var(--discussion-mention-background);
+    color: var(--discussion-mention-text);
+    font-weight: 680;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
   }
 
   .discussion-composer {
-    display: grid;
-    gap: 8px;
-    padding: 10px;
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+    padding: 10px 12px 12px;
     border-top: 1px solid var(--constellation-utility-panel-header-border);
   }
 
-  .discussion-composer textarea {
-    width: 100%;
-    min-width: 0;
-    resize: vertical;
-    max-height: 160px;
-    padding: 9px 10px;
-    border: 1px solid var(--constellation-control-field-border);
-    border-radius: 8px;
-    background: var(--constellation-control-field-background);
-    color: var(--constellation-utility-panel-tab-active-text);
-    font: inherit;
-    font-size: 13px;
-    line-height: 1.4;
+  .discussion-composer :global(.chat-composer-shell.is-thread .cortex-workspace-composer) {
+    min-height: 94px;
+    border-radius: 18px;
   }
 
-  .discussion-composer textarea:focus {
-    outline: 2px solid var(--constellation-control-focus-ring);
-    outline-offset: 2px;
-  }
+  @container (max-width: 360px) {
+    .discussion-message {
+      padding-inline: 10px;
+    }
 
-  .discussion-composer button {
-    justify-self: end;
-    min-height: 32px;
-    padding: 0 12px;
-    border: 1px solid var(--constellation-control-button-secondary-border);
-    border-radius: 8px;
-    background: var(--constellation-control-button-secondary-background);
-    color: var(--constellation-control-button-secondary-text);
-    font: inherit;
-    font-size: 12px;
-    font-weight: 720;
-    cursor: pointer;
-  }
+    .discussion-stream {
+      padding-inline: 10px;
+    }
 
-  .discussion-composer button:hover:not(:disabled),
-  .discussion-composer button:focus-visible {
-    border-color: var(--constellation-control-focus-ring);
-  }
-
-  .discussion-composer button:disabled,
-  .discussion-composer textarea:disabled {
-    cursor: default;
-    opacity: 0.55;
-  }
-
-  .discussion-inline-error {
-    font-size: 12px;
+    .discussion-composer {
+      padding-inline: 10px;
+    }
   }
 </style>

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -629,7 +629,6 @@
   }
 
   .right-dock-content[data-active-tab='activity'],
-  .right-dock-content[data-active-tab='discussion'],
   .right-dock-content[data-active-tab='handoff-summary'],
   .right-dock-content[data-active-tab='vault'],
   .right-dock-content[data-active-tab='cycles'] {
@@ -640,6 +639,11 @@
 
   .right-dock-content[data-active-tab='app'] {
     overflow: hidden;
+  }
+
+  .right-dock-content[data-active-tab='discussion'] {
+    overflow: hidden;
+    padding: 0;
   }
 
   .right-dock-pane,
@@ -689,7 +693,6 @@
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar,
-  .right-dock-content[data-active-tab='discussion']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='handoff-summary']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='vault']::-webkit-scrollbar,
   .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar {
@@ -697,7 +700,6 @@
   }
 
   .right-dock-content[data-active-tab='activity']::-webkit-scrollbar-thumb,
-  .right-dock-content[data-active-tab='discussion']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='handoff-summary']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='vault']::-webkit-scrollbar-thumb,
   .right-dock-content[data-active-tab='cycles']::-webkit-scrollbar-thumb {

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -741,6 +741,7 @@
             {@const runKey = getRunKey(item, index)}
             {@const liveWorkStream = isRunLiveWorkStream(item)}
             {#if liveWorkStream}
+              {@const showLiveCue = item.showLiveCue !== false}
               {@const liveCueWorkIndex = getRunLiveCueWorkIndex(item)}
               {@const liveCueLabel = getRunLiveCueLabel(item, liveCueWorkIndex)}
               <section class="run-live-work-stream" aria-label="Live run work">
@@ -781,14 +782,16 @@
                   </div>
                 {/if}
 
-                <div class="run-live-work-cue" aria-live="polite" aria-label={liveCueLabel}>
-                  <span class="thinking-status-label">{liveCueLabel}</span>
-                  <span class="thinking-status-dots" aria-hidden="true">
-                    <span>.</span>
-                    <span>.</span>
-                    <span>.</span>
-                  </span>
-                </div>
+                {#if showLiveCue}
+                  <div class="run-live-work-cue" aria-live="polite" aria-label={liveCueLabel}>
+                    <span class="thinking-status-label">{liveCueLabel}</span>
+                    <span class="thinking-status-dots" aria-hidden="true">
+                      <span>.</span>
+                      <span>.</span>
+                      <span>.</span>
+                    </span>
+                  </div>
+                {/if}
               </section>
             {:else}
               <details

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -19,10 +19,13 @@ import { shouldRenderLiveAgentTextItem, streamItemRunId } from '$lib/utils/corte
 import { parseServerDate, parseServerTimeMs, relativeTimeAgo } from '$lib/utils/datetime';
 import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
 import { buildRunEvidenceDebug } from '$lib/utils/runEvidenceDebug';
+import { buildChronologicalRunSegments } from '$lib/utils/threadRunChronology';
 import { orderQueuedThreadStreamItems } from '$lib/utils/threadStreamOrdering';
 import type { Idea, StreamItem } from '$lib/types/cortex';
 import type {
   CortexThreadStageAttachmentItem,
+  CortexThreadStageMessageItem,
+  CortexThreadStageRunItem,
   CortexThreadStageRunStatus,
   CortexThreadStageRunStepStatus,
   CortexThreadStageTranscriptItem,
@@ -334,6 +337,194 @@ export function getRunActivity(source: StreamItem | null | undefined): string | 
   return null;
 }
 
+interface TranscriptMappingContext {
+  idea?: Idea | null;
+  themeMode: ThreadThemeMode;
+  currentUser?: ThreadCurrentUser | null;
+  nowMs: number;
+  onApproveRun?: (runId: number) => void;
+  onDenyRun?: (runId: number) => void;
+}
+
+function mapThreadMessageItem(
+  item: StreamItem,
+  {
+    idea,
+    themeMode,
+    currentUser,
+    nowMs,
+  }: TranscriptMappingContext,
+): CortexThreadStageMessageItem {
+  const isAgent = item.role === 'assistant' || item.role === 'illo';
+  const userAccent = isAgent ? null : resolveUserAccent(item, idea, currentUser);
+  const rawAttachments = Array.isArray(item.attachments) ? item.attachments : [];
+  const attachments = [...rawAttachments, ...messageLinkAttachments(item.content, rawAttachments)]
+    .map((attachment) => mapThreadAttachment(attachment))
+    .filter(Boolean) as CortexThreadStageAttachmentItem[];
+
+  const userShellColor = themeMode === 'light'
+    ? THREAD_USER_LIGHT_SHELL_COLOR
+    : THREAD_USER_DARK_SHELL_COLOR;
+  const userOwnerText = themeMode === 'light'
+    ? THREAD_USER_LIGHT_OWNER_TEXT
+    : THREAD_USER_DARK_OWNER_TEXT;
+
+  return {
+    kind: 'message',
+    id: item.id,
+    role: isAgent ? 'illo' : 'user',
+    author: isAgent ? 'Illo' : item.user_name || 'You',
+    timestamp: timeAgo(item.timestamp, nowMs),
+    tag: messageTag(item),
+    tone: isAgent ? 'spectral' : accentTone(userAccent),
+    accentColor: userAccent ?? undefined,
+    coreColor: userAccent ? mixHex(userAccent, userShellColor, themeMode === 'light' ? 0.16 : 0.68) : undefined,
+    ownerColor: userAccent ? mixHex(userAccent, userOwnerText, themeMode === 'light' ? 0.22 : 0.78) : undefined,
+    html: item.content ? renderReadableMarkdown(item.content) : undefined,
+    attachments: attachments.length ? attachments : undefined,
+  };
+}
+
+function runLiveLines(item: StreamItem, fallback: string | null): CortexThreadStageRunItem['liveLines'] {
+  if (item.work_log?.length) return item.work_log;
+  if (item.live_lines?.length) return item.live_lines;
+  return fallback ? [fallback] : [];
+}
+
+function mapThreadRunItem(
+  item: StreamItem,
+  {
+    nowMs,
+    onApproveRun,
+    onDenyRun,
+  }: TranscriptMappingContext,
+): CortexThreadStageRunItem {
+  const runActivity = getRunActivity(item);
+  const runStatus = normalizeRunStatus(item.status);
+  const activeRun = isActiveRun(item);
+  const runId = Number(item.id);
+  const canApproveRun = Boolean(item.requires_approval && Number.isFinite(runId));
+  const workItems = runWorkTimelineItems(item).map((workItem) => ({
+    ...workItem,
+    time: workItem.at ? formatRunClock(workItem.at) : undefined,
+  }));
+  return {
+    kind: 'run',
+    id: item.id,
+    status: runStatus,
+    skill: item.skill_name || item.title || (isFastRun(item) ? 'Fast' : 'run'),
+    event: item.title || (isFastRun(item) ? 'Fast work log' : 'Latest run'),
+    summaryTitle: runWorkSummaryTitle(item),
+    summarySubtitle: runWorkSummarySubtitle(item),
+    defaultExpanded: activeRun || Boolean(item.requires_approval),
+    timestamp: formatRunClock(item.started_at || item.timestamp) || timeAgo(item.timestamp, nowMs),
+    model: item.model_used || undefined,
+    thinking: item.thinking_used || undefined,
+    tokens: formatCompactTokens(item.tokens_total),
+    cost: formatCost(item.estimated_cost),
+    telemetry: buildRunTelemetry(item),
+    duration: item.duration_sec ? formatDuration(item.duration_sec) : undefined,
+    error: item.error || undefined,
+    requiresApproval: Boolean(item.requires_approval),
+    runSteps: (item.run_steps || []).map((step: any, index: number) => ({
+      id: String(
+        step.id ||
+          `${step.node_id || step.step_id || step.skill_name || step.label || 'step'}-${step.wave ?? 0}-${index}`,
+      ),
+      label: step.node_id || step.step_id || step.label || step.skill_name || 'Step',
+      skill: step.skill_name || undefined,
+      duration: step.duration_sec ? formatDuration(step.duration_sec) : undefined,
+      tokens: formatCompactTokens(step.tokens_total),
+      task: step.task || undefined,
+      wave: step.wave,
+      status: normalizeStepStatus(step.status),
+    })),
+    workItems,
+    liveLines: runLiveLines(item, runActivity),
+    liveLinesEyebrow: activeRun ? 'Live work' : 'Work log',
+    toolCalls: (item.tool_calls || []).map((toolCall: any) => ({
+      tool: toolCall.tool,
+      args: toolCall.args || undefined,
+      at: toolCall.at || undefined,
+      status: toolCall.status || undefined,
+      display: toolCall.display || undefined,
+    })),
+    toolCallsDefaultOpen: activeRun,
+    evidenceDebug: buildRunEvidenceDebug(item) ?? undefined,
+    onApprove:
+      canApproveRun && onApproveRun
+        ? () => onApproveRun(runId)
+        : undefined,
+    onDeny:
+      canApproveRun && onDenyRun
+        ? () => onDenyRun(runId)
+        : undefined,
+  };
+}
+
+function groupedRenderableLiveAgentTextItems(visibleItems: readonly StreamItem[]): Map<string, StreamItem[]> {
+  const visibleRunIds = new Set<string>();
+  for (const item of visibleItems) {
+    if (item.type !== 'run' || !shouldShowRunInTranscript(item) || !canSplitRunLiveText(item)) continue;
+    const runId = streamItemRunId(item) ?? String(item.id);
+    if (runId) visibleRunIds.add(runId);
+  }
+
+  const liveTextByRun = new Map<string, StreamItem[]>();
+  for (const item of visibleItems) {
+    if (item.type !== 'message' || !item.metadata?.live_agent_text) continue;
+    if (!shouldRenderLiveAgentTextItem(item, visibleItems)) continue;
+    const runId = streamItemRunId(item);
+    if (!runId || !visibleRunIds.has(runId)) continue;
+    const runItems = liveTextByRun.get(runId);
+    if (runItems) runItems.push(item);
+    else liveTextByRun.set(runId, [item]);
+  }
+  return liveTextByRun;
+}
+
+function liveAgentTextItemIds(liveTextByRun: Map<string, StreamItem[]>): Set<string> {
+  const ids = new Set<string>();
+  for (const items of liveTextByRun.values()) {
+    for (const item of items) {
+      ids.add(String(item.id));
+    }
+  }
+  return ids;
+}
+
+function canSplitRunLiveText(item: StreamItem): boolean {
+  return isActiveRun(item) && !item.requires_approval && item.status !== 'pending_approval';
+}
+
+function appendChronologicalRunSegments(
+  transcriptItems: CortexThreadStageTranscriptItem[],
+  runItem: CortexThreadStageRunItem,
+  liveTextItems: readonly StreamItem[],
+  context: TranscriptMappingContext,
+) {
+  const segments = buildChronologicalRunSegments(runItem.workItems ?? [], liveTextItems, {
+    includeTrailingCue: true,
+  });
+  let workSegmentIndex = 0;
+  for (const segment of segments) {
+    if (segment.kind === 'live_text') {
+      transcriptItems.push(mapThreadMessageItem(segment.item, context));
+      continue;
+    }
+    if (segment.items.length === 0 && !segment.showLiveCue) continue;
+    workSegmentIndex += 1;
+    transcriptItems.push({
+      ...runItem,
+      id: `${runItem.id}:work:${workSegmentIndex}`,
+      workItems: segment.items,
+      liveLines: [],
+      showLiveCue: segment.showLiveCue,
+      toolCalls: [],
+    });
+  }
+}
+
 export function buildThreadTranscriptItems({
   idea,
   stream,
@@ -347,39 +538,22 @@ export function buildThreadTranscriptItems({
 }: BuildThreadTranscriptOptions): CortexThreadStageTranscriptItem[] {
   const items: CortexThreadStageTranscriptItem[] = [];
   const visibleItems = orderQueuedThreadStreamItems(visibleThreadStreamItems(stream));
+  const liveTextByRun = groupedRenderableLiveAgentTextItems(visibleItems);
+  const consumedLiveTextIds = liveAgentTextItemIds(liveTextByRun);
+  const mappingContext: TranscriptMappingContext = {
+    idea,
+    themeMode,
+    currentUser,
+    nowMs,
+    onApproveRun,
+    onDenyRun,
+  };
 
   for (const item of visibleItems) {
     if (item.type === 'message') {
+      if (consumedLiveTextIds.has(String(item.id))) continue;
       if (!shouldRenderLiveAgentTextItem(item, visibleItems)) continue;
-
-      const isAgent = item.role === 'assistant' || item.role === 'illo';
-      const userAccent = isAgent ? null : resolveUserAccent(item, idea, currentUser);
-      const rawAttachments = Array.isArray(item.attachments) ? item.attachments : [];
-      const attachments = [...rawAttachments, ...messageLinkAttachments(item.content, rawAttachments)]
-        .map((attachment) => mapThreadAttachment(attachment))
-        .filter(Boolean) as CortexThreadStageAttachmentItem[];
-
-      const userShellColor = themeMode === 'light'
-        ? THREAD_USER_LIGHT_SHELL_COLOR
-        : THREAD_USER_DARK_SHELL_COLOR;
-      const userOwnerText = themeMode === 'light'
-        ? THREAD_USER_LIGHT_OWNER_TEXT
-        : THREAD_USER_DARK_OWNER_TEXT;
-
-      items.push({
-        kind: 'message',
-        id: item.id,
-        role: isAgent ? 'illo' : 'user',
-        author: isAgent ? 'Illo' : item.user_name || 'You',
-        timestamp: timeAgo(item.timestamp, nowMs),
-        tag: messageTag(item),
-        tone: isAgent ? 'spectral' : accentTone(userAccent),
-        accentColor: userAccent ?? undefined,
-        coreColor: userAccent ? mixHex(userAccent, userShellColor, themeMode === 'light' ? 0.16 : 0.68) : undefined,
-        ownerColor: userAccent ? mixHex(userAccent, userOwnerText, themeMode === 'light' ? 0.22 : 0.78) : undefined,
-        html: item.content ? renderReadableMarkdown(item.content) : undefined,
-        attachments: attachments.length ? attachments : undefined,
-      });
+      items.push(mapThreadMessageItem(item, mappingContext));
       continue;
     }
 
@@ -398,72 +572,14 @@ export function buildThreadTranscriptItems({
 
     if (item.type === 'run') {
       if (!shouldShowRunInTranscript(item)) continue;
-      const runActivity = getRunActivity(item);
-      const runStatus = normalizeRunStatus(item.status);
-      const activeRun = isActiveRun(item);
-      const workItems = runWorkTimelineItems(item).map((workItem) => ({
-        ...workItem,
-        time: workItem.at ? formatRunClock(workItem.at) : undefined,
-      }));
-      const runId = Number(item.id);
-      items.push({
-        kind: 'run',
-        id: item.id,
-        status: runStatus,
-        skill: item.skill_name || item.title || (isFastRun(item) ? 'Fast' : 'run'),
-        event: item.title || (isFastRun(item) ? 'Fast work log' : 'Latest run'),
-        summaryTitle: runWorkSummaryTitle(item),
-        summarySubtitle: runWorkSummarySubtitle(item),
-        defaultExpanded: activeRun || Boolean(item.requires_approval),
-        timestamp: formatRunClock(item.started_at || item.timestamp) || timeAgo(item.timestamp, nowMs),
-        model: item.model_used || undefined,
-        thinking: item.thinking_used || undefined,
-        tokens: formatCompactTokens(item.tokens_total),
-        cost: formatCost(item.estimated_cost),
-        telemetry: buildRunTelemetry(item),
-        duration: item.duration_sec ? formatDuration(item.duration_sec) : undefined,
-        error: item.error || undefined,
-        requiresApproval: Boolean(item.requires_approval),
-        runSteps: (item.run_steps || []).map((step: any, index: number) => ({
-          id: String(
-            step.id ||
-              `${step.node_id || step.step_id || step.skill_name || step.label || 'step'}-${step.wave ?? 0}-${index}`,
-          ),
-          label: step.node_id || step.step_id || step.label || step.skill_name || 'Step',
-          skill: step.skill_name || undefined,
-          duration: step.duration_sec ? formatDuration(step.duration_sec) : undefined,
-          tokens: formatCompactTokens(step.tokens_total),
-          task: step.task || undefined,
-          wave: step.wave,
-          status: normalizeStepStatus(step.status),
-        })),
-        workItems,
-        liveLines: item.work_log?.length
-          ? item.work_log
-          : item.live_lines?.length
-            ? item.live_lines
-            : runActivity
-              ? [runActivity]
-              : [],
-        liveLinesEyebrow: activeRun ? 'Live work' : 'Work log',
-        toolCalls: (item.tool_calls || []).map((toolCall: any) => ({
-          tool: toolCall.tool,
-          args: toolCall.args || undefined,
-          at: toolCall.at || undefined,
-          status: toolCall.status || undefined,
-          display: toolCall.display || undefined,
-        })),
-        toolCallsDefaultOpen: activeRun,
-        evidenceDebug: buildRunEvidenceDebug(item) ?? undefined,
-        onApprove:
-          item.requires_approval && Number.isFinite(runId) && onApproveRun
-            ? () => onApproveRun(runId)
-            : undefined,
-        onDeny:
-          item.requires_approval && Number.isFinite(runId) && onDenyRun
-            ? () => onDenyRun(runId)
-            : undefined,
-      });
+      const runItem = mapThreadRunItem(item, mappingContext);
+      const runId = streamItemRunId(item) ?? String(item.id);
+      const liveTextItems = liveTextByRun.get(runId) ?? [];
+      if (liveTextItems.length > 0 && canSplitRunLiveText(item)) {
+        appendChronologicalRunSegments(items, runItem, liveTextItems, mappingContext);
+        continue;
+      }
+      items.push(runItem);
     }
   }
 

--- a/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
@@ -160,6 +160,7 @@ export interface CortexThreadStageRunItem {
   workerLanes?: readonly CortexThreadStageWorkerLane[];
   workerEyebrow?: string;
   workItems?: readonly CortexThreadStageWorkTimelineItem[];
+  showLiveCue?: boolean;
   liveLines?: readonly CortexThreadStageLiveLine[];
   liveLinesEyebrow?: string;
   toolCalls?: readonly CortexThreadStageToolCall[];

--- a/frontend/src/lib/utils/cortexRunStream.test.js
+++ b/frontend/src/lib/utils/cortexRunStream.test.js
@@ -125,6 +125,38 @@ test('keeps live agent text visible until a settled run reply exists', () => {
   assert.equal(shouldRenderLiveAgentTextItem(settled, [run, live, settled]), true);
 });
 
+test('starts a new live text segment after tool work begins', () => {
+  const preamble = applyAgentTextDeltaToStream([], {
+    idea_id: 'idea-1',
+    run_id: 12,
+    delta: 'I will inspect first.',
+    profile: 'fast',
+    event_created_at: '2026-05-05T10:00:01Z',
+  }, 'idea-1');
+  const withTool = applyAgentActivityToStream(preamble, {
+    type: 'tool_started',
+    idea_id: 'idea-1',
+    run_id: 12,
+    activity: 'Using read_file',
+    tool_name: 'read_file',
+    event_created_at: '2026-05-05T10:00:02Z',
+  }, 'idea-1', 'fast');
+  const next = applyAgentTextDeltaToStream(withTool, {
+    idea_id: 'idea-1',
+    run_id: 12,
+    delta: 'I found the file.',
+    event_created_at: '2026-05-05T10:00:03Z',
+  }, 'idea-1');
+  const liveMessages = next.filter((item) => item.metadata?.live_agent_text);
+
+  assert.deepEqual(liveMessages.map((item) => item.content), [
+    'I will inspect first.',
+    'I found the file.',
+  ]);
+  assert.equal(liveMessages[0].metadata.live_agent_text_after_tool, false);
+  assert.equal(liveMessages[1].metadata.live_agent_text_after_tool, true);
+});
+
 test('creates and updates run activity with tool call state', () => {
   const started = applyAgentActivityToStream([], {
     type: 'tool_started',

--- a/frontend/src/lib/utils/cortexRunStream.ts
+++ b/frontend/src/lib/utils/cortexRunStream.ts
@@ -66,6 +66,91 @@ export function isLivePartialReply(item: Partial<CortexRunStreamItem> | null | u
   return Boolean(item?.metadata?.live_agent_text);
 }
 
+function timestampMs(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function livePartialItemsForRun(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+): CortexRunStreamItem[] {
+  const key = runIdKey(runId);
+  if (!key) return [];
+  return stream.filter((item) => isLivePartialReply(item) && streamItemRunId(item) === key);
+}
+
+function lastLivePartialForRun(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+): CortexRunStreamItem | null {
+  return livePartialItemsForRun(stream, runId).at(-1) ?? null;
+}
+
+function nextLivePartialId(runId: unknown, stream: readonly CortexRunStreamItem[]): string | null {
+  const baseId = livePartialId(runId);
+  if (!baseId) return null;
+  const count = livePartialItemsForRun(stream, runId).length;
+  return count === 0 ? baseId : `${baseId}-${count + 1}`;
+}
+
+function runToolTimes(run: CortexRunStreamItem): number[] {
+  const times = [
+    ...(run.tool_calls || []).map((call) => timestampMs(call.at)),
+    ...(run.activity_trace || [])
+      .filter((entry) => Boolean(entry.tool_name))
+      .map((entry) => timestampMs(entry.at)),
+    ...(run.work_log || [])
+      .filter((entry) => String(entry.kind || '').includes('tool'))
+      .map((entry) => timestampMs(entry.time)),
+  ];
+  return times.filter((value): value is number => value !== null);
+}
+
+function hasRunToolWork(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+  matches: (time: number) => boolean,
+): boolean {
+  const key = runIdKey(runId);
+  if (!key) return false;
+  return stream.some((item) => {
+    if (item.type !== 'run' || streamItemRunId(item) !== key) return false;
+    return runToolTimes(item).some(matches);
+  });
+}
+
+function hasRunToolWorkSince(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+  sinceMs: number,
+): boolean {
+  return hasRunToolWork(stream, runId, (time) => time > sinceMs);
+}
+
+function hasRunToolWorkBefore(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+  beforeMs: number,
+): boolean {
+  return hasRunToolWork(stream, runId, (time) => time <= beforeMs);
+}
+
+function livePartialLastDeltaMs(item: CortexRunStreamItem): number | null {
+  return timestampMs(item.metadata?.live_agent_text_last_delta_at) ?? timestampMs(item.timestamp);
+}
+
+function shouldStartNewLivePartial(
+  stream: readonly CortexRunStreamItem[],
+  runId: unknown,
+  currentPartial: CortexRunStreamItem | null,
+): boolean {
+  if (!currentPartial) return true;
+  const lastDeltaMs = livePartialLastDeltaMs(currentPartial);
+  return lastDeltaMs !== null && hasRunToolWorkSince(stream, runId, lastDeltaMs);
+}
+
 function isSettledAgentRunReply(item: Partial<CortexRunStreamItem>, runId: string): boolean {
   if (item.type !== 'message' || isLivePartialReply(item)) return false;
   const isAgentMessage = item.role === 'assistant' || item.role === 'illo';
@@ -202,31 +287,46 @@ export function applyAgentTextDeltaToStream(
 ): CortexRunStreamItem[] {
   if (!msg || msg.idea_id !== selectedIdeaId) return stream;
   const runId = msg.run_id;
-  const partialId = livePartialId(runId);
-  if (!partialId) return stream;
+  const partialBaseId = livePartialId(runId);
+  if (!partialBaseId) return stream;
 
   if (msg.reset) {
-    return stream.filter((item) => item.id !== partialId);
+    return stream.filter((item) => {
+      return item.id !== partialBaseId && !String(item.id).startsWith(`${partialBaseId}-`);
+    });
   }
 
   const delta = typeof msg.delta === 'string' ? msg.delta : '';
   if (!delta) return stream;
 
-  const existing = stream.find((item) => item.id === partialId);
-  if (existing) {
+  const deltaAt = eventAt(msg, nowIso);
+  const existing = lastLivePartialForRun(stream, runId);
+  if (!shouldStartNewLivePartial(stream, runId, existing)) {
     return stream.map((item) =>
-      item.id === partialId
-        ? { ...item, content: `${item.content || ''}${delta}` }
+      item.id === existing?.id
+        ? {
+            ...item,
+            content: `${item.content || ''}${delta}`,
+            metadata: {
+              ...(item.metadata || {}),
+              live_agent_text_last_delta_at: deltaAt,
+            },
+          }
         : item,
     );
   }
+
+  const partialId = nextLivePartialId(runId, stream);
+  if (!partialId) return stream;
+  const deltaAtMs = timestampMs(deltaAt);
+  const afterTool = deltaAtMs !== null && hasRunToolWorkBefore(stream, runId, deltaAtMs);
 
   return [
     ...stream,
     {
       type: 'message',
       id: partialId,
-      timestamp: nowIso,
+      timestamp: deltaAt,
       role: 'illo',
       content: delta,
       metadata: {
@@ -234,6 +334,9 @@ export function applyAgentTextDeltaToStream(
         idea_id: msg.idea_id,
         execution_profile: msg.profile || 'fast',
         live_agent_text: true,
+        live_agent_text_after_tool: afterTool,
+        live_agent_text_first_delta_at: deltaAt,
+        live_agent_text_last_delta_at: deltaAt,
       },
     },
   ];

--- a/frontend/src/lib/utils/threadRunChronology.test.js
+++ b/frontend/src/lib/utils/threadRunChronology.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildChronologicalRunSegments } from './threadRunChronology.ts';
+
+test('places live text between the run work that happened around it', () => {
+  const segments = buildChronologicalRunSegments(
+    [
+      { kind: 'thought', text: 'Reading context', at: '2026-05-21T15:06:34Z' },
+      { kind: 'thought', text: 'Writing response... (~4 output tokens)', at: '2026-05-21T15:06:35Z' },
+      { kind: 'tool', tool: 'read_team_activity', at: '2026-05-21T15:06:38Z' },
+      { kind: 'tool', tool: 'read_roster', at: '2026-05-21T15:06:42Z' },
+    ],
+    [{
+      id: 'live-run-255',
+      timestamp: '2026-05-21T15:06:35.399537Z',
+      metadata: {
+        live_agent_text: true,
+        live_agent_text_first_delta_at: '2026-05-21T15:06:35.399537Z',
+      },
+    }],
+    { includeTrailingCue: true },
+  );
+
+  assert.deepEqual(segments.map((segment) => segment.kind), ['work', 'live_text', 'work']);
+  assert.deepEqual(segments[0].items.map((item) => item.text ?? item.tool), ['Reading context']);
+  assert.equal(segments[1].item.id, 'live-run-255');
+  assert.deepEqual(segments[2].items.map((item) => item.text ?? item.tool), [
+    'read_team_activity',
+    'read_roster',
+  ]);
+  assert.equal(segments[2].showLiveCue, true);
+});
+
+test('splits additional live text after tool work into a new chronological segment', () => {
+  const segments = buildChronologicalRunSegments(
+    [
+      { kind: 'tool', tool: 'read_file', at: '2026-05-21T15:06:38Z' },
+      { kind: 'tool', tool: 'search_files', at: '2026-05-21T15:06:45Z' },
+    ],
+    [
+      {
+        id: 'live-run-255',
+        timestamp: '2026-05-21T15:06:35Z',
+        metadata: { live_agent_text_first_delta_at: '2026-05-21T15:06:35Z' },
+      },
+      {
+        id: 'live-run-255-2',
+        timestamp: '2026-05-21T15:06:41Z',
+        metadata: { live_agent_text_first_delta_at: '2026-05-21T15:06:41Z' },
+      },
+    ],
+  );
+
+  assert.deepEqual(segments.map((segment) => segment.kind), ['live_text', 'work', 'live_text', 'work']);
+  assert.equal(segments[0].item.id, 'live-run-255');
+  assert.deepEqual(segments[1].items.map((item) => item.tool), ['read_file']);
+  assert.equal(segments[2].item.id, 'live-run-255-2');
+  assert.deepEqual(segments[3].items.map((item) => item.tool), ['search_files']);
+});

--- a/frontend/src/lib/utils/threadRunChronology.ts
+++ b/frontend/src/lib/utils/threadRunChronology.ts
@@ -1,0 +1,135 @@
+export type ThreadRunChronologyWorkItem = {
+  kind?: string;
+  at?: string;
+  time?: string;
+  text?: string;
+};
+
+export type ThreadRunChronologyLiveTextItem = {
+  id?: string | number | null;
+  timestamp?: string;
+  metadata?: Record<string, any> | null;
+};
+
+export type ThreadRunChronologySegment<TWork, TLive> =
+  | {
+      kind: 'work';
+      items: TWork[];
+      showLiveCue: boolean;
+    }
+  | {
+      kind: 'live_text';
+      item: TLive;
+    };
+
+function parseTimeMs(value: unknown): number | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function metadataFor(item: ThreadRunChronologyLiveTextItem): Record<string, any> {
+  return item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
+}
+
+function liveTextStartMs(item: ThreadRunChronologyLiveTextItem): number | null {
+  const metadata = metadataFor(item);
+  return parseTimeMs(metadata.live_agent_text_first_delta_at) ?? parseTimeMs(item.timestamp);
+}
+
+function workItemTimeMs(item: ThreadRunChronologyWorkItem): number | null {
+  return parseTimeMs(item.at) ?? parseTimeMs(item.time);
+}
+
+function normalizedText(value: unknown): string {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[`*_#>\[\]()]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isLiveResponseStatus(item: ThreadRunChronologyWorkItem): boolean {
+  if (item.kind !== 'thought') return false;
+  const text = normalizedText(item.text);
+  return text.startsWith('writing response') || text.startsWith('streaming');
+}
+
+function compareNullableTimes(left: number | null, right: number | null): number {
+  if (left !== null && right !== null && left !== right) return left - right;
+  if (left !== null && right === null) return -1;
+  if (left === null && right !== null) return 1;
+  return 0;
+}
+
+function workBelongsBeforeLiveText(
+  work: { ms: number | null; index: number },
+  live: { ms: number | null; index: number },
+): boolean {
+  const timeOrder = compareNullableTimes(work.ms, live.ms);
+  return timeOrder < 0 || (timeOrder === 0 && work.index < live.index);
+}
+
+export function buildChronologicalRunSegments<
+  TWork extends ThreadRunChronologyWorkItem,
+  TLive extends ThreadRunChronologyLiveTextItem,
+>(
+  workItems: readonly TWork[],
+  liveTextItems: readonly TLive[],
+  {
+    includeTrailingCue = false,
+    suppressLiveResponseStatus = true,
+  }: {
+    includeTrailingCue?: boolean;
+    suppressLiveResponseStatus?: boolean;
+  } = {},
+): ThreadRunChronologySegment<TWork, TLive>[] {
+  const liveRecords = liveTextItems
+    .map((item, index) => ({ item, index, ms: liveTextStartMs(item) }))
+    .sort((left, right) => compareNullableTimes(left.ms, right.ms) || left.index - right.index);
+  const hasLiveText = liveRecords.length > 0;
+
+  const filteredWorkItems = suppressLiveResponseStatus && hasLiveText
+    ? workItems.filter((item) => !isLiveResponseStatus(item))
+    : [...workItems];
+
+  const workRecords = filteredWorkItems.map((item, index) => ({
+    item,
+    index,
+    ms: workItemTimeMs(item),
+  }));
+
+  if (!hasLiveText) {
+    if (workRecords.length === 0 && !includeTrailingCue) return [];
+    return [{
+      kind: 'work',
+      items: workRecords.map((record) => record.item),
+      showLiveCue: includeTrailingCue,
+    }];
+  }
+
+  const segments: ThreadRunChronologySegment<TWork, TLive>[] = [];
+  let workCursor = 0;
+  const pushWorkSegment = (items: TWork[], showLiveCue: boolean) => {
+    if (items.length === 0 && !showLiveCue) return;
+    segments.push({ kind: 'work', items, showLiveCue });
+  };
+
+  for (const live of liveRecords) {
+    const segmentWork: TWork[] = [];
+    while (
+      workCursor < workRecords.length
+      && workBelongsBeforeLiveText(workRecords[workCursor], live)
+    ) {
+      segmentWork.push(workRecords[workCursor].item);
+      workCursor += 1;
+    }
+    pushWorkSegment(segmentWork, false);
+    segments.push({ kind: 'live_text', item: live.item });
+  }
+
+  const tailWork = workRecords.slice(workCursor).map((record) => record.item);
+  pushWorkSegment(tailWork, includeTrailingCue);
+
+  return segments;
+}

--- a/frontend/src/lib/utils/threadStreamOrdering.test.js
+++ b/frontend/src/lib/utils/threadStreamOrdering.test.js
@@ -75,6 +75,22 @@ test('keeps queued follow-ups after the active run card until a final reply exis
   ]);
 });
 
+test('places pre-tool live agent text before its active run card', () => {
+  const ordered = orderQueuedThreadStreamItems([
+    { type: 'message', id: 'prompt-1', role: 'user', content: 'What is the team doing?' },
+    { type: 'run', id: 'run-1', run_id: 1, status: 'running' },
+    {
+      type: 'message',
+      id: 'live-run-1',
+      role: 'illo',
+      content: 'I will check recent workspace activity first.',
+      metadata: { run_id: 1, live_agent_text: true },
+    },
+  ]);
+
+  assert.deepEqual(ordered.map((item) => item.id), ['prompt-1', 'live-run-1', 'run-1']);
+});
+
 test('preserves unanchored queued messages in timestamp order', () => {
   const ordered = orderQueuedThreadStreamItems([
     { type: 'message', id: 'prompt-1', role: 'user', content: 'Build the app' },

--- a/frontend/src/lib/utils/threadStreamOrdering.ts
+++ b/frontend/src/lib/utils/threadStreamOrdering.ts
@@ -33,23 +33,78 @@ function isAgentRunReply(item: ThreadStreamOrderingItem): boolean {
   return Boolean(String(item.content || '').trim() && itemRunId(item));
 }
 
+function isPreToolLiveAgentText(item: ThreadStreamOrderingItem): boolean {
+  const metadata = metadataFor(item);
+  const role = item.role === 'assistant' || item.role === 'illo';
+  return (
+    item.type === 'message'
+    && role
+    && Boolean(metadata.live_agent_text)
+    && metadata.live_agent_text_after_tool !== true
+    && Boolean(itemRunId(item))
+  );
+}
+
+function orderPreToolLiveTextBeforeRuns<T extends ThreadStreamOrderingItem>(items: readonly T[]): T[] {
+  const runIds = new Set<string>();
+  for (const item of items) {
+    if (item.type !== 'run') continue;
+    const runId = itemRunId(item);
+    if (runId) runIds.add(runId);
+  }
+  if (runIds.size === 0) return [...items];
+
+  const liveTextByRun = new Map<string, T[]>();
+  const movedLiveText = new Set<T>();
+  for (const item of items) {
+    const runId = itemRunId(item);
+    if (!runId || !runIds.has(runId) || !isPreToolLiveAgentText(item)) continue;
+    const runItems = liveTextByRun.get(runId);
+    if (runItems) runItems.push(item);
+    else liveTextByRun.set(runId, [item]);
+    movedLiveText.add(item);
+  }
+  if (movedLiveText.size === 0) return [...items];
+
+  const flushedRunIds = new Set<string>();
+  const ordered: T[] = [];
+  const flushLiveText = (runId: string) => {
+    if (flushedRunIds.has(runId)) return;
+    const liveText = liveTextByRun.get(runId);
+    if (liveText?.length) ordered.push(...liveText);
+    flushedRunIds.add(runId);
+  };
+
+  for (const item of items) {
+    if (movedLiveText.has(item)) continue;
+    const runId = item.type === 'run' ? itemRunId(item) : null;
+    if (runId) flushLiveText(runId);
+    ordered.push(item);
+  }
+
+  return ordered;
+}
+
 export function orderQueuedThreadStreamItems<T extends ThreadStreamOrderingItem>(items: readonly T[]): T[] {
+  const orderedItems = orderPreToolLiveTextBeforeRuns(items);
   const blocksByAnchor = new Map<string, T[]>();
   const anchorIds = new Set<string>();
 
-  for (const item of items) {
+  for (const item of orderedItems) {
     const anchorId = queuedAfterRunId(item);
     if (!anchorId) continue;
     anchorIds.add(anchorId);
-    blocksByAnchor.set(anchorId, [...(blocksByAnchor.get(anchorId) ?? []), item]);
+    const block = blocksByAnchor.get(anchorId);
+    if (block) block.push(item);
+    else blocksByAnchor.set(anchorId, [item]);
   }
 
-  if (blocksByAnchor.size === 0) return [...items];
+  if (blocksByAnchor.size === 0) return orderedItems;
 
   const lastRunReplyIndexByAnchor = new Map<string, number>();
   const anchorsWithTarget = new Set<string>();
-  for (let index = 0; index < items.length; index += 1) {
-    const item = items[index];
+  for (let index = 0; index < orderedItems.length; index += 1) {
+    const item = orderedItems[index];
     const runId = itemRunId(item);
     if (!runId || !anchorIds.has(runId)) continue;
     anchorsWithTarget.add(runId);
@@ -59,7 +114,7 @@ export function orderQueuedThreadStreamItems<T extends ThreadStreamOrderingItem>
   const movedAnchors = new Set(
     [...anchorIds].filter((anchorId) => anchorsWithTarget.has(anchorId)),
   );
-  if (movedAnchors.size === 0) return [...items];
+  if (movedAnchors.size === 0) return orderedItems;
 
   const flushedAnchors = new Set<string>();
   const flush = (anchorId: string, output: T[]) => {
@@ -71,8 +126,8 @@ export function orderQueuedThreadStreamItems<T extends ThreadStreamOrderingItem>
   };
 
   const ordered: T[] = [];
-  for (let index = 0; index < items.length; index += 1) {
-    const item = items[index];
+  for (let index = 0; index < orderedItems.length; index += 1) {
+    const item = orderedItems[index];
     const anchorId = queuedAfterRunId(item);
     if (anchorId && movedAnchors.has(anchorId)) continue;
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -521,6 +521,53 @@ def test_fast_tool_surface_is_direct_coordinator_without_staged_reply_tools(monk
     assert roles == ["coordinator"]
 
 
+def test_fast_discussion_origin_surface_keeps_explicit_timeline_reply_tool(monkeypatch):
+    from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_agent_tools",
+        lambda role: [
+            {"name": "post_thread_discussion_reply"},
+            {"name": "cortex_reply"},
+            {"name": "cortex_visual_reply"},
+        ],
+    )
+
+    runtime = SimpleNamespace(
+        request=SimpleNamespace(
+            metadata={"originating_surface": "thread_discussion"},
+            target_ref={"originating_surface": "thread_discussion"},
+        )
+    )
+
+    assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == [
+        "post_thread_discussion_reply",
+        "cortex_reply",
+    ]
+
+
+def test_discussion_origin_run_does_not_auto_mirror_final_answer_to_timeline():
+    from brain.systems.runs.cortex.runner import _run_should_mirror_final_answer_to_timeline
+
+    run = SimpleNamespace(
+        target_ref={"originating_surface": "thread_discussion"},
+        metadata_={"final_answer_target_surface": "originating_surface"},
+    )
+
+    assert _run_should_mirror_final_answer_to_timeline(run) is False
+
+
+def test_discussion_origin_run_can_explicitly_target_ai_timeline():
+    from brain.systems.runs.cortex.runner import _run_should_mirror_final_answer_to_timeline
+
+    run = SimpleNamespace(
+        target_ref={"originating_surface": "thread_discussion"},
+        metadata_={"final_answer_target_surface": "ai_timeline"},
+    )
+
+    assert _run_should_mirror_final_answer_to_timeline(run) is True
+
+
 async def test_runtime_drain_steering_can_use_isolated_durable_drain():
     from brain.systems.runs.steering import SteeringMessage
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1271,7 +1271,7 @@ async def test_create_thread_discussion_comment_commits_before_broadcast_without
 
 
 @pytest.mark.asyncio
-async def test_create_thread_discussion_illo_mention_routes_main_thread_trigger(client, mock_session_factory):
+async def test_create_thread_discussion_illo_mention_routes_surface_aware_trigger(client, mock_session_factory):
     idea = _make_idea(id="some-id", title="Shared Thread", org_id="test-org")
     trigger_response = {"status": "queued", "run_id": "run-1"}
 
@@ -1303,8 +1303,90 @@ async def test_create_thread_discussion_illo_mention_routes_main_thread_trigger(
     assert kwargs["idea_id"] == "some-id"
     assert kwargs["thread_message"] == "@illo this is what we decided, carry on"
     assert kwargs["metadata"]["source"] == "thread_discussion"
+    assert kwargs["metadata"]["originating_surface"] == "thread_discussion"
+    assert kwargs["metadata"]["triggering_surface"] == "thread_discussion"
+    assert kwargs["metadata"]["required_response_tool"] == "post_thread_discussion_reply"
     assert kwargs["metadata"]["discussion_comment_id"] == 7
+    assert kwargs["metadata"]["discussion_trigger"] == {
+        "surface": "thread_discussion",
+        "thread_id": "some-id",
+        "comment_id": 7,
+        "body": "@illo this is what we decided, carry on",
+        "author_user_id": ANY,
+        "response_target": {
+            "surface": "thread_discussion",
+            "thread_id": "some-id",
+            "reply_to_comment_id": 7,
+        },
+    }
     route_trigger.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_thread_discussion_reply
+
+    created = []
+
+    class _Session:
+        async def get(self, _model, thread_id):
+            return SimpleNamespace(id=thread_id, org_id="test-org")
+
+        def add(self, obj):
+            obj.id = 9
+            obj.created_at = datetime(2026, 5, 21, 12, 5, tzinfo=timezone.utc)
+            created.append(obj)
+
+        async def flush(self):
+            return None
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    broadcast = AsyncMock()
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+    monkeypatch.setattr("brain.app.api.routers.ws.ws_manager.broadcast_product_event", broadcast)
+
+    with bind_agent_context(
+        {
+            "org_id": "test-org",
+            "run_id": 42,
+            "target_ref": {
+                "discussion_trigger": {
+                    "surface": "thread_discussion",
+                    "thread_id": "some-id",
+                    "comment_id": 7,
+                    "response_target": {
+                        "surface": "thread_discussion",
+                        "thread_id": "some-id",
+                        "reply_to_comment_id": 7,
+                    },
+                }
+            },
+        }
+    ):
+        raw = await _handle_post_thread_discussion_reply("Got it, I will carry that forward.")
+
+    payload = json.loads(raw)
+    assert payload["ok"] is True
+    assert payload["comment"]["body"] == "Got it, I will carry that forward."
+    assert payload["comment"]["author_kind"] == "illo"
+    assert payload["comment"]["metadata"]["created_by_run_id"] == 42
+    assert payload["comment"]["metadata"]["reply_to_comment_id"] == 7
+    assert created[0].thread_id == "some-id"
+    assert created[0].org_id == "test-org"
+    assert created[0].author_user_id is None
+    broadcast.assert_awaited_once_with(
+        "thread_discussion_comment",
+        {"idea_id": "some-id", "comment": payload["comment"]},
+        org_id="test-org",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import pytest_asyncio
@@ -1349,9 +1349,9 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             return None
 
-    broadcast = AsyncMock()
+    published = Mock()
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
-    monkeypatch.setattr("brain.app.api.routers.ws.ws_manager.broadcast_product_event", broadcast)
+    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
 
     with bind_agent_context(
         {
@@ -1382,10 +1382,9 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
     assert created[0].thread_id == "some-id"
     assert created[0].org_id == "test-org"
     assert created[0].author_user_id is None
-    broadcast.assert_awaited_once_with(
+    published.assert_called_once_with(
         "thread_discussion_comment",
-        {"idea_id": "some-id", "comment": payload["comment"]},
-        org_id="test-org",
+        {"idea_id": "some-id", "org_id": "test-org", "comment": payload["comment"]},
     )
 
 

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -509,7 +509,9 @@ async def test_hosted_mcp_submit_context_builds_shared_envelope():
             "ilo_outcome": {
                 "operation": "created",
                 "thread_id": "idea-1",
-                "url": "/cortex?idea=idea-1",
+                "thread_url": "https://illo.example.com/cortex?idea=idea-1",
+                "thread_route": "/cortex?idea=idea-1",
+                "url": "https://illo.example.com/cortex?idea=idea-1",
                 "message": "Context accepted and a Thread was created.",
                 "context_submission_id": "sub-1",
             },
@@ -554,7 +556,9 @@ async def test_hosted_mcp_submit_context_builds_shared_envelope():
     assert payload["status"] == "processed"
     assert payload["event_id"] == "evt-1"
     assert payload["thread_id"] == "idea-1"
-    assert payload["url"] == "/cortex?idea=idea-1"
+    assert payload["thread_url"] == "https://illo.example.com/cortex?idea=idea-1"
+    assert payload["thread_route"] == "/cortex?idea=idea-1"
+    assert payload["url"] == payload["thread_url"]
     assert payload["context_submission_id"] == "sub-1"
     submit.assert_awaited_once()
     assert captured["db"] is session

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -145,6 +145,7 @@ async def test_headless_ask_blocks_thread_mutation_tools():
     blocked_tools = event.payload["metadata"]["tool_policy"]["blocked_tools"]
     assert "manage_idea" in blocked_tools
     assert "post_chat_message" in blocked_tools
+    assert "post_thread_discussion_reply" in blocked_tools
     request_source = event.payload["metadata"]["request_source"]
     assert request_source["surface"] == "personal_agent_bridge"
     assert request_source["personal_agent"] == "Hermes"

--- a/tests/test_illo_personal_agent_mcp.py
+++ b/tests/test_illo_personal_agent_mcp.py
@@ -37,6 +37,7 @@ def test_tool_catalog_contains_behavior_guidance():
         "illo_get_team_members",
     } == set(tools)
     assert "team agent" in tools["illo_submit_context"]["description"]
+    assert "thread_url" in tools["illo_submit_context"]["description"]
     assert "before creating a new thread" in tools["illo_search_workspace"]["description"]
     assert "without creating a visible thread" in tools["illo_ask"]["description"]
     assert "Advanced compatibility tool" in tools["illo_create_thread"]["description"]
@@ -48,13 +49,31 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
 
     def fake_json_request(method, url, **kwargs):
         calls.append({"method": method, "url": url, **kwargs})
+        if url == "https://illo.test/api/mcp":
+            return {
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "thread_id": "idea-1",
+                                    "thread_url": "https://illo.test/cortex?idea=idea-1",
+                                    "thread_route": "/cortex?idea=idea-1",
+                                    "url": "https://illo.test/cortex?idea=idea-1",
+                                }
+                            ),
+                        }
+                    ]
+                }
+            }
         return {"ok": True}
 
     monkeypatch.setattr(module, "_json_request", fake_json_request)
     client = module.IlloBridgeClient(module.IlloBridgeConfig("https://illo.test", "bridge-token", 12))
 
     client.search_workspace("roadmap", limit=5)
-    client.submit_context(
+    submit_result = client.submit_context(
         "Ask the team to review the implementation context",
         parts=[{"type": "text", "text": "Implemented context submission"}],
         repo="illospace-project",
@@ -98,6 +117,9 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
     assert context_payload["params"]["arguments"]["files_touched"] == [
         "brain/app/api/routers/agent_mcp.py"
     ]
+    assert submit_result["thread_url"] == "https://illo.test/cortex?idea=idea-1"
+    assert submit_result["url"] == submit_result["thread_url"]
+    assert submit_result["thread_route"] == "/cortex?idea=idea-1"
     assert calls[4]["payload"]["teammate_user_ids"] == ["user-1"]
     assert calls[4]["payload"]["trigger_illo"] is True
     assert calls[6]["payload"]["context"] == {"topic": "roadmap"}

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -330,7 +330,8 @@ async def test_authenticated_source_traffic_marks_pending_connection_configured(
     assert token.last_used_at is not None
 
 
-async def test_webhook_and_mcp_context_share_inbound_event_path(session):
+async def test_webhook_and_mcp_context_share_inbound_event_path(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com/app")
     await _seed_connection(session)
 
     webhook_response = await _post_webhook(
@@ -374,7 +375,9 @@ async def test_webhook_and_mcp_context_share_inbound_event_path(session):
     assert mcp_payload["status"] == "processed"
     assert mcp_payload["matched_policy_id"] is None
     assert mcp_payload["thread_id"]
-    assert mcp_payload["url"] == f"/cortex?idea={mcp_payload['thread_id']}"
+    assert mcp_payload["thread_url"] == f"https://illo.example.com/cortex?idea={mcp_payload['thread_id']}"
+    assert mcp_payload["url"] == mcp_payload["thread_url"]
+    assert mcp_payload["thread_route"] == f"/cortex?idea={mcp_payload['thread_id']}"
     webhook_triage = await _assert_queued_triage(
         session,
         webhook_response.json()["ilo_outcome"],
@@ -431,7 +434,8 @@ async def test_malformed_mcp_json_fails_without_creating_event(session):
     assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 0
 
 
-async def test_mcp_context_ignores_signal_policy_and_creates_thread(session):
+async def test_mcp_context_ignores_signal_policy_and_creates_thread(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com")
     await _seed_connection(session)
     await inbound.create_source_policy(
         session,
@@ -471,7 +475,9 @@ async def test_mcp_context_ignores_signal_policy_and_creates_thread(session):
     assert response.status_code == 200
     assert body["status"] == "processed"
     assert body["thread_id"]
-    assert body["url"] == f"/cortex?idea={body['thread_id']}"
+    assert body["thread_url"] == f"https://illo.example.com/cortex?idea={body['thread_id']}"
+    assert body["url"] == body["thread_url"]
+    assert body["thread_route"] == f"/cortex?idea={body['thread_id']}"
     assert body["matched_policy_id"] is None
     assert body["error"] is None
     assert event.status == "processed"
@@ -819,7 +825,8 @@ async def test_idempotent_insert_integrity_error_returns_existing_replay(session
     assert await session.scalar(select(func.count()).select_from(InboundEventRow)) == 1
 
 
-async def test_context_envelope_creates_thread_submission_and_preview(session):
+async def test_context_envelope_creates_thread_submission_and_preview(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com")
     principal = await _seed_connection(session)
 
     result = await inbound.submit_inbound_envelope(
@@ -843,7 +850,9 @@ async def test_context_envelope_creates_thread_submission_and_preview(session):
     assert result["matched_policy_id"] is None
     assert result["ilo_outcome"]["operation"] == "created"
     thread_id = result["ilo_outcome"]["thread_id"]
-    assert result["ilo_outcome"]["url"] == f"/cortex?idea={thread_id}"
+    assert result["ilo_outcome"]["thread_url"] == f"https://illo.example.com/cortex?idea={thread_id}"
+    assert result["ilo_outcome"]["url"] == result["ilo_outcome"]["thread_url"]
+    assert result["ilo_outcome"]["thread_route"] == f"/cortex?idea={thread_id}"
 
     idea = await session.get(Idea, thread_id)
     assert idea is not None
@@ -856,6 +865,8 @@ async def test_context_envelope_creates_thread_submission_and_preview(session):
     assert submission.source["source_tool"] == "codex"
     assert submission.parts[0]["type"] == "conversation"
     assert submission.routing_result["thread_id"] == thread_id
+    assert submission.routing_result["thread_url"] == result["ilo_outcome"]["thread_url"]
+    assert submission.routing_result["thread_route"] == result["ilo_outcome"]["thread_route"]
 
     preview = (await session.scalars(select(IdeaThread).where(IdeaThread.idea_id == thread_id))).one()
     assert preview.message_type == "context_submission"
@@ -863,7 +874,8 @@ async def test_context_envelope_creates_thread_submission_and_preview(session):
     assert preview.metadata_["context_submission_id"] == str(submission.id)
 
 
-async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempotently(session):
+async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempotently(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com")
     principal = await _seed_connection(session)
     thread = Idea(
         id="77777777-7777-4777-8777-777777777777",
@@ -888,6 +900,16 @@ async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempo
             "idempotency_key": "codex:context:attach",
         },
     )
+    event = await session.get(InboundEventRow, first["event_id"])
+    assert event is not None
+    event.action_result = {
+        "operation": "attached",
+        "thread_id": str(thread.id),
+        "url": f"/cortex?idea={thread.id}",
+        "context_submission_id": first["ilo_outcome"]["context_submission_id"],
+        "message": first["ilo_outcome"]["message"],
+    }
+    await session.flush()
     replay = await inbound.submit_inbound_envelope(
         session,
         connection=principal,
@@ -903,7 +925,12 @@ async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempo
 
     assert first["ilo_outcome"]["operation"] == "attached"
     assert first["ilo_outcome"]["thread_id"] == str(thread.id)
+    assert first["ilo_outcome"]["thread_url"] == f"https://illo.example.com/cortex?idea={thread.id}"
+    assert first["ilo_outcome"]["url"] == first["ilo_outcome"]["thread_url"]
+    assert first["ilo_outcome"]["thread_route"] == f"/cortex?idea={thread.id}"
     assert replay["idempotent_replay"] is True
+    assert replay["ilo_outcome"]["thread_url"] == first["ilo_outcome"]["thread_url"]
+    assert replay["ilo_outcome"]["thread_route"] == first["ilo_outcome"]["thread_route"]
     assert await session.scalar(select(func.count()).select_from(ThreadContextSubmission)) == 1
 
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -84,6 +84,23 @@ def test_workspace_data_tool_is_read_only_agent_run_surface():
     assert "read_team_activity" in _get_tool_handlers()
 
 
+def test_thread_discussion_reply_tool_is_registered_and_exposed():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "post_thread_discussion_reply"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name in _names(WORKER_TOOLS)
+    assert name in _get_tool_handlers()
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert registration.permission == "write_chat"
+    assert registration.side_effect_class == "chat_message"
+    assert registration.reversibility == "append_only"
+
+
 def test_context_route_surface_is_registry_driven():
     from brain.systems.runs.tool_catalog.registry import context_route_payload, context_route_tool_names
 

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -181,6 +181,75 @@ async def test_cortex_agent_run_request_uses_shared_work_intake_policy(monkeypat
     assert request.metadata["priority"] == 3
 
 
+@pytest.mark.asyncio
+async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_comment(monkeypatch):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    class _Session:
+        async def get(self, _model, _idea_id):
+            return SimpleNamespace(
+                id="idea-1",
+                title="Launch",
+                org_id="org-1",
+                user_id="owner-1",
+                agent_details=None,
+            )
+
+        async def scalars(self, *_args, **_kwargs):
+            return SimpleNamespace(first=lambda: None)
+
+    async def fake_thread_context(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "brain.systems.runs.work_intake.async_build_agent_visible_thread_context",
+        fake_thread_context,
+    )
+
+    discussion_trigger = {
+        "surface": "thread_discussion",
+        "thread_id": "idea-1",
+        "comment_id": 7,
+        "body": "@illo this is what we decided, carry on",
+        "author_user_id": "user-1",
+        "response_target": {
+            "surface": "thread_discussion",
+            "thread_id": "idea-1",
+            "reply_to_comment_id": 7,
+        },
+    }
+
+    request = await build_agent_run_request(
+        _Session(),
+        WorkIntakeEvent(
+            source="cortex",
+            event_type="cortex.thread_reply",
+            org_id="org-1",
+            actor={"id": "user-1", "org_id": "org-1", "internal": False},
+            target={"kind": "cortex_idea", "idea_id": "idea-1"},
+            payload={
+                "message": "[Idea: \"Launch\" | idea-1]\n\n@illo this is what we decided, carry on",
+                "metadata": {
+                    "originating_surface": "thread_discussion",
+                    "triggering_surface": "thread_discussion",
+                    "discussion_trigger": discussion_trigger,
+                    "required_response_tool": "post_thread_discussion_reply",
+                    "final_answer_target_surface": "originating_surface",
+                },
+            },
+            policy={"priority": 0, "producer": "trigger", "run_event": "thread_reply"},
+        ),
+    )
+
+    assert request.thread_id == "idea-1"
+    assert request.target_ref["originating_surface"] == "thread_discussion"
+    assert request.target_ref["triggering_surface"] == "thread_discussion"
+    assert request.target_ref["discussion_trigger"] == discussion_trigger
+    assert request.metadata["discussion_trigger"] == discussion_trigger
+    assert request.metadata["required_response_tool"] == "post_thread_discussion_reply"
+    assert request.metadata["final_answer_target_surface"] == "originating_surface"
+
+
 def test_legacy_routing_logic_is_removed_from_adapters():
     files = {
         "brain/app/triggers/router.py": {

--- a/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
+++ b/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
@@ -382,7 +382,8 @@ TOOLS: dict[str, dict[str, Any]] = {
             "Submit ordered context from a personal agent to Illo, the user's team agent. "
             "Use this when the user wants Illo or the team to have the current AI thread, "
             "trace, artifacts, files, links, diffs, or other source material. The personal "
-            "agent supplies context and provenance; Illo coordinates the team workspace."
+            "agent supplies context and provenance; Illo coordinates the team workspace "
+            "and returns thread_url when routed to a Thread."
         ),
         "inputSchema": {
             "type": "object",


### PR DESCRIPTION
## Summary
- Split active fast-run transcript output into chronological segments so live Illo text appears where it was actually emitted relative to tool work.
- Suppress duplicate “writing response” status rows when real streamed assistant text is present.
- Add focused regressions for live-text ordering and run-stream segmentation.

## Testing
- `node --test src/lib/utils/threadRunChronology.test.js src/lib/utils/threadStreamOrdering.test.js src/lib/utils/cortexRunStream.test.js`
- `npm run check`
- `npm test`