### PR TITLE
Make capability lookup query-first

### DIFF
--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -274,7 +274,7 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "name": "Slack",
         "category": "external_surface",
         "summary": "Illo can participate in Slack conversations when a Slack source connection is registered for the workspace.",
-        "aliases": ("slack", "team chat", "chat teammate", "communication", "messaging", "slack integration"),
+        "aliases": ("slack", "team chat", "chat teammate", "slack integration"),
         "tools": ("manage_slack", "read_slack_conversation", "post_slack_reply"),
         "status_check": {"tool": "manage_slack", "args": {"action": "status"}},
         "setup": {
@@ -543,7 +543,7 @@ def filter_capability_manifests(
     for manifest in manifest_list:
         if key and key not in {manifest.key.lower(), *(alias.lower() for alias in manifest.aliases)}:
             continue
-        if cat and manifest.category.lower() != cat:
+        if cat and not key and manifest.category.lower() != cat:
             continue
         if q and not _matches_query(manifest, q):
             continue

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -274,7 +274,7 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "name": "Slack",
         "category": "external_surface",
         "summary": "Illo can participate in Slack conversations when a Slack source connection is registered for the workspace.",
-        "aliases": ("slack", "team chat", "chat teammate"),
+        "aliases": ("slack", "team chat", "chat teammate", "communication", "messaging", "slack integration"),
         "tools": ("manage_slack", "read_slack_conversation", "post_slack_reply"),
         "status_check": {"tool": "manage_slack", "args": {"action": "status"}},
         "setup": {
@@ -502,6 +502,22 @@ def _matches_query(manifest: CapabilityManifest, query: str) -> bool:
     return any(term in haystack for term in terms)
 
 
+def _identity_matches_query(manifest: CapabilityManifest, query: str) -> bool:
+    text = query.lower()
+    identities = (manifest.key, manifest.name, *manifest.aliases)
+    for identity in identities:
+        term = _coerce_text(identity).lower()
+        if not term:
+            continue
+        if " " in term:
+            if term in text:
+                return True
+            continue
+        if re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", text):
+            return True
+    return False
+
+
 def filter_capability_manifests(
     manifests: Iterable[CapabilityManifest],
     *,
@@ -512,8 +528,19 @@ def filter_capability_manifests(
     key = _coerce_text(capability_key).lower()
     cat = _coerce_text(category).lower()
     q = _coerce_text(query).lower()
+    manifest_list = list(manifests)
+    if q and not key:
+        identity_matches = [
+            manifest
+            for manifest in manifest_list
+            if (not cat or manifest.category.lower() == cat)
+            and _identity_matches_query(manifest, q)
+        ]
+        if identity_matches:
+            return identity_matches
+
     result: list[CapabilityManifest] = []
-    for manifest in manifests:
+    for manifest in manifest_list:
         if key and key not in {manifest.key.lower(), *(alias.lower() for alias in manifest.aliases)}:
             continue
         if cat and manifest.category.lower() != cat:

--- a/brain/systems/runs/tool_catalog/handlers/capabilities.py
+++ b/brain/systems/runs/tool_catalog/handlers/capabilities.py
@@ -58,66 +58,13 @@ def _resolved_detail_level(
     *,
     matches: list,
     capability_key: str | None,
-    include_setup_guide: bool,
 ) -> str:
     detail = str(requested or "auto").strip().lower()
     if detail in {"summary", "tools", "full"}:
         return detail
-    if capability_key or include_setup_guide or len(matches) == 1:
+    if capability_key or len(matches) == 1:
         return "full"
     return "summary"
-
-
-def _filter_with_fallbacks(
-    manifests: list,
-    *,
-    query: str | None,
-    capability_key: str | None,
-    category: str | None,
-) -> tuple[list, list[str]]:
-    matches = filter_capability_manifests(
-        manifests,
-        query=query,
-        capability_key=capability_key,
-        category=category,
-    )
-    if matches:
-        return matches, []
-
-    ignored: list[str] = []
-    if category:
-        matches = filter_capability_manifests(
-            manifests,
-            query=query,
-            capability_key=capability_key,
-        )
-        if matches:
-            ignored.append("category")
-            return matches, ignored
-
-    if capability_key:
-        matches = filter_capability_manifests(
-            manifests,
-            query=query,
-            category=category,
-        )
-        if matches:
-            ignored.append("capability_key")
-            return matches, ignored
-
-    if query:
-        matches = filter_capability_manifests(manifests, query=query)
-        if matches:
-            ignored.extend(
-                field for field, value in (
-                    ("capability_key", capability_key),
-                    ("category", category),
-                )
-                if value
-            )
-            return matches, ignored
-
-    return matches, ignored
 
 
 def _handle_read_capabilities(
@@ -142,17 +89,17 @@ def _handle_read_capabilities(
             registered_tool_names=registered_tools,
         ),
     ])
-    matches, ignored_filters = _filter_with_fallbacks(
+    matches = filter_capability_manifests(
         manifests,
         query=query,
         capability_key=capability_key,
         category=category,
     )
+    ignored_filters = ["category"] if category and capability_key else []
     resolved_detail = _resolved_detail_level(
         detail_level,
         matches=matches,
         capability_key=capability_key,
-        include_setup_guide=include_setup_guide,
     )
     payload: dict[str, Any] = {
         "ok": True,

--- a/brain/systems/runs/tool_catalog/handlers/capabilities.py
+++ b/brain/systems/runs/tool_catalog/handlers/capabilities.py
@@ -18,6 +18,9 @@ from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 
 
+_FILTER_FIELDS = ("capability_key", "category")
+
+
 def _context_containers() -> list[dict[str, Any]]:
     containers: list[dict[str, Any]] = []
     for attr in ("target_ref", "workspace_ref"):
@@ -65,6 +68,58 @@ def _resolved_detail_level(
     return "summary"
 
 
+def _filter_with_fallbacks(
+    manifests: list,
+    *,
+    query: str | None,
+    capability_key: str | None,
+    category: str | None,
+) -> tuple[list, list[str]]:
+    matches = filter_capability_manifests(
+        manifests,
+        query=query,
+        capability_key=capability_key,
+        category=category,
+    )
+    if matches:
+        return matches, []
+
+    ignored: list[str] = []
+    if category:
+        matches = filter_capability_manifests(
+            manifests,
+            query=query,
+            capability_key=capability_key,
+        )
+        if matches:
+            ignored.append("category")
+            return matches, ignored
+
+    if capability_key:
+        matches = filter_capability_manifests(
+            manifests,
+            query=query,
+            category=category,
+        )
+        if matches:
+            ignored.append("capability_key")
+            return matches, ignored
+
+    if query:
+        matches = filter_capability_manifests(manifests, query=query)
+        if matches:
+            ignored.extend(
+                field for field, value in (
+                    ("capability_key", capability_key),
+                    ("category", category),
+                )
+                if value
+            )
+            return matches, ignored
+
+    return matches, ignored
+
+
 def _handle_read_capabilities(
     query: str | None = None,
     capability_key: str | None = None,
@@ -87,7 +142,7 @@ def _handle_read_capabilities(
             registered_tool_names=registered_tools,
         ),
     ])
-    matches = filter_capability_manifests(
+    matches, ignored_filters = _filter_with_fallbacks(
         manifests,
         query=query,
         capability_key=capability_key,
@@ -103,27 +158,31 @@ def _handle_read_capabilities(
         "ok": True,
         "source": "runtime_capability_registry",
         "query": query,
-        "capability_key": capability_key,
-        "category": category,
         "detail_level": resolved_detail,
         "count": len(matches),
+        "ignored_filters": ignored_filters,
         "capabilities": [
             manifest.to_payload(detail_level=resolved_detail)
             for manifest in matches
         ],
         "answering_guidance": [
             "Use capability manifests and tool schemas as the authority for what Illo can inspect, do, or guide.",
-            "Use summary results as a capability index; request a single capability or detail_level=full before relying on exact tools or setup fields.",
+            "Use summary results as a capability index; single matches include setup/status fields when they exist.",
+            "Setup guides are optional extra documentation; when no setup guide is returned, use the capability setup/status fields.",
             "For custom capabilities, rely on the provided manifest fields instead of general model assumptions.",
         ],
     }
+    for field in _FILTER_FIELDS:
+        payload[f"{field}_ignored"] = field in ignored_filters
     if include_setup_guide:
         guide_targets = matches if capability_key or len(matches) == 1 else []
-        payload["setup_guides"] = [
+        setup_guides = [
             guide
             for guide in (load_setup_guide(manifest) for manifest in guide_targets)
             if guide is not None
         ]
+        if setup_guides:
+            payload["setup_guides"] = setup_guides
     return json.dumps(payload, default=str)
 
 

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -419,28 +419,20 @@ BRAIN_TOOLS = [
             "Read machine-readable capability manifests for Illo's runtime and installed/custom capabilities. "
             "Use this before answering setup, connect, install, integration, connector, plugin, tool, "
             "or 'can you do X?' questions. Capability manifests and tool schemas are the source of truth "
-            "for setup modes, status checks, credential stores, and agent actions. For a matched setup "
-            "request, set include_setup_guide=true when the manifest points to a registered setup guide."
+            "for setup modes, status checks, credential stores, and agent actions. Pass the user's natural "
+            "language request as query; do not invent capability keys or categories. Auto expands single matches."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Natural-language capability lookup, such as the integration or action the user asked about.",
-                },
-                "capability_key": {
-                    "type": "string",
-                    "description": "Optional exact capability key or alias, such as a registered integration key.",
-                },
-                "category": {
-                    "type": "string",
-                    "description": "Optional capability category filter, such as communication, project, data, or custom.",
+                    "description": "The user's natural-language capability/setup question, such as 'help me set up Slack'.",
                 },
                 "include_setup_guide": {
                     "type": "boolean",
                     "default": False,
-                    "description": "When true, include the registered setup guide for an exact or single matched capability.",
+                    "description": "When true, include a registered setup guide for a single matched capability.",
                 },
                 "detail_level": {
                     "type": "string",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1785,7 +1785,7 @@ class TestCortexReplyHandler:
         from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
 
         payload = json.loads(_handle_read_capabilities(
-            query="communication integration setup guide connect Illospace to Slack",
+            query="Slack integration setup guide connect Illospace to Slack",
             detail_level="auto",
             include_setup_guide=True,
         ))
@@ -1796,6 +1796,26 @@ class TestCortexReplyHandler:
         assert slack["key"] == "slack"
         assert slack["setup"]["credential_store"] == "Vault"
         assert "setup_guides" not in payload
+
+    def test_read_capabilities_does_not_treat_generic_communication_as_slack(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(query="communication setup"))
+
+        assert payload["count"] == 0
+
+    def test_read_capabilities_keeps_broad_setup_guide_query_compact(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(
+            query="what integrations can you do?",
+            include_setup_guide=True,
+        ))
+
+        assert payload["count"] >= 10
+        assert payload["detail_level"] == "summary"
+        assert len(json.dumps(payload)) < 16_000
+        assert all("tool_details" not in capability for capability in payload["capabilities"])
 
     def test_read_capabilities_internal_key_recovers_from_wrong_category_hint(self):
         from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -242,6 +242,18 @@ class TestToolDefinitions:
         assert "read_self_context" in names
         assert "read_capabilities" in names
 
+    def test_read_capabilities_schema_is_query_first_for_models(self):
+        from brain.systems.runs.direct_agent import BRAIN_TOOLS
+
+        tool = next(tool for tool in BRAIN_TOOLS if tool["name"] == "read_capabilities")
+        properties = tool["input_schema"]["properties"]
+
+        assert "query" in properties
+        assert "detail_level" in properties
+        assert "include_setup_guide" in properties
+        assert "capability_key" not in properties
+        assert "category" not in properties
+
     def test_exec_tools_defined(self):
         from brain.systems.runs.direct_agent import EXEC_TOOLS
         names = [t["name"] for t in EXEC_TOOLS]
@@ -1768,6 +1780,35 @@ class TestCortexReplyHandler:
         assert domains["tools"] == ["read_workspace_records", "manage_domain"]
         assert {detail["name"] for detail in domains["tool_details"]} == set(domains["tools"])
         assert any("domain" in (detail["expected_effect"] or "").lower() for detail in domains["tool_details"])
+
+    def test_read_capabilities_query_first_matches_slack_communication_setup(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(
+            query="communication integration setup guide connect Illospace to Slack",
+            detail_level="auto",
+            include_setup_guide=True,
+        ))
+
+        assert payload["count"] == 1
+        assert payload["detail_level"] == "full"
+        slack = payload["capabilities"][0]
+        assert slack["key"] == "slack"
+        assert slack["setup"]["credential_store"] == "Vault"
+        assert "setup_guides" not in payload
+
+    def test_read_capabilities_internal_key_recovers_from_wrong_category_hint(self):
+        from brain.systems.runs.tool_catalog.handlers.capabilities import _handle_read_capabilities
+
+        payload = json.loads(_handle_read_capabilities(
+            capability_key="slack",
+            category="communication",
+            detail_level="full",
+        ))
+
+        assert payload["count"] == 1
+        assert payload["category_ignored"] is True
+        assert payload["capabilities"][0]["key"] == "slack"
 
     def test_read_capabilities_marks_disabled_capability_tools_unavailable(self):
         from brain.systems.runs.execution_context import bind_agent_context


### PR DESCRIPTION
## Summary
- simplify the model-facing read_capabilities schema to natural-language query + detail controls
- make capability matching prefer explicit capability identities/aliases before broad keyword matches
- recover from legacy/wrong category hints and avoid empty setup_guides as a negative setup signal

## Verification
- .venv/bin/python -m py_compile brain/systems/runs/capabilities.py brain/systems/runs/tool_catalog/handlers/capabilities.py brain/systems/runs/tool_definitions.py
- .venv/bin/python -m pytest tests/test_tool_registry.py tests/test_agent_split.py tests/test_agent.py::TestToolDefinitions tests/test_agent.py::TestCortexReplyHandler tests/test_agent.py::TestFinalReplyReview tests/test_slack_teammate.py -q
- git diff --check origin/main...HEAD