### PR TITLE
Ground final replies in tool evidence

### DIFF
--- a/brain/systems/personality/agent_profile.py
+++ b/brain/systems/personality/agent_profile.py
@@ -14,6 +14,9 @@ how Illo works and shapes visible thread replies.
 
 ## Operating Mode
 
+Illo is the agent. Illospace is the open-source workspace/product where Illo
+operates with team context, tools, memory, and durable workspace objects.
+
 Use the lightest path that can satisfy the current request. Read context before
 asking the user to repeat themselves. Use tools when evidence, files, workspace
 state, or external state matters. Ask clearly when the request is risky,

--- a/brain/systems/personality/agent_profile.py
+++ b/brain/systems/personality/agent_profile.py
@@ -42,10 +42,10 @@ Use run evidence as source material, not as prose to copy.
 - Include caveats only when they change what the user should do next.
 - Never claim a test, command, external check, file change, or access change ran
   unless the evidence says it did.
-- Never invent Illospace screens, settings paths, setup flows, authority roles,
-  deployment paths, or OAuth surfaces. Mention those only when current tools or
-  source context explicitly provide them; otherwise state what is verified and
-  what remains unknown.
+- Ground Illospace-specific screens, settings paths, setup flows, authority
+  roles, deployment paths, and OAuth surfaces in current tools, capability
+  manifests, or source context. When the source is not available, answer with
+  the verified state and the source needed next.
 """
 
 

--- a/brain/systems/personality/agent_profile.py
+++ b/brain/systems/personality/agent_profile.py
@@ -42,6 +42,10 @@ Use run evidence as source material, not as prose to copy.
 - Include caveats only when they change what the user should do next.
 - Never claim a test, command, external check, file change, or access change ran
   unless the evidence says it did.
+- Never invent Illospace screens, settings paths, setup flows, authority roles,
+  deployment paths, or OAuth surfaces. Mention those only when current tools or
+  source context explicitly provide them; otherwise state what is verified and
+  what remains unknown.
 """
 
 

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -1,0 +1,239 @@
+"""Runtime capability manifests for Illo's agent-visible self model."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+from typing import Any
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_GUIDE_MAX_CHARS = 8_000
+
+
+@dataclass(frozen=True)
+class CapabilityManifest:
+    key: str
+    name: str
+    category: str
+    summary: str
+    aliases: tuple[str, ...] = ()
+    affordances: tuple[str, ...] = ()
+    tools: tuple[str, ...] = ()
+    status_check: Mapping[str, Any] | None = None
+    setup: Mapping[str, Any] = field(default_factory=dict)
+    source: str = "builtin"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "name": self.name,
+            "category": self.category,
+            "summary": self.summary,
+            "aliases": list(self.aliases),
+            "affordances": list(self.affordances),
+            "tools": list(self.tools),
+            "status_check": dict(self.status_check or {}),
+            "setup": dict(self.setup or {}),
+            "source": self.source,
+        }
+
+
+def builtin_capability_manifests() -> list[CapabilityManifest]:
+    return [
+        CapabilityManifest(
+            key="slack",
+            name="Slack",
+            category="communication",
+            summary=(
+                "Illo can participate in Slack conversations when a Slack source "
+                "connection is registered for the workspace."
+            ),
+            aliases=("slack", "team chat", "chat teammate"),
+            affordances=(
+                "inspect connection health",
+                "map Slack users to Illospace users",
+                "read bounded Slack context for Slack-triggered runs",
+                "reply to the originating Slack conversation",
+            ),
+            tools=("manage_slack", "read_slack_conversation", "post_slack_reply"),
+            status_check={"tool": "manage_slack", "args": {"action": "status"}},
+            setup={
+                "mode": "guided_user_action",
+                "agent_role": "check_status_collect_credentials_and_answer_questions",
+                "credential_store": "Vault",
+                "credentials": [
+                    {
+                        "key_name": "SLACK_BOT_TOKEN",
+                        "description": "Slack bot token for the Illo app.",
+                    },
+                    {
+                        "key_name": "SLACK_APP_TOKEN",
+                        "description": "Slack app-level Socket Mode token for the Illo app.",
+                    },
+                ],
+            },
+        ),
+    ]
+
+
+def _coerce_text(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _coerce_text_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value.strip(),) if value.strip() else ()
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, Mapping)):
+        return tuple(str(item).strip() for item in value if str(item or "").strip())
+    return ()
+
+
+def _manifest_from_mapping(value: Mapping[str, Any], *, default_key: str | None = None, source: str) -> CapabilityManifest | None:
+    key = _coerce_text(value.get("key") or default_key)
+    if not key:
+        return None
+    name = _coerce_text(value.get("name"), key.replace("_", " ").replace("-", " ").title())
+    return CapabilityManifest(
+        key=key,
+        name=name,
+        category=_coerce_text(value.get("category"), "custom"),
+        summary=_coerce_text(value.get("summary") or value.get("description"), f"{name} capability."),
+        aliases=_coerce_text_tuple(value.get("aliases")),
+        affordances=_coerce_text_tuple(value.get("affordances") or value.get("capabilities")),
+        tools=_coerce_text_tuple(value.get("tools")),
+        status_check=value.get("status_check") if isinstance(value.get("status_check"), Mapping) else None,
+        setup=value.get("setup") if isinstance(value.get("setup"), Mapping) else {},
+        source=source,
+    )
+
+
+def custom_capability_manifests(*containers: Mapping[str, Any] | None) -> list[CapabilityManifest]:
+    manifests: list[CapabilityManifest] = []
+    for container in containers:
+        if not isinstance(container, Mapping):
+            continue
+        for field_name in ("capability_manifests", "runtime_capabilities", "capabilities"):
+            raw = container.get(field_name)
+            if isinstance(raw, Mapping) and raw.get("key"):
+                manifest = _manifest_from_mapping(raw, source=field_name)
+                if manifest:
+                    manifests.append(manifest)
+            elif isinstance(raw, Mapping):
+                for key, value in raw.items():
+                    if isinstance(value, Mapping):
+                        manifest = _manifest_from_mapping(value, default_key=str(key), source=field_name)
+                        if manifest:
+                            manifests.append(manifest)
+            elif isinstance(raw, list):
+                for item in raw:
+                    if isinstance(item, Mapping):
+                        manifest = _manifest_from_mapping(item, source=field_name)
+                        if manifest:
+                            manifests.append(manifest)
+    return manifests
+
+
+def merge_capability_manifests(manifests: Iterable[CapabilityManifest]) -> list[CapabilityManifest]:
+    merged: dict[str, CapabilityManifest] = {}
+    for manifest in manifests:
+        merged[manifest.key] = manifest
+    return list(merged.values())
+
+
+def _matches_query(manifest: CapabilityManifest, query: str) -> bool:
+    haystack = " ".join((
+        manifest.key,
+        manifest.name,
+        manifest.category,
+        manifest.summary,
+        " ".join(manifest.aliases),
+        " ".join(manifest.affordances),
+        " ".join(manifest.tools),
+    )).lower()
+    stopwords = {
+        "a", "about", "add", "agent", "an", "app", "apps", "can",
+        "capabilities", "capability", "configure", "connect", "connector",
+        "connectors", "do", "enable", "for", "help", "i", "illo", "in",
+        "install", "integrate", "integration", "integrations", "me", "my",
+        "of", "on", "our", "please", "plugin", "plugins", "set", "setup",
+        "the", "to", "tool", "tools", "up", "what", "which", "with", "you",
+    }
+    terms = [
+        term
+        for term in re.split(r"[^a-z0-9_/-]+", query.lower())
+        if term and term not in stopwords
+    ]
+    if not terms:
+        return True
+    return any(term in haystack for term in terms)
+
+
+def filter_capability_manifests(
+    manifests: Iterable[CapabilityManifest],
+    *,
+    query: str | None = None,
+    capability_key: str | None = None,
+    category: str | None = None,
+) -> list[CapabilityManifest]:
+    key = _coerce_text(capability_key).lower()
+    cat = _coerce_text(category).lower()
+    q = _coerce_text(query).lower()
+    result: list[CapabilityManifest] = []
+    for manifest in manifests:
+        if key and key not in {manifest.key.lower(), *(alias.lower() for alias in manifest.aliases)}:
+            continue
+        if cat and manifest.category.lower() != cat:
+            continue
+        if q and not _matches_query(manifest, q):
+            continue
+        result.append(manifest)
+    return result
+
+
+def load_setup_guide(manifest: CapabilityManifest) -> dict[str, Any] | None:
+    setup = manifest.setup or {}
+    inline_guide = _coerce_text(setup.get("guide_markdown") or setup.get("guide_content") or setup.get("guide"))
+    if inline_guide:
+        title = next((line.lstrip("#").strip() for line in inline_guide.splitlines() if line.startswith("#")), manifest.name)
+        truncated = len(inline_guide) > _GUIDE_MAX_CHARS
+        return {
+            "ref": "inline",
+            "available": True,
+            "title": title,
+            "content": inline_guide[:_GUIDE_MAX_CHARS],
+            "truncated": truncated,
+        }
+    guide_ref = _coerce_text(setup.get("guide_ref"))
+    if not guide_ref:
+        return None
+    path = (_REPO_ROOT / guide_ref).resolve()
+    try:
+        path.relative_to(_REPO_ROOT)
+    except ValueError:
+        return {"ref": guide_ref, "available": False, "error": "guide_ref escapes repository root"}
+    if not path.exists() or not path.is_file():
+        return {"ref": guide_ref, "available": False, "error": "guide_ref not found"}
+    text = path.read_text(encoding="utf-8")
+    title = next((line.lstrip("#").strip() for line in text.splitlines() if line.startswith("#")), manifest.name)
+    truncated = len(text) > _GUIDE_MAX_CHARS
+    return {
+        "ref": guide_ref,
+        "available": True,
+        "title": title,
+        "content": text[:_GUIDE_MAX_CHARS],
+        "truncated": truncated,
+    }
+
+
+__all__ = [
+    "CapabilityManifest",
+    "builtin_capability_manifests",
+    "custom_capability_manifests",
+    "filter_capability_manifests",
+    "load_setup_guide",
+    "merge_capability_manifests",
+]

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 import re
 from typing import Any
@@ -11,6 +11,23 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUIDE_MAX_CHARS = 8_000
+_DETAIL_LEVELS = {"summary", "tools", "full"}
+CAPABILITY_COVERAGE_EXEMPT_TOOLS = frozenset({
+    "build_implementation_map",
+    "file_summary",
+    "parallel_tool_batch",
+    "read_thread_messages",
+    "semantic_search",
+    "session_append",
+    "session_close",
+    "session_list",
+    "session_promote",
+    "session_read",
+    "session_write",
+    "summarize_file_for_task",
+    "summarize_files_for_task",
+    "trace_symbol",
+})
 
 
 @dataclass(frozen=True)
@@ -22,63 +39,89 @@ class CapabilityManifest:
     aliases: tuple[str, ...] = ()
     affordances: tuple[str, ...] = ()
     tools: tuple[str, ...] = ()
+    unavailable_tools: tuple[str, ...] = ()
     tool_details: tuple[Mapping[str, Any], ...] = ()
     status_check: Mapping[str, Any] | None = None
     setup: Mapping[str, Any] = field(default_factory=dict)
+    availability: str = "available"
     source: str = "builtin"
 
-    def to_payload(self) -> dict[str, Any]:
-        return {
+    def to_payload(self, *, detail_level: str = "summary") -> dict[str, Any]:
+        """Return a model-visible capability card at the requested detail level."""
+
+        detail = detail_level if detail_level in _DETAIL_LEVELS else "summary"
+        payload: dict[str, Any] = {
             "key": self.key,
             "name": self.name,
             "category": self.category,
             "summary": self.summary,
+            "availability": self.availability,
+            "source": self.source,
+        }
+        if self.unavailable_tools:
+            payload["unavailable_tools"] = list(self.unavailable_tools)
+
+        setup = _setup_payload(self.setup, detail_level=detail)
+        if setup:
+            payload["setup"] = setup
+
+        if detail == "summary":
+            payload["tool_count"] = len(self.tools)
+            if self.status_check:
+                payload["has_status_check"] = True
+            return payload
+
+        payload.update({
             "aliases": list(self.aliases),
             "affordances": list(self.affordances),
             "tools": list(self.tools),
-            "tool_details": [dict(detail) for detail in self.tool_details],
-            "status_check": dict(self.status_check or {}),
-            "setup": dict(self.setup or {}),
-            "source": self.source,
-        }
+        })
+        if self.status_check:
+            payload["status_check"] = dict(self.status_check)
+            payload["status_check_available"] = _status_check_available(self)
+        if detail == "full":
+            payload["tool_details"] = [dict(detail) for detail in self.tool_details]
+        return payload
+
+
+def _setup_payload(setup: Mapping[str, Any], *, detail_level: str) -> dict[str, Any]:
+    if not setup:
+        return {}
+    if detail_level == "full":
+        return dict(setup)
+    payload = {
+        key: setup[key]
+        for key in ("mode", "credential_store", "guide_ref")
+        if key in setup
+    }
+    credentials = setup.get("credentials")
+    if isinstance(credentials, list) and credentials:
+        payload["credential_keys"] = [
+            str(item.get("key_name"))
+            for item in credentials
+            if isinstance(item, Mapping) and item.get("key_name")
+        ]
+    return payload
+
+
+def _status_check_available(manifest: CapabilityManifest) -> bool:
+    status_check = manifest.status_check or {}
+    tool = status_check.get("tool")
+    if not tool:
+        return False
+    return str(tool) in set(manifest.tools)
+
+
+def _availability_for(tools: tuple[str, ...], unavailable_tools: tuple[str, ...]) -> str:
+    if unavailable_tools and not tools:
+        return "unavailable"
+    if unavailable_tools:
+        return "partial"
+    return "available"
 
 
 def builtin_capability_manifests() -> list[CapabilityManifest]:
-    return [
-        CapabilityManifest(
-            key="slack",
-            name="Slack",
-            category="external_surface",
-            summary=(
-                "Illo can participate in Slack conversations when a Slack source "
-                "connection is registered for the workspace."
-            ),
-            aliases=("slack", "team chat", "chat teammate"),
-            affordances=(
-                "inspect connection health",
-                "map Slack users to Illospace users",
-                "read bounded Slack context for Slack-triggered runs",
-                "reply to the originating Slack conversation",
-            ),
-            tools=("manage_slack", "read_slack_conversation", "post_slack_reply"),
-            status_check={"tool": "manage_slack", "args": {"action": "status"}},
-            setup={
-                "mode": "guided_user_action",
-                "agent_role": "check_status_collect_credentials_and_answer_questions",
-                "credential_store": "Vault",
-                "credentials": [
-                    {
-                        "key_name": "SLACK_BOT_TOKEN",
-                        "description": "Slack bot token for the Illo app.",
-                    },
-                    {
-                        "key_name": "SLACK_APP_TOKEN",
-                        "description": "Slack app-level Socket Mode token for the Illo app.",
-                    },
-                ],
-            },
-        ),
-    ]
+    return []
 
 
 def _coerce_text(value: Any, default: str = "") -> str:
@@ -107,12 +150,14 @@ def _manifest_from_mapping(value: Mapping[str, Any], *, default_key: str | None 
         aliases=_coerce_text_tuple(value.get("aliases")),
         affordances=_coerce_text_tuple(value.get("affordances") or value.get("capabilities")),
         tools=_coerce_text_tuple(value.get("tools")),
+        unavailable_tools=_coerce_text_tuple(value.get("unavailable_tools")),
         tool_details=tuple(
             dict(item) for item in value.get("tool_details", ())
             if isinstance(item, Mapping)
         ) if isinstance(value.get("tool_details"), Iterable) else (),
         status_check=value.get("status_check") if isinstance(value.get("status_check"), Mapping) else None,
         setup=value.get("setup") if isinstance(value.get("setup"), Mapping) else {},
+        availability=_coerce_text(value.get("availability"), "available"),
         source=source,
     )
 
@@ -225,6 +270,30 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "tools": ("manage_inbound",),
     },
     {
+        "key": "slack",
+        "name": "Slack",
+        "category": "external_surface",
+        "summary": "Illo can participate in Slack conversations when a Slack source connection is registered for the workspace.",
+        "aliases": ("slack", "team chat", "chat teammate"),
+        "tools": ("manage_slack", "read_slack_conversation", "post_slack_reply"),
+        "status_check": {"tool": "manage_slack", "args": {"action": "status"}},
+        "setup": {
+            "mode": "guided_user_action",
+            "agent_role": "check_status_collect_credentials_and_answer_questions",
+            "credential_store": "Vault",
+            "credentials": [
+                {
+                    "key_name": "SLACK_BOT_TOKEN",
+                    "description": "Slack bot token for the Illo app.",
+                },
+                {
+                    "key_name": "SLACK_APP_TOKEN",
+                    "description": "Slack app-level Socket Mode token for the Illo app.",
+                },
+            ],
+        },
+    },
+    {
         "key": "code_execution",
         "name": "Code and File Execution",
         "category": "runtime_surface",
@@ -314,6 +383,50 @@ def _tool_affordance(registration: Any) -> str:
     return str(registration.description)
 
 
+def first_party_capability_tool_names() -> set[str]:
+    return {
+        str(tool_name)
+        for spec in _FIRST_PARTY_CAPABILITY_SPECS
+        for tool_name in spec.get("tools", ())
+    }
+
+
+def normalize_capability_manifests(
+    manifests: Iterable[CapabilityManifest],
+    *,
+    available_tool_names: Iterable[str] | None = None,
+    registered_tool_names: Iterable[str] | None = None,
+) -> list[CapabilityManifest]:
+    if available_tool_names is None:
+        return list(manifests)
+
+    available = {str(name) for name in available_tool_names}
+    registered = {str(name) for name in registered_tool_names or available}
+    normalized: list[CapabilityManifest] = []
+    for manifest in manifests:
+        tools: list[str] = []
+        unavailable = list(manifest.unavailable_tools)
+        for tool_name in manifest.tools:
+            if tool_name in registered and tool_name not in available:
+                unavailable.append(tool_name)
+            else:
+                tools.append(tool_name)
+        unavailable_tuple = tuple(dict.fromkeys(unavailable))
+        tools_tuple = tuple(tools)
+        availability = (
+            manifest.availability
+            if not unavailable_tuple and manifest.availability != "available"
+            else _availability_for(tools_tuple, unavailable_tuple)
+        )
+        normalized.append(replace(
+            manifest,
+            tools=tools_tuple,
+            unavailable_tools=unavailable_tuple,
+            availability=availability,
+        ))
+    return normalized
+
+
 def registry_capability_manifests(
     *,
     available_tool_names: Iterable[str] | None = None,
@@ -324,13 +437,15 @@ def registry_capability_manifests(
     available = {str(name) for name in available_tool_names} if available_tool_names is not None else set(registrations)
     manifests: list[CapabilityManifest] = []
     for spec in _FIRST_PARTY_CAPABILITY_SPECS:
-        tools = tuple(
+        registered_tools = tuple(
             name
             for name in spec["tools"]
-            if name in registrations and name in available
+            if name in registrations
         )
-        if not tools:
+        if not registered_tools:
             continue
+        tools = tuple(name for name in registered_tools if name in available)
+        unavailable_tools = tuple(name for name in registered_tools if name not in available)
         details = tuple(_tool_detail(name, registrations[name]) for name in tools)
         affordances = tuple(_tool_affordance(registrations[name]) for name in tools)
         manifests.append(CapabilityManifest(
@@ -341,8 +456,11 @@ def registry_capability_manifests(
             aliases=_coerce_text_tuple(spec.get("aliases")),
             affordances=affordances,
             tools=tools,
+            unavailable_tools=unavailable_tools,
             tool_details=details,
-            setup={"mode": "built_in"},
+            status_check=spec.get("status_check") if isinstance(spec.get("status_check"), Mapping) else None,
+            setup=spec.get("setup") if isinstance(spec.get("setup"), Mapping) else {"mode": "built_in"},
+            availability=_availability_for(tools, unavailable_tools),
             source="tool_registry",
         ))
     return manifests
@@ -443,10 +561,13 @@ def load_setup_guide(manifest: CapabilityManifest) -> dict[str, Any] | None:
 
 __all__ = [
     "CapabilityManifest",
+    "CAPABILITY_COVERAGE_EXEMPT_TOOLS",
     "builtin_capability_manifests",
     "custom_capability_manifests",
     "filter_capability_manifests",
+    "first_party_capability_tool_names",
     "load_setup_guide",
     "merge_capability_manifests",
+    "normalize_capability_manifests",
     "registry_capability_manifests",
 ]

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -22,6 +22,7 @@ class CapabilityManifest:
     aliases: tuple[str, ...] = ()
     affordances: tuple[str, ...] = ()
     tools: tuple[str, ...] = ()
+    tool_details: tuple[Mapping[str, Any], ...] = ()
     status_check: Mapping[str, Any] | None = None
     setup: Mapping[str, Any] = field(default_factory=dict)
     source: str = "builtin"
@@ -35,6 +36,7 @@ class CapabilityManifest:
             "aliases": list(self.aliases),
             "affordances": list(self.affordances),
             "tools": list(self.tools),
+            "tool_details": [dict(detail) for detail in self.tool_details],
             "status_check": dict(self.status_check or {}),
             "setup": dict(self.setup or {}),
             "source": self.source,
@@ -46,7 +48,7 @@ def builtin_capability_manifests() -> list[CapabilityManifest]:
         CapabilityManifest(
             key="slack",
             name="Slack",
-            category="communication",
+            category="external_surface",
             summary=(
                 "Illo can participate in Slack conversations when a Slack source "
                 "connection is registered for the workspace."
@@ -105,6 +107,10 @@ def _manifest_from_mapping(value: Mapping[str, Any], *, default_key: str | None 
         aliases=_coerce_text_tuple(value.get("aliases")),
         affordances=_coerce_text_tuple(value.get("affordances") or value.get("capabilities")),
         tools=_coerce_text_tuple(value.get("tools")),
+        tool_details=tuple(
+            dict(item) for item in value.get("tool_details", ())
+            if isinstance(item, Mapping)
+        ) if isinstance(value.get("tool_details"), Iterable) else (),
         status_check=value.get("status_check") if isinstance(value.get("status_check"), Mapping) else None,
         setup=value.get("setup") if isinstance(value.get("setup"), Mapping) else {},
         source=source,
@@ -137,6 +143,211 @@ def custom_capability_manifests(*containers: Mapping[str, Any] | None) -> list[C
     return manifests
 
 
+_FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "key": "workspace_context",
+        "name": "Workspace Context",
+        "category": "core_workspace",
+        "summary": "Illo can inspect current Illospace workspace context: roster, recent activity, projects, records, apps, cycles, and run provenance.",
+        "aliases": ("workspace", "team activity", "workspace overview", "what can you see"),
+        "tools": ("read_workspace_overview", "read_team_activity", "read_team_members", "query_workspace_data", "my_activity"),
+    },
+    {
+        "key": "threads",
+        "name": "Threads and Discussion",
+        "category": "core_workspace",
+        "summary": "Illo can work with Illospace Threads, AI Timeline messages, and Thread Discussion surfaces.",
+        "aliases": ("thread", "threads", "discussion", "ai timeline", "ideas"),
+        "tools": ("manage_idea", "read_thread_discussion", "post_thread_discussion_reply", "post_ai_timeline_message", "post_chat_message", "cortex_reply", "cortex_visual_reply"),
+    },
+    {
+        "key": "domains",
+        "name": "Domains",
+        "category": "core_workspace",
+        "summary": "Illo can inspect and mutate user-created structured workspace databases, schemas, records, and Domain audit events.",
+        "aliases": ("domain", "domains", "workspace records", "structured records", "team database"),
+        "tools": ("read_workspace_records", "manage_domain"),
+    },
+    {
+        "key": "cycles",
+        "name": "Cycles",
+        "category": "core_workspace",
+        "summary": "Illo can inspect and manage recurring workspace work such as scheduled prompts, check-ins, reports, and automation runs.",
+        "aliases": ("cycle", "cycles", "recurring work", "automations", "scheduled work"),
+        "tools": ("read_cycles", "manage_cycle"),
+    },
+    {
+        "key": "project_context",
+        "name": "Project Context",
+        "category": "core_workspace",
+        "summary": "Illo can inspect and manage durable project context profiles, connected resources, files, folders, repos, docs, and thread attachments.",
+        "aliases": ("project", "projects", "repos", "files", "docs", "connected repo", "project context"),
+        "tools": ("read_project_contexts", "manage_project"),
+    },
+    {
+        "key": "workspace_apps",
+        "name": "Workspace Apps",
+        "category": "core_workspace",
+        "summary": "Illo can inspect and manage generated workspace apps, dashboards, app metadata, and app-local state.",
+        "aliases": ("apps", "dashboards", "workspace apps", "generated apps"),
+        "tools": ("read_workspace_apps", "manage_workspace_app"),
+    },
+    {
+        "key": "vault",
+        "name": "Vault",
+        "category": "security",
+        "summary": "Illo can reason about Vault secret metadata, ask the user for missing credentials, and request task-scoped secret access without exposing raw values.",
+        "aliases": ("secrets", "credentials", "tokens", "vault"),
+        "tools": ("vault_inventory", "vault_secret_prompt", "brain_vault"),
+    },
+    {
+        "key": "skills",
+        "name": "Skills",
+        "category": "agent_runtime",
+        "summary": "Illo can inspect, load, create, update, archive, and package installed skills and skill assets.",
+        "aliases": ("skill", "skills", "procedures", "agent skills"),
+        "tools": ("brain_skills", "skill_view", "skill_asset", "manage_skill"),
+    },
+    {
+        "key": "memory",
+        "name": "Memory",
+        "category": "agent_runtime",
+        "summary": "Illo can search and write long-term semantic memories, lessons, facts, patterns, episodes, and guardrails.",
+        "aliases": ("memory", "memories", "remember", "lessons", "guardrails"),
+        "tools": ("brain_recall", "brain_encode", "brain_guardrails"),
+    },
+    {
+        "key": "inbound_coordination",
+        "name": "Inbound Coordination",
+        "category": "integration_foundation",
+        "summary": "Illo can inspect and manage inbound source connections, tokens, policies, replay, source cards, and Domain projections.",
+        "aliases": ("inbound", "sources", "webhooks", "mcp", "personal agents", "external agents"),
+        "tools": ("manage_inbound",),
+    },
+    {
+        "key": "code_execution",
+        "name": "Code and File Execution",
+        "category": "runtime_surface",
+        "summary": "Illo can inspect files and, when enabled for the run, write/edit files and execute shell, Python, or test commands in the available workspace.",
+        "aliases": ("code", "files", "scripts", "commands", "terminal", "tests", "repository"),
+        "tools": ("read_file", "search_files", "list_files", "write_file", "edit_file", "exec_command", "run_script", "test_runner", "project_context"),
+    },
+    {
+        "key": "web_research",
+        "name": "Web Research",
+        "category": "external_read",
+        "summary": "Illo can search and fetch external web content when web tools are available.",
+        "aliases": ("web", "internet", "search", "fetch", "research"),
+        "tools": ("web_search", "web_fetch"),
+    },
+    {
+        "key": "browser_automation",
+        "name": "Browser Automation",
+        "category": "runtime_surface",
+        "summary": "Illo can inspect and operate a live browser session when browser automation is exposed to the run.",
+        "aliases": ("browser", "ui automation", "web app testing"),
+        "tools": ("browser",),
+    },
+    {
+        "key": "worker_coordination",
+        "name": "Worker Coordination",
+        "category": "agent_runtime",
+        "summary": "Illo can spawn scoped worker runs for parallel or delegated investigation when the coordinator tool is available.",
+        "aliases": ("workers", "spawn worker", "parallel agents"),
+        "tools": ("spawn_worker",),
+    },
+    {
+        "key": "runtime_self_context",
+        "name": "Runtime and Self Context",
+        "category": "agent_runtime",
+        "summary": "Illo can inspect its runtime settings, capability registry, and verified source/install context.",
+        "aliases": ("runtime", "self context", "who are you", "where are you installed", "models"),
+        "tools": ("runtime_settings", "read_self_context", "read_capabilities"),
+    },
+    {
+        "key": "deployment",
+        "name": "Deployment",
+        "category": "operations",
+        "summary": "Illo can inspect or start the self-update deployment flow when the deployment management tool is available.",
+        "aliases": ("deploy", "deployment", "update", "self update"),
+        "tools": ("manage_deployment",),
+    },
+    {
+        "key": "voice",
+        "name": "Voice and Audio",
+        "category": "media",
+        "summary": "Illo can transcribe audio attachments when the voice runtime is configured.",
+        "aliases": ("voice", "audio", "transcription", "voice notes"),
+        "tools": ("transcribe_audio_attachment",),
+    },
+    {
+        "key": "agent_personality",
+        "name": "Agent Personality",
+        "category": "agent_runtime",
+        "summary": "Illo can inspect or update its private SOUL.md personality file when that management surface is exposed.",
+        "aliases": ("soul", "personality", "agent behavior"),
+        "tools": ("manage_soul",),
+    },
+)
+
+
+def _tool_detail(name: str, registration: Any) -> dict[str, Any]:
+    route = registration.context_route
+    return {
+        "name": name,
+        "toolset": registration.toolset,
+        "availability": [role.value for role in registration.availability],
+        "permission": registration.permission.value,
+        "risk_class": registration.risk_class.value,
+        "side_effect_class": registration.side_effect_class.value,
+        "reversibility": registration.reversibility.value,
+        "expected_effect": registration.expected_effect,
+        "context_domains": list(route.domains) if route is not None else [],
+    }
+
+
+def _tool_affordance(registration: Any) -> str:
+    if registration.expected_effect:
+        return str(registration.expected_effect)
+    if registration.context_route is not None:
+        return str(registration.context_route.description)
+    return str(registration.description)
+
+
+def registry_capability_manifests(
+    *,
+    available_tool_names: Iterable[str] | None = None,
+) -> list[CapabilityManifest]:
+    from brain.systems.runs.tool_catalog.registry import all_tool_registrations
+
+    registrations = all_tool_registrations()
+    available = {str(name) for name in available_tool_names} if available_tool_names is not None else set(registrations)
+    manifests: list[CapabilityManifest] = []
+    for spec in _FIRST_PARTY_CAPABILITY_SPECS:
+        tools = tuple(
+            name
+            for name in spec["tools"]
+            if name in registrations and name in available
+        )
+        if not tools:
+            continue
+        details = tuple(_tool_detail(name, registrations[name]) for name in tools)
+        affordances = tuple(_tool_affordance(registrations[name]) for name in tools)
+        manifests.append(CapabilityManifest(
+            key=str(spec["key"]),
+            name=str(spec["name"]),
+            category=str(spec["category"]),
+            summary=str(spec["summary"]),
+            aliases=_coerce_text_tuple(spec.get("aliases")),
+            affordances=affordances,
+            tools=tools,
+            tool_details=details,
+            setup={"mode": "built_in"},
+            source="tool_registry",
+        ))
+    return manifests
+
+
 def merge_capability_manifests(manifests: Iterable[CapabilityManifest]) -> list[CapabilityManifest]:
     merged: dict[str, CapabilityManifest] = {}
     for manifest in manifests:
@@ -153,6 +364,7 @@ def _matches_query(manifest: CapabilityManifest, query: str) -> bool:
         " ".join(manifest.aliases),
         " ".join(manifest.affordances),
         " ".join(manifest.tools),
+        " ".join(str(detail.get("expected_effect") or "") for detail in manifest.tool_details),
     )).lower()
     stopwords = {
         "a", "about", "add", "agent", "an", "app", "apps", "can",
@@ -236,4 +448,5 @@ __all__ = [
     "filter_capability_manifests",
     "load_setup_guide",
     "merge_capability_manifests",
+    "registry_capability_manifests",
 ]

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1357,6 +1357,10 @@ async def run_agent_async(
     _previous_agent_session_id = getattr(_agent_context, "session_id", _session_sentinel)
     context_attrs = {
         "session_id": session_id,
+        "start_time": start_time,
+        "reply_contents": [],
+        "tool_calls_log": [],
+        "recent_tool_results": [],
         "final_reply_review": None,
     }
     if workspace_root:

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import json
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -27,6 +28,46 @@ from brain.systems.sessions import _content_to_dicts
 logger = logging.getLogger("agent")
 
 _RESOLVED_STATUSES = {"resolved", "blocked_on_user"}
+_PRODUCT_SURFACE_EVIDENCE_MARKERS = (
+    "recent tool result",
+    "artifact",
+    "worker",
+    "evidence",
+    "source",
+    "runtime",
+)
+_PRODUCT_SURFACE_TERMS = (
+    "settings",
+    "integrations",
+    "oauth",
+    "setup screen",
+    "setup path",
+    "setup ui",
+    "admin screen",
+    "admin/integration screen",
+    "illospace admin",
+    "workspace admin",
+    "admin approval",
+    "deployment/admin",
+    "deployment",
+    "self-serve ui",
+)
+_PRODUCT_SURFACE_UNCERTAINTY = (
+    "i don't have a confirmed",
+    "i do not have a confirmed",
+    "i don't see a confirmed",
+    "i do not see a confirmed",
+    "i shouldn't invent",
+    "i should not invent",
+    "not confirmed",
+    "was not confirmed",
+    "i didn't read",
+    "i did not read",
+)
+_PRODUCT_SURFACE_NAV_RE = re.compile(
+    r"\b(open|go to|navigate to|click|choose|approve|redirect|select|configure)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -138,6 +179,62 @@ def _review_scope(
     }
 
 
+def _normalize_grounding_text(text: str | None) -> str:
+    normalized = str(text or "").lower()
+    normalized = normalized.replace("→", "->")
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized
+
+
+def _supported_by_execution_evidence(candidate: str, execution_context: str | None) -> bool:
+    evidence = _normalize_grounding_text(execution_context)
+    if not evidence:
+        return False
+    if not any(marker in evidence for marker in _PRODUCT_SURFACE_EVIDENCE_MARKERS):
+        return False
+    mentioned_terms = [term for term in _PRODUCT_SURFACE_TERMS if term in candidate]
+    if not mentioned_terms:
+        return False
+    return all(term in evidence for term in mentioned_terms)
+
+
+def _ungrounded_product_surface_issue(
+    candidate_output: str,
+    execution_context: str | None,
+) -> str | None:
+    """Detect invented product UI/setup surfaces before the LLM checker can bless them."""
+
+    candidate = _normalize_grounding_text(candidate_output)
+    if "illospace" not in candidate:
+        return None
+
+    has_route_chain = "->" in candidate
+    has_product_terms = any(term in candidate for term in _PRODUCT_SURFACE_TERMS)
+    has_navigation_step = bool(_PRODUCT_SURFACE_NAV_RE.search(candidate))
+    explicitly_uncertain = any(marker in candidate for marker in _PRODUCT_SURFACE_UNCERTAINTY)
+    asserts_surface = (
+        (has_route_chain and has_product_terms)
+        or (has_navigation_step and has_product_terms)
+        or "illospace admin" in candidate
+        or "workspace admin" in candidate
+        or "admin approval" in candidate
+        or "deployment/admin" in candidate
+        or "admin/integration screen" in candidate
+    )
+    if not asserts_surface:
+        return None
+    if explicitly_uncertain and not has_navigation_step and not any(
+        marker in candidate for marker in ("deployment/admin", "admin/integration screen")
+    ):
+        return None
+    if _supported_by_execution_evidence(candidate, execution_context):
+        return None
+    return (
+        "The candidate asserts an Illospace UI/setup/deployment surface that is not present "
+        "in this run's execution evidence."
+    )
+
+
 def _token_resolution_verdict(
     provider,
     llm,
@@ -211,6 +308,18 @@ def review_candidate_final_reply(
 ) -> dict:
     """Run the final-reply checker and return a dict-compatible review payload."""
 
+    grounding_issue = _ungrounded_product_surface_issue(candidate_output, execution_context)
+    if grounding_issue:
+        return FinalReplyReview(
+            status="continue",
+            approved=False,
+            rationale=grounding_issue,
+            missing_requirements=(
+                "Answer only with setup/product surfaces supported by current tool results or source context.",
+            ),
+            raw_output="deterministic_product_surface_grounding",
+        ).to_dict()
+
     checker_model = normalize_model(model) if model else None
     checker_llm = llm
     checker_provider = provider
@@ -248,7 +357,9 @@ def review_candidate_final_reply(
             "For light quick-answer intents, do not demand extra work when the answer directly satisfies the question. "
             "For analysis intents, caveats are acceptable when the requested analysis or judgment is delivered. "
             "For strict_contract intents, reject partial progress, first-slice completions, unsupported side-effect claims, "
-            "or 'there may be more' endings unless a concrete blocker makes further work impossible."
+            "or 'there may be more' endings unless a concrete blocker makes further work impossible. "
+            "Reject candidate replies that invent Illospace UI screens, settings paths, setup flows, admin roles, "
+            "deployment paths, or external OAuth flows not present in execution evidence."
         ),
     }]
     message_parts = [

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -17,6 +17,9 @@ logger = logging.getLogger("agent")
 _DEFAULT_TOOL_TIMEOUT_SECONDS = 180.0
 _DEFAULT_TOOL_TIMEOUT_GRACE_SECONDS = 5.0
 _DEFAULT_TOOL_TIMEOUT_MAX_SECONDS = 900.0
+_RECENT_TOOL_RESULT_LIMIT = 8
+_RECENT_TOOL_RESULT_PREVIEW_CHARS = 1200
+_RECENT_TOOL_ARGS_PREVIEW_CHARS = 400
 
 
 @dataclass(frozen=True)
@@ -134,6 +137,38 @@ def _extract_model_visible_tool_content(result: Any) -> tuple[Any, Any | None]:
     cleaned = dict(result)
     model_content = cleaned.pop("_tool_result_content", None)
     return cleaned, model_content
+
+
+def _record_agent_tool_result(agent_context, resolved: ResolvedToolCall, result_text: str) -> None:
+    if agent_context is None:
+        return
+    try:
+        tool_log = getattr(agent_context, "tool_calls_log", None)
+        if not isinstance(tool_log, list):
+            tool_log = []
+        tool_log.append(resolved.tool_name)
+        setattr(agent_context, "tool_calls_log", tool_log)
+
+        try:
+            args_preview = json.dumps(resolved.tool_input, sort_keys=True, default=str)
+        except Exception:
+            args_preview = str(resolved.tool_input)
+
+        recent = getattr(agent_context, "recent_tool_results", None)
+        if not isinstance(recent, list):
+            recent = []
+        recent.append({
+            "tool_name": resolved.tool_name,
+            "args_preview": _truncate_middle_text(args_preview, _RECENT_TOOL_ARGS_PREVIEW_CHARS),
+            "is_error": bool(resolved.is_error),
+            "result_preview": _truncate_middle_text(
+                str(result_text or ""),
+                _RECENT_TOOL_RESULT_PREVIEW_CHARS,
+            ),
+        })
+        setattr(agent_context, "recent_tool_results", recent[-_RECENT_TOOL_RESULT_LIMIT:])
+    except Exception:
+        logger.debug("Failed to record recent tool result for final-reply context", exc_info=True)
 
 
 def _run_sync_boundary(awaitable: Any, *, name: str) -> Any:
@@ -369,6 +404,8 @@ def emit_resolved_tool_call(
     run_id,
     idea_id,
     tool_call_source: str,
+    *,
+    agent_context=None,
 ) -> str:
     """Append tool_result content and record side effects in block order."""
     tool_results.append({
@@ -380,6 +417,7 @@ def emit_resolved_tool_call(
     callback_result_text = resolved.result_text
     if resolved.tool_name == "brain_vault":
         callback_result_text = "[secret redacted]"
+    _record_agent_tool_result(agent_context, resolved, callback_result_text)
     if on_tool_call:
         on_tool_call(resolved.tool_name, resolved.tool_input, callback_result_text)
     return callback_result_text
@@ -392,6 +430,8 @@ async def async_emit_resolved_tool_call(
     run_id,
     idea_id,
     tool_call_source: str,
+    *,
+    agent_context=None,
 ) -> None:
     """Append a tool result and persist its trace through the async event log."""
     callback_result_text = emit_resolved_tool_call(
@@ -401,6 +441,7 @@ async def async_emit_resolved_tool_call(
         None,
         None,
         tool_call_source,
+        agent_context=agent_context,
     )
     if run_id and idea_id:
         from brain.systems.runs.events import async_record_tool_call
@@ -443,6 +484,7 @@ def execute_parallel_tool_batch(
             run_id,
             idea_id,
             tool_call_source,
+            agent_context=agent_context,
         )
 
 
@@ -475,6 +517,7 @@ async def async_execute_parallel_tool_batch(
                 run_id,
                 idea_id,
                 tool_call_source,
+                agent_context=agent_context,
             )
         return
 
@@ -513,6 +556,7 @@ async def async_execute_parallel_tool_batch(
                     run_id,
                     idea_id,
                     tool_call_source,
+                    agent_context=agent_context,
                 )
         finally:
             for _, task in tasks:
@@ -646,6 +690,7 @@ def execute_tool_calls(
             run_id,
             idea_id,
             tool_call_source,
+            agent_context=agent_context,
         )
 
     flush_parallel_batch()
@@ -763,6 +808,7 @@ async def async_execute_tool_calls(
             run_id,
             idea_id,
             tool_call_source,
+            agent_context=agent_context,
         )
 
     await flush_parallel_batch()

--- a/brain/systems/runs/execution_context.py
+++ b/brain/systems/runs/execution_context.py
@@ -66,6 +66,7 @@ class AgentExecutionContext:
     start_time: float | None = None
     reply_contents: list[str] = field(default_factory=list)
     tool_calls_log: list[str] = field(default_factory=list)
+    recent_tool_results: list[dict] = field(default_factory=list)
     execution_artifacts: list[dict] = field(default_factory=list)
     execution_metadata: dict | None = None
     intent_satisfaction: dict | None = None

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import re
 
-from brain.systems.runs.capabilities import builtin_capability_manifests, custom_capability_manifests
+from brain.systems.runs.capabilities import (
+    builtin_capability_manifests,
+    custom_capability_manifests,
+    registry_capability_manifests,
+)
 from brain.systems.runs.execution_context import _agent_context
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
@@ -32,16 +36,19 @@ _WORKSPACE_ACTIVITY_PHRASES = (
 _WORKSPACE_OVERVIEW_PHRASES = (
     "finish setting up this workspace",
     "help me understand this workspace",
-    "help me understand what you can do to help me",
     "help me finish setting up this workspace",
     "introduce yourself",
-    "what can you do to help me",
     "what can you see",
     "what do you know about this workspace",
     "what you should know about the team",
     "what is this workspace",
     "workspace overview",
     "workspace setup",
+)
+_SELF_CONTEXT_PATTERNS = (
+    re.compile(r"\b(?:who are you|what is illo|what is illospace|what are you)\b"),
+    re.compile(r"\bwhere\b[^?]{0,100}\b(?:installed|running|hosted|source|code|repo|repository)\b"),
+    re.compile(r"\b(?:open[- ]source repo|github repo|source code|your code|own code|inspect yourself)\b"),
 )
 _PROJECT_CONTEXT_PHRASES = (
     "connected repo",
@@ -70,6 +77,10 @@ _CAPABILITY_SETUP_PATTERNS = (
         r"[^?]{0,100}\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
     ),
     re.compile(r"\b(?:what|which)\b[^?]{0,80}\b(?:capabilities|integrations|connectors|plugins|tools)\b"),
+    re.compile(r"\b(?:what|which)\b[^?]{0,80}\b(?:can|could)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:do|help)\b"),
+    re.compile(r"\b(?:what|which)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:do|help)\b"),
+    re.compile(r"\bhelp\b[^?]{0,80}\b(?:what|which)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:do|help)\b"),
+    re.compile(r"\bhelp\b[^?]{0,80}\b(?:what|which)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:do|help)\b"),
 )
 _CAPABILITY_CONTEXT_PATTERN_COUNT = 3
 
@@ -95,9 +106,16 @@ def _looks_like_capability_setup_question(message: str | None) -> bool:
     context_patterns = _CAPABILITY_SETUP_PATTERNS[1:_CAPABILITY_CONTEXT_PATTERN_COUNT]
     if any(pattern.search(text) for pattern in context_patterns):
         return True
-    if _CAPABILITY_SETUP_PATTERNS[-1].search(text):
+    if any(pattern.search(text) for pattern in _CAPABILITY_SETUP_PATTERNS[_CAPABILITY_CONTEXT_PATTERN_COUNT:]):
         return True
     return setup_verb and _mentions_known_capability(text)
+
+
+def _looks_like_self_context_question(message: str | None) -> bool:
+    text = _normalized_text(message)
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in _SELF_CONTEXT_PATTERNS)
 
 
 def _agent_context_containers() -> list[dict]:
@@ -118,6 +136,7 @@ def _agent_context_containers() -> list[dict]:
 
 def _known_capability_terms() -> tuple[str, ...]:
     manifests = [
+        *registry_capability_manifests(),
         *builtin_capability_manifests(),
         *custom_capability_manifests(*_agent_context_containers()),
     ]
@@ -158,6 +177,16 @@ def required_introspection_tool(
     if registration and registration.context_route is not None:
         route = registration.context_route
         return tool, f"This question requires {tool}. {route.description}"
+    if _looks_like_self_context_question(message):
+        tool = "read_self_context"
+        registration = get_tool_registration(tool)
+        if registration and registration.context_route is not None:
+            route = registration.context_route
+            return (
+                tool,
+                f"This question asks for Illo's verified identity/source/runtime context. Use {tool} "
+                f"before answering from memory. {route.description}",
+            )
     if _looks_like_capability_setup_question(message):
         tool = "read_capabilities"
         registration = get_tool_registration(tool)

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import re
 
+from brain.systems.runs.capabilities import builtin_capability_manifests, custom_capability_manifests
+from brain.systems.runs.execution_context import _agent_context
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 _PERSON_ACTIVITY_PATTERNS = (
@@ -55,6 +57,21 @@ _WORKSPACE_RECORD_PHRASES = (
     "team database",
     "workspace records",
 )
+_CAPABILITY_SETUP_PATTERNS = (
+    re.compile(
+        r"\b(?:set\s+(?:you|illo|it|this|that|me|us|them)\s+up|set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+    ),
+    re.compile(
+        r"\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+        r"[^?]{0,100}\b(?:you|illo|agent|integration|connector|capability|tool|plugin|app|mcp)\b"
+    ),
+    re.compile(
+        r"\b(?:you|illo|agent|integration|connector|capability|tool|plugin|app|mcp)\b"
+        r"[^?]{0,100}\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+    ),
+    re.compile(r"\b(?:what|which)\b[^?]{0,80}\b(?:capabilities|integrations|connectors|plugins|tools)\b"),
+)
+_CAPABILITY_CONTEXT_PATTERN_COUNT = 3
 
 
 def _normalized_text(message: str | None) -> str:
@@ -68,6 +85,54 @@ def _looks_like_workspace_activity_question(message: str | None) -> bool:
     if any(pattern.search(text) for pattern in _PERSON_ACTIVITY_PATTERNS):
         return True
     return any(phrase in text for phrase in _WORKSPACE_ACTIVITY_PHRASES)
+
+
+def _looks_like_capability_setup_question(message: str | None) -> bool:
+    text = _normalized_text(message)
+    if not text:
+        return False
+    setup_verb = bool(_CAPABILITY_SETUP_PATTERNS[0].search(text))
+    context_patterns = _CAPABILITY_SETUP_PATTERNS[1:_CAPABILITY_CONTEXT_PATTERN_COUNT]
+    if any(pattern.search(text) for pattern in context_patterns):
+        return True
+    if _CAPABILITY_SETUP_PATTERNS[-1].search(text):
+        return True
+    return setup_verb and _mentions_known_capability(text)
+
+
+def _agent_context_containers() -> list[dict]:
+    containers: list[dict] = []
+    for attr in ("target_ref", "workspace_ref"):
+        value = getattr(_agent_context, attr, None)
+        if isinstance(value, dict):
+            containers.append(value)
+    metadata = getattr(_agent_context, "execution_metadata", None)
+    if isinstance(metadata, dict):
+        containers.append(metadata)
+        for key in ("target_ref", "workspace_ref"):
+            value = metadata.get(key)
+            if isinstance(value, dict):
+                containers.append(value)
+    return containers
+
+
+def _known_capability_terms() -> tuple[str, ...]:
+    manifests = [
+        *builtin_capability_manifests(),
+        *custom_capability_manifests(*_agent_context_containers()),
+    ]
+    terms: set[str] = set()
+    for manifest in manifests:
+        terms.update((manifest.key.lower(), manifest.name.lower()))
+        terms.update(alias.lower() for alias in manifest.aliases)
+    return tuple(sorted(term for term in terms if len(term) >= 2))
+
+
+def _mentions_known_capability(text: str) -> bool:
+    return any(
+        re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text)
+        for term in _known_capability_terms()
+    )
 
 
 def _looks_like_any_phrase(message: str | None, phrases: tuple[str, ...]) -> bool:
@@ -93,6 +158,16 @@ def required_introspection_tool(
     if registration and registration.context_route is not None:
         route = registration.context_route
         return tool, f"This question requires {tool}. {route.description}"
+    if _looks_like_capability_setup_question(message):
+        tool = "read_capabilities"
+        registration = get_tool_registration(tool)
+        if registration and registration.context_route is not None:
+            route = registration.context_route
+            return (
+                tool,
+                f"This question asks for Illo's current capability/setup context. Use {tool} "
+                f"before answering from memory. {route.description}",
+            )
     if _looks_like_any_phrase(message, _WORKSPACE_OVERVIEW_PHRASES):
         tool = "read_workspace_overview"
         registration = get_tool_registration(tool)

--- a/brain/systems/runs/tool_catalog/handlers/capabilities.py
+++ b/brain/systems/runs/tool_catalog/handlers/capabilities.py
@@ -1,0 +1,76 @@
+"""Capability discovery handlers for Illo's runtime self model."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from brain.systems.runs.capabilities import (
+    builtin_capability_manifests,
+    custom_capability_manifests,
+    filter_capability_manifests,
+    load_setup_guide,
+    merge_capability_manifests,
+)
+from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+
+
+def _context_containers() -> list[dict[str, Any]]:
+    containers: list[dict[str, Any]] = []
+    for attr in ("target_ref", "workspace_ref"):
+        value = getattr(_agent_context, attr, None)
+        if isinstance(value, dict):
+            containers.append(value)
+    metadata = getattr(_agent_context, "execution_metadata", None)
+    if isinstance(metadata, dict):
+        containers.append(metadata)
+        for key in ("target_ref", "workspace_ref"):
+            value = metadata.get(key)
+            if isinstance(value, dict):
+                containers.append(value)
+    return containers
+
+
+def _handle_read_capabilities(
+    query: str | None = None,
+    capability_key: str | None = None,
+    category: str | None = None,
+    include_setup_guide: bool = False,
+) -> str:
+    """Read machine-readable capability manifests available in this run."""
+
+    manifests = merge_capability_manifests([
+        *builtin_capability_manifests(),
+        *custom_capability_manifests(*_context_containers()),
+    ])
+    matches = filter_capability_manifests(
+        manifests,
+        query=query,
+        capability_key=capability_key,
+        category=category,
+    )
+    payload: dict[str, Any] = {
+        "ok": True,
+        "source": "runtime_capability_registry",
+        "query": query,
+        "capability_key": capability_key,
+        "category": category,
+        "count": len(matches),
+        "capabilities": [manifest.to_payload() for manifest in matches],
+        "answering_guidance": [
+            "Use capability manifests and tool schemas as the authority for what Illo can inspect, do, or guide.",
+            "For setup requests, match the capability, inspect its status_check tool when present, then use its setup guide when available.",
+            "For custom capabilities, rely on the provided manifest fields instead of general model assumptions.",
+        ],
+    }
+    if include_setup_guide:
+        guide_targets = matches if capability_key or len(matches) == 1 else []
+        payload["setup_guides"] = [
+            guide
+            for guide in (load_setup_guide(manifest) for manifest in guide_targets)
+            if guide is not None
+        ]
+    return json.dumps(payload, default=str)
+
+
+__all__ = ["_handle_read_capabilities"]

