### PR TITLE
Add Project tab selector for accessible projects

### DIFF
--- a/brain/app/api/routers/cortex/_project_context.py
+++ b/brain/app/api/routers/cortex/_project_context.py
@@ -28,6 +28,13 @@ from brain.systems.cortex.project_context.browser import (
     with_project_file_browser,
 )
 from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.systems.cortex.project_context.profile_browser import (
+    ProjectProfileBrowserError,
+    project_profile_draft_state_payload,
+    project_profile_file_blob,
+    project_profile_file_payload,
+    update_project_profile_draft_file,
+)
 from brain.systems.cortex.project_context.profiles import attachment_to_read, profile_to_read
 from brain.systems.cortex.project_context.access import (
     can_manage_project_profile,
@@ -548,6 +555,53 @@ async def _project_draft_file_blob_response(
     )
 
 
+async def _project_profile_draft_file_payload(
+    db: AsyncSession,
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    profile_id: str,
+    path: str,
+    user: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+    profile = await _get_project_profile(db, profile_id, _profile_org_id(user or {}), user)
+    try:
+        return project_profile_file_payload(profile, run, idea_id=idea_id, path=path)
+    except ProjectProfileBrowserError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+async def _project_profile_draft_file_blob_response(
+    db: AsyncSession,
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    profile_id: str,
+    path: str,
+    layer: str,
+    user: dict[str, Any] | None = None,
+) -> FileResponse:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+    profile = await _get_project_profile(db, profile_id, _profile_org_id(user or {}), user)
+    try:
+        blob = project_profile_file_blob(profile, run, idea_id=idea_id, path=path, layer=layer)
+    except ProjectProfileBrowserError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(
+        blob["path"],
+        media_type=blob["media_type"],
+        filename=blob["filename"],
+        content_disposition_type="inline",
+    )
+
+
 async def _update_project_draft_file_payload(
     run: AgentRun | None,
     *,
@@ -585,6 +639,32 @@ async def _update_project_draft_file_payload(
             path=body.path,
             content=body.content,
         )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+async def _update_project_profile_draft_file_payload(
+    db: AsyncSession,
+    run: AgentRun | None,
+    *,
+    idea_id: str,
+    profile_id: str,
+    body: ProjectDraftFileUpdate,
+    user: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if run is None:
+        raise HTTPException(status_code=404, detail="No AgentRun exists for this Cortex thread.")
+    profile = await _get_project_profile(db, profile_id, _profile_org_id(user or {}), user)
+    try:
+        return update_project_profile_draft_file(
+            profile,
+            run,
+            idea_id=idea_id,
+            path=body.path,
+            content=body.content,
+        )
+    except ProjectProfileBrowserError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -975,6 +1055,24 @@ async def get_idea_project_context_draft_state(
     return await _project_draft_state_payload(run, idea_id=idea_id, user=user)
 
 
+@router.get("/ideas/{idea_id}/project-context/profile-draft-state")
+async def get_idea_project_profile_context_draft_state(
+    idea_id: str,
+    profile_id: str,
+    run_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    if run is None:
+        return _empty_project_draft_state_payload()
+    profile = await _get_project_profile(db, profile_id, _profile_org_id(user), user)
+    try:
+        return project_profile_draft_state_payload(profile, run, idea_id=idea_id)
+    except ProjectProfileBrowserError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @router.get("/ideas/{idea_id}/project-context/draft-file")
 async def get_idea_project_context_draft_file(
     idea_id: str,
@@ -990,6 +1088,26 @@ async def get_idea_project_context_draft_file(
         idea_id=idea_id,
         path=path,
         resource_id=resource_id,
+        user=user,
+    )
+
+
+@router.get("/ideas/{idea_id}/project-context/profile-draft-file")
+async def get_idea_project_profile_context_draft_file(
+    idea_id: str,
+    profile_id: str,
+    path: str,
+    run_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _project_profile_draft_file_payload(
+        db,
+        run,
+        idea_id=idea_id,
+        profile_id=profile_id,
+        path=path,
         user=user,
     )
 
@@ -1015,6 +1133,28 @@ async def get_idea_project_context_draft_file_blob(
     )
 
 
+@router.get("/ideas/{idea_id}/project-context/profile-draft-file/blob")
+async def get_idea_project_profile_context_draft_file_blob(
+    idea_id: str,
+    profile_id: str,
+    path: str,
+    layer: str = "draft",
+    run_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _project_profile_draft_file_blob_response(
+        db,
+        run,
+        idea_id=idea_id,
+        profile_id=profile_id,
+        path=path,
+        layer=layer,
+        user=user,
+    )
+
+
 @router.patch("/ideas/{idea_id}/project-context/draft-file")
 async def update_idea_project_context_draft_file(
     idea_id: str,
@@ -1027,6 +1167,26 @@ async def update_idea_project_context_draft_file(
     return await _update_project_draft_file_payload(
         run,
         idea_id=idea_id,
+        body=body,
+        user=user,
+    )
+
+
+@router.patch("/ideas/{idea_id}/project-context/profile-draft-file")
+async def update_idea_project_profile_context_draft_file(
+    idea_id: str,
+    profile_id: str,
+    body: ProjectDraftFileUpdate,
+    run_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    run = await _project_draft_state_run(db, idea_id, run_id, user)
+    return await _update_project_profile_draft_file_payload(
+        db,
+        run,
+        idea_id=idea_id,
+        profile_id=profile_id,
         body=body,
         user=user,
     )

--- a/brain/systems/cortex/project_context/profile_browser.py
+++ b/brain/systems/cortex/project_context/profile_browser.py
@@ -1,0 +1,319 @@
+"""Browse any accessible Project root through a thread-scoped draft overlay."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from brain.systems.cortex.project_context.browser import (
+    project_file_blob,
+    project_file_payload,
+    update_project_draft_file,
+    with_project_file_browser,
+)
+from brain.systems.cortex.project_context.drafts import plan_draft_publish, sync_draft_from_root
+from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.systems.cortex.project_context.project_root import (
+    PROJECT_ROOT_MOUNT_PATH,
+    PROJECT_ROOT_RESOURCE_ID,
+    PROJECT_ROOT_RESOURCE_KIND,
+    project_draft_root_path,
+    project_key_from_context,
+    project_root_path,
+)
+from brain.systems.cortex.project_context.profiles import profile_to_read
+from brain.systems.cortex.project_context.workspace_manifest import PROJECT_CONTEXT_DIR
+
+
+class ProjectProfileBrowserError(ValueError):
+    """Raised when a Project profile cannot be browsed in the current thread."""
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _project_resources(profile: Any) -> list[dict[str, Any]]:
+    context = profile.project_context if isinstance(profile.project_context, Mapping) else {}
+    return [dict(item) for item in (context.get("resources") or []) if isinstance(item, Mapping)]
+
+
+def _run_project_manifests(run: Any) -> list[dict[str, Any]]:
+    manifests: list[dict[str, Any]] = []
+    for payload in (
+        _mapping(getattr(run, "workspace_ref", None)),
+        _mapping(getattr(run, "metadata_", None)),
+        _mapping(getattr(run, "target_ref", None)),
+    ):
+        direct = _mapping(payload.get("project_workspace_manifest"))
+        if direct:
+            manifests.append(direct)
+        materialization = _mapping(payload.get("project_context_materialization"))
+        nested = _mapping(materialization.get("workspace_manifest"))
+        if nested:
+            manifests.append(nested)
+    return manifests
+
+
+def _thread_workspace_root_from_path(path: Any) -> Path | None:
+    text = str(path or "").strip()
+    if not text:
+        return None
+    parts = Path(text).expanduser().parts
+    if PROJECT_CONTEXT_DIR not in parts:
+        return None
+    index = parts.index(PROJECT_CONTEXT_DIR)
+    return Path(*parts[:index]) if index > 0 else None
+
+
+def _thread_workspace_root_for_run(run: Any) -> Path | None:
+    for manifest in _run_project_manifests(run):
+        for mount in manifest.get("mounts") or []:
+            mount_payload = _mapping(mount)
+            draft_identity = _mapping(mount_payload.get("draft_identity"))
+            thread_root = draft_identity.get("thread_workspace_root")
+            if isinstance(thread_root, str) and thread_root.strip():
+                return Path(thread_root).expanduser()
+            derived = _thread_workspace_root_from_path(
+                mount_payload.get("workspace_path")
+                or mount_payload.get("resource_path")
+                or mount_payload.get("source_path")
+            )
+            if derived is not None:
+                return derived
+        derived = _thread_workspace_root_from_path(manifest.get("workspace_root"))
+        if derived is not None:
+            return derived
+
+    for payload in (
+        _mapping(getattr(run, "workspace_ref", None)),
+        _mapping(getattr(run, "metadata_", None)),
+    ):
+        for key in ("resolved_workspace_root", "workspace_root", "workspace_hint"):
+            derived = _thread_workspace_root_from_path(payload.get(key))
+            if derived is not None:
+                return derived
+        for workspace in payload.get("workspaces") or []:
+            derived = _thread_workspace_root_from_path(_mapping(workspace).get("path"))
+            if derived is not None:
+                return derived
+    return None
+
+
+def _profile_project_key(profile: Any) -> str:
+    context = stamped_project_context(profile)
+    return project_key_from_context(
+        context,
+        resources=_project_resources(profile),
+        fallback=getattr(profile, "slug", None) or getattr(profile, "id", None),
+    )
+
+
+def _draft_change_payload(root_path: Path, draft_path: Path) -> dict[str, Any]:
+    paths = {
+        "changed_paths": [],
+        "new_paths": [],
+        "deleted_paths": [],
+        "conflicted_paths": [],
+        "out_of_date_paths": [],
+    }
+    if draft_path.exists():
+        plan = plan_draft_publish(root_path, draft_path)
+        paths.update({
+            "changed_paths": plan.modified,
+            "new_paths": plan.created,
+            "deleted_paths": plan.deleted,
+            "conflicted_paths": plan.conflicted,
+            "out_of_date_paths": plan.out_of_date,
+        })
+    return {
+        **paths,
+        "counts": {
+            key: len(paths[key])
+            for key in ("changed_paths", "new_paths", "deleted_paths", "conflicted_paths")
+        },
+        "total": sum(len(paths[key]) for key in ("changed_paths", "new_paths", "deleted_paths", "conflicted_paths")),
+    }
+
+
+def _project_root_resource(profile: Any, run: Any, *, create_draft: bool = False) -> dict[str, Any]:
+    thread_root = _thread_workspace_root_for_run(run)
+    if thread_root is None:
+        raise ProjectProfileBrowserError("No thread workspace root is available for Project browsing.")
+
+    project_key = _profile_project_key(profile)
+    root_path = project_root_path(thread_root, project_key)
+    root_path.mkdir(parents=True, exist_ok=True)
+    draft_path = project_draft_root_path(thread_root, project_key)
+    if create_draft and not draft_path.exists():
+        sync_draft_from_root(root_path, draft_path)
+
+    changes = _draft_change_payload(root_path, draft_path)
+    resource: dict[str, Any] = {
+        "id": PROJECT_ROOT_RESOURCE_ID,
+        "label": profile.name or profile.slug or "Project root",
+        "kind": PROJECT_ROOT_RESOURCE_KIND,
+        "mount_path": PROJECT_ROOT_MOUNT_PATH,
+        "source_path": str(root_path),
+        "project_profile_id": str(profile.id),
+        "project_key": project_key,
+        "changes": changes,
+        "change_counts": changes["counts"],
+        "out_of_date_paths": changes["out_of_date_paths"],
+        "out_of_date": bool(changes["out_of_date_paths"]),
+        "status": (
+            "conflicted"
+            if changes["conflicted_paths"]
+            else "out_of_date"
+            if changes["out_of_date_paths"] and changes["total"] == 0
+            else "modified"
+            if changes["total"] > 0
+            else "clean"
+        ),
+    }
+    if draft_path.exists():
+        resource.update({
+            "workspace_path": str(draft_path),
+            "resource_path": str(draft_path),
+            "is_draft_workspace": True,
+            "materialization": {
+                "provider": "project_root",
+                "draft": True,
+                "project_key": project_key,
+                "path": str(draft_path),
+                "workspace_path": str(draft_path),
+                "source_path": str(root_path),
+            },
+        })
+    return resource
+
+
+def _aggregate_changes(resource: Mapping[str, Any]) -> dict[str, Any]:
+    changes = _mapping(resource.get("changes"))
+    aggregate = {
+        key: [
+            {"resource_id": resource["id"], "mount_path": resource["mount_path"], "path": path}
+            for path in changes.get(key) or []
+        ]
+        for key in ("changed_paths", "new_paths", "deleted_paths", "conflicted_paths", "out_of_date_paths")
+    }
+    aggregate["counts"] = {
+        key: len(aggregate[key])
+        for key in ("changed_paths", "new_paths", "deleted_paths", "conflicted_paths")
+    }
+    aggregate["total"] = sum(aggregate["counts"].values())
+    return aggregate
+
+
+def project_profile_draft_status_payload(profile: Any, run: Any, *, idea_id: str) -> dict[str, Any]:
+    resource = _project_root_resource(profile, run)
+    return with_project_file_browser({
+        "ok": True,
+        "action": "profile_draft_status",
+        "idea_id": str(idea_id),
+        "run_id": str(getattr(run, "id", "") or ""),
+        "project_profile_id": str(profile.id),
+        "project": profile_to_read(profile).model_dump(mode="json", by_alias=True),
+        "resources": [resource],
+        "changes": _aggregate_changes(resource),
+    })
+
+
+def project_profile_publish_plan_payload(draft_status: Mapping[str, Any]) -> dict[str, Any]:
+    resources = [item for item in draft_status.get("resources") or [] if isinstance(item, Mapping)]
+    groups: list[dict[str, Any]] = []
+    operation_count = 0
+    blocked_count = 0
+    for resource in resources:
+        changes = _mapping(resource.get("changes"))
+        operations = [
+            {"operation": "update", "path": path}
+            for path in changes.get("changed_paths") or []
+        ] + [
+            {"operation": "create", "path": path}
+            for path in changes.get("new_paths") or []
+        ] + [
+            {"operation": "delete", "path": path}
+            for path in changes.get("deleted_paths") or []
+        ]
+        operation_count += len(operations)
+        blocked = len(changes.get("conflicted_paths") or [])
+        blocked_count += 1 if blocked else 0
+        groups.append({
+            "resource_id": resource.get("id"),
+            "mount_path": resource.get("mount_path"),
+            "label": resource.get("label"),
+            "workspace_path": resource.get("workspace_path"),
+            "publish_target": {"kind": "local_path", "path": resource.get("source_path")},
+            "status": "blocked" if blocked else "ready" if operations else "clean",
+            "blocked_reasons": ["conflicts"] if blocked else [],
+            "change_counts": resource.get("change_counts") or {},
+            "operations": operations,
+        })
+    return {
+        "ok": True,
+        "action": "plan_publish",
+        "mutates_project_root": True,
+        "plan_only": True,
+        "summary": {
+            "resource_count": len(groups),
+            "operation_count": operation_count,
+            "blocked_count": blocked_count,
+        },
+        "groups": groups,
+    }
+
+
+def project_profile_draft_state_payload(profile: Any, run: Any, *, idea_id: str) -> dict[str, Any]:
+    draft_status = project_profile_draft_status_payload(profile, run, idea_id=idea_id)
+    return {
+        "ok": True,
+        "idea_id": str(idea_id),
+        "run_id": str(getattr(run, "id", "") or ""),
+        "project_profile_id": str(profile.id),
+        "project": profile_to_read(profile).model_dump(mode="json", by_alias=True),
+        "draft_status": draft_status,
+        "plan_publish": project_profile_publish_plan_payload(draft_status),
+        "root_versions": {
+            "ok": True,
+            "action": "root_versions",
+            "summary": {"resource_count": 1, "version_count": 0},
+            "groups": [],
+        },
+    }
+
+
+def project_profile_file_payload(profile: Any, run: Any, *, idea_id: str, path: str) -> dict[str, Any]:
+    draft_status = project_profile_draft_status_payload(profile, run, idea_id=idea_id)
+    return project_file_payload(draft_status, resource_id=PROJECT_ROOT_RESOURCE_ID, path=path)
+
+
+def project_profile_file_blob(profile: Any, run: Any, *, idea_id: str, path: str, layer: str) -> dict[str, Any]:
+    draft_status = project_profile_draft_status_payload(profile, run, idea_id=idea_id)
+    return project_file_blob(draft_status, resource_id=PROJECT_ROOT_RESOURCE_ID, path=path, layer=layer)
+
+
+def update_project_profile_draft_file(
+    profile: Any,
+    run: Any,
+    *,
+    idea_id: str,
+    path: str,
+    content: str,
+) -> dict[str, Any]:
+    resource = _project_root_resource(profile, run, create_draft=True)
+    draft_status = with_project_file_browser({
+        "ok": True,
+        "action": "profile_draft_status",
+        "idea_id": str(idea_id),
+        "run_id": str(getattr(run, "id", "") or ""),
+        "project_profile_id": str(profile.id),
+        "resources": [resource],
+        "changes": _aggregate_changes(resource),
+    })
+    return update_project_draft_file(
+        draft_status,
+        resource_id=PROJECT_ROOT_RESOURCE_ID,
+        path=path,
+        content=content,
+    )

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -809,6 +809,8 @@ export interface ProjectDraftStateResponse {
   error?: string;
   run_id?: string | number | null;
   idea_id?: string | null;
+  project_profile_id?: string | null;
+  project?: Record<string, any> | null;
   draft_status?: ProjectDraftStateRead;
   plan_publish?: {
     ok?: boolean;
@@ -1059,6 +1061,16 @@ export const api = {
         run_id: options.runId,
       }),
     ),
+  getIdeaProjectProfileDraftState: (
+    ideaId: string,
+    options: { runId?: string | number | null; projectProfileId: string },
+  ) =>
+    fetchJson<ProjectDraftStateResponse>(
+      withQuery(`/api/cortex/ideas/${ideaId}/project-context/profile-draft-state`, {
+        run_id: options.runId,
+        profile_id: options.projectProfileId,
+      }),
+    ),
   getIdeaProjectDraftFile: (
     ideaId: string,
     options: { runId?: string | number | null; resourceId?: string | null; path: string },
@@ -1067,6 +1079,17 @@ export const api = {
       withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-file`, {
         run_id: options.runId,
         resource_id: options.resourceId,
+        path: options.path,
+      }),
+    ),
+  getIdeaProjectProfileDraftFile: (
+    ideaId: string,
+    options: { runId?: string | number | null; projectProfileId: string; path: string },
+  ) =>
+    fetchJson<ProjectDraftFileResponse>(
+      withQuery(`/api/cortex/ideas/${ideaId}/project-context/profile-draft-file`, {
+        run_id: options.runId,
+        profile_id: options.projectProfileId,
         path: options.path,
       }),
     ),
@@ -1085,6 +1108,21 @@ export const api = {
       path: options.path,
       layer: options.layer,
     }),
+  getIdeaProjectProfileDraftFileBlobUrl: (
+    ideaId: string,
+    options: {
+      runId?: string | number | null;
+      projectProfileId: string;
+      path: string;
+      layer?: 'root' | 'base' | 'draft';
+    },
+  ) =>
+    withQuery(`/api/cortex/ideas/${ideaId}/project-context/profile-draft-file/blob`, {
+      run_id: options.runId,
+      profile_id: options.projectProfileId,
+      path: options.path,
+      layer: options.layer,
+    }),
   updateIdeaProjectDraftFile: (
     ideaId: string,
     data: ProjectDraftFileUpdateInput,
@@ -1092,6 +1130,24 @@ export const api = {
     fetchJson<ProjectDraftFileResponse>(
       withQuery(`/api/cortex/ideas/${ideaId}/project-context/draft-file`, {
         run_id: data.runId,
+      }),
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          resource_id: data.resourceId,
+          path: data.path,
+          content: data.content,
+        }),
+      },
+    ),
+  updateIdeaProjectProfileDraftFile: (
+    ideaId: string,
+    data: ProjectDraftFileUpdateInput & { projectProfileId: string },
+  ) =>
+    fetchJson<ProjectDraftFileResponse>(
+      withQuery(`/api/cortex/ideas/${ideaId}/project-context/profile-draft-file`, {
+        run_id: data.runId,
+        profile_id: data.projectProfileId,
       }),
       {
         method: 'PATCH',

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -15,6 +15,7 @@ export type RunStatus = Awaited<ReturnType<typeof api.runStatus>>;
 export type SkillFeedbackInput = Parameters<typeof api.skillFeedback>[1];
 export type UploadedThreadFile = Awaited<ReturnType<typeof api.uploadFile>>;
 export type UploadPreview = Awaited<ReturnType<typeof api.previewUpload>>;
+export type ThreadProjectContextProfile = Awaited<ReturnType<typeof api.listProjectContextProfiles>>[number];
 export type ThreadProjectContextAttachment = Awaited<ReturnType<typeof api.listIdeaProjectContext>>[number];
 export type AttachThreadProjectContextInput = Parameters<typeof api.attachIdeaProjectContext>[1];
 export type ThreadProjectDraftState = Awaited<ReturnType<typeof api.getIdeaProjectDraftState>>;
@@ -51,12 +52,17 @@ type ThreadApiMethods = {
   generateTitle: typeof api.generateTitle;
   uploadFile: (file: File) => Promise<UploadedThreadFile>;
   previewUpload: typeof api.previewUpload;
+  listProjectContextProfiles: typeof api.listProjectContextProfiles;
   listIdeaProjectContext: typeof api.listIdeaProjectContext;
   attachIdeaProjectContext: typeof api.attachIdeaProjectContext;
   getIdeaProjectDraftState: typeof api.getIdeaProjectDraftState;
+  getIdeaProjectProfileDraftState: typeof api.getIdeaProjectProfileDraftState;
   getIdeaProjectDraftFile: typeof api.getIdeaProjectDraftFile;
+  getIdeaProjectProfileDraftFile: typeof api.getIdeaProjectProfileDraftFile;
   getIdeaProjectDraftFileBlobUrl: typeof api.getIdeaProjectDraftFileBlobUrl;
+  getIdeaProjectProfileDraftFileBlobUrl: typeof api.getIdeaProjectProfileDraftFileBlobUrl;
   updateIdeaProjectDraftFile: typeof api.updateIdeaProjectDraftFile;
+  updateIdeaProjectProfileDraftFile: typeof api.updateIdeaProjectProfileDraftFile;
   ideaAudit: typeof api.ideaAudit;
   ideaAuditAnalyze: typeof api.ideaAuditAnalyze;
   ideaAuditAnalysisResult: typeof api.ideaAuditAnalysisResult;
@@ -87,12 +93,17 @@ export const threadApi = pickTypedApiMethods<ThreadApiMethods>([
   'generateTitle',
   'uploadFile',
   'previewUpload',
+  'listProjectContextProfiles',
   'listIdeaProjectContext',
   'attachIdeaProjectContext',
   'getIdeaProjectDraftState',
+  'getIdeaProjectProfileDraftState',
   'getIdeaProjectDraftFile',
+  'getIdeaProjectProfileDraftFile',
   'getIdeaProjectDraftFileBlobUrl',
+  'getIdeaProjectProfileDraftFileBlobUrl',
   'updateIdeaProjectDraftFile',
+  'updateIdeaProjectProfileDraftFile',
   'ideaAudit',
   'ideaAuditAnalyze',
   'ideaAuditAnalysisResult',
@@ -123,12 +134,17 @@ export const {
   generateTitle,
   uploadFile,
   previewUpload,
+  listProjectContextProfiles,
   listIdeaProjectContext,
   attachIdeaProjectContext,
   getIdeaProjectDraftState,
+  getIdeaProjectProfileDraftState,
   getIdeaProjectDraftFile,
+  getIdeaProjectProfileDraftFile,
   getIdeaProjectDraftFileBlobUrl,
+  getIdeaProjectProfileDraftFileBlobUrl,
   updateIdeaProjectDraftFile,
+  updateIdeaProjectProfileDraftFile,
   ideaAudit,
   ideaAuditAnalyze,
   ideaAuditAnalysisResult,

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -5,7 +5,15 @@
     getIdeaProjectDraftFile,
     getIdeaProjectDraftFileBlobUrl,
     getIdeaProjectDraftState,
+    getIdeaProjectProfileDraftFile,
+    getIdeaProjectProfileDraftFileBlobUrl,
+    getIdeaProjectProfileDraftState,
+    listIdeaProjectContext,
+    listProjectContextProfiles,
     updateIdeaProjectDraftFile,
+    updateIdeaProjectProfileDraftFile,
+    type ThreadProjectContextAttachment,
+    type ThreadProjectContextProfile,
   } from '$lib/features/threads/api/threadApi';
   import {
     buildProjectDraftPanelView,
@@ -40,6 +48,13 @@
 
   const CHANGE_METRICS = PROJECT_DRAFT_CHANGE_METRICS;
 
+  type ProjectSelectorItem = {
+    id: string;
+    name: string;
+    subtitle: string;
+    group: 'attached' | 'recent';
+  };
+
   let {
     idea,
     runId = null,
@@ -53,6 +68,13 @@
   let loadError = $state('');
   let loadedKey = $state('');
   let requestSeq = 0;
+  let projectProfiles = $state<ThreadProjectContextProfile[]>([]);
+  let projectAttachments = $state<ThreadProjectContextAttachment[]>([]);
+  let projectsLoading = $state(false);
+  let projectsLoadedKey = $state('');
+  let selectedProjectProfileId = $state('');
+  let projectSelectorOpen = $state(false);
+  let projectSelectorQuery = $state('');
 
   let selectedFileKey = $state('');
   let filePreview = $state<ProjectDraftFileResponse | null>(null);
@@ -81,6 +103,18 @@
   const readiness = $derived(draftView.readiness);
   const signalTone = $derived(readiness.tone);
   const signalLabel = $derived(readiness.label);
+  const projectSelectorItems = $derived(projectSelectorOptions(projectProfiles, projectAttachments));
+  const filteredProjectSelectorItems = $derived(
+    filterProjectSelectorItems(projectSelectorItems, projectSelectorQuery),
+  );
+  const selectedProjectItem = $derived(
+    projectSelectorItems.find((item) => item.id === selectedProjectProfileId) ?? projectSelectorItems[0] ?? null,
+  );
+  const selectedProjectLabel = $derived(selectedProjectItem?.name ?? 'Project');
+  const selectedProjectSubtitle = $derived(
+    selectedProjectItem?.subtitle
+      ?? (selectedProjectProfileId ? 'Accessible project' : 'Current thread Project'),
+  );
   const selectedFile = $derived(
     fileBrowser.files.find((file) => file.key === selectedFileKey) ?? null,
   );
@@ -162,6 +196,14 @@
     const ideaId = idea?.id ?? null;
     const file = selectedFile;
     if (!ideaId || !file || !layer) return '';
+    if (selectedProjectProfileId) {
+      return getIdeaProjectProfileDraftFileBlobUrl(ideaId, {
+        runId: runId ?? statePayload?.run_id ?? null,
+        projectProfileId: selectedProjectProfileId,
+        path: file.path,
+        layer,
+      });
+    }
     return getIdeaProjectDraftFileBlobUrl(ideaId, {
       runId: runId ?? statePayload?.run_id ?? null,
       resourceId: file.resourceId,
@@ -189,6 +231,99 @@
 
   function canEmbedFinalKind(kind: ProjectFileKind): boolean {
     return kind === 'image' || kind === 'pdf' || kind === 'video';
+  }
+
+  function projectText(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  function projectNameFromSnapshot(snapshot: any): string {
+    return (
+      projectText(snapshot?.selected_profile_name)
+      || projectText(snapshot?.name)
+      || projectText(snapshot?.title)
+      || projectText(snapshot?.project_slug)
+      || 'Project'
+    );
+  }
+
+  function projectSelectorOptions(
+    profiles: ThreadProjectContextProfile[],
+    attachments: ThreadProjectContextAttachment[],
+  ): ProjectSelectorItem[] {
+    const profilesById = new Map<string, ThreadProjectContextProfile>();
+    for (const profile of profiles) {
+      const id = projectText((profile as any)?.id);
+      if (id) profilesById.set(id, profile);
+    }
+
+    const seen = new Set<string>();
+    const attached: ProjectSelectorItem[] = [];
+    for (const attachment of attachments) {
+      const id = projectText((attachment as any)?.project_profile_id);
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const profile = profilesById.get(id);
+      const snapshot = (attachment as any)?.snapshot;
+      const name = projectText((profile as any)?.name) || projectNameFromSnapshot(snapshot);
+      attached.push({
+        id,
+        name,
+        subtitle: 'Attached project',
+        group: 'attached',
+      });
+    }
+
+    const recent: ProjectSelectorItem[] = [];
+    for (const profile of profiles) {
+      const id = projectText((profile as any)?.id);
+      if (!id || seen.has(id)) continue;
+      const name = projectText((profile as any)?.name) || projectText((profile as any)?.slug) || 'Project';
+      recent.push({
+          id,
+          name,
+          subtitle: 'Recent project',
+        group: 'recent',
+      });
+    }
+
+    return [...attached, ...recent];
+  }
+
+  function filterProjectSelectorItems(
+    items: ProjectSelectorItem[],
+    query: string,
+  ): ProjectSelectorItem[] {
+    const terms = query
+      .trim()
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (terms.length === 0) return items;
+    return items.filter((item) => {
+      const blob = `${item.name} ${item.subtitle} ${item.group}`.toLowerCase();
+      return terms.every((term) => blob.includes(term));
+    });
+  }
+
+  function selectProjectProfile(projectId: string) {
+    if (projectId === selectedProjectProfileId) {
+      projectSelectorOpen = false;
+      projectSelectorQuery = '';
+      return;
+    }
+    selectedProjectProfileId = projectId;
+    projectSelectorOpen = false;
+    projectSelectorQuery = '';
+    selectedFileKey = '';
+    filePreview = null;
+    loadedFileKey = '';
+    collapsedDirectoryKeys = [];
+    editingFileKey = '';
+    editorContent = '';
+    fileSaveError = '';
+    fileSaveNotice = '';
+    previewMode = 'review';
   }
 
   function selectFile(file: ProjectExplorerFile) {
@@ -241,19 +376,27 @@
     fileSaveError = '';
     fileSaveNotice = '';
     try {
-      const result = await updateIdeaProjectDraftFile(ideaId, {
-        runId: currentRunId,
-        resourceId: file.resourceId,
-        path: file.path,
-        content: editorContent,
-      });
+      const result = selectedProjectProfileId
+        ? await updateIdeaProjectProfileDraftFile(ideaId, {
+            runId: currentRunId,
+            projectProfileId: selectedProjectProfileId,
+            resourceId: file.resourceId,
+            path: file.path,
+            content: editorContent,
+          })
+        : await updateIdeaProjectDraftFile(ideaId, {
+            runId: currentRunId,
+            resourceId: file.resourceId,
+            path: file.path,
+            content: editorContent,
+          });
       filePreview = result;
       editingFileKey = '';
       editorContent = '';
-      loadedFileKey = `${ideaId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
+      loadedFileKey = `${ideaId}:${selectedProjectProfileId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
       fileSaveNotice = 'Thread draft saved.';
       previewMode = 'final';
-      await loadDraftState(ideaId, currentRunId);
+      await loadDraftState(ideaId, currentRunId, selectedProjectProfileId);
     } catch (error: any) {
       fileSaveError = error?.detail || error?.message || 'Project draft file could not be updated.';
     } finally {
@@ -267,12 +410,45 @@
     return ' ';
   }
 
-  async function loadDraftState(ideaId: string, currentRunId: string | number | null) {
+  async function loadProjectSelector(ideaId: string) {
+    projectsLoading = true;
+    try {
+      const [attachments, profiles] = await Promise.all([
+        listIdeaProjectContext(ideaId),
+        listProjectContextProfiles(),
+      ]);
+      if (idea?.id !== ideaId) return;
+      projectAttachments = attachments;
+      projectProfiles = profiles;
+      const options = projectSelectorOptions(profiles, attachments);
+      if (!selectedProjectProfileId || !options.some((item) => item.id === selectedProjectProfileId)) {
+        selectedProjectProfileId = options[0]?.id ?? '';
+      }
+    } catch {
+      if (idea?.id === ideaId) {
+        projectAttachments = [];
+        projectProfiles = [];
+      }
+    } finally {
+      if (idea?.id === ideaId) projectsLoading = false;
+    }
+  }
+
+  async function loadDraftState(
+    ideaId: string,
+    currentRunId: string | number | null,
+    projectProfileId: string,
+  ) {
     const requestId = ++requestSeq;
     loading = true;
     loadError = '';
     try {
-      const result = await getIdeaProjectDraftState(ideaId, { runId: currentRunId });
+      const result = projectProfileId
+        ? await getIdeaProjectProfileDraftState(ideaId, {
+            runId: currentRunId,
+            projectProfileId,
+          })
+        : await getIdeaProjectDraftState(ideaId, { runId: currentRunId });
       if (requestId !== requestSeq) return;
       draftState = result;
     } catch (error: any) {
@@ -288,16 +464,23 @@
     ideaId: string,
     currentRunId: string | number | null,
     file: ProjectExplorerFile,
+    projectProfileId: string,
   ) {
     const requestId = ++fileRequestSeq;
     filePreviewLoading = true;
     filePreviewError = '';
     try {
-      const result = await getIdeaProjectDraftFile(ideaId, {
-        runId: currentRunId,
-        resourceId: file.resourceId,
-        path: file.path,
-      });
+      const result = projectProfileId
+        ? await getIdeaProjectProfileDraftFile(ideaId, {
+            runId: currentRunId,
+            projectProfileId,
+            path: file.path,
+          })
+        : await getIdeaProjectDraftFile(ideaId, {
+            runId: currentRunId,
+            resourceId: file.resourceId,
+            path: file.path,
+          });
       if (requestId !== fileRequestSeq) return;
       filePreview = result;
     } catch (error: any) {
@@ -311,8 +494,23 @@
 
   $effect(() => {
     const ideaId = idea?.id ?? null;
+    if (!ideaId) {
+      projectAttachments = [];
+      projectProfiles = [];
+      selectedProjectProfileId = '';
+      projectsLoadedKey = '';
+      projectsLoading = false;
+      return;
+    }
+    if (projectsLoadedKey === ideaId) return;
+    projectsLoadedKey = ideaId;
+    void loadProjectSelector(ideaId);
+  });
+
+  $effect(() => {
+    const ideaId = idea?.id ?? null;
     const currentRunId = runId ?? null;
-    const key = `${ideaId ?? ''}:${currentRunId ?? ''}`;
+    const key = `${ideaId ?? ''}:${currentRunId ?? ''}:${selectedProjectProfileId}`;
     if (!ideaId) {
       requestSeq += 1;
       draftState = null;
@@ -323,7 +521,7 @@
     }
     if (loadedKey === key) return;
     loadedKey = key;
-    void loadDraftState(ideaId, currentRunId);
+    void loadDraftState(ideaId, currentRunId, selectedProjectProfileId);
   });
 
   $effect(() => {
@@ -360,19 +558,89 @@
       loadedFileKey = '';
       return;
     }
-    const key = `${ideaId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
+    const key = `${ideaId}:${selectedProjectProfileId}:${currentRunId ?? ''}:${file.resourceId}:${file.path}`;
     if (loadedFileKey === key) return;
     loadedFileKey = key;
-    void loadFilePreview(ideaId, currentRunId, file);
+    void loadFilePreview(ideaId, currentRunId, file, selectedProjectProfileId);
   });
 </script>
 
 <section class="project-draft-panel" aria-label="Project workspace">
   <div class="project-draft-summary">
-    <div class="project-draft-kicker">Project</div>
+    <div class="project-selector-row">
+      <div class="project-selector-anchor">
+        <button
+          type="button"
+          class="project-selector-button"
+          aria-expanded={projectSelectorOpen}
+          aria-haspopup="listbox"
+          disabled={projectsLoading || projectSelectorItems.length === 0}
+          onclick={() => { projectSelectorOpen = !projectSelectorOpen; }}
+        >
+          <span class="project-selector-copy">
+            <span class="project-draft-kicker">Project</span>
+            <strong>{selectedProjectLabel}</strong>
+            <small>{selectedProjectSubtitle}</small>
+          </span>
+          <span class="project-selector-action">
+            {projectSelectorItems.length > 1 ? 'Switch' : projectsLoading ? 'Loading' : 'Current'}
+            {#if projectSelectorItems.length > 1}
+              <ConstellationIcon name="chevron-down" size={11} />
+            {/if}
+          </span>
+        </button>
+        {#if projectSelectorOpen && projectSelectorItems.length > 0}
+          <div class="project-selector-menu" role="listbox" aria-label="Accessible Projects">
+            <div class="project-selector-search">
+              <input
+                type="search"
+                bind:value={projectSelectorQuery}
+                placeholder={`Search ${projectSelectorItems.length} Projects`}
+                aria-label="Search accessible Projects"
+              />
+              <small>
+                {filteredProjectSelectorItems.length} of {projectSelectorItems.length} shown. Attached Projects stay first.
+              </small>
+            </div>
+            <div class="project-selector-menu-scroll">
+              {#if filteredProjectSelectorItems.length === 0}
+                <div class="project-selector-empty">No Projects match that search.</div>
+              {:else}
+                {#each ['attached', 'recent'] as group (group)}
+                  {@const groupItems = filteredProjectSelectorItems.filter((item) => item.group === group)}
+                  {#if groupItems.length > 0}
+                    <div class="project-selector-menu-section">
+                      <div class="project-selector-menu-label">
+                        {group === 'attached' ? 'Attached projects' : 'Recent projects'} / {groupItems.length}
+                      </div>
+                      {#each groupItems as project (project.id)}
+                        <button
+                          type="button"
+                          class="project-selector-option"
+                          class:project-selector-option-active={project.id === selectedProjectProfileId}
+                          role="option"
+                          aria-selected={project.id === selectedProjectProfileId}
+                          onclick={() => selectProjectProfile(project.id)}
+                        >
+                          <span>
+                            <strong>{project.name}</strong>
+                            <small>{project.subtitle}</small>
+                          </span>
+                          <em>{project.id === selectedProjectProfileId ? 'Current' : 'Open'}</em>
+                        </button>
+                      {/each}
+                    </div>
+                  {/if}
+                {/each}
+              {/if}
+            </div>
+          </div>
+        {/if}
+      </div>
+      <span class="project-draft-signal" data-tone={signalTone}>{signalLabel}</span>
+    </div>
     <div class="project-draft-title-row">
       <span class="project-draft-title">Root + thread overlay</span>
-      <span class="project-draft-signal" data-tone={signalTone}>{signalLabel}</span>
     </div>
     <div class="project-draft-meta">
       <span>{runLabel}</span>
@@ -819,6 +1087,272 @@
   .project-draft-title-row {
     align-items: center;
     margin-top: 7px;
+  }
+
+  .project-selector-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 10px;
+  }
+
+  .project-selector-anchor {
+    position: relative;
+    min-width: 0;
+  }
+
+  .project-selector-button {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-width: 0;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: rgba(255, 255, 255, 0.035);
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .project-selector-button:disabled {
+    cursor: default;
+    opacity: 0.72;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-button {
+    border-color: rgba(85, 104, 120, 0.14);
+    background: rgba(255, 253, 248, 0.82);
+  }
+
+  .project-selector-copy {
+    min-width: 0;
+  }
+
+  .project-selector-copy strong {
+    display: block;
+    overflow: hidden;
+    color: rgba(243, 247, 255, 0.94);
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-copy strong {
+    color: rgba(20, 29, 38, 0.92);
+  }
+
+  .project-selector-copy small {
+    display: block;
+    margin-top: 3px;
+    overflow: hidden;
+    color: rgba(231, 238, 247, 0.52);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 10px;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-copy small {
+    color: rgba(82, 98, 111, 0.66);
+  }
+
+  .project-selector-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 7px;
+    padding: 4px 7px;
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(231, 238, 247, 0.6);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-action {
+    background: rgba(85, 104, 120, 0.06);
+    color: rgba(57, 70, 82, 0.66);
+  }
+
+  .project-selector-menu {
+    position: absolute;
+    z-index: 5;
+    top: calc(100% + 6px);
+    left: 0;
+    width: 100%;
+    max-height: min(68vh, 560px);
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 10px;
+    background: #10151b;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.26);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-menu {
+    border-color: rgba(85, 104, 120, 0.16);
+    background: #fffdf8;
+    box-shadow: 0 16px 40px rgba(29, 39, 49, 0.16);
+  }
+
+  .project-selector-search {
+    display: grid;
+    gap: 5px;
+    padding: 9px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+    background: #10151b;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-search {
+    border-bottom-color: rgba(85, 104, 120, 0.1);
+    background: #fffdf8;
+  }
+
+  .project-selector-search input {
+    width: 100%;
+    height: 30px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 7px;
+    padding: 0 9px;
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    font: inherit;
+    font-size: 11px;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-search input {
+    border-color: rgba(85, 104, 120, 0.14);
+    background: rgba(250, 250, 246, 0.92);
+  }
+
+  .project-selector-search small,
+  .project-selector-empty {
+    color: rgba(231, 238, 247, 0.5);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.35;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-search small,
+  :global(:root[data-color-scheme='light']) .project-selector-empty {
+    color: rgba(82, 98, 111, 0.62);
+  }
+
+  .project-selector-menu-scroll {
+    max-height: min(58vh, 460px);
+    overflow: auto;
+  }
+
+  .project-selector-empty {
+    padding: 14px 16px;
+  }
+
+  .project-selector-menu-section {
+    padding: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  }
+
+  .project-selector-menu-section:last-child {
+    border-bottom: 0;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-menu-section {
+    border-bottom-color: rgba(85, 104, 120, 0.1);
+  }
+
+  .project-selector-menu-label {
+    margin: 2px 2px 6px;
+    color: rgba(231, 238, 247, 0.46);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 8px;
+    font-weight: 650;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-menu-label {
+    color: rgba(82, 98, 111, 0.62);
+  }
+
+  .project-selector-option {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 44px;
+    border: 0;
+    border-radius: 7px;
+    padding: 8px;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .project-selector-option:hover,
+  .project-selector-option-active {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-option:hover,
+  :global(:root[data-color-scheme='light']) .project-selector-option-active {
+    background: rgba(82, 117, 139, 0.08);
+  }
+
+  .project-selector-option strong {
+    display: block;
+    overflow: hidden;
+    color: rgba(243, 247, 255, 0.9);
+    font-size: 12px;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-option strong {
+    color: rgba(29, 39, 49, 0.88);
+  }
+
+  .project-selector-option small {
+    display: block;
+    margin-top: 2px;
+    overflow: hidden;
+    color: rgba(231, 238, 247, 0.5);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-option small {
+    color: rgba(82, 98, 111, 0.62);
+  }
+
+  .project-selector-option em {
+    color: rgba(231, 238, 247, 0.46);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 8px;
+    font-style: normal;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-option em {
+    color: rgba(82, 98, 111, 0.52);
   }
 
   .project-draft-title {

--- a/tests/test_project_context_browser.py
+++ b/tests/test_project_context_browser.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from types import SimpleNamespace
+from datetime import datetime, timezone
 
 import pytest
 
@@ -10,6 +12,12 @@ from brain.systems.cortex.project_context.browser import (
     with_project_file_browser,
 )
 from brain.systems.cortex.project_context.drafts import build_file_manifest, save_draft_metadata
+from brain.systems.cortex.project_context.profile_browser import (
+    project_profile_draft_state_payload,
+    project_profile_file_payload,
+    update_project_profile_draft_file,
+)
+from brain.systems.cortex.project_context.project_root import project_draft_root_path
 
 
 def _write(path: Path, content: str) -> None:
@@ -161,3 +169,58 @@ def test_project_file_payload_rejects_escaping_paths(tmp_path):
         project_file_payload({"resources": []}, resource_id=None, path="../secret.md")
     with pytest.raises(ValueError, match="internal metadata"):
         project_file_payload({"resources": []}, resource_id=None, path=".illo-project-history/version.json")
+
+
+def test_project_profile_browser_reads_root_and_creates_thread_draft_on_edit(tmp_path):
+    thread_root = tmp_path / "ideas" / "thread-a"
+    project_root = tmp_path / "project-roots" / "project-1"
+    _write(project_root / "README.md", "root readme\n")
+    profile = SimpleNamespace(
+        id="project-1",
+        org_id="org-1",
+        user_id="user-1",
+        slug="payments",
+        name="Payments",
+        description=None,
+        project_context={"version": 1, "resources": []},
+        visibility="public",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=datetime.now(timezone.utc),
+    )
+    run = SimpleNamespace(
+        id=17,
+        workspace_ref={
+            "project_workspace_manifest": {
+                "mounts": [{
+                    "draft_identity": {"thread_workspace_root": str(thread_root)},
+                }],
+            },
+        },
+        metadata_={},
+        target_ref={},
+    )
+
+    state = project_profile_draft_state_payload(profile, run, idea_id="idea-1")
+    entries = {entry["path"]: entry for entry in state["draft_status"]["file_browser"]["entries"]}
+    assert entries["README.md"]["has_root"] is True
+    assert entries["README.md"]["has_draft"] is False
+    assert entries["README.md"]["status"] == "clean"
+    assert project_profile_file_payload(profile, run, idea_id="idea-1", path="README.md")["layers"]["root"]["content"] == "root readme\n"
+
+    updated = update_project_profile_draft_file(
+        profile,
+        run,
+        idea_id="idea-1",
+        path="README.md",
+        content="draft readme\n",
+    )
+
+    draft_root = project_draft_root_path(thread_root, "project-1")
+    assert updated["updated"] is True
+    assert (project_root / "README.md").read_text(encoding="utf-8") == "root readme\n"
+    assert (draft_root / "README.md").read_text(encoding="utf-8") == "draft readme\n"
+    refreshed = project_profile_draft_state_payload(profile, run, idea_id="idea-1")
+    refreshed_entries = {entry["path"]: entry for entry in refreshed["draft_status"]["file_browser"]["entries"]}
+    assert refreshed_entries["README.md"]["status"] == "changed"


### PR DESCRIPTION
## Summary
- Add a Project selector in the thread Project tab with attached Projects first and searchable recent/accessed Projects.
- Add profile-scoped Project root browsing endpoints that reuse the root + thread draft overlay browser and create a draft on text edit.
- Add regression coverage for browsing a non-attached Project root and creating a thread draft from an edit.

## Tests
- npm run check
- python3 -m pytest tests/test_project_context_browser.py tests/test_manage_project_cross_references.py