### PR TITLE
Refactor frontend thread and chat seams

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -134,6 +134,26 @@ export interface ChatParticipant {
   email: string | null;
 }
 
+export interface ChatAttachmentPayload {
+  id?: string;
+  kind?: string;
+  type?: string;
+  content_type?: string;
+  contentType?: string;
+  mime_type?: string;
+  label?: string;
+  title?: string;
+  filename?: string;
+  name?: string;
+  url?: string;
+  href?: string;
+  previewUrl?: string;
+  download_url?: string;
+  downloadUrl?: string;
+  size?: number;
+  [key: string]: unknown;
+}
+
 export interface ChatMessage {
   id: number;
   conversation_id: string;
@@ -146,7 +166,7 @@ export interface ChatMessage {
   client_generated_id: string | null;
   thread_root_message_id: number | null;
   reply_to_message_id: number | null;
-  attachments: any[];
+  attachments: ChatAttachmentPayload[];
   metadata: Record<string, any> | null;
   conversation_seq: number;
   reply_count: number;
@@ -212,14 +232,14 @@ export interface ThreadDiscussionComment {
   author_name: string | null;
   author_color: string | null;
   body: string;
-  attachments: any[];
+  attachments: ChatAttachmentPayload[];
   metadata: Record<string, any> | null;
   created_at: string | null;
 }
 
 export interface ThreadDiscussionCreateInput {
   body: string;
-  attachments?: any[];
+  attachments?: ChatAttachmentPayload[];
   metadata?: Record<string, any> | null;
 }
 
@@ -306,7 +326,7 @@ export interface ChatMessageCreateInput {
   body: string;
   body_format?: 'markdown' | 'plain';
   client_generated_id?: string | null;
-  attachments?: any[];
+  attachments?: ChatAttachmentPayload[];
   reply_to_message_id?: number | null;
   metadata?: Record<string, any> | null;
 }
@@ -1170,7 +1190,7 @@ export const api = {
         ? `/api/cortex/ideas/${ideaId}/unified-stream?include_debug=true`
         : `/api/cortex/ideas/${ideaId}/unified-stream`
     ),
-  addThreadMessage: (ideaId: string, data: { content: string; role?: string; attachments?: any[]; metadata?: Record<string, any> }) =>
+  addThreadMessage: (ideaId: string, data: { content: string; role?: string; attachments?: ChatAttachmentPayload[]; metadata?: Record<string, any> }) =>
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/thread`, { method: 'POST', body: JSON.stringify(data) }),
   updatePosition: (ideaId: string, x: number, y: number) =>
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/position`, { method: 'PATCH', body: JSON.stringify({ position_x: x, position_y: y }) }),
@@ -1239,7 +1259,7 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/split`, { method: 'POST', body: JSON.stringify(data) }),
   timelineData: (limit?: number) =>
     fetchJson<any>(withQuery('/api/cortex/timeline-data', { limit })),
-  uploadFile: (file: File) => {
+  uploadFile: (file: File): Promise<ChatAttachmentPayload> => {
     const form = new FormData();
     form.append('file', file);
     return fetch('/api/cortex/upload', { method: 'POST', body: form }).then(r => {

--- a/frontend/src/lib/components/chat/ChatDock.svelte
+++ b/frontend/src/lib/components/chat/ChatDock.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
 
-  import { api, type ChatConversationSummary, type ChatUnreadThread } from '$lib/api/client';
+  import { api, type ChatAttachmentPayload, type ChatConversationSummary, type ChatUnreadThread } from '$lib/api/client';
   import {
     mentionHandleForPerson,
     type MentionAutocompleteOption,
@@ -16,6 +16,7 @@
   import AttachmentPreviewDialog from '$lib/components/chat/AttachmentPreviewDialog.svelte';
   import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
+  import type { ChatAttachmentItem, ChatAttachmentKind } from '$lib/components/chat/chatTypes';
   import {
     CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
     conversationIsNearBottom,
@@ -62,6 +63,14 @@
 
   type ChatStreamKind = 'room' | 'thread' | 'dm';
 
+  type ChatDraftBinding = {
+    key: string;
+    label: string;
+    textareaSelector: string;
+    value: string;
+    assignValue: (value: string) => void;
+  };
+
   let {
     surface = 'workspace',
     previewMembers = [],
@@ -78,11 +87,11 @@
   let shellEl: HTMLElement | undefined = $state();
   let mainLayoutEl: HTMLDivElement | undefined = $state();
   let fileInputEl: HTMLInputElement | undefined = $state();
-  let pendingAttachmentsByContext = $state<Record<string, any[]>>({});
+  let pendingAttachmentsByContext = $state<Record<string, ChatAttachmentPayload[]>>({});
   let attachmentTargetKey = $state<string | null>(null);
   let dockDragOver = $state(false);
   let dockDragTargetKey = $state<string | null>(null);
-  let previewAttachment = $state<any | null>(null);
+  let previewAttachment = $state<ChatAttachmentPayload | null>(null);
   let teamMembers = $state<TeamMember[]>([]);
   let roomComposerValue = $state('');
   let threadComposerValue = $state('');
@@ -753,11 +762,36 @@
     ui.toast('Reactions are next up.', 'info');
   }
 
-  function setAttachmentsForKey(key: string, attachments: any[]) {
+  function setAttachmentsForKey(key: string, attachments: ChatAttachmentPayload[]) {
     pendingAttachmentsByContext = {
       ...pendingAttachmentsByContext,
       [key]: attachments,
     };
+  }
+
+  function composerAttachmentKind(attachment: ChatAttachmentPayload): ChatAttachmentKind {
+    if (attachment.kind === 'image' || attachment.kind === 'link' || attachment.kind === 'file') {
+      return attachment.kind;
+    }
+
+    const previewKind = attachmentPreviewKind(attachment);
+    if (previewKind === 'image' || previewKind === 'link') return previewKind;
+    return 'file';
+  }
+
+  function composerAttachments(attachments: readonly ChatAttachmentPayload[]): ChatAttachmentItem[] {
+    return attachments.map((attachment, index) => {
+      const url = attachmentUrl(attachment);
+      const previewUrl = typeof attachment.previewUrl === 'string' ? attachment.previewUrl : undefined;
+      return {
+        id: attachment.id ?? `${url || attachmentLabel(attachment)}-${index}`,
+        kind: composerAttachmentKind(attachment),
+        label: attachmentLabel(attachment),
+        detail: attachmentDetail(attachment),
+        url,
+        previewUrl,
+      };
+    });
   }
 
   function queueAttachmentPicker(targetKey: string) {
@@ -767,7 +801,7 @@
 
   async function uploadFiles(files: File[], targetKey: string) {
     const results = await Promise.allSettled(files.map((file) => api.uploadFile(file)));
-    const succeeded: any[] = [];
+    const succeeded: ChatAttachmentPayload[] = [];
 
     for (const result of results) {
       if (result.status === 'fulfilled') {
@@ -821,29 +855,64 @@
     return activeChatDropTargetKey;
   }
 
+  function draftBindings(): ChatDraftBinding[] {
+    const bindings: ChatDraftBinding[] = [
+      {
+        key: roomDraftKey,
+        label: 'team room',
+        textareaSelector: '.chat-room-column textarea:not(:disabled)',
+        value: roomComposerValue,
+        assignValue: (value) => {
+          roomComposerValue = value;
+        },
+      },
+    ];
+
+    if (threadDraftKey) {
+      bindings.push({
+        key: threadDraftKey,
+        label: 'thread reply',
+        textareaSelector: '.chat-thread-column textarea:not(:disabled)',
+        value: threadComposerValue,
+        assignValue: (value) => {
+          threadComposerValue = value;
+        },
+      });
+    }
+
+    if (dmDraftKey) {
+      bindings.push({
+        key: dmDraftKey,
+        label: activeDmDisplayName || 'direct message',
+        textareaSelector: '.chat-dm-column textarea:not(:disabled)',
+        value: dmComposerValue,
+        assignValue: (value) => {
+          dmComposerValue = value;
+        },
+      });
+    }
+
+    return bindings;
+  }
+
+  function draftBindingForKey(targetKey: string | null) {
+    if (!targetKey) return null;
+    return draftBindings().find((binding) => binding.key === targetKey) ?? null;
+  }
+
   function dropTargetLabelForKey(targetKey: string | null) {
     if (!targetKey) return 'chat';
-    if (threadDraftKey && targetKey === threadDraftKey) return 'thread reply';
-    if (dmDraftKey && targetKey === dmDraftKey) return activeDmDisplayName || 'direct message';
-    return 'team room';
+    return draftBindingForKey(targetKey)?.label ?? 'team room';
   }
 
   function draftValueForKey(targetKey: string) {
-    if (targetKey === roomDraftKey) return roomComposerValue;
-    if (threadDraftKey && targetKey === threadDraftKey) return threadComposerValue;
-    if (dmDraftKey && targetKey === dmDraftKey) return dmComposerValue;
+    const binding = draftBindingForKey(targetKey);
+    if (binding) return binding.value;
     return chat.draftByContext[targetKey] ?? '';
   }
 
   function setDraftValueForKey(targetKey: string, nextValue: string) {
-    if (targetKey === roomDraftKey) {
-      roomComposerValue = nextValue;
-    } else if (threadDraftKey && targetKey === threadDraftKey) {
-      threadComposerValue = nextValue;
-    } else if (dmDraftKey && targetKey === dmDraftKey) {
-      dmComposerValue = nextValue;
-    }
-
+    draftBindingForKey(targetKey)?.assignValue(nextValue);
     chat.setDraft(targetKey, nextValue);
   }
 
@@ -858,9 +927,7 @@
   }
 
   function composerSelectorForKey(targetKey: string) {
-    if (threadDraftKey && targetKey === threadDraftKey) return '.chat-thread-column textarea:not(:disabled)';
-    if (dmDraftKey && targetKey === dmDraftKey) return '.chat-dm-column textarea:not(:disabled)';
-    return '.chat-room-column textarea:not(:disabled)';
+    return draftBindingForKey(targetKey)?.textareaSelector ?? '.chat-room-column textarea:not(:disabled)';
   }
 
   function focusComposerForKey(targetKey: string) {
@@ -1511,7 +1578,7 @@
               variant="room"
               placeholder={`Message ${conversationTitle(activeDmConversation)}…`}
               value={dmComposerValue}
-              attachments={dmAttachments}
+              attachments={composerAttachments(dmAttachments)}
               mentionOptions={chatMentionOptions}
               disabled={activeDmPage.sending}
               loading={activeDmPage.sending}
@@ -1702,7 +1769,7 @@
             variant="room"
             placeholder="Message…"
             value={roomComposerValue}
-            attachments={roomAttachments}
+            attachments={composerAttachments(roomAttachments)}
             mentionOptions={chatMentionOptions}
             disabled={roomPage.sending}
             loading={roomPage.sending}
@@ -1860,7 +1927,7 @@
                   variant="thread"
                   placeholder="Reply in thread…"
                   value={threadComposerValue}
-                  attachments={threadAttachments}
+                  attachments={composerAttachments(threadAttachments)}
                   mentionOptions={chatMentionOptions}
                   disabled={threadPage.sending}
                   loading={threadPage.sending}
@@ -1996,7 +2063,7 @@
   {/if}
 {/snippet}
 
-{#snippet messageLinkAttachmentList(body: string | null | undefined, attachments: any[] | null | undefined)}
+{#snippet messageLinkAttachmentList(body: string | null | undefined, attachments: ChatAttachmentPayload[] | null | undefined)}
   {@const linkAttachments = messageLinkAttachments(body, attachments)}
   {#if linkAttachments.length}
     <div class="chat-attachments chat-link-attachments">

--- a/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
+++ b/frontend/src/lib/features/threads/components/ProjectDraftStatePanel.svelte
@@ -28,12 +28,15 @@
     projectFileStatusLabel,
     projectFileStatusTone,
     projectSpreadsheetPreviewRows,
+    filterProjectSelectorItems,
+    projectSelectorOptions,
     visibleProjectExplorerRows,
     type ProjectFileKind,
     type ProjectExplorerFile,
     type ProjectExplorerDirectory,
     type ProjectExplorerRow,
     type ProjectPreviewLayerKey,
+    type ProjectSelectorItem,
   } from '$lib/features/threads/domain/projectDraftStatePresenter';
   import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
   import type {
@@ -47,15 +50,6 @@
   } | null;
 
   const CHANGE_METRICS = PROJECT_DRAFT_CHANGE_METRICS;
-
-  type ProjectSelectorItem = {
-    id: string;
-    name: string;
-    subtitle: string;
-    group: 'attached' | 'recent';
-    contentLabels: string[];
-    searchText: string;
-  };
 
   let {
     idea,
@@ -234,139 +228,6 @@
 
   function canEmbedFinalKind(kind: ProjectFileKind): boolean {
     return kind === 'image' || kind === 'pdf' || kind === 'video';
-  }
-
-  function projectText(value: unknown): string {
-    return typeof value === 'string' ? value.trim() : '';
-  }
-
-  function projectNameFromSnapshot(snapshot: any): string {
-    return (
-      projectText(snapshot?.selected_profile_name)
-      || projectText(snapshot?.name)
-      || projectText(snapshot?.title)
-      || projectText(snapshot?.project_slug)
-      || 'Project'
-    );
-  }
-
-  function positiveInteger(value: unknown): number | null {
-    return typeof value === 'number' && Number.isFinite(value) && value >= 0
-      ? Math.floor(value)
-      : null;
-  }
-
-  function projectResourcesFromContext(context: any): any[] {
-    return Array.isArray(context?.resources) ? context.resources : [];
-  }
-
-  function projectResourceIsRepo(resource: any): boolean {
-    const kind = projectText(resource?.kind || resource?.type || resource?.resource_type).toLowerCase();
-    const source = projectText(resource?.source || resource?.provider).toLowerCase();
-    const uri = projectText(resource?.uri || resource?.url || resource?.repo_url).toLowerCase();
-    return (
-      ['github', 'github_repo', 'github_repository', 'repo', 'repository'].includes(kind)
-      || ['github', 'git'].includes(source)
-      || Boolean(projectText(resource?.repo))
-      || uri.startsWith('git@')
-      || uri.startsWith('https://github.com/')
-      || uri.startsWith('http://github.com/')
-      || uri.endsWith('.git')
-    );
-  }
-
-  function inferredProjectFileCount(resources: any[]): number {
-    let count = 0;
-    for (const resource of resources) {
-      const explicitCount = positiveInteger(resource?.file_count ?? resource?.uploaded_file_count);
-      if (explicitCount !== null) {
-        count += explicitCount;
-        continue;
-      }
-      const kind = projectText(resource?.kind || resource?.type || resource?.resource_type).toLowerCase();
-      if (kind === 'file' || kind === 'doc') count += 1;
-      if (Array.isArray(resource?.files)) count += resource.files.length;
-      if (Array.isArray(resource?.uploaded_files)) count += resource.uploaded_files.length;
-    }
-    return count;
-  }
-
-  function projectSelectorContentLabels(profile: any, fallbackContext: any = null): string[] {
-    const summary = profile?.content_summary || {};
-    const context = profile?.project_context || fallbackContext || {};
-    const resources = projectResourcesFromContext(context);
-    const summaryFileCount = positiveInteger(summary?.file_count);
-    const fileCount = summaryFileCount ?? inferredProjectFileCount(resources);
-    const repoCount = positiveInteger(summary?.repo_count) ?? resources.filter(projectResourceIsRepo).length;
-    const fileSuffix = summary?.file_count_exact === false ? '+' : '';
-    const labels = [`${fileCount}${fileSuffix} file${fileCount === 1 ? '' : 's'}`];
-    if (repoCount > 0) labels.push(`${repoCount} repo${repoCount === 1 ? '' : 's'}`);
-    return labels;
-  }
-
-  function projectSelectorOptions(
-    profiles: ThreadProjectContextProfile[],
-    attachments: ThreadProjectContextAttachment[],
-  ): ProjectSelectorItem[] {
-    const profilesById = new Map<string, ThreadProjectContextProfile>();
-    for (const profile of profiles) {
-      const id = projectText((profile as any)?.id);
-      if (id) profilesById.set(id, profile);
-    }
-
-    const seen = new Set<string>();
-    const attached: ProjectSelectorItem[] = [];
-    for (const attachment of attachments) {
-      const id = projectText((attachment as any)?.project_profile_id);
-      if (!id || seen.has(id)) continue;
-      seen.add(id);
-      const profile = profilesById.get(id);
-      const snapshot = (attachment as any)?.snapshot;
-      const name = projectText((profile as any)?.name) || projectNameFromSnapshot(snapshot);
-      const contentLabels = projectSelectorContentLabels(profile, snapshot);
-      attached.push({
-        id,
-        name,
-        subtitle: 'Attached project',
-        group: 'attached',
-        contentLabels,
-        searchText: contentLabels.join(' '),
-      });
-    }
-
-    const recent: ProjectSelectorItem[] = [];
-    for (const profile of profiles) {
-      const id = projectText((profile as any)?.id);
-      if (!id || seen.has(id)) continue;
-      const name = projectText((profile as any)?.name) || projectText((profile as any)?.slug) || 'Project';
-      const contentLabels = projectSelectorContentLabels(profile);
-      recent.push({
-        id,
-        name,
-        subtitle: 'Recent project',
-        group: 'recent',
-        contentLabels,
-        searchText: contentLabels.join(' '),
-      });
-    }
-
-    return [...attached, ...recent];
-  }
-
-  function filterProjectSelectorItems(
-    items: ProjectSelectorItem[],
-    query: string,
-  ): ProjectSelectorItem[] {
-    const terms = query
-      .trim()
-      .toLowerCase()
-      .split(/\s+/)
-      .filter(Boolean);
-    if (terms.length === 0) return items;
-    return items.filter((item) => {
-      const blob = `${item.name} ${item.subtitle} ${item.group} ${item.searchText}`.toLowerCase();
-      return terms.every((term) => blob.includes(term));
-    });
   }
 
   function selectProjectProfile(projectId: string) {

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -8,7 +8,6 @@
   } from '$lib/components/constellation';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
   import AttachmentPreviewDialog from '$lib/components/chat/AttachmentPreviewDialog.svelte';
-  import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
   import {
     attachmentDetail,
     attachmentKindLabel,
@@ -16,19 +15,14 @@
     attachmentPreviewKind,
     attachmentUrl,
     normalizeServerUploadPreviewUrl,
-    type AttachmentPreviewKind,
   } from '$lib/utils/attachmentPreview';
-  import { LIVE_RUN_STATUSES, OPEN_AGENT_RUN_STATUSES } from '$lib/constants/statuses';
-  import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
   import StreamVisualBlock from '$lib/features/threads/components/StreamVisualBlock.svelte';
   import ThreadAuthorMark from '$lib/features/threads/components/ThreadAuthorMark.svelte';
 
   import {
-    getCortexThreadRunStepTone,
     getCortexThreadRunStatusGlyph,
     getCortexThreadRunStatusLabel,
     getCortexThreadStepStatusGlyph,
-    type CortexThreadStageAttachmentItem,
     type CortexThreadStageFileAttachment,
     type CortexThreadStageImageAttachment,
     normalizeCortexThreadLiveLine,
@@ -36,16 +30,44 @@
     summarizeCortexThreadRunSteps,
     type CortexThreadStageRunItem,
     type ThreadTranscriptProps,
-    type CortexThreadStageMessageItem,
-    type CortexThreadStageThinkingItem,
-    type CortexThreadStageTone,
-    type CortexThreadStageTranscriptItem,
-    type CortexThreadStageWorkTimelineItem,
   } from '$lib/features/threads/domain/threadTranscriptAdapter';
-
-  const RUN_INLINE_SECTIONS = ['graph', 'tools', 'evidence'] as const;
-  type RunInlineSection = (typeof RUN_INLINE_SECTIONS)[number];
-  const THINKING_STATUS_LABEL = 'Thinking';
+  import {
+    RUN_INLINE_SECTIONS,
+    attachmentIconName,
+    attachmentPreviewLabel,
+    attachmentPreviewType,
+    getAttachmentKey,
+    getMessageTone,
+    getMessageClass,
+    getRunClass,
+    getRunDefaultExpanded,
+    getRunKey,
+    getRunLiveCueLabel,
+    getRunLiveCueWorkIndex,
+    getRunSectionKey,
+    getStepToneClass,
+    getThinkingStatusLabel,
+    getThinkingSteps,
+    getThreadHeaderStatusLabel,
+    getThreadHeaderStatusState,
+    getTimelineToolDetail,
+    getTimelineToolLabel,
+    getTimelineToolTarget,
+    getTimelineToolTitle,
+    getToolCallDetail,
+    getToolCallLabel,
+    getUserPresenceStyle,
+    getWorkThoughtClass,
+    getWorkThoughtHtml,
+    hasMessageSupplementalMeta,
+    hasVisibleLiveWorkItems,
+    isIlloMessage,
+    isRunActiveStatus,
+    isRunLiveWorkStream,
+    shouldRenderLiveWorkItem,
+    shouldShowTimelineToolArgs,
+    type RunInlineSection,
+  } from '$lib/features/threads/domain/threadTranscriptPresentation';
 
   let {
     header = null,
@@ -82,65 +104,10 @@
   const previewAttachmentLabel = $derived(previewAttachment ? attachmentPreviewLabel(previewAttachment) : '');
   const previewAttachmentDetail = $derived(previewAttachment?.kind === 'file' ? (previewAttachment.detail ?? '') : '');
   const previewAttachmentKind = $derived(previewAttachment ? attachmentPreviewType(previewAttachment) : 'file');
-  function getMessageTone(item: CortexThreadStageMessageItem): CortexThreadStageTone {
-    return item.tone ?? 'spectral';
-  }
-
-  function getStepToneClass(item: CortexThreadStageRunItem) {
-    return getCortexThreadRunStepTone(item.runSteps ?? []);
-  }
-
-  function getRunClass(item: CortexThreadStageRunItem) {
-    return [
-      'run-insert',
-      `run-${item.status}`,
-      item.workItems?.length ? 'run-with-work-timeline' : '',
-    ].filter(Boolean).join(' ');
-  }
-
-  function getRunKey(item: CortexThreadStageRunItem, index: number) {
-    return String(item.id ?? `run-${index}`);
-  }
-
-  function getRunDefaultExpanded(item: CortexThreadStageRunItem) {
-    return item.defaultExpanded ?? Boolean(item.requiresApproval || isRunActiveStatus(item.status));
-  }
-
-  function isRunActiveStatus(status: string | undefined) {
-    return Boolean(status && (LIVE_RUN_STATUSES as readonly string[]).includes(status));
-  }
-
-  function isRunLiveWorkStream(item: CortexThreadStageRunItem) {
-    if (item.requiresApproval || item.status === 'pending_approval') return false;
-    return (OPEN_AGENT_RUN_STATUSES as readonly string[]).includes(item.status);
-  }
-
-  function getHeaderStatusState() {
-    if (header?.statusState) return header.statusState;
-
-    const status = header?.statusLabel?.toLowerCase() ?? '';
-    const runStatus = header?.runStatus?.toLowerCase() ?? '';
-    if (status.includes('working') || OPEN_AGENT_RUN_STATUSES.some((value) => runStatus.includes(value))) {
-      return 'working';
-    }
-    if (status.includes('unread') || status.includes('done')) return 'unread';
-    return 'idle';
-  }
-
-  function getHeaderStatusLabel() {
-    const state = getHeaderStatusState();
-    if (state === 'working') return 'Illo is working';
-    if (state === 'unread') return 'Unread thread';
-    return 'Idle thread';
-  }
 
   function isRunExpanded(item: CortexThreadStageRunItem, index: number) {
     const key = getRunKey(item, index);
     return runExpandedByKey[key] ?? getRunDefaultExpanded(item);
-  }
-
-  function getRunSectionKey(runKey: string, section: RunInlineSection) {
-    return `${runKey}:${section}`;
   }
 
   function isRunSectionExpanded(
@@ -176,237 +143,6 @@
       ...runSectionExpandedByKey,
       [getRunSectionKey(runKey, section)]: details.open,
     };
-  }
-
-  function parseTimelineToolArgs(args: string | undefined): Record<string, any> | null {
-    if (!args) return null;
-    try {
-      const parsed = JSON.parse(args);
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
-    } catch {
-      return null;
-    }
-  }
-
-  function compactTimelineTarget(value: unknown): string | undefined {
-    if (typeof value !== 'string') return undefined;
-    const text = value.trim();
-    if (!text) return undefined;
-    return text.length > 96 ? `...${text.slice(-93)}` : text;
-  }
-
-  function getTimelineToolTarget(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
-    const displayTarget = typeof item.display?.target === 'string' ? item.display.target.trim() : '';
-    if (displayTarget) return compactTimelineTarget(displayTarget);
-    const args = parseTimelineToolArgs(item.args);
-    if (!args) return undefined;
-    return compactTimelineTarget(
-      args.path ??
-        args.file_path ??
-        args.filename ??
-        args.cwd ??
-        args.url ??
-        args.query ??
-        args.command ??
-        args.cmd,
-    );
-  }
-
-  function getTimelineToolLabel(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
-    const displayLabel = typeof item.display?.label === 'string' ? item.display.label.trim() : '';
-    if (displayLabel) return displayLabel;
-    const tool = item.tool.trim() || 'tool';
-    const target = getTimelineToolTarget(item);
-    const normalized = tool.toLowerCase();
-
-    if (/(edit|patch|update)/.test(normalized) && target) return `Editing ${target}`;
-    if (/(write|create|save)/.test(normalized) && target) return `Writing ${target}`;
-    if (/(read|view|open|load)/.test(normalized) && target) return `Reading ${target}`;
-    if (/(exec|command|shell|terminal|bash)/.test(normalized)) return target ? `Ran ${target}` : 'Ran command';
-    if (target) return `${tool} ${target}`;
-    return item.status === 'running' ? `Using ${tool}` : `Used ${tool}`;
-  }
-
-  function getRunLiveCueWorkIndex(item: CortexThreadStageRunItem) {
-    const workItems = item.workItems ?? [];
-    for (let index = workItems.length - 1; index >= 0; index -= 1) {
-      const workItem = workItems[index];
-      if (workItem.kind === 'tool' && workItem.status === 'running') return index;
-    }
-    return -1;
-  }
-
-  function getRunLiveCueLabel(item: CortexThreadStageRunItem, cueIndex = getRunLiveCueWorkIndex(item)) {
-    if (cueIndex >= 0) {
-      const workItem = item.workItems?.[cueIndex];
-      if (workItem?.kind === 'tool') return getTimelineToolLabel(workItem);
-    }
-
-    return THINKING_STATUS_LABEL;
-  }
-
-  function shouldRenderLiveWorkItem(workIndex: number, cueIndex: number) {
-    return workIndex !== cueIndex;
-  }
-
-  function hasVisibleLiveWorkItems(item: CortexThreadStageRunItem, cueIndex: number) {
-    return Boolean(item.workItems?.some((_workItem, workIndex) => shouldRenderLiveWorkItem(workIndex, cueIndex)));
-  }
-
-  function getTimelineToolTitle(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
-    const parts = [getTimelineToolLabel(item), item.tool, item.status, item.time].filter(Boolean);
-    return parts.join(' · ');
-  }
-
-  function getTimelineToolDetail(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
-    return typeof item.display?.detail === 'string' ? item.display.detail.trim() : '';
-  }
-
-  function shouldShowTimelineToolArgs(item: Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>) {
-    return Boolean(item.args && !item.display?.label && !getTimelineToolTarget(item));
-  }
-
-  function stripReflectionPrefix(text: string) {
-    return text.trim().replace(/^Reflecting:\s*/i, '').trim();
-  }
-
-  function getWorkThoughtText(text: string) {
-    const cleaned = stripReflectionPrefix(text) || text.trim();
-    const boldMatch = cleaned.match(/^\*\*([^*]+)\*\*\s*([\s\S]*)$/);
-    if (!boldMatch) return cleaned;
-
-    const title = boldMatch[1]?.trim();
-    const tail = (boldMatch[2] ?? '').trim();
-    if (!title) return cleaned;
-    if (!tail || tail.length < 12 || /^[A-Za-z][.,;:]?$/.test(tail)) return `**${title}**`;
-    return cleaned;
-  }
-
-  function getToolCallDisplay(call: NonNullable<CortexThreadStageRunItem['toolCalls']>[number]) {
-    return call.display && typeof call.display === 'object' ? call.display : null;
-  }
-
-  function getToolCallLabel(call: NonNullable<CortexThreadStageRunItem['toolCalls']>[number]) {
-    const display = getToolCallDisplay(call);
-    const label = typeof display?.label === 'string' ? display.label.trim() : '';
-    if (label) return label;
-    return call.tool;
-  }
-
-  function getToolCallDetail(call: NonNullable<CortexThreadStageRunItem['toolCalls']>[number]) {
-    const display = getToolCallDisplay(call);
-    const detail = typeof display?.detail === 'string' ? display.detail.trim() : '';
-    if (detail) return detail;
-    return call.args;
-  }
-
-  function getWorkThoughtHtml(text: string) {
-    return renderReadableMarkdown(getWorkThoughtText(text));
-  }
-
-  function getWorkThoughtClass(text: string) {
-    return [
-      'run-work-item',
-      'run-work-thought',
-      /^Reflecting:/i.test(text.trim()) ? 'run-work-reflection' : '',
-    ].filter(Boolean).join(' ');
-  }
-
-  function getThinkingStatusLabel(item: CortexThreadStageThinkingItem) {
-    const latestStep = item.steps?.at(-1)?.label?.trim();
-    return latestStep || item.label || THINKING_STATUS_LABEL;
-  }
-
-  function getThinkingSteps(item: CortexThreadStageThinkingItem) {
-    const steps = [...(item.steps ?? [])];
-    const latestStep = steps.at(-1);
-    if (latestStep?.label?.trim() && latestStep.label.trim() === getThinkingStatusLabel(item)) {
-      return steps.slice(0, -1);
-    }
-    return steps;
-  }
-
-  function getMessageClass(item: CortexThreadStageMessageItem) {
-    const role = item.role ?? 'illo';
-    const tone = getMessageTone(item);
-
-    return [
-      'thread-message',
-      role === 'user' ? 'thread-message-user' : 'thread-message-illo',
-      role === 'user' ? `thread-message-${tone}` : '',
-      item.inlineWithWork ? 'thread-message-inline-work' : '',
-    ]
-      .filter(Boolean)
-      .join(' ');
-  }
-
-  function isIlloMessage(item: CortexThreadStageMessageItem) {
-    return (item.role ?? 'illo') === 'illo';
-  }
-
-  function hasMessageSupplementalMeta(item: CortexThreadStageMessageItem) {
-    return Boolean(item.timestamp || item.tag);
-  }
-
-  function normalizeHexColor(value: string | null | undefined): string | null {
-    if (typeof value !== 'string') return null;
-    const trimmed = value.trim();
-    if (!/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(trimmed)) return null;
-    if (trimmed.length === 4) {
-      return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
-    }
-    return trimmed;
-  }
-
-  function getUserPresenceStyle(item: CortexThreadStageMessageItem) {
-    if ((item.role ?? 'illo') !== 'user') return undefined;
-    const accent = normalizeHexColor(item.accentColor);
-    const core = normalizeHexColor(item.coreColor);
-    const owner = normalizeHexColor(item.ownerColor);
-    if (!accent) return undefined;
-
-    const seedCore =
-      core ??
-      `color-mix(in srgb, ${accent} var(--constellation-presence-seed-user-core-accent-strength, 52%), var(--constellation-presence-seed-user-core-base, #050910))`;
-    const seedOwner =
-      owner ??
-      `color-mix(in srgb, ${accent} var(--constellation-presence-seed-user-owner-accent-strength, 18%), var(--constellation-presence-seed-user-owner-base, #f0f0fa))`;
-
-    return [
-      `--seed-accent:${accent}`,
-      `--seed-core:${seedCore}`,
-      `--seed-owner:${seedOwner}`,
-    ].join('; ');
-  }
-
-  function getAttachmentKey(attachment: CortexThreadStageAttachmentItem, index: number) {
-    if (attachment.kind === 'visual') {
-      return attachment.block.title || `${attachment.block.type}-${index}`;
-    }
-
-    return attachment.url || `${attachment.kind}-${index}`;
-  }
-
-  function attachmentPreviewLabel(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment) {
-    return attachment.kind === 'image' ? attachment.alt : attachment.label;
-  }
-
-  function attachmentPreviewType(
-    attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment,
-  ): AttachmentPreviewKind {
-    return attachment.kind === 'image' ? 'image' : (attachment.previewKind ?? 'file');
-  }
-
-  function attachmentIconName(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment): ConstellationIconName {
-    const kind = attachmentPreviewType(attachment);
-    if (kind === 'image') return 'image';
-    if (kind === 'video') return 'video';
-    if (kind === 'pdf') return 'pdf';
-    if (kind === 'link') return 'link';
-    if (kind === 'archive') return 'archive';
-    if (kind === 'text') return 'code';
-    if (kind === 'file') return 'file';
-    return 'document';
   }
 
   function openAttachmentPreview(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment) {
@@ -543,8 +279,8 @@
     <header class="thread-panel-header thread-column">
       <div class="thread-header-title-row">
         <ConstellationSignalStatusIndicator
-          state={getHeaderStatusState()}
-          label={getHeaderStatusLabel()}
+          state={getThreadHeaderStatusState(header)}
+          label={getThreadHeaderStatusLabel(header)}
           className="thread-header-status-indicator"
         />
         <h1 class="thread-header-title" title={header.title}>{header.title}</h1>
@@ -1541,6 +1277,10 @@
     position: relative;
     display: grid;
     gap: 10px;
+    /* Own these box metrics so legacy global .thread-message styles cannot indent Illo replies. */
+    margin-bottom: 0;
+    padding: 0;
+    border-radius: 0;
     color: var(--thread-color-text-primary);
   }
 

--- a/frontend/src/lib/features/threads/domain/index.ts
+++ b/frontend/src/lib/features/threads/domain/index.ts
@@ -1,3 +1,4 @@
 export * from './threadContracts';
 export * from './threadStreamAdapter';
 export * from './threadTranscriptAdapter';
+export * from './threadTranscriptPresentation';

--- a/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
+++ b/frontend/src/lib/features/threads/domain/projectDraftStatePresenter.ts
@@ -19,6 +19,31 @@ export type DraftChangeMetric = {
   tone: 'changed' | 'new' | 'deleted' | 'conflicted';
 };
 
+export type ProjectSelectorItem = {
+  id: string;
+  name: string;
+  subtitle: string;
+  group: 'attached' | 'recent';
+  contentLabels: string[];
+  searchText: string;
+};
+
+type ProjectContextResourceRecord = Record<string, unknown>;
+type ProjectContextSnapshotRecord = Record<string, unknown> & {
+  resources?: ProjectContextResourceRecord[];
+};
+type ProjectSelectorProfileRecord = Record<string, unknown> & {
+  id?: string | number | null;
+  name?: string | null;
+  slug?: string | null;
+  content_summary?: Record<string, unknown> | null;
+  project_context?: ProjectContextSnapshotRecord | null;
+};
+type ProjectSelectorAttachmentRecord = Record<string, unknown> & {
+  project_profile_id?: string | number | null;
+  snapshot?: ProjectContextSnapshotRecord | null;
+};
+
 export type NormalizedRootVersions = {
   groups: ProjectDraftRootVersionGroup[];
   versionCount: number;
@@ -151,6 +176,144 @@ export const PROJECT_DRAFT_CHANGE_METRICS: DraftChangeMetric[] = [
 ];
 
 type ProjectDraftStateLike = ProjectDraftStateResponse | ProjectDraftStateRead | null;
+
+function projectText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function projectNameFromSnapshot(snapshot: ProjectContextSnapshotRecord | null | undefined): string {
+  return (
+    projectText(snapshot?.selected_profile_name)
+    || projectText(snapshot?.name)
+    || projectText(snapshot?.title)
+    || projectText(snapshot?.project_slug)
+    || 'Project'
+  );
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : null;
+}
+
+function projectResourcesFromContext(
+  context: ProjectContextSnapshotRecord | null | undefined,
+): ProjectContextResourceRecord[] {
+  return Array.isArray(context?.resources) ? context.resources : [];
+}
+
+function projectResourceIsRepo(resource: ProjectContextResourceRecord): boolean {
+  const kind = projectText(resource.kind || resource.type || resource.resource_type).toLowerCase();
+  const source = projectText(resource.source || resource.provider).toLowerCase();
+  const uri = projectText(resource.uri || resource.url || resource.repo_url).toLowerCase();
+  return (
+    ['github', 'github_repo', 'github_repository', 'repo', 'repository'].includes(kind)
+    || ['github', 'git'].includes(source)
+    || Boolean(projectText(resource.repo))
+    || uri.startsWith('git@')
+    || uri.startsWith('https://github.com/')
+    || uri.startsWith('http://github.com/')
+    || uri.endsWith('.git')
+  );
+}
+
+function inferredProjectFileCount(resources: ProjectContextResourceRecord[]): number {
+  let count = 0;
+  for (const resource of resources) {
+    const explicitCount = positiveInteger(resource.file_count ?? resource.uploaded_file_count);
+    if (explicitCount !== null) {
+      count += explicitCount;
+      continue;
+    }
+    const kind = projectText(resource.kind || resource.type || resource.resource_type).toLowerCase();
+    if (kind === 'file' || kind === 'doc') count += 1;
+    if (Array.isArray(resource.files)) count += resource.files.length;
+    if (Array.isArray(resource.uploaded_files)) count += resource.uploaded_files.length;
+  }
+  return count;
+}
+
+function projectSelectorContentLabels(
+  profile: ProjectSelectorProfileRecord | undefined,
+  fallbackContext: ProjectContextSnapshotRecord | null = null,
+): string[] {
+  const summary = profile?.content_summary || {};
+  const context = profile?.project_context || fallbackContext || {};
+  const resources = projectResourcesFromContext(context);
+  const summaryFileCount = positiveInteger(summary.file_count);
+  const fileCount = summaryFileCount ?? inferredProjectFileCount(resources);
+  const repoCount = positiveInteger(summary.repo_count) ?? resources.filter(projectResourceIsRepo).length;
+  const fileSuffix = summary.file_count_exact === false ? '+' : '';
+  const labels = [`${fileCount}${fileSuffix} file${fileCount === 1 ? '' : 's'}`];
+  if (repoCount > 0) labels.push(`${repoCount} repo${repoCount === 1 ? '' : 's'}`);
+  return labels;
+}
+
+export function projectSelectorOptions(
+  profiles: readonly ProjectSelectorProfileRecord[],
+  attachments: readonly ProjectSelectorAttachmentRecord[],
+): ProjectSelectorItem[] {
+  const profilesById = new Map<string, ProjectSelectorProfileRecord>();
+  for (const profile of profiles) {
+    const id = projectText(profile.id);
+    if (id) profilesById.set(id, profile);
+  }
+
+  const seen = new Set<string>();
+  const attached: ProjectSelectorItem[] = [];
+  for (const attachment of attachments) {
+    const id = projectText(attachment.project_profile_id);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const profile = profilesById.get(id);
+    const snapshot = attachment.snapshot ?? null;
+    const name = projectText(profile?.name) || projectNameFromSnapshot(snapshot);
+    const contentLabels = projectSelectorContentLabels(profile, snapshot);
+    attached.push({
+      id,
+      name,
+      subtitle: 'Attached project',
+      group: 'attached',
+      contentLabels,
+      searchText: contentLabels.join(' '),
+    });
+  }
+
+  const recent: ProjectSelectorItem[] = [];
+  for (const profile of profiles) {
+    const id = projectText(profile.id);
+    if (!id || seen.has(id)) continue;
+    const name = projectText(profile.name) || projectText(profile.slug) || 'Project';
+    const contentLabels = projectSelectorContentLabels(profile);
+    recent.push({
+      id,
+      name,
+      subtitle: 'Recent project',
+      group: 'recent',
+      contentLabels,
+      searchText: contentLabels.join(' '),
+    });
+  }
+
+  return [...attached, ...recent];
+}
+
+export function filterProjectSelectorItems(
+  items: readonly ProjectSelectorItem[],
+  query: string,
+): ProjectSelectorItem[] {
+  const terms = query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (terms.length === 0) return [...items];
+  return items.filter((item) => {
+    const blob = `${item.name} ${item.subtitle} ${item.group} ${item.searchText}`.toLowerCase();
+    return terms.every((term) => blob.includes(term));
+  });
+}
 
 export function buildProjectDraftPanelView({
   draftState,

--- a/frontend/src/lib/features/threads/domain/threadTranscriptPresentation.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptPresentation.ts
@@ -1,0 +1,313 @@
+import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
+import { LIVE_RUN_STATUSES, OPEN_AGENT_RUN_STATUSES } from '$lib/constants/statuses';
+import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
+
+import {
+  getCortexThreadRunStepTone,
+  type CortexThreadStageAttachmentItem,
+  type CortexThreadStageFileAttachment,
+  type CortexThreadStageHeaderConfig,
+  type CortexThreadStageImageAttachment,
+  type CortexThreadStageMessageItem,
+  type CortexThreadStageRunItem,
+  type CortexThreadStageThinkingItem,
+  type CortexThreadStageTone,
+  type CortexThreadStageWorkTimelineItem,
+} from './threadTranscriptAdapter';
+
+export const RUN_INLINE_SECTIONS = ['graph', 'tools', 'evidence'] as const;
+export type RunInlineSection = (typeof RUN_INLINE_SECTIONS)[number];
+
+const THINKING_STATUS_LABEL = 'Thinking';
+
+type TimelineToolItem = Extract<CortexThreadStageWorkTimelineItem, { kind: 'tool' }>;
+type ToolCallItem = NonNullable<CortexThreadStageRunItem['toolCalls']>[number];
+
+export function getMessageTone(item: CortexThreadStageMessageItem): CortexThreadStageTone {
+  return item.tone ?? 'spectral';
+}
+
+export function getStepToneClass(item: CortexThreadStageRunItem) {
+  return getCortexThreadRunStepTone(item.runSteps ?? []);
+}
+
+export function getRunClass(item: CortexThreadStageRunItem) {
+  return [
+    'run-insert',
+    `run-${item.status}`,
+    item.workItems?.length ? 'run-with-work-timeline' : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function getRunKey(item: CortexThreadStageRunItem, index: number) {
+  return String(item.id ?? `run-${index}`);
+}
+
+export function isRunActiveStatus(status: string | undefined) {
+  return Boolean(status && (LIVE_RUN_STATUSES as readonly string[]).includes(status));
+}
+
+export function getRunDefaultExpanded(item: CortexThreadStageRunItem) {
+  return item.defaultExpanded ?? Boolean(item.requiresApproval || isRunActiveStatus(item.status));
+}
+
+export function isRunLiveWorkStream(item: CortexThreadStageRunItem) {
+  if (item.requiresApproval || item.status === 'pending_approval') return false;
+  return (OPEN_AGENT_RUN_STATUSES as readonly string[]).includes(item.status);
+}
+
+export function getThreadHeaderStatusState(header: CortexThreadStageHeaderConfig | null | undefined) {
+  if (header?.statusState) return header.statusState;
+
+  const status = header?.statusLabel?.toLowerCase() ?? '';
+  const runStatus = header?.runStatus?.toLowerCase() ?? '';
+  if (status.includes('working') || OPEN_AGENT_RUN_STATUSES.some((value) => runStatus.includes(value))) {
+    return 'working';
+  }
+  if (status.includes('unread') || status.includes('done')) return 'unread';
+  return 'idle';
+}
+
+export function getThreadHeaderStatusLabel(header: CortexThreadStageHeaderConfig | null | undefined) {
+  const state = getThreadHeaderStatusState(header);
+  if (state === 'working') return 'Illo is working';
+  if (state === 'unread') return 'Unread thread';
+  return 'Idle thread';
+}
+
+export function getRunSectionKey(runKey: string, section: RunInlineSection) {
+  return `${runKey}:${section}`;
+}
+
+export function parseTimelineToolArgs(args: string | undefined): Record<string, unknown> | null {
+  if (!args) return null;
+  try {
+    const parsed = JSON.parse(args);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function compactTimelineTarget(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  if (!text) return undefined;
+  return text.length > 96 ? `...${text.slice(-93)}` : text;
+}
+
+export function getTimelineToolTarget(item: TimelineToolItem) {
+  const displayTarget = typeof item.display?.target === 'string' ? item.display.target.trim() : '';
+  if (displayTarget) return compactTimelineTarget(displayTarget);
+  const args = parseTimelineToolArgs(item.args);
+  if (!args) return undefined;
+  return compactTimelineTarget(
+    args.path ??
+      args.file_path ??
+      args.filename ??
+      args.cwd ??
+      args.url ??
+      args.query ??
+      args.command ??
+      args.cmd,
+  );
+}
+
+export function getTimelineToolLabel(item: TimelineToolItem) {
+  const displayLabel = typeof item.display?.label === 'string' ? item.display.label.trim() : '';
+  if (displayLabel) return displayLabel;
+  const tool = item.tool.trim() || 'tool';
+  const target = getTimelineToolTarget(item);
+  const normalized = tool.toLowerCase();
+
+  if (/(edit|patch|update)/.test(normalized) && target) return `Editing ${target}`;
+  if (/(write|create|save)/.test(normalized) && target) return `Writing ${target}`;
+  if (/(read|view|open|load)/.test(normalized) && target) return `Reading ${target}`;
+  if (/(exec|command|shell|terminal|bash)/.test(normalized)) return target ? `Ran ${target}` : 'Ran command';
+  if (target) return `${tool} ${target}`;
+  return item.status === 'running' ? `Using ${tool}` : `Used ${tool}`;
+}
+
+export function getRunLiveCueWorkIndex(item: CortexThreadStageRunItem) {
+  const workItems = item.workItems ?? [];
+  for (let index = workItems.length - 1; index >= 0; index -= 1) {
+    const workItem = workItems[index];
+    if (workItem.kind === 'tool' && workItem.status === 'running') return index;
+  }
+  return -1;
+}
+
+export function getRunLiveCueLabel(item: CortexThreadStageRunItem, cueIndex = getRunLiveCueWorkIndex(item)) {
+  if (cueIndex >= 0) {
+    const workItem = item.workItems?.[cueIndex];
+    if (workItem?.kind === 'tool') return getTimelineToolLabel(workItem);
+  }
+
+  return THINKING_STATUS_LABEL;
+}
+
+export function shouldRenderLiveWorkItem(workIndex: number, cueIndex: number) {
+  return workIndex !== cueIndex;
+}
+
+export function hasVisibleLiveWorkItems(item: CortexThreadStageRunItem, cueIndex: number) {
+  return Boolean(item.workItems?.some((_workItem, workIndex) => shouldRenderLiveWorkItem(workIndex, cueIndex)));
+}
+
+export function getTimelineToolTitle(item: TimelineToolItem) {
+  const parts = [getTimelineToolLabel(item), item.tool, item.status, item.time].filter(Boolean);
+  return parts.join(' · ');
+}
+
+export function getTimelineToolDetail(item: TimelineToolItem) {
+  return typeof item.display?.detail === 'string' ? item.display.detail.trim() : '';
+}
+
+export function shouldShowTimelineToolArgs(item: TimelineToolItem) {
+  return Boolean(item.args && !item.display?.label && !getTimelineToolTarget(item));
+}
+
+function stripReflectionPrefix(text: string) {
+  return text.trim().replace(/^Reflecting:\s*/i, '').trim();
+}
+
+export function getWorkThoughtText(text: string) {
+  const cleaned = stripReflectionPrefix(text) || text.trim();
+  const boldMatch = cleaned.match(/^\*\*([^*]+)\*\*\s*([\s\S]*)$/);
+  if (!boldMatch) return cleaned;
+
+  const title = boldMatch[1]?.trim();
+  const tail = (boldMatch[2] ?? '').trim();
+  if (!title) return cleaned;
+  if (!tail || tail.length < 12 || /^[A-Za-z][.,;:]?$/.test(tail)) return `**${title}**`;
+  return cleaned;
+}
+
+export function getToolCallDisplay(call: ToolCallItem) {
+  return call.display && typeof call.display === 'object' ? call.display : null;
+}
+
+export function getToolCallLabel(call: ToolCallItem) {
+  const display = getToolCallDisplay(call);
+  const label = typeof display?.label === 'string' ? display.label.trim() : '';
+  if (label) return label;
+  return call.tool;
+}
+
+export function getToolCallDetail(call: ToolCallItem) {
+  const display = getToolCallDisplay(call);
+  const detail = typeof display?.detail === 'string' ? display.detail.trim() : '';
+  if (detail) return detail;
+  return call.args;
+}
+
+export function getWorkThoughtHtml(text: string) {
+  return renderReadableMarkdown(getWorkThoughtText(text));
+}
+
+export function getWorkThoughtClass(text: string) {
+  return [
+    'run-work-item',
+    'run-work-thought',
+    /^Reflecting:/i.test(text.trim()) ? 'run-work-reflection' : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function getThinkingStatusLabel(item: CortexThreadStageThinkingItem) {
+  const latestStep = item.steps?.at(-1)?.label?.trim();
+  return latestStep || item.label || THINKING_STATUS_LABEL;
+}
+
+export function getThinkingSteps(item: CortexThreadStageThinkingItem) {
+  const steps = [...(item.steps ?? [])];
+  const latestStep = steps.at(-1);
+  if (latestStep?.label?.trim() && latestStep.label.trim() === getThinkingStatusLabel(item)) {
+    return steps.slice(0, -1);
+  }
+  return steps;
+}
+
+export function getMessageClass(item: CortexThreadStageMessageItem) {
+  const role = item.role ?? 'illo';
+  const tone = getMessageTone(item);
+
+  return [
+    'thread-message',
+    role === 'user' ? 'thread-message-user' : 'thread-message-illo',
+    role === 'user' ? `thread-message-${tone}` : '',
+    item.inlineWithWork ? 'thread-message-inline-work' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function isIlloMessage(item: CortexThreadStageMessageItem) {
+  return (item.role ?? 'illo') === 'illo';
+}
+
+export function hasMessageSupplementalMeta(item: CortexThreadStageMessageItem) {
+  return Boolean(item.timestamp || item.tag);
+}
+
+function normalizeHexColor(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(trimmed)) return null;
+  if (trimmed.length === 4) {
+    return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
+  }
+  return trimmed;
+}
+
+export function getUserPresenceStyle(item: CortexThreadStageMessageItem) {
+  if ((item.role ?? 'illo') !== 'user') return undefined;
+  const accent = normalizeHexColor(item.accentColor);
+  const core = normalizeHexColor(item.coreColor);
+  const owner = normalizeHexColor(item.ownerColor);
+  if (!accent) return undefined;
+
+  const seedCore =
+    core ??
+    `color-mix(in srgb, ${accent} var(--constellation-presence-seed-user-core-accent-strength, 52%), var(--constellation-presence-seed-user-core-base, #050910))`;
+  const seedOwner =
+    owner ??
+    `color-mix(in srgb, ${accent} var(--constellation-presence-seed-user-owner-accent-strength, 18%), var(--constellation-presence-seed-user-owner-base, #f0f0fa))`;
+
+  return [
+    `--seed-accent:${accent}`,
+    `--seed-core:${seedCore}`,
+    `--seed-owner:${seedOwner}`,
+  ].join('; ');
+}
+
+export function getAttachmentKey(attachment: CortexThreadStageAttachmentItem, index: number) {
+  if (attachment.kind === 'visual') {
+    return attachment.block.title || `${attachment.block.type}-${index}`;
+  }
+
+  return attachment.url || `${attachment.kind}-${index}`;
+}
+
+export function attachmentPreviewLabel(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment) {
+  return attachment.kind === 'image' ? attachment.alt : attachment.label;
+}
+
+export function attachmentPreviewType(
+  attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment,
+) {
+  return attachment.kind === 'image' ? 'image' : (attachment.previewKind ?? 'file');
+}
+
+export function attachmentIconName(attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment): ConstellationIconName {
+  const kind = attachmentPreviewType(attachment);
+  if (kind === 'image') return 'image';
+  if (kind === 'video') return 'video';
+  if (kind === 'pdf') return 'pdf';
+  if (kind === 'link') return 'link';
+  if (kind === 'archive') return 'archive';
+  if (kind === 'text') return 'code';
+  if (kind === 'file') return 'file';
+  return 'document';
+}

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -85,7 +85,11 @@
     clearOwnerOrbitLayout,
     createOrbitNodeFromIdea,
     orbitNodeCoords,
+    sceneNodeSnapshotChanged,
+    sceneNodeSnapshotFromIdea,
     type OrbitNode,
+    type WorkspaceSceneIdeaSnapshot,
+    type WorkspaceSceneNodeSnapshot,
   } from '../domain/workspaceSceneState';
   import {
     birthRenderPosition,
@@ -569,7 +573,7 @@
     });
   }
 
-  function computeQueuePositions(ideas: any[]): Map<string, number> {
+  function computeQueuePositions(_ideas: WorkspaceSceneIdeaSnapshot[]): Map<string, number> {
     return new Map<string, number>();
   }
 
@@ -817,13 +821,13 @@
     return `translate(${x},${y})`;
   }
 
-  function mergeIdeaIntoSceneNode(node: OrbitNode, idea: any) {
+  function mergeIdeaIntoSceneNode(node: OrbitNode, idea: WorkspaceSceneIdeaSnapshot) {
     applyIdeaSnapshotToSceneNode(node, idea, {
       usePersistedCoordsWhenUnpositioned: orbitAnchors.length === 0,
     });
   }
 
-  function createSceneNode(idea: any, totalIdeas: number): OrbitNode {
+  function createSceneNode(idea: WorkspaceSceneIdeaSnapshot, totalIdeas: number): OrbitNode {
     const persistedCoords = orbitAnchors.length === 0
       ? orbitNodeCoords({
           x: idea.position_x ?? undefined,
@@ -843,7 +847,11 @@
     beginBirthLifecycle(node, birthFrom, orbitPoint);
   }
 
-  function ensureSceneNode(idea: any, totalIdeas: number, options: { birth?: boolean } = {}) {
+  function ensureSceneNode(
+    idea: WorkspaceSceneIdeaSnapshot,
+    totalIdeas: number,
+    options: { birth?: boolean } = {},
+  ) {
     let node = orbitSceneNodesById.get(idea.id);
     const isNew = !node;
 
@@ -863,11 +871,11 @@
     return node;
   }
 
-  function syncSceneNodes(ideas: any[]) {
-    const visibleIdeas = ideas.filter((idea: any) => !idea?.archived_at);
+  function syncSceneNodes(ideas: WorkspaceSceneIdeaSnapshot[]) {
+    const visibleIdeas = ideas.filter((idea) => !idea?.archived_at);
     applyClusterMetrics(visibleIdeas as any[]);
     const nextIds = new Set<string>();
-    const nodes = visibleIdeas.map((idea: any) => {
+    const nodes = visibleIdeas.map((idea) => {
       const node = ensureSceneNode(idea, visibleIdeas.length);
       nextIds.add(node.id);
       return node;
@@ -3823,12 +3831,12 @@
   let renderedIds = new Set<string>();
   let initialIdeaHydrationComplete = false;
 
-  function seedRenderedIdeaTracking(ideas: any[]) {
+  function seedRenderedIdeaTracking(ideas: WorkspaceSceneIdeaSnapshot[]) {
     renderedIds = new Set();
     nodeSnapshotMap = new Map();
     for (const idea of ideas) {
       renderedIds.add(idea.id);
-      nodeSnapshotMap.set(idea.id, ideaSnapshot(idea));
+      nodeSnapshotMap.set(idea.id, sceneNodeSnapshotFromIdea(idea));
     }
   }
 
@@ -3836,10 +3844,10 @@
    * Add a single new bubble to the existing SVG with birth animation from core.
    * Called reactively when cortex.ideas changes.
    */
-  function addBubbleBirth(idea: any) {
+  function addBubbleBirth(idea: WorkspaceSceneIdeaSnapshot) {
     if (!g || !simulation) return;
 
-    const totalIdeas = cortex.filteredIdeas.filter((entry: any) => !entry?.archived_at).length;
+    const totalIdeas = (cortex.filteredIdeas as WorkspaceSceneIdeaSnapshot[]).filter((entry) => !entry?.archived_at).length;
     const sceneNode = ensureSceneNode(idea, totalIdeas, { birth: true });
 
     const nodes = simulation.nodes() as OrbitNode[];
@@ -4118,47 +4126,10 @@
   });
 
   // Track node properties for change detection
-  let nodeSnapshotMap = new Map<string, {
-    status: string;
-    title: string;
-    display_title?: string;
-    salience_score: number;
-    attachments_count: number;
-    thread_count: number;
-    user_id?: string;
-    orbit_anchor_type?: string | null;
-    orbit_anchor_id?: string | null;
-    author_name?: string;
-    author_color?: string;
-    user_color?: string;
-  }>();
-
-  function ideaSnapshot(idea: any) {
-    return {
-      status: idea.status, title: idea.title, display_title: idea.display_title,
-      salience_score: idea.salience_score || 5,
-      attachments_count: (idea.attachments || []).length,
-      thread_count: idea.thread_count || 0, user_id: idea.user_id,
-      orbit_anchor_type: idea.orbit_anchor_type ?? null,
-      orbit_anchor_id: idea.orbit_anchor_id ?? null,
-      author_name: idea.author_name,
-      author_color: idea.author_color,
-      user_color: idea.user_color,
-    };
-  }
-
-  function snapshotChanged(a: any, b: any): boolean {
-    return a.status !== b.status || a.title !== b.title || a.display_title !== b.display_title
-      || a.salience_score !== b.salience_score
-      || a.attachments_count !== b.attachments_count
-      || a.thread_count !== b.thread_count || a.user_id !== b.user_id
-      || a.orbit_anchor_type !== b.orbit_anchor_type || a.orbit_anchor_id !== b.orbit_anchor_id
-      || a.author_name !== b.author_name || a.author_color !== b.author_color
-      || a.user_color !== b.user_color;
-  }
+  let nodeSnapshotMap = new Map<string, WorkspaceSceneNodeSnapshot>();
 
   $effect(() => {
-    const ideas = cortex.filteredIdeas.filter((idea: any) => !idea?.archived_at);
+    const ideas = (cortex.filteredIdeas as WorkspaceSceneIdeaSnapshot[]).filter((idea) => !idea?.archived_at);
 
     if (!initialIdeaHydrationComplete && cortex.loading && renderedIds.size === 0) {
       return;
@@ -4173,21 +4144,21 @@
       }
     }
 
-    const currentIds = new Set(ideas.map((i: any) => i.id));
+    const currentIds = new Set(ideas.map((idea) => idea.id));
     syncSceneNodes(ideas);
     const queuePosMap = computeQueuePositions(ideas);
 
     for (const idea of ideas) {
       if (!renderedIds.has(idea.id)) {
         renderedIds.add(idea.id);
-        nodeSnapshotMap.set(idea.id, ideaSnapshot(idea));
+        nodeSnapshotMap.set(idea.id, sceneNodeSnapshotFromIdea(idea));
         addBubbleBirth(idea);
       } else {
         const sceneNode = ensureSceneNode(idea, ideas.length);
         const prevSnap = nodeSnapshotMap.get(idea.id);
-        const currSnap = ideaSnapshot(idea);
+        const currSnap = sceneNodeSnapshotFromIdea(idea);
 
-        if (prevSnap && snapshotChanged(prevSnap, currSnap)) {
+        if (prevSnap && sceneNodeSnapshotChanged(prevSnap, currSnap)) {
           nodeSnapshotMap.set(idea.id, currSnap);
           if (
             prevSnap.orbit_anchor_type !== currSnap.orbit_anchor_type

--- a/frontend/src/lib/features/workspace-scene/domain/workspaceSceneState.ts
+++ b/frontend/src/lib/features/workspace-scene/domain/workspaceSceneState.ts
@@ -5,6 +5,50 @@ export type ScenePoint = {
 
 export type OrbitNodeSceneState = 'free' | 'birth';
 
+export type WorkspaceSceneIdeaSnapshot = {
+  id: string;
+  title: string;
+  display_title?: string;
+  description?: string | null;
+  status: string;
+  salience_score?: number | null;
+  position_x: number | null;
+  position_y: number | null;
+  thread_count?: number;
+  attachments?: readonly unknown[];
+  updated_at?: string;
+  created_at?: string;
+  archived_at?: string | null;
+  user_id?: string;
+  orbit_anchor_type?: string | null;
+  orbit_anchor_id?: string | null;
+  author_name?: string;
+  author_color?: string;
+  user_color?: string;
+  _ownerRank?: number;
+  _ownerCount?: number;
+  _ownerRingIndex?: number;
+  _ownerSlotIndex?: number;
+  _ownerSlotCount?: number;
+  _ownerOrbitRadius?: number;
+  _ownerSeedAngle?: number;
+};
+
+export type WorkspaceSceneNodeSnapshot = {
+  status: string;
+  title: string;
+  display_title?: string;
+  salience_score: number;
+  attachments_count: number;
+  thread_count: number;
+  user_id?: string;
+  orbit_anchor_type?: string | null;
+  orbit_anchor_id?: string | null;
+  author_name?: string;
+  author_color?: string;
+  user_color?: string;
+};
+
 export type OrbitNode = {
   id: string;
   title: string;
@@ -15,7 +59,7 @@ export type OrbitNode = {
   position_x: number | null;
   position_y: number | null;
   thread_count?: number;
-  attachments?: any[];
+  attachments?: readonly unknown[];
   updated_at?: string;
   created_at?: string;
   user_id?: string;
@@ -54,7 +98,37 @@ export function orbitNodeCoords(source: Partial<OrbitNode>): ScenePoint | null {
   return typeof x === 'number' && typeof y === 'number' ? { x, y } : null;
 }
 
-export function createOrbitNodeFromIdea(idea: any, initialCoords: ScenePoint): OrbitNode {
+export function sceneNodeSnapshotFromIdea(idea: WorkspaceSceneIdeaSnapshot): WorkspaceSceneNodeSnapshot {
+  return {
+    status: idea.status,
+    title: idea.title,
+    display_title: idea.display_title,
+    salience_score: idea.salience_score || 5,
+    attachments_count: idea.attachments?.length ?? 0,
+    thread_count: idea.thread_count || 0,
+    user_id: idea.user_id,
+    orbit_anchor_type: idea.orbit_anchor_type ?? null,
+    orbit_anchor_id: idea.orbit_anchor_id ?? null,
+    author_name: idea.author_name,
+    author_color: idea.author_color,
+    user_color: idea.user_color,
+  };
+}
+
+export function sceneNodeSnapshotChanged(
+  previous: WorkspaceSceneNodeSnapshot,
+  next: WorkspaceSceneNodeSnapshot,
+): boolean {
+  return previous.status !== next.status || previous.title !== next.title || previous.display_title !== next.display_title
+    || previous.salience_score !== next.salience_score
+    || previous.attachments_count !== next.attachments_count
+    || previous.thread_count !== next.thread_count || previous.user_id !== next.user_id
+    || previous.orbit_anchor_type !== next.orbit_anchor_type || previous.orbit_anchor_id !== next.orbit_anchor_id
+    || previous.author_name !== next.author_name || previous.author_color !== next.author_color
+    || previous.user_color !== next.user_color;
+}
+
+export function createOrbitNodeFromIdea(idea: WorkspaceSceneIdeaSnapshot, initialCoords: ScenePoint): OrbitNode {
   return {
     id: idea.id,
     title: idea.title,
@@ -91,7 +165,7 @@ export function createOrbitNodeFromIdea(idea: any, initialCoords: ScenePoint): O
 
 export function applyIdeaSnapshotToSceneNode(
   node: OrbitNode,
-  idea: any,
+  idea: WorkspaceSceneIdeaSnapshot,
   options: { usePersistedCoordsWhenUnpositioned?: boolean } = {},
 ) {
   const nextCoords = orbitNodeCoords({
@@ -105,7 +179,7 @@ export function applyIdeaSnapshotToSceneNode(
   node.display_title = idea.display_title;
   node.description = idea.description;
   node.status = idea.status;
-  node.salience_score = idea.salience_score;
+  node.salience_score = idea.salience_score || 5;
   node.position_x = idea.position_x;
   node.position_y = idea.position_y;
   node.thread_count = idea.thread_count;

--- a/frontend/src/lib/stores/chat.svelte.ts
+++ b/frontend/src/lib/stores/chat.svelte.ts
@@ -1,5 +1,6 @@
 import {
   api,
+  type ChatAttachmentPayload,
   type ChatBootstrap,
   type ChatConversationPage as ChatConversationPageResponse,
   type ChatConversationSummary,
@@ -777,7 +778,7 @@ class ChatStore {
     body?: string,
     options: {
       bodyFormat?: 'markdown' | 'plain';
-      attachments?: any[];
+      attachments?: ChatAttachmentPayload[];
       replyToMessageId?: number | null;
       metadata?: Record<string, any> | null;
     } = {},
@@ -795,7 +796,7 @@ class ChatStore {
     body?: string,
     options: {
       bodyFormat?: 'markdown' | 'plain';
-      attachments?: any[];
+      attachments?: ChatAttachmentPayload[];
       metadata?: Record<string, any> | null;
     } = {},
   ) {
@@ -854,7 +855,7 @@ class ChatStore {
     body?: string,
     options: {
       bodyFormat?: 'markdown' | 'plain';
-      attachments?: any[];
+      attachments?: ChatAttachmentPayload[];
       replyToMessageId?: number | null;
       metadata?: Record<string, any> | null;
     } = {},
@@ -1365,7 +1366,7 @@ class ChatStore {
     conversationId: string;
     body: string;
     bodyFormat: 'markdown' | 'plain';
-    attachments: any[];
+    attachments: ChatAttachmentPayload[];
     metadata: Record<string, any> | null;
     clientGeneratedId: string;
     threadRootMessageId: number | null;

--- a/frontend/src/lib/styles/components.css
+++ b/frontend/src/lib/styles/components.css
@@ -1129,15 +1129,6 @@
 .msg-tag-discuss { color: var(--text-3); background: var(--bg-3); }
 .msg-tag-trigger { color: #57CFA0; background: color-mix(in srgb, var(--constellation-color-amber, #57CFA0) 15%, transparent); }
 
-.thread-message {
-  display: flex; flex-direction: column; gap: 4px;
-  padding: 8px 16px; border-radius: 4px; margin-bottom: 2px;
-}
-.thread-message.agent {
-  border-left: 2px solid rgba(94,168,152,0.3);
-  background: rgba(94,168,152,0.06) !important;
-}
-
 /* ── Presence Pills (Multiplayer) ─────────────────────────────── */
 .presence-pills {
   display: flex; align-items: center; gap: 4px; margin-left: auto; margin-right: 8px;

--- a/frontend/src/lib/utils/threadTranscriptStyleContract.test.js
+++ b/frontend/src/lib/utils/threadTranscriptStyleContract.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const threadTranscriptPath = resolve(
+  __dirname,
+  '../features/threads/components/ThreadTranscript.svelte',
+);
+const globalComponentsPath = resolve(__dirname, '../styles/components.css');
+
+function styleRule(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  return match?.[1] ?? '';
+}
+
+test('thread transcript messages own box metrics inside the component', () => {
+  const source = readFileSync(threadTranscriptPath, 'utf8');
+  const rule = styleRule(source, '.thread-message');
+
+  assert.match(rule, /padding:\s*0\s*;/);
+  assert.match(rule, /margin-bottom:\s*0\s*;/);
+  assert.match(rule, /border-radius:\s*0\s*;/);
+});
+
+test('global component styles do not define generic thread-message rules', () => {
+  const source = readFileSync(globalComponentsPath, 'utf8');
+
+  assert.doesNotMatch(source, /(^|\n)\s*\.thread-message(?:[^\w-]|\s*\{)/);
+});


### PR DESCRIPTION
## Summary
- remove the leaking global `.thread-message` style and add a contract test to keep it out
- extract transcript presentation helpers into a domain module and move project selector shaping into the draft presenter
- type chat attachment payloads and workspace scene snapshots while reducing room/thread/DM branching

## Tests
- `npm run check`
- `npm test`