### PR TITLE
Refine Discussion thread surface handling

### DIFF
--- a/brain/app/api/routers/cortex/_discussion.py
+++ b/brain/app/api/routers/cortex/_discussion.py
@@ -89,7 +89,7 @@ def _discussion_trigger_metadata(
         "discussion_comment_id": comment.id,
         "discussion_trigger": discussion_trigger,
         "required_response_tool": THREAD_DISCUSSION_REPLY_TOOL,
-        "final_answer_target_surface": "originating_surface",
+        "final_answer_target_surface": THREAD_DISCUSSION_SURFACE,
         "thread_message": comment.body,
         "request_source_context": {
             "surface": THREAD_DISCUSSION_SURFACE,
@@ -126,19 +126,18 @@ async def _trigger_illo_from_discussion(
     comment: ThreadDiscussionComment,
     user: dict[str, Any],
 ) -> dict[str, Any]:
-    from brain.app.triggers.adapters.internal import build_cortex_notify_trigger
+    from brain.app.triggers.adapters.internal import build_thread_discussion_mention_trigger
     from brain.app.triggers.router import async_route_trigger
 
     discussion_trigger = _discussion_trigger_context(idea=idea, comment=comment, user=user)
     metadata = _discussion_trigger_metadata(comment=comment, discussion_trigger=discussion_trigger)
-    trigger = build_cortex_notify_trigger(
-        event="thread_reply",
+    trigger = build_thread_discussion_mention_trigger(
         idea_id=str(idea.id),
         idea=idea,
+        comment=comment,
         user=user,
-        thread_message=comment.body,
+        discussion_trigger=discussion_trigger,
         metadata=metadata,
-        effective_metadata=metadata,
         priority=0,
     )
     return (await async_route_trigger(trigger, session=db)).to_response()

--- a/brain/app/triggers/adapters/internal.py
+++ b/brain/app/triggers/adapters/internal.py
@@ -18,27 +18,29 @@ def _idea_payload(idea: Any) -> dict[str, Any]:
     }
 
 
-def _discussion_reply_run_message(
+THREAD_DISCUSSION_SURFACE = "thread_discussion"
+THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
+THREAD_DISCUSSION_EVENT = "thread_discussion_mention"
+THREAD_DISCUSSION_EVENT_TYPE = f"cortex.{THREAD_DISCUSSION_EVENT}"
+
+
+def _discussion_mention_run_message(
     *,
     idea_data: dict[str, Any],
     idea_id: str,
     thread_message: str,
-    metadata: dict[str, Any] | None,
+    discussion_trigger: dict[str, Any],
 ) -> str:
-    metadata = dict(metadata or {})
-    discussion_trigger = metadata.get("discussion_trigger")
-    if not isinstance(discussion_trigger, dict):
-        discussion_trigger = {}
-    comment_id = discussion_trigger.get("comment_id") or metadata.get("discussion_comment_id")
+    comment_id = discussion_trigger.get("comment_id")
     return "\n".join(
         [
             f"[Thread: \"{idea_data['title']}\" | {idea_id}]",
             "",
             "A teammate summoned @illo from Thread Discussion.",
-            "Originating surface: thread_discussion.",
+            "This is a separate Discussion conversation attached to the Thread, not an AI Timeline reply.",
             "Acknowledge or answer in Discussion with post_thread_discussion_reply when a visible response fits.",
             "Use read_thread_discussion if more Discussion context is needed.",
-            "Use AI Timeline tools such as cortex_reply only when continuing the underlying Thread work belongs there.",
+            "Treat the AI Timeline as related context only unless a separate tool explicitly asks you to act there.",
             "You may also act headlessly when no visible surface update is appropriate.",
             "",
             f"Triggering Discussion comment id: {comment_id}",
@@ -84,18 +86,7 @@ def build_cortex_notify_trigger(
         run_metadata = metadata
     else:
         run_metadata = effective_metadata if effective_metadata is not None else metadata
-        if (
-            isinstance(run_metadata, dict)
-            and str(run_metadata.get("originating_surface") or "") == "thread_discussion"
-        ):
-            run_message = _discussion_reply_run_message(
-                idea_data=idea_data,
-                idea_id=idea_id,
-                thread_message=thread_message,
-                metadata=run_metadata,
-            )
-        else:
-            run_message = f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n{thread_message[:2000]}"
+        run_message = f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n{thread_message[:2000]}"
 
     payload = {
         "idea_id": idea_id,
@@ -129,6 +120,90 @@ def build_cortex_notify_trigger(
             "run_event": event,
             "priority": int(priority),
             "auth_path": "cortex_session",
+        },
+    )
+
+
+def build_thread_discussion_mention_trigger(
+    *,
+    idea_id: str,
+    idea: Any,
+    comment: Any,
+    user: dict[str, Any],
+    discussion_trigger: dict[str, Any],
+    metadata: dict[str, Any] | None = None,
+    priority: int = 0,
+) -> IlloTrigger:
+    """Normalize a Thread Discussion @illo mention into its own conversation trigger.
+
+    Discussion is not a disguised Cortex thread reply. It is a separate comment
+    surface linked to the Thread, so this trigger gets its own event and target
+    kind. Keeping that split explicit prevents agents from answering Discussion
+    mentions in the AI Timeline by accident.
+    """
+    org_id = str(getattr(idea, "org_id", None) or user.get("org_id") or "")
+    actor = human_identity(user) if user and user.get("id") and user.get("id") != "system" else None
+    idea_data = _idea_payload(idea)
+    comment_id = int(getattr(comment, "id"))
+    body = str(getattr(comment, "body", "") or "")
+    discussion_trigger = dict(discussion_trigger or {})
+    metadata = dict(metadata or {})
+    metadata.setdefault("source", THREAD_DISCUSSION_SURFACE)
+    metadata.setdefault("originating_surface", THREAD_DISCUSSION_SURFACE)
+    metadata.setdefault("triggering_surface", THREAD_DISCUSSION_SURFACE)
+    metadata.setdefault("source_surface", THREAD_DISCUSSION_SURFACE)
+    metadata.setdefault("required_response_tool", THREAD_DISCUSSION_REPLY_TOOL)
+    metadata.setdefault("final_answer_target_surface", THREAD_DISCUSSION_SURFACE)
+    metadata.setdefault("discussion_comment_id", comment_id)
+    metadata.setdefault("discussion_trigger", discussion_trigger)
+
+    target = {
+        "kind": THREAD_DISCUSSION_SURFACE,
+        "idea_id": idea_id,
+        "parent_thread_id": idea_id,
+        "discussion_comment_id": comment_id,
+        "surface": THREAD_DISCUSSION_SURFACE,
+    }
+    payload = {
+        "idea_id": idea_id,
+        "parent_thread_id": idea_id,
+        "idea": idea_data,
+        "discussion": discussion_trigger,
+        "thread_message": body[:2000],
+        "run_message": _discussion_mention_run_message(
+            idea_data=idea_data,
+            idea_id=idea_id,
+            thread_message=body,
+            discussion_trigger=discussion_trigger,
+        ),
+        "metadata": metadata,
+        "priority": int(priority),
+        "user_id": user.get("id") if user else None,
+    }
+    idempotency_key = stable_idempotency_key(
+        source="cortex",
+        event_type=THREAD_DISCUSSION_EVENT_TYPE,
+        org_id=org_id,
+        target=target,
+        payload={
+            "discussion_comment_id": comment_id,
+            "thread_message": payload["thread_message"],
+            "priority": payload["priority"],
+        },
+    )
+    return IlloTrigger(
+        source="cortex",
+        event_type=THREAD_DISCUSSION_EVENT_TYPE,
+        actor=actor,
+        org_id=org_id,
+        target=target,
+        payload=payload,
+        idempotency_key=idempotency_key,
+        policy={
+            "route": "run",
+            "run_event": THREAD_DISCUSSION_EVENT,
+            "priority": int(priority),
+            "auth_path": "cortex_discussion_session",
         },
     )
 

--- a/brain/app/triggers/contracts.py
+++ b/brain/app/triggers/contracts.py
@@ -29,6 +29,7 @@ ILLO_NATIVE_SOURCES = frozenset({
 ILLO_NATIVE_EVENTS = frozenset({
     "cortex.thread_reply",
     "cortex.idea_created",
+    "cortex.thread_discussion_mention",
     "cortex.thought_state_changed",
     "cycle.due_run",
     "memory.review_due",

--- a/brain/app/triggers/router.py
+++ b/brain/app/triggers/router.py
@@ -7,7 +7,11 @@ from typing import Any
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.app.triggers.contracts import IlloTrigger, TriggerRouteResult
 
-_CORTEX_TRIGGER_EVENTS = {"cortex.idea_created", "cortex.thread_reply"}
+_CORTEX_TRIGGER_EVENTS = {
+    "cortex.idea_created",
+    "cortex.thread_reply",
+    "cortex.thread_discussion_mention",
+}
 _CHAT_TRIGGER_EVENTS = {"chat.room_message_mention", "chat.room_thread_mention"}
 _RUN_TRIGGER_EVENTS = _CORTEX_TRIGGER_EVENTS | _CHAT_TRIGGER_EVENTS
 

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -31,7 +31,7 @@ from brain.systems.cortex.project_context.materializer import (
 )
 from brain.systems.cortex.thought_lifecycle import TerminalRunSettlementCommand, settle_terminal_run
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
-from brain.platform.db.models.idea import Idea, IdeaThread
+from brain.platform.db.models.idea import Idea, IdeaThread, ThreadDiscussionComment
 
 logger = logging.getLogger(__name__)
 UnitOfWork = None
@@ -212,22 +212,47 @@ _TERMINAL_RUN_IDEA_STATUS = {
 }
 _PROTECTED_IDEA_STATUSES = {"archived", "resolved"}
 _AI_TIMELINE_SURFACES = {"ai_timeline", "thread_timeline", "cortex_thread", "main_thread"}
+_THREAD_DISCUSSION_SURFACE = "thread_discussion"
+_THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 _NON_TIMELINE_FINAL_ANSWER_TARGETS = {
     "discussion",
     "headless",
     "none",
     "originating_surface",
-    "thread_discussion",
+    _THREAD_DISCUSSION_SURFACE,
 }
 
 
+def _run_target_ref(run: AgentRunRow) -> dict[str, Any]:
+    value = getattr(run, "target_ref", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _run_metadata(run: AgentRunRow) -> dict[str, Any]:
+    value = getattr(run, "metadata_", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _run_context_maps(run: AgentRunRow):
+    for container in (_run_target_ref(run), _run_metadata(run)):
+        if container:
+            yield container
+
+
+def _run_is_thread_discussion_conversation(run: AgentRunRow) -> bool:
+    for container in _run_context_maps(run):
+        if container.get("kind") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("originating_surface") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("surface") == _THREAD_DISCUSSION_SURFACE:
+            return True
+    thread_id = str(getattr(run, "thread_id", "") or "")
+    return thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+
+
 def _run_surface_value(run: AgentRunRow, key: str) -> str:
-    for container in (
-        getattr(run, "target_ref", None),
-        getattr(run, "metadata_", None),
-    ):
-        if not isinstance(container, dict):
-            continue
+    for container in _run_context_maps(run):
         value = container.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
@@ -235,36 +260,15 @@ def _run_surface_value(run: AgentRunRow, key: str) -> str:
 
 
 def _run_should_mirror_final_answer_to_timeline(run: AgentRunRow) -> bool:
+    if _run_is_thread_discussion_conversation(run):
+        return False
     target_surface = _run_surface_value(run, "final_answer_target_surface")
     if target_surface in _AI_TIMELINE_SURFACES:
         return True
     if target_surface in _NON_TIMELINE_FINAL_ANSWER_TARGETS:
         return False
     originating_surface = _run_surface_value(run, "originating_surface")
-    return originating_surface != "thread_discussion"
-
-
-async def _run_completed_tool(session, *, run_id: int, tool_name: str) -> bool:
-    if not hasattr(session, "scalars"):
-        return False
-    try:
-        result = await session.scalars(
-            select(AgentRunEventRow)
-            .where(
-                AgentRunEventRow.run_id == int(run_id),
-                AgentRunEventRow.event_type == "run.tool_completed",
-            )
-            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
-            .limit(50)
-        )
-        events = list(result.all())
-    except Exception:
-        return False
-    for event in events:
-        payload = event.payload if isinstance(event.payload, dict) else {}
-        if str(payload.get("tool_name") or payload.get("tool") or "") == tool_name:
-            return True
-    return False
+    return originating_surface != _THREAD_DISCUSSION_SURFACE
 
 
 def _message_belongs_to_run(message: IdeaThread, run_id: int) -> bool:
@@ -274,7 +278,7 @@ def _message_belongs_to_run(message: IdeaThread, run_id: int) -> bool:
     return str(metadata.get("run_id") or "") == str(run_id)
 
 
-async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Idea) -> tuple[str | None, int | None]:
+async def _latest_final_answer_artifact(session, *, run: AgentRunRow) -> tuple[str | None, int | None]:
     artifact = (
         await session.scalars(
             select(AgentRunArtifactRow)
@@ -289,6 +293,13 @@ async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Id
     text = str(getattr(artifact, "text", None) or "").strip()
     if not text:
         return None, None
+    return text, getattr(artifact, "id", None)
+
+
+async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Idea) -> tuple[str | None, int | None]:
+    text, artifact_id = await _latest_final_answer_artifact(session, run=run)
+    if not text:
+        return None, None
     recent_responses = (
         await session.scalars(
             select(IdeaThread)
@@ -301,17 +312,152 @@ async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Id
     ).all()
     if any(_message_belongs_to_run(message, int(run.id)) for message in recent_responses):
         return None, None
-    return text, getattr(artifact, "id", None)
+    return text, artifact_id
+
+
+def _run_discussion_trigger(run: AgentRunRow) -> dict[str, Any]:
+    for container in _run_context_maps(run):
+        trigger = container.get("discussion_trigger")
+        if isinstance(trigger, dict):
+            return dict(trigger)
+    return {}
+
+
+def _run_discussion_thread_id(run: AgentRunRow) -> str:
+    trigger = _run_discussion_trigger(run)
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    target_ref = _run_target_ref(run)
+    for candidate in (
+        response_target.get("thread_id") if isinstance(response_target, dict) else None,
+        trigger.get("thread_id"),
+        target_ref.get("parent_thread_id"),
+        target_ref.get("idea_id"),
+    ):
+        value = str(candidate or "").strip()
+        if value:
+            return value
+    thread_id = str(getattr(run, "thread_id", "") or "")
+    return (
+        thread_id[len(_THREAD_DISCUSSION_THREAD_PREFIX):]
+        if thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+        else ""
+    )
+
+
+def _comment_belongs_to_run(comment: ThreadDiscussionComment, run_id: int) -> bool:
+    metadata = getattr(comment, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return False
+    return str(metadata.get("created_by_run_id") or "") == str(run_id)
+
+
+async def _discussion_reply_already_recorded(session, *, run: AgentRunRow, thread_id: str) -> bool:
+    if not hasattr(session, "scalars"):
+        return False
+    try:
+        result = await session.scalars(
+            select(ThreadDiscussionComment)
+            .where(
+                ThreadDiscussionComment.thread_id == str(thread_id),
+                ThreadDiscussionComment.author_kind == "illo",
+            )
+            .order_by(ThreadDiscussionComment.created_at.desc(), ThreadDiscussionComment.id.desc())
+            .limit(100)
+        )
+        comments = list(result.all())
+    except Exception:
+        return False
+    return any(_comment_belongs_to_run(comment, int(run.id)) for comment in comments)
+
+
+def _thread_discussion_comment_payload(comment: ThreadDiscussionComment) -> dict[str, Any]:
+    return {
+        "id": comment.id,
+        "thread_id": str(comment.thread_id),
+        "org_id": str(comment.org_id),
+        "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
+        "author_kind": comment.author_kind,
+        "author_name": None,
+        "author_color": None,
+        "body": comment.body,
+        "attachments": comment.attachments or [],
+        "metadata": comment.metadata_ or {},
+        "created_at": comment.created_at.isoformat() if comment.created_at else None,
+    }
+
+
+async def _settle_thread_discussion_conversation_run_async(
+    session,
+    run: AgentRunRow,
+) -> dict[str, Any] | None:
+    """Settle a Discussion-origin run back into Discussion, never the AI Timeline."""
+    if not _run_is_thread_discussion_conversation(run):
+        return None
+    if run.parent_run_id is not None:
+        return None
+    thread_id = _run_discussion_thread_id(run)
+    org_id = str(getattr(run, "org_id", "") or "").strip()
+    if not thread_id or not org_id:
+        return None
+    if await _discussion_reply_already_recorded(session, run=run, thread_id=thread_id):
+        return None
+    final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
+    if not final_answer:
+        return None
+
+    trigger = _run_discussion_trigger(run)
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    reply_to_comment_id = response_target.get("reply_to_comment_id") or trigger.get("comment_id")
+    metadata: dict[str, Any] = {
+        "source": "agent_run_final_answer",
+        "surface": _THREAD_DISCUSSION_SURFACE,
+        "created_by_run_id": int(run.id),
+        "artifact_id": artifact_id,
+    }
+    if reply_to_comment_id not in (None, ""):
+        metadata["reply_to_comment_id"] = reply_to_comment_id
+
+    comment = ThreadDiscussionComment(
+        thread_id=thread_id,
+        org_id=org_id,
+        author_user_id=None,
+        author_kind="illo",
+        body=final_answer,
+        attachments=[],
+        metadata_=metadata,
+    )
+    session.add(comment)
+    if hasattr(session, "flush"):
+        await session.flush()
+    payload = _thread_discussion_comment_payload(comment)
+    publish_safe(
+        "thread_discussion_comment",
+        {"idea_id": thread_id, "org_id": org_id, "comment": payload},
+    )
+    return {
+        "surface": _THREAD_DISCUSSION_SURFACE,
+        "idea_id": thread_id,
+        "run_id": int(run.id),
+        "comment_id": getattr(comment, "id", None),
+    }
+
+
+async def _settle_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
+    run = await session.get(AgentRunRow, int(run_id))
+    if run is None or run.parent_run_id is not None:
+        return None
+    if _run_is_thread_discussion_conversation(run):
+        return await _settle_thread_discussion_conversation_run_async(session, run)
+    return await _settle_idea_for_terminal_root_run_async(session, run_id)
 
 
 async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
     run = await session.get(AgentRunRow, int(run_id))
     if run is None or run.parent_run_id is not None:
         return None
-    if (
-        not _run_should_mirror_final_answer_to_timeline(run)
-        and not await _run_completed_tool(session, run_id=int(run_id), tool_name="cortex_reply")
-    ):
+    if _run_is_thread_discussion_conversation(run):
+        return None
+    if not _run_should_mirror_final_answer_to_timeline(run):
         return None
     target_status = _TERMINAL_RUN_IDEA_STATUS.get(str(run.status or ""))
     if not target_status or not run.thread_id:
@@ -602,7 +748,7 @@ async def reap_stale_active_runs(
             event_row = await store.append_event(event)
             await store.set_status(int(row.id), RunStatus.FAILED, reason="runner_heartbeat_stale")
             await _project_live_event_async(uow.session, event.event_type, _event_stream_payload(event, event_row, row))
-            status_payload = await _settle_idea_for_terminal_root_run_async(uow.session, int(row.id))
+            status_payload = await _settle_terminal_root_run_async(uow.session, int(row.id))
             if status_payload:
                 status_payloads.append(status_payload)
             reaped += 1
@@ -700,7 +846,7 @@ async def _mark_run_failed_after_runner_error_async(
                 )
             await store.append_event(run_event(int(run_id), "run.failed", {"error": error}, root_run_id=row.root_run_id))
             await store.set_status(int(run_id), RunStatus.FAILED, reason=error[:500])
-        return await _settle_idea_for_terminal_root_run_async(uow.session, int(run_id))
+        return await _settle_terminal_root_run_async(uow.session, int(run_id))
 
 
 def _mark_run_failed_after_runner_error(
@@ -740,7 +886,7 @@ async def _run_queued_once_async(*, limit: int = 1) -> int:
                 async with _unit_of_work_factory()() as uow:
                     completed_run = await _engine_for_session(uow.session).run_existing(int(run_id))
                     completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
-                    status_payload = await _settle_idea_for_terminal_root_run_async(uow.session, int(run_id))
+                    status_payload = await _settle_terminal_root_run_async(uow.session, int(run_id))
                 await _finalize_cycle_run_if_needed_async(int(run_id), status=completed_status)
             if status_payload:
                 publish_safe("status_change", status_payload)

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -53,15 +53,6 @@ def _disabled_tool_names(runtime: RunRuntime) -> set[str]:
 
 def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
     hidden = _FAST_HIDDEN_TOOL_NAMES | _disabled_tool_names(runtime)
-    target_ref = getattr(runtime.request, "target_ref", {}) or {}
-    surface = str(
-        runtime.request.metadata.get("originating_surface")
-        or target_ref.get("originating_surface")
-        or ""
-    )
-    if surface == "thread_discussion":
-        hidden = set(hidden)
-        hidden.discard("cortex_reply")
     return [
         tool
         for tool in build_agent_tools("coordinator")

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1147,8 +1147,8 @@ CHAT_TOOLS = [
             "Post an Illo-authored reply into the current Thread Discussion. "
             "Use this when a run was summoned from Discussion, or when the natural "
             "answer belongs in Discussion rather than the AI Timeline. This does not "
-            "post to the AI Timeline; use cortex_reply or other Thread tools when the "
-            "underlying AI Timeline work should visibly continue there."
+            "post to the AI Timeline. Discussion and AI Timeline are separate "
+            "conversation surfaces linked by Thread context."
         ),
         "input_schema": {
             "type": "object",

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -22,6 +22,9 @@ from brain.systems.runs.store import AsyncAgentRunStore
 _VALID_MODEL_TIERS = {"low", "medium", "high"}
 _VALID_EFFORT_LEVELS = {"low", "medium", "high", "xhigh"}
 _VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
+THREAD_DISCUSSION_SURFACE = "thread_discussion"
+THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
+THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 
 
 @dataclass(frozen=True)
@@ -233,6 +236,29 @@ def _chat_thread_id(chat_trigger: dict[str, Any], target: dict[str, Any]) -> str
     return f"chat:{conversation_id}:{message_id}"
 
 
+def _thread_discussion_parent_thread_id(
+    discussion_trigger: dict[str, Any],
+    target: dict[str, Any],
+) -> str:
+    response_target = discussion_trigger.get("response_target")
+    if not isinstance(response_target, dict):
+        response_target = {}
+    thread_id = str(
+        response_target.get("thread_id")
+        or discussion_trigger.get("thread_id")
+        or target.get("parent_thread_id")
+        or target.get("idea_id")
+        or ""
+    ).strip()
+    if not thread_id:
+        raise ValueError("Thread Discussion run triggers require a parent Thread id")
+    return thread_id
+
+
+def _thread_discussion_conversation_id(parent_thread_id: str) -> str:
+    return f"{THREAD_DISCUSSION_THREAD_PREFIX}{parent_thread_id}"
+
+
 def _run_event(trigger: dict[str, Any], policy: dict[str, Any]) -> str:
     event_type = str(trigger.get("event_type") or "")
     return str(policy.get("run_event") or event_type.split(".", 1)[-1])
@@ -372,6 +398,111 @@ def _agent_run_request_for_chat(trigger_payload: dict[str, Any] | Any) -> AgentR
     )
 
 
+async def _agent_run_request_for_thread_discussion(
+    session: Any,
+    trigger_payload: dict[str, Any] | Any,
+) -> AgentRunRequest:
+    trigger = _trigger_dict(trigger_payload)
+    target = _trigger_target(trigger)
+    payload = _trigger_payload(trigger)
+    policy = _trigger_policy(trigger)
+    trigger_org_id = str(trigger.get("org_id") or "") or None
+    actor_user_id = _payload_user_id(payload, trigger, org_id=trigger_org_id)
+    metadata = _merge_trigger_metadata(
+        trigger,
+        payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None,
+    )
+    discussion_trigger = dict(metadata.get("discussion_trigger") or payload.get("discussion") or {})
+    parent_thread_id = _thread_discussion_parent_thread_id(discussion_trigger, target)
+    idea = await _a_get_idea_for_intake(
+        session,
+        parent_thread_id,
+        fallback_user_id=actor_user_id,
+    )
+    if idea is None:
+        raise LookupError(f"Thread {parent_thread_id} not found")
+
+    surface_context = {
+        "originating_surface": THREAD_DISCUSSION_SURFACE,
+        "triggering_surface": THREAD_DISCUSSION_SURFACE,
+        "source_surface": THREAD_DISCUSSION_SURFACE,
+        "required_response_tool": THREAD_DISCUSSION_REPLY_TOOL,
+        "final_answer_target_surface": THREAD_DISCUSSION_SURFACE,
+    }
+    for key, value in surface_context.items():
+        metadata.setdefault(key, value)
+    metadata["discussion_trigger"] = discussion_trigger
+
+    message = str(payload.get("run_message") or payload.get("message") or payload.get("thread_message") or "")
+    metadata = annotate_metadata_with_slash_skill_commands(metadata, message)
+    profile = profile_from_metadata(metadata)
+    recipe = recipe_for_profile(profile, metadata)
+    priority = _priority(payload, policy)
+    run_event = _run_event(trigger, policy)
+    project_context, project_context_snapshot, project_context_validation_errors = await _a_select_project_context(
+        session,
+        idea=idea,
+        idea_id=parent_thread_id,
+        metadata=metadata,
+    )
+    target_ref = {
+        **target,
+        "kind": THREAD_DISCUSSION_SURFACE,
+        "event": str(run_event),
+        "surface": THREAD_DISCUSSION_SURFACE,
+        "idea_id": parent_thread_id,
+        "parent_thread_id": parent_thread_id,
+        "discussion_trigger": discussion_trigger,
+        **surface_context,
+        "related_surfaces": {
+            "ai_timeline": {
+                "kind": "ai_timeline",
+                "thread_id": parent_thread_id,
+            }
+        },
+    }
+    workspace_ref = dict(project_context) if project_context_snapshot else {}
+    if project_context_validation_errors:
+        metadata["project_context_validation_errors"] = project_context_validation_errors
+    if project_context_snapshot:
+        metadata["project_context"] = project_context
+        metadata.pop("project_context_snapshot", None)
+        target_ref["project_context_snapshot"] = project_context_snapshot
+        workspace_ref["project_context_snapshot"] = project_context_snapshot
+    else:
+        metadata.pop("project_context", None)
+        metadata.pop("project_context_snapshot", None)
+    if not isinstance(metadata.get("thread_context"), dict):
+        thread_context = await async_build_agent_visible_thread_context(
+            session,
+            parent_thread_id,
+            current_message=message,
+        )
+        if thread_context:
+            metadata["thread_context"] = thread_context
+
+    return AgentRunRequest(
+        org_id=str(getattr(idea, "org_id", None) or trigger_org_id or "") or None,
+        user_id=actor_user_id or getattr(idea, "user_id", None),
+        thread_id=_thread_discussion_conversation_id(parent_thread_id),
+        message=message,
+        profile=profile,
+        recipe=recipe,
+        target_ref=target_ref,
+        workspace_ref=workspace_ref,
+        model_policy=model_policy_from_metadata(metadata),
+        metadata={
+            **metadata,
+            "event": str(run_event),
+            "priority": priority,
+            "source": trigger.get("source"),
+            "producer": "trigger",
+            "idempotency_key": trigger.get("idempotency_key"),
+            "org_id": trigger_org_id,
+        },
+    )
+
+
 def _external_agent_headless_thread_id(target: dict[str, Any]) -> str:
     thread_id = str(target.get("thread_id") or "")
     if thread_id:
@@ -445,6 +576,38 @@ async def build_agent_run_request(
             },
         }
         request = _agent_run_request_for_chat(trigger_payload)
+        return AgentRunRequest(
+            **{
+                **request.__dict__,
+                "metadata": {
+                    **request.metadata,
+                    "source": event.source,
+                    "producer": producer,
+                    "idempotency_key": idempotency_key,
+                    "work_intake": metadata["work_intake"],
+                },
+            }
+        )
+
+    if target.get("kind") == THREAD_DISCUSSION_SURFACE:
+        trigger_payload = {
+            "source": event.source,
+            "event_type": event.event_type,
+            "actor": _as_mapping(event.actor),
+            "org_id": event.org_id,
+            "target": target,
+            "payload": {
+                **dict(event.payload or {}),
+                "message": message,
+                "metadata": metadata,
+            },
+            "idempotency_key": idempotency_key,
+            "policy": {
+                **_event_policy(event),
+                "priority": priority,
+            },
+        }
+        request = await _agent_run_request_for_thread_discussion(session, trigger_payload)
         return AgentRunRequest(
             **{
                 **request.__dict__,

--- a/docs/prd-universal-thread-context-ingress.md
+++ b/docs/prd-universal-thread-context-ingress.md
@@ -363,7 +363,7 @@ largest product gaps:
   to the absolute URL. `thread_route` preserves the relative `/cortex?idea=...`
   route for internal/programmatic clients.
 - Absolute Thread URLs are built from `ILLO_PUBLIC_URL` first, then
-  `ILLO_DASHBOARD_URL`, then a local-development fallback of
+  `ILLO_DASHBOARD_URL`, then the local-development value
   `http://localhost:8080`. Deployed environments should set `ILLO_PUBLIC_URL`
   to the browser-reachable Illospace origin.
 - Discussion still uses dedicated Thread-attached storage
@@ -371,20 +371,20 @@ largest product gaps:
   frontend correction is visual/interaction reuse: the panel now owns its full
   right-dock surface and is built from the existing chat composer, state,
   presence, mention, scroll, and token primitives.
-- `@illo` from Discussion now creates a surface-aware run. The trigger carries
-  `originating_surface=thread_discussion`, the triggering comment, and a
-  Discussion response target.
+- `@illo` from Discussion now creates a dedicated Discussion trigger:
+  `cortex.thread_discussion_mention`, target kind `thread_discussion`. It is
+  not routed as `cortex.thread_reply`.
+- Discussion-origin work is admitted into a separate run conversation id:
+  `thread-discussion:{thread_id}`. The AI Timeline Thread id is carried as a
+  related surface for context only.
 - Illo now has an explicit `post_thread_discussion_reply` tool, paired with
   `read_thread_discussion`, so it can acknowledge or answer in Discussion
   without pretending every response belongs in the AI Timeline.
-- Discussion-origin runs no longer automatically mirror final answers into the
-  AI Timeline. Illo can still use AI Timeline tools such as `cortex_reply` when
-  continuing the underlying Thread work is the right action.
-- There is intentionally no deterministic fallback that auto-posts an
-  acknowledgement if the model ignores the Discussion reply tool. That preserves
-  the "Illo has the right surface tools and decides how to act" product
-  contract, but it leaves prompt/tool-choice quality as an important behavior to
-  observe in real usage.
+- Discussion-origin final answers settle back into `thread_discussion_comments`.
+  They do not mirror into `IdeaThread`, and Fast mode hides `cortex_reply` for
+  Discussion-origin runs. If future product work needs Illo to visibly continue
+  the AI Timeline from a Discussion request, that should be a separate explicit
+  action/tool, not a reused reply channel.
 
 ## Testing Decisions And Coverage
 
@@ -406,8 +406,8 @@ implementation details. The important behaviors are:
 - `@illo` in Discussion triggers a surface-aware Illo run linked to the Thread.
 - Illo can explicitly inspect Discussion through a tool.
 - Illo can explicitly reply in Discussion through a tool.
-- Illo can continue in the AI Timeline, run headlessly, or act in another
-  Thread surface when that is the natural response to the user's ask.
+- Illo can answer in Discussion, run headlessly, or use a separate explicit
+  action/tool when the user's ask should affect the AI Timeline.
 - The existing Thread UI continues to open, stream, reply, and render normal
   Illo messages after context preview blocks are added.
 
@@ -422,8 +422,10 @@ Recommended test modules:
 - Discussion API/service tests for right-panel comment behavior, mention
   triggering, and Discussion-targeted Illo acknowledgements/replies.
 - Agent tool tests for explicit Discussion inspection and Discussion replies.
-- Surface-routing tests proving that a Discussion-originated summon carries
-  surface metadata and does not force every Illo action into the AI Timeline.
+- Surface-routing tests proving that a Discussion-originated summon uses the
+  dedicated `cortex.thread_discussion_mention` event, enters a separate
+  Discussion run conversation, and never displays its final answer in the AI
+  Timeline.
 - Frontend component tests or Playwright smoke tests for opening an existing
   Thread with a submitted context preview and Discussion panel available, using
   the same chat primitives/tokens as the general team room.
@@ -441,9 +443,11 @@ Coverage added in this implementation pass:
 - Model metadata coverage for `thread_context_submissions` and
   `thread_discussion_comments`.
 - Discussion API coverage for normal comments not triggering Illo, explicit
-  `@illo` comments triggering the current main Thread run path, and
-  commit-before-broadcast ordering. Follow-up coverage must update this to the
-  surface-aware reply/action contract described above.
+  `@illo` comments triggering the dedicated Discussion event, and
+  commit-before-broadcast ordering.
+- Work-intake/runtime coverage for the separate `thread-discussion:{thread_id}`
+  run conversation, hidden AI Timeline reply tools on Discussion-origin runs,
+  and Discussion final-answer settlement into `thread_discussion_comments`.
 - Frontend typecheck coverage for the Discussion tab/pane and context timeline
   tag changes.
 

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -11,12 +11,12 @@
     shouldShowConversationScrollCue,
   } from '$lib/components/chat/conversationScroll';
   import { ConstellationNotice, ConstellationPresenceSeed } from '$lib/components/constellation';
+  import { defaultIlloMentionOption } from '$lib/features/composer/domain/mentionAutocomplete';
   import {
     listThreadDiscussion,
     postThreadDiscussionComment,
     type ThreadDiscussionComment,
   } from '$lib/features/threads/api/threadApi';
-  import { auth } from '$lib/stores/auth.svelte';
   import { buildPresenceSeedStyle, normalizeHexColor, presenceToneForColor } from '$lib/utils/constellationPresence';
   import { parseServerDate } from '$lib/utils/datetime';
 
@@ -48,9 +48,7 @@
   const composerPlaceholder = $derived(
     ideaId ? 'Comment on this Thread...' : 'Open a Thread to comment...',
   );
-  const composerHint = $derived(
-    posting ? 'Posting comment...' : '@illo brings Illo into this Discussion.',
-  );
+  const mentionOptions = $derived([defaultIlloMentionOption()]);
 
   $effect(() => {
     if (!ideaId) {
@@ -148,14 +146,6 @@
     return comment.author_kind === 'illo' || comment.author_kind === 'agent';
   }
 
-  function isOwnComment(comment: ThreadDiscussionComment) {
-    return (
-      comment.author_user_id != null &&
-      auth.user?.id != null &&
-      String(comment.author_user_id) === String(auth.user.id)
-    );
-  }
-
   function participantTone(comment: ThreadDiscussionComment) {
     if (isIlloComment(comment)) return 'spectral';
     return presenceToneForColor(comment.author_color);
@@ -171,9 +161,7 @@
     if (!accent || isIlloComment(comment)) return undefined;
 
     return [
-      `--discussion-message-author-color:color-mix(in srgb, ${accent} 76%, var(--constellation-color-text-primary))`,
-      `--discussion-message-hover-border:color-mix(in srgb, ${accent} 20%, transparent)`,
-      `--discussion-message-hover-background:color-mix(in srgb, ${accent} 8%, transparent)`,
+      `--chat-message-author-color:color-mix(in srgb, ${accent} 76%, var(--constellation-color-text-primary))`,
       `--seed-accent:${accent}`,
     ].join('; ');
   }
@@ -327,7 +315,6 @@
             class="discussion-message"
             class:has-header={showHeader}
             class:is-continuation={!showHeader}
-            class:is-own={isOwnComment(comment)}
             class:is-illo={isIlloComment(comment)}
             style={messageStyle(comment)}
           >
@@ -354,7 +341,7 @@
             <p class="discussion-message-body">
               {#each messageTextSegments(comment.body) as segment, segmentIndex (segmentIndex)}
                 {#if segment.mention}
-                  <span class="discussion-mention">{segment.text}</span>
+                  <span class="chat-mention">{segment.text}</span>
                 {:else}
                   {segment.text}
                 {/if}
@@ -387,8 +374,7 @@
       variant="thread"
       placeholder={composerPlaceholder}
       value={body}
-      hint={composerHint}
-      modeLabel="Discussion"
+      mentionOptions={mentionOptions}
       disabled={posting || !ideaId}
       loading={posting}
       canSubmit={Boolean(ideaId) && body.trim().length > 0 && !posting}
@@ -402,13 +388,13 @@
 
 <style>
   .thread-discussion-pane {
-    --discussion-message-hover-background: rgba(255, 255, 255, 0.025);
-    --discussion-message-hover-border: rgba(255, 255, 255, 0.03);
-    --discussion-message-body-text: var(--constellation-thread-message-illo-body);
-    --discussion-message-meta-text: var(--constellation-thread-message-illo-meta);
-    --discussion-message-author-color: var(--constellation-thread-message-author);
-    --discussion-mention-background: rgba(150, 188, 255, 0.16);
-    --discussion-mention-text: rgba(207, 224, 255, 0.98);
+    --chat-message-hover-background: rgba(255, 255, 255, 0.025);
+    --chat-message-hover-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    --chat-message-body-text: var(--constellation-thread-message-illo-body);
+    --chat-message-meta-text: var(--constellation-thread-message-illo-meta);
+    --chat-message-author-color: var(--constellation-thread-message-author);
+    --chat-mention-background: rgba(150, 188, 255, 0.16);
+    --chat-mention-text: rgba(207, 224, 255, 0.98);
     width: 100%;
     height: 100%;
     min-width: 0;
@@ -416,15 +402,15 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    color: var(--discussion-message-body-text);
+    color: var(--chat-message-body-text);
     container-type: inline-size;
   }
 
   :global(:root[data-color-scheme='light']) .thread-discussion-pane {
-    --discussion-message-hover-background: rgba(255, 255, 255, 0.42);
-    --discussion-message-hover-border: rgba(24, 35, 49, 0.04);
-    --discussion-mention-background: rgba(72, 111, 168, 0.14);
-    --discussion-mention-text: #315a91;
+    --chat-message-hover-background: rgba(255, 255, 255, 0.42);
+    --chat-message-hover-shadow: inset 0 0 0 1px rgba(24, 35, 49, 0.04);
+    --chat-mention-background: rgba(72, 111, 168, 0.14);
+    --chat-mention-text: #315a91;
   }
 
   .discussion-stream {
@@ -480,7 +466,7 @@
     z-index: -1;
     border-radius: inherit;
     background: transparent;
-    box-shadow: inset 0 0 0 1px transparent;
+    box-shadow: none;
     transition:
       background-color 140ms ease,
       box-shadow 140ms ease;
@@ -488,10 +474,9 @@
   }
 
   .discussion-message:hover::before,
-  .discussion-message:focus-within::before,
-  .discussion-message.is-own::before {
-    background: var(--discussion-message-hover-background);
-    box-shadow: inset 0 0 0 1px var(--discussion-message-hover-border);
+  .discussion-message:focus-within::before {
+    background: var(--chat-message-hover-background);
+    box-shadow: var(--chat-message-hover-shadow);
   }
 
   .discussion-message.is-continuation {
@@ -523,33 +508,33 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--discussion-message-author-color);
+    color: var(--chat-message-author-color);
     font-size: 13px;
     font-weight: 600;
     line-height: 1.15;
   }
 
   .discussion-message-author-copy time {
-    color: var(--discussion-message-meta-text);
+    color: var(--chat-message-meta-text);
     font-size: 11px;
     line-height: 1.2;
   }
 
   .discussion-message-body {
     margin: 0;
-    color: var(--discussion-message-body-text);
+    color: var(--chat-message-body-text);
     font-size: 14px;
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
   }
 
-  .discussion-mention {
+  .chat-mention {
     display: inline;
     padding: 0 0.24em;
     border-radius: 5px;
-    background: var(--discussion-mention-background);
-    color: var(--discussion-mention-text);
+    background: var(--chat-mention-background);
+    color: var(--chat-mention-text);
     font-weight: 680;
     -webkit-box-decoration-break: clone;
     box-decoration-break: clone;

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -333,6 +333,7 @@
       'thread-message',
       role === 'user' ? 'thread-message-user' : 'thread-message-illo',
       role === 'user' ? `thread-message-${tone}` : '',
+      item.inlineWithWork ? 'thread-message-inline-work' : '',
     ]
       .filter(Boolean)
       .join(' ');
@@ -1560,6 +1561,13 @@
     --thread-message-meta: var(--constellation-thread-message-illo-meta);
     justify-self: start;
     margin-right: auto;
+  }
+
+  .thread-message-inline-work.thread-message-illo {
+    --thread-inline-work-outdent: 16px;
+    width: min(calc(100% + var(--thread-inline-work-outdent)), 776px);
+    margin-inline-start: calc(var(--thread-inline-work-outdent) * -1);
+    gap: 8px;
   }
 
   .thread-message-user {
@@ -3088,6 +3096,10 @@
     .message-stack {
       gap: 14px;
       padding-bottom: 22px;
+    }
+
+    .thread-message-inline-work.thread-message-illo {
+      --thread-inline-work-outdent: 0px;
     }
 
     .thread-composer-dock {

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -354,6 +354,7 @@ function mapThreadMessageItem(
     currentUser,
     nowMs,
   }: TranscriptMappingContext,
+  { inlineWithWork = false }: { inlineWithWork?: boolean } = {},
 ): CortexThreadStageMessageItem {
   const isAgent = item.role === 'assistant' || item.role === 'illo';
   const userAccent = isAgent ? null : resolveUserAccent(item, idea, currentUser);
@@ -382,6 +383,7 @@ function mapThreadMessageItem(
     ownerColor: userAccent ? mixHex(userAccent, userOwnerText, themeMode === 'light' ? 0.22 : 0.78) : undefined,
     html: item.content ? renderReadableMarkdown(item.content) : undefined,
     attachments: attachments.length ? attachments : undefined,
+    inlineWithWork: inlineWithWork || undefined,
   };
 }
 
@@ -509,7 +511,7 @@ function appendChronologicalRunSegments(
   let workSegmentIndex = 0;
   for (const segment of segments) {
     if (segment.kind === 'live_text') {
-      transcriptItems.push(mapThreadMessageItem(segment.item, context));
+      transcriptItems.push(mapThreadMessageItem(segment.item, context, { inlineWithWork: true }));
       continue;
     }
     if (segment.items.length === 0 && !segment.showLiveCue) continue;

--- a/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
@@ -76,6 +76,7 @@ export interface CortexThreadStageMessageItem {
   paragraphs?: readonly string[];
   sections?: readonly CortexThreadStageMessageSection[];
   attachments?: readonly CortexThreadStageAttachmentItem[];
+  inlineWithWork?: boolean;
 }
 
 export interface CortexThreadStageRunStep {

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -521,7 +521,7 @@ def test_fast_tool_surface_is_direct_coordinator_without_staged_reply_tools(monk
     assert roles == ["coordinator"]
 
 
-def test_fast_discussion_origin_surface_keeps_explicit_timeline_reply_tool(monkeypatch):
+def test_fast_discussion_origin_surface_keeps_timeline_reply_tools_hidden(monkeypatch):
     from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
 
     monkeypatch.setattr(
@@ -542,7 +542,6 @@ def test_fast_discussion_origin_surface_keeps_explicit_timeline_reply_tool(monke
 
     assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == [
         "post_thread_discussion_reply",
-        "cortex_reply",
     ]
 
 
@@ -557,7 +556,7 @@ def test_discussion_origin_run_does_not_auto_mirror_final_answer_to_timeline():
     assert _run_should_mirror_final_answer_to_timeline(run) is False
 
 
-def test_discussion_origin_run_can_explicitly_target_ai_timeline():
+def test_discussion_origin_run_never_mirrors_final_answer_to_ai_timeline():
     from brain.systems.runs.cortex.runner import _run_should_mirror_final_answer_to_timeline
 
     run = SimpleNamespace(
@@ -565,7 +564,7 @@ def test_discussion_origin_run_can_explicitly_target_ai_timeline():
         metadata_={"final_answer_target_surface": "ai_timeline"},
     )
 
-    assert _run_should_mirror_final_answer_to_timeline(run) is True
+    assert _run_should_mirror_final_answer_to_timeline(run) is False
 
 
 async def test_runtime_drain_steering_can_use_isolated_durable_drain():
@@ -2136,3 +2135,91 @@ async def test_runner_does_not_settle_non_idea_thread_id():
             return None
 
     assert await _settle_idea_for_terminal_root_run_async(FakeSession(), 44) is None
+
+
+async def test_runner_settles_discussion_origin_run_into_discussion_not_timeline(monkeypatch):
+    from brain.systems.runs.cortex.runner import _settle_terminal_root_run_async
+    from brain.platform.db.models.agent_run import AgentRunRow
+    from brain.platform.db.models.idea import IdeaThread, ThreadDiscussionComment
+
+    discussion_trigger = {
+        "thread_id": "idea-1",
+        "comment_id": 7,
+        "response_target": {
+            "surface": "thread_discussion",
+            "thread_id": "idea-1",
+            "reply_to_comment_id": 7,
+        },
+    }
+    run = SimpleNamespace(
+        id=46,
+        parent_run_id=None,
+        thread_id="thread-discussion:idea-1",
+        status="completed",
+        org_id="org-1",
+        target_ref={
+            "kind": "thread_discussion",
+            "idea_id": "idea-1",
+            "parent_thread_id": "idea-1",
+            "discussion_trigger": discussion_trigger,
+        },
+        metadata_={"originating_surface": "thread_discussion"},
+    )
+    final_artifact = SimpleNamespace(
+        id=101,
+        run_id=46,
+        artifact_type="final_answer",
+        text="Yes, I can see this Discussion comment.",
+    )
+    added = []
+    published = []
+    scalar_calls = 0
+
+    class FakeSession:
+        async def get(self, model, key):
+            if model is AgentRunRow and int(key) == 46:
+                return run
+            raise AssertionError("Discussion-origin settlement must not load the AI Timeline Thread")
+
+        def add(self, obj):
+            if isinstance(obj, ThreadDiscussionComment):
+                obj.id = 8
+            added.append(obj)
+
+        async def scalars(self, stmt):
+            nonlocal scalar_calls
+            scalar_calls += 1
+            if scalar_calls == 1:
+                return _ScalarRows([])
+            return _ScalarRows([final_artifact])
+
+        async def flush(self):
+            pass
+
+    monkeypatch.setattr(
+        "brain.systems.runs.cortex.runner.publish_safe",
+        lambda event, payload: published.append((event, payload)),
+    )
+
+    payload = await _settle_terminal_root_run_async(FakeSession(), 46)
+
+    assert payload == {
+        "surface": "thread_discussion",
+        "idea_id": "idea-1",
+        "run_id": 46,
+        "comment_id": 8,
+    }
+    assert not any(isinstance(obj, IdeaThread) for obj in added)
+    comment = next(obj for obj in added if isinstance(obj, ThreadDiscussionComment))
+    assert comment.thread_id == "idea-1"
+    assert comment.author_kind == "illo"
+    assert comment.body == "Yes, I can see this Discussion comment."
+    assert comment.metadata_ == {
+        "source": "agent_run_final_answer",
+        "surface": "thread_discussion",
+        "created_by_run_id": 46,
+        "artifact_id": 101,
+        "reply_to_comment_id": 7,
+    }
+    assert published[0][0] == "thread_discussion_comment"
+    assert published[0][1]["idea_id"] == "idea-1"

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1411,7 +1411,10 @@ async def test_create_thread_discussion_illo_mention_routes_surface_aware_trigge
     with (
         patch("brain.app.api.routers.cortex._discussion._require_idea_for_user", AsyncMock(return_value=idea)),
         patch("brain.app.api.routers.cortex._discussion.ws_manager.broadcast_product_event", AsyncMock()),
-        patch("brain.app.triggers.adapters.internal.build_cortex_notify_trigger", return_value=SimpleNamespace(event_type="cortex.thread_reply")) as build_trigger,
+        patch(
+            "brain.app.triggers.adapters.internal.build_thread_discussion_mention_trigger",
+            return_value=SimpleNamespace(event_type="cortex.thread_discussion_mention"),
+        ) as build_trigger,
         patch("brain.app.triggers.router.async_route_trigger", side_effect=_route_trigger) as route_trigger,
     ):
         resp = await client.post(
@@ -1423,9 +1426,9 @@ async def test_create_thread_discussion_illo_mention_routes_surface_aware_trigge
     assert resp.json()["trigger"] == trigger_response
     build_trigger.assert_called_once()
     _, kwargs = build_trigger.call_args
-    assert kwargs["event"] == "thread_reply"
     assert kwargs["idea_id"] == "some-id"
-    assert kwargs["thread_message"] == "@illo this is what we decided, carry on"
+    assert kwargs["comment"].body == "@illo this is what we decided, carry on"
+    assert kwargs["discussion_trigger"]["surface"] == "thread_discussion"
     assert kwargs["metadata"]["source"] == "thread_discussion"
     assert kwargs["metadata"]["originating_surface"] == "thread_discussion"
     assert kwargs["metadata"]["triggering_surface"] == "thread_discussion"

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -77,6 +77,41 @@ def test_internal_adapter_builds_cortex_thread_trigger():
     assert trigger.policy["route"] == "run"
 
 
+def test_internal_adapter_builds_thread_discussion_trigger_as_separate_surface():
+    from brain.app.triggers.adapters.internal import build_thread_discussion_mention_trigger
+
+    discussion_trigger = {
+        "surface": "thread_discussion",
+        "thread_id": "idea-1",
+        "comment_id": 77,
+        "response_target": {
+            "surface": "thread_discussion",
+            "thread_id": "idea-1",
+            "reply_to_comment_id": 77,
+        },
+    }
+    trigger = build_thread_discussion_mention_trigger(
+        idea_id="idea-1",
+        idea=_idea(),
+        comment=SimpleNamespace(id=77, body="@illo can you see this?"),
+        user=_user(),
+        discussion_trigger=discussion_trigger,
+    )
+
+    assert trigger.source == "cortex"
+    assert trigger.event_type == "cortex.thread_discussion_mention"
+    assert trigger.target == {
+        "kind": "thread_discussion",
+        "idea_id": "idea-1",
+        "parent_thread_id": "idea-1",
+        "discussion_comment_id": 77,
+        "surface": "thread_discussion",
+    }
+    assert trigger.payload["metadata"]["required_response_tool"] == "post_thread_discussion_reply"
+    assert "separate Discussion conversation" in trigger.payload["run_message"]
+    assert "not an AI Timeline reply" in trigger.payload["run_message"]
+
+
 def test_trigger_rejects_actor_cross_org():
     from brain.app.triggers.adapters.internal import build_cortex_notify_trigger
 

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -223,10 +223,16 @@ async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_
         _Session(),
         WorkIntakeEvent(
             source="cortex",
-            event_type="cortex.thread_reply",
+            event_type="cortex.thread_discussion_mention",
             org_id="org-1",
             actor={"id": "user-1", "org_id": "org-1", "internal": False},
-            target={"kind": "cortex_idea", "idea_id": "idea-1"},
+            target={
+                "kind": "thread_discussion",
+                "idea_id": "idea-1",
+                "parent_thread_id": "idea-1",
+                "discussion_comment_id": 7,
+                "surface": "thread_discussion",
+            },
             payload={
                 "message": "[Idea: \"Launch\" | idea-1]\n\n@illo this is what we decided, carry on",
                 "metadata": {
@@ -234,20 +240,29 @@ async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_
                     "triggering_surface": "thread_discussion",
                     "discussion_trigger": discussion_trigger,
                     "required_response_tool": "post_thread_discussion_reply",
-                    "final_answer_target_surface": "originating_surface",
+                    "final_answer_target_surface": "thread_discussion",
                 },
             },
-            policy={"priority": 0, "producer": "trigger", "run_event": "thread_reply"},
+            policy={"priority": 0, "producer": "trigger", "run_event": "thread_discussion_mention"},
         ),
     )
 
-    assert request.thread_id == "idea-1"
+    assert request.thread_id == "thread-discussion:idea-1"
+    assert request.target_ref["kind"] == "thread_discussion"
+    assert request.target_ref["idea_id"] == "idea-1"
+    assert request.target_ref["parent_thread_id"] == "idea-1"
     assert request.target_ref["originating_surface"] == "thread_discussion"
     assert request.target_ref["triggering_surface"] == "thread_discussion"
     assert request.target_ref["discussion_trigger"] == discussion_trigger
+    assert request.target_ref["related_surfaces"] == {
+        "ai_timeline": {
+            "kind": "ai_timeline",
+            "thread_id": "idea-1",
+        }
+    }
     assert request.metadata["discussion_trigger"] == discussion_trigger
     assert request.metadata["required_response_tool"] == "post_thread_discussion_reply"
-    assert request.metadata["final_answer_target_surface"] == "originating_surface"
+    assert request.metadata["final_answer_target_surface"] == "thread_discussion"
 
 
 def test_legacy_routing_logic_is_removed_from_adapters():


### PR DESCRIPTION
## Summary
- Keep Discussion runs isolated from the AI timeline and settle them back into Discussion comments only
- Simplify runner and work-intake handling around the new `thread_discussion` surface and its conversation id
- Align the Discussion pane with shared chat/composer primitives and remove unused own-message state

## Testing
- Focused backend test suite passed, including Discussion run admission and settlement coverage
- `svelte-check` passed with no errors or warnings
- Production frontend build passed