### PR TITLE
Report Slack connection facts only

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -204,46 +204,6 @@ def _slack_connection_payload(connection) -> dict[str, Any]:
     }
 
 
-def _slack_setup_instructions() -> dict[str, Any]:
-    return {
-        "slack_apps_url": "https://api.slack.com/apps",
-        "summary": (
-            "Slack is not connected to this Illospace workspace yet. "
-            "Illo can guide you through the Slack-side setup, "
-            "but the Slack tokens must be entered outside chat."
-        ),
-        "steps": [
-            "Open Slack's app management page and create or select the Illo app for this Slack workspace.",
-            "Enable Socket Mode for the Slack app.",
-            (
-                "Grant the app permission to receive mentions, DMs, messages in channels where it is invited, "
-                "and files shared in those conversations."
-            ),
-            "Install the app to the Slack workspace.",
-            "Copy the app-level Socket Mode token and bot token into the Illospace Slack connection setup outside chat.",
-            "Ask Illo to check Slack status again, then invite Illo to channels or DM it.",
-        ],
-        "what_illo_can_do": [
-            "Check whether Slack is connected to this Illospace workspace.",
-            "Link Slack users to Illospace users after Slack is connected.",
-            "Read and reply in Slack conversations after Illo is mentioned or DM'd.",
-        ],
-        "what_illo_cannot_do": [
-            "Create or install the Slack app for the workspace.",
-            "Receive Slack tokens in chat.",
-            "Change Slack or Illospace installation settings.",
-        ],
-        "setup_boundary": (
-            "If Slack is not connected, the setup has to be completed through Slack and the Illospace "
-            "Slack connection screen, not by pasting tokens into Illo, Slack chat, or Thread chat."
-        ),
-        "after_connected": [
-            "Ask Illo to check Slack status.",
-            "Invite Illo to the Slack channels where it should participate, then mention @Illo or DM it.",
-        ],
-    }
-
-
 async def _handle_manage_slack(
     action: str,
     connection_id: str | None = None,
@@ -253,9 +213,6 @@ async def _handle_manage_slack(
     """Inspect Slack connection health and manage minimal identity mappings."""
 
     normalized_action = str(action or "").strip().lower()
-    if normalized_action == "setup_instructions":
-        return json.dumps({"ok": True, "setup": _slack_setup_instructions()}, default=str)
-
     org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
     if not org_id:
         return json.dumps({"error": "manage_slack could not access this workspace context"})
@@ -287,15 +244,8 @@ async def _handle_manage_slack(
                 {
                     "ok": True,
                     "setup_state": setup_state,
-                    "next_step": (
-                        "Slack is connected. Invite Illo to a channel, mention @Illo, or DM it."
-                        if rows
-                        else (
-                            "Slack is not connected. Share setup_guidance with the user, then ask them to "
-                            "tell Illo when setup is complete so Illo can check status again."
-                        )
-                    ),
-                    **({} if rows else {"setup_guidance": _slack_setup_instructions()}),
+                    "needs_connection": not bool(rows),
+                    "connection_count": len(rows),
                     "connections": [_slack_connection_payload(row) for row in rows],
                 },
                 default=str,

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1372,11 +1372,8 @@ CHAT_TOOLS = [
         "name": "manage_slack",
         "description": (
             "Inspect Slack connection health and Slack-to-Illospace identity mappings. "
-            "Use this to check whether Slack is connected or when a Slack actor needs "
-            "to be linked to an Illospace user. This tool only reports connection "
-            "state and identity mappings; it cannot change Slack or Illospace "
-            "installation settings. When status returns setup_guidance, summarize "
-            "those steps for the user without adding details that are not in the tool result."
+            "Use action='status' to check whether Slack is connected, and use "
+            "identity mapping actions to link Slack users to Illospace users."
         ),
         "input_schema": {
             "type": "object",

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -492,37 +492,12 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
     assert "deploy" not in serialized_tool
     assert "manifest" not in serialized_tool
     assert "secret" not in serialized_tool
+    assert "does not" not in serialized_tool.lower()
+    assert "cannot" not in serialized_tool.lower()
 
 
 @pytest.mark.asyncio
-async def test_manage_slack_setup_instructions_are_runtime_safe_user_guidance():
-    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
-
-    result = json.loads(await _handle_manage_slack(action="setup_instructions"))
-
-    setup = result["setup"]
-    assert setup["slack_apps_url"] == "https://api.slack.com/apps"
-    assert any("Check whether Slack is connected" in step for step in setup["what_illo_can_do"])
-    assert any("Change Slack or Illospace installation settings" in step for step in setup["what_illo_cannot_do"])
-    assert "not by pasting tokens" in setup["setup_boundary"]
-    assert any("Invite Illo" in step for step in setup["after_connected"])
-
-    serialized_setup = json.dumps(setup)
-    delegated_role = "ad" + "min"
-    assert "Illospace " + delegated_role not in serialized_setup
-    assert "admin" not in serialized_setup.lower()
-    assert "SLACK_" not in serialized_setup
-    assert "deploy/slack" not in serialized_setup
-    assert "docker compose" not in serialized_setup
-    assert "python -m" not in serialized_setup
-    assert "manifest" not in serialized_setup
-    assert "runtime configuration" not in serialized_setup
-    assert "secret manager" not in serialized_setup
-    assert "server secret store" not in serialized_setup
-
-
-@pytest.mark.asyncio
-async def test_manage_slack_status_returns_actionable_runtime_setup_guidance(monkeypatch):
+async def test_manage_slack_status_returns_connection_facts_not_setup_guidance(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
 
@@ -550,18 +525,18 @@ async def test_manage_slack_status_returns_actionable_runtime_setup_guidance(mon
 
     assert result["ok"] is True
     assert result["setup_state"] == "not_connected"
+    assert result["needs_connection"] is True
+    assert result["connection_count"] == 0
     assert result["connections"] == []
-    assert "setup_guidance" in result
-    guidance = result["setup_guidance"]
-    assert guidance["slack_apps_url"] == "https://api.slack.com/apps"
-    assert any("Socket Mode" in step for step in guidance["steps"])
-    assert any("Install the app" in step for step in guidance["steps"])
-    assert any("Illospace Slack connection setup" in step for step in guidance["steps"])
-    assert "setup_guidance" in result["next_step"]
+    assert "setup_guidance" not in result
+    assert "next_step" not in result
     serialized = json.dumps(result)
     delegated_role = "ad" + "min"
     assert "Illospace " + delegated_role not in serialized
     assert "admin" not in serialized.lower()
+    assert "setup screen" not in serialized.lower()
+    assert "connection setup" not in serialized.lower()
+    assert "Socket Mode" not in serialized
     assert "SLACK_" not in serialized
     assert "docker compose" not in serialized
     assert "python -m" not in serialized
@@ -569,6 +544,8 @@ async def test_manage_slack_status_returns_actionable_runtime_setup_guidance(mon
     assert "manifest" not in serialized
     assert "secret manager" not in serialized
     assert "server secret store" not in serialized
+    invented_surface = "Illospace Slack " + "connection setup"
+    assert invented_surface not in serialized
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the over-hardcoded Slack setup guidance regression after PR #162.

Root cause:
- `manage_slack` had become a setup-instruction surface instead of a state-inspection tool.
- That made Illo repeat invented product surfaces such as an Illospace Slack setup screen.

Changes:
- Remove `setup_guidance`, `next_step`, and the hidden `setup_instructions` handler path from `manage_slack`.
- Make `manage_slack status` return only connection facts: `setup_state`, `needs_connection`, `connection_count`, and `connections`.
- Keep the tool description positive and minimal: status checks and identity mappings only.
- Add regressions that block setup-screen, connection-setup, Socket Mode, secret, deploy, docker, and negative-policy wording from the model-visible Slack management surface.

Validation:
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py::test_manage_slack_tool_definition_has_no_operator_setup_action tests/test_slack_teammate.py::test_manage_slack_status_returns_connection_facts_not_setup_guidance tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestBrainGate` — 12 passed
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestBrainGate` — 27 passed
- `git diff --check`
- `/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m py_compile brain/systems/runs/tool_definitions.py brain/systems/runs/tool_catalog/handlers/slack.py`
