### PR TITLE
Improve Project panel width and selector counts

### DIFF
--- a/brain/systems/cortex/project_context/profiles.py
+++ b/brain/systems/cortex/project_context/profiles.py
@@ -1,19 +1,88 @@
 """Project Context persistence read-model adapters."""
 from __future__ import annotations
 
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
+from brain.kernel import config
 from brain.systems.cortex.project_context.access import project_profile_visibility
+from brain.systems.cortex.project_context.drafts import IGNORED_DRAFT_DIRS
 from brain.systems.cortex.project_context.identity import stamped_project_context
+from brain.systems.cortex.project_context.project_root import project_key_from_context, project_root_path
 from brain.systems.cortex.project_context.schemas import IdeaProjectAttachmentRead, ProjectProfileRead
+from brain.systems.cortex.project_context.workspace_manifest import PROJECT_CONTEXT_DIR
 from brain.platform.db.models.idea import IdeaProjectAttachment, ProjectProfile
+
+
+PROFILE_CONTENT_FILE_COUNT_LIMIT = 1_000
+_PROFILE_CONTENT_INTERNAL_DIRS = {*IGNORED_DRAFT_DIRS, PROJECT_CONTEXT_DIR, ".git"}
+_REPO_RESOURCE_KINDS = {"github", "github_repo", "github_repository", "repo", "repository"}
 
 
 def _profile_context_for_read(profile: ProjectProfile) -> dict[str, Any]:
     return stamped_project_context(profile)
 
 
+def _profile_resources(project_context: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [dict(item) for item in (project_context.get("resources") or []) if isinstance(item, Mapping)]
+
+
+def _is_repo_resource(resource: Mapping[str, Any]) -> bool:
+    kind = str(resource.get("kind") or resource.get("type") or resource.get("resource_type") or "").strip().lower()
+    source = str(resource.get("source") or resource.get("provider") or "").strip().lower()
+    uri = str(resource.get("uri") or resource.get("url") or resource.get("repo_url") or "").strip().lower()
+    return (
+        kind in _REPO_RESOURCE_KINDS
+        or source in {"github", "git"}
+        or bool(resource.get("repo"))
+        or uri.startswith(("git@", "https://github.com/", "http://github.com/"))
+        or uri.endswith(".git")
+    )
+
+
+def _count_project_root_files(root: Path, *, limit: int = PROFILE_CONTENT_FILE_COUNT_LIMIT) -> tuple[int, bool]:
+    if not root.exists() or not root.is_dir():
+        return 0, True
+
+    count = 0
+    try:
+        for path in root.rglob("*"):
+            relative = path.relative_to(root)
+            if any(part in _PROFILE_CONTENT_INTERNAL_DIRS for part in relative.parts):
+                continue
+            if path.is_symlink():
+                continue
+            if path.is_file():
+                count += 1
+                if count >= limit:
+                    return count, False
+    except OSError:
+        return count, False
+    return count, True
+
+
+def _profile_content_summary(profile: ProjectProfile, project_context: Mapping[str, Any]) -> dict[str, Any]:
+    resources = _profile_resources(project_context)
+    project_key = project_key_from_context(
+        project_context,
+        resources=resources,
+        fallback=getattr(profile, "slug", None) or getattr(profile, "id", None),
+    )
+    workspace_root = config.resolve_workspace_root(default=config.BRAIN_DIR.parent).expanduser()
+    root = project_root_path(workspace_root, project_key)
+    file_count, file_count_exact = _count_project_root_files(root)
+    return {
+        "root_exists": root.exists() and root.is_dir(),
+        "file_count": file_count,
+        "file_count_exact": file_count_exact,
+        "repo_count": sum(1 for resource in resources if _is_repo_resource(resource)),
+        "resource_count": len(resources),
+    }
+
+
 def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None = None) -> ProjectProfileRead:
