### PR TITLE
Self-heal stalled AgentRun queue

### DIFF
--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -8,7 +8,7 @@ import os
 import signal
 import time
 
-from brain.systems.runs.cortex.runner import start_runner, stop_runner
+from brain.systems.runs.cortex.runner import runner_health_snapshot, start_runner, stop_runner
 from brain.systems.cycles import start_cycle_scheduler, stop_cycle_scheduler
 
 logging.basicConfig(
@@ -52,6 +52,13 @@ def _shutdown_drain_timeout_seconds() -> float | None:
         return None
 
 
+def _runner_health_grace_seconds() -> float:
+    try:
+        return max(1.0, float(os.getenv("ILLO_AGENT_RUNNER_HEALTH_GRACE_SECONDS", "15")))
+    except Exception:
+        return 15.0
+
+
 def _require_embedding_backend_ready() -> None:
     """Block worker startup until the configured GPU embedding worker is ready."""
     import brain.kernel.config as cfg
@@ -87,8 +94,19 @@ def main() -> None:
     else:
         logger.info("cycle scheduler disabled for this worker")
     start_runner()
+    last_healthy = time.monotonic()
+    health_grace_seconds = _runner_health_grace_seconds()
     try:
         while _running:
+            health = runner_health_snapshot()
+            if health.get("runner_running"):
+                last_healthy = time.monotonic()
+            elif time.monotonic() - last_healthy > health_grace_seconds:
+                logger.error(
+                    "agent-run worker runner supervisor unhealthy; exiting for restart",
+                    extra={"runner_health": health},
+                )
+                raise SystemExit(1)
             time.sleep(_poll_interval())
     finally:
         stop_runner(drain_timeout_seconds=_shutdown_drain_timeout_seconds())

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -66,7 +66,11 @@ _default_runner_concurrency = 4
 _max_runner_concurrency = 32
 _default_heartbeat_interval_sec = 10.0
 _default_stale_run_sec = 300.0
+_default_queued_watchdog_after_sec = 15.0
+_queued_watchdog_interval_sec = 5.0
 _last_stale_reconcile_monotonic = 0.0
+_last_queued_watchdog_monotonic = 0.0
+_queued_watchdog_tasks: set[asyncio.Task[int]] = set()
 
 _PROCESS_ACTIVE_STATUS_VALUES = PROCESSING_RUN_STATUS_VALUES
 
@@ -109,6 +113,14 @@ def _stale_run_seconds() -> float:
     )
 
 
