### PR TITLE
Fix thread discussion and AI timeline surfaces

### DIFF
--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -71,6 +71,7 @@ HEADLESS_ASK_BLOCKED_TOOLS = (
     "manage_idea",
     "manage_workspace_app",
     "post_chat_message",
+    "post_ai_timeline_message",
     "post_thread_discussion_reply",
 )
 

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -7,6 +7,8 @@ from typing import Any
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
 
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
+AI_TIMELINE_SURFACE = "ai_timeline"
+THREAD_DISCUSSION_CONVERSATION_PREFIX = "thread-discussion:"
 
 
 def _execution_metadata() -> dict[str, Any]:
@@ -63,6 +65,14 @@ def _current_thread_id() -> str | None:
     return None
 
 
+def _current_target_ref() -> dict[str, Any]:
+    target_ref = getattr(_agent_context, "target_ref", None)
+    if isinstance(target_ref, dict):
+        return dict(target_ref)
+    target_ref = _execution_metadata().get("target_ref")
+    return dict(target_ref) if isinstance(target_ref, dict) else {}
+
+
 def _coerce_optional_int(value: Any) -> int | None:
     if value in (None, ""):
         return None
@@ -87,6 +97,32 @@ def _first_nonempty(*values: Any) -> str:
         if text:
             return text
     return ""