+    project_context = _profile_context_for_read(profile)
     return ProjectProfileRead.model_validate({
         "id": profile.id,
         "org_id": profile.org_id,
@@ -21,11 +90,12 @@ def profile_to_read(profile: ProjectProfile, access: list[dict[str, Any]] | None
         "slug": profile.slug,
         "name": profile.name,
         "description": profile.description,
-        "project_context": _profile_context_for_read(profile),
+        "project_context": project_context,
         "visibility": project_profile_visibility(profile),
         "access": access or [],
         "default_environment_binding_id": profile.default_environment_binding_id,
         "active": True if profile.active is None else profile.active,
+        "content_summary": _profile_content_summary(profile, project_context),
         "metadata": profile.metadata_ or {},
         "created_at": profile.created_at,
     })

--- a/brain/systems/cortex/project_context/schemas.py
+++ b/brain/systems/cortex/project_context/schemas.py
@@ -41,6 +41,14 @@ class ProjectProfileAccessRead(BaseModel):
     created_at: datetime | None = None
 
 
+class ProjectProfileContentSummary(BaseModel):
+    root_exists: bool = False
+    file_count: int = 0
+    file_count_exact: bool = True
+    repo_count: int = 0
+    resource_count: int = 0
+
+
 class ProjectProfileRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -55,6 +63,7 @@ class ProjectProfileRead(BaseModel):
     access: list[ProjectProfileAccessRead] = Field(default_factory=list)
     default_environment_binding_id: int | None = None
     active: bool = True
+    content_summary: ProjectProfileContentSummary = Field(default_factory=ProjectProfileContentSummary)
     metadata_: dict[str, Any] | None = Field(default=None, alias="metadata")
     created_at: datetime | None = None
 

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -53,6 +53,8 @@
     name: string;
     subtitle: string;
     group: 'attached' | 'recent';
+    contentLabels: string[];
+    searchText: string;
   };
 
   let {
@@ -115,6 +117,7 @@
     selectedProjectItem?.subtitle
       ?? (selectedProjectProfileId ? 'Accessible project' : 'Current thread Project'),
   );
+  const selectedProjectContentLabels = $derived(selectedProjectItem?.contentLabels ?? []);
   const selectedFile = $derived(
     fileBrowser.files.find((file) => file.key === selectedFileKey) ?? null,
   );
@@ -247,6 +250,60 @@
     );
   }
 
+  function positiveInteger(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0
+      ? Math.floor(value)
+      : null;
+  }
+
+  function projectResourcesFromContext(context: any): any[] {
+    return Array.isArray(context?.resources) ? context.resources : [];
+  }
+
+  function projectResourceIsRepo(resource: any): boolean {
+    const kind = projectText(resource?.kind || resource?.type || resource?.resource_type).toLowerCase();
+    const source = projectText(resource?.source || resource?.provider).toLowerCase();
+    const uri = projectText(resource?.uri || resource?.url || resource?.repo_url).toLowerCase();
+    return (
+      ['github', 'github_repo', 'github_repository', 'repo', 'repository'].includes(kind)
+      || ['github', 'git'].includes(source)
+      || Boolean(projectText(resource?.repo))
+      || uri.startsWith('git@')
+      || uri.startsWith('https://github.com/')
+      || uri.startsWith('http://github.com/')
+      || uri.endsWith('.git')
+    );
+  }
+
+  function inferredProjectFileCount(resources: any[]): number {
+    let count = 0;
+    for (const resource of resources) {
+      const explicitCount = positiveInteger(resource?.file_count ?? resource?.uploaded_file_count);
+      if (explicitCount !== null) {
+        count += explicitCount;
+        continue;
+      }
+      const kind = projectText(resource?.kind || resource?.type || resource?.resource_type).toLowerCase();
+      if (kind === 'file' || kind === 'doc') count += 1;
+      if (Array.isArray(resource?.files)) count += resource.files.length;
+      if (Array.isArray(resource?.uploaded_files)) count += resource.uploaded_files.length;
+    }
+    return count;
+  }
+
+  function projectSelectorContentLabels(profile: any, fallbackContext: any = null): string[] {
+    const summary = profile?.content_summary || {};
+    const context = profile?.project_context || fallbackContext || {};
+    const resources = projectResourcesFromContext(context);
+    const summaryFileCount = positiveInteger(summary?.file_count);
+    const fileCount = summaryFileCount ?? inferredProjectFileCount(resources);
+    const repoCount = positiveInteger(summary?.repo_count) ?? resources.filter(projectResourceIsRepo).length;
+    const fileSuffix = summary?.file_count_exact === false ? '+' : '';
+    const labels = [`${fileCount}${fileSuffix} file${fileCount === 1 ? '' : 's'}`];
+    if (repoCount > 0) labels.push(`${repoCount} repo${repoCount === 1 ? '' : 's'}`);
+    return labels;
+  }
+
   function projectSelectorOptions(
     profiles: ThreadProjectContextProfile[],
     attachments: ThreadProjectContextAttachment[],
@@ -266,11 +323,14 @@
       const profile = profilesById.get(id);
       const snapshot = (attachment as any)?.snapshot;
       const name = projectText((profile as any)?.name) || projectNameFromSnapshot(snapshot);
+      const contentLabels = projectSelectorContentLabels(profile, snapshot);
       attached.push({
         id,
         name,
         subtitle: 'Attached project',
         group: 'attached',
+        contentLabels,
+        searchText: contentLabels.join(' '),
       });
     }
 
