### PR TITLE
Clarify Slack runtime secret guidance

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -206,55 +206,25 @@ def _slack_connection_payload(connection) -> dict[str, Any]:
 
 def _slack_setup_instructions() -> dict[str, Any]:
     return {
-        "audience": "Slack admin and Illospace deployment admin",
         "slack_admin_url": "https://api.slack.com/apps",
-        "token_handling": (
-            "Slack tokens are secrets. Ask the admin to add them to the Illospace server configuration "
-            "or secret store; do not paste them into chat and do not store them in Illospace metadata."
+        "what_illo_can_do": [
+            "Check whether Slack is connected to this Illospace workspace.",
+            "Link Slack users to Illospace users after Slack is connected.",
+            "Read and reply in Slack conversations after Illo is mentioned or DM'd.",
+        ],
+        "what_illo_cannot_do": [
+            "Create or install the Slack app for the workspace.",
+            "Receive Slack tokens in chat.",
+            "Change Slack or Illospace installation settings.",
+        ],
+        "setup_boundary": (
+            "If Slack is not connected, an Illospace admin must finish the Slack connection outside this chat. "
+            "Slack tokens must never be pasted to Illo, Slack chat, or Thread chat, "
+            "and they are not Illospace Vault entries."
         ),
-        "slack_steps": [
-            "Open https://api.slack.com/apps and create a new Slack app for Illo in the target workspace.",
-            "Set the app name and bot display name to Illo.",
-            "Enable Socket Mode.",
-            "Create an app-level token with the connections:write scope.",
-            "Add the required bot OAuth scopes.",
-            "Subscribe the bot to the required Slack events.",
-            "Install the app to the Slack workspace and copy the Bot User OAuth Token.",
-            "Invite Illo to any channels where it should participate, then mention @Illo or DM it.",
-        ],
-        "illospace_admin_steps": [
-            "Add the Bot User OAuth Token to the Illospace server secret named SLACK_BOT_TOKEN.",
-            "Add the app-level Socket Mode token to the Illospace server secret named SLACK_APP_TOKEN.",
-            "Enable or restart the Illospace Slack connector using the deployment's normal service controls.",
-            "Return here and ask Illo to check Slack status.",
-        ],
-        "required_bot_scopes": [
-            "app_mentions:read",
-            "channels:history",
-            "channels:read",
-            "chat:write",
-            "files:read",
-            "files:write",
-            "groups:history",
-            "groups:read",
-            "im:history",
-            "im:read",
-            "im:write",
-            "users:read",
-        ],
-        "required_bot_events": ["app_mention", "message.channels", "message.groups", "message.im"],
-        "required_secret_names": ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
-        "optional_secret_names": ["SLACK_TEAM_ID", "SLACK_BOT_USER_ID", "ILLO_SLACK_ORG_ID", "ILLO_SLACK_OWNER_USER_ID"],
-        "token_sources": {
-            "SLACK_BOT_TOKEN": "Slack app > OAuth & Permissions > Bot User OAuth Token",
-            "SLACK_APP_TOKEN": "Slack app > Basic Information > App-Level Tokens > token with connections:write",
-            "SLACK_TEAM_ID": "Slack workspace/team id, visible in event payloads or Slack admin URLs",
-            "SLACK_BOT_USER_ID": "Slack app bot user id, visible in app authorizations or bot profile details",
-        },
-        "success_checks": [
-            "manage_slack action=status should show a Slack connection after the connector starts.",
-            "Mentioning @Illo in an invited channel should create a slack_message inbound event.",
-            "Illo should answer in Slack through post_slack_reply.",
+        "after_connected": [
+            "Ask Illo to check Slack status.",
+            "Invite Illo to the Slack channels where it should participate, then mention @Illo or DM it.",
         ],
     }
 
@@ -265,7 +235,7 @@ async def _handle_manage_slack(
     slack_user_id: str | None = None,
     user_id: str | None = None,
 ) -> str:
-    """Inspect Slack setup/health and manage minimal identity mappings."""
+    """Inspect Slack connection health and manage minimal identity mappings."""
 
     normalized_action = str(action or "").strip().lower()
     if normalized_action == "setup_instructions":
@@ -297,10 +267,16 @@ async def _handle_manage_slack(
                 .order_by(ExternalAgentConnectionRow.created_at.asc(), ExternalAgentConnectionRow.id.asc())
             )
             rows = list((await uow.session.scalars(stmt)).all())
+            setup_state = "connected" if rows else "not_connected"
             return json.dumps(
                 {
                     "ok": True,
-                    "setup": _slack_setup_instructions(),
+                    "setup_state": setup_state,
+                    "next_step": (
+                        "Slack is connected. Invite Illo to a channel, mention @Illo, or DM it."
+                        if rows
+                        else "Slack is not connected. Ask an Illospace admin to finish the Slack connection outside this chat, then ask Illo to check status again."
+                    ),
                     "connections": [_slack_connection_payload(row) for row in rows],
                 },
                 default=str,
@@ -339,7 +315,7 @@ async def _handle_manage_slack(
             )
             return json.dumps({"ok": True, "mapping": mapping}, default=str)
 
-    return json.dumps({"error": "manage_slack action must be setup_instructions, status, list_mappings, link_identity, or unlink_identity"})
+    return json.dumps({"error": "manage_slack action must be status, list_mappings, link_identity, or unlink_identity"})
 
 
 __all__ = [

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -333,7 +333,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "inbound_configuration",
         "reversibility": "variable",
         "action_manifest": True,
-        "expected_effect": "inspect Slack setup/health or update Slack-to-Illospace identity mappings",
+        "expected_effect": "inspect Slack connection health or update Slack-to-Illospace identity mappings",
         "output_budget_chars": 12_000,
     },
     "manage_project": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1371,9 +1371,11 @@ CHAT_TOOLS = [
     {
         "name": "manage_slack",
         "description": (
-            "Inspect self-hosted Slack setup, connector health, and Slack-to-Illospace "
-            "identity mappings. Use this when helping an admin set up Slack or when "
-            "a Slack actor needs to be linked to an Illospace user."
+            "Inspect Slack connection health and Slack-to-Illospace identity mappings. "
+            "Use this to check whether Slack is connected or when a Slack actor needs "
+            "to be linked to an Illospace user. This tool only reports connection "
+            "state and identity mappings; it cannot change Slack or Illospace "
+            "installation settings."
         ),
         "input_schema": {
             "type": "object",
@@ -1381,7 +1383,6 @@ CHAT_TOOLS = [
                 "action": {
                     "type": "string",
                     "enum": [
-                        "setup_instructions",
                         "status",
                         "list_mappings",
                         "link_identity",

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -478,6 +478,22 @@ def test_slack_tools_are_available_on_normal_illo_tool_surface():
     assert {"post_slack_reply", "read_slack_conversation", "manage_slack"} <= names
 
 
+def test_manage_slack_tool_definition_has_no_operator_setup_action():
+    from brain.systems.runs.tool_definitions import CHAT_TOOLS
+
+    tool = next(tool for tool in CHAT_TOOLS if tool["name"] == "manage_slack")
+    actions = tool["input_schema"]["properties"]["action"]["enum"]
+    serialized_tool = json.dumps(tool)
+
+    assert actions == ["status", "list_mappings", "link_identity", "unlink_identity"]
+    assert "setup_instructions" not in serialized_tool
+    assert "SLACK_" not in serialized_tool
+    assert "docker" not in serialized_tool
+    assert "deploy" not in serialized_tool
+    assert "manifest" not in serialized_tool
+    assert "secret" not in serialized_tool
+
+
 @pytest.mark.asyncio
 async def test_manage_slack_setup_instructions_are_runtime_safe_admin_guidance():
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
@@ -486,19 +502,20 @@ async def test_manage_slack_setup_instructions_are_runtime_safe_admin_guidance()
 
     setup = result["setup"]
     assert setup["slack_admin_url"] == "https://api.slack.com/apps"
-    assert setup["audience"] == "Slack admin and Illospace deployment admin"
-    assert setup["token_sources"]["SLACK_BOT_TOKEN"].endswith("Bot User OAuth Token")
-    assert setup["token_sources"]["SLACK_APP_TOKEN"].endswith("token with connections:write")
-    assert {"app_mentions:read", "chat:write", "im:history"} <= set(setup["required_bot_scopes"])
-    assert {"app_mention", "message.im"} <= set(setup["required_bot_events"])
-    assert any("Invite Illo" in step for step in setup["slack_steps"])
-    assert any("SLACK_BOT_TOKEN" in step for step in setup["illospace_admin_steps"])
-    assert "do not store them in Illospace metadata" in setup["token_handling"]
-    serialized = json.dumps(setup)
-    assert "docker compose" not in serialized
-    assert "python -m" not in serialized
-    assert "deploy/slack" not in serialized
-    assert "manifest_path" not in setup
+    assert any("Check whether Slack is connected" in step for step in setup["what_illo_can_do"])
+    assert any("Change Slack or Illospace installation settings" in step for step in setup["what_illo_cannot_do"])
+    assert "not Illospace Vault entries" in setup["setup_boundary"]
+    assert any("Invite Illo" in step for step in setup["after_connected"])
+
+    serialized_setup = json.dumps(setup)
+    assert "SLACK_" not in serialized_setup
+    assert "deploy/slack" not in serialized_setup
+    assert "docker compose" not in serialized_setup
+    assert "python -m" not in serialized_setup
+    assert "manifest" not in serialized_setup
+    assert "runtime configuration" not in serialized_setup
+    assert "secret manager" not in serialized_setup
+    assert "server secret store" not in serialized_setup
 
 
 @pytest.mark.asyncio
@@ -529,12 +546,17 @@ async def test_manage_slack_status_does_not_leak_developer_setup_details(monkeyp
         result = json.loads(await _handle_manage_slack(action="status"))
 
     assert result["ok"] is True
+    assert result["setup_state"] == "not_connected"
     assert result["connections"] == []
-    serialized = json.dumps(result["setup"])
+    assert "setup" not in result
+    serialized = json.dumps(result)
+    assert "SLACK_" not in serialized
     assert "docker compose" not in serialized
     assert "python -m" not in serialized
     assert "deploy/slack" not in serialized
-    assert "manifest_path" not in result["setup"]
+    assert "manifest" not in serialized
+    assert "secret manager" not in serialized
+    assert "server secret store" not in serialized
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Tightens Illo's Slack runtime surface so agent-facing tools do not expose deployment/operator details. The Slack management tool now reports connection state and identity mappings only, removes the exposed setup action from the tool schema, keeps legacy setup output to a boundary-only response, and adds regression coverage rejecting env token names, manifests, docker commands, and secret-store language from agent-facing Slack guidance.

Tests: venv/bin/python -m pytest tests/test_slack_teammate.py