### PR TITLE
Record Slack connector health before first event

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -239,7 +239,15 @@ async def _handle_manage_slack(
                 .order_by(ExternalAgentConnectionRow.created_at.asc(), ExternalAgentConnectionRow.id.asc())
             )
             rows = list((await uow.session.scalars(stmt)).all())
-            setup_state = "connected" if rows else "not_connected"
+            statuses = {str(row.status or "").strip().lower() for row in rows}
+            if not rows:
+                setup_state = "not_connected"
+            elif statuses & {"connected", "online"}:
+                setup_state = "connected"
+            elif "error" in statuses:
+                setup_state = "error"
+            else:
+                setup_state = "configured"
             return json.dumps(
                 {
                     "ok": True,

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 import json
 import logging
@@ -19,6 +19,7 @@ from brain.systems.inbound.service import submit_inbound_envelope
 from brain.systems.slack.client import (
     SlackApiError,
     SlackConfigurationError,
+    SlackWebClient,
     slack_app_token_from_env,
     slack_bot_token_from_env,
 )
@@ -222,6 +223,59 @@ async def ensure_slack_connection(
     return connection
 
 
+async def resolve_slack_team_metadata(config: SlackConnectorConfig) -> tuple[str | None, str | None, str | None]:
+    """Resolve Slack team/bot metadata from env or Slack auth.test."""
+
+    if config.team_id and config.bot_user_id:
+        return config.team_id, config.bot_user_id, None
+
+    auth = await SlackWebClient(config.bot_token).auth_test()
+    team_id = config.team_id or auth.get("team_id")
+    bot_user_id = config.bot_user_id or auth.get("user_id") or auth.get("bot_id")
+    team_name = auth.get("team")
+    return (
+        str(team_id) if team_id else None,
+        str(bot_user_id) if bot_user_id else None,
+        str(team_name) if team_name else None,
+    )
+
+
+async def ensure_slack_connection_for_config(
+    session,
+    config: SlackConnectorConfig,
+    *,
+    status: str = "connected",
+    last_error: str | None = None,
+) -> tuple[ExternalAgentConnectionRow, SlackConnectorConfig]:
+    """Create or refresh Slack health before waiting for the first event."""
+
+    org_id, owner_user_id = await resolve_slack_connection_identity(session, config)
+    team_name = None
+    if last_error:
+        team_id = config.team_id
+        bot_user_id = config.bot_user_id
+    else:
+        team_id, bot_user_id, team_name = await resolve_slack_team_metadata(config)
+    enriched_config = replace(
+        config,
+        org_id=config.org_id or org_id,
+        owner_user_id=config.owner_user_id or owner_user_id,
+        team_id=team_id,
+        bot_user_id=bot_user_id,
+    )
+    connection = await ensure_slack_connection(
+        session,
+        org_id=org_id,
+        owner_user_id=owner_user_id,
+        team_id=team_id,
+        bot_user_id=bot_user_id,
+        team_name=team_name,
+        status=status,
+        last_error=last_error,
+    )
+    return connection, enriched_config
+
+
 async def resolve_slack_connection_identity(session, config: SlackConnectorConfig) -> tuple[str, str]:
     """Resolve the org/user authority for a self-hosted Slack connector."""
 
@@ -299,56 +353,124 @@ async def run_socket_mode_loop(
 
     import websockets
 
-    from brain.platform.db.repositories.unit_of_work import UnitOfWork
-
     config = config or await SlackConnectorConfig.from_runtime()
+    _, config = await _ensure_runtime_connection(
+        config,
+        status="configured",
+        session_factory=session_factory,
+        connection_factory=connection_factory,
+    )
     socket_url = config.socket_mode_url or await open_socket_mode_url(config)
     logger.info("slack_socket_mode_connecting")
     async with websockets.connect(socket_url) as websocket:
         logger.info("slack_socket_mode_connected")
+        _, config = await _ensure_runtime_connection(
+            config,
+            status="connected",
+            session_factory=session_factory,
+            connection_factory=connection_factory,
+        )
         async for raw_message in websocket:
             socket_payload = json.loads(raw_message)
             ack = socket_mode_ack(socket_payload)
             if ack:
                 await websocket.send(json.dumps(ack))
             try:
-                if session_factory is not None:
-                    async with session_factory() as session:
-                        connection = await connection_factory(session) if connection_factory else None
-                        if connection is None:
-                            raise SlackConfigurationError("Slack connection factory returned no connection")
-                        await process_socket_payload(
-                            session,
-                            connection=connection,
-                            socket_payload=socket_payload,
-                            config=config,
-                        )
-                else:
-                    async with UnitOfWork() as uow:
-                        org_id, owner_user_id = await resolve_slack_connection_identity(uow.session, config)
-                        connection = await ensure_slack_connection(
-                            uow.session,
-                            org_id=org_id,
-                            owner_user_id=owner_user_id,
-                            team_id=config.team_id,
-                            bot_user_id=config.bot_user_id,
-                            status="connected",
-                        )
-                        await process_socket_payload(
-                            uow.session,
-                            connection=connection,
-                            socket_payload=socket_payload,
-                            config=config,
-                        )
+                await _process_runtime_socket_payload(
+                    config,
+                    socket_payload=socket_payload,
+                    session_factory=session_factory,
+                    connection_factory=connection_factory,
+                )
             except Exception as exc:
                 logger.exception("slack_socket_mode_payload_failed: %s", exc)
 
 
+async def _ensure_runtime_connection(
+    config: SlackConnectorConfig,
+    *,
+    status: str,
+    session_factory=None,
+    connection_factory=None,
+) -> tuple[ExternalAgentConnectionRow, SlackConnectorConfig]:
+    if session_factory is not None:
+        async with session_factory() as session:
+            if connection_factory is not None:
+                connection = await connection_factory(session)
+                if connection is None:
+                    raise SlackConfigurationError("Slack connection factory returned no connection")
+                return connection, config
+            return await ensure_slack_connection_for_config(session, config, status=status)
+
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    async with UnitOfWork() as uow:
+        return await ensure_slack_connection_for_config(uow.session, config, status=status)
+
+
+async def _process_runtime_socket_payload(
+    config: SlackConnectorConfig,
+    *,
+    socket_payload: Mapping[str, Any],
+    session_factory=None,
+    connection_factory=None,
+) -> None:
+    if session_factory is not None:
+        async with session_factory() as session:
+            if connection_factory is not None:
+                connection = await connection_factory(session)
+                if connection is None:
+                    raise SlackConfigurationError("Slack connection factory returned no connection")
+            else:
+                connection, config = await ensure_slack_connection_for_config(
+                    session,
+                    config,
+                    status="connected",
+                )
+            await process_socket_payload(
+                session,
+                connection=connection,
+                socket_payload=socket_payload,
+                config=config,
+            )
+        return
+
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    async with UnitOfWork() as uow:
+        connection, config = await ensure_slack_connection_for_config(
+            uow.session,
+            config,
+            status="connected",
+        )
+        await process_socket_payload(
+            uow.session,
+            connection=connection,
+            socket_payload=socket_payload,
+            config=config,
+        )
+
+
 async def run_forever() -> None:
     while True:
+        config = None
         try:
-            await run_socket_mode_loop()
+            config = await SlackConnectorConfig.from_runtime()
+            await run_socket_mode_loop(config=config)
         except Exception as exc:
+            if config is not None:
+                try:
+                    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+                    async with UnitOfWork() as uow:
+                        await ensure_slack_connection_for_config(
+                            uow.session,
+                            config,
+                            status="error",
+                            last_error=str(exc),
+                        )
+                except Exception:
+                    logger.exception("slack_socket_mode_error_record_failed")
             logger.exception("slack_socket_mode_loop_failed: %s", exc)
             await asyncio.sleep(5)
 
@@ -356,9 +478,11 @@ async def run_forever() -> None:
 __all__ = [
     "SlackConnectorConfig",
     "ensure_slack_connection",
+    "ensure_slack_connection_for_config",
     "socket_mode_ack",
     "process_socket_payload",
     "resolve_slack_connection_identity",
+    "resolve_slack_team_metadata",
     "open_socket_mode_url",
     "run_socket_mode_loop",
     "run_forever",

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -504,6 +504,67 @@ def test_socket_mode_ack_payload_uses_envelope_id():
     assert socket_mode_ack({"envelope_id": "env-1"}) == {"envelope_id": "env-1"}
 
 
+@pytest.mark.asyncio
+async def test_slack_connector_registers_connection_before_first_socket_event(session, monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    from brain.systems.slack.connector import SlackConnectorConfig, run_socket_mode_loop
+
+    session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    await session.flush()
+
+    async def auth_test(_client):
+        return {"team_id": "T789", "user_id": "BILLO", "team": "Test Slack"}
+
+    class _SessionFactory:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        def __call__(self):
+            return self
+
+    class _Socket:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    monkeypatch.setattr("brain.systems.slack.connector.SlackWebClient.auth_test", auth_test)
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=lambda _url: _Socket()))
+
+    await run_socket_mode_loop(
+        config=SlackConnectorConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            org_id=ORG_ID,
+            owner_user_id=USER_ID,
+            socket_mode_url="wss://socket.test",
+        ),
+        session_factory=_SessionFactory(),
+    )
+
+    connection = (await session.scalars(select(ExternalAgentConnectionRow))).one()
+    assert connection.agent_kind == "slack"
+    assert connection.transport == "slack_socket_mode"
+    assert connection.remote_agent_id == "T789"
+    assert connection.status == "connected"
+    assert connection.last_seen_at is not None
+    assert connection.metadata_["slack"]["team_id"] == "T789"
+    assert connection.metadata_["slack"]["bot_user_id"] == "BILLO"
+
+
 def test_slack_tools_are_available_on_normal_illo_tool_surface():
     from brain.systems.runs.tool_definitions import CHAT_TOOLS
 


### PR DESCRIPTION
## Summary
- create/update the Slack source connection as soon as Socket Mode opens, before waiting for the first Slack event
- resolve Slack team and bot metadata through auth.test when env values are absent
- report Slack connection status as connected/configured/error/not_connected instead of treating any row as connected

## Tests
- .venv/bin/python -m py_compile brain/systems/slack/connector.py brain/systems/runs/tool_catalog/handlers/slack.py brain/app/cli/slack_connector.py
- git diff --check
- .venv/bin/pytest tests/test_slack_teammate.py tests/test_agent.py::TestCortexReplyHandler tests/test_tool_registry.py