### PR TITLE
Fix realtime voice session payload

### DIFF
--- a/brain/systems/runtime_settings/voice.py
+++ b/brain/systems/runtime_settings/voice.py
@@ -185,28 +185,10 @@ def _openai_transcription_settings(language: str) -> dict[str, str]:
     normalized = _voice_language(language)
     settings = {
         "model": OPENAI_REALTIME_TRANSCRIPTION_MODEL,
-        "prompt": _openai_transcription_prompt(normalized),
     }
     if normalized in {"en", "fr"}:
         settings["language"] = normalized
     return settings
-
-
-def _openai_transcription_prompt(language: str) -> str:
-    if language == "en":
-        return (
-            "Transcribe the user's speech in English for an AI chat composer. "
-            "Do not translate to another language. Preserve product names, code terms, and natural punctuation."
-        )
-    if language == "fr":
-        return (
-            "Transcribe the user's speech in French for an AI chat composer. "
-            "Do not translate to another language. Preserve product names, code terms, and natural punctuation."
-        )
-    return (
-        "The user may speak English or French. Transcribe in the same language the user speaks. "
-        "Do not translate. Preserve product names, code terms, and natural punctuation."
-    )
 
 
 def _voice_provider(value: object) -> str:

--- a/tests/test_runtime_voice_settings.py
+++ b/tests/test_runtime_voice_settings.py
@@ -171,7 +171,7 @@ async def test_openai_realtime_secret_request_uses_manual_commit_for_realtime_wh
     assert request_json["session"]["type"] == "transcription"
     assert audio_input["transcription"]["model"] == "gpt-realtime-whisper"
     assert "language" not in audio_input["transcription"]
-    assert "English or French" in audio_input["transcription"]["prompt"]
+    assert "prompt" not in audio_input["transcription"]
     assert audio_input["turn_detection"] is None
 
 
@@ -196,8 +196,9 @@ async def test_openai_realtime_secret_request_can_pin_french_language(monkeypatc
     await voice_settings._async_create_openai_realtime_client_secret("sk-memory-openai", language="fr")
 
     transcription = captured["kwargs"]["json"]["session"]["audio"]["input"]["transcription"]
+    assert transcription["model"] == "gpt-realtime-whisper"
     assert transcription["language"] == "fr"
-    assert "French" in transcription["prompt"]
+    assert "prompt" not in transcription
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep voice dictation on OpenAI Realtime with gpt-realtime-whisper
- remove the unsupported transcription prompt from the realtime client-secret payload
- keep manual commit and optional en/fr language hints covered by tests

## Diagnosis
Production was returning 502 for POST /api/runtime-settings/voice/session because OpenAI rejected the realtime client-secret session config. The deployed payload included transcription.prompt while using gpt-realtime-whisper; OpenAI's GA Realtime docs say prompt is not supported for gpt-realtime-whisper sessions.

## Tests
- venv/bin/python -m pytest tests/test_runtime_voice_settings.py -q
- venv/bin/python -m pytest tests/test_runtime_settings.py tests/test_openai_oauth_ui_contract.py tests/test_runtime_voice_settings.py -q
- git diff --check