### PR TITLE
Remove automatic right-panel openings in thread stage

### DIFF
--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -140,11 +140,6 @@
   let activeSidePanelTabId = $state<string | null>('activity');
   let sidePanelTabs = $state<ThreadStageRightDockTab[]>(createDefaultThreadSidePanelTabs());
   let nextBrowserTabIndex = $state(1);
-  let lastAutoOpenedVaultPromptId = $state<string | null>(null);
-  let lastAutoOpenedVaultGrantPromptId = $state<string | null>(null);
-  let lastAutoOpenedCycleSignal = $state<number | null>(null);
-  let lastAutoOpenedCodeReviewSignature = $state<string | null>(null);
-  let lastAutoSelectedAppId = $state<string | null>(null);
   let dockPreviewAttachment = $state<CortexThreadStageImageAttachment | CortexThreadStageFileAttachment | null>(null);
   let teamMembers = $state<any[]>([]);
   let teamMembersLoading = false;
@@ -883,64 +878,6 @@
     }
   }
 
-  $effect(() => {
-    const changedAppId = workspaceApps.lastChangedAppId;
-    if (!changedAppId || changedAppId === lastAutoSelectedAppId) return;
-    if (workspaceApps.lastChangeAction !== 'create') return;
-    if (!workspaceApps.appById(changedAppId)) return;
-    lastAutoSelectedAppId = changedAppId;
-    openAppTab(changedAppId);
-  });
-
-  $effect(() => {
-    const prompt = cortex.vaultSecretPrompt;
-    const promptId = prompt && String(prompt.idea_id ?? '') === String(idea?.id ?? '') ? prompt.id : null;
-    if (!promptId) {
-      lastAutoOpenedVaultPromptId = null;
-      return;
-    }
-    if (promptId === lastAutoOpenedVaultPromptId) return;
-    lastAutoOpenedVaultPromptId = promptId;
-    openSingletonTab('vault');
-  });
-
-  $effect(() => {
-    const prompt = cortex.vaultAgentGrantPrompt;
-    const promptId = prompt && String(prompt.idea_id ?? '') === String(idea?.id ?? '') ? prompt.id : null;
-    if (!promptId) {
-      lastAutoOpenedVaultGrantPromptId = null;
-      return;
-    }
-    if (promptId === lastAutoOpenedVaultGrantPromptId) return;
-    lastAutoOpenedVaultGrantPromptId = promptId;
-    openSingletonTab('vault');
-  });
-
-  $effect(() => {
-    const signal = cortex.cyclePanelSignal;
-    if (!signal || signal.ideaId !== idea?.id) return;
-    if (signal.serial === lastAutoOpenedCycleSignal) return;
-    lastAutoOpenedCycleSignal = signal.serial;
-    openSingletonTab('cycles');
-  });
-
-  $effect(() => {
-    const currentIdeaId = idea?.id ?? null;
-    if (!currentIdeaId) {
-      lastAutoOpenedCodeReviewSignature = null;
-      return;
-    }
-    const signature = codeReviewSignature;
-    if (!signature) {
-      lastAutoOpenedCodeReviewSignature = null;
-      return;
-    }
-    const scopedSignature = `${currentIdeaId}:${signature}`;
-    if (scopedSignature === lastAutoOpenedCodeReviewSignature) return;
-    lastAutoOpenedCodeReviewSignature = scopedSignature;
-    openSingletonTab('code-review');
-  });
-
   let pendingInitialScrollIdeaId = $state<string | null>(null);
   let lastSelectedIdeaId = $state<string | null>(null);
 
@@ -966,8 +903,11 @@
       ideaProjectContextAttachments = [];
       ideaProjectContextLoadedForIdeaId = null;
       ideaProjectContextLoadingForIdeaId = null;
+      activeSidePanelTabId = 'activity';
+      sidePanelTabs = createDefaultThreadSidePanelTabs();
+      nextBrowserTabIndex = 1;
       dockPreviewAttachment = null;
-      lastAutoOpenedCodeReviewSignature = null;
+      onBrowserOpenChange?.(false);
       if (currentIdeaId) void loadIdeaProjectContext(currentIdeaId);
     }
   });

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -627,11 +627,9 @@
                   presenceStyle={getUserPresenceStyle(item)}
                 />
 
