### PR TITLE
Add cross-project reference mounts

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -406,7 +406,7 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         "mark_read": {"required": ["idea_id unless a current thread is bound"], "optional": [], "effect": "mark a thought read"},
     },
     "manage_project": {
-        "list": {"required": [], "optional": ["include_inactive"], "effect": "read project context profiles"},
+        "list": {"required": [], "optional": ["query", "limit", "include_inactive"], "effect": "read project context profiles, optionally filtered by project name, description, aliases, or resources"},
         "get": {"required": ["project_id"], "optional": ["include_inactive"], "effect": "read one project profile"},
         "create": {
             "required": ["slug", "name"],
@@ -428,6 +428,28 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
             "required": ["project_id or project_context", "idea_id unless a current thread is bound"],
             "optional": ["environment_binding_id", "metadata"],
             "effect": "attach project context to a thought",
+        },
+        "search_files": {
+            "required": ["query"],
+            "optional": ["project_id", "paths", "glob", "limit"],
+            "effect": "search files in visible Projects without loading all Project contents",
+            "parameters": {
+                "query": "Search text to match in files across visible Projects.",
+                "limit": "Maximum search results to return.",
+                "paths": "Optional file or folder paths to constrain the search.",
+                "glob": "Optional file glob filter such as '**/*.md'.",
+            },
+        },
+        "mount_reference": {
+            "required": ["project_id"],
+            "optional": ["paths", "path", "glob", "limit", "mount_path"],
+            "effect": "expose selected files or folders from another Project as read-only reference mounts for read_file/list_files/search_files",
+            "parameters": {
+                "paths": "Selected file or folder paths from the source Project to expose.",
+                "glob": "Optional file glob filter for selecting Project files to expose.",
+                "limit": "Maximum glob-selected mounts to create.",
+                "mount_path": "Workspace mount path where the read-only reference should appear.",
+            },
         },
     },
     "manage_workspace_app": {

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -198,6 +198,14 @@ def _block_project_source_write(resolved: str) -> None:
         return
     resolved_real = os.path.realpath(resolved)
     for mount in manifest.mounts:
+        if _project_mount_is_read_only(mount):
+            workspace_real = os.path.realpath(getattr(mount, "workspace_path", "") or "")
+            if workspace_real and _path_is_within(resolved_real, workspace_real):
+                raise ValueError(
+                    f"Blocked write to read-only Project reference mount: "
+                    f"{getattr(mount, 'mount_path', '<project mount>')}. "
+                    "Mount it as a draft or copy the file into the current Project before editing."
+                )
         if not mount.source_path:
             continue
         source_real = os.path.realpath(mount.source_path)
@@ -214,6 +222,17 @@ def _project_source_mounts() -> list[object]:
     if manifest is None:
         return []
     return [mount for mount in manifest.mounts if mount.source_path]
+
+
+def _project_mount_is_read_only(mount: object) -> bool:
+    metadata = _context_mapping(getattr(mount, "metadata", None))
+    materialization = _context_mapping(metadata.get("materialization"))
+    return bool(
+        metadata.get("read_only")
+        or metadata.get("reference_mount")
+        or materialization.get("read_only")
+        or materialization.get("reference_mount")
+    )
 
 
 _PROJECT_SOURCE_WRITE_PATTERNS = [
@@ -235,12 +254,38 @@ def _block_project_source_command_write(text: str, *, operation: str, cwd: str |
     if not text or not _command_or_script_may_write(text):
         return
     cwd_real = os.path.realpath(cwd) if cwd else None
+    cwd_text = cwd or ""
     for mount in _project_source_mounts():
         source_path = getattr(mount, "source_path", None)
         if not isinstance(source_path, str) or not source_path.strip():
             continue
         source_real = os.path.realpath(source_path)
         workspace_real = os.path.realpath(getattr(mount, "workspace_path", "") or "")
+        mount_path = str(getattr(mount, "mount_path", "") or "")
+        if _project_mount_is_read_only(mount):
+            names_read_only_path = (
+                source_path in text
+                or source_real in text
+                or (workspace_real and workspace_real in text)
+                or (mount_path and mount_path in text)
+            )
+            runs_in_read_only_path = bool(
+                cwd_real
+                and (
+                    _path_is_within(cwd_real, source_real)
+                    or (workspace_real and _path_is_within(cwd_real, workspace_real))
+                )
+            )
+            runs_in_read_only_mount = bool(
+                mount_path
+                and (cwd_text == mount_path or cwd_text.startswith(mount_path.rstrip("/") + "/"))
+            )
+            if names_read_only_path or runs_in_read_only_path or runs_in_read_only_mount:
+                raise ValueError(
+                    f"Blocked {operation} that may write to read-only Project reference mount: "
+                    f"{mount_path or source_real}. Copy the file into the current Project draft before editing."
+                )
+            continue
         names_source_path = source_path in text or source_real in text
         runs_in_source_path = bool(cwd_real and _path_is_within(cwd_real, source_real))
         runs_in_draft_path = bool(cwd_real and workspace_real and _path_is_within(cwd_real, workspace_real))

--- a/brain/systems/runs/tool_catalog/handlers/project_references.py
+++ b/brain/systems/runs/tool_catalog/handlers/project_references.py
@@ -1,0 +1,456 @@
+"""Cross-Project search and read-only reference mount helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from fnmatch import fnmatch
+from pathlib import Path, PurePosixPath
+from typing import Any
+import json
+import re
+
+from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.systems.cortex.project_context.project_root import project_key_from_context, project_root_path
+from brain.systems.cortex.project_context.profiles import profile_to_read
+from brain.systems.runs.execution_context import _agent_context
+from brain.systems.runs.project_execution_env import _current_workspace_root_hint
+from brain.systems.runs.tool_catalog.handlers.common import _patched_workspace_root
+
+
+PROJECT_FILE_SEARCH_DEFAULT_LIMIT = 20
+PROJECT_FILE_SEARCH_MAX_LIMIT = 100
+
+_PROJECT_REFERENCE_MOUNT_ROOT = "/references"
+_PROJECT_FILE_SEARCH_MAX_BYTES = 512 * 1024
+_TEXT_FILE_EXTENSIONS = {
+    ".csv",
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mdx",
+    ".py",
+    ".rb",
+    ".rst",
+    ".sql",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+_PROJECT_INTERNAL_DIRS = {".illo-project-draft", ".illo-project-history"}
+
+
+def _clean_query(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _query_terms(value: Any) -> list[str]:
+    return [term for term in re.split(r"\s+", _clean_query(value)) if term]
+
+
+def profile_matches_query(profile, query: str | None) -> bool:
+    terms = _query_terms(query)
+    if not terms:
+        return True
+    blob = _profile_search_blob(profile)
+    return all(term in blob for term in terms)
+
+
+def limit_value(value: Any, *, default: int, maximum: int) -> int:
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(limit, maximum))
+
+
+def search_project_root_files(
+    profile,
+    *,
+    query: str | None,
+    path: str | None,
+    paths: list[str] | None,
+    glob: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    root_path = _profile_root_path(profile)
+    if root_path is None:
+        return {
+            "project": _profile_read(profile),
+            "root_available": False,
+            "results": [],
+            "error": "No workspace root is available to locate Project roots",
+        }
+    if not root_path.exists():
+        return {
+            "project": _profile_read(profile),
+            "root_available": False,
+            "root_path": str(root_path),
+            "results": [],
+        }
+
+    relative_roots = _normalise_requested_paths(path, paths)
+    results: list[dict[str, Any]] = []
+    for file_path in _iter_project_files(root_path, relative_roots, glob):
+        result = _project_file_search_result(profile, root_path, file_path, query or "")
+        if result is None:
+            continue
+        results.append(result)
+        if len(results) >= limit:
+            break
+    return {
+        "project": _profile_read(profile),
+        "root_available": True,
+        "root_path": str(root_path),
+        "results": results,
+    }
+
+
+def mount_project_reference(
+    profile,
+    *,
+    path: str | None,
+    paths: list[str] | None,
+    glob: str | None,
+    limit: int | None,
+    mount_path: str | None,
+) -> dict[str, Any]:
+    root_path = _profile_root_path(profile)
+    if root_path is None:
+        raise ValueError("No workspace root is available to locate Project roots")
+    if not root_path.exists():
+        raise ValueError(f"Project root is not materialized yet: {root_path}")
+
+    if glob and not path and not paths:
+        max_matches = limit_value(limit, default=PROJECT_FILE_SEARCH_DEFAULT_LIMIT, maximum=PROJECT_FILE_SEARCH_MAX_LIMIT)
+        relative_paths = [
+            candidate.relative_to(root_path).as_posix()
+            for candidate in _iter_project_files(root_path, [""], glob)
+        ][:max_matches]
+        if not relative_paths:
+            raise ValueError(f"No Project files matched glob: {glob}")
+    else:
+        relative_paths = _normalise_requested_paths(path, paths)
+
+    workspace_ref = _ensure_workspace_ref_mapping()
+    manifest = _ensure_manifest_payload(workspace_ref)
+    mounts = manifest["mounts"]
+    workspaces = manifest["workspaces"]
+
+    mounted: list[dict[str, Any]] = []
+    for relative_path in relative_paths:
+        agent_mount_path = _mount_path_for_reference(profile, relative_path, mount_path, count=len(relative_paths))
+        mount = _reference_mount_payload(profile, root_path, relative_path, agent_mount_path)
+        mounts[:] = [
+            existing
+            for existing in mounts
+            if not (isinstance(existing, dict) and existing.get("mount_path") == agent_mount_path)
+        ]
+        workspaces[:] = [
+            existing
+            for existing in workspaces
+            if not (isinstance(existing, dict) and existing.get("name") == agent_mount_path)
+        ]
+        mounts.append(mount)
+        workspaces.append({"name": agent_mount_path, "path": mount["workspace_path"]})
+        mounted.append(mount)
+
+    _sync_workspace_ref_to_run(workspace_ref)
+    return {
+        "ok": True,
+        "project": _profile_read(profile),
+        "mounts": mounted,
+        "guidance": (
+            "Reference mounts are read-only. Use normal file tools such as read_file, list_files, "
+            "or search_files against the returned mount_path values."
+        ),
+    }
+
+
+def _profile_read(profile) -> dict[str, Any]:
+    return profile_to_read(profile).model_dump(mode="json", by_alias=True)
+
+
+def _profile_resources(profile) -> list[dict[str, Any]]:
+    context = profile.project_context if isinstance(profile.project_context, Mapping) else {}
+    return [dict(item) for item in (context.get("resources") or []) if isinstance(item, Mapping)]
+
+
+def _profile_search_blob(profile) -> str:
+    metadata = getattr(profile, "metadata_", None)
+    context = getattr(profile, "project_context", None)
+    parts: list[str] = []
+    for value in (
+        getattr(profile, "id", None),
+        getattr(profile, "slug", None),
+        getattr(profile, "name", None),
+        getattr(profile, "description", None),
+    ):
+        if value is not None:
+            parts.append(str(value))
+    for payload in (metadata, context):
+        if isinstance(payload, Mapping):
+            parts.append(json.dumps(payload, sort_keys=True, default=str))
+    return " ".join(parts).lower()
+
+
+def _profile_project_key(profile) -> str:
+    context = stamped_project_context(profile)
+    return project_key_from_context(
+        context,
+        resources=_profile_resources(profile),
+        fallback=getattr(profile, "slug", None) or getattr(profile, "id", None),
+    )
+
+
+def _current_workspace_root_path() -> Path | None:
+    workspace_root = _current_workspace_root_hint() or _patched_workspace_root()
+    if not isinstance(workspace_root, str) or not workspace_root.strip():
+        return None
+    return Path(workspace_root).expanduser()
+
+
+def _profile_root_path(profile) -> Path | None:
+    workspace_root = _current_workspace_root_path()
+    if workspace_root is None:
+        return None
+    return project_root_path(workspace_root, _profile_project_key(profile))
+
+
+def _safe_project_relative_path(value: Any) -> str | None:
+    text = str(value or "").replace("\\", "/").strip()
+    if text in {"", ".", "/"}:
+        return ""
+    text = text.strip("/")
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return path.as_posix()
+
+
+def _safe_reference_segment(value: Any, *, fallback: str) -> str:
+    text = str(value or fallback).strip().strip("/")
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in text)[:80]
+    return safe or fallback
+
+
+def _normalise_requested_paths(path: str | None, paths: list[str] | None) -> list[str]:
+    raw_paths: list[Any] = []
+    if path is not None:
+        raw_paths.append(path)
+    if isinstance(paths, list):
+        raw_paths.extend(paths)
+    if not raw_paths:
+        return [""]
+
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for raw_path in raw_paths:
+        relative = _safe_project_relative_path(raw_path)
+        if relative is None:
+            raise ValueError(f"Invalid Project path: {raw_path}")
+        if relative not in seen:
+            normalised.append(relative)
+            seen.add(relative)
+    return normalised or [""]
+
+
+def _is_internal_project_path(relative_path: Path) -> bool:
+    return any(part in _PROJECT_INTERNAL_DIRS for part in relative_path.parts)
+
+
+def _iter_project_files(root_path: Path, relative_roots: Iterable[str], glob: str | None = None) -> Iterable[Path]:
+    for relative_root in relative_roots:
+        base_path = root_path / relative_root if relative_root else root_path
+        if not base_path.exists():
+            continue
+        candidates = [base_path] if base_path.is_file() else base_path.rglob("*")
+        for candidate in candidates:
+            if not candidate.is_file():
+                continue
+            try:
+                relative = candidate.relative_to(root_path)
+            except ValueError:
+                continue
+            if _is_internal_project_path(relative):
+                continue
+            relative_posix = relative.as_posix()
+            if glob and not fnmatch(relative_posix, glob) and not fnmatch(candidate.name, glob):
+                continue
+            yield candidate
+
+
+def _file_kind(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}:
+        return "image"
+    if suffix == ".pdf":
+        return "pdf"
+    if suffix in {".csv", ".tsv", ".xls", ".xlsx"}:
+        return "sheet"
+    if suffix in _TEXT_FILE_EXTENSIONS:
+        return "text"
+    return suffix.lstrip(".") or "file"
+
+
+def _looks_textual(path: Path, data: bytes) -> bool:
+    if path.suffix.lower() in _TEXT_FILE_EXTENSIONS:
+        return True
+    if b"\x00" in data[:4096]:
+        return False
+    try:
+        data[:4096].decode("utf-8")
+        return True
+    except UnicodeDecodeError:
+        return False
+
+
+def _content_snippets(path: Path, query: str, *, max_snippets: int = 3) -> list[dict[str, Any]]:
+    terms = _query_terms(query)
+    if not terms:
+        return []
+    try:
+        data = path.read_bytes()[:_PROJECT_FILE_SEARCH_MAX_BYTES]
+    except OSError:
+        return []
+    if not _looks_textual(path, data):
+        return []
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        text = data.decode("utf-8", errors="replace")
+    snippets: list[dict[str, Any]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        lowered = line.lower()
+        if all(term in lowered for term in terms):
+            snippets.append({"line": line_no, "text": line.strip()[:300]})
+            if len(snippets) >= max_snippets:
+                break
+    return snippets
+
+
+def _project_file_search_result(profile, root_path: Path, file_path: Path, query: str) -> dict[str, Any] | None:
+    relative_path = file_path.relative_to(root_path).as_posix()
+    path_blob = relative_path.lower()
+    terms = _query_terms(query)
+    path_matches = bool(terms and all(term in path_blob for term in terms))
+    snippets = _content_snippets(file_path, query)
+    if terms and not path_matches and not snippets:
+        return None
+    stat = file_path.stat()
+    project_segment = _safe_reference_segment(getattr(profile, "slug", None) or getattr(profile, "id", None), fallback="project")
+    return {
+        "project_id": getattr(profile, "id", None),
+        "project_slug": getattr(profile, "slug", None),
+        "project_name": getattr(profile, "name", None),
+        "path": relative_path,
+        "mount_path_hint": f"{_PROJECT_REFERENCE_MOUNT_ROOT}/{project_segment}/{relative_path}",
+        "kind": _file_kind(file_path),
+        "size_bytes": stat.st_size,
+        "matched_by": ["path"] if path_matches else ["content"],
+        "snippets": snippets,
+    }
+
+
+def _ensure_workspace_ref_mapping() -> dict[str, Any]:
+    workspace_ref = getattr(_agent_context, "workspace_ref", None)
+    if not isinstance(workspace_ref, dict):
+        run = getattr(_agent_context, "run", None)
+        workspace_ref = getattr(run, "workspace_ref", None)
+    if not isinstance(workspace_ref, dict):
+        workspace_ref = {}
+    setattr(_agent_context, "workspace_ref", workspace_ref)
+    return workspace_ref
+
+
+def _ensure_manifest_payload(workspace_ref: dict[str, Any]) -> dict[str, Any]:
+    manifest = workspace_ref.get("project_workspace_manifest")
+    if not isinstance(manifest, dict):
+        manifest = {}
+        workspace_ref["project_workspace_manifest"] = manifest
+    mounts = manifest.get("mounts")
+    if not isinstance(mounts, list):
+        manifest["mounts"] = []
+    workspaces = manifest.get("workspaces")
+    if not isinstance(workspaces, list):
+        manifest["workspaces"] = []
+    if not manifest.get("schema_version"):
+        manifest["schema_version"] = 1
+    return manifest
+
+
+def _sync_workspace_ref_to_run(workspace_ref: dict[str, Any]) -> None:
+    run = getattr(_agent_context, "run", None)
+    if run is None:
+        return
+    try:
+        run.workspace_ref = workspace_ref
+    except Exception:
+        return
+    metadata = getattr(run, "metadata_", None)
+    if isinstance(metadata, dict):
+        metadata["project_workspace_manifest"] = workspace_ref.get("project_workspace_manifest")
+
+
+def _mount_path_for_reference(profile, relative_path: str, mount_path: str | None, *, count: int) -> str:
+    if mount_path:
+        safe_mount_path = _safe_project_relative_path(mount_path)
+        if safe_mount_path is None:
+            raise ValueError(f"Invalid reference mount_path: {mount_path}")
+        base = "/" + safe_mount_path.strip("/")
+    else:
+        segment = _safe_reference_segment(getattr(profile, "slug", None) or getattr(profile, "id", None), fallback="project")
+        base = f"{_PROJECT_REFERENCE_MOUNT_ROOT}/{segment}"
+    if count <= 1 and not relative_path:
+        return base
+    suffix = relative_path if relative_path else "root"
+    return f"{base.rstrip('/')}/{suffix}"
+
+
+def _reference_mount_payload(profile, root_path: Path, relative_path: str, mount_path: str) -> dict[str, Any]:
+    source_path = root_path / relative_path if relative_path else root_path
+    if not source_path.exists():
+        raise ValueError(f"Project path does not exist: {relative_path or '/'}")
+    metadata = {
+        "reference_mount": True,
+        "read_only": True,
+        "source_project_id": getattr(profile, "id", None),
+        "source_project_slug": getattr(profile, "slug", None),
+        "source_project_name": getattr(profile, "name", None),
+        "source_relative_path": relative_path,
+        "materialization": {
+            "provider": "project_reference",
+            "workspace_path": str(source_path),
+            "path": str(source_path),
+            "source_path": str(source_path),
+            "read_only": True,
+            "reference_mount": True,
+        },
+    }
+    return {
+        "id": mount_path,
+        "resource_id": f"reference:{getattr(profile, 'id', 'project')}:{relative_path or '/'}",
+        "kind": "folder" if source_path.is_dir() else "file",
+        "mount_path": mount_path,
+        "workspace_path": str(source_path),
+        "resource_path": str(source_path),
+        "source_path": str(source_path),
+        "label": f"{getattr(profile, 'name', None) or getattr(profile, 'slug', None) or 'Project'}: {relative_path or '/'}",
+        "metadata": metadata,
+        "file_kind": _file_kind(source_path) if source_path.is_file() else "folder",
+    }
+
+
+__all__ = [
+    "PROJECT_FILE_SEARCH_DEFAULT_LIMIT",
+    "PROJECT_FILE_SEARCH_MAX_LIMIT",
+    "limit_value",
+    "mount_project_reference",
+    "profile_matches_query",
+    "search_project_root_files",
+]

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -17,6 +17,14 @@ from brain.systems.cortex.project_context.root_history import (
     project_restore_root_version_payload,
     project_root_versions_payload,
 )
+from brain.systems.runs.tool_catalog.handlers.project_references import (
+    PROJECT_FILE_SEARCH_DEFAULT_LIMIT,
+    PROJECT_FILE_SEARCH_MAX_LIMIT,
+    limit_value as _project_limit_value,
+    mount_project_reference,
+    profile_matches_query,
+    search_project_root_files,
+)
 from brain.systems.runs.tool_catalog.handlers.common import *
 
 
@@ -224,6 +232,11 @@ async def _handle_manage_project(
     idea_id: str | None = None,
     publish_paths: list[str] | None = None,
     path: str | None = None,
+    paths: list[str] | None = None,
+    query: str | None = None,
+    glob: str | None = None,
+    limit: int | None = None,
+    mount_path: str | None = None,
     version_id: str | None = None,
     branch_name: str | None = None,
     commit_message: str | None = None,
@@ -309,7 +322,13 @@ async def _handle_manage_project(
         async with UnitOfWork() as uow:
             if action == "list":
                 stmt = _profile_stmt(org_id, user_id, include_inactive=include_inactive).order_by(ProjectProfile.created_at.desc())
-                profiles = (await uow.session.scalars(stmt)).all()
+                profiles = [
+                    profile
+                    for profile in (await uow.session.scalars(stmt)).all()
+                    if profile_matches_query(profile, query)
+                ]
+                if limit is not None:
+                    profiles = profiles[:_project_limit_value(limit, default=len(profiles) or 1, maximum=PROJECT_FILE_SEARCH_MAX_LIMIT)]
                 return json.dumps({"projects": [_profile_read(profile) for profile in profiles]}, default=str)
 
             if action == "get":
@@ -317,6 +336,74 @@ async def _handle_manage_project(
                     return json.dumps({"error": "get requires: project_id"})
                 profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=include_inactive)
                 return json.dumps({"project": _profile_read(profile)}, default=str)
+
+            if action == "search_files":
+                if not query and not path and not paths and not glob:
+                    return json.dumps({"error": "search_files requires query, path, paths, or glob"})
+                effective_limit = _project_limit_value(limit, default=PROJECT_FILE_SEARCH_DEFAULT_LIMIT, maximum=PROJECT_FILE_SEARCH_MAX_LIMIT)
+                if selected_project_id:
+                    profiles = [
+                        await _get_profile(
+                            uow.session,
+                            org_id,
+                            user_id,
+                            selected_project_id,
+                            include_inactive=include_inactive,
+                        )
+                    ]
+                else:
+                    stmt = _profile_stmt(org_id, user_id, include_inactive=include_inactive).order_by(ProjectProfile.created_at.desc())
+                    profiles = (await uow.session.scalars(stmt)).all()
+                    profiles = sorted(
+                        profiles,
+                        key=lambda profile: 0 if profile_matches_query(profile, query) else 1,
+                    )
+
+                searched: list[dict[str, Any]] = []
+                results: list[dict[str, Any]] = []
+                remaining = effective_limit
+                for profile in profiles:
+                    payload = search_project_root_files(
+                        profile,
+                        query=query,
+                        path=path,
+                        paths=paths,
+                        glob=glob,
+                        limit=remaining,
+                    )
+                    project_results = payload.pop("results", [])
+                    searched.append(payload)
+                    results.extend(project_results)
+                    remaining = effective_limit - len(results)
+                    if remaining <= 0:
+                        break
+                return json.dumps(
+                    {
+                        "query": query,
+                        "results": results,
+                        "projects_searched": searched,
+                        "truncated": remaining <= 0,
+                        "guidance": (
+                            "Use manage_project(action='mount_reference', project_id=..., paths=[...]) "
+                            "to expose selected matches as read-only mounts, then read them with normal file tools."
+                        ),
+                    },
+                    default=str,
+                )
+
+            if action == "mount_reference":
+                if not selected_project_id:
+                    return json.dumps({"error": "mount_reference requires: project_id"})
+                profile = await _get_profile(uow.session, org_id, user_id, selected_project_id, include_inactive=include_inactive)
+                payload = mount_project_reference(
+                    profile,
+                    path=path,
+                    paths=paths,
+                    glob=glob,
+                    limit=limit,
+                    mount_path=mount_path,
+                )
+                return json.dumps(payload, default=str)
 
             if action == "create":
                 if not slug or not name:

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -774,7 +774,7 @@ def action_policy_for_tool(
         }
     if tool_name == "manage_idea" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "get"}:
         return None
-    if tool_name == "manage_project" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "get"}:
+    if tool_name == "manage_project" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "get", "search_files", "mount_reference"}:
         return None
     if tool_name == "manage_workspace_app" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "get", "get_state"}:
         return None

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1256,6 +1256,8 @@ PROJECT_TOOLS = [
             "Use refresh_draft_from_root to explicitly apply latest root changes into untouched draft files. "
             "Use publish_draft to publish local Project draft changes back to root; conflicts return guidance for the agent to reconcile root and draft before retrying. "
             "Use root_versions, preview_root_version, and restore_root_version to inspect, preview, or roll back local Project root history. "
+            "Use search_files to find files in visible Projects without loading everything, and mount_reference to expose selected files or folders from another Project as read-only reference mounts. "
+            "Projects are context boundaries, not permission boundaries; mounted references can then be inspected with normal read_file/list_files/search_files tools. "
             "For awareness questions about what project context exists or what Illo can see, prefer "
             "read_project_contexts first. Thread attachments do not require a project. Use action='help' or "
             "action='schema' with operation to inspect arguments before mutating."
@@ -1286,13 +1288,16 @@ PROJECT_TOOLS = [
                         "root_versions",
                         "preview_root_version",
                         "restore_root_version",
+                        "search_files",
+                        "mount_reference",
                     ],
                     "description": (
                         "The project operation to run. delete archives the project profile; "
                         "draft_status and plan_publish are read-only draft inspection actions; "
                         "refresh_draft_from_root mutates only the thread draft workspace by copying latest root files into untouched draft paths; "
                         "publish_draft mutates supported Project roots after conflict checkpoints are resolved; "
-                        "preview_root_version is read-only; restore_root_version mutates a local Project root back to a captured version."
+                        "preview_root_version is read-only; restore_root_version mutates a local Project root back to a captured version; "
+                        "search_files searches visible Projects without loading full files; mount_reference exposes selected Project files/folders as read-only reference mounts."
                     ),
                 },
                 "operation": {
@@ -1328,6 +1333,28 @@ PROJECT_TOOLS = [
                 "path": {
                     "type": "string",
                     "description": "Optional single path filter for publish_draft.",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search text for action='search_files' across visible Projects; returns matching paths without loading every file.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 50,
+                    "description": "Maximum search results to return for action='search_files', or maximum glob-selected mounts for action='mount_reference'.",
+                },
+                "paths": {
+                    "type": "array",
+                    "description": "Optional file or folder paths to constrain action='search_files', or selected paths to expose with action='mount_reference'.",
+                    "items": {"type": "string"},
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "Optional glob filter for action='search_files' or action='mount_reference' path selection, e.g. '**/*.md'.",
+                },
+                "mount_path": {
+                    "type": "string",
+                    "description": "Workspace mount path for action='mount_reference'; exposes selected files/folders from another Project as a read-only reference mount.",
                 },
                 "metadata": {"type": "object", "description": "Optional metadata for profile or attachment provenance."},
                 "visibility": {

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -806,7 +806,8 @@ small enough to stay useful, and attached to the right Cortex conversations.
 
 Use when the user asks to create, attach, rename, update, archive, delete, or
 organize a project, or when they want the same repo, folder, docs, or files to
-be reusable across multiple Illo threads.
+be reusable across multiple Illo threads. Also use when they need to find or
+read a small set of files from another visible Project as reference context.
 
 ## Do Not Use When
 
@@ -818,6 +819,9 @@ are immediate message context and should just work without a project.
 List existing projects first when the user is managing durable context. Load
 the target project profile, current resources, current thread id when attaching,
 and any newly uploaded file/resource metadata the user wants to keep.
+For cross-project reference lookups, search visible Projects with
+`manage_project(action="search_files", query=..., limit=..., paths=..., glob=...)`
+before mounting anything. Do not load whole Projects just to find candidate files.
 
 ## Operating Loop
 
@@ -829,13 +833,19 @@ and any newly uploaded file/resource metadata the user wants to keep.
    attach the smallest Project Context that represents the working set before
    trying raw paths or unauthenticated remotes.
 6. Attach a project to the current thread when the user wants Illo to use it here.
-7. Archive projects by default for delete requests; treat permanent deletion as unavailable unless the product adds it.
-8. Tell the user what changed in plain language without exposing internal validation or status machinery.
+7. Treat Projects as context boundaries, not permission boundaries.
+8. For cross-project references, use `manage_project(action="mount_reference",
+   project_id=..., paths=..., glob=..., mount_path=...)` to expose only selected
+   files or folders as read-only reference mounts. Then inspect them with normal
+   `read_file`, `list_files`, or `search_files`.
+9. Archive projects by default for delete requests; treat permanent deletion as unavailable unless the product adds it.
+10. Tell the user what changed in plain language without exposing internal validation or status machinery.
 
 ## Output Contract
 
 Return the project name, the resource changes, whether it is attached to the
-current thread, and one short note if the user should drop or upload files.
+current thread, any read-only reference mount path created, and one short note
+if the user should drop or upload files.
 
 ## Failure Modes
 

--- a/brain/systems/skills/builtin_skill_bundles/manage-projects/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/manage-projects/SKILL.md
@@ -7,7 +7,8 @@ small enough to stay useful, and attached to the right Cortex conversations.
 
 Use when the user asks to create, attach, rename, update, archive, delete, or
 organize a project, or when they want the same repo, folder, docs, or files to
-be reusable across multiple Illo threads.
+be reusable across multiple Illo threads. Also use when they need to find or
+read a small set of files from another visible Project as reference context.
 
 ## Do Not Use When
 
@@ -19,6 +20,9 @@ are immediate message context and should just work without a project.
 List existing projects first when the user is managing durable context. Load
 the target project profile, current resources, current thread id when attaching,
 and any newly uploaded file/resource metadata the user wants to keep.
+For cross-project reference lookups, search visible Projects with
+`manage_project(action="search_files", query=..., limit=..., paths=..., glob=...)`
+before mounting anything. Do not load whole Projects just to find candidate files.
 
 ## Operating Loop
 
@@ -30,13 +34,19 @@ and any newly uploaded file/resource metadata the user wants to keep.
    attach the smallest Project Context that represents the working set before
    trying raw paths or unauthenticated remotes.
 6. Attach a project to the current thread when the user wants Illo to use it here.
-7. Archive projects by default for delete requests; treat permanent deletion as unavailable unless the product adds it.
-8. Tell the user what changed in plain language without exposing internal validation or status machinery.
+7. Treat Projects as context boundaries, not permission boundaries.
+8. For cross-project references, use `manage_project(action="mount_reference",
+   project_id=..., paths=..., glob=..., mount_path=...)` to expose only selected
+   files or folders as read-only reference mounts. Then inspect them with normal
+   `read_file`, `list_files`, or `search_files`.
+9. Archive projects by default for delete requests; treat permanent deletion as unavailable unless the product adds it.
+10. Tell the user what changed in plain language without exposing internal validation or status machinery.
 
 ## Output Contract
 
 Return the project name, the resource changes, whether it is attached to the
-current thread, and one short note if the user should drop or upload files.
+current thread, any read-only reference mount path created, and one short note
+if the user should drop or upload files.
 
 ## Failure Modes
 

--- a/tests/test_manage_project_cross_references.py
+++ b/tests/test_manage_project_cross_references.py
@@ -1,0 +1,166 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from brain.systems.cortex.project_context.project_root import project_root_path
+from brain.systems.runs.execution_context import bind_agent_context
+from brain.systems.runs.tool_catalog.handlers import files, projects
+
+
+async def test_manage_project_schema_exposes_cross_project_reference_actions():
+    from brain.systems.runs.tool_definitions import PROJECT_TOOLS
+
+    tool = next(item for item in PROJECT_TOOLS if item["name"] == "manage_project")
+    actions = tool["input_schema"]["properties"]["action"]["enum"]
+
+    assert "search_files" in actions
+    assert "mount_reference" in actions
+    assert "query" in tool["input_schema"]["properties"]
+    assert "paths" in tool["input_schema"]["properties"]
+    assert "mount_path" in tool["input_schema"]["properties"]
+
+    guide = json.loads(await projects._handle_manage_project(action="schema", operation="mount_reference"))
+    assert guide["operation"] == "mount_reference"
+    assert "read-only reference mounts" in guide["effect"]
+
+
+def _project_profile(project_id: str, *, slug: str, name: str, description: str = ""):
+    return SimpleNamespace(
+        id=project_id,
+        org_id="org-1",
+        user_id="user-1",
+        slug=slug,
+        name=name,
+        description=description,
+        project_context={
+            "version": 1,
+            "source": "test",
+            "resources": [],
+        },
+        visibility="public",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class _FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, profiles):
+        self.profiles = profiles
+
+    async def scalars(self, _stmt):
+        return _FakeScalars(self.profiles)
+
+    async def scalar(self, _stmt):
+        return self.profiles[0] if self.profiles else None
+
+
+class _FakeUow:
+    def __init__(self, profiles):
+        self.session = _FakeSession(profiles)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _patch_project_profiles(monkeypatch, profiles):
+    from brain.platform.db.repositories import unit_of_work
+
+    class FakeUnitOfWork(_FakeUow):
+        def __init__(self):
+            super().__init__(profiles)
+
+    monkeypatch.setattr(unit_of_work, "UnitOfWork", FakeUnitOfWork)
+
+
+def _project_root(workspace_root, profile):
+    return project_root_path(workspace_root, profile.id)
+
+
+async def test_manage_project_list_filters_by_project_name_and_resources(monkeypatch):
+    payments = _project_profile(
+        "project-payments",
+        slug="payments",
+        name="Payments",
+        description="Stripe settlement docs",
+    )
+    marketing = _project_profile(
+        "project-marketing",
+        slug="marketing",
+        name="Marketing",
+        description="Launch plans",
+    )
+    _patch_project_profiles(monkeypatch, [marketing, payments])
+
+    with bind_agent_context({"org_id": "org-1", "user_id": "user-1"}):
+        payload = json.loads(await projects._handle_manage_project(action="list", query="stripe"))
+
+    assert [project["id"] for project in payload["projects"]] == ["project-payments"]
+
+
+async def test_manage_project_search_files_finds_paths_and_content_without_loading_projects(tmp_path, monkeypatch):
+    profile = _project_profile("project-payments", slug="payments", name="Payments")
+    root = _project_root(tmp_path / "ideas" / "thread-1", profile)
+    (root / "analysis").mkdir(parents=True)
+    (root / "analysis" / "summary.md").write_text("Stripe settlement notes\nRefunds reviewed\n", encoding="utf-8")
+    (root / "assets").mkdir()
+    (root / "assets" / "onboarding.pdf").write_bytes(b"%PDF-1.4\n")
+    _patch_project_profiles(monkeypatch, [profile])
+
+    with bind_agent_context({"org_id": "org-1", "user_id": "user-1", "workspace_root": str(tmp_path / "ideas" / "thread-1")}):
+        content_payload = json.loads(await projects._handle_manage_project(action="search_files", query="stripe"))
+        path_payload = json.loads(await projects._handle_manage_project(action="search_files", query="onboarding pdf"))
+
+    assert content_payload["results"][0]["path"] == "analysis/summary.md"
+    assert content_payload["results"][0]["snippets"][0]["text"] == "Stripe settlement notes"
+    assert path_payload["results"][0]["path"] == "assets/onboarding.pdf"
+    assert path_payload["results"][0]["matched_by"] == ["path"]
+
+
+async def test_manage_project_mount_reference_exposes_read_only_files_to_normal_file_tools(tmp_path, monkeypatch):
+    profile = _project_profile("project-payments", slug="payments", name="Payments")
+    workspace_root = tmp_path / "ideas" / "thread-1"
+    root = _project_root(workspace_root, profile)
+    (root / "analysis").mkdir(parents=True)
+    (root / "analysis" / "summary.md").write_text("Stripe settlement notes\n", encoding="utf-8")
+    _patch_project_profiles(monkeypatch, [profile])
+    run = SimpleNamespace(id=123, workspace_ref={}, target_ref={}, metadata_={})
+
+    with bind_agent_context({
+        "run": run,
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "workspace_root": str(workspace_root),
+    }):
+        payload = json.loads(
+            await projects._handle_manage_project(
+                action="mount_reference",
+                project_id="project-payments",
+                paths=["analysis/summary.md"],
+            )
+        )
+        mount_path = payload["mounts"][0]["mount_path"]
+        read_result = files._handle_read_file(mount_path, _workspace=str(workspace_root))
+        write_result = files._handle_write_file(mount_path, "changed", _workspace=str(workspace_root))
+        command_result = files._handle_exec_command(
+            f"touch {mount_path}",
+            _workspace=str(workspace_root),
+        )
+
+    assert mount_path == "/references/payments/analysis/summary.md"
+    assert "Stripe settlement notes" in read_result["content"]
+    assert "read-only Project reference mount" in write_result["error"]
+    assert "read-only Project reference mount" in command_result["error"]
+    assert run.workspace_ref["project_workspace_manifest"]["mounts"][0]["metadata"]["read_only"] is True


### PR DESCRIPTION
## Summary
- add manage_project search_files to find files across visible Projects without loading full Project contents
- add manage_project mount_reference to expose selected files/folders from another Project as read-only mounts for normal file tools
- block file writes and write-like commands against read-only Project reference mounts
- document the workflow and keep builtin skill bundle/bootstrap mirrors in sync
- cover schema, search, mount, read, write-block, and command-block behavior

## Tests
- python3 -m py_compile brain/systems/runs/tool_catalog/handlers/projects.py brain/systems/runs/tool_catalog/handlers/project_references.py brain/systems/runs/tool_catalog/handlers/files.py brain/systems/runs/tool_definitions.py brain/systems/runs/tool_catalog/handlers/common.py brain/systems/runs/tool_catalog/registry.py brain/systems/skills/builtin.py
- pytest tests/test_builtin_skill_suite.py::test_builtin_skill_bundles_parse_and_mirror_bootstrap_procedures tests/test_manage_project_drafts.py tests/test_manage_project_workflow_integration.py tests/test_project_context_workspace_manifest.py tests/test_file_tool_project_mount_paths.py tests/test_manage_project_cross_references.py tests/test_tool_registry.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestExecToolHandlers::test_search_files tests/test_project_context_root_materializer.py tests/test_project_context_materializer.py -q
- git diff --check
- GitHub CI: all checks passing