### PR TITLE
Centralize runtime secret resolution

### DIFF
--- a/brain/app/web/research.py
+++ b/brain/app/web/research.py
@@ -42,6 +42,26 @@ class WebResearchError(RuntimeError):
     """Raised when web research fails safely."""
 
 
+async def _search_api_key(key_name: str, runtime_secret_context: Any = None) -> str:
+    from brain.systems.vault.runtime_secrets import (
+        RuntimeSecretContext,
+        RuntimeSecretUnavailable,
+        read_runtime_secret,
+    )
+
+    try:
+        return await read_runtime_secret(
+            key_name,
+            context=runtime_secret_context or RuntimeSecretContext(actor_user_id=None, org_id=None),
+            reason="Run Illo's web search tool through a configured search provider.",
+            requested_by="web_search",
+            access="service",
+            allow_env_fallback=True,
+        )
+    except RuntimeSecretUnavailable as exc:
+        raise WebResearchError(f"{key_name} is not configured") from exc
+
+
 def _cache_get(cache: dict[str, _CacheEntry], key: str):
     now = time.time()
     with _cache_lock:
@@ -121,6 +141,27 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+def _accepts_runtime_secret_context(fn) -> bool:
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    positional = 0
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == "runtime_secret_context":
+            return True
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }:
+            positional += 1
+    return positional >= 3
+
+
 def _strip_html(text: str) -> str:
     text = re.sub(r"(?is)<(script|style|noscript).*?>.*?</\1>", " ", text)
     text = re.sub(r"(?is)<br\s*/?>", "\n", text)
@@ -161,10 +202,8 @@ def _markdown_from_text(text: str) -> str:
     return "\n\n".join(lines)
 
 
