### PR TITLE
Add runtime service restart management

### DIFF
--- a/brain/app/cli/slack_connector.py
+++ b/brain/app/cli/slack_connector.py
@@ -34,7 +34,7 @@ def build_parser() -> argparse.ArgumentParser:
 async def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
-    config = SlackConnectorConfig.from_env()
+    config = await SlackConnectorConfig.from_runtime()
     if args.check:
         print(
             json.dumps(

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1303,6 +1303,50 @@ async def tool_manage_deployment(
     return payload
 
 
+async def tool_manage_runtime_services(
+    action: str = "list",
+    services: list[str] | str | None = None,
+    user_id: str | None = None,
+    org_id: str | None = None,
+) -> dict:
+    """Inspect or restart known Illospace runtime services through the host controller."""
+    from brain.platform.db.models.org import User
+    from brain.systems.runtime_settings.runtime_services import (
+        async_get_runtime_services_status,
+        async_restart_runtime_services,
+    )
+
+    normalized_action = str(action or "list").strip().lower()
+    if normalized_action not in {"list", "status", "restart"}:
+        raise ValueError("manage_runtime_services action must be 'list', 'status', or 'restart'.")
+
+    async with UnitOfWork() as uow:
+        user = await uow.session.get(User, user_id) if user_id else None
+        if user is None:
+            return {
+                "action": normalized_action,
+                "status": "denied",
+                "available": False,
+                "detail": "Runtime service management requires an authenticated workspace user.",
+            }
+        if org_id and str(getattr(user, "org_id", "")) != str(org_id):
+            return {
+                "action": normalized_action,
+                "status": "denied",
+                "available": False,
+                "detail": "Runtime service management requires a user in the active organization.",
+            }
+
+        if normalized_action == "restart":
+            service_status = await async_restart_runtime_services(services, requested_by=str(user.id))
+        else:
+            service_status = await async_get_runtime_services_status()
+
+    payload = service_status.model_dump(mode="json")
+    payload["action"] = normalized_action
+    return payload
+
+
 # ── MCP Protocol Layer ───────────────────────────────────────
 
 TOOLS = {
@@ -1512,6 +1556,30 @@ TOOLS = {
                 "worker_drain_timeout_seconds": {
                     "type": "integer",
                     "description": "For start_update, optional positive timeout for active worker drain before leaving old worker to finish.",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    "manage_runtime_services": {
+        "function": tool_manage_runtime_services,
+        "description": (
+            "List, inspect, or restart known Illospace runtime services through the host controller. "
+            "Use list first when choosing services; restart accepts one or more returned service ids, or all."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "status", "restart"],
+                    "default": "list",
+                    "description": "Use list/status to inspect service management, or restart to queue a service restart.",
+                },
+                "services": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "For restart, one or more service ids returned by list, or all.",
                 },
             },
             "required": ["action"],

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -335,11 +335,11 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
     },
     {
         "key": "deployment",
-        "name": "Deployment",
+        "name": "Deployment and Runtime Operations",
         "category": "operations",
-        "summary": "Illo can inspect or start the self-update deployment flow when the deployment management tool is available.",
-        "aliases": ("deploy", "deployment", "update", "self update"),
-        "tools": ("manage_deployment",),
+        "summary": "Illo can inspect or start the self-update deployment flow, and can list or restart known runtime services when host management is available.",
+        "aliases": ("deploy", "deployment", "update", "self update", "restart", "services", "runtime services"),
+        "tools": ("manage_deployment", "manage_runtime_services"),
     },
     {
         "key": "voice",

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -158,6 +158,7 @@ def _get_tool_handlers(
         tool_vault_secret_prompt,
         tool_runtime_settings,
         tool_manage_deployment,
+        tool_manage_runtime_services,
     )
     from brain.systems.personality import manage_agent_soul
 
@@ -166,6 +167,14 @@ def _get_tool_handlers(
             action=action,
             build_no_cache=build_no_cache,
             worker_drain_timeout_seconds=worker_drain_timeout_seconds,
+            user_id=getattr(_agent_context, "user_id", None),
+            org_id=getattr(_agent_context, "org_id", None),
+        )
+
+    def _manage_runtime_services(action="list", services=None):
+        return tool_manage_runtime_services(
+            action=action,
+            services=services,
             user_id=getattr(_agent_context, "user_id", None),
             org_id=getattr(_agent_context, "org_id", None),
         )
@@ -215,6 +224,7 @@ def _get_tool_handlers(
         "read_self_context": _handle_read_self_context,
         "read_capabilities": _handle_read_capabilities,
         "manage_deployment": _manage_deployment,
+        "manage_runtime_services": _manage_runtime_services,
         "transcribe_audio_attachment": lambda **kw: _patched_private(
             "_handle_transcribe_audio_attachment",
             _handle_transcribe_audio_attachment,

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -76,6 +76,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "start or inspect the Illospace self-update deployment flow",
         "output_budget_chars": 8_000,
     },
+    "manage_runtime_services": {
+        "permission": "manage_runtime",
+        "risk_class": "high",
+        "side_effect_class": "deployment_management",
+        "reversibility": "variable",
+        "action_manifest": True,
+        "expected_effect": "list, inspect, or restart known Illospace runtime services",
+        "output_budget_chars": 8_000,
+    },
     "brain_encode": {
         "permission": "write_memory",
         "risk_class": "low",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -2576,6 +2576,31 @@ DEPLOYMENT_TOOLS = [
             "required": ["action"],
         },
     },
+    {
+        "name": "manage_runtime_services",
+        "description": (
+            "List, inspect, or restart known Illospace runtime services through the host controller. "
+            "Use list before choosing targets. Use restart when an authenticated workspace user asks "
+            "Illo to restart one, many, or all services in this Illospace installation."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "status", "restart"],
+                    "default": "list",
+                    "description": "Use list/status to inspect service management, or restart to queue a service restart.",
+                },
+                "services": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "For restart, one or more service ids returned by list, or all.",
+                },
+            },
+            "required": ["action"],
+        },
+    },
 ]
 
 # ── Composite Tool Lists ─────────────────────────────────────

