### PR TITLE
Harden Slack threading and processing status

### DIFF
--- a/brain/platform/db/alembic/versions/0015_agent_run_source_idempotency.py
+++ b/brain/platform/db/alembic/versions/0015_agent_run_source_idempotency.py
@@ -1,0 +1,82 @@
+"""Add source idempotency keys to agent runs.
+
+Revision ID: 0015_agent_run_source_idempotency
+Revises: 0014_backfill_domain_write_scope
+Create Date: 2026-06-01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0015_agent_run_source_idempotency"
+down_revision = "0014_backfill_domain_write_scope"
+branch_labels = None
+depends_on = None
+
+
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema="public"))
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return column_name in {
+        column["name"]
+        for column in _inspector().get_columns(table_name, schema="public")
+    }
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    constraints = _inspector().get_unique_constraints(table_name, schema="public")
+    constraints += _inspector().get_foreign_keys(table_name, schema="public")
+    return constraint_name in {constraint["name"] for constraint in constraints}
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if _table_exists(table_name) and not _column_exists(table_name, str(column.name)):
+        op.add_column(table_name, column)
+
+
+def _create_unique_if_missing(table_name: str, constraint_name: str, columns: list[str]) -> None:
+    if (
+        _table_exists(table_name)
+        and all(_column_exists(table_name, column) for column in columns)
+        and not _constraint_exists(table_name, constraint_name)
+    ):
+        op.create_unique_constraint(constraint_name, table_name, columns)
+
+
+def _drop_constraint_if_exists(table_name: str, constraint_name: str, type_: str) -> None:
+    if _constraint_exists(table_name, constraint_name):
+        op.drop_constraint(constraint_name, table_name, type_=type_)
+
+
+def _drop_column_if_exists(table_name: str, column_name: str) -> None:
+    if _column_exists(table_name, column_name):
+        op.drop_column(table_name, column_name)
+
+
+def upgrade() -> None:
+    _add_column_if_missing("agent_runs", sa.Column("source_idempotency_scope", sa.String(length=80), nullable=True))
+    _add_column_if_missing("agent_runs", sa.Column("source_idempotency_key", sa.Text(), nullable=True))
+    _create_unique_if_missing(
+        "agent_runs",
+        "uq_agent_runs_org_source_idempotency",
+        ["org_id", "source_idempotency_scope", "source_idempotency_key"],
+    )
+
+
+def downgrade() -> None:
+    _drop_constraint_if_exists("agent_runs", "uq_agent_runs_org_source_idempotency", type_="unique")
+    _drop_column_if_exists("agent_runs", "source_idempotency_key")
+    _drop_column_if_exists("agent_runs", "source_idempotency_scope")

--- a/brain/platform/db/models/agent_run.py
+++ b/brain/platform/db/models/agent_run.py
@@ -47,6 +47,12 @@ class AgentRunRow(Base, TimestampMixin):
         Index("ix_agent_runs_parent_run_id", "parent_run_id"),
         Index("ix_agent_runs_parent_created", "parent_run_id", "created_at", "id"),
         Index("ix_agent_runs_trace_id", "trace_id"),
+        UniqueConstraint(
+            "org_id",
+            "source_idempotency_scope",
+            "source_idempotency_key",
+            name="uq_agent_runs_org_source_idempotency",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -73,6 +79,8 @@ class AgentRunRow(Base, TimestampMixin):
     model_policy: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default=sql_text("'{}'::jsonb"), default=dict)
     context_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, nullable=False, server_default=sql_text("'{}'::jsonb"), default=dict)
+    source_idempotency_scope: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    source_idempotency_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -7,6 +7,7 @@ import threading
 from typing import Any
 
 from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.systems.runs.domain import (
@@ -41,6 +42,7 @@ _DEFERRED_RUN_ACTIVE_STATUS_VALUES = frozenset({
     RunStatus.PAUSED.value,
     RunStatus.VERIFYING.value,
 })
+_SOURCE_IDEMPOTENCY_METADATA_KEYS = ("idempotency_key", "idempotencyKey")
 
 
 _EVENT_LOCKS_GUARD = threading.Lock()
@@ -103,6 +105,31 @@ def _deferred_run_target_id(row: AgentRunRow) -> int | None:
     return None
 
 
+def _source_idempotency_parts(request: AgentRunRequest) -> tuple[str | None, str | None]:
+    metadata = dict(request.metadata or {})
+    key = ""
+    for metadata_key in _SOURCE_IDEMPOTENCY_METADATA_KEYS:
+        key = str(metadata.get(metadata_key) or "").strip()
+        if key:
+            break
+    if not key:
+        return None, None
+    # Slack can deliver one human mention through multiple event shapes and even
+    # duplicate connector rows. Lock the canonical Slack message identity at the
+    # run boundary without changing idempotency semantics for unrelated sources.
+    if not key.startswith("slack:"):
+        return None, None
+
+    work_intake = metadata.get("work_intake")
+    source = ""
+    if isinstance(work_intake, dict):
+        source = str(work_intake.get("source") or "").strip()
+    source = source or str(metadata.get("source") or "").strip()
+    if source.startswith("trigger:"):
+        source = source.split(":", 1)[1].strip()
+    return (source or "unknown")[:80], key
+
+
 async def _reconcile_inbound_triage_run_if_needed(session: AsyncSession, row: AgentRunRow) -> None:
     metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
     inbound_event = metadata.get("inbound_event")
@@ -120,9 +147,39 @@ class AsyncAgentRunStore:
         self.session = session
         self.auto_commit = bool(auto_commit)
 
+    async def _run_for_source_idempotency(
+        self,
+        *,
+        org_id: str | None,
+        scope: str | None,
+        key: str | None,
+    ) -> AgentRunRow | None:
+        if not org_id or not scope or not key:
+            return None
+        stmt = (
+            select(AgentRunRow)
+            .where(
+                AgentRunRow.org_id == str(org_id),
+                AgentRunRow.source_idempotency_scope == str(scope),
+                AgentRunRow.source_idempotency_key == str(key),
+            )
+            .order_by(AgentRunRow.id.asc())
+            .limit(1)
+        )
+        return (await self.session.scalars(stmt)).first()
+
     async def create_run(self, request: AgentRunRequest) -> AgentRun:
         profile = request.normalized_profile
         recipe = request.normalized_recipe
+        source_idempotency_scope, source_idempotency_key = _source_idempotency_parts(request)
+        existing = await self._run_for_source_idempotency(
+            org_id=request.org_id,
+            scope=source_idempotency_scope,
+            key=source_idempotency_key,
+        )
+        if existing is not None:
+            return to_domain(existing)
+
         row = AgentRunRow(
             org_id=request.org_id,
             user_id=request.user_id,
@@ -137,13 +194,26 @@ class AsyncAgentRunStore:
             workspace_ref=dict(request.workspace_ref or {}),
             model_policy=dict(request.model_policy or {}),
             metadata_=dict(request.metadata or {}),
+            source_idempotency_scope=source_idempotency_scope,
+            source_idempotency_key=source_idempotency_key,
         )
-        self.session.add(row)
-        await self.session.flush()
-        row.trace_id = trace_id_for_run_id(row.id)
-        if row.root_run_id is None:
-            row.root_run_id = row.id
-        await self.session.flush()
+        try:
+            async with self.session.begin_nested():
+                self.session.add(row)
+                await self.session.flush()
+                row.trace_id = trace_id_for_run_id(row.id)
+                if row.root_run_id is None:
+                    row.root_run_id = row.id
+                await self.session.flush()
+        except IntegrityError:
+            existing = await self._run_for_source_idempotency(
+                org_id=request.org_id,
+                scope=source_idempotency_scope,
+                key=source_idempotency_key,
+            )
+            if existing is not None:
+                return to_domain(existing)
+            raise
         await self.append_event(
             run_event(
                 row.id,

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -74,6 +74,20 @@ async def _resolve_post_channel(client, channel_id: str, visibility: str) -> str
     return resolved or channel_id
 
 
+async def _clear_processing_status(client: Any, trigger: dict[str, Any]) -> None:
+    set_status = getattr(client, "set_assistant_status", None)
+    if not callable(set_status):
+        return
+    channel_id = str(trigger.get("channel_id") or "").strip()
+    thread_ts = str(trigger.get("thread_ts") or trigger.get("message_ts") or "").strip()
+    if not channel_id or not thread_ts:
+        return
+    try:
+        await set_status(channel_id=channel_id, thread_ts=thread_ts, status="")
+    except Exception:
+        return
+
+
 async def _handle_post_slack_reply(
     body: str,
     channel_id: str | None = None,
@@ -127,6 +141,7 @@ async def _handle_post_slack_reply(
                 text=text,
                 thread_ts=target_thread_ts,
             )
+        await _clear_processing_status(client, trigger)
     except Exception as exc:
         return json.dumps({"error": str(exc)})
 

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -79,6 +79,23 @@ class SlackWebClient:
             payload["thread_ts"] = thread_ts
         return await self.api_call("chat.postEphemeral", payload)
 
+    async def set_assistant_status(
+        self,
+        *,
+        channel_id: str,
+        thread_ts: str,
+        status: str,
+        loading_messages: list[str] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "status": status,
+        }
+        if loading_messages:
+            payload["loading_messages"] = loading_messages[:10]
+        return await self.api_call("assistant.threads.setStatus", payload)
+
     async def open_conversation(self, *, users: str) -> dict[str, Any]:
         return await self.api_call("conversations.open", {"users": users})
 

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -13,18 +13,21 @@ from typing import Any, Mapping
 import httpx
 from sqlalchemy import select
 
+from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.service import submit_inbound_envelope
 from brain.systems.slack.client import (
     SlackApiError,
     SlackConfigurationError,
+    SlackWebClient,
     slack_app_token_from_env,
     slack_bot_token_from_env,
 )
 from brain.systems.slack.ingress import normalize_slack_socket_event
 
 logger = logging.getLogger(__name__)
+SLACK_PROCESSING_STATUS = "is working on it..."
 
 
 @dataclass(frozen=True)
@@ -246,6 +249,7 @@ async def process_socket_payload(
     )
     if envelope is None:
         return {"ack": ack, "ignored": True}
+    existing_run_for_message = await _has_slack_run_for_envelope(session, connection, envelope)
     inbound = await submit_inbound_envelope(
         session,
         connection=connection,
@@ -255,7 +259,68 @@ async def process_socket_payload(
             "envelope_id": ack.get("envelope_id"),
         },
     )
+    # Slack clears this status when the bot replies and applies a short timeout
+    # if the run fails or completes without sending a Slack message.
+    if not existing_run_for_message and _admitted_slack_run(inbound):
+        await _set_processing_status(config, envelope)
     return {"ack": ack, "ignored": False, "inbound": inbound}
+
+
+def _connection_org_id(connection: ExternalAgentConnectionRow | Mapping[str, Any]) -> str | None:
+    if isinstance(connection, Mapping):
+        return str(connection.get("org_id") or "").strip() or None
+    return str(getattr(connection, "org_id", "") or "").strip() or None
+
+
+def _envelope_idempotency_key(envelope: Mapping[str, Any]) -> str | None:
+    key = str(envelope.get("idempotency_key") or "").strip()
+    return key if key.startswith("slack:") else None
+
+
+async def _has_slack_run_for_envelope(
+    session,
+    connection: ExternalAgentConnectionRow | Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> bool:
+    org_id = _connection_org_id(connection)
+    key = _envelope_idempotency_key(envelope)
+    if not org_id or not key:
+        return False
+    stmt = (
+        select(AgentRunRow.id)
+        .where(
+            AgentRunRow.org_id == org_id,
+            AgentRunRow.source_idempotency_scope == "slack",
+            AgentRunRow.source_idempotency_key == key,
+        )
+        .limit(1)
+    )
+    return (await session.scalar(stmt)) is not None
+
+
+def _admitted_slack_run(inbound: Mapping[str, Any]) -> bool:
+    if inbound.get("idempotent_replay"):
+        return False
+    outcome = inbound.get("ilo_outcome")
+    outcome = outcome if isinstance(outcome, Mapping) else {}
+    return outcome.get("operation") == "slack_run_admitted" and outcome.get("run_id") is not None
+
+
+async def _set_processing_status(config: SlackConnectorConfig, envelope: Mapping[str, Any]) -> None:
+    payload = envelope.get("payload") if isinstance(envelope.get("payload"), Mapping) else {}
+    channel_id = str(payload.get("channel_id") or "").strip()
+    thread_ts = str(payload.get("thread_ts") or payload.get("message_ts") or "").strip()
+    if not channel_id or not thread_ts:
+        return
+    try:
+        client = SlackWebClient(config.bot_token, timeout=2.0)
+        await client.set_assistant_status(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            status=SLACK_PROCESSING_STATUS,
+        )
+    except Exception as exc:
+        logger.info("slack_processing_status_failed: %s", exc)
 
 
 async def open_socket_mode_url(config: SlackConnectorConfig) -> str:

--- a/deploy/slack/illo-self-hosted-manifest.yml
+++ b/deploy/slack/illo-self-hosted-manifest.yml
@@ -26,8 +26,6 @@ settings:
   event_subscriptions:
     bot_events:
       - type: app_mention
-      - type: message.channels
-      - type: message.groups
       - type: message.im
   interactivity:
     is_enabled: true

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -44,7 +44,15 @@ Optional Slack hints:
 - `app_mention` events and every DM are actionable.
 - Top-level channel mentions reply as normal channel messages; mentions inside
   Slack threads reply back into that thread; DMs reply as normal DM messages.
+- Illo sets a best-effort Slack working status while a Slack-origin run is
+  being admitted, so teammates can see that the request was accepted. This uses
+  the existing `chat:write` scope and Slack clears the status on reply or after
+  its short timeout.
 - Regular channel messages without an Illo mention are ignored.
+- The default manifest subscribes to `app_mention` and `message.im` only. It
+  keeps channel history scopes for context reads, but avoids generic channel
+  message events as trigger sources because Slack can also deliver the same
+  human mention as `app_mention`.
 - Socket Mode envelopes are acknowledged before durable inbound processing.
 - Actionable Slack events are stored as inbound events with kind
   `slack_message`.

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -86,6 +86,26 @@ async def _seed_slack_connection(session):
     return connection
 
 
+async def _seed_second_slack_connection(session):
+    connection = ExternalAgentConnectionRow(
+        id="44444444-4444-4444-8444-444444444444",
+        org_id=ORG_ID,
+        owner_user_id=USER_ID,
+        display_name="Slack duplicate connector",
+        agent_kind="slack",
+        transport="slack_socket_mode",
+        status="online",
+        remote_agent_id="T789",
+        remote_agent_card={},
+        capabilities={"slack": {"socket_mode": True}},
+        auth_metadata={"bot_token_ref": "env:SLACK_BOT_TOKEN", "app_token_ref": "env:SLACK_APP_TOKEN"},
+        metadata_={"slack": {"team_id": "T789", "bot_user_id": "BILLO"}},
+    )
+    session.add(connection)
+    await session.flush()
+    return connection
+
+
 def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
     manifest = yaml.safe_load(MANIFEST_PATH.read_text())
 
@@ -111,12 +131,9 @@ def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
     }.issubset(bot_scopes)
 
     bot_events = {event["type"] for event in manifest["settings"]["event_subscriptions"]["bot_events"]}
-    assert {
-        "app_mention",
-        "message.channels",
-        "message.groups",
-        "message.im",
-    }.issubset(bot_events)
+    assert {"app_mention", "message.im"} <= bot_events
+    assert "message.channels" not in bot_events
+    assert "message.groups" not in bot_events
 
     features = manifest["features"]
     assert features["bot_user"]["display_name"] == "Illo"
@@ -423,6 +440,142 @@ async def test_slack_inbound_envelope_records_event_and_admits_slack_run(session
 
 
 @pytest.mark.asyncio
+async def test_duplicate_slack_events_across_connection_rows_share_one_run(session):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    first_connection = await _seed_slack_connection(session)
+    second_connection = await _seed_second_slack_connection(session)
+    app_mention = normalize_slack_socket_event(
+        _socket_mode_app_mention(event_id="Ev-app-mention"),
+        bot_user_id="BILLO",
+    )
+    message_event = normalize_slack_socket_event(
+        _socket_mode_app_mention(
+            type="message",
+            event_id="Ev-message-channel",
+        ),
+        bot_user_id="BILLO",
+    )
+
+    first = await submit_inbound_envelope(
+        session,
+        connection=first_connection,
+        envelope=app_mention,
+        ingress_context={"transport": "slack_socket_mode", "envelope_id": "env-1"},
+    )
+    second = await submit_inbound_envelope(
+        session,
+        connection=second_connection,
+        envelope=message_event,
+        ingress_context={"transport": "slack_socket_mode", "envelope_id": "env-2"},
+    )
+
+    runs = (await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id.asc()))).all()
+    events = (await session.scalars(select(InboundEventRow).order_by(InboundEventRow.created_at.asc()))).all()
+
+    assert len(events) == 2
+    assert len(runs) == 1
+    assert runs[0].source_idempotency_scope == "slack"
+    assert runs[0].source_idempotency_key == "slack:T789:C456:1716900000.000100"
+    assert first["ilo_outcome"]["run_id"] == runs[0].id
+    assert second["ilo_outcome"]["run_id"] == runs[0].id
+
+
+@pytest.mark.asyncio
+async def test_slack_connector_sets_processing_status_for_actionable_payload(session, monkeypatch):
+    from brain.systems.slack import connector
+
+    connection = await _seed_slack_connection(session)
+    calls = []
+
+    class _SlackClient:
+        def __init__(self, token, **_kwargs):
+            calls.append(("init", token))
+
+        async def set_assistant_status(self, **kwargs):
+            calls.append(("status", kwargs))
+            return {"ok": True}
+
+    monkeypatch.setattr(connector, "SlackWebClient", _SlackClient, raising=False)
+
+    await connector.process_socket_payload(
+        session,
+        connection=connection,
+        socket_payload=_socket_mode_app_mention(),
+        config=connector.SlackConnectorConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            bot_user_id="BILLO",
+        ),
+    )
+
+    assert calls == [
+        ("init", "xoxb-test"),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "is working on it...",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slack_connector_does_not_reset_status_for_existing_duplicate_run(session, monkeypatch):
+    from brain.systems.slack import connector
+
+    first_connection = await _seed_slack_connection(session)
+    second_connection = await _seed_second_slack_connection(session)
+    calls = []
+
+    class _SlackClient:
+        def __init__(self, token, **_kwargs):
+            calls.append(("init", token))
+
+        async def set_assistant_status(self, **kwargs):
+            calls.append(("status", kwargs))
+            return {"ok": True}
+
+    monkeypatch.setattr(connector, "SlackWebClient", _SlackClient, raising=False)
+
+    await connector.process_socket_payload(
+        session,
+        connection=first_connection,
+        socket_payload=_socket_mode_app_mention(event_id="Ev-app-mention"),
+        config=connector.SlackConnectorConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            bot_user_id="BILLO",
+        ),
+    )
+    await connector.process_socket_payload(
+        session,
+        connection=second_connection,
+        socket_payload=_socket_mode_app_mention(type="message", event_id="Ev-message-channel"),
+        config=connector.SlackConnectorConfig(
+            bot_token="xoxb-test",
+            app_token="xapp-test",
+            bot_user_id="BILLO",
+        ),
+    )
+
+    assert calls == [
+        ("init", "xoxb-test"),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "is working on it...",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_post_slack_reply_tool_posts_to_triggering_thread(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
@@ -517,6 +670,70 @@ async def test_post_slack_reply_tool_posts_top_level_mentions_to_channel(monkeyp
             "text": "On it.",
             "thread_ts": None,
         }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_tool_clears_processing_status(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(("post", kwargs))
+            return {"ok": True, "ts": "1716900200.000300", "channel": kwargs["channel"]}
+
+        async def set_assistant_status(self, **kwargs):
+            calls.append(("status", kwargs))
+            return {"ok": True}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                },
+            },
+        }
+    ):
+        result = json.loads(await _handle_post_slack_reply(body="Done."))
+
+    assert result["ok"] is True
+    assert calls == [
+        (
+            "post",
+            {
+                "channel": "C456",
+                "text": "Done.",
+                "thread_ts": None,
+            },
+        ),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "",
+            },
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- add DB-backed source idempotency keys for canonical Slack message run admission
- set best-effort Slack assistant processing status for newly admitted Slack runs and clear it on Slack reply
- narrow the self-hosted Slack manifest to app_mention and message.im triggers to avoid duplicate channel/group deliveries

## Migration
- Run Alembic migration 0015_agent_run_source_idempotency after deploy.

## Slack app update
- Update/reinstall the Slack app manifest so bot events are app_mention and message.im only.
- Keep chat:write.public for top-level public-channel replies.

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py -q
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_agent_run_domain.py tests/test_pipeline.py -q
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m py_compile brain/platform/db/models/agent_run.py brain/systems/runs/store.py brain/systems/slack/client.py brain/systems/slack/connector.py brain/systems/runs/tool_catalog/handlers/slack.py tests/test_slack_teammate.py
- git diff --check