-async def _brave_search(query: str, limit: int) -> dict[str, Any]:
-    api_key = os.environ.get("BRAVE_SEARCH_API_KEY")
-    if not api_key:
-        raise WebResearchError("BRAVE_SEARCH_API_KEY is not configured")
+async def _brave_search(query: str, limit: int, runtime_secret_context: Any = None) -> dict[str, Any]:
+    api_key = await _search_api_key("BRAVE_SEARCH_API_KEY", runtime_secret_context)
     async with _http_client() as client:
         response = await client.get(
             "https://api.search.brave.com/res/v1/web/search",
@@ -184,10 +223,8 @@ async def _brave_search(query: str, limit: int) -> dict[str, Any]:
     return {"provider": "brave", "results": results}
 
 
-async def _tavily_search(query: str, limit: int) -> dict[str, Any]:
-    api_key = os.environ.get("TAVILY_API_KEY")
-    if not api_key:
-        raise WebResearchError("TAVILY_API_KEY is not configured")
+async def _tavily_search(query: str, limit: int, runtime_secret_context: Any = None) -> dict[str, Any]:
+    api_key = await _search_api_key("TAVILY_API_KEY", runtime_secret_context)
     async with _http_client() as client:
         response = await client.post(
             "https://api.tavily.com/search",
@@ -274,7 +311,13 @@ def _normalize_duckduckgo_result_url(value: str) -> str | None:
     return url if url.startswith(("http://", "https://")) else None
 
 
-async def web_search(query: str, *, provider: str | None = None, limit: int = 5) -> dict[str, Any]:
+async def web_search(
+    query: str,
+    *,
+    provider: str | None = None,
+    limit: int = 5,
+    runtime_secret_context: Any = None,
+) -> dict[str, Any]:
     normalized_query = (query or "").strip()
     if not normalized_query:
         raise WebResearchError("Query is required")
@@ -301,7 +344,10 @@ async def web_search(query: str, *, provider: str | None = None, limit: int = 5)
             provider_errors.append({"provider": name, "error": f"Unsupported search provider: {name}"})
             continue
         try:
-            result = await _maybe_await(fn(normalized_query, limit))
+            if _accepts_runtime_secret_context(fn):
+                result = await _maybe_await(fn(normalized_query, limit, runtime_secret_context))
+            else:
+                result = await _maybe_await(fn(normalized_query, limit))
             results = list(result.get("results") or [])
             if auto_mode and not results:
                 provider_errors.append({"provider": result.get("provider", name), "error": "No results returned"})

--- a/brain/systems/runs/secret_mounts.py
+++ b/brain/systems/runs/secret_mounts.py
@@ -84,36 +84,26 @@ async def resolve_secret_env_mounts(
     if not mounts:
         return {}
 
-    from brain.systems.vault.agent_access import read_agent_secret_for_runtime
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, runtime_secret_env
 
     user_id = str(context.get("actor_id") or "").strip()
     org_id = str(context.get("org_id") or "").strip() or None
     if not user_id:
         raise PermissionError("secret_env mounts require an authenticated user context")
 
-    resolved: dict[str, str] = {}
-    for env_name, mount in mounts.items():
-        response = await read_agent_secret_for_runtime(
-            mount.vault_key,
-            reason=mount.reason,
-            user_id=user_id,
+    return await runtime_secret_env(
+        {env_name: (mount.vault_key, mount.reason) for env_name, mount in mounts.items()},
+        context=RuntimeSecretContext(
+            actor_user_id=user_id,
             org_id=org_id,
             run_id=run_id,
             idea_id=str(context.get("idea_id") or "").strip() or None,
-            requested_by="secret_env_mount",
             project_slug=context.get("project_slug"),
             project_slugs=context.get("project_slugs"),
             target_registry_id=context.get("target_registry_id"),
-        )
-        if not isinstance(response, dict):
-            raise PermissionError(f"Vault secret '{mount.vault_key}' could not be read")
-        if response.get("error"):
-            raise PermissionError(str(response.get("error")))
-        value = response.get("value")
-        if value is None:
-            raise PermissionError(f"Vault secret '{mount.vault_key}' did not return a value")
-        resolved[env_name] = str(value)
-    return resolved
+        ),
+        requested_by="secret_env_mount",
+    )
 
 
 def handler_args_with_resolved_secret_env(

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -546,6 +546,34 @@ def _looks_like_concrete_blocker_reply(reply: str, execution_context: str | None
     return (
         any(marker in text for marker in _BLOCKED_REPLY_MARKERS)
         and any(marker in text for marker in _CONCRETE_BLOCKER_MARKERS)
+)
+
+
+def _coerce_agent_run_id(value) -> int | None:
+    try:
+        return int(value) if value else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _current_runtime_secret_context():
+    """Return the current AgentRun identity for trusted runtime secret reads."""
+
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext
+
+    execution_metadata = getattr(_agent_context, "execution_metadata", None)
+    metadata = execution_metadata if isinstance(execution_metadata, dict) else {}
+    run = getattr(_agent_context, "run", None)
+    run_id = (
+        getattr(_agent_context, "run_id", None)
+        or getattr(run, "run_id", None)
+        or metadata.get("run_id")
+    )
+    return RuntimeSecretContext(
+        actor_user_id=str(getattr(_agent_context, "user_id", None) or metadata.get("user_id") or "").strip() or None,
+        org_id=str(getattr(_agent_context, "org_id", None) or metadata.get("org_id") or "").strip() or None,
+        run_id=_coerce_agent_run_id(run_id),
+        idea_id=str(getattr(_agent_context, "idea_id", None) or metadata.get("idea_id") or "").strip() or None,
     )
 
 

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 
 
 def _execution_metadata() -> dict[str, Any]:
@@ -46,10 +46,32 @@ def _coerce_slack_limit(value: Any, default: int = 50) -> int:
         return default
 
 
-def _slack_client_from_env():
-    from brain.systems.slack.client import slack_web_client_from_env
+async def _slack_client_from_runtime():
+    from brain.systems.slack.client import SlackWebClient
+    from brain.systems.vault.runtime_secrets import read_runtime_secret
 
-    return slack_web_client_from_env()
+    token = await read_runtime_secret(
+        "SLACK_BOT_TOKEN",
+        context=_current_runtime_secret_context(),
+        reason="Use the configured Slack app to read and reply from Illo's Slack teammate surface.",
+        requested_by="slack_runtime_tool",
+        access="service",
+        allow_env_fallback=True,
+    )
+    return SlackWebClient(token)
+
+
+def _looks_like_slack_user_id(value: str) -> bool:
+    return value.startswith(("U", "W"))
+
+
+async def _resolve_post_channel(client, channel_id: str, visibility: str) -> str:
+    if visibility == "ephemeral" or not _looks_like_slack_user_id(channel_id):
+        return channel_id
+    response = await client.open_conversation(users=channel_id)
+    channel = response.get("channel") if isinstance(response.get("channel"), dict) else {}
+    resolved = str(channel.get("id") or "").strip()
+    return resolved or channel_id
 
 
 async def _handle_post_slack_reply(
@@ -78,7 +100,8 @@ async def _handle_post_slack_reply(
         return json.dumps({"error": "post_slack_reply requires channel_id outside a Slack-triggered run"})
 
     try:
-        client = _slack_client_from_env()
+        client = await _slack_client_from_runtime()
+        target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
         if target_visibility == "ephemeral":
             target_user = str(user_id or trigger.get("slack_user_id") or "").strip()
             if not target_user:
@@ -137,7 +160,7 @@ async def _handle_read_slack_conversation(
     if not target_channel:
         return json.dumps({"error": "read_slack_conversation requires channel_id outside a Slack-triggered run"})
     try:
-        client = _slack_client_from_env()
+        client = await _slack_client_from_runtime()
         if normalized_scope == "thread":
             if not target_thread_ts:
                 return json.dumps({"error": "read_slack_conversation scope=thread requires thread_ts"})

--- a/brain/systems/runs/tool_catalog/handlers/web.py
+++ b/brain/systems/runs/tool_catalog/handlers/web.py
@@ -7,7 +7,12 @@ from brain.systems.runs.tool_catalog.handlers.common import *
 def _handle_web_search(query: str, provider: str | None = None, limit: int = 5) -> dict:
     from brain.app.web import web_search
 
-    return web_search(query, provider=provider, limit=limit)
+    return web_search(
+        query,
+        provider=provider,
+        limit=limit,
+        runtime_secret_context=_current_runtime_secret_context(),
+    )
 
 
 def _handle_web_fetch(url: str, extract_mode: str = "markdown", max_chars: int = 12000) -> dict:

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -79,6 +79,9 @@ class SlackWebClient:
             payload["thread_ts"] = thread_ts
         return await self.api_call("chat.postEphemeral", payload)
 
+    async def open_conversation(self, *, users: str) -> dict[str, Any]:
+        return await self.api_call("conversations.open", {"users": users})
+
     async def conversation_replies(
         self,
         *,

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -53,32 +53,40 @@ class SlackConnectorConfig:
 
     @classmethod
     async def from_runtime(cls) -> "SlackConnectorConfig":
-        """Load connector config from env first, then trusted org Vault secrets."""
+        """Load connector config through the central Vault-first runtime resolver."""
 
-        bot_token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
-        app_token = os.environ.get("SLACK_APP_TOKEN", "").strip()
         org_id = os.environ.get("ILLO_SLACK_ORG_ID") or os.environ.get("ILLO_ORG_ID")
         owner_user_id = (
             os.environ.get("ILLO_SLACK_OWNER_USER_ID")
             or os.environ.get("ILLO_OWNER_USER_ID")
         )
-        if not bot_token or not app_token or not org_id or not owner_user_id:
+        if not org_id or not owner_user_id:
             org_id, owner_user_id = await resolve_slack_connector_authority(
                 org_id=org_id,
                 owner_user_id=owner_user_id,
             )
-        if not bot_token:
-            bot_token = await _runtime_vault_secret(
-                "SLACK_BOT_TOKEN",
-                org_id=org_id,
-                owner_user_id=owner_user_id,
-            )
-        if not app_token:
-            app_token = await _runtime_vault_secret(
-                "SLACK_APP_TOKEN",
-                org_id=org_id,
-                owner_user_id=owner_user_id,
-            )
+        from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+        secret_context = RuntimeSecretContext(
+            actor_user_id=owner_user_id,
+            org_id=org_id,
+        )
+        bot_token = await read_runtime_secret(
+            "SLACK_BOT_TOKEN",
+            context=secret_context,
+            reason="Run the self-hosted Slack connector.",
+            requested_by="slack_connector",
+            access="service",
+            allow_env_fallback=True,
+        )
+        app_token = await read_runtime_secret(
+            "SLACK_APP_TOKEN",
+            context=secret_context,
+            reason="Run the self-hosted Slack connector.",
+            requested_by="slack_connector",
+            access="service",
+            allow_env_fallback=True,
+        )
         if not bot_token:
             raise SlackConfigurationError("SLACK_BOT_TOKEN is required")
         if not app_token:
@@ -123,25 +131,6 @@ async def resolve_slack_connector_authority(
             "No Illospace user found; set ILLO_SLACK_ORG_ID and ILLO_SLACK_OWNER_USER_ID"
         )
     return str(org_id or user.org_id), str(owner_user_id or user.id)
-
-
-async def _runtime_vault_secret(
-    key_name: str,
-    *,
-    org_id: str,
-    owner_user_id: str,
-) -> str:
-    from brain.systems.vault import get_secret
-
-    return (
-        await get_secret(
-            key_name,
-            actor_user_id=owner_user_id,
-            org_id=org_id,
-            accessed_by="slack_connector",
-        )
-        or ""
-    )
 
 
 async def ensure_slack_connection(

--- a/brain/systems/vault/runtime_secrets.py
+++ b/brain/systems/vault/runtime_secrets.py
@@ -1,0 +1,136 @@
+"""Central runtime secret resolution for trusted Illospace tool execution."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+
+RuntimeSecretAccess = Literal["agent_tool", "service"]
+
+
+class RuntimeSecretUnavailable(PermissionError):
+    """Raised when a runtime tool cannot resolve a required secret."""
+
+
+@dataclass(frozen=True)
+class RuntimeSecretContext:
+    actor_user_id: str | None
+    org_id: str | None
+    run_id: int | None = None
+    idea_id: str | None = None
+    project_slug: str | None = None
+    project_slugs: list[str] | tuple[str, ...] | set[str] | None = None
+    target_registry_id: int | None = None
+
+
+def _clean_key_name(key_name: str) -> str:
+    key = str(key_name or "").strip().upper()
+    if not key:
+        raise RuntimeSecretUnavailable("Vault secret key name is required")
+    return key
+
+
+def _clean_env_names(key_name: str, env_names: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    names = tuple(str(name or "").strip() for name in (env_names or (key_name,)))
+    return tuple(name for name in names if name)
+
+
+def _env_secret(env_names: tuple[str, ...]) -> str | None:
+    for env_name in env_names:
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return None
+
+
+async def read_runtime_secret(
+    key_name: str,
+    *,
+    context: RuntimeSecretContext,
+    reason: str,
+    requested_by: str,
+    access: RuntimeSecretAccess = "agent_tool",
+    allow_env_fallback: bool = False,
+    env_names: tuple[str, ...] | list[str] | None = None,
+) -> str:
+    """Resolve a secret for trusted runtime code without exposing it to the agent."""
+
+    key = _clean_key_name(key_name)
+    env_candidates = _clean_env_names(key, env_names)
+
+    actor_user_id = str(context.actor_user_id or "").strip()
+    org_id = str(context.org_id or "").strip()
+
+    if access == "service":
+        if actor_user_id and org_id:
+            from brain.systems.vault import get_secret
+
+            value = await get_secret(
+                key,
+                actor_user_id=actor_user_id,
+                org_id=org_id,
+                accessed_by=requested_by,
+            )
+            if value:
+                return str(value)
+        if allow_env_fallback:
+            value = _env_secret(env_candidates)
+            if value:
+                return value
+        raise RuntimeSecretUnavailable(f"Vault secret '{key}' is not available to the runtime")
+
+    if access != "agent_tool":
+        raise RuntimeSecretUnavailable(f"Unknown runtime secret access mode: {access}")
+
+    if not actor_user_id:
+        raise RuntimeSecretUnavailable("Runtime secret reads require an authenticated user context")
+    if not org_id:
+        raise RuntimeSecretUnavailable("Runtime secret reads require a workspace org context")
+    if context.run_id is None:
+        raise RuntimeSecretUnavailable("Runtime secret reads require an AgentRun id")
+
+    from brain.systems.vault.agent_access import read_agent_secret_for_runtime
+
+    response = await read_agent_secret_for_runtime(
+        key,
+        reason=reason,
+        user_id=actor_user_id,
+        org_id=org_id,
+        run_id=int(context.run_id),
+        idea_id=context.idea_id,
+        requested_by=requested_by,
+        project_slug=context.project_slug,
+        project_slugs=context.project_slugs,
+        target_registry_id=context.target_registry_id,
+    )
+    if not isinstance(response, dict):
+        raise RuntimeSecretUnavailable(f"Vault secret '{key}' could not be read")
+    if response.get("error"):
+        raise RuntimeSecretUnavailable(str(response.get("error")))
+    value = response.get("value")
+    if value is None:
+        raise RuntimeSecretUnavailable(f"Vault secret '{key}' did not return a value")
+    return str(value)
+
+
+async def runtime_secret_env(
+    mounts: dict[str, tuple[str, str]],
+    *,
+    context: RuntimeSecretContext,
+    requested_by: str,
+) -> dict[str, str]:
+    """Resolve env-name -> (vault-key, reason) mounts through the central resolver."""
+
+    resolved: dict[str, str] = {}
+    for env_name, (vault_key, reason) in mounts.items():
+        resolved[env_name] = await read_runtime_secret(
+            vault_key,
+            context=context,
+            reason=reason,
+            requested_by=requested_by,
+            access="agent_tool",
+            allow_env_fallback=False,
+        )
+    return resolved

--- a/brain/systems/workspace_apps/generic_http.py
+++ b/brain/systems/workspace_apps/generic_http.py
@@ -156,13 +156,15 @@ async def _resolve_secret(
             raise WorkspaceAppActionContractError("vault_key auth requires connector_spec.auth.vault_key")
         if not context.user_id:
             raise WorkspaceAppActionContractError("Vault-backed connector auth requires a human user")
-        from brain.systems.vault import get_secret
+        from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
 
-        return await get_secret(
+        return await read_runtime_secret(
             key,
-            actor_user_id=context.user_id,
-            org_id=context.org_id,
-            accessed_by="workspace_app_connector",
+            context=RuntimeSecretContext(actor_user_id=context.user_id, org_id=context.org_id),
+            reason=f"Run workspace app connector action {context.action_key}.",
+            requested_by="workspace_app_connector",
+            access="service",
+            allow_env_fallback=False,
         )
     if source in {"project_env", "project_vault_binding"}:
         env_name = str(auth.get("env") or auth.get("env_name") or "GITHUB_TOKEN").strip()

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -19,6 +19,10 @@ trusted local automation system, not as a hardened multi-tenant sandbox.
   for that tool call, and redacts the mounted value from command output and
   artifacts; prompts and public traces should contain only Vault key names and
   environment variable names.
+- First-party runtime tools and integrations resolve required credentials
+  through the same central runtime secret resolver instead of reading
+  secret-like environment variables directly. Service integrations use audited
+  Vault reads in server-side code; raw values are never returned to the model.
 - Never paste real secrets into issues, PRs, logs, screenshots, or fixtures.
 
 ## Tool Execution

--- a/tests/test_runtime_secrets.py
+++ b/tests/test_runtime_secrets.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SENSITIVE_ENV_RE = re.compile(r"(API[_-]?KEY|AUTH|CREDENTIAL|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_runtime_secret_uses_central_agent_access(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    calls = []
+
+    async def read_agent_secret_for_runtime(**kwargs):
+        calls.append(kwargs)
+        return {"key": kwargs["key_name"], "value": "vault-value"}
+
+    async def read_agent_secret_for_runtime_with_key(key_name, **kwargs):
+        kwargs["key_name"] = key_name
+        return await read_agent_secret_for_runtime(**kwargs)
+
+    monkeypatch.setattr(
+        "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
+        read_agent_secret_for_runtime_with_key,
+    )
+
+    value = await read_runtime_secret(
+        "github_token",
+        context=RuntimeSecretContext(
+            actor_user_id="user-1",
+            org_id="org-1",
+            run_id=42,
+            idea_id="thread-1",
+        ),
+        reason="Fetch repository data for this run.",
+        requested_by="test_tool",
+        access="agent_tool",
+    )
+
+    assert value == "vault-value"
+    assert calls == [
+        {
+            "key_name": "GITHUB_TOKEN",
+            "reason": "Fetch repository data for this run.",
+            "user_id": "user-1",
+            "org_id": "org-1",
+            "run_id": 42,
+            "idea_id": "thread-1",
+            "requested_by": "test_tool",
+            "project_slug": None,
+            "project_slugs": None,
+            "target_registry_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_service_runtime_secret_prefers_vault_before_env(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    calls = []
+
+    async def get_secret(key_name, actor_user_id, *, org_id, accessed_by):
+        calls.append(
+            {
+                "key_name": key_name,
+                "actor_user_id": actor_user_id,
+                "org_id": org_id,
+                "accessed_by": accessed_by,
+            }
+        )
+        return "vault-token"
+
+    monkeypatch.setenv("SERVICE_TOKEN", "env-token")
+    monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
+
+    value = await read_runtime_secret(
+        "SERVICE_TOKEN",
+        context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1"),
+        reason="Call a configured first-party integration.",
+        requested_by="service_tool",
+        access="service",
+        allow_env_fallback=True,
+    )
+
+    assert value == "vault-token"
+    assert calls == [
+        {
+            "key_name": "SERVICE_TOKEN",
+            "actor_user_id": "user-1",
+            "org_id": "org-1",
+            "accessed_by": "service_tool",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_service_runtime_secret_can_fall_back_to_env(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    async def get_secret(key_name, actor_user_id, *, org_id, accessed_by):
+        return None
+
+    monkeypatch.setenv("SERVICE_TOKEN", "env-token")
+    monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
+
+    value = await read_runtime_secret(
+        "SERVICE_TOKEN",
+        context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1"),
+        reason="Call a configured first-party integration.",
+        requested_by="service_tool",
+        access="service",
+        allow_env_fallback=True,
+    )
+
+    assert value == "env-token"
+
+
+def _string_arg(node: ast.Call) -> str | None:
+    if not node.args:
+        return None
+    arg = node.args[0]
+    return arg.value if isinstance(arg, ast.Constant) and isinstance(arg.value, str) else None
+
+
+def _is_os_getenv(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "getenv"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "os"
+    )
+
+
+def _is_os_environ_get(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "get"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "environ"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "os"
+    )
+
+
+def _is_os_environ_subscript(node: ast.Subscript) -> str | None:
+    if not (
+        isinstance(node.value, ast.Attribute)
+        and node.value.attr == "environ"
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "os"
+    ):
+        return None
+    key = node.slice
+    return key.value if isinstance(key, ast.Constant) and isinstance(key.value, str) else None
+
+
+def test_first_party_tool_handlers_do_not_read_secret_env_vars_directly():
+    offenders: list[str] = []
+    paths = [
+        *(ROOT / "brain" / "systems" / "runs" / "tool_catalog" / "handlers").glob("*.py"),
+        ROOT / "brain" / "app" / "web" / "research.py",
+        ROOT / "brain" / "systems" / "workspace_apps" / "generic_http.py",
+    ]
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and (_is_os_getenv(node) or _is_os_environ_get(node)):
+                key = _string_arg(node)
+                if key and SENSITIVE_ENV_RE.search(key):
+                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} reads {key}")
+            elif isinstance(node, ast.Subscript):
+                key = _is_os_environ_subscript(node)
+                if key and SENSITIVE_ENV_RE.search(key):
+                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} reads {key}")
+            elif isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name.endswith("_from_env"):
+                        offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} imports {alias.name}")
+
+    assert offenders == []
+
+
+def test_first_party_runtime_integrations_use_runtime_secret_resolver_for_vault_reads():
+    offenders: list[str] = []
+    paths = [
+        ROOT / "brain" / "systems" / "workspace_apps" / "generic_http.py",
+        ROOT / "brain" / "systems" / "slack" / "connector.py",
+        ROOT / "brain" / "app" / "web" / "research.py",
+    ]
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "brain.systems.vault":
+                imported = {alias.name for alias in node.names}
+                if "get_secret" in imported or "async_get_secret" in imported:
+                    offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} imports direct Vault secret reads")
+
+    assert offenders == []

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -136,16 +136,20 @@ async def test_slack_connector_runtime_config_falls_back_to_vault(monkeypatch):
         assert owner_user_id is None
         return ORG_ID, USER_ID
 
-    async def vault_secret(key_name, *, org_id, owner_user_id):
-        assert org_id == ORG_ID
-        assert owner_user_id == USER_ID
+    async def read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback):
+        assert context.org_id == ORG_ID
+        assert context.actor_user_id == USER_ID
+        assert reason
+        assert requested_by == "slack_connector"
+        assert access == "service"
+        assert allow_env_fallback is True
         return {
             "SLACK_BOT_TOKEN": "xoxb-from-vault",
             "SLACK_APP_TOKEN": "xapp-from-vault",
         }[key_name]
 
     monkeypatch.setattr(connector, "resolve_slack_connector_authority", resolve_authority)
-    monkeypatch.setattr(connector, "_runtime_vault_secret", vault_secret)
+    monkeypatch.setattr("brain.systems.vault.runtime_secrets.read_runtime_secret", read_runtime_secret)
 
     config = await connector.SlackConnectorConfig.from_runtime()
 
@@ -367,10 +371,12 @@ async def test_post_slack_reply_tool_posts_to_triggering_thread(monkeypatch):
             calls.append(kwargs)
             return {"ok": True, "ts": "1716900200.000300", "channel": kwargs["channel"]}
 
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    async def slack_client():
+        return _SlackClient()
+
     monkeypatch.setattr(
-        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_env",
-        lambda: _SlackClient(),
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
     )
 
     with bind_agent_context(
@@ -399,6 +405,89 @@ async def test_post_slack_reply_tool_posts_to_triggering_thread(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slack_runtime_client_uses_central_vault_resolver(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _slack_client_from_runtime
+
+    calls = []
+
+    async def read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback):
+        calls.append(
+            {
+                "key_name": key_name,
+                "actor_user_id": context.actor_user_id,
+                "org_id": context.org_id,
+                "run_id": context.run_id,
+                "reason": reason,
+                "requested_by": requested_by,
+                "access": access,
+                "allow_env_fallback": allow_env_fallback,
+            }
+        )
+        return "xoxb-from-vault"
+
+    class _SlackClient:
+        def __init__(self, token):
+            self.token = token
+
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.setattr("brain.systems.vault.runtime_secrets.read_runtime_secret", read_runtime_secret)
+    monkeypatch.setattr("brain.systems.slack.client.SlackWebClient", _SlackClient)
+
+    with bind_agent_context({"org_id": ORG_ID, "user_id": USER_ID, "run_id": 9, "idea_id": "thread-1"}):
+        client = await _slack_client_from_runtime()
+
+    assert client.token == "xoxb-from-vault"
+    assert calls == [
+        {
+            "key_name": "SLACK_BOT_TOKEN",
+            "actor_user_id": USER_ID,
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "reason": "Use the configured Slack app to read and reply from Illo's Slack teammate surface.",
+            "requested_by": "slack_runtime_tool",
+            "access": "service",
+            "allow_env_fallback": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_tool_opens_dm_for_slack_user_id(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def open_conversation(self, **kwargs):
+            calls.append(("open", kwargs))
+            return {"ok": True, "channel": {"id": "D456"}}
+
+        async def post_message(self, **kwargs):
+            calls.append(("post", kwargs))
+            return {"ok": True, "ts": "1716900200.000300", "channel": kwargs["channel"]}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context({"org_id": ORG_ID, "user_id": USER_ID, "run_id": 9}):
+        result = json.loads(await _handle_post_slack_reply(body="hi", channel_id="U04R1A6MZST"))
+
+    assert result["ok"] is True
+    assert result["channel_id"] == "D456"
+    assert calls == [
+        ("open", {"users": "U04R1A6MZST"}),
+        ("post", {"channel": "D456", "text": "hi", "thread_ts": None}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_read_slack_conversation_tool_reads_bounded_thread_context(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_read_slack_conversation
@@ -416,10 +505,12 @@ async def test_read_slack_conversation_tool_reads_bounded_thread_context(monkeyp
                 ],
             }
 
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    async def slack_client():
+        return _SlackClient()
+
     monkeypatch.setattr(
-        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_env",
-        lambda: _SlackClient(),
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
     )
 
     with bind_agent_context(

--- a/tests/test_web_research.py
+++ b/tests/test_web_research.py
@@ -105,6 +105,64 @@ async def test_web_search_uses_provider_and_caches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_web_search_uses_runtime_vault_secret_context(monkeypatch):
+    from brain.app.web.research import _search_cache, web_search
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext
+
+    _search_cache.clear()
+
+    calls = []
+
+    async def read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback):
+        calls.append(
+            {
+                "key_name": key_name,
+                "actor_user_id": context.actor_user_id,
+                "org_id": context.org_id,
+                "run_id": context.run_id,
+                "reason": reason,
+                "requested_by": requested_by,
+                "access": access,
+                "allow_env_fallback": allow_env_fallback,
+            }
+        )
+        return "vault-brave-key"
+
+    payload = {"web": {"results": [{"title": "Result A", "url": "https://a.test", "description": "Snippet A"}]}}
+    client = _FakeClient(_FakeResponse(json_data=payload, headers={"content-type": "application/json"}))
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+    monkeypatch.setattr("brain.systems.vault.runtime_secrets.read_runtime_secret", read_runtime_secret)
+    monkeypatch.setattr("brain.app.web.research._http_client", lambda: client)
+
+    result = await web_search(
+        "illo brain",
+        provider="brave",
+        limit=1,
+        runtime_secret_context=RuntimeSecretContext(
+            actor_user_id="user-1",
+            org_id="org-1",
+            run_id=42,
+            idea_id="thread-1",
+        ),
+    )
+
+    assert result["provider"] == "brave"
+    assert client.calls[0][2]["headers"]["X-Subscription-Token"] == "vault-brave-key"
+    assert calls == [
+        {
+            "key_name": "BRAVE_SEARCH_API_KEY",
+            "actor_user_id": "user-1",
+            "org_id": "org-1",
+            "run_id": 42,
+            "reason": "Run Illo's web search tool through a configured search provider.",
+            "requested_by": "web_search",
+            "access": "service",
+            "allow_env_fallback": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_web_search_auto_skips_empty_provider_without_caching(monkeypatch):
     from brain.app.web.research import WebResearchError, _search_cache, web_search
 

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -1406,6 +1406,100 @@ async def test_workspace_app_action_generic_http_request_returns_compact_respons
     assert result["result"] == {"response": {"id": "abc", "ok": True}}
 
 
+async def test_workspace_app_action_generic_http_auth_uses_runtime_secret_resolver(session, monkeypatch):
+    domain = await _todo_domain(session)
+    manifest = _manifest_with_action(
+        domain.id,
+        {
+            "kind": "connector",
+            "effects": ["external.write"],
+            "executor": {"type": "registered", "key": "generic.http"},
+            "connector_spec": {
+                "kind": "http_request",
+                "auth": {"source": "vault_key", "vault_key": "TICKETING_TOKEN", "type": "bearer"},
+                "request": {
+                    "method": "POST",
+                    "url": "https://api.example.test/issues",
+                    "json": {"title": "{title}"},
+                },
+            },
+        },
+    )
+    app = await a_create_app(
+        session,
+        org_id=ORG_ID,
+        key="generic-http-auth",
+        name="Generic HTTP Auth",
+        renderer_key="generated-ui-app",
+        source_kind="json",
+        source_code=json.dumps(VALID_GENERATED_UI_SPEC),
+        manifest=manifest,
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+    calls = []
+
+    async def read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback):
+        calls.append(
+            {
+                "key_name": key_name,
+                "actor_user_id": context.actor_user_id,
+                "org_id": context.org_id,
+                "reason": reason,
+                "requested_by": requested_by,
+                "access": access,
+                "allow_env_fallback": allow_env_fallback,
+            }
+        )
+        return "vault-ticketing-token"
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, headers=None, params=None, json=None):
+            assert headers == {"Authorization": "Bearer vault-ticketing-token"}
+            return type(
+                "_Response",
+                (),
+                {
+                    "is_success": True,
+                    "status_code": 200,
+                    "content": b'{"id":"abc","ok":true}',
+                    "json": lambda self: {"id": "abc", "ok": True},
+                },
+            )()
+
+    monkeypatch.setattr("brain.systems.vault.runtime_secrets.read_runtime_secret", read_runtime_secret)
+    monkeypatch.setattr("brain.systems.workspace_apps.generic_http.async_http_client", lambda **kwargs: _Client())
+
+    result = await async_run_workspace_app_action(
+        session,
+        org_id=ORG_ID,
+        app_id=app.id,
+        action_key="tickets.syncExternal",
+        payload={"title": "Ship it"},
+        user_id=USER_ID,
+    )
+
+    assert result["ok"] is True
+    assert result["result"] == {"response": {"id": "abc", "ok": True}}
+    assert calls == [
+        {
+            "key_name": "TICKETING_TOKEN",
+            "actor_user_id": USER_ID,
+            "org_id": ORG_ID,
+            "reason": "Run workspace app connector action tickets.syncExternal.",
+            "requested_by": "workspace_app_connector",
+            "access": "service",
+            "allow_env_fallback": False,
+        }
+    ]
+
+
 async def test_workspace_app_action_generic_http_rejects_invalid_mapping_at_save(session):
     domain = await _todo_domain(session)
 


### PR DESCRIPTION
## Summary
- add a central Vault-first runtime secret resolver for agent-command mounts and trusted first-party service tools
- route Slack connector/reply/read tools and web search provider credentials through the resolver
- add regression tests that prevent first-party runtime handlers from reading secret-like env vars directly

## Tests
- venv/bin/python -m py_compile brain/systems/vault/runtime_secrets.py brain/systems/runs/secret_mounts.py brain/systems/runs/tool_catalog/handlers/common.py brain/systems/runs/tool_catalog/handlers/slack.py brain/systems/runs/tool_catalog/handlers/web.py brain/systems/slack/client.py brain/systems/slack/connector.py brain/app/web/research.py tests/test_runtime_secrets.py tests/test_slack_teammate.py tests/test_web_research.py
- venv/bin/pytest tests/test_runtime_secrets.py tests/test_slack_teammate.py tests/test_web_research.py tests/test_vault_hardening.py tests/test_agent.py::TestCortexReplyHandler tests/test_tool_registry.py tests/test_agent_run_runtime.py -q
- git diff --check