### PR TITLE
Fix cycle snapshot JSONB serialization

### DIFF
--- a/brain/kernel/common/serialization.py
+++ b/brain/kernel/common/serialization.py
@@ -12,6 +12,7 @@ import json
 import math
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 
 
@@ -28,6 +29,8 @@ def jsonable(value: Any, *, enum_values: bool = False, sort_sets: bool = True) -
         return value.value if enum_values else str(value)
     if isinstance(value, (datetime, date)):
         return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
     if isinstance(value, Decimal):
         return float(value)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from sqlalchemy import func, select
 
+from brain.kernel.common.serialization import jsonable
 from brain.platform.db.models.cycle import (
     Cycle,
     CycleGuidance,
@@ -148,20 +149,45 @@ async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: Cy
     revision = await _async_latest_cycle_revision(session, cycle.id)
     guidance_rows = await _async_active_cycle_guidance(session, cycle.id)
     target_rows = await _async_active_cycle_output_targets(session, cycle.id)
+    snapshot = _build_cycle_run_memory_snapshot(
+        cycle,
+        revision=revision,
+        guidance_rows=guidance_rows,
+        target_rows=target_rows,
+    )
 
-    if revision is not None:
-        run.revision_id = revision.id
+    if snapshot["revision_id"] is not None:
+        run.revision_id = snapshot["revision_id"]
 
+    run.guidance_snapshot = snapshot["guidance_snapshot"]
+    run.output_targets_snapshot = snapshot["output_targets_snapshot"]
+    run.context_snapshot = snapshot["context_snapshot"]
+
+
+def _build_cycle_run_memory_snapshot(
+    cycle: Cycle,
+    *,
+    revision: CycleRevision | None,
+    guidance_rows: list[CycleGuidance],
+    target_rows: list[CycleOutputTarget],
+) -> dict:
     output_targets = [serialize_cycle_output_target(target) for target in target_rows]
     _ensure_default_output_targets(cycle, output_targets)
 
-    run.guidance_snapshot = [serialize_cycle_guidance(row) for row in guidance_rows]
-    run.output_targets_snapshot = output_targets
-    run.context_snapshot = {
-        "revision": serialize_cycle_revision(revision),
-        "workspace_id": string_or_none(cycle.org_id),
-        "owner_user_id": string_or_none(cycle.user_id),
-        **creator_payload(cycle),
+    return {
+        "revision_id": revision.id if revision is not None else None,
+        "guidance_snapshot": jsonable(
+            [serialize_cycle_guidance(row) for row in guidance_rows]
+        ),
+        "output_targets_snapshot": jsonable(output_targets),
+        "context_snapshot": jsonable(
+            {
+                "revision": serialize_cycle_revision(revision),
+                "workspace_id": string_or_none(cycle.org_id),
+                "owner_user_id": string_or_none(cycle.user_id),
+                **creator_payload(cycle),
+            }
+        ),
     }
 
 
@@ -194,7 +220,7 @@ def append_cycle_run_output_target_snapshot(
             "is_active": True,
         }
     )
-    run.output_targets_snapshot = output_targets
+    run.output_targets_snapshot = jsonable(output_targets)
 
 
 async def finalize_cycle_run(

--- a/tests/test_common_helpers.py
+++ b/tests/test_common_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from uuid import UUID
 
 import pytest
 
@@ -90,8 +91,16 @@ def test_env_helpers_support_strict_and_permissive_boolean_semantics() -> None:
 
 
 def test_serialization_helpers_are_stable_and_bounded() -> None:
-    payload = {"when": datetime(2026, 1, 2, tzinfo=timezone.utc), "items": {"b", "a"}}
-    assert jsonable(payload) == {"when": "2026-01-02T00:00:00+00:00", "items": ["a", "b"]}
+    payload = {
+        "when": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "items": {"b", "a"},
+        "workspace_id": UUID("00000000-0000-0000-0000-000000000123"),
+    }
+    assert jsonable(payload) == {
+        "when": "2026-01-02T00:00:00+00:00",
+        "items": ["a", "b"],
+        "workspace_id": "00000000-0000-0000-0000-000000000123",
+    }
     assert stable_digest({"b": 2, "a": 1}, length=12) == stable_digest({"a": 1, "b": 2}, length=12)
     safe = json_safe({"text": "x" * 20, "empty": {}, "none": None}, max_text_chars=10)
     assert "empty" not in safe

--- a/tests/test_cycles_memory.py
+++ b/tests/test_cycles_memory.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import UUID
+
+from brain.platform.db.models.cycle import (
+    Cycle,
+    CycleGuidance,
+    CycleOutputTarget,
+    CycleRevision,
+    CycleRun,
+)
+from brain.systems.cycles import memory as cycle_memory
+
+
+def test_build_cycle_run_memory_snapshot_returns_jsonb_safe_values():
+    created_at = datetime(2026, 5, 29, 14, 25, tzinfo=timezone.utc)
+    workspace_id = UUID("00000000-0000-0000-0000-000000000123")
+    owner_user_id = UUID("00000000-0000-0000-0000-000000000456")
+    target_idea_id = UUID("00000000-0000-0000-0000-000000000789")
+    source_id = UUID("00000000-0000-0000-0000-000000000abc")
+
+    cycle = Cycle()
+    cycle.id = 42
+    cycle.user_id = owner_user_id
+    cycle.org_id = workspace_id
+    cycle.creator_type = "user"
+    cycle.creator_id = owner_user_id
+    cycle.target_idea_id = target_idea_id
+
+    revision = CycleRevision()
+    revision.id = 11
+    revision.cycle_id = cycle.id
+    revision.revision_number = 3
+    revision.source_type = "user"
+    revision.source_id = source_id
+    revision.rationale = "Updated guidance"
+    revision.name = "Morning brief"
+    revision.prompt = "Summarize the current workspace"
+    revision.schedule_expr = "0 9 * * *"
+    revision.timezone = "America/Toronto"
+    revision.enabled = True
+    revision.model_override = None
+    revision.thinking_override = "medium"
+    revision.target_idea_id = target_idea_id
+    revision.context_policy = {"workspace_id": workspace_id, "captured_at": created_at}
+    revision.created_at = created_at
+
+    guidance = CycleGuidance()
+    guidance.id = 12
+    guidance.cycle_id = cycle.id
+    guidance.revision_id = revision.id
+    guidance.source_type = "user"
+    guidance.source_id = source_id
+    guidance.guidance = "Mention stuck runs"
+    guidance.rationale = None
+    guidance.is_active = True
+    guidance.created_at = created_at
+
+    output_target = CycleOutputTarget()
+    output_target.id = 13
+    output_target.cycle_id = cycle.id
+    output_target.revision_id = revision.id
+    output_target.target_type = "cycle_ledger"
+    output_target.target_id = str(cycle.id)
+    output_target.label = "Cycle ledger"
+    output_target.config = {"nested": {"captured_at": created_at, "owner": owner_user_id}}
+    output_target.source_type = "system"
+    output_target.source_id = None
+    output_target.rationale = "Durable memory target"
+    output_target.is_active = True
+    output_target.created_at = created_at
+    output_target.updated_at = created_at
+
+    snapshot = cycle_memory._build_cycle_run_memory_snapshot(
+        cycle,
+        revision=revision,
+        guidance_rows=[guidance],
+        target_rows=[output_target],
+    )
+
+    json.dumps(snapshot)
+    assert snapshot["revision_id"] == revision.id
+    assert (
+        snapshot["context_snapshot"]["revision"]["created_at"]
+        == created_at.isoformat()
+    )
+    assert snapshot["context_snapshot"]["revision"]["context_policy"][
+        "workspace_id"
+    ] == str(workspace_id)
+    assert snapshot["guidance_snapshot"][0]["created_at"] == created_at.isoformat()
+    assert snapshot["output_targets_snapshot"][0]["created_at"] == created_at.isoformat()
+    assert (
+        snapshot["output_targets_snapshot"][0]["config"]["nested"]["captured_at"]
+        == created_at.isoformat()
+    )
+    assert snapshot["output_targets_snapshot"][0]["config"]["nested"]["owner"] == str(
+        owner_user_id
+    )
+
+
+def test_append_cycle_run_output_target_snapshot_returns_jsonb_safe_values():
+    created_at = datetime(2026, 5, 29, 14, 25, tzinfo=timezone.utc)
+    owner_user_id = UUID("00000000-0000-0000-0000-000000000456")
+    run = CycleRun()
+    run.output_targets_snapshot = []
+
+    cycle_memory.append_cycle_run_output_target_snapshot(
+        run,
+        target_type="thread",
+        target_id="idea-123",
+        label="Cycle thread",
+        config={"captured_at": created_at, "owner": owner_user_id},
+    )
+
+    json.dumps(run.output_targets_snapshot)
+    assert (
+        run.output_targets_snapshot[0]["config"]["captured_at"]
+        == created_at.isoformat()
+    )
+    assert run.output_targets_snapshot[0]["config"]["owner"] == str(owner_user_id)

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -74,7 +74,6 @@ class _AllResult:
         return list(self._values)
 
 
-
 class _RouterCycleResult:
     def __init__(self, cycle):
         self._cycle = cycle


### PR DESCRIPTION
Summary:
- Convert cycle run memory snapshots through the canonical jsonable() helper before JSONB persistence.
- Extend jsonable() to normalize UUIDs.
- Add focused cycle memory regression tests for datetime and UUID snapshot values.

Tests:
- venv/bin/python -m pytest tests/test_common_helpers.py tests/test_cycles_memory.py tests/test_cycles_service.py -q