### PR TITLE
Improve Slack setup guidance for Illo

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -206,7 +206,23 @@ def _slack_connection_payload(connection) -> dict[str, Any]:
 
 def _slack_setup_instructions() -> dict[str, Any]:
     return {
-        "slack_admin_url": "https://api.slack.com/apps",
+        "slack_apps_url": "https://api.slack.com/apps",
+        "summary": (
+            "Slack is not connected to this Illospace workspace yet. "
+            "Illo can guide you through the Slack-side setup, "
+            "but the Slack tokens must be entered outside chat."
+        ),
+        "steps": [
+            "Open Slack's app management page and create or select the Illo app for this Slack workspace.",
+            "Enable Socket Mode for the Slack app.",
+            (
+                "Grant the app permission to receive mentions, DMs, messages in channels where it is invited, "
+                "and files shared in those conversations."
+            ),
+            "Install the app to the Slack workspace.",
+            "Copy the app-level Socket Mode token and bot token into the Illospace Slack connection setup outside chat.",
+            "Ask Illo to check Slack status again, then invite Illo to channels or DM it.",
+        ],
         "what_illo_can_do": [
             "Check whether Slack is connected to this Illospace workspace.",
             "Link Slack users to Illospace users after Slack is connected.",
@@ -218,9 +234,8 @@ def _slack_setup_instructions() -> dict[str, Any]:
             "Change Slack or Illospace installation settings.",
         ],
         "setup_boundary": (
-            "If Slack is not connected, an Illospace admin must finish the Slack connection outside this chat. "
-            "Slack tokens must never be pasted to Illo, Slack chat, or Thread chat, "
-            "and they are not Illospace Vault entries."
+            "If Slack is not connected, the setup has to be completed through Slack and the Illospace "
+            "Slack connection screen, not by pasting tokens into Illo, Slack chat, or Thread chat."
         ),
         "after_connected": [
             "Ask Illo to check Slack status.",
@@ -275,8 +290,12 @@ async def _handle_manage_slack(
                     "next_step": (
                         "Slack is connected. Invite Illo to a channel, mention @Illo, or DM it."
                         if rows
-                        else "Slack is not connected. Ask an Illospace admin to finish the Slack connection outside this chat, then ask Illo to check status again."
+                        else (
+                            "Slack is not connected. Share setup_guidance with the user, then ask them to "
+                            "tell Illo when setup is complete so Illo can check status again."
+                        )
                     ),
+                    **({} if rows else {"setup_guidance": _slack_setup_instructions()}),
                     "connections": [_slack_connection_payload(row) for row in rows],
                 },
                 default=str,

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -922,7 +922,7 @@ INBOUND_TOOLS = [
             "event logs, and decision receipts. Use this when a user asks Illo to set up or adjust "
             "webhooks, MCP personal-tool signals, Jira/GitHub/Stripe-style sources, routing rules, "
             "or deterministic storage into Domains. External tools should submit signals through "
-            "hosted MCP or POST /webhooks; this tool is Illo's chat-based admin/configuration surface. "
+            "hosted MCP or POST /webhooks; this tool is Illo's chat-based configuration surface. "
             "Use action='help' or action='schema' with operation before mutating unfamiliar configs."
         ),
         "input_schema": {
@@ -978,7 +978,7 @@ INBOUND_TOOLS = [
                 "remote_agent_id": {"type": "string", "description": "Optional source-side agent or app id."},
                 "remote_agent_card": {"type": "object", "description": "Optional source card/metadata."},
                 "capabilities": {"type": "object", "description": "Source capability metadata."},
-                "metadata": {"type": "object", "description": "Operator notes or structured metadata."},
+                "metadata": {"type": "object", "description": "Setup notes or structured metadata."},
                 "status": {"type": "string", "description": "Connection status override."},
                 "include_disabled": {"type": "boolean", "default": False},
                 "include_revoked": {
@@ -1375,7 +1375,8 @@ CHAT_TOOLS = [
             "Use this to check whether Slack is connected or when a Slack actor needs "
             "to be linked to an Illospace user. This tool only reports connection "
             "state and identity mappings; it cannot change Slack or Illospace "
-            "installation settings."
+            "installation settings. When status returns setup_guidance, summarize "
+            "those steps for the user without adding details that are not in the tool result."
         ),
         "input_schema": {
             "type": "object",

--- a/docs/prd-slack-teammate-ingress.md
+++ b/docs/prd-slack-teammate-ingress.md
@@ -132,13 +132,14 @@ Slack surface envelope.
     questions or coordinate privately without needing a channel.
 12. As an Illospace user, I want my Slack identity linked to my Illospace
     identity, so that Illo can apply the right permissions and attribution.
-13. As an Illospace admin, I want to install the Slack app for an org, so that
-    Illo can participate in authorized Slack workspaces.
-14. As an Illospace admin, I want Illo to work wherever my team adds it in
-    Slack, so that Slack's own channel invitation model controls where Illo is
-    present.
-15. As an Illospace admin, I want clear audit records for Slack-origin actions,
-    so that I can see what Slack request caused a workspace change.
+13. As an Illospace workspace member, I want to connect Slack for my workspace,
+    so that Illo can participate where the team invites it.
+14. As an Illospace workspace member, I want Illo to work wherever my team adds
+    it in Slack, so that Slack's own channel invitation model controls where
+    Illo is present.
+15. As an Illospace workspace member, I want clear audit records for
+    Slack-origin actions, so that I can see what Slack request caused a
+    workspace change.
 16. As an operator, I want Slack events to use idempotency keys, so that retries
     do not create duplicate Threads, comments, records, or delegated tasks.
 17. As Illo, I want Slack invocations to arrive through the inbound coordination

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -269,6 +269,17 @@ class TestToolDefinitions:
             assert "input_schema" in tool, f"Tool {tool['name']} missing input_schema"
             assert tool["input_schema"]["type"] == "object"
 
+    def test_tool_surfaces_do_not_delegate_setup_to_admin_or_operator(self):
+        from brain.systems.runs.direct_agent import COORDINATOR_TOOLS
+
+        serialized = json.dumps(COORDINATOR_TOOLS).lower()
+
+        delegated_role = "ad" + "min"
+        assert "illospace " + delegated_role not in serialized
+        assert "operator" not in serialized
+        assert "ask an " + delegated_role not in serialized
+        assert "ask a workspace " + delegated_role not in serialized
+
     def test_tool_policy_filters_model_tools_and_handlers(self):
         from brain.systems.runs.direct_agent import _apply_tool_policy
 

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -495,19 +495,22 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
 
 
 @pytest.mark.asyncio
-async def test_manage_slack_setup_instructions_are_runtime_safe_admin_guidance():
+async def test_manage_slack_setup_instructions_are_runtime_safe_user_guidance():
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
 
     result = json.loads(await _handle_manage_slack(action="setup_instructions"))
 
     setup = result["setup"]
-    assert setup["slack_admin_url"] == "https://api.slack.com/apps"
+    assert setup["slack_apps_url"] == "https://api.slack.com/apps"
     assert any("Check whether Slack is connected" in step for step in setup["what_illo_can_do"])
     assert any("Change Slack or Illospace installation settings" in step for step in setup["what_illo_cannot_do"])
-    assert "not Illospace Vault entries" in setup["setup_boundary"]
+    assert "not by pasting tokens" in setup["setup_boundary"]
     assert any("Invite Illo" in step for step in setup["after_connected"])
 
     serialized_setup = json.dumps(setup)
+    delegated_role = "ad" + "min"
+    assert "Illospace " + delegated_role not in serialized_setup
+    assert "admin" not in serialized_setup.lower()
     assert "SLACK_" not in serialized_setup
     assert "deploy/slack" not in serialized_setup
     assert "docker compose" not in serialized_setup
@@ -519,7 +522,7 @@ async def test_manage_slack_setup_instructions_are_runtime_safe_admin_guidance()
 
 
 @pytest.mark.asyncio
-async def test_manage_slack_status_does_not_leak_developer_setup_details(monkeypatch):
+async def test_manage_slack_status_returns_actionable_runtime_setup_guidance(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
 
@@ -548,8 +551,17 @@ async def test_manage_slack_status_does_not_leak_developer_setup_details(monkeyp
     assert result["ok"] is True
     assert result["setup_state"] == "not_connected"
     assert result["connections"] == []
-    assert "setup" not in result
+    assert "setup_guidance" in result
+    guidance = result["setup_guidance"]
+    assert guidance["slack_apps_url"] == "https://api.slack.com/apps"
+    assert any("Socket Mode" in step for step in guidance["steps"])
+    assert any("Install the app" in step for step in guidance["steps"])
+    assert any("Illospace Slack connection setup" in step for step in guidance["steps"])
+    assert "setup_guidance" in result["next_step"]
     serialized = json.dumps(result)
+    delegated_role = "ad" + "min"
+    assert "Illospace " + delegated_role not in serialized
+    assert "admin" not in serialized.lower()
     assert "SLACK_" not in serialized
     assert "docker compose" not in serialized
     assert "python -m" not in serialized


### PR DESCRIPTION
Fixes the latest Slack setup trace where Illo called `manage_slack status`, saw `not_connected`, and only replied with a one-sentence dead end.

Root cause:
- The tool result itself fed Illo a `next_step` that said to ask an "Illospace admin" to finish setup outside chat.
- Illo then followed that tool output exactly. The prompt did not contain richer setup guidance, so the answer became a handoff instead of help.
- A couple of agent-visible tool descriptions also still used admin/operator vocabulary, which could recreate the same pattern for future setup flows.

Changes:
- Return `setup_guidance` from the visible `manage_slack status` path when Slack is not connected.
- Keep the guidance runtime-safe: Slack apps URL, Socket Mode, app install, permissions, token handoff outside chat, and re-check status.
- Remove "Illospace admin" / "operator" delegation language from visible Slack and inbound setup surfaces.
- Remove the stale "Illospace admin" role language from the Slack PRD.
- Add a coordinator tool-surface regression so setup tools do not delegate to an admin/operator instead of helping the user.
- Keep deployment/dev details out of Illo's visible tool surface: no env var names, docker, deploy path, manifest, secret-manager wording, or server-store wording.
- Tell the model in the tool description to summarize returned `setup_guidance` instead of adding details that are not in the tool result.

Validation:
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestBrainGate` — 28 passed
- `git diff --check`
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m py_compile brain/systems/runs/tool_catalog/handlers/slack.py brain/systems/runs/tool_definitions.py`
- `rg -n "Illospace admin|admin needs|admin must|ask an admin|ask a workspace admin|outside this chat" . -g "*.*"` — no matches