--- a/brain/systems/runtime_settings/runtime_services.py
+++ b/brain/systems/runtime_settings/runtime_services.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+
+from brain.kernel import config as cfg
+
+from .schemas import RuntimeServiceRead, RuntimeServicesRead
+from .sidecar_queue import (
+    SidecarQueue,
+    acquire_start_lock,
+    parse_datetime,
+    release_start_lock,
+)
+
+_RUNTIME_SERVICES_QUEUE = SidecarQueue(
+    request_file_env="ILLO_RUNTIME_SERVICES_REQUEST_FILE",
+    status_file_env="ILLO_RUNTIME_SERVICES_STATUS_FILE",
+    log_path_env="ILLO_RUNTIME_SERVICES_LOG_PATH",
+    default_log_name="illo-runtime-services.log",
+    ready_detail="Queues runtime service operations for the host controller.",
+    queue_unavailable_label="Runtime service queue",
+    waiting_detail="Runtime service management is waiting for the host controller.",
+    stale_detail="Runtime service management is unavailable because the host controller heartbeat is stale.",
+    heartbeat_file_env="ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE",
+    fallback_heartbeat_file_env="ILLO_SELF_UPDATE_HEARTBEAT_FILE",
+)
+
+
+async def async_get_runtime_services_status() -> RuntimeServicesRead:
+    request_file = _RUNTIME_SERVICES_QUEUE.request_file()
+    services = runtime_service_catalog()
+    if request_file is None:
+        return RuntimeServicesRead(
+            status="idle",
+            available=False,
+            services=services,
+            log_path=str(_RUNTIME_SERVICES_QUEUE.log_path()),
+            detail="Runtime service management is unavailable because no host-side service queue is configured.",
+        )
+
+    available, availability_detail = _RUNTIME_SERVICES_QUEUE.availability(request_file)
+    status_data = _RUNTIME_SERVICES_QUEUE.status_data(request_file)
+    detail = status_data.get("detail") if isinstance(status_data.get("detail"), str) else None
+
+    return RuntimeServicesRead(
+        status="running" if _RUNTIME_SERVICES_QUEUE.status_is_running(request_file, status_data) else "idle",
+        available=available,
+        services=services,
+        requested_services=_coerce_service_list(status_data.get("services")),
+        started_at=parse_datetime(status_data.get("started_at") or status_data.get("requested_at")),
+        log_path=str(_RUNTIME_SERVICES_QUEUE.log_path()),
+        detail=detail or availability_detail,
+    )
+
+
+async def async_restart_runtime_services(
+    services: list[str] | tuple[str, ...] | str | None,
+    *,
+    requested_by: str | None = None,
+) -> RuntimeServicesRead:
+    request_file = _RUNTIME_SERVICES_QUEUE.request_file()
+    if request_file is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Runtime service management is unavailable because no host-side service queue is configured.",
+        )
+
+    available, detail = _RUNTIME_SERVICES_QUEUE.availability(request_file)
+    if not available:
+        raise HTTPException(status_code=409, detail=detail or "Runtime service management is unavailable.")
+
+    requested_services = normalize_runtime_service_ids(services)
+    existing = await async_get_runtime_services_status()
+    if existing.status == "running":
+        return RuntimeServicesRead(
+            **{
+                **existing.model_dump(),
+                "detail": "A runtime service operation is already running.",
+            }
+        )
+
+    lock_path = _RUNTIME_SERVICES_QUEUE.start_lock_path(request_file)
+    lock_fd = acquire_start_lock(lock_path)
+    if lock_fd is None:
+        current = await async_get_runtime_services_status()
+        return RuntimeServicesRead(
+            **{
+                **current.model_dump(),
+                "status": "running",
+                "detail": "A runtime service operation is starting.",
+            }
+        )
+
+    try:
+        started_at = datetime.now(timezone.utc)
+        payload = {
+            "action": "restart",
+            "services": requested_services,
+            "requested_at": started_at.isoformat(),
+            "requested_by": requested_by,
+        }
+        _RUNTIME_SERVICES_QUEUE.write_json(request_file, payload)
+        _RUNTIME_SERVICES_QUEUE.write_json(
+            _RUNTIME_SERVICES_QUEUE.status_file(request_file),
+            {
+                **payload,
+                "started_at": started_at.isoformat(),
+                "status": "queued",
+                "detail": "Runtime service restart queued for the host controller.",
+            },
+        )
+        return RuntimeServicesRead(
+            status="running",
+            available=True,
+            services=runtime_service_catalog(),
+            requested_services=requested_services,
+            started_at=started_at,
+            log_path=str(_RUNTIME_SERVICES_QUEUE.log_path()),
+            detail="Runtime service restart queued for the host controller.",
+        )
+    finally:
+        release_start_lock(lock_fd, lock_path)
+
+
+def runtime_service_catalog() -> list[RuntimeServiceRead]:
+    services = _read_runtime_service_catalog().get("services")
+    if not isinstance(services, list):
+        return []
+
+    catalog: list[RuntimeServiceRead] = []
+    for item in services:
+        if not isinstance(item, dict):
+            continue
+        service_id = str(item.get("id") or "").strip()
+        name = str(item.get("name") or service_id).strip()
+        description = str(item.get("description") or "").strip()
+        if not service_id or not name or not description:
+            continue
+        catalog.append(
+            RuntimeServiceRead(
+                id=service_id,
+                name=name,
+                description=description,
+                restartable=bool(item.get("restartable", True)),
+                optional=bool(item.get("optional", False)),
+            )
+        )
+    return catalog
+
+
+def normalize_runtime_service_ids(services: list[str] | tuple[str, ...] | str | None) -> list[str]:
+    values = _coerce_service_list(services)
+    if not values:
+        raise HTTPException(status_code=400, detail="services must include at least one runtime service id.")
+
+    known = {service.id for service in runtime_service_catalog()}
+    expanded: list[str] = []
+    unknown: list[str] = []
+    for value in values:
+        normalized = _normalize_service_id(value)
+        if normalized == "all":
+            expanded.append("all")
+        elif normalized in known:
+            expanded.append(normalized)
+        else:
+            unknown.append(str(value))
+
+    if unknown:
+        allowed = ", ".join(["all", *sorted(known)])
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown runtime service id(s): {', '.join(unknown)}. Allowed: {allowed}.",
+        )
+    return _dedupe_preserving_order(expanded)
+
+
+def _read_runtime_service_catalog() -> dict[str, Any]:
+    catalog_path = Path(cfg.BRAIN_DIR) / "deploy" / "compose" / "runtime-services.json"
+    try:
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _coerce_service_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_values = value.replace(",", " ").split()
+    elif isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        raw_values = [value]
+    return [str(item).strip() for item in raw_values if str(item).strip()]
+
+
+def _normalize_service_id(value: str) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    for value in values:
+        if value not in deduped:
+            deduped.append(value)
+    return deduped

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -11,6 +11,7 @@ ConnectionStatus = Literal["connected", "missing", "error"]
 EmbedderKey = Literal["local_gpu", "local_cpu", "openai", "gemini"]
 RerankerKey = Literal["weighted"]
 RuntimeUpdateStatus = Literal["idle", "running"]
+RuntimeServiceStatus = Literal["idle", "running"]
 VoiceProviderKey = Literal["openai", "gemini"]
 VoiceLanguageKey = Literal["auto", "en", "fr"]
 VoiceStatus = Literal["ready", "missing", "error"]
@@ -91,6 +92,24 @@ class RuntimeUpdateRead(BaseModel):
     pid: int | None = None
     started_at: datetime | None = None
     active_agent_runs: int = 0
+    log_path: str | None = None
+    detail: str | None = None
+
+
+class RuntimeServiceRead(BaseModel):
+    id: str
+    name: str
+    description: str
+    restartable: bool = True
+    optional: bool = False
+
+
+class RuntimeServicesRead(BaseModel):
+    status: RuntimeServiceStatus
+    available: bool
+    services: list[RuntimeServiceRead]
+    requested_services: list[str] = Field(default_factory=list)
+    started_at: datetime | None = None
     log_path: str | None = None
     detail: str | None = None
 

--- a/brain/systems/runtime_settings/self_update.py
+++ b/brain/systems/runtime_settings/self_update.py
@@ -4,7 +4,7 @@ import json
 import os
 import shlex
 import subprocess
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,12 +18,29 @@ from brain.platform.db.models.agent_run import AgentRunRow
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES
 
 from .schemas import RuntimeUpdateRead
+from .sidecar_queue import (
+    SidecarQueue,
+    acquire_start_lock,
+    parse_datetime,
+    read_json,
+    release_start_lock,
+)
 
 _LOG_NAME = "illo-self-update.log"
 _META_NAME = "illo-self-update.json"
 _PID_NAME = "illo-self-update.pid"
 _START_LOCK_NAME = "illo-self-update.starting"
-_REQUEST_RUNNING_STATUSES = {"queued", "starting", "running"}
+_UPDATE_QUEUE = SidecarQueue(
+    request_file_env="ILLO_SELF_UPDATE_REQUEST_FILE",
+    status_file_env="ILLO_SELF_UPDATE_STATUS_FILE",
+    log_path_env="ILLO_SELF_UPDATE_LOG_PATH",
+    default_log_name=_LOG_NAME,
+    ready_detail="Queues the update for the Compose updater sidecar.",
+    queue_unavailable_label="Illospace update queue",
+    waiting_detail="Illospace update is waiting for the Compose updater sidecar.",
+    stale_detail="Illospace update is unavailable because the Compose updater sidecar heartbeat is stale.",
+    heartbeat_file_env="ILLO_SELF_UPDATE_HEARTBEAT_FILE",
+)
 
 
 async def async_get_runtime_update_status(session: AsyncSession) -> RuntimeUpdateRead:
@@ -37,7 +54,7 @@ async def async_get_runtime_update_status(session: AsyncSession) -> RuntimeUpdat
     metadata = _read_metadata(state_dir)
     pid = _coerce_pid(metadata.get("pid")) or _read_pid(state_dir / _PID_NAME)
     running = bool(pid and _pid_running(pid))
