### PR TITLE
Require runtime service controller heartbeat

### DIFF
--- a/brain/systems/runtime_settings/runtime_services.py
+++ b/brain/systems/runtime_settings/runtime_services.py
@@ -27,7 +27,7 @@ _RUNTIME_SERVICES_QUEUE = SidecarQueue(
     waiting_detail="Runtime service management is waiting for the host controller.",
     stale_detail="Runtime service management is unavailable because the host controller heartbeat is stale.",
     heartbeat_file_env="ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE",
-    fallback_heartbeat_file_env="ILLO_SELF_UPDATE_HEARTBEAT_FILE",
+    require_heartbeat=True,
 )
 
 
@@ -47,14 +47,16 @@ async def async_get_runtime_services_status() -> RuntimeServicesRead:
     status_data = _RUNTIME_SERVICES_QUEUE.status_data(request_file)
     detail = status_data.get("detail") if isinstance(status_data.get("detail"), str) else None
 
+    running = available and _RUNTIME_SERVICES_QUEUE.status_is_running(request_file, status_data)
+
     return RuntimeServicesRead(
-        status="running" if _RUNTIME_SERVICES_QUEUE.status_is_running(request_file, status_data) else "idle",
+        status="running" if running else "idle",
         available=available,
         services=services,
         requested_services=_coerce_service_list(status_data.get("services")),
         started_at=parse_datetime(status_data.get("started_at") or status_data.get("requested_at")),
         log_path=str(_RUNTIME_SERVICES_QUEUE.log_path()),
-        detail=detail or availability_detail,
+        detail=(detail if available else None) or availability_detail,
     )
 
 

--- a/brain/systems/runtime_settings/sidecar_queue.py
+++ b/brain/systems/runtime_settings/sidecar_queue.py
@@ -25,6 +25,7 @@ class SidecarQueue:
     heartbeat_file_env: str | None = None
     fallback_heartbeat_file_env: str | None = None
     default_status_name: str = "status.json"
+    require_heartbeat: bool = False
 
     def request_file(self) -> Path | None:
         raw = os.getenv(self.request_file_env, "").strip()
@@ -57,6 +58,8 @@ class SidecarQueue:
             return False, f"{self.queue_unavailable_label} is not writable: {request_file.parent}"
 
         heartbeat_file = self.heartbeat_file()
+        if heartbeat_file is None and self.require_heartbeat:
+            return False, self.waiting_detail
         if heartbeat_file is not None:
             heartbeat = read_json(heartbeat_file)
             updated_at = parse_datetime(heartbeat.get("updated_at"))

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -35,7 +35,7 @@ x-illo-env: &illo-env
   ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
   ILLO_RUNTIME_SERVICES_REQUEST_FILE: /data/private/runtime-services/request.json
   ILLO_RUNTIME_SERVICES_STATUS_FILE: /data/private/runtime-services/status.json
-  ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+  ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/runtime-services/heartbeat.json
   ILLO_RUNTIME_SERVICES_LOG_PATH: /data/private/logs/illo-runtime-services.log
 
 x-backend-service: &backend-service
@@ -173,7 +173,7 @@ services:
       ILLO_SELF_UPDATE_LOG_PATH: /data/private/logs/illo-self-update.log
       ILLO_RUNTIME_SERVICES_REQUEST_FILE: /data/private/runtime-services/request.json
       ILLO_RUNTIME_SERVICES_STATUS_FILE: /data/private/runtime-services/status.json
-      ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json
+      ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/runtime-services/heartbeat.json
       ILLO_RUNTIME_SERVICES_LOG_PATH: /data/private/logs/illo-runtime-services.log
       ILLO_COMPOSE_ENV_FILE: /repo/deploy/compose/.env
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-illospace}

--- a/deploy/scripts/self-update-daemon.sh
+++ b/deploy/scripts/self-update-daemon.sh
@@ -8,6 +8,7 @@ HEARTBEAT_FILE="${ILLO_SELF_UPDATE_HEARTBEAT_FILE:-/data/private/self-update/hea
 LOG_PATH="${ILLO_SELF_UPDATE_LOG_PATH:-/data/private/logs/illo-self-update.log}"
 RUNTIME_SERVICES_REQUEST_FILE="${ILLO_RUNTIME_SERVICES_REQUEST_FILE:-/data/private/runtime-services/request.json}"
 RUNTIME_SERVICES_STATUS_FILE="${ILLO_RUNTIME_SERVICES_STATUS_FILE:-/data/private/runtime-services/status.json}"
