### PR TITLE
Preserve Vault key casing in runtime secret mounts

### DIFF
--- a/brain/systems/vault/runtime_secrets.py
+++ b/brain/systems/vault/runtime_secrets.py
@@ -26,15 +26,34 @@ class RuntimeSecretContext:
 
 
 def _clean_key_name(key_name: str) -> str:
-    key = str(key_name or "").strip().upper()
+    key = str(key_name or "").strip()
     if not key:
         raise RuntimeSecretUnavailable("Vault secret key name is required")
     return key
 
 
+def _vault_key_candidates(key_name: str) -> tuple[str, ...]:
+    """Return Vault lookup candidates, preserving exact keys before legacy uppercase aliases."""
+
+    key = _clean_key_name(key_name)
+    candidates = [key]
+    upper_key = key.upper()
+    if upper_key != key:
+        candidates.append(upper_key)
+    return tuple(dict.fromkeys(candidates))
+
+
 def _clean_env_names(key_name: str, env_names: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
-    names = tuple(str(name or "").strip() for name in (env_names or (key_name,)))
-    return tuple(name for name in names if name)
+    raw_names = tuple(str(name or "").strip() for name in (env_names or (key_name,)))
+    names: list[str] = []
+    for name in raw_names:
+        if not name:
+            continue
+        names.append(name)
+        upper_name = name.upper()
+        if upper_name != name:
+            names.append(upper_name)
+    return tuple(dict.fromkeys(names))
 
 
 def _env_secret(env_names: tuple[str, ...]) -> str | None:
@@ -43,6 +62,30 @@ def _env_secret(env_names: tuple[str, ...]) -> str | None:
         if value:
             return value
     return None
+
+
+async def _select_existing_vault_key_candidate(
+    candidates: tuple[str, ...],
+    *,
+    actor_user_id: str,
+    org_id: str,
+) -> str:
+    """Choose an existing Vault key without recording false missing-key requests."""
+
+    if len(candidates) <= 1:
+        return candidates[0]
+
+    from brain.systems.vault import async_get_secret_record
+
+    for candidate in candidates:
+        secret = await async_get_secret_record(
+            candidate,
+            actor_user_id=actor_user_id,
+            org_id=org_id,
+        )
+        if secret is not None:
+            return candidate
+    return candidates[0]
 
 
 async def read_runtime_secret(
@@ -58,6 +101,7 @@ async def read_runtime_secret(
     """Resolve a secret for trusted runtime code without exposing it to the agent."""
 
     key = _clean_key_name(key_name)
+    key_candidates = _vault_key_candidates(key)
     env_candidates = _clean_env_names(key, env_names)
 
     actor_user_id = str(context.actor_user_id or "").strip()
@@ -67,8 +111,13 @@ async def read_runtime_secret(
         if actor_user_id and org_id:
             from brain.systems.vault import get_secret
 
+            candidate = await _select_existing_vault_key_candidate(
+                key_candidates,
+                actor_user_id=actor_user_id,
+                org_id=org_id,
+            )
             value = await get_secret(
-                key,
+                candidate,
                 actor_user_id=actor_user_id,
                 org_id=org_id,
                 accessed_by=requested_by,
@@ -93,8 +142,13 @@ async def read_runtime_secret(
 
     from brain.systems.vault.agent_access import read_agent_secret_for_runtime
 
+    candidate = await _select_existing_vault_key_candidate(
+        key_candidates,
+        actor_user_id=actor_user_id,
+        org_id=org_id,
+    )
     response = await read_agent_secret_for_runtime(
-        key,
+        candidate,
         reason=reason,
         user_id=actor_user_id,
         org_id=org_id,
@@ -106,12 +160,12 @@ async def read_runtime_secret(
         target_registry_id=context.target_registry_id,
     )
     if not isinstance(response, dict):
-        raise RuntimeSecretUnavailable(f"Vault secret '{key}' could not be read")
+        raise RuntimeSecretUnavailable(f"Vault secret '{candidate}' could not be read")
     if response.get("error"):
         raise RuntimeSecretUnavailable(str(response.get("error")))
     value = response.get("value")
     if value is None:
-        raise RuntimeSecretUnavailable(f"Vault secret '{key}' did not return a value")
+        raise RuntimeSecretUnavailable(f"Vault secret '{candidate}' did not return a value")
     return str(value)
 
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1756,10 +1756,14 @@ async def test_runtime_tool_executor_resolves_secret_env_mount_without_public_va
     secret_value = "ghp-secret-value"
     vault_calls = []
 
+    async def fake_get_secret_record(key, actor_user_id, *, org_id):
+        return object() if key == "DataForSeoLogin" else None
+
     async def fake_runtime_secret_read(key, **kwargs):
         vault_calls.append({"key": key, **kwargs})
         return {"key": key, "value": secret_value}
 
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", fake_get_secret_record)
     monkeypatch.setattr("brain.systems.vault.agent_access.read_agent_secret_for_runtime", fake_runtime_secret_read)
 
     runtime = _runtime("worker")
@@ -1777,9 +1781,9 @@ async def test_runtime_tool_executor_resolves_secret_env_mount_without_public_va
             args={
                 "command": "gh api user",
                 "secret_env": {
-                    "GH_TOKEN": {
-                        "vault_key": "GITHUB_TOKEN",
-                        "reason": "Check the token identity without exposing it.",
+                    "DATAFORSEO_LOGIN": {
+                        "vault_key": "DataForSeoLogin",
+                        "reason": "Run a bounded DataForSEO SERP check without exposing the login.",
                     },
                 },
             },
@@ -1789,10 +1793,10 @@ async def test_runtime_tool_executor_resolves_secret_env_mount_without_public_va
     )
 
     assert result["exit_code"] == 0
-    assert seen["kwargs"]["_resolved_secret_env"] == {"GH_TOKEN": secret_value}
+    assert seen["kwargs"]["_resolved_secret_env"] == {"DATAFORSEO_LOGIN": secret_value}
     assert vault_calls == [{
-        "key": "GITHUB_TOKEN",
-        "reason": "Check the token identity without exposing it.",
+        "key": "DataForSeoLogin",
+        "reason": "Run a bounded DataForSEO SERP check without exposing the login.",
         "user_id": "user-1",
         "org_id": "org-1",
         "run_id": 42,

--- a/tests/test_runtime_secrets.py
+++ b/tests/test_runtime_secrets.py
@@ -31,7 +31,7 @@ async def test_agent_tool_runtime_secret_uses_central_agent_access(monkeypatch):
     )
 
     value = await read_runtime_secret(
-        "github_token",
+        "GITHUB_TOKEN",
         context=RuntimeSecretContext(
             actor_user_id="user-1",
             org_id="org-1",
@@ -205,3 +205,124 @@ def test_first_party_runtime_integrations_use_runtime_secret_resolver_for_vault_
                     offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} imports direct Vault secret reads")
 
     assert offenders == []
+
+
+def test_clean_key_name_preserves_vault_key_case():
+    from brain.systems.vault.runtime_secrets import _clean_key_name
+
+    assert _clean_key_name("DataForSeoLogin") == "DataForSeoLogin"
+
+
+def test_vault_key_candidates_preserve_exact_key_before_uppercase_alias():
+    from brain.systems.vault.runtime_secrets import _vault_key_candidates
+
+    assert _vault_key_candidates("DataForSeoLogin") == ("DataForSeoLogin", "DATAFORSEOLOGIN")
+    assert _vault_key_candidates("GITHUB_TOKEN") == ("GITHUB_TOKEN",)
+
+
+def test_clean_env_names_includes_uppercase_fallback_without_changing_key():
+    from brain.systems.vault.runtime_secrets import _clean_env_names
+
+    assert _clean_env_names("DataForSeoLogin", None) == ("DataForSeoLogin", "DATAFORSEOLOGIN")
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_runtime_secret_falls_back_to_uppercase_legacy_key_when_exact_missing(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    record_calls = []
+    read_calls = []
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        record_calls.append((key_name, actor_user_id, org_id))
+        return object() if key_name == "DATAFORSEOLOGIN" else None
+
+    async def read_agent_secret_for_runtime(key_name, **kwargs):
+        read_calls.append(key_name)
+        return {"key": key_name, "value": "legacy-uppercase-value"}
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr(
+        "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
+        read_agent_secret_for_runtime,
+    )
+
+    value = await read_runtime_secret(
+        "DataForSeoLogin",
+        context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1", run_id=42),
+        reason="Run a bounded DataForSEO SERP check.",
+        requested_by="secret_env_mount",
+        access="agent_tool",
+    )
+
+    assert value == "legacy-uppercase-value"
+    assert record_calls == [
+        ("DataForSeoLogin", "user-1", "org-1"),
+        ("DATAFORSEOLOGIN", "user-1", "org-1"),
+    ]
+    assert read_calls == ["DATAFORSEOLOGIN"]
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_runtime_secret_does_not_fall_back_on_permission_error(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, RuntimeSecretUnavailable, read_runtime_secret
+
+    calls = []
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        return object() if key_name == "DataForSeoLogin" else None
+
+    async def read_agent_secret_for_runtime(key_name, **kwargs):
+        calls.append(key_name)
+        return {"error": "secret is marked manual and cannot be auto-read by agents"}
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr(
+        "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
+        read_agent_secret_for_runtime,
+    )
+
+    with pytest.raises(RuntimeSecretUnavailable, match="marked manual"):
+        await read_runtime_secret(
+            "DataForSeoLogin",
+            context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1", run_id=42),
+            reason="Run a bounded DataForSEO SERP check.",
+            requested_by="secret_env_mount",
+            access="agent_tool",
+        )
+
+    assert calls == ["DataForSeoLogin"]
+
+
+@pytest.mark.asyncio
+async def test_service_runtime_secret_falls_back_to_uppercase_legacy_vault_key(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    record_calls = []
+    calls = []
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        record_calls.append((key_name, actor_user_id, org_id))
+        return object() if key_name == "SERVICE_TOKEN" else None
+
+    async def get_secret(key_name, actor_user_id, *, org_id, accessed_by):
+        calls.append((key_name, actor_user_id, org_id, accessed_by))
+        return "legacy-service-token" if key_name == "SERVICE_TOKEN" else None
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
+
+    value = await read_runtime_secret(
+        "service_token",
+        context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1"),
+        reason="Call a configured first-party integration.",
+        requested_by="service_tool",
+        access="service",
+    )
+
+    assert value == "legacy-service-token"
+    assert record_calls == [
+        ("service_token", "user-1", "org-1"),
+        ("SERVICE_TOKEN", "user-1", "org-1"),
+    ]
+    assert calls == [("SERVICE_TOKEN", "user-1", "org-1", "service_tool")]


### PR DESCRIPTION
## Summary
- Preserve exact Vault key casing when resolving runtime secret mounts.
- Keep uppercase environment variable fallback behavior for generated env names.
- Add regression coverage for mixed-case Vault keys and agent-run secret mounting.

## Why
Mixed-case Vault keys such as `DataForSeoLogin` were being normalized before lookup, causing the trusted injector to search for `DATAFORSEOLOGIN` and fail before the command could start. This made valid workspace credentials unusable unless users duplicated uppercase aliases.

## Verification
- `python -m py_compile brain/systems/vault/runtime_secrets.py tests/test_runtime_secrets.py tests/test_agent_run_runtime.py`

Note: full pytest was not available in this container, so this PR includes regression tests but they were not run here.
