### PR TITLE
Fix Project root browsing from any thread

### DIFF
--- a/brain/systems/cortex/project_context/profile_browser.py
+++ b/brain/systems/cortex/project_context/profile_browser.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from brain.kernel import config
 from brain.systems.cortex.project_context.browser import (
     project_file_blob,
     project_file_payload,
@@ -66,7 +67,7 @@ def _thread_workspace_root_from_path(path: Any) -> Path | None:
     return Path(*parts[:index]) if index > 0 else None
 
 
-def _thread_workspace_root_for_run(run: Any) -> Path | None:
+def _thread_workspace_root_for_run(run: Any, *, idea_id: str | None = None) -> Path | None:
     for manifest in _run_project_manifests(run):
         for mount in manifest.get("mounts") or []:
             mount_payload = _mapping(mount)
@@ -97,6 +98,18 @@ def _thread_workspace_root_for_run(run: Any) -> Path | None:
             derived = _thread_workspace_root_from_path(_mapping(workspace).get("path"))
             if derived is not None:
                 return derived
+    thread_id = str(idea_id or "").strip() or str(getattr(run, "thread_id", "") or "").strip()
+    if not thread_id:
+        for payload in (
+            _mapping(getattr(run, "target_ref", None)),
+            _mapping(getattr(run, "metadata_", None)),
+        ):
+            thread_id = str(payload.get("idea_id") or payload.get("thread_id") or "").strip()
+            if thread_id:
+                break
+    if thread_id:
+        workspace_root = config.resolve_workspace_root(default=config.BRAIN_DIR.parent).expanduser()
+        return workspace_root / "ideas" / thread_id
     return None
 
 
@@ -136,14 +149,23 @@ def _draft_change_payload(root_path: Path, draft_path: Path) -> dict[str, Any]:
     }
 
 
-def _project_root_resource(profile: Any, run: Any, *, create_draft: bool = False) -> dict[str, Any]:
-    thread_root = _thread_workspace_root_for_run(run)
+def _project_root_resource(
+    profile: Any,
+    run: Any,
+    *,
+    idea_id: str | None = None,
+    create_draft: bool = False,
+) -> dict[str, Any]:
+    thread_root = _thread_workspace_root_for_run(run, idea_id=idea_id)
     if thread_root is None:
         raise ProjectProfileBrowserError("No thread workspace root is available for Project browsing.")
 
     project_key = _profile_project_key(profile)
     root_path = project_root_path(thread_root, project_key)
-    root_path.mkdir(parents=True, exist_ok=True)
+    root_available = root_path.exists()
+    if create_draft and not root_available:
+        root_path.mkdir(parents=True, exist_ok=True)
+        root_available = True
     draft_path = project_draft_root_path(thread_root, project_key)
     if create_draft and not draft_path.exists():
         sync_draft_from_root(root_path, draft_path)