+RUNTIME_SERVICES_HEARTBEAT_FILE="${ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE:-/data/private/runtime-services/heartbeat.json}"
 RUNTIME_SERVICES_LOG_PATH="${ILLO_RUNTIME_SERVICES_LOG_PATH:-/data/private/logs/illo-runtime-services.log}"
 WORKER_DRAIN_TIMEOUT_FILE="${ILLO_SELF_UPDATE_WORKER_DRAIN_TIMEOUT_FILE:-/data/private/self-update/worker-drain-timeout.json}"
 POLL_SECONDS="${ILLO_SELF_UPDATE_POLL_SECONDS:-2}"
@@ -17,10 +18,10 @@ RUNNING_FILE="${REQUEST_FILE}.running"
 RUNTIME_SERVICES_RUNNING_FILE="${RUNTIME_SERVICES_REQUEST_FILE}.running"
 
 prepare_shared_paths() {
-  mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" "$(dirname "$RUNTIME_SERVICES_LOG_PATH")"
+  mkdir -p "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$LOG_PATH")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" "$(dirname "$RUNTIME_SERVICES_HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_LOG_PATH")"
   if [ "$(id -u)" = "0" ]; then
-    chown "$APP_UID:$APP_GID" "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" 2>/dev/null || true
-    chmod 0775 "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" 2>/dev/null || true
+    chown "$APP_UID:$APP_GID" "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" "$(dirname "$RUNTIME_SERVICES_HEARTBEAT_FILE")" 2>/dev/null || true
+    chmod 0775 "$(dirname "$REQUEST_FILE")" "$(dirname "$STATUS_FILE")" "$(dirname "$HEARTBEAT_FILE")" "$(dirname "$RUNTIME_SERVICES_REQUEST_FILE")" "$(dirname "$RUNTIME_SERVICES_STATUS_FILE")" "$(dirname "$RUNTIME_SERVICES_HEARTBEAT_FILE")" 2>/dev/null || true
   fi
   git config --global --add safe.directory "$REPO" >/dev/null 2>&1 || true
 }
