### PR TITLE
Fix spawn worker parent run context

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -46,21 +46,35 @@ def _current_agent_value(name: str) -> Any:
 
 
 def _current_run_id() -> int | None:
+    explicit_run_id = _coerce_run_id(getattr(_agent_context, "run_id", None))
+    if explicit_run_id is not None:
+        return explicit_run_id
+
+    execution_metadata = getattr(_agent_context, "execution_metadata", None)
+    if isinstance(execution_metadata, Mapping):
+        metadata_run_id = _coerce_run_id(execution_metadata.get("run_id"))
+        if metadata_run_id is not None:
+            return metadata_run_id
+
     run = getattr(_agent_context, "run", None)
     candidates = (
         getattr(run, "run_id", None),
         getattr(run, "id", None),
-        getattr(_agent_context, "run_id", None),
-        _current_agent_value("run_id"),
     )
     for candidate in candidates:
-        if candidate in (None, ""):
-            continue
-        try:
-            return int(candidate)
-        except (TypeError, ValueError):
-            continue
+        run_id = _coerce_run_id(candidate)
+        if run_id is not None:
+            return run_id
     return None
+
+
+def _coerce_run_id(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _current_mapping(name: str) -> dict[str, Any]:
@@ -163,13 +177,14 @@ async def _handle_spawn_worker(
     risk_level: str = "medium",
     tool_policy: dict | None = None,
     metadata: dict | None = None,
+    _runtime_run_id: int | str | None = None,
     **_: Any,
 ) -> str:
     objective_text = str(objective or "").strip()
     if not objective_text:
         return json.dumps({"error": "spawn_worker requires objective"})
 
-    parent_run_id = _current_run_id()
+    parent_run_id = _coerce_run_id(_runtime_run_id) or _current_run_id()
     if parent_run_id is None:
         return json.dumps({"error": "spawn_worker requires an active AgentRun context"})
 

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -414,9 +414,19 @@ def wrap_tool_handlers(
             continue
 
         async def _handler(_tool_name=tool_name, _handler=handler, **kwargs):
+            tool_args = dict(kwargs or {})
+            handler_for_execution = _handler
+            if _tool_name == "spawn_worker":
+                async def _handler_with_runtime_run_id(**inner_kwargs):
+                    return await _maybe_await(
+                        _handler(_runtime_run_id=run_id, **inner_kwargs)
+                    )
+
+                handler_for_execution = _handler_with_runtime_run_id
+
             return await executor.execute(
                 run_id,
-                ToolExecution(name=_tool_name, args=dict(kwargs or {}), handler=_handler),
+                ToolExecution(name=_tool_name, args=tool_args, handler=handler_for_execution),
                 root_run_id=root_run_id,
                 scope=scope,
                 collector=collector,

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -986,6 +986,74 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
     assert [event.event_type for event in events] == ["run.worker_spawned"]
 
 
+async def test_spawn_worker_handler_prefers_runtime_run_id_over_stale_context(monkeypatch):
+    from brain.systems.runs.domain import RunProfile, RunRecipe
+    from brain.systems.runs.execution_context import bind_agent_context
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    stale_parent = SimpleNamespace(id=375)
+    current_parent = SimpleNamespace(
+        id=377,
+        org_id="org-1",
+        user_id="user-1",
+        root_run_id=377,
+        profile=RunProfile.FAST,
+        target_ref={"kind": "cortex_idea", "idea_id": "idea-1"},
+        workspace_ref={},
+        model_policy={},
+    )
+    child = SimpleNamespace(id=378, root_run_id=377, recipe=RunRecipe.WORKER)
+    created = {}
+
+    class _Uow:
+        session = object()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+    class _Store:
+        def __init__(self, session):
+            self.session = session
+
+        async def require_run(self, run_id):
+            assert run_id == current_parent.id
+            return current_parent
+
+        async def child_run_for_step(self, parent_id, step_key):
+            assert parent_id == current_parent.id
+            return None
+
+        async def create_child_run(self, parent_arg, **kwargs):
+            assert parent_arg is current_parent
+            created.update(kwargs)
+            return child
+
+        async def append_event(self, event):
+            assert event.run_id == current_parent.id
+
+    monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
+    monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
+
+    with bind_agent_context(run=stale_parent):
+        payload = json.loads(
+            await worker_handlers._handle_spawn_worker(
+                objective="File the browser status bug.",
+                role="report_bug",
+                headless=True,
+                idempotency_key="bug-report",
+                _runtime_run_id=current_parent.id,
+            )
+        )
+
+    assert payload["ok"] is True
+    assert payload["parent_run_id"] == current_parent.id
+    assert payload["root_run_id"] == current_parent.root_run_id
+    assert created["thread_id"].startswith("headless-worker:377:")
+
+
 async def test_fast_recipe_passes_project_workspace_registry_to_tools(monkeypatch):
     from brain.systems.runs.recipes.fast import FastRecipe
 


### PR DESCRIPTION
## Summary
- Pass the runtime AgentRun id into spawn_worker from the run tool wrapper
- Prefer explicit/current run metadata before stale context when resolving worker parent runs
- Add a regression test for stale AgentRun context parenting workers to the wrong root

## Tests
- venv/bin/python -m pytest tests/test_agent_run_runtime.py tests/test_pipeline.py -k "spawn_worker or child_run or worker"