-                {#if !isIllo || hasSupplementalMeta}
+                {#if !isIllo}
                   <div class="thread-message-meta">
-                    {#if !isIllo}
-                      <span class="thread-message-author">{item.author}</span>
-                    {/if}
+                    <span class="thread-message-author">{item.author}</span>
 
                     {#if hasSupplementalMeta}
                       <span class="thread-message-meta-supplemental">
@@ -1558,8 +1556,24 @@
     --thread-message-owner: var(--constellation-thread-message-illo-owner);
     --thread-message-body: var(--constellation-thread-message-illo-body);
     --thread-message-meta: var(--constellation-thread-message-illo-meta);
+    grid-template-columns: 18px minmax(0, 1fr);
+    align-items: start;
+    column-gap: 10px;
+    row-gap: 0;
     justify-self: start;
     margin-right: auto;
+  }
+
+  .thread-message-illo .thread-message-header {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+    margin-top: 2px;
+  }
+
+  .thread-message-illo .thread-message-content {
+    grid-column: 2;
+    grid-row: 1;
   }
 
   .thread-message-inline-work.thread-message-illo {

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -262,14 +262,6 @@ export function addBrowserThreadSidePanelTab(
   };
 }
 
-export function openBrowserThreadSidePanelTab(
-  state: ThreadSidePanelTabState,
-): ThreadSidePanelTabState {
-  const existing = state.tabs.find((tab) => tab.kind === 'browser');
-  if (existing) return { ...state, activeTabId: existing.id };
-  return addBrowserThreadSidePanelTab(state);
-}
-
 export function openSingletonThreadSidePanelTab(
   state: ThreadSidePanelTabState,
   kind: ThreadStageRightDockSingletonKind,

--- a/tests/test_theme_and_workspace_app_design_contracts.py
+++ b/tests/test_theme_and_workspace_app_design_contracts.py
@@ -363,6 +363,36 @@ def test_thread_stage_expands_while_reading_column_stays_bounded():
     assert "--thread-column-max: var(--thread-stage-thread-max);" not in stage_screen
 
 
+def test_thread_stage_right_dock_does_not_auto_open_from_loaded_thread_state():
+    source = (REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadStageScreen.svelte").read_text()
+    idea_change_body = source.split("const currentIdeaId = idea?.id ?? null;", 1)[1].split(
+        "$effect(() => {\n    if (!idea) return;",
+        1,
+    )[0]
+
+    assert "onBrowserOpenChange?.(false);" in idea_change_body
+    assert "sidePanelTabs = createDefaultThreadSidePanelTabs();" in idea_change_body
+    assert "lastAutoOpenedBrowserSessionId" not in source
+    assert "lastAutoOpenedVaultPromptId" not in source
+    assert "lastAutoOpenedVaultGrantPromptId" not in source
+    assert "lastAutoOpenedCycleSignal" not in source
+    assert "lastAutoOpenedCodeReviewSignature" not in source
+    assert "lastAutoSelectedAppId" not in source
+
+
+def test_thread_transcript_keeps_illo_mark_without_illo_message_meta_header():
+    source = (REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadTranscript.svelte").read_text()
+    message_block = source.split("{:else if item.kind === 'message'}", 1)[1].split(
+        "{:else if item.kind === 'visual'}",
+        1,
+    )[0]
+
+    assert "<ThreadAuthorMark" in message_block
+    assert "{#if !isIllo}" in message_block
+    assert "{#if !isIllo || hasSupplementalMeta}" not in message_block
+    assert ".thread-message-illo .thread-message-content" in source
+
+
 def test_thread_stage_dismiss_preserves_mounted_workspace_scene():
     source = (REPO_ROOT / "frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte").read_text()
     dismiss_body = source.split("function handleThreadStageDismiss()", 1)[1].split(


### PR DESCRIPTION
## Summary
- Stop the thread right panel from auto-opening when threads load or when runtime sidecar state appears.
- Reset the side panel to a closed/default state when switching threads, while keeping explicit user actions working.
- Remove the extra Illo message meta header in the main transcript so Illo keeps the mini astre without the redundant text header.
- Add regression coverage for both the no-auto-open behavior and the transcript rendering change.

## Testing
- `npm test`
- `npm run check`
- `venv/bin/python -m pytest tests/test_theme_and_workspace_app_design_contracts.py -k 'right_dock or illo_message_meta'`