@@ -86,6 +87,12 @@ write_runtime_services_status() {
 
 write_heartbeat() {
   json_write "$HEARTBEAT_FILE" \
+    --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    '{status: "ready", updated_at: $updated_at}'
+}
+
+write_runtime_services_heartbeat() {
+  json_write "$RUNTIME_SERVICES_HEARTBEAT_FILE" \
     --arg updated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
     '{status: "ready", updated_at: $updated_at}'
 }
@@ -170,6 +177,7 @@ write_runtime_services_status "idle" "Runtime service host controller is ready."
 
 while true; do
   write_heartbeat
+  write_runtime_services_heartbeat
   if [ -f "$REQUEST_FILE" ]; then
     set +e
     process_request

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -69,6 +69,19 @@ all_runtime_services() {
   non_worker_services
 }
 
+schedule_updater_refresh_after_self_update() {
+  local delay
+  [ "$SKIP_UPDATER_RESTART" = "1" ] || return 0
+  delay="${ILLO_COMPOSE_UPDATER_SELF_REFRESH_DELAY_SECONDS:-15}"
+  if [[ ! "$delay" =~ ^[0-9]+$ ]]; then
+    delay="15"
+  fi
+  echo "Updater: scheduling self-refresh in ${delay}s so the host controller runs the latest code."
+  compose run -d --rm --no-deps --entrypoint sh updater -lc \
+    "sleep $delay; docker compose --env-file \"\${ILLO_COMPOSE_ENV_FILE:-/repo/deploy/compose/.env}\" -f /repo/deploy/compose/docker-compose.yml up -d --force-recreate --no-deps updater" \
+    >/dev/null || echo "Updater: could not schedule delayed self-refresh; restart updater manually after this update." >&2
+}
+
 if [ "$PULL" = "1" ]; then
   compose pull postgres api web updater || {
     echo "Image pull failed. If release images are not published yet, rerun with --build." >&2
@@ -99,3 +112,4 @@ else
 fi
 
 "$SCRIPT_DIR/doctor.sh"
+schedule_updater_refresh_after_self_update

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -230,6 +230,60 @@ async def test_runtime_services_queues_restart_request(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runtime_services_requires_dedicated_controller_heartbeat(monkeypatch, tmp_path):
+    import json
+    from datetime import datetime, timezone
+
+    from fastapi import HTTPException
+
+    from brain.systems.runtime_settings.runtime_services import (
+        async_get_runtime_services_status,
+        async_restart_runtime_services,
+    )
+
+    request_file = tmp_path / "runtime-services" / "request.json"
+    status_file = tmp_path / "runtime-services" / "status.json"
+    runtime_heartbeat_file = tmp_path / "runtime-services" / "heartbeat.json"
+    self_update_heartbeat_file = tmp_path / "self-update" / "heartbeat.json"
+    request_file.parent.mkdir(parents=True)
+    self_update_heartbeat_file.parent.mkdir(parents=True)
+    request_file.write_text(
+        json.dumps({"action": "restart", "services": ["slack_connector"]}),
+        encoding="utf-8",
+    )
+    status_file.write_text(
+        json.dumps(
+            {
+                "status": "queued",
+                "detail": "Runtime service restart queued for the host controller.",
+                "services": ["slack_connector"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    self_update_heartbeat_file.write_text(
+        json.dumps({"status": "ready", "updated_at": datetime.now(timezone.utc).isoformat()}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_REQUEST_FILE", str(request_file))
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_STATUS_FILE", str(status_file))
+    monkeypatch.setenv("ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE", str(runtime_heartbeat_file))
+    monkeypatch.setenv("ILLO_SELF_UPDATE_HEARTBEAT_FILE", str(self_update_heartbeat_file))
+
+    result = await async_get_runtime_services_status()
+
+    assert result.available is False
+    assert result.status == "idle"
+    assert result.requested_services == ["slack_connector"]
+    assert result.detail == "Runtime service management is waiting for the host controller."
+
+    with pytest.raises(HTTPException) as exc:
+        await async_restart_runtime_services(["slack_connector"], requested_by="user-1")
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Runtime service management is waiting for the host controller."
+
+
+@pytest.mark.asyncio
 async def test_runtime_update_http_endpoint_allows_workspace_member():
     from types import SimpleNamespace
 

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -282,6 +282,9 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     assert "ILLO_SELF_UPDATE_HEARTBEAT_FILE" in compose
     assert "ILLO_RUNTIME_SERVICES_REQUEST_FILE" in compose
     assert "ILLO_RUNTIME_SERVICES_STATUS_FILE" in compose
+    assert "ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE" in compose
+    assert "/data/private/runtime-services/heartbeat.json" in compose
+    assert "ILLO_RUNTIME_SERVICES_HEARTBEAT_FILE: /data/private/self-update/heartbeat.json" not in compose
     assert "shared_preload_libraries=pg_stat_statements" in compose
     assert "pg_stat_statements.track=all" in compose
     assert "track_io_timing=on" in compose
@@ -310,6 +313,8 @@ def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
     assert "safe.directory" in self_update_daemon
     assert "ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES=1" in self_update_daemon
     assert "process_runtime_services_request" in self_update_daemon
+    assert "RUNTIME_SERVICES_HEARTBEAT_FILE" in self_update_daemon
+    assert "write_runtime_services_heartbeat" in self_update_daemon
     assert "deploy/scripts/runtime-services.sh" in self_update_daemon
 
 
@@ -333,6 +338,9 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "non_worker_services" in upgrade
     assert "api scheduler web updater" in upgrade
     assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
+    assert "schedule_updater_refresh_after_self_update" in upgrade
+    assert "ILLO_COMPOSE_UPDATER_SELF_REFRESH_DELAY_SECONDS" in upgrade
+    assert "up -d --force-recreate --no-deps updater" in upgrade
     assert "start_worker_handoff" in runtime_lib
     assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in runtime_lib
     assert "started handoff worker" in runtime_lib


### PR DESCRIPTION
## Summary
- require a dedicated runtime-services heartbeat before reporting the restart controller available
- make the updater daemon publish that heartbeat separately from self-update readiness
- schedule a delayed updater self-refresh after Compose self-update so the first rollout moves the host controller onto the latest code
- add regression coverage for the trace shape where an old updater heartbeat made runtime-service restarts look stuck

## Tests
- bash -n deploy/scripts/runtime-services.sh deploy/scripts/compose-runtime-lib.sh deploy/scripts/upgrade.sh deploy/scripts/self-update-daemon.sh
- .venv/bin/python -m py_compile brain/systems/runtime_settings/sidecar_queue.py brain/systems/runtime_settings/runtime_services.py brain/systems/runtime_settings/self_update.py brain/app/mcp/server.py brain/systems/slack/connector.py brain/app/cli/slack_connector.py
- git diff --check
- .venv/bin/pytest tests/test_runtime_settings.py tests/test_tool_registry.py tests/test_safe_deploy.py tests/test_slack_teammate.py tests/test_agent.py::TestCortexReplyHandler