@@ -279,11 +339,14 @@
       const id = projectText((profile as any)?.id);
       if (!id || seen.has(id)) continue;
       const name = projectText((profile as any)?.name) || projectText((profile as any)?.slug) || 'Project';
+      const contentLabels = projectSelectorContentLabels(profile);
       recent.push({
-          id,
-          name,
-          subtitle: 'Recent project',
+        id,
+        name,
+        subtitle: 'Recent project',
         group: 'recent',
+        contentLabels,
+        searchText: contentLabels.join(' '),
       });
     }
 
@@ -301,7 +364,7 @@
       .filter(Boolean);
     if (terms.length === 0) return items;
     return items.filter((item) => {
-      const blob = `${item.name} ${item.subtitle} ${item.group}`.toLowerCase();
+      const blob = `${item.name} ${item.subtitle} ${item.group} ${item.searchText}`.toLowerCase();
       return terms.every((term) => blob.includes(term));
     });
   }
@@ -581,6 +644,13 @@
             <span class="project-draft-kicker">Project</span>
             <strong>{selectedProjectLabel}</strong>
             <small>{selectedProjectSubtitle}</small>
+            {#if selectedProjectContentLabels.length > 0}
+              <span class="project-selector-counts" aria-label="Selected Project contents">
+                {#each selectedProjectContentLabels as label (label)}
+                  <span>{label}</span>
+                {/each}
+              </span>
+            {/if}
           </span>
           <span class="project-selector-action">
             {projectSelectorItems.length > 1 ? 'Switch' : projectsLoading ? 'Loading' : 'Current'}
@@ -622,11 +692,18 @@
                           aria-selected={project.id === selectedProjectProfileId}
                           onclick={() => selectProjectProfile(project.id)}
                         >
-                          <span>
+                          <span class="project-selector-option-copy">
                             <strong>{project.name}</strong>
                             <small>{project.subtitle}</small>
                           </span>
-                          <em>{project.id === selectedProjectProfileId ? 'Current' : 'Open'}</em>
+                          <span class="project-selector-option-aside">
+                            <span class="project-selector-option-counts" aria-label="Project contents">
+                              {#each project.contentLabels as label (label)}
+                                <span>{label}</span>
+                              {/each}
+                            </span>
+                            <em>{project.id === selectedProjectProfileId ? 'Current' : 'Open'}</em>
+                          </span>
                         </button>
                       {/each}
                     </div>
@@ -1028,7 +1105,9 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
+    flex: 1 1 auto;
     width: 100%;
+    min-height: 100%;
     min-width: 0;
     color: rgba(239, 244, 251, 0.86);
     font-size: 12px;
@@ -1129,6 +1208,8 @@
   }
 
   .project-selector-copy {
+    display: grid;
+    gap: 3px;
     min-width: 0;
   }
 
@@ -1149,7 +1230,6 @@
 
   .project-selector-copy small {
     display: block;
-    margin-top: 3px;
     overflow: hidden;
     color: rgba(231, 238, 247, 0.52);
     font-family: var(--constellation-font-mono, var(--font-mono));
@@ -1161,6 +1241,35 @@
 
   :global(:root[data-color-scheme='light']) .project-selector-copy small {
     color: rgba(82, 98, 111, 0.66);
+  }
+
+  .project-selector-counts,
+  .project-selector-option-counts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .project-selector-counts span,
+  .project-selector-option-counts span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    border-radius: 6px;
+    padding: 2px 6px;
+    background: rgba(255, 255, 255, 0.055);
+    color: rgba(231, 238, 247, 0.62);
+    font-family: var(--constellation-font-mono, var(--font-mono));
+    font-size: 9px;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  :global(:root[data-color-scheme='light']) .project-selector-counts span,
+  :global(:root[data-color-scheme='light']) .project-selector-option-counts span {
+    background: rgba(85, 104, 120, 0.06);
+    color: rgba(57, 70, 82, 0.7);
   }
 
   .project-selector-action {
@@ -1298,6 +1407,21 @@
     text-align: left;
     font: inherit;
     cursor: pointer;
+  }
+
+  .project-selector-option-copy,
+  .project-selector-option-aside {
+    min-width: 0;
+  }
+
+  .project-selector-option-aside {
+    display: grid;
+    justify-items: end;
+    gap: 4px;
+  }
+
+  .project-selector-option-counts {
+    justify-content: flex-end;
   }
 
   .project-selector-option:hover,

--- a/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageRightDock.svelte
@@ -644,7 +644,14 @@
   }
 
   .right-dock-project {
+    align-items: stretch;
     overflow: visible;
+  }
+
+  .right-dock-project > :global(*) {
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
   }
 
   .right-dock-vault {

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1396,6 +1396,8 @@
   .thread-utility-surface {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
     min-height: 0;
     height: 100%;
     gap: 14px;
@@ -1403,6 +1405,8 @@
 
   .thread-utility-surface-body {
     flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
     min-height: 0;
     display: flex;
   }

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1962,6 +1962,48 @@ def test_project_profile_read_includes_visibility_and_access():
     assert payload.project_context["slug"] == "yc"
 
 
+def test_project_profile_read_includes_root_file_and_repo_counts(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context.profiles import profile_to_read
+
+    workspace_root = tmp_path / "workspaces"
+    root = workspace_root / "project-roots" / "project-1"
+    root.mkdir(parents=True)
+    (root / "README.md").write_text("Project notes", encoding="utf-8")
+    (root / "docs").mkdir()
+    (root / "docs" / "summary.md").write_text("Summary", encoding="utf-8")
+    (root / ".illo-project-history").mkdir()
+    (root / ".illo-project-history" / "internal.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("WORKSPACE_ROOT", str(workspace_root))
+
+    profile = SimpleNamespace(
+        id="project-1",
+        org_id="org-1",
+        user_id="owner-1",
+        slug="yc",
+        name="YC",
+        description=None,
+        project_context={
+            "resources": [
+                {"kind": "github_repo", "repo": "Illospace/illospace"},
+                {"kind": "file", "path": "README.md"},
+            ]
+        },
+        visibility="private",
+        default_environment_binding_id=None,
+        active=True,
+        metadata_={},
+        created_at=None,
+    )
+
+    summary = profile_to_read(profile).content_summary
+
+    assert summary.root_exists is True
+    assert summary.file_count == 2
+    assert summary.file_count_exact is True
+    assert summary.repo_count == 1
+    assert summary.resource_count == 2
+
+
 def test_project_profile_create_defaults_private():
     from brain.systems.cortex.project_context.schemas import ProjectProfileCreate
 


### PR DESCRIPTION
## Summary
- add Project profile content summaries with canonical root file counts and repo resource counts
- show file/repo count chips in the Project selector and selected Project header
- stretch Project panel containers so the file workspace uses the available dock width

## Tests
- python3 -m pytest tests/test_api_cortex.py::test_project_profile_read_includes_root_file_and_repo_counts tests/test_api_cortex.py::test_project_profile_read_includes_visibility_and_access
- python3 -m pytest tests/test_api_cortex.py -k "project_profile or project_context"
- npm run check