### PR TITLE
Make CI workflows path-aware

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -13,11 +13,71 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.selected.outputs.backend }}
+      frontend: ${{ steps.selected.outputs.frontend }}
+      db: ${{ steps.selected.outputs.db }}
+
+    steps:
+      - name: Check out repository
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed areas
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - "brain/**"
+              - "tests/**"
+              - "requirements*.txt"
+              - "requirements-gpu.txt"
+              - "pyproject.toml"
+              - "alembic.ini"
+              - "docker-compose.test.yml"
+              - ".github/workflows/brain-ci.yml"
+            frontend:
+              - "frontend/**"
+              - ".github/workflows/brain-ci.yml"
+            db:
+              - "brain/platform/db/**"
+              - "tests/test_schema_contract.py"
+              - "tests/test_db_*.py"
+              - "tests/db_engine_utils.py"
+              - "scripts/sync_schema.py"
+              - "scripts/check_db_audit_objectives.py"
+              - "scripts/async_*db*.py"
+              - "alembic.ini"
+              - ".github/workflows/brain-ci.yml"
+
+      - name: Select jobs
+        id: selected
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            echo "db=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=${{ steps.filter.outputs.backend }}" >> "$GITHUB_OUTPUT"
+            echo "frontend=${{ steps.filter.outputs.frontend }}" >> "$GITHUB_OUTPUT"
+            echo "db=${{ steps.filter.outputs.db }}" >> "$GITHUB_OUTPUT"
+          fi
+
   backend-fast:
     name: Backend fast suite
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
 
     steps:
       - name: Check out repository
@@ -50,6 +110,8 @@ jobs:
   backend-review:
     name: Backend review-fix suites
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
 
     steps:
       - name: Check out repository
@@ -82,6 +144,8 @@ jobs:
   frontend:
     name: Frontend check and build
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Check out repository
@@ -113,6 +177,8 @@ jobs:
   db-contract:
     name: DB migration contract
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.db == 'true'
 
     services:
       postgres:
@@ -156,3 +222,31 @@ jobs:
 
       - name: Run schema contract tests
         run: python3 -m pytest tests/test_schema_contract.py -v --tb=short
+
+  ci-result:
+    name: CI result
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - backend-fast
+      - backend-review
+      - frontend
+      - db-contract
+    if: always()
+
+    steps:
+      - name: Check selected CI jobs
+        run: |
+          for result in \
+            "${{ needs.changes.result }}" \
+            "${{ needs.backend-fast.result }}" \
+            "${{ needs.backend-review.result }}" \
+            "${{ needs.frontend.result }}" \
+            "${{ needs.db-contract.result }}"
+          do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "A selected CI job failed or was cancelled."
+              exit 1
+            fi
+          done
+          echo "Selected CI jobs passed."

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -7,14 +7,16 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "brain/**"
-      - "frontend/**"
-      - "deploy/compose/**"
+      - ".dockerignore"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
       - "deploy/docker/**"
-      - "requirements.txt"
+      - "deploy/scripts/self-update-daemon.sh"
+      - "deploy/scripts/self-update-healthcheck.sh"
       - "requirements-production.txt"
       - "pyproject.toml"
       - "alembic.ini"
+      - "ops/install-browser-runtime.sh"
       - ".github/workflows/container-images.yml"
   workflow_dispatch:
 
@@ -24,20 +26,72 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
   packages: write
 
 jobs:
-  build:
-    name: Build ${{ matrix.image }} image
+  changes:
+    name: Detect image changes
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: api
-            dockerfile: deploy/docker/api.Dockerfile
-          - image: web
-            dockerfile: deploy/docker/web.Dockerfile
+    outputs:
+      api: ${{ steps.selected.outputs.api }}
+      web: ${{ steps.selected.outputs.web }}
+      updater: ${{ steps.selected.outputs.updater }}
+
+    steps:
+      - name: Check out repository
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Detect image changes
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - ".dockerignore"
+              - "deploy/docker/api.Dockerfile"
+              - "requirements-production.txt"
+              - "pyproject.toml"
+              - "alembic.ini"
+              - "ops/install-browser-runtime.sh"
+              - ".github/workflows/container-images.yml"
+            web:
+              - ".dockerignore"
+              - "frontend/package.json"
+              - "frontend/package-lock.json"
+              - "deploy/docker/web.Dockerfile"
+              - "deploy/docker/web.nginx.conf"
+              - ".github/workflows/container-images.yml"
+            updater:
+              - ".dockerignore"
+              - "deploy/docker/updater.Dockerfile"
+              - "deploy/scripts/self-update-daemon.sh"
+              - "deploy/scripts/self-update-healthcheck.sh"
+              - ".github/workflows/container-images.yml"
+
+      - name: Select images
+        id: selected
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "api=${{ steps.filter.outputs.api }}" >> "$GITHUB_OUTPUT"
+            echo "web=${{ steps.filter.outputs.web }}" >> "$GITHUB_OUTPUT"
+            echo "updater=${{ steps.filter.outputs.updater }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "updater=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-api:
+    name: Build api image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    env:
+      IMAGE_NAME: api
+      DOCKERFILE: deploy/docker/api.Dockerfile
 
     steps:
       - name: Check out repository
@@ -58,7 +112,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/illospace/${{ matrix.image }}
+          images: ghcr.io/illospace/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -71,9 +125,105 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ${{ env.DOCKERFILE }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
+
+  build-web:
+    name: Build web image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    env:
+      IMAGE_NAME: web
+      DOCKERFILE: deploy/docker/web.Dockerfile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/illospace/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
+
+  build-updater:
+    name: Build updater image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.updater == 'true'
+    env:
+      IMAGE_NAME: updater
+      DOCKERFILE: deploy/docker/updater.Dockerfile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/illospace/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}

--- a/.github/workflows/deployment-smoke.yml
+++ b/.github/workflows/deployment-smoke.yml
@@ -4,13 +4,16 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "brain/**"
-      - "frontend/**"
       - "deploy/**"
       - "requirements.txt"
       - "requirements-production.txt"
+      - "requirements-gpu.txt"
       - "pyproject.toml"
       - "alembic.ini"
+      - "brain/platform/db/**"
+      - "brain/app/api/main.py"
+      - "brain/app/api/config.py"
+      - "brain/app/api/deps.py"
       - ".github/workflows/deployment-smoke.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- detect changed backend, frontend, and DB areas before running Brain CI jobs
- narrow PR container image builds to image-affecting files and include the updater image
- restrict deployment smoke PR runs to deploy, dependency, DB, and startup-sensitive paths

## Validation
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/brain-ci.yml .github/workflows/container-images.yml .github/workflows/deployment-smoke.yml
- git diff --check -- .github/workflows/brain-ci.yml .github/workflows/container-images.yml .github/workflows/deployment-smoke.yml