+def _queued_watchdog_after_seconds() -> float:
+    return _coerce_float(
+        os.getenv("ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS"),
+        default=_default_queued_watchdog_after_sec,
+        minimum=1.0,
+    )
+
+
 def _runner_concurrency() -> int:
     return _coerce_concurrency(
         os.getenv("ILLO_AGENT_RUNNER_CONCURRENCY"),
@@ -119,6 +131,17 @@ def _runner_concurrency() -> int:
 def _active_runner_count() -> int:
     with _runner_lock:
         return sum(1 for task, stop_event in _runner_slots if not task.done() and not stop_event.is_set())
+
+
+def runner_health_snapshot() -> dict[str, int | bool]:
+    supervisor_alive = bool(_runner_supervisor_thread and _runner_supervisor_thread.is_alive())
+    active_runner_count = _active_runner_count()
+    return {
+        "runner_running": supervisor_alive and active_runner_count > 0,
+        "supervisor_alive": supervisor_alive,
+        "active_runner_count": active_runner_count,
+        "configured_concurrency": _runner_concurrency(),
+    }
 
 
 def _int_value(value: Any) -> int | None:
@@ -772,6 +795,76 @@ async def _reap_stale_runs_if_due_async(*, force: bool = False) -> int:
         return 0
 
 
+async def _queued_backlog_snapshot_async() -> tuple[int, datetime | None, int]:
+    async with _unit_of_work_factory()() as uow:
+        queued_result = await uow.session.execute(
+            select(func.count(AgentRunRow.id), func.min(AgentRunRow.created_at)).where(
+                AgentRunRow.status == RunStatus.QUEUED.value
+            )
+        )
+        queued_count, oldest_created_at = queued_result.one()
+        active_count = await uow.session.scalar(
+            select(func.count(AgentRunRow.id)).where(
+                AgentRunRow.status.in_(_PROCESS_ACTIVE_STATUS_VALUES)
+            )
+        )
+    return int(queued_count or 0), _normalize_datetime(oldest_created_at), int(active_count or 0)
+
+
+def _forget_queued_watchdog_task(task: asyncio.Task[int]) -> None:
+    _queued_watchdog_tasks.discard(task)
+    if task.cancelled():
+        return
+    try:
+        processed = task.result()
+    except Exception:
+        logger.exception("agent_run_queued_watchdog_failed")
+        return
+    if processed:
+        logger.info("agent_run_queued_watchdog_processed", extra={"processed": processed})
+
+
+async def _nudge_stale_queued_runs_if_due_async(*, force: bool = False) -> bool:
+    global _last_queued_watchdog_monotonic
+    now_monotonic = time.monotonic()
+    if not force and now_monotonic - _last_queued_watchdog_monotonic < _queued_watchdog_interval_sec:
+        return False
+    _last_queued_watchdog_monotonic = now_monotonic
+
+    if any(not task.done() for task in _queued_watchdog_tasks):
+        return False
+
+    try:
+        queued_count, oldest_queued_at, active_count = await _queued_backlog_snapshot_async()
+    except Exception:
+        logger.exception("agent_run_queued_watchdog_snapshot_failed")
+        return False
+    if queued_count <= 0 or oldest_queued_at is None:
+        return False
+    if active_count >= _runner_concurrency():
+        return False
+
+    age_seconds = (datetime.now(timezone.utc) - oldest_queued_at).total_seconds()
+    if age_seconds < _queued_watchdog_after_seconds():
+        return False
+
+    logger.warning(
+        "agent_run_queued_watchdog_nudge",
+        extra={
+            "queued": queued_count,
+            "oldest_queued_age_seconds": int(age_seconds),
+            "active_runs": active_count,
+        },
+    )
+    task = asyncio.create_task(
+        _run_queued_once_async(limit=1),
+        name="agent-runner-queued-watchdog",
+    )
+    _queued_watchdog_tasks.add(task)
+    task.add_done_callback(_forget_queued_watchdog_task)
+    return True
+
+
 async def _async_materialize_project_context(run_id: int) -> tuple[bool, dict[str, Any] | None]:
     async with _unit_of_work_factory()() as uow:
         run = await uow.session.get(AgentRunRow, int(run_id))
@@ -986,6 +1079,7 @@ async def _supervisor_async_loop() -> None:
             try:
                 reconcile_runner_pool(allow_start=True)
                 await _reap_stale_runs_if_due_async(force=first_reconcile)
+                await _nudge_stale_queued_runs_if_due_async(force=first_reconcile)
                 first_reconcile = False
             except Exception:
                 logger.exception("agent_run_runner_reconcile_failed")
@@ -1014,6 +1108,20 @@ async def _supervisor_async_loop() -> None:
             for task in done:
                 with suppress(asyncio.CancelledError, Exception):
                     await task
+        queued_watchdogs = [task for task in _queued_watchdog_tasks if not task.done()]
+        for task in queued_watchdogs:
+            task.cancel()
+        if queued_watchdogs:
+            done, pending = await asyncio.wait(queued_watchdogs, timeout=1.0)
+            for task in pending:
+                logger.warning(
+                    "agent_run_queued_watchdog_shutdown_timeout",
+                    extra={"task": task.get_name()},
+                )
+            for task in done:
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
+        _queued_watchdog_tasks.clear()
         with _runner_lock:
             _runner_slots.clear()
 
@@ -1079,6 +1187,7 @@ __all__ = [
     "queue_status",
     "queue_status_async",
     "reap_stale_active_runs",
+    "runner_health_snapshot",
     "run_queued_once",
     "start_runner",
     "stop_runner",

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 
 
 def test_runner_concurrency_is_configurable(monkeypatch):
@@ -49,6 +50,7 @@ def test_start_runner_starts_configured_worker_pool(monkeypatch):
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 3)
     monkeypatch.setattr(runner, "_loop", fake_loop)
     monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
+    monkeypatch.setattr(runner, "_nudge_stale_queued_runs_if_due_async", _noop_nudge)
     try:
         runner.start_runner()
         for _ in range(100):
@@ -80,6 +82,7 @@ def test_stop_runner_can_drain_active_slots(monkeypatch):
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 1)
     monkeypatch.setattr(runner, "_loop", fake_loop)
     monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
