### PR TITLE
Fix Compose self-update bootstrap issues

### DIFF
--- a/deploy/docker/updater.Dockerfile
+++ b/deploy/docker/updater.Dockerfile
@@ -3,9 +3,11 @@ FROM docker:27-cli
 RUN apk add --no-cache \
     bash \
     coreutils \
+    curl \
     docker-cli-compose \
     git \
-    jq
+    jq \
+    python3
 
 WORKDIR /repo
 

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -8,7 +8,18 @@ HEARTBEAT_FILE="${ILLO_SELF_UPDATE_HEARTBEAT_FILE:-/data/private/self-update/hea
 LOG_PATH="${ILLO_SELF_UPDATE_LOG_PATH:-/data/private/logs/illo-self-update.log}"
 WORKER_DRAIN_TIMEOUT_FILE="${ILLO_SELF_UPDATE_WORKER_DRAIN_TIMEOUT_FILE:-/data/private/self-update/worker-drain-timeout.json}"
 POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
+APP_UID="${ILLO_APP_UID:-10001}"
+APP_GID="${ILLO_APP_GID:-10001}"
 RUNNING_FILE="${REQUEST_FILE}.running"
+
+prepare_shared_paths() {
+  mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")"
+  if [ "$(id -u)" = "0" ]; then
+    chown "$APP_UID:$APP_GID" "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" 2>/dev/null || true
+    chmod 0775 "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" 2>/dev/null || true
+  fi
+  git config --global --add safe.directory "$REPO" >/dev/null 2>&1 || true
+}
 
 json_write() {
   local path="$1"
@@ -89,7 +100,7 @@ process_request() {
   rm -f "$RUNNING_FILE"
 }
 
-mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")"
+prepare_shared_paths
 write_status "idle" "Compose updater sidecar is ready." "" ""
 
 while true; do

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -295,6 +295,19 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     assert "deploy " + "publish" not in launcher
 
 
+def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
+    root = Path(__file__).resolve().parents[1]
+    updater_dockerfile = (root / "deploy" / "docker" / "updater.Dockerfile").read_text()
+    self_update_daemon = (root / "deploy" / "scripts" / "self-update-daemon.sh").read_text()
+
+    assert "python3" in updater_dockerfile
+    assert "curl" in updater_dockerfile
+    assert "APP_UID" in self_update_daemon
+    assert "chown \"$APP_UID:$APP_GID\"" in self_update_daemon
+    assert "chmod 0775" in self_update_daemon
+    assert "safe.directory" in self_update_daemon
+
+
 def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     upgrade = (Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "upgrade.sh").read_text()
 


### PR DESCRIPTION
## Summary
- make the updater sidecar mark the self-update queue directory writable by the API user
- configure Git safe.directory for the mounted /repo checkout inside the updater container
- include python3 and curl in the updater image so the deploy doctor can run from self-update

## Live test notes
- Triggered the existing self-update service on the dev server after PR #164 merged
- It updated the server repo and recreated API/web/worker/scheduler on latest main
- The live test exposed these bootstrap issues, which this PR fixes durably

## Tests
- bash -n deploy/scripts/self-update-daemon.sh deploy/scripts/upgrade.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_runtime_settings.py tests/test_tool_registry.py tests/test_tool_policy.py -q