-    started_at = _parse_datetime(metadata.get("started_at"))
+    started_at = parse_datetime(metadata.get("started_at"))
 
     return RuntimeUpdateRead(
         status="running" if running else "idle",
@@ -85,7 +102,7 @@ async def async_start_runtime_update(
         )
 
     lock_path = state_dir / _START_LOCK_NAME
-    lock_fd = _acquire_start_lock(lock_path)
+    lock_fd = acquire_start_lock(lock_path)
     if lock_fd is None:
         current = await async_get_runtime_update_status(session)
         return RuntimeUpdateRead(
@@ -154,7 +171,7 @@ async def async_start_runtime_update(
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Could not start Illospace update: {exc}") from exc
     finally:
-        _release_start_lock(lock_fd, lock_path)
+        release_start_lock(lock_fd, lock_path)
 
 
 def _repo_root() -> Path:
@@ -170,59 +187,32 @@ def _state_dir(root: Path) -> Path:
 
 
 def _request_file() -> Path | None:
-    raw = os.getenv("ILLO_SELF_UPDATE_REQUEST_FILE", "").strip()
-    return Path(raw).resolve() if raw else None
+    return _UPDATE_QUEUE.request_file()
 
 
 def _request_status_file(request_file: Path) -> Path:
-    raw = os.getenv("ILLO_SELF_UPDATE_STATUS_FILE", "").strip()
-    return Path(raw).resolve() if raw else request_file.with_name("status.json")
+    return _UPDATE_QUEUE.status_file(request_file)
 
 
 def _request_log_path(request_file: Path) -> Path:
-    raw = os.getenv("ILLO_SELF_UPDATE_LOG_PATH", "").strip()
-    if raw:
-        return Path(raw).resolve()
-    return Path(cfg.BRAIN_LOG_DIR).resolve() / _LOG_NAME
-
-
-def _request_heartbeat_file(request_file: Path) -> Path | None:
-    raw = os.getenv("ILLO_SELF_UPDATE_HEARTBEAT_FILE", "").strip()
-    return Path(raw).resolve() if raw else None
+    return _UPDATE_QUEUE.log_path()
 
 
 def _request_availability(request_file: Path) -> tuple[bool, str | None]:
-    try:
-        request_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        return False, f"Illospace update queue is unavailable: {exc}"
-    if not os.access(request_file.parent, os.W_OK):
-        return False, f"Illospace update queue is not writable: {request_file.parent}"
-    heartbeat_file = _request_heartbeat_file(request_file)
-    if heartbeat_file is not None:
-        heartbeat = _read_json(heartbeat_file)
-        updated_at = _parse_datetime(heartbeat.get("updated_at"))
-        if updated_at is None:
-            return False, "Illospace update is waiting for the Compose updater sidecar."
-        if updated_at.tzinfo is None:
-            updated_at = updated_at.replace(tzinfo=timezone.utc)
-        if datetime.now(timezone.utc) - updated_at > timedelta(seconds=60):
-            return False, "Illospace update is unavailable because the Compose updater sidecar heartbeat is stale."
-    return True, "Queues the update for the Compose updater sidecar."
+    return _UPDATE_QUEUE.availability(request_file)
 
 
 async def _async_request_update_status(session: AsyncSession, request_file: Path) -> RuntimeUpdateRead:
     available, availability_detail = _request_availability(request_file)
-    status_data = _read_json(_request_status_file(request_file))
-    raw_status = str(status_data.get("status") or "").strip().lower()
-    running = raw_status in _REQUEST_RUNNING_STATUSES or request_file.exists()
+    status_data = _UPDATE_QUEUE.status_data(request_file)
+    running = _UPDATE_QUEUE.status_is_running(request_file, status_data)
     detail = status_data.get("detail") if isinstance(status_data.get("detail"), str) else None
 
     return RuntimeUpdateRead(
         status="running" if running else "idle",
         available=available,
         pid=None,
-        started_at=_parse_datetime(status_data.get("started_at") or status_data.get("requested_at")),
+        started_at=parse_datetime(status_data.get("started_at") or status_data.get("requested_at")),
         active_agent_runs=await _async_active_agent_run_count(session),
         log_path=str(_request_log_path(request_file)),
         detail=detail or availability_detail,
@@ -250,8 +240,8 @@ async def _async_start_request_update(
             }
         )
 
-    lock_path = request_file.with_name(f".{request_file.name}.starting")
-    lock_fd = _acquire_start_lock(lock_path)
+    lock_path = _UPDATE_QUEUE.start_lock_path(request_file)
+    lock_fd = acquire_start_lock(lock_path)
     if lock_fd is None:
         current = await _async_request_update_status(session, request_file)
         return RuntimeUpdateRead(
@@ -272,8 +262,8 @@ async def _async_start_request_update(
             payload["build_no_cache"] = True
         if worker_drain_timeout_seconds is not None:
             payload["worker_drain_timeout_seconds"] = worker_drain_timeout_seconds
-        _write_json_atomic(request_file, payload)
-        _write_json_atomic(
+        _UPDATE_QUEUE.write_json(request_file, payload)
+        _UPDATE_QUEUE.write_json(
             _request_status_file(request_file),
             {
                 **payload,
@@ -293,7 +283,7 @@ async def _async_start_request_update(
             detail="Illospace update queued for the Compose updater sidecar.",
         )
     finally:
-        _release_start_lock(lock_fd, lock_path)
+        release_start_lock(lock_fd, lock_path)
 
 
 def _availability(root: Path) -> tuple[bool, str | None]:
@@ -344,15 +334,7 @@ async def _async_active_agent_run_count(session: AsyncSession) -> int:
 
 
 def _read_metadata(state_dir: Path) -> dict[str, Any]:
-    return _read_json(state_dir / _META_NAME)
-
-
-def _read_json(path: Path) -> dict[str, Any]:
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    return data if isinstance(data, dict) else {}
+    return read_json(state_dir / _META_NAME)
 
 
 def _read_pid(path: Path) -> int | None:
@@ -382,15 +364,6 @@ def _pid_running(pid: int) -> bool:
         return False
 
 
-def _parse_datetime(value: Any) -> datetime | None:
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        return None
-
-
 def _write_log_header(log_path: Path, started_at: datetime, *, requested_by: str | None) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("ab") as handle:
@@ -398,28 +371,3 @@ def _write_log_header(log_path: Path, started_at: datetime, *, requested_by: str
         handle.write(f"=== Illospace self-update requested at {started_at.isoformat()} ===\n".encode("utf-8"))
         if requested_by:
             handle.write(f"Requested by: {requested_by}\n".encode("utf-8"))
-
-
-def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
-    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-    tmp_path.replace(path)
-
-
-def _acquire_start_lock(path: Path) -> int | None:
-    try:
-        return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-    except FileExistsError:
-        return None
-
-
-def _release_start_lock(fd: int, path: Path) -> None:
-    try:
-        os.close(fd)
-    except OSError:
-        pass
-    try:
-        path.unlink()
-    except OSError:
-        pass

--- a/brain/systems/runtime_settings/sidecar_queue.py
+++ b/brain/systems/runtime_settings/sidecar_queue.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from brain.kernel import config as cfg
+
+RUNNING_QUEUE_STATUSES = {"queued", "starting", "running"}
+
+
+@dataclass(frozen=True)
+class SidecarQueue:
+    request_file_env: str
+    status_file_env: str
+    log_path_env: str
+    default_log_name: str
+    ready_detail: str
+    queue_unavailable_label: str
+    waiting_detail: str
+    stale_detail: str
+    heartbeat_file_env: str | None = None
+    fallback_heartbeat_file_env: str | None = None
+    default_status_name: str = "status.json"
+
+    def request_file(self) -> Path | None:
+        raw = os.getenv(self.request_file_env, "").strip()
+        return Path(raw).resolve() if raw else None
+
+    def status_file(self, request_file: Path) -> Path:
+        raw = os.getenv(self.status_file_env, "").strip()
+        return Path(raw).resolve() if raw else request_file.with_name(self.default_status_name)
+
+    def log_path(self) -> Path:
+        raw = os.getenv(self.log_path_env, "").strip()
+        if raw:
+            return Path(raw).resolve()
+        return Path(cfg.BRAIN_LOG_DIR).resolve() / self.default_log_name
+
+    def heartbeat_file(self) -> Path | None:
+        raw = ""
+        if self.heartbeat_file_env:
+            raw = os.getenv(self.heartbeat_file_env, "").strip()
+        if not raw and self.fallback_heartbeat_file_env:
+            raw = os.getenv(self.fallback_heartbeat_file_env, "").strip()
+        return Path(raw).resolve() if raw else None
+
+    def availability(self, request_file: Path) -> tuple[bool, str | None]:
+        try:
+            request_file.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return False, f"{self.queue_unavailable_label} is unavailable: {exc}"
+        if not os.access(request_file.parent, os.W_OK):
+            return False, f"{self.queue_unavailable_label} is not writable: {request_file.parent}"
+
+        heartbeat_file = self.heartbeat_file()
+        if heartbeat_file is not None:
+            heartbeat = read_json(heartbeat_file)
+            updated_at = parse_datetime(heartbeat.get("updated_at"))
+            if updated_at is None:
+                return False, self.waiting_detail
+            if updated_at.tzinfo is None:
+                updated_at = updated_at.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) - updated_at > timedelta(seconds=60):
+                return False, self.stale_detail
+        return True, self.ready_detail
+
+    def status_data(self, request_file: Path) -> dict[str, Any]:
+        return read_json(self.status_file(request_file))
+
+    def status_is_running(self, request_file: Path, status_data: dict[str, Any] | None = None) -> bool:
+        status_data = status_data if status_data is not None else self.status_data(request_file)
+        raw_status = str(status_data.get("status") or "").strip().lower()
+        return raw_status in RUNNING_QUEUE_STATUSES or request_file.exists()
+
+    def start_lock_path(self, request_file: Path) -> Path:
+        return request_file.with_name(f".{request_file.name}.starting")
+
+    def write_json(self, path: Path, data: dict[str, Any]) -> None:
+        write_json_atomic(path, data)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def acquire_start_lock(path: Path) -> int | None:
+    try:
+        return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        return None
+
+
+def release_start_lock(fd: int, path: Path) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -51,9 +51,97 @@ class SlackConnectorConfig:
             bot_user_id=os.environ.get("SLACK_BOT_USER_ID"),
         )
 
+    @classmethod
+    async def from_runtime(cls) -> "SlackConnectorConfig":
+        """Load connector config from env first, then trusted org Vault secrets."""
+
+        bot_token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+        app_token = os.environ.get("SLACK_APP_TOKEN", "").strip()
+        org_id = os.environ.get("ILLO_SLACK_ORG_ID") or os.environ.get("ILLO_ORG_ID")
+        owner_user_id = (
+            os.environ.get("ILLO_SLACK_OWNER_USER_ID")
+            or os.environ.get("ILLO_OWNER_USER_ID")
+        )
+        if not bot_token or not app_token or not org_id or not owner_user_id:
+            org_id, owner_user_id = await resolve_slack_connector_authority(
+                org_id=org_id,
+                owner_user_id=owner_user_id,
+            )
+        if not bot_token:
+            bot_token = await _runtime_vault_secret(
+                "SLACK_BOT_TOKEN",
+                org_id=org_id,
+                owner_user_id=owner_user_id,
+            )
+        if not app_token:
+            app_token = await _runtime_vault_secret(
+                "SLACK_APP_TOKEN",
+                org_id=org_id,
+                owner_user_id=owner_user_id,
+            )
+        if not bot_token:
+            raise SlackConfigurationError("SLACK_BOT_TOKEN is required")
+        if not app_token:
+            raise SlackConfigurationError("SLACK_APP_TOKEN is required")
+        return cls(
+            bot_token=bot_token,
+            app_token=app_token,
+            org_id=org_id,
+            owner_user_id=owner_user_id,
+            team_id=os.environ.get("SLACK_TEAM_ID"),
+            bot_user_id=os.environ.get("SLACK_BOT_USER_ID"),
+        )
+
 
 def utcnow() -> datetime:
     return datetime.now(timezone.utc)
+
+
+async def resolve_slack_connector_authority(
+    *,
+    org_id: str | None,
+    owner_user_id: str | None,
+) -> tuple[str, str]:
+    if org_id and owner_user_id:
+        return str(org_id), str(owner_user_id)
+
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    async with UnitOfWork() as uow:
+        if owner_user_id:
+            user = await uow.session.get(User, str(owner_user_id))
+            if user is None:
+                raise SlackConfigurationError("ILLO_SLACK_OWNER_USER_ID does not match an Illospace user")
+            return str(org_id or user.org_id), str(owner_user_id)
+
+        stmt = select(User).order_by(User.created_at.asc(), User.id.asc()).limit(1)
+        if org_id:
+            stmt = stmt.where(User.org_id == str(org_id))
+        user = (await uow.session.scalars(stmt)).first()
+    if user is None:
+        raise SlackConfigurationError(
+            "No Illospace user found; set ILLO_SLACK_ORG_ID and ILLO_SLACK_OWNER_USER_ID"
+        )
+    return str(org_id or user.org_id), str(owner_user_id or user.id)
+
+
+async def _runtime_vault_secret(
+    key_name: str,
+    *,
+    org_id: str,
+    owner_user_id: str,
+) -> str:
+    from brain.systems.vault import get_secret
+
+    return (
+        await get_secret(
+            key_name,
+            actor_user_id=owner_user_id,
+            org_id=org_id,
+            accessed_by="slack_connector",
+        )
+        or ""
+    )
 
 
 async def ensure_slack_connection(
@@ -213,7 +301,7 @@ async def run_socket_mode_loop(
 
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
-    config = config or SlackConnectorConfig.from_env()
+    config = config or await SlackConnectorConfig.from_runtime()
     socket_url = config.socket_mode_url or await open_socket_mode_url(config)
     logger.info("slack_socket_mode_connecting")
     async with websockets.connect(socket_url) as websocket:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -33,6 +33,10 @@ x-illo-env: &illo-env
   ILLO_SELF_UPDATE_STATUS_FILE: /data/private/self-update/status.json
   ILLO_SELF_UPDATE_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
   ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
+  ILLO_RUNTIME_SERVICES_REQUEST_FILE: /data/private/runtime-services/request.json
+  ILLO_RUNTIME_SERVICES_STATUS_FILE: /data/private/runtime-services/status.json
+  ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+  ILLO_RUNTIME_SERVICES_LOG_PATH: /data/private/logs/illo-runtime-services.log
 
 x-backend-service: &backend-service
   image: ${ILLO_API_IMAGE:-ghcr.io/illospace/api:latest}
@@ -167,6 +171,10 @@ services:
       ILLO_SELF_UPDATE_STATUS_FILE: /data/private/self-update/status.json
       ILLO_SELF_UPDATE_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
       ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
+      ILLO_RUNTIME_SERVICES_REQUEST_FILE: /data/private/runtime-services/request.json
+      ILLO_RUNTIME_SERVICES_STATUS_FILE: /data/private/runtime-services/status.json
+      ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+      ILLO_RUNTIME_SERVICES_LOG_PATH: /data/private/logs/illo-runtime-services.log
       ILLO_COMPOSE_ENV_FILE: /repo/deploy/compose/.env
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-illospace}
     volumes:

--- a/deploy/compose/runtime-services.json
+++ b/deploy/compose/runtime-services.json
@@ -1,0 +1,35 @@
+{
+  "services": [
+    {
+      "id": "api",
+      "compose_service": "api",
+      "name": "Illospace API",
+      "description": "HTTP API and backend request handling."
+    },
+    {
+      "id": "worker",
+      "compose_service": "worker",
+      "name": "Agent worker",
+      "description": "Background AgentRun worker for Illo tasks."
+    },
+    {
+      "id": "scheduler",
+      "compose_service": "scheduler",
+      "name": "Scheduler",
+      "description": "Recurring work and scheduled run materialization."
+    },
+    {
+      "id": "web",
+      "compose_service": "web",
+      "name": "Web app",
+      "description": "Illospace browser interface."
+    },
+    {
+      "id": "slack_connector",
+      "compose_service": "slack-connector",
+      "name": "Slack connector",
+      "description": "Socket Mode bridge between Slack conversations and Illospace.",
+      "optional": true
+    }
+  ]
+}

--- a/deploy/docker/api.Dockerfile
+++ b/deploy/docker/api.Dockerfile
@@ -36,6 +36,7 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
     && python3 -m pip install -r requirements-production.txt
 
 COPY brain ./brain
+COPY deploy/compose/runtime-services.json ./deploy/compose/runtime-services.json
 COPY ops/install-browser-runtime.sh ./ops/install-browser-runtime.sh
 COPY README.md LICENSE NOTICE.md ./
 

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+COMPOSE_RUNTIME_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${ROOT:-$(cd "$COMPOSE_RUNTIME_LIB_DIR/../.." && pwd)}"
+COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/deploy/compose/docker-compose.yml}"
+ENV_FILE="${ENV_FILE:-${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}}"
+RUNTIME_SERVICE_CATALOG="${RUNTIME_SERVICE_CATALOG:-$ROOT/deploy/compose/runtime-services.json}"
+
+compose() {
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+runtime_service_ids() {
+  jq -r '.services[].id' "$RUNTIME_SERVICE_CATALOG"
+}
+
+runtime_service_name() {
+  local service="$1"
+  local compose_name
+  compose_name="$(jq -er --arg id "$service" '.services[] | select(.id == $id) | .compose_service' "$RUNTIME_SERVICE_CATALOG")" || {
+    echo "Unknown runtime service id: $service" >&2
+    return 2
+  }
+  printf '%s\n' "$compose_name"
+}
+
+normalize_service_id() {
+  printf '%s\n' "$1" | tr '[:upper:]-' '[:lower:]_'
+}
+
+append_unique_service() {
+  local service="$1"
+  local existing
+  for existing in "${expanded_services[@]:-}"; do
+    [ "$existing" != "$service" ] || return 0
+  done
+  expanded_services+=("$service")
+}
+
+expand_runtime_services() {
+  local raw service include_all=0
+  expanded_services=()
+  if [ "$#" -eq 0 ]; then
+    echo "At least one runtime service id is required." >&2
+    return 2
+  fi
+
+  for raw in "$@"; do
+    service="$(normalize_service_id "$raw")"
+    if [ "$service" = "all" ]; then
+      include_all=1
+      continue
+    fi
+    runtime_service_name "$service" >/dev/null
+    append_unique_service "$service"
+  done
+
+  if [ "$include_all" = "1" ]; then
+    while IFS= read -r service; do
+      append_unique_service "$service"
+    done < <(runtime_service_ids)
+  fi
+
+  printf '%s\n' "${expanded_services[@]}"
+}
+
+active_agent_run_count() {
+  local count
+  if count="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "
+SELECT count(*) FROM agent_runs WHERE status IN ('\''starting'\'', '\''running'\'', '\''paused'\'', '\''verifying'\'');
+"' 2>/dev/null | tr -d '[:space:]')"; then
+    if [[ "$count" =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "$count"
+      return 0
+    fi
+  fi
+  printf 'unknown\n'
+}
+
+worker_container_id() {
+  compose ps -q worker 2>/dev/null || true
+}
+
+container_running() {
+  local id="$1"
+  [ -n "$id" ] || return 1
+  [ "$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null || echo false)" = "true" ]
+}
+
+start_worker_handoff() {
+  compose run \
+    -d \
+    --no-deps \
+    -e ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1 \
+    -e ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS="${ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS:-infinity}" \
+    worker
+}
+
+record_worker_drain_timeout() {
+  [ -n "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE:-}" ] || return 0
+  mkdir -p "$(dirname "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE")" 2>/dev/null || true
+  printf '{"status":"worker_draining","updated_at":"%s"}\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    > "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
+}
+
+wait_for_worker_exit() {
+  local id="$1"
+  local wait_seconds="${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
+  local deadline=$((SECONDS + wait_seconds))
+  while container_running "$id"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Worker did not drain within ${wait_seconds}s; leaving it running to avoid interrupting active AgentRuns." >&2
+      record_worker_drain_timeout
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+update_worker_after_drain() {
+  local active_runs="$1"
+  local worker_id handoff_id
+  worker_id="$(worker_container_id)"
+
+  if [ -z "$worker_id" ]; then
+    echo "Worker container is not running; starting worker."
+    compose up -d --force-recreate --no-deps worker
+    return 0
+  fi
+
+  handoff_id="$(start_worker_handoff)"
+  echo "Worker: started handoff worker ${handoff_id:-unknown} for new AgentRuns."
+  echo "Worker: ${active_runs} active AgentRun(s); signaling existing worker to drain."
+  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
+  docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
+  if ! wait_for_worker_exit "$worker_id"; then
+    docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
+    return 0
+  fi
+  compose up -d --force-recreate --no-deps worker
+  if [ -n "$handoff_id" ]; then
+    echo "Worker: regular worker is restarted; draining handoff worker $handoff_id."
+    docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
+    (
+      docker wait "$handoff_id" >/dev/null 2>&1 || true
+      docker rm "$handoff_id" >/dev/null 2>&1 || true
+    ) &
+  fi
+}
+
+replace_idle_worker() {
+  local worker_id stop_seconds
+  worker_id="$(worker_container_id)"
+  stop_seconds="${ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS:-30}"
+
+  if [ -z "$worker_id" ]; then
+    echo "Worker container is not running; starting worker."
+    compose up -d --force-recreate --no-deps worker
+    return 0
+  fi
+
+  echo "Worker: no active AgentRuns; replacing worker with a ${stop_seconds}s stop timeout."
+  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
+  if ! docker stop -t "$stop_seconds" "$worker_id" >/dev/null 2>&1; then
+    echo "Worker did not stop within ${stop_seconds}s despite no active AgentRuns; forcing replacement." >&2
+    docker kill "$worker_id" >/dev/null 2>&1 || true
+  fi
+  compose up -d --force-recreate --no-deps worker
+}
+
+restart_runtime_worker_service() {
+  local active_runs
+  active_runs="$(active_agent_run_count)"
+  if [ "$active_runs" = "unknown" ]; then
+    echo "Cannot safely restart worker because active AgentRun count is unknown." >&2
+    return 1
+  fi
+  if [ "$active_runs" = "0" ]; then
+    replace_idle_worker
+  else
+    update_worker_after_drain "$active_runs"
+  fi
+}
+
+restart_runtime_service() {
+  local service="$1"
+  local compose_name
+  if [ "$service" = "worker" ]; then
+    restart_runtime_worker_service
+    return $?
+  fi
+  compose_name="$(runtime_service_name "$service")"
+  echo "Restarting runtime service: $service"
+  compose up -d --force-recreate --no-deps "$compose_name"
+}
+
+restart_runtime_services() {
+  local service
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "Missing $ENV_FILE; run ./illo deploy init first." >&2
+    return 1
+  fi
+  mapfile -t services < <(expand_runtime_services "$@")
+  if [ "${#services[@]}" -eq 0 ]; then
+    echo "No runtime services selected." >&2
+    return 2
+  fi
+  compose ps >/dev/null
+  for service in "${services[@]}"; do
+    restart_runtime_service "$service"
+  done
+}

--- a/deploy/scripts/runtime-services.sh
+++ b/deploy/scripts/runtime-services.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$ROOT/deploy/compose/docker-compose.yml"
+ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}"
+COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS="${ILLO_RUNTIME_SERVICE_WORKER_DRAIN_TIMEOUT_SECONDS:-${ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS:-120}}"
+
+source "$SCRIPT_DIR/compose-runtime-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: deploy/scripts/runtime-services.sh list
+       deploy/scripts/runtime-services.sh restart <service-id> [service-id...]
+
+Service ids:
+EOF
+  runtime_service_ids | sed 's/^/  /'
+  printf '  all\n'
+}
+
+case "${1:-}" in
+  list)
+    runtime_service_ids
+    ;;
+  restart)
+    shift
+    restart_runtime_services "$@"
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -6,17 +6,21 @@ REQUEST_FILE="${ILLO_SELF_UPDATE_REQUEST_FILE:-/data/private/self-update/request
 STATUS_FILE="${ILLO_SELF_UPDATE_STATUS_FILE:-/data/private/self-update/status.json}"
 HEARTBEAT_FILE="${ILLO_SELF_UPDATE_HEARTBEAT_FILE:-/data/private/self-update/heartbeat.json}"
 LOG_PATH="${ILLO_SELF_UPDATE_LOG_PATH:-/data/private/logs/illo-self-update.log}"
+RUNTIME_SERVICES_REQUEST_FILE="${ILLO_RUNTIME_SERVICES_REQUEST_FILE:-/data/private/runtime-services/request.json}"
+RUNTIME_SERVICES_STATUS_FILE="${ILLO_RUNTIME_SERVICES_STATUS_FILE:-/data/private/runtime-services/status.json}"
+RUNTIME_SERVICES_LOG_PATH="${ILLO_RUNTIME_SERVICES_LOG_PATH:-/data/private/logs/illo-runtime-services.log}"
 WORKER_DRAIN_TIMEOUT_FILE="${ILLO_SELF_UPDATE_WORKER_DRAIN_TIMEOUT_FILE:-/data/private/self-update/worker-drain-timeout.json}"
 POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
 APP_UID="${ILLO_APP_UID:-10001}"
 APP_GID="${ILLO_APP_GID:-10001}"
 RUNNING_FILE="${REQUEST_FILE}.running"
+RUNTIME_SERVICES_RUNNING_FILE="${RUNTIME_SERVICES_REQUEST_FILE}.running"
 
 prepare_shared_paths() {
-  mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")"
+  mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" "$(dirname "$RUNTIME_SERVICES_LOG_PATH")"
   if [ "$(id -u)" = "0" ]; then
-    chown "$APP_UID:$APP_GID" "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" 2>/dev/null || true
-    chmod 0775 "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" 2>/dev/null || true
+    chown "$APP_UID:$APP_GID" "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" 2>/dev/null || true
+    chmod 0775 "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" 2>/dev/null || true
   fi
   git config --global --add safe.directory "$REPO" >/dev/null 2>&1 || true
 }
@@ -45,6 +49,33 @@ write_status() {
     '{
       status: $status,
       detail: $detail,
+      requested_at: (if $requested_at | length > 0 then $requested_at else null end),
+      started_at: (if $requested_at | length > 0 then $requested_at else null end),
+      requested_by: (if $requested_by | length > 0 then $requested_by else null end),
+      updated_at: $updated_at,
+      exit_code: (if $exit_code | length > 0 then ($exit_code | tonumber) else null end)
+    }'
+}
+
+write_runtime_services_status() {
+  local status="$1"
+  local detail="$2"
+  local requested_at="${3:-}"
+  local requested_by="${4:-}"
+  local exit_code="${5:-}"
+  local services_json="${6:-[]}"
+  json_write "$RUNTIME_SERVICES_STATUS_FILE" \
+    --arg status "$status" \
+    --arg detail "$detail" \
+    --arg requested_at "$requested_at" \
+    --arg requested_by "$requested_by" \
+    --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg exit_code "$exit_code" \
+    --argjson services "$services_json" \
+    '{
+      status: $status,
+      detail: $detail,
+      services: $services,
       requested_at: (if $requested_at | length > 0 then $requested_at else null end),
       started_at: (if $requested_at | length > 0 then $requested_at else null end),
       requested_by: (if $requested_by | length > 0 then $requested_by else null end),
@@ -101,8 +132,41 @@ process_request() {
   rm -f "$RUNNING_FILE"
 }
 
+process_runtime_services_request() {
+  local requested_at requested_by services_json exit_code
+  local services=()
+  if ! mv "$RUNTIME_SERVICES_REQUEST_FILE" "$RUNTIME_SERVICES_RUNNING_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  requested_at="$(jq -r '.requested_at // ""' "$RUNTIME_SERVICES_RUNNING_FILE" 2>/dev/null || true)"
+  requested_by="$(jq -r '.requested_by // ""' "$RUNTIME_SERVICES_RUNNING_FILE" 2>/dev/null || true)"
+  services_json="$(jq -c '.services // []' "$RUNTIME_SERVICES_RUNNING_FILE" 2>/dev/null || echo '[]')"
+  mapfile -t services < <(jq -r '.services[]?' "$RUNTIME_SERVICES_RUNNING_FILE" 2>/dev/null || true)
+  write_runtime_services_status "running" "Runtime service restart is running." "$requested_at" "$requested_by" "" "$services_json"
+
+  mkdir -p "$(dirname "$RUNTIME_SERVICES_LOG_PATH")"
+  {
+    echo
+    echo "=== Illospace runtime service restart started at $(date -u +"%Y-%m-%dT%H:%M:%SZ") ==="
+    [ -z "$requested_by" ] || echo "Requested by: $requested_by"
+    [ "${#services[@]}" -eq 0 ] || printf 'Services: %s\n' "${services[*]}"
+    cd "$REPO"
+    bash "$REPO/deploy/scripts/runtime-services.sh" restart "${services[@]}"
+  } >> "$RUNTIME_SERVICES_LOG_PATH" 2>&1
+  exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    write_runtime_services_status "idle" "Runtime service restart completed." "$requested_at" "$requested_by" "$exit_code" "$services_json"
+  else
+    write_runtime_services_status "idle" "Runtime service restart failed with exit code $exit_code. Check the runtime service log." "$requested_at" "$requested_by" "$exit_code" "$services_json"
+  fi
+  rm -f "$RUNTIME_SERVICES_RUNNING_FILE"
+}
+
 prepare_shared_paths
 write_status "idle" "Compose updater sidecar is ready." "" ""
+write_runtime_services_status "idle" "Runtime service host controller is ready." "" "" "" "[]"
 
 while true; do
   write_heartbeat
@@ -114,6 +178,16 @@ while true; do
     if [ "$exit_code" -ne 0 ]; then
       write_status "idle" "Illospace update failed with exit code $exit_code. Check the update log." "" "" "$exit_code"
       rm -f "$RUNNING_FILE"
+    fi
+  fi
+  if [ -f "$RUNTIME_SERVICES_REQUEST_FILE" ]; then
+    set +e
+    process_runtime_services_request
+    exit_code=$?
+    set -e
+    if [ "$exit_code" -ne 0 ]; then
+      write_runtime_services_status "idle" "Runtime service restart failed with exit code $exit_code. Check the runtime service log." "" "" "$exit_code" "[]"
+      rm -f "$RUNTIME_SERVICES_RUNNING_FILE"
     fi
   fi
   sleep "$POLL_SECONDS"

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -52,9 +52,10 @@ fi
 
 [ -z "$WORKER_DRAIN_TIMEOUT_FILE" ] || rm -f "$WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
 
-compose() {
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
-}
+COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE="$WORKER_DRAIN_TIMEOUT_FILE"
+COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS="${ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
+
+source "$SCRIPT_DIR/compose-runtime-lib.sh"
 
 non_worker_services() {
   if [ "$SKIP_UPDATER_RESTART" = "1" ]; then
@@ -66,110 +67,6 @@ non_worker_services() {
 
 all_runtime_services() {
   non_worker_services
-}
-
-active_agent_run_count() {
-  local count
-  if count="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "
-SELECT count(*) FROM agent_runs WHERE status IN ('\''starting'\'', '\''running'\'', '\''paused'\'', '\''verifying'\'');
-"' 2>/dev/null | tr -d '[:space:]')"; then
-    if [[ "$count" =~ ^[0-9]+$ ]]; then
-      printf '%s\n' "$count"
-      return 0
-    fi
-  fi
-  printf 'unknown\n'
-}
-
-worker_container_id() {
-  compose ps -q worker 2>/dev/null || true
-}
-
-start_worker_handoff() {
-  compose run \
-    -d \
-    --no-deps \
-    -e ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1 \
-    -e ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS="${ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS:-infinity}" \
-    worker
-}
-
-container_running() {
-  local id="$1"
-  [ -n "$id" ] || return 1
-  [ "$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null || echo false)" = "true" ]
-}
-
-record_worker_drain_timeout() {
-  [ -n "$WORKER_DRAIN_TIMEOUT_FILE" ] || return 0
-  mkdir -p "$(dirname "$WORKER_DRAIN_TIMEOUT_FILE")" 2>/dev/null || true
-  printf '{"status":"worker_draining","updated_at":"%s"}\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    > "$WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
-}
-
-wait_for_worker_exit() {
-  local id="$1"
-  local wait_seconds="${ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
-  local deadline=$((SECONDS + wait_seconds))
-  while container_running "$id"; do
-    if [ "$SECONDS" -ge "$deadline" ]; then
-      echo "Worker did not drain within ${wait_seconds}s; leaving it on the old image to avoid killing active AgentRuns." >&2
-      record_worker_drain_timeout
-      return 1
-    fi
-    sleep 5
-  done
-}
-
-update_worker_after_drain() {
-  local active_runs="$1"
-  local worker_id handoff_id
-  worker_id="$(worker_container_id)"
-
-  if [ -z "$worker_id" ]; then
-    echo "Worker container is not running; starting worker on the new image."
-    compose up -d --force-recreate --no-deps worker
-    return 0
-  fi
-
-  handoff_id="$(start_worker_handoff)"
-  echo "Worker: started handoff worker ${handoff_id:-unknown} on the new image for new AgentRuns."
-  echo "Worker: ${active_runs} active AgentRun(s); signaling drain before replacing worker."
-  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
-  docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  if ! wait_for_worker_exit "$worker_id"; then
-    docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
-    return 0
-  fi
-  compose up -d --force-recreate --no-deps worker
-  if [ -n "$handoff_id" ]; then
-    echo "Worker: regular worker is on the new image; draining handoff worker $handoff_id."
-    docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
-    (
-      docker wait "$handoff_id" >/dev/null 2>&1 || true
-      docker rm "$handoff_id" >/dev/null 2>&1 || true
-    ) &
-  fi
-}
-
-replace_idle_worker() {
-  local worker_id stop_seconds
-  worker_id="$(worker_container_id)"
-  stop_seconds="${ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS:-30}"
-
-  if [ -z "$worker_id" ]; then
-    echo "Worker container is not running; starting worker on the new image."
-    compose up -d --force-recreate --no-deps worker
-    return 0
-  fi
-
-  echo "Worker: no active AgentRuns; replacing worker with a ${stop_seconds}s stop timeout."
-  docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
-  if ! docker stop -t "$stop_seconds" "$worker_id" >/dev/null 2>&1; then
-    echo "Worker did not stop within ${stop_seconds}s despite no active AgentRuns; forcing replacement." >&2
-    docker kill "$worker_id" >/dev/null 2>&1 || true
-  fi
-  compose up -d --force-recreate --no-deps worker
 }
 
 if [ "$PULL" = "1" ]; then

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -9,8 +9,10 @@ public Slack Events API endpoint.
 1. Create a Slack app from `deploy/slack/illo-self-hosted-manifest.yml`.
 2. Enable Socket Mode in Slack.
 3. Install the app to your Slack workspace.
-4. Set `SLACK_BOT_TOKEN` to the bot token.
-5. Set `SLACK_APP_TOKEN` to the app-level Socket Mode token.
+4. Save `SLACK_BOT_TOKEN` to Illospace Vault, or set it as an environment
+   variable for the connector process.
+5. Save `SLACK_APP_TOKEN` to Illospace Vault, or set it as an environment
+   variable for the connector process.
 6. Start the connector process:
 
 ```bash
@@ -22,6 +24,9 @@ For Docker Compose, run the optional Slack profile:
 ```bash
 docker compose --profile slack up -d slack-connector
 ```
+
+When using the Illospace server deployment, Illo can queue a restart for known
+runtime services through the host controller after the Vault tokens are saved.
 
 `ILLO_SLACK_ORG_ID` and `ILLO_SLACK_OWNER_USER_ID` are optional. If omitted,
 the connector uses the first Illospace user it can find as the permissive

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -142,6 +142,94 @@ async def test_manage_deployment_tool_requires_active_org_membership():
 
 
 @pytest.mark.asyncio
+async def test_manage_runtime_services_tool_requires_authenticated_user():
+    import brain.systems.runtime_settings.runtime_services as runtime_services
+    from brain.app.mcp.server import tool_manage_runtime_services
+
+    mock_uow = MagicMock()
+    mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+    mock_uow.__aexit__ = AsyncMock(return_value=False)
+    mock_uow.session = MagicMock()
+
+    with patch("brain.app.mcp.server.UnitOfWork", return_value=mock_uow), \
+         patch.object(runtime_services, "async_restart_runtime_services", AsyncMock(side_effect=AssertionError("must not restart"))):
+        data = await tool_manage_runtime_services(action="restart", services=["api"], user_id=None, org_id="org-1")
+
+    assert data["status"] == "denied"
+    assert "authenticated workspace user" in data["detail"]
+
+
+@pytest.mark.asyncio
+async def test_manage_runtime_services_tool_restarts_multiple_services_for_workspace_member():
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.runtime_services as runtime_services
+    from brain.app.mcp.server import tool_manage_runtime_services
+    from brain.systems.runtime_settings.schemas import RuntimeServiceRead, RuntimeServicesRead
+
+    mock_uow = MagicMock()
+    mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+    mock_uow.__aexit__ = AsyncMock(return_value=False)
+    mock_uow.session = MagicMock()
+    mock_uow.session.get = AsyncMock(return_value=SimpleNamespace(id="user-1", org_id="org-1", role="member"))
+    status = RuntimeServicesRead(
+        status="running",
+        available=True,
+        services=[
+            RuntimeServiceRead(id="api", name="Illospace API", description="HTTP API"),
+            RuntimeServiceRead(id="worker", name="Agent worker", description="AgentRun worker"),
+        ],
+        requested_services=["api", "worker"],
+        log_path="/data/private/logs/illo-runtime-services.log",
+        detail="Runtime service restart queued for the host controller.",
+    )
+
+    with patch("brain.app.mcp.server.UnitOfWork", return_value=mock_uow), \
+         patch.object(runtime_services, "async_restart_runtime_services", AsyncMock(return_value=status)) as restart:
+        data = await tool_manage_runtime_services(
+            action="restart",
+            services=["api", "worker"],
+            user_id="user-1",
+            org_id="org-1",
+        )
+
+    assert data["action"] == "restart"
+    assert data["status"] == "running"
+    assert data["requested_services"] == ["api", "worker"]
+    restart.assert_awaited_once_with(["api", "worker"], requested_by="user-1")
+
+
+@pytest.mark.asyncio
+async def test_runtime_services_queues_restart_request(monkeypatch, tmp_path):
+    import json
+    from datetime import datetime, timezone
+
+    from brain.systems.runtime_settings.runtime_services import async_restart_runtime_services
+
+    request_file = tmp_path / "runtime-services" / "request.json"
+    status_file = tmp_path / "runtime-services" / "status.json"
+    heartbeat_file = tmp_path / "self-update" / "heartbeat.json"
+    heartbeat_file.parent.mkdir(parents=True)
+    heartbeat_file.write_text(
+        json.dumps({"status": "ready", "updated_at": datetime.now(timezone.utc).isoformat()}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_REQUEST_FILE", str(request_file))
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_STATUS_FILE", str(status_file))
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE", str(heartbeat_file))
+
+    result = await async_restart_runtime_services(["api", "worker"], requested_by="user-1")
+
+    assert result.status == "running"
+    assert result.requested_services == ["api", "worker"]
+    payload = json.loads(request_file.read_text(encoding="utf-8"))
+    assert payload["action"] == "restart"
+    assert payload["services"] == ["api", "worker"]
+    status = json.loads(status_file.read_text(encoding="utf-8"))
+    assert status["detail"] == "Runtime service restart queued for the host controller."
+
+
+@pytest.mark.asyncio
 async def test_runtime_update_http_endpoint_allows_workspace_member():
     from types import SimpleNamespace
 

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -280,6 +280,8 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     assert "127.0.0.1:${ILLO_WEB_PORT:-8080}:8080" in compose
     assert "ILLO_SELF_UPDATE_REQUEST_FILE" in compose
     assert "ILLO_SELF_UPDATE_HEARTBEAT_FILE" in compose
+    assert "ILLO_RUNTIME_SERVICES_REQUEST_FILE" in compose
+    assert "ILLO_RUNTIME_SERVICES_STATUS_FILE" in compose
     assert "shared_preload_libraries=pg_stat_statements" in compose
     assert "pg_stat_statements.track=all" in compose
     assert "track_io_timing=on" in compose
@@ -307,6 +309,8 @@ def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
     assert "chmod 0775" in self_update_daemon
     assert "safe.directory" in self_update_daemon
     assert "ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES=1" in self_update_daemon
+    assert "process_runtime_services_request" in self_update_daemon
+    assert "deploy/scripts/runtime-services.sh" in self_update_daemon
 
 
 def test_compose_doctor_can_skip_host_local_http_probes_from_sidecars():
@@ -318,28 +322,49 @@ def test_compose_doctor_can_skip_host_local_http_probes_from_sidecars():
 
 
 def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
-    upgrade = (Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "upgrade.sh").read_text()
+    root = Path(__file__).resolve().parents[1]
+    upgrade = (root / "deploy" / "scripts" / "upgrade.sh").read_text()
+    runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
+    combined = upgrade + runtime_lib
 
-    assert "active_agent_run_count" in upgrade
-    assert "status IN" in upgrade
+    assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in upgrade
+    assert "active_agent_run_count" in runtime_lib
+    assert "status IN" in runtime_lib
     assert "non_worker_services" in upgrade
     assert "api scheduler web updater" in upgrade
     assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
-    assert "start_worker_handoff" in upgrade
-    assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in upgrade
-    assert "started handoff worker" in upgrade
-    assert "docker update --restart=no" in upgrade
-    assert 'docker kill -s TERM "$worker_id"' in upgrade
-    assert "wait_for_worker_exit" in upgrade
-    assert "compose up -d --force-recreate --no-deps worker" in upgrade
+    assert "start_worker_handoff" in runtime_lib
+    assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in runtime_lib
+    assert "started handoff worker" in runtime_lib
+    assert "docker update --restart=no" in runtime_lib
+    assert 'docker kill -s TERM "$worker_id"' in runtime_lib
+    assert "wait_for_worker_exit" in runtime_lib
+    assert "compose up -d --force-recreate --no-deps worker" in runtime_lib
     assert "compose up -d --force-recreate --remove-orphans" in upgrade
-    assert "replace_idle_worker" in upgrade
-    assert "ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS" in upgrade
-    assert "no active AgentRuns" in upgrade
+    assert "replace_idle_worker" in combined
+    assert "ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS" in runtime_lib
+    assert "no active AgentRuns" in runtime_lib
     assert "ILLO_COMPOSE_BUILD_NO_CACHE" in upgrade
     assert "ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE" in upgrade
-    assert "record_worker_drain_timeout" in upgrade
-    assert "avoid killing active AgentRuns" in upgrade
+
+
+def test_compose_runtime_service_restart_supports_one_many_or_all_services():
+    root = Path(__file__).resolve().parents[1]
+    runtime_services = (root / "deploy" / "scripts" / "runtime-services.sh").read_text()
+    runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
+    catalog = (root / "deploy" / "compose" / "runtime-services.json").read_text()
+
+    assert "runtime_service_ids" in runtime_services
+    assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in runtime_services
+    assert "expand_runtime_services" in runtime_lib
+    assert "slack_connector" in catalog
+    assert "slack-connector" in catalog
+    assert "runtime-services.json" in runtime_lib
+    assert "compose up -d --force-recreate --no-deps" in runtime_lib
+    assert "restart_runtime_worker_service" in runtime_lib
+    assert "active_agent_run_count" in runtime_lib
+    assert "started handoff worker" in runtime_lib
+    assert "avoid interrupting active AgentRuns" in runtime_lib
 
 
 def test_safe_deploy_active_run_guards_match_canonical_active_statuses():
@@ -347,9 +372,10 @@ def test_safe_deploy_active_run_guards_match_canonical_active_statuses():
     upgrade = (root / "deploy" / "scripts" / "upgrade.sh").read_text()
     launcher = (root / "illo").read_text()
     ops_deploy = (root / "ops" / "deploy.sh").read_text()
+    runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
 
     for status in ACTIVE_RUN_STATUS_VALUES:
-        assert repr(status) in upgrade
+        assert repr(status) in upgrade + runtime_lib
     assert "ACTIVE_RUN_STATUS_VALUES" in launcher
     assert "ACTIVE_RUN_STATUS_VALUES" in ops_deploy
     assert '("starting", "running", "verifying")' not in launcher

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -122,6 +122,39 @@ def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
     assert "assistant_view" not in features
 
 
+@pytest.mark.asyncio
+async def test_slack_connector_runtime_config_falls_back_to_vault(monkeypatch):
+    from brain.systems.slack import connector
+
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_ORG_ID", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_OWNER_USER_ID", raising=False)
+
+    async def resolve_authority(*, org_id, owner_user_id):
+        assert org_id is None
+        assert owner_user_id is None
+        return ORG_ID, USER_ID
+
+    async def vault_secret(key_name, *, org_id, owner_user_id):
+        assert org_id == ORG_ID
+        assert owner_user_id == USER_ID
+        return {
+            "SLACK_BOT_TOKEN": "xoxb-from-vault",
+            "SLACK_APP_TOKEN": "xapp-from-vault",
+        }[key_name]
+
+    monkeypatch.setattr(connector, "resolve_slack_connector_authority", resolve_authority)
+    monkeypatch.setattr(connector, "_runtime_vault_secret", vault_secret)
+
+    config = await connector.SlackConnectorConfig.from_runtime()
+
+    assert config.bot_token == "xoxb-from-vault"
+    assert config.app_token == "xapp-from-vault"
+    assert config.org_id == ORG_ID
+    assert config.owner_user_id == USER_ID
+
+
 def _socket_mode_app_mention(**event_overrides):
     event = {
         "type": "app_mention",

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -210,6 +210,24 @@ def test_manage_deployment_tool_is_coordinator_only_and_registered():
     assert registration.reversibility == "variable"
 
 
+def test_manage_runtime_services_tool_is_coordinator_only_and_registered():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "manage_runtime_services"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name not in _names(WORKER_TOOLS)
+    assert name in _get_tool_handlers()
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert [role.value for role in registration.availability] == ["coordinator"]
+    assert registration.permission == "manage_runtime"
+    assert registration.side_effect_class == "deployment_management"
+    assert registration.reversibility == "variable"
+
+
 def test_context_route_surface_is_registry_driven():
     from brain.systems.runs.tool_catalog.registry import context_route_payload, context_route_tool_names
 


### PR DESCRIPTION
## Summary
- add a generic manage_runtime_services tool for listing/status/restarting known Illospace runtime services
- route service restart requests through the existing updater sidecar host-control boundary
- let the Slack connector load Socket Mode tokens from Vault as well as env vars

## Tests
- .venv/bin/pytest tests/test_runtime_settings.py tests/test_tool_registry.py tests/test_safe_deploy.py tests/test_slack_teammate.py tests/test_agent.py::TestCortexReplyHandler
- .venv/bin/python -m py_compile brain/systems/runtime_settings/runtime_services.py brain/app/mcp/server.py brain/systems/slack/connector.py brain/app/cli/slack_connector.py
- git diff --check