@@ -155,6 +177,7 @@ def _project_root_resource(profile: Any, run: Any, *, create_draft: bool = False
         "kind": PROJECT_ROOT_RESOURCE_KIND,
         "mount_path": PROJECT_ROOT_MOUNT_PATH,
         "source_path": str(root_path),
+        "root_available": root_available,
         "project_profile_id": str(profile.id),
         "project_key": project_key,
         "changes": changes,
@@ -206,7 +229,7 @@ def _aggregate_changes(resource: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def project_profile_draft_status_payload(profile: Any, run: Any, *, idea_id: str) -> dict[str, Any]:
-    resource = _project_root_resource(profile, run)
+    resource = _project_root_resource(profile, run, idea_id=idea_id)
     return with_project_file_browser({
         "ok": True,
         "action": "profile_draft_status",
@@ -301,7 +324,7 @@ def update_project_profile_draft_file(
     path: str,
     content: str,
 ) -> dict[str, Any]:
-    resource = _project_root_resource(profile, run, create_draft=True)
+    resource = _project_root_resource(profile, run, idea_id=idea_id, create_draft=True)
     draft_status = with_project_file_browser({
         "ok": True,
         "action": "profile_draft_status",

--- a/brain/systems/cortex/project_context/project_root.py
+++ b/brain/systems/cortex/project_context/project_root.py
@@ -106,6 +106,14 @@ def is_synthetic_project_root_resource(resource: Mapping[str, Any]) -> bool:
 
 def project_roots_parent(thread_workspace_root: Path) -> Path:
     root = Path(thread_workspace_root).expanduser()
+    if root.name == PROJECT_ROOTS_DIR:
+        return root
+    if PROJECT_CONTEXT_DIR in root.parts:
+        index = root.parts.index(PROJECT_CONTEXT_DIR)
+        if index > 0:
+            return project_roots_parent(Path(*root.parts[:index]))
+    if root.name == "workspaces" or (root / "ideas").exists():
+        return root / PROJECT_ROOTS_DIR
     parent = root.parent
     if parent.name == "ideas":
         return parent.parent / PROJECT_ROOTS_DIR

--- a/tests/test_manage_project_cross_references.py
+++ b/tests/test_manage_project_cross_references.py
@@ -129,6 +129,16 @@ async def test_manage_project_search_files_finds_paths_and_content_without_loadi
     assert path_payload["results"][0]["matched_by"] == ["path"]
 
 
+def test_project_root_path_accepts_workspace_base_and_draft_paths(tmp_path):
+    workspace_base = tmp_path / "workspaces"
+    workspace_base.mkdir()
+    thread_root = workspace_base / "ideas" / "thread-1"
+    draft_path = thread_root / ".illo-project-context" / "local" / "project-payments" / "project-root"
+
+    assert project_root_path(workspace_base, "project-payments") == workspace_base / "project-roots" / "project-payments"
+    assert project_root_path(draft_path, "project-payments") == workspace_base / "project-roots" / "project-payments"
+
+
 async def test_manage_project_mount_reference_exposes_read_only_files_to_normal_file_tools(tmp_path, monkeypatch):
     profile = _project_profile("project-payments", slug="payments", name="Payments")
     workspace_root = tmp_path / "ideas" / "thread-1"

--- a/tests/test_project_context_browser.py
+++ b/tests/test_project_context_browser.py
@@ -17,7 +17,7 @@ from brain.systems.cortex.project_context.profile_browser import (
     project_profile_file_payload,
     update_project_profile_draft_file,
 )
-from brain.systems.cortex.project_context.project_root import project_draft_root_path
+from brain.systems.cortex.project_context.project_root import project_draft_root_path, project_root_path
 
 
 def _write(path: Path, content: str) -> None:
@@ -224,3 +224,83 @@ def test_project_profile_browser_reads_root_and_creates_thread_draft_on_edit(tmp
     refreshed = project_profile_draft_state_payload(profile, run, idea_id="idea-1")
     refreshed_entries = {entry["path"]: entry for entry in refreshed["draft_status"]["file_browser"]["entries"]}
     assert refreshed_entries["README.md"]["status"] == "changed"
+
+
+def test_project_profile_browser_falls_back_to_thread_workspace_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+    project_root = tmp_path / "project-roots" / "project-1"
+    _write(project_root / "README.md", "root readme\n")
+    profile = SimpleNamespace(
+        id="project-1",
+        org_id="org-1",
+        user_id="user-1",
+        slug="payments",
+        name="Payments",
+        description=None,
+        project_context={"version": 1, "resources": []},
+        visibility="public",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=datetime.now(timezone.utc),
+    )
+    run = SimpleNamespace(
+        id=18,
+        workspace_ref={},
+        metadata_={},
+        target_ref={},
+    )
+
+    state = project_profile_draft_state_payload(profile, run, idea_id="thread-a")
+    resource = state["draft_status"]["resources"][0]
+    entries = {entry["path"]: entry for entry in state["draft_status"]["file_browser"]["entries"]}
+
+    assert resource["source_path"] == str(project_root)
+    assert resource["root_available"] is True
+    assert entries["README.md"]["has_root"] is True
+
+
+def test_project_profile_browser_does_not_create_missing_root_on_read(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+    profile = SimpleNamespace(
+        id="empty-project",
+        org_id="org-1",
+        user_id="user-1",
+        slug="empty",
+        name="Empty",
+        description=None,
+        project_context={"version": 1, "resources": []},
+        visibility="public",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=datetime.now(timezone.utc),
+    )
+    run = SimpleNamespace(
+        id=19,
+        thread_id="thread-a",
+        workspace_ref={},
+        metadata_={},
+        target_ref={},
+    )
+    root = project_root_path(tmp_path / "ideas" / "thread-a", "empty-project")
+
+    state = project_profile_draft_state_payload(profile, run, idea_id="thread-a")
+    resource = state["draft_status"]["resources"][0]
+
+    assert root.exists() is False
+    assert resource["root_available"] is False
+    assert state["draft_status"]["file_browser"]["summary"]["file_count"] == 0
+
+    update_project_profile_draft_file(
+        profile,
+        run,
+        idea_id="thread-a",
+        path="notes.md",
+        content="draft note\n",
+    )
+
+    assert root.exists() is True
+    assert (project_draft_root_path(tmp_path / "ideas" / "thread-a", "empty-project") / "notes.md").read_text(
+        encoding="utf-8"
+    ) == "draft note\n"


### PR DESCRIPTION
## Summary
- let Project profile browsing derive a thread workspace from the route/thread when a run has no Project materialization metadata
- stop read-only Project browsing from creating empty canonical roots as a side effect
- normalize Project root path resolution for workspace base paths and draft overlay paths

## Server finding
On the Tailscale server, persisted data is present under /workspaces/project-roots (18 roots, 795 non-history files), including test-empty-project with unified_payments.csv and analysis docs. The failure is that profile browsing could not locate a thread workspace for runs without Project materialization metadata, and the read path could silently create empty roots.

## Tests
- python3 -m pytest tests/test_project_context_browser.py tests/test_manage_project_cross_references.py tests/test_project_context_root_materializer.py
- python3 -m py_compile brain/systems/cortex/project_context/project_root.py brain/systems/cortex/project_context/profile_browser.py
- git diff --check