### PR TITLE
Refine generated app stage shell

### DIFF
--- a/frontend/src/lib/components/layout/WorkspaceStageShell.svelte
+++ b/frontend/src/lib/components/layout/WorkspaceStageShell.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    entering = false,
+    ready = true,
+    zIndex = 25,
+    dismissLabel,
+    dismissCursor = 'default',
+    className = '',
+    frameClassName = '',
+    style = '',
+    ondismiss,
+    periphery,
+    children,
+  }: {
+    entering?: boolean;
+    ready?: boolean;
+    zIndex?: number;
+    dismissLabel?: string;
+    dismissCursor?: string;
+    className?: string;
+    frameClassName?: string;
+    style?: string;
+    ondismiss?: () => void;
+    periphery?: Snippet;
+    children?: Snippet;
+  } = $props();
+
+  const shellStyle = $derived(
+    [
+      `--workspace-stage-z-index:${zIndex}`,
+      `--workspace-stage-dismiss-cursor:${dismissCursor}`,
+      style,
+    ].filter(Boolean).join('; '),
+  );
+</script>
+
+<div class={`workspace-stage-shell ${className}`} class:entering={entering} class:ready={ready} style={shellStyle}>
+  {@render periphery?.()}
+
+  {#if ondismiss}
+    <button
+      type="button"
+      class="workspace-stage-edge-dismiss"
+      tabindex="-1"
+      aria-label={dismissLabel}
+      onclick={ondismiss}
+    ></button>
+  {/if}
+
+  <div class={`workspace-stage-frame ${frameClassName}`}>
+    {@render children?.()}
+  </div>
+</div>
+
+<style>
+  .workspace-stage-shell {
+    --workspace-stage-frame-width: clamp(1040px, 78vw, 1760px);
+    position: absolute;
+    inset: 0;
+    z-index: var(--workspace-stage-z-index);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: clamp(18px, 2.4vw, 30px);
+    pointer-events: auto;
+    opacity: 1;
+  }
+
+  .workspace-stage-frame {
+    position: relative;
+    z-index: 3;
+    width: min(100%, var(--workspace-stage-frame-width));
+    height: calc(100% - 6px);
+    max-height: 100%;
+    overflow: visible;
+    isolation: isolate;
+    pointer-events: none;
+    transform-origin: 50% 54%;
+    opacity: 0;
+    transform: translate3d(0, 10px, 0) scale(0.985);
+    will-change: opacity, transform;
+    transition:
+      opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
+      transform 340ms cubic-bezier(0.18, 0.95, 0.32, 1);
+  }
+
+  .workspace-stage-frame > :global(*) {
+    pointer-events: auto;
+  }
+
+  .workspace-stage-shell.ready .workspace-stage-frame {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  .workspace-stage-edge-dismiss {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    cursor: var(--workspace-stage-dismiss-cursor);
+  }
+
+  .workspace-stage-shell.entering {
+    animation: workspace-stage-presence 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  @keyframes workspace-stage-presence {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @media (max-width: 900px) {
+    .workspace-stage-shell {
+      padding: 6px 10px 4px;
+    }
+
+    .workspace-stage-frame {
+      width: calc(100% - 18px);
+      height: calc(100% - 6px);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .workspace-stage-shell {
+      animation: none !important;
+    }
+
+    .workspace-stage-frame {
+      transition: none;
+      opacity: 1;
+      transform: none;
+      filter: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import { onMount, onDestroy, type Component } from 'svelte';
   import { fly } from 'svelte/transition';
+  import WorkspaceStageShell from '$lib/components/layout/WorkspaceStageShell.svelte';
   import type { AppNotification } from '$lib/features/notifications/api/notificationsApi';
   import type { WorkspaceAppRead } from '$lib/features/workspace-apps/api/workspaceAppsApi';
   import type { WorkspacePinRead } from '$lib/features/workspace-scene/api/workspacePinsApi';
@@ -1151,21 +1152,25 @@
     {/if}
 
     {#if !cortex.panelOpen && activeWorkspaceApp && GeneratedAppRendererComponent}
-      <button
-        type="button"
-        class="workspace-app-dismiss-surface"
-        tabindex="-1"
-        aria-label="Close generated app"
-        onclick={() => workspaceOverlay.closeWorkspaceApp()}
-      ></button>
-
-      <div
-        class="workspace-app-overlay"
-        in:fly={{ y: 42, duration: 240 }}
-        out:fly={{ y: 28, duration: 160 }}
+      <WorkspaceStageShell
+        className="workspace-app-stage"
+        frameClassName="workspace-app-stage-frame"
+        zIndex={29}
+        dismissLabel="Close generated app"
+        ondismiss={() => workspaceOverlay.closeWorkspaceApp()}
       >
-        <GeneratedAppRendererComponent app={activeWorkspaceApp} onclose={() => workspaceOverlay.closeWorkspaceApp()} />
-      </div>
+        <div
+          class="workspace-app-overlay"
+          in:fly={{ y: 42, duration: 240 }}
+          out:fly={{ y: 28, duration: 160 }}
+        >
+          <GeneratedAppRendererComponent
+            app={activeWorkspaceApp}
+            surface="stage"
+            onclose={() => workspaceOverlay.closeWorkspaceApp()}
+          />
+        </div>
+      </WorkspaceStageShell>
     {/if}
 
     {#if activeWorkspacePageModal}
@@ -1356,22 +1361,6 @@
     z-index: 0;
   }
 
-  .workspace-app-dismiss-surface {
-    position: absolute;
-    inset: 0;
-    z-index: 18;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    background: transparent;
-    cursor: default;
-  }
-
-  .workspace-app-dismiss-surface:focus,
-  .workspace-app-dismiss-surface:focus-visible {
-    outline: none;
-  }
-
   .workspace-top-tools {
     display: inline-flex;
     align-items: center;
@@ -1467,25 +1456,17 @@
   }
 
   .workspace-app-overlay {
-    position: absolute;
-    top: 88px;
-    left: 50%;
-    bottom: 22px;
-    z-index: 29;
     display: flex;
-    width: min(1040px, calc(100% - 132px));
+    width: 100%;
+    height: 100%;
     min-width: 0;
     min-height: 0;
-    translate: -50% 0;
-    justify-content: center;
-    pointer-events: auto;
   }
 
   .workspace-app-overlay > :global(*) {
     flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
-    overflow: auto;
   }
 
   .cortex-main {
@@ -1643,12 +1624,6 @@
       --constellation-workspace-backdrop-composer-width: clamp(300px, 40vw, 440px);
     }
 
-    .workspace-app-overlay {
-      top: 76px;
-      left: 50%;
-      bottom: 16px;
-      width: calc(100% - 20px);
-    }
   }
 
   @media (max-width: 700px) {

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -41,7 +41,6 @@
     createDefaultThreadSidePanelTabs,
     isThreadSidePanelSingletonKind,
     openAppThreadSidePanelTab,
-    openBrowserThreadSidePanelTab,
     openSingletonThreadSidePanelTab,
     type ThreadSidePanelTabState,
     type ThreadStageRightDockAddMenuItem,
@@ -141,7 +140,6 @@
   let activeSidePanelTabId = $state<string | null>('activity');
   let sidePanelTabs = $state<ThreadStageRightDockTab[]>(createDefaultThreadSidePanelTabs());
   let nextBrowserTabIndex = $state(1);
-  let lastAutoOpenedBrowserSessionId = $state<string | null>(null);
   let lastAutoOpenedVaultPromptId = $state<string | null>(null);
   let lastAutoOpenedVaultGrantPromptId = $state<string | null>(null);
   let lastAutoOpenedCycleSignal = $state<number | null>(null);
@@ -832,10 +830,6 @@
     applySidePanelState(addBrowserThreadSidePanelTab(sidePanelState()));
   }
 
-  function openBrowserSessionTab() {
-    applySidePanelState(openBrowserThreadSidePanelTab(sidePanelState()));
-  }
-
   function openSingletonTab(kind: ThreadStageRightDockSingletonKind) {
     applySidePanelState(openSingletonThreadSidePanelTab(sidePanelState(), kind));
   }
@@ -896,17 +890,6 @@
     if (!workspaceApps.appById(changedAppId)) return;
     lastAutoSelectedAppId = changedAppId;
     openAppTab(changedAppId);
-  });
-
-  $effect(() => {
-    const browserSessionId = cortex.browserSession?.id ?? null;
-    if (!browserSessionId) {
-      lastAutoOpenedBrowserSessionId = null;
-      return;
-    }
-    if (browserSessionId === lastAutoOpenedBrowserSessionId) return;
-    lastAutoOpenedBrowserSessionId = browserSessionId;
-    openBrowserSessionTab();
   });
 
   $effect(() => {

--- a/frontend/src/lib/features/threads/components/ThreadStageShell.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageShell.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import WorkspaceStageShell from '$lib/components/layout/WorkspaceStageShell.svelte';
   import type { Snippet } from 'svelte';
 
   type ThreadEdgeSide = 'top' | 'right' | 'bottom' | 'left';
@@ -77,92 +78,39 @@
   }
 </script>
 
-<div class="thread-stage-shell" class:entering={entering} class:ready={ready} style={shellStyle}>
-  {#if peripherySignals.length > 0}
-    <div class="thread-periphery-layer" aria-hidden="true">
-      {#each peripherySignals as cue, index (`${cue.side}-${Math.round(cue.offset)}-${index}`)}
-        <div
-          class={`thread-edge-signal side-${cue.side} kind-${cue.kind} ${cue.related ? 'is-related' : ''}`}
-          style={`--signal-offset:${cue.offset}%; --signal-color:${cue.color}; --signal-rgb:${cue.rgb}; --signal-strength:${cue.strength}; --signal-duration:${cue.pulseMs}ms; --signal-span:${cue.span}px; --signal-opacity:${cue.opacity};`}
-        >
-          <div class="thread-edge-aura"></div>
-          <div class="thread-edge-core"></div>
-          {#if cue.count > 1}
-            <div class="thread-edge-trace"></div>
-          {/if}
-        </div>
-      {/each}
-    </div>
-  {/if}
+<WorkspaceStageShell
+  className="thread-stage-shell"
+  frameClassName="thread-stage-frame"
+  {entering}
+  {ready}
+  style={shellStyle}
+  dismissLabel="Leave thread"
+  dismissCursor="zoom-out"
+  ondismiss={handleDismiss}
+>
+  {#snippet periphery()}
+    {#if peripherySignals.length > 0}
+      <div class="thread-periphery-layer" aria-hidden="true">
+        {#each peripherySignals as cue, index (`${cue.side}-${Math.round(cue.offset)}-${index}`)}
+          <div
+            class={`thread-edge-signal side-${cue.side} kind-${cue.kind} ${cue.related ? 'is-related' : ''}`}
+            style={`--signal-offset:${cue.offset}%; --signal-color:${cue.color}; --signal-rgb:${cue.rgb}; --signal-strength:${cue.strength}; --signal-duration:${cue.pulseMs}ms; --signal-span:${cue.span}px; --signal-opacity:${cue.opacity};`}
+          >
+            <div class="thread-edge-aura"></div>
+            <div class="thread-edge-core"></div>
+            {#if cue.count > 1}
+              <div class="thread-edge-trace"></div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/snippet}
 
-  <button
-    type="button"
-    class="thread-stage-edge-dismiss"
-    tabindex="-1"
-    aria-label="Leave thread"
-    onclick={handleDismiss}
-  ></button>
-
-  <div class="thread-stage-frame">
-    {@render children?.()}
-  </div>
-</div>
+  {@render children?.()}
+</WorkspaceStageShell>
 
 <style>
-  .thread-stage-shell {
-    --thread-origin-x: 50%;
-    --thread-origin-y: 56%;
-    --thread-stage-frame-width: clamp(1040px, 78vw, 1760px);
-    position: absolute;
-    inset: 0;
-    z-index: 25;
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding: clamp(18px, 2.4vw, 30px);
-    box-sizing: border-box;
-    pointer-events: auto;
-    opacity: 1;
-  }
-
-  .thread-stage-frame {
-    width: min(100%, var(--thread-stage-frame-width));
-    height: calc(100% - 6px);
-    max-height: 100%;
-    pointer-events: none;
-    transform-origin: 50% 54%;
-    position: relative;
-    z-index: 3;
-    overflow: visible;
-    isolation: isolate;
-    opacity: 0;
-    transform: translate3d(0, 10px, 0) scale(0.985);
-    will-change: opacity, transform;
-    transition:
-      opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
-      transform 340ms cubic-bezier(0.18, 0.95, 0.32, 1);
-  }
-
-  .thread-stage-frame > * {
-    pointer-events: auto;
-  }
-
-  .thread-stage-shell.ready .thread-stage-frame {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-
-  .thread-stage-edge-dismiss {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    background: transparent;
-    cursor: zoom-out;
-  }
-
   .thread-periphery-layer {
     position: absolute;
     inset: 0;
@@ -332,29 +280,7 @@
     }
   }
 
-  .thread-stage-shell.entering {
-    animation: thread-shell-presence 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
-  }
-
-  @keyframes thread-shell-presence {
-    0% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
-
   @media (max-width: 900px) {
-    .thread-stage-shell {
-      padding: 6px 10px 4px;
-    }
-
-    .thread-stage-frame {
-      width: calc(100% - 18px);
-      height: calc(100% - 6px);
-    }
-
     .thread-edge-signal.side-left,
     .thread-edge-signal.side-right {
       width: 108px;
@@ -367,18 +293,10 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .thread-stage-shell,
     .thread-edge-aura,
     .thread-edge-core,
     .thread-edge-trace {
       animation: none !important;
-    }
-
-    .thread-stage-frame {
-      transition: none;
-      opacity: 1;
-      transform: none;
-      filter: none;
     }
   }
 </style>

--- a/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
@@ -2,7 +2,8 @@
   import { browser } from '$app/environment';
   import { onMount } from 'svelte';
 
-  import { ConstellationIcon, ConstellationIconButton, ConstellationPill } from '$lib/components/constellation';
+  import { ConstellationIcon, ConstellationPill } from '$lib/components/constellation';
+  import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
   import {
     runWorkspaceAppAction,
     runWorkspaceAppBinding,
@@ -16,6 +17,8 @@
   import { theme } from '$lib/stores/theme.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
+
+  import GeneratedAppChrome from './GeneratedAppChrome.svelte';
 
   type RuntimeMessage = {
     source?: string;
@@ -36,7 +39,7 @@
     onclose,
   }: {
     app: WorkspaceAppRead;
-    surface?: 'workspace' | 'dock';
+    surface?: GeneratedAppSurface;
     onclose?: () => void;
   } = $props();
 
@@ -256,12 +259,6 @@
     scheduleSmokeGate(frameGeneration);
   }
 
-  function handleCloseClick(event: MouseEvent) {
-    event.preventDefault();
-    event.stopPropagation();
-    onclose?.();
-  }
-
   onMount(() => {
     window.addEventListener('message', handleMessage);
     return () => {
@@ -294,27 +291,19 @@
   });
 </script>
 
-<section class="app-capsule generated-app-shell" class:is-dock={surface === 'dock'} aria-label={app.name}>
-  <header class="app-capsule__header generated-app-shell__header">
-    <div class="app-capsule__identity">
-      <span class="app-capsule__dot" style={`--app-accent:${appAccent}`} aria-hidden="true"></span>
-      <div>
-        <span class="app-capsule__eyebrow">App capsule</span>
-        <h2>{app.name}</h2>
-      </div>
-    </div>
-
-    <div class="app-capsule__actions">
-      <ConstellationPill variant={smokeError ? 'danger' : saving ? 'warning' : 'info'} leadingDot>
-        {smokeError ? 'error' : saving ? 'saving' : loading ? 'loading' : versionLabel}
-      </ConstellationPill>
-      {#if onclose}
-        <ConstellationIconButton label="Close app capsule" variant="quiet" size="md" onclick={handleCloseClick}>
-          <ConstellationIcon name="close" size={15} stroke={2} />
-        </ConstellationIconButton>
-      {/if}
-    </div>
-  </header>
+<GeneratedAppChrome
+  className="app-capsule"
+  title={app.name}
+  accent={appAccent}
+  {surface}
+  {onclose}
+  closeLabel="Close workspace app"
+>
+  {#snippet actions()}
+    <ConstellationPill variant={smokeError ? 'danger' : saving ? 'warning' : 'info'} leadingDot>
+      {smokeError ? 'error' : saving ? 'saving' : loading ? 'loading' : versionLabel}
+    </ConstellationPill>
+  {/snippet}
 
   <div class="app-capsule__body">
     <iframe
@@ -336,12 +325,10 @@
       </div>
     {/if}
   </div>
-</section>
+</GeneratedAppChrome>
 
 <style>
-.app-capsule {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+:global(.generated-app-chrome.app-capsule) {
   width: min(1400px, calc(100vw - 32px));
   height: min(900px, calc(100vh - 56px));
   min-width: min(360px, calc(100vw - 32px));
@@ -350,55 +337,12 @@
   border-radius: var(--radius-lg);
 }
 
-.app-capsule.is-dock {
+:global(.generated-app-chrome.app-capsule.is-dock) {
   width: 100%;
   height: 100%;
   min-width: 0;
   min-height: 100%;
   border-radius: 0;
-}
-
-.app-capsule__header {
-  align-items: center;
-  justify-content: space-between;
-}
-
-.app-capsule__identity,
-.app-capsule__actions {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 10px;
-}
-
-.app-capsule__dot {
-  width: 10px;
-  height: 10px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--app-accent, var(--positive));
-  box-shadow: var(--constellation-orbit-core-shadow);
-}
-
-.app-capsule__eyebrow {
-  display: block;
-  color: var(--constellation-section-description);
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0;
-  line-height: 1.1;
-  text-transform: uppercase;
-}
-
-.app-capsule h2 {
-  margin: 0;
-  overflow: hidden;
-  color: var(--constellation-section-title);
-  font-size: 15px;
-  letter-spacing: 0;
-  line-height: 1.18;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .app-capsule__body {

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedAppChrome.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedAppChrome.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { ConstellationIcon, ConstellationIconButton } from '$lib/components/constellation';
+  import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
+
+  let {
+    title,
+    description = '',
+    eyebrow = 'Workspace app',
+    accent = 'var(--positive)',
+    surface = 'workspace',
+    className = '',
+    closeLabel = 'Close workspace app',
+    onclose,
+    actions,
+    children,
+  }: {
+    title: string;
+    description?: string | null;
+    eyebrow?: string;
+    accent?: string;
+    surface?: GeneratedAppSurface;
+    className?: string;
+    closeLabel?: string;
+    onclose?: () => void;
+    actions?: Snippet;
+    children?: Snippet;
+  } = $props();
+
+  function handleCloseClick(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    onclose?.();
+  }
+</script>
+
+<section
+  class={`generated-app-chrome generated-app-shell ${className}`}
+  class:is-dock={surface === 'dock'}
+  class:is-stage={surface === 'stage'}
+  aria-label={title}
+>
+  <header class="generated-app-chrome__header generated-app-shell__header">
+    <div class="generated-app-chrome__identity">
+      <span class="generated-app-chrome__dot" style={`--app-accent:${accent}`} aria-hidden="true"></span>
+      <div class="generated-app-chrome__title-block">
+        <span class="generated-app-chrome__eyebrow">{eyebrow}</span>
+        <h2 class="generated-app-chrome__title">{title}</h2>
+        {#if description}
+          <p class="generated-app-chrome__description">{description}</p>
+        {/if}
+      </div>
+    </div>
+
+    <div class="generated-app-chrome__actions">
+      {@render actions?.()}
+      {#if onclose}
+        <ConstellationIconButton label={closeLabel} variant="quiet" size="md" onclick={handleCloseClick}>
+          <ConstellationIcon name="close" size={15} stroke={2} />
+        </ConstellationIconButton>
+      {/if}
+    </div>
+  </header>
+
+  {@render children?.()}
+</section>
+
+<style>
+  .generated-app-chrome {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .generated-app-chrome.generated-app-shell.is-stage {
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    max-height: none;
+    border-color: var(--constellation-thread-reading-core-border);
+    border-radius: 24px;
+    background: var(--constellation-thread-reading-core-background);
+    box-shadow: var(--constellation-thread-reading-core-shadow);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .generated-app-chrome.generated-app-shell.is-dock {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    max-height: none;
+    border-radius: 0;
+  }
+
+  .generated-app-chrome__header {
+    display: flex;
+    min-width: 0;
+    min-height: 52px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    box-sizing: border-box;
+    padding: 8px 12px;
+  }
+
+  .generated-app-chrome__identity,
+  .generated-app-chrome__actions {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .generated-app-chrome__identity {
+    flex: 1 1 auto;
+  }
+
+  .generated-app-chrome__actions {
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .generated-app-chrome__dot {
+    width: 10px;
+    height: 10px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--app-accent, var(--positive));
+    box-shadow: var(--constellation-orbit-core-shadow);
+  }
+
+  .generated-app-chrome__title-block {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .generated-app-chrome__eyebrow {
+    display: block;
+    color: var(--constellation-section-description);
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1.1;
+    text-transform: uppercase;
+  }
+
+  .generated-app-chrome__title,
+  .generated-app-chrome__description {
+    margin: 0;
+    overflow: hidden;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .generated-app-chrome__title {
+    color: var(--constellation-section-title);
+    font-size: 15px;
+    line-height: 1.18;
+  }
+
+  .generated-app-chrome__description {
+    color: var(--constellation-section-description);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  @media (max-width: 900px) {
+    .generated-app-chrome.generated-app-shell.is-stage {
+      border-radius: 22px;
+    }
+  }
+
+  @media (max-width: 680px) {
+    .generated-app-chrome__header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .generated-app-chrome__actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedAppRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedAppRenderer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { WorkspaceAppRead } from '$lib/features/workspace-apps/api/workspaceAppsApi';
   import { ConstellationIcon, ConstellationPill } from '$lib/components/constellation';
+  import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
 
   import AppCapsuleRenderer from './AppCapsuleRenderer.svelte';
   import GeneratedHtmlAppRuntime from './GeneratedHtmlAppRuntime.svelte';
@@ -12,7 +13,7 @@
     onclose,
   }: {
     app: WorkspaceAppRead | null;
-    surface?: 'workspace' | 'dock';
+    surface?: GeneratedAppSurface;
     onclose?: () => void;
   } = $props();
 
@@ -49,7 +50,11 @@
 {:else if app && canRenderHtml}
   <GeneratedHtmlAppRuntime {app} {surface} {onclose} />
 {:else if app}
-  <section class="generated-app-unsupported generated-app-shell" class:is-dock={surface === 'dock'}>
+  <section
+    class="generated-app-unsupported generated-app-shell"
+    class:is-dock={surface === 'dock'}
+    class:is-stage={surface === 'stage'}
+  >
     <div class="generated-app-unsupported__glyph" aria-hidden="true">
       <ConstellationIcon name="code" size={18} stroke={1.9} />
     </div>
@@ -76,6 +81,11 @@
   width: 100%;
   min-height: 100%;
   border-radius: 0;
+}
+
+.generated-app-unsupported.is-stage {
+  width: 100%;
+  min-height: 100%;
 }
 
 .generated-app-unsupported__glyph {

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
@@ -16,11 +16,14 @@
     updateDomainRecord,
     type WorkspaceAppRead,
   } from '$lib/features/workspace-apps/api/workspaceAppsApi';
-  import { ConstellationIcon, ConstellationIconButton, ConstellationPill } from '$lib/components/constellation';
+  import { ConstellationPill } from '$lib/components/constellation';
+  import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
   import { theme } from '$lib/stores/theme.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import { normalizeDomainRequest, withDomainRecordAliases } from '$lib/utils/generatedAppBridge';
+
+  import GeneratedAppChrome from './GeneratedAppChrome.svelte';
 
   type RuntimeMessage = {
     source?: string;
@@ -47,7 +50,7 @@
     onclose,
   }: {
     app: WorkspaceAppRead;
-    surface?: 'workspace' | 'dock';
+    surface?: GeneratedAppSurface;
     onclose?: () => void;
   } = $props();
 
@@ -972,12 +975,6 @@
     sendInit({ force: true });
   }
 
-  function handleCloseClick(event: MouseEvent) {
-    event.preventDefault();
-    event.stopPropagation();
-    onclose?.();
-  }
-
   onMount(() => {
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
@@ -998,25 +995,18 @@
   });
 </script>
 
-<section class="generated-html-app generated-app-shell" class:is-dock={surface === 'dock'} aria-label={app.name}>
-  <header class="generated-html-app__header generated-app-shell__header">
-    <div class="generated-html-app__identity">
-      <span class="generated-html-app__dot" style={`--app-accent:${appAccent}`} aria-hidden="true"></span>
-      <div>
-        <span class="generated-html-app__eyebrow">Generated app</span>
-        <h2>{app.name}</h2>
-      </div>
-    </div>
-
-    <div class="generated-html-app__actions">
-      <ConstellationPill variant={saving ? 'warning' : 'info'} leadingDot>{saving ? 'saving' : loading ? 'loading' : versionLabel}</ConstellationPill>
-      {#if onclose}
-        <ConstellationIconButton label="Close generated app" variant="quiet" size="md" onclick={handleCloseClick}>
-          <ConstellationIcon name="close" size={15} stroke={2} />
-        </ConstellationIconButton>
-      {/if}
-    </div>
-  </header>
+<GeneratedAppChrome
+  className="generated-html-app"
+  title={app.name}
+  eyebrow="Generated app"
+  accent={appAccent}
+  {surface}
+  {onclose}
+  closeLabel="Close generated app"
+>
+  {#snippet actions()}
+    <ConstellationPill variant={saving ? 'warning' : 'info'} leadingDot>{saving ? 'saving' : loading ? 'loading' : versionLabel}</ConstellationPill>
+  {/snippet}
 
   <iframe
     bind:this={iframeEl}
@@ -1026,10 +1016,10 @@
     {srcdoc}
     onload={handleFrameLoad}
   ></iframe>
-</section>
+</GeneratedAppChrome>
 
 <style>
-.generated-html-app {
+:global(.generated-app-chrome.generated-html-app) {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   width: min(760px, calc(100vw - 28px));
@@ -1040,66 +1030,11 @@
   border-radius: 22px;
 }
 
-.generated-html-app.is-dock {
+:global(.generated-app-chrome.generated-html-app.is-dock) {
   width: 100%;
   height: 100%;
   min-height: 0;
   border-radius: 0;
-}
-
-.generated-html-app__header {
-  position: relative;
-  z-index: 2;
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 13px 14px;
-}
-
-.generated-html-app.is-dock .generated-html-app__header {
-  padding-inline: 0;
-}
-
-.generated-html-app__identity,
-.generated-html-app__actions {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  gap: 10px;
-}
-
-.generated-html-app__dot {
-  --app-accent: var(--positive);
-  width: 12px;
-  height: 12px;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: var(--app-accent);
-  box-shadow: 0 0 18px color-mix(in srgb, var(--app-accent) 42%, transparent);
-}
-
-.generated-html-app__eyebrow {
-  display: block;
-  color: var(--constellation-label-meta);
-  font-family: var(--constellation-font-mono);
-  font-size: 9px;
-  font-weight: 680;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.generated-html-app h2 {
-  overflow: hidden;
-  margin: 2px 0 0;
-  color: var(--constellation-section-title);
-  font-size: 14px;
-  font-weight: 720;
-  letter-spacing: 0;
-  line-height: 1.2;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .generated-html-app__frame {
@@ -1112,7 +1047,7 @@
 }
 
 @media (max-width: 720px) {
-  .generated-html-app {
+  :global(.generated-app-chrome.generated-html-app) {
     width: calc(100vw - 20px);
     height: min(720px, calc(100vh - 74px));
     min-height: 320px;

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedUiRenderer.svelte
@@ -10,11 +10,14 @@
     type WorkspaceAppRead,
   } from '$lib/features/workspace-apps/api/workspaceAppsApi';
   import { ConstellationIcon } from '$lib/components/constellation';
+  import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import {
     bindingAllowsField,
     bindingAllowsOperation,
   } from '$lib/utils/generatedWorkspaceAppContract';
+
+  import GeneratedAppChrome from './GeneratedAppChrome.svelte';
 
   type GeneratedUiColumn = {
     key: string;
@@ -111,7 +114,7 @@
     onclose,
   }: {
     app: WorkspaceAppRead;
-    surface?: 'workspace' | 'dock';
+    surface?: GeneratedAppSurface;
     onclose?: () => void;
   } = $props();
 
@@ -136,6 +139,7 @@
   const stateKey = $derived(String(manifest.state_key || 'default'));
   const parsedSpec = $derived(parseSpec(activeVersion?.source_code || ''));
   const spec = $derived(parsedSpec.spec);
+  const appAccent = $derived(String(app.visual_spec?.accent || '#57CFA0'));
   const domainBindings = $derived(extractDomainBindings(manifest));
   const primaryBindingAlias = $derived(
     spec?.primary_binding || Object.keys(domainBindings)[0] || null,
@@ -754,16 +758,17 @@
   }
 </script>
 
-<section class="generated-ui generated-app-shell" class:is-dock={surface === 'dock'} class:has-board={hasBoardView}>
-  <header class="generated-ui__header generated-app-shell__header">
-    <div class="generated-ui__title-block">
-      <span class="generated-ui__eyebrow">Generated UI</span>
-      <h2>{spec?.title || app.name}</h2>
-      {#if spec?.description || app.description}
-        <p>{spec?.description || app.description}</p>
-      {/if}
-    </div>
-
+<GeneratedAppChrome
+  className={`generated-ui ${hasBoardView ? 'has-board' : ''}`}
+  title={spec?.title || app.name}
+  description={spec?.description || app.description}
+  eyebrow="Generated UI"
+  accent={appAccent}
+  {surface}
+  {onclose}
+  closeLabel="Close app"
+>
+  {#snippet actions()}
     <div class="generated-ui__actions">
       {#each structuredActions as action (action.key)}
         <button
@@ -787,13 +792,8 @@
       <button type="button" class="generated-ui__icon-button" title="Refresh records" onclick={loadBoundRecords}>
         <ConstellationIcon name="refresh" size={14} stroke={1.9} />
       </button>
-      {#if onclose}
-        <button type="button" class="generated-ui__icon-button" title="Close app" onclick={onclose}>
-          <ConstellationIcon name="close" size={14} stroke={1.9} />
-        </button>
-      {/if}
     </div>
-  </header>
+  {/snippet}
 
   {#if parsedSpec.error}
     <div class="generated-ui__empty">{parsedSpec.error}</div>
@@ -1028,68 +1028,33 @@
       {/each}
     </div>
   {/if}
-</section>
+</GeneratedAppChrome>
 
 <style>
-.generated-ui {
+:global(.generated-app-chrome.generated-ui) {
   width: min(760px, calc(100vw - 28px));
   max-height: min(820px, calc(100vh - 112px));
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
   border-radius: 18px;
 }
 
-.generated-ui.has-board {
+:global(.generated-app-chrome.generated-ui.has-board) {
   width: min(1040px, calc(100vw - 28px));
 }
 
-.generated-ui.is-dock {
+:global(.generated-app-chrome.generated-ui.is-dock) {
   width: 100%;
   max-height: none;
   min-height: 100%;
   border-radius: 0;
 }
 
-.generated-ui__header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px;
-  padding: 18px 18px 14px;
-}
-
-.generated-ui__title-block {
-  display: grid;
-  gap: 5px;
-  min-width: 0;
-}
-
-.generated-ui__eyebrow {
-  color: var(--constellation-color-spectral);
-  font-family: var(--constellation-font-mono, monospace);
-  font-size: 10px;
-  font-weight: 680;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.generated-ui h2,
-.generated-ui h3,
-.generated-ui p {
+:global(.generated-app-chrome.generated-ui) h3,
+:global(.generated-app-chrome.generated-ui) p {
   margin: 0;
   letter-spacing: 0;
 }
 
-.generated-ui h2 {
-  overflow: hidden;
-  color: var(--constellation-section-title);
-  font-size: 19px;
-  font-weight: 680;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.generated-ui p {
+:global(.generated-app-chrome.generated-ui) p {
   color: var(--constellation-section-description);
   font-size: 12px;
   line-height: 1.45;
@@ -1120,8 +1085,8 @@
   text-transform: uppercase;
 }
 
-.generated-ui input,
-.generated-ui select {
+:global(.generated-app-chrome.generated-ui) input,
+:global(.generated-app-chrome.generated-ui) select {
   min-height: 34px;
   border: 1px solid var(--constellation-control-field-border);
   border-radius: 10px;
@@ -1130,12 +1095,12 @@
   font: inherit;
 }
 
-.generated-ui input {
+:global(.generated-app-chrome.generated-ui) input {
   min-width: 0;
   padding: 0 10px;
 }
 
-.generated-ui select {
+:global(.generated-app-chrome.generated-ui) select {
   width: 100%;
   padding: 0 8px;
 }
@@ -1229,14 +1194,14 @@
   overflow: auto;
 }
 
-.generated-ui table {
+:global(.generated-app-chrome.generated-ui) table {
   width: 100%;
   min-width: 460px;
   border-collapse: collapse;
   font-size: 12px;
 }
 
-.generated-ui th {
+:global(.generated-app-chrome.generated-ui) th {
   padding: 0 10px 9px;
   color: var(--constellation-label-meta);
   font-family: var(--constellation-font-mono, monospace);
@@ -1247,7 +1212,7 @@
   text-transform: uppercase;
 }
 
-.generated-ui td {
+:global(.generated-app-chrome.generated-ui) td {
   max-width: 220px;
   padding: 10px;
   border-top: 1px solid var(--constellation-surface-panel-separator);
@@ -1539,13 +1504,9 @@
 }
 
 @media (max-width: 680px) {
-  .generated-ui {
+  :global(.generated-app-chrome.generated-ui) {
     width: calc(100vw - 20px);
     max-height: calc(100vh - 96px);
-  }
-
-  .generated-ui__header {
-    grid-template-columns: 1fr;
   }
 
   .generated-ui__actions {

--- a/frontend/src/lib/features/workspace-apps/domain/generatedAppSurface.ts
+++ b/frontend/src/lib/features/workspace-apps/domain/generatedAppSurface.ts
@@ -1,0 +1,1 @@
+export type GeneratedAppSurface = 'workspace' | 'stage' | 'dock';


### PR DESCRIPTION
Summary:
- Share the thread stage shell sizing with generated app overlays
- Centralize generated app host chrome across generated app renderers
- Add a stage surface mode so generated apps fill the shared viewport frame

Verification:
- npm run check
- npm run build
- Dev server HTTP 200 smoke check; backend proxy was not running for authenticated visual verification