+
+
+def _thread_id_from_discussion_conversation(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.startswith(THREAD_DISCUSSION_CONVERSATION_PREFIX):
+        return text.removeprefix(THREAD_DISCUSSION_CONVERSATION_PREFIX).strip()
+    return text
+
+
+def _current_ai_timeline_thread_id(explicit_thread_id: str | None = None) -> str:
+    trigger = _current_discussion_trigger()
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    target_ref = _current_target_ref()
+    related_surfaces = target_ref.get("related_surfaces") if isinstance(target_ref.get("related_surfaces"), dict) else {}
+    ai_timeline = related_surfaces.get(AI_TIMELINE_SURFACE) if isinstance(related_surfaces.get(AI_TIMELINE_SURFACE), dict) else {}
+    parent_thread_id = _first_nonempty(
+        explicit_thread_id,
+        response_target.get("thread_id"),
+        trigger.get("thread_id"),
+        target_ref.get("parent_thread_id"),
+        target_ref.get("idea_id"),
+        target_ref.get("thread_id"),
+        ai_timeline.get("thread_id"),
+        _current_thread_id(),
+    )
+    return _thread_id_from_discussion_conversation(parent_thread_id)
 
 
 def _discussion_comment_payload(comment: Any) -> dict[str, Any]:
@@ -244,6 +280,75 @@ async def _handle_post_thread_discussion_reply(
     return json.dumps({"ok": True, "comment": payload}, default=str)
 
 
+async def _handle_post_ai_timeline_message(
+    body: str,
+    thread_id: str | None = None,
+) -> str:
+    """Post an Illo-authored message to a Thread's AI Timeline surface."""
+    from brain.platform.db.models.idea import Idea
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+    from brain.systems.cortex.events import publish_safe
+    from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
+
+    text = str(body or "").strip()
+    if not text:
+        return json.dumps({"error": "post_ai_timeline_message requires body"})
+
+    target_thread_id = _current_ai_timeline_thread_id(thread_id)
+    if not target_thread_id:
+        return json.dumps({"error": "post_ai_timeline_message requires a Thread id or active Thread run"})
+
+    org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
+    if not org_id:
+        return json.dumps({"error": "post_ai_timeline_message requires an org-scoped run"})
+
+    trigger = _current_discussion_trigger()
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    reply_to_comment_id = _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
+
+    async with UnitOfWork() as uow:
+        idea = await uow.session.get(Idea, target_thread_id)
+        if idea is None:
+            return json.dumps({"error": "Thread not found"})
+        idea_org_id = str(getattr(idea, "org_id", "") or "")
+        if idea_org_id and idea_org_id != org_id:
+            return json.dumps({"error": "Thread is outside this org"})
+
+        metadata = {
+            "source": "illo_agent",
+            "surface": AI_TIMELINE_SURFACE,
+            "originating_surface": THREAD_DISCUSSION_SURFACE if trigger else AI_TIMELINE_SURFACE,
+            "created_by_run_id": _current_run_id(),
+        }
+        if reply_to_comment_id is not None:
+            metadata["discussion_comment_id"] = reply_to_comment_id
+        result = await post_thread_message(
+            uow.session,
+            idea=idea,
+            command=ThreadMessageCommand(
+                idea_id=target_thread_id,
+                role="illo",
+                content=text,
+                actor={"org_id": org_id},
+                metadata=metadata,
+            ),
+            lifecycle_trigger="agent_tool_ai_timeline_message",
+        )
+        message_payload = result.message_payload
+        status_change = result.status_change
+
+    publish_safe(
+        "thread_message",
+        {"idea_id": target_thread_id, "message": message_payload},
+    )
+    if status_change:
+        publish_safe(
+            "status_change",
+            {"idea_id": target_thread_id, "new_status": status_change["new_status"]},
+        )
+    return json.dumps({"ok": True, "message": message_payload}, default=str)
+
+
 async def _handle_read_thread_discussion(
     thread_id: str | None = None,
     limit: int = 50,
@@ -303,6 +408,7 @@ async def _handle_read_thread_discussion(
 
 __all__ = [
     "_handle_post_chat_message",
+    "_handle_post_ai_timeline_message",
     "_handle_post_thread_discussion_reply",
     "_handle_read_thread_discussion",
 ]

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -31,6 +31,7 @@ from brain.systems.runs.tool_catalog.handlers.cortex_reply import (
     _handle_cortex_visual_reply,
 )
 from brain.systems.runs.tool_catalog.handlers.chat import (
+    _handle_post_ai_timeline_message,
     _handle_post_chat_message,
     _handle_post_thread_discussion_reply,
     _handle_read_thread_discussion,
@@ -208,6 +209,10 @@ def _get_tool_handlers(
         "post_thread_discussion_reply": lambda **kw: _patched_private(
             "_handle_post_thread_discussion_reply",
             _handle_post_thread_discussion_reply,
+        )(**kw),
+        "post_ai_timeline_message": lambda **kw: _patched_private(
+            "_handle_post_ai_timeline_message",
+            _handle_post_ai_timeline_message,
         )(**kw),
         "read_thread_discussion": lambda **kw: _patched_private(
             "_handle_read_thread_discussion",

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -282,6 +282,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "post an Illo-authored reply to Thread Discussion",
         "output_budget_chars": 8_000,
     },
+    "post_ai_timeline_message": {
+        "permission": "write_chat",
+        "risk_class": "medium",
+        "side_effect_class": "chat_message",
+        "reversibility": "append_only",
+        "action_manifest": True,
+        "expected_effect": "post an Illo-authored message to the linked Thread AI Timeline",
+        "output_budget_chars": 8_000,
+    },
     "read_thread_discussion": {
         "permission": "read_workspace",
         "risk_class": "low",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1170,6 +1170,31 @@ CHAT_TOOLS = [
         },
     },
     {
+        "name": "post_ai_timeline_message",
+        "description": (
+            "Post an Illo-authored message into the linked Thread AI Timeline. "
+            "Use this only when the user explicitly asks you to carry something into "
+            "the AI Timeline, or when the work product naturally belongs there. This "
+            "does not reply in Discussion. Discussion and AI Timeline are separate "
+            "conversation surfaces linked by Thread context, so acknowledge in "
+            "Discussion separately when the user summoned you there."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "description": "Concise markdown message to post in the Thread AI Timeline as Illo.",
+                },
+                "thread_id": {
+                    "type": "string",
+                    "description": "Optional Thread id. Defaults to the linked/current Thread.",
+                },
+            },
+            "required": ["body"],
+        },
+    },
+    {
         "name": "read_thread_discussion",
         "description": (
             "Read the Discussion comments attached to the current Thread. "

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -48,6 +48,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_browser_wait",
     "_handle_cortex_reply",
     "_handle_cortex_visual_reply",
+    "_handle_post_ai_timeline_message",
     "_handle_post_chat_message",
     "_handle_post_thread_discussion_reply",
     "_handle_read_thread_discussion",

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -28,7 +28,11 @@ SENSITIVE_ARG_PARTS = ("api_key", "apikey", "authorization", "cookie", "password
 FILE_OBSERVATION_TOOLS = frozenset({"file_summary", "list_files", "read_file", "search_files", "semantic_search"})
 FILE_EDIT_TOOLS = frozenset({"apply_patch", "edit_file", "write_file"})
 COMMAND_OUTPUT_TOOLS = frozenset({"exec_command", "run_script", "test_runner"})
-CHAT_MESSAGE_TOOLS = frozenset({"post_chat_message", "post_thread_discussion_reply"})
+CHAT_MESSAGE_TOOLS = frozenset({
+    "post_chat_message",
+    "post_thread_discussion_reply",
+    "post_ai_timeline_message",
+})
 
 
 async def _maybe_await(value):

--- a/docs/prd-universal-thread-context-ingress.md
+++ b/docs/prd-universal-thread-context-ingress.md
@@ -330,10 +330,11 @@ loop and left a few product/technical decisions explicit for future review:
   frontend should invent a weaker Discussion UI; it should still reuse the
   general room's chat primitives and design tokens.
 - Discussion is available as a right-panel tab on the existing Thread stage.
-  The backend broadcasts a `thread_discussion_comment` websocket event, but the
-  first frontend pass reloads Discussion on panel open and after posting rather
-  than subscribing live. Live subscription is a straightforward follow-up, not a
-  requirement for proving the loop.
+  The backend persists Discussion replies in `thread_discussion_comments` and
+  emits `thread_discussion_comment` when it is in the API process. Production
+  testing showed that Illo replies created by the worker can be correctly
+  persisted without appearing in the open panel, so the pane must also subscribe
+  to Discussion events and reconcile after Discussion-origin run/tool events.
 - `@illo` in Discussion routes through the existing Cortex notify/run path and
   links the run to the main Thread. The deployed behavior exposed a semantic
   bug: Illo answered in the AI Timeline with insufficient awareness that the
@@ -382,9 +383,24 @@ largest product gaps:
   without pretending every response belongs in the AI Timeline.
 - Discussion-origin final answers settle back into `thread_discussion_comments`.
   They do not mirror into `IdeaThread`, and Fast mode hides `cortex_reply` for
-  Discussion-origin runs. If future product work needs Illo to visibly continue
-  the AI Timeline from a Discussion request, that should be a separate explicit
-  action/tool, not a reused reply channel.
+  Discussion-origin runs. When Illo visibly continues the AI Timeline from a
+  Discussion request, it must use a separate explicit action/tool, not a reused
+  reply channel.
+- Production test run `283` proved that separate explicit action/tool is needed:
+  when asked from Discussion to "send something or do something in the AI
+  timeline", Illo correctly replied in Discussion but had no direct AI Timeline
+  write surface and fell back to awkward status-only `manage_idea` calls. The
+  correction is `post_ai_timeline_message`, a distinct Illo-authored Timeline
+  write tool. `cortex_reply` remains hidden for Discussion-origin final answers;
+  Discussion replies, Timeline messages, and Thread management are three
+  intentionally separate tools.
+- A deployed debug run confirmed the backend surface contract was correct:
+  the `@illo` Discussion request created run `282`, Illo used
+  `post_thread_discussion_reply`, and comment `12` was stored in
+  `thread_discussion_comments`. The missing visible reply was a frontend live
+  rendering gap, so the pane now listens for `thread_discussion_comment`,
+  refreshes after `thread-discussion:{thread_id}` run/tool events, and performs
+  a short post-trigger reconciliation window.
 
 ## Testing Decisions And Coverage
 
@@ -406,6 +422,9 @@ implementation details. The important behaviors are:
 - `@illo` in Discussion triggers a surface-aware Illo run linked to the Thread.
 - Illo can explicitly inspect Discussion through a tool.
 - Illo can explicitly reply in Discussion through a tool.
+- Illo can explicitly post an Illo-authored message to the linked AI Timeline
+  through a separate tool when a Discussion request asks it to affect that
+  surface.
 - Illo can answer in Discussion, run headlessly, or use a separate explicit
   action/tool when the user's ask should affect the AI Timeline.
 - The existing Thread UI continues to open, stream, reply, and render normal

--- a/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
+++ b/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
@@ -18,6 +18,7 @@ export const CORTEX_RUN_REALTIME_EVENT_TYPES = [
 export const CORTEX_REALTIME_EVENT_TYPES = [
   'status_change',
   'thread_message',
+  'thread_discussion_comment',
   'visual_reply',
   'browser_session_state',
   'browser_session_frame',
@@ -55,6 +56,23 @@ export type CortexRealtimePayloadByType = {
       created_at?: string;
       content?: string | null;
       metadata?: Record<string, unknown> | null;
+    };
+  };
+  thread_discussion_comment: {
+    idea_id?: string;
+    org_id?: string;
+    comment?: {
+      id?: string | number;
+      thread_id?: string;
+      org_id?: string;
+      author_user_id?: string | null;
+      author_kind?: string;
+      author_name?: string | null;
+      author_color?: string | null;
+      body?: string;
+      attachments?: unknown[];
+      metadata?: Record<string, unknown> | null;
+      created_at?: string | null;
     };
   };
   visual_reply: {

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from 'svelte';
+  import { onDestroy, tick } from 'svelte';
 
   import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
   import ChatStateView from '$lib/components/chat/ChatStateView.svelte';
@@ -17,6 +17,7 @@
     postThreadDiscussionComment,
     type ThreadDiscussionComment,
   } from '$lib/features/threads/api/threadApi';
+  import { wsClient } from '$lib/stores/ws.svelte';
   import { buildPresenceSeedStyle, normalizeHexColor, presenceToneForColor } from '$lib/utils/constellationPresence';
   import { parseServerDate } from '$lib/utils/datetime';
 
@@ -44,16 +45,23 @@
 
   const MESSAGE_GROUP_WINDOW_MS = 15 * 60 * 1000;
   const MENTION_RENDER_RE = /(^|[^A-Za-z0-9_])@([A-Za-z0-9._-]+)([.,:;!?]?)/g;
+  const THREAD_DISCUSSION_RUN_PREFIX = 'thread-discussion:';
+  const THREAD_DISCUSSION_REPLY_TOOL = 'post_thread_discussion_reply';
+  const DISCUSSION_REPLY_RECONCILE_DELAYS_MS = [1200, 3000, 7000, 15000, 30000, 45000];
   const tailSignature = $derived(`${comments.length}:${comments.at(-1)?.id ?? 'empty'}`);
   const composerPlaceholder = $derived(
     ideaId ? 'Comment on this Thread...' : 'Open a Thread to comment...',
   );
   const mentionOptions = $derived([defaultIlloMentionOption()]);
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  let replyReconcileTimers: ReturnType<typeof setTimeout>[] = [];
 
   $effect(() => {
     if (!ideaId) {
       comments = [];
       loadedForIdeaId = null;
+      clearReplyReconcileTimers();
+      clearScheduledRefresh();
       return;
     }
     if (loadedForIdeaId === ideaId) return;
@@ -73,17 +81,56 @@
     tick().then(() => scrollDiscussionToBottom());
   });
 
-  async function loadComments(targetIdeaId = ideaId) {
+  $effect(() => {
+    const activeIdeaId = ideaId;
+    if (!activeIdeaId) return;
+
+    const unsubs = [
+      wsClient.on('thread_discussion_comment', (msg) => {
+        handleDiscussionCommentEvent(activeIdeaId, msg);
+      }),
+      wsClient.on('tool_finished', (msg) => {
+        handleDiscussionRunEvent(activeIdeaId, msg, { requireReplyTool: true, delayMs: 180 });
+      }),
+      wsClient.on('run_completed', (msg) => {
+        handleDiscussionRunEvent(activeIdeaId, msg, { delayMs: 450 });
+      }),
+      wsClient.onReconnect(() => {
+        scheduleCommentRefresh(activeIdeaId, 150);
+      }),
+    ];
+
+    return () => {
+      unsubs.forEach((unsub) => unsub());
+      clearReplyReconcileTimers();
+      clearScheduledRefresh();
+    };
+  });
+
+  onDestroy(() => {
+    clearReplyReconcileTimers();
+    clearScheduledRefresh();
+  });
+
+  async function loadComments(targetIdeaId = ideaId, options: { silent?: boolean } = {}) {
     if (!targetIdeaId) return;
-    loading = true;
-    error = '';
+    if (!options.silent) {
+      loading = true;
+      error = '';
+    }
     try {
-      comments = await listThreadDiscussion(targetIdeaId);
+      const nextComments = await listThreadDiscussion(targetIdeaId);
+      if (targetIdeaId !== ideaId) return;
+      comments = sortDiscussionComments(nextComments);
       loadedForIdeaId = targetIdeaId;
     } catch (err: any) {
-      error = err?.detail || 'Failed to load Discussion.';
+      if (options.silent) {
+        console.warn('[thread-discussion] failed to refresh comments', err);
+      } else {
+        error = err?.detail || 'Failed to load Discussion.';
+      }
     } finally {
-      loading = false;
+      if (!options.silent) loading = false;
     }
   }
 
@@ -97,9 +144,10 @@
         body: text,
         metadata: { source: 'thread_discussion_panel' },
       });
-      comments = [...comments, result.comment];
+      upsertDiscussionComment(result.comment);
       body = '';
       userScrolledUp = false;
+      if (result.trigger) scheduleReplyReconcile(ideaId);
     } catch (err: any) {
       error = err?.detail || 'Failed to post comment.';
     } finally {
@@ -144,6 +192,95 @@
 
   function isIlloComment(comment: ThreadDiscussionComment) {
     return comment.author_kind === 'illo' || comment.author_kind === 'agent';
+  }
+
+  function handleDiscussionCommentEvent(targetIdeaId: string, msg: any) {
+    if (!eventIdeaMatches(targetIdeaId, msg)) return;
+    const comment = msg?.comment;
+    if (comment && typeof comment === 'object') {
+      upsertDiscussionComment(comment as ThreadDiscussionComment);
+      if (isIlloComment(comment as ThreadDiscussionComment)) clearReplyReconcileTimers();
+      return;
+    }
+    scheduleCommentRefresh(targetIdeaId, 150);
+  }
+
+  function handleDiscussionRunEvent(
+    targetIdeaId: string,
+    msg: any,
+    options: { requireReplyTool?: boolean; delayMs?: number } = {},
+  ) {
+    if (!eventMatchesDiscussionRun(targetIdeaId, msg)) return;
+    if (options.requireReplyTool && !eventUsesDiscussionReplyTool(msg)) return;
+    scheduleCommentRefresh(targetIdeaId, options.delayMs ?? 350);
+  }
+
+  function eventIdeaMatches(targetIdeaId: string, msg: any) {
+    const eventIdeaId = String(msg?.idea_id ?? msg?.thread_id ?? msg?.comment?.thread_id ?? '');
+    return eventIdeaId === targetIdeaId;
+  }
+
+  function eventMatchesDiscussionRun(targetIdeaId: string, msg: any) {
+    const discussionRunThreadId = `${THREAD_DISCUSSION_RUN_PREFIX}${targetIdeaId}`;
+    return String(msg?.thread_id ?? '') === discussionRunThreadId
+      || String(msg?.idea_id ?? '') === discussionRunThreadId;
+  }
+
+  function eventUsesDiscussionReplyTool(msg: any) {
+    return String(msg?.tool_name ?? msg?.tool ?? '') === THREAD_DISCUSSION_REPLY_TOOL;
+  }
+
+  function upsertDiscussionComment(comment: ThreadDiscussionComment) {
+    if (comment.thread_id && ideaId && String(comment.thread_id) !== String(ideaId)) return;
+    const commentId = String(comment.id);
+    const existingIndex = comments.findIndex((row) => String(row.id) === commentId);
+    const nextComments = existingIndex >= 0
+      ? comments.map((row, index) => (index === existingIndex ? { ...row, ...comment } : row))
+      : [...comments, comment];
+    comments = sortDiscussionComments(nextComments);
+  }
+
+  function sortDiscussionComments(rows: ThreadDiscussionComment[]) {
+    return [...rows].sort((a, b) => {
+      const byTime = discussionCommentTime(a) - discussionCommentTime(b);
+      if (byTime !== 0) return byTime;
+      return Number(a.id) - Number(b.id);
+    });
+  }
+
+  function discussionCommentTime(comment: ThreadDiscussionComment) {
+    const time = Date.parse(comment.created_at ?? '');
+    return Number.isFinite(time) ? time : 0;
+  }
+
+  function scheduleCommentRefresh(targetIdeaId = ideaId, delayMs = 350) {
+    if (!targetIdeaId) return;
+    clearScheduledRefresh();
+    refreshTimer = setTimeout(() => {
+      refreshTimer = null;
+      void loadComments(targetIdeaId, { silent: true });
+    }, delayMs);
+  }
+
+  function scheduleReplyReconcile(targetIdeaId: string | null) {
+    if (!targetIdeaId) return;
+    clearReplyReconcileTimers();
+    replyReconcileTimers = DISCUSSION_REPLY_RECONCILE_DELAYS_MS.map((delayMs) =>
+      setTimeout(() => {
+        void loadComments(targetIdeaId, { silent: true });
+      }, delayMs),
+    );
+  }
+
+  function clearScheduledRefresh() {
+    if (refreshTimer === null) return;
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+
+  function clearReplyReconcileTimers() {
+    replyReconcileTimers.forEach((timer) => clearTimeout(timer));
+    replyReconcileTimers = [];
   }
 
   function participantTone(comment: ThreadDiscussionComment) {

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -528,6 +528,7 @@ def test_fast_discussion_origin_surface_keeps_timeline_reply_tools_hidden(monkey
         "brain.systems.runs.recipes.fast.build_agent_tools",
         lambda role: [
             {"name": "post_thread_discussion_reply"},
+            {"name": "post_ai_timeline_message"},
             {"name": "cortex_reply"},
             {"name": "cortex_visual_reply"},
         ],
@@ -542,6 +543,7 @@ def test_fast_discussion_origin_surface_keeps_timeline_reply_tools_hidden(monkey
 
     assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == [
         "post_thread_discussion_reply",
+        "post_ai_timeline_message",
     ]
 
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1516,6 +1516,92 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_post_ai_timeline_message_tool_writes_linked_thread_message(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_ai_timeline_message
+
+    idea = SimpleNamespace(id="some-id", org_id="test-org", status="active", user_id=None, title="Test Thread")
+    created = []
+
+    class _Session:
+        async def get(self, _model, thread_id):
+            return idea if thread_id == "some-id" else None
+
+        def add(self, obj):
+            if hasattr(obj, "content"):
+                obj.id = 19
+                obj.created_at = datetime(2026, 5, 21, 12, 6, tzinfo=timezone.utc)
+            created.append(obj)
+
+        async def flush(self):
+            return None
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    published = Mock()
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
+
+    with bind_agent_context(
+        {
+            "org_id": "test-org",
+            "run_id": 43,
+            "thread_id": "thread-discussion:some-id",
+            "target_ref": {
+                "kind": "thread_discussion",
+                "idea_id": "some-id",
+                "thread_id": "thread-discussion:some-id",
+                "discussion_trigger": {
+                    "surface": "thread_discussion",
+                    "thread_id": "some-id",
+                    "comment_id": 13,
+                    "response_target": {
+                        "surface": "thread_discussion",
+                        "thread_id": "some-id",
+                        "reply_to_comment_id": 13,
+                    },
+                },
+                "related_surfaces": {
+                    "ai_timeline": {
+                        "thread_id": "some-id",
+                    },
+                },
+            },
+        }
+    ):
+        raw = await _handle_post_ai_timeline_message("Adding this to the AI Timeline.")
+
+    payload = json.loads(raw)
+    assert payload["ok"] is True
+    assert payload["message"]["idea_id"] == "some-id"
+    assert payload["message"]["role"] == "illo"
+    assert payload["message"]["content"] == "Adding this to the AI Timeline."
+    assert payload["message"]["metadata"] == {
+        "source": "illo_agent",
+        "surface": "ai_timeline",
+        "originating_surface": "thread_discussion",
+        "created_by_run_id": 43,
+        "discussion_comment_id": 13,
+    }
+    assert created[0].idea_id == "some-id"
+    assert idea.status == "unread_reply"
+    assert published.call_args_list[0].args == (
+        "thread_message",
+        {"idea_id": "some-id", "message": payload["message"]},
+    )
+    assert published.call_args_list[1].args == (
+        "status_change",
+        {"idea_id": "some-id", "new_status": "unread_reply"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_update_idea_status_commits_before_broadcast(client, mock_session_factory):
     idea = _make_idea(id="status-idea", status="emerged", org_id="test-org")
     order: list[str] = []

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -145,6 +145,7 @@ async def test_headless_ask_blocks_thread_mutation_tools():
     blocked_tools = event.payload["metadata"]["tool_policy"]["blocked_tools"]
     assert "manage_idea" in blocked_tools
     assert "post_chat_message" in blocked_tools
+    assert "post_ai_timeline_message" in blocked_tools
     assert "post_thread_discussion_reply" in blocked_tools
     request_source = event.payload["metadata"]["request_source"]
     assert request_source["surface"] == "personal_agent_bridge"

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -101,6 +101,23 @@ def test_thread_discussion_reply_tool_is_registered_and_exposed():
     assert registration.reversibility == "append_only"
 
 
+def test_ai_timeline_message_tool_is_registered_and_exposed():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "post_ai_timeline_message"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name in _names(WORKER_TOOLS)
+    assert name in _get_tool_handlers()
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert registration.permission == "write_chat"
+    assert registration.side_effect_class == "chat_message"
+    assert registration.reversibility == "append_only"
+
+
 def test_context_route_surface_is_registry_driven():
     from brain.systems.runs.tool_catalog.registry import context_route_payload, context_route_tool_names
 


### PR DESCRIPTION
## Summary
- add a distinct post_ai_timeline_message tool so Discussion-origin runs can explicitly write to the linked AI Timeline without reusing cortex_reply
- keep Discussion replies, AI Timeline messages, and Thread management as separate surface tools with registry/runtime coverage
- make the Discussion pane reconcile live Illo replies from worker-origin events and document the production findings in the PRD

## Tests
- ./venv/bin/pytest tests/test_agent_run_runtime.py::test_fast_discussion_origin_surface_keeps_timeline_reply_tools_hidden tests/test_api_cortex.py::test_post_ai_timeline_message_tool_writes_linked_thread_message tests/test_api_cortex.py::test_post_thread_discussion_reply_tool_writes_illo_comment tests/test_tool_registry.py::test_ai_timeline_message_tool_is_registered_and_exposed tests/test_tool_registry.py::test_thread_discussion_reply_tool_is_registered_and_exposed tests/test_external_agents_service.py::test_headless_ask_blocks_thread_mutation_tools
- npm run check
- npm run build
- git diff --check