### PR TITLE
Harden Project context foundations

### DIFF
--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -43,6 +43,7 @@ from brain.systems.cortex.thought_lifecycle import (
     post_thread_message,
     transition_thought_status,
 )
+from brain.systems.cortex.project_context.merge import merge_project_context_resources
 from brain.systems.cortex.project_context.snapshot import (
     ProjectContextValidationError,
     validated_project_context_snapshot,
@@ -374,51 +375,6 @@ def _apply_run_events_to_item(item: dict[str, Any], events: list[Any]) -> None:
     }
 
 
-def _resource_identity(resource: dict[str, Any]) -> str:
-    for key in ("path", "uri", "repo", "name", "label"):
-        value = resource.get(key)
-        if isinstance(value, str) and value.strip():
-            return f"{key}:{value.strip()}"
-    return json.dumps(resource, sort_keys=True, default=str)
-
-
-def _merge_project_context_payloads(
-    base: dict[str, Any] | None,
-    addition: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    if not base:
-        return copy.deepcopy(addition) if addition else None
-    if not addition:
-        return copy.deepcopy(base)
-
-    merged = copy.deepcopy(base)
-    resources = [
-        dict(resource)
-        for resource in (merged.get("resources") or [])
-        if isinstance(resource, dict)
-    ]
-    seen = {_resource_identity(resource) for resource in resources}
-    for resource in addition.get("resources") or []:
-        if not isinstance(resource, dict):
-            continue
-        key = _resource_identity(resource)
-        if key in seen:
-            continue
-        seen.add(key)
-        resources.append(copy.deepcopy(resource))
-    merged["resources"] = resources
-    merged.setdefault("source", "cortex-thread-message")
-    if addition.get("source"):
-        sources = [
-            item
-            for item in [merged.get("source"), addition.get("source")]
-            if isinstance(item, str) and item.strip()
-        ]
-        if sources:
-            merged["source"] = "+".join(dict.fromkeys(sources))
-    return merged
-
-
 def _extract_project_context_from_message(
     attachments: list[dict[str, Any]] | None,
     metadata: dict[str, Any] | None,
@@ -434,9 +390,9 @@ def _extract_project_context_from_message(
             continue
         candidate = attachment.get("project_context")
         if attachment.get("type") == "project_context" and isinstance(candidate, dict):
-            explicit = _merge_project_context_payloads(explicit, candidate)
+            explicit = merge_project_context_resources(explicit, candidate)
     readable_attachments = project_context_from_text_attachments(attachments)
-    return _merge_project_context_payloads(explicit, readable_attachments)
+    return merge_project_context_resources(explicit, readable_attachments)
 
 
 def _validate_thread_project_context(project_context: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -46,6 +46,7 @@ from brain.systems.cortex.thought_lifecycle import (
     post_thread_message,
     transition_thought_status,
 )
+from brain.systems.cortex.project_context.resolution import merge_project_context_metadata
 from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
 
 
@@ -161,29 +162,13 @@ def _mention_skip_response() -> dict[str, Any]:
 
 
 async def _latest_user_thread_metadata(db: AsyncSession, idea_id: str) -> dict[str, Any]:
-    result = await db.execute(
-        select(IdeaThread.metadata_)
-        .where(IdeaThread.idea_id == idea_id, IdeaThread.role == "user")
-        .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
-        .limit(1)
-    )
-    latest = result.scalar_one_or_none()
-    return dict(latest or {}) if isinstance(latest, dict) else {}
+    from brain.systems.cortex.project_context.resolution import latest_user_thread_metadata
+
+    return await latest_user_thread_metadata(db, idea_id)
 
 
 async def _effective_notify_metadata(db: AsyncSession, idea_id: str, metadata: Any) -> dict[str, Any]:
-    """Merge the freshly persisted thread metadata into run metadata.
-
-    The composer stores attachment-derived Project Context on the thread first;
-    /notify may then send only execution-profile metadata. Keep the thread's
-    resource snapshot unless the caller explicitly sends a replacement.
-    """
-    effective = await _latest_user_thread_metadata(db, idea_id)
-    if isinstance(metadata, dict):
-        for key, value in metadata.items():
-            if value is not None:
-                effective[key] = value
-    return effective
+    return merge_project_context_metadata(await _latest_user_thread_metadata(db, idea_id), metadata)
 
 
 async def _author_hints_for_ideas(

--- a/brain/systems/cortex/project_context/identity.py
+++ b/brain/systems/cortex/project_context/identity.py
@@ -5,17 +5,62 @@ from collections.abc import Mapping
 from typing import Any
 
 
-PROJECT_IDENTITY_FIELDS = (
-    "project_key",
+PROJECT_DURABLE_IDENTITY_FIELDS = (
     "project_id",
+    "project_profile_id",
+    "selected_profile_id",
+)
+
+PROJECT_IDENTITY_FIELDS = (
+    *PROJECT_DURABLE_IDENTITY_FIELDS,
+    "project_key",
     "slug",
 )
+
+PROJECT_IDENTITY_SENTINELS = {
+    "current",
+    "current-thread-project",
+    "current_thread_project",
+    "new",
+    "none",
+}
 
 
 def _clean_text(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _clean_identity_field(key: str, value: Any) -> str | None:
+    text = _clean_text(value)
+    if not text:
+        return None
+    if key == "selected_profile_id" and ":" in text:
+        namespace, raw_id = text.split(":", 1)
+        if namespace in {"server", "profile", "project"} and raw_id.strip():
+            return raw_id.strip()
+    if key == "selected_profile_id" and text.lower() in PROJECT_IDENTITY_SENTINELS:
+        return None
+    return text
+
+
+def durable_project_id_from_context(project_context: Mapping[str, Any] | None) -> str | None:
+    """Return the durable persisted Project identity from a context payload."""
+
+    context = project_context if isinstance(project_context, Mapping) else {}
+    for key in PROJECT_DURABLE_IDENTITY_FIELDS:
+        value = _clean_identity_field(key, context.get(key))
+        if value:
+            return value
+    return None
+
+
+def project_identity_field_value(project_context: Mapping[str, Any] | None, key: str) -> str | None:
+    """Return a normalized identity field value."""
+
+    context = project_context if isinstance(project_context, Mapping) else {}
+    return _clean_identity_field(key, context.get(key))
 
 
 def project_context_identity(
@@ -88,8 +133,12 @@ def stamped_project_context(
 
 
 __all__ = [
+    "PROJECT_DURABLE_IDENTITY_FIELDS",
     "PROJECT_IDENTITY_FIELDS",
+    "PROJECT_IDENTITY_SENTINELS",
+    "durable_project_id_from_context",
     "project_context_identity",
+    "project_identity_field_value",
     "stamp_project_identity",
     "stamped_project_context",
 ]

--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -16,18 +16,19 @@ from brain.platform.db.models.run import AgentRun
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import parse_github_repo_slug
 from brain.systems.cortex.project_context.drafts import load_draft_metadata, sync_draft_from_root
+from brain.systems.cortex.project_context.identity import durable_project_id_from_context
 from brain.systems.cortex.project_context.permissions import derive_project_permission_scope
-from brain.systems.cortex.project_context.project_root import (
-    PROJECT_ROOT_MOUNT_PATH,
-    PROJECT_ROOT_RESOURCE_ID,
-    PROJECT_ROOT_RESOURCE_KIND,
-    ProjectRootImportCandidate,
-    directory_import_candidates,
-    import_candidates_into_project_root,
-    project_draft_root_path,
-    project_key_from_context,
-    project_root_path,
-    safe_project_relative_path,
+from brain.systems.cortex.project_context.project_root import is_synthetic_project_root_resource, project_key_from_context
+from brain.systems.cortex.project_context.resource_imports import (
+    backend_readable_resource_path,
+    path_is_relative_to,
+    runtime_workspace_path,
+    should_use_existing_resource_path,
+)
+from brain.systems.cortex.project_context.root_materializer import materialize_project_native_root
+from brain.systems.cortex.project_context.runtime_context import (
+    PROJECT_RUNTIME_CONTEXT_KEY,
+    build_project_runtime_context,
 )
 from brain.systems.cortex.project_context.snapshot import snapshot_from_project_context
 from brain.systems.cortex.project_context.workspace_manifest import (
@@ -261,31 +262,6 @@ def _git_output(cwd: Path, *args: str) -> str | None:
         return None
 
 
-def _path_is_relative_to(path: Path, parent: Path) -> bool:
-    try:
-        path.expanduser().resolve().relative_to(parent.expanduser().resolve())
-        return True
-    except Exception:
-        return False
-
-
-def _is_managed_project_context_path(path: Path) -> bool:
-    return ".illo-project-context" in path.expanduser().parts
-
-
-def _should_use_existing_resource_path(existing_path: str | None, workspace_root: Path) -> Path | None:
-    if not existing_path:
-        return None
-    path = Path(existing_path).expanduser()
-    if not path.exists():
-        return None
-    if _path_is_relative_to(path, workspace_root):
-        return path
-    if _is_managed_project_context_path(path):
-        return None
-    return path
-
-
 def _existing_git_checkout(destination: Path, slug: str, branch: str | None) -> dict[str, str] | None:
     """Return metadata for an existing checkout without mutating local state."""
 
@@ -421,7 +397,7 @@ def _repo_workspace_path(resource: dict[str, Any], repo_path: Path) -> tuple[Pat
     if not subpath:
         return repo_path, None
     workspace_path = (repo_path / subpath).expanduser()
-    if not _path_is_relative_to(workspace_path, repo_path):
+    if not path_is_relative_to(workspace_path, repo_path):
         return None, f"GitHub Project subpath escapes repository root: {subpath}"
     if not workspace_path.exists():
         return None, f"GitHub Project subpath does not exist in {resource.get('repo') or repo_path.name}: {subpath}"
@@ -513,10 +489,6 @@ def _rewrite_scope_paths_to_draft(resource: dict[str, Any], source_path: Path, d
                 nested[path_key] = rewrite_list(nested.get(path_key))
 
 
-def _runtime_workspace_path(path: Path) -> Path:
-    return path if path.is_dir() else path.parent
-
-
 def _sync_resource_to_draft(source_path: Path, draft_path: Path) -> dict[str, list[str]]:
     draft_workspace_path = draft_path.parent if source_path.is_file() else draft_path
     had_base_manifest = bool(load_draft_metadata(draft_workspace_path).get("base_manifest"))
@@ -531,203 +503,14 @@ def _sync_resource_to_draft(source_path: Path, draft_path: Path) -> dict[str, li
     }
 
 
-def _path_texts_from_uploaded_files(resource: dict[str, Any]) -> list[str]:
-    paths: list[str] = []
-    uploaded_files = resource.get("uploaded_files")
-    if not isinstance(uploaded_files, list):
-        return paths
-    for item in uploaded_files:
-        if not isinstance(item, dict):
-            continue
-        value = _clean_text(item.get("storage_path") or item.get("path") or item.get("local_path"))
-        if value:
-            paths.append(value)
-    return paths
-
-
-def _path_texts_from_resource_scope(resource: dict[str, Any]) -> list[str]:
-    paths: list[str] = []
-    for key in ("allowed_paths", "files", "folders"):
-        values = resource.get(key)
-        if not isinstance(values, list):
-            continue
-        for item in values:
-            value = _clean_text(item)
-            if value:
-                paths.append(value)
-    return paths
-
-
-def _resource_id(resource: dict[str, Any]) -> str | None:
-    return _clean_text(resource.get("id") or resource.get("name") or resource.get("label"))
-
-
 def _is_project_root_resource(resource: dict[str, Any]) -> bool:
-    return (
-        _resource_kind(resource) == PROJECT_ROOT_RESOURCE_KIND
-        or _clean_text(resource.get("id")) == PROJECT_ROOT_RESOURCE_ID
-        or _clean_text(resource.get("mount_path")) == PROJECT_ROOT_MOUNT_PATH
-    )
+    return is_synthetic_project_root_resource(resource)
 
 
 def _is_project_native_seed_resource(resource: dict[str, Any]) -> bool:
     if _is_project_root_resource(resource) or _github_slug_from_resource(resource):
         return False
     return _resource_kind(resource) in _LOCAL_FIRST_RESOURCE_KINDS
-
-
-def _uploaded_file_import_candidates(
-    resource: dict[str, Any],
-    *,
-    workspace_root: Path,
-) -> list[ProjectRootImportCandidate]:
-    uploaded_files = resource.get("uploaded_files")
-    if not isinstance(uploaded_files, list):
-        return []
-
-    candidates: list[ProjectRootImportCandidate] = []
-    resource_id = _resource_id(resource)
-    for item in uploaded_files:
-        if not isinstance(item, dict):
-            continue
-        source = _should_use_existing_resource_path(
-            _clean_text(item.get("storage_path") or item.get("path") or item.get("local_path")),
-            workspace_root,
-        )
-        if not source or not source.is_file():
-            continue
-        relative_path = safe_project_relative_path(
-            item.get("relative_path") or item.get("filename") or item.get("name") or source.name,
-            fallback=source.name,
-        )
-        if relative_path:
-            candidates.append(ProjectRootImportCandidate(source, relative_path, resource_id=resource_id))
-    return candidates
-
-
-def _direct_path_import_candidates(
-    resource: dict[str, Any],
-    *,
-    workspace_root: Path,
-) -> list[ProjectRootImportCandidate]:
-    source, checked = _backend_readable_resource_path(resource, workspace_root=workspace_root)
-    if not source or not checked:
-        return []
-    resource_id = _resource_id(resource)
-    if source.is_file():
-        relative_path = safe_project_relative_path(
-            resource.get("relative_path") or resource.get("name") or resource.get("label") or source.name,
-            fallback=source.name,
-        )
-        return [ProjectRootImportCandidate(source, relative_path, resource_id=resource_id)] if relative_path else []
-    return directory_import_candidates(source, resource_id=resource_id)
-
-
-def _project_native_import_candidates(
-    resource: dict[str, Any],
-    *,
-    workspace_root: Path,
-) -> list[ProjectRootImportCandidate]:
-    if not _is_project_native_seed_resource(resource):
-        return []
-    uploaded = _uploaded_file_import_candidates(resource, workspace_root=workspace_root)
-    if uploaded:
-        return uploaded
-    return _direct_path_import_candidates(resource, workspace_root=workspace_root)
-
-
-def _common_runtime_workspace_path(paths: list[Path]) -> Path | None:
-    if not paths:
-        return None
-    workspace_paths = [_runtime_workspace_path(path).resolve() for path in paths]
-    try:
-        common = Path(os.path.commonpath([str(path) for path in workspace_paths]))
-    except ValueError:
-        return None
-    return common if common.exists() else None
-
-
-def _backend_readable_resource_path(
-    resource: dict[str, Any],
-    *,
-    workspace_root: Path,
-) -> tuple[Path | None, bool]:
-    for key in ("path", "local_path", "storage_path"):
-        value = _clean_text(resource.get(key))
-        existing_path = _should_use_existing_resource_path(value, workspace_root)
-        if existing_path:
-            return existing_path, True
-
-    scoped_paths: list[Path] = []
-    path_texts = [*_path_texts_from_uploaded_files(resource), *_path_texts_from_resource_scope(resource)]
-    for value in path_texts:
-        existing_path = _should_use_existing_resource_path(value, workspace_root)
-        if existing_path:
-            scoped_paths.append(existing_path)
-
-    common_path = _common_runtime_workspace_path(scoped_paths)
-    if common_path:
-        return common_path, True
-    return None, bool(path_texts)
-
-
-def _materialize_project_native_root(
-    project_context: dict[str, Any],
-    resources: list[dict[str, Any]],
-    *,
-    workspace_root: Path,
-    run_id: int | None,
-) -> tuple[dict[str, Any], dict[str, str]]:
-    project_key = project_key_from_context(
-        project_context,
-        resources=resources,
-        fallback=f"run-{run_id}" if run_id else None,
-    )
-    source_root = project_root_path(workspace_root, project_key)
-    source_root.mkdir(parents=True, exist_ok=True)
-
-    import_candidates: list[ProjectRootImportCandidate] = []
-    for resource in resources:
-        import_candidates.extend(_project_native_import_candidates(resource, workspace_root=workspace_root))
-    import_summary = import_candidates_into_project_root(source_root, import_candidates)
-
-    draft_root = project_draft_root_path(workspace_root, project_key)
-    had_base_manifest = bool(load_draft_metadata(draft_root).get("base_manifest"))
-    sync_result = sync_draft_from_root(source_root, draft_root)
-    draft_status = {
-        "updated_from_root": sync_result.copied,
-        "removed_from_root": sync_result.removed,
-        "conflicts": sync_result.conflicts,
-        "out_of_date": sync_result.out_of_date,
-    } if had_base_manifest else {}
-
-    materialization: dict[str, Any] = {
-        "status": "ready",
-        "provider": "project_native",
-        "kind": PROJECT_ROOT_RESOURCE_KIND,
-        "path": str(draft_root),
-        "workspace_path": str(draft_root),
-        "source_path": str(source_root),
-        "draft": True,
-        "project_key": project_key,
-    }
-    if any(import_summary.values()):
-        materialization["imports"] = import_summary
-    if draft_status and any(draft_status.values()):
-        materialization["draft_status"] = draft_status
-
-    resource = {
-        "id": PROJECT_ROOT_RESOURCE_ID,
-        "kind": PROJECT_ROOT_RESOURCE_KIND,
-        "name": "Project root",
-        "label": "Project root",
-        "mount_path": PROJECT_ROOT_MOUNT_PATH,
-        "path": str(draft_root),
-        "workspace_path": str(draft_root),
-        "source_path": str(source_root),
-        "materialization": materialization,
-    }
-    return resource, _workspace_entry_from_resource(resource, draft_root)
 
 
 def _materialize_backend_readable_resource(
@@ -737,17 +520,17 @@ def _materialize_backend_readable_resource(
     project_context: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str] | None, str | None, bool]:
     materialization = resource.get("materialization") if isinstance(resource.get("materialization"), dict) else {}
-    previous_source = _should_use_existing_resource_path(_clean_text(materialization.get("source_path")), workspace_root)
-    previous_draft = _should_use_existing_resource_path(
+    previous_source = should_use_existing_resource_path(_clean_text(materialization.get("source_path")), workspace_root)
+    previous_draft = should_use_existing_resource_path(
         _clean_text(resource.get("path") or materialization.get("path")),
         workspace_root,
     )
-    if previous_source and previous_draft and _path_is_relative_to(previous_draft, workspace_root):
+    if previous_source and previous_draft and path_is_relative_to(previous_draft, workspace_root):
         existing_path = previous_draft
         source_path = previous_source
         checked = True
     else:
-        existing_path, checked = _backend_readable_resource_path(resource, workspace_root=workspace_root)
+        existing_path, checked = backend_readable_resource_path(resource, workspace_root=workspace_root)
         source_path = existing_path
     if not existing_path:
         return None, None, checked
@@ -757,7 +540,7 @@ def _materialize_backend_readable_resource(
     draft = False
     draft_status: dict[str, list[str]] | None = None
     draft_identity: ThreadDraftIdentity | None = None
-    if not _path_is_relative_to(existing_path, workspace_root):
+    if not path_is_relative_to(existing_path, workspace_root):
         draft_identity = ThreadDraftIdentity.from_project_resource(
             {**resource, "path": str(existing_path)},
             thread_workspace_root=workspace_root,
@@ -796,7 +579,7 @@ def _materialize_backend_readable_resource(
         draft = True
         _rewrite_scope_paths_to_draft(resource, source_path, existing_path)
 
-    workspace_path = _runtime_workspace_path(existing_path)
+    workspace_path = runtime_workspace_path(existing_path)
     kind = _resource_kind(resource)
     resource["path"] = str(existing_path)
     materialization = {
@@ -842,8 +625,8 @@ async def _materialize_resource(
             project_context=project_context,
         )
         return workspace, error
-    existing_path = _should_use_existing_resource_path(_clean_text(resource.get("path")), workspace_root)
-    if existing_path and _path_is_relative_to(existing_path, workspace_root):
+    existing_path = should_use_existing_resource_path(_clean_text(resource.get("path")), workspace_root)
+    if existing_path and path_is_relative_to(existing_path, workspace_root):
         return _workspace_entry_from_resource(resource, existing_path), None
 
     destination = _safe_repo_destination(workspace_root, slug)
@@ -958,6 +741,47 @@ def _snapshot_from_run(run: Any) -> dict[str, Any] | None:
     return None
 
 
+def _identity_sources_from_run(
+    *,
+    snapshot: dict[str, Any],
+    target_payload: dict[str, Any],
+    workspace_payload: dict[str, Any],
+    metadata: dict[str, Any],
+) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = [snapshot, target_payload, workspace_payload]
+    for payload in (target_payload, workspace_payload, metadata):
+        for key in ("project_context", "project_context_snapshot"):
+            value = payload.get(key)
+            if isinstance(value, dict):
+                sources.append(value)
+    return sources
+
+
+def _stamp_materialization_identity(
+    snapshot: dict[str, Any],
+    *,
+    target_payload: dict[str, Any],
+    workspace_payload: dict[str, Any],
+    metadata: dict[str, Any],
+    resources: list[dict[str, Any]],
+    fallback: str,
+) -> str:
+    for source in _identity_sources_from_run(
+        snapshot=snapshot,
+        target_payload=target_payload,
+        workspace_payload=workspace_payload,
+        metadata=metadata,
+    ):
+        durable_project_id = durable_project_id_from_context(source)
+        if durable_project_id:
+            snapshot["project_id"] = durable_project_id
+            snapshot["project_key"] = durable_project_id
+            return durable_project_id
+    project_key = project_key_from_context(snapshot, resources=resources, fallback=fallback)
+    snapshot["project_key"] = project_key
+    return project_key
+
+
 async def materialize_project_context_workspaces(
     run_id: int | None,
     *,
@@ -979,30 +803,41 @@ async def materialize_project_context_workspaces(
         if not run:
             return result.fail(f"Agent run {run_id} was not found.")
         metadata = dict(getattr(run, "metadata_", None) or {})
+        target_payload = _run_target_payload(run)
+        workspace_payload = _run_workspace_payload(run)
         snapshot = _snapshot_from_run(run)
         if not isinstance(snapshot, dict):
             return result.fail("Project Context snapshot is missing.")
         snapshot = dict(snapshot)
         resources = [dict(item) for item in snapshot.get("resources") or [] if isinstance(item, dict)]
-        result.empty_project = not resources
-        snapshot.setdefault(
-            "project_key",
-            project_key_from_context(snapshot, resources=resources, fallback=f"run-{run_id}"),
+        _stamp_materialization_identity(
+            snapshot,
+            target_payload=target_payload,
+            workspace_payload=workspace_payload,
+            metadata=metadata,
+            resources=resources,
+            fallback=f"run-{run_id}",
         )
         user_id = user_id or (str(run.user_id) if getattr(run, "user_id", None) else None)
         org_id = org_id or _clean_text(getattr(run, "org_id", None)) or _clean_text(metadata.get("org_id"))
 
     materialized_resources: list[dict[str, Any]] = []
     workspaces: list[dict[str, str]] = []
-    root_resource, root_workspace = _materialize_project_native_root(
+    root_resource, root_workspace = materialize_project_native_root(
         snapshot,
         resources,
         workspace_root=root,
         run_id=run_id,
+        actor_id=user_id,
+        org_id=org_id,
+        is_project_native_seed=_is_project_native_seed_resource,
+        workspace_entry_from_resource=_workspace_entry_from_resource,
     )
     materialized_resources.append(root_resource)
     workspaces.append(root_workspace)
     result.resources_checked += 1
+    root_materialization = root_resource.get("materialization") if isinstance(root_resource.get("materialization"), dict) else {}
+    result.empty_project = bool(root_materialization.get("root_empty", True))
 
     for resource in resources:
         if _is_project_root_resource(resource):
@@ -1032,6 +867,7 @@ async def materialize_project_context_workspaces(
         thread_workspace_root=root,
     )
     workspace_manifest_payload = workspace_manifest.to_dict()
+    snapshot["project_workspace_manifest"] = workspace_manifest_payload
     result.workspaces = workspaces
     status = "materialized" if not result.errors else "failed"
     project_context_materialization = {
@@ -1040,6 +876,11 @@ async def materialize_project_context_workspaces(
         "workspace_manifest": workspace_manifest_payload,
         "errors": result.errors[:10],
         "empty_project": result.empty_project,
+        "seed_resource_count": len(resources),
+        "project_root_path_count": int(root_materialization.get("root_path_count") or 0),
+        "project_root_file_count": int(root_materialization.get("root_file_count") or 0),
+        "project_draft_path_count": int(root_materialization.get("draft_path_count") or 0),
+        "project_draft_file_count": int(root_materialization.get("draft_file_count") or 0),
     }
     snapshot["permission_scope"] = derive_project_permission_scope(snapshot)
     if result.errors:
@@ -1055,9 +896,16 @@ async def materialize_project_context_workspaces(
         current_target_payload = _run_target_payload(run)
         current_workspace_payload = _run_workspace_payload(run)
         permission_scope = derive_project_permission_scope(snapshot)
+        project_runtime_context = build_project_runtime_context(
+            snapshot=snapshot,
+            permission_scope=permission_scope,
+            workspace_manifest=workspace_manifest_payload,
+            materialization=project_context_materialization,
+        )
 
         current_target_payload["project_context_snapshot"] = snapshot
         current_target_payload["project_context_permission_scope"] = permission_scope
+        current_workspace_payload[PROJECT_RUNTIME_CONTEXT_KEY] = project_runtime_context
         current_workspace_payload["project_context_snapshot"] = snapshot
         current_workspace_payload["project_context_permission_scope"] = permission_scope
         current_workspace_payload["project_workspace_manifest"] = workspace_manifest_payload

--- a/brain/systems/cortex/project_context/merge.py
+++ b/brain/systems/cortex/project_context/merge.py
@@ -1,0 +1,66 @@
+"""Project Context payload merge helpers."""
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+
+def project_resource_identity(resource: dict[str, Any]) -> str:
+    for key in ("path", "uri", "repo", "name", "label"):
+        value = resource.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"{key}:{value.strip()}"
+    return json.dumps(resource, sort_keys=True, default=str)
+
+
+def merge_project_context_resources(
+    base: dict[str, Any] | None,
+    addition: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return base Project identity with additional resources appended.
+
+    Project Context merges are intentionally asymmetric: the base context owns
+    durable identity and top-level metadata, while the addition can contribute
+    resource references gathered later in the thread.
+    """
+
+    if not base:
+        return copy.deepcopy(addition) if addition else None
+    if not addition:
+        return copy.deepcopy(base)
+
+    merged = copy.deepcopy(base)
+    resources = [
+        dict(resource)
+        for resource in (merged.get("resources") or [])
+        if isinstance(resource, dict)
+    ]
+    seen = {project_resource_identity(resource) for resource in resources}
+    for resource in addition.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        key = project_resource_identity(resource)
+        if key in seen:
+            continue
+        seen.add(key)
+        resources.append(copy.deepcopy(resource))
+    merged["resources"] = resources
+    merged.setdefault("source", "cortex-thread-message")
+    if addition.get("source"):
+        sources = [
+            part.strip()
+            for item in [merged.get("source"), addition.get("source")]
+            if isinstance(item, str) and item.strip()
+            for part in item.split("+")
+            if part.strip()
+        ]
+        if sources:
+            merged["source"] = "+".join(dict.fromkeys(sources))
+    return merged
+
+
+__all__ = [
+    "merge_project_context_resources",
+    "project_resource_identity",
+]

--- a/brain/systems/cortex/project_context/project_root.py
+++ b/brain/systems/cortex/project_context/project_root.py
@@ -15,7 +15,7 @@ import json
 import shutil
 
 from brain.systems.cortex.project_context.drafts import PROJECT_HISTORY_DIR
-from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS
+from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS, project_identity_field_value
 from brain.systems.cortex.project_context.workspace_manifest import (
     PROJECT_CONTEXT_DIR,
     PROJECT_CONTEXT_LOCAL_DIR,
@@ -60,7 +60,6 @@ def _project_fingerprint(project_context: Mapping[str, Any], resources: Sequence
         "description": project_context.get("description"),
         "resources": [
             {
-                "id": resource.get("id"),
                 "kind": resource.get("kind") or resource.get("type") or resource.get("resource_type"),
                 "name": resource.get("name") or resource.get("label"),
                 "path": resource.get("path") or resource.get("local_path") or resource.get("storage_path"),
@@ -83,11 +82,7 @@ def project_key_from_context(
     context = project_context if isinstance(project_context, Mapping) else {}
     resource_list = [resource for resource in (resources or []) if isinstance(resource, Mapping)]
     for key in PROJECT_KEY_FIELDS:
-        value = _clean_text(context.get(key))
-        if value:
-            return _safe_segment(value, fallback="project")
-    for resource in resource_list:
-        value = _clean_text(resource.get("id"))
+        value = project_identity_field_value(context, key)
         if value:
             return _safe_segment(value, fallback="project")
     value = _clean_text(context.get("name") or context.get("title"))
@@ -96,6 +91,17 @@ def project_key_from_context(
     if fallback:
         return _safe_segment(fallback, fallback="project")
     return f"project-{_project_fingerprint(context, resource_list)}"
+
+
+def is_synthetic_project_root_resource(resource: Mapping[str, Any]) -> bool:
+    """Return true only for the materializer-created Project root resource."""
+
+    kind = (_clean_text(resource.get("kind") or resource.get("type") or resource.get("resource_type")) or "").lower()
+    return (
+        kind == PROJECT_ROOT_RESOURCE_KIND
+        and _clean_text(resource.get("id")) == PROJECT_ROOT_RESOURCE_ID
+        and _clean_text(resource.get("mount_path")) == PROJECT_ROOT_MOUNT_PATH
+    )
 
 
 def project_roots_parent(thread_workspace_root: Path) -> Path:
@@ -177,8 +183,13 @@ def _unique_relative_path(project_root: Path, relative_path: str) -> str:
     return candidate.as_posix()
 
 
-def _copy_import_file(source_path: Path, target_path: Path) -> None:
+def _copy_import_path(source_path: Path, target_path: Path) -> None:
     target_path.parent.mkdir(parents=True, exist_ok=True)
+    if source_path.is_dir() and not source_path.is_symlink():
+        if target_path.exists() and not target_path.is_dir():
+            target_path.unlink()
+        target_path.mkdir(parents=True, exist_ok=True)
+        return
     shutil.copy2(source_path, target_path)
 
 
@@ -195,7 +206,9 @@ def import_candidates_into_project_root(
 
     for candidate in candidates:
         source_path = Path(candidate.source_path).expanduser()
-        if not source_path.exists() or not source_path.is_file() or source_path.is_symlink():
+        if not source_path.exists() or source_path.is_symlink():
+            continue
+        if not source_path.is_file() and not source_path.is_dir():
             continue
         existing = imports.get(candidate.key)
         if isinstance(existing, Mapping):
@@ -210,13 +223,18 @@ def import_candidates_into_project_root(
         if target_path.exists() or target_path.is_symlink():
             relative_path = _unique_relative_path(project_root, relative_path)
             target_path = project_root / relative_path
-        _copy_import_file(source_path, target_path)
+        _copy_import_path(source_path, target_path)
         imports[candidate.key] = {
             "source_path": str(source_path),
             "relative_path": relative_path,
             "resource_id": candidate.resource_id,
+            "kind": "directory" if source_path.is_dir() else "file",
         }
-        imported.append({"source_path": str(source_path), "relative_path": relative_path})
+        imported.append({
+            "source_path": str(source_path),
+            "relative_path": relative_path,
+            "kind": "directory" if source_path.is_dir() else "file",
+        })
 
     metadata["imports"] = imports
     save_project_root_imports(project_root, metadata)
@@ -234,7 +252,7 @@ def directory_import_candidates(
         return []
     candidates: list[ProjectRootImportCandidate] = []
     for path in sorted(source_root.rglob("*")):
-        if not path.is_file() or path.is_symlink():
+        if path.is_symlink() or (not path.is_file() and not path.is_dir()):
             continue
         relative = path.relative_to(source_root).as_posix()
         if any(part in {PROJECT_HISTORY_DIR, PROJECT_CONTEXT_DIR} for part in Path(relative).parts):

--- a/brain/systems/cortex/project_context/resolution.py
+++ b/brain/systems/cortex/project_context/resolution.py
@@ -1,0 +1,158 @@
+"""Canonical Project Context resolution for thread and run entrypoints."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import select
+
+from brain.platform.db.models.idea import IdeaProjectAttachment, IdeaThread, ProjectProfile
+from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.systems.cortex.project_context.merge import merge_project_context_resources
+from brain.systems.cortex.project_context.snapshot import (
+    ProjectContextValidationError,
+    validated_project_context_snapshot,
+)
+
+
+@dataclass(frozen=True)
+class ProjectContextResolution:
+    project_context: dict[str, Any]
+    snapshot: dict[str, Any] | None
+    validation_errors: list[dict[str, Any]] = field(default_factory=list)
+
+
+def project_context_from_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    payload = payload or {}
+    for key in ("project_context", "project_context_snapshot"):
+        candidate = payload.get(key)
+        if isinstance(candidate, dict):
+            return dict(candidate)
+    return {}
+
+
+def project_context_from_idea(idea: Any) -> dict[str, Any]:
+    details = getattr(idea, "agent_details", None)
+    if not isinstance(details, dict):
+        return {}
+    return project_context_from_payload(details)
+
+
+def snapshot_for_project_context(project_context: dict[str, Any]) -> tuple[dict[str, Any] | None, list[str]]:
+    if not project_context:
+        return None, []
+    try:
+        return validated_project_context_snapshot(project_context, validate_local_paths=False), []
+    except ProjectContextValidationError as exc:
+        return None, exc.errors
+    except Exception:
+        return None, ["Project Context could not be validated."]
+
+
+async def latest_attached_project_context(session: Any, idea_id: str) -> dict[str, Any]:
+    if not hasattr(session, "scalars"):
+        return {}
+    try:
+        result = await session.scalars(
+            select(IdeaProjectAttachment)
+            .where(
+                IdeaProjectAttachment.idea_id == idea_id,
+                IdeaProjectAttachment.status != "invalid",
+            )
+            .order_by(IdeaProjectAttachment.created_at.desc(), IdeaProjectAttachment.id.desc())
+        )
+        attachment = result.first()
+    except Exception:
+        return {}
+
+    project_id = getattr(attachment, "project_profile_id", None)
+    if project_id and hasattr(session, "get"):
+        try:
+            profile = await session.get(ProjectProfile, project_id)
+        except Exception:
+            profile = None
+        if profile is not None and getattr(profile, "active", True) is not False:
+            project_context = getattr(profile, "project_context", None)
+            if isinstance(project_context, dict):
+                return stamped_project_context(profile, project_context, project_id=project_id)
+
+    snapshot = getattr(attachment, "snapshot", None)
+    return dict(snapshot) if isinstance(snapshot, dict) else {}
+
+
+async def latest_user_thread_metadata(session: Any, idea_id: str) -> dict[str, Any]:
+    if not hasattr(session, "execute"):
+        return {}
+    result = await session.execute(
+        select(IdeaThread.metadata_)
+        .where(IdeaThread.idea_id == idea_id, IdeaThread.role == "user")
+        .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
+        .limit(1)
+    )
+    latest = result.scalar_one_or_none()
+    return dict(latest or {}) if isinstance(latest, dict) else {}
+
+
+def merge_project_context_metadata(
+    base_metadata: dict[str, Any],
+    metadata: Any,
+) -> dict[str, Any]:
+    effective = dict(base_metadata)
+    if not isinstance(metadata, dict):
+        return effective
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        if key == "project_context" and isinstance(value, dict):
+            thread_project_context = effective.get("project_context")
+            if isinstance(thread_project_context, dict):
+                effective[key] = merge_project_context_resources(thread_project_context, value)
+            else:
+                effective[key] = value
+        else:
+            effective[key] = value
+    return effective
+
+
+async def resolve_effective_project_context(
+    session: Any,
+    *,
+    idea: Any,
+    idea_id: str,
+    metadata: dict[str, Any],
+) -> ProjectContextResolution:
+    validation_errors: list[dict[str, Any]] = []
+    metadata_candidate = project_context_from_payload(metadata)
+    attachment_candidate = await latest_attached_project_context(session, idea_id)
+    if metadata_candidate and attachment_candidate:
+        candidate = merge_project_context_resources(attachment_candidate, metadata_candidate)
+        snapshot, errors = snapshot_for_project_context(candidate or {})
+        if snapshot and candidate:
+            return ProjectContextResolution(candidate, snapshot, validation_errors)
+        validation_errors.append({"source": "metadata+latest_attachment", "errors": errors})
+
+    for source, candidate in (
+        ("metadata", metadata_candidate),
+        ("latest_attachment", attachment_candidate),
+        ("idea", project_context_from_idea(idea)),
+    ):
+        if not candidate:
+            continue
+        snapshot, errors = snapshot_for_project_context(candidate)
+        if snapshot:
+            return ProjectContextResolution(candidate, snapshot, validation_errors)
+        validation_errors.append({"source": source, "errors": errors})
+
+    return ProjectContextResolution({}, None, validation_errors)
+
+
+__all__ = [
+    "ProjectContextResolution",
+    "latest_attached_project_context",
+    "latest_user_thread_metadata",
+    "merge_project_context_metadata",
+    "project_context_from_idea",
+    "project_context_from_payload",
+    "resolve_effective_project_context",
+    "snapshot_for_project_context",
+]

--- a/brain/systems/cortex/project_context/resource_imports.py
+++ b/brain/systems/cortex/project_context/resource_imports.py
@@ -1,0 +1,190 @@
+"""Resource-to-Project-root import planning."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+import os
+
+from brain.systems.cortex.project_context.project_root import (
+    ProjectRootImportCandidate,
+    directory_import_candidates,
+    safe_project_relative_path,
+)
+
+
+ProjectSeedPredicate = Callable[[dict[str, Any]], bool]
+
+
+def clean_text(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def path_is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.expanduser().resolve().relative_to(parent.expanduser().resolve())
+        return True
+    except Exception:
+        return False
+
+
+def is_managed_project_context_path(path: Path) -> bool:
+    return ".illo-project-context" in path.expanduser().parts
+
+
+def should_use_existing_resource_path(existing_path: str | None, workspace_root: Path) -> Path | None:
+    if not existing_path:
+        return None
+    path = Path(existing_path).expanduser()
+    if not path.exists():
+        return None
+    if path_is_relative_to(path, workspace_root):
+        return path
+    if is_managed_project_context_path(path):
+        return None
+    return path
+
+
+def runtime_workspace_path(path: Path) -> Path:
+    return path if path.is_dir() else path.parent
+
+
+def _path_texts_from_uploaded_files(resource: Mapping[str, Any]) -> list[str]:
+    paths: list[str] = []
+    uploaded_files = resource.get("uploaded_files")
+    if not isinstance(uploaded_files, list):
+        return paths
+    for item in uploaded_files:
+        if not isinstance(item, Mapping):
+            continue
+        value = clean_text(item.get("storage_path") or item.get("path") or item.get("local_path"))
+        if value:
+            paths.append(value)
+    return paths
+
+
+def _path_texts_from_resource_scope(resource: Mapping[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for key in ("allowed_paths", "files", "folders"):
+        values = resource.get(key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            value = clean_text(item)
+            if value:
+                paths.append(value)
+    return paths
+
+
+def resource_id(resource: Mapping[str, Any]) -> str | None:
+    return clean_text(resource.get("id") or resource.get("name") or resource.get("label"))
+
+
+def _common_runtime_workspace_path(paths: list[Path]) -> Path | None:
+    if not paths:
+        return None
+    workspace_paths = [runtime_workspace_path(path).resolve() for path in paths]
+    try:
+        common = Path(os.path.commonpath([str(path) for path in workspace_paths]))
+    except ValueError:
+        return None
+    return common if common.exists() else None
+
+
+def backend_readable_resource_path(
+    resource: Mapping[str, Any],
+    *,
+    workspace_root: Path,
+) -> tuple[Path | None, bool]:
+    for key in ("path", "local_path", "storage_path"):
+        value = clean_text(resource.get(key))
+        existing_path = should_use_existing_resource_path(value, workspace_root)
+        if existing_path:
+            return existing_path, True
+
+    scoped_paths: list[Path] = []
+    path_texts = [*_path_texts_from_uploaded_files(resource), *_path_texts_from_resource_scope(resource)]
+    for value in path_texts:
+        existing_path = should_use_existing_resource_path(value, workspace_root)
+        if existing_path:
+            scoped_paths.append(existing_path)
+
+    common_path = _common_runtime_workspace_path(scoped_paths)
+    if common_path:
+        return common_path, True
+    return None, bool(path_texts)
+
+
+def _uploaded_file_import_candidates(
+    resource: Mapping[str, Any],
+    *,
+    workspace_root: Path,
+) -> list[ProjectRootImportCandidate]:
+    uploaded_files = resource.get("uploaded_files")
+    if not isinstance(uploaded_files, list):
+        return []
+
+    candidates: list[ProjectRootImportCandidate] = []
+    resource_key = resource_id(resource)
+    for item in uploaded_files:
+        if not isinstance(item, Mapping):
+            continue
+        source = should_use_existing_resource_path(
+            clean_text(item.get("storage_path") or item.get("path") or item.get("local_path")),
+            workspace_root,
+        )
+        if not source or not source.is_file():
+            continue
+        relative_path = safe_project_relative_path(
+            item.get("relative_path") or item.get("filename") or item.get("name") or source.name,
+            fallback=source.name,
+        )
+        if relative_path:
+            candidates.append(ProjectRootImportCandidate(source, relative_path, resource_id=resource_key))
+    return candidates
+
+
+def _direct_path_import_candidates(
+    resource: Mapping[str, Any],
+    *,
+    workspace_root: Path,
+) -> list[ProjectRootImportCandidate]:
+    source, checked = backend_readable_resource_path(resource, workspace_root=workspace_root)
+    if not source or not checked:
+        return []
+    resource_key = resource_id(resource)
+    if source.is_file():
+        relative_path = safe_project_relative_path(
+            resource.get("relative_path") or resource.get("name") or resource.get("label") or source.name,
+            fallback=source.name,
+        )
+        return [ProjectRootImportCandidate(source, relative_path, resource_id=resource_key)] if relative_path else []
+    return directory_import_candidates(source, resource_id=resource_key)
+
+
+def project_native_import_candidates(
+    resource: dict[str, Any],
+    *,
+    workspace_root: Path,
+    is_project_native_seed: ProjectSeedPredicate,
+) -> list[ProjectRootImportCandidate]:
+    if not is_project_native_seed(resource):
+        return []
+    uploaded = _uploaded_file_import_candidates(resource, workspace_root=workspace_root)
+    if uploaded:
+        return uploaded
+    return _direct_path_import_candidates(resource, workspace_root=workspace_root)
+
+
+__all__ = [
+    "ProjectSeedPredicate",
+    "backend_readable_resource_path",
+    "clean_text",
+    "path_is_relative_to",
+    "project_native_import_candidates",
+    "resource_id",
+    "runtime_workspace_path",
+    "should_use_existing_resource_path",
+]

--- a/brain/systems/cortex/project_context/root_aliases.py
+++ b/brain/systems/cortex/project_context/root_aliases.py
@@ -1,0 +1,84 @@
+"""Explicit Project root alias adoption."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+import shutil
+
+from brain.systems.cortex.project_context.drafts import build_file_manifest
+from brain.systems.cortex.project_context.project_root import project_root_path
+
+
+def _clean_text(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _extend_alias_values(values: list[Any], value: Any) -> None:
+    if isinstance(value, list):
+        values.extend(value)
+    else:
+        values.append(value)
+
+
+def explicit_project_root_alias_paths(
+    project_context: Mapping[str, Any],
+    resources: Sequence[Mapping[str, Any]],
+    *,
+    workspace_root: Path,
+    canonical_key: str,
+) -> list[Path]:
+    values: list[Any] = [
+        project_context.get("slug"),
+        project_context.get("project_key"),
+        project_context.get("previous_project_key"),
+    ]
+    for key in ("root_alias", "root_aliases", "previous_project_keys"):
+        _extend_alias_values(values, project_context.get(key))
+    for resource in resources:
+        if not isinstance(resource, Mapping):
+            continue
+        values.extend([resource.get("project_key"), resource.get("slug")])
+        for key in ("root_alias", "root_aliases", "previous_project_keys"):
+            _extend_alias_values(values, resource.get(key))
+
+    canonical_root = project_root_path(workspace_root, canonical_key)
+    aliases: list[Path] = []
+    for value in values:
+        text = _clean_text(value)
+        if not text or text == canonical_key:
+            continue
+        alias = project_root_path(workspace_root, text)
+        if alias != canonical_root and alias not in aliases:
+            aliases.append(alias)
+    return aliases
+
+
+def adopt_existing_project_root_alias(source_root: Path, alias_roots: Sequence[Path]) -> str | None:
+    if build_file_manifest(source_root):
+        return None
+    for alias_root in alias_roots:
+        if not alias_root.exists() or not alias_root.is_dir() or alias_root == source_root:
+            continue
+        if not build_file_manifest(alias_root):
+            continue
+        source_root.mkdir(parents=True, exist_ok=True)
+        for item in alias_root.iterdir():
+            target = source_root / item.name
+            if target.exists():
+                continue
+            if item.is_dir() and not item.is_symlink():
+                shutil.copytree(item, target, symlinks=False)
+            elif item.is_file() and not item.is_symlink():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(item, target)
+        return str(alias_root)
+    return None
+
+
+__all__ = [
+    "adopt_existing_project_root_alias",
+    "explicit_project_root_alias_paths",
+]

--- a/brain/systems/cortex/project_context/root_imports.py
+++ b/brain/systems/cortex/project_context/root_imports.py
@@ -1,0 +1,107 @@
+"""Locked and versioned Project root imports."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from brain.systems.cortex.project_context.project_root import (
+    ProjectRootImportCandidate,
+    import_candidates_into_project_root,
+    load_project_root_imports,
+)
+from brain.systems.cortex.project_context.root_transaction import project_root_lock
+from brain.systems.cortex.project_context.versioning import (
+    build_project_root_version_metadata,
+    capture_project_root_version,
+)
+
+
+def _version_dict(version: Any | None) -> dict[str, Any] | None:
+    if version is None:
+        return None
+    if hasattr(version, "to_dict"):
+        return version.to_dict()
+    if isinstance(version, Mapping):
+        return dict(version)
+    return {"id": str(version), "version_id": str(version)}
+
+
+def import_candidates_into_project_root_versioned(
+    project_root: Path,
+    candidates: Sequence[ProjectRootImportCandidate],
+    *,
+    run_id: int | str | None = None,
+    idea_id: str | None = None,
+    actor_id: str | None = None,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Import seed resources into a Project root under lock and record root history."""
+
+    root = Path(project_root).expanduser()
+    if not candidates:
+        return {"imported": [], "skipped": []}
+    root.mkdir(parents=True, exist_ok=True)
+    with project_root_lock(root):
+        metadata = load_project_root_imports(root)
+        imports = metadata.get("imports") if isinstance(metadata.get("imports"), Mapping) else {}
+        has_new_candidate = False
+        for candidate in candidates:
+            source = Path(candidate.source_path).expanduser()
+            if (
+                source.exists()
+                and not source.is_symlink()
+                and (source.is_file() or source.is_dir())
+                and candidate.key not in imports
+            ):
+                has_new_candidate = True
+                break
+        if not has_new_candidate:
+            return import_candidates_into_project_root(root, candidates)
+
+        before_version = capture_project_root_version(
+            root,
+            label="before-root-import",
+            metadata=build_project_root_version_metadata(
+                run_id=run_id,
+                idea_id=idea_id,
+                actor_id=actor_id,
+                org_id=org_id,
+                phase="before",
+                operations=[],
+            ),
+        )
+        summary = import_candidates_into_project_root(root, candidates)
+        imported = [item for item in summary.get("imported") or [] if isinstance(item, Mapping)]
+        if not imported:
+            return summary
+
+        operations = [
+            {
+                "operation": "import",
+                "path": item.get("relative_path"),
+                "source_path": item.get("source_path"),
+                "kind": item.get("kind"),
+            }
+            for item in imported
+        ]
+        after_version = capture_project_root_version(
+            root,
+            label="after-root-import",
+            metadata=build_project_root_version_metadata(
+                run_id=run_id,
+                idea_id=idea_id,
+                actor_id=actor_id,
+                org_id=org_id,
+                phase="after",
+                operations=operations,
+            ),
+        )
+    summary["root_versions"] = {
+        "before": _version_dict(before_version),
+        "after": _version_dict(after_version),
+    }
+    return summary
+
+
+__all__ = ["import_candidates_into_project_root_versioned"]

--- a/brain/systems/cortex/project_context/root_materializer.py
+++ b/brain/systems/cortex/project_context/root_materializer.py
@@ -1,0 +1,124 @@
+"""Project-native root draft materialization helpers."""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from brain.systems.cortex.project_context.drafts import build_file_manifest, load_draft_metadata, sync_draft_from_root
+from brain.systems.cortex.project_context.project_root import (
+    PROJECT_ROOT_MOUNT_PATH,
+    PROJECT_ROOT_RESOURCE_ID,
+    PROJECT_ROOT_RESOURCE_KIND,
+    ProjectRootImportCandidate,
+    project_draft_root_path,
+    project_key_from_context,
+    project_root_path,
+)
+from brain.systems.cortex.project_context.resource_imports import (
+    ProjectSeedPredicate,
+    project_native_import_candidates,
+)
+from brain.systems.cortex.project_context.root_aliases import (
+    adopt_existing_project_root_alias,
+    explicit_project_root_alias_paths,
+)
+from brain.systems.cortex.project_context.root_imports import import_candidates_into_project_root_versioned
+
+
+WorkspaceEntryFactory = Callable[[dict[str, Any], Path | str], dict[str, str]]
+
+
+def materialize_project_native_root(
+    project_context: dict[str, Any],
+    resources: Sequence[dict[str, Any]],
+    *,
+    workspace_root: Path,
+    run_id: int | None,
+    actor_id: str | None = None,
+    org_id: str | None = None,
+    is_project_native_seed: ProjectSeedPredicate,
+    workspace_entry_from_resource: WorkspaceEntryFactory,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    project_key = project_key_from_context(
+        project_context,
+        resources=resources,
+        fallback=f"run-{run_id}" if run_id else None,
+    )
+    source_root = project_root_path(workspace_root, project_key)
+    source_root.mkdir(parents=True, exist_ok=True)
+    adopted_from_root = adopt_existing_project_root_alias(
+        source_root,
+        explicit_project_root_alias_paths(
+            project_context,
+            resources,
+            workspace_root=workspace_root,
+            canonical_key=project_key,
+        ),
+    )
+
+    import_candidates: list[ProjectRootImportCandidate] = []
+    for resource in resources:
+        import_candidates.extend(
+            project_native_import_candidates(
+                resource,
+                workspace_root=workspace_root,
+                is_project_native_seed=is_project_native_seed,
+            )
+        )
+    import_summary = import_candidates_into_project_root_versioned(
+        source_root,
+        import_candidates,
+        run_id=run_id,
+        actor_id=actor_id,
+        org_id=org_id,
+    )
+
+    draft_root = project_draft_root_path(workspace_root, project_key)
+    had_base_manifest = bool(load_draft_metadata(draft_root).get("base_manifest"))
+    sync_result = sync_draft_from_root(source_root, draft_root)
+    root_manifest = build_file_manifest(source_root)
+    draft_manifest = build_file_manifest(draft_root)
+    root_file_count = sum(1 for entry in root_manifest.values() if entry.get("kind") == "file")
+    draft_file_count = sum(1 for entry in draft_manifest.values() if entry.get("kind") == "file")
+    draft_status = {
+        "updated_from_root": sync_result.copied,
+        "removed_from_root": sync_result.removed,
+        "conflicts": sync_result.conflicts,
+        "out_of_date": sync_result.out_of_date,
+    } if had_base_manifest else {}
+
+    materialization: dict[str, Any] = {
+        "status": "ready",
+        "provider": "project_native",
+        "kind": PROJECT_ROOT_RESOURCE_KIND,
+        "path": str(draft_root),
+        "workspace_path": str(draft_root),
+        "source_path": str(source_root),
+        "draft": True,
+        "project_key": project_key,
+        "root_empty": not root_manifest,
+        "root_path_count": len(root_manifest),
+        "root_file_count": root_file_count,
+        "draft_path_count": len(draft_manifest),
+        "draft_file_count": draft_file_count,
+    }
+    if any(import_summary.values()):
+        materialization["imports"] = import_summary
+    if adopted_from_root:
+        materialization["adopted_from_root"] = adopted_from_root
+    if draft_status and any(draft_status.values()):
+        materialization["draft_status"] = draft_status
+
+    resource = {
+        "id": PROJECT_ROOT_RESOURCE_ID,
+        "kind": PROJECT_ROOT_RESOURCE_KIND,
+        "name": "Project root",
+        "label": "Project root",
+        "mount_path": PROJECT_ROOT_MOUNT_PATH,
+        "path": str(draft_root),
+        "workspace_path": str(draft_root),
+        "source_path": str(source_root),
+        "materialization": materialization,
+    }
+    return resource, workspace_entry_from_resource(resource, draft_root)

--- a/brain/systems/cortex/project_context/root_transaction.py
+++ b/brain/systems/cortex/project_context/root_transaction.py
@@ -1,0 +1,47 @@
+"""Serialized Project root mutation helpers."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from typing import Iterator
+import fcntl
+
+from brain.systems.cortex.project_context.drafts import PROJECT_HISTORY_DIR
+
+
+LOCK_FILE = "root.lock"
+
+
+def _lock_path(root: Path) -> Path:
+    path = Path(root).expanduser()
+    base = path if not path.exists() or path.is_dir() else path.parent
+    return base / PROJECT_HISTORY_DIR / LOCK_FILE
+
+
+@contextmanager
+def project_root_lock(root: Path) -> Iterator[None]:
+    """Hold an exclusive lock for one local Project root."""
+
+    path = _lock_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def project_root_locks(roots: Iterable[Path]) -> Iterator[None]:
+    """Hold exclusive locks for local Project roots in deterministic order."""
+
+    ordered = sorted({str(Path(root).expanduser()) for root in roots})
+    with ExitStack() as stack:
+        for root in ordered:
+            stack.enter_context(project_root_lock(Path(root)))
+        yield
+
+
+__all__ = ["project_root_lock", "project_root_locks"]

--- a/brain/systems/cortex/project_context/runtime_context.py
+++ b/brain/systems/cortex/project_context/runtime_context.py
@@ -1,0 +1,97 @@
+"""Canonical runtime Project context payloads."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+PROJECT_RUNTIME_CONTEXT_KEY = "project_runtime_context"
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def build_project_runtime_context(
+    *,
+    snapshot: Mapping[str, Any],
+    permission_scope: Mapping[str, Any],
+    workspace_manifest: Mapping[str, Any],
+    materialization: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the canonical Project runtime payload stored on ``workspace_ref``."""
+
+    return {
+        "schema_version": 1,
+        "project_context_snapshot": dict(snapshot),
+        "permission_scope": dict(permission_scope),
+        "project_workspace_manifest": dict(workspace_manifest),
+        "project_context_materialization": dict(materialization),
+    }
+
+
+def project_runtime_context_from_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the canonical runtime context from a run payload, if present."""
+
+    mapped = _as_mapping(payload)
+    return _as_mapping(mapped.get(PROJECT_RUNTIME_CONTEXT_KEY))
+
+
+def project_runtime_context_from_payloads(*payloads: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the best Project runtime context from canonical or compatibility payloads."""
+
+    mapped_payloads = [_as_mapping(payload) for payload in payloads]
+    for payload in mapped_payloads:
+        runtime = project_runtime_context_from_payload(payload)
+        if runtime:
+            return runtime
+
+    snapshot = {}
+    manifest = {}
+    materialization = {}
+    permission_scope = {}
+    for payload in mapped_payloads:
+        if not snapshot:
+            snapshot = _as_mapping(payload.get("project_context_snapshot"))
+        if not manifest:
+            manifest = _as_mapping(payload.get("project_workspace_manifest"))
+        if not materialization:
+            materialization = _as_mapping(payload.get("project_context_materialization"))
+        if not permission_scope:
+            permission_scope = _as_mapping(payload.get("project_context_permission_scope"))
+        if not manifest:
+            manifest = _as_mapping(materialization.get("workspace_manifest"))
+    if not any((snapshot, manifest, materialization, permission_scope)):
+        return {}
+    return build_project_runtime_context(
+        snapshot=snapshot,
+        permission_scope=permission_scope,
+        workspace_manifest=manifest,
+        materialization=materialization,
+    )
+
+
+def project_runtime_snapshot(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    runtime = project_runtime_context_from_payload(payload)
+    return _as_mapping(runtime.get("project_context_snapshot"))
+
+
+def project_runtime_manifest(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    runtime = project_runtime_context_from_payload(payload)
+    return _as_mapping(runtime.get("project_workspace_manifest"))
+
+
+def project_runtime_materialization(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    runtime = project_runtime_context_from_payload(payload)
+    return _as_mapping(runtime.get("project_context_materialization"))
+
+
+__all__ = [
+    "PROJECT_RUNTIME_CONTEXT_KEY",
+    "build_project_runtime_context",
+    "project_runtime_context_from_payload",
+    "project_runtime_context_from_payloads",
+    "project_runtime_manifest",
+    "project_runtime_materialization",
+    "project_runtime_snapshot",
+]

--- a/brain/systems/cortex/project_context/snapshot.py
+++ b/brain/systems/cortex/project_context/snapshot.py
@@ -20,6 +20,7 @@ from brain.systems.cortex.project_context.permissions import (
     derive_project_permission_scope,
     normalize_project_path,
 )
+from brain.systems.cortex.project_context.identity import durable_project_id_from_context
 from brain.systems.cortex.project_context.resources import normalize_project_resource
 from brain.systems.cortex.project_context.workspace_manifest import attach_project_workspace_manifest_contract
 
@@ -256,17 +257,25 @@ def build_project_context_snapshot(
             "source": "metadata.project_context" if "project_context" in metadata else "metadata.project",
             "resources": resources,
         }
+        durable_project_id = durable_project_id_from_context(project)
+        if durable_project_id:
+            snapshot["project_id"] = durable_project_id
+            snapshot["project_key"] = durable_project_id
         for key in (
             "project_key",
             "slug",
             "project_id",
+            "project_profile_id",
+            "selected_profile_id",
             "name",
             "description",
             "permissions",
             "mode",
         ):
             value = project.get(key)
-            if value is not None:
+            if value is not None and key not in {"project_key", "project_id"}:
+                snapshot[key] = value
+            elif value is not None and not durable_project_id:
                 snapshot[key] = value
         if run_id is not None:
             snapshot["run_id"] = run_id

--- a/brain/systems/cortex/project_context/workspace_manifest.py
+++ b/brain/systems/cortex/project_context/workspace_manifest.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 import posixpath
 
-from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS
+from brain.systems.cortex.project_context.identity import PROJECT_IDENTITY_FIELDS, project_identity_field_value
 from brain.systems.cortex.project_context.resources import ProjectResource
 
 
@@ -39,7 +39,7 @@ def _safe_segment(value: Any, *, fallback: str) -> str:
 def _project_key_from_context(project_context: Mapping[str, Any] | None) -> str | None:
     context = project_context if isinstance(project_context, Mapping) else {}
     for key in PROJECT_KEY_FIELDS:
-        value = _clean_text(context.get(key))
+        value = project_identity_field_value(context, key)
         if value:
             return _safe_segment(value, fallback="project")
     return None

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -7,14 +7,10 @@ from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import text
 
-from brain.platform.db.models.idea import Idea, IdeaProjectAttachment, ProjectProfile
-from brain.systems.cortex.project_context.snapshot import (
-    ProjectContextValidationError,
-    validated_project_context_snapshot,
-)
-from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.platform.db.models.idea import Idea
+from brain.systems.cortex.project_context.resolution import resolve_effective_project_context
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
@@ -650,37 +646,6 @@ async def build_agent_run_request(
     )
 
 
-def _snapshot_for_project_context(project_context: dict[str, Any]) -> tuple[dict[str, Any] | None, list[str]]:
-    if not project_context:
-        return None, []
-    try:
-        return validated_project_context_snapshot(project_context, validate_local_paths=False), []
-    except ProjectContextValidationError as exc:
-        return None, exc.errors
-    except Exception:
-        return None, ["Project Context could not be validated."]
-
-
-def _project_context_from_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
-    metadata = metadata or {}
-    for key in ("project_context", "project_context_snapshot"):
-        candidate = metadata.get(key)
-        if isinstance(candidate, dict):
-            return dict(candidate)
-    return {}
-
-
-def _project_context_from_idea(idea: Idea) -> dict[str, Any]:
-    details = getattr(idea, "agent_details", None)
-    if not isinstance(details, dict):
-        return {}
-    for key in ("project_context", "project_context_snapshot"):
-        candidate = details.get(key)
-        if isinstance(candidate, dict):
-            return dict(candidate)
-    return {}
-
-
 def _metadata_int(metadata: dict[str, Any], *keys: str) -> int | None:
     for key in keys:
         raw = metadata.get(key)
@@ -709,35 +674,6 @@ def _surface_context_for_target(metadata: dict[str, Any]) -> dict[str, Any]:
     if isinstance(discussion_trigger, dict):
         surface_context["discussion_trigger"] = dict(discussion_trigger)
     return surface_context
-
-
-async def _a_latest_attached_project_context(session: Any, idea_id: str) -> dict[str, Any]:
-    if not hasattr(session, "scalars"):
-        return {}
-    try:
-        result = await session.scalars(
-            select(IdeaProjectAttachment)
-            .where(
-                IdeaProjectAttachment.idea_id == idea_id,
-                IdeaProjectAttachment.status != "invalid",
-            )
-            .order_by(IdeaProjectAttachment.created_at.desc(), IdeaProjectAttachment.id.desc())
-        )
-        attachment = result.first()
-    except Exception:
-        return {}
-    project_id = getattr(attachment, "project_profile_id", None)
-    if project_id and hasattr(session, "get"):
-        try:
-            profile = await session.get(ProjectProfile, project_id)
-        except Exception:
-            profile = None
-        if profile is not None and getattr(profile, "active", True) is not False:
-            project_context = getattr(profile, "project_context", None)
-            if isinstance(project_context, dict):
-                return stamped_project_context(profile, project_context, project_id=project_id)
-    snapshot = getattr(attachment, "snapshot", None)
-    return dict(snapshot) if isinstance(snapshot, dict) else {}
 
 
 def _session_dialect_name(session: Any) -> str | None:
@@ -805,29 +741,13 @@ async def _a_select_project_context(
     idea_id: str,
     metadata: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any] | None, list[dict[str, Any]]]:
-    validation_errors: list[dict[str, Any]] = []
-    candidate = _project_context_from_metadata(metadata)
-    if candidate:
-        snapshot, errors = _snapshot_for_project_context(candidate)
-        if snapshot:
-            return candidate, snapshot, validation_errors
-        validation_errors.append({"source": "metadata", "errors": errors})
-
-    candidate = await _a_latest_attached_project_context(session, idea_id)
-    if candidate:
-        snapshot, errors = _snapshot_for_project_context(candidate)
-        if snapshot:
-            return candidate, snapshot, validation_errors
-        validation_errors.append({"source": "latest_attachment", "errors": errors})
-
-    candidate = _project_context_from_idea(idea)
-    if candidate:
-        snapshot, errors = _snapshot_for_project_context(candidate)
-        if snapshot:
-            return candidate, snapshot, validation_errors
-        validation_errors.append({"source": "idea", "errors": errors})
-
-    return {}, None, validation_errors
+    resolution = await resolve_effective_project_context(
+        session,
+        idea=idea,
+        idea_id=idea_id,
+        metadata=metadata,
+    )
+    return resolution.project_context, resolution.snapshot, resolution.validation_errors
 
 
 async def _agent_run_request_for_cortex(

--- a/tests/test_manage_project_workflow_integration.py
+++ b/tests/test_manage_project_workflow_integration.py
@@ -15,7 +15,7 @@ def _project_run(run_id: int, project_root: Path, *, project_id: str = "profile-
         target_ref={
             "kind": "cortex_idea",
             "project_context_snapshot": {
-                "id": project_id,
+                "project_id": project_id,
                 "status": "validated",
                 "resources": [
                     {

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -46,6 +46,80 @@ def test_project_root_key_uses_canonical_project_key():
     assert project_key_from_context({"project_key": "project-1"}) == "project-1"
 
 
+def test_project_root_key_prefers_picker_profile_identity_over_slug_key():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    assert project_key_from_context({
+        "name": "test empty project",
+        "project_key": "test-empty-project",
+        "project_profile_id": "fec2d533-e4a0-40e7-9055-b5b619e91ab6",
+        "selected_profile_id": "server:fec2d533-e4a0-40e7-9055-b5b619e91ab6",
+    }) == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+    assert project_key_from_context({
+        "name": "test empty project",
+        "selected_profile_id": "server:fec2d533-e4a0-40e7-9055-b5b619e91ab6",
+    }) == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+
+
+def test_project_root_key_ignores_current_thread_project_picker_sentinel():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    assert project_key_from_context({
+        "name": "test empty project",
+        "selected_profile_id": "current-thread-project",
+    }) == "test-empty-project"
+
+
+def test_project_root_key_ignores_ambiguous_top_level_id():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    assert project_key_from_context({"id": "context-1"}, fallback="run-73") == "run-73"
+
+
+def test_project_root_key_does_not_use_child_resource_id():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    assert project_key_from_context(
+        {},
+        resources=[{"id": "project-root", "kind": "folder", "mount_path": "/reports"}],
+        fallback="run-73",
+    ) == "run-73"
+
+
+def test_project_root_fingerprint_ignores_child_resource_ids():
+    from brain.systems.cortex.project_context.project_root import project_key_from_context
+
+    first = project_key_from_context(
+        {"description": "scratch"},
+        resources=[{"id": "child-a", "kind": "file"}],
+    )
+    second = project_key_from_context(
+        {"description": "scratch"},
+        resources=[{"id": "child-b", "kind": "file"}],
+    )
+
+    assert first == second
+
+
+def test_validated_snapshot_stamps_project_picker_profile_identity():
+    from brain.systems.cortex.project_context.snapshot import validated_project_context_snapshot
+
+    snapshot = validated_project_context_snapshot(
+        {
+            "name": "test empty project",
+            "project_profile_id": "fec2d533-e4a0-40e7-9055-b5b619e91ab6",
+            "selected_profile_id": "server:fec2d533-e4a0-40e7-9055-b5b619e91ab6",
+            "resources": [],
+        },
+        validate_local_paths=False,
+    )
+
+    assert snapshot["project_id"] == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+    assert snapshot["project_key"] == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+    assert snapshot["project_workspace_manifest"]["project_id"] == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+    assert snapshot["project_workspace_manifest"]["project_key"] == "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+
+
 def test_runner_materializes_thread_attachment_files_as_project_resources(monkeypatch):
     from brain.systems.runs.cortex import runner
 
@@ -311,7 +385,7 @@ async def test_materialize_github_folder_uri_mounts_repo_subpath(tmp_path, monke
 
     expected_repo = tmp_path / "thread-root" / ".illo-project-context" / "github" / "uwear-ai" / "agent-mission-control"
     expected_workspace = expected_repo / "workspaces" / "linkedin-outbound"
-    expected_root = tmp_path / "thread-root" / ".illo-project-context" / "local" / "resource-2" / "project-root"
+    expected_root = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-54" / "project-root"
     assert result.ok
     assert result.workspaces == [
         {"name": "/", "path": str(expected_root)},
@@ -743,444 +817,6 @@ async def test_materialize_refuses_to_overwrite_non_matching_thread_checkout(tmp
     assert (checkout / "local-change.txt").read_text() == "do not delete"
     assert "refusing to overwrite live workspace state" in result.errors[0]
     assert run.target_status == "invalid"
-
-
-async def test_materialize_empty_project_context_creates_project_root(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    run = SimpleNamespace(
-        id=48,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={
-            "kind": "cortex_idea",
-            "project_context_snapshot": {
-                "status": "validated",
-                "resources": [],
-            },
-        },
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    result = await materialize_project_context_workspaces(48, workspace_root=str(tmp_path), user_id="user-1")
-
-    assert result.ok
-    draft_dir = tmp_path / ".illo-project-context" / "local" / "run-48" / "project-root"
-    source_root = tmp_path.parent / "project-roots" / "run-48"
-    assert result.empty_project is True
-    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
-    assert result.errors == []
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
-    assert resource["id"] == "project-root"
-    assert resource["mount_path"] == "/"
-    assert resource["materialization"]["source_path"] == str(source_root)
-    assert run.workspace_ref["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
-    assert run.workspace_ref["project_workspace_manifest"]["workspaces"] == [{"name": "/", "path": str(draft_dir)}]
-    assert run.workspace_ref["project_context_materialization"]["status"] == "materialized"
-    assert run.workspace_ref["project_context_materialization"]["empty_project"] is True
-    assert run.workspace_ref["workspace_root"] == str(draft_dir)
-
-
-async def test_materialize_missing_project_context_snapshot_reports_error(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    run = SimpleNamespace(
-        id=50,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={"kind": "cortex_idea"},
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    result = await materialize_project_context_workspaces(50, workspace_root=str(tmp_path), user_id="user-1")
-
-    assert not result.ok
-    assert result.errors == ["Project Context snapshot is missing."]
-
-
-async def test_materialize_backend_readable_folder_becomes_thread_draft_workspace(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    project_dir = tmp_path / "project-root"
-    project_dir.mkdir()
-    (project_dir / "brief.md").write_text("runtime context")
-
-    run = SimpleNamespace(
-        id=51,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={
-            "kind": "cortex_idea",
-            "project_context_snapshot": {
-                "project_id": "profile-abc",
-                "status": "validated",
-                "resources": [
-                    {
-                        "id": "resource-folder",
-                        "kind": "folder",
-                        "mount_path": "/reports",
-                        "path": str(project_dir),
-                    }
-                ],
-            },
-        },
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-    monkeypatch.setattr(
-        materializer,
-        "_clone_github_repo",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("local folders should not be cloned as GitHub repositories")
-        ),
-    )
-
-    result = await materialize_project_context_workspaces(51, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
-
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "profile-abc" / "project-root"
-    source_root = tmp_path / "project-roots" / "profile-abc"
-    assert result.ok
-    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
-    assert (draft_dir / "brief.md").read_text() == "runtime context"
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
-    assert resource["id"] == "project-root"
-    assert resource["mount_path"] == "/"
-    assert resource["path"] == str(draft_dir)
-    assert resource["materialization"]["source_path"] == str(source_root)
-    assert (source_root / "brief.md").read_text() == "runtime context"
-    assert resource["materialization"]["workspace_path"] == str(draft_dir)
-    assert resource["materialization"]["draft"] is True
-    assert resource["materialization"]["project_key"] == "profile-abc"
-    assert run.workspace_ref["workspace_root"] == str(draft_dir)
-    assert run.workspace_ref["project_workspace_manifest"]["workspaces"][0]["name"] == "/"
-
-
-async def test_materialize_single_uploaded_file_uses_project_native_folder_root(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    attachment_dir = tmp_path / "attachments"
-    attachment_dir.mkdir()
-    spec_file = attachment_dir / "spec.md"
-    spec_file.write_text("# Spec")
-
-    run = SimpleNamespace(
-        id=53,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={
-            "kind": "cortex_idea",
-            "project_context_snapshot": {
-                "status": "validated",
-                "resources": [
-                    {
-                        "id": "attachment-1",
-                        "kind": "file",
-                        "name": "spec.md",
-                        "path": str(spec_file),
-                        "source": "thread_attachment",
-                    }
-                ],
-            },
-        },
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    result = await materialize_project_context_workspaces(53, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
-
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "attachment-1" / "project-root"
-    assert result.ok
-    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
-    assert (draft_dir / "spec.md").read_text() == "# Spec"
-    resource = run.target_ref["project_context_snapshot"]["resources"][0]
-    source_root = Path(resource["materialization"]["source_path"])
-    assert source_root != spec_file
-    assert source_root.is_dir()
-    assert (source_root / "spec.md").read_text() == "# Spec"
-    assert resource["id"] == "project-root"
-    assert resource["mount_path"] == "/"
-    assert resource["path"] == str(draft_dir)
-    assert resource["materialization"]["path"] == str(draft_dir)
-    assert resource["materialization"]["kind"] == "project_root"
-    assert resource["materialization"]["workspace_path"] == str(draft_dir)
-    assert resource["materialization"]["draft"] is True
-    assert run.workspace_ref["workspace_root"] == str(draft_dir)
-    mount = run.workspace_ref["project_workspace_manifest"]["mounts"][0]
-    assert mount["kind"] == "project_root"
-    assert mount["source_path"] == str(source_root)
-    assert mount["resource_path"] == str(draft_dir)
-
-
-async def test_materialize_uploaded_folder_imports_files_into_project_native_root(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    upload_dir = tmp_path / "uploads"
-    (upload_dir / "folder").mkdir(parents=True)
-    first_file = upload_dir / "folder" / "brief.md"
-    second_file = upload_dir / "folder" / "data" / "metrics.csv"
-    second_file.parent.mkdir()
-    first_file.write_text("brief", encoding="utf-8")
-    second_file.write_text("metric,value\n", encoding="utf-8")
-
-    run = SimpleNamespace(
-        id=57,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={
-            "kind": "cortex_idea",
-            "project_context_snapshot": {
-                "status": "validated",
-                "resources": [
-                    {
-                        "id": "folder-upload",
-                        "kind": "folder",
-                        "name": "folder",
-                        "uri": "project-context-upload://folder",
-                        "uploaded_files": [
-                            {
-                                "filename": "brief.md",
-                                "relative_path": "folder/brief.md",
-                                "storage_path": str(first_file),
-                            },
-                            {
-                                "filename": "metrics.csv",
-                                "relative_path": "folder/data/metrics.csv",
-                                "storage_path": str(second_file),
-                            },
-                        ],
-                    }
-                ],
-            },
-        },
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    result = await materialize_project_context_workspaces(
-        57,
-        workspace_root=str(tmp_path / "thread-root"),
-        user_id="user-1",
-    )
-
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "folder-upload" / "project-root"
-    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
-    assert result.ok
-    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
-    assert (source_root / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
-    assert (source_root / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
-    assert (draft_dir / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
-    assert (draft_dir / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
-
-
-async def test_materialize_saved_project_root_identity_survives_resource_changes(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    seed = tmp_path / "seed.md"
-    seed.write_text("seed", encoding="utf-8")
-    runs: dict[int, SimpleNamespace] = {}
-
-    def run_for(run_id: int, resources: list[dict[str, str]]):
-        run = SimpleNamespace(
-            id=run_id,
-            user_id="user-1",
-            org_id="org-1",
-            metadata_={},
-            target_ref={
-                "kind": "cortex_idea",
-                "project_context_snapshot": {
-                    "project_key": "profile-stable",
-                    "project_id": "profile-stable",
-                    "slug": "strategy-room",
-                    "status": "validated",
-                    "resources": resources,
-                },
-            },
-            workspace_ref={},
-        )
-        runs[run_id] = run
-        return run
-
-    first_run = run_for(71, [])
-    second_run = run_for(72, [{"id": "seed", "kind": "file", "name": "seed.md", "path": str(seed)}])
-
-    class FakeSession:
-        async def get(self, _model, run_id):
-            return runs.get(run_id)
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    first = await materialize_project_context_workspaces(
-        71,
-        workspace_root=str(tmp_path / "ideas" / "thread-one"),
-        user_id="user-1",
-    )
-    second = await materialize_project_context_workspaces(
-        72,
-        workspace_root=str(tmp_path / "ideas" / "thread-two"),
-        user_id="user-1",
-    )
-
-    first_source = Path(first_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
-    second_source = Path(second_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
-    assert first.ok
-    assert second.ok
-    assert first_source == second_source == tmp_path / "project-roots" / "profile-stable"
-    assert (second_source / "seed.md").read_text(encoding="utf-8") == "seed"
-
-
-async def test_materialize_thread_draft_marks_conflict_when_root_and_draft_changed(tmp_path, monkeypatch):
-    from brain.systems.cortex.project_context import materializer
-    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
-
-    project_dir = tmp_path / "project-root"
-    project_dir.mkdir()
-    (project_dir / "brief.md").write_text("root v1")
-
-    run = SimpleNamespace(
-        id=56,
-        user_id="user-1",
-        org_id="org-1",
-        metadata_={},
-        target_ref={
-            "kind": "cortex_idea",
-            "project_context_snapshot": {
-                "status": "validated",
-                "resources": [
-                    {
-                        "id": "resource-folder",
-                        "kind": "folder",
-                        "mount_path": "/reports",
-                        "path": str(project_dir),
-                    }
-                ],
-            },
-        },
-        workspace_ref={},
-    )
-
-    class FakeSession:
-        async def get(self, _model, _id):
-            return run
-
-    class FakeUow:
-        session = FakeSession()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-
-    first = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
-    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "resource-folder" / "project-root"
-    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
-
-    assert first.ok
-    (draft_dir / "brief.md").write_text("draft edit")
-    (source_root / "brief.md").write_text("root v2")
-
-    second = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
-
-    assert second.ok
-    assert (draft_dir / "brief.md").read_text() == "draft edit"
-    status = run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["draft_status"]
-    assert status["conflicts"] == ["brief.md"]
-    assert status["out_of_date"] == ["brief.md"]
-
 
 def test_project_context_root_is_scoped_by_thread(monkeypatch, tmp_path):
     from brain.systems.runs.cortex.runner import _project_context_root

--- a/tests/test_project_context_root_materializer.py
+++ b/tests/test_project_context_root_materializer.py
@@ -1,0 +1,834 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+
+async def test_materialize_empty_project_context_creates_project_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=48,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(48, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert result.ok
+    draft_dir = tmp_path / ".illo-project-context" / "local" / "run-48" / "project-root"
+    source_root = tmp_path.parent / "project-roots" / "run-48"
+    assert result.empty_project is True
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert result.errors == []
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
+    assert resource["materialization"]["source_path"] == str(source_root)
+    assert run.workspace_ref["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
+    assert run.workspace_ref["project_workspace_manifest"]["workspaces"] == [{"name": "/", "path": str(draft_dir)}]
+    assert run.workspace_ref["project_context_materialization"]["status"] == "materialized"
+    assert run.workspace_ref["project_context_materialization"]["empty_project"] is True
+    runtime = run.workspace_ref["project_runtime_context"]
+    assert runtime["project_context_snapshot"]["resources"][0]["id"] == "project-root"
+    assert runtime["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
+    assert runtime["project_context_materialization"]["status"] == "materialized"
+    assert run.workspace_ref["workspace_root"] == str(draft_dir)
+
+
+async def test_materialize_missing_project_context_snapshot_reports_error(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=50,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={"kind": "cortex_idea"},
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(50, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert not result.ok
+    assert result.errors == ["Project Context snapshot is missing."]
+
+
+async def test_materialize_backend_readable_folder_becomes_thread_draft_workspace(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    project_dir = tmp_path / "project-root"
+    project_dir.mkdir()
+    (project_dir / "brief.md").write_text("runtime context")
+
+    run = SimpleNamespace(
+        id=51,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "project_id": "profile-abc",
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "resource-folder",
+                        "kind": "folder",
+                        "mount_path": "/reports",
+                        "path": str(project_dir),
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(
+        materializer,
+        "_clone_github_repo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("local folders should not be cloned as GitHub repositories")
+        ),
+    )
+
+    result = await materialize_project_context_workspaces(51, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "profile-abc" / "project-root"
+    source_root = tmp_path / "project-roots" / "profile-abc"
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (draft_dir / "brief.md").read_text() == "runtime context"
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
+    assert resource["path"] == str(draft_dir)
+    assert resource["materialization"]["source_path"] == str(source_root)
+    assert (source_root / "brief.md").read_text() == "runtime context"
+    assert resource["materialization"]["workspace_path"] == str(draft_dir)
+    assert resource["materialization"]["draft"] is True
+    assert resource["materialization"]["project_key"] == "profile-abc"
+    assert run.workspace_ref["workspace_root"] == str(draft_dir)
+    assert run.workspace_ref["project_workspace_manifest"]["workspaces"][0]["name"] == "/"
+
+
+async def test_materialize_child_resource_id_project_root_does_not_claim_root_identity(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "brief.md").write_text("brief", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=52,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "project-root",
+                        "kind": "folder",
+                        "mount_path": "/reports",
+                        "path": str(source_dir),
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        52,
+        workspace_root=str(tmp_path / "thread-root"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-52" / "project-root"
+    source_root = tmp_path / "project-roots" / "run-52"
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (source_root / "brief.md").read_text(encoding="utf-8") == "brief"
+    assert (draft_dir / "brief.md").read_text(encoding="utf-8") == "brief"
+    root_resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert root_resource["id"] == "project-root"
+    assert root_resource["kind"] == "project_root"
+    assert root_resource["materialization"]["project_key"] == "run-52"
+
+
+async def test_materialize_root_mounted_local_resource_is_not_skipped(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    source_dir = tmp_path / "selected-root"
+    source_dir.mkdir()
+    (source_dir / "README.md").write_text("local root", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=55,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "selected-root",
+                        "kind": "folder",
+                        "mount_path": "/",
+                        "path": str(source_dir),
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        55,
+        workspace_root=str(tmp_path / "thread-root"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-55" / "project-root"
+    source_root = tmp_path / "project-roots" / "run-55"
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (source_root / "README.md").read_text(encoding="utf-8") == "local root"
+    assert (draft_dir / "README.md").read_text(encoding="utf-8") == "local root"
+    assert run.workspace_ref["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
+
+
+async def test_materialize_single_uploaded_file_uses_project_native_folder_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    attachment_dir = tmp_path / "attachments"
+    attachment_dir.mkdir()
+    spec_file = attachment_dir / "spec.md"
+    spec_file.write_text("# Spec")
+
+    run = SimpleNamespace(
+        id=53,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "attachment-1",
+                        "kind": "file",
+                        "name": "spec.md",
+                        "path": str(spec_file),
+                        "source": "thread_attachment",
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(53, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-53" / "project-root"
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (draft_dir / "spec.md").read_text() == "# Spec"
+    resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    source_root = Path(resource["materialization"]["source_path"])
+    assert source_root != spec_file
+    assert source_root.is_dir()
+    assert (source_root / "spec.md").read_text() == "# Spec"
+    assert resource["id"] == "project-root"
+    assert resource["mount_path"] == "/"
+    assert resource["path"] == str(draft_dir)
+    assert resource["materialization"]["path"] == str(draft_dir)
+    assert resource["materialization"]["kind"] == "project_root"
+    assert resource["materialization"]["workspace_path"] == str(draft_dir)
+    assert resource["materialization"]["draft"] is True
+    assert run.workspace_ref["workspace_root"] == str(draft_dir)
+    mount = run.workspace_ref["project_workspace_manifest"]["mounts"][0]
+    assert mount["kind"] == "project_root"
+    assert mount["source_path"] == str(source_root)
+    assert mount["resource_path"] == str(draft_dir)
+
+
+async def test_materialize_uploaded_folder_imports_files_into_project_native_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    upload_dir = tmp_path / "uploads"
+    (upload_dir / "folder").mkdir(parents=True)
+    first_file = upload_dir / "folder" / "brief.md"
+    second_file = upload_dir / "folder" / "data" / "metrics.csv"
+    second_file.parent.mkdir()
+    first_file.write_text("brief", encoding="utf-8")
+    second_file.write_text("metric,value\n", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=57,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "folder-upload",
+                        "kind": "folder",
+                        "name": "folder",
+                        "uri": "project-context-upload://folder",
+                        "uploaded_files": [
+                            {
+                                "filename": "brief.md",
+                                "relative_path": "folder/brief.md",
+                                "storage_path": str(first_file),
+                            },
+                            {
+                                "filename": "metrics.csv",
+                                "relative_path": "folder/data/metrics.csv",
+                                "storage_path": str(second_file),
+                            },
+                        ],
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        57,
+        workspace_root=str(tmp_path / "thread-root"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-57" / "project-root"
+    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert (source_root / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
+    assert (source_root / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
+    assert (draft_dir / "folder" / "brief.md").read_text(encoding="utf-8") == "brief"
+    assert (draft_dir / "folder" / "data" / "metrics.csv").read_text(encoding="utf-8") == "metric,value\n"
+    imports = run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["imports"]
+    assert imports["root_versions"]["before"]["label"] == "before-root-import"
+    assert imports["root_versions"]["after"]["label"] == "after-root-import"
+
+
+async def test_materialize_saved_project_root_identity_survives_resource_changes(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    seed = tmp_path / "seed.md"
+    seed.write_text("seed", encoding="utf-8")
+    runs: dict[int, SimpleNamespace] = {}
+
+    def run_for(run_id: int, resources: list[dict[str, str]]):
+        run = SimpleNamespace(
+            id=run_id,
+            user_id="user-1",
+            org_id="org-1",
+            metadata_={},
+            target_ref={
+                "kind": "cortex_idea",
+                "project_context_snapshot": {
+                    "project_key": "profile-stable",
+                    "project_id": "profile-stable",
+                    "slug": "strategy-room",
+                    "status": "validated",
+                    "resources": resources,
+                },
+            },
+            workspace_ref={},
+        )
+        runs[run_id] = run
+        return run
+
+    first_run = run_for(71, [])
+    second_run = run_for(72, [{"id": "seed", "kind": "file", "name": "seed.md", "path": str(seed)}])
+
+    class FakeSession:
+        async def get(self, _model, run_id):
+            return runs.get(run_id)
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    first = await materialize_project_context_workspaces(
+        71,
+        workspace_root=str(tmp_path / "ideas" / "thread-one"),
+        user_id="user-1",
+    )
+    second = await materialize_project_context_workspaces(
+        72,
+        workspace_root=str(tmp_path / "ideas" / "thread-two"),
+        user_id="user-1",
+    )
+
+    first_source = Path(first_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    second_source = Path(second_run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+    assert first.ok
+    assert second.ok
+    assert first.empty_project is True
+    assert second.empty_project is False
+    assert first_source == second_source == tmp_path / "project-roots" / "profile-stable"
+    assert (second_source / "seed.md").read_text(encoding="utf-8") == "seed"
+    assert first_run.workspace_ref["project_context_materialization"]["empty_project"] is True
+    assert second_run.workspace_ref["project_context_materialization"]["empty_project"] is False
+    assert second_run.workspace_ref["project_context_materialization"]["seed_resource_count"] == 1
+    assert second_run.workspace_ref["project_context_materialization"]["project_root_file_count"] == 1
+
+
+async def test_materialize_picker_project_context_uses_profile_id_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    profile_id = "fec2d533-e4a0-40e7-9055-b5b619e91ab6"
+    run = SimpleNamespace(
+        id=73,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={
+            "project_context": {
+                "name": "test empty project",
+                "project_profile_id": profile_id,
+                "selected_profile_id": f"server:{profile_id}",
+                "resources": [],
+            },
+        },
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "name": "test empty project",
+                "project_key": "test-empty-project",
+                "resources": [],
+            },
+        },
+        workspace_ref={
+            "name": "test empty project",
+            "project_profile_id": profile_id,
+            "selected_profile_id": f"server:{profile_id}",
+            "project_context_snapshot": {
+                "status": "validated",
+                "name": "test empty project",
+                "project_key": "test-empty-project",
+                "resources": [],
+            },
+        },
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        73,
+        workspace_root=str(tmp_path / "ideas" / "thread-one"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "ideas" / "thread-one" / ".illo-project-context" / "local" / profile_id / "project-root"
+    source_root = tmp_path / "project-roots" / profile_id
+    snapshot = run.target_ref["project_context_snapshot"]
+    assert result.ok
+    assert result.workspaces == [{"name": "/", "path": str(draft_dir)}]
+    assert snapshot["project_id"] == profile_id
+    assert snapshot["project_key"] == profile_id
+    assert snapshot["resources"][0]["materialization"]["source_path"] == str(source_root)
+    assert snapshot["project_workspace_manifest"]["project_id"] == profile_id
+    assert snapshot["project_workspace_manifest"]["project_key"] == profile_id
+    assert snapshot["project_workspace_manifest"]["mounts"][0]["mount_path"] == "/"
+
+
+async def test_materialize_empty_saved_project_reports_non_empty_after_root_publish(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    profile_id = "profile-stable"
+    source_root = tmp_path / "project-roots" / profile_id
+    source_root.mkdir(parents=True)
+    (source_root / "analysis").mkdir()
+    (source_root / "analysis" / "summary.md").write_text("published", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=74,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={
+            "project_context": {
+                "project_profile_id": profile_id,
+                "selected_profile_id": f"server:{profile_id}",
+                "name": "Empty profile with published root",
+                "resources": [],
+            },
+        },
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "name": "Empty profile with published root",
+                "project_profile_id": profile_id,
+                "resources": [],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        74,
+        workspace_root=str(tmp_path / "ideas" / "thread-after-publish"),
+        user_id="user-1",
+    )
+
+    draft_dir = tmp_path / "ideas" / "thread-after-publish" / ".illo-project-context" / "local" / profile_id / "project-root"
+    materialization = run.workspace_ref["project_context_materialization"]
+    root_resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert result.ok
+    assert result.empty_project is False
+    assert materialization["empty_project"] is False
+    assert materialization["seed_resource_count"] == 0
+    assert materialization["project_root_file_count"] == 1
+    assert root_resource["materialization"]["root_empty"] is False
+    assert root_resource["materialization"]["root_file_count"] == 1
+    assert (draft_dir / "analysis" / "summary.md").read_text(encoding="utf-8") == "published"
+
+
+async def test_materialize_saved_project_adopts_existing_slug_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    profile_id = "profile-stable"
+    slug_root = tmp_path / "project-roots" / "test-empty-project"
+    slug_root.mkdir(parents=True)
+    (slug_root / "analysis").mkdir()
+    (slug_root / "unified_payments.csv").write_text("full csv", encoding="utf-8")
+    (slug_root / "analysis" / "summary.md").write_text("published", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=75,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "name": "test empty project",
+                "slug": "test-empty-project",
+                "project_id": profile_id,
+                "project_key": profile_id,
+                "resources": [],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        75,
+        workspace_root=str(tmp_path / "ideas" / "thread-adopt"),
+        user_id="user-1",
+    )
+
+    canonical_root = tmp_path / "project-roots" / profile_id
+    draft_dir = tmp_path / "ideas" / "thread-adopt" / ".illo-project-context" / "local" / profile_id / "project-root"
+    root_resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert result.ok
+    assert result.empty_project is False
+    assert (canonical_root / "unified_payments.csv").read_text(encoding="utf-8") == "full csv"
+    assert (canonical_root / "analysis" / "summary.md").read_text(encoding="utf-8") == "published"
+    assert (draft_dir / "unified_payments.csv").read_text(encoding="utf-8") == "full csv"
+    assert root_resource["materialization"]["adopted_from_root"] == str(slug_root)
+
+
+async def test_materialize_saved_project_does_not_adopt_display_name_root(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    profile_id = "profile-stable"
+    name_root = tmp_path / "project-roots" / "test-empty-project"
+    name_root.mkdir(parents=True)
+    (name_root / "unified_payments.csv").write_text("wrong root", encoding="utf-8")
+
+    run = SimpleNamespace(
+        id=76,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "name": "test empty project",
+                "project_id": profile_id,
+                "project_key": profile_id,
+                "resources": [],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    result = await materialize_project_context_workspaces(
+        76,
+        workspace_root=str(tmp_path / "ideas" / "thread-no-name-adopt"),
+        user_id="user-1",
+    )
+
+    canonical_root = tmp_path / "project-roots" / profile_id
+    root_resource = run.target_ref["project_context_snapshot"]["resources"][0]
+    assert result.ok
+    assert result.empty_project is True
+    assert not (canonical_root / "unified_payments.csv").exists()
+    assert "adopted_from_root" not in root_resource["materialization"]
+
+
+async def test_materialize_thread_draft_marks_conflict_when_root_and_draft_changed(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    project_dir = tmp_path / "project-root"
+    project_dir.mkdir()
+    (project_dir / "brief.md").write_text("root v1")
+
+    run = SimpleNamespace(
+        id=56,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "id": "resource-folder",
+                        "kind": "folder",
+                        "mount_path": "/reports",
+                        "path": str(project_dir),
+                    }
+                ],
+            },
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+
+    first = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
+    draft_dir = tmp_path / "thread-root" / ".illo-project-context" / "local" / "run-56" / "project-root"
+    source_root = Path(run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["source_path"])
+
+    assert first.ok
+    (draft_dir / "brief.md").write_text("draft edit")
+    (source_root / "brief.md").write_text("root v2")
+
+    second = await materialize_project_context_workspaces(56, workspace_root=str(tmp_path / "thread-root"), user_id="user-1")
+
+    assert second.ok
+    assert (draft_dir / "brief.md").read_text() == "draft edit"
+    status = run.target_ref["project_context_snapshot"]["resources"][0]["materialization"]["draft_status"]
+    assert status["conflicts"] == ["brief.md"]
+    assert status["out_of_date"] == ["brief.md"]


### PR DESCRIPTION
## Summary
- centralize effective Project Context resolution so stale picker metadata and uploaded resources converge on the same durable Project identity
- make Project identity ignore generic ambiguous ids, while preserving profile/context keys and thread-safe runtime context stamping
- split Project root materialization into focused root alias/import/materializer helpers with versioned root transactions
- keep empty/single-file/folder/repo Projects in the same native folder-root model, including sibling-file publishing and stale-root refresh behavior
- split the oversized materializer test file and add regressions for display-name roots, published empty roots, sibling files, and current-root visibility across threads

## Verification
- pytest tests/test_project_context_materializer.py tests/test_project_context_root_materializer.py tests/test_manage_project_workflow_integration.py tests/test_manage_project_drafts.py tests/test_manage_project_root_versions.py tests/test_api_cortex.py::test_notify_metadata_preserves_thread_project_context tests/test_notify_routing.py::test_notify_idea_created_to_team_member_from_thread_metadata_does_not_enqueue_agent_run tests/test_work_intake.py::test_cortex_work_intake_stamps_project_identity_from_latest_attachment tests/test_agent_run_runtime.py::test_work_intake_falls_back_to_latest_project_attachment tests/test_agent_run_runtime.py::test_work_intake_resolves_attached_profile_to_latest_project_root
- pytest
- npm --prefix frontend run check
- git diff --cached --check before commit