### PR TITLE
Cap Project context prompt surfaces

### DIFF
--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -20,6 +20,10 @@ from brain.systems.cortex.project_context.github import (
     async_search_repos,
     parse_github_repo_slug,
 )
+from brain.systems.cortex.project_context.browser import (
+    project_file_payload,
+    with_project_file_browser,
+)
 from brain.systems.cortex.project_context.identity import stamped_project_context
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
 from brain.systems.cortex.project_context.access import (
@@ -443,6 +447,7 @@ async def _project_draft_state_payload(
         draft_status = await _manage_project_payload("draft_status")
         plan_publish = await _manage_project_payload("plan_publish")
         root_versions = await _manage_project_payload("root_versions")
+    draft_status = with_project_file_browser(draft_status)
 
     return {
         "ok": bool(
@@ -456,6 +461,43 @@ async def _project_draft_state_payload(
         "plan_publish": plan_publish,
         "root_versions": root_versions,
     }
+
+
+async def _project_draft_file_payload(
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    path: str,
+    resource_id: str | None = None,
+    user: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+
+    run_id = str(getattr(run, "id", "") or "")
+    org_id = str(getattr(run, "org_id", "") or (user or {}).get("org_id") or "") or None
+    user_id = str(getattr(run, "user_id", "") or (user or {}).get("id") or "") or None
+    context = {
+        "run": run,
+        "run_id": run_id,
+        "idea_id": str(idea_id),
+        "org_id": org_id,
+        "user_id": user_id,
+        "execution_metadata": {
+            "run_id": run_id,
+            "idea_id": str(idea_id),
+            "org_id": org_id,
+            "user_id": user_id,
+        },
+    }
+    with bind_agent_context(context):
+        draft_status = await _manage_project_payload("draft_status")
+    if not draft_status.get("ok"):
+        raise HTTPException(status_code=404, detail=draft_status.get("error") or "Project draft state is unavailable.")
+    try:
+        return project_file_payload(draft_status, resource_id=resource_id, path=path)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 async def _project_draft_state_run(
@@ -842,6 +884,25 @@ async def get_idea_project_context_draft_state(
 ):
     run = await _project_draft_state_run(db, idea_id, run_id, user)
     return await _project_draft_state_payload(run, idea_id=idea_id, user=user)
+
+
+@router.get("/ideas/{idea_id}/project-context/draft-file")
+async def get_idea_project_context_draft_file(
+    idea_id: str,
+    path: str,
+    run_id: int | None = None,
+    resource_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _project_draft_file_payload(
+        run,
+        idea_id=idea_id,
+        path=path,
+        resource_id=resource_id,
+        user=user,
+    )
 
 
 @router.get("/ideas/{idea_id}/project-context", response_model=list[IdeaProjectAttachmentRead])

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 from fastapi import Depends, File, Form, HTTPException, Request, UploadFile
+from starlette.responses import FileResponse
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +22,7 @@ from brain.systems.cortex.project_context.github import (
     parse_github_repo_slug,
 )
 from brain.systems.cortex.project_context.browser import (
+    project_file_blob,
     project_file_payload,
     update_project_draft_file,
     with_project_file_browser,
@@ -502,6 +504,50 @@ async def _project_draft_file_payload(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+async def _project_draft_file_blob_response(
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    path: str,
+    layer: str,
+    resource_id: str | None = None,
+    user: dict[str, Any] | None = None,
+) -> FileResponse:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+
+    run_id = str(getattr(run, "id", "") or "")
+    org_id = str(getattr(run, "org_id", "") or (user or {}).get("org_id") or "") or None
+    user_id = str(getattr(run, "user_id", "") or (user or {}).get("id") or "") or None
+    context = {
+        "run": run,
+        "run_id": run_id,
+        "idea_id": str(idea_id),
+        "org_id": org_id,
+        "user_id": user_id,
+        "execution_metadata": {
+            "run_id": run_id,
+            "idea_id": str(idea_id),
+            "org_id": org_id,
+            "user_id": user_id,
+        },
+    }
+    with bind_agent_context(context):
+        draft_status = await _manage_project_payload("draft_status")
+    if not draft_status.get("ok"):
+        raise HTTPException(status_code=404, detail=draft_status.get("error") or "Project draft state is unavailable.")
+    try:
+        blob = project_file_blob(draft_status, resource_id=resource_id, path=path, layer=layer)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(
+        blob["path"],
+        media_type=blob["media_type"],
+        filename=blob["filename"],
+        content_disposition_type="inline",
+    )
+
+
 async def _update_project_draft_file_payload(
     run: AgentRun | None,
     *,
@@ -943,6 +989,27 @@ async def get_idea_project_context_draft_file(
         run,
         idea_id=idea_id,
         path=path,
+        resource_id=resource_id,
+        user=user,
+    )
+
+
+@router.get("/ideas/{idea_id}/project-context/draft-file/blob")
+async def get_idea_project_context_draft_file_blob(
+    idea_id: str,
+    path: str,
+    layer: str = "draft",
+    run_id: int | None = None,
+    resource_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _project_draft_file_blob_response(
+        run,
+        idea_id=idea_id,
+        path=path,
+        layer=layer,
         resource_id=resource_id,
         user=user,
     )

--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -22,6 +22,7 @@ from brain.systems.cortex.project_context.github import (
 )
 from brain.systems.cortex.project_context.browser import (
     project_file_payload,
+    update_project_draft_file,
     with_project_file_browser,
 )
 from brain.systems.cortex.project_context.identity import stamped_project_context
@@ -41,6 +42,7 @@ from brain.systems.cortex.project_context.schemas import (
     GitHubVaultTokenRequest,
     IdeaProjectAttachmentCreate,
     IdeaProjectAttachmentRead,
+    ProjectDraftFileUpdate,
     ProjectProfileCreate,
     ProjectProfileRead,
     ProjectProfileUpdate,
@@ -500,6 +502,47 @@ async def _project_draft_file_payload(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+async def _update_project_draft_file_payload(
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    body: ProjectDraftFileUpdate,
+    user: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+
+    run_id = str(getattr(run, "id", "") or "")
+    org_id = str(getattr(run, "org_id", "") or (user or {}).get("org_id") or "") or None
+    user_id = str(getattr(run, "user_id", "") or (user or {}).get("id") or "") or None
+    context = {
+        "run": run,
+        "run_id": run_id,
+        "idea_id": str(idea_id),
+        "org_id": org_id,
+        "user_id": user_id,
+        "execution_metadata": {
+            "run_id": run_id,
+            "idea_id": str(idea_id),
+            "org_id": org_id,
+            "user_id": user_id,
+        },
+    }
+    with bind_agent_context(context):
+        draft_status = await _manage_project_payload("draft_status")
+    if not draft_status.get("ok"):
+        raise HTTPException(status_code=404, detail=draft_status.get("error") or "Project draft state is unavailable.")
+    try:
+        return update_project_draft_file(
+            draft_status,
+            resource_id=body.resource_id,
+            path=body.path,
+            content=body.content,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
 async def _project_draft_state_run(
     db: AsyncSession,
     idea_id: str,
@@ -901,6 +944,23 @@ async def get_idea_project_context_draft_file(
         idea_id=idea_id,
         path=path,
         resource_id=resource_id,
+        user=user,
+    )
+
+
+@router.patch("/ideas/{idea_id}/project-context/draft-file")
+async def update_idea_project_context_draft_file(
+    idea_id: str,
+    body: ProjectDraftFileUpdate,
+    run_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _update_project_draft_file_payload(
+        run,
+        idea_id=idea_id,
+        body=body,
         user=user,
     )
 

--- a/brain/systems/cortex/project_context/browser.py
+++ b/brain/systems/cortex/project_context/browser.py
@@ -1,7 +1,8 @@
-"""Read-only Project draft browser payloads for the thread UI."""
+"""Project draft browser payloads for the thread UI."""
 from __future__ import annotations
 
 from collections.abc import Mapping
+import os
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -14,6 +15,7 @@ from brain.systems.cortex.project_context.drafts import (
 
 MAX_BROWSER_FILES = 2_000
 MAX_FILE_PREVIEW_BYTES = 120_000
+MAX_FILE_UPDATE_BYTES = 2_000_000
 _TEXT_EXTENSIONS = {
     ".css",
     ".csv",
@@ -251,6 +253,30 @@ def _resolve_file_path(root: Path | None, relative_path: str) -> Path | None:
     return root / relative_path
 
 
+def _writable_draft_file(root: Path | None, relative_path: str) -> Path:
+    if root is None:
+        raise ValueError("Project draft workspace is not writable for this file.")
+    root = root.expanduser()
+    if root.is_file():
+        if relative_path != root.name:
+            raise ValueError("Project file path is outside the draft resource.")
+        if root.is_symlink():
+            raise ValueError("Project draft file cannot be a symlink.")
+        return root
+
+    target = root / relative_path
+    if target.exists() and target.is_symlink():
+        raise ValueError("Project draft file cannot be a symlink.")
+    if target.exists() and not target.is_file():
+        raise ValueError("Project draft path is not a regular file.")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    root_resolved = root.resolve()
+    parent_resolved = target.parent.resolve()
+    if os.path.commonpath([str(root_resolved), str(parent_resolved)]) != str(root_resolved):
+        raise ValueError("Project file path must stay inside the mounted Project resource.")
+    return target
+
+
 def _read_text_layer(path: Path | None) -> dict[str, Any]:
     if path is None:
         return {"exists": False}
@@ -312,6 +338,38 @@ def project_file_payload(
             "base": _read_text_layer(base_file),
             "draft": _read_text_layer(draft_file),
         },
+    }
+
+
+def update_project_draft_file(
+    draft_status: Mapping[str, Any],
+    *,
+    resource_id: str | None,
+    path: str,
+    content: str,
+) -> dict[str, Any]:
+    """Write a text file into the thread draft overlay and return its refreshed preview."""
+
+    relative_path = _safe_relative_path(path)
+    encoded = content.encode("utf-8")
+    if len(encoded) > MAX_FILE_UPDATE_BYTES:
+        raise ValueError("Project draft file update is too large.")
+
+    resources = [resource for resource in draft_status.get("resources") or [] if isinstance(resource, Mapping)]
+    resource = _select_resource(resources, resource_id, relative_path)
+    if resource is None:
+        raise ValueError("Project resource not found for selected file.")
+
+    draft = _root_path(resource.get("workspace_path") or resource.get("resource_path"))
+    target = _writable_draft_file(draft, relative_path)
+    try:
+        target.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Project draft file could not be updated: {exc}") from exc
+
+    return {
+        **project_file_payload(draft_status, resource_id=resource_id, path=relative_path),
+        "updated": True,
     }
 
 

--- a/brain/systems/cortex/project_context/browser.py
+++ b/brain/systems/cortex/project_context/browser.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import mimetypes
 import os
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -338,6 +339,44 @@ def project_file_payload(
             "base": _read_text_layer(base_file),
             "draft": _read_text_layer(draft_file),
         },
+    }
+
+
+def project_file_blob(
+    draft_status: Mapping[str, Any],
+    *,
+    resource_id: str | None,
+    path: str,
+    layer: str,
+) -> dict[str, Any]:
+    """Resolve a selected root/base/draft file for browser-native previews."""
+
+    relative_path = _safe_relative_path(path)
+    layer_key = _clean_text(layer).lower() or "draft"
+    if layer_key not in {"root", "base", "draft"}:
+        raise ValueError("Project file layer must be root, base, or draft.")
+
+    resources = [resource for resource in draft_status.get("resources") or [] if isinstance(resource, Mapping)]
+    resource = _select_resource(resources, resource_id, relative_path)
+    if resource is None:
+        raise ValueError("Project resource not found for selected file.")
+
+    root = _root_path(resource.get("source_path"))
+    draft = _root_path(resource.get("workspace_path") or resource.get("resource_path"))
+    if layer_key == "root":
+        file_path = _resolve_file_path(root, relative_path)
+    elif layer_key == "base":
+        file_path = draft / DRAFT_METADATA_DIR / "base" / relative_path if draft is not None else None
+    else:
+        file_path = _resolve_file_path(draft, relative_path)
+
+    if file_path is None or not file_path.exists() or not file_path.is_file() or file_path.is_symlink():
+        raise ValueError("Project file layer is not available for preview.")
+    media_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+    return {
+        "path": file_path,
+        "filename": file_path.name,
+        "media_type": media_type,
     }
 
 

--- a/brain/systems/cortex/project_context/browser.py
+++ b/brain/systems/cortex/project_context/browser.py
@@ -1,0 +1,346 @@
+"""Read-only Project draft browser payloads for the thread UI."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from brain.systems.cortex.project_context.drafts import (
+    DRAFT_METADATA_DIR,
+    build_file_manifest,
+    load_draft_metadata,
+)
+
+
+MAX_BROWSER_FILES = 2_000
+MAX_FILE_PREVIEW_BYTES = 120_000
+_TEXT_EXTENSIONS = {
+    ".css",
+    ".csv",
+    ".html",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".py",
+    ".rst",
+    ".svelte",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _root_path(value: Any) -> Path | None:
+    text = _clean_text(value)
+    if not text:
+        return None
+    return Path(text).expanduser()
+
+
+def _safe_relative_path(value: Any) -> str:
+    text = _clean_text(value).replace("\\", "/").lstrip("/")
+    pure = PurePosixPath(text)
+    if not text or pure.is_absolute() or ".." in pure.parts:
+        raise ValueError("Project file path must stay inside the mounted Project resource.")
+    if pure.parts and pure.parts[0].startswith(".illo-project-"):
+        raise ValueError("Project internal metadata is not browsable.")
+    return pure.as_posix()
+
+
+def _manifest_for(root: Path | None) -> dict[str, dict[str, Any]]:
+    if root is None or not root.exists():
+        return {}
+    return build_file_manifest(root)
+
+
+def _base_manifest_for(draft_root: Path | None) -> dict[str, dict[str, Any]]:
+    if draft_root is None:
+        return {}
+    metadata = load_draft_metadata(draft_root)
+    base = metadata.get("base_manifest")
+    if not isinstance(base, Mapping):
+        return {}
+    return {str(path): dict(entry) for path, entry in base.items() if isinstance(entry, Mapping)}
+
+
+def _path_set(changes: Mapping[str, Any], key: str) -> set[str]:
+    values = changes.get(key)
+    if not isinstance(values, list):
+        return set()
+    paths: set[str] = set()
+    for value in values:
+        if isinstance(value, str):
+            path = value.strip()
+        elif isinstance(value, Mapping):
+            path = _clean_text(value.get("path") or value.get("relative_path") or value.get("name"))
+        else:
+            path = ""
+        if path:
+            paths.add(path)
+    return paths
+
+
+def _entry_status(
+    path: str,
+    *,
+    root_entry: Mapping[str, Any] | None,
+    draft_entry: Mapping[str, Any] | None,
+    base_entry: Mapping[str, Any] | None,
+    changes: Mapping[str, Any],
+) -> str:
+    if path in _path_set(changes, "conflicted_paths"):
+        return "conflicted"
+    if path in _path_set(changes, "deleted_paths"):
+        return "deleted"
+    if path in _path_set(changes, "new_paths"):
+        return "new"
+    if path in _path_set(changes, "changed_paths"):
+        return "changed"
+    if path in _path_set(changes, "out_of_date_paths"):
+        return "out_of_date"
+    if draft_entry is None and base_entry is not None:
+        return "deleted"
+    if draft_entry is not None and root_entry is None and base_entry is None:
+        return "new"
+    if draft_entry is not None and base_entry is not None and dict(draft_entry) != dict(base_entry):
+        return "changed"
+    if draft_entry is not None and root_entry is not None and dict(draft_entry) != dict(root_entry):
+        return "changed"
+    if path in _path_set(changes, "out_of_date_paths"):
+        return "out_of_date"
+    return "clean"
+
+
+def _file_name(path: str) -> str:
+    return PurePosixPath(path).name or path
+
+
+def _file_parent(path: str) -> str:
+    parent = PurePosixPath(path).parent.as_posix()
+    return "" if parent == "." else parent
+
+
+def project_resource_file_browser(
+    resource: Mapping[str, Any],
+    *,
+    max_files: int = MAX_BROWSER_FILES,
+) -> dict[str, Any]:
+    """Return a bounded file list for one materialized Project resource."""
+
+    root = _root_path(resource.get("source_path"))
+    draft = _root_path(resource.get("workspace_path") or resource.get("resource_path"))
+    root_manifest = _manifest_for(root)
+    draft_manifest = _manifest_for(draft)
+    base_manifest = _base_manifest_for(draft)
+    changes = _as_mapping(resource.get("changes"))
+    change_paths = set().union(*(
+        _path_set(changes, key)
+        for key in ("changed_paths", "new_paths", "deleted_paths", "conflicted_paths", "out_of_date_paths")
+    ))
+    all_paths = sorted(set(root_manifest) | set(draft_manifest) | set(base_manifest) | change_paths)
+    visible_paths = all_paths[:max_files]
+    entries: list[dict[str, Any]] = []
+
+    for path in visible_paths:
+        root_entry = root_manifest.get(path)
+        draft_entry = draft_manifest.get(path)
+        base_entry = base_manifest.get(path)
+        status = _entry_status(
+            path,
+            root_entry=root_entry,
+            draft_entry=draft_entry,
+            base_entry=base_entry,
+            changes=changes,
+        )
+        size = (draft_entry or root_entry or base_entry or {}).get("size")
+        entries.append({
+            "path": path,
+            "name": _file_name(path),
+            "parent": _file_parent(path),
+            "extension": PurePosixPath(path).suffix.lower(),
+            "status": status,
+            "layer": "draft" if draft_entry is not None else "root",
+            "has_root": root_entry is not None,
+            "has_draft": draft_entry is not None,
+            "has_base": base_entry is not None,
+            "size": size,
+            "root_size": root_entry.get("size") if root_entry else None,
+            "draft_size": draft_entry.get("size") if draft_entry else None,
+            "root_sha256": root_entry.get("sha256") if root_entry else None,
+            "draft_sha256": draft_entry.get("sha256") if draft_entry else None,
+            "conflicted": status == "conflicted",
+            "out_of_date": status == "out_of_date",
+        })
+
+    return {
+        "entries": entries,
+        "summary": {
+            "file_count": len(all_paths),
+            "visible_count": len(entries),
+            "truncated": max(0, len(all_paths) - len(entries)),
+        },
+    }
+
+
+def with_project_file_browser(draft_status: Mapping[str, Any]) -> dict[str, Any]:
+    """Attach read-only browser entries to a draft-status payload."""
+
+    payload = dict(draft_status)
+    resources = payload.get("resources")
+    if not isinstance(resources, list):
+        payload["file_browser"] = {"entries": [], "summary": {"file_count": 0, "visible_count": 0, "truncated": 0}}
+        return payload
+
+    next_resources: list[dict[str, Any]] = []
+    aggregate_entries: list[dict[str, Any]] = []
+    total_files = 0
+    total_truncated = 0
+    for resource in resources:
+        if not isinstance(resource, Mapping):
+            continue
+        item = dict(resource)
+        browser = project_resource_file_browser(item)
+        item["file_browser"] = browser
+        summary = _as_mapping(browser.get("summary"))
+        total_files += int(summary.get("file_count") or 0)
+        total_truncated += int(summary.get("truncated") or 0)
+        for entry in browser.get("entries") or []:
+            if isinstance(entry, Mapping):
+                aggregate_entries.append({
+                    **dict(entry),
+                    "resource_id": item.get("id"),
+                    "mount_path": item.get("mount_path"),
+                    "resource_label": item.get("label"),
+                })
+        next_resources.append(item)
+
+    payload["resources"] = next_resources
+    payload["file_browser"] = {
+        "entries": aggregate_entries,
+        "summary": {
+            "file_count": total_files,
+            "visible_count": len(aggregate_entries),
+            "truncated": total_truncated,
+        },
+    }
+    return payload
+
+
+def _resolve_file_path(root: Path | None, relative_path: str) -> Path | None:
+    if root is None:
+        return None
+    root = root.expanduser()
+    if root.is_file():
+        if relative_path != root.name:
+            return None
+        return root
+    return root / relative_path
+
+
+def _read_text_layer(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {"exists": False}
+    try:
+        if not path.exists() or not path.is_file() or path.is_symlink():
+            return {"exists": False}
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_FILE_PREVIEW_BYTES + 1)
+        truncated = len(raw) > MAX_FILE_PREVIEW_BYTES
+        raw = raw[:MAX_FILE_PREVIEW_BYTES]
+        suffix = path.suffix.lower()
+        is_probably_text = suffix in _TEXT_EXTENSIONS or b"\x00" not in raw[:4096]
+        if not is_probably_text:
+            return {"exists": True, "binary": True, "size": size, "truncated": False}
+        return {
+            "exists": True,
+            "binary": False,
+            "size": size,
+            "content": raw.decode("utf-8", errors="replace"),
+            "truncated": truncated,
+        }
+    except OSError as exc:
+        return {"exists": False, "error": str(exc)}
+
+
+def project_file_payload(
+    draft_status: Mapping[str, Any],
+    *,
+    resource_id: str | None,
+    path: str,
+) -> dict[str, Any]:
+    """Return bounded root/base/draft contents for a selected Project file."""
+
+    relative_path = _safe_relative_path(path)
+    resources = [resource for resource in draft_status.get("resources") or [] if isinstance(resource, Mapping)]
+    resource = _select_resource(resources, resource_id, relative_path)
+    if resource is None:
+        raise ValueError("Project resource not found for selected file.")
+
+    root = _root_path(resource.get("source_path"))
+    draft = _root_path(resource.get("workspace_path") or resource.get("resource_path"))
+    root_file = _resolve_file_path(root, relative_path)
+    draft_file = _resolve_file_path(draft, relative_path)
+    base_file = draft / DRAFT_METADATA_DIR / "base" / relative_path if draft is not None else None
+    entry = project_resource_file_browser(resource, max_files=MAX_BROWSER_FILES)
+    selected_entry = next(
+        (dict(item) for item in entry.get("entries") or [] if isinstance(item, Mapping) and item.get("path") == relative_path),
+        {"path": relative_path, "name": _file_name(relative_path), "status": "unknown"},
+    )
+    return {
+        "ok": True,
+        "resource_id": resource.get("id"),
+        "mount_path": resource.get("mount_path"),
+        "path": relative_path,
+        "entry": selected_entry,
+        "layers": {
+            "root": _read_text_layer(root_file),
+            "base": _read_text_layer(base_file),
+            "draft": _read_text_layer(draft_file),
+        },
+    }
+
+
+def _select_resource(
+    resources: list[Mapping[str, Any]],
+    resource_id: str | None,
+    relative_path: str,
+) -> Mapping[str, Any] | None:
+    if resource_id:
+        wanted = resource_id.strip()
+        for resource in resources:
+            candidates = {
+                _clean_text(resource.get("id")),
+                _clean_text(resource.get("mount_path")),
+                _clean_text(resource.get("label")),
+            }
+            if wanted in candidates:
+                return resource
+    if len(resources) == 1:
+        return resources[0]
+    for resource in resources:
+        browser = project_resource_file_browser(resource)
+        if any(isinstance(item, Mapping) and item.get("path") == relative_path for item in browser.get("entries") or []):
+            return resource
+    return None
+
+
+__all__ = [
+    "project_file_payload",
+    "project_resource_file_browser",
+    "with_project_file_browser",
+]

--- a/brain/systems/cortex/project_context/schemas.py
+++ b/brain/systems/cortex/project_context/schemas.py
@@ -94,6 +94,12 @@ class IdeaProjectAttachmentRead(BaseModel):
     created_at: datetime | None = None
 
 
+class ProjectDraftFileUpdate(BaseModel):
+    resource_id: str | None = None
+    path: str = Field(..., min_length=1)
+    content: str
+
+
 class GitHubVaultTokenRequest(BaseModel):
     vault_key: str = Field(..., min_length=1, max_length=255)
 

--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -16,9 +16,11 @@ PROMPT_DICT_ITEM_LIMIT = 48
 PromptPath = tuple[str, ...]
 
 PROJECT_REFERENCE_HEAVY_PATHS: tuple[PromptPath, ...] = (
+    ("project_context_snapshot", "resources", "*", "content"),
     ("project_context_snapshot", "resources", "*", "uploaded_files"),
     ("project_context_snapshot", "resources", "*", "materialization", "imports"),
     ("project_context_snapshot", "resources", "*", "materialization", "root_versions"),
+    ("project_runtime_context", "project_context_snapshot", "resources", "*", "content"),
     ("project_runtime_context", "project_context_snapshot", "resources", "*", "uploaded_files"),
     ("project_runtime_context", "project_context_snapshot", "resources", "*", "materialization", "imports"),
     ("project_runtime_context", "project_context_snapshot", "resources", "*", "materialization", "root_versions"),
@@ -93,8 +95,6 @@ def _compact_heavy_value(value: Any) -> dict[str, Any]:
     else:
         text = str(value or "")
         summary["char_count"] = len(text)
-        if text:
-            summary["preview"] = _truncate_scalar(text, 160)
     return summary
 
 
@@ -248,4 +248,4 @@ class RunContextLoader:
         )
 
 
-__all__ = ["RunContext", "RunContextLoader"]
+__all__ = ["RunContext", "RunContextLoader", "compact_project_reference"]

--- a/brain/systems/runs/direct_loop/context_recovery.py
+++ b/brain/systems/runs/direct_loop/context_recovery.py
@@ -13,6 +13,7 @@ _CONTEXT_OVERFLOW_PATTERNS = (
     re.compile(r"input is too long", re.IGNORECASE),
     re.compile(r"request too large", re.IGNORECASE),
     re.compile(r"prompt is too long", re.IGNORECASE),
+    re.compile(r"instructions.*string too long", re.IGNORECASE),
     re.compile(r"token limit", re.IGNORECASE),
     re.compile(r"exceeds? the model", re.IGNORECASE),
 )
@@ -75,4 +76,3 @@ def context_overflow_payload(exc: Exception, *, provider_name: str | None = None
         "request_id": headers.get("x-request-id") or headers.get("request-id"),
         "message": text[:1_000],
     }
-

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from brain.systems.runs.assignments import WorkerAssignment
+from brain.systems.runs.context import compact_project_reference
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
 from brain.systems.runs.recipes.base import BaseRunRecipe
@@ -106,11 +107,12 @@ class WorkerRecipe(BaseRunRecipe):
         async def _guidance() -> list[str]:
             return await runtime.drain_steering()
 
+        prompt_context = context.prompt_context()
         system_prompt = build_worker_prompt(
             assignment,
             target_ref=runtime.request.target_ref,
             workspace_ref=runtime.request.workspace_ref,
-            context=context.prompt_context(),
+            context=prompt_context,
             evidence_so_far=runtime.request.metadata.get("evidence") or runtime.request.metadata.get("parent_evidence"),
         )
         await runtime.activity("Starting scoped worker", workspace_root=workspace_root)
@@ -133,7 +135,7 @@ class WorkerRecipe(BaseRunRecipe):
             on_stream_activity=_activity,
             on_stream_delta=_delta,
             live_guidance_loader=_guidance,
-            brain_context_preloaded=bool(context.prompt_context()),
+            brain_context_preloaded=bool(prompt_context or runtime.request.target_ref or runtime.request.workspace_ref),
             skip_harvest=True,
             metadata={
                 "profile": str(runtime.request.normalized_profile.value),
@@ -219,13 +221,19 @@ def build_worker_prompt(
     context: str = "",
     evidence_so_far: Any = None,
 ) -> str:
+    context_block = context
+    if not context_block:
+        context_parts = []
+        if target_ref:
+            context_parts.append("Target:\n" + compact_project_reference(target_ref))
+        if workspace_ref:
+            context_parts.append("Workspace:\n" + compact_project_reference(workspace_ref))
+        context_block = "\n\n".join(context_parts)
     return (
         WORKER_AGENT_INSTRUCTIONS
         + _json_block("Worker Assignment", assignment.to_payload())
-        + _json_block("Target", target_ref)
-        + _json_block("Workspace", workspace_ref)
         + _json_block("Parent Evidence", evidence_so_far)
-        + (f"\n\n## Context\n{context}" if context else "")
+        + (f"\n\n## Context\n{context_block}" if context_block else "")
     )
 
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -633,6 +633,37 @@ export interface ProjectDraftChangeSet {
   out_of_date_paths?: string[];
 }
 
+export interface ProjectDraftFileEntry {
+  path: string;
+  name?: string | null;
+  parent?: string | null;
+  extension?: string | null;
+  status?: string | null;
+  layer?: 'root' | 'draft' | string | null;
+  resource_id?: string | null;
+  mount_path?: string | null;
+  resource_label?: string | null;
+  has_root?: boolean;
+  has_base?: boolean;
+  has_draft?: boolean;
+  size?: number | null;
+  root_size?: number | null;
+  draft_size?: number | null;
+  root_sha256?: string | null;
+  draft_sha256?: string | null;
+  conflicted?: boolean;
+  out_of_date?: boolean;
+}
+
+export interface ProjectDraftFileBrowser {
+  entries?: ProjectDraftFileEntry[];
+  summary?: {
+    file_count?: number;
+    visible_count?: number;
+    truncated?: number;
+  } | Record<string, any> | null;
+}
+
 export interface ProjectDraftResourceState {
   id: string;
   label?: string | null;
@@ -653,6 +684,7 @@ export interface ProjectDraftResourceState {
   changes?: ProjectDraftChangeSet;
   root_versions_summary?: Record<string, any> | null;
   root_versions?: Record<string, any> | null;
+  file_browser?: ProjectDraftFileBrowser | null;
 }
 
 export interface ProjectRootVersionState {
@@ -711,6 +743,7 @@ export interface ProjectDraftStateRead {
   workspaces?: Array<Record<string, any>>;
   materialization?: Record<string, any>;
   resources?: ProjectDraftResourceState[];
+  file_browser?: ProjectDraftFileBrowser | null;
   changes?: {
     counts?: Partial<Record<ProjectDraftChangeKey, number>>;
     total?: number;
@@ -726,6 +759,28 @@ export interface ProjectDraftStateRead {
   };
   root_versions_summary?: Record<string, any>;
   summary?: Record<string, any>;
+}
+
+export interface ProjectDraftFileLayer {
+  exists?: boolean;
+  binary?: boolean;
+  size?: number;
+  content?: string;
+  truncated?: boolean;
+  error?: string;
+}
+
+export interface ProjectDraftFileResponse {
+  ok: boolean;
+  resource_id?: string | null;
+  mount_path?: string | null;
+  path: string;
+  entry?: ProjectDraftFileEntry;
+  layers?: {
+    root?: ProjectDraftFileLayer;
+    base?: ProjectDraftFileLayer;
+    draft?: ProjectDraftFileLayer;
+  };
 }
 
 export interface ProjectDraftStateResponse {
@@ -982,6 +1037,17 @@ export const api = {
     fetchJson<ProjectDraftStateResponse>(
       withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-state`, {
         run_id: options.runId,
+      }),
+    ),
+  getIdeaProjectDraftFile: (
+    ideaId: string,
+    options: { runId?: string | number | null; resourceId?: string | null; path: string },
+  ) =>
+    fetchJson<ProjectDraftFileResponse>(
+      withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-file`, {
+        run_id: options.runId,
+        resource_id: options.resourceId,
+        path: options.path,
       }),
     ),
   deleteIdea: (id: string) =>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -783,6 +783,13 @@ export interface ProjectDraftFileResponse {
   };
 }
 
+export interface ProjectDraftFileUpdateInput {
+  runId?: string | number | null;
+  resourceId?: string | null;
+  path: string;
+  content: string;
+}
+
 export interface ProjectDraftStateResponse {
   ok: boolean;
   code?: string;
@@ -1049,6 +1056,23 @@ export const api = {
         resource_id: options.resourceId,
         path: options.path,
       }),
+    ),
+  updateIdeaProjectDraftFile: (
+    ideaId: string,
+    data: ProjectDraftFileUpdateInput,
+  ) =>
+    fetchJson<ProjectDraftFileResponse>(
+      withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-file`, {
+        run_id: data.runId,
+      }),
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          resource_id: data.resourceId,
+          path: data.path,
+          content: data.content,
+        }),
+      },
     ),
   deleteIdea: (id: string) =>
     fetchJson<any>(`/api/cortex/ideas/${id}`, { method: 'DELETE' }),

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1057,6 +1057,21 @@ export const api = {
         path: options.path,
       }),
     ),
+  getIdeaProjectDraftFileBlobUrl: (
+    ideaId: string,
+    options: {
+      runId?: string | number | null;
+      resourceId?: string | null;
+      path: string;
+      layer?: 'root' | 'base' | 'draft';
+    },
+  ) =>
+    withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-file/blob`, {
+      run_id: options.runId,
+      resource_id: options.resourceId,
+      path: options.path,
+      layer: options.layer,
+    }),
   updateIdeaProjectDraftFile: (
     ideaId: string,
     data: ProjectDraftFileUpdateInput,

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -18,6 +18,7 @@ export type UploadPreview = Awaited<ReturnType<typeof api.previewUpload>>;
 export type ThreadProjectContextAttachment = Awaited<ReturnType<typeof api.listIdeaProjectContext>>[number];
 export type AttachThreadProjectContextInput = Parameters<typeof api.attachIdeaProjectContext>[1];
 export type ThreadProjectDraftState = Awaited<ReturnType<typeof api.getIdeaProjectDraftState>>;
+export type ThreadProjectDraftFile = Awaited<ReturnType<typeof api.getIdeaProjectDraftFile>>;
 export type ThreadActivityTimelineItem = Awaited<ReturnType<typeof api.activityTimeline>>[number];
 export type IdeaAudit = Awaited<ReturnType<typeof api.ideaAudit>>;
 export type IdeaAuditAnalysisResult = Awaited<ReturnType<typeof api.ideaAuditAnalysisResult>>;
@@ -52,6 +53,7 @@ type ThreadApiMethods = {
   listIdeaProjectContext: typeof api.listIdeaProjectContext;
   attachIdeaProjectContext: typeof api.attachIdeaProjectContext;
   getIdeaProjectDraftState: typeof api.getIdeaProjectDraftState;
+  getIdeaProjectDraftFile: typeof api.getIdeaProjectDraftFile;
   ideaAudit: typeof api.ideaAudit;
   ideaAuditAnalyze: typeof api.ideaAuditAnalyze;
   ideaAuditAnalysisResult: typeof api.ideaAuditAnalysisResult;
@@ -85,6 +87,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'listIdeaProjectContext',
   'attachIdeaProjectContext',
   'getIdeaProjectDraftState',
+  'getIdeaProjectDraftFile',
   'ideaAudit',
   'ideaAuditAnalyze',
   'ideaAuditAnalysisResult',
@@ -118,6 +121,7 @@ export const {
   listIdeaProjectContext,
   attachIdeaProjectContext,
   getIdeaProjectDraftState,
+  getIdeaProjectDraftFile,
   ideaAudit,
   ideaAuditAnalyze,
   ideaAuditAnalysisResult,

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -55,6 +55,7 @@ type ThreadApiMethods = {
   attachIdeaProjectContext: typeof api.attachIdeaProjectContext;
   getIdeaProjectDraftState: typeof api.getIdeaProjectDraftState;
   getIdeaProjectDraftFile: typeof api.getIdeaProjectDraftFile;
+  getIdeaProjectDraftFileBlobUrl: typeof api.getIdeaProjectDraftFileBlobUrl;
   updateIdeaProjectDraftFile: typeof api.updateIdeaProjectDraftFile;
   ideaAudit: typeof api.ideaAudit;
   ideaAuditAnalyze: typeof api.ideaAuditAnalyze;
@@ -90,6 +91,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'attachIdeaProjectContext',
   'getIdeaProjectDraftState',
   'getIdeaProjectDraftFile',
+  'getIdeaProjectDraftFileBlobUrl',
   'updateIdeaProjectDraftFile',
   'ideaAudit',
   'ideaAuditAnalyze',
@@ -125,6 +127,7 @@ export const {
   attachIdeaProjectContext,
   getIdeaProjectDraftState,
   getIdeaProjectDraftFile,
+  getIdeaProjectDraftFileBlobUrl,
   updateIdeaProjectDraftFile,
   ideaAudit,
   ideaAuditAnalyze,

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -19,6 +19,7 @@ export type ThreadProjectContextAttachment = Awaited<ReturnType<typeof api.listI
 export type AttachThreadProjectContextInput = Parameters<typeof api.attachIdeaProjectContext>[1];
 export type ThreadProjectDraftState = Awaited<ReturnType<typeof api.getIdeaProjectDraftState>>;
 export type ThreadProjectDraftFile = Awaited<ReturnType<typeof api.getIdeaProjectDraftFile>>;
+export type ThreadProjectDraftFileUpdateInput = Parameters<typeof api.updateIdeaProjectDraftFile>[1];
 export type ThreadActivityTimelineItem = Awaited<ReturnType<typeof api.activityTimeline>>[number];
 export type IdeaAudit = Awaited<ReturnType<typeof api.ideaAudit>>;
 export type IdeaAuditAnalysisResult = Awaited<ReturnType<typeof api.ideaAuditAnalysisResult>>;
@@ -54,6 +55,7 @@ type ThreadApiMethods = {
   attachIdeaProjectContext: typeof api.attachIdeaProjectContext;
   getIdeaProjectDraftState: typeof api.getIdeaProjectDraftState;
   getIdeaProjectDraftFile: typeof api.getIdeaProjectDraftFile;
+  updateIdeaProjectDraftFile: typeof api.updateIdeaProjectDraftFile;
   ideaAudit: typeof api.ideaAudit;
   ideaAuditAnalyze: typeof api.ideaAuditAnalyze;
   ideaAuditAnalysisResult: typeof api.ideaAuditAnalysisResult;
@@ -88,6 +90,7 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'attachIdeaProjectContext',
   'getIdeaProjectDraftState',
   'getIdeaProjectDraftFile',
+  'updateIdeaProjectDraftFile',
   'ideaAudit',
   'ideaAuditAnalyze',
   'ideaAuditAnalysisResult',
@@ -122,6 +125,7 @@ export const {
   attachIdeaProjectContext,
   getIdeaProjectDraftState,
   getIdeaProjectDraftFile,
+  updateIdeaProjectDraftFile,
   ideaAudit,
   ideaAuditAnalyze,
   ideaAuditAnalysisResult,

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -438,59 +438,64 @@
         <div class="project-draft-empty">No browsable files found in this Project.</div>
       {:else}
         <div class="project-browser-layout" data-tree-collapsed={fileTreeCollapsed}>
-          {#if !fileTreeCollapsed}
-            <div id="project-file-tree" class="project-file-tree" aria-label="Project files">
-              {#each visibleRows as row (row.key)}
-                {#if row.kind === 'directory'}
-                  <button
-                    type="button"
-                    class="project-tree-row project-tree-directory"
-                    style={rowStyle(row)}
-                    data-tone={rowTone(row)}
-                    aria-expanded={!directoryCollapsed(row)}
-                    title={row.displayPath}
-                    onclick={() => toggleDirectory(row)}
-                  >
-                    <span class="project-tree-folder-glyph" aria-hidden="true">
-                      <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
-                      <ConstellationIcon name="folder" size={14} />
-                    </span>
-                    <span title={row.displayPath}>{row.name}</span>
-                    <small>{row.fileCount}</small>
-                  </button>
-                {:else}
-                  <button
-                    type="button"
-                    class="project-tree-row project-tree-file"
-                    class:project-tree-file-selected={selectedFileKey === row.key}
-                    style={rowStyle(row)}
-                    data-tone={rowTone(row)}
-                    title={row.displayPath}
-                    onclick={() => selectFile(row)}
-                  >
-                    <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
-                      <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
-                    </span>
-                    <span>{row.name}</span>
-                    <small>{projectFileStatusLabel(row.status)}</small>
-                  </button>
-                {/if}
-              {/each}
-            </div>
-          {/if}
-
-          <div class="project-tree-rail" aria-label="File tree controls">
+          <div
+            id="project-file-tree"
+            class="project-file-tree"
+            data-collapsed={fileTreeCollapsed}
+            aria-label="Project files"
+          >
             <button
               type="button"
-              class="project-tree-rail-toggle"
+              class="project-tree-row project-tree-collapse-action"
               aria-expanded={!fileTreeCollapsed}
               aria-controls="project-file-tree"
-              title={fileTreeCollapsed ? 'Show files' : 'Collapse file tree'}
+              aria-label={fileTreeCollapsed ? 'Expand file tree' : 'Collapse file tree'}
+              title={fileTreeCollapsed ? 'Expand file tree' : 'Collapse file tree'}
               onclick={toggleFileTree}
             >
-              <ConstellationIcon name={fileTreeCollapsed ? 'chevron-right' : 'chevron-left'} size={12} />
-              <span>{fileTreeCollapsed ? 'Files' : 'Collapse'}</span>
+              <span class="project-tree-file-glyph" aria-hidden="true">
+                <ConstellationIcon name="side-panel" size={14} />
+              </span>
+              <span class="project-tree-label">{fileTreeCollapsed ? 'Files' : 'Collapse files'}</span>
+              <small>{fileTreeCollapsed ? 'open' : 'hide'}</small>
             </button>
+
+            {#each visibleRows as row (row.key)}
+              {#if row.kind === 'directory'}
+                <button
+                  type="button"
+                  class="project-tree-row project-tree-directory"
+                  style={rowStyle(row)}
+                  data-tone={rowTone(row)}
+                  aria-expanded={!directoryCollapsed(row)}
+                  title={row.displayPath}
+                  onclick={() => toggleDirectory(row)}
+                >
+                  <span class="project-tree-folder-glyph" aria-hidden="true">
+                    <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
+                    <ConstellationIcon name="folder" size={14} />
+                  </span>
+                  <span class="project-tree-label" title={row.displayPath}>{row.name}</span>
+                  <small>{row.fileCount}</small>
+                </button>
+              {:else}
+                <button
+                  type="button"
+                  class="project-tree-row project-tree-file"
+                  class:project-tree-file-selected={selectedFileKey === row.key}
+                  style={rowStyle(row)}
+                  data-tone={rowTone(row)}
+                  title={row.displayPath}
+                  onclick={() => selectFile(row)}
+                >
+                  <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
+                    <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
+                  </span>
+                  <span class="project-tree-label">{row.name}</span>
+                  <small>{projectFileStatusLabel(row.status)}</small>
+                </button>
+              {/if}
+            {/each}
           </div>
 
           <div class="project-file-preview" aria-live="polite">
@@ -1032,78 +1037,77 @@
   }
 
   .project-browser-layout {
+    --project-tree-collapsed-width: var(--constellation-nav-rail-collapsed-width, 54px);
+    --project-tree-expanded-width: minmax(190px, 0.72fr);
     display: grid;
-    grid-template-columns: minmax(190px, 0.72fr) 28px minmax(0, 1.55fr);
+    grid-template-columns: var(--project-tree-expanded-width) minmax(0, 1.55fr);
     min-height: min(72vh, 700px);
   }
 
   .project-browser-layout[data-tree-collapsed='true'] {
-    grid-template-columns: 28px minmax(0, 1fr);
+    grid-template-columns: var(--project-tree-collapsed-width) minmax(0, 1fr);
   }
 
   .project-file-tree {
+    position: relative;
+    z-index: 1;
     min-width: 0;
+    width: 100%;
     max-height: min(72vh, 700px);
     overflow: auto;
     padding: 6px;
-  }
-
-  .project-tree-rail {
-    display: grid;
-    align-content: stretch;
-    justify-items: center;
-    min-width: 0;
-    padding: 6px 3px;
-    border-left: 1px solid rgba(255, 255, 255, 0.055);
     border-right: 1px solid rgba(255, 255, 255, 0.055);
-    background: rgba(255, 255, 255, 0.018);
+    background: inherit;
+    transition:
+      width 180ms ease,
+      box-shadow 180ms ease;
   }
 
-  :global(:root[data-color-scheme='light']) .project-tree-rail {
-    border-color: rgba(85, 104, 120, 0.12);
-    background: rgba(85, 104, 120, 0.025);
+  .project-file-tree[data-collapsed='true'] {
+    width: var(--project-tree-collapsed-width);
+    overflow-x: hidden;
   }
 
-  .project-tree-rail-toggle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 6px;
-    width: 100%;
-    min-height: 132px;
-    border: 0;
-    border-radius: 7px;
-    padding: 8px 3px;
-    background: transparent;
-    color: rgba(231, 238, 247, 0.58);
-    font-size: 9px;
-    font-weight: 650;
-    line-height: 1;
-    cursor: pointer;
-    writing-mode: vertical-rl;
+  .project-file-tree[data-collapsed='true']:hover,
+  .project-file-tree[data-collapsed='true']:focus-within {
+    width: min(260px, calc(100vw - 56px));
+    box-shadow:
+      18px 0 34px rgba(0, 0, 0, 0.16),
+      inset -1px 0 0 rgba(255, 255, 255, 0.055);
   }
 
-  .project-tree-rail-toggle:hover {
-    background: rgba(255, 255, 255, 0.055);
-    color: rgba(239, 244, 251, 0.82);
+  :global(:root[data-color-scheme='light']) .project-file-tree {
+    border-right-color: rgba(85, 104, 120, 0.12);
   }
 
-  .project-tree-rail-toggle :global(svg) {
-    transform: rotate(90deg);
+  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:hover,
+  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:focus-within {
+    box-shadow:
+      18px 0 34px rgba(54, 70, 82, 0.11),
+      inset -1px 0 0 rgba(85, 104, 120, 0.12);
   }
 
-  .project-tree-rail-toggle span {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row {
+    grid-template-columns: 28px 0 0;
+    gap: 0;
+    padding-inline: 7px;
+    padding-left: 7px;
   }
 
-  :global(:root[data-color-scheme='light']) .project-tree-rail-toggle {
-    color: rgba(82, 98, 111, 0.68);
+  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-label,
+  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row small {
+    max-width: 0;
+    opacity: 0;
+    transform: translateX(-6px);
+    pointer-events: none;
   }
 
-  :global(:root[data-color-scheme='light']) .project-tree-rail-toggle:hover {
-    background: rgba(82, 117, 139, 0.08);
-    color: rgba(29, 39, 49, 0.82);
+  .project-tree-label,
+  .project-tree-row small {
+    transition:
+      max-width 180ms ease,
+      opacity 180ms ease,
+      transform 180ms ease;
   }
 
   .project-tree-row {
@@ -1128,20 +1132,35 @@
   }
 
   .project-tree-file,
-  .project-tree-directory {
+  .project-tree-directory,
+  .project-tree-collapse-action {
     cursor: pointer;
   }
 
   .project-tree-file:hover,
   .project-tree-directory:hover,
+  .project-tree-collapse-action:hover,
   .project-tree-file-selected {
     background: rgba(255, 255, 255, 0.055);
   }
 
   :global(:root[data-color-scheme='light']) .project-tree-file:hover,
   :global(:root[data-color-scheme='light']) .project-tree-directory:hover,
+  :global(:root[data-color-scheme='light']) .project-tree-collapse-action:hover,
   :global(:root[data-color-scheme='light']) .project-tree-file-selected {
     background: rgba(82, 117, 139, 0.08);
+  }
+
+  .project-tree-collapse-action {
+    color: rgba(231, 238, 247, 0.58);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-collapse-action {
+    color: rgba(82, 98, 111, 0.68);
   }
 
   .project-tree-directory {
@@ -1824,14 +1843,31 @@
   }
 
   @media (max-width: 720px) {
-    .project-browser-layout {
+    .project-browser-layout,
+    .project-browser-layout[data-tree-collapsed='true'] {
       grid-template-columns: minmax(0, 1fr);
     }
 
-    .project-file-tree {
+    .project-file-tree,
+    .project-file-tree[data-collapsed='true'] {
+      width: 100%;
       max-height: 260px;
       border-right: 0;
       border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+    }
+
+    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row {
+      grid-template-columns: 26px minmax(0, 1fr) auto;
+      gap: 7px;
+      padding: 5px 7px 5px calc(7px + (var(--depth) * 14px));
+    }
+
+    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-label,
+    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row small {
+      max-width: none;
+      opacity: 1;
+      transform: translateX(0);
+      pointer-events: auto;
     }
 
     :global(:root[data-color-scheme='light']) .project-file-tree {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -57,6 +57,7 @@
   let fileSaveLoading = $state(false);
   let fileSaveError = $state('');
   let fileSaveNotice = $state('');
+  let previewMode = $state<'review' | 'final'>('review');
 
   const draftView = $derived.by(() =>
     buildProjectDraftPanelView({ draftState, loading, loadError, runId }),
@@ -77,6 +78,7 @@
   const visibleRows = $derived(visibleProjectExplorerRows(fileBrowser.rows, collapsedDirectoryKeys));
   const previewView = $derived(buildProjectFilePreviewView(filePreview, selectedFile));
   const isEditingSelectedFile = $derived(Boolean(selectedFile && editingFileKey === selectedFile.key));
+  const activePreviewMode = $derived(previewMode === 'review' && previewView.mode === 'diff' ? 'review' : 'final');
 
   function metricCountLabel(value: number): string {
     return Number.isFinite(value) ? String(value) : '0';
@@ -92,12 +94,17 @@
 
   function selectFile(file: ProjectExplorerFile) {
     selectedFileKey = file.key;
+    previewMode = 'review';
     fileSaveError = '';
     fileSaveNotice = '';
     if (editingFileKey && editingFileKey !== file.key) {
       editingFileKey = '';
       editorContent = '';
     }
+  }
+
+  function setPreviewMode(mode: 'review' | 'final') {
+    previewMode = mode;
   }
 
   function directoryCollapsed(row: ProjectExplorerDirectory): boolean {
@@ -145,7 +152,8 @@
       editingFileKey = '';
       editorContent = '';
       loadedFileKey = `${ideaId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
-      fileSaveNotice = 'Thread draft updated.';
+      fileSaveNotice = 'Thread draft saved.';
+      previewMode = 'final';
       await loadDraftState(ideaId, currentRunId);
     } catch (error: any) {
       fileSaveError = error?.detail || error?.message || 'Project draft file could not be updated.';
@@ -223,6 +231,7 @@
     if (fileBrowser.files.length === 0) {
       selectedFileKey = '';
       collapsedDirectoryKeys = [];
+      previewMode = 'review';
       return;
     }
     if (selectedFileKey && fileBrowser.files.some((file) => file.key === selectedFileKey)) return;
@@ -374,11 +383,11 @@
                     type="button"
                     class="project-file-edit-button"
                     disabled={!previewView.canEdit || filePreviewLoading || fileSaveLoading}
-                    title={previewView.canEdit ? 'Update this file in the thread draft' : 'This file cannot be edited as text here'}
+                    title={previewView.canEdit ? 'Edit this file in the thread draft' : 'This file cannot be edited as text here'}
                     onclick={isEditingSelectedFile ? cancelFileEdit : beginFileEdit}
                   >
                     <ConstellationIcon name={isEditingSelectedFile ? 'close' : 'edit'} size={12} />
-                    <span>{isEditingSelectedFile ? 'Cancel' : 'Update'}</span>
+                    <span>{isEditingSelectedFile ? 'Cancel' : 'Edit'}</span>
                   </button>
                   <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
                     {projectFileStatusLabel(selectedFile.status)}
@@ -392,6 +401,25 @@
                 <span data-present={selectedFile.has_draft === true}>Draft</span>
               </div>
 
+              <div class="project-preview-mode-tabs" aria-label="Project file preview mode">
+                <button
+                  type="button"
+                  class:project-preview-mode-active={activePreviewMode === 'review'}
+                  disabled={previewView.mode !== 'diff' || isEditingSelectedFile}
+                  onclick={() => setPreviewMode('review')}
+                >
+                  Review
+                </button>
+                <button
+                  type="button"
+                  class:project-preview-mode-active={activePreviewMode === 'final'}
+                  disabled={isEditingSelectedFile}
+                  onclick={() => setPreviewMode('final')}
+                >
+                  Final
+                </button>
+              </div>
+
               {#if filePreviewLoading}
                 <div class="project-draft-empty">Loading file preview...</div>
               {:else if filePreviewError}
@@ -401,7 +429,7 @@
               {:else if isEditingSelectedFile}
                 <div class="project-file-editor">
                   <div class="project-preview-layer-head">
-                    <strong>Update thread draft</strong>
+                    <strong>Edit thread draft</strong>
                     <span>Saved changes stay in the draft until publish.</span>
                   </div>
                   <textarea
@@ -426,7 +454,7 @@
                 {#if fileSaveNotice}
                   <div class="project-file-save-message" data-tone="clean">{fileSaveNotice}</div>
                 {/if}
-                {#if previewView.mode === 'diff'}
+                {#if activePreviewMode === 'review' && previewView.mode === 'diff'}
                   <div class="project-preview-layer project-preview-diff">
                     <div class="project-preview-layer-head">
                       <strong>{previewView.title}</strong>
@@ -439,6 +467,16 @@
                           <code>{line.text || ' '}</code>
                         </div>
                       {/each}
+                    </div>
+                  </div>
+                {:else if previewView.finalLayer}
+                  <div class="project-preview-layers">
+                    <div class="project-preview-layer" data-layer={previewView.finalLayer.key}>
+                      <div class="project-preview-layer-head">
+                        <strong>{previewView.finalLayer.label}</strong>
+                        <span>{previewView.finalLayer.detail}</span>
+                      </div>
+                      <pre>{previewView.finalLayer.content}</pre>
                     </div>
                   </div>
                 {:else}
@@ -954,6 +992,55 @@
 
   .project-file-layer-strip span[data-present='true'] {
     color: color-mix(in srgb, var(--positive, #6BC785) 78%, white);
+  }
+
+  .project-preview-mode-tabs {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    max-width: 100%;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.065);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.035);
+  }
+
+  .project-preview-mode-tabs button {
+    min-width: 64px;
+    min-height: 26px;
+    border: 0;
+    border-radius: 0;
+    padding: 4px 10px;
+    background: transparent;
+    color: rgba(231, 238, 247, 0.56);
+    font-size: 10px;
+    font-weight: 650;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .project-preview-mode-tabs button:disabled {
+    cursor: default;
+    opacity: 0.42;
+  }
+
+  .project-preview-mode-tabs button.project-preview-mode-active {
+    background: rgba(255, 255, 255, 0.075);
+    color: rgba(239, 244, 251, 0.86);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-preview-mode-tabs {
+    border-color: rgba(85, 104, 120, 0.13);
+    background: rgba(85, 104, 120, 0.045);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-preview-mode-tabs button {
+    color: rgba(57, 70, 82, 0.58);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-preview-mode-tabs button.project-preview-mode-active {
+    background: rgba(255, 255, 255, 0.7);
+    color: rgba(29, 39, 49, 0.86);
   }
 
   .project-preview-layers {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -3,19 +3,23 @@
   import {
     getIdeaProjectDraftFile,
     getIdeaProjectDraftState,
+    updateIdeaProjectDraftFile,
   } from '$lib/features/threads/api/threadApi';
   import {
     buildProjectDraftPanelView,
+    buildProjectFilePreviewView,
     PROJECT_DRAFT_CHANGE_METRICS,
+    projectDirectoryAncestorKeys,
     projectFileLayerLabel,
     projectFileSizeLabel,
     projectFileStatusLabel,
     projectFileStatusTone,
+    visibleProjectExplorerRows,
     type ProjectExplorerFile,
+    type ProjectExplorerDirectory,
     type ProjectExplorerRow,
   } from '$lib/features/threads/domain/projectDraftStatePresenter';
   import type {
-    ProjectDraftFileLayer,
     ProjectDraftFileResponse,
     ProjectDraftStateRead,
     ProjectDraftStateResponse,
@@ -24,13 +28,6 @@
   type DraftIdea = {
     id?: string | null;
   } | null;
-
-  type PreviewLayer = {
-    key: 'root' | 'base' | 'draft';
-    label: string;
-    detail: string;
-    layer: ProjectDraftFileLayer | undefined;
-  };
 
   const CHANGE_METRICS = PROJECT_DRAFT_CHANGE_METRICS;
 
@@ -54,6 +51,12 @@
   let filePreviewError = $state('');
   let loadedFileKey = $state('');
   let fileRequestSeq = 0;
+  let collapsedDirectoryKeys = $state<string[]>([]);
+  let editingFileKey = $state('');
+  let editorContent = $state('');
+  let fileSaveLoading = $state(false);
+  let fileSaveError = $state('');
+  let fileSaveNotice = $state('');
 
   const draftView = $derived.by(() =>
     buildProjectDraftPanelView({ draftState, loading, loadError, runId }),
@@ -71,7 +74,9 @@
   const selectedFile = $derived(
     fileBrowser.files.find((file) => file.key === selectedFileKey) ?? null,
   );
-  const previewLayers = $derived(buildPreviewLayers(filePreview, selectedFile));
+  const visibleRows = $derived(visibleProjectExplorerRows(fileBrowser.rows, collapsedDirectoryKeys));
+  const previewView = $derived(buildProjectFilePreviewView(filePreview, selectedFile));
+  const isEditingSelectedFile = $derived(Boolean(selectedFile && editingFileKey === selectedFile.key));
 
   function metricCountLabel(value: number): string {
     return Number.isFinite(value) ? String(value) : '0';
@@ -87,60 +92,72 @@
 
   function selectFile(file: ProjectExplorerFile) {
     selectedFileKey = file.key;
+    fileSaveError = '';
+    fileSaveNotice = '';
+    if (editingFileKey && editingFileKey !== file.key) {
+      editingFileKey = '';
+      editorContent = '';
+    }
   }
 
-  function layerContent(layer: ProjectDraftFileLayer | undefined): string {
-    if (!layer?.exists) return 'Not present in this layer.';
-    if (layer.binary) return 'Binary file preview is not available.';
-    if (layer.error) return layer.error;
-    return layer.content ?? '';
+  function directoryCollapsed(row: ProjectExplorerDirectory): boolean {
+    return collapsedDirectoryKeys.includes(row.key);
   }
 
-  function layerDetail(layer: ProjectDraftFileLayer | undefined): string {
-    if (!layer?.exists) return 'missing';
-    return [
-      projectFileSizeLabel(layer.size),
-      layer.binary ? 'binary' : 'text',
-      layer.truncated ? 'truncated' : '',
-    ].filter(Boolean).join(' / ');
+  function toggleDirectory(row: ProjectExplorerDirectory) {
+    fileSaveError = '';
+    fileSaveNotice = '';
+    collapsedDirectoryKeys = directoryCollapsed(row)
+      ? collapsedDirectoryKeys.filter((key) => key !== row.key)
+      : [...collapsedDirectoryKeys, row.key];
   }
 
-  function buildPreviewLayers(
-    preview: ProjectDraftFileResponse | null,
-    file: ProjectExplorerFile | null,
-  ): PreviewLayer[] {
-    const layers = preview?.layers ?? {};
-    const root = layers.root;
-    const draft = layers.draft;
-    const base = layers.base;
-    const rootContent = root?.content ?? '';
-    const draftContent = draft?.content ?? '';
-    const showComparison = Boolean(
-      root?.exists
-      && draft?.exists
-      && (rootContent !== draftContent || projectFileStatusTone(file?.status) !== 'clean'),
-    );
+  function beginFileEdit() {
+    if (!selectedFile || !previewView.canEdit) return;
+    editingFileKey = selectedFile.key;
+    editorContent = previewView.editableContent;
+    fileSaveError = '';
+    fileSaveNotice = '';
+  }
 
-    if (showComparison) {
-      const rows: PreviewLayer[] = [
-        { key: 'root', label: 'Project root', detail: layerDetail(root), layer: root },
-      ];
-      if (base?.exists && base.content !== rootContent && base.content !== draftContent) {
-        rows.push({ key: 'base', label: 'Thread base', detail: layerDetail(base), layer: base });
-      }
-      rows.push({ key: 'draft', label: 'Thread draft', detail: layerDetail(draft), layer: draft });
-      return rows;
+  function cancelFileEdit() {
+    editingFileKey = '';
+    editorContent = '';
+    fileSaveError = '';
+  }
+
+  async function saveFileEdit() {
+    const ideaId = idea?.id ?? null;
+    const file = selectedFile;
+    const currentRunId = runId ?? statePayload?.run_id ?? null;
+    if (!ideaId || !file) return;
+    fileSaveLoading = true;
+    fileSaveError = '';
+    fileSaveNotice = '';
+    try {
+      const result = await updateIdeaProjectDraftFile(ideaId, {
+        runId: currentRunId,
+        resourceId: file.resourceId,
+        path: file.path,
+        content: editorContent,
+      });
+      filePreview = result;
+      editingFileKey = '';
+      editorContent = '';
+      loadedFileKey = `${ideaId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
+      fileSaveNotice = 'Thread draft updated.';
+      await loadDraftState(ideaId, currentRunId);
+    } catch (error: any) {
+      fileSaveError = error?.detail || error?.message || 'Project draft file could not be updated.';
+    } finally {
+      fileSaveLoading = false;
     }
-    if (draft?.exists) {
-      return [{ key: 'draft', label: 'Thread draft', detail: layerDetail(draft), layer: draft }];
-    }
-    if (root?.exists) {
-      return [{ key: 'root', label: 'Project root', detail: layerDetail(root), layer: root }];
-    }
-    if (base?.exists) {
-      return [{ key: 'base', label: 'Thread base', detail: layerDetail(base), layer: base }];
-    }
-    return [];
+  }
+
+  function diffMarker(kind: 'context' | 'removed' | 'added'): string {
+    if (kind === 'added') return '+';
+    if (kind === 'removed') return '-';
+    return ' ';
   }
 
   async function loadDraftState(ideaId: string, currentRunId: string | number | null) {
@@ -205,11 +222,22 @@
   $effect(() => {
     if (fileBrowser.files.length === 0) {
       selectedFileKey = '';
+      collapsedDirectoryKeys = [];
       return;
     }
     if (selectedFileKey && fileBrowser.files.some((file) => file.key === selectedFileKey)) return;
     const changed = fileBrowser.files.find((file) => projectFileStatusTone(file.status) !== 'clean');
     selectedFileKey = (changed ?? fileBrowser.files[0]).key;
+  });
+
+  $effect(() => {
+    const file = selectedFile;
+    if (!file || collapsedDirectoryKeys.length === 0) return;
+    const selectedAncestors = new Set(projectDirectoryAncestorKeys(file.resourceId, file.path));
+    const next = collapsedDirectoryKeys.filter((key) => !selectedAncestors.has(key));
+    if (next.length !== collapsedDirectoryKeys.length) {
+      collapsedDirectoryKeys = next;
+    }
   });
 
   $effect(() => {
@@ -293,13 +321,24 @@
       {:else}
         <div class="project-browser-layout">
           <div class="project-file-tree" aria-label="Project files">
-            {#each fileBrowser.rows as row (row.key)}
+            {#each visibleRows as row (row.key)}
               {#if row.kind === 'directory'}
-                <div class="project-tree-row project-tree-directory" style={rowStyle(row)} data-tone={rowTone(row)}>
-                  <ConstellationIcon name="folder" size={14} />
+                <button
+                  type="button"
+                  class="project-tree-row project-tree-directory"
+                  style={rowStyle(row)}
+                  data-tone={rowTone(row)}
+                  aria-expanded={!directoryCollapsed(row)}
+                  title={row.displayPath}
+                  onclick={() => toggleDirectory(row)}
+                >
+                  <span class="project-tree-folder-glyph" aria-hidden="true">
+                    <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
+                    <ConstellationIcon name="folder" size={14} />
+                  </span>
                   <span title={row.displayPath}>{row.name}</span>
                   <small>{row.fileCount}</small>
-                </div>
+                </button>
               {:else}
                 <button
                   type="button"
@@ -330,9 +369,21 @@
                     {/if}
                   </span>
                 </div>
-                <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
-                  {projectFileStatusLabel(selectedFile.status)}
-                </span>
+                <div class="project-file-preview-actions">
+                  <button
+                    type="button"
+                    class="project-file-edit-button"
+                    disabled={!previewView.canEdit || filePreviewLoading || fileSaveLoading}
+                    title={previewView.canEdit ? 'Update this file in the thread draft' : 'This file cannot be edited as text here'}
+                    onclick={isEditingSelectedFile ? cancelFileEdit : beginFileEdit}
+                  >
+                    <ConstellationIcon name={isEditingSelectedFile ? 'close' : 'edit'} size={12} />
+                    <span>{isEditingSelectedFile ? 'Cancel' : 'Update'}</span>
+                  </button>
+                  <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
+                    {projectFileStatusLabel(selectedFile.status)}
+                  </span>
+                </div>
               </div>
 
               <div class="project-file-layer-strip" aria-label="Selected file layers">
@@ -345,20 +396,64 @@
                 <div class="project-draft-empty">Loading file preview...</div>
               {:else if filePreviewError}
                 <div class="project-draft-empty project-draft-empty-warning">{filePreviewError}</div>
-              {:else if previewLayers.length === 0}
+              {:else if previewView.mode === 'layers' && previewView.layers.length === 0}
                 <div class="project-draft-empty">No readable preview for this file.</div>
-              {:else}
-                <div class="project-preview-layers">
-                  {#each previewLayers as item (item.key)}
-                    <div class="project-preview-layer" data-layer={item.key}>
-                      <div class="project-preview-layer-head">
-                        <strong>{item.label}</strong>
-                        <span>{item.detail}</span>
-                      </div>
-                      <pre>{layerContent(item.layer)}</pre>
-                    </div>
-                  {/each}
+              {:else if isEditingSelectedFile}
+                <div class="project-file-editor">
+                  <div class="project-preview-layer-head">
+                    <strong>Update thread draft</strong>
+                    <span>Saved changes stay in the draft until publish.</span>
+                  </div>
+                  <textarea
+                    bind:value={editorContent}
+                    spellcheck="false"
+                    aria-label="Thread draft file contents"
+                  ></textarea>
+                  {#if fileSaveError}
+                    <div class="project-file-save-message" data-tone="warning">{fileSaveError}</div>
+                  {:else if fileSaveNotice}
+                    <div class="project-file-save-message" data-tone="clean">{fileSaveNotice}</div>
+                  {/if}
+                  <div class="project-file-editor-actions">
+                    <button type="button" onclick={cancelFileEdit} disabled={fileSaveLoading}>Cancel</button>
+                    <button type="button" data-primary="true" onclick={saveFileEdit} disabled={fileSaveLoading}>
+                      <ConstellationIcon name="check" size={13} />
+                      <span>{fileSaveLoading ? 'Saving...' : 'Save draft file'}</span>
+                    </button>
+                  </div>
                 </div>
+              {:else}
+                {#if fileSaveNotice}
+                  <div class="project-file-save-message" data-tone="clean">{fileSaveNotice}</div>
+                {/if}
+                {#if previewView.mode === 'diff'}
+                  <div class="project-preview-layer project-preview-diff">
+                    <div class="project-preview-layer-head">
+                      <strong>{previewView.title}</strong>
+                      <span>{previewView.detail}</span>
+                    </div>
+                    <div class="project-diff-lines" aria-label="Project root to thread draft diff">
+                      {#each previewView.lines as line, index (`${index}:${line.kind}:${line.text}`)}
+                        <div class="project-diff-line" data-kind={line.kind}>
+                          <span class="project-diff-marker">{diffMarker(line.kind)}</span>
+                          <code>{line.text || ' '}</code>
+                        </div>
+                      {/each}
+                    </div>
+                  </div>
+                {:else}
+                  <div class="project-preview-layers">
+                    {#each previewView.layers as item (item.key)}
+                      <div class="project-preview-layer" data-layer={item.key}>
+                        <div class="project-preview-layer-head">
+                          <strong>{item.label}</strong>
+                          <span>{item.detail}</span>
+                        </div>
+                        <pre>{item.content}</pre>
+                      </div>
+                    {/each}
+                  </div>
+                {/if}
               {/if}
             {:else}
               <div class="project-draft-empty">No file selected.</div>
@@ -688,7 +783,7 @@
   .project-tree-row {
     --depth: 0;
     display: grid;
-    grid-template-columns: 16px minmax(0, 1fr) auto;
+    grid-template-columns: 26px minmax(0, 1fr) auto;
     align-items: center;
     gap: 7px;
     width: 100%;
@@ -706,16 +801,19 @@
     color: rgba(29, 39, 49, 0.78);
   }
 
-  .project-tree-file {
+  .project-tree-file,
+  .project-tree-directory {
     cursor: pointer;
   }
 
   .project-tree-file:hover,
+  .project-tree-directory:hover,
   .project-tree-file-selected {
     background: rgba(255, 255, 255, 0.055);
   }
 
   :global(:root[data-color-scheme='light']) .project-tree-file:hover,
+  :global(:root[data-color-scheme='light']) .project-tree-directory:hover,
   :global(:root[data-color-scheme='light']) .project-tree-file-selected {
     background: rgba(82, 117, 139, 0.08);
   }
@@ -728,12 +826,25 @@
     color: rgba(82, 98, 111, 0.72);
   }
 
+  .project-tree-folder-glyph {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    min-width: 0;
+    overflow: visible;
+  }
+
   .project-tree-row span {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 11px;
+  }
+
+  .project-tree-row .project-tree-folder-glyph {
+    overflow: visible;
+    white-space: normal;
   }
 
   .project-tree-row small {
@@ -796,6 +907,45 @@
     min-width: 0;
   }
 
+  .project-file-preview-actions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .project-file-edit-button,
+  .project-file-editor-actions button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    min-height: 26px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 7px;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.045);
+    color: rgba(239, 244, 251, 0.76);
+    font-size: 10px;
+    line-height: 1.1;
+    cursor: pointer;
+  }
+
+  .project-file-edit-button:disabled,
+  .project-file-editor-actions button:disabled {
+    cursor: default;
+    opacity: 0.48;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-edit-button,
+  :global(:root[data-color-scheme='light']) .project-file-editor-actions button {
+    border-color: rgba(85, 104, 120, 0.14);
+    background: rgba(85, 104, 120, 0.055);
+    color: rgba(29, 39, 49, 0.78);
+  }
+
   .project-file-layer-strip {
     display: flex;
     flex-wrap: wrap;
@@ -852,6 +1002,129 @@
   :global(:root[data-color-scheme='light']) .project-preview-layer pre {
     background: rgba(246, 248, 248, 0.95);
     color: rgba(28, 36, 45, 0.86);
+  }
+
+  .project-diff-lines {
+    display: grid;
+    max-height: 360px;
+    min-width: 0;
+    overflow: auto;
+    border-radius: 7px;
+    background: rgba(6, 10, 15, 0.34);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    line-height: 1.5;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-diff-lines {
+    background: rgba(246, 248, 248, 0.95);
+  }
+
+  .project-diff-line {
+    display: grid;
+    grid-template-columns: 20px minmax(0, 1fr);
+    min-width: 0;
+    padding: 0 8px 0 0;
+    color: rgba(240, 245, 251, 0.82);
+  }
+
+  .project-diff-line[data-kind='removed'] {
+    background: rgba(220, 92, 103, 0.16);
+    color: #f1b0b7;
+  }
+
+  .project-diff-line[data-kind='added'] {
+    background: rgba(72, 181, 118, 0.16);
+    color: #a7e5bd;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-diff-line {
+    color: rgba(28, 36, 45, 0.86);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-diff-line[data-kind='removed'] {
+    background: rgba(207, 73, 87, 0.12);
+    color: rgba(132, 37, 49, 0.92);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-diff-line[data-kind='added'] {
+    background: rgba(35, 151, 86, 0.13);
+    color: rgba(21, 100, 56, 0.94);
+  }
+
+  .project-diff-marker {
+    display: inline-flex;
+    justify-content: center;
+    user-select: none;
+    opacity: 0.72;
+  }
+
+  .project-diff-line code {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  .project-file-editor {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .project-file-editor textarea {
+    width: 100%;
+    min-height: 280px;
+    resize: vertical;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 7px;
+    padding: 10px;
+    background: rgba(6, 10, 15, 0.34);
+    color: rgba(240, 245, 251, 0.86);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 11px;
+    line-height: 1.55;
+    outline: none;
+    white-space: pre-wrap;
+  }
+
+  .project-file-editor textarea:focus {
+    border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 45%, transparent);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-editor textarea {
+    border-color: rgba(85, 104, 120, 0.14);
+    background: rgba(246, 248, 248, 0.95);
+    color: rgba(28, 36, 45, 0.9);
+  }
+
+  .project-file-editor-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+  }
+
+  .project-file-editor-actions button[data-primary='true'] {
+    border-color: color-mix(in srgb, var(--thread-accent, #57CFA0) 28%, transparent);
+    background: color-mix(in srgb, var(--thread-accent, #57CFA0) 14%, transparent);
+    color: color-mix(in srgb, var(--thread-accent, #57CFA0) 78%, white);
+  }
+
+  .project-file-save-message {
+    border-radius: 7px;
+    padding: 7px 8px;
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
+  .project-file-save-message[data-tone='clean'] {
+    background: color-mix(in srgb, var(--positive, #6BC785) 12%, transparent);
+    color: color-mix(in srgb, var(--positive, #6BC785) 78%, white);
+  }
+
+  .project-file-save-message[data-tone='warning'] {
+    background: rgba(236, 180, 95, 0.11);
+    color: #e7bc77;
   }
 
   .project-publish-mini {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -19,6 +19,7 @@
     projectFileSizeLabel,
     projectFileStatusLabel,
     projectFileStatusTone,
+    projectSpreadsheetPreviewRows,
     visibleProjectExplorerRows,
     type ProjectFileKind,
     type ProjectExplorerFile,
@@ -103,8 +104,27 @@
     });
   });
   const finalSheetRows = $derived(
-    spreadsheetPreviewRows(previewView.finalLayer?.content ?? '', projectFileExtension(selectedFile)),
+    projectSpreadsheetPreviewRows(previewView.finalLayer?.content ?? '', projectFileExtension(selectedFile)),
   );
+  const finalSheetColumnIndexes = $derived(sheetColumnIndexes(finalSheetRows));
+  const finalSheetHeader = $derived(sheetHeaderCells(finalSheetRows, finalSheetColumnIndexes));
+  const finalSheetBodyRows = $derived(finalSheetRows.slice(1));
+  const reviewSheetRows = $derived.by(() => {
+    if (previewView.mode !== 'diff') return [];
+    return previewView.lines
+      .map((line) => ({
+        kind: line.kind,
+        cells: projectSpreadsheetPreviewRows(line.text, projectFileExtension(selectedFile), 1)[0] ?? [''],
+      }))
+      .filter((row) => row.cells.some((cell) => cell.trim()));
+  });
+  const reviewSheetColumnIndexes = $derived(
+    sheetColumnIndexes(reviewSheetRows.map((row) => row.cells)),
+  );
+  const reviewSheetHeader = $derived(
+    sheetHeaderCells(reviewSheetRows.map((row) => row.cells), reviewSheetColumnIndexes),
+  );
+  const reviewSheetBodyRows = $derived(reviewSheetRows.slice(1));
 
   function metricCountLabel(value: number): string {
     return Number.isFinite(value) ? String(value) : '0';
@@ -143,15 +163,14 @@
     ].filter(Boolean).join(' / ');
   }
 
-  function spreadsheetPreviewRows(content: string, extension: string): string[][] {
-    const suffix = extension.toLowerCase();
-    if (!['.csv', '.tsv'].includes(suffix) || !content.trim()) return [];
-    const delimiter = suffix === '.tsv' ? '\t' : ',';
-    return content
-      .split('\n')
-      .slice(0, 24)
-      .map((line) => line.split(delimiter).slice(0, 10).map((cell) => cell.trim()))
-      .filter((row) => row.some(Boolean));
+  function sheetColumnIndexes(rows: string[][]): number[] {
+    const count = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    return Array.from({ length: count }, (_value, index) => index);
+  }
+
+  function sheetHeaderCells(rows: string[][], columnIndexes: number[]): string[] {
+    const header = rows[0] ?? [];
+    return columnIndexes.map((columnIndex) => header[columnIndex] || `Column ${columnIndex + 1}`);
   }
 
   function canEmbedFinalKind(kind: ProjectFileKind): boolean {
@@ -533,7 +552,38 @@
                 {#if fileSaveNotice}
                   <div class="project-file-save-message" data-tone="clean">{fileSaveNotice}</div>
                 {/if}
-                {#if activePreviewMode === 'review' && previewView.mode === 'diff'}
+                {#if activePreviewMode === 'review' && previewView.mode === 'diff' && selectedFileKind === 'spreadsheet' && reviewSheetRows.length > 0}
+                  <div class="project-preview-layer project-preview-sheet-review">
+                    <div class="project-preview-layer-head">
+                      <strong>{previewView.title}</strong>
+                      <span>{previewView.detail}</span>
+                    </div>
+                    <div class="project-sheet-preview" data-review="true" aria-label="Project root to thread draft spreadsheet diff">
+                      <table>
+                        <thead>
+                          <tr>
+                            <th class="project-sheet-index" scope="col">#</th>
+                            {#each reviewSheetColumnIndexes as columnIndex (`review-head-${columnIndex}`)}
+                              <th scope="col">{reviewSheetHeader[columnIndex]}</th>
+                            {/each}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {#each reviewSheetBodyRows as row, rowIndex (`review-row-${rowIndex}-${row.kind}`)}
+                            <tr data-kind={row.kind}>
+                              <th class="project-sheet-index" scope="row">
+                                <span>{diffMarker(row.kind)}</span>{rowIndex + 1}
+                              </th>
+                              {#each reviewSheetColumnIndexes as columnIndex (`review-cell-${rowIndex}-${columnIndex}`)}
+                                <td>{row.cells[columnIndex] ?? ''}</td>
+                              {/each}
+                            </tr>
+                          {/each}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                {:else if activePreviewMode === 'review' && previewView.mode === 'diff'}
                   <div class="project-preview-layer project-preview-diff">
                     <div class="project-preview-layer-head">
                       <strong>{previewView.title}</strong>
@@ -573,11 +623,20 @@
                       {:else if selectedFileKind === 'spreadsheet' && finalSheetRows.length > 0}
                         <div class="project-sheet-preview">
                           <table>
+                            <thead>
+                              <tr>
+                                <th class="project-sheet-index" scope="col">#</th>
+                                {#each finalSheetColumnIndexes as columnIndex (`final-head-${columnIndex}`)}
+                                  <th scope="col">{finalSheetHeader[columnIndex]}</th>
+                                {/each}
+                              </tr>
+                            </thead>
                             <tbody>
-                              {#each finalSheetRows as row, rowIndex (`row-${rowIndex}`)}
+                              {#each finalSheetBodyRows as row, rowIndex (`row-${rowIndex}`)}
                                 <tr>
-                                  {#each row as cell, cellIndex (`cell-${rowIndex}-${cellIndex}`)}
-                                    <td>{cell}</td>
+                                  <th class="project-sheet-index" scope="row">{rowIndex + 1}</th>
+                                  {#each finalSheetColumnIndexes as columnIndex (`cell-${rowIndex}-${columnIndex}`)}
+                                    <td>{row[columnIndex] ?? ''}</td>
                                   {/each}
                                 </tr>
                               {/each}
@@ -1377,7 +1436,7 @@
   }
 
   .project-sheet-preview {
-    max-height: 420px;
+    max-height: min(54vh, 520px);
     overflow: auto;
     border: 1px solid rgba(255, 255, 255, 0.065);
     border-radius: 8px;
@@ -1385,28 +1444,72 @@
   }
 
   .project-sheet-preview table {
-    width: 100%;
-    min-width: 420px;
-    border-collapse: collapse;
+    width: max-content;
+    min-width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
     font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
+    font-size: 10.5px;
     line-height: 1.35;
   }
 
+  .project-sheet-preview th,
   .project-sheet-preview td {
-    max-width: 220px;
+    min-width: 118px;
+    max-width: 320px;
     border-right: 1px solid rgba(255, 255, 255, 0.055);
     border-bottom: 1px solid rgba(255, 255, 255, 0.055);
-    padding: 6px 8px;
+    padding: 7px 9px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-align: left;
+    vertical-align: top;
   }
 
-  .project-sheet-preview tr:first-child td {
+  .project-sheet-preview thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
     background: rgba(255, 255, 255, 0.05);
     color: rgba(240, 245, 251, 0.88);
     font-weight: 650;
+  }
+
+  .project-sheet-preview .project-sheet-index {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    width: 46px;
+    min-width: 46px;
+    max-width: 46px;
+    background: rgba(12, 18, 26, 0.92);
+    color: rgba(180, 194, 208, 0.78);
+    text-align: right;
+    font-weight: 600;
+  }
+
+  .project-sheet-preview thead .project-sheet-index {
+    z-index: 3;
+  }
+
+  .project-sheet-preview .project-sheet-index span {
+    margin-right: 5px;
+    font-weight: 800;
+  }
+
+  .project-sheet-preview tbody tr[data-kind='added'] td {
+    background: rgba(47, 166, 107, 0.16);
+    color: rgba(218, 248, 231, 0.94);
+  }
+
+  .project-sheet-preview tbody tr[data-kind='removed'] td {
+    background: rgba(220, 92, 92, 0.15);
+    color: rgba(255, 223, 223, 0.94);
+  }
+
+  .project-sheet-preview tbody tr[data-kind='context'] td {
+    color: rgba(223, 231, 240, 0.78);
   }
 
   :global(:root[data-color-scheme='light']) .project-sheet-preview {
@@ -1414,13 +1517,33 @@
     background: rgba(246, 248, 248, 0.95);
   }
 
+  :global(:root[data-color-scheme='light']) .project-sheet-preview th,
   :global(:root[data-color-scheme='light']) .project-sheet-preview td {
     border-color: rgba(85, 104, 120, 0.12);
   }
 
-  :global(:root[data-color-scheme='light']) .project-sheet-preview tr:first-child td {
+  :global(:root[data-color-scheme='light']) .project-sheet-preview thead th {
     background: rgba(85, 104, 120, 0.075);
     color: rgba(20, 29, 38, 0.88);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview .project-sheet-index {
+    background: rgba(250, 251, 250, 0.96);
+    color: rgba(82, 98, 111, 0.74);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview tbody tr[data-kind='added'] td {
+    background: rgba(47, 166, 107, 0.14);
+    color: rgba(17, 92, 54, 0.94);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview tbody tr[data-kind='removed'] td {
+    background: rgba(220, 92, 92, 0.13);
+    color: rgba(134, 34, 42, 0.94);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview tbody tr[data-kind='context'] td {
+    color: rgba(57, 70, 82, 0.82);
   }
 
   .project-code-preview {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -1068,8 +1068,9 @@
     overflow-x: hidden;
   }
 
-  .project-file-tree[data-collapsed='true']:hover,
-  .project-file-tree[data-collapsed='true']:focus-within {
+  .project-file-tree[data-collapsed='true']:has(.project-tree-file:hover),
+  .project-file-tree[data-collapsed='true']:has(.project-tree-directory:hover),
+  .project-file-tree[data-collapsed='true']:has(.project-tree-row:focus-visible) {
     width: min(260px, calc(100vw - 56px));
     box-shadow:
       18px 0 34px rgba(0, 0, 0, 0.16),
@@ -1080,22 +1081,23 @@
     border-right-color: rgba(85, 104, 120, 0.12);
   }
 
-  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:hover,
-  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:focus-within {
+  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-file:hover),
+  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-directory:hover),
+  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-row:focus-visible) {
     box-shadow:
       18px 0 34px rgba(54, 70, 82, 0.11),
       inset -1px 0 0 rgba(85, 104, 120, 0.12);
   }
 
-  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row {
+  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row {
     grid-template-columns: 28px 0 0;
     gap: 0;
     padding-inline: 7px;
     padding-left: 7px;
   }
 
-  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-label,
-  .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row small {
+  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-label,
+  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row small {
     max-width: 0;
     opacity: 0;
     transform: translateX(-6px);
@@ -1856,14 +1858,14 @@
       border-bottom: 1px solid rgba(255, 255, 255, 0.055);
     }
 
-    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row {
+    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row {
       grid-template-columns: 26px minmax(0, 1fr) auto;
       gap: 7px;
       padding: 5px 7px 5px calc(7px + (var(--depth) * 14px));
     }
 
-    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-label,
-    .project-file-tree[data-collapsed='true']:not(:hover):not(:focus-within) .project-tree-row small {
+    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-label,
+    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row small {
       max-width: none;
       opacity: 1;
       transform: translateX(0);

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -67,6 +67,7 @@
   let fileSaveError = $state('');
   let fileSaveNotice = $state('');
   let previewMode = $state<'review' | 'final'>('review');
+  let fileTreeCollapsed = $state(false);
 
   const draftView = $derived.by(() =>
     buildProjectDraftPanelView({ draftState, loading, loadError, runId }),
@@ -216,6 +217,10 @@
     collapsedDirectoryKeys = directoryCollapsed(row)
       ? collapsedDirectoryKeys.filter((key) => key !== row.key)
       : [...collapsedDirectoryKeys, row.key];
+  }
+
+  function toggleFileTree() {
+    fileTreeCollapsed = !fileTreeCollapsed;
   }
 
   function beginFileEdit() {
@@ -421,54 +426,68 @@
             {/if}
           </span>
         </div>
-        <div class="project-browser-legend" aria-label="Project layers">
-          <span><ConstellationIcon name="lock" size={12} /> Root</span>
-          <span><ConstellationIcon name="edit" size={12} /> Draft</span>
+        <div class="project-browser-tools">
+          <div class="project-browser-legend" aria-label="Project layers">
+            <span><ConstellationIcon name="lock" size={12} /> Root</span>
+            <span><ConstellationIcon name="edit" size={12} /> Draft</span>
+          </div>
+          <button
+            type="button"
+            class="project-browser-tree-toggle"
+            aria-expanded={!fileTreeCollapsed}
+            aria-controls="project-file-tree"
+            onclick={toggleFileTree}
+          >
+            <ConstellationIcon name={fileTreeCollapsed ? 'side-panel' : 'eye-off'} size={12} />
+            <span>{fileTreeCollapsed ? 'Show files' : 'Hide files'}</span>
+          </button>
         </div>
       </div>
 
       {#if fileBrowser.rows.length === 0}
         <div class="project-draft-empty">No browsable files found in this Project.</div>
       {:else}
-        <div class="project-browser-layout">
-          <div class="project-file-tree" aria-label="Project files">
-            {#each visibleRows as row (row.key)}
-              {#if row.kind === 'directory'}
-                <button
-                  type="button"
-                  class="project-tree-row project-tree-directory"
-                  style={rowStyle(row)}
-                  data-tone={rowTone(row)}
-                  aria-expanded={!directoryCollapsed(row)}
-                  title={row.displayPath}
-                  onclick={() => toggleDirectory(row)}
-                >
-                  <span class="project-tree-folder-glyph" aria-hidden="true">
-                    <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
-                    <ConstellationIcon name="folder" size={14} />
-                  </span>
-                  <span title={row.displayPath}>{row.name}</span>
-                  <small>{row.fileCount}</small>
-                </button>
-              {:else}
-                <button
-                  type="button"
-                  class="project-tree-row project-tree-file"
-                  class:project-tree-file-selected={selectedFileKey === row.key}
-                  style={rowStyle(row)}
-                  data-tone={rowTone(row)}
-                  title={row.displayPath}
-                  onclick={() => selectFile(row)}
-                >
-                  <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
-                    <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
-                  </span>
-                  <span>{row.name}</span>
-                  <small>{projectFileStatusLabel(row.status)}</small>
-                </button>
-              {/if}
-            {/each}
-          </div>
+        <div class="project-browser-layout" data-tree-collapsed={fileTreeCollapsed}>
+          {#if !fileTreeCollapsed}
+            <div id="project-file-tree" class="project-file-tree" aria-label="Project files">
+              {#each visibleRows as row (row.key)}
+                {#if row.kind === 'directory'}
+                  <button
+                    type="button"
+                    class="project-tree-row project-tree-directory"
+                    style={rowStyle(row)}
+                    data-tone={rowTone(row)}
+                    aria-expanded={!directoryCollapsed(row)}
+                    title={row.displayPath}
+                    onclick={() => toggleDirectory(row)}
+                  >
+                    <span class="project-tree-folder-glyph" aria-hidden="true">
+                      <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
+                      <ConstellationIcon name="folder" size={14} />
+                    </span>
+                    <span title={row.displayPath}>{row.name}</span>
+                    <small>{row.fileCount}</small>
+                  </button>
+                {:else}
+                  <button
+                    type="button"
+                    class="project-tree-row project-tree-file"
+                    class:project-tree-file-selected={selectedFileKey === row.key}
+                    style={rowStyle(row)}
+                    data-tone={rowTone(row)}
+                    title={row.displayPath}
+                    onclick={() => selectFile(row)}
+                  >
+                    <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
+                      <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
+                    </span>
+                    <span>{row.name}</span>
+                    <small>{projectFileStatusLabel(row.status)}</small>
+                  </button>
+                {/if}
+              {/each}
+            </div>
+          {/if}
 
           <div class="project-file-preview" aria-live="polite">
             {#if selectedFile}
@@ -483,16 +502,18 @@
                   </span>
                 </div>
                 <div class="project-file-preview-actions">
-                  <button
-                    type="button"
-                    class="project-file-edit-button"
-                    disabled={!previewView.canEdit || filePreviewLoading || fileSaveLoading}
-                    title={previewView.canEdit ? 'Edit this file in the thread draft' : 'This file cannot be edited as text here'}
-                    onclick={isEditingSelectedFile ? cancelFileEdit : beginFileEdit}
-                  >
-                    <ConstellationIcon name={isEditingSelectedFile ? 'close' : 'edit'} size={12} />
-                    <span>{isEditingSelectedFile ? 'Cancel' : 'Edit'}</span>
-                  </button>
+                  {#if previewView.canEdit}
+                    <button
+                      type="button"
+                      class="project-file-edit-button"
+                      disabled={filePreviewLoading || fileSaveLoading}
+                      title="Edit this file in the thread draft"
+                      onclick={isEditingSelectedFile ? cancelFileEdit : beginFileEdit}
+                    >
+                      <ConstellationIcon name={isEditingSelectedFile ? 'close' : 'edit'} size={12} />
+                      <span>{isEditingSelectedFile ? 'Cancel' : 'Edit'}</span>
+                    </button>
+                  {/if}
                   <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
                     {projectFileStatusLabel(selectedFile.status)}
                   </span>
@@ -970,12 +991,43 @@
     min-width: 0;
   }
 
+  .project-browser-tools {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
   .project-browser-legend {
     display: inline-flex;
     align-items: center;
     flex-wrap: wrap;
     justify-content: flex-end;
     gap: 5px;
+  }
+
+  .project-browser-tree-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    min-height: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.065);
+    border-radius: 7px;
+    padding: 3px 7px;
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(231, 238, 247, 0.66);
+    font-size: 10px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-browser-tree-toggle {
+    border-color: rgba(85, 104, 120, 0.13);
+    background: rgba(85, 104, 120, 0.055);
+    color: rgba(57, 70, 82, 0.72);
   }
 
   .project-browser-legend span,
@@ -1001,6 +1053,10 @@
     display: grid;
     grid-template-columns: minmax(190px, 0.72fr) minmax(0, 1.55fr);
     min-height: min(72vh, 700px);
+  }
+
+  .project-browser-layout[data-tree-collapsed='true'] {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .project-file-tree {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -25,6 +25,7 @@
     type ProjectExplorerFile,
     type ProjectExplorerDirectory,
     type ProjectExplorerRow,
+    type ProjectPreviewLayerKey,
   } from '$lib/features/threads/domain/projectDraftStatePresenter';
   import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
   import type {
@@ -86,23 +87,25 @@
   const visibleRows = $derived(visibleProjectExplorerRows(fileBrowser.rows, collapsedDirectoryKeys));
   const previewView = $derived(buildProjectFilePreviewView(filePreview, selectedFile));
   const isEditingSelectedFile = $derived(Boolean(selectedFile && editingFileKey === selectedFile.key));
-  const activePreviewMode = $derived(previewMode === 'review' && previewView.mode === 'diff' ? 'review' : 'final');
   const selectedFileKind = $derived(projectFileKind(selectedFile));
+  const selectedFileTone = $derived(projectFileStatusTone(selectedFile?.status));
+  const selectedFileIsRich = $derived(canEmbedFinalKind(selectedFileKind));
+  const showPreviewModeTabs = $derived(previewView.mode === 'diff' && !selectedFileIsRich);
+  const activePreviewMode = $derived(showPreviewModeTabs && previewMode === 'review' ? 'review' : 'final');
   const selectedFileKindLabel = $derived(projectFileKindLabel(selectedFile));
   const selectedFileIcon = $derived(projectFileIconName(selectedFileKind));
   const selectedFileExtension = $derived(projectFileExtension(selectedFile).replace(/^\./, '').toUpperCase());
-  const finalBlobUrl = $derived.by(() => {
-    const ideaId = idea?.id ?? null;
-    const file = selectedFile;
-    const layer = previewView.finalLayer?.key;
-    if (!ideaId || !file || !layer || !previewView.finalLayer?.layer?.exists) return '';
-    return getIdeaProjectDraftFileBlobUrl(ideaId, {
-      runId: runId ?? statePayload?.run_id ?? null,
-      resourceId: file.resourceId,
-      path: file.path,
-      layer,
-    });
-  });
+  const finalBlobUrl = $derived(projectLayerBlobUrl(previewView.finalLayer?.key ?? null));
+  const rootPreviewLayer = $derived(previewView.layers.find((item) => item.key === 'root') ?? null);
+  const draftPreviewLayer = $derived(previewView.layers.find((item) => item.key === 'draft') ?? null);
+  const rootBlobUrl = $derived(projectLayerBlobUrl('root'));
+  const draftBlobUrl = $derived(projectLayerBlobUrl('draft'));
+  const showRichReplacementCompare = $derived(
+    selectedFileIsRich
+      && selectedFileTone !== 'clean'
+      && Boolean(rootPreviewLayer?.layer?.exists)
+      && Boolean(draftPreviewLayer?.layer?.exists),
+  );
   const finalSheetRows = $derived(
     projectSpreadsheetPreviewRows(previewView.finalLayer?.content ?? '', projectFileExtension(selectedFile)),
   );
@@ -155,12 +158,23 @@
     return 'thread draft';
   }
 
-  function previewKindDetail(): string {
-    return [
-      selectedFileKindLabel,
-      selectedFileExtension,
-      projectFileLayerLabel(selectedFile),
-    ].filter(Boolean).join(' / ');
+  function projectLayerBlobUrl(layer: ProjectPreviewLayerKey | null): string {
+    const ideaId = idea?.id ?? null;
+    const file = selectedFile;
+    if (!ideaId || !file || !layer) return '';
+    return getIdeaProjectDraftFileBlobUrl(ideaId, {
+      runId: runId ?? statePayload?.run_id ?? null,
+      resourceId: file.resourceId,
+      path: file.path,
+      layer,
+    });
+  }
+
+  function primaryPreviewTitle(layer: ProjectPreviewLayerKey): string {
+    if (showPreviewModeTabs) return 'Final';
+    if (layer === 'root') return 'Project root';
+    if (layer === 'base') return 'Thread base';
+    return 'Thread draft';
   }
 
   function sheetColumnIndexes(rows: string[][]): number[] {
@@ -366,6 +380,18 @@
       <span>{fileBrowser.fileCount} file{fileBrowser.fileCount === 1 ? '' : 's'}</span>
       <span>{readiness.detail}</span>
     </div>
+    <div class="project-draft-summary-chips" aria-label="Project draft summary">
+      {#each CHANGE_METRICS as metric (metric.key)}
+        <span data-tone={metric.tone}>
+          <strong>{metricCountLabel(aggregateCounts[metric.key])}</strong>
+          {metric.label}
+        </span>
+      {/each}
+      <span data-tone={publishPlan.blockedCount > 0 ? 'conflicted' : 'clean'}>
+        <strong>{publishPlan.operationCount}</strong>
+        publish ops
+      </span>
+    </div>
   </div>
 
   {#if loading && !statePayload}
@@ -377,19 +403,10 @@
       {statePayload.error || 'No Project draft state is bound to this run.'}
     </div>
   {:else}
-    <div class="project-draft-counts" aria-label="Draft change counts">
-      {#each CHANGE_METRICS as metric (metric.key)}
-        <div class="project-draft-count" data-tone={metric.tone}>
-          <span>{metric.label}</span>
-          <strong>{metricCountLabel(aggregateCounts[metric.key])}</strong>
-        </div>
-      {/each}
-    </div>
-
     {#if outOfDatePaths.length > 0}
-      <div class="project-draft-alert" data-tone="warning">
-        <strong>Out of date</strong>
-        <span>{outOfDatePaths.length} path{outOfDatePaths.length === 1 ? '' : 's'} need attention.</span>
+      <div class="project-draft-alert" data-tone="warning" aria-label="Out of date Project files">
+        <ConstellationIcon name="refresh" size={13} />
+        <span>{outOfDatePaths.length} out-of-date path{outOfDatePaths.length === 1 ? '' : 's'} need attention.</span>
       </div>
     {/if}
 
@@ -482,41 +499,47 @@
                 </div>
               </div>
 
-              <div class="project-file-layer-strip" aria-label="Selected file layers">
-                <span data-present={selectedFile.has_root === true}>Root</span>
-                <span data-present={selectedFile.has_base === true}>Base</span>
-                <span data-present={selectedFile.has_draft === true}>Draft</span>
-              </div>
-
-              <div class="project-file-profile" data-kind={selectedFileKind}>
-                <span class="project-file-profile-icon" aria-hidden="true">
-                  <ConstellationIcon name={selectedFileIcon} size={18} stroke={1.7} />
-                </span>
-                <div>
-                  <strong>{selectedFileKindLabel}</strong>
-                  <span>{previewKindDetail()}</span>
+              <div class="project-file-context-row">
+                <div class="project-file-layer-strip" aria-label="Selected file layers">
+                  {#if selectedFile.has_root === true}
+                    <span data-present="true">Root</span>
+                  {/if}
+                  {#if selectedFile.has_base === true}
+                    <span data-present="true">Base</span>
+                  {/if}
+                  {#if selectedFile.has_draft === true}
+                    <span data-present="true">Draft</span>
+                  {/if}
                 </div>
-                <small>{selectedFileExtension || 'FILE'}</small>
+                <span class="project-file-kind-chip" data-kind={selectedFileKind}>
+                  <ConstellationIcon name={selectedFileIcon} size={12} />
+                  {selectedFileKindLabel}
+                  {#if selectedFileExtension}
+                    / {selectedFileExtension}
+                  {/if}
+                </span>
               </div>
 
-              <div class="project-preview-mode-tabs" aria-label="Project file preview mode">
-                <button
-                  type="button"
-                  class:project-preview-mode-active={activePreviewMode === 'review'}
-                  disabled={previewView.mode !== 'diff' || isEditingSelectedFile}
-                  onclick={() => setPreviewMode('review')}
-                >
-                  Review
-                </button>
-                <button
-                  type="button"
-                  class:project-preview-mode-active={activePreviewMode === 'final'}
-                  disabled={isEditingSelectedFile}
-                  onclick={() => setPreviewMode('final')}
-                >
-                  Final
-                </button>
-              </div>
+              {#if showPreviewModeTabs}
+                <div class="project-preview-mode-tabs" aria-label="Project file preview mode">
+                  <button
+                    type="button"
+                    class:project-preview-mode-active={activePreviewMode === 'review'}
+                    disabled={isEditingSelectedFile}
+                    onclick={() => setPreviewMode('review')}
+                  >
+                    Review
+                  </button>
+                  <button
+                    type="button"
+                    class:project-preview-mode-active={activePreviewMode === 'final'}
+                    disabled={isEditingSelectedFile}
+                    onclick={() => setPreviewMode('final')}
+                  >
+                    Final
+                  </button>
+                </div>
+              {/if}
 
               {#if filePreviewLoading}
                 <div class="project-draft-empty">Loading file preview...</div>
@@ -598,11 +621,46 @@
                       {/each}
                     </div>
                   </div>
+                {:else if showRichReplacementCompare}
+                  <div class="project-rich-compare" data-kind={selectedFileKind}>
+                    <div class="project-rich-compare-item">
+                      <div class="project-preview-layer-head">
+                        <strong>Project root</strong>
+                        <span>{rootPreviewLayer?.detail}</span>
+                      </div>
+                      <div class="project-rich-preview" data-kind={selectedFileKind}>
+                        {#if selectedFileKind === 'image'}
+                          <img src={rootBlobUrl} alt={`${selectedFile.name} in project root`} />
+                        {:else if selectedFileKind === 'pdf'}
+                          <iframe src={rootBlobUrl} title={`${selectedFile.name} in project root`}></iframe>
+                        {:else if selectedFileKind === 'video'}
+                          <!-- svelte-ignore a11y_media_has_caption -->
+                          <video src={rootBlobUrl} controls playsinline preload="metadata"></video>
+                        {/if}
+                      </div>
+                    </div>
+                    <div class="project-rich-compare-item">
+                      <div class="project-preview-layer-head">
+                        <strong>Thread draft</strong>
+                        <span>{draftPreviewLayer?.detail}</span>
+                      </div>
+                      <div class="project-rich-preview" data-kind={selectedFileKind}>
+                        {#if selectedFileKind === 'image'}
+                          <img src={draftBlobUrl} alt={`${selectedFile.name} in thread draft`} />
+                        {:else if selectedFileKind === 'pdf'}
+                          <iframe src={draftBlobUrl} title={`${selectedFile.name} in thread draft`}></iframe>
+                        {:else if selectedFileKind === 'video'}
+                          <!-- svelte-ignore a11y_media_has_caption -->
+                          <video src={draftBlobUrl} controls playsinline preload="metadata"></video>
+                        {/if}
+                      </div>
+                    </div>
+                  </div>
                 {:else if previewView.finalLayer}
                   <div class="project-preview-layers">
                     <div class="project-preview-layer" data-layer={previewView.finalLayer.key}>
                       <div class="project-preview-layer-head">
-                        <strong>{previewView.finalLayer.label}</strong>
+                        <strong>{primaryPreviewTitle(previewView.finalLayer.key)}</strong>
                         <span>{previewView.finalLayer.detail} / {finalLayerSourceLabel(previewView.finalLayer.key)}</span>
                       </div>
                       {#if canEmbedFinalKind(selectedFileKind) && finalBlobUrl}
@@ -683,17 +741,6 @@
       {/if}
     </div>
 
-    <div class="project-publish-mini">
-      <div class="project-draft-kicker">Publish plan</div>
-      <div class="project-publish-metrics">
-        <span><strong>{publishPlan.resourceCount}</strong> resources</span>
-        <span><strong>{publishPlan.operationCount}</strong> operations</span>
-        <span data-tone={publishPlan.blockedCount > 0 ? 'conflicted' : 'clean'}>
-          <strong>{publishPlan.blockedCount}</strong> blocked
-        </span>
-        <span><strong>{publishPlan.readyCount}</strong> ready</span>
-      </div>
-    </div>
   {/if}
 </section>
 
@@ -714,8 +761,7 @@
 
   .project-draft-summary,
   .project-draft-alert,
-  .project-browser,
-  .project-publish-mini {
+  .project-browser {
     border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.03);
@@ -723,14 +769,12 @@
 
   :global(:root[data-color-scheme='light']) .project-draft-summary,
   :global(:root[data-color-scheme='light']) .project-draft-alert,
-  :global(:root[data-color-scheme='light']) .project-browser,
-  :global(:root[data-color-scheme='light']) .project-publish-mini {
+  :global(:root[data-color-scheme='light']) .project-browser {
     border-color: rgba(85, 104, 120, 0.13);
     background: rgba(250, 250, 246, 0.78);
   }
 
-  .project-draft-summary,
-  .project-publish-mini {
+  .project-draft-summary {
     padding: 12px;
   }
 
@@ -849,88 +893,59 @@
     color: rgba(82, 98, 111, 0.66);
   }
 
-  .project-draft-counts,
-  .project-publish-metrics {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 6px;
+  .project-draft-summary-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 9px;
   }
 
-  .project-draft-count,
-  .project-publish-metrics span {
-    display: grid;
+  .project-draft-summary-chips span,
+  .project-draft-alert {
+    display: inline-flex;
+    align-items: center;
     gap: 5px;
     min-width: 0;
-    min-height: 48px;
-    padding: 9px 8px;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.035);
-    border: 1px solid rgba(255, 255, 255, 0.04);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-draft-count,
-  :global(:root[data-color-scheme='light']) .project-publish-metrics span {
-    border-color: rgba(85, 104, 120, 0.12);
-    background: rgba(248, 250, 248, 0.74);
-  }
-
-  .project-draft-count span,
-  .project-publish-metrics span {
-    color: rgba(231, 238, 247, 0.5);
-    font-size: 9px;
-    line-height: 1.2;
-  }
-
-  .project-draft-count strong,
-  .project-publish-metrics strong {
-    color: rgba(243, 247, 255, 0.92);
+    border-radius: 7px;
+    padding: 4px 7px;
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(231, 238, 247, 0.58);
     font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 16px;
-    line-height: 1;
+    font-size: 9px;
+    line-height: 1.35;
   }
 
-  :global(:root[data-color-scheme='light']) .project-draft-count span,
-  :global(:root[data-color-scheme='light']) .project-publish-metrics span {
-    color: rgba(82, 98, 111, 0.64);
+  .project-draft-summary-chips strong {
+    color: rgba(243, 247, 255, 0.86);
+    font-size: 10px;
   }
 
-  :global(:root[data-color-scheme='light']) .project-draft-count strong,
-  :global(:root[data-color-scheme='light']) .project-publish-metrics strong {
-    color: rgba(20, 29, 38, 0.9);
+  :global(:root[data-color-scheme='light']) .project-draft-summary-chips span,
+  :global(:root[data-color-scheme='light']) .project-draft-alert {
+    background: rgba(85, 104, 120, 0.055);
+    color: rgba(82, 98, 111, 0.72);
   }
 
-  .project-draft-count[data-tone='conflicted'] strong,
-  .project-publish-metrics [data-tone='conflicted'] strong {
-    color: #efa5b0;
+  :global(:root[data-color-scheme='light']) .project-draft-summary-chips strong {
+    color: rgba(20, 29, 38, 0.86);
   }
 
-  .project-draft-count[data-tone='new'] strong {
+  .project-draft-summary-chips span[data-tone='new'] strong,
+  .project-draft-summary-chips span[data-tone='clean'] strong {
     color: color-mix(in srgb, var(--positive, #6BC785) 82%, white);
   }
 
-  .project-draft-count[data-tone='deleted'] strong {
+  .project-draft-summary-chips span[data-tone='deleted'] strong {
     color: #e7bc77;
   }
 
-  .project-draft-alert {
-    display: grid;
-    gap: 3px;
-    padding: 10px 11px;
-  }
-
-  .project-draft-alert strong {
-    color: rgba(243, 247, 255, 0.9);
-    font-size: 12px;
-  }
-
-  .project-draft-alert span {
-    color: rgba(231, 238, 247, 0.58);
-    font-size: 11px;
-    line-height: 1.35;
+  .project-draft-summary-chips span[data-tone='conflicted'] strong {
+    color: #efa5b0;
   }
 
   .project-draft-alert[data-tone='warning'] {
     border-color: rgba(236, 180, 95, 0.18);
+    color: #e7bc77;
   }
 
   .project-browser {
@@ -984,13 +999,13 @@
 
   .project-browser-layout {
     display: grid;
-    grid-template-columns: minmax(170px, 0.9fr) minmax(0, 1.2fr);
-    min-height: 420px;
+    grid-template-columns: minmax(190px, 0.72fr) minmax(0, 1.55fr);
+    min-height: min(72vh, 700px);
   }
 
   .project-file-tree {
     min-width: 0;
-    max-height: 540px;
+    max-height: min(72vh, 700px);
     overflow: auto;
     padding: 6px;
     border-right: 1px solid rgba(255, 255, 255, 0.055);
@@ -1054,8 +1069,7 @@
     overflow: visible;
   }
 
-  .project-tree-file-glyph,
-  .project-file-profile-icon {
+  .project-tree-file-glyph {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1070,26 +1084,26 @@
   }
 
   .project-tree-file-glyph[data-kind='image'],
-  .project-file-profile[data-kind='image'] .project-file-profile-icon {
+  .project-file-kind-chip[data-kind='image'] {
     color: #8bd4bd;
   }
 
   .project-tree-file-glyph[data-kind='pdf'],
-  .project-file-profile[data-kind='pdf'] .project-file-profile-icon {
+  .project-file-kind-chip[data-kind='pdf'] {
     color: #efa5b0;
   }
 
   .project-tree-file-glyph[data-kind='spreadsheet'],
   .project-tree-file-glyph[data-kind='data'],
-  .project-file-profile[data-kind='spreadsheet'] .project-file-profile-icon,
-  .project-file-profile[data-kind='data'] .project-file-profile-icon {
+  .project-file-kind-chip[data-kind='spreadsheet'],
+  .project-file-kind-chip[data-kind='data'] {
     color: #e7bc77;
   }
 
   .project-tree-file-glyph[data-kind='code'],
   .project-tree-file-glyph[data-kind='graph'],
-  .project-file-profile[data-kind='code'] .project-file-profile-icon,
-  .project-file-profile[data-kind='graph'] .project-file-profile-icon {
+  .project-file-kind-chip[data-kind='code'],
+  .project-file-kind-chip[data-kind='graph'] {
     color: #9dc2ff;
   }
 
@@ -1142,7 +1156,7 @@
     align-content: start;
     gap: 9px;
     min-width: 0;
-    max-height: 540px;
+    max-height: min(72vh, 700px);
     overflow: auto;
     padding: 11px;
   }
@@ -1205,87 +1219,43 @@
     color: rgba(29, 39, 49, 0.78);
   }
 
+  .project-file-context-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
   .project-file-layer-strip {
     display: flex;
     flex-wrap: wrap;
     gap: 5px;
+    min-width: 0;
+  }
+
+  .project-file-kind-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    border-radius: 6px;
+    padding: 3px 7px;
+    background: rgba(255, 255, 255, 0.045);
+    color: rgba(231, 238, 247, 0.56);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.2;
   }
 
   .project-file-layer-strip span[data-present='true'] {
     color: color-mix(in srgb, var(--positive, #6BC785) 78%, white);
   }
 
-  .project-file-profile {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 9px;
-    min-width: 0;
-    border: 1px solid rgba(255, 255, 255, 0.055);
-    border-radius: 8px;
-    padding: 8px 9px;
-    background:
-      linear-gradient(90deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
-  }
-
-  :global(:root[data-color-scheme='light']) .project-file-profile {
-    border-color: rgba(85, 104, 120, 0.12);
-    background:
-      linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(248, 250, 248, 0.62));
-  }
-
-  .project-file-profile-icon {
-    width: 34px;
-    height: 34px;
-    background: rgba(255, 255, 255, 0.055);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-file-profile-icon {
-    background: rgba(85, 104, 120, 0.065);
-  }
-
-  .project-file-profile > div {
-    display: grid;
-    gap: 3px;
-    min-width: 0;
-  }
-
-  .project-file-profile strong,
-  .project-file-profile span,
-  .project-file-profile small {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .project-file-profile strong {
-    color: rgba(243, 247, 255, 0.9);
-    font-size: 12px;
-    line-height: 1.2;
-  }
-
-  .project-file-profile span,
-  .project-file-profile small {
-    color: rgba(231, 238, 247, 0.52);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 9px;
-    line-height: 1.2;
-  }
-
-  .project-file-profile small {
-    border-radius: 6px;
-    padding: 3px 6px;
-    background: rgba(255, 255, 255, 0.04);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-file-profile strong {
-    color: rgba(20, 29, 38, 0.9);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-file-profile span,
-  :global(:root[data-color-scheme='light']) .project-file-profile small {
-    color: rgba(82, 98, 111, 0.68);
+  :global(:root[data-color-scheme='light']) .project-file-kind-chip {
+    background: rgba(85, 104, 120, 0.06);
+    color: rgba(82, 98, 111, 0.72);
   }
 
   .project-preview-mode-tabs {
@@ -1365,7 +1335,7 @@
   }
 
   .project-preview-layer pre {
-    max-height: 260px;
+    max-height: min(58vh, 560px);
     min-width: 0;
     overflow: auto;
     margin: 0;
@@ -1385,9 +1355,23 @@
     color: rgba(28, 36, 45, 0.86);
   }
 
+  .project-rich-compare {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .project-rich-compare-item {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+    min-width: 0;
+  }
+
   .project-rich-preview {
-    min-height: 300px;
-    max-height: 520px;
+    min-height: min(58vh, 520px);
+    max-height: min(72vh, 680px);
     overflow: hidden;
     border-radius: 8px;
     border: 1px solid rgba(255, 255, 255, 0.06);
@@ -1402,7 +1386,7 @@
     display: block;
     width: 100%;
     height: 100%;
-    min-height: 300px;
+    min-height: min(58vh, 520px);
     border: 0;
     background: rgba(255, 255, 255, 0.94);
   }
@@ -1416,6 +1400,12 @@
   :global(:root[data-color-scheme='light']) .project-rich-preview {
     border-color: rgba(85, 104, 120, 0.12);
     background: rgba(246, 248, 248, 0.95);
+  }
+
+  @media (max-width: 980px) {
+    .project-rich-compare {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 
   .project-markdown-preview {
@@ -1727,11 +1717,6 @@
     color: #e7bc77;
   }
 
-  .project-publish-mini {
-    display: grid;
-    gap: 9px;
-  }
-
   .project-draft-empty {
     color: rgba(231, 238, 247, 0.48);
     font-size: 12px;
@@ -1748,11 +1733,6 @@
   }
 
   @media (max-width: 720px) {
-    .project-draft-counts,
-    .project-publish-metrics {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
     .project-browser-layout {
       grid-template-columns: minmax(0, 1fr);
     }

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import ConstellationIcon from '$lib/components/constellation/ConstellationIcon.svelte';
+  import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
   import {
     getIdeaProjectDraftFile,
+    getIdeaProjectDraftFileBlobUrl,
     getIdeaProjectDraftState,
     updateIdeaProjectDraftFile,
   } from '$lib/features/threads/api/threadApi';
@@ -10,15 +12,20 @@
     buildProjectFilePreviewView,
     PROJECT_DRAFT_CHANGE_METRICS,
     projectDirectoryAncestorKeys,
+    projectFileExtension,
+    projectFileKind,
+    projectFileKindLabel,
     projectFileLayerLabel,
     projectFileSizeLabel,
     projectFileStatusLabel,
     projectFileStatusTone,
     visibleProjectExplorerRows,
+    type ProjectFileKind,
     type ProjectExplorerFile,
     type ProjectExplorerDirectory,
     type ProjectExplorerRow,
   } from '$lib/features/threads/domain/projectDraftStatePresenter';
+  import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
   import type {
     ProjectDraftFileResponse,
     ProjectDraftStateRead,
@@ -79,6 +86,25 @@
   const previewView = $derived(buildProjectFilePreviewView(filePreview, selectedFile));
   const isEditingSelectedFile = $derived(Boolean(selectedFile && editingFileKey === selectedFile.key));
   const activePreviewMode = $derived(previewMode === 'review' && previewView.mode === 'diff' ? 'review' : 'final');
+  const selectedFileKind = $derived(projectFileKind(selectedFile));
+  const selectedFileKindLabel = $derived(projectFileKindLabel(selectedFile));
+  const selectedFileIcon = $derived(projectFileIconName(selectedFileKind));
+  const selectedFileExtension = $derived(projectFileExtension(selectedFile).replace(/^\./, '').toUpperCase());
+  const finalBlobUrl = $derived.by(() => {
+    const ideaId = idea?.id ?? null;
+    const file = selectedFile;
+    const layer = previewView.finalLayer?.key;
+    if (!ideaId || !file || !layer || !previewView.finalLayer?.layer?.exists) return '';
+    return getIdeaProjectDraftFileBlobUrl(ideaId, {
+      runId: runId ?? statePayload?.run_id ?? null,
+      resourceId: file.resourceId,
+      path: file.path,
+      layer,
+    });
+  });
+  const finalSheetRows = $derived(
+    spreadsheetPreviewRows(previewView.finalLayer?.content ?? '', projectFileExtension(selectedFile)),
+  );
 
   function metricCountLabel(value: number): string {
     return Number.isFinite(value) ? String(value) : '0';
@@ -90,6 +116,46 @@
 
   function rowTone(row: ProjectExplorerRow): ReturnType<typeof projectFileStatusTone> {
     return projectFileStatusTone(row.status);
+  }
+
+  function projectFileIconName(kind: ProjectFileKind): ConstellationIconName {
+    if (kind === 'image') return 'image';
+    if (kind === 'pdf') return 'pdf';
+    if (kind === 'spreadsheet' || kind === 'data') return 'database';
+    if (kind === 'code' || kind === 'graph') return 'code';
+    if (kind === 'video') return 'video';
+    if (kind === 'archive') return 'archive';
+    if (kind === 'markdown' || kind === 'document') return 'document';
+    return 'file';
+  }
+
+  function finalLayerSourceLabel(key: 'root' | 'base' | 'draft'): string {
+    if (key === 'root') return 'project root';
+    if (key === 'base') return 'thread base';
+    return 'thread draft';
+  }
+
+  function previewKindDetail(): string {
+    return [
+      selectedFileKindLabel,
+      selectedFileExtension,
+      projectFileLayerLabel(selectedFile),
+    ].filter(Boolean).join(' / ');
+  }
+
+  function spreadsheetPreviewRows(content: string, extension: string): string[][] {
+    const suffix = extension.toLowerCase();
+    if (!['.csv', '.tsv'].includes(suffix) || !content.trim()) return [];
+    const delimiter = suffix === '.tsv' ? '\t' : ',';
+    return content
+      .split('\n')
+      .slice(0, 24)
+      .map((line) => line.split(delimiter).slice(0, 10).map((cell) => cell.trim()))
+      .filter((row) => row.some(Boolean));
+  }
+
+  function canEmbedFinalKind(kind: ProjectFileKind): boolean {
+    return kind === 'image' || kind === 'pdf' || kind === 'video';
   }
 
   function selectFile(file: ProjectExplorerFile) {
@@ -358,7 +424,9 @@
                   title={row.displayPath}
                   onclick={() => selectFile(row)}
                 >
-                  <ConstellationIcon name={row.extension === '.md' ? 'document' : 'file'} size={14} />
+                  <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
+                    <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
+                  </span>
                   <span>{row.name}</span>
                   <small>{projectFileStatusLabel(row.status)}</small>
                 </button>
@@ -399,6 +467,17 @@
                 <span data-present={selectedFile.has_root === true}>Root</span>
                 <span data-present={selectedFile.has_base === true}>Base</span>
                 <span data-present={selectedFile.has_draft === true}>Draft</span>
+              </div>
+
+              <div class="project-file-profile" data-kind={selectedFileKind}>
+                <span class="project-file-profile-icon" aria-hidden="true">
+                  <ConstellationIcon name={selectedFileIcon} size={18} stroke={1.7} />
+                </span>
+                <div>
+                  <strong>{selectedFileKindLabel}</strong>
+                  <span>{previewKindDetail()}</span>
+                </div>
+                <small>{selectedFileExtension || 'FILE'}</small>
               </div>
 
               <div class="project-preview-mode-tabs" aria-label="Project file preview mode">
@@ -474,9 +553,53 @@
                     <div class="project-preview-layer" data-layer={previewView.finalLayer.key}>
                       <div class="project-preview-layer-head">
                         <strong>{previewView.finalLayer.label}</strong>
-                        <span>{previewView.finalLayer.detail}</span>
+                        <span>{previewView.finalLayer.detail} / {finalLayerSourceLabel(previewView.finalLayer.key)}</span>
                       </div>
-                      <pre>{previewView.finalLayer.content}</pre>
+                      {#if canEmbedFinalKind(selectedFileKind) && finalBlobUrl}
+                        <div class="project-rich-preview" data-kind={selectedFileKind}>
+                          {#if selectedFileKind === 'image'}
+                            <img src={finalBlobUrl} alt={selectedFile.name} />
+                          {:else if selectedFileKind === 'pdf'}
+                            <iframe src={finalBlobUrl} title={selectedFile.name}></iframe>
+                          {:else if selectedFileKind === 'video'}
+                            <!-- svelte-ignore a11y_media_has_caption -->
+                            <video src={finalBlobUrl} controls playsinline preload="metadata"></video>
+                          {/if}
+                        </div>
+                      {:else if selectedFileKind === 'markdown' && previewView.finalLayer.content.trim()}
+                        <div class="project-markdown-preview constellation-prose">
+                          {@html renderReadableMarkdown(previewView.finalLayer.content)}
+                        </div>
+                      {:else if selectedFileKind === 'spreadsheet' && finalSheetRows.length > 0}
+                        <div class="project-sheet-preview">
+                          <table>
+                            <tbody>
+                              {#each finalSheetRows as row, rowIndex (`row-${rowIndex}`)}
+                                <tr>
+                                  {#each row as cell, cellIndex (`cell-${rowIndex}-${cellIndex}`)}
+                                    <td>{cell}</td>
+                                  {/each}
+                                </tr>
+                              {/each}
+                            </tbody>
+                          </table>
+                        </div>
+                      {:else if previewView.finalLayer.layer?.binary}
+                        <div class="project-binary-preview" data-kind={selectedFileKind}>
+                          <span aria-hidden="true">
+                            <ConstellationIcon name={selectedFileIcon} size={30} stroke={1.5} />
+                          </span>
+                          <strong>{selectedFileKindLabel} preview</strong>
+                          <p>{previewView.finalLayer.detail || 'Binary file'} is available in the Project, but cannot be rendered inline here.</p>
+                          {#if finalBlobUrl}
+                            <a href={finalBlobUrl} target="_blank" rel="noreferrer">Open file</a>
+                          {/if}
+                        </div>
+                      {:else if selectedFileKind === 'code' || selectedFileKind === 'data' || selectedFileKind === 'graph'}
+                        <pre class="project-code-preview" data-kind={selectedFileKind}>{previewView.finalLayer.content}</pre>
+                      {:else}
+                        <pre>{previewView.finalLayer.content}</pre>
+                      {/if}
                     </div>
                   </div>
                 {:else}
@@ -872,6 +995,45 @@
     overflow: visible;
   }
 
+  .project-tree-file-glyph,
+  .project-file-profile-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.045);
+    color: rgba(157, 194, 255, 0.86);
+  }
+
+  .project-tree-file-glyph {
+    width: 18px;
+    height: 18px;
+  }
+
+  .project-tree-file-glyph[data-kind='image'],
+  .project-file-profile[data-kind='image'] .project-file-profile-icon {
+    color: #8bd4bd;
+  }
+
+  .project-tree-file-glyph[data-kind='pdf'],
+  .project-file-profile[data-kind='pdf'] .project-file-profile-icon {
+    color: #efa5b0;
+  }
+
+  .project-tree-file-glyph[data-kind='spreadsheet'],
+  .project-tree-file-glyph[data-kind='data'],
+  .project-file-profile[data-kind='spreadsheet'] .project-file-profile-icon,
+  .project-file-profile[data-kind='data'] .project-file-profile-icon {
+    color: #e7bc77;
+  }
+
+  .project-tree-file-glyph[data-kind='code'],
+  .project-tree-file-glyph[data-kind='graph'],
+  .project-file-profile[data-kind='code'] .project-file-profile-icon,
+  .project-file-profile[data-kind='graph'] .project-file-profile-icon {
+    color: #9dc2ff;
+  }
+
   .project-tree-row span {
     min-width: 0;
     overflow: hidden;
@@ -994,6 +1156,79 @@
     color: color-mix(in srgb, var(--positive, #6BC785) 78%, white);
   }
 
+  .project-file-profile {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    border: 1px solid rgba(255, 255, 255, 0.055);
+    border-radius: 8px;
+    padding: 8px 9px;
+    background:
+      linear-gradient(90deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-profile {
+    border-color: rgba(85, 104, 120, 0.12);
+    background:
+      linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(248, 250, 248, 0.62));
+  }
+
+  .project-file-profile-icon {
+    width: 34px;
+    height: 34px;
+    background: rgba(255, 255, 255, 0.055);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-profile-icon {
+    background: rgba(85, 104, 120, 0.065);
+  }
+
+  .project-file-profile > div {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .project-file-profile strong,
+  .project-file-profile span,
+  .project-file-profile small {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .project-file-profile strong {
+    color: rgba(243, 247, 255, 0.9);
+    font-size: 12px;
+    line-height: 1.2;
+  }
+
+  .project-file-profile span,
+  .project-file-profile small {
+    color: rgba(231, 238, 247, 0.52);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.2;
+  }
+
+  .project-file-profile small {
+    border-radius: 6px;
+    padding: 3px 6px;
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-profile strong {
+    color: rgba(20, 29, 38, 0.9);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-profile span,
+  :global(:root[data-color-scheme='light']) .project-file-profile small {
+    color: rgba(82, 98, 111, 0.68);
+  }
+
   .project-preview-mode-tabs {
     display: inline-flex;
     align-items: center;
@@ -1089,6 +1324,161 @@
   :global(:root[data-color-scheme='light']) .project-preview-layer pre {
     background: rgba(246, 248, 248, 0.95);
     color: rgba(28, 36, 45, 0.86);
+  }
+
+  .project-rich-preview {
+    min-height: 300px;
+    max-height: 520px;
+    overflow: hidden;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018)),
+      rgba(5, 9, 14, 0.34);
+  }
+
+  .project-rich-preview img,
+  .project-rich-preview iframe,
+  .project-rich-preview video {
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 300px;
+    border: 0;
+    background: rgba(255, 255, 255, 0.94);
+  }
+
+  .project-rich-preview img,
+  .project-rich-preview video {
+    object-fit: contain;
+    background: rgba(5, 9, 14, 0.82);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-rich-preview {
+    border-color: rgba(85, 104, 120, 0.12);
+    background: rgba(246, 248, 248, 0.95);
+  }
+
+  .project-markdown-preview {
+    max-height: 520px;
+    min-width: 0;
+    overflow: auto;
+    border-radius: 8px;
+    padding: 14px;
+    background: rgba(6, 10, 15, 0.28);
+    color: rgba(240, 245, 251, 0.88);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-markdown-preview {
+    background: rgba(246, 248, 248, 0.95);
+    color: rgba(28, 36, 45, 0.9);
+  }
+
+  .project-sheet-preview {
+    max-height: 420px;
+    overflow: auto;
+    border: 1px solid rgba(255, 255, 255, 0.065);
+    border-radius: 8px;
+    background: rgba(6, 10, 15, 0.3);
+  }
+
+  .project-sheet-preview table {
+    width: 100%;
+    min-width: 420px;
+    border-collapse: collapse;
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    line-height: 1.35;
+  }
+
+  .project-sheet-preview td {
+    max-width: 220px;
+    border-right: 1px solid rgba(255, 255, 255, 0.055);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+    padding: 6px 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .project-sheet-preview tr:first-child td {
+    background: rgba(255, 255, 255, 0.05);
+    color: rgba(240, 245, 251, 0.88);
+    font-weight: 650;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview {
+    border-color: rgba(85, 104, 120, 0.12);
+    background: rgba(246, 248, 248, 0.95);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview td {
+    border-color: rgba(85, 104, 120, 0.12);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-sheet-preview tr:first-child td {
+    background: rgba(85, 104, 120, 0.075);
+    color: rgba(20, 29, 38, 0.88);
+  }
+
+  .project-code-preview {
+    border-left: 3px solid rgba(157, 194, 255, 0.34);
+  }
+
+  .project-code-preview[data-kind='data'],
+  .project-code-preview[data-kind='graph'] {
+    border-left-color: rgba(231, 188, 119, 0.42);
+  }
+
+  .project-binary-preview {
+    display: grid;
+    justify-items: center;
+    gap: 8px;
+    min-height: 220px;
+    border-radius: 8px;
+    padding: 26px 18px;
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.018)),
+      rgba(6, 10, 15, 0.28);
+    color: rgba(231, 238, 247, 0.68);
+    text-align: center;
+  }
+
+  .project-binary-preview strong {
+    color: rgba(243, 247, 255, 0.9);
+    font-size: 12px;
+  }
+
+  .project-binary-preview p {
+    max-width: 340px;
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.5;
+  }
+
+  .project-binary-preview a {
+    border-radius: 7px;
+    padding: 5px 9px;
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(240, 245, 251, 0.88);
+    font-size: 11px;
+    text-decoration: none;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-binary-preview {
+    background: rgba(246, 248, 248, 0.95);
+    color: rgba(82, 98, 111, 0.72);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-binary-preview strong {
+    color: rgba(20, 29, 38, 0.9);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-binary-preview a {
+    background: rgba(85, 104, 120, 0.08);
+    color: rgba(29, 39, 49, 0.84);
   }
 
   .project-diff-lines {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -431,16 +431,6 @@
             <span><ConstellationIcon name="lock" size={12} /> Root</span>
             <span><ConstellationIcon name="edit" size={12} /> Draft</span>
           </div>
-          <button
-            type="button"
-            class="project-browser-tree-toggle"
-            aria-expanded={!fileTreeCollapsed}
-            aria-controls="project-file-tree"
-            onclick={toggleFileTree}
-          >
-            <ConstellationIcon name={fileTreeCollapsed ? 'side-panel' : 'eye-off'} size={12} />
-            <span>{fileTreeCollapsed ? 'Show files' : 'Hide files'}</span>
-          </button>
         </div>
       </div>
 
@@ -488,6 +478,20 @@
               {/each}
             </div>
           {/if}
+
+          <div class="project-tree-rail" aria-label="File tree controls">
+            <button
+              type="button"
+              class="project-tree-rail-toggle"
+              aria-expanded={!fileTreeCollapsed}
+              aria-controls="project-file-tree"
+              title={fileTreeCollapsed ? 'Show files' : 'Collapse file tree'}
+              onclick={toggleFileTree}
+            >
+              <ConstellationIcon name={fileTreeCollapsed ? 'chevron-right' : 'chevron-left'} size={12} />
+              <span>{fileTreeCollapsed ? 'Files' : 'Collapse'}</span>
+            </button>
+          </div>
 
           <div class="project-file-preview" aria-live="polite">
             {#if selectedFile}
@@ -1008,28 +1012,6 @@
     gap: 5px;
   }
 
-  .project-browser-tree-toggle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 5px;
-    min-height: 24px;
-    border: 1px solid rgba(255, 255, 255, 0.065);
-    border-radius: 7px;
-    padding: 3px 7px;
-    background: rgba(255, 255, 255, 0.04);
-    color: rgba(231, 238, 247, 0.66);
-    font-size: 10px;
-    line-height: 1;
-    cursor: pointer;
-  }
-
-  :global(:root[data-color-scheme='light']) .project-browser-tree-toggle {
-    border-color: rgba(85, 104, 120, 0.13);
-    background: rgba(85, 104, 120, 0.055);
-    color: rgba(57, 70, 82, 0.72);
-  }
-
   .project-browser-legend span,
   .project-file-layer-strip span {
     display: inline-flex;
@@ -1051,12 +1033,12 @@
 
   .project-browser-layout {
     display: grid;
-    grid-template-columns: minmax(190px, 0.72fr) minmax(0, 1.55fr);
+    grid-template-columns: minmax(190px, 0.72fr) 28px minmax(0, 1.55fr);
     min-height: min(72vh, 700px);
   }
 
   .project-browser-layout[data-tree-collapsed='true'] {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: 28px minmax(0, 1fr);
   }
 
   .project-file-tree {
@@ -1064,11 +1046,64 @@
     max-height: min(72vh, 700px);
     overflow: auto;
     padding: 6px;
-    border-right: 1px solid rgba(255, 255, 255, 0.055);
   }
 
-  :global(:root[data-color-scheme='light']) .project-file-tree {
-    border-right-color: rgba(85, 104, 120, 0.12);
+  .project-tree-rail {
+    display: grid;
+    align-content: stretch;
+    justify-items: center;
+    min-width: 0;
+    padding: 6px 3px;
+    border-left: 1px solid rgba(255, 255, 255, 0.055);
+    border-right: 1px solid rgba(255, 255, 255, 0.055);
+    background: rgba(255, 255, 255, 0.018);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-rail {
+    border-color: rgba(85, 104, 120, 0.12);
+    background: rgba(85, 104, 120, 0.025);
+  }
+
+  .project-tree-rail-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 6px;
+    width: 100%;
+    min-height: 132px;
+    border: 0;
+    border-radius: 7px;
+    padding: 8px 3px;
+    background: transparent;
+    color: rgba(231, 238, 247, 0.58);
+    font-size: 9px;
+    font-weight: 650;
+    line-height: 1;
+    cursor: pointer;
+    writing-mode: vertical-rl;
+  }
+
+  .project-tree-rail-toggle:hover {
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(239, 244, 251, 0.82);
+  }
+
+  .project-tree-rail-toggle :global(svg) {
+    transform: rotate(90deg);
+  }
+
+  .project-tree-rail-toggle span {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-rail-toggle {
+    color: rgba(82, 98, 111, 0.68);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-rail-toggle:hover {
+    background: rgba(82, 117, 139, 0.08);
+    color: rgba(29, 39, 49, 0.82);
   }
 
   .project-tree-row {

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -1,34 +1,36 @@
 <script lang="ts">
   import ConstellationIcon from '$lib/components/constellation/ConstellationIcon.svelte';
-  import { getIdeaProjectDraftState } from '$lib/features/threads/api/threadApi';
+  import {
+    getIdeaProjectDraftFile,
+    getIdeaProjectDraftState,
+  } from '$lib/features/threads/api/threadApi';
   import {
     buildProjectDraftPanelView,
-    cleanLabel,
-    countResourceChange,
-    fileCountLabel,
-    latestGroupVersion,
     PROJECT_DRAFT_CHANGE_METRICS,
-    publishGroupTitle,
-    publishOperationLabel,
-    publishOperationPath,
-    publishStatus,
-    publishTargetLabel,
-    resourceMeta,
-    resourceStatus,
-    resourceTitle,
-    restoreTitle,
-    versionTitle,
+    projectFileLayerLabel,
+    projectFileSizeLabel,
+    projectFileStatusLabel,
+    projectFileStatusTone,
+    type ProjectExplorerFile,
+    type ProjectExplorerRow,
   } from '$lib/features/threads/domain/projectDraftStatePresenter';
-  import { relativeTimeAgo } from '$lib/utils/datetime';
   import type {
-    ProjectDraftStateResponse,
+    ProjectDraftFileLayer,
+    ProjectDraftFileResponse,
     ProjectDraftStateRead,
-    ProjectRootVersionState,
+    ProjectDraftStateResponse,
   } from '$lib/api/client';
 
   type DraftIdea = {
     id?: string | null;
   } | null;
+
+  type PreviewLayer = {
+    key: 'root' | 'base' | 'draft';
+    label: string;
+    detail: string;
+    layer: ProjectDraftFileLayer | undefined;
+  };
 
   const CHANGE_METRICS = PROJECT_DRAFT_CHANGE_METRICS;
 
@@ -46,6 +48,13 @@
   let loadedKey = $state('');
   let requestSeq = 0;
 
+  let selectedFileKey = $state('');
+  let filePreview = $state<ProjectDraftFileResponse | null>(null);
+  let filePreviewLoading = $state(false);
+  let filePreviewError = $state('');
+  let loadedFileKey = $state('');
+  let fileRequestSeq = 0;
+
   const draftView = $derived.by(() =>
     buildProjectDraftPanelView({ draftState, loading, loadError, runId }),
   );
@@ -53,29 +62,85 @@
   const resources = $derived(draftView.resources);
   const aggregateCounts = $derived(draftView.aggregateCounts);
   const outOfDatePaths = $derived(draftView.outOfDatePaths);
-  const fileGroups = $derived(draftView.fileGroups);
+  const fileBrowser = $derived(draftView.fileBrowser);
   const publishPlan = $derived(draftView.publishPlan);
-  const rootVersions = $derived(draftView.rootVersions);
   const runLabel = $derived(draftView.runLabel);
   const readiness = $derived(draftView.readiness);
   const signalTone = $derived(readiness.tone);
   const signalLabel = $derived(readiness.label);
+  const selectedFile = $derived(
+    fileBrowser.files.find((file) => file.key === selectedFileKey) ?? null,
+  );
+  const previewLayers = $derived(buildPreviewLayers(filePreview, selectedFile));
 
-  function formatBytes(value: unknown): string {
-    const size = Number(value);
-    if (!Number.isFinite(size) || size <= 0) return '';
-    if (size < 1024) return `${size} B`;
-    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
-    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  function metricCountLabel(value: number): string {
+    return Number.isFinite(value) ? String(value) : '0';
   }
 
-  function versionMeta(version: ProjectRootVersionState | null): string {
-    if (!version) return 'No root versions yet';
+  function rowStyle(row: ProjectExplorerRow): string {
+    return `--depth: ${Math.min(row.depth, 8)}`;
+  }
+
+  function rowTone(row: ProjectExplorerRow): ReturnType<typeof projectFileStatusTone> {
+    return projectFileStatusTone(row.status);
+  }
+
+  function selectFile(file: ProjectExplorerFile) {
+    selectedFileKey = file.key;
+  }
+
+  function layerContent(layer: ProjectDraftFileLayer | undefined): string {
+    if (!layer?.exists) return 'Not present in this layer.';
+    if (layer.binary) return 'Binary file preview is not available.';
+    if (layer.error) return layer.error;
+    return layer.content ?? '';
+  }
+
+  function layerDetail(layer: ProjectDraftFileLayer | undefined): string {
+    if (!layer?.exists) return 'missing';
     return [
-      cleanLabel(version.label, 'Version'),
-      version.created_at ? relativeTimeAgo(version.created_at) : '',
-      formatBytes(version.total_size),
+      projectFileSizeLabel(layer.size),
+      layer.binary ? 'binary' : 'text',
+      layer.truncated ? 'truncated' : '',
     ].filter(Boolean).join(' / ');
+  }
+
+  function buildPreviewLayers(
+    preview: ProjectDraftFileResponse | null,
+    file: ProjectExplorerFile | null,
+  ): PreviewLayer[] {
+    const layers = preview?.layers ?? {};
+    const root = layers.root;
+    const draft = layers.draft;
+    const base = layers.base;
+    const rootContent = root?.content ?? '';
+    const draftContent = draft?.content ?? '';
+    const showComparison = Boolean(
+      root?.exists
+      && draft?.exists
+      && (rootContent !== draftContent || projectFileStatusTone(file?.status) !== 'clean'),
+    );
+
+    if (showComparison) {
+      const rows: PreviewLayer[] = [
+        { key: 'root', label: 'Project root', detail: layerDetail(root), layer: root },
+      ];
+      if (base?.exists && base.content !== rootContent && base.content !== draftContent) {
+        rows.push({ key: 'base', label: 'Thread base', detail: layerDetail(base), layer: base });
+      }
+      rows.push({ key: 'draft', label: 'Thread draft', detail: layerDetail(draft), layer: draft });
+      return rows;
+    }
+    if (draft?.exists) {
+      return [{ key: 'draft', label: 'Thread draft', detail: layerDetail(draft), layer: draft }];
+    }
+    if (root?.exists) {
+      return [{ key: 'root', label: 'Project root', detail: layerDetail(root), layer: root }];
+    }
+    if (base?.exists) {
+      return [{ key: 'base', label: 'Thread base', detail: layerDetail(base), layer: base }];
+    }
+    return [];
   }
 
   async function loadDraftState(ideaId: string, currentRunId: string | number | null) {
@@ -95,6 +160,31 @@
     }
   }
 
+  async function loadFilePreview(
+    ideaId: string,
+    currentRunId: string | number | null,
+    file: ProjectExplorerFile,
+  ) {
+    const requestId = ++fileRequestSeq;
+    filePreviewLoading = true;
+    filePreviewError = '';
+    try {
+      const result = await getIdeaProjectDraftFile(ideaId, {
+        runId: currentRunId,
+        resourceId: file.resourceId,
+        path: file.path,
+      });
+      if (requestId !== fileRequestSeq) return;
+      filePreview = result;
+    } catch (error: any) {
+      if (requestId !== fileRequestSeq) return;
+      filePreview = null;
+      filePreviewError = error?.detail || error?.message || 'Project file preview is unavailable.';
+    } finally {
+      if (requestId === fileRequestSeq) filePreviewLoading = false;
+    }
+  }
+
   $effect(() => {
     const ideaId = idea?.id ?? null;
     const currentRunId = runId ?? null;
@@ -111,23 +201,48 @@
     loadedKey = key;
     void loadDraftState(ideaId, currentRunId);
   });
+
+  $effect(() => {
+    if (fileBrowser.files.length === 0) {
+      selectedFileKey = '';
+      return;
+    }
+    if (selectedFileKey && fileBrowser.files.some((file) => file.key === selectedFileKey)) return;
+    const changed = fileBrowser.files.find((file) => projectFileStatusTone(file.status) !== 'clean');
+    selectedFileKey = (changed ?? fileBrowser.files[0]).key;
+  });
+
+  $effect(() => {
+    const ideaId = idea?.id ?? null;
+    const file = selectedFile;
+    const currentRunId = runId ?? statePayload?.run_id ?? null;
+    if (!ideaId || !file) {
+      fileRequestSeq += 1;
+      filePreview = null;
+      filePreviewError = '';
+      filePreviewLoading = false;
+      loadedFileKey = '';
+      return;
+    }
+    const key = `${ideaId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
+    if (loadedFileKey === key) return;
+    loadedFileKey = key;
+    void loadFilePreview(ideaId, currentRunId, file);
+  });
 </script>
 
-<section class="project-draft-panel" aria-label="Project draft state">
+<section class="project-draft-panel" aria-label="Project workspace">
   <div class="project-draft-summary">
-    <div class="project-draft-summary-main">
-      <div class="project-draft-kicker">Project draft</div>
-      <div class="project-draft-title-row">
-        <span class="project-draft-title">Root + thread overlay</span>
-        <span class="project-draft-signal" data-tone={signalTone}>{signalLabel}</span>
-      </div>
-      <div class="project-draft-meta">
-        <span>{runLabel}</span>
-        {#if resources.length > 0}
-          <span>{resources.length} resource{resources.length === 1 ? '' : 's'}</span>
-        {/if}
-        <span>{readiness.detail}</span>
-      </div>
+    <div class="project-draft-kicker">Project</div>
+    <div class="project-draft-title-row">
+      <span class="project-draft-title">Root + thread overlay</span>
+      <span class="project-draft-signal" data-tone={signalTone}>{signalLabel}</span>
+    </div>
+    <div class="project-draft-meta">
+      <span>{runLabel}</span>
+      <span>{resources.length} resource{resources.length === 1 ? '' : 's'}</span>
+      <span>{fileBrowser.fileCount} file{fileBrowser.fileCount === 1 ? '' : 's'}</span>
+      <span>{readiness.detail}</span>
     </div>
   </div>
 
@@ -140,35 +255,11 @@
       {statePayload.error || 'No Project draft state is bound to this run.'}
     </div>
   {:else}
-    <div class="project-draft-layers" aria-label="Project workspace layers">
-      <div class="project-draft-layer" data-layer="root">
-        <div class="project-draft-layer-icon">
-          <ConstellationIcon name="lock" size={14} />
-        </div>
-        <div>
-          <strong>Project root</strong>
-          <span>Read-only source</span>
-        </div>
-      </div>
-      <div class="project-draft-layer-arrow" aria-hidden="true">
-        <ConstellationIcon name="forward" size={14} />
-      </div>
-      <div class="project-draft-layer" data-layer="draft">
-        <div class="project-draft-layer-icon">
-          <ConstellationIcon name="edit" size={14} />
-        </div>
-        <div>
-          <strong>Thread draft</strong>
-          <span>Overlay workspace</span>
-        </div>
-      </div>
-    </div>
-
     <div class="project-draft-counts" aria-label="Draft change counts">
       {#each CHANGE_METRICS as metric (metric.key)}
         <div class="project-draft-count" data-tone={metric.tone}>
           <span>{metric.label}</span>
-          <strong>{aggregateCounts[metric.key]}</strong>
+          <strong>{metricCountLabel(aggregateCounts[metric.key])}</strong>
         </div>
       {/each}
     </div>
@@ -180,203 +271,113 @@
       </div>
     {/if}
 
-    {#if aggregateCounts.conflicted_paths > 0}
-      <div class="project-draft-alert" data-tone="conflict">
-        <strong>Conflicts</strong>
-        <span>{aggregateCounts.conflicted_paths} conflicted path{aggregateCounts.conflicted_paths === 1 ? '' : 's'} detected.</span>
-      </div>
-    {/if}
-
-    <div class="project-draft-section">
-      <div class="project-draft-section-head">
-        <h4>Files</h4>
-        <span>{fileGroups.length}</span>
-      </div>
-      {#if fileGroups.length === 0}
-        <div class="project-draft-empty">No changed files in the thread draft.</div>
-      {:else}
-        <div class="project-draft-file-list">
-          {#each fileGroups as group (group.key)}
-            <div class="project-draft-path-group" data-tone={group.tone}>
-              <div class="project-draft-path-label">
-                <span>{group.label}</span>
-                <strong>{group.paths.length}</strong>
-              </div>
-              <div class="project-draft-paths">
-                {#each group.paths.slice(0, 10) as path (path)}
-                  <code title={path}>{path}</code>
-                {/each}
-                {#if group.paths.length > 10}
-                  <span class="project-draft-more">+{group.paths.length - 10} more</span>
-                {/if}
-              </div>
-            </div>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
-    <div class="project-draft-section">
-      <div class="project-draft-section-head">
-        <h4>Resources</h4>
-        <span>{resources.length}</span>
-      </div>
-      {#if resources.length === 0}
-        <div class="project-draft-empty">No Project resources found for this run.</div>
-      {:else}
-        <div class="project-draft-resource-list">
-          {#each resources as resource (resource.id)}
-            <div class="project-draft-resource" data-status={resourceStatus(resource)}>
-              <div class="project-draft-resource-head">
-                <div class="project-draft-resource-copy">
-                  <h5>{resourceTitle(resource)}</h5>
-                  {#if resourceMeta(resource)}
-                    <p>{resourceMeta(resource)}</p>
-                  {/if}
-                </div>
-                <span class="project-draft-resource-status">{resourceStatus(resource)}</span>
-              </div>
-
-              <div class="project-draft-resource-paths">
-                <div>
-                  <span>Root</span>
-                  <code title={resource.source_path || publishTargetLabel({ publish_target: { kind: 'unknown' } })}>
-                    {resource.source_path || resource.repo || 'read-only source unavailable'}
-                  </code>
-                </div>
-                <div>
-                  <span>Draft</span>
-                  <code title={resource.workspace_path || resource.resource_path || ''}>
-                    {resource.workspace_path || resource.resource_path || 'thread overlay unavailable'}
-                  </code>
-                </div>
-              </div>
-
-              <div class="project-draft-resource-counts">
-                {#each CHANGE_METRICS as metric (metric.key)}
-                  <span data-tone={metric.tone}>{metric.label} {countResourceChange(resource, metric.key)}</span>
-                {/each}
-              </div>
-            </div>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
-    <div class="project-draft-section">
-      <div class="project-draft-section-head">
-        <h4>Publish plan</h4>
-        <span>{publishPlan.planOnly && !publishPlan.mutatesProjectRoot ? 'Preview' : 'Mutation'}</span>
-      </div>
-      <div class="project-draft-version-summary project-draft-publish-summary">
+    <div class="project-browser">
+      <div class="project-browser-head">
         <div>
-          <strong>{publishPlan.resourceCount}</strong>
-          <span>resource{publishPlan.resourceCount === 1 ? '' : 's'}</span>
-        </div>
-        <div>
-          <strong>{publishPlan.operationCount}</strong>
-          <span>operation{publishPlan.operationCount === 1 ? '' : 's'}</span>
-        </div>
-        <div data-tone={publishPlan.blockedCount > 0 ? 'conflicted' : 'changed'}>
-          <strong>{publishPlan.blockedCount}</strong>
-          <span>blocked</span>
-        </div>
-        <div>
-          <strong>{publishPlan.readyCount}</strong>
-          <span>ready</span>
-        </div>
-      </div>
-      {#if publishPlan.groups.length === 0}
-        <div class="project-draft-empty">No publish plan is available for this run.</div>
-      {:else}
-        <div class="project-draft-publish-groups">
-          {#each publishPlan.groups as group (group.resource_id ?? group.mount_path ?? group.label)}
-            {@const operations = Array.isArray(group.operations) ? group.operations : []}
-            <div class="project-draft-publish-group" data-status={publishStatus(group)}>
-              <div class="project-draft-publish-head">
-                <div>
-                  <strong>{publishGroupTitle(group)}</strong>
-                  <span>{publishTargetLabel(group)}</span>
-                </div>
-                <span class="project-draft-resource-status">{publishStatus(group)}</span>
-              </div>
-              {#if group.blocked_reasons?.length}
-                <div class="project-draft-blockers">
-                  {#each group.blocked_reasons as reason (reason)}
-                    <span>{cleanLabel(reason)}</span>
-                  {/each}
-                </div>
-              {/if}
-              {#if operations.length > 0}
-                <div class="project-draft-operations">
-                  {#each operations.slice(0, 6) as operation (`${operation.operation}:${operation.path}:${operation.target_path}`)}
-                    <span data-operation={publishOperationLabel(operation)}>
-                      <strong>{publishOperationLabel(operation)}</strong>
-                      <code title={publishOperationPath(operation)}>{publishOperationPath(operation)}</code>
-                    </span>
-                  {/each}
-                  {#if operations.length > 6}
-                    <span class="project-draft-more">+{operations.length - 6} more</span>
-                  {/if}
-                </div>
-              {/if}
-            </div>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
-    <div class="project-draft-section">
-      <div class="project-draft-section-head">
-        <h4>Root versions</h4>
-        <span>{rootVersions.versionCount}</span>
-      </div>
-      <div class="project-draft-version-summary">
-        <div>
-          <strong>{rootVersions.resourceCount}</strong>
-          <span>resource{rootVersions.resourceCount === 1 ? '' : 's'}</span>
-        </div>
-        <div>
-          <strong>{rootVersions.versionCount}</strong>
-          <span>version{rootVersions.versionCount === 1 ? '' : 's'}</span>
-        </div>
-      </div>
-      <div class="project-draft-version-latest">
-        {versionMeta(rootVersions.latestVersion)}
-      </div>
-
-      {#if rootVersions.groups.length > 0}
-        <div class="project-draft-version-groups">
-          {#each rootVersions.groups as group (group.resource_id ?? group.mount_path ?? group.label)}
-            {@const versions = Array.isArray(group.versions) ? group.versions : []}
-            {@const latest = latestGroupVersion(group)}
-            <div class="project-draft-version-group">
-              <div>
-                <strong>{group.mount_path || group.label || group.resource_id || 'Project root'}</strong>
-                <span>{versionMeta(latest)}</span>
-              </div>
-              <span>{versions.length}</span>
-            </div>
-            {#if versions.length > 0}
-              <div class="project-draft-version-list">
-                {#each versions.slice(0, 3) as version (version.version_id ?? version.id ?? version.label)}
-                  <div class="project-draft-version-row">
-                    <div>
-                      <strong>{versionTitle(version)}</strong>
-                      <span>{[version.created_at ? relativeTimeAgo(version.created_at) : '', fileCountLabel(version), formatBytes(version.total_size)].filter(Boolean).join(' / ')}</span>
-                    </div>
-                    <button type="button" class="project-draft-restore" disabled title={restoreTitle(version)} aria-label={restoreTitle(version)}>
-                      <ConstellationIcon name="cycles" size={13} />
-                    </button>
-                  </div>
-                {/each}
-              </div>
+          <h4>Files</h4>
+          <span>
+            {fileBrowser.visibleCount} shown
+            {#if fileBrowser.truncatedCount > 0}
+              / {fileBrowser.truncatedCount} hidden
             {/if}
-          {/each}
+          </span>
         </div>
+        <div class="project-browser-legend" aria-label="Project layers">
+          <span><ConstellationIcon name="lock" size={12} /> Root</span>
+          <span><ConstellationIcon name="edit" size={12} /> Draft</span>
+        </div>
+      </div>
+
+      {#if fileBrowser.rows.length === 0}
+        <div class="project-draft-empty">No browsable files found in this Project.</div>
       {:else}
-        <div class="project-draft-empty">No restorable root versions found.</div>
+        <div class="project-browser-layout">
+          <div class="project-file-tree" aria-label="Project files">
+            {#each fileBrowser.rows as row (row.key)}
+              {#if row.kind === 'directory'}
+                <div class="project-tree-row project-tree-directory" style={rowStyle(row)} data-tone={rowTone(row)}>
+                  <ConstellationIcon name="folder" size={14} />
+                  <span title={row.displayPath}>{row.name}</span>
+                  <small>{row.fileCount}</small>
+                </div>
+              {:else}
+                <button
+                  type="button"
+                  class="project-tree-row project-tree-file"
+                  class:project-tree-file-selected={selectedFileKey === row.key}
+                  style={rowStyle(row)}
+                  data-tone={rowTone(row)}
+                  title={row.displayPath}
+                  onclick={() => selectFile(row)}
+                >
+                  <ConstellationIcon name={row.extension === '.md' ? 'document' : 'file'} size={14} />
+                  <span>{row.name}</span>
+                  <small>{projectFileStatusLabel(row.status)}</small>
+                </button>
+              {/if}
+            {/each}
+          </div>
+
+          <div class="project-file-preview" aria-live="polite">
+            {#if selectedFile}
+              <div class="project-file-preview-head">
+                <div>
+                  <h4 title={selectedFile.displayPath}>{selectedFile.displayPath}</h4>
+                  <span>
+                    {projectFileLayerLabel(selectedFile)}
+                    {#if selectedFile.size}
+                      / {projectFileSizeLabel(selectedFile.size)}
+                    {/if}
+                  </span>
+                </div>
+                <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
+                  {projectFileStatusLabel(selectedFile.status)}
+                </span>
+              </div>
+
+              <div class="project-file-layer-strip" aria-label="Selected file layers">
+                <span data-present={selectedFile.has_root === true}>Root</span>
+                <span data-present={selectedFile.has_base === true}>Base</span>
+                <span data-present={selectedFile.has_draft === true}>Draft</span>
+              </div>
+
+              {#if filePreviewLoading}
+                <div class="project-draft-empty">Loading file preview...</div>
+              {:else if filePreviewError}
+                <div class="project-draft-empty project-draft-empty-warning">{filePreviewError}</div>
+              {:else if previewLayers.length === 0}
+                <div class="project-draft-empty">No readable preview for this file.</div>
+              {:else}
+                <div class="project-preview-layers">
+                  {#each previewLayers as item (item.key)}
+                    <div class="project-preview-layer" data-layer={item.key}>
+                      <div class="project-preview-layer-head">
+                        <strong>{item.label}</strong>
+                        <span>{item.detail}</span>
+                      </div>
+                      <pre>{layerContent(item.layer)}</pre>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            {:else}
+              <div class="project-draft-empty">No file selected.</div>
+            {/if}
+          </div>
+        </div>
       {/if}
+    </div>
+
+    <div class="project-publish-mini">
+      <div class="project-draft-kicker">Publish plan</div>
+      <div class="project-publish-metrics">
+        <span><strong>{publishPlan.resourceCount}</strong> resources</span>
+        <span><strong>{publishPlan.operationCount}</strong> operations</span>
+        <span data-tone={publishPlan.blockedCount > 0 ? 'conflicted' : 'clean'}>
+          <strong>{publishPlan.blockedCount}</strong> blocked
+        </span>
+        <span><strong>{publishPlan.readyCount}</strong> ready</span>
+      </div>
     </div>
   {/if}
 </section>
@@ -397,25 +398,29 @@
   }
 
   .project-draft-summary,
-  .project-draft-alert {
-    border: 1px solid rgba(255, 255, 255, 0.055);
+  .project-draft-alert,
+  .project-browser,
+  .project-publish-mini {
+    border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 8px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
+    background: rgba(255, 255, 255, 0.03);
   }
 
   :global(:root[data-color-scheme='light']) .project-draft-summary,
-  :global(:root[data-color-scheme='light']) .project-draft-alert {
-    border-color: rgba(126, 92, 52, 0.09);
-    background: rgba(255, 253, 247, 0.7);
+  :global(:root[data-color-scheme='light']) .project-draft-alert,
+  :global(:root[data-color-scheme='light']) .project-browser,
+  :global(:root[data-color-scheme='light']) .project-publish-mini {
+    border-color: rgba(85, 104, 120, 0.13);
+    background: rgba(250, 250, 246, 0.78);
   }
 
-  .project-draft-summary {
+  .project-draft-summary,
+  .project-publish-mini {
     padding: 12px;
   }
 
   .project-draft-kicker,
-  .project-draft-section-head h4,
-  .project-draft-path-label span {
+  .project-browser-head h4 {
     margin: 0;
     color: rgba(240, 240, 250, 0.56);
     font-family: var(--constellation-font-mono, var(--font-mono));
@@ -426,16 +431,23 @@
   }
 
   :global(:root[data-color-scheme='light']) .project-draft-kicker,
-  :global(:root[data-color-scheme='light']) .project-draft-section-head h4,
-  :global(:root[data-color-scheme='light']) .project-draft-path-label span {
+  :global(:root[data-color-scheme='light']) .project-browser-head h4 {
     color: rgba(82, 98, 111, 0.66);
   }
 
-  .project-draft-title-row {
+  .project-draft-title-row,
+  .project-browser-head,
+  .project-file-preview-head,
+  .project-preview-layer-head {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
+    min-width: 0;
+  }
+
+  .project-draft-title-row {
+    align-items: center;
     margin-top: 7px;
   }
 
@@ -452,7 +464,7 @@
   }
 
   .project-draft-signal,
-  .project-draft-resource-status {
+  .project-file-status {
     flex: 0 0 auto;
     border-radius: 7px;
     padding: 3px 8px;
@@ -465,24 +477,40 @@
     text-transform: uppercase;
   }
 
-  .project-draft-signal[data-tone='clean'] {
+  .project-draft-signal[data-tone='clean'],
+  .project-file-status[data-tone='clean'] {
     background: color-mix(in srgb, var(--positive, #6BC785) 16%, transparent);
     color: color-mix(in srgb, var(--positive, #6BC785) 82%, white);
   }
 
-  .project-draft-signal[data-tone='modified'] {
+  .project-draft-signal[data-tone='modified'],
+  .project-file-status[data-tone='changed'],
+  .project-file-status[data-tone='new'] {
     background: color-mix(in srgb, var(--thread-accent, #57CFA0) 14%, transparent);
     color: color-mix(in srgb, var(--thread-accent, #57CFA0) 78%, white);
   }
 
-  .project-draft-signal[data-tone='warning'] {
+  .project-draft-signal[data-tone='warning'],
+  .project-file-status[data-tone='warning'],
+  .project-file-status[data-tone='deleted'] {
     background: rgba(236, 180, 95, 0.13);
     color: #e7bc77;
   }
 
-  .project-draft-signal[data-tone='conflict'] {
+  .project-draft-signal[data-tone='conflict'],
+  .project-file-status[data-tone='conflicted'] {
     background: rgba(212, 128, 143, 0.14);
     color: #efa5b0;
+  }
+
+  .project-draft-meta,
+  .project-browser-head span,
+  .project-file-preview-head span,
+  .project-preview-layer-head span {
+    color: rgba(231, 238, 247, 0.52);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    line-height: 1.35;
   }
 
   .project-draft-meta {
@@ -490,101 +518,31 @@
     flex-wrap: wrap;
     gap: 5px 10px;
     margin-top: 7px;
-    color: rgba(231, 238, 247, 0.5);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
-    line-height: 1.35;
   }
 
-  .project-draft-meta span {
+  .project-draft-meta span,
+  .project-browser-head span,
+  .project-file-preview-head span {
     min-width: 0;
     overflow-wrap: anywhere;
   }
 
-  :global(:root[data-color-scheme='light']) .project-draft-meta {
+  :global(:root[data-color-scheme='light']) .project-draft-meta,
+  :global(:root[data-color-scheme='light']) .project-browser-head span,
+  :global(:root[data-color-scheme='light']) .project-file-preview-head span,
+  :global(:root[data-color-scheme='light']) .project-preview-layer-head span {
     color: rgba(82, 98, 111, 0.66);
   }
 
-  .project-draft-layers {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 20px minmax(0, 1fr);
-    align-items: stretch;
-    gap: 6px;
-  }
-
-  .project-draft-layer {
-    display: grid;
-    grid-template-columns: 28px minmax(0, 1fr);
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
-    min-height: 52px;
-    padding: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.055);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.028);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-draft-layer {
-    border-color: rgba(126, 92, 52, 0.08);
-    background: rgba(248, 250, 248, 0.72);
-  }
-
-  .project-draft-layer-icon {
-    display: grid;
-    place-items: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 7px;
-    background: rgba(255, 255, 255, 0.05);
-    color: rgba(231, 238, 247, 0.72);
-  }
-
-  .project-draft-layer[data-layer='root'] .project-draft-layer-icon {
-    color: #9cb7e4;
-  }
-
-  .project-draft-layer[data-layer='draft'] .project-draft-layer-icon {
-    color: color-mix(in srgb, var(--thread-accent, #57CFA0) 86%, white);
-  }
-
-  .project-draft-layer strong,
-  .project-draft-layer span {
-    display: block;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .project-draft-layer strong {
-    color: rgba(243, 247, 255, 0.9);
-    font-size: 12px;
-    font-weight: 650;
-  }
-
-  .project-draft-layer span {
-    margin-top: 2px;
-    color: rgba(231, 238, 247, 0.48);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 9px;
-  }
-
-  .project-draft-layer-arrow {
-    display: grid;
-    place-items: center;
-    color: rgba(231, 238, 247, 0.42);
-  }
-
   .project-draft-counts,
-  .project-draft-version-summary {
+  .project-publish-metrics {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 6px;
   }
 
   .project-draft-count,
-  .project-draft-version-summary > div {
+  .project-publish-metrics span {
     display: grid;
     gap: 5px;
     min-width: 0;
@@ -596,20 +554,20 @@
   }
 
   :global(:root[data-color-scheme='light']) .project-draft-count,
-  :global(:root[data-color-scheme='light']) .project-draft-version-summary > div {
-    border-color: rgba(126, 92, 52, 0.08);
+  :global(:root[data-color-scheme='light']) .project-publish-metrics span {
+    border-color: rgba(85, 104, 120, 0.12);
     background: rgba(248, 250, 248, 0.74);
   }
 
   .project-draft-count span,
-  .project-draft-version-summary span {
-    color: rgba(231, 238, 247, 0.48);
+  .project-publish-metrics span {
+    color: rgba(231, 238, 247, 0.5);
     font-size: 9px;
-    line-height: 1.15;
+    line-height: 1.2;
   }
 
   .project-draft-count strong,
-  .project-draft-version-summary strong {
+  .project-publish-metrics strong {
     color: rgba(243, 247, 255, 0.92);
     font-family: var(--constellation-font-mono, var(--font-mono));
     font-size: 16px;
@@ -617,16 +575,17 @@
   }
 
   :global(:root[data-color-scheme='light']) .project-draft-count span,
-  :global(:root[data-color-scheme='light']) .project-draft-version-summary span {
+  :global(:root[data-color-scheme='light']) .project-publish-metrics span {
     color: rgba(82, 98, 111, 0.64);
   }
 
   :global(:root[data-color-scheme='light']) .project-draft-count strong,
-  :global(:root[data-color-scheme='light']) .project-draft-version-summary strong {
+  :global(:root[data-color-scheme='light']) .project-publish-metrics strong {
     color: rgba(20, 29, 38, 0.9);
   }
 
-  .project-draft-count[data-tone='conflicted'] strong {
+  .project-draft-count[data-tone='conflicted'] strong,
+  .project-publish-metrics [data-tone='conflicted'] strong {
     color: #efa5b0;
   }
 
@@ -659,301 +618,245 @@
     border-color: rgba(236, 180, 95, 0.18);
   }
 
-  .project-draft-alert[data-tone='conflict'] {
-    border-color: rgba(212, 128, 143, 0.22);
-  }
-
-  .project-draft-section {
+  .project-browser {
     display: grid;
-    gap: 9px;
-    padding-top: 12px;
-    border-top: 1px solid rgba(255, 255, 255, 0.055);
-  }
-
-  :global(:root[data-color-scheme='light']) .project-draft-section {
-    border-top-color: rgba(126, 92, 52, 0.09);
-  }
-
-  .project-draft-section-head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-  }
-
-  .project-draft-section-head > span {
-    color: rgba(231, 238, 247, 0.48);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
-  }
-
-  .project-draft-resource-list,
-  .project-draft-file-list,
-  .project-draft-publish-groups,
-  .project-draft-version-groups,
-  .project-draft-version-list {
-    display: grid;
-    gap: 8px;
-    min-width: 0;
-  }
-
-  .project-draft-resource {
-    display: grid;
-    gap: 9px;
-    min-width: 0;
-    padding: 10px 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
-  }
-
-  .project-draft-resource[data-status*='conflict'] {
-    border-top-color: rgba(212, 128, 143, 0.22);
-  }
-
-  .project-draft-resource-head,
-  .project-draft-publish-head,
-  .project-draft-version-group,
-  .project-draft-version-row {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 10px;
-    min-width: 0;
-  }
-
-  .project-draft-resource-copy,
-  .project-draft-publish-head > div,
-  .project-draft-version-group > div,
-  .project-draft-version-row > div {
-    display: grid;
-    gap: 4px;
-    min-width: 0;
-  }
-
-  .project-draft-resource-copy h5,
-  .project-draft-publish-head strong,
-  .project-draft-version-group strong,
-  .project-draft-version-row strong {
-    margin: 0;
-    overflow-wrap: anywhere;
-    color: rgba(243, 247, 255, 0.9);
-    font-size: 12px;
-    font-weight: 650;
-    line-height: 1.3;
-  }
-
-  .project-draft-resource-copy p,
-  .project-draft-publish-head span,
-  .project-draft-version-group span,
-  .project-draft-version-row span,
-  .project-draft-version-latest {
-    margin: 0;
-    overflow-wrap: anywhere;
-    color: rgba(231, 238, 247, 0.48);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 9px;
-    line-height: 1.4;
-  }
-
-  .project-draft-resource-paths {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px;
-    min-width: 0;
-  }
-
-  .project-draft-resource-paths div {
-    display: grid;
-    gap: 4px;
-    min-width: 0;
-  }
-
-  .project-draft-resource-paths span {
-    color: rgba(231, 238, 247, 0.42);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 9px;
-    text-transform: uppercase;
-  }
-
-  .project-draft-resource-paths code {
-    min-width: 0;
+    gap: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
-    border-radius: 6px;
-    padding: 5px 6px;
-    background: rgba(255, 255, 255, 0.035);
-    color: rgba(239, 244, 251, 0.7);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 9px;
-    line-height: 1.25;
-    white-space: nowrap;
   }
 
-  .project-draft-resource-counts {
-    display: flex;
+  .project-browser-head {
+    align-items: center;
+    padding: 11px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-browser-head {
+    border-bottom-color: rgba(85, 104, 120, 0.12);
+  }
+
+  .project-browser-head > div:first-child {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .project-browser-legend {
+    display: inline-flex;
+    align-items: center;
     flex-wrap: wrap;
-    gap: 6px;
+    justify-content: flex-end;
+    gap: 5px;
   }
 
-  .project-draft-resource-counts span {
+  .project-browser-legend span,
+  .project-file-layer-strip span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     border-radius: 7px;
     padding: 3px 7px;
     background: rgba(255, 255, 255, 0.045);
-    color: rgba(231, 238, 247, 0.55);
+    color: rgba(231, 238, 247, 0.6);
     font-family: var(--constellation-font-mono, var(--font-mono));
     font-size: 9px;
-    line-height: 1.25;
   }
 
-  .project-draft-path-group {
+  :global(:root[data-color-scheme='light']) .project-browser-legend span,
+  :global(:root[data-color-scheme='light']) .project-file-layer-strip span {
+    background: rgba(85, 104, 120, 0.06);
+    color: rgba(57, 70, 82, 0.72);
+  }
+
+  .project-browser-layout {
     display: grid;
-    gap: 6px;
-    min-width: 0;
-    padding: 9px 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.045);
+    grid-template-columns: minmax(170px, 0.9fr) minmax(0, 1.2fr);
+    min-height: 420px;
   }
 
-  .project-draft-path-label {
-    display: flex;
+  .project-file-tree {
+    min-width: 0;
+    max-height: 540px;
+    overflow: auto;
+    padding: 6px;
+    border-right: 1px solid rgba(255, 255, 255, 0.055);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-file-tree {
+    border-right-color: rgba(85, 104, 120, 0.12);
+  }
+
+  .project-tree-row {
+    --depth: 0;
+    display: grid;
+    grid-template-columns: 16px minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: space-between;
-    gap: 8px;
+    gap: 7px;
+    width: 100%;
+    min-height: 30px;
+    margin: 1px 0;
+    padding: 5px 7px 5px calc(7px + (var(--depth) * 14px));
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: rgba(239, 244, 251, 0.74);
+    text-align: left;
   }
 
-  .project-draft-path-label strong {
-    color: rgba(231, 238, 247, 0.5);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
+  :global(:root[data-color-scheme='light']) .project-tree-row {
+    color: rgba(29, 39, 49, 0.78);
   }
 
-  .project-draft-paths {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
+  .project-tree-file {
+    cursor: pointer;
+  }
+
+  .project-tree-file:hover,
+  .project-tree-file-selected {
+    background: rgba(255, 255, 255, 0.055);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-file:hover,
+  :global(:root[data-color-scheme='light']) .project-tree-file-selected {
+    background: rgba(82, 117, 139, 0.08);
+  }
+
+  .project-tree-directory {
+    color: rgba(231, 238, 247, 0.58);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-directory {
+    color: rgba(82, 98, 111, 0.72);
+  }
+
+  .project-tree-row span {
     min-width: 0;
-  }
-
-  .project-draft-paths code,
-  .project-draft-more,
-  .project-draft-blockers span,
-  .project-draft-operations span {
-    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    border-radius: 6px;
-    padding: 4px 6px;
-    background: rgba(255, 255, 255, 0.045);
-    color: rgba(239, 244, 251, 0.78);
+    white-space: nowrap;
+    font-size: 11px;
+  }
+
+  .project-tree-row small {
+    min-width: 0;
+    max-width: 78px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: rgba(231, 238, 247, 0.46);
     font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
-    line-height: 1.25;
+    font-size: 8px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     white-space: nowrap;
   }
 
-  .project-draft-path-group[data-tone='warning'] .project-draft-paths code {
-    background: rgba(236, 180, 95, 0.12);
+  :global(:root[data-color-scheme='light']) .project-tree-row small {
+    color: rgba(82, 98, 111, 0.58);
+  }
+
+  .project-tree-row[data-tone='changed'] small,
+  .project-tree-row[data-tone='new'] small {
+    color: color-mix(in srgb, var(--thread-accent, #57CFA0) 82%, white);
+  }
+
+  .project-tree-row[data-tone='warning'] small,
+  .project-tree-row[data-tone='deleted'] small {
     color: #e7bc77;
   }
 
-  .project-draft-path-group[data-tone='conflicted'] .project-draft-paths code {
-    background: rgba(212, 128, 143, 0.12);
+  .project-tree-row[data-tone='conflicted'] small {
     color: #efa5b0;
   }
 
-  .project-draft-version-summary {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .project-draft-publish-summary {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .project-draft-publish-summary [data-tone='conflicted'] strong {
-    color: #efa5b0;
-  }
-
-  .project-draft-publish-group {
+  .project-file-preview {
     display: grid;
-    gap: 8px;
+    align-content: start;
+    gap: 9px;
     min-width: 0;
-    padding: 10px 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    max-height: 540px;
+    overflow: auto;
+    padding: 11px;
   }
 
-  .project-draft-publish-group[data-status='blocked'] {
-    border-top-color: rgba(212, 128, 143, 0.22);
+  .project-file-preview-head h4 {
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: rgba(243, 247, 255, 0.92);
+    font-size: 12px;
+    font-weight: 650;
+    line-height: 1.35;
   }
 
-  .project-draft-blockers,
-  .project-draft-operations {
+  :global(:root[data-color-scheme='light']) .project-file-preview-head h4 {
+    color: rgba(20, 29, 38, 0.92);
+  }
+
+  .project-file-preview-head > div {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .project-file-layer-strip {
     display: flex;
     flex-wrap: wrap;
     gap: 5px;
+  }
+
+  .project-file-layer-strip span[data-present='true'] {
+    color: color-mix(in srgb, var(--positive, #6BC785) 78%, white);
+  }
+
+  .project-preview-layers {
+    display: grid;
+    gap: 9px;
     min-width: 0;
   }
 
-  .project-draft-blockers span {
-    background: rgba(212, 128, 143, 0.12);
-    color: #efa5b0;
+  .project-preview-layer {
+    display: grid;
+    gap: 7px;
+    min-width: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.055);
+    padding-top: 9px;
   }
 
-  .project-draft-operations span {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
+  :global(:root[data-color-scheme='light']) .project-preview-layer {
+    border-top-color: rgba(85, 104, 120, 0.12);
   }
 
-  .project-draft-operations strong {
-    color: rgba(231, 238, 247, 0.62);
-    font-weight: 650;
+  .project-preview-layer-head strong {
+    color: rgba(243, 247, 255, 0.86);
+    font-size: 11px;
   }
 
-  .project-draft-operations code {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: rgba(239, 244, 251, 0.78);
+  :global(:root[data-color-scheme='light']) .project-preview-layer-head strong {
+    color: rgba(20, 29, 38, 0.86);
   }
 
-  .project-draft-version-latest {
+  .project-preview-layer pre {
+    max-height: 260px;
+    min-width: 0;
+    overflow: auto;
     margin: 0;
-  }
-
-  .project-draft-version-groups {
-    margin-top: 2px;
-  }
-
-  .project-draft-version-group {
-    padding: 9px 0 4px;
-    border-top: 1px solid rgba(255, 255, 255, 0.05);
-  }
-
-  .project-draft-version-group > span {
-    flex: 0 0 auto;
-    color: rgba(231, 238, 247, 0.5);
+    border-radius: 7px;
+    padding: 9px;
+    background: rgba(6, 10, 15, 0.34);
+    color: rgba(240, 245, 251, 0.82);
     font-family: var(--constellation-font-mono, var(--font-mono));
     font-size: 10px;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
 
-  .project-draft-version-row {
-    min-height: 34px;
-    padding-left: 8px;
-    border-left: 1px solid rgba(255, 255, 255, 0.06);
+  :global(:root[data-color-scheme='light']) .project-preview-layer pre {
+    background: rgba(246, 248, 248, 0.95);
+    color: rgba(28, 36, 45, 0.86);
   }
 
-  .project-draft-restore {
-    display: inline-grid;
-    flex: 0 0 auto;
-    place-items: center;
-    width: 26px;
-    height: 26px;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 7px;
-    background: rgba(255, 255, 255, 0.035);
-    color: rgba(231, 238, 247, 0.42);
-  }
-
-  .project-draft-restore:disabled {
-    cursor: not-allowed;
-    opacity: 0.72;
+  .project-publish-mini {
+    display: grid;
+    gap: 9px;
   }
 
   .project-draft-empty {
@@ -963,20 +866,36 @@
     padding: 10px 0;
   }
 
+  :global(:root[data-color-scheme='light']) .project-draft-empty {
+    color: rgba(82, 98, 111, 0.68);
+  }
+
   .project-draft-empty-warning {
     color: #e7bc77;
   }
 
   @media (max-width: 720px) {
     .project-draft-counts,
-    .project-draft-publish-summary,
-    .project-draft-layers,
-    .project-draft-resource-paths {
+    .project-publish-metrics {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .project-draft-layer-arrow {
-      display: none;
+    .project-browser-layout {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .project-file-tree {
+      max-height: 260px;
+      border-right: 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+    }
+
+    :global(:root[data-color-scheme='light']) .project-file-tree {
+      border-bottom-color: rgba(85, 104, 120, 0.12);
+    }
+
+    .project-file-preview {
+      max-height: none;
     }
   }
 </style>

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -67,7 +67,6 @@
   let fileSaveError = $state('');
   let fileSaveNotice = $state('');
   let previewMode = $state<'review' | 'final'>('review');
-  let fileTreeCollapsed = $state(false);
 
   const draftView = $derived.by(() =>
     buildProjectDraftPanelView({ draftState, loading, loadError, runId }),
@@ -217,10 +216,6 @@
     collapsedDirectoryKeys = directoryCollapsed(row)
       ? collapsedDirectoryKeys.filter((key) => key !== row.key)
       : [...collapsedDirectoryKeys, row.key];
-  }
-
-  function toggleFileTree() {
-    fileTreeCollapsed = !fileTreeCollapsed;
   }
 
   function beginFileEdit() {
@@ -437,65 +432,51 @@
       {#if fileBrowser.rows.length === 0}
         <div class="project-draft-empty">No browsable files found in this Project.</div>
       {:else}
-        <div class="project-browser-layout" data-tree-collapsed={fileTreeCollapsed}>
-          <div
-            id="project-file-tree"
-            class="project-file-tree"
-            data-collapsed={fileTreeCollapsed}
-            aria-label="Project files"
-          >
-            <button
-              type="button"
-              class="project-tree-row project-tree-collapse-action"
-              aria-expanded={!fileTreeCollapsed}
-              aria-controls="project-file-tree"
-              aria-label={fileTreeCollapsed ? 'Expand file tree' : 'Collapse file tree'}
-              title={fileTreeCollapsed ? 'Expand file tree' : 'Collapse file tree'}
-              onclick={toggleFileTree}
+        <div class="project-browser-layout">
+          <div id="project-file-tree" class="project-file-tree" aria-label="Project files">
+            <div
+              class="project-tree-rail"
+              aria-hidden="true"
+              title="Project files"
             >
-              <span class="project-tree-file-glyph" aria-hidden="true">
-                <ConstellationIcon name="side-panel" size={14} />
-              </span>
-              <span class="project-tree-label">{fileTreeCollapsed ? 'Files' : 'Collapse files'}</span>
-              <small>{fileTreeCollapsed ? 'open' : 'hide'}</small>
-            </button>
+              <span class="project-tree-rail-label">Files</span>
+              <small>{fileBrowser.visibleCount}</small>
+            </div>
 
-            {#each visibleRows as row (row.key)}
-              {#if row.kind === 'directory'}
-                <button
-                  type="button"
-                  class="project-tree-row project-tree-directory"
-                  style={rowStyle(row)}
-                  data-tone={rowTone(row)}
-                  aria-expanded={!directoryCollapsed(row)}
-                  title={row.displayPath}
-                  onclick={() => toggleDirectory(row)}
-                >
-                  <span class="project-tree-folder-glyph" aria-hidden="true">
-                    <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
-                    <ConstellationIcon name="folder" size={14} />
-                  </span>
-                  <span class="project-tree-label" title={row.displayPath}>{row.name}</span>
-                  <small>{row.fileCount}</small>
-                </button>
-              {:else}
-                <button
-                  type="button"
-                  class="project-tree-row project-tree-file"
-                  class:project-tree-file-selected={selectedFileKey === row.key}
-                  style={rowStyle(row)}
-                  data-tone={rowTone(row)}
-                  title={row.displayPath}
-                  onclick={() => selectFile(row)}
-                >
-                  <span class="project-tree-file-glyph" data-kind={projectFileKind(row)} aria-hidden="true">
-                    <ConstellationIcon name={projectFileIconName(projectFileKind(row))} size={14} />
-                  </span>
-                  <span class="project-tree-label">{row.name}</span>
-                  <small>{projectFileStatusLabel(row.status)}</small>
-                </button>
-              {/if}
-            {/each}
+            <div class="project-tree-list">
+              {#each visibleRows as row (row.key)}
+                {#if row.kind === 'directory'}
+                  <button
+                    type="button"
+                    class="project-tree-row project-tree-directory"
+                    style={rowStyle(row)}
+                    data-tone={rowTone(row)}
+                    aria-expanded={!directoryCollapsed(row)}
+                    title={row.displayPath}
+                    onclick={() => toggleDirectory(row)}
+                  >
+                    <span class="project-tree-chevron" aria-hidden="true">
+                      <ConstellationIcon name={directoryCollapsed(row) ? 'chevron-right' : 'chevron-down'} size={11} />
+                    </span>
+                    <span class="project-tree-label" title={row.displayPath}>{row.name}</span>
+                    <small>{row.fileCount}</small>
+                  </button>
+                {:else}
+                  <button
+                    type="button"
+                    class="project-tree-row project-tree-file"
+                    class:project-tree-file-selected={selectedFileKey === row.key}
+                    style={rowStyle(row)}
+                    data-tone={rowTone(row)}
+                    title={row.displayPath}
+                    onclick={() => selectFile(row)}
+                  >
+                    <span class="project-tree-label">{row.name}</span>
+                    <small>{projectFileStatusLabel(row.status)}</small>
+                  </button>
+                {/if}
+              {/each}
+            </div>
           </div>
 
           <div class="project-file-preview" aria-live="polite">
@@ -511,16 +492,16 @@
                   </span>
                 </div>
                 <div class="project-file-preview-actions">
-                  {#if previewView.canEdit}
+                  {#if previewView.canEdit && !isEditingSelectedFile}
                     <button
                       type="button"
                       class="project-file-edit-button"
                       disabled={filePreviewLoading || fileSaveLoading}
                       title="Edit this file in the thread draft"
-                      onclick={isEditingSelectedFile ? cancelFileEdit : beginFileEdit}
+                      onclick={beginFileEdit}
                     >
-                      <ConstellationIcon name={isEditingSelectedFile ? 'close' : 'edit'} size={12} />
-                      <span>{isEditingSelectedFile ? 'Cancel' : 'Edit'}</span>
+                      <ConstellationIcon name="edit" size={12} />
+                      <span>Edit</span>
                     </button>
                   {/if}
                   <span class="project-file-status" data-tone={projectFileStatusTone(selectedFile.status)}>
@@ -1037,71 +1018,122 @@
   }
 
   .project-browser-layout {
-    --project-tree-collapsed-width: var(--constellation-nav-rail-collapsed-width, 54px);
-    --project-tree-expanded-width: minmax(190px, 0.72fr);
-    display: grid;
-    grid-template-columns: var(--project-tree-expanded-width) minmax(0, 1.55fr);
+    --project-tree-collapsed-width: 62px;
+    --project-tree-expanded-width: 260px;
+    display: flex;
     min-height: min(72vh, 700px);
-  }
-
-  .project-browser-layout[data-tree-collapsed='true'] {
-    grid-template-columns: var(--project-tree-collapsed-width) minmax(0, 1fr);
   }
 
   .project-file-tree {
     position: relative;
     z-index: 1;
+    flex: 0 0 var(--project-tree-collapsed-width);
     min-width: 0;
-    width: 100%;
     max-height: min(72vh, 700px);
+    overflow: hidden;
+    border-right: 1px solid rgba(255, 255, 255, 0.055);
+    background: #10151b;
+    transition: flex-basis 220ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .project-file-tree:hover,
+  .project-file-tree:focus-within {
+    flex-basis: var(--project-tree-expanded-width);
+  }
+
+  .project-tree-rail,
+  .project-tree-list {
+    position: absolute;
+    inset: 0;
+  }
+
+  .project-tree-rail {
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto;
+    justify-items: center;
+    gap: 10px;
+    width: 100%;
+    border: 0;
+    padding: 12px 6px;
+    background: #10151b;
+    color: rgba(231, 238, 247, 0.68);
+    cursor: default;
+    transition: visibility 0s linear 120ms;
+  }
+
+  .project-tree-rail-label {
+    align-self: center;
+    color: rgba(239, 244, 251, 0.78);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.16em;
+    line-height: 1;
+    text-transform: uppercase;
+    transform: rotate(180deg);
+    writing-mode: vertical-rl;
+  }
+
+  .project-tree-rail small {
+    min-width: 24px;
+    border-radius: 999px;
+    padding: 3px 5px;
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(231, 238, 247, 0.58);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    font-weight: 650;
+    line-height: 1;
+    text-align: center;
+  }
+
+  .project-tree-list {
+    min-width: 0;
     overflow: auto;
     padding: 6px;
     border-right: 1px solid rgba(255, 255, 255, 0.055);
-    background: inherit;
-    transition:
-      width 180ms ease,
-      box-shadow 180ms ease;
-  }
-
-  .project-file-tree[data-collapsed='true'] {
-    width: var(--project-tree-collapsed-width);
-    overflow-x: hidden;
-  }
-
-  .project-file-tree[data-collapsed='true']:has(.project-tree-file:hover),
-  .project-file-tree[data-collapsed='true']:has(.project-tree-directory:hover),
-  .project-file-tree[data-collapsed='true']:has(.project-tree-row:focus-visible) {
-    width: min(260px, calc(100vw - 56px));
-    box-shadow:
-      18px 0 34px rgba(0, 0, 0, 0.16),
-      inset -1px 0 0 rgba(255, 255, 255, 0.055);
+    background: #10151b;
+    clip-path: inset(0 100% 0 0);
+    pointer-events: none;
+    transition: clip-path 220ms cubic-bezier(0.2, 0, 0, 1);
+    visibility: hidden;
   }
 
   :global(:root[data-color-scheme='light']) .project-file-tree {
     border-right-color: rgba(85, 104, 120, 0.12);
+    background: #fbfaf5;
   }
 
-  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-file:hover),
-  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-directory:hover),
-  :global(:root[data-color-scheme='light']) .project-file-tree[data-collapsed='true']:has(.project-tree-row:focus-visible) {
-    box-shadow:
-      18px 0 34px rgba(54, 70, 82, 0.11),
-      inset -1px 0 0 rgba(85, 104, 120, 0.12);
+  :global(:root[data-color-scheme='light']) .project-tree-rail,
+  :global(:root[data-color-scheme='light']) .project-tree-list {
+    background: #fbfaf5;
   }
 
-  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row {
-    grid-template-columns: 28px 0 0;
-    gap: 0;
-    padding-inline: 7px;
-    padding-left: 7px;
+  :global(:root[data-color-scheme='light']) .project-tree-rail {
+    color: rgba(82, 98, 111, 0.68);
   }
 
-  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-label,
-  .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row small {
-    max-width: 0;
-    opacity: 0;
-    transform: translateX(-6px);
+  :global(:root[data-color-scheme='light']) .project-tree-rail small {
+    background: rgba(85, 104, 120, 0.07);
+    color: rgba(82, 98, 111, 0.76);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-tree-rail-label {
+    color: rgba(57, 70, 82, 0.82);
+  }
+
+  .project-file-tree:hover .project-tree-rail,
+  .project-file-tree:focus-within .project-tree-rail {
     pointer-events: none;
+    transition-delay: 0s;
+    visibility: hidden;
+  }
+
+  .project-file-tree:hover .project-tree-list,
+  .project-file-tree:focus-within .project-tree-list {
+    clip-path: inset(0 0 0 0);
+    pointer-events: auto;
+    visibility: visible;
   }
 
   .project-tree-label,
@@ -1115,13 +1147,13 @@
   .project-tree-row {
     --depth: 0;
     display: grid;
-    grid-template-columns: 26px minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 7px;
     width: 100%;
     min-height: 30px;
     margin: 1px 0;
-    padding: 5px 7px 5px calc(7px + (var(--depth) * 14px));
+    padding: 5px 7px 5px calc(20px + (var(--depth) * 14px));
     border: 0;
     border-radius: 6px;
     background: transparent;
@@ -1134,35 +1166,20 @@
   }
 
   .project-tree-file,
-  .project-tree-directory,
-  .project-tree-collapse-action {
+  .project-tree-directory {
     cursor: pointer;
   }
 
   .project-tree-file:hover,
   .project-tree-directory:hover,
-  .project-tree-collapse-action:hover,
   .project-tree-file-selected {
     background: rgba(255, 255, 255, 0.055);
   }
 
   :global(:root[data-color-scheme='light']) .project-tree-file:hover,
   :global(:root[data-color-scheme='light']) .project-tree-directory:hover,
-  :global(:root[data-color-scheme='light']) .project-tree-collapse-action:hover,
   :global(:root[data-color-scheme='light']) .project-tree-file-selected {
     background: rgba(82, 117, 139, 0.08);
-  }
-
-  .project-tree-collapse-action {
-    color: rgba(231, 238, 247, 0.58);
-    font-family: var(--constellation-font-mono, var(--font-mono));
-    font-size: 10px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  :global(:root[data-color-scheme='light']) .project-tree-collapse-action {
-    color: rgba(82, 98, 111, 0.68);
   }
 
   .project-tree-directory {
@@ -1173,47 +1190,32 @@
     color: rgba(82, 98, 111, 0.72);
   }
 
-  .project-tree-folder-glyph {
+  .project-tree-directory {
+    grid-template-columns: 14px minmax(0, 1fr) auto;
+    padding-left: calc(7px + (var(--depth) * 14px));
+  }
+
+  .project-tree-chevron {
     display: inline-flex;
     align-items: center;
-    gap: 1px;
+    justify-content: center;
     min-width: 0;
     overflow: visible;
   }
 
-  .project-tree-file-glyph {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 6px;
-    background: rgba(255, 255, 255, 0.045);
-    color: rgba(157, 194, 255, 0.86);
-  }
-
-  .project-tree-file-glyph {
-    width: 18px;
-    height: 18px;
-  }
-
-  .project-tree-file-glyph[data-kind='image'],
   .project-file-kind-chip[data-kind='image'] {
     color: #8bd4bd;
   }
 
-  .project-tree-file-glyph[data-kind='pdf'],
   .project-file-kind-chip[data-kind='pdf'] {
     color: #efa5b0;
   }
 
-  .project-tree-file-glyph[data-kind='spreadsheet'],
-  .project-tree-file-glyph[data-kind='data'],
   .project-file-kind-chip[data-kind='spreadsheet'],
   .project-file-kind-chip[data-kind='data'] {
     color: #e7bc77;
   }
 
-  .project-tree-file-glyph[data-kind='code'],
-  .project-tree-file-glyph[data-kind='graph'],
   .project-file-kind-chip[data-kind='code'],
   .project-file-kind-chip[data-kind='graph'] {
     color: #9dc2ff;
@@ -1227,7 +1229,7 @@
     font-size: 11px;
   }
 
-  .project-tree-row .project-tree-folder-glyph {
+  .project-tree-row .project-tree-chevron {
     overflow: visible;
     white-space: normal;
   }
@@ -1265,6 +1267,7 @@
 
   .project-file-preview {
     display: grid;
+    flex: 1 1 auto;
     align-content: start;
     gap: 9px;
     min-width: 0;
@@ -1845,31 +1848,28 @@
   }
 
   @media (max-width: 720px) {
-    .project-browser-layout,
-    .project-browser-layout[data-tree-collapsed='true'] {
-      grid-template-columns: minmax(0, 1fr);
+    .project-browser-layout {
+      flex-direction: column;
     }
 
     .project-file-tree,
-    .project-file-tree[data-collapsed='true'] {
-      width: 100%;
+    .project-file-tree:hover,
+    .project-file-tree:focus-within {
+      flex-basis: auto;
       max-height: 260px;
       border-right: 0;
       border-bottom: 1px solid rgba(255, 255, 255, 0.055);
     }
 
-    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row {
-      grid-template-columns: 26px minmax(0, 1fr) auto;
-      gap: 7px;
-      padding: 5px 7px 5px calc(7px + (var(--depth) * 14px));
+    .project-tree-rail {
+      display: none;
     }
 
-    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-label,
-    .project-file-tree[data-collapsed='true']:not(:has(.project-tree-file:hover)):not(:has(.project-tree-directory:hover)):not(:has(.project-tree-row:focus-visible)) .project-tree-row small {
-      max-width: none;
-      opacity: 1;
-      transform: translateX(0);
+    .project-tree-list {
+      position: static;
+      clip-path: none;
       pointer-events: auto;
+      visibility: visible;
     }
 
     :global(:root[data-color-scheme='light']) .project-file-tree {

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -611,6 +611,52 @@ export function projectFileKindLabel(file: ProjectDraftFileEntry | null | undefi
   return 'File';
 }
 
+function parseDelimitedPreviewRow(line: string, delimiter: string, maxColumns: number): string[] {
+  const cells: string[] = [];
+  let current = '';
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const next = line[index + 1];
+    if (char === '"' && quoted && next === '"') {
+      current += '"';
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === delimiter && !quoted) {
+      cells.push(current.trim());
+      current = '';
+      if (cells.length >= maxColumns) break;
+      continue;
+    }
+    current += char;
+  }
+  if (cells.length < maxColumns) {
+    cells.push(current.trim());
+  }
+  return cells;
+}
+
+export function projectSpreadsheetPreviewRows(
+  content: string,
+  extension: string,
+  maxRows = 50,
+  maxColumns = 12,
+): string[][] {
+  const suffix = extension.toLowerCase();
+  if (!['.csv', '.tsv'].includes(suffix) || !content.trim()) return [];
+  const delimiter = suffix === '.tsv' ? '\t' : ',';
+  return normaliseProjectPreviewText(content)
+    .split('\n')
+    .slice(0, maxRows)
+    .map((line) => parseDelimitedPreviewRow(line, delimiter, maxColumns))
+    .filter((row) => row.some(Boolean));
+}
+
 export function normaliseProjectPreviewText(value: unknown): string {
   const text = String(value ?? '').replace(/\r\n?/g, '\n');
   const escapedBreaks = (text.match(/\\n/g) ?? []).length;

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -89,6 +89,7 @@ export type ProjectFilePreviewView =
     title: string;
     detail: string;
     layers: ProjectPreviewLayerView[];
+    finalLayer: ProjectPreviewLayerView | null;
     lines: ProjectTextDiffLine[];
     editableContent: string;
     canEdit: boolean;
@@ -96,6 +97,7 @@ export type ProjectFilePreviewView =
   | {
     mode: 'layers';
     layers: ProjectPreviewLayerView[];
+    finalLayer: ProjectPreviewLayerView | null;
     editableContent: string;
     canEdit: boolean;
   };
@@ -602,6 +604,25 @@ function previewLayerView(
   };
 }
 
+function previewFinalLayer(
+  file: ProjectExplorerFile | null,
+  root: ProjectDraftFileLayer | undefined,
+  base: ProjectDraftFileLayer | undefined,
+  draft: ProjectDraftFileLayer | undefined,
+): ProjectPreviewLayerView | null {
+  const tone = projectFileStatusTone(file?.status);
+  if (tone === 'deleted' || file?.has_draft || draft?.exists) {
+    return previewLayerView('draft', 'Final', draft);
+  }
+  if (root?.exists || file?.has_root) {
+    return previewLayerView('root', 'Final', root);
+  }
+  if (base?.exists) {
+    return previewLayerView('base', 'Final', base);
+  }
+  return null;
+}
+
 function samePreviewText(left: string, right: string): boolean {
   return left === right;
 }
@@ -700,6 +721,7 @@ export function buildProjectFilePreviewView(
     base?.exists ? previewLayerView('base', 'Thread base', base) : null,
     previewLayerView('draft', 'Thread draft', draft),
   ].filter((item): item is ProjectPreviewLayerView => Boolean(item));
+  const finalLayer = previewFinalLayer(file, root, base, draft);
   const editableLayer = draftReadable ? draft : rootReadable ? root : undefined;
   const editableContent = editableLayer ? projectLayerContent(editableLayer) : '';
   const canEdit = Boolean(file && editableLayer && !editableLayer.binary && !editableLayer.error);
@@ -710,6 +732,7 @@ export function buildProjectFilePreviewView(
       title: 'Project root -> thread draft',
       detail: 'red removed / green added',
       layers: layerViews,
+      finalLayer,
       lines: buildProjectTextDiff(rootContent, draftContent),
       editableContent,
       canEdit,
@@ -722,6 +745,7 @@ export function buildProjectFilePreviewView(
       title: 'New draft file',
       detail: 'green added',
       layers: layerViews,
+      finalLayer,
       lines: splitPreviewLines(draftContent).map((text) => ({ kind: 'added', text })),
       editableContent,
       canEdit,
@@ -734,6 +758,7 @@ export function buildProjectFilePreviewView(
       title: 'Deleted from thread draft',
       detail: 'red removed',
       layers: layerViews,
+      finalLayer,
       lines: splitPreviewLines(rootContent).map((text) => ({ kind: 'removed', text })),
       editableContent,
       canEdit,
@@ -744,6 +769,7 @@ export function buildProjectFilePreviewView(
   return {
     mode: 'layers',
     layers: fallbackLayers.length > 0 ? fallbackLayers : layerViews,
+    finalLayer,
     editableContent,
     canEdit,
   };

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -2,6 +2,8 @@ import type {
   ProjectDraftChangeKey,
   ProjectDraftChangeSet,
   ProjectDraftFileEntry,
+  ProjectDraftFileLayer,
+  ProjectDraftFileResponse,
   ProjectDraftPublishGroup,
   ProjectDraftPublishOperation,
   ProjectDraftResourceState,
@@ -65,6 +67,38 @@ export type ProjectFileBrowserView = {
   visibleCount: number;
   truncatedCount: number;
 };
+
+export type ProjectTextDiffLine = {
+  kind: 'context' | 'removed' | 'added';
+  text: string;
+};
+
+export type ProjectPreviewLayerKey = 'root' | 'base' | 'draft';
+
+export type ProjectPreviewLayerView = {
+  key: ProjectPreviewLayerKey;
+  label: string;
+  detail: string;
+  content: string;
+  layer: ProjectDraftFileLayer | undefined;
+};
+
+export type ProjectFilePreviewView =
+  | {
+    mode: 'diff';
+    title: string;
+    detail: string;
+    layers: ProjectPreviewLayerView[];
+    lines: ProjectTextDiffLine[];
+    editableContent: string;
+    canEdit: boolean;
+  }
+  | {
+    mode: 'layers';
+    layers: ProjectPreviewLayerView[];
+    editableContent: string;
+    canEdit: boolean;
+  };
 
 export type PublishPlanSummary = {
   ok: boolean;
@@ -400,6 +434,28 @@ export function buildProjectFileBrowserView(
   };
 }
 
+export function projectDirectoryAncestorKeys(resourceId: string, path: string): string[] {
+  const parts = cleanProjectPath(path).split('/').filter(Boolean);
+  const keys: string[] = [];
+  let current = '';
+  for (const part of parts.slice(0, -1)) {
+    current = current ? `${current}/${part}` : part;
+    keys.push(`${resourceId}:dir:${current}`);
+  }
+  return keys;
+}
+
+export function visibleProjectExplorerRows(
+  rows: ProjectExplorerRow[],
+  collapsedDirectoryKeys: Iterable<string>,
+): ProjectExplorerRow[] {
+  const collapsed = new Set(collapsedDirectoryKeys);
+  if (collapsed.size === 0) return rows;
+  return rows.filter((row) =>
+    projectDirectoryAncestorKeys(row.resourceId, row.path).every((key) => !collapsed.has(key)),
+  );
+}
+
 function buildProjectExplorerRows(files: ProjectExplorerFile[]): ProjectExplorerRow[] {
   const directories = new Map<string, ProjectExplorerDirectory>();
   for (const file of files) {
@@ -500,6 +556,197 @@ export function projectFileSizeLabel(value: unknown): string {
   if (size < 1024) return `${size} B`;
   if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function normaliseProjectPreviewText(value: unknown): string {
+  const text = String(value ?? '').replace(/\r\n?/g, '\n');
+  const escapedBreaks = (text.match(/\\n/g) ?? []).length;
+  const realBreaks = (text.match(/\n/g) ?? []).length;
+  if (escapedBreaks > realBreaks) {
+    return text.replace(/\\r\\n/g, '\n').replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+  }
+  return text;
+}
+
+function projectLayerContent(layer: ProjectDraftFileLayer | undefined): string {
+  if (!layer?.exists) return 'Not present in this layer.';
+  if (layer.binary) return 'Binary file preview is not available.';
+  if (layer.error) return layer.error;
+  return normaliseProjectPreviewText(layer.content ?? '');
+}
+
+function projectLayerDetail(layer: ProjectDraftFileLayer | undefined): string {
+  if (!layer?.exists) return 'missing';
+  return [
+    projectFileSizeLabel(layer.size),
+    layer.binary ? 'binary' : 'text',
+    layer.truncated ? 'truncated' : '',
+  ].filter(Boolean).join(' / ');
+}
+
+function canReadTextLayer(layer: ProjectDraftFileLayer | undefined): boolean {
+  return Boolean(layer?.exists && !layer.binary && !layer.error);
+}
+
+function previewLayerView(
+  key: ProjectPreviewLayerKey,
+  label: string,
+  layer: ProjectDraftFileLayer | undefined,
+): ProjectPreviewLayerView {
+  return {
+    key,
+    label,
+    detail: projectLayerDetail(layer),
+    content: projectLayerContent(layer),
+    layer,
+  };
+}
+
+function samePreviewText(left: string, right: string): boolean {
+  return left === right;
+}
+
+function splitPreviewLines(value: unknown): string[] {
+  return normaliseProjectPreviewText(value).split('\n');
+}
+
+function cappedProjectDiffLines(lines: ProjectTextDiffLine[], maxLines: number): ProjectTextDiffLine[] {
+  if (lines.length <= maxLines) return lines;
+  const omitted = lines.length - maxLines + 1;
+  return [
+    ...lines.slice(0, maxLines - 1),
+    { kind: 'context', text: `... ${omitted} diff lines omitted ...` },
+  ];
+}
+
+function buildFallbackDiff(
+  rootLines: string[],
+  draftLines: string[],
+  maxLines: number,
+): ProjectTextDiffLine[] {
+  return cappedProjectDiffLines([
+    ...rootLines.map((text) => ({ kind: 'removed' as const, text })),
+    ...draftLines.map((text) => ({ kind: 'added' as const, text })),
+  ], maxLines);
+}
+
+export function buildProjectTextDiff(
+  rootContent: unknown,
+  draftContent: unknown,
+  maxLines = 700,
+): ProjectTextDiffLine[] {
+  const rootLines = splitPreviewLines(rootContent);
+  const draftLines = splitPreviewLines(draftContent);
+  if (samePreviewText(rootLines.join('\n'), draftLines.join('\n'))) {
+    return cappedProjectDiffLines(rootLines.map((text) => ({ kind: 'context', text })), maxLines);
+  }
+  if (rootLines.length * draftLines.length > 160_000) {
+    return buildFallbackDiff(rootLines, draftLines, maxLines);
+  }
+
+  const matrix = Array.from({ length: rootLines.length + 1 }, () =>
+    Array<number>(draftLines.length + 1).fill(0),
+  );
+  for (let row = rootLines.length - 1; row >= 0; row -= 1) {
+    for (let column = draftLines.length - 1; column >= 0; column -= 1) {
+      matrix[row][column] = rootLines[row] === draftLines[column]
+        ? matrix[row + 1][column + 1] + 1
+        : Math.max(matrix[row + 1][column], matrix[row][column + 1]);
+    }
+  }
+
+  const lines: ProjectTextDiffLine[] = [];
+  let rootIndex = 0;
+  let draftIndex = 0;
+  while (rootIndex < rootLines.length && draftIndex < draftLines.length) {
+    if (rootLines[rootIndex] === draftLines[draftIndex]) {
+      lines.push({ kind: 'context', text: rootLines[rootIndex] });
+      rootIndex += 1;
+      draftIndex += 1;
+    } else if (matrix[rootIndex + 1][draftIndex] >= matrix[rootIndex][draftIndex + 1]) {
+      lines.push({ kind: 'removed', text: rootLines[rootIndex] });
+      rootIndex += 1;
+    } else {
+      lines.push({ kind: 'added', text: draftLines[draftIndex] });
+      draftIndex += 1;
+    }
+  }
+  while (rootIndex < rootLines.length) {
+    lines.push({ kind: 'removed', text: rootLines[rootIndex] });
+    rootIndex += 1;
+  }
+  while (draftIndex < draftLines.length) {
+    lines.push({ kind: 'added', text: draftLines[draftIndex] });
+    draftIndex += 1;
+  }
+  return cappedProjectDiffLines(lines, maxLines);
+}
+
+export function buildProjectFilePreviewView(
+  preview: ProjectDraftFileResponse | null,
+  file: ProjectExplorerFile | null,
+): ProjectFilePreviewView {
+  const layers = preview?.layers ?? {};
+  const root = layers.root;
+  const draft = layers.draft;
+  const base = layers.base;
+  const rootContent = projectLayerContent(root);
+  const draftContent = projectLayerContent(draft);
+  const rootReadable = canReadTextLayer(root);
+  const draftReadable = canReadTextLayer(draft);
+  const fileTone = projectFileStatusTone(file?.status);
+  const layerViews = [
+    previewLayerView('root', 'Project root', root),
+    base?.exists ? previewLayerView('base', 'Thread base', base) : null,
+    previewLayerView('draft', 'Thread draft', draft),
+  ].filter((item): item is ProjectPreviewLayerView => Boolean(item));
+  const editableLayer = draftReadable ? draft : rootReadable ? root : undefined;
+  const editableContent = editableLayer ? projectLayerContent(editableLayer) : '';
+  const canEdit = Boolean(file && editableLayer && !editableLayer.binary && !editableLayer.error);
+
+  if (rootReadable && draftReadable && (!samePreviewText(rootContent, draftContent) || fileTone !== 'clean')) {
+    return {
+      mode: 'diff',
+      title: 'Project root -> thread draft',
+      detail: 'red removed / green added',
+      layers: layerViews,
+      lines: buildProjectTextDiff(rootContent, draftContent),
+      editableContent,
+      canEdit,
+    };
+  }
+
+  if (!root?.exists && draftReadable) {
+    return {
+      mode: 'diff',
+      title: 'New draft file',
+      detail: 'green added',
+      layers: layerViews,
+      lines: splitPreviewLines(draftContent).map((text) => ({ kind: 'added', text })),
+      editableContent,
+      canEdit,
+    };
+  }
+
+  if (rootReadable && !draft?.exists && fileTone === 'deleted') {
+    return {
+      mode: 'diff',
+      title: 'Deleted from thread draft',
+      detail: 'red removed',
+      layers: layerViews,
+      lines: splitPreviewLines(rootContent).map((text) => ({ kind: 'removed', text })),
+      editableContent,
+      canEdit,
+    };
+  }
+
+  const fallbackLayers = layerViews.filter((item) => item.layer?.exists);
+  return {
+    mode: 'layers',
+    layers: fallbackLayers.length > 0 ? fallbackLayers : layerViews,
+    editableContent,
+    canEdit,
+  };
 }
 
 function publishPlanPayload(payload: ProjectDraftStateLike): Record<string, any> | null {

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -1,6 +1,7 @@
 import type {
   ProjectDraftChangeKey,
   ProjectDraftChangeSet,
+  ProjectDraftFileEntry,
   ProjectDraftPublishGroup,
   ProjectDraftPublishOperation,
   ProjectDraftResourceState,
@@ -30,6 +31,41 @@ export type DraftFileGroup = {
   paths: string[];
 };
 
+export type ProjectExplorerFile = ProjectDraftFileEntry & {
+  kind: 'file';
+  key: string;
+  resourceId: string;
+  resourceTitle: string;
+  mountPath: string;
+  displayPath: string;
+  depth: number;
+};
+
+export type ProjectExplorerDirectory = {
+  kind: 'directory';
+  key: string;
+  resourceId: string;
+  resourceTitle: string;
+  mountPath: string;
+  path: string;
+  name: string;
+  displayPath: string;
+  depth: number;
+  status: string;
+  fileCount: number;
+};
+
+export type ProjectExplorerRow = ProjectExplorerDirectory | ProjectExplorerFile;
+
+export type ProjectFileBrowserView = {
+  files: ProjectExplorerFile[];
+  rows: ProjectExplorerRow[];
+  fileCount: number;
+  changedCount: number;
+  visibleCount: number;
+  truncatedCount: number;
+};
+
 export type PublishPlanSummary = {
   ok: boolean;
   planOnly: boolean;
@@ -50,6 +86,7 @@ export type ProjectDraftPanelView = {
   totalChangeCount: number;
   outOfDatePaths: string[];
   fileGroups: DraftFileGroup[];
+  fileBrowser: ProjectFileBrowserView;
   publishPlan: PublishPlanSummary;
   rootVersions: NormalizedRootVersions;
   effectiveRunId: string | number | null | undefined;
@@ -86,6 +123,7 @@ export function buildProjectDraftPanelView({
   );
   const outOfDatePaths = collectOutOfDatePaths(statePayload, resources);
   const fileGroups = collectFileGroups(statePayload, resources, outOfDatePaths);
+  const fileBrowser = buildProjectFileBrowserView(statePayload, resources);
   const publishPlan = summarizePublishPlan(draftState, resources);
   const rootVersions = summarizeRootVersions(draftState, resources);
   const effectiveRunId = statePayload?.run_id ?? draftState?.run_id ?? runId;
@@ -97,6 +135,7 @@ export function buildProjectDraftPanelView({
     totalChangeCount,
     outOfDatePaths,
     fileGroups,
+    fileBrowser,
     publishPlan,
     rootVersions,
     effectiveRunId,
@@ -293,6 +332,174 @@ export function collectFileGroups(
     paths: stalePaths,
   });
   return groups.filter((group) => group.paths.length > 0);
+}
+
+function browserEntriesFromPayload(
+  payload: ProjectDraftStateRead | null,
+  resourceList: ProjectDraftResourceState[],
+): ProjectDraftFileEntry[] {
+  const topLevelEntries = (payload as any)?.file_browser?.entries;
+  if (Array.isArray(topLevelEntries) && topLevelEntries.length > 0) {
+    return topLevelEntries.filter((entry) => entry && typeof entry === 'object') as ProjectDraftFileEntry[];
+  }
+  return resourceList.flatMap((resource) => {
+    const entries = (resource as any)?.file_browser?.entries;
+    if (!Array.isArray(entries)) return [];
+    return entries
+      .filter((entry) => entry && typeof entry === 'object')
+      .map((entry) => ({
+        ...(entry as ProjectDraftFileEntry),
+        resource_id: resource.id,
+        mount_path: resource.mount_path,
+        resource_label: resource.label,
+      }));
+  });
+}
+
+export function buildProjectFileBrowserView(
+  payload: ProjectDraftStateRead | null,
+  resourceList: ProjectDraftResourceState[],
+): ProjectFileBrowserView {
+  const resourcesById = new Map(resourceList.map((resource) => [resource.id, resource]));
+  const files = browserEntriesFromPayload(payload, resourceList)
+    .map((entry, index): ProjectExplorerFile | null => {
+      const path = cleanProjectPath(entry.path);
+      if (!path) return null;
+      const resourceId = cleanLabel(entry.resource_id, 'project-root');
+      const resource = resourcesById.get(resourceId);
+      const mountPath = cleanProjectMount(entry.mount_path ?? resource?.mount_path ?? '/');
+      const resourceName = cleanLabel(entry.resource_label ?? resource?.label ?? mountPath, 'Project root');
+      return {
+        ...entry,
+        kind: 'file',
+        key: `${resourceId}:${path}:${index}`,
+        resourceId,
+        resourceTitle: resourceName,
+        mountPath,
+        path,
+        name: cleanLabel(entry.name, path.split('/').at(-1) ?? path),
+        displayPath: joinProjectDisplayPath(mountPath, path),
+        depth: Math.max(0, path.split('/').length - 1),
+      };
+    })
+    .filter((entry): entry is ProjectExplorerFile => Boolean(entry))
+    .sort((left, right) => left.displayPath.localeCompare(right.displayPath));
+  const rows = buildProjectExplorerRows(files);
+  const changedCount = files.filter((file) => projectFileStatusTone(file.status) !== 'clean').length;
+  const summary = (payload as any)?.file_browser?.summary ?? {};
+  const visibleCount = Number(summary.visible_count);
+  const fileCount = Number(summary.file_count);
+  const truncatedCount = Number(summary.truncated);
+  return {
+    files,
+    rows,
+    fileCount: Number.isFinite(fileCount) ? fileCount : files.length,
+    changedCount,
+    visibleCount: Number.isFinite(visibleCount) ? visibleCount : files.length,
+    truncatedCount: Number.isFinite(truncatedCount) ? truncatedCount : 0,
+  };
+}
+
+function buildProjectExplorerRows(files: ProjectExplorerFile[]): ProjectExplorerRow[] {
+  const directories = new Map<string, ProjectExplorerDirectory>();
+  for (const file of files) {
+    const parts = cleanProjectPath(file.path).split('/').filter(Boolean);
+    let current = '';
+    for (const part of parts.slice(0, -1)) {
+      current = current ? `${current}/${part}` : part;
+      const key = `${file.resourceId}:dir:${current}`;
+      const existing = directories.get(key);
+      if (existing) {
+        existing.fileCount += 1;
+        existing.status = combineFileStatuses(existing.status, file.status);
+        continue;
+      }
+      directories.set(key, {
+        kind: 'directory',
+        key,
+        resourceId: file.resourceId,
+        resourceTitle: file.resourceTitle,
+        mountPath: file.mountPath,
+        path: current,
+        name: part,
+        displayPath: joinProjectDisplayPath(file.mountPath, current),
+        depth: current.split('/').length - 1,
+        status: cleanLabel(file.status, 'clean'),
+        fileCount: 1,
+      });
+    }
+  }
+  return [...directories.values(), ...files]
+    .sort((left, right) => {
+      const byPath = left.displayPath.localeCompare(right.displayPath);
+      if (byPath !== 0) return byPath;
+      return left.kind === right.kind ? 0 : left.kind === 'directory' ? -1 : 1;
+    });
+}
+
+function combineFileStatuses(left: unknown, right: unknown): string {
+  const priority = ['conflicted', 'out_of_date', 'deleted', 'changed', 'new', 'clean'];
+  const leftStatus = normaliseProjectFileStatus(left);
+  const rightStatus = normaliseProjectFileStatus(right);
+  const leftIndex = priority.indexOf(leftStatus);
+  const rightIndex = priority.indexOf(rightStatus);
+  if (leftIndex === -1) return rightStatus;
+  if (rightIndex === -1) return leftStatus;
+  return leftIndex <= rightIndex ? leftStatus : rightStatus;
+}
+
+function normaliseProjectFileStatus(status: unknown): string {
+  const value = String(status ?? 'clean').trim().toLowerCase().replaceAll(' ', '_').replaceAll('-', '_');
+  return value || 'clean';
+}
+
+export function cleanProjectPath(path: unknown): string {
+  return String(path ?? '').replaceAll('\\', '/').replace(/^\/+/, '').trim();
+}
+
+export function cleanProjectMount(path: unknown): string {
+  const cleaned = String(path ?? '').replaceAll('\\', '/').trim();
+  if (!cleaned || cleaned === '.') return '/';
+  return cleaned.startsWith('/') ? cleaned : `/${cleaned}`;
+}
+
+export function joinProjectDisplayPath(mountPath: unknown, filePath: unknown): string {
+  const mount = cleanProjectMount(mountPath);
+  const path = cleanProjectPath(filePath);
+  if (!path) return mount;
+  if (mount === '/') return `/${path}`;
+  return `${mount.replace(/\/+$/, '')}/${path}`;
+}
+
+export function projectFileStatusLabel(status: unknown): string {
+  const value = normaliseProjectFileStatus(status);
+  if (value === 'out_of_date') return 'out of date';
+  return cleanLabel(value, 'clean');
+}
+
+export function projectFileStatusTone(status: unknown): 'clean' | 'changed' | 'new' | 'deleted' | 'conflicted' | 'warning' {
+  const value = normaliseProjectFileStatus(status);
+  if (value === 'conflicted') return 'conflicted';
+  if (value === 'out_of_date') return 'warning';
+  if (value === 'deleted') return 'deleted';
+  if (value === 'new') return 'new';
+  if (value === 'changed' || value === 'modified') return 'changed';
+  return 'clean';
+}
+
+export function projectFileLayerLabel(file: ProjectDraftFileEntry | null | undefined): string {
+  if (!file) return 'No file selected';
+  if (file.has_draft) return file.has_root ? 'draft overlay' : 'new draft file';
+  if (file.has_root) return 'project root';
+  return cleanLabel(file.layer, 'unknown layer');
+}
+
+export function projectFileSizeLabel(value: unknown): string {
+  const size = Number(value);
+  if (!Number.isFinite(size) || size < 0) return '';
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function publishPlanPayload(payload: ProjectDraftStateLike): Record<string, any> | null {

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -73,6 +73,19 @@ export type ProjectTextDiffLine = {
   text: string;
 };
 
+export type ProjectFileKind =
+  | 'archive'
+  | 'code'
+  | 'data'
+  | 'document'
+  | 'graph'
+  | 'image'
+  | 'markdown'
+  | 'pdf'
+  | 'spreadsheet'
+  | 'video'
+  | 'file';
+
 export type ProjectPreviewLayerKey = 'root' | 'base' | 'draft';
 
 export type ProjectPreviewLayerView = {
@@ -558,6 +571,44 @@ export function projectFileSizeLabel(value: unknown): string {
   if (size < 1024) return `${size} B`;
   if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function projectFileExtension(file: ProjectDraftFileEntry | null | undefined): string {
+  const extension = cleanLabel(file?.extension).toLowerCase();
+  if (extension.startsWith('.')) return extension;
+  const path = cleanProjectPath(file?.path);
+  const suffix = path.split('/').at(-1)?.match(/\.[^.]+$/)?.[0] ?? '';
+  return suffix.toLowerCase();
+}
+
+export function projectFileKind(file: ProjectDraftFileEntry | null | undefined): ProjectFileKind {
+  const extension = projectFileExtension(file);
+  if (['.md', '.markdown', '.mdx'].includes(extension)) return 'markdown';
+  if (['.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif', '.bmp', '.tif', '.tiff', '.svg'].includes(extension)) return 'image';
+  if (extension === '.pdf') return 'pdf';
+  if (['.csv', '.tsv', '.xls', '.xlsx', '.ods'].includes(extension)) return 'spreadsheet';
+  if (['.json', '.jsonl', '.ndjson', '.yaml', '.yml', '.xml', '.parquet'].includes(extension)) return 'data';
+  if (['.drawio', '.mmd', '.mermaid', '.dot', '.graphml'].includes(extension)) return 'graph';
+  if (['.ts', '.tsx', '.js', '.jsx', '.mjs', '.py', '.rb', '.go', '.rs', '.java', '.kt', '.swift', '.php', '.c', '.cc', '.cpp', '.h', '.hpp', '.cs', '.sql', '.sh', '.bash', '.zsh', '.svelte', '.css', '.scss', '.html', '.toml', '.ipynb'].includes(extension)) return 'code';
+  if (['.doc', '.docx', '.rtf', '.txt', '.pages', '.ppt', '.pptx', '.key'].includes(extension)) return 'document';
+  if (['.mp4', '.mov', '.webm', '.m4v', '.avi'].includes(extension)) return 'video';
+  if (['.zip', '.tar', '.gz', '.tgz', '.rar', '.7z'].includes(extension)) return 'archive';
+  return 'file';
+}
+
+export function projectFileKindLabel(file: ProjectDraftFileEntry | null | undefined): string {
+  const kind = projectFileKind(file);
+  if (kind === 'markdown') return 'Markdown';
+  if (kind === 'spreadsheet') return 'Spreadsheet';
+  if (kind === 'pdf') return 'PDF';
+  if (kind === 'code') return 'Code';
+  if (kind === 'data') return 'Data';
+  if (kind === 'image') return 'Image';
+  if (kind === 'graph') return 'Graph';
+  if (kind === 'video') return 'Video';
+  if (kind === 'archive') return 'Archive';
+  if (kind === 'document') return 'Document';
+  return 'File';
 }
 
 export function normaliseProjectPreviewText(value: unknown): string {

--- a/frontend/src/lib/utils/projectDraftStatePresenter.test.js
+++ b/frontend/src/lib/utils/projectDraftStatePresenter.test.js
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 
 import {
   buildProjectDraftPanelView,
+  joinProjectDisplayPath,
+  projectFileLayerLabel,
+  projectFileStatusTone,
   publishOperationPath,
   resourceMeta,
   resourceTitle,
@@ -28,6 +31,13 @@ test('project draft presenter summarizes root, draft, conflicts, and stale paths
             conflicted_paths: [{ relative_path: 'summary.md' }],
             out_of_date_paths: ['root.md'],
           },
+          file_browser: {
+            entries: [
+              { path: 'brief.md', name: 'brief.md', status: 'changed', has_root: true, has_draft: true, size: 120 },
+              { path: 'appendix.md', name: 'appendix.md', status: 'new', has_root: false, has_draft: true, size: 80 },
+              { path: 'archive/old.md', name: 'old.md', status: 'clean', has_root: true, has_draft: false, size: 60 },
+            ],
+          },
         },
       ],
     },
@@ -49,6 +59,10 @@ test('project draft presenter summarizes root, draft, conflicts, and stale paths
   assert.equal(view.publishPlan.blockedCount, 1);
   assert.equal(view.publishPlan.operationCount, 3);
   assert.equal(view.fileGroups.find((group) => group.key === 'conflicted_paths')?.paths[0], '/reports/summary.md');
+  assert.equal(view.fileBrowser.fileCount, 3);
+  assert.equal(view.fileBrowser.changedCount, 2);
+  assert.ok(view.fileBrowser.files.some((file) => file.displayPath === '/reports/archive/old.md'));
+  assert.ok(view.fileBrowser.rows.some((row) => row.kind === 'directory' && row.displayPath === '/reports/archive'));
   assert.equal(resourceTitle(view.resources[0]), '/reports');
   assert.equal(resourceMeta(view.resources[0]), 'folder / local / thread draft');
 });
@@ -90,4 +104,10 @@ test('project draft presenter respects explicit publish plan summaries', () => {
   assert.equal(view.publishPlan.operationCount, 2);
   assert.equal(view.publishPlan.readyCount, 1);
   assert.equal(publishOperationPath(view.publishPlan.groups[0].operations?.[0] ?? {}), 'strategy/report.md');
+});
+
+test('project file presenter formats status, layer, and mounted paths', () => {
+  assert.equal(joinProjectDisplayPath('/reports', 'analysis/summary.md'), '/reports/analysis/summary.md');
+  assert.equal(projectFileStatusTone('out_of_date'), 'warning');
+  assert.equal(projectFileLayerLabel({ path: 'new.md', has_draft: true, has_root: false }), 'new draft file');
 });

--- a/frontend/src/lib/utils/projectDraftStatePresenter.test.js
+++ b/frontend/src/lib/utils/projectDraftStatePresenter.test.js
@@ -11,6 +11,7 @@ import {
   projectFileKind,
   projectFileKindLabel,
   projectFileStatusTone,
+  projectSpreadsheetPreviewRows,
   publishOperationPath,
   resourceMeta,
   resourceTitle,
@@ -120,6 +121,25 @@ test('project file presenter formats status, layer, and mounted paths', () => {
   assert.equal(projectFileKind({ path: 'finance.xlsx' }), 'spreadsheet');
   assert.equal(projectFileKind({ path: 'diagram.mmd' }), 'graph');
   assert.equal(projectFileKindLabel({ path: 'analysis.ipynb' }), 'Code');
+});
+
+test('project spreadsheet previews parse escaped rows and quoted cells', () => {
+  assert.deepEqual(
+    projectSpreadsheetPreviewRows('name,notes\\nstripe,"keeps, comma"\\nadyen,plain', '.csv'),
+    [
+      ['name', 'notes'],
+      ['stripe', 'keeps, comma'],
+      ['adyen', 'plain'],
+    ],
+  );
+
+  assert.deepEqual(
+    projectSpreadsheetPreviewRows('name\tcount\\nprocessor\t12', '.tsv'),
+    [
+      ['name', 'count'],
+      ['processor', '12'],
+    ],
+  );
 });
 
 test('project file presenter filters rows under collapsed directories', () => {

--- a/frontend/src/lib/utils/projectDraftStatePresenter.test.js
+++ b/frontend/src/lib/utils/projectDraftStatePresenter.test.js
@@ -3,12 +3,16 @@ import assert from 'node:assert/strict';
 
 import {
   buildProjectDraftPanelView,
+  buildProjectFilePreviewView,
+  buildProjectTextDiff,
   joinProjectDisplayPath,
+  normaliseProjectPreviewText,
   projectFileLayerLabel,
   projectFileStatusTone,
   publishOperationPath,
   resourceMeta,
   resourceTitle,
+  visibleProjectExplorerRows,
 } from '../features/threads/domain/projectDraftStatePresenter.ts';
 
 test('project draft presenter summarizes root, draft, conflicts, and stale paths', () => {
@@ -110,4 +114,116 @@ test('project file presenter formats status, layer, and mounted paths', () => {
   assert.equal(joinProjectDisplayPath('/reports', 'analysis/summary.md'), '/reports/analysis/summary.md');
   assert.equal(projectFileStatusTone('out_of_date'), 'warning');
   assert.equal(projectFileLayerLabel({ path: 'new.md', has_draft: true, has_root: false }), 'new draft file');
+});
+
+test('project file presenter filters rows under collapsed directories', () => {
+  const draftState = {
+    ok: true,
+    draft_status: {
+      ok: true,
+      resources: [
+        {
+          id: 'reports',
+          mount_path: '/reports',
+          file_browser: {
+            entries: [
+              { path: 'archive/old.md', name: 'old.md', status: 'clean', has_root: true, size: 60 },
+              { path: 'archive/new.md', name: 'new.md', status: 'new', has_draft: true, size: 80 },
+              { path: 'brief.md', name: 'brief.md', status: 'changed', has_root: true, has_draft: true, size: 120 },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const rows = buildProjectDraftPanelView({
+    draftState,
+    loading: false,
+    loadError: '',
+    runId: null,
+  }).fileBrowser.rows;
+  const archive = rows.find((row) => row.kind === 'directory' && row.path === 'archive');
+  assert.ok(archive);
+
+  const visible = visibleProjectExplorerRows(rows, [archive.key]);
+
+  assert.ok(visible.some((row) => row.kind === 'directory' && row.path === 'archive'));
+  assert.ok(visible.some((row) => row.kind === 'file' && row.path === 'brief.md'));
+  assert.equal(visible.some((row) => row.kind === 'file' && row.path === 'archive/old.md'), false);
+});
+
+test('project file preview renders readable root to draft diffs', () => {
+  assert.equal(
+    normaliseProjectPreviewText('# Title\\n\\nBody'),
+    '# Title\n\nBody',
+  );
+
+  const lines = buildProjectTextDiff('root\nkeep\n', 'draft\nkeep\nnext\n');
+  assert.deepEqual(
+    lines.filter((line) => line.kind !== 'context').map((line) => `${line.kind}:${line.text}`),
+    ['removed:root', 'added:draft', 'added:next'],
+  );
+
+  const view = buildProjectFilePreviewView(
+    {
+      ok: true,
+      path: 'summary.md',
+      layers: {
+        root: { exists: true, binary: false, size: 20, content: 'root\\nkeep\\n' },
+        draft: { exists: true, binary: false, size: 26, content: 'draft\\nkeep\\nnext\\n' },
+      },
+    },
+    {
+      kind: 'file',
+      key: 'root:summary.md:0',
+      resourceId: 'root',
+      resourceTitle: 'Project root',
+      mountPath: '/',
+      path: 'summary.md',
+      name: 'summary.md',
+      displayPath: '/summary.md',
+      depth: 0,
+      status: 'changed',
+      has_root: true,
+      has_draft: true,
+    },
+  );
+
+  assert.equal(view.mode, 'diff');
+  assert.equal(view.canEdit, true);
+  assert.equal(view.editableContent, 'draft\nkeep\nnext\n');
+  assert.ok(view.lines.some((line) => line.kind === 'removed' && line.text === 'root'));
+  assert.ok(view.lines.some((line) => line.kind === 'added' && line.text === 'draft'));
+});
+
+test('project file preview falls back to layers for binary previews', () => {
+  const view = buildProjectFilePreviewView(
+    {
+      ok: true,
+      path: 'image.png',
+      layers: {
+        root: { exists: true, binary: true, size: 100 },
+        draft: { exists: true, binary: true, size: 100 },
+      },
+    },
+    {
+      kind: 'file',
+      key: 'root:image.png:0',
+      resourceId: 'root',
+      resourceTitle: 'Project root',
+      mountPath: '/',
+      path: 'image.png',
+      name: 'image.png',
+      displayPath: '/image.png',
+      depth: 0,
+      status: 'clean',
+      has_root: true,
+      has_draft: true,
+    },
+  );
+
+  assert.equal(view.mode, 'layers');
+  assert.equal(view.canEdit, false);
+  assert.equal(view.layers[0].content, 'Binary file preview is not available.');
 });

--- a/frontend/src/lib/utils/projectDraftStatePresenter.test.js
+++ b/frontend/src/lib/utils/projectDraftStatePresenter.test.js
@@ -8,6 +8,8 @@ import {
   joinProjectDisplayPath,
   normaliseProjectPreviewText,
   projectFileLayerLabel,
+  projectFileKind,
+  projectFileKindLabel,
   projectFileStatusTone,
   publishOperationPath,
   resourceMeta,
@@ -114,6 +116,10 @@ test('project file presenter formats status, layer, and mounted paths', () => {
   assert.equal(joinProjectDisplayPath('/reports', 'analysis/summary.md'), '/reports/analysis/summary.md');
   assert.equal(projectFileStatusTone('out_of_date'), 'warning');
   assert.equal(projectFileLayerLabel({ path: 'new.md', has_draft: true, has_root: false }), 'new draft file');
+  assert.equal(projectFileKind({ path: 'deck.pdf' }), 'pdf');
+  assert.equal(projectFileKind({ path: 'finance.xlsx' }), 'spreadsheet');
+  assert.equal(projectFileKind({ path: 'diagram.mmd' }), 'graph');
+  assert.equal(projectFileKindLabel({ path: 'analysis.ipynb' }), 'Code');
 });
 
 test('project file presenter filters rows under collapsed directories', () => {

--- a/frontend/src/lib/utils/projectDraftStatePresenter.test.js
+++ b/frontend/src/lib/utils/projectDraftStatePresenter.test.js
@@ -193,6 +193,8 @@ test('project file preview renders readable root to draft diffs', () => {
   assert.equal(view.mode, 'diff');
   assert.equal(view.canEdit, true);
   assert.equal(view.editableContent, 'draft\nkeep\nnext\n');
+  assert.equal(view.finalLayer?.label, 'Final');
+  assert.equal(view.finalLayer?.content, 'draft\nkeep\nnext\n');
   assert.ok(view.lines.some((line) => line.kind === 'removed' && line.text === 'root'));
   assert.ok(view.lines.some((line) => line.kind === 'added' && line.text === 'draft'));
 });

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -488,7 +488,7 @@ async def test_fast_recipe_keeps_large_project_context_out_of_system_prompt(monk
         captured["spec"] = spec
         return SimpleNamespace(output="ok", success=True, error=None)
 
-    huge_value = "x" * 2_000_000
+    huge_value = "RAW_PROJECT_FILE_CONTEXT_SHOULD_NOT_BE_IN_SYSTEM_PROMPT" * 80_000
     large_ref = {
         "kind": "cortex_idea",
         "title": "Port the SEO workflow",
@@ -496,8 +496,10 @@ async def test_fast_recipe_keeps_large_project_context_out_of_system_prompt(monk
             "name": "Agent Mission Control Reference",
             "resources": [
                 {
+                    "id": "resource-1",
                     "kind": "folder",
                     "path": "/workspaces/agent-mission-control-reference",
+                    "content": huge_value,
                     "materialization": {
                         "status": "ready",
                         "project_root_file_count": 779,
@@ -508,6 +510,42 @@ async def test_fast_recipe_keeps_large_project_context_out_of_system_prompt(monk
                     },
                 }
             ],
+        },
+        "project_runtime_context": {
+            "project_context_snapshot": {
+                "project_id": "project-1",
+                "project_key": "project-1",
+                "resources": [
+                    {
+                        "id": "resource-1",
+                        "kind": "folder",
+                        "name": "agent-mission-control-reference",
+                        "path": "/workspaces/agent-mission-control-reference",
+                        "content": huge_value,
+                    }
+                ],
+                "permission_scope": {
+                    "allowed_paths": [f"/workspaces/project/file-{index}.md" for index in range(2_000)],
+                    "mode": "enforce",
+                    "permission_mode": "read_write",
+                },
+            },
+            "project_workspace_manifest": {
+                "workspace_root": "/workspaces/ideas/idea-1/.illo-project-context/local/project/project-root",
+                "workspaces": [
+                    {
+                        "name": "/",
+                        "path": "/workspaces/ideas/idea-1/.illo-project-context/local/project/project-root",
+                    }
+                ],
+            },
+            "project_context_materialization": {
+                "status": "materialized",
+                "project_root_file_count": 779,
+                "project_root_path_count": 779,
+                "project_draft_file_count": 779,
+                "project_draft_path_count": 779,
+            },
         },
         "workspace_root": "/workspaces/agent-mission-control-reference",
     }
@@ -523,8 +561,9 @@ async def test_fast_recipe_keeps_large_project_context_out_of_system_prompt(monk
 
     assert result.status.value == "completed"
     assert len(captured["spec"].system_prompt) < 40_000
-    assert huge_value[:1000] not in captured["spec"].system_prompt
+    assert "RAW_PROJECT_FILE_CONTEXT_SHOULD_NOT_BE_IN_SYSTEM_PROMPT" not in captured["spec"].system_prompt
     assert "large value omitted from prompt context" in captured["spec"].system_prompt
+    assert "project_root_file_count" in captured["spec"].system_prompt
     assert captured["spec"].system_prompt.count("## Context") == 1
 
 

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -210,6 +210,13 @@ def test_context_overflow_classifier_recognizes_provider_shapes():
     exc = ContextError("maximum context length exceeded; request too large")
 
     assert is_context_overflow_error(exc, provider_name="openai")
+    assert is_context_overflow_error(
+        RuntimeError(
+            "API error: Invalid 'instructions': string too long. "
+            "Expected a string with maximum length 1048576, but got a string with length 12256492 instead."
+        ),
+        provider_name="openai",
+    )
     assert context_overflow_payload(exc, provider_name="openai")["provider"] == "openai"
     assert not is_context_overflow_error(RuntimeError("temporarily overloaded"), provider_name="openai")
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -426,6 +426,11 @@ async def test_project_context_draft_state_payload_uses_manage_project_helpers(t
     assert payload["idea_id"] == "idea-1"
     assert payload["draft_status"]["resources"][0]["changes"]["changed_paths"] == ["brief.md"]
     assert payload["draft_status"]["resources"][0]["changes"]["new_paths"] == ["new.md"]
+    assert payload["draft_status"]["resources"][0]["file_browser"]["summary"]["file_count"] == 2
+    assert {
+        entry["path"]: entry["status"]
+        for entry in payload["draft_status"]["resources"][0]["file_browser"]["entries"]
+    } == {"brief.md": "changed", "new.md": "new"}
     assert payload["plan_publish"]["summary"] == {"resource_count": 1, "operation_count": 2, "blocked_count": 0}
     assert payload["root_versions"]["summary"] == {"resource_count": 1, "version_count": 0}
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -435,6 +435,30 @@ async def test_project_context_draft_state_payload_uses_manage_project_helpers(t
     assert payload["root_versions"]["summary"] == {"resource_count": 1, "version_count": 0}
 
 
+async def test_project_context_draft_file_update_payload_writes_thread_overlay(tmp_path):
+    from brain.app.api.routers.cortex import _project_context
+    from brain.systems.cortex.project_context.schemas import ProjectDraftFileUpdate
+
+    source_dir = tmp_path / "source"
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "reports"
+    source_dir.mkdir()
+    draft_dir.mkdir(parents=True)
+    (source_dir / "brief.md").write_text("original", encoding="utf-8")
+
+    payload = await _project_context._update_project_draft_file_payload(
+        _project_draft_run_for_test(source_dir, draft_dir),
+        idea_id="idea-1",
+        body=ProjectDraftFileUpdate(resource_id="reports", path="brief.md", content="manual draft edit"),
+        user={"id": "user-1", "org_id": "test-org"},
+    )
+
+    assert payload["updated"] is True
+    assert payload["layers"]["root"]["content"] == "original"
+    assert payload["layers"]["draft"]["content"] == "manual draft edit"
+    assert (source_dir / "brief.md").read_text(encoding="utf-8") == "original"
+    assert (draft_dir / "brief.md").read_text(encoding="utf-8") == "manual draft edit"
+
+
 async def test_project_context_draft_state_payload_handles_missing_run():
     from brain.app.api.routers.cortex import _project_context
 

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -459,6 +459,30 @@ async def test_project_context_draft_file_update_payload_writes_thread_overlay(t
     assert (draft_dir / "brief.md").read_text(encoding="utf-8") == "manual draft edit"
 
 
+async def test_project_context_draft_file_blob_response_serves_inline_layer(tmp_path):
+    from brain.app.api.routers.cortex import _project_context
+
+    source_dir = tmp_path / "source"
+    draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "reports"
+    source_dir.mkdir()
+    draft_dir.mkdir(parents=True)
+    (source_dir / "diagram.svg").write_text("<svg></svg>", encoding="utf-8")
+    (draft_dir / "diagram.svg").write_text("<svg><title>draft</title></svg>", encoding="utf-8")
+
+    response = await _project_context._project_draft_file_blob_response(
+        _project_draft_run_for_test(source_dir, draft_dir),
+        idea_id="idea-1",
+        path="diagram.svg",
+        layer="draft",
+        resource_id="reports",
+        user={"id": "user-1", "org_id": "test-org"},
+    )
+
+    assert response.media_type == "image/svg+xml"
+    assert str(response.path) == str(draft_dir / "diagram.svg")
+    assert response.headers["content-disposition"].startswith("inline;")
+
+
 async def test_project_context_draft_state_payload_handles_missing_run():
     from brain.app.api.routers.cortex import _project_context
 

--- a/tests/test_project_context_browser.py
+++ b/tests/test_project_context_browser.py
@@ -5,6 +5,7 @@ import pytest
 from brain.systems.cortex.project_context.browser import (
     project_file_payload,
     project_resource_file_browser,
+    update_project_draft_file,
     with_project_file_browser,
 )
 from brain.systems.cortex.project_context.drafts import build_file_manifest, save_draft_metadata
@@ -98,6 +99,34 @@ def test_project_file_payload_reads_root_base_and_draft_layers(tmp_path):
     assert payload["layers"]["root"]["content"] == "root v1\n"
     assert payload["layers"]["base"]["content"] == "root v1\n"
     assert payload["layers"]["draft"]["content"] == "draft v2\n"
+
+
+def test_update_project_draft_file_writes_only_thread_overlay(tmp_path):
+    root = tmp_path / "root"
+    draft = tmp_path / "draft"
+    _write(root / "report.md", "root v1\n")
+    _write(draft / ".illo-project-draft" / "base" / "report.md", "root v1\n")
+    save_draft_metadata(draft, base_manifest=build_file_manifest(root))
+
+    payload = update_project_draft_file(
+        {
+            "resources": [{
+                "id": "root",
+                "mount_path": "/",
+                "source_path": str(root),
+                "workspace_path": str(draft),
+            }],
+        },
+        resource_id="root",
+        path="report.md",
+        content="manual edit\n",
+    )
+
+    assert payload["updated"] is True
+    assert payload["layers"]["root"]["content"] == "root v1\n"
+    assert payload["layers"]["draft"]["content"] == "manual edit\n"
+    assert (root / "report.md").read_text(encoding="utf-8") == "root v1\n"
+    assert (draft / "report.md").read_text(encoding="utf-8") == "manual edit\n"
 
 
 def test_project_file_payload_rejects_escaping_paths(tmp_path):

--- a/tests/test_project_context_browser.py
+++ b/tests/test_project_context_browser.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import pytest
+
+from brain.systems.cortex.project_context.browser import (
+    project_file_payload,
+    project_resource_file_browser,
+    with_project_file_browser,
+)
+from brain.systems.cortex.project_context.drafts import build_file_manifest, save_draft_metadata
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_project_resource_file_browser_marks_root_draft_statuses(tmp_path):
+    root = tmp_path / "root"
+    draft = tmp_path / "draft"
+    _write(root / "docs" / "brief.md", "root brief\n")
+    _write(root / "docs" / "deleted.md", "delete me\n")
+    _write(root / "docs" / "same.md", "same\n")
+    _write(draft / "docs" / "brief.md", "draft brief\n")
+    _write(draft / "docs" / "new.md", "new\n")
+    _write(draft / "docs" / "same.md", "same\n")
+
+    save_draft_metadata(draft, base_manifest=build_file_manifest(root))
+
+    browser = project_resource_file_browser({
+        "id": "project-root",
+        "mount_path": "/",
+        "source_path": str(root),
+        "workspace_path": str(draft),
+        "changes": {
+            "changed_paths": ["docs/brief.md"],
+            "new_paths": ["docs/new.md"],
+            "deleted_paths": ["docs/deleted.md"],
+            "conflicted_paths": [],
+            "out_of_date_paths": ["docs/stale.md"],
+        },
+    })
+
+    entries = {entry["path"]: entry for entry in browser["entries"]}
+    assert entries["docs/brief.md"]["status"] == "changed"
+    assert entries["docs/new.md"]["status"] == "new"
+    assert entries["docs/deleted.md"]["status"] == "deleted"
+    assert entries["docs/same.md"]["status"] == "clean"
+    assert entries["docs/stale.md"]["status"] == "out_of_date"
+    assert browser["summary"]["file_count"] == 5
+
+
+def test_with_project_file_browser_keeps_browser_payload_outside_tools_shape(tmp_path):
+    root = tmp_path / "root"
+    draft = tmp_path / "draft"
+    _write(root / "README.md", "root\n")
+    _write(draft / "README.md", "root\n")
+    save_draft_metadata(draft, base_manifest=build_file_manifest(root))
+
+    payload = with_project_file_browser({
+        "ok": True,
+        "resources": [{
+            "id": "root",
+            "mount_path": "/",
+            "source_path": str(root),
+            "workspace_path": str(draft),
+        }],
+    })
+
+    assert payload["file_browser"]["summary"]["file_count"] == 1
+    assert payload["resources"][0]["file_browser"]["entries"][0]["path"] == "README.md"
+
+
+def test_project_file_payload_reads_root_base_and_draft_layers(tmp_path):
+    root = tmp_path / "root"
+    draft = tmp_path / "draft"
+    _write(root / "report.md", "root v1\n")
+    _write(draft / "report.md", "draft v2\n")
+    _write(draft / ".illo-project-draft" / "base" / "report.md", "root v1\n")
+    save_draft_metadata(draft, base_manifest=build_file_manifest(root))
+
+    payload = project_file_payload(
+        {
+            "resources": [{
+                "id": "root",
+                "mount_path": "/",
+                "source_path": str(root),
+                "workspace_path": str(draft),
+                "changes": {"changed_paths": ["report.md"]},
+            }],
+        },
+        resource_id="root",
+        path="report.md",
+    )
+
+    assert payload["ok"] is True
+    assert payload["entry"]["status"] == "changed"
+    assert payload["layers"]["root"]["content"] == "root v1\n"
+    assert payload["layers"]["base"]["content"] == "root v1\n"
+    assert payload["layers"]["draft"]["content"] == "draft v2\n"
+
+
+def test_project_file_payload_rejects_escaping_paths(tmp_path):
+    with pytest.raises(ValueError, match="inside the mounted Project resource"):
+        project_file_payload({"resources": []}, resource_id=None, path="../secret.md")
+    with pytest.raises(ValueError, match="internal metadata"):
+        project_file_payload({"resources": []}, resource_id=None, path=".illo-project-history/version.json")

--- a/tests/test_project_context_browser.py
+++ b/tests/test_project_context_browser.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from brain.systems.cortex.project_context.browser import (
+    project_file_blob,
     project_file_payload,
     project_resource_file_browser,
     update_project_draft_file,
@@ -127,6 +128,32 @@ def test_update_project_draft_file_writes_only_thread_overlay(tmp_path):
     assert payload["layers"]["draft"]["content"] == "manual edit\n"
     assert (root / "report.md").read_text(encoding="utf-8") == "root v1\n"
     assert (draft / "report.md").read_text(encoding="utf-8") == "manual edit\n"
+
+
+def test_project_file_blob_resolves_previewable_layers(tmp_path):
+    root = tmp_path / "root"
+    draft = tmp_path / "draft"
+    _write(root / "image.svg", "<svg></svg>")
+    _write(draft / "image.svg", "<svg><title>draft</title></svg>")
+    save_draft_metadata(draft, base_manifest=build_file_manifest(root))
+
+    blob = project_file_blob(
+        {
+            "resources": [{
+                "id": "root",
+                "mount_path": "/",
+                "source_path": str(root),
+                "workspace_path": str(draft),
+            }],
+        },
+        resource_id="root",
+        path="image.svg",
+        layer="draft",
+    )
+
+    assert blob["path"] == draft / "image.svg"
+    assert blob["filename"] == "image.svg"
+    assert blob["media_type"] == "image/svg+xml"
 
 
 def test_project_file_payload_rejects_escaping_paths(tmp_path):


### PR DESCRIPTION
## Summary
- add a prompt-safe run reference projection so Fast/Worker instructions receive Project names, mount paths, workspace roots, and counts instead of full runtime snapshots
- keep full Project runtime metadata available to tools and audit paths while removing raw `workspace_ref` / `target_ref` dumps from system prompts
- recognize OpenAI `Invalid instructions: string too long` failures as context overflows for clearer recovery/telemetry
- add a regression using a multi-megabyte Project runtime payload that stays under the prompt cap and does not leak raw Project file context into instructions

## Trace reproduced
From `illo-thread-trace-b9129f30-fe5d-4835-8b19-ef1192cc4486 (1).zip`:
- run 315 failed with `instructions` length `12256492` > `1048576`
- run 316 failed with `instructions` length `3910418` > `1048576`
- both happened after a folder Project with 779 paths was materialized

## Verification
- pytest tests/test_agent_run_runtime.py::test_fast_recipe_prompt_compacts_large_project_runtime_context tests/test_agent_runtime_modules.py::test_context_overflow_classifier_recognizes_provider_shapes
- pytest tests/test_agent_run_runtime.py tests/test_agent_runtime_modules.py tests/test_cortex_thread_context.py tests/test_slash_skill_commands.py tests/test_worker_roles.py tests/test_project_context_root_materializer.py tests/test_file_tool_project_mount_paths.py
- pytest -> 2987 passed, 58 skipped
- npm --prefix frontend run check
- git diff --check