### PR TITLE
Add live voice waveform levels

### DIFF
--- a/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
@@ -464,7 +464,7 @@
 
   {#snippet footerStatus()}
     {#if isVoiceRecording}
-      <WorkspaceVoiceRecording elapsedMs={voiceDictation.elapsedMs} />
+      <WorkspaceVoiceRecording elapsedMs={voiceDictation.elapsedMs} levels={voiceDictation.audioLevels} />
     {/if}
   {/snippet}
 

--- a/frontend/src/lib/features/composer/components/WorkspaceVoiceRecording.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceVoiceRecording.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
-  let { elapsedMs }: { elapsedMs: number } = $props();
+  import { voiceLevelToBarHeight } from '$lib/features/composer/domain/voiceLevels';
 
-  const voiceWaveBars = [7, 14, 18, 10, 16, 22, 12, 19, 14, 8, 17, 11];
+  let { elapsedMs, levels = [] }: { elapsedMs: number; levels?: number[] } = $props();
+
+  const voiceWaveBars = $derived.by(() =>
+    levels.map((level) => ({
+      height: voiceLevelToBarHeight(level),
+      opacity: Math.max(0.42, 0.58 + level * 0.38),
+    })),
+  );
 
   function formatVoiceDuration(ms: number) {
     const totalSeconds = Math.max(0, Math.floor(ms / 1000));
@@ -14,8 +21,8 @@
 <div class="workspace-voice-recording" role="status" aria-live="polite">
   <span class="sr-only">Dictation recording</span>
   <span class="workspace-voice-wave" aria-hidden="true">
-    {#each voiceWaveBars as height, bar}
-      <span style={`height:${height}px;animation-delay:${bar * -70}ms`}></span>
+    {#each voiceWaveBars as bar}
+      <span style={`height:${bar.height}px;opacity:${bar.opacity}`}></span>
     {/each}
   </span>
   <span class="workspace-voice-duration">{formatVoiceDuration(elapsedMs)}</span>
@@ -43,11 +50,13 @@
   }
 
   .workspace-voice-wave span {
-    width: 2px;
+    flex: 0 0 2px;
     border-radius: 999px;
     background: currentColor;
-    opacity: 0.78;
-    animation: workspace-voice-wave 880ms ease-in-out infinite;
+    min-height: 3px;
+    transition:
+      height 80ms linear,
+      opacity 80ms linear;
   }
 
   .workspace-voice-wave::after {
@@ -79,18 +88,5 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
-  }
-
-  @keyframes workspace-voice-wave {
-    0%,
-    100% {
-      transform: scaleY(0.72);
-      opacity: 0.54;
-    }
-
-    50% {
-      transform: scaleY(1.12);
-      opacity: 0.96;
-    }
   }
 </style>

--- a/frontend/src/lib/features/composer/controllers/openaiRealtimeVoice.ts
+++ b/frontend/src/lib/features/composer/controllers/openaiRealtimeVoice.ts
@@ -5,6 +5,16 @@ import type {
 } from '$lib/features/composer/domain/voiceDictation';
 
 const OPENAI_REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
+const AUDIO_LEVEL_SAMPLE_MS = 80;
+const AUDIO_LEVEL_GAIN = 6.5;
+
+type AudioContextWindow = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+type AudioLevelMonitor = {
+  stop: () => void;
+};
 
 type OpenAIRealtimeEvent = {
   type?: string;
@@ -19,6 +29,7 @@ export async function createOpenAIRealtimeVoiceConnection(
   const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
   const pc = new RTCPeerConnection();
   const dc = pc.createDataChannel('oai-events');
+  let levelMonitor: AudioLevelMonitor | null = null;
   let transcriptCompleted: (() => void) | null = null;
   let closed = false;
 
@@ -26,6 +37,7 @@ export async function createOpenAIRealtimeVoiceConnection(
     if (closed) return;
     closed = true;
     transcriptCompleted = null;
+    levelMonitor?.stop();
     for (const track of stream.getTracks()) {
       track.stop();
     }
@@ -34,6 +46,7 @@ export async function createOpenAIRealtimeVoiceConnection(
   }
 
   try {
+    levelMonitor = createAudioLevelMonitor(stream, handlers.onAudioLevel);
     for (const track of stream.getAudioTracks()) {
       pc.addTrack(track, stream);
     }
@@ -79,6 +92,61 @@ export async function createOpenAIRealtimeVoiceConnection(
       } finally {
         cleanup();
       }
+    },
+  };
+}
+
+function createAudioLevelMonitor(
+  stream: MediaStream,
+  onAudioLevel?: (level: number) => void,
+): AudioLevelMonitor | null {
+  if (!onAudioLevel || typeof window === 'undefined') return null;
+  const AudioContextCtor = window.AudioContext || (window as AudioContextWindow).webkitAudioContext;
+  if (!AudioContextCtor) return null;
+
+  const audioContext = new AudioContextCtor();
+  const analyser = audioContext.createAnalyser();
+  analyser.fftSize = 512;
+  analyser.smoothingTimeConstant = 0.7;
+
+  const source = audioContext.createMediaStreamSource(stream);
+  const samples = new Uint8Array(analyser.fftSize);
+  let interval: ReturnType<typeof window.setInterval> | null = null;
+  let stopped = false;
+
+  source.connect(analyser);
+  if (audioContext.state === 'suspended') {
+    void audioContext.resume().catch(() => {});
+  }
+
+  const sample = () => {
+    if (stopped) return;
+    analyser.getByteTimeDomainData(samples);
+    let sum = 0;
+    for (const value of samples) {
+      const centered = (value - 128) / 128;
+      sum += centered * centered;
+    }
+    const rms = Math.sqrt(sum / samples.length);
+    onAudioLevel(Math.min(1, rms * AUDIO_LEVEL_GAIN));
+  };
+
+  sample();
+  interval = window.setInterval(sample, AUDIO_LEVEL_SAMPLE_MS);
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      if (interval) window.clearInterval(interval);
+      onAudioLevel(0);
+      source.disconnect();
+      try {
+        analyser.disconnect();
+      } catch {
+        // Some browsers throw when disconnecting a node without downstream connections.
+      }
+      void audioContext.close().catch(() => {});
     },
   };
 }

--- a/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
+++ b/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
@@ -4,6 +4,7 @@ import {
   createVoiceDictationController,
   type VoiceDictationSnapshot,
 } from '$lib/features/composer/domain/voiceDictation';
+import { appendVoiceLevel } from '$lib/features/composer/domain/voiceLevels';
 import type { RuntimeVoiceSettings } from '$lib/types/runtimeSettings';
 
 type VoiceErrorReporter = (message: string) => void;
@@ -25,6 +26,7 @@ export class WorkspaceVoiceDictationController {
   settings = $state<RuntimeVoiceSettings | null>(null);
   snapshot = $state<VoiceDictationSnapshot>(idleSnapshot());
   elapsedMs = $state(0);
+  audioLevels = $state<number[]>([]);
 
   private controller: ReturnType<typeof createVoiceDictationController> | null = null;
   private startedAt = 0;
@@ -81,12 +83,14 @@ export class WorkspaceVoiceDictationController {
   async start() {
     if (!this.isReady) return;
     const controller = this.ensureController();
+    this.resetAudioLevels();
     await controller.start();
     this.refreshSnapshot();
     if (this.snapshot.status === 'recording') {
       this.startTimer();
       return;
     }
+    this.resetAudioLevels();
     this.reportCurrentError('Voice dictation could not start.');
   }
 
@@ -118,6 +122,7 @@ export class WorkspaceVoiceDictationController {
 
   destroy() {
     this.stopTimer();
+    this.resetAudioLevels();
   }
 
   private ensureController() {
@@ -127,7 +132,13 @@ export class WorkspaceVoiceDictationController {
       setDraft: this.deps.setDraft,
       submit: this.deps.submit,
       createSession: () => api.createRuntimeVoiceSession(),
-      connect: createOpenAIRealtimeVoiceConnection,
+      connect: (session, handlers) =>
+        createOpenAIRealtimeVoiceConnection(session, {
+          ...handlers,
+          onAudioLevel: (level) => {
+            this.audioLevels = appendVoiceLevel(this.audioLevels, level);
+          },
+        }),
     });
     this.refreshSnapshot();
     return this.controller;
@@ -139,7 +150,7 @@ export class WorkspaceVoiceDictationController {
   }
 
   private startTimer() {
-    this.stopTimer();
+    this.clearTimer();
     this.startedAt = Date.now();
     this.elapsedMs = 0;
     this.timer = window.setInterval(() => {
@@ -147,16 +158,25 @@ export class WorkspaceVoiceDictationController {
     }, 250);
   }
 
-  private stopTimer() {
+  private clearTimer() {
     if (this.timer) {
       window.clearInterval(this.timer);
       this.timer = null;
     }
+  }
+
+  private stopTimer() {
+    this.clearTimer();
     this.startedAt = 0;
     this.elapsedMs = 0;
+    this.resetAudioLevels();
   }
 
   private reportCurrentError(fallback: string) {
     this.deps.onError(this.snapshot.error || fallback);
+  }
+
+  private resetAudioLevels() {
+    this.audioLevels = [];
   }
 }

--- a/frontend/src/lib/features/composer/domain/voiceDictation.ts
+++ b/frontend/src/lib/features/composer/domain/voiceDictation.ts
@@ -17,6 +17,7 @@ export interface VoiceDictationSession {
 export interface VoiceDictationTransportHandlers {
   onTranscriptDelta: (delta: string) => void;
   onTranscriptCompleted?: (transcript: string) => void;
+  onAudioLevel?: (level: number) => void;
 }
 
 export interface VoiceDictationConnection {

--- a/frontend/src/lib/features/composer/domain/voiceLevels.ts
+++ b/frontend/src/lib/features/composer/domain/voiceLevels.ts
@@ -1,0 +1,21 @@
+export const VOICE_LEVEL_HISTORY_LIMIT = 36;
+
+export function clampVoiceLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+export function appendVoiceLevel(
+  history: readonly number[],
+  level: number,
+  limit = VOICE_LEVEL_HISTORY_LIMIT,
+): number[] {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const retained = safeLimit > 1 ? history.slice(-(safeLimit - 1)) : [];
+  return [...retained, clampVoiceLevel(level)];
+}
+
+export function voiceLevelToBarHeight(level: number, minHeight = 3, maxHeight = 24): number {
+  const shapedLevel = Math.pow(clampVoiceLevel(level), 0.55);
+  return Math.round((minHeight + shapedLevel * (maxHeight - minHeight)) * 10) / 10;
+}

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1118,7 +1118,7 @@
         {/snippet}
         {#snippet footerStatus()}
           {#if isVoiceRecording}
-            <WorkspaceVoiceRecording elapsedMs={voiceDictation.elapsedMs} />
+            <WorkspaceVoiceRecording elapsedMs={voiceDictation.elapsedMs} levels={voiceDictation.audioLevels} />
           {/if}
         {/snippet}
         {#snippet extraTrailingControls()}

--- a/frontend/src/lib/utils/composerVoiceDictation.test.js
+++ b/frontend/src/lib/utils/composerVoiceDictation.test.js
@@ -5,6 +5,10 @@ import {
   appendVoiceTranscriptDraft,
   createVoiceDictationController,
 } from '../features/composer/domain/voiceDictation.ts';
+import {
+  appendVoiceLevel,
+  voiceLevelToBarHeight,
+} from '../features/composer/domain/voiceLevels.ts';
 
 test('voice dictation appends transcript to the end of an existing draft with smart spacing', () => {
   assert.equal(
@@ -111,4 +115,22 @@ test('voice dictation stop leaves recoverable error state when transport cleanup
   assert.equal(draft, 'Please update the UI.');
   assert.equal(controller.snapshot().status, 'error');
   assert.equal(controller.snapshot().error, 'Could not commit audio.');
+});
+
+test('voice level history clamps samples and keeps the latest values', () => {
+  const history = [0.1, 0.2];
+  assert.deepEqual(appendVoiceLevel(history, 2, 3), [0.1, 0.2, 1]);
+  assert.deepEqual(appendVoiceLevel([0.1, 0.2, 0.3], -1, 3), [0.2, 0.3, 0]);
+  assert.deepEqual(appendVoiceLevel([0.1, 0.2, 0.3], 0.4, 1), [0.4]);
+});
+
+test('voice level bar heights grow with louder input', () => {
+  const silence = voiceLevelToBarHeight(0);
+  const speech = voiceLevelToBarHeight(0.35);
+  const loud = voiceLevelToBarHeight(1);
+
+  assert.equal(silence, 3);
+  assert.ok(speech > silence);
+  assert.ok(loud > speech);
+  assert.equal(loud, 24);
 });


### PR DESCRIPTION
## Summary
- connect the dictation waveform to the live microphone stream via a local AudioContext analyser
- keep OpenAI Realtime/WebRTC transcription unchanged; this is only local UI visualization
- share the live audio levels across workspace and thread composers
- add tests for voice level clamping/history and bar-height mapping

## Tests
- node --test src/lib/utils/composerVoiceDictation.test.js
- npm test
- npm run check
- npm run build
- git diff --check