### PR TITLE
Allow workspace members to self-update deployment

### DIFF
--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1266,7 +1266,6 @@ async def tool_manage_deployment(
         async_get_runtime_update_status,
         async_start_runtime_update,
     )
-    from brain.systems.runtime_settings.service import can_manage_runtime_settings
 
     normalized_action = str(action or "status").strip().lower()
     if normalized_action not in {"status", "start_update"}:
@@ -1279,21 +1278,14 @@ async def tool_manage_deployment(
                 "action": normalized_action,
                 "status": "denied",
                 "available": False,
-                "detail": "Deployment updates require an authenticated owner or admin.",
+                "detail": "Deployment updates require an authenticated workspace user.",
             }
         if org_id and str(getattr(user, "org_id", "")) != str(org_id):
             return {
                 "action": normalized_action,
                 "status": "denied",
                 "available": False,
-                "detail": "Deployment updates require an owner/admin in the active organization.",
-            }
-        if not can_manage_runtime_settings(user):
-            return {
-                "action": normalized_action,
-                "status": "denied",
-                "available": False,
-                "detail": "Deployment updates require an owner or admin.",
+                "detail": "Deployment updates require a user in the active organization.",
             }
 
         if normalized_action == "start_update":

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -2556,10 +2556,11 @@ DEPLOYMENT_TOOLS = [
         "name": "manage_deployment",
         "description": (
             "Check or start the Illospace self-update flow for the running server. "
-            "Use this only when an owner/admin explicitly asks Illo to update, deploy, "
-            "redeploy, or pull latest main for this Illospace instance. The update flow "
-            "syncs origin/main, rebuilds the Compose app images, runs database migrations, "
-            "and restarts runtime services through the updater sidecar when available."
+            "Use this only when an authenticated workspace user explicitly asks Illo "
+            "to update, deploy, redeploy, or pull latest main for this Illospace instance. "
+            "The update flow syncs origin/main, rebuilds the Compose app images, runs "
+            "database migrations, and restarts runtime services through the updater sidecar "
+            "when available."
         ),
         "input_schema": {
             "type": "object",

--- a/brain/systems/runtime_settings/router.py
+++ b/brain/systems/runtime_settings/router.py
@@ -190,7 +190,6 @@ async def read_runtime_update(
     user: User = Depends(_runtime_user),
     db: AsyncSession = Depends(get_db),
 ) -> RuntimeUpdateRead:
-    _require_settings_admin(user)
     return await async_get_runtime_update_status(db)
 
 
@@ -199,5 +198,4 @@ async def start_illospace_update(
     user: User = Depends(_runtime_user),
     db: AsyncSession = Depends(get_db),
 ) -> RuntimeUpdateRead:
-    _require_settings_admin(user)
     return await async_start_runtime_update(db, requested_by=str(user.id))

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -62,9 +62,7 @@ async def test_runtime_settings_tool_returns_model_mappings_and_active_status():
 
 
 @pytest.mark.asyncio
-async def test_manage_deployment_tool_requires_owner_or_admin():
-    from types import SimpleNamespace
-
+async def test_manage_deployment_tool_requires_authenticated_user():
     import brain.systems.runtime_settings.self_update as self_update
     from brain.app.mcp.server import tool_manage_deployment
 
@@ -72,18 +70,17 @@ async def test_manage_deployment_tool_requires_owner_or_admin():
     mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
     mock_uow.__aexit__ = AsyncMock(return_value=False)
     mock_uow.session = MagicMock()
-    mock_uow.session.get = AsyncMock(return_value=SimpleNamespace(id="user-1", org_id="org-1", role="member"))
 
     with patch("brain.app.mcp.server.UnitOfWork", return_value=mock_uow), \
          patch.object(self_update, "async_start_runtime_update", AsyncMock(side_effect=AssertionError("must not start"))):
-        data = await tool_manage_deployment(action="start_update", user_id="user-1", org_id="org-1")
+        data = await tool_manage_deployment(action="start_update", user_id=None, org_id="org-1")
 
     assert data["status"] == "denied"
-    assert "owner or admin" in data["detail"]
+    assert "authenticated workspace user" in data["detail"]
 
 
 @pytest.mark.asyncio
-async def test_manage_deployment_tool_starts_update_for_owner():
+async def test_manage_deployment_tool_starts_update_for_workspace_member():
     from types import SimpleNamespace
 
     import brain.systems.runtime_settings.self_update as self_update
@@ -94,7 +91,7 @@ async def test_manage_deployment_tool_starts_update_for_owner():
     mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
     mock_uow.__aexit__ = AsyncMock(return_value=False)
     mock_uow.session = MagicMock()
-    mock_uow.session.get = AsyncMock(return_value=SimpleNamespace(id="owner-1", org_id="org-1", role="owner"))
+    mock_uow.session.get = AsyncMock(return_value=SimpleNamespace(id="user-1", org_id="org-1", role="member"))
     update = RuntimeUpdateRead(
         status="running",
         available=True,
@@ -110,7 +107,7 @@ async def test_manage_deployment_tool_starts_update_for_owner():
             action="start_update",
             build_no_cache=True,
             worker_drain_timeout_seconds=45,
-            user_id="owner-1",
+            user_id="user-1",
             org_id="org-1",
         )
 
@@ -118,9 +115,58 @@ async def test_manage_deployment_tool_starts_update_for_owner():
     assert data["status"] == "running"
     start_update.assert_awaited_once()
     _, kwargs = start_update.await_args
-    assert kwargs["requested_by"] == "owner-1"
+    assert kwargs["requested_by"] == "user-1"
     assert kwargs["build_no_cache"] is True
     assert kwargs["worker_drain_timeout_seconds"] == 45
+
+
+@pytest.mark.asyncio
+async def test_manage_deployment_tool_requires_active_org_membership():
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.self_update as self_update
+    from brain.app.mcp.server import tool_manage_deployment
+
+    mock_uow = MagicMock()
+    mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+    mock_uow.__aexit__ = AsyncMock(return_value=False)
+    mock_uow.session = MagicMock()
+    mock_uow.session.get = AsyncMock(return_value=SimpleNamespace(id="user-1", org_id="other-org", role="member"))
+
+    with patch("brain.app.mcp.server.UnitOfWork", return_value=mock_uow), \
+         patch.object(self_update, "async_start_runtime_update", AsyncMock(side_effect=AssertionError("must not start"))):
+        data = await tool_manage_deployment(action="start_update", user_id="user-1", org_id="org-1")
+
+    assert data["status"] == "denied"
+    assert "active organization" in data["detail"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_update_http_endpoint_allows_workspace_member():
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.router as router
+    from brain.systems.runtime_settings.schemas import RuntimeUpdateRead
+
+    update = RuntimeUpdateRead(
+        status="idle",
+        available=True,
+        pid=None,
+        active_agent_runs=0,
+        log_path="/data/private/logs/illo-self-update.log",
+        detail="Queues the update for the Compose updater sidecar.",
+    )
+    user = SimpleNamespace(id="user-1", org_id="org-1", role="member")
+
+    with patch.object(router, "async_get_runtime_update_status", AsyncMock(return_value=update)) as get_status, \
+         patch.object(router, "async_start_runtime_update", AsyncMock(return_value=update)) as start_update:
+        assert await router.read_runtime_update(user=user, db=MagicMock()) == update
+        assert await router.start_illospace_update(user=user, db=MagicMock()) == update
+
+    get_status.assert_awaited_once()
+    start_update.assert_awaited_once()
+    _, kwargs = start_update.await_args
+    assert kwargs["requested_by"] == "user-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow authenticated workspace members to call manage_deployment and runtime update endpoints
- keep runtime settings admin-only while treating public-main redeploys as member-safe
- update deployment tool wording and tests for member-triggered self-updates

## Tests
- venv/bin/python -m pytest tests/test_runtime_settings.py -q
- venv/bin/python -m pytest tests/test_runtime_settings.py::test_manage_deployment_tool_requires_authenticated_user tests/test_runtime_settings.py::test_manage_deployment_tool_starts_update_for_workspace_member tests/test_runtime_settings.py::test_manage_deployment_tool_requires_active_org_membership tests/test_runtime_settings.py::test_runtime_update_http_endpoint_allows_workspace_member tests/test_tool_registry.py::test_manage_deployment_tool_is_coordinator_only_and_registered -q
- git diff --check