+    monkeypatch.setattr(runner, "_nudge_stale_queued_runs_if_due_async", _noop_nudge)
     try:
         runner.start_runner()
         assert entered.wait(timeout=1)
@@ -110,6 +113,7 @@ def test_runner_pool_uses_one_event_loop(monkeypatch):
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 3)
     monkeypatch.setattr(runner, "_loop", fake_loop)
     monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", _noop_reap)
+    monkeypatch.setattr(runner, "_nudge_stale_queued_runs_if_due_async", _noop_nudge)
     try:
         runner.start_runner()
         for _ in range(100):
@@ -122,6 +126,31 @@ def test_runner_pool_uses_one_event_loop(monkeypatch):
 
     assert len(loops) == 3
     assert len(set(loops)) == 1
+
+
+def test_runner_health_snapshot_requires_supervisor_and_slots(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    class AliveThread:
+        def is_alive(self):
+            return True
+
+    class DeadThread:
+        def is_alive(self):
+            return False
+
+    runner.stop_runner()
+    monkeypatch.setattr(runner, "_runner_concurrency", lambda: 2)
+    monkeypatch.setattr(runner, "_active_runner_count", lambda: 1)
+    monkeypatch.setattr(runner, "_runner_supervisor_thread", AliveThread())
+    assert runner.runner_health_snapshot()["runner_running"] is True
+
+    monkeypatch.setattr(runner, "_runner_supervisor_thread", DeadThread())
+    assert runner.runner_health_snapshot()["runner_running"] is False
+
+    monkeypatch.setattr(runner, "_runner_supervisor_thread", AliveThread())
+    monkeypatch.setattr(runner, "_active_runner_count", lambda: 0)
+    assert runner.runner_health_snapshot()["runner_running"] is False
 
 
 async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(monkeypatch):
@@ -145,6 +174,7 @@ async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(mo
     runner._stop_event.clear()
     monkeypatch.setattr(runner, "_runner_concurrency", lambda: 1)
     monkeypatch.setattr(runner, "_reap_stale_runs_if_due_async", blocked_reap)
+    monkeypatch.setattr(runner, "_nudge_stale_queued_runs_if_due_async", _noop_nudge)
     monkeypatch.setattr(runner, "_loop", fake_loop)
     supervisor = asyncio.create_task(runner._supervisor_async_loop())
     try:
@@ -187,5 +217,68 @@ async def test_runner_slot_logs_and_survives_queue_errors(monkeypatch, caplog):
     assert "agent_run_runner_slot_failed" in caplog.text
 
 
+async def test_queued_watchdog_nudges_stale_queue_when_capacity_available(monkeypatch, caplog):
+    from brain.systems.runs.cortex import runner
+
+    calls = 0
+    oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
+    release = asyncio.Event()
+
+    async def fake_snapshot():
+        return 1, oldest, 0
+
+    async def fake_run_queued_once(*, limit=1):
+        nonlocal calls
+        calls += 1
+        assert limit == 1
+        await release.wait()
+        return 1
+
+    runner._queued_watchdog_tasks.clear()
+    runner._last_queued_watchdog_monotonic = 0
+    monkeypatch.setattr(runner, "_queued_backlog_snapshot_async", fake_snapshot)
+    monkeypatch.setattr(runner, "_queued_watchdog_after_seconds", lambda: 10)
+    monkeypatch.setattr(runner, "_runner_concurrency", lambda: 4)
+    monkeypatch.setattr(runner, "_run_queued_once_async", fake_run_queued_once)
+    caplog.set_level(logging.WARNING, logger=runner.__name__)
+
+    nudged = await runner._nudge_stale_queued_runs_if_due_async(force=True)
+    assert nudged is True
+    assert len(runner._queued_watchdog_tasks) == 1
+    task = next(iter(runner._queued_watchdog_tasks))
+    release.set()
+    await asyncio.wait_for(task, timeout=1)
+    await asyncio.sleep(0)
+
+    assert calls == 1
+    assert "agent_run_queued_watchdog_nudge" in caplog.text
+
+
+async def test_queued_watchdog_respects_configured_capacity(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
+
+    async def fake_snapshot():
+        return 1, oldest, 4
+
+    async def fail_run_queued_once(*, limit=1):
+        raise AssertionError("watchdog should not run when capacity is full")
+
+    runner._queued_watchdog_tasks.clear()
+    runner._last_queued_watchdog_monotonic = 0
+    monkeypatch.setattr(runner, "_queued_backlog_snapshot_async", fake_snapshot)
+    monkeypatch.setattr(runner, "_queued_watchdog_after_seconds", lambda: 10)
+    monkeypatch.setattr(runner, "_runner_concurrency", lambda: 4)
+    monkeypatch.setattr(runner, "_run_queued_once_async", fail_run_queued_once)
+
+    assert await runner._nudge_stale_queued_runs_if_due_async(force=True) is False
+    assert not runner._queued_watchdog_tasks
+
+
 async def _noop_reap(**_kwargs):
     return 0
+
+
+async def _noop_nudge(**_kwargs):
+    return False

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -43,6 +43,22 @@ def test_shutdown_drain_timeout_accepts_numeric_override(monkeypatch):
     assert _shutdown_drain_timeout_seconds() == 42.5
 
 
+def test_runner_health_grace_accepts_numeric_override(monkeypatch):
+    from brain.systems.cortex.worker import _runner_health_grace_seconds
+
+    monkeypatch.setenv("ILLO_AGENT_RUNNER_HEALTH_GRACE_SECONDS", "3.5")
+
+    assert _runner_health_grace_seconds() == 3.5
+
+
+def test_runner_health_grace_has_safe_minimum(monkeypatch):
+    from brain.systems.cortex.worker import _runner_health_grace_seconds
+
+    monkeypatch.setenv("ILLO_AGENT_RUNNER_HEALTH_GRACE_SECONDS", "0")
+
+    assert _runner_health_grace_seconds() == 1.0
+
+
 def test_cycle_scheduler_can_be_disabled_for_handoff_worker(monkeypatch):
     from brain.systems.cortex.worker import _cycle_scheduler_enabled
 


### PR DESCRIPTION
## Summary
- add a worker-supervisor watchdog for AgentRuns that remain queued while runner capacity is available
- nudge stale queued work through the same DB-locked claim path, preventing duplicate execution
- cover watchdog behavior and keep existing runner/stale-run tests green

## Incident notes
After the last deploy, run 471 stayed queued for several minutes with only run.created recorded while the worker container was healthy. A manual run_queued_once() immediately claimed and completed it, so this guards the long-lived runner against alive-but-not-consuming states.

## Tests
- venv/bin/python -m pytest tests/test_agent_run_runner.py -q
- venv/bin/python -m pytest tests/test_agent_run_runner.py tests/test_agent_run_state_machine.py::test_stale_active_run_reaper_fails_abandoned_runs tests/test_agent_run_state_machine.py::test_stale_active_run_reaper_uses_recent_events_as_liveness tests/test_agent_run_state_machine.py::test_stale_active_run_reaper_does_not_reap_child_while_root_active -q
- git diff --check