### PR TITLE
Use runtime embedding config in async memory paths

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -887,9 +887,10 @@ async def audit_apply(
         from brain.systems.memory.embeddings import embed_document
         from brain.systems.memory.scope import classify_scope
         from brain.systems.quality.gate import check_quality
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
         salience = float(payload.get("salience", 7.0))
-        qr = check_quality(content, salience=salience, memory_type=payload.get("memory_type", "lesson"))
+        qr = await check_quality(content, salience=salience, memory_type=payload.get("memory_type", "lesson"))
         if not qr.passed:
             raise HTTPException(status_code=422, detail=f"Memory rejected: {qr.reason}")
         if qr.adjusted_salience is not None:
@@ -903,8 +904,9 @@ async def audit_apply(
             confidence=payload.get("confidence"),
             evidence={"audit_action_payload": payload},
         )
-        semantic_embedding = embed_document(content)
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_embedding = embed_document(content, runtime_config=runtime_config)
             result = await uow.memories.insert_memory(
                 content=content,
                 memory_type=payload.get("memory_type", "lesson"),

--- a/brain/app/hooks/brain_context.py
+++ b/brain/app/hooks/brain_context.py
@@ -40,6 +40,7 @@ async def async_get_context(
     from sqlalchemy import text
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
     from brain.systems.memory.embeddings import embed_query
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     user_id = user_id or os.environ.get("BRAIN_USER_ID")
     org_id = org_id or os.environ.get("BRAIN_ORG_ID")
@@ -52,10 +53,11 @@ async def async_get_context(
 
     # 1. Semantic search for relevant memories
     try:
-        query_emb = embed_query(message)
-        emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
-
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            query_emb = embed_query(message, runtime_config=runtime_config)
+            emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
+
             # Get top relevant memories (lessons and patterns weighted higher)
             memories_result = await _session_execute(uow.session, text("""
                 SELECT id, content, memory_type, salience,

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -238,8 +238,8 @@ async def async_tool_brain_recall(
     Without viewer context, recall intentionally returns no memories.
     """
     from brain.systems.memory.embeddings import embed_query
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
-    query_emb = embed_query(query)
     visibility_context = MemoryVisibilityContext(
         user_id=user_id,
         org_id=org_id,
@@ -249,6 +249,8 @@ async def async_tool_brain_recall(
 
     try:
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            query_emb = embed_query(query, runtime_config=runtime_config)
             results = await _maybe_await(uow.memories.graph_augmented_recall(
                 query_embedding=query_emb,
                 limit=limit,
@@ -404,7 +406,10 @@ async def async_tool_brain_guardrails(skill: str | None = None) -> dict:
         # High-salience warnings (lessons with salience >= 9)
         if skill:
             from brain.systems.memory.embeddings import embed_query
-            skill_emb = embed_query(skill)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            skill_emb = embed_query(skill, runtime_config=runtime_config)
             result["warnings"].extend(
                 await _maybe_await(uow.memories.high_salience_warnings_for_skill(skill_embedding=skill_emb))
             )
@@ -561,19 +566,22 @@ async def async_tool_brain_skills(task: str) -> dict:
         """), {"name": name})
         return result.mappings().first()
 
-    task_emb = None
-    emb_str = None
-    embedding_error = None
-    try:
-        task_emb = embed_query(task)
-        emb_str = vec_to_pg(task_emb)
-    except Exception as exc:
-        embedding_error = str(exc)[:300]
-        logger.warning("brain_skills running in degraded mode; embedding unavailable: %s", embedding_error)
-
     _SMALL_SKILLSET_THRESHOLD = 30  # below this, send ALL skills — model picks better than embeddings
 
     async with UnitOfWork() as uow:
+        task_emb = None
+        emb_str = None
+        embedding_error = None
+        try:
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            task_emb = embed_query(task, runtime_config=runtime_config)
+            emb_str = vec_to_pg(task_emb)
+        except Exception as exc:
+            embedding_error = str(exc)[:300]
+            logger.warning("brain_skills running in degraded mode; embedding unavailable: %s", embedding_error)
+
         # Count active skills to decide strategy
         count_result = await _session_execute(uow.session, text(
             "SELECT COUNT(*) as cnt FROM skills WHERE NOT archived"
@@ -961,6 +969,7 @@ async def async_tool_brain_encode(
 ) -> dict:
     """Encode a new memory into the brain, scoped to the current user."""
     from brain.systems.memory.embeddings import embed_document
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     if len(content.strip()) < 20:
         return {"error": "Content too short (min 20 chars)"}
@@ -990,17 +999,18 @@ async def async_tool_brain_encode(
     semantic_emb = None
     degraded_reason = None
 
-    try:
-        semantic_emb = embed_document(content)
-    except Exception as exc:
-        error_text = str(exc)
-        lower = error_text.lower()
-        if any(term in lower for term in ("out of memory", "oom", "cuda")):
-            degraded_reason = f"embedding_oom: {error_text[:200]}"
-        else:
-            degraded_reason = f"embedding_failed: {error_text[:200]}"
-
     async with UnitOfWork() as uow:
+        try:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(content, runtime_config=runtime_config)
+        except Exception as exc:
+            error_text = str(exc)
+            lower = error_text.lower()
+            if any(term in lower for term in ("out of memory", "oom", "cuda")):
+                degraded_reason = f"embedding_oom: {error_text[:200]}"
+            else:
+                degraded_reason = f"embedding_failed: {error_text[:200]}"
+
         result = await _maybe_await(uow.memories.insert_memory(
             content=content,
             memory_type=memory_type,

--- a/brain/jobs/pipelines/consolidate.py
+++ b/brain/jobs/pipelines/consolidate.py
@@ -163,7 +163,10 @@ async def import_daily_log(uow, filepath: str, log_date: date) -> int:
 
         dense = compress_text(title, body)
         memory_type, salience = classify_memory(title, body)
-        semantic_emb = embed_document(dense)
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        semantic_emb = embed_document(dense, runtime_config=runtime_config)
         tags = extract_tags(title + " " + body)
         tags.append(log_date.isoformat())
 
@@ -218,7 +221,10 @@ async def import_domain_file(uow, filepath: str) -> int:
             memory_type = 'fact'
             salience = max(salience, 5.0)
 
-        semantic_emb = embed_document(dense)
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        semantic_emb = embed_document(dense, runtime_config=runtime_config)
 
         tags = extract_tags(title + " " + body)
         tags.append(filename.replace('.md', ''))

--- a/brain/jobs/pipelines/divergence.py
+++ b/brain/jobs/pipelines/divergence.py
@@ -109,9 +109,12 @@ async def store_divergence_results(
     content = "\n".join(summary_lines)
 
     from brain.systems.memory.embeddings import embed_document, vec_to_pg
-    embedding = embed_document(content)
+    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
     async with UnitOfWork() as uow:
+        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+        embedding = embed_document(content, runtime_config=runtime_config)
+
         await uow.session.execute(text("""
             INSERT INTO memories (content, memory_type, semantic_embedding,
                 salience, tags, source, org_id, user_id, scope)

--- a/brain/systems/cognition/consolidate.py
+++ b/brain/systems/cognition/consolidate.py
@@ -407,7 +407,10 @@ async def extract_semantic(
         # Compute embedding for the new semantic memory
         try:
             from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            semantic_emb = embed_document(synthesized)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(synthesized, runtime_config=runtime_config)
             source_ref = f"cluster:{scoped.visibility}:{len(cluster_ids)}:{cluster_ids[0]}-{cluster_ids[-1]}"
             promotion_evidence = {
                 "source_memory_ids": cluster_ids,
@@ -567,7 +570,10 @@ async def crystallize_procedural(
 
         try:
             from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            semantic_emb = embed_document(procedure_text)
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            semantic_emb = embed_document(procedure_text, runtime_config=runtime_config)
             source_ids = [s["id"] for s in semantics]
             max_sal = max(s["salience"] or 5 for s in semantics)
             source_ref = f"skill:{scoped.visibility}:{skill_name}"[:120]

--- a/brain/systems/quality/checks.py
+++ b/brain/systems/quality/checks.py
@@ -25,6 +25,7 @@ from brain.platform.db.repositories.memory_visibility import (
 )
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.memory.embeddings import embed_document, vec_to_pg
+from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,6 @@ async def check_duplicate(
 
     Returns (is_duplicate, details) where details includes the similar memory if found.
     """
-    if embedding is None:
-        embedding = embed_document(content)
-
-    emb_str = vec_to_pg(embedding)
     visibility_context = MemoryVisibilityContext(
         user_id=user_id,
         org_id=org_id,
@@ -99,6 +96,11 @@ async def check_duplicate(
     vis_clause, vis_params = memory_visibility_sql(visibility_context, alias="")
 
     async with UnitOfWork() as uow:
+        if embedding is None:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            embedding = embed_document(content, runtime_config=runtime_config)
+
+        emb_str = vec_to_pg(embedding)
         row = (await uow.session.execute(text("""
             SELECT id, content,
                    1 - (semantic_embedding <=> CAST(:emb AS vector)) as similarity

--- a/brain/systems/quality/gate.py
+++ b/brain/systems/quality/gate.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.memory.embeddings import embed_document, vec_to_pg
+from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +81,10 @@ async def check_quality(
 async def _check_near_duplicate(content: str, threshold: float = 0.90) -> dict | None:
     """Check if content is a near-duplicate of an existing memory."""
     try:
-        emb = embed_document(content)
-        emb_str = vec_to_pg(emb)
         async with UnitOfWork() as uow:
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            emb = embed_document(content, runtime_config=runtime_config)
+            emb_str = vec_to_pg(emb)
             row = (await uow.session.execute(text("""
                 SELECT id, content, 1 - (semantic_embedding <=> CAST(:emb AS vector)) as similarity
                 FROM memories

--- a/brain/systems/runs/tool_catalog/handlers/skills.py
+++ b/brain/systems/runs/tool_catalog/handlers/skills.py
@@ -185,13 +185,10 @@ async def _handle_create_skill(
 
     try:
         from brain.systems.memory.embeddings import embed_document, vec_to_pg
+        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
         source_kind = "private_local" if user_requested else "agent_draft"
         trust_level = "private_local" if user_requested else "agent_draft"
-
-        # Embed before DB work (most expensive part, no need to hold conn)
-        emb_text = f"{name}: {description}"
-        embedding = embed_document(emb_text)
 
         # Atomic upsert — INSERT ... ON CONFLICT avoids race conditions
         from sqlalchemy import text as sa_text
@@ -202,6 +199,10 @@ async def _handle_create_skill(
 
         asset_specs = assets or []
         async with UnitOfWork() as uow:
+            emb_text = f"{name}: {description}"
+            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            embedding = embed_document(emb_text, runtime_config=runtime_config)
+
             row = (await uow.session.execute(sa_text("""
                 INSERT INTO skills
                     (name, description, procedure, level, model_tier, thinking_tier,

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -259,7 +259,17 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
     # Code search via embeddings
     if scope in ("code", "both"):
         try:
-            code_results = _semantic_code_search(query, limit=limit, workspace_root=workspace_root)
+            from brain.platform.db.repositories.unit_of_work import UnitOfWork
+            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+
+            async with UnitOfWork() as uow:
+                runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
+            code_results = _semantic_code_search(
+                query,
+                limit=limit,
+                workspace_root=workspace_root,
+                runtime_config=runtime_config,
+            )
             results.extend(code_results)
         except Exception as e:
             logger.debug(f"Code semantic search failed: {e}")
@@ -274,7 +284,12 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
     }
 
 
-def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None = None) -> list[dict]:
+def _semantic_code_search(
+    query: str,
+    limit: int = 5,
+    workspace_root: str | None = None,
+    runtime_config=None,
+) -> list[dict]:
     """Search code files using embeddings.
 
     Strategy: embed the query, then compare against file-level summaries.
@@ -283,7 +298,7 @@ def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None
     try:
         from brain.systems.memory.embeddings import embed_query
 
-        query_vec = embed_query(query)
+        query_vec = embed_query(query, runtime_config=runtime_config)
 
         # Get candidate files (Python files, limited to avoid embedding everything)
         workspace = pathlib.Path(workspace_root or WORKSPACE_ROOT)
@@ -310,7 +325,7 @@ def _semantic_code_search(query: str, limit: int = 5, workspace_root: str | None
         # Embed summaries
         from brain.systems.memory.embeddings import embed_batch
         texts = [f"{path}: {preview}" for path, preview in candidates]
-        vecs = embed_batch(texts, mode="document")
+        vecs = embed_batch(texts, mode="document", runtime_config=runtime_config)
 
         # Compute similarities
         similarities = np.dot(vecs, query_vec) / (

--- a/tests/test_progressive_skill_loading.py
+++ b/tests/test_progressive_skill_loading.py
@@ -400,6 +400,60 @@ async def test_brain_skills_degrades_when_embedding_unavailable():
     uow.memories.guardrail_memories_for_task.assert_not_called()
 
 
+async def test_brain_skills_uses_db_backed_runtime_config_for_embeddings():
+    from brain.app.mcp.server import async_tool_brain_skills
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    row = {
+        "id": 1,
+        "name": "develop",
+        "description": "Ship focused changes.",
+        "version": 3,
+        "maturity": "proficient",
+        "confidence": 0.8,
+        "use_count": 4,
+        "success_rate": 0.75,
+        "model_tier": "medium",
+        "thinking_tier": "medium",
+        "pitfalls": [],
+        "triggers": [],
+        "bundle_version_id": 7,
+        "bundle_digest": "sha256:bundle",
+        "overlay_revision": None,
+        "effective_digest": "sha256:effective",
+        "source_kind": "illo-core",
+        "trust_level": "illo_core",
+        "skill_match": 0.5,
+        "centroid_match": None,
+        "centroid_count": 0,
+    }
+    uow = _FakeUow(
+        execute_results=[
+            _ExecuteResult(one_value={"cnt": 1}),
+            _ExecuteResult(all_value=[row]),
+            _ExecuteResult(all_value=[]),
+        ],
+    )
+    runtime = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="openai",
+        api_model="text-embedding-3-small",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=768,
+        api_key="secret",
+    )
+
+    with patch("brain.app.mcp.server.UnitOfWork", return_value=uow), \
+         patch("brain.systems.runtime_settings.memory.async_get_embedding_runtime_config", return_value=runtime), \
+         patch("brain.systems.memory.embeddings.embed_query", return_value=[0.1]) as embed_query, \
+         patch("brain.systems.memory.embeddings.vec_to_pg", return_value="[0.1]"):
+        result = await async_tool_brain_skills("fix a bug")
+
+    embed_query.assert_called_once_with("fix a bug", runtime_config=runtime)
+    assert "degraded_reason" not in result
+    assert result["recommended_skills"][0]["name"] == "develop"
+
+
 async def test_skill_view_loads_procedure_with_digest_metadata():
     from brain.app.mcp.server import async_tool_skill_view
 


### PR DESCRIPTION
## Summary
- load DB-backed runtime embedding config before async MCP memory/skill embedding calls
- apply the same fix to async hooks, audit memory writes, quality duplicate checks, scheduler/consolidation jobs, and semantic code search
- add a regression test that ensures brain_skills passes runtime_config into embed_query

## Audit notes
- fixed async/server/job embedding call sites that could fall back to process defaults and surface unconfigured Gemini credentials
- remaining direct embedding calls are CLI/local helper paths or already pass runtime_config explicitly

## Tests
- pytest tests/test_progressive_skill_loading.py tests/test_async_runtime_migration_metrics.py -q
- pytest tests/test_memory.py -q
- pytest tests -q -k "quality or memory or progressive_skill_loading or async_runtime"
- pytest -q