### PR TITLE
Centralize async embedding runtime boundary

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -884,10 +884,9 @@ async def audit_apply(
         if not content or len(content) < 20:
             raise HTTPException(status_code=400, detail="Lesson content must be >= 20 chars")
         from brain.platform.db.repositories.memory_write_context import MemoryWriteContext
-        from brain.systems.memory.embeddings import embed_document
+        from brain.systems.memory.embedding_service import EmbeddingService
         from brain.systems.memory.scope import classify_scope
         from brain.systems.quality.gate import check_quality
-        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
 
         salience = float(payload.get("salience", 7.0))
         qr = await check_quality(content, salience=salience, memory_type=payload.get("memory_type", "lesson"))
@@ -905,8 +904,8 @@ async def audit_apply(
             evidence={"audit_action_payload": payload},
         )
         async with UnitOfWork() as uow:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            semantic_embedding = embed_document(content, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            semantic_embedding = embedding_service.document(content)
             result = await uow.memories.insert_memory(
                 content=content,
                 memory_type=payload.get("memory_type", "lesson"),

--- a/brain/app/hooks/brain_context.py
+++ b/brain/app/hooks/brain_context.py
@@ -39,8 +39,7 @@ async def async_get_context(
     """Query the brain for context relevant to this message."""
     from sqlalchemy import text
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
-    from brain.systems.memory.embeddings import embed_query
-    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+    from brain.systems.memory.embedding_service import EmbeddingService
 
     user_id = user_id or os.environ.get("BRAIN_USER_ID")
     org_id = org_id or os.environ.get("BRAIN_ORG_ID")
@@ -54,8 +53,8 @@ async def async_get_context(
     # 1. Semantic search for relevant memories
     try:
         async with UnitOfWork() as uow:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            query_emb = embed_query(message, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            query_emb = embedding_service.query(message)
             emb_str = "[" + ",".join(str(x) for x in query_emb) + "]"
 
             # Get top relevant memories (lessons and patterns weighted higher)

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -237,8 +237,7 @@ async def async_tool_brain_recall(
     Multiplayer: pass user_id + org_id for visibility-scoped recall.
     Without viewer context, recall intentionally returns no memories.
     """
-    from brain.systems.memory.embeddings import embed_query
-    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+    from brain.systems.memory.embedding_service import EmbeddingService, embedding_degradation_reason
 
     visibility_context = MemoryVisibilityContext(
         user_id=user_id,
@@ -247,10 +246,11 @@ async def async_tool_brain_recall(
         principal_type="service" if service_retrieval or user_id == "system" else None,
     )
 
+    query_emb = None
     try:
         async with UnitOfWork() as uow:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            query_emb = embed_query(query, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            query_emb = embedding_service.query(query)
             results = await _maybe_await(uow.memories.graph_augmented_recall(
                 query_embedding=query_emb,
                 limit=limit,
@@ -282,9 +282,22 @@ async def async_tool_brain_recall(
             attention_debug=attention_debug,
             expand_lazy_load=expand_lazy_load,
             service_retrieval=service_retrieval,
-        )
+            )
     except Exception as e:
         logger.warning(f"Graph recall failed, falling back to vector: {e}")
+        if query_emb is None:
+            response = await _finalize_recall_response(
+                query=query,
+                memories=[],
+                limit=limit,
+                user_id=user_id,
+                org_id=org_id,
+                attention_debug=attention_debug,
+                expand_lazy_load=expand_lazy_load,
+                service_retrieval=service_retrieval,
+            )
+            response["warning"] = embedding_degradation_reason(e)
+            return response
 
     # Fallback: pure vector search with same visibility filtering
     async with UnitOfWork() as uow:
@@ -405,11 +418,10 @@ async def async_tool_brain_guardrails(skill: str | None = None) -> dict:
 
         # High-salience warnings (lessons with salience >= 9)
         if skill:
-            from brain.systems.memory.embeddings import embed_query
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+            from brain.systems.memory.embedding_service import EmbeddingService
 
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            skill_emb = embed_query(skill, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            skill_emb = embedding_service.query(skill)
             result["warnings"].extend(
                 await _maybe_await(uow.memories.high_salience_warnings_for_skill(skill_embedding=skill_emb))
             )
@@ -440,7 +452,8 @@ async def async_tool_brain_skills(task: str) -> dict:
     Returns the same structure as `skills.py plan` but without the subprocess overhead.
     """
     from brain.systems.skills.builtin import ensure_builtin_skills_cached
-    from brain.systems.memory.embeddings import embed_query, vec_to_pg
+    from brain.systems.memory.embedding_service import EmbeddingService, embedding_degradation_reason
+    from brain.systems.memory.embeddings import vec_to_pg
 
     await ensure_builtin_skills_cached()
 
@@ -573,13 +586,11 @@ async def async_tool_brain_skills(task: str) -> dict:
         emb_str = None
         embedding_error = None
         try:
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
-
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            task_emb = embed_query(task, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            task_emb = embedding_service.query(task)
             emb_str = vec_to_pg(task_emb)
         except Exception as exc:
-            embedding_error = str(exc)[:300]
+            embedding_error = embedding_degradation_reason(exc)[:300]
             logger.warning("brain_skills running in degraded mode; embedding unavailable: %s", embedding_error)
 
         # Count active skills to decide strategy
@@ -968,8 +979,7 @@ async def async_tool_brain_encode(
     evidence: dict | None = None,
 ) -> dict:
     """Encode a new memory into the brain, scoped to the current user."""
-    from brain.systems.memory.embeddings import embed_document
-    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+    from brain.systems.memory.embedding_service import EmbeddingService, embedding_degradation_reason
 
     if len(content.strip()) < 20:
         return {"error": "Content too short (min 20 chars)"}
@@ -1001,15 +1011,10 @@ async def async_tool_brain_encode(
 
     async with UnitOfWork() as uow:
         try:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            semantic_emb = embed_document(content, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            semantic_emb = embedding_service.document(content)
         except Exception as exc:
-            error_text = str(exc)
-            lower = error_text.lower()
-            if any(term in lower for term in ("out of memory", "oom", "cuda")):
-                degraded_reason = f"embedding_oom: {error_text[:200]}"
-            else:
-                degraded_reason = f"embedding_failed: {error_text[:200]}"
+            degraded_reason = embedding_degradation_reason(exc)
 
         result = await _maybe_await(uow.memories.insert_memory(
             content=content,

--- a/brain/app/ops/health.py
+++ b/brain/app/ops/health.py
@@ -14,6 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.run import AgentRun
 from brain.platform.provider_health import provider_health_snapshot
 from brain.app.scheduler.daemon import async_scheduler_health_snapshot
+from brain.systems.runtime_settings.embedding_diagnostics import (
+    embedding_backend_label,
+    embedding_provider_label,
+)
 from brain.systems.runtime_settings.memory import async_get_embedding_info
 
 APP_VERSION = "6.0.0"
@@ -360,7 +364,7 @@ async def _embedding_health_check(session: AsyncSession | None) -> HealthCheck:
             return HealthCheck(
                 name="embedding",
                 status="ok",
-                summary=f"{_embedding_backend_label(info)} embedding backend is ready",
+                summary=f"{embedding_backend_label(info)} embedding backend is ready",
                 latency_ms=_elapsed_ms(start),
                 details=details,
             )
@@ -377,7 +381,7 @@ async def _embedding_health_check(session: AsyncSession | None) -> HealthCheck:
 
         summary = str(info.get("detail") or f"embedding backend is {runtime_status}")
         if runtime_status == "missing_key":
-            summary = f"{_embedding_provider_label(info)} embedding credentials missing"
+            summary = f"{embedding_provider_label(info)} embedding credentials missing"
         return HealthCheck(
             name="embedding",
             status="failed",
@@ -397,27 +401,6 @@ async def _embedding_health_check(session: AsyncSession | None) -> HealthCheck:
             details={"error": str(exc)},
             remediation="Verify embedding backend configuration and service availability.",
         )
-
-
-def _embedding_backend_label(info: dict[str, Any]) -> str:
-    backend = str(info.get("backend") or "").lower()
-    if backend == "api":
-        return _embedding_provider_label(info)
-    if backend == "cpu":
-        return "CPU"
-    if backend == "gpu":
-        return "GPU"
-    return backend or "unknown"
-
-
-def _embedding_provider_label(info: dict[str, Any]) -> str:
-    provider = str(info.get("provider") or "").lower()
-    if provider in {"gemini", "google"}:
-        return "Gemini"
-    if provider == "openai":
-        return "OpenAI"
-    return provider.upper() if provider else "API"
-
 
 def _provider_health_check() -> HealthCheck:
     start = time.monotonic()

--- a/brain/app/ops/health.py
+++ b/brain/app/ops/health.py
@@ -11,15 +11,14 @@ from typing import Any
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.async_io import http_get
 from brain.platform.db.models.run import AgentRun
 from brain.platform.provider_health import provider_health_snapshot
 from brain.app.scheduler.daemon import async_scheduler_health_snapshot
+from brain.systems.runtime_settings.memory import async_get_embedding_info
 
 APP_VERSION = "6.0.0"
 DEFAULT_DB_TIMEOUT_MS = 1500
 DEFAULT_DEEP_TIMEOUT_MS = 2500
-DEFAULT_GPU_HEALTH_TIMEOUT_SECONDS = 1.0
 DEFAULT_STUCK_RUN_SECONDS = 15 * 60
 DEFAULT_RECENT_FAILURE_WINDOW_MINUTES = 60
 DEFAULT_RECENT_FAILURE_LIMIT = 10
@@ -75,13 +74,6 @@ def _elapsed_ms(start: float) -> int:
 def _timeout_ms(env_name: str, default: int) -> int:
     try:
         return max(100, int(os.getenv(env_name, str(default))))
-    except Exception:
-        return default
-
-
-def _timeout_seconds(env_name: str, default: float) -> float:
-    try:
-        return max(0.05, float(os.getenv(env_name, str(default))))
     except Exception:
         return default
 
@@ -350,95 +342,53 @@ async def readiness_health_snapshot(
     }
 
 
-def _embedding_health_check() -> HealthCheck:
+async def _embedding_health_check(session: AsyncSession | None) -> HealthCheck:
     start = time.monotonic()
     try:
-        import brain.kernel.config as cfg
+        if session is None:
+            raise RuntimeError("embedding health checks require an explicit database session")
 
-        backend = cfg.EMBEDDING_BACKEND
-        details: dict[str, Any] = {
-            "backend": backend,
-            "dimensions": cfg.EMBEDDING_DIM,
+        info = await async_get_embedding_info(session)
+        runtime_status = str(info.get("status") or "unknown")
+        details = {
+            key: value
+            for key, value in info.items()
+            if key not in {"detail", "remediation"}
         }
-        if backend == "api":
-            details.update({
-                "provider": cfg.EMBEDDING_API_PROVIDER,
-                "model": cfg.EMBEDDING_API_MODEL,
-                "api_key_configured": bool(cfg.EMBEDDING_API_KEY),
-            })
-            if not cfg.EMBEDDING_API_KEY:
-                return HealthCheck(
-                    name="embedding",
-                    status="failed",
-                    summary="API embedding backend is missing credentials",
-                    latency_ms=_elapsed_ms(start),
-                    details=details,
-                    remediation="Add embedding credentials in System/Access, or switch EMBEDDING_BACKEND.",
-                )
+        remediation = info.get("remediation")
+        if runtime_status == "ready":
             return HealthCheck(
                 name="embedding",
                 status="ok",
-                summary="API embedding backend is configured",
+                summary=f"{_embedding_backend_label(info)} embedding backend is ready",
                 latency_ms=_elapsed_ms(start),
                 details=details,
             )
-        if backend == "cpu":
-            details["model"] = cfg.EMBEDDING_CPU_MODEL
+
+        if runtime_status == "initializing":
             return HealthCheck(
                 name="embedding",
-                status="ok",
-                summary="CPU embedding backend is configured",
+                status="degraded",
+                summary="GPU embedding backend is initializing",
                 latency_ms=_elapsed_ms(start),
                 details=details,
+                remediation=str(remediation) if remediation else None,
             )
-        if backend == "gpu":
-            timeout_s = _timeout_seconds(
-                "HEALTH_DEEP_GPU_TIMEOUT_SECONDS",
-                DEFAULT_GPU_HEALTH_TIMEOUT_SECONDS,
-            )
-            url = f"{cfg.GPU_SERVER_URL.rstrip('/')}/health"
-            response = http_get(url, timeout=timeout_s)
-            payload = response.json()
-            details.update({
-                "gpu_server_url": cfg.GPU_SERVER_URL,
-                "http_status": response.status_code,
-                "server": payload,
-            })
-            server_status = payload.get("status")
-            if response.status_code == 200 and server_status in {"ok", "healthy"}:
-                return HealthCheck(
-                    name="embedding",
-                    status="ok",
-                    summary="GPU embedding backend is healthy",
-                    latency_ms=_elapsed_ms(start),
-                    details=details,
-                )
-            if response.status_code == 200 and server_status == "degraded":
-                return HealthCheck(
-                    name="embedding",
-                    status="degraded",
-                    summary="GPU embedding backend reports degraded",
-                    latency_ms=_elapsed_ms(start),
-                    details=details,
-                    remediation="Inspect GPU server worker status and logs.",
-                )
-            return HealthCheck(
-                name="embedding",
-                status="failed",
-                summary="GPU embedding backend is not healthy",
-                latency_ms=_elapsed_ms(start),
-                details=details,
-                remediation="Restart or inspect the GPU model server before runing semantic work.",
-            )
+
+        summary = str(info.get("detail") or f"embedding backend is {runtime_status}")
+        if runtime_status == "missing_key":
+            summary = f"{_embedding_provider_label(info)} embedding credentials missing"
         return HealthCheck(
             name="embedding",
             status="failed",
-            summary=f"unknown embedding backend: {backend}",
+            summary=summary,
             latency_ms=_elapsed_ms(start),
             details=details,
-            remediation="Set EMBEDDING_BACKEND to api, cpu, or gpu.",
+            remediation=str(remediation) if remediation else None,
         )
     except Exception as exc:
+        if session is not None:
+            await _rollback_health_session(session)
         return HealthCheck(
             name="embedding",
             status="failed",
@@ -447,6 +397,26 @@ def _embedding_health_check() -> HealthCheck:
             details={"error": str(exc)},
             remediation="Verify embedding backend configuration and service availability.",
         )
+
+
+def _embedding_backend_label(info: dict[str, Any]) -> str:
+    backend = str(info.get("backend") or "").lower()
+    if backend == "api":
+        return _embedding_provider_label(info)
+    if backend == "cpu":
+        return "CPU"
+    if backend == "gpu":
+        return "GPU"
+    return backend or "unknown"
+
+
+def _embedding_provider_label(info: dict[str, Any]) -> str:
+    provider = str(info.get("provider") or "").lower()
+    if provider in {"gemini", "google"}:
+        return "Gemini"
+    if provider == "openai":
+        return "OpenAI"
+    return provider.upper() if provider else "API"
 
 
 def _provider_health_check() -> HealthCheck:
@@ -643,7 +613,7 @@ async def deep_health_snapshot(
     session: AsyncSession | None = None,
 ) -> dict[str, Any]:
     checks = {
-        "embedding": _embedding_health_check(),
+        "embedding": await _embedding_health_check(session),
         "providers": _provider_health_check(),
         "scheduler": await _scheduler_health_check(session),
         "run": await _run_health_check(session),

--- a/brain/jobs/pipelines/consolidate.py
+++ b/brain/jobs/pipelines/consolidate.py
@@ -31,10 +31,7 @@ from brain.platform.async_io import (
     read_text as read_text_async,
     write_text as write_text_async,
 )
-from brain.systems.memory.embeddings import (
-    embed_document, embed_batch, embed_query,
-    vec_to_pg,
-)
+from brain.systems.memory.embeddings import vec_to_pg
 
 WORKSPACE = str(config.WORKSPACE_ROOT)
 MEMORY_DIR = str(config.JOURNAL_DIR)  # illo-brain/journal/ — standalone, no external deps
@@ -163,10 +160,10 @@ async def import_daily_log(uow, filepath: str, log_date: date) -> int:
 
         dense = compress_text(title, body)
         memory_type, salience = classify_memory(title, body)
-        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+        from brain.systems.memory.embedding_service import EmbeddingService
 
-        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-        semantic_emb = embed_document(dense, runtime_config=runtime_config)
+        embedding_service = await EmbeddingService.from_session(uow.session)
+        semantic_emb = embedding_service.document(dense)
         tags = extract_tags(title + " " + body)
         tags.append(log_date.isoformat())
 
@@ -221,10 +218,10 @@ async def import_domain_file(uow, filepath: str) -> int:
             memory_type = 'fact'
             salience = max(salience, 5.0)
 
-        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+        from brain.systems.memory.embedding_service import EmbeddingService
 
-        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-        semantic_emb = embed_document(dense, runtime_config=runtime_config)
+        embedding_service = await EmbeddingService.from_session(uow.session)
+        semantic_emb = embedding_service.document(dense)
 
         tags = extract_tags(title + " " + body)
         tags.append(filename.replace('.md', ''))

--- a/brain/jobs/pipelines/cortex_emerge.py
+++ b/brain/jobs/pipelines/cortex_emerge.py
@@ -28,7 +28,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.kernel import config
 from brain.platform.async_io import run_subprocess
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.memory.embeddings import embed_document, embed_batch, vec_to_pg
+from brain.systems.memory.embedding_service import EmbeddingService
+from brain.systems.memory.embeddings import vec_to_pg
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [cortex_emerge] %(message)s")
 log = logging.getLogger(__name__)
@@ -142,7 +143,7 @@ async def _async_create_emerged_idea(
 # Source: Conversation Patterns (recurring topics in memories)
 # ---------------------------------------------------------------------------
 
-async def _async_scan_conversation_patterns(session: AsyncSession, runtime_config) -> list[dict]:
+async def _async_scan_conversation_patterns(session: AsyncSession, embedding_service: EmbeddingService) -> list[dict]:
     """Find recurring topics in recent memories through async DB access."""
     candidates = []
     try:
@@ -166,7 +167,7 @@ async def _async_scan_conversation_patterns(session: AsyncSession, runtime_confi
         if len(texts) > 50:
             texts = texts[:50]
 
-        embs = embed_batch(texts, mode='document', runtime_config=runtime_config)
+        embs = embedding_service.batch(texts, mode='document')
 
         clusters = []
         used = set()
@@ -359,15 +360,13 @@ async def async_run_emergence(session: AsyncSession) -> dict:
     """Async emergence entry point for API-triggered runs."""
     log.info("=== Cortex Emergence Pipeline Starting ===")
 
-    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
-
-    runtime_config = await async_get_embedding_runtime_config(session, include_secret=True)
+    embedding_service = await EmbeddingService.from_session(session)
     thresholds = await _async_load_thresholds(session)
     existing = await _async_get_existing_ideas_with_embeddings(session)
     log.info("Loaded %s existing ideas for dedup", len(existing))
 
     all_candidates = []
-    all_candidates.extend([(c, 'conversation') for c in await _async_scan_conversation_patterns(session, runtime_config)])
+    all_candidates.extend([(c, 'conversation') for c in await _async_scan_conversation_patterns(session, embedding_service)])
     all_candidates.extend([(c, 'error') for c in await _async_scan_error_patterns(session)])
     all_candidates.extend([(c, 'github') for c in await _async_scan_github_issues()])
     all_candidates.extend([(c, 'nightly_insight') for c in await _async_scan_nightly_insights(session)])
@@ -388,7 +387,7 @@ async def async_run_emergence(session: AsyncSession) -> dict:
             continue
 
         text_content = f"{candidate['title']} {candidate.get('description', '')}"
-        emb = embed_document(text_content, runtime_config=runtime_config)
+        emb = embedding_service.document(text_content)
 
         is_dup, dup_id = _is_duplicate(emb, existing)
         if is_dup:

--- a/brain/jobs/pipelines/divergence.py
+++ b/brain/jobs/pipelines/divergence.py
@@ -108,12 +108,12 @@ async def store_divergence_results(
 
     content = "\n".join(summary_lines)
 
-    from brain.systems.memory.embeddings import embed_document, vec_to_pg
-    from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+    from brain.systems.memory.embedding_service import EmbeddingService
+    from brain.systems.memory.embeddings import vec_to_pg
 
     async with UnitOfWork() as uow:
-        runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-        embedding = embed_document(content, runtime_config=runtime_config)
+        embedding_service = await EmbeddingService.from_session(uow.session)
+        embedding = embedding_service.document(content)
 
         await uow.session.execute(text("""
             INSERT INTO memories (content, memory_type, semantic_embedding,

--- a/brain/systems/cognition/consolidate.py
+++ b/brain/systems/cognition/consolidate.py
@@ -406,11 +406,11 @@ async def extract_semantic(
 
         # Compute embedding for the new semantic memory
         try:
-            from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+            from brain.systems.memory.embeddings import vec_to_pg
+            from brain.systems.memory.embedding_service import EmbeddingService
 
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            semantic_emb = embed_document(synthesized, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            semantic_emb = embedding_service.document(synthesized)
             source_ref = f"cluster:{scoped.visibility}:{len(cluster_ids)}:{cluster_ids[0]}-{cluster_ids[-1]}"
             promotion_evidence = {
                 "source_memory_ids": cluster_ids,
@@ -569,11 +569,11 @@ async def crystallize_procedural(
             )
 
         try:
-            from brain.systems.memory.embeddings import embed_document, vec_to_pg
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+            from brain.systems.memory.embeddings import vec_to_pg
+            from brain.systems.memory.embedding_service import EmbeddingService
 
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            semantic_emb = embed_document(procedure_text, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            semantic_emb = embedding_service.document(procedure_text)
             source_ids = [s["id"] for s in semantics]
             max_sal = max(s["salience"] or 5 for s in semantics)
             source_ref = f"skill:{scoped.visibility}:{skill_name}"[:120]

--- a/brain/systems/cortex/intelligence.py
+++ b/brain/systems/cortex/intelligence.py
@@ -14,7 +14,8 @@ import numpy as np
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.systems.memory.embeddings import embed_query, vec_to_pg
+from brain.systems.memory.embedding_service import EmbeddingService
+from brain.systems.memory.embeddings import vec_to_pg
 
 log = logging.getLogger(__name__)
 
@@ -216,10 +217,8 @@ async def async_compute_gravity(
             query_emb = row['embedding']
     elif query_text:
         try:
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
-
-            runtime = await async_get_embedding_runtime_config(session, include_secret=True)
-            emb_arr = embed_query(query_text, runtime_config=runtime)
+            embedding_service = await EmbeddingService.from_session(session)
+            emb_arr = embedding_service.query(query_text)
             query_emb = vec_to_pg(emb_arr)
         except Exception as e:
             log.warning("Failed to embed gravity query: %s", e)

--- a/brain/systems/memory/embedding_service.py
+++ b/brain/systems/memory/embedding_service.py
@@ -1,0 +1,126 @@
+"""DB-backed embedding service for async server and job paths."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.systems.memory import embeddings as embedding_backend
+from brain.systems.runtime_settings.memory import (
+    EmbeddingRuntimeConfig,
+    async_get_embedding_runtime_config,
+    get_embedding_runtime_config,
+)
+
+EmbeddingMode = Literal["document", "query"]
+
+
+class EmbeddingServiceError(RuntimeError):
+    """Base error for DB-backed embedding service failures."""
+
+
+class EmbeddingConfigUnavailable(EmbeddingServiceError):
+    """Runtime embedding settings could not be loaded or are invalid."""
+
+
+class EmbeddingCredentialsUnavailable(EmbeddingServiceError):
+    """The selected API embedding provider has no usable credentials."""
+
+
+class EmbeddingProviderUnavailable(EmbeddingServiceError):
+    """The selected embedding provider failed the request."""
+
+
+@dataclass(frozen=True)
+class EmbeddingService:
+    """Small seam for embedding calls that must use DB-backed runtime settings."""
+
+    runtime_config: EmbeddingRuntimeConfig
+
+    @classmethod
+    async def from_session(cls, session: AsyncSession) -> "EmbeddingService":
+        try:
+            runtime_config = await async_get_embedding_runtime_config(session, include_secret=True)
+        except Exception as exc:
+            raise EmbeddingConfigUnavailable(
+                "Embedding runtime config could not be loaded. Check runtime memory settings."
+            ) from exc
+        return cls(runtime_config=runtime_config)
+
+    @classmethod
+    def from_legacy_sync_config(cls) -> "EmbeddingService":
+        """Build from process defaults for legacy sync callers and CLIs."""
+        return cls(runtime_config=get_embedding_runtime_config(include_secret=True))
+
+    @property
+    def provider(self) -> str:
+        return (self.runtime_config.provider or "").lower()
+
+    def query(self, text: str) -> np.ndarray:
+        self._ensure_ready()
+        try:
+            return embedding_backend.embed_query(text, runtime_config=self.runtime_config)
+        except EmbeddingServiceError:
+            raise
+        except RuntimeError as exc:
+            raise self._typed_provider_error(exc) from exc
+
+    def document(self, text: str) -> np.ndarray:
+        self._ensure_ready()
+        try:
+            return embedding_backend.embed_document(text, runtime_config=self.runtime_config)
+        except EmbeddingServiceError:
+            raise
+        except RuntimeError as exc:
+            raise self._typed_provider_error(exc) from exc
+
+    def batch(self, texts: list[str], *, mode: EmbeddingMode = "document") -> np.ndarray:
+        self._ensure_ready()
+        try:
+            return embedding_backend.embed_batch(texts, mode=mode, runtime_config=self.runtime_config)
+        except EmbeddingServiceError:
+            raise
+        except RuntimeError as exc:
+            raise self._typed_provider_error(exc) from exc
+
+    def _ensure_ready(self) -> None:
+        backend = (self.runtime_config.backend or "").lower()
+        if backend not in {"gpu", "cpu", "api"}:
+            raise EmbeddingConfigUnavailable(
+                f"Unknown embedding backend {self.runtime_config.backend!r}. Use gpu, cpu, or api."
+            )
+        if backend == "api" and not self.runtime_config.api_key:
+            raise EmbeddingCredentialsUnavailable(_credential_message(self.provider))
+
+    def _typed_provider_error(self, exc: RuntimeError) -> EmbeddingServiceError:
+        detail = str(exc)
+        lower = detail.lower()
+        if "credentials are not configured" in lower or "embedding_api_key" in lower:
+            return EmbeddingCredentialsUnavailable(_credential_message(self.provider))
+        return EmbeddingProviderUnavailable(detail)
+
+
+def _credential_message(provider: str) -> str:
+    if provider in {"gemini", "google"}:
+        return "Gemini embedding credentials are not configured. Add them in System/Access."
+    if provider == "openai":
+        return "OpenAI embedding credentials are not configured. Add them in System/Access."
+    return "Embedding credentials are not configured. Add them in System/Access."
+
+
+def embedding_degradation_reason(exc: Exception) -> str:
+    """Return a stable degradation reason for embedding failures."""
+    error_text = str(exc)
+    if isinstance(exc, EmbeddingCredentialsUnavailable):
+        return f"embedding_credentials_unavailable: {error_text[:200]}"
+    if isinstance(exc, EmbeddingConfigUnavailable):
+        return f"embedding_config_unavailable: {error_text[:200]}"
+    if isinstance(exc, EmbeddingProviderUnavailable):
+        return f"embedding_provider_unavailable: {error_text[:200]}"
+
+    lower = error_text.lower()
+    if any(term in lower for term in ("out of memory", "oom", "cuda")):
+        return f"embedding_oom: {error_text[:200]}"
+    return f"embedding_failed: {error_text[:200]}"

--- a/brain/systems/memory/embedding_service.py
+++ b/brain/systems/memory/embedding_service.py
@@ -92,17 +92,18 @@ class EmbeddingService:
                 f"Unknown embedding backend {self.runtime_config.backend!r}. Use gpu, cpu, or api."
             )
         if backend == "api" and not self.runtime_config.api_key:
-            raise EmbeddingCredentialsUnavailable(_credential_message(self.provider))
+            raise EmbeddingCredentialsUnavailable(embedding_credentials_message(self.provider))
 
     def _typed_provider_error(self, exc: RuntimeError) -> EmbeddingServiceError:
         detail = str(exc)
         lower = detail.lower()
         if "credentials are not configured" in lower or "embedding_api_key" in lower:
-            return EmbeddingCredentialsUnavailable(_credential_message(self.provider))
+            return EmbeddingCredentialsUnavailable(embedding_credentials_message(self.provider))
         return EmbeddingProviderUnavailable(detail)
 
 
-def _credential_message(provider: str) -> str:
+def embedding_credentials_message(provider: str) -> str:
+    """Return the operator-facing missing-credentials message for a provider."""
     if provider in {"gemini", "google"}:
         return "Gemini embedding credentials are not configured. Add them in System/Access."
     if provider == "openai":

--- a/brain/systems/memory/embedding_service.py
+++ b/brain/systems/memory/embedding_service.py
@@ -13,6 +13,10 @@ from brain.systems.runtime_settings.memory import (
     async_get_embedding_runtime_config,
     get_embedding_runtime_config,
 )
+from brain.systems.runtime_settings.embedding_diagnostics import (
+    VALID_EMBEDDING_BACKENDS,
+    embedding_credentials_message,
+)
 
 EmbeddingMode = Literal["document", "query"]
 
@@ -87,7 +91,7 @@ class EmbeddingService:
 
     def _ensure_ready(self) -> None:
         backend = (self.runtime_config.backend or "").lower()
-        if backend not in {"gpu", "cpu", "api"}:
+        if backend not in VALID_EMBEDDING_BACKENDS:
             raise EmbeddingConfigUnavailable(
                 f"Unknown embedding backend {self.runtime_config.backend!r}. Use gpu, cpu, or api."
             )
@@ -100,16 +104,6 @@ class EmbeddingService:
         if "credentials are not configured" in lower or "embedding_api_key" in lower:
             return EmbeddingCredentialsUnavailable(embedding_credentials_message(self.provider))
         return EmbeddingProviderUnavailable(detail)
-
-
-def embedding_credentials_message(provider: str) -> str:
-    """Return the operator-facing missing-credentials message for a provider."""
-    if provider in {"gemini", "google"}:
-        return "Gemini embedding credentials are not configured. Add them in System/Access."
-    if provider == "openai":
-        return "OpenAI embedding credentials are not configured. Add them in System/Access."
-    return "Embedding credentials are not configured. Add them in System/Access."
-
 
 def embedding_degradation_reason(exc: Exception) -> str:
     """Return a stable degradation reason for embedding failures."""

--- a/brain/systems/quality/checks.py
+++ b/brain/systems/quality/checks.py
@@ -24,8 +24,8 @@ from brain.platform.db.repositories.memory_visibility import (
     memory_visibility_sql,
 )
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.memory.embeddings import embed_document, vec_to_pg
-from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+from brain.systems.memory.embedding_service import EmbeddingService
+from brain.systems.memory.embeddings import vec_to_pg
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +97,8 @@ async def check_duplicate(
 
     async with UnitOfWork() as uow:
         if embedding is None:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            embedding = embed_document(content, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            embedding = embedding_service.document(content)
 
         emb_str = vec_to_pg(embedding)
         row = (await uow.session.execute(text("""

--- a/brain/systems/quality/gate.py
+++ b/brain/systems/quality/gate.py
@@ -10,8 +10,8 @@ import logging
 from sqlalchemy import text
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.memory.embeddings import embed_document, vec_to_pg
-from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+from brain.systems.memory.embedding_service import EmbeddingService
+from brain.systems.memory.embeddings import vec_to_pg
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +82,8 @@ async def _check_near_duplicate(content: str, threshold: float = 0.90) -> dict |
     """Check if content is a near-duplicate of an existing memory."""
     try:
         async with UnitOfWork() as uow:
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            emb = embed_document(content, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            emb = embedding_service.document(content)
             emb_str = vec_to_pg(emb)
             row = (await uow.session.execute(text("""
                 SELECT id, content, 1 - (semantic_embedding <=> CAST(:emb AS vector)) as similarity

--- a/brain/systems/runs/tool_catalog/handlers/skills.py
+++ b/brain/systems/runs/tool_catalog/handlers/skills.py
@@ -184,8 +184,8 @@ async def _handle_create_skill(
         }
 
     try:
-        from brain.systems.memory.embeddings import embed_document, vec_to_pg
-        from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+        from brain.systems.memory.embedding_service import EmbeddingService
+        from brain.systems.memory.embeddings import vec_to_pg
 
         source_kind = "private_local" if user_requested else "agent_draft"
         trust_level = "private_local" if user_requested else "agent_draft"
@@ -200,8 +200,8 @@ async def _handle_create_skill(
         asset_specs = assets or []
         async with UnitOfWork() as uow:
             emb_text = f"{name}: {description}"
-            runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            embedding = embed_document(emb_text, runtime_config=runtime_config)
+            embedding_service = await EmbeddingService.from_session(uow.session)
+            embedding = embedding_service.document(emb_text)
 
             row = (await uow.session.execute(sa_text("""
                 INSERT INTO skills

--- a/brain/systems/runtime_settings/embedding_diagnostics.py
+++ b/brain/systems/runtime_settings/embedding_diagnostics.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+VALID_EMBEDDING_BACKENDS = {"api", "cpu", "gpu"}
+
+
+def embedding_credentials_message(provider: str) -> str:
+    """Return the operator-facing missing-credentials message for a provider."""
+    provider = (provider or "").lower()
+    if provider in {"gemini", "google"}:
+        return "Gemini embedding credentials are not configured. Add them in System/Access."
+    if provider == "openai":
+        return "OpenAI embedding credentials are not configured. Add them in System/Access."
+    return "Embedding credentials are not configured. Add them in System/Access."
+
+
+def embedding_status_detail(info: dict[str, Any]) -> str | None:
+    provider = str(info.get("provider") or "").lower()
+    status = info.get("status")
+    if status == "missing_key":
+        return embedding_credentials_message(provider)
+    if status == "invalid_config":
+        return f"Unknown embedding backend {info.get('backend')!r}. Use gpu, cpu, or api."
+    if status == "unavailable":
+        return "The local GPU embedding worker is not responding."
+    if status == "initializing":
+        return "The local GPU embedding worker is still initializing."
+    return None
+
+
+def embedding_status_remediation(info: dict[str, Any]) -> str | None:
+    status = info.get("status")
+    if status == "missing_key":
+        return "Add embedding credentials in System/Access, or choose Local CPU."
+    if status == "invalid_config":
+        return "Set the memory embedder to Local GPU, Local CPU, Gemini, or OpenAI."
+    if status == "unavailable":
+        return "Start or inspect the GPU embedding worker, or switch memory to Local CPU/API."
+    if status == "initializing":
+        return "Wait for the GPU embedding worker to finish loading before running semantic work."
+    return None
+
+
+def finalize_embedding_info(info: dict[str, Any]) -> dict[str, Any]:
+    detail = embedding_status_detail(info)
+    remediation = embedding_status_remediation(info)
+    if detail:
+        info["detail"] = detail
+    if remediation:
+        info["remediation"] = remediation
+    info["ready"] = str(info.get("status") or "") == "ready"
+    return info
+
+
+def embedding_backend_label(info: dict[str, Any]) -> str:
+    backend = str(info.get("backend") or "").lower()
+    if backend == "api":
+        return embedding_provider_label(info)
+    if backend == "cpu":
+        return "CPU"
+    if backend == "gpu":
+        return "GPU"
+    return backend or "unknown"
+
+
+def embedding_provider_label(info: dict[str, Any]) -> str:
+    provider = str(info.get("provider") or "").lower()
+    if provider in {"gemini", "google"}:
+        return "Gemini"
+    if provider == "openai":
+        return "OpenAI"
+    return provider.upper() if provider else "API"

--- a/brain/systems/runtime_settings/memory.py
+++ b/brain/systems/runtime_settings/memory.py
@@ -12,7 +12,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel import config as cfg
-from brain.platform.async_io import http_post
+from brain.platform.async_io import http_get, http_post
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import VaultConfig
 
@@ -41,6 +41,8 @@ EMBEDDER_OPTIONS = embedder_options()
 RERANKER_OPTIONS = [
     RuntimeOption(key="weighted", label="Built-in ranking", description="Use the current memory ranking stack."),
 ]
+VALID_EMBEDDING_BACKENDS = {"api", "cpu", "gpu"}
+GPU_EMBEDDING_INFO_TIMEOUT_SECONDS = 1.0
 
 
 @dataclass(frozen=True)
@@ -472,6 +474,52 @@ def _embedder_from_backend_provider(backend: str, provider: str | None) -> str:
     return "local_gpu"
 
 
+def _embedding_credentials_detail(provider: str) -> str:
+    try:
+        from brain.systems.memory.embedding_service import embedding_credentials_message
+
+        return embedding_credentials_message(provider)
+    except Exception:
+        if provider in {"gemini", "google"}:
+            return "Gemini embedding credentials are not configured. Add them in System/Access."
+        if provider == "openai":
+            return "OpenAI embedding credentials are not configured. Add them in System/Access."
+        return "Embedding credentials are not configured. Add them in System/Access."
+
+
+def _finalize_embedding_info(info: dict[str, Any]) -> dict[str, Any]:
+    detail = _embedding_detail(info)
+    remediation = _embedding_remediation(info)
+    if detail:
+        info["detail"] = detail
+    if remediation:
+        info["remediation"] = remediation
+    info["ready"] = str(info.get("status") or "") == "ready"
+    return info
+
+
+def _apply_gpu_embedding_info(info: dict[str, Any]) -> None:
+    try:
+        url = f"{cfg.GPU_SERVER_URL.rstrip('/')}/health"
+        response = http_get(url, timeout=GPU_EMBEDDING_INFO_TIMEOUT_SECONDS)
+        health = response.json()
+        worker = health.get("workers", {}).get("embedding", {})
+        worker_status = worker.get("status")
+        server_status = health.get("status")
+        ready = bool(health.get("ready")) or worker_status == "ready" or server_status in {"ok", "healthy"}
+        info.update(
+            {
+                "status": "ready" if ready else "initializing",
+                "model": health.get("model") or info["model"],
+                "loaded": ready,
+                "gpu_server_status": server_status,
+                "gpu_worker_status": worker_status,
+            }
+        )
+    except Exception:
+        info.update({"status": "unavailable", "loaded": False})
+
+
 def get_embedding_info(user: User | None = None) -> dict[str, Any]:
     runtime = get_embedding_runtime_config()
     backend = runtime.backend.lower()
@@ -484,27 +532,17 @@ def get_embedding_info(user: User | None = None) -> dict[str, Any]:
         "dimensions": runtime.dimensions,
         "api_key_set": api_key_set,
     }
-    if backend == "gpu":
-        try:
-            from brain.platform.gpu_client import get_client
-
-            health = get_client().health()
-            info.update(
-                {
-                    "status": "ready" if health.get("ready") or health.get("status") == "ok" else "initializing",
-                    "model": health.get("model") or info["model"],
-                    "loaded": bool(health.get("loaded", health.get("ready", False))),
-                }
-            )
-        except Exception:
-            info.update({"status": "unavailable", "loaded": False})
+    if backend not in VALID_EMBEDDING_BACKENDS:
+        info.update({"status": "invalid_config", "loaded": False})
+    elif backend == "gpu":
+        _apply_gpu_embedding_info(info)
     elif backend == "api":
         info["status"] = "ready" if info["api_key_set"] else "missing_key"
         info["loaded"] = info["api_key_set"]
     else:
         info["status"] = "ready"
         info["loaded"] = True
-    return info
+    return _finalize_embedding_info(info)
 
 
 async def async_get_embedding_info(session: AsyncSession, user: User | None = None) -> dict[str, Any]:
@@ -519,27 +557,17 @@ async def async_get_embedding_info(session: AsyncSession, user: User | None = No
         "dimensions": runtime.dimensions,
         "api_key_set": api_key_set,
     }
-    if backend == "gpu":
-        try:
-            from brain.platform.gpu_client import get_client
-
-            health = get_client().health()
-            info.update(
-                {
-                    "status": "ready" if health.get("ready") or health.get("status") == "ok" else "initializing",
-                    "model": health.get("model") or info["model"],
-                    "loaded": bool(health.get("loaded", health.get("ready", False))),
-                }
-            )
-        except Exception:
-            info.update({"status": "unavailable", "loaded": False})
+    if backend not in VALID_EMBEDDING_BACKENDS:
+        info.update({"status": "invalid_config", "loaded": False})
+    elif backend == "gpu":
+        _apply_gpu_embedding_info(info)
     elif backend == "api":
         info["status"] = "ready" if info["api_key_set"] else "missing_key"
         info["loaded"] = info["api_key_set"]
     else:
         info["status"] = "ready"
         info["loaded"] = True
-    return info
+    return _finalize_embedding_info(info)
 
 
 def _embedder_from_info(info: dict[str, Any]) -> str:
@@ -553,11 +581,26 @@ def _embedding_detail(info: dict[str, Any]) -> str | None:
     provider = str(info.get("provider") or "").lower()
     status = info.get("status")
     if status == "missing_key":
-        if provider in {"gemini", "google"}:
-            return "Gemini memory needs a Google AI Studio API key. Add a Gemini key in Access or choose Local CPU."
-        return "OpenAI memory needs an OpenAI API key. Connect an API key in Access or choose Local CPU."
+        return _embedding_credentials_detail(provider)
+    if status == "invalid_config":
+        return f"Unknown embedding backend {info.get('backend')!r}. Use gpu, cpu, or api."
     if status == "unavailable":
         return "The local GPU embedding worker is not responding."
+    if status == "initializing":
+        return "The local GPU embedding worker is still initializing."
+    return None
+
+
+def _embedding_remediation(info: dict[str, Any]) -> str | None:
+    status = info.get("status")
+    if status == "missing_key":
+        return "Add embedding credentials in System/Access, or choose Local CPU."
+    if status == "invalid_config":
+        return "Set the memory embedder to Local GPU, Local CPU, Gemini, or OpenAI."
+    if status == "unavailable":
+        return "Start or inspect the GPU embedding worker, or switch memory to Local CPU/API."
+    if status == "initializing":
+        return "Wait for the GPU embedding worker to finish loading before running semantic work."
     return None
 
 
@@ -611,6 +654,7 @@ def get_runtime_memory(user: User) -> RuntimeMemoryRead:
         embedding_dimensions=info.get("dimensions"),
         embedding_status=str(info.get("status") or "unknown"),
         embedding_detail=_embedding_detail(info),
+        embedding_remediation=_embedding_remediation(info),
         indexed_vectors=_indexed_vector_count(),
         api_key_statuses={
             "openai": bool(_installation_embedding_api_key("openai")),
@@ -641,6 +685,7 @@ async def async_get_runtime_memory(session: AsyncSession, user: User) -> Runtime
         embedding_dimensions=info.get("dimensions"),
         embedding_status=str(info.get("status") or "unknown"),
         embedding_detail=_embedding_detail(info),
+        embedding_remediation=_embedding_remediation(info),
         indexed_vectors=await _async_indexed_vector_count(session),
         api_key_statuses={
             "openai": bool(await _async_installation_embedding_api_key(session, "openai")),
@@ -782,12 +827,13 @@ async def async_update_runtime_memory(
 def check_runtime_memory(user: User) -> RuntimeMemoryCheckRead:
     started = time.perf_counter()
     try:
-        from brain.systems.memory.embeddings import embed_query
+        from brain.systems.memory.embedding_service import EmbeddingService
 
-        vector = embed_query("illo brain memory setup check")
+        embedding_service = EmbeddingService.from_legacy_sync_config()
+        vector = embedding_service.query("illo brain memory setup check")
         shape = getattr(vector, "shape", None)
         dimensions = int(shape[0] if shape else len(vector))
-        expected = get_embedding_runtime_config(include_secret=False).dimensions
+        expected = embedding_service.runtime_config.dimensions
         duration_ms = int(round((time.perf_counter() - started) * 1000))
         if dimensions != expected:
             return RuntimeMemoryCheckRead(
@@ -803,16 +849,9 @@ def check_runtime_memory(user: User) -> RuntimeMemoryCheckRead:
             duration_ms=duration_ms,
         )
     except Exception as exc:
-        detail = str(exc)
-        provider = get_embedding_runtime_config(include_secret=False).provider.lower()
-        if "EMBEDDING_API_KEY" in detail:
-            if provider in {"gemini", "google"}:
-                detail = "Gemini memory needs a Google AI Studio API key. Add a Gemini key in Access or choose Local CPU."
-            elif provider == "openai":
-                detail = "OpenAI memory needs an OpenAI API key. Connect an API key in Access or choose Local CPU."
         return RuntimeMemoryCheckRead(
             status="error",
-            detail=detail,
+            detail=_memory_check_error_detail(exc),
             duration_ms=int(round((time.perf_counter() - started) * 1000)),
         )
 
@@ -822,14 +861,14 @@ async def async_check_runtime_memory(
     user: User,
 ) -> RuntimeMemoryCheckRead:
     started = time.perf_counter()
-    runtime = await async_get_embedding_runtime_config(session, include_secret=True)
     try:
-        from brain.systems.memory.embeddings import embed_query
+        from brain.systems.memory.embedding_service import EmbeddingService
 
-        vector = embed_query("illo brain memory setup check", runtime_config=runtime)
+        embedding_service = await EmbeddingService.from_session(session)
+        vector = embedding_service.query("illo brain memory setup check")
         shape = getattr(vector, "shape", None)
         dimensions = int(shape[0] if shape else len(vector))
-        expected = runtime.dimensions
+        expected = embedding_service.runtime_config.dimensions
         duration_ms = int(round((time.perf_counter() - started) * 1000))
         if dimensions != expected:
             return RuntimeMemoryCheckRead(
@@ -845,15 +884,23 @@ async def async_check_runtime_memory(
             duration_ms=duration_ms,
         )
     except Exception as exc:
-        detail = str(exc)
-        provider = runtime.provider.lower()
-        if "EMBEDDING_API_KEY" in detail:
-            if provider in {"gemini", "google"}:
-                detail = "Gemini memory needs a Google AI Studio API key. Add a Gemini key in Access or choose Local CPU."
-            elif provider == "openai":
-                detail = "OpenAI memory needs an OpenAI API key. Connect an API key in Access or choose Local CPU."
         return RuntimeMemoryCheckRead(
             status="error",
-            detail=detail,
+            detail=_memory_check_error_detail(exc),
             duration_ms=int(round((time.perf_counter() - started) * 1000)),
         )
+
+
+def _memory_check_error_detail(exc: Exception) -> str:
+    detail = str(exc)
+    if "EMBEDDING_API_KEY" not in detail:
+        return detail
+    try:
+        provider = get_embedding_runtime_config(include_secret=False).provider.lower()
+    except Exception:
+        provider = ""
+    if provider in {"gemini", "google"}:
+        return _embedding_credentials_detail(provider)
+    if provider == "openai":
+        return _embedding_credentials_detail(provider)
+    return detail

--- a/brain/systems/runtime_settings/memory.py
+++ b/brain/systems/runtime_settings/memory.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 from sqlalchemy import select, text
@@ -24,9 +24,19 @@ from .embedding_registry import (
     embedding_model_options,
     embedding_model_supported,
 )
+from .embedding_diagnostics import (
+    VALID_EMBEDDING_BACKENDS,
+    embedding_credentials_message,
+    embedding_status_detail,
+    embedding_status_remediation,
+    finalize_embedding_info,
+)
 from .schemas import RuntimeMemoryCheckRead, RuntimeMemoryRead, RuntimeMemoryUpdate, RuntimeOption
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from brain.systems.memory.embedding_service import EmbeddingService
 
 RUNTIME_MEMORY_SETTINGS_KEY = "runtime_memory"
 RUNTIME_MEMORY_SECRET_PREFIX = "runtime_memory_api_key_"
@@ -41,8 +51,8 @@ EMBEDDER_OPTIONS = embedder_options()
 RERANKER_OPTIONS = [
     RuntimeOption(key="weighted", label="Built-in ranking", description="Use the current memory ranking stack."),
 ]
-VALID_EMBEDDING_BACKENDS = {"api", "cpu", "gpu"}
 GPU_EMBEDDING_INFO_TIMEOUT_SECONDS = 1.0
+EMBEDDING_CHECK_QUERY = "illo brain memory setup check"
 
 
 @dataclass(frozen=True)
@@ -474,30 +484,6 @@ def _embedder_from_backend_provider(backend: str, provider: str | None) -> str:
     return "local_gpu"
 
 
-def _embedding_credentials_detail(provider: str) -> str:
-    try:
-        from brain.systems.memory.embedding_service import embedding_credentials_message
-
-        return embedding_credentials_message(provider)
-    except Exception:
-        if provider in {"gemini", "google"}:
-            return "Gemini embedding credentials are not configured. Add them in System/Access."
-        if provider == "openai":
-            return "OpenAI embedding credentials are not configured. Add them in System/Access."
-        return "Embedding credentials are not configured. Add them in System/Access."
-
-
-def _finalize_embedding_info(info: dict[str, Any]) -> dict[str, Any]:
-    detail = _embedding_detail(info)
-    remediation = _embedding_remediation(info)
-    if detail:
-        info["detail"] = detail
-    if remediation:
-        info["remediation"] = remediation
-    info["ready"] = str(info.get("status") or "") == "ready"
-    return info
-
-
 def _apply_gpu_embedding_info(info: dict[str, Any]) -> None:
     try:
         url = f"{cfg.GPU_SERVER_URL.rstrip('/')}/health"
@@ -520,8 +506,7 @@ def _apply_gpu_embedding_info(info: dict[str, Any]) -> None:
         info.update({"status": "unavailable", "loaded": False})
 
 
-def get_embedding_info(user: User | None = None) -> dict[str, Any]:
-    runtime = get_embedding_runtime_config()
+def _embedding_info_from_runtime(runtime: EmbeddingRuntimeConfig) -> dict[str, Any]:
     backend = runtime.backend.lower()
     provider = runtime.provider.lower()
     api_key_set = bool(runtime.api_key)
@@ -542,32 +527,15 @@ def get_embedding_info(user: User | None = None) -> dict[str, Any]:
     else:
         info["status"] = "ready"
         info["loaded"] = True
-    return _finalize_embedding_info(info)
+    return finalize_embedding_info(info)
+
+
+def get_embedding_info(user: User | None = None) -> dict[str, Any]:
+    return _embedding_info_from_runtime(get_embedding_runtime_config())
 
 
 async def async_get_embedding_info(session: AsyncSession, user: User | None = None) -> dict[str, Any]:
-    runtime = await async_get_embedding_runtime_config(session)
-    backend = runtime.backend.lower()
-    provider = runtime.provider.lower()
-    api_key_set = bool(runtime.api_key)
-    info: dict[str, Any] = {
-        "backend": backend,
-        "provider": provider,
-        "model": runtime.api_model if backend == "api" else runtime.cpu_model if backend == "cpu" else "local-gpu",
-        "dimensions": runtime.dimensions,
-        "api_key_set": api_key_set,
-    }
-    if backend not in VALID_EMBEDDING_BACKENDS:
-        info.update({"status": "invalid_config", "loaded": False})
-    elif backend == "gpu":
-        _apply_gpu_embedding_info(info)
-    elif backend == "api":
-        info["status"] = "ready" if info["api_key_set"] else "missing_key"
-        info["loaded"] = info["api_key_set"]
-    else:
-        info["status"] = "ready"
-        info["loaded"] = True
-    return _finalize_embedding_info(info)
+    return _embedding_info_from_runtime(await async_get_embedding_runtime_config(session))
 
 
 def _embedder_from_info(info: dict[str, Any]) -> str:
@@ -575,33 +543,6 @@ def _embedder_from_info(info: dict[str, Any]) -> str:
         str(info.get("backend") or "gpu"),
         str(info.get("provider") or ""),
     )
-
-
-def _embedding_detail(info: dict[str, Any]) -> str | None:
-    provider = str(info.get("provider") or "").lower()
-    status = info.get("status")
-    if status == "missing_key":
-        return _embedding_credentials_detail(provider)
-    if status == "invalid_config":
-        return f"Unknown embedding backend {info.get('backend')!r}. Use gpu, cpu, or api."
-    if status == "unavailable":
-        return "The local GPU embedding worker is not responding."
-    if status == "initializing":
-        return "The local GPU embedding worker is still initializing."
-    return None
-
-
-def _embedding_remediation(info: dict[str, Any]) -> str | None:
-    status = info.get("status")
-    if status == "missing_key":
-        return "Add embedding credentials in System/Access, or choose Local CPU."
-    if status == "invalid_config":
-        return "Set the memory embedder to Local GPU, Local CPU, Gemini, or OpenAI."
-    if status == "unavailable":
-        return "Start or inspect the GPU embedding worker, or switch memory to Local CPU/API."
-    if status == "initializing":
-        return "Wait for the GPU embedding worker to finish loading before running semantic work."
-    return None
 
 
 def _indexed_vector_count() -> int:
@@ -636,9 +577,13 @@ async def _async_indexed_vector_count(session: AsyncSession) -> int:
         return 0
 
 
-def get_runtime_memory(user: User) -> RuntimeMemoryRead:
-    info = get_embedding_info(user)
-    runtime = get_embedding_runtime_config(include_secret=False)
+def _runtime_memory_read(
+    *,
+    info: dict[str, Any],
+    runtime: EmbeddingRuntimeConfig,
+    indexed_vectors: int,
+    api_key_statuses: dict[str, bool],
+) -> RuntimeMemoryRead:
     reranker = runtime.reranker or "weighted"
     if reranker != "weighted":
         reranker = "weighted"
@@ -653,13 +598,10 @@ def get_runtime_memory(user: User) -> RuntimeMemoryRead:
         embedding_model=embedding_model,
         embedding_dimensions=info.get("dimensions"),
         embedding_status=str(info.get("status") or "unknown"),
-        embedding_detail=_embedding_detail(info),
-        embedding_remediation=_embedding_remediation(info),
-        indexed_vectors=_indexed_vector_count(),
-        api_key_statuses={
-            "openai": bool(_installation_embedding_api_key("openai")),
-            "gemini": bool(_installation_embedding_api_key("gemini")),
-        },
+        embedding_detail=embedding_status_detail(info),
+        embedding_remediation=embedding_status_remediation(info),
+        indexed_vectors=indexed_vectors,
+        api_key_statuses=api_key_statuses,
         reranker=reranker,
         embedder_options=EMBEDDER_OPTIONS,
         embedding_model_options=EMBEDDING_MODEL_OPTIONS,
@@ -667,34 +609,29 @@ def get_runtime_memory(user: User) -> RuntimeMemoryRead:
     )
 
 
+def get_runtime_memory(user: User) -> RuntimeMemoryRead:
+    info = get_embedding_info(user)
+    return _runtime_memory_read(
+        info=info,
+        runtime=get_embedding_runtime_config(include_secret=False),
+        indexed_vectors=_indexed_vector_count(),
+        api_key_statuses={
+            "openai": bool(_installation_embedding_api_key("openai")),
+            "gemini": bool(_installation_embedding_api_key("gemini")),
+        },
+    )
+
+
 async def async_get_runtime_memory(session: AsyncSession, user: User) -> RuntimeMemoryRead:
     info = await async_get_embedding_info(session, user)
-    runtime = await async_get_embedding_runtime_config(session, include_secret=False)
-    reranker = runtime.reranker or "weighted"
-    if reranker != "weighted":
-        reranker = "weighted"
-    embedder = _embedder_from_info(info)
-    embedding_model = info.get("model")
-    if not embedding_model_supported(embedder, str(embedding_model or "")):
-        embedding_model = default_embedding_model(embedder)
-
-    return RuntimeMemoryRead(
-        scope="installation",
-        embedder=embedder,
-        embedding_model=embedding_model,
-        embedding_dimensions=info.get("dimensions"),
-        embedding_status=str(info.get("status") or "unknown"),
-        embedding_detail=_embedding_detail(info),
-        embedding_remediation=_embedding_remediation(info),
+    return _runtime_memory_read(
+        info=info,
+        runtime=await async_get_embedding_runtime_config(session, include_secret=False),
         indexed_vectors=await _async_indexed_vector_count(session),
         api_key_statuses={
             "openai": bool(await _async_installation_embedding_api_key(session, "openai")),
             "gemini": bool(await _async_installation_embedding_api_key(session, "gemini")),
         },
-        reranker=reranker,
-        embedder_options=EMBEDDER_OPTIONS,
-        embedding_model_options=EMBEDDING_MODEL_OPTIONS,
-        reranker_options=RERANKER_OPTIONS,
     )
 
 
@@ -829,31 +766,9 @@ def check_runtime_memory(user: User) -> RuntimeMemoryCheckRead:
     try:
         from brain.systems.memory.embedding_service import EmbeddingService
 
-        embedding_service = EmbeddingService.from_legacy_sync_config()
-        vector = embedding_service.query("illo brain memory setup check")
-        shape = getattr(vector, "shape", None)
-        dimensions = int(shape[0] if shape else len(vector))
-        expected = embedding_service.runtime_config.dimensions
-        duration_ms = int(round((time.perf_counter() - started) * 1000))
-        if dimensions != expected:
-            return RuntimeMemoryCheckRead(
-                status="error",
-                detail=f"Embedding returned {dimensions} dimensions, expected {expected}.",
-                dimensions=dimensions,
-                duration_ms=duration_ms,
-            )
-        return RuntimeMemoryCheckRead(
-            status="ok",
-            detail=f"Embedding check returned {dimensions} dimensions.",
-            dimensions=dimensions,
-            duration_ms=duration_ms,
-        )
+        return _check_runtime_memory_with_service(EmbeddingService.from_legacy_sync_config(), started)
     except Exception as exc:
-        return RuntimeMemoryCheckRead(
-            status="error",
-            detail=_memory_check_error_detail(exc),
-            duration_ms=int(round((time.perf_counter() - started) * 1000)),
-        )
+        return _runtime_memory_check_error(exc, started)
 
 
 async def async_check_runtime_memory(
@@ -864,31 +779,45 @@ async def async_check_runtime_memory(
     try:
         from brain.systems.memory.embedding_service import EmbeddingService
 
-        embedding_service = await EmbeddingService.from_session(session)
-        vector = embedding_service.query("illo brain memory setup check")
-        shape = getattr(vector, "shape", None)
-        dimensions = int(shape[0] if shape else len(vector))
-        expected = embedding_service.runtime_config.dimensions
-        duration_ms = int(round((time.perf_counter() - started) * 1000))
-        if dimensions != expected:
-            return RuntimeMemoryCheckRead(
-                status="error",
-                detail=f"Embedding returned {dimensions} dimensions, expected {expected}.",
-                dimensions=dimensions,
-                duration_ms=duration_ms,
-            )
+        return _check_runtime_memory_with_service(await EmbeddingService.from_session(session), started)
+    except Exception as exc:
+        return _runtime_memory_check_error(exc, started)
+
+
+def _check_runtime_memory_with_service(
+    embedding_service: "EmbeddingService",
+    started: float,
+) -> RuntimeMemoryCheckRead:
+    vector = embedding_service.query(EMBEDDING_CHECK_QUERY)
+    shape = getattr(vector, "shape", None)
+    dimensions = int(shape[0] if shape else len(vector))
+    expected = embedding_service.runtime_config.dimensions
+    duration_ms = _elapsed_check_ms(started)
+    if dimensions != expected:
         return RuntimeMemoryCheckRead(
-            status="ok",
-            detail=f"Embedding check returned {dimensions} dimensions.",
+            status="error",
+            detail=f"Embedding returned {dimensions} dimensions, expected {expected}.",
             dimensions=dimensions,
             duration_ms=duration_ms,
         )
-    except Exception as exc:
-        return RuntimeMemoryCheckRead(
-            status="error",
-            detail=_memory_check_error_detail(exc),
-            duration_ms=int(round((time.perf_counter() - started) * 1000)),
-        )
+    return RuntimeMemoryCheckRead(
+        status="ok",
+        detail=f"Embedding check returned {dimensions} dimensions.",
+        dimensions=dimensions,
+        duration_ms=duration_ms,
+    )
+
+
+def _runtime_memory_check_error(exc: Exception, started: float) -> RuntimeMemoryCheckRead:
+    return RuntimeMemoryCheckRead(
+        status="error",
+        detail=_memory_check_error_detail(exc),
+        duration_ms=_elapsed_check_ms(started),
+    )
+
+
+def _elapsed_check_ms(started: float) -> int:
+    return int(round((time.perf_counter() - started) * 1000))
 
 
 def _memory_check_error_detail(exc: Exception) -> str:
@@ -900,7 +829,7 @@ def _memory_check_error_detail(exc: Exception) -> str:
     except Exception:
         provider = ""
     if provider in {"gemini", "google"}:
-        return _embedding_credentials_detail(provider)
+        return embedding_credentials_message(provider)
     if provider == "openai":
-        return _embedding_credentials_detail(provider)
+        return embedding_credentials_message(provider)
     return detail

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -44,6 +44,7 @@ class RuntimeMemoryRead(BaseModel):
     embedding_dimensions: int | None = None
     embedding_status: str
     embedding_detail: str | None = None
+    embedding_remediation: str | None = None
     indexed_vectors: int = 0
     api_key_statuses: dict[str, bool] = Field(default_factory=dict)
     reranker: RerankerKey = "weighted"

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -23,8 +23,6 @@ import subprocess
 import sys
 import time
 
-import numpy as np
-
 from brain.kernel import config as brain_config
 from brain.systems.runs.project_execution_env import (
     annotate_project_execution_result,
@@ -32,6 +30,7 @@ from brain.systems.runs.project_execution_env import (
     redact_sensitive_output,
 )
 from brain.platform.async_io import run_blocking, run_subprocess_sync
+from brain.systems.tools.semantic_search import semantic_code_search
 
 logger = logging.getLogger("agent.tools")
 
@@ -240,125 +239,44 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
     """Search using embedding similarity."""
     results = []
 
-    # Memory search
     if scope in ("memories", "both"):
         try:
             from brain.app.mcp.server import async_tool_brain_recall
+
             memories = await async_tool_brain_recall(query=query, limit=limit)
             if isinstance(memories, dict) and "memories" in memories:
-                for m in memories["memories"]:
+                for memory in memories["memories"]:
                     results.append({
                         "source": "memory",
-                        "type": m.get("type", "unknown"),
-                        "content": m.get("content", "")[:300],
-                        "similarity": m.get("similarity", 0),
+                        "type": memory.get("type", "unknown"),
+                        "content": memory.get("content", "")[:300],
+                        "similarity": memory.get("similarity", 0),
                     })
-        except Exception as e:
-            logger.debug(f"Memory search failed: {e}")
+        except Exception as exc:
+            logger.debug("Memory search failed: %s", exc)
 
-    # Code search via embeddings
     if scope in ("code", "both"):
         try:
             from brain.platform.db.repositories.unit_of_work import UnitOfWork
-            from brain.systems.runtime_settings.memory import async_get_embedding_runtime_config
+            from brain.systems.memory.embedding_service import EmbeddingService, embedding_degradation_reason
 
             async with UnitOfWork() as uow:
-                runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            code_results = _semantic_code_search(
+                embedding_service = await EmbeddingService.from_session(uow.session)
+            results.extend(semantic_code_search(
                 query,
                 limit=limit,
                 workspace_root=workspace_root,
-                runtime_config=runtime_config,
-            )
-            results.extend(code_results)
-        except Exception as e:
-            logger.debug(f"Code semantic search failed: {e}")
+                embedding_service=embedding_service,
+            ))
+        except Exception as exc:
+            logger.debug("Code semantic search failed: %s", embedding_degradation_reason(exc))
 
-    # Sort by similarity
-    results.sort(key=lambda r: r.get("similarity", 0), reverse=True)
-
+    results.sort(key=lambda result: result.get("similarity", 0), reverse=True)
     return {
         "results": results[:limit],
         "count": len(results),
         "query": query,
     }
-
-
-def _semantic_code_search(
-    query: str,
-    limit: int = 5,
-    workspace_root: str | None = None,
-    runtime_config=None,
-) -> list[dict]:
-    """Search code files using embeddings.
-
-    Strategy: embed the query, then compare against file-level summaries.
-    Falls back to grep if embeddings unavailable.
-    """
-    try:
-        from brain.systems.memory.embeddings import embed_query
-
-        query_vec = embed_query(query, runtime_config=runtime_config)
-
-        # Get candidate files (Python files, limited to avoid embedding everything)
-        workspace = pathlib.Path(workspace_root or WORKSPACE_ROOT)
-        py_files = sorted(workspace.glob("**/*.py"), key=lambda p: p.stat().st_mtime, reverse=True)
-        # Skip venv, __pycache__, .git
-        py_files = [
-            f for f in py_files
-            if not any(skip in str(f) for skip in ("venv/", "__pycache__", ".git/", "node_modules/"))
-        ][:50]  # Cap at 50 most recent
-
-        # Build lightweight summaries for embedding
-        candidates = []
-        for f in py_files:
-            try:
-                first_lines = f.read_text(errors="replace")[:500]
-                rel_path = str(f.relative_to(workspace))
-                candidates.append((rel_path, first_lines))
-            except Exception:
-                continue
-
-        if not candidates:
-            return []
-
-        # Embed summaries
-        from brain.systems.memory.embeddings import embed_batch
-        texts = [f"{path}: {preview}" for path, preview in candidates]
-        vecs = embed_batch(texts, mode="document", runtime_config=runtime_config)
-
-        # Compute similarities
-        similarities = np.dot(vecs, query_vec) / (
-            np.linalg.norm(vecs, axis=1) * np.linalg.norm(query_vec) + 1e-8
-        )
-
-        # Return top matches
-        top_indices = np.argsort(similarities)[::-1][:limit]
-        results = []
-        for idx in top_indices:
-            if similarities[idx] > 0.3:  # minimum threshold
-                path, preview = candidates[idx]
-                results.append({
-                    "source": "code",
-                    "path": path,
-                    "preview": preview[:200],
-                    "similarity": round(float(similarities[idx]), 3),
-                })
-
-        return results
-
-    except Exception as e:
-        logger.debug(f"Semantic code search fell back to grep: {e}")
-        # Fallback: simple grep
-        try:
-            proc = run_subprocess_sync(
-                ["grep", "-rn", "--include=*.py", "-l", query.split()[0], workspace_root or WORKSPACE_ROOT],
-                capture_output=True, text=True, timeout=10,
-            )
-            files = proc.stdout.strip().split("\n")[:limit]
-            return [{"source": "code", "path": f, "similarity": 0.5} for f in files if f]
-        except Exception:
-            return []
 
 
 def _workspace_search_root(path: str | None = None, workspace_root: str | None = None) -> str:

--- a/brain/systems/tools/semantic_search.py
+++ b/brain/systems/tools/semantic_search.py
@@ -1,0 +1,90 @@
+"""Semantic search tool implementation."""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import numpy as np
+
+from brain.kernel import config as brain_config
+from brain.platform.async_io import run_subprocess_sync
+
+logger = logging.getLogger("agent.tools.semantic_search")
+
+WORKSPACE_ROOT = str(brain_config.resolve_workspace_root(default=brain_config.BRAIN_DIR))
+
+
+def semantic_code_search(
+    query: str,
+    limit: int = 5,
+    workspace_root: str | None = None,
+    embedding_service=None,
+) -> dict:
+    """Search code files using embeddings, with grep fallback."""
+    try:
+        if embedding_service is None:
+            from brain.systems.memory.embedding_service import EmbeddingService
+
+            embedding_service = EmbeddingService.from_legacy_sync_config()
+
+        query_vec = embedding_service.query(query)
+        candidates = _candidate_python_previews(workspace_root)
+        if not candidates:
+            return []
+
+        texts = [f"{path}: {preview}" for path, preview in candidates]
+        vecs = embedding_service.batch(texts, mode="document")
+        similarities = np.dot(vecs, query_vec) / (
+            np.linalg.norm(vecs, axis=1) * np.linalg.norm(query_vec) + 1e-8
+        )
+
+        results = []
+        for idx in np.argsort(similarities)[::-1][:limit]:
+            if similarities[idx] > 0.3:
+                path, preview = candidates[idx]
+                results.append({
+                    "source": "code",
+                    "path": path,
+                    "preview": preview[:200],
+                    "similarity": round(float(similarities[idx]), 3),
+                })
+        return results
+    except Exception as exc:
+        from brain.systems.memory.embedding_service import embedding_degradation_reason
+
+        logger.debug("Semantic code search fell back to grep: %s", embedding_degradation_reason(exc))
+        return _grep_code_fallback(query, limit, workspace_root)
+
+
+def _candidate_python_previews(workspace_root: str | None) -> list[tuple[str, str]]:
+    workspace = pathlib.Path(workspace_root or WORKSPACE_ROOT)
+    py_files = sorted(workspace.glob("**/*.py"), key=lambda path: path.stat().st_mtime, reverse=True)
+    candidates = []
+    for path in py_files:
+        if any(skip in str(path) for skip in ("venv/", "__pycache__", ".git/", "node_modules/")):
+            continue
+        try:
+            candidates.append((str(path.relative_to(workspace)), path.read_text(errors="replace")[:500]))
+        except Exception:
+            continue
+        if len(candidates) >= 50:
+            break
+    return candidates
+
+
+def _grep_code_fallback(query: str, limit: int, workspace_root: str | None) -> list[dict]:
+    try:
+        first_term = query.split()[0]
+    except IndexError:
+        return []
+    try:
+        proc = run_subprocess_sync(
+            ["grep", "-rn", "--include=*.py", "-l", first_term, workspace_root or WORKSPACE_ROOT],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        files = proc.stdout.strip().split("\n")[:limit]
+        return [{"source": "code", "path": path, "similarity": 0.5} for path in files if path]
+    except Exception:
+        return []

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -676,22 +676,22 @@
       const data = await api.revealSecret(keyName, token);
       const value = String(data?.value || '');
       if (!value) throw new Error('Vault secret is empty.');
+      let memory;
       if (provider === 'gemini') {
-        await api.connectRuntimeGeminiKey({ api_key: value });
+        memory = await api.connectRuntimeGeminiKey({ api_key: value });
       } else {
-        await api.connectRuntimeOpenAIEmbeddingKey({ api_key: value });
+        memory = await api.connectRuntimeOpenAIEmbeddingKey({ api_key: value });
       }
       selectedMemoryVaultKey = keyName;
       if (settings) {
         settings = {
           ...settings,
-          memory: {
-            ...settings.memory,
-            api_key_statuses: {
-              ...(settings.memory.api_key_statuses ?? {}),
-              [provider]: true,
-            },
-          },
+          memory,
+        };
+        memoryDraft = {
+          embedder: memory.embedder,
+          embedding_model: memory.embedding_model || defaultEmbeddingModel(memory.embedder, { ...settings, memory }),
+          reranker: memory.reranker || 'weighted',
         };
       }
       memoryCheck = null;
@@ -737,12 +737,13 @@
         detail: `${label} selected. Save changes to apply.`,
       };
     }
-    if (!settings.memory.embedding_detail) return null;
+    if (!settings.memory.embedding_detail && !settings.memory.embedding_remediation) return null;
     const needsApiKey = usesApiEmbedder(settings.memory.embedder) && settings.memory.embedding_status === 'missing_key';
+    const detail = settings.memory.embedding_detail || settings.memory.embedding_remediation || undefined;
     return {
       tone: 'warning',
       title: needsApiKey ? 'Memory is not set up.' : 'Memory status',
-      detail: needsApiKey ? undefined : settings.memory.embedding_detail,
+      detail,
     };
   }
 

--- a/frontend/src/routes/system/types.ts
+++ b/frontend/src/routes/system/types.ts
@@ -32,6 +32,7 @@ export interface RuntimeSettings {
     embedding_dimensions?: number | null;
     embedding_status: string;
     embedding_detail?: string | null;
+    embedding_remediation?: string | null;
     indexed_vectors: number;
     api_key_statuses?: Record<string, boolean>;
     reranker: string;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import text
@@ -65,12 +65,29 @@ def mock_embeddings():
         patch("brain.systems.memory.embeddings.embed_document", return_value=fake_vec),
         patch("brain.systems.memory.embeddings.embed_query", return_value=fake_vec),
         patch("brain.systems.memory.embeddings.embed_batch", return_value=[fake_vec]),
+        patch(
+            "brain.systems.memory.embedding_service.EmbeddingService.from_session",
+            new=AsyncMock(return_value=_test_embedding_service()),
+        ),
     ]
     for p in patches:
         p.start()
     yield fake_vec
     for p in patches:
         p.stop()
+
+
+def _test_embedding_service():
+    from brain.systems.memory.embedding_service import EmbeddingService
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    return EmbeddingService(EmbeddingRuntimeConfig(
+        backend="cpu",
+        provider="gemini",
+        api_model="gemini-embedding-2",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=2000,
+    ))
 
 
 @pytest.fixture

--- a/tests/test_brain_context.py
+++ b/tests/test_brain_context.py
@@ -160,7 +160,9 @@ class TestGetContextMocked:
 
     def test_error_captured(self):
         """DB errors should be captured in result, not raised."""
-        with patch("brain.systems.memory.embeddings.embed_query", side_effect=Exception("DB down")):
+        service = MagicMock()
+        service.query.side_effect = Exception("DB down")
+        with patch("brain.systems.memory.embedding_service.EmbeddingService.from_session", new=AsyncMock(return_value=service)):
             result = get_context("test")
         assert "error" in result
         assert "DB down" in result["error"]

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -29,6 +30,10 @@ def _make_mapping_result(rows):
     result.mappings.return_value = mappings
     result.rowcount = len(rows)
     return result
+
+
+def _mock_embedding_service(vector=None):
+    return SimpleNamespace(document=MagicMock(return_value=vector if vector is not None else np.zeros(2000)))
 
 
 TEST_USER_ID = "00000000-0000-0000-0000-000000000002"
@@ -154,14 +159,15 @@ class TestExtractSemantic:
 
     @patch("brain.systems.cognition.consolidate._synthesize_with_gpu_server")
     @patch("brain.systems.memory.embeddings.vec_to_pg")
-    @patch("brain.systems.memory.embeddings.embed_document")
+    @patch("brain.systems.memory.embedding_service.EmbeddingService.from_session")
     @patch("brain.systems.cognition.consolidate.UnitOfWork")
-    async def test_creates_semantic_memory(self, mock_uow_cls, mock_emb, mock_vec, mock_gpu):
+    async def test_creates_semantic_memory(self, mock_uow_cls, mock_service_from_session, mock_vec, mock_gpu):
         """Should create a semantic memory from episode cluster."""
         from brain.systems.cognition.consolidate import extract_semantic
 
         mock_gpu.return_value = "[semantic] Redis TTLs require explicit expiry for session data"
-        mock_emb.return_value = np.zeros(2000)
+        embedding_service = _mock_embedding_service()
+        mock_service_from_session.return_value = embedding_service
         mock_vec.return_value = "[0,0,0]"
 
         uow, session = _make_mock_uow()
@@ -195,14 +201,15 @@ class TestExtractSemantic:
 
     @patch("brain.systems.cognition.consolidate._synthesize_with_gpu_server")
     @patch("brain.systems.memory.embeddings.vec_to_pg")
-    @patch("brain.systems.memory.embeddings.embed_document")
+    @patch("brain.systems.memory.embedding_service.EmbeddingService.from_session")
     @patch("brain.systems.cognition.consolidate.UnitOfWork")
-    async def test_fallback_when_ollama_fails(self, mock_uow_cls, mock_emb, mock_vec, mock_gpu):
+    async def test_fallback_when_ollama_fails(self, mock_uow_cls, mock_service_from_session, mock_vec, mock_gpu):
         """Should use heuristic fallback when GPU server unavailable."""
         from brain.systems.cognition.consolidate import extract_semantic
 
         mock_gpu.return_value = None  # Ollama fails
-        mock_emb.return_value = np.zeros(2000)
+        embedding_service = _mock_embedding_service()
+        mock_service_from_session.return_value = embedding_service
         mock_vec.return_value = "[0,0,0]"
 
         uow, session = _make_mock_uow()
@@ -267,14 +274,15 @@ class TestCrystallizeProcedural:
 
     @patch("brain.systems.cognition.consolidate._crystallize_with_gpu_server")
     @patch("brain.systems.memory.embeddings.vec_to_pg")
-    @patch("brain.systems.memory.embeddings.embed_document")
+    @patch("brain.systems.memory.embedding_service.EmbeddingService.from_session")
     @patch("brain.systems.cognition.consolidate.UnitOfWork")
-    async def test_creates_procedural_from_semantics(self, mock_uow_cls, mock_emb, mock_vec, mock_gpu):
+    async def test_creates_procedural_from_semantics(self, mock_uow_cls, mock_service_from_session, mock_vec, mock_gpu):
         """Should crystallize semantic memories into a procedure."""
         from brain.systems.cognition.consolidate import crystallize_procedural
 
         mock_gpu.return_value = "1. Check TTL\n2. Set expiry\n3. Monitor"
-        mock_emb.return_value = np.zeros(2000)
+        embedding_service = _mock_embedding_service()
+        mock_service_from_session.return_value = embedding_service
         mock_vec.return_value = "[0,0,0]"
 
         uow, session = _make_mock_uow()

--- a/tests/test_create_skill_tool.py
+++ b/tests/test_create_skill_tool.py
@@ -19,6 +19,17 @@ VALID_PROCEDURE = (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_embedding_service():
+    service = MagicMock()
+    service.document.return_value = [0.1] * 384
+    with patch(
+        "brain.systems.memory.embedding_service.EmbeddingService.from_session",
+        new=AsyncMock(return_value=service),
+    ):
+        yield service
+
+
 @pytest.mark.asyncio
 class TestCreateSkillGateEnforcement:
     """Test that create_skill enforces the live gate."""

--- a/tests/test_embedding_architecture.py
+++ b/tests/test_embedding_architecture.py
@@ -11,7 +11,6 @@ RAW_EMBEDDING_CALLS = {"embed_query", "embed_document", "embed_batch"}
 RAW_EMBEDDING_ALLOWLIST = {
     "brain/systems/memory/embeddings.py",
     "brain/systems/memory/embedding_service.py",
-    "brain/systems/runtime_settings/memory.py",
 }
 
 
@@ -67,11 +66,13 @@ def _parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
 
 
 def _is_raw_embedding_call(node: ast.AST) -> bool:
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id in RAW_EMBEDDING_CALLS
-    )
+    if not isinstance(node, ast.Call):
+        return False
+    if isinstance(node.func, ast.Name):
+        return node.func.id in RAW_EMBEDDING_CALLS
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr in RAW_EMBEDDING_CALLS
+    return False
 
 
 def _enclosing_function_is_async(node: ast.AST, parent_map: dict[ast.AST, ast.AST]) -> bool:

--- a/tests/test_embedding_architecture.py
+++ b/tests/test_embedding_architecture.py
@@ -1,0 +1,85 @@
+"""Architecture guardrails for DB-backed embeddings."""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RAW_EMBEDDING_CALLS = {"embed_query", "embed_document", "embed_batch"}
+RAW_EMBEDDING_ALLOWLIST = {
+    "brain/systems/memory/embeddings.py",
+    "brain/systems/memory/embedding_service.py",
+    "brain/systems/runtime_settings/memory.py",
+}
+
+
+def test_async_runtime_paths_use_embedding_service() -> None:
+    offenders: list[str] = []
+    for path in _runtime_python_files():
+        rel = path.relative_to(ROOT).as_posix()
+        if rel in RAW_EMBEDDING_ALLOWLIST or rel.startswith("brain/app/cli/"):
+            continue
+
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+        parent_map = _parent_map(tree)
+        for node in ast.walk(tree):
+            if not _is_raw_embedding_call(node):
+                continue
+            if _enclosing_function_is_async(node, parent_map):
+                offenders.append(f"{rel}:{node.lineno} calls {node.func.id}()")
+
+    assert not offenders, (
+        "Async server/job/system code must use EmbeddingService instead of raw "
+        "embed_query/embed_document/embed_batch calls:\n" + "\n".join(offenders)
+    )
+
+
+def _runtime_python_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "brain/app", "brain/jobs", "brain/systems"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return [
+            ROOT / line
+            for line in result.stdout.splitlines()
+            if line.endswith(".py")
+        ]
+    return [
+        path
+        for folder in ("brain/app", "brain/jobs", "brain/systems")
+        for path in (ROOT / folder).rglob("*.py")
+        if "__pycache__" not in path.parts
+    ]
+
+
+def _parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    return {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+
+
+def _is_raw_embedding_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in RAW_EMBEDDING_CALLS
+    )
+
+
+def _enclosing_function_is_async(node: ast.AST, parent_map: dict[ast.AST, ast.AST]) -> bool:
+    current = parent_map.get(node)
+    while current is not None:
+        if isinstance(current, ast.AsyncFunctionDef):
+            return True
+        if isinstance(current, ast.FunctionDef):
+            return False
+        current = parent_map.get(current)
+    return False

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from brain.systems.memory.embedding_service import (
+    EmbeddingCredentialsUnavailable,
+    EmbeddingService,
+)
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+
+def _runtime_config(*, api_key: str = "secret") -> EmbeddingRuntimeConfig:
+    return EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="gemini-embedding-2",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=768,
+        api_key=api_key,
+    )
+
+
+async def test_embedding_service_loads_db_backed_runtime_config():
+    runtime_config = _runtime_config()
+
+    with patch(
+        "brain.systems.memory.embedding_service.async_get_embedding_runtime_config",
+        new=AsyncMock(return_value=runtime_config),
+    ) as load_config:
+        service = await EmbeddingService.from_session(object())
+
+    assert service.runtime_config is runtime_config
+    load_config.assert_awaited_once()
+
+
+def test_embedding_service_rejects_missing_api_credentials_before_provider_call():
+    service = EmbeddingService(runtime_config=_runtime_config(api_key=""))
+
+    with pytest.raises(EmbeddingCredentialsUnavailable, match="Gemini embedding credentials"):
+        service.query("hello")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -12,6 +12,25 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
 
 
+@pytest.fixture(autouse=True)
+def mock_embedding_service_runtime():
+    from brain.systems.memory.embedding_service import EmbeddingService
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    service = EmbeddingService(EmbeddingRuntimeConfig(
+        backend="cpu",
+        provider="gemini",
+        api_model="gemini-embedding-2",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=2000,
+    ))
+    with patch(
+        "brain.systems.memory.embedding_service.EmbeddingService.from_session",
+        new=AsyncMock(return_value=service),
+    ):
+        yield service
+
+
 def _mock_session_execute(results_sequence):
     """Helper: build a mock session whose .execute() returns results in sequence.
 

--- a/tests/test_health_tiers.py
+++ b/tests/test_health_tiers.py
@@ -156,17 +156,16 @@ async def test_deep_health_reports_degradation_without_secrets(monkeypatch):
         model="gpt-5.4-mini",
         exc="provider failed with sk-test-secret-token",
     )
-    monkeypatch.setattr(
-        health,
-        "_embedding_health_check",
-        lambda: health.HealthCheck(
+    async def embedding_check(_session=None):
+        return health.HealthCheck(
             name="embedding",
             status="ok",
             summary="embedding configured",
             latency_ms=1,
             details={"api_key_configured": True},
-        ),
-    )
+        )
+
+    monkeypatch.setattr(health, "_embedding_health_check", embedding_check)
     async def scheduler_check(_session=None):
         return health.HealthCheck(
             name="scheduler",
@@ -197,3 +196,60 @@ async def test_deep_health_reports_degradation_without_secrets(monkeypatch):
     assert "super-secret-token" not in payload
     assert "[redacted]" in payload
     reset_provider_health()
+
+
+@pytest.mark.asyncio
+async def test_deep_health_uses_db_backed_embedding_runtime(monkeypatch):
+    monkeypatch.setattr(
+        health,
+        "async_get_embedding_info",
+        AsyncMock(return_value={
+            "backend": "api",
+            "provider": "gemini",
+            "model": "gemini-embedding-2",
+            "dimensions": 768,
+            "status": "missing_key",
+            "api_key_set": False,
+            "loaded": False,
+            "ready": False,
+            "detail": "Gemini embedding credentials are not configured. Add them in System/Access.",
+            "remediation": "Add embedding credentials in System/Access, or choose Local CPU.",
+        }),
+    )
+    monkeypatch.setattr(
+        health,
+        "_provider_health_check",
+        lambda: health.HealthCheck(
+            name="providers",
+            status="ok",
+            summary="provider health is clear",
+            latency_ms=1,
+        ),
+    )
+
+    async def scheduler_check(_session=None):
+        return health.HealthCheck(
+            name="scheduler",
+            status="ok",
+            summary="scheduler healthy",
+            latency_ms=1,
+        )
+
+    async def run_check(_session=None):
+        return health.HealthCheck(
+            name="run",
+            status="ok",
+            summary="run health is clear",
+            latency_ms=1,
+        )
+
+    monkeypatch.setattr(health, "_scheduler_health_check", scheduler_check)
+    monkeypatch.setattr(health, "_run_health_check", run_check)
+
+    snapshot = await health.deep_health_snapshot(session=MagicMock())
+
+    assert snapshot["status"] == "unhealthy"
+    assert snapshot["checks"]["embedding"]["status"] == "failed"
+    assert snapshot["checks"]["embedding"]["summary"] == "Gemini embedding credentials missing"
+    assert snapshot["checks"]["embedding"]["remediation"] == "Add embedding credentials in System/Access, or choose Local CPU."
+    assert snapshot["checks"]["embedding"]["details"]["api_key_set"] is False

--- a/tests/test_progressive_skill_loading.py
+++ b/tests/test_progressive_skill_loading.py
@@ -402,7 +402,6 @@ async def test_brain_skills_degrades_when_embedding_unavailable():
 
 async def test_brain_skills_uses_db_backed_runtime_config_for_embeddings():
     from brain.app.mcp.server import async_tool_brain_skills
-    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 
     row = {
         "id": 1,
@@ -434,22 +433,15 @@ async def test_brain_skills_uses_db_backed_runtime_config_for_embeddings():
             _ExecuteResult(all_value=[]),
         ],
     )
-    runtime = EmbeddingRuntimeConfig(
-        backend="api",
-        provider="openai",
-        api_model="text-embedding-3-small",
-        cpu_model="all-MiniLM-L6-v2",
-        dimensions=768,
-        api_key="secret",
-    )
+    embedding_service = SimpleNamespace(query=MagicMock(return_value=[0.1]))
 
     with patch("brain.app.mcp.server.UnitOfWork", return_value=uow), \
-         patch("brain.systems.runtime_settings.memory.async_get_embedding_runtime_config", return_value=runtime), \
-         patch("brain.systems.memory.embeddings.embed_query", return_value=[0.1]) as embed_query, \
+         patch("brain.systems.memory.embedding_service.EmbeddingService.from_session", return_value=embedding_service) as load_service, \
          patch("brain.systems.memory.embeddings.vec_to_pg", return_value="[0.1]"):
         result = await async_tool_brain_skills("fix a bug")
 
-    embed_query.assert_called_once_with("fix a bug", runtime_config=runtime)
+    load_service.assert_awaited_once_with(uow.session)
+    embedding_service.query.assert_called_once_with("fix a bug")
     assert "degraded_reason" not in result
     assert result["recommended_skills"][0]["name"] == "develop"
 

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -406,6 +406,103 @@ def test_runtime_memory_does_not_use_env_api_keys(monkeypatch):
     assert memory_settings._installation_embedding_api_key("gemini") is None
 
 
+def test_runtime_memory_reports_missing_gemini_key_with_system_access_detail(monkeypatch):
+    import json
+    from types import SimpleNamespace
+
+    import brain.kernel.config as cfg
+    import brain.systems.runtime_settings.memory as memory_settings
+
+    stored_config = {
+        memory_settings.RUNTIME_MEMORY_SETTINGS_KEY: json.dumps({
+            "backend": "api",
+            "provider": "gemini",
+            "api_model": "gemini-embedding-2",
+            "cpu_model": "all-MiniLM-L6-v2",
+            "dimensions": 768,
+            "reranker": "weighted",
+        }),
+    }
+
+    monkeypatch.setattr(cfg, "EMBEDDING_BACKEND", "api", raising=False)
+    monkeypatch.setattr(cfg, "EMBEDDING_API_PROVIDER", "gemini", raising=False)
+    monkeypatch.setattr(memory_settings, "_read_runtime_config_value", lambda key: stored_config.get(key))
+    monkeypatch.setattr(memory_settings, "_indexed_vector_count", lambda: 0)
+
+    data = memory_settings.get_runtime_memory(SimpleNamespace(id="user-1", org_id="org-1"))
+
+    assert data.embedding_status == "missing_key"
+    assert data.embedding_detail == "Gemini embedding credentials are not configured. Add them in System/Access."
+    assert data.embedding_remediation == "Add embedding credentials in System/Access, or choose Local CPU."
+
+
+def test_embedding_info_gpu_uses_bounded_health_probe(monkeypatch):
+    import brain.kernel.config as cfg
+    import brain.systems.runtime_settings.memory as memory_settings
+
+    captured = {}
+
+    class Response:
+        def json(self):
+            return {
+                "status": "ok",
+                "workers": {
+                    "embedding": {"status": "ready"},
+                },
+            }
+
+    def fake_http_get(url, *, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(cfg, "EMBEDDING_BACKEND", "gpu", raising=False)
+    monkeypatch.setattr(cfg, "GPU_SERVER_URL", "http://gpu.example", raising=False)
+    monkeypatch.setattr(memory_settings, "_read_runtime_config_value", lambda key: None)
+    monkeypatch.setattr(memory_settings, "http_get", fake_http_get)
+
+    info = memory_settings.get_embedding_info()
+
+    assert info["status"] == "ready"
+    assert info["loaded"] is True
+    assert info["gpu_worker_status"] == "ready"
+    assert captured == {
+        "url": "http://gpu.example/health",
+        "timeout": memory_settings.GPU_EMBEDDING_INFO_TIMEOUT_SECONDS,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_check_runtime_memory_rejects_missing_credentials_before_provider_call(monkeypatch):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.memory as memory_settings
+    from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+    runtime_config = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="gemini-embedding-2",
+        cpu_model="all-MiniLM-L6-v2",
+        dimensions=768,
+        api_key="",
+    )
+    monkeypatch.setattr(
+        "brain.systems.memory.embedding_service.async_get_embedding_runtime_config",
+        AsyncMock(return_value=runtime_config),
+    )
+
+    with patch("brain.systems.memory.embeddings.embed_query") as embed_query:
+        result = await memory_settings.async_check_runtime_memory(
+            MagicMock(),
+            SimpleNamespace(id="user-1", org_id="org-1"),
+        )
+
+    assert result.status == "error"
+    assert result.detail == "Gemini embedding credentials are not configured. Add them in System/Access."
+    embed_query.assert_not_called()
+
+
 def test_update_runtime_memory_blocks_embedder_change_when_installation_vectors_exist(monkeypatch):
     from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- Add `EmbeddingService` as the canonical DB-backed async embedding seam with typed config, credential, and provider failures.
- Migrate async server, job, quality, cognition, skill, context, and semantic-search paths away from scattered runtime config loading.
- Add an architecture guardrail banning raw async `embed_query` / `embed_document` / `embed_batch` calls outside the embedding seam, including attribute-style calls.
- Extract semantic code search out of the oversized tools handler module.
- Harden System/Access diagnostics so missing Gemini/OpenAI embedding credentials surface as precise detail/remediation before users hit memory/search paths.
- Route deep health through DB-backed runtime memory settings instead of env-only embedding config, with bounded GPU health probes.
- Keep the System UI memory state live after selecting a Vault key.
- Apply thermo-nuclear cleanup: split embedding diagnostic copy/status labels into a focused runtime-settings module and collapse duplicated sync/async memory diagnostic/check flows.
- Fix `brain_recall` when embedding fails before graph fallback has a query vector.

## Box objectives
- [x] Create clean worktree and confirm merged base
- [x] Add canonical async `EmbeddingService` seam
- [x] Migrate async/server/job embedding call sites
- [x] Add architecture test banning raw async embedding calls
- [x] Split oversized MCP/tools modules where behavior stays stable
- [x] Replace broad embedding fallback with typed degradation errors
- [x] Add DB-backed embedding diagnostics/remediation
- [x] Route deep health through runtime settings
- [x] Keep System/Access UI status live after key selection
- [x] Add tests for diagnostics and missing-key guardrails
- [x] Run thermo-nuclear code-quality cleanup
- [x] Run full backend/frontend verification

## Tests
- `pytest tests/test_embedding_service.py tests/test_embedding_architecture.py tests/test_progressive_skill_loading.py tests/test_async_runtime_migration_metrics.py tests/test_tools.py -q` -> 53 passed
- `pytest tests/test_runtime_settings.py tests/test_health_tiers.py tests/test_embedding_service.py tests/test_embedding_architecture.py -q` -> 39 passed
- `pytest tests -q -k "runtime_settings or health or embedding or progressive_skill_loading or tools"` -> 198 passed, 1 skipped, 2836 deselected
- `pytest -q` -> 2977 passed, 58 skipped, 67 warnings
- `npm run check` -> 0 Svelte errors/warnings
- `npm test` -> 154 passed