--- a/brain/systems/runs/tool_catalog/handlers/capabilities.py
+++ b/brain/systems/runs/tool_catalog/handlers/capabilities.py
@@ -11,6 +11,7 @@ from brain.systems.runs.capabilities import (
     filter_capability_manifests,
     load_setup_guide,
     merge_capability_manifests,
+    normalize_capability_manifests,
     registry_capability_manifests,
 )
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
@@ -43,18 +44,48 @@ def _available_registry_tool_names() -> set[str] | None:
     return set(all_tool_registrations()) - disabled
 
 
+def _registered_registry_tool_names() -> set[str]:
+    from brain.systems.runs.tool_catalog.registry import all_tool_registrations
+
+    return set(all_tool_registrations())
+
+
+def _resolved_detail_level(
+    requested: str | None,
+    *,
+    matches: list,
+    capability_key: str | None,
+    include_setup_guide: bool,
+) -> str:
+    detail = str(requested or "auto").strip().lower()
+    if detail in {"summary", "tools", "full"}:
+        return detail
+    if capability_key or include_setup_guide or len(matches) == 1:
+        return "full"
+    return "summary"
+
+
 def _handle_read_capabilities(
     query: str | None = None,
     capability_key: str | None = None,
     category: str | None = None,
     include_setup_guide: bool = False,
+    detail_level: str | None = "auto",
 ) -> str:
     """Read machine-readable capability manifests available in this run."""
 
