### PR TITLE
Prevent idle worker replacement from blocking deploy

### DIFF
--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -65,11 +65,7 @@ non_worker_services() {
 }
 
 all_runtime_services() {
-  if [ "$SKIP_UPDATER_RESTART" = "1" ]; then
-    printf '%s\n' api worker scheduler web
-  else
-    printf '%s\n' api worker scheduler web updater
-  fi
+  non_worker_services
 }
 
 active_agent_run_count() {
@@ -156,6 +152,26 @@ update_worker_after_drain() {
   fi
 }
 
+replace_idle_worker() {
+  local worker_id stop_seconds
+  worker_id="$(worker_container_id)"
+  stop_seconds="${ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS:-30}"
+
+  if [ -z "$worker_id" ]; then
+    echo "Worker container is not running; starting worker on the new image."
+    compose up -d --force-recreate --no-deps worker
+    return 0
+  fi
+
+  echo "Worker: no active AgentRuns; replacing worker with a ${stop_seconds}s stop timeout."
+  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
+  if ! docker stop -t "$stop_seconds" "$worker_id" >/dev/null 2>&1; then
+    echo "Worker did not stop within ${stop_seconds}s despite no active AgentRuns; forcing replacement." >&2
+    docker kill "$worker_id" >/dev/null 2>&1 || true
+  fi
+  compose up -d --force-recreate --no-deps worker
+}
+
 if [ "$PULL" = "1" ]; then
   compose pull postgres api web updater || {
     echo "Image pull failed. If release images are not published yet, rerun with --build." >&2
@@ -177,6 +193,7 @@ ACTIVE_RUNS="$(active_agent_run_count)"
 if [ "$ACTIVE_RUNS" = "0" ]; then
   mapfile -t runtime_services < <(all_runtime_services)
   compose up -d --force-recreate --remove-orphans "${runtime_services[@]}"
+  replace_idle_worker
 else
   echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
   mapfile -t services < <(non_worker_services)

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -333,6 +333,9 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "wait_for_worker_exit" in upgrade
     assert "compose up -d --force-recreate --no-deps worker" in upgrade
     assert "compose up -d --force-recreate --remove-orphans" in upgrade
+    assert "replace_idle_worker" in upgrade
+    assert "ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS" in upgrade
+    assert "no active AgentRuns" in upgrade
     assert "ILLO_COMPOSE_BUILD_NO_CACHE" in upgrade
     assert "ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE" in upgrade
     assert "record_worker_drain_timeout" in upgrade


### PR DESCRIPTION
## Summary
- stop updating worker inside the all-services compose up fast path
- update API/scheduler/web first, then replace idle worker separately with a bounded stop timeout
- keep the active-AgentRun handoff path unchanged

## Live test notes
- Illo-managed self-update pulled PR #167 to the server, but the no-active-runs worker recreate blocked compose while the worker drained after SIGTERM
- Manual recovery required stopping worker with a short timeout and rerunning compose up
- This patch makes that bounded replacement the normal no-active-runs path

## Tests
- bash -n deploy/scripts/upgrade.sh deploy/scripts/doctor.sh deploy/scripts/self-update-daemon.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_runtime_settings.py -q