### PR TITLE
Make Projects materialize folder roots

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -887,9 +887,10 @@ async def audit_apply(
         from brain.systems.memory.embeddings import embed_document
         from brain.systems.memory.scope import classify_scope
         from brain.systems.quality.gate import check_quality
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
         salience = float(payload.get("salience", 7.0))
-        qr = check_quality(content, salience=salience, memory_type=payload.get("memory_type", "lesson"))
+        qr = await check_quality(content, salience=salience, memory_type=payload.get("memory_type", "lesson"))
         if not qr.passed:
             raise HTTPException(status_code=422, detail=f"Memory rejected: {qr.reason}")
         if qr.adjusted_salience is not None:
@@ -903,8 +904,9 @@ async def audit_apply(
             confidence=payload.get("confidence"),
             evidence={"audit_action_payload": payload},
         )
-        semantic_embedding = embed_document(content)
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_embedding = embed_document(content, runtime_config=runtime_config)
             result = await uow.memories.insert_memory(
                 content=content,
                 memory_type=payload.get("memory_type", "lesson"),

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -20,6 +20,7 @@ from brain.systems.cortex.project_context.github import (
     async_search_repos,
     parse_github_repo_slug,
 )
+from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
 from brain.systems.cortex.project_context.access import (
     can_manage_project_profile,
@@ -311,6 +312,18 @@ def _validated_snapshot_or_422(project_context: dict[str, Any]) -> dict[str, Any
         raise HTTPException(status_code=422, detail={"validation_errors": exc.errors}) from exc
 
 
+def _profile_project_context(profile: ProjectProfile, project_context: dict[str, Any] | None = None) -> dict[str, Any]:
+    context = dict(project_context if isinstance(project_context, dict) else profile.project_context or {})
+    stamped = stamp_project_profile_identity(
+        context,
+        profile_id=profile.id,
+        slug=profile.slug,
+        name=profile.name,
+        description=profile.description,
+    )
+    return _validated_snapshot_or_422(stamped)
+
+
 def _resource_identity(resource: dict[str, Any]) -> str:
     value = resource.get("id")
     if isinstance(value, str) and value.strip():
@@ -342,7 +355,7 @@ def _project_resources(profile: ProjectProfile) -> list[dict[str, Any]]:
 def _replace_project_resources(profile: ProjectProfile, resources: list[dict[str, Any]]) -> None:
     context = dict(profile.project_context or {})
     context["resources"] = resources
-    profile.project_context = _validated_snapshot_or_422(context)
+    profile.project_context = _profile_project_context(profile, context)
 
 
 def _empty_project_change_summary() -> dict[str, Any]:
@@ -520,6 +533,7 @@ async def create_project_profile(
     )
     db.add(profile)
     await db.flush()
+    profile.project_context = _profile_project_context(profile, project_context)
     await _sync_project_access_list(
         db,
         profile,
@@ -571,7 +585,7 @@ async def update_project_profile(
     if "description" in fields:
         profile.description = body.description
     if "project_context" in fields and body.project_context is not None:
-        profile.project_context = _validated_snapshot_or_422(body.project_context)
+        profile.project_context = _profile_project_context(profile, _validated_snapshot_or_422(body.project_context))
     if "visibility" in fields and body.visibility is not None:
         profile.visibility = _request_visibility(body.visibility)
     if "default_environment_binding_id" in fields:
@@ -580,6 +594,7 @@ async def update_project_profile(
         profile.active = body.active
     if "metadata" in fields:
         profile.metadata_ = body.metadata or {}
+    profile.project_context = _profile_project_context(profile)
     db.add(profile)
     if "shared_usernames" in fields and body.shared_usernames is not None:
         await _sync_project_access_list(
@@ -865,7 +880,7 @@ async def attach_idea_project_context(
     if body.project_profile_id:
         org_id = _profile_org_id(user)
         profile = await _get_project_profile(db, body.project_profile_id, org_id, user)
-        project_context = dict(profile.project_context or {})
+        project_context = _profile_project_context(profile)
     if not project_context:
         raise HTTPException(status_code=422, detail="project_profile_id or project_context is required")
     snapshot = _validated_snapshot_or_422(project_context)

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -20,7 +20,7 @@ from brain.systems.cortex.project_context.github import (
     async_search_repos,
     parse_github_repo_slug,
 )
-from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
+from brain.systems.cortex.project_context.identity import stamped_project_context
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
 from brain.systems.cortex.project_context.access import (
     can_manage_project_profile,
@@ -313,15 +313,7 @@ def _validated_snapshot_or_422(project_context: dict[str, Any]) -> dict[str, Any
 
 
 def _profile_project_context(profile: ProjectProfile, project_context: dict[str, Any] | None = None) -> dict[str, Any]:
-    context = dict(project_context if isinstance(project_context, dict) else profile.project_context or {})
-    stamped = stamp_project_profile_identity(
-        context,
-        profile_id=profile.id,
-        slug=profile.slug,
-        name=profile.name,
-        description=profile.description,
-    )
-    return _validated_snapshot_or_422(stamped)
+    return _validated_snapshot_or_422(stamped_project_context(profile, project_context))
 
 
 def _resource_identity(resource: dict[str, Any]) -> str:

--- a/brain/app/hooks/brain_context.py
+++ b/brain/app/hooks/brain_context.py
@@ -40,6 +40,7 @@ async def async_get_context(
     from sqlalchemy import text
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
     from brain.systems.memory.embeddings import embed_query
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     user_id = user_id or os.environ.get("BRAIN_USER_ID")
     org_id = org_id or os.environ.get("BRAIN_ORG_ID")
@@ -52,10 +53,11 @@ async def async_get_context(
 
     # 1. Semantic search for relevant memories
     try:
-        query_emb = embed_query(message)
-        emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
-
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            query_emb = embed_query(message, runtime_config=runtime_config)
+            emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
+
             # Get top relevant memories (lessons and patterns weighted higher)
             memories_result = await _session_execute(uow.session, text("""
                 SELECT id, content, memory_type, salience,

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -238,8 +238,8 @@ async def async_tool_brain_recall(
     Without viewer context, recall intentionally returns no memories.
     """
     from brain.systems.memory.embeddings import embed_query
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
-    query_emb = embed_query(query)
     visibility_context = MemoryVisibilityContext(
         user_id=user_id,
         org_id=org_id,
@@ -249,6 +249,8 @@ async def async_tool_brain_recall(
 
     try:
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            query_emb = embed_query(query, runtime_config=runtime_config)
             results = await _maybe_await(uow.memories.graph_augmented_recall(
                 query_embedding=query_emb,
                 limit=limit,
@@ -404,7 +406,10 @@ async def async_tool_brain_guardrails(skill: str | None = None) -> dict:
         # High-salience warnings (lessons with salience >= 9)
         if skill:
             from brain.systems.memory.embeddings import embed_query
-            skill_emb = embed_query(skill)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            skill_emb = embed_query(skill, runtime_config=runtime_config)
             result["warnings"].extend(
                 await _maybe_await(uow.memories.high_salience_warnings_for_skill(skill_embedding=skill_emb))
             )
@@ -561,19 +566,22 @@ async def async_tool_brain_skills(task: str) -> dict:
         """), {"name": name})
         return result.mappings().first()
 
-    task_emb = None
-    emb_str = None
-    embedding_error = None
-    try:
-        task_emb = embed_query(task)
-        emb_str = vec_to_pg(task_emb)
-    except Exception as exc:
-        embedding_error = str(exc)[:300]
-        logger.warning("brain_skills running in degraded mode; embedding unavailable: %s", embedding_error)
-
     _SMALL_SKILLSET_THRESHOLD = 30  # below this, send ALL skills — model picks better than embeddings
 
     async with UnitOfWork() as uow:
+        task_emb = None
+        emb_str = None
+        embedding_error = None
+        try:
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            task_emb = embed_query(task, runtime_config=runtime_config)
+            emb_str = vec_to_pg(task_emb)
+        except Exception as exc:
+            embedding_error = str(exc)[:300]
+            logger.warning("brain_skills running in degraded mode; embedding unavailable: %s", embedding_error)
+
         # Count active skills to decide strategy
         count_result = await _session_execute(uow.session, text(
             "SELECT COUNT(*) as cnt FROM skills WHERE NOT archived"
@@ -961,6 +969,7 @@ async def async_tool_brain_encode(
 ) -> dict:
     """Encode a new memory into the brain, scoped to the current user."""
     from brain.systems.memory.embeddings import embed_document
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     if len(content.strip()) < 20:
         return {"error": "Content too short (min 20 chars)"}
@@ -990,17 +999,18 @@ async def async_tool_brain_encode(
     semantic_emb = None
     degraded_reason = None
 
-    try:
-        semantic_emb = embed_document(content)
-    except Exception as exc:
-        error_text = str(exc)
-        lower = error_text.lower()
-        if any(term in lower for term in ("out of memory", "oom", "cuda")):
-            degraded_reason = f"embedding_oom: {error_text[:200]}"
-        else:
-            degraded_reason = f"embedding_failed: {error_text[:200]}"
-
     async with UnitOfWork() as uow:
+        try:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(content, runtime_config=runtime_config)
+        except Exception as exc:
+            error_text = str(exc)
+            lower = error_text.lower()
+            if any(term in lower for term in ("out of memory", "oom", "cuda")):
+                degraded_reason = f"embedding_oom: {error_text[:200]}"
+            else:
+                degraded_reason = f"embedding_failed: {error_text[:200]}"
+
         result = await _maybe_await(uow.memories.insert_memory(
             content=content,
             memory_type=memory_type,

--- a/brain/jobs/pipelines/consolidate.py
+++ b/brain/jobs/pipelines/consolidate.py
@@ -163,7 +163,10 @@ async def import_daily_log(uow, filepath: str, log_date: date) -> int:
 
         dense = compress_text(title, body)
         memory_type, salience = classify_memory(title, body)
-        semantic_emb = embed_document(dense)
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        semantic_emb = embed_document(dense, runtime_config=runtime_config)
         tags = extract_tags(title + " " + body)
         tags.append(log_date.isoformat())
 
@@ -218,7 +221,10 @@ async def import_domain_file(uow, filepath: str) -> int:
             memory_type = 'fact'
             salience = max(salience, 5.0)
 
-        semantic_emb = embed_document(dense)
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        semantic_emb = embed_document(dense, runtime_config=runtime_config)
 
         tags = extract_tags(title + " " + body)
         tags.append(filename.replace('.md', ''))

--- a/brain/jobs/pipelines/divergence.py
+++ b/brain/jobs/pipelines/divergence.py
@@ -109,9 +109,12 @@ async def store_divergence_results(
     content = "\n".join(summary_lines)
 
     from brain.systems.memory.embeddings import embed_document, vec_to_pg
-    embedding = embed_document(content)
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     async with UnitOfWork() as uow:
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        embedding = embed_document(content, runtime_config=runtime_config)
+
         await uow.session.execute(text("""
             INSERT INTO memories (content, memory_type, semantic_embedding,
                 salience, tags, source, org_id, user_id, scope)

--- a/brain/systems/cognition/consolidate.py
+++ b/brain/systems/cognition/consolidate.py
@@ -407,7 +407,10 @@ async def extract_semantic(
         # Compute embedding for the new semantic memory
         try:
             from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            semantic_emb = embed_document(synthesized)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(synthesized, runtime_config=runtime_config)
             source_ref = f"cluster:{scoped.visibility}:{len(cluster_ids)}:{cluster_ids[0]}-{cluster_ids[-1]}"
             promotion_evidence = {
                 "source_memory_ids": cluster_ids,
@@ -567,7 +570,10 @@ async def crystallize_procedural(
 
         try:
             from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            semantic_emb = embed_document(procedure_text)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(procedure_text, runtime_config=runtime_config)
             source_ids = [s["id"] for s in semantics]
             max_sal = max(s["salience"] or 5 for s in semantics)
             source_ref = f"skill:{scoped.visibility}:{skill_name}"[:120]

--- a/brain/systems/cortex/project_context/draft_state.py
+++ b/brain/systems/cortex/project_context/draft_state.py
@@ -449,7 +449,9 @@ def project_draft_status_payload(
         repo_upstream_status=repo_upstream_status,
         allow_conflict_checkpoint_publish=allow_conflict_checkpoint_publish,
     )
-    if not resources:
+    snapshot_resources = snapshot.get("resources") if isinstance(snapshot.get("resources"), list) else []
+    manifest_mounts = manifest.get("mounts") if isinstance(manifest.get("mounts"), list) else []
+    if not resources and (snapshot_resources or manifest_mounts):
         return {
             "ok": False,
             "code": "project_draft_not_materialized",

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -27,6 +27,7 @@ def parse_github_repo_slug(value: str) -> str | None:
         return None
     slug = re.sub(r"^git@github\.com:", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"^https?://github\.com/", "", slug, flags=re.IGNORECASE)
+    slug = re.sub(r"^github://", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"^github\.com/", "", slug, flags=re.IGNORECASE)
     slug = re.sub(r"[?#].*$", "", slug).strip("/")
     parts = [part for part in slug.split("/") if part]

--- a/brain/systems/cortex/project_context/identity.py
+++ b/brain/systems/cortex/project_context/identity.py
@@ -1,0 +1,87 @@
+"""Stable Project identity helpers."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+PROJECT_IDENTITY_FIELDS = (
+    "project_key",
+    "profile_id",
+    "project_id",
+    "selected_profile_id",
+    "id",
+    "profile_slug",
+    "selected_profile_slug",
+    "slug",
+)
+
+
+def _clean_text(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def project_profile_context_identity(
+    *,
+    profile_id: Any,
+    slug: Any = None,
+    name: Any = None,
+    description: Any = None,
+) -> dict[str, str]:
+    """Return canonical identity fields for a persisted Project profile."""
+
+    profile_id_text = _clean_text(str(profile_id)) if profile_id is not None else None
+    slug_text = _clean_text(slug)
+    name_text = _clean_text(name)
+    description_text = _clean_text(description)
+    identity: dict[str, str] = {}
+    if profile_id_text:
+        identity.update({
+            "id": profile_id_text,
+            "project_id": profile_id_text,
+            "profile_id": profile_id_text,
+            "selected_profile_id": profile_id_text,
+            "project_key": profile_id_text,
+        })
+    if slug_text:
+        identity.update({
+            "slug": slug_text,
+            "profile_slug": slug_text,
+            "selected_profile_slug": slug_text,
+        })
+    if name_text:
+        identity["name"] = name_text
+    if description_text:
+        identity["description"] = description_text
+    return identity
+
+
+def stamp_project_profile_identity(
+    project_context: Mapping[str, Any] | None,
+    *,
+    profile_id: Any,
+    slug: Any = None,
+    name: Any = None,
+    description: Any = None,
+) -> dict[str, Any]:
+    """Stamp a Project profile context with its durable profile identity."""
+
+    context = dict(project_context or {})
+    context.update(
+        project_profile_context_identity(
+            profile_id=profile_id,
+            slug=slug,
+            name=name,
+            description=description,
+        )
+    )
+    return context
+
+
+__all__ = [
+    "PROJECT_IDENTITY_FIELDS",
+    "project_profile_context_identity",
+    "stamp_project_profile_identity",
+]

--- a/brain/systems/cortex/project_context/identity.py
+++ b/brain/systems/cortex/project_context/identity.py
@@ -7,12 +7,7 @@ from typing import Any
 
 PROJECT_IDENTITY_FIELDS = (
     "project_key",
-    "profile_id",
     "project_id",
-    "selected_profile_id",
-    "id",
-    "profile_slug",
-    "selected_profile_slug",
     "slug",
 )
 
@@ -23,34 +18,27 @@ def _clean_text(value: Any) -> str | None:
     return None
 
 
-def project_profile_context_identity(
+def project_context_identity(
     *,
-    profile_id: Any,
+    project_id: Any,
     slug: Any = None,
     name: Any = None,
     description: Any = None,
 ) -> dict[str, str]:
-    """Return canonical identity fields for a persisted Project profile."""
+    """Return canonical identity fields for a persisted Project."""
 
-    profile_id_text = _clean_text(str(profile_id)) if profile_id is not None else None
+    project_id_text = _clean_text(str(project_id)) if project_id is not None else None
     slug_text = _clean_text(slug)
     name_text = _clean_text(name)
     description_text = _clean_text(description)
     identity: dict[str, str] = {}
-    if profile_id_text:
+    if project_id_text:
         identity.update({
-            "id": profile_id_text,
-            "project_id": profile_id_text,
-            "profile_id": profile_id_text,
-            "selected_profile_id": profile_id_text,
-            "project_key": profile_id_text,
+            "project_id": project_id_text,
+            "project_key": project_id_text,
         })
     if slug_text:
-        identity.update({
-            "slug": slug_text,
-            "profile_slug": slug_text,
-            "selected_profile_slug": slug_text,
-        })
+        identity["slug"] = slug_text
     if name_text:
         identity["name"] = name_text
     if description_text:
@@ -58,20 +46,20 @@ def project_profile_context_identity(
     return identity
 
 
-def stamp_project_profile_identity(
+def stamp_project_identity(
     project_context: Mapping[str, Any] | None,
     *,
-    profile_id: Any,
+    project_id: Any,
     slug: Any = None,
     name: Any = None,
     description: Any = None,
 ) -> dict[str, Any]:
-    """Stamp a Project profile context with its durable profile identity."""
+    """Stamp a Project context with its durable Project identity."""
 
     context = dict(project_context or {})
     context.update(
-        project_profile_context_identity(
-            profile_id=profile_id,
+        project_context_identity(
+            project_id=project_id,
             slug=slug,
             name=name,
             description=description,
@@ -80,8 +68,28 @@ def stamp_project_profile_identity(
     return context
 
 
+def stamped_project_context(
+    project: Any,
+    project_context: Mapping[str, Any] | None = None,
+    *,
+    project_id: Any = None,
+) -> dict[str, Any]:
+    """Return a Project context stamped with its durable Project identity."""
+
+    source = project_context if isinstance(project_context, Mapping) else getattr(project, "project_context", None)
+    context = dict(source) if isinstance(source, Mapping) else {}
+    return stamp_project_identity(
+        context,
+        project_id=project_id if project_id is not None else getattr(project, "id", None),
+        slug=getattr(project, "slug", None),
+        name=getattr(project, "name", None),
+        description=getattr(project, "description", None),
+    )
+
+
 __all__ = [
     "PROJECT_IDENTITY_FIELDS",
-    "project_profile_context_identity",
-    "stamp_project_profile_identity",
+    "project_context_identity",
+    "stamp_project_identity",
+    "stamped_project_context",
 ]

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -17,6 +17,18 @@ from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.cortex.project_context.drafts import load_draft_metadata, sync_draft_from_root
 from brain.systems.cortex.project_context.permissions import derive_project_permission_scope
+from brain.systems.cortex.project_context.project_root import (
+    PROJECT_ROOT_MOUNT_PATH,
+    PROJECT_ROOT_RESOURCE_ID,
+    PROJECT_ROOT_RESOURCE_KIND,
+    ProjectRootImportCandidate,
+    directory_import_candidates,
+    import_candidates_into_project_root,
+    project_draft_root_path,
+    project_key_from_context,
+    project_root_path,
+    safe_project_relative_path,
+)
 from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
 from brain.systems.cortex.project_context.workspace_manifest import (
     ThreadDraftIdentity,
@@ -134,32 +146,14 @@ def _github_subpath_from_resource(resource: dict[str, Any]) -> str | None:
     return None
 
 
-def _resource_has_backend_path_hint(resource: dict[str, Any]) -> bool:
-    for key in ("path", "local_path", "storage_path"):
-        value = _clean_text(resource.get(key))
-        if value and Path(value).expanduser().is_absolute() and Path(value).expanduser().exists():
-            return True
-    return any(
-        Path(path).expanduser().is_absolute() and Path(path).expanduser().exists()
-        for path in [*_path_texts_from_uploaded_files(resource), *_path_texts_from_resource_scope(resource)]
-    )
-
-
 def project_context_has_materializable_resources(context: dict[str, Any] | None) -> bool:
     resources = context.get("resources") if isinstance(context, dict) else None
-    if not isinstance(resources, list):
-        return False
-    return any(
-        isinstance(resource, dict)
-        and (
-            bool(_github_slug_from_resource(resource))
-            or (
-                _resource_kind(resource) in _LOCAL_FIRST_RESOURCE_KINDS
-                and _resource_has_backend_path_hint(resource)
-            )
-        )
-        for resource in resources
-    )
+    if isinstance(resources, list):
+        return True
+    if isinstance(context, dict) and context.get("project_context_snapshot"):
+        snapshot = context.get("project_context_snapshot")
+        return isinstance(snapshot, dict) and isinstance(snapshot.get("resources"), list)
+    return False
 
 
 def _vault_key_from_resource(resource: dict[str, Any]) -> str | None:
@@ -564,6 +558,84 @@ def _path_texts_from_resource_scope(resource: dict[str, Any]) -> list[str]:
     return paths
 
 
+def _resource_id(resource: dict[str, Any]) -> str | None:
+    return _clean_text(resource.get("id") or resource.get("name") or resource.get("label"))
+
+
+def _is_project_root_resource(resource: dict[str, Any]) -> bool:
+    return (
+        _resource_kind(resource) == PROJECT_ROOT_RESOURCE_KIND
+        or _clean_text(resource.get("id")) == PROJECT_ROOT_RESOURCE_ID
+        or _clean_text(resource.get("mount_path")) == PROJECT_ROOT_MOUNT_PATH
+    )
+
+
+def _is_project_native_seed_resource(resource: dict[str, Any]) -> bool:
+    if _is_project_root_resource(resource) or _github_slug_from_resource(resource):
+        return False
+    return _resource_kind(resource) in _LOCAL_FIRST_RESOURCE_KINDS
+
+
+def _uploaded_file_import_candidates(
+    resource: dict[str, Any],
+    *,
+    workspace_root: Path,
+) -> list[ProjectRootImportCandidate]:
+    uploaded_files = resource.get("uploaded_files")
+    if not isinstance(uploaded_files, list):
+        return []
+
+    candidates: list[ProjectRootImportCandidate] = []
+    resource_id = _resource_id(resource)
+    for item in uploaded_files:
+        if not isinstance(item, dict):
+            continue
+        source = _should_use_existing_resource_path(
+            _clean_text(item.get("storage_path") or item.get("path") or item.get("local_path")),
+            workspace_root,
+        )
+        if not source or not source.is_file():
+            continue
+        relative_path = safe_project_relative_path(
+            item.get("relative_path") or item.get("filename") or item.get("name") or source.name,
+            fallback=source.name,
+        )
+        if relative_path:
+            candidates.append(ProjectRootImportCandidate(source, relative_path, resource_id=resource_id))
+    return candidates
+
+
+def _direct_path_import_candidates(
+    resource: dict[str, Any],
+    *,
+    workspace_root: Path,
+) -> list[ProjectRootImportCandidate]:
+    source, checked = _backend_readable_resource_path(resource, workspace_root=workspace_root)
+    if not source or not checked:
+        return []
+    resource_id = _resource_id(resource)
+    if source.is_file():
+        relative_path = safe_project_relative_path(
+            resource.get("relative_path") or resource.get("name") or resource.get("label") or source.name,
+            fallback=source.name,
+        )
+        return [ProjectRootImportCandidate(source, relative_path, resource_id=resource_id)] if relative_path else []
+    return directory_import_candidates(source, resource_id=resource_id)
+
+
+def _project_native_import_candidates(
+    resource: dict[str, Any],
+    *,
+    workspace_root: Path,
+) -> list[ProjectRootImportCandidate]:
+    if not _is_project_native_seed_resource(resource):
+        return []
+    uploaded = _uploaded_file_import_candidates(resource, workspace_root=workspace_root)
+    if uploaded:
+        return uploaded
+    return _direct_path_import_candidates(resource, workspace_root=workspace_root)
+
+
 def _common_runtime_workspace_path(paths: list[Path]) -> Path | None:
     if not paths:
         return None
@@ -597,6 +669,65 @@ def _backend_readable_resource_path(
     if common_path:
         return common_path, True
     return None, bool(path_texts)
+
+
+def _materialize_project_native_root(
+    project_context: dict[str, Any],
+    resources: list[dict[str, Any]],
+    *,
+    workspace_root: Path,
+    run_id: int | None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    project_key = project_key_from_context(
+        project_context,
+        resources=resources,
+        fallback=f"run-{run_id}" if run_id else None,
+    )
+    source_root = project_root_path(workspace_root, project_key)
+    source_root.mkdir(parents=True, exist_ok=True)
+
+    import_candidates: list[ProjectRootImportCandidate] = []
+    for resource in resources:
+        import_candidates.extend(_project_native_import_candidates(resource, workspace_root=workspace_root))
+    import_summary = import_candidates_into_project_root(source_root, import_candidates)
+
+    draft_root = project_draft_root_path(workspace_root, project_key)
+    had_base_manifest = bool(load_draft_metadata(draft_root).get("base_manifest"))
+    sync_result = sync_draft_from_root(source_root, draft_root)
+    draft_status = {
+        "updated_from_root": sync_result.copied,
+        "removed_from_root": sync_result.removed,
+        "conflicts": sync_result.conflicts,
+        "out_of_date": sync_result.out_of_date,
+    } if had_base_manifest else {}
+
+    materialization: dict[str, Any] = {
+        "status": "ready",
+        "provider": "project_native",
+        "kind": PROJECT_ROOT_RESOURCE_KIND,
+        "path": str(draft_root),
+        "workspace_path": str(draft_root),
+        "source_path": str(source_root),
+        "draft": True,
+        "project_key": project_key,
+    }
+    if any(import_summary.values()):
+        materialization["imports"] = import_summary
+    if draft_status and any(draft_status.values()):
+        materialization["draft_status"] = draft_status
+
+    resource = {
+        "id": PROJECT_ROOT_RESOURCE_ID,
+        "kind": PROJECT_ROOT_RESOURCE_KIND,
+        "name": "Project root",
+        "label": "Project root",
+        "mount_path": PROJECT_ROOT_MOUNT_PATH,
+        "path": str(draft_root),
+        "workspace_path": str(draft_root),
+        "source_path": str(source_root),
+        "materialization": materialization,
+    }
+    return resource, _workspace_entry_from_resource(resource, draft_root)
 
 
 def _materialize_backend_readable_resource(
@@ -854,12 +985,30 @@ async def materialize_project_context_workspaces(
         snapshot = dict(snapshot)
         resources = [dict(item) for item in snapshot.get("resources") or [] if isinstance(item, dict)]
         result.empty_project = not resources
-        snapshot["resources"] = resources
+        snapshot.setdefault(
+            "project_key",
+            project_key_from_context(snapshot, resources=resources, fallback=f"run-{run_id}"),
+        )
         user_id = user_id or (str(run.user_id) if getattr(run, "user_id", None) else None)
         org_id = org_id or _clean_text(getattr(run, "org_id", None)) or _clean_text(metadata.get("org_id"))
 
+    materialized_resources: list[dict[str, Any]] = []
     workspaces: list[dict[str, str]] = []
+    root_resource, root_workspace = _materialize_project_native_root(
+        snapshot,
+        resources,
+        workspace_root=root,
+        run_id=run_id,
+    )
+    materialized_resources.append(root_resource)
+    workspaces.append(root_workspace)
+    result.resources_checked += 1
+
     for resource in resources:
+        if _is_project_root_resource(resource):
+            continue
+        if _is_project_native_seed_resource(resource):
+            continue
         workspace, error = await _materialize_resource(
             resource,
             workspace_root=root,
@@ -869,13 +1018,13 @@ async def materialize_project_context_workspaces(
         )
         if workspace or error or isinstance(resource.get("materialization"), dict):
             result.resources_checked += 1
+            materialized_resources.append(resource)
         if workspace:
             workspaces.append(workspace)
         if error:
             result.errors.append(error)
 
-    if resources and not result.resources_checked:
-        return result.fail("Project Context resources do not include a supported repository or local workspace.")
+    snapshot["resources"] = materialized_resources
 
     workspace_manifest = normalize_project_workspace_manifest(
         snapshot,
@@ -912,18 +1061,14 @@ async def materialize_project_context_workspaces(
         current_workspace_payload["project_context_snapshot"] = snapshot
         current_workspace_payload["project_context_permission_scope"] = permission_scope
         current_workspace_payload["project_workspace_manifest"] = workspace_manifest_payload
-        current_workspace_payload["workspaces"] = (
-            [] if result.empty_project else _merge_workspaces(current_workspace_payload.get("workspaces"), workspaces)
-        )
+        current_workspace_payload["workspaces"] = _merge_workspaces(current_workspace_payload.get("workspaces"), workspaces)
         if workspaces:
             default_workspace = workspaces[0]["path"]
             current_workspace_payload["workspace_root"] = default_workspace
             current_workspace_payload["resolved_workspace_root"] = default_workspace
         current_workspace_payload["project_context_materialization"] = project_context_materialization
 
-        current_metadata["workspaces"] = (
-            [] if result.empty_project else _merge_workspaces(current_metadata.get("workspaces"), workspaces)
-        )
+        current_metadata["workspaces"] = _merge_workspaces(current_metadata.get("workspaces"), workspaces)
         current_metadata["project_workspace_manifest"] = workspace_manifest_payload
         current_metadata["project_context_materialization"] = project_context_materialization
         run.metadata_ = current_metadata

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -40,10 +40,11 @@ class ProjectContextMaterializationResult:
     workspaces: list[dict[str, str]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     resources_checked: int = 0
+    empty_project: bool = False
 
     @property
     def ok(self) -> bool:
-        return bool(self.workspaces) and not self.errors
+        return (bool(self.workspaces) or self.empty_project) and not self.errors
 
     def fail(self, message: str) -> "ProjectContextMaterializationResult":
         self.errors.append(message)
@@ -745,8 +746,7 @@ async def materialize_project_context_workspaces(
             return result.fail("Project Context snapshot is missing.")
         snapshot = dict(snapshot)
         resources = [dict(item) for item in snapshot.get("resources") or [] if isinstance(item, dict)]
-        if not resources:
-            return result.fail("Project Context has no resources to materialize.")
+        result.empty_project = not resources
         snapshot["resources"] = resources
         user_id = user_id or (str(run.user_id) if getattr(run, "user_id", None) else None)
         org_id = org_id or _clean_text(getattr(run, "org_id", None)) or _clean_text(metadata.get("org_id"))
@@ -767,7 +767,7 @@ async def materialize_project_context_workspaces(
         if error:
             result.errors.append(error)
 
-    if not result.resources_checked:
+    if resources and not result.resources_checked:
         return result.fail("Project Context resources do not include a supported repository or local workspace.")
 
     workspace_manifest = normalize_project_workspace_manifest(
@@ -778,6 +778,13 @@ async def materialize_project_context_workspaces(
     workspace_manifest_payload = workspace_manifest.to_dict()
     result.workspaces = workspaces
     status = "materialized" if not result.errors else "failed"
+    project_context_materialization = {
+        "status": status,
+        "workspaces": workspaces,
+        "workspace_manifest": workspace_manifest_payload,
+        "errors": result.errors[:10],
+        "empty_project": result.empty_project,
+    }
     snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
     if result.errors:
         existing_errors = snapshot.get("validation_errors") if isinstance(snapshot.get("validation_errors"), list) else []
@@ -798,26 +805,20 @@ async def materialize_project_context_workspaces(
         current_workspace_payload["project_context_snapshot"] = snapshot
         current_workspace_payload["project_context_permission_scope"] = permission_scope
         current_workspace_payload["project_workspace_manifest"] = workspace_manifest_payload
-        current_workspace_payload["workspaces"] = _merge_workspaces(current_workspace_payload.get("workspaces"), workspaces)
+        current_workspace_payload["workspaces"] = (
+            [] if result.empty_project else _merge_workspaces(current_workspace_payload.get("workspaces"), workspaces)
+        )
         if workspaces:
             default_workspace = workspaces[0]["path"]
             current_workspace_payload["workspace_root"] = default_workspace
             current_workspace_payload["resolved_workspace_root"] = default_workspace
-        current_workspace_payload["project_context_materialization"] = {
-            "status": status,
-            "workspaces": workspaces,
-            "workspace_manifest": workspace_manifest_payload,
-            "errors": result.errors[:10],
-        }
+        current_workspace_payload["project_context_materialization"] = project_context_materialization
 
-        current_metadata["workspaces"] = _merge_workspaces(current_metadata.get("workspaces"), workspaces)
+        current_metadata["workspaces"] = (
+            [] if result.empty_project else _merge_workspaces(current_metadata.get("workspaces"), workspaces)
+        )
         current_metadata["project_workspace_manifest"] = workspace_manifest_payload
-        current_metadata["project_context_materialization"] = {
-            "status": status,
-            "workspaces": workspaces,
-            "workspace_manifest": workspace_manifest_payload,
-            "errors": result.errors[:10],
-        }
+        current_metadata["project_context_materialization"] = project_context_materialization
         run.metadata_ = current_metadata
         _set_run_target_payload(run, current_target_payload)
         _set_run_workspace_payload(run, current_workspace_payload)

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import inspect
 import os
 import shutil
@@ -67,6 +67,7 @@ def _looks_like_github_remote(value: str) -> bool:
         lowered.startswith("git@github.com:")
         or lowered.startswith("https://github.com/")
         or lowered.startswith("http://github.com/")
+        or lowered.startswith("github://")
         or lowered.startswith("github.com/")
     )
 
@@ -100,6 +101,50 @@ def _github_slug_from_resource(resource: dict[str, Any]) -> str | None:
     return None
 
 
+def _normalise_repo_subpath(value: Any) -> str | None:
+    text = _clean_text(value)
+    if not text:
+        return None
+    path = PurePosixPath(text.replace("\\", "/"))
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return path.as_posix() or None
+
+
+def _github_uri_subpath(value: Any) -> str | None:
+    text = _clean_text(value)
+    if not text or not text.lower().startswith("github://"):
+        return None
+    body = text.split("://", 1)[1].split("?", 1)[0].split("#", 1)[0].strip("/")
+    parts = [part for part in body.split("/") if part]
+    if len(parts) <= 2:
+        return None
+    return _normalise_repo_subpath("/".join(parts[2:]))
+
+
+def _github_subpath_from_resource(resource: dict[str, Any]) -> str | None:
+    for key in ("subpath", "path_in_repo", "relative_path"):
+        subpath = _normalise_repo_subpath(resource.get(key))
+        if subpath:
+            return subpath
+    for key in ("uri", "url"):
+        subpath = _github_uri_subpath(resource.get(key))
+        if subpath:
+            return subpath
+    return None
+
+
+def _resource_has_backend_path_hint(resource: dict[str, Any]) -> bool:
+    for key in ("path", "local_path", "storage_path"):
+        value = _clean_text(resource.get(key))
+        if value and Path(value).expanduser().is_absolute() and Path(value).expanduser().exists():
+            return True
+    return any(
+        Path(path).expanduser().is_absolute() and Path(path).expanduser().exists()
+        for path in [*_path_texts_from_uploaded_files(resource), *_path_texts_from_resource_scope(resource)]
+    )
+
+
 def project_context_has_materializable_resources(context: dict[str, Any] | None) -> bool:
     resources = context.get("resources") if isinstance(context, dict) else None
     if not isinstance(resources, list):
@@ -107,8 +152,11 @@ def project_context_has_materializable_resources(context: dict[str, Any] | None)
     return any(
         isinstance(resource, dict)
         and (
-            _resource_kind(resource) in _LOCAL_FIRST_RESOURCE_KINDS
-            or _github_slug_from_resource(resource)
+            bool(_github_slug_from_resource(resource))
+            or (
+                _resource_kind(resource) in _LOCAL_FIRST_RESOURCE_KINDS
+                and _resource_has_backend_path_hint(resource)
+            )
         )
         for resource in resources
     )
@@ -374,6 +422,51 @@ def _workspace_entry_from_resource(resource: dict[str, Any], path: Path | str) -
     return {"name": _resource_workspace_name(resource, workspace_path), "path": str(workspace_path)}
 
 
+def _repo_workspace_path(resource: dict[str, Any], repo_path: Path) -> tuple[Path | None, str | None]:
+    subpath = _github_subpath_from_resource(resource)
+    if not subpath:
+        return repo_path, None
+    workspace_path = (repo_path / subpath).expanduser()
+    if not _path_is_relative_to(workspace_path, repo_path):
+        return None, f"GitHub Project subpath escapes repository root: {subpath}"
+    if not workspace_path.exists():
+        return None, f"GitHub Project subpath does not exist in {resource.get('repo') or repo_path.name}: {subpath}"
+    return workspace_path, subpath
+
+
+def _mark_github_materialized(
+    resource: dict[str, Any],
+    *,
+    slug: str,
+    repo_path: Path,
+    workspace_path: Path,
+    branch: str | None,
+    commit: str | None,
+    credential: str,
+    subpath: str | None = None,
+    reused: bool = False,
+) -> dict[str, str]:
+    resource["path"] = str(workspace_path)
+    resource["repo"] = slug
+    materialization = {
+        "status": "ready",
+        "provider": "github",
+        "repo": slug,
+        "branch": branch,
+        "commit": commit,
+        "credential": credential,
+    }
+    if subpath:
+        materialization["path"] = str(workspace_path)
+        materialization["workspace_path"] = str(workspace_path)
+        materialization["repo_path"] = str(repo_path)
+        materialization["subpath"] = subpath
+    if reused:
+        materialization["reused"] = True
+    resource["materialization"] = materialization
+    return _workspace_entry_from_resource(resource, workspace_path)
+
+
 def _draft_equivalent_path(value: Any, source_path: Path, draft_path: Path) -> str | None:
     text = _clean_text(value)
     if not text:
@@ -627,18 +720,28 @@ async def _materialize_resource(
     existing_checkout = _existing_git_checkout(destination, slug, branch)
     if existing_checkout:
         clone = existing_checkout
-        resource["path"] = clone["path"]
-        resource["repo"] = slug
-        resource["materialization"] = {
-            "status": "ready",
-            "provider": "github",
-            "repo": slug,
-            "branch": clone.get("branch") or branch,
-            "commit": clone.get("commit") or None,
-            "credential": "existing",
-            "reused": True,
-        }
-        return _workspace_entry_from_resource(resource, clone["path"]), None
+        repo_path = Path(clone["path"])
+        workspace_path, subpath = _repo_workspace_path(resource, repo_path)
+        if workspace_path is None:
+            message = subpath or f"Could not resolve GitHub Project workspace for {slug}."
+            resource["materialization"] = {
+                "status": "failed",
+                "provider": "github",
+                "repo": slug,
+                "error": message,
+            }
+            return None, message
+        return _mark_github_materialized(
+            resource,
+            slug=slug,
+            repo_path=repo_path,
+            workspace_path=workspace_path,
+            branch=clone.get("branch") or branch,
+            commit=clone.get("commit") or None,
+            credential="existing",
+            subpath=subpath,
+            reused=True,
+        ), None
     if destination.exists() and any(destination.iterdir()):
         message = (
             f"Project context destination {destination} already exists but is not a matching GitHub "
@@ -660,23 +763,27 @@ async def _materialize_resource(
             prefix = f"Vault key {key_name}: " if key_name else "public clone: "
             errors.append(prefix + _sanitize_git_error(str(exc)))
             continue
-        resource["path"] = clone["path"]
-        resource["repo"] = slug
-        resource["materialization"] = {
-            "status": "ready",
-            "provider": "github",
-            "repo": slug,
-            "branch": clone.get("branch") or branch,
-            "commit": clone.get("commit") or None,
-            "credential": "vault" if key_name else "public",
-        }
+        repo_path = Path(clone["path"])
+        workspace_path, subpath = _repo_workspace_path(resource, repo_path)
+        if workspace_path is None:
+            errors.append(subpath or f"Could not resolve GitHub Project workspace for {slug}.")
+            continue
         if key_name and "credential_ref" not in resource:
             resource["credential_ref"] = {
                 "type": "vault_secret",
                 "provider": "github",
                 "key_name": key_name,
             }
-        return _workspace_entry_from_resource(resource, clone["path"]), None
+        return _mark_github_materialized(
+            resource,
+            slug=slug,
+            repo_path=repo_path,
+            workspace_path=workspace_path,
+            branch=clone.get("branch") or branch,
+            commit=clone.get("commit") or None,
+            credential="vault" if key_name else "public",
+            subpath=subpath,
+        ), None
 
     resource["materialization"] = {
         "status": "failed",

--- a/brain/systems/cortex/project_context/permissions.py
+++ b/brain/systems/cortex/project_context/permissions.py
@@ -210,7 +210,7 @@ def attach_project_provenance(
     path = _clean_text(payload.get("path") or payload.get("relative_path") or payload.get("absolute_path"))
     provenance = dict(payload.get("provenance") or {}) if isinstance(payload.get("provenance"), Mapping) else {}
     project_ref = {
-        "project_context_id": snapshot.get("id"),
+        "project_context_id": snapshot.get("project_id") or snapshot.get("project_key"),
         "project_context_name": snapshot.get("name"),
         "project_context_status": snapshot.get("status"),
     }

--- a/brain/systems/cortex/project_context/profiles.py
+++ b/brain/systems/cortex/project_context/profiles.py
@@ -4,8 +4,20 @@ from __future__ import annotations
 from typing import Any
 
 from brain.systems.cortex.project_context.access import project_profile_visibility
+from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
 from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentRead, ProjectProfileRead
 from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
+
+
+def _profile_context_for_read(profile: ProjectProfile) -> dict[str, Any]:
+    context = profile.project_context if isinstance(profile.project_context, dict) else {}
+    return stamp_project_profile_identity(
+        context,
+        profile_id=profile.id,
+        slug=profile.slug,
+        name=profile.name,
+        description=profile.description,
+    )
 
 
 def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None = None) -> ProjectProfileRead:
@@ -16,7 +28,7 @@ def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None
         "slug": profile.slug,
         "name": profile.name,
         "description": profile.description,
-        "project_context": profile.project_context,
+        "project_context": _profile_context_for_read(profile),
         "visibility": project_profile_visibility(profile),
         "access": access or [],
         "default_environment_binding_id": profile.default_environment_binding_id,

--- a/brain/systems/cortex/project_context/profiles.py
+++ b/brain/systems/cortex/project_context/profiles.py
@@ -4,20 +4,13 @@ from __future__ import annotations
 from typing import Any
 
 from brain.systems.cortex.project_context.access import project_profile_visibility
-from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
+from brain.systems.cortex.project_context.identity import stamped_project_context
 from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentRead, ProjectProfileRead
 from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
 
 
 def _profile_context_for_read(profile: ProjectProfile) -> dict[str, Any]:
-    context = profile.project_context if isinstance(profile.project_context, dict) else {}
-    return stamp_project_profile_identity(
-        context,
-        profile_id=profile.id,
-        slug=profile.slug,
-        name=profile.name,
-        description=profile.description,
-    )
+    return stamped_project_context(profile)
 
 
 def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None = None) -> ProjectProfileRead:

--- a/brain/systems/cortex/project_context/project_root.py
+++ b/brain/systems/cortex/project_context/project_root.py
@@ -15,6 +15,7 @@ import json
 import shutil
 
 from brain.systems.cortex.project_context.drafts import PROJECT_HISTORY_DIR
+from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS
 from brain.systems.cortex.project_context.workspace_manifest import (
     PROJECT_CONTEXT_DIR,
     PROJECT_CONTEXT_LOCAL_DIR,
@@ -26,15 +27,7 @@ PROJECT_ROOT_RESOURCE_ID = "project-root"
 PROJECT_ROOT_RESOURCE_KIND = "project_root"
 PROJECT_ROOT_MOUNT_PATH = "/"
 PROJECT_ROOT_IMPORTS_FILE = "imports.json"
-PROJECT_KEY_FIELDS = (
-    "id",
-    "project_id",
-    "profile_id",
-    "selected_profile_id",
-    "slug",
-    "selected_profile_slug",
-    "project_key",
-)
+PROJECT_KEY_FIELDS = PROJECT_IDENTITY_FIELDS
 
 
 @dataclass(frozen=True)
@@ -252,4 +245,3 @@ def directory_import_candidates(
         if safe_relative:
             candidates.append(ProjectRootImportCandidate(path, safe_relative, resource_id=resource_id))
     return candidates
-

--- a/brain/systems/cortex/project_context/project_root.py
+++ b/brain/systems/cortex/project_context/project_root.py
@@ -1,0 +1,255 @@
+"""Project-native root storage helpers.
+
+A Project is always a folder-like root. Imported files, folders, and thread
+attachments seed that root once; thread drafts then work against the root by
+copy-on-write using the normal draft metadata.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+import hashlib
+import json
+import shutil
+
+from brain.systems.cortex.project_context.drafts import PROJECT_HISTORY_DIR
+from brain.systems.cortex.project_context.workspace_manifest import (
+    PROJECT_CONTEXT_DIR,
+    PROJECT_CONTEXT_LOCAL_DIR,
+)
+
+
+PROJECT_ROOTS_DIR = "project-roots"
+PROJECT_ROOT_RESOURCE_ID = "project-root"
+PROJECT_ROOT_RESOURCE_KIND = "project_root"
+PROJECT_ROOT_MOUNT_PATH = "/"
+PROJECT_ROOT_IMPORTS_FILE = "imports.json"
+PROJECT_KEY_FIELDS = (
+    "id",
+    "project_id",
+    "profile_id",
+    "selected_profile_id",
+    "slug",
+    "selected_profile_slug",
+    "project_key",
+)
+
+
+@dataclass(frozen=True)
+class ProjectRootImportCandidate:
+    source_path: Path
+    relative_path: str
+    resource_id: str | None = None
+
+    @property
+    def key(self) -> str:
+        raw = f"{self.resource_id or ''}:{self.source_path}:{self.relative_path}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _clean_text(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _safe_segment(value: Any, *, fallback: str) -> str:
+    text = _clean_text(value) or fallback
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in text.strip("/"))[:120]
+    return safe or fallback
+
+
+def _project_fingerprint(project_context: Mapping[str, Any], resources: Sequence[Mapping[str, Any]]) -> str:
+    payload = {
+        "name": project_context.get("name"),
+        "description": project_context.get("description"),
+        "resources": [
+            {
+                "id": resource.get("id"),
+                "kind": resource.get("kind") or resource.get("type") or resource.get("resource_type"),
+                "name": resource.get("name") or resource.get("label"),
+                "path": resource.get("path") or resource.get("local_path") or resource.get("storage_path"),
+                "uri": resource.get("uri") or resource.get("url") or resource.get("repo_url"),
+                "repo": resource.get("repo"),
+            }
+            for resource in resources
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def project_key_from_context(
+    project_context: Mapping[str, Any] | None,
+    *,
+    resources: Sequence[Mapping[str, Any]] | None = None,
+    fallback: str | None = None,
+) -> str:
+    context = project_context if isinstance(project_context, Mapping) else {}
+    resource_list = [resource for resource in (resources or []) if isinstance(resource, Mapping)]
+    for key in PROJECT_KEY_FIELDS:
+        value = _clean_text(context.get(key))
+        if value:
+            return _safe_segment(value, fallback="project")
+    for resource in resource_list:
+        value = _clean_text(resource.get("id"))
+        if value:
+            return _safe_segment(value, fallback="project")
+    value = _clean_text(context.get("name") or context.get("title"))
+    if value:
+        return _safe_segment(value, fallback="project")
+    if fallback:
+        return _safe_segment(fallback, fallback="project")
+    return f"project-{_project_fingerprint(context, resource_list)}"
+
+
+def project_roots_parent(thread_workspace_root: Path) -> Path:
+    root = Path(thread_workspace_root).expanduser()
+    parent = root.parent
+    if parent.name == "ideas":
+        return parent.parent / PROJECT_ROOTS_DIR
+    return parent / PROJECT_ROOTS_DIR
+
+
+def project_root_path(thread_workspace_root: Path, project_key: str) -> Path:
+    return project_roots_parent(thread_workspace_root) / _safe_segment(project_key, fallback="project")
+
+
+def project_draft_root_path(thread_workspace_root: Path, project_key: str) -> Path:
+    return (
+        Path(thread_workspace_root).expanduser()
+        / PROJECT_CONTEXT_DIR
+        / PROJECT_CONTEXT_LOCAL_DIR
+        / _safe_segment(project_key, fallback="project")
+        / PROJECT_ROOT_RESOURCE_ID
+    )
+
+
+def safe_project_relative_path(value: Any, *, fallback: str) -> str | None:
+    text = (_clean_text(value) or fallback).replace("\\", "/").strip("/")
+    if not text:
+        text = fallback
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    safe_parts = [_safe_segment(part, fallback="item") for part in path.parts]
+    return PurePosixPath(*safe_parts).as_posix()
+
+
+def _imports_path(project_root: Path) -> Path:
+    return Path(project_root) / PROJECT_HISTORY_DIR / PROJECT_ROOT_IMPORTS_FILE
+
+
+def load_project_root_imports(project_root: Path) -> dict[str, Any]:
+    path = _imports_path(project_root)
+    if not path.exists():
+        return {"schema_version": 1, "imports": {}}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "imports": {}}
+    if not isinstance(payload, dict):
+        return {"schema_version": 1, "imports": {}}
+    imports = payload.get("imports")
+    if not isinstance(imports, dict):
+        imports = {}
+    return {"schema_version": 1, "imports": dict(imports)}
+
+
+def save_project_root_imports(project_root: Path, metadata: Mapping[str, Any]) -> None:
+    payload = {
+        "schema_version": 1,
+        "imports": dict(metadata.get("imports") if isinstance(metadata.get("imports"), Mapping) else {}),
+    }
+    path = _imports_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _unique_relative_path(project_root: Path, relative_path: str) -> str:
+    candidate = PurePosixPath(relative_path)
+    stem = candidate.stem
+    suffix = candidate.suffix
+    parent = candidate.parent
+    index = 2
+    while (project_root / candidate.as_posix()).exists():
+        leaf = f"{stem}-{index}{suffix}" if stem else f"item-{index}{suffix}"
+        candidate = parent / leaf if parent.as_posix() != "." else PurePosixPath(leaf)
+        index += 1
+    return candidate.as_posix()
+
+
+def _copy_import_file(source_path: Path, target_path: Path) -> None:
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, target_path)
+
+
+def import_candidates_into_project_root(
+    project_root: Path,
+    candidates: Sequence[ProjectRootImportCandidate],
+) -> dict[str, Any]:
+    project_root = Path(project_root)
+    project_root.mkdir(parents=True, exist_ok=True)
+    metadata = load_project_root_imports(project_root)
+    imports = dict(metadata.get("imports") or {})
+    imported: list[dict[str, str]] = []
+    skipped: list[dict[str, str]] = []
+
+    for candidate in candidates:
+        source_path = Path(candidate.source_path).expanduser()
+        if not source_path.exists() or not source_path.is_file() or source_path.is_symlink():
+            continue
+        existing = imports.get(candidate.key)
+        if isinstance(existing, Mapping):
+            skipped.append({
+                "source_path": str(source_path),
+                "relative_path": str(existing.get("relative_path") or candidate.relative_path),
+            })
+            continue
+
+        relative_path = candidate.relative_path
+        target_path = project_root / relative_path
+        if target_path.exists() or target_path.is_symlink():
+            relative_path = _unique_relative_path(project_root, relative_path)
+            target_path = project_root / relative_path
+        _copy_import_file(source_path, target_path)
+        imports[candidate.key] = {
+            "source_path": str(source_path),
+            "relative_path": relative_path,
+            "resource_id": candidate.resource_id,
+        }
+        imported.append({"source_path": str(source_path), "relative_path": relative_path})
+
+    metadata["imports"] = imports
+    save_project_root_imports(project_root, metadata)
+    return {"imported": imported, "skipped": skipped}
+
+
+def directory_import_candidates(
+    source_root: Path,
+    *,
+    resource_id: str | None = None,
+    prefix: str | None = None,
+) -> list[ProjectRootImportCandidate]:
+    source_root = Path(source_root).expanduser()
+    if not source_root.exists() or not source_root.is_dir():
+        return []
+    candidates: list[ProjectRootImportCandidate] = []
+    for path in sorted(source_root.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        relative = path.relative_to(source_root).as_posix()
+        if any(part in {PROJECT_HISTORY_DIR, PROJECT_CONTEXT_DIR} for part in Path(relative).parts):
+            continue
+        if prefix:
+            relative = f"{prefix.strip('/')}/{relative}"
+        safe_relative = safe_project_relative_path(relative, fallback=path.name)
+        if safe_relative:
+            candidates.append(ProjectRootImportCandidate(path, safe_relative, resource_id=resource_id))
+    return candidates
+

--- a/brain/systems/cortex/project_context/publish.py
+++ b/brain/systems/cortex/project_context/publish.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 import shutil
 
@@ -86,10 +86,13 @@ def _current_publish_actor() -> tuple[str | None, str | None]:
 def _plan_path(base_path: str | None, relative_path: str) -> str | None:
     if not base_path:
         return None
+    normalised = PurePosixPath(str(relative_path or "").replace("\\", "/"))
+    if normalised.is_absolute() or any(part in {"", ".", ".."} for part in normalised.parts):
+        return None
     base = Path(base_path).expanduser()
     if base.exists() and base.is_file():
-        return str(base)
-    return str(base / relative_path)
+        return str(base) if normalised.as_posix() == base.name else None
+    return str(base / normalised.as_posix())
 
 
 def _publish_target(resource: Mapping[str, Any]) -> dict[str, Any]:
@@ -114,7 +117,7 @@ def _publish_operations(resource: Mapping[str, Any]) -> list[dict[str, Any]]:
             operations.append({
                 "operation": operation,
                 "path": path,
-                "draft_path": _plan_path(resource.get("resource_path") or resource.get("workspace_path"), path),
+                "draft_path": _plan_path(resource.get("workspace_path") or resource.get("resource_path"), path),
                 "target_path": _plan_path(resource.get("source_path"), path),
             })
     return operations
@@ -143,6 +146,17 @@ def _publish_blocked_reasons(group: Mapping[str, Any], operations: list[dict[str
         blocked_reasons.append("conflicted_paths_require_resolution")
     if operations and _as_mapping(group.get("publish_target")).get("kind") == "unknown":
         blocked_reasons.append("publish_target_unavailable")
+    publish_target = _as_mapping(group.get("publish_target"))
+    if publish_target.get("kind") == "local_path" and any(
+        operation.get("operation") in {"create", "update", "delete"}
+        and not operation.get("target_path")
+        for operation in operations
+    ):
+        target_path = _clean_text(publish_target.get("path"))
+        if target_path and Path(target_path).expanduser().is_file():
+            blocked_reasons.append("file_project_root_cannot_publish_additional_paths")
+        else:
+            blocked_reasons.append("publish_operation_path_unavailable")
     return blocked_reasons
 
 

--- a/brain/systems/cortex/project_context/publish.py
+++ b/brain/systems/cortex/project_context/publish.py
@@ -91,7 +91,9 @@ def _plan_path(base_path: str | None, relative_path: str) -> str | None:
         return None
     base = Path(base_path).expanduser()
     if base.exists() and base.is_file():
-        return str(base) if normalised.as_posix() == base.name else None
+        if normalised.as_posix() == base.name:
+            return str(base)
+        return str(base.parent / normalised.as_posix())
     return str(base / normalised.as_posix())
 
 
@@ -152,11 +154,7 @@ def _publish_blocked_reasons(group: Mapping[str, Any], operations: list[dict[str
         and not operation.get("target_path")
         for operation in operations
     ):
-        target_path = _clean_text(publish_target.get("path"))
-        if target_path and Path(target_path).expanduser().is_file():
-            blocked_reasons.append("file_project_root_cannot_publish_additional_paths")
-        else:
-            blocked_reasons.append("publish_operation_path_unavailable")
+        blocked_reasons.append("publish_operation_path_unavailable")
     return blocked_reasons
 
 
@@ -347,6 +345,11 @@ def _delete_publish_path(target_path: str | None) -> None:
         target.unlink()
 
 
+def _local_publish_root(source_path: str) -> Path:
+    source = Path(source_path).expanduser()
+    return source.parent if source.exists() and source.is_file() else source
+
+
 def _version_metadata(
     group: Mapping[str, Any],
     *,
@@ -429,8 +432,9 @@ def _publish_local_group(
 
     applied: list[dict[str, Any]] = []
     operations = [dict(operation) for operation in group.get("operations") or [] if isinstance(operation, Mapping)]
+    source_root = _local_publish_root(source_path)
     before_version = capture_project_root_version(
-        Path(source_path).expanduser(),
+        source_root,
         label="before-draft-publish",
         metadata=_version_metadata(
             group,
@@ -457,11 +461,11 @@ def _publish_local_group(
     except Exception as exc:
         rollback_errors: list[str] = []
         try:
-            restore_project_root_version(Path(source_path).expanduser(), before_version.version_id)
+            restore_project_root_version(source_root, before_version.version_id)
             if sync_after_publish:
-                sync_draft_from_root(Path(source_path).expanduser(), Path(workspace_path).expanduser())
+                sync_draft_from_root(source_root, Path(workspace_path).expanduser())
             else:
-                _refresh_published_draft_paths(source_path, workspace_path, applied)
+                _refresh_published_draft_paths(str(source_root), workspace_path, applied)
         except Exception as rollback_exc:
             rollback_errors.append(str(rollback_exc))
         blocked_reasons = ["publish_failed_rolled_back"] if not rollback_errors else ["publish_failed_rollback_failed"]
@@ -480,7 +484,7 @@ def _publish_local_group(
         }
 
     after_version = capture_project_root_version(
-        Path(source_path).expanduser(),
+        source_root,
         label="after-draft-publish",
         metadata=_version_metadata(
             group,
@@ -493,9 +497,9 @@ def _publish_local_group(
         ),
     )
     if sync_after_publish:
-        sync_draft_from_root(Path(source_path).expanduser(), Path(workspace_path).expanduser())
+        sync_draft_from_root(source_root, Path(workspace_path).expanduser())
     else:
-        _refresh_published_draft_paths(source_path, workspace_path, applied)
+        _refresh_published_draft_paths(str(source_root), workspace_path, applied)
     return {
         "resource_id": group.get("resource_id"),
         "mount_path": group.get("mount_path"),

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -152,8 +152,6 @@ def validate_project_context_snapshot(
     resources = snapshot.get("resources")
     if not isinstance(resources, list):
         return "invalid", ["project_context_snapshot.resources must be a list."]
-    if not resources:
-        return "invalid", ["project_context_snapshot.resources must contain at least one resource."]
 
     errors: list[str] = []
     seen_ids: set[str] = set()

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -257,14 +257,9 @@ def build_project_context_snapshot(
             "resources": resources,
         }
         for key in (
-            "id",
-            "project_id",
-            "profile_id",
-            "selected_profile_id",
             "project_key",
             "slug",
-            "profile_slug",
-            "selected_profile_slug",
+            "project_id",
             "name",
             "description",
             "permissions",

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -256,7 +256,20 @@ def build_project_context_snapshot(
             "source": "metadata.project_context" if "project_context" in metadata else "metadata.project",
             "resources": resources,
         }
-        for key in ("id", "name", "description", "permissions", "mode"):
+        for key in (
+            "id",
+            "project_id",
+            "profile_id",
+            "selected_profile_id",
+            "project_key",
+            "slug",
+            "profile_slug",
+            "selected_profile_slug",
+            "name",
+            "description",
+            "permissions",
+            "mode",
+        ):
             value = project.get(key)
             if value is not None:
                 snapshot[key] = value

--- a/brain/systems/cortex/project_context/workspace_manifest.py
+++ b/brain/systems/cortex/project_context/workspace_manifest.py
@@ -414,7 +414,7 @@ class ProjectWorkspaceManifest:
         return cls(
             mounts=mounts,
             project_key=_project_key_from_context(snapshot),
-            project_id=_clean_text(snapshot.get("id") or snapshot.get("project_id") or snapshot.get("profile_id")),
+            project_id=_clean_text(snapshot.get("project_id")),
             workspace_root=workspace_root,
         )
 
@@ -600,7 +600,7 @@ def build_project_workspace_manifest_contract(project_context: Mapping[str, Any]
     return {
         "schema_version": 1,
         "project_key": _project_key_from_context(snapshot),
-        "project_id": _clean_text(snapshot.get("id") or snapshot.get("project_id") or snapshot.get("profile_id")),
+        "project_id": _clean_text(snapshot.get("project_id")),
         "mounts": mounts,
     }
 

--- a/brain/systems/cortex/project_context/workspace_manifest.py
+++ b/brain/systems/cortex/project_context/workspace_manifest.py
@@ -18,7 +18,15 @@ from brain.systems.cortex.project_context.resources import ProjectResource
 
 PROJECT_CONTEXT_DIR = ".illo-project-context"
 PROJECT_CONTEXT_LOCAL_DIR = "local"
-PROJECT_KEY_FIELDS = ("id", "project_id", "profile_id", "selected_profile_id", "slug", "selected_profile_slug")
+PROJECT_KEY_FIELDS = (
+    "id",
+    "project_id",
+    "profile_id",
+    "selected_profile_id",
+    "slug",
+    "selected_profile_slug",
+    "project_key",
+)
 FILE_RESOURCE_KINDS = {"file", "doc", "document"}
 ProjectResourceLike = Mapping[str, Any] | ProjectResource
 

--- a/brain/systems/cortex/project_context/workspace_manifest.py
+++ b/brain/systems/cortex/project_context/workspace_manifest.py
@@ -13,20 +13,13 @@ from pathlib import Path
 from typing import Any
 import posixpath
 
+from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS
 from brain.systems.cortex.project_context.resources import ProjectResource
 
 
 PROJECT_CONTEXT_DIR = ".illo-project-context"
 PROJECT_CONTEXT_LOCAL_DIR = "local"
-PROJECT_KEY_FIELDS = (
-    "id",
-    "project_id",
-    "profile_id",
-    "selected_profile_id",
-    "slug",
-    "selected_profile_slug",
-    "project_key",
-)
+PROJECT_KEY_FIELDS = PROJECT_IDENTITY_FIELDS
 FILE_RESOURCE_KINDS = {"file", "doc", "document"}
 ProjectResourceLike = Mapping[str, Any] | ProjectResource
 

--- a/brain/systems/cortex/thread_context.py
+++ b/brain/systems/cortex/thread_context.py
@@ -227,22 +227,23 @@ def _format_entries(
     *,
     char_limit: int,
 ) -> tuple[str, list[ThreadContextEntry]]:
-    lines: list[str] = []
-    kept: list[ThreadContextEntry] = []
+    selected: list[tuple[str, ThreadContextEntry]] = []
     used = 0
-    for entry in entries:
+    for entry in reversed(entries):
         label = "User" if entry.role == "user" else "Illo"
         content = _truncate(entry.content, MAX_ENTRY_CHARS)
         line = f"{label}: {content}"
-        next_used = used + len(line) + (1 if lines else 0)
-        if lines and next_used > char_limit:
+        next_used = used + len(line) + (1 if selected else 0)
+        if selected and next_used > char_limit:
             continue
-        if not lines and len(line) > char_limit:
+        if not selected and len(line) > char_limit:
             line = _truncate(line, char_limit)
             next_used = len(line)
-        lines.append(line)
-        kept.append(entry)
+        selected.append((line, entry))
         used = next_used
+    selected.reverse()
+    lines = [line for line, _entry in selected]
+    kept = [entry for _line, entry in selected]
     return "\n".join(lines).strip(), kept
 
 

--- a/brain/systems/quality/checks.py
+++ b/brain/systems/quality/checks.py
@@ -25,6 +25,7 @@ from brain.platform.db.repositories.memory_visibility import (
 )
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.memory.embeddings import embed_document, vec_to_pg
+from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,6 @@ async def check_duplicate(
 
     Returns (is_duplicate, details) where details includes the similar memory if found.
     """
-    if embedding is None:
-        embedding = embed_document(content)
-
-    emb_str = vec_to_pg(embedding)
     visibility_context = MemoryVisibilityContext(
         user_id=user_id,
         org_id=org_id,
@@ -99,6 +96,11 @@ async def check_duplicate(
     vis_clause, vis_params = memory_visibility_sql(visibility_context, alias="")
 
     async with UnitOfWork() as uow:
+        if embedding is None:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            embedding = embed_document(content, runtime_config=runtime_config)
+
+        emb_str = vec_to_pg(embedding)
         row = (await uow.session.execute(text("""
             SELECT id, content,
                    1 - (semantic_embedding <=> CAST(:emb AS vector)) as similarity

--- a/brain/systems/quality/gate.py
+++ b/brain/systems/quality/gate.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.memory.embeddings import embed_document, vec_to_pg
+from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +81,10 @@ async def check_quality(
 async def _check_near_duplicate(content: str, threshold: float = 0.90) -> dict | None:
     """Check if content is a near-duplicate of an existing memory."""
     try:
-        emb = embed_document(content)
-        emb_str = vec_to_pg(emb)
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            emb = embed_document(content, runtime_config=runtime_config)
+            emb_str = vec_to_pg(emb)
             row = (await uow.session.execute(text("""
                 SELECT id, content, 1 - (semantic_embedding <=> CAST(:emb AS vector)) as similarity
                 FROM memories

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 import json
 from pathlib import PurePath
+import re
 from typing import Any
 import zipfile
 
@@ -117,6 +118,18 @@ TRACE_MAX_CYCLE_RUNS = 200
 TRACE_MAX_STRING_CHARS = 4000
 TRACE_MAX_COLLECTION_ITEMS = 80
 TRACE_MAX_DEPTH = 6
+TRACE_REDACTED_VALUE = "[redacted]"
+TRACE_REDACTED_SECRET = "[secret redacted]"
+TRACE_SECRET_KEY_RE = re.compile(
+    r"(^|[_.-])(api[_.-]?key|authorization|credential|credentials|password|private[_.-]?key|secret|token)([_.-]|$)",
+    re.IGNORECASE,
+)
+TRACE_SECRET_VALUE_PATTERNS = [
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"gh[opusr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9][A-Za-z0-9_-]{20,}"),
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{20,}"),
+]
 
 
 async def build_agent_trace_snapshot_async(
@@ -214,6 +227,7 @@ def _agent_trace_snapshot_payload(
         "cycles": cycle_state,
         "diagnostics": diagnostics,
     }
+    bundle = _redact_trace_secrets(bundle)
     bundle["storage_estimate"] = {
         "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
         "truncated": _contains_truncation(bundle),
@@ -323,6 +337,7 @@ def _thread_trace_snapshot_payload(
         "cycles": cycle_state,
         "diagnostics": diagnostics,
     }
+    bundle = _redact_trace_secrets(bundle)
     bundle["storage_estimate"] = {
         "json_bytes": len(json.dumps(_jsonable(bundle), sort_keys=True, default=str).encode("utf-8")),
         "truncated": _contains_truncation(bundle),
@@ -335,7 +350,7 @@ def build_agent_trace_export_zip(
 ) -> bytes:
     """Package a trace snapshot as a small shareable zip."""
 
-    trace = _jsonable(snapshot)
+    trace = _redact_trace_secrets(_jsonable(snapshot))
     run = trace.get("run") if isinstance(trace.get("run"), dict) else {}
     thread = trace.get("thread") if isinstance(trace.get("thread"), dict) else {}
     is_thread_export = trace.get("export_scope") == "thread"
@@ -1131,6 +1146,28 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     return str(value)
+
+
+def _redact_trace_secrets(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if TRACE_SECRET_KEY_RE.search(key_text):
+                redacted[key_text] = TRACE_REDACTED_VALUE
+            else:
+                redacted[key_text] = _redact_trace_secrets(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_trace_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_trace_secrets(item) for item in value]
+    if isinstance(value, str):
+        text = value
+        for pattern in TRACE_SECRET_VALUE_PATTERNS:
+            text = pattern.sub(TRACE_REDACTED_SECRET, text)
+        return text
+    return value
 
 
 def _safe_filename_part(value: Any) -> str:

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import pathlib
 import re as _re
 import shlex as _shlex
 
+from brain.systems.cortex.project_context.drafts import IGNORED_DRAFT_DIRS
 from brain.systems.cortex.project_context.workspace_manifest import (
     ProjectWorkspaceManifest,
     normalize_project_workspace_manifest,
@@ -21,6 +23,15 @@ from brain.platform.async_io import run_subprocess_sync
 
 def _path_is_within(path: str, root: str) -> bool:
     return path == root or path.startswith(root + os.sep)
+
+
+def _is_project_internal_relative_path(path: pathlib.Path) -> bool:
+    return any(part in IGNORED_DRAFT_DIRS for part in path.parts)
+
+
+def _block_project_internal_path(path: str) -> None:
+    if any(part in IGNORED_DRAFT_DIRS for part in pathlib.Path(path).parts):
+        raise ValueError("Project draft metadata is internal and is not accessible through file tools.")
 
 
 def _context_mapping(value: object) -> Mapping[str, object]:
@@ -251,6 +262,7 @@ def _resolve_path(path: str, working_dir: str | None = None, *, for_write: bool 
     project_resolution = _project_mount_resolution(path)
     if project_resolution is not None:
         resolved, _mount = project_resolution
+        _block_project_internal_path(resolved)
         if for_write:
             _block_project_source_write(resolved)
         return resolved
@@ -262,6 +274,7 @@ def _resolve_path(path: str, working_dir: str | None = None, *, for_write: bool 
 
     if for_write:
         _block_project_source_write(resolved)
+    _block_project_internal_path(resolved)
 
     # Path containment: must stay within workspace
     if not _path_is_within(resolved, base):
@@ -743,7 +756,16 @@ def _handle_search_files(pattern: str, path: str | None = None, glob: str | None
             result,
         )
         return result
-    cmd = ["grep", "-rn", "--include", glob or "*", "-E", pattern, search_path]
+    cmd = [
+        "grep",
+        "-rn",
+        *[f"--exclude-dir={name}" for name in sorted(IGNORED_DRAFT_DIRS)],
+        "--include",
+        glob or "*",
+        "-E",
+        pattern,
+        search_path,
+    ]
 
     try:
         proc = run_subprocess_sync(
@@ -782,7 +804,6 @@ def _handle_search_files(pattern: str, path: str | None = None, glob: str | None
 
 def _handle_list_files(pattern: str, path: str | None = None, _workspace: str | None = None) -> dict:
     """List files matching a glob pattern."""
-    import pathlib
 
     try:
         base = pathlib.Path(_resolve_path(path, _workspace) if path else (_workspace or _patched_workspace_root()))
@@ -796,7 +817,11 @@ def _handle_list_files(pattern: str, path: str | None = None, _workspace: str | 
         return result
 
     try:
-        matches = sorted(base.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+        matches = [
+            match
+            for match in sorted(base.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+            if not _is_project_internal_relative_path(match.relative_to(base))
+        ]
         # Limit results
         paths = [str(m.relative_to(base)) for m in matches[:100]]
         total = len(matches)

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -139,18 +139,9 @@ def _validated_project_context(project_context: dict[str, Any]) -> dict[str, Any
 
 
 def _profile_project_context(profile, project_context: dict[str, Any] | None = None) -> dict[str, Any]:
-    from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
+    from brain.systems.cortex.project_context.identity import stamped_project_context
 
-    context = dict(project_context if isinstance(project_context, dict) else profile.project_context or {})
-    return _validated_project_context(
-        stamp_project_profile_identity(
-            context,
-            profile_id=profile.id,
-            slug=profile.slug,
-            name=profile.name,
-            description=profile.description,
-        )
-    )
+    return _validated_project_context(stamped_project_context(profile, project_context))
 
 
 def _context_from_inputs(
@@ -217,7 +208,6 @@ async def _handle_manage_project(
     action: str,
     operation: str | None = None,
     project_id: str | None = None,
-    profile_id: str | None = None,
     slug: str | None = None,
     name: str | None = None,
     description: str | None = None,
@@ -313,7 +303,7 @@ async def _handle_manage_project(
         "role": "owner",
         "principal_type": "human",
     }
-    selected_profile_id = profile_id or project_id
+    selected_project_id = project_id
 
     try:
         async with UnitOfWork() as uow:
@@ -323,9 +313,9 @@ async def _handle_manage_project(
                 return json.dumps({"projects": [_profile_read(profile) for profile in profiles]}, default=str)
 
             if action == "get":
-                if not selected_profile_id:
+                if not selected_project_id:
                     return json.dumps({"error": "get requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=include_inactive)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=include_inactive)
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "create":
@@ -362,9 +352,9 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "update":
-                if not selected_profile_id:
+                if not selected_project_id:
                     return json.dumps({"error": "update requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 if slug and slug != profile.slug:
                     existing = await uow.session.scalar(
@@ -407,9 +397,9 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action in {"archive", "delete"}:
-                if not selected_profile_id:
+                if not selected_project_id:
                     return json.dumps({"error": f"{action} requires: project_id"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 profile.active = False
                 uow.session.add(profile)
@@ -417,12 +407,12 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile), "archived": True}, default=str)
 
             if action == "add_resource":
-                if not selected_profile_id:
+                if not selected_project_id:
                     return json.dumps({"error": "add_resource requires: project_id"})
                 incoming = resources or ([resource] if isinstance(resource, dict) else [])
                 if not incoming:
                     return json.dumps({"error": "add_resource requires: resource or resources"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 existing_ids = {str(item.get("id")) for item in current if item.get("id")}
@@ -436,9 +426,9 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "update_resource":
-                if not selected_profile_id or not resource_id or not isinstance(resource, dict):
+                if not selected_project_id or not resource_id or not isinstance(resource, dict):
                     return json.dumps({"error": "update_resource requires: project_id, resource_id, resource"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 for index, existing in enumerate(current):
@@ -455,9 +445,9 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "remove_resource":
-                if not selected_profile_id or not resource_id:
+                if not selected_project_id or not resource_id:
                     return json.dumps({"error": "remove_resource requires: project_id, resource_id"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 next_resources = [item for item in current if not _resource_matches(item, resource_id)]
@@ -469,9 +459,9 @@ async def _handle_manage_project(
                 return json.dumps({"project": _profile_read(profile)}, default=str)
 
             if action == "reorder_resources":
-                if not selected_profile_id or not resource_ids:
+                if not selected_project_id or not resource_ids:
                     return json.dumps({"error": "reorder_resources requires: project_id, resource_ids"})
-                profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id, include_inactive=True)
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=True)
                 _require_manage_access(profile, actor)
                 current = _project_resources(profile)
                 by_id = {str(item.get("id")): item for item in current if item.get("id")}
@@ -490,8 +480,8 @@ async def _handle_manage_project(
                 await require_idea_for_project_actor(uow.session, target_idea_id, actor)
                 profile = None
                 context = project_context
-                if selected_profile_id:
-                    profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id)
+                if selected_project_id:
+                    profile = await _get_profile(uow.session, org_id, user_id, selected_project_id)
                     context = _profile_project_context(profile)
                 if not context:
                     return json.dumps({"error": "attach_to_thread requires: project_id or project_context"})
@@ -501,7 +491,7 @@ async def _handle_manage_project(
                     return json.dumps({"error": "Invalid project context", "validation_errors": exc.errors})
                 attachment = IdeaProjectAttachment(
                     idea_id=target_idea_id,
-                    project_profile_id=profile.id if profile else selected_profile_id,
+                    project_profile_id=profile.id if profile else selected_project_id,
                     attached_by=user_id,
                     snapshot=snapshot,
                     permission_scope=snapshot.get("permission_scope") or {},

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -138,6 +138,21 @@ def _validated_project_context(project_context: dict[str, Any]) -> dict[str, Any
         raise ValueError(str(exc)) from exc
 
 
+def _profile_project_context(profile, project_context: dict[str, Any] | None = None) -> dict[str, Any]:
+    from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
+
+    context = dict(project_context if isinstance(project_context, dict) else profile.project_context or {})
+    return _validated_project_context(
+        stamp_project_profile_identity(
+            context,
+            profile_id=profile.id,
+            slug=profile.slug,
+            name=profile.name,
+            description=profile.description,
+        )
+    )
+
+
 def _context_from_inputs(
     *,
     project_context: dict[str, Any] | None = None,
@@ -173,7 +188,7 @@ def _project_resources(profile) -> list[dict[str, Any]]:
 def _store_resources(profile, resources: list[dict[str, Any]]) -> None:
     context = dict(profile.project_context or {})
     context["resources"] = resources
-    profile.project_context = _validated_project_context(context)
+    profile.project_context = _profile_project_context(profile, context)
 
 
 def _unique_resource_id(resource: dict[str, Any], existing_ids: set[str], index: int) -> str:
@@ -335,6 +350,7 @@ async def _handle_manage_project(
                 )
                 uow.session.add(profile)
                 await uow.session.flush()
+                profile.project_context = _profile_project_context(profile, context)
                 await sync_project_access_list(
                     uow.session,
                     profile,
@@ -385,6 +401,7 @@ async def _handle_manage_project(
                     profile.default_environment_binding_id = default_environment_binding_id
                 if metadata is not None:
                     profile.metadata_ = metadata
+                profile.project_context = _profile_project_context(profile)
                 uow.session.add(profile)
                 await uow.commit()
                 return json.dumps({"project": _profile_read(profile)}, default=str)
@@ -475,7 +492,7 @@ async def _handle_manage_project(
                 context = project_context
                 if selected_profile_id:
                     profile = await _get_profile(uow.session, org_id, user_id, selected_profile_id)
-                    context = dict(profile.project_context or {})
+                    context = _profile_project_context(profile)
                 if not context:
                     return json.dumps({"error": "attach_to_thread requires: project_id or project_context"})
                 try:

--- a/brain/systems/runs/tool_catalog/handlers/skills.py
+++ b/brain/systems/runs/tool_catalog/handlers/skills.py
@@ -185,13 +185,10 @@ async def _handle_create_skill(
 
     try:
         from brain.systems.memory.embeddings import embed_document, vec_to_pg
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
         source_kind = "private_local" if user_requested else "agent_draft"
         trust_level = "private_local" if user_requested else "agent_draft"
-
-        # Embed before DB work (most expensive part, no need to hold conn)
-        emb_text = f"{name}: {description}"
-        embedding = embed_document(emb_text)
 
         # Atomic upsert — INSERT ... ON CONFLICT avoids race conditions
         from sqlalchemy import text as sa_text
@@ -202,6 +199,10 @@ async def _handle_create_skill(
 
         asset_specs = assets or []
         async with UnitOfWork() as uow:
+            emb_text = f"{name}: {description}"
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            embedding = embed_document(emb_text, runtime_config=runtime_config)
+
             row = (await uow.session.execute(sa_text("""
                 INSERT INTO skills
                     (name, description, procedure, level, model_tier, thinking_tier,

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -14,6 +14,7 @@ from brain.systems.cortex.project_context.snapshot import (
     ProjectContextValidationError,
     validated_project_context_snapshot,
 )
+from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
@@ -571,7 +572,13 @@ async def _a_latest_attached_project_context(session: Any, idea_id: str) -> dict
         if profile is not None and getattr(profile, "active", True) is not False:
             project_context = getattr(profile, "project_context", None)
             if isinstance(project_context, dict):
-                return dict(project_context)
+                return stamp_project_profile_identity(
+                    project_context,
+                    profile_id=getattr(profile, "id", None),
+                    slug=getattr(profile, "slug", None),
+                    name=getattr(profile, "name", None),
+                    description=getattr(profile, "description", None),
+                )
     snapshot = getattr(attachment, "snapshot", None)
     return dict(snapshot) if isinstance(snapshot, dict) else {}
 

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -14,7 +14,7 @@ from brain.systems.cortex.project_context.snapshot import (
     ProjectContextValidationError,
     validated_project_context_snapshot,
 )
-from brain.systems.cortex.project_context.identity import stamp_project_profile_identity
+from brain.systems.cortex.project_context.identity import stamped_project_context
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
@@ -563,22 +563,16 @@ async def _a_latest_attached_project_context(session: Any, idea_id: str) -> dict
         attachment = result.first()
     except Exception:
         return {}
-    profile_id = getattr(attachment, "project_profile_id", None)
-    if profile_id and hasattr(session, "get"):
+    project_id = getattr(attachment, "project_profile_id", None)
+    if project_id and hasattr(session, "get"):
         try:
-            profile = await session.get(ProjectProfile, profile_id)
+            profile = await session.get(ProjectProfile, project_id)
         except Exception:
             profile = None
         if profile is not None and getattr(profile, "active", True) is not False:
             project_context = getattr(profile, "project_context", None)
             if isinstance(project_context, dict):
-                return stamp_project_profile_identity(
-                    project_context,
-                    profile_id=getattr(profile, "id", None),
-                    slug=getattr(profile, "slug", None),
-                    name=getattr(profile, "name", None),
-                    description=getattr(profile, "description", None),
-                )
+                return stamped_project_context(profile, project_context, project_id=project_id)
     snapshot = getattr(attachment, "snapshot", None)
     return dict(snapshot) if isinstance(snapshot, dict) else {}
 

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -259,7 +259,17 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
     # Code search via embeddings
     if scope in ("code", "both"):
         try:
-            code_results = _semantic_code_search(query, limit=limit, workspace_root=workspace_root)
+            from brain.platform.db.repositories.unit_of_work import UnitOfWork
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            async with UnitOfWork() as uow:
+                runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            code_results = _semantic_code_search(
+                query,
+                limit=limit,
+                workspace_root=workspace_root,
+                runtime_config=runtime_config,
+            )
             results.extend(code_results)
         except Exception as e:
             logger.debug(f"Code semantic search failed: {e}")
@@ -274,7 +284,12 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
     }
 
 
-def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None = None) -> list[dict]:
+def _semantic_code_search(
+    query: str,
+    limit: int = 5,
+    workspace_root: str | None = None,
+    runtime_config=None,
+) -> list[dict]:
     """Search code files using embeddings.
 
     Strategy: embed the query, then compare against file-level summaries.
@@ -283,7 +298,7 @@ def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None
     try:
         from brain.systems.memory.embeddings import embed_query
 
-        query_vec = embed_query(query)
+        query_vec = embed_query(query, runtime_config=runtime_config)
 
         # Get candidate files (Python files, limited to avoid embedding everything)
         workspace = pathlib.Path(workspace_root or WORKSPACE_ROOT)
@@ -310,7 +325,7 @@ def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None
         # Embed summaries
         from brain.systems.memory.embeddings import embed_batch
         texts = [f"{path}: {preview}" for path, preview in candidates]
-        vecs = embed_batch(texts, mode="document")
+        vecs = embed_batch(texts, mode="document", runtime_config=runtime_config)
 
         # Compute similarities
         similarities = np.dot(vecs, query_vec) / (

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -1,8 +1,9 @@
 # Project Workspaces
 
-Projects give agents an unambiguous workspace: the user selects the files,
-folders, repositories, and documents that matter, and the agent sees those
-resources through stable Project mount paths.
+Projects give agents an unambiguous workspace. A Project may start empty as a
+named collaboration container, then gain files, folders, repositories, and
+documents over time. Once resources exist, agents see them through stable
+Project mount paths.
 
 This page documents the backend contract for Project roots and thread drafts.
 
@@ -10,6 +11,9 @@ This page documents the backend contract for Project roots and thread drafts.
 
 - Project root: the published source of truth. Users and future threads read
   from the root.
+- Empty Project: a valid Project with no resources yet. It carries identity,
+  visibility, sharing, and future workspace intent, but has no mount paths until
+  resources are added.
 - Project resource: one mounted file, folder, repository, or external resource
   in a Project.
 - Project mount path: the agent-facing truth for a resource location, such as
@@ -26,6 +30,8 @@ This page documents the backend contract for Project roots and thread drafts.
 ## Invariants
 
 - The Project root is read-only during normal agent work.
+- A Project can have zero resources. Empty Projects are valid and report a
+  clean draft state with no mount paths.
 - The thread draft is the only writable local workspace for Project-mounted
   paths.
 - `draft_status` and `plan_publish` are read-only.

--- a/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
+++ b/frontend/src/lib/features/composer/components/ProjectContextPicker.svelte
@@ -98,7 +98,6 @@
   const canSaveProject = $derived(
     creatingProject
       && newProjectName.trim().length > 0
-      && selectedResources.length > 0
       && activeProjectValidation.valid
       && !projectSaving,
   );

--- a/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
+++ b/frontend/src/lib/features/composer/components/project-context/ProjectContextCreateForm.svelte
@@ -207,7 +207,7 @@
 
 <div class="project-create-intro">
   <strong>Projects are saved context containers.</strong>
-  <span>Add a GitHub repo or backend-readable files before saving.</span>
+  <span>Start empty, or add GitHub repos and backend-readable files now.</span>
 </div>
 
 <div class="project-create-fields">
@@ -332,7 +332,7 @@
     onRemove={onRemoveResource}
   />
 {:else}
-  <p class="project-context-muted project-empty-note">No resources yet. Add a GitHub repo, file, or folder before saving.</p>
+  <p class="project-context-muted project-empty-note">No resources yet. Illo can add documents to this Project later.</p>
 {/if}
 
 {#if !validation.valid}

--- a/frontend/src/lib/utils/projectContext.test.js
+++ b/frontend/src/lib/utils/projectContext.test.js
@@ -68,8 +68,8 @@ test('normalizes connector resources before project save or run', () => {
     });
 });
 
-test('flags duplicate or empty resources before run', () => {
-    assert.equal(validateProjectContextResources([]).valid, false);
+test('allows empty projects and flags invalid resource entries before run', () => {
+    assert.equal(validateProjectContextResources([]).valid, true);
     assert.equal(validateProjectContextResources([{ path: 'frontend' }, { path: 'frontend' }]).valid, false);
     assert.equal(validateProjectContextResources([{ path: 'frontend' }, { repo: 'example-org/example-repo' }]).valid, true);
     assert.equal(validateProjectContextResources([{ uri: 'browser-file://spec.md', name: 'spec.md' }]).valid, false);

--- a/frontend/src/lib/utils/projectContext.ts
+++ b/frontend/src/lib/utils/projectContext.ts
@@ -136,9 +136,6 @@ export function normalizeProjectContextResources(resources: ProjectContextResour
 
 export function validateProjectContextResources(resources: ProjectContextResource[]): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
-  if (!resources.length) {
-    errors.push('Project context needs at least one repo, folder, file, or doc.');
-  }
   const seen = new Set<string>();
   for (const resource of normalizeProjectContextResources(resources)) {
     const key = (resource.path ?? resource.repo ?? resource.uri ?? resource.name ?? resource.label ?? '').trim();

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1326,6 +1326,27 @@ class TestExecToolHandlers:
         result = _handle_search_files("def hello", str(tmp_path))
         assert result["count"] >= 1
 
+    def test_project_draft_metadata_is_hidden_from_file_tools(self, tmp_path):
+        from brain.systems.runs.direct_agent import _handle_list_files, _handle_read_file, _handle_search_files
+
+        (tmp_path / "unified_payments.csv").write_text("visible,target\n", encoding="utf-8")
+        metadata = tmp_path / ".illo-project-draft"
+        metadata.mkdir()
+        (metadata / "metadata.json").write_text('{"internal": "target"}', encoding="utf-8")
+        base = metadata / "base"
+        base.mkdir()
+        (base / "unified_payments.csv").write_text("internal,target\n", encoding="utf-8")
+
+        listed = _handle_list_files("**/*", str(tmp_path))
+        searched = _handle_search_files("target", str(tmp_path))
+        direct_read = _handle_read_file(str(metadata / "metadata.json"))
+
+        assert listed["files"] == ["unified_payments.csv"]
+        assert listed["total"] == 1
+        assert ".illo-project-draft" not in searched["matches"]
+        assert "unified_payments.csv" in searched["matches"]
+        assert "error" in direct_read
+
     def test_workspace_selector_reads_from_additional_repo(self, tmp_path):
         from brain.systems.runs.tool_handlers import _get_tool_handlers
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1837,7 +1837,7 @@ async def test_work_intake_inherits_project_context_from_idea():
     assert request.workspace_ref["project_context_snapshot"]["resources"][0]["path"] == "projects/yc-application"
 
 
-async def test_work_intake_skips_invalid_metadata_project_context_for_valid_idea_context():
+async def test_work_intake_prefers_empty_metadata_project_context_over_idea_context():
     idea = SimpleNamespace(
         id="idea-1",
         org_id="org-1",
@@ -1861,17 +1861,12 @@ async def test_work_intake_skips_invalid_metadata_project_context_for_valid_idea
         metadata={"project_context": {"name": "Stale empty project", "resources": []}},
     )
 
-    assert request.metadata["project_context"]["name"] == "Illospace"
-    assert request.target_ref["project_context_snapshot"]["resources"][0]["name"] == "Illospace/illospace"
-    assert request.metadata["project_context_validation_errors"] == [
-        {
-            "source": "metadata",
-            "errors": ["project_context_snapshot.resources must contain at least one resource."],
-        }
-    ]
+    assert request.metadata["project_context"]["name"] == "Stale empty project"
+    assert request.target_ref["project_context_snapshot"]["resources"] == []
+    assert "project_context_validation_errors" not in request.metadata
 
 
-async def test_work_intake_drops_invalid_legacy_project_context_when_no_valid_fallback():
+async def test_work_intake_keeps_empty_legacy_project_context_when_no_resource_fallback():
     idea = SimpleNamespace(
         id="idea-1",
         org_id="org-1",
@@ -1890,15 +1885,10 @@ async def test_work_intake_drops_invalid_legacy_project_context_when_no_valid_fa
         metadata={},
     )
 
-    assert "project_context" not in request.metadata
-    assert "project_context_snapshot" not in request.target_ref
-    assert request.workspace_ref == {}
-    assert request.metadata["project_context_validation_errors"] == [
-        {
-            "source": "idea",
-            "errors": ["project_context_snapshot.resources must contain at least one resource."],
-        }
-    ]
+    assert request.metadata["project_context"]["name"] == "Legacy empty project"
+    assert request.target_ref["project_context_snapshot"]["resources"] == []
+    assert request.workspace_ref["project_context_snapshot"]["resources"] == []
+    assert "project_context_validation_errors" not in request.metadata
 
 
 async def test_work_intake_falls_back_to_latest_project_attachment():

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -402,3 +402,65 @@ def test_agent_trace_export_zip_contains_shareable_trace_files():
     assert "trace.json" in readme
     assert "CycleRun" in readme
     assert "not saved as a database artifact" in readme
+
+
+def test_agent_trace_export_zip_redacts_secret_like_values():
+    from brain.systems.runs.cortex.recording import build_agent_trace_export_zip
+
+    snapshot = {
+        "schema_version": 1,
+        "trace_id": "run:42",
+        "run": {
+            "run_id": 42,
+            "status": "completed",
+            "metadata": {"github_token": "ghp_" + "a" * 36},
+        },
+        "thread": {"messages": []},
+        "events": [
+            {
+                "id": 2,
+                "run_id": 42,
+                "sequence_no": 1,
+                "event_type": "run.tool_started",
+                "created_at": "2026-05-12T12:00:02+00:00",
+                "payload": {
+                    "tool_name": "exec_command",
+                    "args": {
+                        "cmd": "printf '%s' ghp_" + "b" * 36,
+                        "authorization": "Bearer " + "c" * 36,
+                    },
+                },
+            }
+        ],
+        "tools": [
+            {
+                "tool_name": "exec_command",
+                "args": {"cmd": "gh auth login --with-token <<< ghp_" + "d" * 36},
+            }
+        ],
+        "artifacts": [],
+        "cycles": {},
+        "diagnostics": {
+            "delivery_signals": [
+                {
+                    "payload": {
+                        "api_key": "sk-" + "e" * 36,
+                        "message": "token was ghp_" + "f" * 36,
+                    }
+                }
+            ]
+        },
+    }
+
+    archive_bytes = build_agent_trace_export_zip(snapshot)
+
+    with zipfile.ZipFile(BytesIO(archive_bytes)) as archive:
+        trace_text = archive.read("trace.json").decode("utf-8")
+        activity_text = archive.read("activity.json").decode("utf-8")
+
+    assert "ghp_" not in trace_text
+    assert "ghp_" not in activity_text
+    assert "sk-" not in trace_text
+    assert "Bearer c" not in trace_text
+    assert "[secret redacted]" in trace_text
+    assert "[redacted]" in trace_text

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -144,18 +144,12 @@ def test_project_context_extraction_from_thread_payload():
     assert _extract_project_context_from_message([], {"project_context": snapshot}) == snapshot
 
 
-def test_thread_project_context_validation_rejects_empty_context():
-    from fastapi import HTTPException
-
+def test_thread_project_context_validation_allows_empty_project():
     from brain.app.api.routers.cortex._idea_ops import _validate_thread_project_context
 
-    with pytest.raises(HTTPException) as excinfo:
-        _validate_thread_project_context({"name": "Legacy empty project", "resources": []})
+    context = {"name": "Empty project", "resources": []}
 
-    assert excinfo.value.status_code == 422
-    assert excinfo.value.detail["validation_errors"] == [
-        "project_context_snapshot.resources must contain at least one resource."
-    ]
+    assert _validate_thread_project_context(context) == context
 
 
 def test_project_context_extraction_promotes_readable_thread_upload(tmp_path, monkeypatch):
@@ -1899,7 +1893,7 @@ async def test_resolve_project_access_users_rejects_ambiguous_names():
 
 
 @pytest.mark.asyncio
-async def test_create_project_profile_rejects_empty_project_context(client, mock_session_factory):
+async def test_create_project_profile_allows_empty_project_context(client, mock_session_factory):
     from brain.app.api.routers.cortex import _project_context as pc_mod
 
     with (
@@ -1920,10 +1914,12 @@ async def test_create_project_profile_rejects_empty_project_context(client, mock
             json={"slug": "empty-project", "name": "Empty Project", "project_context": {"name": "Empty Project", "resources": []}},
         )
 
-    assert response.status_code == 422
-    assert response.json()["detail"]["validation_errors"] == [
-        "project_context_snapshot.resources must contain at least one resource."
-    ]
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["slug"] == "empty-project"
+    assert payload["project_context"]["resources"] == []
+    assert payload["project_context"]["status"] == "validated"
+    assert payload["project_context"]["project_workspace_manifest"]["mounts"] == []
 
 
 async def test_create_project_profile_validates_project_context(client, mock_session_factory):

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -310,6 +310,9 @@ async def test_project_profile_resource_endpoints_mutate_context(tmp_path):
     )
 
     assert [resource["path"] for resource in profile.project_context["resources"]] == [str(first), str(second)]
+    assert profile.project_context["project_key"] == "project-1"
+    assert profile.project_context["profile_id"] == "project-1"
+    assert profile.project_context["profile_slug"] == "yc"
     added_id = profile.project_context["resources"][1]["id"]
 
     await _project_context.reorder_project_resources(
@@ -320,6 +323,7 @@ async def test_project_profile_resource_endpoints_mutate_context(tmp_path):
     )
 
     assert [resource["id"] for resource in profile.project_context["resources"]] == [added_id, "r1"]
+    assert profile.project_context["project_key"] == "project-1"
 
 
 async def test_project_profile_resource_reorder_rejects_duplicates(tmp_path):
@@ -1812,6 +1816,8 @@ def test_project_profile_read_includes_visibility_and_access():
 
     assert payload.visibility == "private"
     assert payload.access[0].name == "Alex"
+    assert payload.project_context["project_key"] == "project-1"
+    assert payload.project_context["profile_slug"] == "yc"
 
 
 def test_project_profile_create_defaults_private():
@@ -1917,6 +1923,10 @@ async def test_create_project_profile_allows_empty_project_context(client, mock_
     assert response.status_code == 201
     payload = response.json()
     assert payload["slug"] == "empty-project"
+    assert payload["project_context"]["project_key"] == "empty-profile-1"
+    assert payload["project_context"]["profile_id"] == "empty-profile-1"
+    assert payload["project_context"]["selected_profile_id"] == "empty-profile-1"
+    assert payload["project_context"]["profile_slug"] == "empty-project"
     assert payload["project_context"]["resources"] == []
     assert payload["project_context"]["status"] == "validated"
     assert payload["project_context"]["project_workspace_manifest"]["mounts"] == []
@@ -2207,3 +2217,51 @@ async def test_attach_idea_project_context_persists_snapshot_scope_and_env_bindi
     assert payload["status"] == "validated"
     assert "brain/app/api" in payload["permission_scope"]["allowed_paths"]
     assert idea.agent_details["project_context"]["resources"][0]["path"] == "brain"
+
+
+async def test_attach_project_profile_stamps_profile_identity_in_snapshot():
+    from brain.app.api.routers.cortex import _project_context
+    from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentCreate
+
+    idea = _make_idea(id="idea-1", org_id="org-1")
+    profile = SimpleNamespace(
+        id="profile-1",
+        org_id="org-1",
+        user_id="user-1",
+        slug="strategy-room",
+        name="Strategy Room",
+        description=None,
+        project_context={"name": "Older Name", "resources": []},
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=None,
+    )
+    session = MagicMock()
+
+    def add(obj):
+        obj.id = 41
+        obj.created_at = datetime.now(timezone.utc)
+
+    session.add.side_effect = add
+    db = _AsyncSession(session)
+    user = {"id": "user-1", "org_id": "org-1", "role": "owner"}
+
+    with (
+        patch.object(_project_context, "_require_idea_for_user", AsyncMock(return_value=idea)),
+        patch.object(_project_context, "_get_project_profile", AsyncMock(return_value=profile)),
+    ):
+        payload = await _project_context.attach_idea_project_context(
+            "idea-1",
+            IdeaProjectAttachmentCreate(project_profile_id="profile-1"),
+            db=db,
+            user=user,
+        )
+
+    snapshot = payload.snapshot
+    assert payload.project_profile_id == "profile-1"
+    assert snapshot["project_key"] == "profile-1"
+    assert snapshot["profile_id"] == "profile-1"
+    assert snapshot["selected_profile_id"] == "profile-1"
+    assert snapshot["profile_slug"] == "strategy-room"
+    assert idea.agent_details["project_context"]["project_key"] == "profile-1"

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -311,8 +311,8 @@ async def test_project_profile_resource_endpoints_mutate_context(tmp_path):
 
     assert [resource["path"] for resource in profile.project_context["resources"]] == [str(first), str(second)]
     assert profile.project_context["project_key"] == "project-1"
-    assert profile.project_context["profile_id"] == "project-1"
-    assert profile.project_context["profile_slug"] == "yc"
+    assert profile.project_context["project_id"] == "project-1"
+    assert profile.project_context["slug"] == "yc"
     added_id = profile.project_context["resources"][1]["id"]
 
     await _project_context.reorder_project_resources(
@@ -1817,7 +1817,7 @@ def test_project_profile_read_includes_visibility_and_access():
     assert payload.visibility == "private"
     assert payload.access[0].name == "Alex"
     assert payload.project_context["project_key"] == "project-1"
-    assert payload.project_context["profile_slug"] == "yc"
+    assert payload.project_context["slug"] == "yc"
 
 
 def test_project_profile_create_defaults_private():
@@ -1924,9 +1924,8 @@ async def test_create_project_profile_allows_empty_project_context(client, mock_
     payload = response.json()
     assert payload["slug"] == "empty-project"
     assert payload["project_context"]["project_key"] == "empty-profile-1"
-    assert payload["project_context"]["profile_id"] == "empty-profile-1"
-    assert payload["project_context"]["selected_profile_id"] == "empty-profile-1"
-    assert payload["project_context"]["profile_slug"] == "empty-project"
+    assert payload["project_context"]["project_id"] == "empty-profile-1"
+    assert payload["project_context"]["slug"] == "empty-project"
     assert payload["project_context"]["resources"] == []
     assert payload["project_context"]["status"] == "validated"
     assert payload["project_context"]["project_workspace_manifest"]["mounts"] == []
@@ -2219,7 +2218,7 @@ async def test_attach_idea_project_context_persists_snapshot_scope_and_env_bindi
     assert idea.agent_details["project_context"]["resources"][0]["path"] == "brain"
 
 
-async def test_attach_project_profile_stamps_profile_identity_in_snapshot():
+async def test_attach_project_profile_stamps_project_identity_in_snapshot():
     from brain.app.api.routers.cortex import _project_context
     from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentCreate
 
@@ -2261,7 +2260,6 @@ async def test_attach_project_profile_stamps_profile_identity_in_snapshot():
     snapshot = payload.snapshot
     assert payload.project_profile_id == "profile-1"
     assert snapshot["project_key"] == "profile-1"
-    assert snapshot["profile_id"] == "profile-1"
-    assert snapshot["selected_profile_id"] == "profile-1"
-    assert snapshot["profile_slug"] == "strategy-room"
+    assert snapshot["project_id"] == "profile-1"
+    assert snapshot["slug"] == "strategy-room"
     assert idea.agent_details["project_context"]["project_key"] == "profile-1"

--- a/tests/test_cortex_thread_context.py
+++ b/tests/test_cortex_thread_context.py
@@ -165,6 +165,39 @@ def test_run_context_prompt_includes_thread_context():
     assert "Illo: earlier answer" in prompt_context
 
 
+def test_thread_context_formatting_prefers_recent_entries_when_budget_is_tight():
+    from brain.systems.cortex.thread_context import ThreadContextEntry, _format_entries
+
+    now = datetime(2026, 5, 6, 18, 0, tzinfo=timezone.utc)
+    entries = [
+        ThreadContextEntry(
+            role="user",
+            content="old " * 200,
+            created_at=now,
+            thread_message_id=1,
+        ),
+        ThreadContextEntry(
+            role="illo",
+            content="new CRM exists",
+            created_at=now + timedelta(minutes=1),
+            artifact_id=2,
+        ),
+        ThreadContextEntry(
+            role="user",
+            content="newest question about drift",
+            created_at=now + timedelta(minutes=2),
+            thread_message_id=3,
+        ),
+    ]
+
+    formatted, kept = _format_entries(entries, char_limit=120)
+
+    assert "old old" not in formatted
+    assert "new CRM exists" in formatted
+    assert "newest question about drift" in formatted
+    assert [entry.thread_message_id or entry.artifact_id for entry in kept] == [2, 3]
+
+
 async def _add_run_final_answer(
     session,
     *,

--- a/tests/test_manage_project_drafts.py
+++ b/tests/test_manage_project_drafts.py
@@ -38,6 +38,38 @@ def _project_run(source_dir, draft_dir):
     )
 
 
+def _file_project_run(source_file, draft_dir):
+    resource = {
+        "id": "resource-1",
+        "kind": "file",
+        "mount_path": f"/{Path(source_file).name}",
+        "path": str(draft_dir / Path(source_file).name),
+        "materialization": {
+            "status": "ready",
+            "provider": "local",
+            "kind": "file",
+            "path": str(draft_dir / Path(source_file).name),
+            "source_path": str(source_file),
+            "workspace_path": str(draft_dir),
+            "draft": True,
+        },
+    }
+    return SimpleNamespace(
+        id=124,
+        target_ref={"project_context_snapshot": {"resources": [resource]}},
+        workspace_ref={
+            "workspaces": [{"name": resource["mount_path"], "path": str(draft_dir)}],
+            "project_context_snapshot": {"resources": [resource]},
+            "project_context_materialization": {
+                "status": "materialized",
+                "workspaces": [{"name": resource["mount_path"], "path": str(draft_dir)}],
+                "errors": [],
+            },
+        },
+        metadata_={},
+    )
+
+
 def _repo_project_run(repo_dir):
     resource = {
         "id": "repo",
@@ -305,6 +337,59 @@ async def test_manage_project_publish_draft_applies_local_changes_and_refreshes_
     assert (source_dir / "new.md").read_text(encoding="utf-8") == "new"
     assert not (source_dir / "delete.md").exists()
     assert plan_after["summary"] == {"resource_count": 1, "operation_count": 0, "blocked_count": 0}
+
+
+async def test_manage_project_blocks_new_sibling_publish_for_file_roots(tmp_path):
+    from brain.systems.cortex.project_context.drafts import sync_draft_from_root
+
+    source_dir = tmp_path / "uploads"
+    source_dir.mkdir()
+    source_file = source_dir / "unified_payments.csv"
+    source_file.write_text("base csv", encoding="utf-8")
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "resource-1"
+    sync_draft_from_root(source_file, draft_dir)
+    (draft_dir / "customer_analysis_past_4_weeks.md").write_text("analysis", encoding="utf-8")
+
+    with bind_agent_context({"run": _file_project_run(source_file, draft_dir), "idea_id": "idea-1"}):
+        plan = json.loads(await projects._handle_manage_project(action="plan_publish"))
+        published = json.loads(
+            await projects._handle_manage_project(
+                action="publish_draft",
+                publish_paths=["customer_analysis_past_4_weeks.md"],
+            )
+        )
+
+    operation = plan["groups"][0]["operations"][0]
+    assert plan["summary"] == {"resource_count": 1, "operation_count": 1, "blocked_count": 1}
+    assert plan["groups"][0]["status"] == "blocked"
+    assert plan["groups"][0]["blocked_reasons"] == ["file_project_root_cannot_publish_additional_paths"]
+    assert operation["draft_path"] == str(draft_dir / "customer_analysis_past_4_weeks.md")
+    assert operation["target_path"] is None
+    assert published["ok"] is False
+    assert published["code"] == "project_draft_publish_blocked"
+    assert source_file.read_text(encoding="utf-8") == "base csv"
+    assert not (source_dir / "customer_analysis_past_4_weeks.md").exists()
+
+
+async def test_manage_project_allows_original_file_root_update(tmp_path):
+    from brain.systems.cortex.project_context.drafts import sync_draft_from_root
+
+    source_dir = tmp_path / "uploads"
+    source_dir.mkdir()
+    source_file = source_dir / "unified_payments.csv"
+    source_file.write_text("base csv", encoding="utf-8")
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "resource-1"
+    sync_draft_from_root(source_file, draft_dir)
+    (draft_dir / "unified_payments.csv").write_text("draft csv", encoding="utf-8")
+
+    with bind_agent_context({"run": _file_project_run(source_file, draft_dir), "idea_id": "idea-1"}):
+        plan = json.loads(await projects._handle_manage_project(action="plan_publish"))
+        published = json.loads(await projects._handle_manage_project(action="publish_draft"))
+
+    assert plan["summary"] == {"resource_count": 1, "operation_count": 1, "blocked_count": 0}
+    assert plan["groups"][0]["operations"][0]["target_path"] == str(source_file)
+    assert published["ok"] is True
+    assert source_file.read_text(encoding="utf-8") == "draft csv"
 
 
 async def test_manage_project_publish_draft_rolls_back_local_root_on_failure(tmp_path, monkeypatch):

--- a/tests/test_manage_project_drafts.py
+++ b/tests/test_manage_project_drafts.py
@@ -339,7 +339,7 @@ async def test_manage_project_publish_draft_applies_local_changes_and_refreshes_
     assert plan_after["summary"] == {"resource_count": 1, "operation_count": 0, "blocked_count": 0}
 
 
-async def test_manage_project_blocks_new_sibling_publish_for_file_roots(tmp_path):
+async def test_manage_project_publish_draft_allows_new_sibling_for_single_uploaded_file_project(tmp_path):
     from brain.systems.cortex.project_context.drafts import sync_draft_from_root
 
     source_dir = tmp_path / "uploads"
@@ -360,15 +360,15 @@ async def test_manage_project_blocks_new_sibling_publish_for_file_roots(tmp_path
         )
 
     operation = plan["groups"][0]["operations"][0]
-    assert plan["summary"] == {"resource_count": 1, "operation_count": 1, "blocked_count": 1}
-    assert plan["groups"][0]["status"] == "blocked"
-    assert plan["groups"][0]["blocked_reasons"] == ["file_project_root_cannot_publish_additional_paths"]
+    assert plan["summary"] == {"resource_count": 1, "operation_count": 1, "blocked_count": 0}
+    assert plan["groups"][0]["status"] == "ready"
+    assert plan["groups"][0]["blocked_reasons"] == []
     assert operation["draft_path"] == str(draft_dir / "customer_analysis_past_4_weeks.md")
-    assert operation["target_path"] is None
-    assert published["ok"] is False
-    assert published["code"] == "project_draft_publish_blocked"
+    assert operation["target_path"] == str(source_dir / "customer_analysis_past_4_weeks.md")
+    assert published["ok"] is True
+    assert published["summary"] == {"published_groups": 1, "operation_count": 1, "blocked_count": 0}
     assert source_file.read_text(encoding="utf-8") == "base csv"
-    assert not (source_dir / "customer_analysis_past_4_weeks.md").exists()
+    assert (source_dir / "customer_analysis_past_4_weeks.md").read_text(encoding="utf-8") == "analysis"
 
 
 async def test_manage_project_allows_original_file_root_update(tmp_path):
@@ -390,6 +390,34 @@ async def test_manage_project_allows_original_file_root_update(tmp_path):
     assert plan["groups"][0]["operations"][0]["target_path"] == str(source_file)
     assert published["ok"] is True
     assert source_file.read_text(encoding="utf-8") == "draft csv"
+
+
+async def test_manage_project_empty_local_project_root_publishes_new_file(tmp_path):
+    from brain.systems.cortex.project_context.drafts import sync_draft_from_root
+
+    source_dir = tmp_path / "empty-project-root"
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "empty-project"
+    source_dir.mkdir()
+    sync_draft_from_root(source_dir, draft_dir)
+    (draft_dir / "README.md").write_text("# New project\n", encoding="utf-8")
+
+    with bind_agent_context({"run": _project_run(source_dir, draft_dir), "idea_id": "idea-1"}):
+        plan = json.loads(await projects._handle_manage_project(action="plan_publish"))
+        published = json.loads(await projects._handle_manage_project(action="publish_draft"))
+
+    assert plan["summary"] == {"resource_count": 1, "operation_count": 1, "blocked_count": 0}
+    assert plan["groups"][0]["status"] == "ready"
+    assert plan["groups"][0]["operations"] == [
+        {
+            "operation": "create",
+            "path": "README.md",
+            "draft_path": str(draft_dir / "README.md"),
+            "target_path": str(source_dir / "README.md"),
+        }
+    ]
+    assert published["ok"] is True
+    assert published["summary"] == {"published_groups": 1, "operation_count": 1, "blocked_count": 0}
+    assert (source_dir / "README.md").read_text(encoding="utf-8") == "# New project\n"
 
 
 async def test_manage_project_publish_draft_rolls_back_local_root_on_failure(tmp_path, monkeypatch):

--- a/tests/test_manage_project_drafts.py
+++ b/tests/test_manage_project_drafts.py
@@ -664,6 +664,39 @@ async def test_manage_project_draft_status_reports_clear_unbound_error():
     assert "current AgentRun or Cortex thread" in payload["error"]
 
 
+async def test_manage_project_draft_status_allows_empty_project():
+    context = {
+        "run": SimpleNamespace(id=123, metadata_={}),
+        "idea_id": "idea-1",
+        "workspace_ref": {
+            "project_context_snapshot": {
+                "name": "Empty project",
+                "status": "validated",
+                "resources": [],
+            },
+            "project_workspace_manifest": {
+                "schema_version": 1,
+                "mounts": [],
+                "workspaces": [],
+            },
+        },
+        "target_ref": {},
+        "execution_metadata": {},
+    }
+    with bind_agent_context(context):
+        status = json.loads(await projects._handle_manage_project(action="draft_status"))
+        plan = json.loads(await projects._handle_manage_project(action="plan_publish"))
+        versions = json.loads(await projects._handle_manage_project(action="root_versions"))
+
+    assert status["ok"] is True
+    assert status["resources"] == []
+    assert status["changes"]["total"] == 0
+    assert plan["ok"] is True
+    assert plan["summary"] == {"resource_count": 0, "operation_count": 0, "blocked_count": 0}
+    assert versions["ok"] is True
+    assert versions["summary"] == {"resource_count": 0, "version_count": 0}
+
+
 async def test_manage_project_schema_exposes_draft_operations():
     from brain.systems.runs.tool_definitions import PROJECT_TOOLS
 

--- a/tests/test_manage_project_workflow_integration.py
+++ b/tests/test_manage_project_workflow_integration.py
@@ -55,6 +55,11 @@ def _resource_workspace(run) -> Path:
     return Path(resource["materialization"]["workspace_path"])
 
 
+def _resource_source_root(run) -> Path:
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    return Path(resource["materialization"]["source_path"])
+
+
 async def test_manage_project_local_draft_publish_is_visible_to_next_thread(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
 
@@ -74,6 +79,7 @@ async def test_manage_project_local_draft_publish_is_visible_to_next_thread(tmp_
         org_id="org-1",
     )
     draft_root = _resource_workspace(first_run)
+    source_root = _resource_source_root(first_run)
     (draft_root / "brief.md").write_text("draft edit", encoding="utf-8")
     (draft_root / "new.md").write_text("new draft file", encoding="utf-8")
     (draft_root / "delete.md").unlink()
@@ -102,9 +108,11 @@ async def test_manage_project_local_draft_publish_is_visible_to_next_thread(tmp_
     assert published["mutated_project_root"] is True
     assert published["summary"] == {"published_groups": 1, "operation_count": 3, "blocked_count": 0}
     assert plan_after_publish["summary"] == {"resource_count": 1, "operation_count": 0, "blocked_count": 0}
-    assert (project_root / "brief.md").read_text(encoding="utf-8") == "draft edit"
-    assert (project_root / "new.md").read_text(encoding="utf-8") == "new draft file"
-    assert not (project_root / "delete.md").exists()
+    assert source_root != project_root
+    assert (source_root / "brief.md").read_text(encoding="utf-8") == "draft edit"
+    assert (source_root / "new.md").read_text(encoding="utf-8") == "new draft file"
+    assert not (source_root / "delete.md").exists()
+    assert (project_root / "brief.md").read_text(encoding="utf-8") == "root v1"
 
     second_run = _project_run(502, project_root)
     runs[502] = second_run
@@ -149,8 +157,9 @@ async def test_manage_project_out_of_date_draft_blocks_publish(tmp_path, monkeyp
         org_id="org-1",
     )
     draft_root = _resource_workspace(run)
+    source_root = _resource_source_root(run)
     (draft_root / "brief.md").write_text("thread draft edit", encoding="utf-8")
-    (project_root / "brief.md").write_text("root v2", encoding="utf-8")
+    (source_root / "brief.md").write_text("root v2", encoding="utf-8")
 
     refreshed = await materialize_project_context_workspaces(
         601,
@@ -180,4 +189,5 @@ async def test_manage_project_out_of_date_draft_blocks_publish(tmp_path, monkeyp
     assert publish["ok"] is False
     assert publish["mutated_project_root"] is False
     assert publish["summary"] == {"published_groups": 0, "operation_count": 0, "blocked_count": 1}
-    assert (project_root / "brief.md").read_text(encoding="utf-8") == "root v2"
+    assert (source_root / "brief.md").read_text(encoding="utf-8") == "root v2"
+    assert (project_root / "brief.md").read_text(encoding="utf-8") == "root v1"

--- a/tests/test_progressive_skill_loading.py
+++ b/tests/test_progressive_skill_loading.py
@@ -400,6 +400,60 @@ async def test_brain_skills_degrades_when_embedding_unavailable():
     uow.memories.guardrail_memories_for_task.assert_not_called()
 
 
+async def test_brain_skills_uses_db_backed_runtime_config_for_embeddings():
+    from brain.app.mcp.server import async_tool_brain_skills
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    row = {
+        "id": 1,
+        "name": "develop",
+        "description": "Ship focused changes.",
+        "version": 3,
+        "maturity": "proficient",
+        "confidence": 0.8,
+        "use_count": 4,
+        "success_rate": 0.75,
+        "model_tier": "medium",
+        "thinking_tier": "medium",
+        "pitfalls": [],
+        "triggers": [],
+        "bundle_version_id": 7,
+        "bundle_digest": "sha256:bundle",
+        "overlay_revision": None,
+        "effective_digest": "sha256:effective",
+        "source_kind": "illo-core",
+        "trust_level": "illo_core",
+        "skill_match": 0.5,
+        "centroid_match": None,
+        "centroid_count": 0,
+    }
+    uow = _FakeUow(
+        execute_results=[
+            _ExecuteResult(one_value={"cnt": 1}),
+            _ExecuteResult(all_value=[row]),
+            _ExecuteResult(all_value=[]),
+        ],
+    )
+    runtime = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="openai",
+        api_model="text-embedding-3-small",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=768,
+        api_key="secret",
+    )
+
+    with patch("brain.app.mcp.server.UnitOfWork", return_value=uow), \
+         patch("brain.systems.runtime_settings.memory.async_get_embedding_runtime_config", return_value=runtime), \
+         patch("brain.systems.memory.embeddings.embed_query", return_value=[0.1]) as embed_query, \
+         patch("brain.systems.memory.embeddings.vec_to_pg", return_value="[0.1]"):
+        result = await async_tool_brain_skills("fix a bug")
+
+    embed_query.assert_called_once_with("fix a bug", runtime_config=runtime)
+    assert "degraded_reason" not in result
+    assert result["recommended_skills"][0]["name"] == "develop"
+
+
 async def test_skill_view_loads_procedure_with_digest_metadata():
     from brain.app.mcp.server import async_tool_skill_view
 

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -40,6 +40,12 @@ def test_project_context_materializable_resources_include_empty_project_roots():
     }) is True
 
 
+def test_project_root_key_prefers_canonical_project_key_over_legacy_id():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    assert project_key_from_context({"id": "legacy-context", "project_key": "profile-1"}) == "profile-1"
+
+
 def test_runner_materializes_thread_attachment_files_as_project_resources(monkeypatch):
     from brain.systems.runs.cortex import runner
 
@@ -1046,6 +1052,72 @@ async def test_materialize_uploaded_folder_imports_files_into_project_native_roo
     assert (source_root / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
     assert (draft_dir / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
     assert (draft_dir / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
+
+
+async def test_materialize_saved_project_root_identity_survives_resource_changes(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    seed = tmp_path / "seed.md"
+    seed.write_text("seed", encoding="utf-8")
+    runs: dict[int, SimpleNamespace] = {}
+
+    def run_for(run_id: int, resources: list[dict[str, str]]):
+        run = SimpleNamespace(
+            id=run_id,
+            user_id="user-1",
+            org_id="org-1",
+            metadata_={},
+            target_ref={
+                "kind": "cortex_idea",
+                "project_context_snapshot": {
+                    "project_key": "profile-stable",
+                    "profile_id": "profile-stable",
+                    "profile_slug": "strategy-room",
+                    "status": "validated",
+                    "resources": resources,
+                },
+            },
+            workspace_ref={},
+        )
+        runs[run_id] = run
+        return run
+
+    first_run = run_for(71, [])
+    second_run = run_for(72, [{"id": "seed", "kind": "file", "name": "seed.md", "path": str(seed)}])
+
+    class FakeSession:
+        async def get(self, _model, run_id):
+            return runs.get(run_id)
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    first = await materialize_project_context_workspaces(
+        71,
+        workspace_root=str(tmp_path / "ideas" / "thread-one"),
+        user_id="user-1",
+    )
+    second = await materialize_project_context_workspaces(
+        72,
+        workspace_root=str(tmp_path / "ideas" / "thread-two"),
+        user_id="user-1",
+    )
+
+    first_source = Path(first_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    second_source = Path(second_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    assert first.ok
+    assert second.ok
+    assert first_source == second_source == tmp_path / "project-roots" / "profile-stable"
+    assert (second_source / "seed.md").read_text(encoding="utf-8") == "seed"
 
 
 async def test_materialize_thread_draft_marks_conflict_when_root_and_draft_changed(tmp_path, monkeypatch):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -571,7 +571,7 @@ async def test_materialize_refuses_to_overwrite_non_matching_thread_checkout(tmp
     assert run.target_status == "invalid"
 
 
-async def test_materialize_empty_project_context_is_not_ready(tmp_path, monkeypatch):
+async def test_materialize_empty_project_context_is_ready_noop(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context import materializer
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
 
@@ -607,9 +607,15 @@ async def test_materialize_empty_project_context_is_not_ready(tmp_path, monkeypa
 
     result = await materialize_project_context_workspaces(48, workspace_root=str(tmp_path), user_id="user-1")
 
-    assert not result.ok
+    assert result.ok
+    assert result.empty_project is True
     assert result.workspaces == []
-    assert result.errors == ["Project Context has no resources to materialize."]
+    assert result.errors == []
+    assert run.target_ref["project_context_snapshot"]["resources"] == []
+    assert run.workspace_ref["project_workspace_manifest"]["mounts"] == []
+    assert run.workspace_ref["project_workspace_manifest"]["workspaces"] == []
+    assert run.workspace_ref["project_context_materialization"]["status"] == "materialized"
+    assert run.workspace_ref["project_context_materialization"]["empty_project"] is True
     assert "workspace_root" not in run.workspace_ref
 
 
@@ -901,7 +907,7 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
         AsyncMock(return_value=SimpleNamespace(
             ok=False,
             workspaces=[],
-            errors=["Project Context has no resources to materialize."],
+            errors=["Could not materialize GitHub repository example-org/missing-repo: repository not found."],
         )),
     )
 

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -13,9 +14,10 @@ def test_thread_attachment_file_is_not_materialized_as_github_workspace():
     }) is None
 
 
-def test_project_context_materializable_resources_require_real_local_path_or_repo():
+def test_project_context_materializable_resources_include_empty_project_roots():
     from brain.systems.cortex.project_context.materializer import project_context_has_materializable_resources
 
+    assert project_context_has_materializable_resources({"resources": []}) is True
     assert project_context_has_materializable_resources({
         "resources": [
             {
@@ -25,7 +27,7 @@ def test_project_context_materializable_resources_require_real_local_path_or_rep
                 "uri": "browser-folder://pending",
             }
         ]
-    }) is False
+    }) is True
     assert project_context_has_materializable_resources({
         "resources": [
             {
@@ -92,7 +94,7 @@ def test_runner_materializes_thread_attachment_files_as_project_resources(monkey
     assert status_payload is None
 
 
-def test_runner_skips_placeholder_project_resources_without_failing(monkeypatch):
+def test_runner_materializes_placeholder_projects_as_empty_roots(monkeypatch):
     from brain.systems.runs.cortex import runner
 
     run = SimpleNamespace(
@@ -130,16 +132,23 @@ def test_runner_skips_placeholder_project_resources_without_failing(monkeypatch)
         async def __aexit__(self, *_args):
             return False
 
-    materialize = AsyncMock()
     monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
     monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
-    monkeypatch.setattr(runner, "materialize_project_context_workspaces", materialize)
+    monkeypatch.setattr(
+        runner,
+        "materialize_project_context_workspaces",
+        AsyncMock(return_value=SimpleNamespace(
+            ok=True,
+            workspaces=[{"name": "/", "path": "/tmp/project-root"}],
+            errors=[],
+        )),
+    )
 
     context_ready, status_payload = runner._materialize_project_context(52)
 
     assert context_ready is True
     assert status_payload is None
-    materialize.assert_not_called()
+    runner.materialize_project_context_workspaces.assert_called_once()
 
 
 async def test_materialize_github_project_context_uses_vault_key_without_persisting_token(tmp_path, monkeypatch):
@@ -212,7 +221,9 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
     )
 
     assert result.ok
+    root_draft = tmp_path / ".illo-project-context" / "local" / "run-42" / "project-root"
     assert result.workspaces == [
+        {"name": "/", "path": str(root_draft)},
         {
             "name": "example-org/example-backend",
             "path": str(tmp_path / ".illo-project-context" / "github" / "example-org" / "example-backend"),
@@ -226,8 +237,9 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
             "branch": "main",
         }
     ]
-    resource = run.target_metadata["project_context_snapshot"]["resources"][0]
-    assert resource["path"] == result.workspaces[0]["path"]
+    resource = run.target_metadata["project_context_snapshot"]["resources"][1]
+    assert run.target_metadata["project_context_snapshot"]["resources"][0]["mount_path"] == "/"
+    assert resource["path"] == result.workspaces[1]["path"]
     assert resource["materialization"]["status"] == "ready"
     assert run.metadata_["workspaces"] == result.workspaces
     assert "test-private-token" not in str(run.metadata_)
@@ -293,9 +305,13 @@ async def test_materialize_github_folder_uri_mounts_repo_subpath(tmp_path, monke
 
     expected_repo = tmp_path / "thread-root" / ".illo-project-context" / "github" / "uwear-ai" / "agent-mission-control"
     expected_workspace = expected_repo / "workspaces" / "linkedin-outbound"
+    expected_root = tmp_path / "thread-root" / ".illo-project-context" / "local" / "resource-2" / "project-root"
     assert result.ok
-    assert result.workspaces == [{"name": "agent-mission-control/workspaces/linkedin-outbound", "path": str(expected_workspace)}]
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert result.workspaces == [
+        {"name": "/", "path": str(expected_root)},
+        {"name": "agent-mission-control/workspaces/linkedin-outbound", "path": str(expected_workspace)},
+    ]
+    resource = run.target_ref["project_context_snapshot"]["resources"][1]
     assert resource["repo"] == "uwear-ai/agent-mission-control"
     assert resource["path"] == str(expected_workspace)
     assert resource["materialization"]["repo_path"] == str(expected_repo)
@@ -572,8 +588,12 @@ async def test_materialize_reuses_existing_thread_checkout_without_reclone(tmp_p
     assert result.ok
     assert clone_calls == []
     assert sentinel.read_text() == "preserve me"
-    assert result.workspaces == [{"name": "example-org/example-repo", "path": str(checkout)}]
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    root_draft = tmp_path / ".illo-project-context" / "local" / "run-45" / "project-root"
+    assert result.workspaces == [
+        {"name": "/", "path": str(root_draft)},
+        {"name": "example-org/example-repo", "path": str(checkout)},
+    ]
+    resource = run.target_ref["project_context_snapshot"]["resources"][1]
     assert resource["path"] == str(checkout)
     assert resource["materialization"] == {
         "status": "ready",
@@ -646,8 +666,12 @@ async def test_materialize_ignores_stale_managed_run_path_and_uses_thread_root(t
 
     assert result.ok
     assert clone_calls == [expected_checkout]
-    assert result.workspaces == [{"name": "example-org/example-repo", "path": str(expected_checkout)}]
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    root_draft = thread_root / ".illo-project-context" / "local" / "run-46" / "project-root"
+    assert result.workspaces == [
+        {"name": "/", "path": str(root_draft)},
+        {"name": "example-org/example-repo", "path": str(expected_checkout)},
+    ]
+    resource = run.target_ref["project_context_snapshot"]["resources"][1]
     assert resource["path"] == str(expected_checkout)
 
 
@@ -715,7 +739,7 @@ async def test_materialize_refuses_to_overwrite_non_matching_thread_checkout(tmp
     assert run.target_status == "invalid"
 
 
-async def test_materialize_empty_project_context_is_ready_noop(tmp_path, monkeypatch):
+async def test_materialize_empty_project_context_creates_project_root(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context import materializer
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
 
@@ -752,15 +776,20 @@ async def test_materialize_empty_project_context_is_ready_noop(tmp_path, monkeyp
     result = await materialize_project_context_workspaces(48, workspace_root=str(tmp_path), user_id="user-1")
 
     assert result.ok
+    draft_dir = tmp_path / ".illo-project-context" / "local" / "run-48" / "project-root"
+    source_root = tmp_path.parent / "project-roots" / "run-48"
     assert result.empty_project is True
-    assert result.workspaces == []
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
     assert result.errors == []
-    assert run.target_ref["project_context_snapshot"]["resources"] == []
-    assert run.workspace_ref["project_workspace_manifest"]["mounts"] == []
-    assert run.workspace_ref["project_workspace_manifest"]["workspaces"] == []
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
+    assert resource["materialization"]["source_path"] == str(source_root)
+    assert run.workspace_ref["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
+    assert run.workspace_ref["project_workspace_manifest"]["workspaces"] == [{"name": "/", "path": str(draft_dir)}]
     assert run.workspace_ref["project_context_materialization"]["status"] == "materialized"
     assert run.workspace_ref["project_context_materialization"]["empty_project"] is True
-    assert "workspace_root" not in run.workspace_ref
+    assert run.workspace_ref["workspace_root"] == str(draft_dir)
 
 
 async def test_materialize_missing_project_context_snapshot_reports_error(tmp_path, monkeypatch):
@@ -852,21 +881,25 @@ async def test_materialize_backend_readable_folder_becomes_thread_draft_workspac
 
     result = await materialize_project_context_workspaces(51, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
 
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "profile-abc" / "resource-folder"
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "profile-abc" / "project-root"
+    source_root = tmp_path / "project-roots" / "profile-abc"
     assert result.ok
-    assert result.workspaces == [{"name": "/reports", "path": str(draft_dir)}]
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
     assert (draft_dir / "brief.md").read_text() == "runtime context"
     resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
     assert resource["path"] == str(draft_dir)
-    assert resource["materialization"]["source_path"] == str(project_dir)
+    assert resource["materialization"]["source_path"] == str(source_root)
+    assert (source_root / "brief.md").read_text() == "runtime context"
     assert resource["materialization"]["workspace_path"] == str(draft_dir)
     assert resource["materialization"]["draft"] is True
     assert resource["materialization"]["project_key"] == "profile-abc"
     assert run.workspace_ref["workspace_root"] == str(draft_dir)
-    assert run.workspace_ref["project_workspace_manifest"]["workspaces"][0]["name"] == "/reports"
+    assert run.workspace_ref["project_workspace_manifest"]["workspaces"][0]["name"] == "/"
 
 
-async def test_materialize_backend_readable_file_uses_parent_workspace(tmp_path, monkeypatch):
+async def test_materialize_single_uploaded_file_uses_project_native_folder_root(tmp_path, monkeypatch):
     from brain.systems.cortex.project_context import materializer
     from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
 
@@ -915,16 +948,104 @@ async def test_materialize_backend_readable_file_uses_parent_workspace(tmp_path,
 
     result = await materialize_project_context_workspaces(53, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
 
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "attachment-1"
-    draft_file = draft_dir / "spec.md"
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "attachment-1" / "project-root"
     assert result.ok
-    assert result.workspaces == [{"name": "spec.md", "path": str(draft_dir)}]
-    assert draft_file.read_text() == "# Spec"
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (draft_dir / "spec.md").read_text() == "# Spec"
     resource = run.target_ref["project_context_snapshot"]["resources"][0]
-    assert resource["path"] == str(draft_file)
-    assert resource["materialization"]["source_path"] == str(spec_file)
+    source_root = Path(resource["materialization"]["source_path"])
+    assert source_root != spec_file
+    assert source_root.is_dir()
+    assert (source_root / "spec.md").read_text() == "# Spec"
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
+    assert resource["path"] == str(draft_dir)
+    assert resource["materialization"]["path"] == str(draft_dir)
+    assert resource["materialization"]["kind"] == "project_root"
     assert resource["materialization"]["workspace_path"] == str(draft_dir)
+    assert resource["materialization"]["draft"] is True
     assert run.workspace_ref["workspace_root"] == str(draft_dir)
+    mount = run.workspace_ref["project_workspace_manifest"]["mounts"][0]
+    assert mount["kind"] == "project_root"
+    assert mount["source_path"] == str(source_root)
+    assert mount["resource_path"] == str(draft_dir)
+
+
+async def test_materialize_uploaded_folder_imports_files_into_project_native_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    upload_dir = tmp_path / "uploads"
+    (upload_dir / "folder").mkdir(parents=True)
+    first_file = upload_dir / "folder" / "brief.md"
+    second_file = upload_dir / "folder" / "data" / "metrics.csv"
+    second_file.parent.mkdir()
+    first_file.write_text("brief", encoding="utf-8")
+    second_file.write_text("metric,value\n", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=57,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "folder-upload",
+                        "kind": "folder",
+                        "name": "folder",
+                        "uri": "project-context-upload://folder",
+                        "uploaded_files": [
+                            {
+                                "filename": "brief.md",
+                                "relative_path": "folder/brief.md",
+                                "storage_path": str(first_file),
+                            },
+                            {
+                                "filename": "metrics.csv",
+                                "relative_path": "folder/data/metrics.csv",
+                                "storage_path": str(second_file),
+                            },
+                        ],
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        57,
+        workspace_root=str(tmp_path / "thread-root"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "folder-upload" / "project-root"
+    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (source_root / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
+    assert (source_root / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
+    assert (draft_dir / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
+    assert (draft_dir / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
 
 
 async def test_materialize_thread_draft_marks_conflict_when_root_and_draft_changed(tmp_path, monkeypatch):
@@ -973,11 +1094,12 @@ async def test_materialize_thread_draft_marks_conflict_when_root_and_draft_chang
     monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
 
     first = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "resource-folder"
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "resource-folder" / "project-root"
+    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
 
     assert first.ok
     (draft_dir / "brief.md").write_text("draft edit")
-    (project_dir / "brief.md").write_text("root v2")
+    (source_root / "brief.md").write_text("root v2")
 
     second = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
 

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -13,6 +13,31 @@ def test_thread_attachment_file_is_not_materialized_as_github_workspace():
     }) is None
 
 
+def test_project_context_materializable_resources_require_real_local_path_or_repo():
+    from brain.systems.cortex.project_context.materializer import project_context_has_materializable_resources
+
+    assert project_context_has_materializable_resources({
+        "resources": [
+            {
+                "id": "placeholder-folder",
+                "kind": "folder",
+                "name": "agent-mission-control/workspaces/linkedin-outbound",
+                "uri": "browser-folder://pending",
+            }
+        ]
+    }) is False
+    assert project_context_has_materializable_resources({
+        "resources": [
+            {
+                "id": "github-folder",
+                "kind": "folder",
+                "name": "agent-mission-control/workspaces/linkedin-outbound",
+                "uri": "github://uwear-ai/agent-mission-control/workspaces/linkedin-outbound",
+            }
+        ]
+    }) is True
+
+
 def test_runner_materializes_thread_attachment_files_as_project_resources(monkeypatch):
     from brain.systems.runs.cortex import runner
 
@@ -65,6 +90,56 @@ def test_runner_materializes_thread_attachment_files_as_project_resources(monkey
 
     assert context_ready is True
     assert status_payload is None
+
+
+def test_runner_skips_placeholder_project_resources_without_failing(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=52,
+        root_run_id=None,
+        user_id="user-1",
+        org_id="org-1",
+        thread_id="idea-5",
+        target_ref={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "placeholder-folder",
+                        "kind": "folder",
+                        "name": "not-yet-uploaded",
+                        "uri": "browser-folder://not-yet-uploaded",
+                    }
+                ],
+            }
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    materialize = AsyncMock()
+    monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
+    monkeypatch.setattr(runner, "materialize_project_context_workspaces", materialize)
+
+    context_ready, status_payload = runner._materialize_project_context(52)
+
+    assert context_ready is True
+    assert status_payload is None
+    materialize.assert_not_called()
 
 
 async def test_materialize_github_project_context_uses_vault_key_without_persisting_token(tmp_path, monkeypatch):
@@ -157,6 +232,75 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
     assert run.metadata_["workspaces"] == result.workspaces
     assert "test-private-token" not in str(run.metadata_)
     assert "test-private-token" not in str(run.target_metadata)
+
+
+async def test_materialize_github_folder_uri_mounts_repo_subpath(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=54,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "resource-2",
+                        "kind": "folder",
+                        "name": "agent-mission-control/workspaces/linkedin-outbound",
+                        "label": "agent-mission-control/workspaces/linkedin-outbound",
+                        "uri": "github://uwear-ai/agent-mission-control/workspaces/linkedin-outbound",
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def fake_clone(slug, destination, *, token, branch):
+        assert slug == "uwear-ai/agent-mission-control"
+        workspace = destination / "workspaces" / "linkedin-outbound"
+        workspace.mkdir(parents=True)
+        (workspace / "README.md").write_text("LinkedIn workflow", encoding="utf-8")
+        return {"path": str(destination), "branch": branch or "main", "commit": "abc123"}
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "_token_candidates", AsyncMock(return_value=[(None, None)]))
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(
+        54,
+        workspace_root=str(tmp_path / "thread-root"),
+        user_id="user-1",
+        org_id="org-1",
+    )
+
+    expected_repo = tmp_path / "thread-root" / ".illo-project-context" / "github" / "uwear-ai" / "agent-mission-control"
+    expected_workspace = expected_repo / "workspaces" / "linkedin-outbound"
+    assert result.ok
+    assert result.workspaces == [{"name": "agent-mission-control/workspaces/linkedin-outbound", "path": str(expected_workspace)}]
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert resource["repo"] == "uwear-ai/agent-mission-control"
+    assert resource["path"] == str(expected_workspace)
+    assert resource["materialization"]["repo_path"] == str(expected_repo)
+    assert resource["materialization"]["subpath"] == "workspaces/linkedin-outbound"
+    assert resource["materialization"]["workspace_path"] == str(expected_workspace)
 
 
 async def test_materialize_github_project_context_finds_general_github_token(tmp_path, monkeypatch):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -40,10 +40,10 @@ def test_project_context_materializable_resources_include_empty_project_roots():
     }) is True
 
 
-def test_project_root_key_prefers_canonical_project_key_over_legacy_id():
+def test_project_root_key_uses_canonical_project_key():
     from brain.systems.cortex.project_context.project_root import project_key_from_context
 
-    assert project_key_from_context({"id": "legacy-context", "project_key": "profile-1"}) == "profile-1"
+    assert project_key_from_context({"project_key": "project-1"}) == "project-1"
 
 
 def test_runner_materializes_thread_attachment_files_as_project_resources(monkeypatch):
@@ -848,7 +848,7 @@ async def test_materialize_backend_readable_folder_becomes_thread_draft_workspac
         target_ref={
             "kind": "cortex_idea",
             "project_context_snapshot": {
-                "id": "profile-abc",
+                "project_id": "profile-abc",
                 "status": "validated",
                 "resources": [
                     {
@@ -1072,8 +1072,8 @@ async def test_materialize_saved_project_root_identity_survives_resource_changes
                 "kind": "cortex_idea",
                 "project_context_snapshot": {
                     "project_key": "profile-stable",
-                    "profile_id": "profile-stable",
-                    "profile_slug": "strategy-room",
+                    "project_id": "profile-stable",
+                    "slug": "strategy-room",
                     "status": "validated",
                     "resources": resources,
                 },

--- a/tests/test_project_context_workspace_manifest.py
+++ b/tests/test_project_context_workspace_manifest.py
@@ -9,7 +9,7 @@ from brain.systems.cortex.project_context.workspace_manifest import (
 
 def test_workspace_manifest_disambiguates_duplicate_mount_paths():
     manifest = ProjectWorkspaceManifest.from_project_context({
-        "id": "profile-a",
+        "project_id": "project-a",
         "resources": [
             {
                 "id": "first-report-pack",
@@ -44,7 +44,7 @@ def test_workspace_manifest_disambiguates_duplicate_mount_paths():
 
 def test_durable_project_workspace_manifest_contract_disambiguates_mounts_without_materialization():
     contract = build_project_workspace_manifest_contract({
-        "id": "profile-a",
+        "project_id": "project-a",
         "resources": [
             {
                 "id": "first-report-pack",
@@ -61,7 +61,7 @@ def test_durable_project_workspace_manifest_contract_disambiguates_mounts_withou
         ],
     })
 
-    assert contract["project_key"] == "profile-a"
+    assert contract["project_key"] == "project-a"
     assert [mount["resource_id"] for mount in contract["mounts"]] == ["first-report-pack", "second-report-pack"]
     assert [mount["mount_path"] for mount in contract["mounts"]] == ["/reports", "/reports-2"]
     assert [mount["original_mount_path"] for mount in contract["mounts"]] == ["/reports", "/reports"]
@@ -78,12 +78,12 @@ def test_thread_draft_identity_is_scoped_by_project():
     first = ThreadDraftIdentity.from_project_resource(
         resource,
         thread_workspace_root="/tmp/thread-root",
-        project_context={"id": "project-alpha"},
+        project_context={"project_id": "project-alpha"},
     )
     second = ThreadDraftIdentity.from_project_resource(
         resource,
         thread_workspace_root="/tmp/thread-root",
-        project_context={"id": "project-beta"},
+        project_context={"project_id": "project-beta"},
     )
     unscoped = ThreadDraftIdentity.from_project_resource(
         resource,
@@ -99,7 +99,7 @@ def test_thread_draft_identity_is_scoped_by_project():
 
 def test_mount_path_is_the_agent_facing_truth():
     manifest = normalize_project_workspace_manifest({
-        "id": "profile-a",
+        "project_id": "project-a",
         "resources": [
             {
                 "id": "resource-folder",

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -182,7 +182,7 @@ async def test_cortex_agent_run_request_uses_shared_work_intake_policy(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_cortex_work_intake_stamps_profile_identity_from_latest_attachment(monkeypatch):
+async def test_cortex_work_intake_stamps_project_identity_from_latest_attachment(monkeypatch):
     from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
 
     class _Session:
@@ -233,8 +233,8 @@ async def test_cortex_work_intake_stamps_profile_identity_from_latest_attachment
     )
 
     assert request.workspace_ref["project_key"] == "profile-1"
-    assert request.workspace_ref["profile_id"] == "profile-1"
-    assert request.workspace_ref["profile_slug"] == "strategy-room"
+    assert request.workspace_ref["project_id"] == "profile-1"
+    assert request.workspace_ref["slug"] == "strategy-room"
     assert request.target_ref["project_context_snapshot"]["project_key"] == "profile-1"
 
 

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -182,6 +182,63 @@ async def test_cortex_agent_run_request_uses_shared_work_intake_policy(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_cortex_work_intake_stamps_profile_identity_from_latest_attachment(monkeypatch):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    class _Session:
+        async def get(self, model, key):
+            name = getattr(model, "__name__", "")
+            if name == "Idea":
+                return SimpleNamespace(
+                    id="idea-1",
+                    title="Launch",
+                    org_id="org-1",
+                    user_id="owner-1",
+                    agent_details=None,
+                )
+            if name == "ProjectProfile":
+                assert key == "profile-1"
+                return SimpleNamespace(
+                    id="profile-1",
+                    slug="strategy-room",
+                    name="Strategy Room",
+                    description=None,
+                    active=True,
+                    project_context={"resources": []},
+                )
+            return None
+
+        async def scalars(self, *_args, **_kwargs):
+            attachment = SimpleNamespace(project_profile_id="profile-1", snapshot={"resources": []})
+            return SimpleNamespace(first=lambda: attachment)
+
+    async def fake_thread_context(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "brain.systems.runs.work_intake.async_build_agent_visible_thread_context",
+        fake_thread_context,
+    )
+
+    request = await build_agent_run_request(
+        _Session(),
+        WorkIntakeEvent(
+            source="cortex",
+            event_type="cortex.thread_reply",
+            org_id="org-1",
+            actor={"id": "user-1", "org_id": "org-1", "internal": False},
+            target={"kind": "cortex_idea", "idea_id": "idea-1"},
+            payload={"message": "@illo continue", "metadata": {}},
+        ),
+    )
+
+    assert request.workspace_ref["project_key"] == "profile-1"
+    assert request.workspace_ref["profile_id"] == "profile-1"
+    assert request.workspace_ref["profile_slug"] == "strategy-room"
+    assert request.target_ref["project_context_snapshot"]["project_key"] == "profile-1"
+
+
+@pytest.mark.asyncio
 async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_comment(monkeypatch):
     from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
 


### PR DESCRIPTION
## Summary
- make every Project materialize a durable Project-native folder root under `project-roots/{project_key}`, even when it starts empty
- import uploaded files, uploaded folders, and local seed folders into that root by default, then expose a thread-level copy-on-write draft mounted at `/`
- keep repo Projects on the same model: `/` is the Project-native root, while repos remain mounted resources that can be materialized/published through their repo adapter
- remove the single-file-root sibling publish blocker so legacy file-root drafts can publish new Project-native files instead of getting trapped
- make materialization idempotent so already-upgraded Project roots do not duplicate resources or resurrect deleted imported files
- stamp saved Project profiles, attachments, read models, agent `manage_project`, and work intake with canonical `project_key`/profile identity so resource changes and thread changes keep the same root

## Verification
- `pytest -q tests/ -m "not requires_db"`: 2944 passed, 58 skipped, 25 deselected
- `pytest -q tests/test_project_context_*.py tests/test_manage_project_*.py tests/test_api_cortex.py::test_create_project_profile_allows_empty_project_context tests/test_api_cortex.py::test_project_profile_resource_endpoints_mutate_context tests/test_api_cortex.py::test_attach_project_profile_stamps_profile_identity_in_snapshot tests/test_work_intake.py`: 103 passed
- `python3 -m py_compile brain/systems/cortex/project_context/identity.py brain/systems/cortex/project_context/profiles.py brain/systems/cortex/project_context/project_root.py brain/systems/cortex/project_context/workspace_manifest.py brain/systems/cortex/project_context/snapshot.py brain/app/api/routers/cortex/_project_context.py brain/systems/runs/tool_catalog/handlers/projects.py brain/systems/runs/work_intake.py`: passed

## Notes
- Local unrelated dirty files remain unstaged and are not part of this PR: `deploy/docker/web.nginx.conf`, `frontend/vite.config.ts`.