+    available_tools = _available_registry_tool_names()
+    registered_tools = _registered_registry_tool_names()
     manifests = merge_capability_manifests([
-        *registry_capability_manifests(available_tool_names=_available_registry_tool_names()),
-        *builtin_capability_manifests(),
-        *custom_capability_manifests(*_context_containers()),
+        *registry_capability_manifests(available_tool_names=available_tools),
+        *normalize_capability_manifests(
+            [
+                *builtin_capability_manifests(),
+                *custom_capability_manifests(*_context_containers()),
+            ],
+            available_tool_names=available_tools,
+            registered_tool_names=registered_tools,
+        ),
     ])
     matches = filter_capability_manifests(
         manifests,
@@ -62,17 +93,27 @@ def _handle_read_capabilities(
         capability_key=capability_key,
         category=category,
     )
+    resolved_detail = _resolved_detail_level(
+        detail_level,
+        matches=matches,
+        capability_key=capability_key,
+        include_setup_guide=include_setup_guide,
+    )
     payload: dict[str, Any] = {
         "ok": True,
         "source": "runtime_capability_registry",
         "query": query,
         "capability_key": capability_key,
         "category": category,
+        "detail_level": resolved_detail,
         "count": len(matches),
-        "capabilities": [manifest.to_payload() for manifest in matches],
+        "capabilities": [
+            manifest.to_payload(detail_level=resolved_detail)
+            for manifest in matches
+        ],
         "answering_guidance": [
             "Use capability manifests and tool schemas as the authority for what Illo can inspect, do, or guide.",
-            "For setup requests, match the capability, inspect its status_check tool when present, then use its setup guide when available.",
+            "Use summary results as a capability index; request a single capability or detail_level=full before relying on exact tools or setup fields.",
             "For custom capabilities, rely on the provided manifest fields instead of general model assumptions.",
         ],
     }

--- a/brain/systems/runs/tool_catalog/handlers/capabilities.py
+++ b/brain/systems/runs/tool_catalog/handlers/capabilities.py
@@ -11,7 +11,9 @@ from brain.systems.runs.capabilities import (
     filter_capability_manifests,
     load_setup_guide,
     merge_capability_manifests,
+    registry_capability_manifests,
 )
+from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 
 
@@ -31,6 +33,16 @@ def _context_containers() -> list[dict[str, Any]]:
     return containers
 
 
+def _available_registry_tool_names() -> set[str] | None:
+    metadata = getattr(_agent_context, "execution_metadata", None)
+    disabled = disabled_tool_names_from_metadata(metadata)
+    if not disabled:
+        return None
+    from brain.systems.runs.tool_catalog.registry import all_tool_registrations
+
+    return set(all_tool_registrations()) - disabled
+
+
 def _handle_read_capabilities(
     query: str | None = None,
     capability_key: str | None = None,
@@ -40,6 +52,7 @@ def _handle_read_capabilities(
     """Read machine-readable capability manifests available in this run."""
 
     manifests = merge_capability_manifests([
+        *registry_capability_manifests(available_tool_names=_available_registry_tool_names()),
         *builtin_capability_manifests(),
         *custom_capability_manifests(*_context_containers()),
     ])

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -61,6 +61,7 @@ from brain.systems.runs.tool_catalog.handlers.session_tools import (
     _handle_session_read,
     _handle_session_write,
 )
+from brain.systems.runs.tool_catalog.handlers.self_context import _handle_read_self_context
 from brain.systems.runs.tool_catalog.handlers.slack import (
     _handle_manage_slack,
     _handle_post_slack_reply,
@@ -211,6 +212,7 @@ def _get_tool_handlers(
             user_id=getattr(_agent_context, "user_id", None),
             org_id=getattr(_agent_context, "org_id", None),
         ),
+        "read_self_context": _handle_read_self_context,
         "read_capabilities": _handle_read_capabilities,
         "manage_deployment": _manage_deployment,
         "transcribe_audio_attachment": lambda **kw: _patched_private(

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -25,6 +25,7 @@ from brain.systems.runs.tool_catalog.handlers.browser import (
     _handle_browser_upload_attachment,
     _handle_browser_wait,
 )
+from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
 from brain.systems.runs.tool_catalog.handlers.cortex_reply import (
     _build_final_reply_check_context,
     _handle_cortex_reply,
@@ -210,6 +211,7 @@ def _get_tool_handlers(
             user_id=getattr(_agent_context, "user_id", None),
             org_id=getattr(_agent_context, "org_id", None),
         ),
+        "read_capabilities": _handle_read_capabilities,
         "manage_deployment": _manage_deployment,
         "transcribe_audio_attachment": lambda **kw: _patched_private(
             "_handle_transcribe_audio_attachment",

--- a/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
+++ b/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
@@ -97,6 +97,25 @@ def _build_final_reply_check_context() -> str:
             compact = str(artifact)
         lines.append(f"Artifact {idx}: {compact[:350]}")
 
+    recent_tool_results = list(getattr(_agent_context, "recent_tool_results", []) or [])
+    for idx, tool_result in enumerate(recent_tool_results[-5:], 1):
+        if not isinstance(tool_result, dict):
+            continue
+        try:
+            compact = json.dumps(
+                {
+                    "tool_name": tool_result.get("tool_name"),
+                    "args_preview": tool_result.get("args_preview"),
+                    "is_error": tool_result.get("is_error"),
+                    "result_preview": tool_result.get("result_preview"),
+                },
+                default=str,
+                sort_keys=True,
+            )
+        except Exception:
+            compact = str(tool_result)
+        lines.append(f"Recent tool result {idx}: {compact[:650]}")
+
     return "\n".join(lines)[:2500]
 
 

--- a/brain/systems/runs/tool_catalog/handlers/self_context.py
+++ b/brain/systems/runs/tool_catalog/handlers/self_context.py
@@ -1,0 +1,179 @@
+"""Runtime self-context handler for Illo's source and identity grounding."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tomllib
+from typing import Any
+
+from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+from brain.systems.runs.tool_catalog.registry import all_tool_registrations
+from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_OPEN_SOURCE_REPO_URL = "https://github.com/Illospace/illospace"
+_SOURCE_INSPECTION_TOOLS = (
+    "read_file",
+    "search_files",
+    "list_files",
+    "project_context",
+    "exec_command",
+    "run_script",
+)
+
+
+def _safe_git(*args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _project_version() -> str | None:
+    pyproject = _REPO_ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return None
+    version = project.get("version")
+    return str(version) if version else None
+
+
+def _path_payload(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "exists": path.exists(),
+        "is_dir": path.is_dir(),
+        "is_file": path.is_file(),
+    }
+
+
+def _docs_payload() -> list[dict[str, Any]]:
+    docs = (
+        "README.md",
+        "docs/server-setup.md",
+        "docs/deployment.md",
+        "docs/configuration.md",
+        "docs/security-model.md",
+        "docs/prd-universal-thread-context-ingress.md",
+        "docs/prd-slack-teammate-ingress.md",
+    )
+    return [
+        {
+            "path": item,
+            "exists": (_REPO_ROOT / item).exists(),
+        }
+        for item in docs
+    ]
+
+
+def _disabled_tools() -> set[str]:
+    metadata = getattr(_agent_context, "execution_metadata", None)
+    return disabled_tool_names_from_metadata(metadata)
+
+
+def _source_inspection_payload() -> dict[str, Any]:
+    registrations = all_tool_registrations()
+    disabled = _disabled_tools()
+    tools: dict[str, dict[str, Any]] = {}
+    for name in _SOURCE_INSPECTION_TOOLS:
+        registration = registrations.get(name)
+        tools[name] = {
+            "registered": registration is not None,
+            "available_after_policy": registration is not None and name not in disabled,
+            "permission": registration.permission.value if registration is not None else None,
+            "side_effect_class": registration.side_effect_class.value if registration is not None else None,
+        }
+    can_read_source = bool(
+        tools.get("read_file", {}).get("available_after_policy")
+        and tools.get("search_files", {}).get("available_after_policy")
+    )
+    return {
+        "can_read_source": can_read_source,
+        "tools": tools,
+        "disabled_by_policy": sorted(disabled & set(_SOURCE_INSPECTION_TOOLS)),
+    }
+
+
+def _runtime_scope_payload() -> dict[str, Any]:
+    execution_metadata = getattr(_agent_context, "execution_metadata", None)
+    metadata = execution_metadata if isinstance(execution_metadata, dict) else {}
+    return {
+        "workspace_bound": bool(getattr(_agent_context, "org_id", None) or metadata.get("org_id")),
+        "user_bound": bool(getattr(_agent_context, "user_id", None) or metadata.get("user_id")),
+        "thread_bound": bool(getattr(_agent_context, "idea_id", None) or metadata.get("idea_id")),
+        "has_target_ref": isinstance(getattr(_agent_context, "target_ref", None), dict)
+        or isinstance(metadata.get("target_ref"), dict),
+        "has_workspace_ref": isinstance(getattr(_agent_context, "workspace_ref", None), dict)
+        or isinstance(metadata.get("workspace_ref"), dict),
+    }
+
+
+def _handle_read_self_context(
+    include_paths: bool = True,
+    include_git: bool = True,
+) -> str:
+    """Read verified identity, source, and runtime context for this Illo run."""
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "source": "runtime_self_context",
+        "identity": {
+            "agent_name": "Illo",
+            "workspace_product": "Illospace",
+            "relationship": "Illo is the agent that operates inside an Illospace workspace.",
+        },
+        "open_source": {
+            "repository_url": _OPEN_SOURCE_REPO_URL,
+            "repository_url_source": "static product identity",
+        },
+        "runtime_scope": _runtime_scope_payload(),
+        "source_inspection": _source_inspection_payload(),
+        "project_version": _project_version(),
+        "answering_guidance": [
+            "Use read_self_context for Illo/Illospace identity, source-root, install, and source-inspection facts.",
+            "Use read_capabilities for what Illo can inspect, do, guide, or set up in the current run.",
+            "When source_inspection.can_read_source is true, inspect local docs or code before claiming Illospace-specific setup paths.",
+        ],
+    }
+    if include_paths:
+        env_project_root = os.environ.get("ILLO_PROJECT_ROOT")
+        payload["installation"] = {
+            "source_root": _path_payload(_REPO_ROOT),
+            "current_working_directory": _path_payload(Path.cwd()),
+            "env_project_root": _path_payload(Path(env_project_root)) if env_project_root else None,
+            "source_roots": [
+                _path_payload(_REPO_ROOT / item)
+                for item in ("brain", "docs", "deploy", "frontend")
+            ],
+            "docs": _docs_payload(),
+        }
+    if include_git:
+        payload["git"] = {
+            "commit": _safe_git("rev-parse", "HEAD"),
+            "short_commit": _safe_git("rev-parse", "--short", "HEAD"),
+            "branch": _safe_git("branch", "--show-current"),
+            "remote_origin_url": _safe_git("config", "--get", "remote.origin.url"),
+        }
+    return json.dumps(payload, default=str)
+
+
+__all__ = ["_handle_read_self_context"]

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -116,6 +116,16 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
             "scopes": ["narrow"],
         },
     },
+    "read_capabilities": {
+        "permission": "read_runtime",
+        "output_budget_chars": 16_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read machine-readable capability manifests: what Illo can inspect, do, or guide; status tools; setup modes; and setup guide references.",
+            "domains": ["capabilities", "integrations", "connectors", "plugins", "tools", "setup", "what Illo can do"],
+            "scopes": ["narrow", "broad"],
+        },
+    },
     "transcribe_audio_attachment": {
         "permission": "network_read",
         "risk_class": "low",

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -116,6 +116,16 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
             "scopes": ["narrow"],
         },
     },
+    "read_self_context": {
+        "permission": "read_runtime",
+        "output_budget_chars": 12_000,
+        "evidence_emitter": True,
+        "context_route": {
+            "description": "Read verified Illo/Illospace identity, source-root, open-source repository, git, install, and source-inspection facts for the current run.",
+            "domains": ["self context", "identity", "source code", "installation", "open source repo", "where Illo runs"],
+            "scopes": ["narrow"],
+        },
+    },
     "read_capabilities": {
         "permission": "read_runtime",
         "output_budget_chars": 16_000,

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -442,6 +442,12 @@ BRAIN_TOOLS = [
                     "default": False,
                     "description": "When true, include the registered setup guide for an exact or single matched capability.",
                 },
+                "detail_level": {
+                    "type": "string",
+                    "enum": ["auto", "summary", "tools", "full"],
+                    "default": "auto",
+                    "description": "Use summary for compact capability lists, tools for tool names, or full for exact setup/tool metadata. Auto expands only narrow matches.",
+                },
             },
         },
     },

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -390,6 +390,30 @@ BRAIN_TOOLS = [
         },
     },
     {
+        "name": "read_self_context",
+        "description": (
+            "Read verified identity, source, and runtime self-context for Illo. Use this for "
+            "questions about who Illo is, what Illospace is, where this open-source install/source "
+            "can be inspected, current git/source facts, or whether code/file inspection tools are "
+            "available. This is not the capability index; use read_capabilities for what Illo can do."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "include_paths": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Include verified local source-root and documentation path facts.",
+                },
+                "include_git": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Include current git branch, commit, and remote facts when available.",
+                },
+            },
+        },
+    },
+    {
         "name": "read_capabilities",
         "description": (
             "Read machine-readable capability manifests for Illo's runtime and installed/custom capabilities. "
@@ -2605,7 +2629,7 @@ COORDINATOR_TOOLS = (
 # Brain gate: these tool names satisfy the "brain context accessed" requirement
 _BRAIN_TOOL_NAMES = frozenset({
     "brain_recall", "brain_guardrails", "brain_skills", "skill_view", "skill_asset",
-    "brain_encode", "runtime_settings", "read_capabilities", "query_workspace_data", "read_workspace_overview",
+    "brain_encode", "runtime_settings", "read_self_context", "read_capabilities", "query_workspace_data", "read_workspace_overview",
     "read_team_activity", "read_project_contexts", "read_team_members", "read_workspace_records",
     "read_cycles", "read_workspace_apps",
 })

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -390,6 +390,38 @@ BRAIN_TOOLS = [
         },
     },
     {
+        "name": "read_capabilities",
+        "description": (
+            "Read machine-readable capability manifests for Illo's runtime and installed/custom capabilities. "
+            "Use this before answering setup, connect, install, integration, connector, plugin, tool, "
+            "or 'can you do X?' questions. Capability manifests and tool schemas are the source of truth "
+            "for setup modes, status checks, credential stores, and agent actions. For a matched setup "
+            "request, set include_setup_guide=true when the manifest points to a registered setup guide."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural-language capability lookup, such as the integration or action the user asked about.",
+                },
+                "capability_key": {
+                    "type": "string",
+                    "description": "Optional exact capability key or alias, such as a registered integration key.",
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Optional capability category filter, such as communication, project, data, or custom.",
+                },
+                "include_setup_guide": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "When true, include the registered setup guide for an exact or single matched capability.",
+                },
+            },
+        },
+    },
+    {
         "name": "transcribe_audio_attachment",
         "description": (
             "Transcribe an audio attachment from the current thread or an uploaded file using "
@@ -530,8 +562,8 @@ BRAIN_TOOLS = [
         "name": "read_workspace_overview",
         "description": (
             "Read a curated overview of the current Illospace workspace before introducing Illo, "
-            "answering broad setup questions, or explaining what context is available. Returns team members, "
-            "active/recent Cortex thoughts, recent agent runs/messages, Project Context profiles and attachments, "
+            "answering broad workspace setup questions, or explaining what context is available. "
+            "Returns team members, active/recent Cortex thoughts, recent agent runs/messages, Project Context profiles and attachments, "
             "Domains/records, workspace apps, Cycles, and setup gaps. Use this first for 'what is this workspace?', "
             "'what can you see?', and onboarding setup guidance. "
             f"{WORKSPACE_OVERVIEW_SPARSE_GUIDANCE}"
@@ -2573,7 +2605,7 @@ COORDINATOR_TOOLS = (
 # Brain gate: these tool names satisfy the "brain context accessed" requirement
 _BRAIN_TOOL_NAMES = frozenset({
     "brain_recall", "brain_guardrails", "brain_skills", "skill_view", "skill_asset",
-    "brain_encode", "runtime_settings", "query_workspace_data", "read_workspace_overview",
+    "brain_encode", "runtime_settings", "read_capabilities", "query_workspace_data", "read_workspace_overview",
     "read_team_activity", "read_project_contexts", "read_team_members", "read_workspace_records",
     "read_cycles", "read_workspace_apps",
 })

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -11,6 +11,7 @@ from brain.systems.runs.tool_catalog.handlers import composition as _composition
 from brain.systems.runs.tool_catalog.handlers.browser import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.common import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.activity import *  # noqa: F401,F403
+from brain.systems.runs.tool_catalog.handlers.capabilities import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.chat import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.cortex_reply import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.cycles import *  # noqa: F401,F403
@@ -48,6 +49,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_browser_type",
     "_handle_browser_upload_attachment",
     "_handle_browser_wait",
+    "_handle_read_capabilities",
     "_handle_cortex_reply",
     "_handle_cortex_visual_reply",
     "_handle_post_ai_timeline_message",

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -20,6 +20,7 @@ from brain.systems.runs.tool_catalog.handlers.files import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.inbound import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.projects import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.session_tools import *  # noqa: F401,F403
+from brain.systems.runs.tool_catalog.handlers.self_context import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.skills import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.voice import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.web import *  # noqa: F401,F403
@@ -50,6 +51,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_browser_upload_attachment",
     "_handle_browser_wait",
     "_handle_read_capabilities",
+    "_handle_read_self_context",
     "_handle_cortex_reply",
     "_handle_cortex_visual_reply",
     "_handle_post_ai_timeline_message",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -239,6 +239,7 @@ class TestToolDefinitions:
         assert "brain_encode" in names
         assert "brain_vault" in names
         assert "runtime_settings" in names
+        assert "read_self_context" in names
         assert "read_capabilities" in names
 
     def test_exec_tools_defined(self):
@@ -1739,8 +1740,36 @@ class TestCortexReplyHandler:
 
         payload = json.loads(_handle_read_capabilities(query="what integrations can you do?"))
 
-        assert payload["count"] >= 1
+        keys = {capability["key"] for capability in payload["capabilities"]}
+
+        assert payload["count"] >= 10
         assert any(capability["key"] == "slack" for capability in payload["capabilities"])
+        assert {"domains", "cycles", "code_execution", "workspace_context"} <= keys
+
+    def test_read_capabilities_registry_details_come_from_tool_registry(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(capability_key="domains"))
+
+        assert payload["count"] == 1
+        domains = payload["capabilities"][0]
+        assert domains["source"] == "tool_registry"
+        assert domains["category"] == "core_workspace"
+        assert domains["tools"] == ["read_workspace_records", "manage_domain"]
+        assert {detail["name"] for detail in domains["tool_details"]} == set(domains["tools"])
+        assert any("domain" in (detail["expected_effect"] or "").lower() for detail in domains["tool_details"])
+
+    def test_read_self_context_reports_identity_source_and_inspection_tools(self):
+        from brain.systems.runs.tool_catalog.handlers.self_context import _handle_read_self_context
+
+        payload = json.loads(_handle_read_self_context(include_git=False))
+
+        assert payload["identity"]["agent_name"] == "Illo"
+        assert payload["identity"]["workspace_product"] == "Illospace"
+        assert payload["open_source"]["repository_url"] == "https://github.com/Illospace/illospace"
+        assert payload["installation"]["source_root"]["exists"] is True
+        assert payload["source_inspection"]["tools"]["read_file"]["registered"] is True
+        assert "git" not in payload
 
     def test_read_capabilities_includes_custom_manifest_from_context(self):
         from brain.systems.runs.execution_context import bind_agent_context

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1505,6 +1505,60 @@ class TestExecToolHandlers:
 
 
 class TestFinalReplyReview:
+    def test_checker_rejects_ungrounded_illospace_setup_surface_without_llm(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+
+        provider = MagicMock()
+        llm = _mock_llm_client(MagicMock(), provider="openai")
+
+        result = review_candidate_final_reply(
+            user_request="Help me set up Slack",
+            candidate_output=(
+                "Slack is not connected yet.\n\n"
+                "Setup path:\n"
+                "1. Open **Illospace -> Settings -> Integrations -> Slack**.\n"
+                "2. Click **Connect Slack**."
+            ),
+            execution_context=(
+                "Evidence guardrail: approve direct source/runtime claims only when supported.\n"
+                'Recent tool result 1: {"tool_name":"manage_slack","result_preview":'
+                '"{\\"ok\\": true, \\"setup_state\\": \\"not_connected\\", '
+                '\\"needs_connection\\": true, \\"connection_count\\": 0, \\"connections\\": []}"}'
+            ),
+            provider=provider,
+            llm=llm,
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["approved"] is False
+        assert "not present in this run's execution evidence" in result["rationale"]
+        provider.create.assert_not_called()
+
+    def test_checker_rejects_ungrounded_illospace_authority_role_without_llm(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+
+        provider = MagicMock()
+        llm = _mock_llm_client(MagicMock(), provider="openai")
+
+        result = review_candidate_final_reply(
+            user_request="Help me set up Slack",
+            candidate_output="Ask your Illospace admin to connect Slack for this workspace.",
+            execution_context=(
+                "Evidence guardrail: approve direct source/runtime claims only when supported.\n"
+                'Recent tool result 1: {"tool_name":"manage_slack","result_preview":'
+                '"{\\"ok\\": true, \\"setup_state\\": \\"not_connected\\", '
+                '\\"connection_count\\": 0, \\"connections\\": []}"}'
+            ),
+            provider=provider,
+            llm=llm,
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["approved"] is False
+        provider.create.assert_not_called()
+
     @patch("brain.systems.runs.direct_loop.final_reply_checker.get_provider")
     @patch("brain.systems.runs.direct_loop.final_reply_checker.resolve_llm_client")
     def test_checker_reviews_partial_reply_with_llm(self, mock_client, mock_get_provider):
@@ -1687,6 +1741,14 @@ class TestCortexReplyHandler:
             ],
         )
         _agent_context.execution_artifacts = []
+        _agent_context.recent_tool_results = [
+            {
+                "tool_name": "manage_slack",
+                "args_preview": '{"action": "status"}',
+                "is_error": False,
+                "result_preview": '{"ok": true, "setup_state": "not_connected", "connection_count": 0}',
+            }
+        ]
         _agent_context.intent_satisfaction = {
             "intent_type": "broad_refactor",
             "completion_mode": "strict_contract",
@@ -1699,6 +1761,7 @@ class TestCortexReplyHandler:
         finally:
             _agent_context.run = None
             _agent_context.execution_artifacts = []
+            _agent_context.recent_tool_results = []
             _agent_context.intent_satisfaction = None
 
         assert "Evidence guardrail" in context
@@ -1708,6 +1771,9 @@ class TestCortexReplyHandler:
         assert "Raw DB row was not available" in context
         assert "strict_contract" in context
         assert "Complete every refactor phase" in context
+        assert "Recent tool result 1" in context
+        assert "manage_slack" in context
+        assert "not_connected" in context
 
     def test_cortex_reply_whitespace_normalizer_collapses_punctuation_lines(self):
         from brain.systems.runs.tool_catalog.handlers.cortex_reply import _normalize_reply_whitespace
@@ -1849,6 +1915,38 @@ class TestCortexReplyHandler:
 
 
 class TestExecutionArtifacts:
+    def test_emit_resolved_tool_call_records_recent_result_for_reply_context(self):
+        from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall, emit_resolved_tool_call
+
+        agent_context = SimpleNamespace(tool_calls_log=[], recent_tool_results=[])
+        tool_results = []
+
+        emit_resolved_tool_call(
+            ResolvedToolCall(
+                block_id="tool-1",
+                tool_name="manage_slack",
+                tool_input={"action": "status"},
+                result_text='{"ok": true, "setup_state": "not_connected"}',
+            ),
+            tool_results,
+            None,
+            None,
+            None,
+            "coordinator",
+            agent_context=agent_context,
+        )
+
+        assert agent_context.tool_calls_log == ["manage_slack"]
+        assert agent_context.recent_tool_results == [
+            {
+                "tool_name": "manage_slack",
+                "args_preview": '{"action": "status"}',
+                "is_error": False,
+                "result_preview": '{"ok": true, "setup_state": "not_connected"}',
+            }
+        ]
+        assert tool_results[0]["content"] == '{"ok": true, "setup_state": "not_connected"}'
+
     def test_exec_command_records_git_provenance(self):
         from brain.systems.runs.direct_agent import _handle_exec_command, _agent_context
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -239,6 +239,7 @@ class TestToolDefinitions:
         assert "brain_encode" in names
         assert "brain_vault" in names
         assert "runtime_settings" in names
+        assert "read_capabilities" in names
 
     def test_exec_tools_defined(self):
         from brain.systems.runs.direct_agent import EXEC_TOOLS
@@ -1716,6 +1717,66 @@ class TestFinalReplyReview:
 
 
 class TestCortexReplyHandler:
+    def test_read_capabilities_reports_builtin_slack_manifest(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(query="help me set up Slack"))
+
+        assert payload["source"] == "runtime_capability_registry"
+        assert payload["count"] == 1
+        slack = payload["capabilities"][0]
+        assert slack["key"] == "slack"
+        assert slack["status_check"] == {"tool": "manage_slack", "args": {"action": "status"}}
+        assert slack["setup"]["credential_store"] == "Vault"
+        assert [credential["key_name"] for credential in slack["setup"]["credentials"]] == [
+            "SLACK_BOT_TOKEN",
+            "SLACK_APP_TOKEN",
+        ]
+        assert "guide_ref" not in slack["setup"]
+
+    def test_read_capabilities_generic_query_returns_registry(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(query="what integrations can you do?"))
+
+        assert payload["count"] >= 1
+        assert any(capability["key"] == "slack" for capability in payload["capabilities"])
+
+    def test_read_capabilities_includes_custom_manifest_from_context(self):
+        from brain.systems.runs.execution_context import bind_agent_context
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        with bind_agent_context({
+            "workspace_ref": {
+                "capability_manifests": [
+                    {
+                        "key": "custom_crm",
+                        "name": "Custom CRM",
+                        "category": "sales",
+                        "summary": "Look up account records from the workspace CRM.",
+                        "aliases": ["accounts"],
+                        "tools": ["crm_lookup"],
+                        "setup": {
+                            "mode": "managed_by_tool",
+                            "guide_markdown": "# CRM Setup\nUse the CRM tool's own connection wizard.",
+                        },
+                    }
+                ]
+            }
+        }):
+            payload = json.loads(_handle_read_capabilities(
+                capability_key="accounts",
+                include_setup_guide=True,
+            ))
+
+        assert payload["count"] == 1
+        capability = payload["capabilities"][0]
+        assert capability["key"] == "custom_crm"
+        assert capability["source"] == "capability_manifests"
+        assert capability["tools"] == ["crm_lookup"]
+        assert payload["setup_guides"][0]["available"] is True
+        assert payload["setup_guides"][0]["ref"] == "inline"
+
     def test_final_reply_context_preserves_worker_evidence_confidence(self):
         from types import SimpleNamespace
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1718,21 +1718,26 @@ class TestFinalReplyReview:
 
 
 class TestCortexReplyHandler:
-    def test_read_capabilities_reports_builtin_slack_manifest(self):
+    def test_read_capabilities_reports_slack_manifest(self):
         from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
 
         payload = json.loads(_handle_read_capabilities(query="help me set up Slack"))
 
         assert payload["source"] == "runtime_capability_registry"
+        assert payload["detail_level"] == "full"
         assert payload["count"] == 1
         slack = payload["capabilities"][0]
         assert slack["key"] == "slack"
+        assert slack["source"] == "tool_registry"
+        assert slack["availability"] == "available"
         assert slack["status_check"] == {"tool": "manage_slack", "args": {"action": "status"}}
+        assert slack["status_check_available"] is True
         assert slack["setup"]["credential_store"] == "Vault"
         assert [credential["key_name"] for credential in slack["setup"]["credentials"]] == [
             "SLACK_BOT_TOKEN",
             "SLACK_APP_TOKEN",
         ]
+        assert {detail["name"] for detail in slack["tool_details"]} == set(slack["tools"])
         assert "guide_ref" not in slack["setup"]
 
     def test_read_capabilities_generic_query_returns_registry(self):
@@ -1742,15 +1747,20 @@ class TestCortexReplyHandler:
 
         keys = {capability["key"] for capability in payload["capabilities"]}
 
+        assert payload["detail_level"] == "summary"
+        assert len(json.dumps(payload)) < 16_000
         assert payload["count"] >= 10
         assert any(capability["key"] == "slack" for capability in payload["capabilities"])
         assert {"domains", "cycles", "code_execution", "workspace_context"} <= keys
+        assert all("tool_details" not in capability for capability in payload["capabilities"])
+        assert all("tool_count" in capability for capability in payload["capabilities"])
 
     def test_read_capabilities_registry_details_come_from_tool_registry(self):
         from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
 
         payload = json.loads(_handle_read_capabilities(capability_key="domains"))
 
+        assert payload["detail_level"] == "full"
         assert payload["count"] == 1
         domains = payload["capabilities"][0]
         assert domains["source"] == "tool_registry"
@@ -1758,6 +1768,30 @@ class TestCortexReplyHandler:
         assert domains["tools"] == ["read_workspace_records", "manage_domain"]
         assert {detail["name"] for detail in domains["tool_details"]} == set(domains["tools"])
         assert any("domain" in (detail["expected_effect"] or "").lower() for detail in domains["tool_details"])
+
+    def test_read_capabilities_marks_disabled_capability_tools_unavailable(self):
+        from brain.systems.runs.execution_context import bind_agent_context
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        disabled_slack_tools = [
+            "manage_slack",
+            "read_slack_conversation",
+            "post_slack_reply",
+        ]
+        with bind_agent_context({
+            "execution_metadata": {
+                "tool_policy": {"disabled_tools": disabled_slack_tools},
+            }
+        }):
+            payload = json.loads(_handle_read_capabilities(query="Slack setup"))
+
+        assert payload["count"] == 1
+        slack = payload["capabilities"][0]
+        assert slack["key"] == "slack"
+        assert slack["availability"] == "unavailable"
+        assert slack["tools"] == []
+        assert set(slack["unavailable_tools"]) == set(disabled_slack_tools)
+        assert slack["status_check_available"] is False
 
     def test_read_self_context_reports_identity_source_and_inspection_tools(self):
         from brain.systems.runs.tool_catalog.handlers.self_context import _handle_read_self_context

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -143,6 +143,7 @@ class TestToolDefinitionContracts:
             "brain_vault",
             "vault_secret_prompt",
             "runtime_settings",
+            "read_capabilities",
             "transcribe_audio_attachment",
             "read_thread_messages",
             "query_workspace_data",

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -143,6 +143,7 @@ class TestToolDefinitionContracts:
             "brain_vault",
             "vault_secret_prompt",
             "runtime_settings",
+            "read_self_context",
             "read_capabilities",
             "transcribe_audio_attachment",
             "read_thread_messages",

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -88,7 +88,16 @@ def test_capability_tool_is_read_only_agent_run_surface():
     from brain.systems.runs.tool_handlers import _get_tool_handlers
     from brain.systems.runs.tool_catalog.registry import context_route_tool_names, get_tool_registration
 
+    self_registration = get_tool_registration("read_self_context")
     registration = get_tool_registration("read_capabilities")
+
+    assert self_registration is not None
+    assert self_registration.permission == "read_runtime"
+    assert self_registration.side_effect_class == "read_only"
+    assert self_registration.evidence_emitter is True
+    assert "self context" in self_registration.context_route.domains
+    assert "read_self_context" in context_route_tool_names()
+    assert "read_self_context" in _get_tool_handlers()
 
     assert registration is not None
     assert registration.permission == "read_runtime"
@@ -201,6 +210,7 @@ def test_context_route_surface_is_registry_driven():
         "read_capabilities",
         "read_cycles",
         "read_project_contexts",
+        "read_self_context",
         "read_team_activity",
         "read_team_members",
         "read_thread_messages",
@@ -215,6 +225,7 @@ def test_context_route_surface_is_registry_driven():
     assert routes["query_workspace_data"]["empty_result_policy"] == "answer_honestly"
     assert "workspace records" in routes["query_workspace_data"]["domains"]
     assert "setup" in routes["read_capabilities"]["domains"]
+    assert "source code" in routes["read_self_context"]["domains"]
     assert "workspace setup" in routes["read_workspace_overview"]["domains"]
 
 
@@ -228,14 +239,24 @@ def test_workspace_activity_question_requires_workspace_data():
     assert "current workspace/team activity" in message
 
 
-def test_onboarding_intro_requires_workspace_overview():
+def test_ability_intro_requires_capabilities():
     from brain.systems.runs.introspection import required_introspection_tool
 
     tool, message = required_introspection_tool("Hey Illo, help me understand what you can do to help me.")
 
-    assert tool == "read_workspace_overview"
+    assert tool == "read_capabilities"
     assert message is not None
-    assert "workspace overview" in message
+    assert "capability/setup context" in message
+
+
+def test_source_identity_question_requires_self_context():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Where is your source code installed?")
+
+    assert tool == "read_self_context"
+    assert message is not None
+    assert "identity/source/runtime context" in message
 
 
 def test_capability_setup_question_requires_capabilities():

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -84,6 +84,22 @@ def test_workspace_data_tool_is_read_only_agent_run_surface():
     assert "read_team_activity" in _get_tool_handlers()
 
 
+def test_capability_tool_is_read_only_agent_run_surface():
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import context_route_tool_names, get_tool_registration
+
+    registration = get_tool_registration("read_capabilities")
+
+    assert registration is not None
+    assert registration.permission == "read_runtime"
+    assert registration.side_effect_class == "read_only"
+    assert registration.evidence_emitter is True
+    assert registration.context_route is not None
+    assert "capabilities" in registration.context_route.domains
+    assert "read_capabilities" in context_route_tool_names()
+    assert "read_capabilities" in _get_tool_handlers()
+
+
 def test_thread_discussion_reply_tool_is_registered_and_exposed():
     from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_handlers import _get_tool_handlers
@@ -182,6 +198,7 @@ def test_context_route_surface_is_registry_driven():
         "brain_recall",
         "my_activity",
         "query_workspace_data",
+        "read_capabilities",
         "read_cycles",
         "read_project_contexts",
         "read_team_activity",
@@ -197,6 +214,7 @@ def test_context_route_surface_is_registry_driven():
     assert "thread transcript" in routes["read_thread_messages"]["domains"]
     assert routes["query_workspace_data"]["empty_result_policy"] == "answer_honestly"
     assert "workspace records" in routes["query_workspace_data"]["domains"]
+    assert "setup" in routes["read_capabilities"]["domains"]
     assert "workspace setup" in routes["read_workspace_overview"]["domains"]
 
 
@@ -218,6 +236,26 @@ def test_onboarding_intro_requires_workspace_overview():
     assert tool == "read_workspace_overview"
     assert message is not None
     assert "workspace overview" in message
+
+
+def test_capability_setup_question_requires_capabilities():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Hi Illo, I would like to set you up in our Slack.")
+
+    assert tool == "read_capabilities"
+    assert message is not None
+    assert "capability/setup context" in message
+
+
+def test_named_capability_setup_question_requires_capabilities_without_agent_mention():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Help me set up Slack for the team.")
+
+    assert tool == "read_capabilities"
+    assert message is not None
+    assert "capability/setup context" in message
 
 
 def test_memory_question_does_not_force_workspace_data():

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -20,6 +20,19 @@ def test_every_exposed_tool_has_registry_metadata():
     assert exposed <= registered
 
 
+def test_registered_tools_have_capability_coverage_or_explicit_exemption():
+    from brain.systems.runs.capabilities import (
+        CAPABILITY_COVERAGE_EXEMPT_TOOLS,
+        first_party_capability_tool_names,
+    )
+    from brain.systems.runs.tool_catalog.registry import all_tool_registrations
+
+    registered = set(all_tool_registrations())
+    covered = first_party_capability_tool_names() | set(CAPABILITY_COVERAGE_EXEMPT_TOOLS)
+
+    assert registered - covered == set()
+
+
 def test_registry_role_membership_matches_current_tool_lists():
     from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_catalog.registry import all_tool_registrations


### PR DESCRIPTION
## Summary
- record recent model-visible tool results on the agent context and include them in final reply review evidence
- reject final replies that assert unverified Illospace UI/setup/deployment surfaces or authority roles
- add `read_capabilities`, backed by machine-readable capability manifests and registry-derived first-party capability bundles
- expose core Illospace abilities through capability groups instead of duplicating every tool description: workspace context, Threads/Discussion, Domains, Cycles, Project Context, Workspace Apps, Vault, Skills, Memory, inbound coordination, code execution, web/browser surfaces, workers, deployment, voice, agent personality, and Slack
- add `read_self_context` for verified Illo/Illospace identity, open-source repo/source-root/git/install facts, and source-inspection availability
- route ability/setup questions to `read_capabilities` and identity/source/install questions to `read_self_context`
- keep Slack setup as a compact external-surface capability manifest with status/credential facts, not hardcoded Docker/manifest instructions in generic agent prose

## Tests
- `.venv/bin/python -m pytest tests/test_tool_registry.py tests/test_agent_split.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestCortexReplyHandler tests/test_agent.py::TestFinalReplyReview tests/test_slack_teammate.py -q`
- `.venv/bin/python -m py_compile brain/systems/personality/agent_profile.py brain/systems/runs/capabilities.py brain/systems/runs/tool_catalog/handlers/capabilities.py brain/systems/runs/tool_catalog/handlers/self_context.py brain/systems/runs/introspection.py brain/systems/runs/tool_definitions.py brain/systems/runs/tool_catalog/registry.py brain/systems/runs/tool_handlers.py`
- `git diff --check`