### PR TITLE
Skip host-local doctor probes during self-update

### DIFF
--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -237,7 +237,9 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
       check_db_provider_credentials
     fi
 
-    if command -v curl >/dev/null 2>&1; then
+    if [ "${ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES:-0}" = "1" ]; then
+      warn "skipping local HTTP probes; this doctor is running outside the host network namespace"
+    elif command -v curl >/dev/null 2>&1; then
       api_port="${ILLO_API_PORT:-8000}"
       web_port="${ILLO_WEB_PORT:-8080}"
       if curl -fsS "http://127.0.0.1:${api_port}/api/health/live" >/dev/null; then

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -84,6 +84,7 @@ process_request() {
       ILLO_COMPOSE_BUILD_NO_CACHE="${build_no_cache:-${ILLO_COMPOSE_BUILD_NO_CACHE:-0}}" \
       ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE="$WORKER_DRAIN_TIMEOUT_FILE" \
       ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS="${worker_drain_timeout_seconds:-${ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS:-120}}" \
+      ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES=1 \
       bash ./illo update --mode compose
   } >> "$LOG_PATH" 2>&1
   exit_code=$?

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -306,6 +306,15 @@ def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
     assert "chown \"$APP_UID:$APP_GID\"" in self_update_daemon
     assert "chmod 0775" in self_update_daemon
     assert "safe.directory" in self_update_daemon
+    assert "ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES=1" in self_update_daemon
+
+
+def test_compose_doctor_can_skip_host_local_http_probes_from_sidecars():
+    root = Path(__file__).resolve().parents[1]
+    doctor = (root / "deploy" / "scripts" / "doctor.sh").read_text()
+
+    assert "ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES" in doctor
+    assert "outside the host network namespace" in doctor
 
 
 def test_compose_upgrade_drains_worker_when_agent_runs_are_active():


### PR DESCRIPTION
## Summary
- let deploy doctor skip host-local 127.0.0.1 HTTP probes when running from the updater sidecar
- set that mode from the self-update daemon while retaining Compose service health, migration, pgvector, and credential checks

## Live test notes
- Illo-managed self-update now pulls/rebuilds/recreates services on latest main
- The remaining failure was doctor probing 127.0.0.1 from inside the updater container, where localhost is not the host network namespace

## Tests
- bash -n deploy/scripts/doctor.sh deploy/scripts/self-update-daemon.sh deploy/scripts/upgrade.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_runtime_settings.py -q