### PR TITLE
Implement Thread URL object references

### DIFF
--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -307,6 +307,7 @@ from brain.app.api.routers.ws import router as ws_router
 from brain.app.api.routers.auth import router as auth_router
 from brain.app.api.routers import brain, cortex, cortex_intel, memory, skills, vault, system, team, costs, journal, domains, workspace_apps, workspace_pins, onboarding, webhooks
 from brain.app.api.routers import agent_bridge, agent_connections, agent_mcp
+from brain.app.api.routers import link_previews
 from brain.app.api.routers.cycles import router as cycles_router
 from brain.app.api.routers.chat import router as chat_router
 from brain.app.api.routers.notifications import router as notifications_router
@@ -327,6 +328,7 @@ app.include_router(agent_connections.router)
 app.include_router(agent_bridge.router)
 app.include_router(agent_mcp.router)
 app.include_router(webhooks.router)
+app.include_router(link_previews.router)
 app.include_router(cycles_router)
 app.include_router(team.router)
 app.include_router(costs.router)

--- a/brain/app/api/routers/agent_bridge.py
+++ b/brain/app/api/routers/agent_bridge.py
@@ -24,6 +24,7 @@ from brain.app.api.schemas.external_agents import (
 )
 from brain.app.mentions import classify_mention_intent
 from brain.platform.db.models.idea import Idea
+from brain.systems.cortex.thread_links import thread_link_payload
 from brain.systems.external_agents import service as external_agents
 
 
@@ -64,15 +65,45 @@ def require_bridge_scope(required_scope: str) -> Callable[..., Any]:
 
 
 def _thread_payload(idea: Idea, message: Any, notified_user_ids: list[str]) -> dict[str, Any]:
+    links = thread_link_payload(idea.id)
+    display_title = getattr(idea, "display_title", None)
+    title = getattr(idea, "title", None)
+    preview_updated_at = getattr(idea, "preview_updated_at", None)
+    thread_reference = {
+        "type": "thread_reference",
+        "object_type": "thread",
+        "object_id": str(idea.id),
+        "thread_id": str(idea.id),
+        "status": "available",
+        "title": display_title or title,
+        "preview_summary": getattr(idea, "preview_summary", None),
+        "preview_source": getattr(idea, "preview_source", None),
+        "preview_updated_at": (
+            preview_updated_at.isoformat()
+            if preview_updated_at
+            else None
+        ),
+        **links,
+    }
     return {
         "idea": {
             "id": str(idea.id),
-            "title": idea.title,
-            "status": idea.status,
-            "origin": idea.origin,
-            "origin_ref": idea.origin_ref,
+            "thread_id": str(idea.id),
+            "title": title,
+            "display_title": display_title,
+            "status": getattr(idea, "status", None),
+            "origin": getattr(idea, "origin", None),
+            "origin_ref": getattr(idea, "origin_ref", None),
+            "preview_summary": getattr(idea, "preview_summary", None),
+            "preview_source": getattr(idea, "preview_source", None),
+            **links,
             "created_at": message.created_at.isoformat() if getattr(message, "created_at", None) else None,
         },
+        "thread_reference": thread_reference,
+        "thread_id": str(idea.id),
+        "thread_url": links["thread_url"],
+        "thread_route": links["thread_route"],
+        "url": links["thread_url"],
         "message": external_agents.serialize_thread_message(message),
         "notified_user_ids": notified_user_ids,
     }

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -20,6 +20,7 @@ from brain.app.api.routers.agent_bridge import (
 from brain.app.api.routers.agent_mcp_domains import DOMAIN_MCP_TOOLS, DOMAIN_TOOL_HANDLERS
 from brain.app.api.routers.external_agent_errors import raise_external_agent_http_error
 from brain.app.mentions import classify_mention_intent
+from brain.systems.cortex.thread_links import thread_id_from_reference
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
 
@@ -87,7 +88,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 },
                 "correlation": {
                     "type": "object",
-                    "description": "Optional correlation such as thread_id, external_session_id, or previous submission reference.",
+                    "description": "Optional correlation such as thread_id, thread_url, external_session_id, or previous submission reference.",
                     "default": {},
                 },
                 "idempotency_key": {
@@ -139,10 +140,11 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "an update so replies preserve team context and avoid repeating prior work."
             ),
             {
-                "idea_id": {"type": "string", "description": "Illo idea/thread id."},
+                "idea_id": {"type": "string", "description": "Illo idea/thread id or canonical Thread URL."},
+                "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL."},
                 "limit": {"type": "integer", "description": "Maximum messages to return.", "default": 100},
             },
-            ["idea_id"],
+            [],
         ),
         "scope": external_agents.SCOPE_WORKSPACE_READ,
     },
@@ -204,7 +206,8 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 f"{CONTEXT_TOOL_NAME} so IloSpace can route the context."
             ),
             {
-                "idea_id": {"type": "string", "description": "Existing Illo idea/thread id."},
+                "idea_id": {"type": "string", "description": "Existing Illo idea/thread id or canonical Thread URL."},
+                "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL."},
                 "body": {"type": "string", "description": "Message body to post into the thread."},
                 "teammate_user_ids": {
                     "type": "array",
@@ -225,7 +228,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 },
                 "metadata": {"type": "object", "description": "Optional machine-readable metadata.", "default": {}},
             },
-            ["idea_id", "body"],
+            ["body"],
         ),
         "scope": external_agents.SCOPE_ILLO_THREAD_WRITE,
         "mutates_thread": True,
@@ -476,6 +479,14 @@ def _context_tool_response(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _thread_argument_id(arguments: dict[str, Any]) -> str:
+    for key in ("thread_url", "url", "thread_route", "idea_id", "thread_id"):
+        thread_id = thread_id_from_reference(arguments.get(key), allow_raw_id=key in {"idea_id", "thread_id"})
+        if thread_id:
+            return thread_id
+    return str(arguments.get("idea_id") or arguments.get("thread_id") or "")
+
+
 async def _tool_submit_context(
     db: AsyncSession,
     principal: external_agents.AgentBridgePrincipal,
@@ -512,7 +523,7 @@ async def _tool_get_thread(
     return await external_agents.get_thread(
         db,
         principal,
-        idea_id=str(arguments.get("idea_id") or ""),
+        idea_id=_thread_argument_id(arguments),
         limit=int(arguments.get("limit") or 100),
     )
 
@@ -559,7 +570,7 @@ async def _tool_post_thread_message(
     idea, message, notified = await external_agents.post_thread_message_from_agent(
         db,
         principal,
-        idea_id=str(arguments.get("idea_id") or ""),
+        idea_id=_thread_argument_id(arguments),
         body=body,
         teammate_user_ids=_clean_string_list(arguments.get("teammate_user_ids")),
         artifacts=_clean_artifacts(arguments.get("artifacts")),

--- a/brain/app/api/routers/cortex/_discussion.py
+++ b/brain/app/api/routers/cortex/_discussion.py
@@ -16,6 +16,11 @@ from brain.app.api.routers.ws import ws_manager
 from brain.app.mentions import classify_mention_intent
 from brain.platform.db.models.idea import ThreadDiscussionComment
 from brain.platform.db.models.org import User
+from brain.systems.cortex.object_references import (
+    SOURCE_THREAD_DISCUSSION_COMMENT,
+    merge_object_reference_metadata,
+    store_object_references_for_source,
+)
 
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
@@ -33,6 +38,7 @@ def _comment_payload(
     author_name: str | None = None,
     author_color: str | None = None,
 ) -> dict[str, Any]:
+    metadata = comment.metadata_ if isinstance(comment.metadata_, dict) else {}
     return {
         "id": comment.id,
         "thread_id": str(comment.thread_id),
@@ -43,7 +49,9 @@ def _comment_payload(
         "author_color": author_color,
         "body": comment.body,
         "attachments": comment.attachments or [],
-        "metadata": comment.metadata_ or {},
+        "metadata": metadata,
+        "object_references": metadata.get("object_references") or [],
+        "thread_references": metadata.get("thread_references") or [],
         "created_at": comment.created_at.isoformat() if comment.created_at else None,
     }
 
@@ -179,6 +187,18 @@ async def create_thread_discussion_comment(
     )
     db.add(comment)
     await db.flush()
+
+    references = await store_object_references_for_source(
+        db,
+        source_type=SOURCE_THREAD_DISCUSSION_COMMENT,
+        source_id=comment.id,
+        org_id=org_id,
+        text=text,
+        user_id=str(user.get("id")) if user.get("id") else None,
+    )
+    if references:
+        comment.metadata_ = merge_object_reference_metadata(comment.metadata_, references)
+        await db.flush()
 
     trigger = None
     if classify_mention_intent(text, invoke_without_mentions=False).should_invoke_illo:

--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -47,6 +47,7 @@ from brain.systems.cortex.thought_lifecycle import (
     transition_thought_status,
 )
 from brain.systems.cortex.project_context.resolution import merge_project_context_metadata
+from brain.systems.cortex.thread_links import thread_link_payload
 from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
 
 
@@ -118,6 +119,28 @@ def _project_context_for_idea(idea) -> dict[str, Any] | None:
         return None
     project_context = details.get("project_context") or details.get("project_context_snapshot")
     return project_context if isinstance(project_context, dict) else None
+
+
+def _apply_thread_link_fields(payload: dict[str, Any], idea_id: Any) -> None:
+    links = thread_link_payload(idea_id)
+    payload["thread_route"] = links["thread_route"]
+    payload["thread_url"] = links["thread_url"]
+
+
+def _thread_message_read_payload(message: IdeaThread) -> dict[str, Any]:
+    metadata = message.metadata_ if isinstance(message.metadata_, dict) else {}
+    return {
+        "id": message.id,
+        "idea_id": str(message.idea_id) if message.idea_id else None,
+        "role": message.role,
+        "content": message.content,
+        "attachments": message.attachments or [],
+        "metadata": metadata,
+        "object_references": metadata.get("object_references") or [],
+        "thread_references": metadata.get("thread_references") or [],
+        "user_id": str(message.user_id) if message.user_id else None,
+        "created_at": message.created_at,
+    }
 
 
 def _product_event_org_id(idea, user: dict[str, Any]) -> str | None:
@@ -262,6 +285,7 @@ async def _idea_read_with_author(
     presentation hint and intentionally can differ from owner after a handoff.
     """
     payload = IdeaRead.model_validate(idea).model_dump()
+    _apply_thread_link_fields(payload, getattr(idea, "id", ""))
     payload["project_context"] = _project_context_for_idea(idea)
     if author_hint_loaded:
         _apply_author_hint(payload, author_hint)
@@ -717,7 +741,8 @@ async def list_threads(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     await _require_idea_for_user(db, idea_id, user)
-    return await IdeaThreadRepository(db).a_list_by_idea(idea_id)
+    messages = await IdeaThreadRepository(db).a_list_by_idea(idea_id)
+    return [ThreadMessageRead.model_validate(_thread_message_read_payload(message)) for message in messages]
 
 
 @router.get("/ideas/{idea_id}/visual-blocks", response_model=list[VisualBlockRead])
@@ -760,7 +785,7 @@ async def create_thread_message(
         ),
     )
     message_payload = result.message_payload
-    response = ThreadMessageRead.model_validate(result.message)
+    response = ThreadMessageRead.model_validate(message_payload)
     event_org_id = _product_event_org_id(idea, user)
     await db.commit()
     await ws_manager.broadcast_product_event(

--- a/brain/app/api/routers/link_previews.py
+++ b/brain/app/api/routers/link_previews.py
@@ -1,0 +1,38 @@
+"""Shared link-preview resolver for product object references."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.app.api.auth import get_current_user
+from brain.app.api.authorization import require_org_context
+from brain.app.api.deps import get_db, rate_limit
+from brain.app.api.schemas.object_references import (
+    LinkPreviewResolveRequest,
+    LinkPreviewResolveResponse,
+)
+from brain.systems.cortex.object_references import resolve_object_reference_values
+
+router = APIRouter(
+    prefix="/api/link-previews",
+    tags=["link-previews"],
+    dependencies=[Depends(rate_limit)],
+)
+
+
+@router.post("/resolve", response_model=LinkPreviewResolveResponse)
+async def resolve_link_previews(
+    body: LinkPreviewResolveRequest,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(get_current_user),
+) -> LinkPreviewResolveResponse:
+    org_id = require_org_context(user)
+    previews = await resolve_object_reference_values(
+        db,
+        body.urls,
+        org_id=org_id,
+        user_id=str(user.get("id")) if user.get("id") else None,
+        include_handoff=True,
+    )
+    await db.commit()
+    return LinkPreviewResolveResponse(previews=previews)

--- a/brain/app/api/schemas/chat.py
+++ b/brain/app/api/schemas/chat.py
@@ -28,6 +28,8 @@ class ChatMessageRead(BaseModel):
     reply_to_message_id: int | None = None
     attachments: list[Any] = Field(default_factory=list)
     metadata: dict[str, Any] | None = None
+    object_references: list[dict[str, Any]] = Field(default_factory=list)
+    thread_references: list[dict[str, Any]] = Field(default_factory=list)
     conversation_seq: int
     reply_count: int = 0
     last_reply_at: datetime | None = None

--- a/brain/app/api/schemas/ideas.py
+++ b/brain/app/api/schemas/ideas.py
@@ -46,6 +46,11 @@ class IdeaRead(_UUIDMixin, BaseModel):
     author_name: str | None = None
     author_color: str | None = None
     project_context: dict | None = None
+    preview_summary: str | None = None
+    preview_source: str | None = None
+    preview_updated_at: datetime | None = None
+    thread_route: str | None = None
+    thread_url: str | None = None
     thread_count: int | None = 0
     active_agents: int = 0
     agent_details: Any = None
@@ -59,6 +64,10 @@ class IdeaRead(_UUIDMixin, BaseModel):
         "orbit_anchor_id",
         "author_name",
         "author_color",
+        "preview_summary",
+        "preview_source",
+        "thread_route",
+        "thread_url",
         mode="before",
     )
     @classmethod
@@ -120,8 +129,22 @@ class ThreadMessageRead(_UUIDMixin, BaseModel):
     idea_id: str | UUID | None = None
     role: str
     content: str
+    attachments: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+    object_references: list[dict[str, Any]] = Field(default_factory=list)
+    thread_references: list[dict[str, Any]] = Field(default_factory=list)
     user_id: str | UUID | None = None
     created_at: datetime
+
+    @field_validator("attachments", "object_references", "thread_references", mode="before")
+    @classmethod
+    def coerce_optional_lists(cls, value):
+        return value if isinstance(value, list) else []
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def coerce_optional_metadata(cls, value):
+        return value if isinstance(value, dict) else None
 
 class ThreadMessageCreate(BaseModel):
     content: str = Field(min_length=1)

--- a/brain/app/api/schemas/object_references.py
+++ b/brain/app/api/schemas/object_references.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class LinkPreviewResolveRequest(BaseModel):
+    urls: list[str] = Field(default_factory=list, max_length=50)
+
+
+class LinkPreviewResolveResponse(BaseModel):
+    previews: list[dict[str, Any]] = Field(default_factory=list)

--- a/brain/app/api/services/chat.py
+++ b/brain/app/api/services/chat.py
@@ -42,6 +42,11 @@ from brain.platform.db.repositories.chat import (
 )
 from brain.platform.db.repositories.notifications import NotificationEventRepository
 from brain.platform.db.repositories.team import TeamRepository
+from brain.systems.cortex.object_references import (
+    SOURCE_CHAT_MESSAGE,
+    merge_object_reference_metadata,
+    store_object_references_for_source,
+)
 
 ILLO_NAME = "Illo"
 ILLO_COLOR = "#5ea898"
@@ -173,6 +178,7 @@ class _ChatSerializationMixin:
             sender_name = sender_user.name if sender_user else "Unknown"
             sender_color = sender_user.color if sender_user else None
 
+        metadata = message.metadata_ if isinstance(message.metadata_, dict) else {}
         return ChatMessageRead(
             id=message.id,
             conversation_id=str(message.conversation_id),
@@ -187,6 +193,8 @@ class _ChatSerializationMixin:
             reply_to_message_id=message.reply_to_message_id,
             attachments=message.attachments or [],
             metadata=message.metadata_,
+            object_references=metadata.get("object_references") or [],
+            thread_references=metadata.get("thread_references") or [],
             conversation_seq=message.conversation_seq,
             reply_count=message.reply_count or 0,
             last_reply_at=message.last_reply_at,
@@ -338,6 +346,7 @@ class ChatService(_ChatSerializationMixin):
             attachments=attachments,
             metadata=dict(body.metadata or {}),
         )
+        await self._store_object_references(message)
         members = list(await self.conversation_repo.a_list_member_users(conversation.id))
         created_notifications = await self._store_mentions_and_notifications(
             conversation=conversation,
@@ -469,6 +478,7 @@ class ChatService(_ChatSerializationMixin):
             thread_root_message_id=root_message.id,
             reply_to_message_id=body.reply_to_message_id,
         )
+        await self._store_object_references(reply)
         members = list(await self.conversation_repo.a_list_member_users(conversation.id))
         created_notifications = await self._store_mentions_and_notifications(
             conversation=conversation,
@@ -530,6 +540,7 @@ class ChatService(_ChatSerializationMixin):
             },
             thread_root_message_id=root_message.id if root_message is not None else None,
         )
+        await self._store_object_references(message)
         members = list(await self.conversation_repo.a_list_member_users(conversation.id))
         created_notifications = await self._store_mentions_and_notifications(
             conversation=conversation,
@@ -1010,6 +1021,18 @@ class ChatService(_ChatSerializationMixin):
             )
 
         return notifications
+
+    async def _store_object_references(self, message: ChatMessage) -> None:
+        references = await store_object_references_for_source(
+            self.db,
+            source_type=SOURCE_CHAT_MESSAGE,
+            source_id=message.id,
+            org_id=self.org_id,
+            text=message.body,
+            user_id=self.viewer_user_id if message.sender_user_id else None,
+        )
+        if references:
+            message.metadata_ = merge_object_reference_metadata(message.metadata_, references)
 
     async def _validate_reply_target_or_400(
         self,

--- a/brain/app/triggers/adapters/internal.py
+++ b/brain/app/triggers/adapters/internal.py
@@ -30,23 +30,33 @@ def _discussion_mention_run_message(
     idea_id: str,
     thread_message: str,
     discussion_trigger: dict[str, Any],
+    thread_references: list[dict[str, Any]] | None = None,
 ) -> str:
     comment_id = discussion_trigger.get("comment_id")
-    return "\n".join(
-        [
-            f"[Thread: \"{idea_data['title']}\" | {idea_id}]",
-            "",
-            "A teammate summoned @illo from Thread Discussion.",
-            "This is a separate Discussion conversation attached to the Thread, not an AI Timeline reply.",
-            "Acknowledge or answer in Discussion with post_thread_discussion_reply when a visible response fits.",
-            "Use read_thread_discussion if more Discussion context is needed.",
-            "Treat the AI Timeline as related context only unless a separate tool explicitly asks you to act there.",
-            "You may also act headlessly when no visible surface update is appropriate.",
-            "",
-            f"Triggering Discussion comment id: {comment_id}",
-            f"Triggering Discussion comment: {thread_message[:2000]}",
-        ]
-    )
+    lines = [
+        f"[Thread: \"{idea_data['title']}\" | {idea_id}]",
+        "",
+        "A teammate summoned @illo from Thread Discussion.",
+        "This is a separate Discussion conversation attached to the Thread, not an AI Timeline reply.",
+        "Acknowledge or answer in Discussion with post_thread_discussion_reply when a visible response fits.",
+        "Use read_thread_discussion if more Discussion context is needed.",
+        "Treat the AI Timeline as related context only unless a separate tool explicitly asks you to act there.",
+        "You may also act headlessly when no visible surface update is appropriate.",
+        "",
+        f"Triggering Discussion comment id: {comment_id}",
+        f"Triggering Discussion comment: {thread_message[:2000]}",
+    ]
+    if thread_references:
+        lines.extend(["", "Referenced Threads:"])
+        for reference in thread_references[:5]:
+            title = reference.get("title") or "Thread"
+            thread_id = reference.get("thread_id") or ""
+            summary = reference.get("preview_summary") or ""
+            url = reference.get("thread_url") or reference.get("url") or reference.get("thread_route") or ""
+            lines.append(f"- {title} ({thread_id}) {url}".strip())
+            if summary:
+                lines.append(f"  {summary[:500]}")
+    return "\n".join(lines)
 
 
 def build_cortex_notify_trigger(
@@ -156,6 +166,7 @@ def build_thread_discussion_mention_trigger(
     metadata.setdefault("final_answer_target_surface", THREAD_DISCUSSION_SURFACE)
     metadata.setdefault("discussion_comment_id", comment_id)
     metadata.setdefault("discussion_trigger", discussion_trigger)
+    thread_references = list(metadata.get("thread_references") or [])
 
     target = {
         "kind": THREAD_DISCUSSION_SURFACE,
@@ -175,6 +186,7 @@ def build_thread_discussion_mention_trigger(
             idea_id=idea_id,
             thread_message=body,
             discussion_trigger=discussion_trigger,
+            thread_references=thread_references,
         ),
         "metadata": metadata,
         "priority": int(priority),
@@ -256,6 +268,9 @@ def build_chat_mention_trigger(
     sender_name = str(user.get("name") or "A teammate")
     body = str(getattr(message, "body", "") or "")
     root_body = str(getattr(root_message, "body", "") or "") if root_message is not None else ""
+    message_metadata = dict(getattr(message, "metadata_", None) or {})
+    object_references = list(message_metadata.get("object_references") or [])
+    thread_references = list(message_metadata.get("thread_references") or [])
     context_lines = [
         f"{sender_name} tagged @illo from the native team room.",
         "Decide whether to answer directly, create Cortex thoughts, or both.",
@@ -268,11 +283,23 @@ def build_chat_mention_trigger(
     if root_body:
         context_lines.extend(["", f"Thread root message: {root_body[:1000]}"])
     context_lines.extend(["", f"Tagged message: {body[:2000]}"])
+    if thread_references:
+        context_lines.extend(["", "Referenced Threads:"])
+        for reference in thread_references[:5]:
+            title = reference.get("title") or "Thread"
+            thread_id = reference.get("thread_id") or ""
+            summary = reference.get("preview_summary") or ""
+            url = reference.get("thread_url") or reference.get("url") or reference.get("thread_route") or ""
+            context_lines.append(f"- {title} ({thread_id}) {url}".strip())
+            if summary:
+                context_lines.append(f"  {summary[:500]}")
     run_message = "\n".join(context_lines)
     metadata = {
         "chat_trigger": chat_trigger,
         "origin": "native_chat_mention",
         "required_response_tool": "post_chat_message",
+        "object_references": object_references,
+        "thread_references": thread_references,
     }
     payload = {
         "chat": chat_trigger,

--- a/brain/platform/db/alembic/versions/0016_thread_urls_object_references.py
+++ b/brain/platform/db/alembic/versions/0016_thread_urls_object_references.py
@@ -1,0 +1,98 @@
+"""Add Thread URL previews and object references.
+
+Revision ID: 0016_thread_urls_object_references
+Revises: 0015_agent_run_source_idempotency
+Create Date: 2026-06-01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0016_thread_urls_object_references"
+down_revision = "0015_agent_run_source_idempotency"
+branch_labels = None
+depends_on = None
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema=_schema()))
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return column_name in {column["name"] for column in _inspector().get_columns(table_name, schema=_schema())}
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name, schema=_schema())}
+
+
+def upgrade() -> None:
+    if _table_exists("ideas"):
+        if not _column_exists("ideas", "preview_summary"):
+            op.add_column("ideas", sa.Column("preview_summary", sa.Text(), nullable=True))
+        if not _column_exists("ideas", "preview_source"):
+            op.add_column("ideas", sa.Column("preview_source", sa.String(length=30), nullable=True))
+        if not _column_exists("ideas", "preview_updated_at"):
+            op.add_column("ideas", sa.Column("preview_updated_at", sa.DateTime(timezone=True), nullable=True))
+
+    if not _table_exists("object_references"):
+        op.create_table(
+            "object_references",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "org_id",
+                postgresql.UUID(as_uuid=False),
+                sa.ForeignKey("orgs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("source_type", sa.String(length=60), nullable=False),
+            sa.Column("source_id", sa.String(length=120), nullable=False),
+            sa.Column("object_type", sa.String(length=60), nullable=False),
+            sa.Column("object_id", sa.String(length=120), nullable=True),
+            sa.Column("original_ref", sa.Text(), nullable=False),
+            sa.Column("canonical_ref", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=30), nullable=False, server_default="available"),
+            sa.Column("reference_payload", postgresql.JSONB(), nullable=True, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+            sa.UniqueConstraint(
+                "source_type",
+                "source_id",
+                "object_type",
+                "object_id",
+                "original_ref",
+                name="uq_object_references_source_object_ref",
+            ),
+        )
+
+    if _table_exists("object_references"):
+        if not _index_exists("object_references", "ix_object_references_source"):
+            op.create_index("ix_object_references_source", "object_references", ["source_type", "source_id"])
+        if not _index_exists("object_references", "ix_object_references_object"):
+            op.create_index("ix_object_references_object", "object_references", ["object_type", "object_id"])
+        if not _index_exists("object_references", "ix_object_references_org_created"):
+            op.create_index("ix_object_references_org_created", "object_references", ["org_id", "created_at"])
+
+
+def downgrade() -> None:
+    if _table_exists("object_references"):
+        op.drop_table("object_references")
+    if _table_exists("ideas"):
+        for column_name in ("preview_updated_at", "preview_source", "preview_summary"):
+            if _column_exists("ideas", column_name):
+                op.drop_column("ideas", column_name)

--- a/brain/platform/db/models/__init__.py
+++ b/brain/platform/db/models/__init__.py
@@ -29,3 +29,4 @@ from brain.platform.db.models.external_agent import *  # noqa
 from brain.platform.db.models.inbound import *  # noqa
 from brain.platform.db.models.workspace_app import *  # noqa
 from brain.platform.db.models.workspace_pin import *  # noqa
+from brain.platform.db.models.object_reference import *  # noqa

--- a/brain/platform/db/models/idea.py
+++ b/brain/platform/db/models/idea.py
@@ -111,6 +111,11 @@ class Idea(Base):
         DateTime(timezone=True), nullable=True
     )
     working_memory: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    preview_summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    preview_source: Mapped[Optional[str]] = mapped_column(String(30), nullable=True)
+    preview_updated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     active_agents: Mapped[int] = mapped_column(
         Integer, server_default=text("0"), default=0
     )

--- a/brain/platform/db/models/object_reference.py
+++ b/brain/platform/db/models/object_reference.py
@@ -1,0 +1,46 @@
+"""Durable object references extracted from user-visible surfaces."""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from brain.platform.db.base import Base, CreatedAtMixin
+
+__all__ = ["ObjectReference"]
+
+
+class ObjectReference(Base, CreatedAtMixin):
+    """A normalized reference from chat/thread text to a product object."""
+
+    __tablename__ = "object_references"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_type",
+            "source_id",
+            "object_type",
+            "object_id",
+            "original_ref",
+            name="uq_object_references_source_object_ref",
+        ),
+        Index("ix_object_references_source", "source_type", "source_id"),
+        Index("ix_object_references_object", "object_type", "object_id"),
+        Index("ix_object_references_org_created", "org_id", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False
+    )
+    source_type: Mapped[str] = mapped_column(String(60), nullable=False)
+    source_id: Mapped[str] = mapped_column(String(120), nullable=False)
+    object_type: Mapped[str] = mapped_column(String(60), nullable=False)
+    object_id: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    original_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    canonical_ref: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, server_default="available", default="available")
+    reference_payload: Mapped[Optional[dict]] = mapped_column(
+        JSONB, nullable=True, server_default=text("'{}'::jsonb"), default=dict
+    )

--- a/brain/systems/cortex/object_references.py
+++ b/brain/systems/cortex/object_references.py
@@ -1,0 +1,163 @@
+"""Shared extraction, resolution, and persistence for product object references."""
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.object_reference import ObjectReference
+from brain.systems.cortex.thread_links import (
+    extract_thread_reference_values,
+    thread_id_from_reference,
+)
+from brain.systems.cortex.thread_read_model import THREAD_OBJECT_TYPE, resolve_thread_reference
+
+SOURCE_CHAT_MESSAGE = "chat_message"
+SOURCE_THREAD_DISCUSSION_COMMENT = "thread_discussion_comment"
+SOURCE_IDEA_THREAD = "idea_thread"
+
+
+def _dedupe_values(values: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values or []:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _thread_ref_metadata(references: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [ref for ref in references if ref.get("object_type") == THREAD_OBJECT_TYPE]
+
+
+async def resolve_object_reference_values(
+    session: AsyncSession,
+    values: list[Any],
+    *,
+    org_id: str,
+    user_id: str | None = None,
+    allow_raw_ids: bool = False,
+    include_handoff: bool = True,
+) -> list[dict[str, Any]]:
+    references: list[dict[str, Any]] = []
+    seen_thread_ids: set[str] = set()
+    for value in _dedupe_values(values):
+        thread_id = thread_id_from_reference(value, allow_raw_id=allow_raw_ids)
+        if not thread_id or thread_id in seen_thread_ids:
+            continue
+        seen_thread_ids.add(thread_id)
+        references.append(
+            await resolve_thread_reference(
+                session,
+                thread_id,
+                org_id=org_id,
+                user_id=user_id,
+                original_ref=value,
+                include_handoff=include_handoff,
+            )
+        )
+    return references
+
+
+async def resolve_object_references_in_text(
+    session: AsyncSession,
+    text: str,
+    *,
+    org_id: str,
+    user_id: str | None = None,
+    include_handoff: bool = True,
+) -> list[dict[str, Any]]:
+    return await resolve_object_reference_values(
+        session,
+        extract_thread_reference_values(text),
+        org_id=org_id,
+        user_id=user_id,
+        include_handoff=include_handoff,
+    )
+
+
+def merge_object_reference_metadata(
+    metadata: dict[str, Any] | None,
+    references: list[dict[str, Any]],
+) -> dict[str, Any]:
+    next_metadata = dict(metadata or {})
+    next_metadata["object_references"] = list(references or [])
+    next_metadata["thread_references"] = _thread_ref_metadata(references)
+    return next_metadata
+
+
+async def store_object_references_for_source(
+    session: AsyncSession,
+    *,
+    source_type: str,
+    source_id: str | int,
+    org_id: str,
+    text: str,
+    user_id: str | None = None,
+    include_handoff: bool = True,
+) -> list[dict[str, Any]]:
+    reference_values = extract_thread_reference_values(text)
+    if not reference_values:
+        return []
+
+    references = await resolve_object_reference_values(
+        session,
+        reference_values,
+        org_id=org_id,
+        user_id=user_id,
+        include_handoff=include_handoff,
+    )
+    await session.execute(
+        delete(ObjectReference).where(
+            ObjectReference.source_type == source_type,
+            ObjectReference.source_id == str(source_id),
+        )
+    )
+    for reference in references:
+        session.add(
+            ObjectReference(
+                org_id=str(org_id),
+                source_type=source_type,
+                source_id=str(source_id),
+                object_type=str(reference.get("object_type") or THREAD_OBJECT_TYPE),
+                object_id=str(reference.get("thread_id")) if reference.get("thread_id") else None,
+                original_ref=str(reference.get("original_ref") or ""),
+                canonical_ref=reference.get("thread_url") or reference.get("url"),
+                status=str(reference.get("status") or "available"),
+                reference_payload=reference,
+            )
+        )
+    return references
+
+
+async def object_references_for_source(
+    session: AsyncSession,
+    *,
+    source_type: str,
+    source_id: str | int,
+) -> list[dict[str, Any]]:
+    result = await session.scalars(
+        select(ObjectReference)
+        .where(
+            ObjectReference.source_type == source_type,
+            ObjectReference.source_id == str(source_id),
+        )
+        .order_by(ObjectReference.id.asc())
+    )
+    return [dict(row.reference_payload or {}) for row in result.all()]
+
+
+__all__ = [
+    "SOURCE_CHAT_MESSAGE",
+    "SOURCE_IDEA_THREAD",
+    "SOURCE_THREAD_DISCUSSION_COMMENT",
+    "merge_object_reference_metadata",
+    "object_references_for_source",
+    "resolve_object_reference_values",
+    "resolve_object_references_in_text",
+    "store_object_references_for_source",
+]

--- a/brain/systems/cortex/thought_lifecycle.py
+++ b/brain/systems/cortex/thought_lifecycle.py
@@ -14,6 +14,15 @@ from brain.platform.db.models.notification import (
     NOTIFICATION_KIND_WORKSPACE_THREAD_ATTENTION,
     NOTIFICATION_SOURCE_WORKSPACE,
 )
+from brain.systems.cortex.object_references import (
+    SOURCE_IDEA_THREAD,
+    merge_object_reference_metadata,
+    store_object_references_for_source,
+)
+from brain.systems.cortex.thread_read_model import (
+    deterministic_preview_summary,
+    refresh_thread_read_model,
+)
 from brain.systems.cortex.status import (
     ASSISTANT_REPLY_BLOCKED_IDEA_STATUSES,
     ASSISTANT_REPLY_UNREAD_IDEA_STATUSES,
@@ -168,6 +177,7 @@ def _next_status_for_message(role: str, current_status: str | None) -> str | Non
 
 def _message_payload(thread_msg: IdeaThread, *, actor: Mapping[str, Any], user_id: str | None) -> dict[str, Any]:
     created_at = getattr(thread_msg, "created_at", None)
+    metadata = thread_msg.metadata_ if isinstance(thread_msg.metadata_, dict) else {}
     payload = {
         "id": thread_msg.id,
         "idea_id": thread_msg.idea_id,
@@ -179,6 +189,12 @@ def _message_payload(thread_msg: IdeaThread, *, actor: Mapping[str, Any], user_i
         "message_type": thread_msg.message_type,
         "created_at": created_at.isoformat() if created_at else None,
     }
+    object_references = metadata.get("object_references") or []
+    thread_references = metadata.get("thread_references") or []
+    if object_references:
+        payload["object_references"] = object_references
+    if thread_references:
+        payload["thread_references"] = thread_references
     if user_id and actor.get("name"):
         payload["user_name"] = actor.get("name")
         payload["user_color"] = actor.get("color", "#6366f1")
@@ -480,6 +496,30 @@ async def post_thread_message(
     )
     await session.flush()
 
+    notification_org_id = _actor_org_id(command, idea)
+    if notification_org_id:
+        references = await store_object_references_for_source(
+            session,
+            source_type=SOURCE_IDEA_THREAD,
+            source_id=thread_msg.id,
+            org_id=notification_org_id,
+            text=content,
+            user_id=user_id,
+        )
+        if references:
+            thread_msg.metadata_ = merge_object_reference_metadata(thread_msg.metadata_, references)
+            metadata = thread_msg.metadata_
+
+    if role == "user" and not getattr(idea, "preview_summary", None):
+        preview = deterministic_preview_summary(title=getattr(idea, "title", None), description=content)
+        if preview:
+            await refresh_thread_read_model(
+                session,
+                idea,
+                preview_summary=preview,
+                preview_source="deterministic",
+            )
+
     await _maybe_append_live_guidance(
         append_live_guidance,
         thread_msg=thread_msg,
@@ -490,7 +530,6 @@ async def post_thread_message(
         user_id=user_id,
     )
 
-    notification_org_id = _actor_org_id(command, idea)
     notification_user_ids = await _notify_mentions(
         idea=idea,
         content=content,
@@ -579,6 +618,18 @@ async def mirror_run_final_answer(
         message_type="agent_response",
     )
     await session.flush()
+    org_id = str(getattr(idea, "org_id", None) or "") or None
+    if org_id:
+        references = await store_object_references_for_source(
+            session,
+            source_type=SOURCE_IDEA_THREAD,
+            source_id=thread_msg.id,
+            org_id=org_id,
+            text=text,
+            user_id=None,
+        )
+        if references:
+            thread_msg.metadata_ = merge_object_reference_metadata(thread_msg.metadata_, references)
     return thread_msg, _message_payload(thread_msg, actor={}, user_id=None)
 
 

--- a/brain/systems/cortex/thread_links.py
+++ b/brain/systems/cortex/thread_links.py
@@ -1,0 +1,126 @@
+"""Canonical Thread URL helpers and parsers."""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+from urllib.parse import parse_qs, quote, unquote, urlsplit, urlunsplit
+
+THREAD_ROUTE_PREFIX = "/threads"
+LEGACY_CORTEX_ROUTE = "/cortex"
+LOCAL_APP_BASE_URL = "http://localhost:8080"
+
+_THREAD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
+_URL_CANDIDATE_RE = re.compile(
+    r"https?://[^\s<>'\"\]\)]+|/(?:threads/|cortex\?)[^\s<>'\"\]\)]+",
+    re.IGNORECASE,
+)
+_TRAILING_PUNCTUATION = ".,;:!?"
+
+
+def public_app_base_url() -> str:
+    raw = os.getenv("ILLO_PUBLIC_URL") or os.getenv("ILLO_DASHBOARD_URL") or LOCAL_APP_BASE_URL
+    parts = urlsplit(str(raw).strip() or LOCAL_APP_BASE_URL)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        return LOCAL_APP_BASE_URL
+    return urlunsplit((parts.scheme, parts.netloc, "", "", "")).rstrip("/")
+
+
+def thread_route_for_id(thread_id: Any) -> str:
+    return f"{THREAD_ROUTE_PREFIX}/{quote(str(thread_id), safe='')}"
+
+
+def legacy_thread_route_for_id(thread_id: Any) -> str:
+    return f"{LEGACY_CORTEX_ROUTE}?idea={quote(str(thread_id), safe='')}"
+
+
+def thread_url_for_route(route: str) -> str:
+    value = str(route or "").strip()
+    if value.startswith(("http://", "https://")):
+        return value
+    if not value.startswith("/"):
+        value = f"/{value}"
+    return f"{public_app_base_url()}{value}"
+
+
+def thread_url_for_id(thread_id: Any) -> str:
+    return thread_url_for_route(thread_route_for_id(thread_id))
+
+
+def thread_link_payload(thread_id: Any) -> dict[str, str]:
+    route = thread_route_for_id(thread_id)
+    url = thread_url_for_route(route)
+    return {
+        "thread_id": str(thread_id),
+        "thread_route": route,
+        "thread_url": url,
+        "url": url,
+    }
+
+
+def _clean_thread_id(value: Any) -> str | None:
+    text = unquote(str(value or "")).strip().rstrip(_TRAILING_PUNCTUATION)
+    if not text:
+        return None
+    return text if _THREAD_ID_RE.match(text) else None
+
+
+def _strip_candidate(value: Any) -> str:
+    cleaned = str(value or "").strip()
+    while cleaned and cleaned[-1] in _TRAILING_PUNCTUATION:
+        cleaned = cleaned[:-1]
+    return cleaned
+
+
+def thread_id_from_reference(value: Any, *, allow_raw_id: bool = False) -> str | None:
+    text = _strip_candidate(value)
+    if not text:
+        return None
+    if allow_raw_id and not any(part in text for part in ("/", "?", "#", "://")):
+        return _clean_thread_id(text)
+
+    parts = urlsplit(text)
+    path = parts.path or text
+    if path.startswith(f"{THREAD_ROUTE_PREFIX}/"):
+        tail = path[len(THREAD_ROUTE_PREFIX) + 1:]
+        return _clean_thread_id(tail.split("/", 1)[0])
+    if path == LEGACY_CORTEX_ROUTE:
+        return _clean_thread_id(parse_qs(parts.query).get("idea", [None])[0])
+    return None
+
+
+def canonicalize_thread_reference(value: Any, *, allow_raw_id: bool = False) -> dict[str, str] | None:
+    thread_id = thread_id_from_reference(value, allow_raw_id=allow_raw_id)
+    if not thread_id:
+        return None
+    payload = thread_link_payload(thread_id)
+    payload["original_ref"] = _strip_candidate(value)
+    return payload
+
+
+def extract_thread_reference_values(text: str) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for match in _URL_CANDIDATE_RE.finditer(str(text or "")):
+        candidate = _strip_candidate(match.group(0))
+        if not candidate or candidate in seen:
+            continue
+        if thread_id_from_reference(candidate):
+            values.append(candidate)
+            seen.add(candidate)
+    return values
+
+
+__all__ = [
+    "LEGACY_CORTEX_ROUTE",
+    "THREAD_ROUTE_PREFIX",
+    "canonicalize_thread_reference",
+    "extract_thread_reference_values",
+    "legacy_thread_route_for_id",
+    "public_app_base_url",
+    "thread_id_from_reference",
+    "thread_link_payload",
+    "thread_route_for_id",
+    "thread_url_for_id",
+    "thread_url_for_route",
+]

--- a/brain/systems/cortex/thread_read_model.py
+++ b/brain/systems/cortex/thread_read_model.py
@@ -1,0 +1,369 @@
+"""Thread preview read-model helpers."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.idea import Idea
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.events import publish_safe
+from brain.systems.cortex.thread_links import thread_link_payload
+
+THREAD_OBJECT_TYPE = "thread"
+PREVIEW_SOURCE_HANDOFF = "handoff"
+PREVIEW_SOURCE_DETERMINISTIC = "deterministic"
+PREVIEW_SOURCE_UNAVAILABLE = "unavailable"
+MAX_PREVIEW_SUMMARY_CHARS = 420
+MAX_HANDOFF_CONTEXT_CHARS = 900
+
+
+def _compact_text(value: Any, *, limit: int) -> str | None:
+    text = " ".join(str(value or "").split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(0, limit - 3)].rstrip()}..."
+
+
+def _checkpoint(summary: dict[str, Any] | None) -> dict[str, Any]:
+    payload = summary if isinstance(summary, dict) else {}
+    body = payload.get("summary") if isinstance(payload.get("summary"), dict) else payload
+    checkpoint = body.get("checkpoint") if isinstance(body, dict) else None
+    return checkpoint if isinstance(checkpoint, dict) else {}
+
+
+def _summary_body(summary: dict[str, Any] | None) -> dict[str, Any]:
+    payload = summary if isinstance(summary, dict) else {}
+    body = payload.get("summary") if isinstance(payload.get("summary"), dict) else payload
+    return body if isinstance(body, dict) else {}
+
+
+def _idea_id_from_run_thread_id(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if text.startswith("thread-discussion:"):
+        text = text.split(":", 1)[1].strip()
+    if not text:
+        return None
+    try:
+        return str(UUID(text))
+    except (TypeError, ValueError):
+        return None
+
+
+def preview_summary_from_handoff(summary: dict[str, Any] | None) -> str | None:
+    checkpoint = _checkpoint(summary)
+    candidates = [
+        checkpoint.get("active_objective"),
+        checkpoint.get("recent_user_intent"),
+        checkpoint.get("current_state"),
+        checkpoint.get("summary"),
+        checkpoint.get("verification_status"),
+    ]
+    sentences = [_compact_text(value, limit=260) for value in candidates if value]
+    text = " ".join(part for part in sentences if part)
+    return _compact_text(text, limit=MAX_PREVIEW_SUMMARY_CHARS)
+
+
+def deterministic_preview_summary(
+    *,
+    title: Any = None,
+    description: Any = None,
+    intent: Any = None,
+    source_tool: Any = None,
+) -> str | None:
+    title_text = _compact_text(title, limit=160)
+    description_text = _compact_text(description, limit=260)
+    intent_text = _compact_text(intent, limit=260)
+    tool_text = _compact_text(source_tool, limit=80)
+    if intent_text:
+        return _compact_text(f"Current ask: {intent_text}", limit=MAX_PREVIEW_SUMMARY_CHARS)
+    if description_text:
+        return _compact_text(description_text, limit=MAX_PREVIEW_SUMMARY_CHARS)
+    if title_text and tool_text:
+        return _compact_text(f"{title_text}. Shared from {tool_text}.", limit=MAX_PREVIEW_SUMMARY_CHARS)
+    return title_text
+
+
+def compact_handoff_context(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    payload = summary if isinstance(summary, dict) else {}
+    body = _summary_body(summary)
+    checkpoint = _checkpoint(summary)
+    if not checkpoint and not payload:
+        return None
+    context: dict[str, Any] = {}
+    for key in ("run_id", "updated_at", "message_count", "session_id"):
+        value = payload.get(key) or body.get(key)
+        if value is not None:
+            context[key] = value
+
+    checkpoint_context: dict[str, Any] = {}
+    for key in (
+        "active_objective",
+        "recent_user_intent",
+        "current_state",
+        "summary",
+        "verification_status",
+    ):
+        value = checkpoint.get(key)
+        if value:
+            checkpoint_context[key] = _compact_text(value, limit=MAX_HANDOFF_CONTEXT_CHARS)
+    for key in (
+        "current_plan",
+        "completed_work",
+        "decisions",
+        "open_questions",
+        "risks_or_unknowns",
+        "failed_attempts",
+        "important_tool_results",
+        "files_or_objects_touched",
+    ):
+        values = _compact_list(checkpoint.get(key), item_limit=320, max_items=8)
+        if values:
+            checkpoint_context[key] = values
+    if checkpoint_context:
+        context["checkpoint"] = checkpoint_context
+    return context or None
+
+
+def _compact_list(value: Any, *, item_limit: int, max_items: int) -> list[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    compacted: list[str] = []
+    for item in items[:max_items]:
+        text = _compact_text(item, limit=item_limit)
+        if text:
+            compacted.append(text)
+    return compacted
+
+
+def unavailable_thread_reference(original_ref: Any = None, thread_id: Any = None) -> dict[str, Any]:
+    normalized_thread_id = str(thread_id) if thread_id else None
+    payload: dict[str, Any] = {
+        "type": "thread_reference",
+        "object_type": THREAD_OBJECT_TYPE,
+        "object_id": normalized_thread_id,
+        "thread_id": normalized_thread_id,
+        "status": "unavailable",
+        "title": None,
+        "preview_summary": None,
+        "preview_source": PREVIEW_SOURCE_UNAVAILABLE,
+    }
+    if original_ref:
+        payload["original_ref"] = str(original_ref)
+    return payload
+
+
+async def _latest_handoff_summary_or_none(session: AsyncSession, idea_id: str) -> dict[str, Any] | None:
+    try:
+        from brain.systems.runs.cortex.handoff_summary import latest_thread_handoff_summary
+
+        summary = await latest_thread_handoff_summary(session, idea_id)
+    except Exception:
+        return None
+    return summary if isinstance(summary, dict) and summary.get("found") else None
+
+
+async def refresh_thread_read_model(
+    session: AsyncSession,
+    idea: Idea,
+    *,
+    preview_summary: str | None,
+    preview_source: str,
+    publish_update: bool = True,
+) -> dict[str, Any] | None:
+    summary = _compact_text(preview_summary, limit=MAX_PREVIEW_SUMMARY_CHARS)
+    if not summary:
+        return None
+
+    now = datetime.now(timezone.utc)
+    changed = (
+        getattr(idea, "preview_summary", None) != summary
+        or getattr(idea, "preview_source", None) != preview_source
+    )
+    if changed:
+        idea.preview_summary = summary
+        idea.preview_source = preview_source
+        idea.preview_updated_at = now
+        await session.flush()
+
+    updated_at = getattr(idea, "preview_updated_at", None)
+    if not changed and updated_at is None:
+        updated_at = now
+
+    payload = {
+        "idea_id": str(idea.id),
+        "thread_id": str(idea.id),
+        "org_id": str(getattr(idea, "org_id", "") or "") or None,
+        "title": getattr(idea, "display_title", None) or getattr(idea, "title", None),
+        "preview_summary": summary,
+        "preview_source": preview_source,
+        "preview_updated_at": updated_at.isoformat() if hasattr(updated_at, "isoformat") else None,
+        **thread_link_payload(idea.id),
+    }
+    if publish_update and changed:
+        publish_safe("thread_read_model_updated", payload)
+    return payload
+
+
+async def ensure_thread_preview_read_model(
+    session: AsyncSession,
+    idea: Idea,
+    *,
+    lazy_refresh: bool = True,
+) -> tuple[str | None, str | None, str | None]:
+    existing_summary = _compact_text(getattr(idea, "preview_summary", None), limit=MAX_PREVIEW_SUMMARY_CHARS)
+    existing_source = getattr(idea, "preview_source", None)
+    existing_updated_at = getattr(idea, "preview_updated_at", None)
+    if existing_summary or not lazy_refresh:
+        updated = existing_updated_at.isoformat() if hasattr(existing_updated_at, "isoformat") else None
+        return existing_summary, existing_source, updated
+
+    handoff = await _latest_handoff_summary_or_none(session, str(idea.id))
+    handoff_preview = preview_summary_from_handoff(handoff)
+    if handoff_preview:
+        payload = await refresh_thread_read_model(
+            session,
+            idea,
+            preview_summary=handoff_preview,
+            preview_source=PREVIEW_SOURCE_HANDOFF,
+        )
+        return (
+            payload.get("preview_summary") if payload else handoff_preview,
+            PREVIEW_SOURCE_HANDOFF,
+            payload.get("preview_updated_at") if payload else None,
+        )
+
+    deterministic = deterministic_preview_summary(title=idea.title, description=idea.description)
+    if deterministic:
+        payload = await refresh_thread_read_model(
+            session,
+            idea,
+            preview_summary=deterministic,
+            preview_source=PREVIEW_SOURCE_DETERMINISTIC,
+        )
+        return (
+            payload.get("preview_summary") if payload else deterministic,
+            PREVIEW_SOURCE_DETERMINISTIC,
+            payload.get("preview_updated_at") if payload else None,
+        )
+    return None, None, None
+
+
+async def thread_reference_payload(
+    session: AsyncSession,
+    idea: Idea,
+    *,
+    original_ref: Any = None,
+    include_handoff: bool = True,
+    lazy_refresh: bool = True,
+) -> dict[str, Any]:
+    preview_summary, preview_source, preview_updated_at = await ensure_thread_preview_read_model(
+        session,
+        idea,
+        lazy_refresh=lazy_refresh,
+    )
+    payload: dict[str, Any] = {
+        "type": "thread_reference",
+        "object_type": THREAD_OBJECT_TYPE,
+        "object_id": str(idea.id),
+        "thread_id": str(idea.id),
+        "status": "available",
+        "title": getattr(idea, "display_title", None) or getattr(idea, "title", None) or "Untitled thread",
+        "preview_summary": preview_summary,
+        "preview_source": preview_source,
+        "preview_updated_at": preview_updated_at,
+        **thread_link_payload(idea.id),
+    }
+    if original_ref:
+        payload["original_ref"] = str(original_ref)
+    if include_handoff:
+        handoff = await _latest_handoff_summary_or_none(session, str(idea.id))
+        compact = compact_handoff_context(handoff)
+        if compact:
+            payload["handoff"] = compact
+    return payload
+
+
+async def resolve_thread_reference(
+    session: AsyncSession,
+    thread_id: str,
+    *,
+    org_id: str,
+    user_id: str | None = None,
+    original_ref: Any = None,
+    include_handoff: bool = True,
+) -> dict[str, Any]:
+    normalized_thread_id = _idea_id_from_run_thread_id(thread_id)
+    if not normalized_thread_id:
+        return unavailable_thread_reference(original_ref=original_ref, thread_id=thread_id)
+    stmt = select(Idea).where(Idea.id == normalized_thread_id, Idea.archived_at.is_(None))
+    if org_id:
+        stmt = stmt.where(Idea.org_id == str(org_id))
+    idea = await session.scalar(stmt)
+    if idea is None:
+        return unavailable_thread_reference(original_ref=original_ref, thread_id=thread_id)
+    return await thread_reference_payload(
+        session,
+        idea,
+        original_ref=original_ref,
+        include_handoff=include_handoff,
+    )
+
+
+async def refresh_thread_read_model_for_run(
+    session: AsyncSession,
+    run_id: int,
+    handoff_summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    run = await session.get(AgentRunRow, int(run_id))
+    if run is None or not getattr(run, "thread_id", None):
+        return None
+    idea_id = _idea_id_from_run_thread_id(run.thread_id)
+    if not idea_id:
+        return None
+    idea = await session.get(Idea, idea_id)
+    if idea is None:
+        return None
+    preview = preview_summary_from_handoff(handoff_summary)
+    if not preview:
+        return None
+    return await refresh_thread_read_model(
+        session,
+        idea,
+        preview_summary=preview,
+        preview_source=PREVIEW_SOURCE_HANDOFF,
+    )
+
+
+async def refresh_thread_read_model_for_run_id(
+    run_id: int | None,
+    handoff_summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if run_id is None:
+        return None
+    async with UnitOfWork() as uow:
+        return await refresh_thread_read_model_for_run(uow.session, int(run_id), handoff_summary)
+
+
+__all__ = [
+    "PREVIEW_SOURCE_DETERMINISTIC",
+    "PREVIEW_SOURCE_HANDOFF",
+    "THREAD_OBJECT_TYPE",
+    "compact_handoff_context",
+    "deterministic_preview_summary",
+    "ensure_thread_preview_read_model",
+    "preview_summary_from_handoff",
+    "refresh_thread_read_model",
+    "refresh_thread_read_model_for_run",
+    "refresh_thread_read_model_for_run_id",
+    "resolve_thread_reference",
+    "thread_reference_payload",
+    "unavailable_thread_reference",
+]

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -35,6 +35,8 @@ from brain.systems.cortex.thought_lifecycle import (
     post_thread_message,
     transition_thought_status,
 )
+from brain.systems.cortex.thread_links import thread_id_from_reference, thread_link_payload
+from brain.systems.cortex.thread_read_model import thread_reference_payload
 from brain.systems.cortex.status import EXTERNAL_TASK_STARTABLE_IDEA_STATUSES
 from brain.systems.external_agents.status import EXTERNAL_AGENT_TASK_TERMINAL_STATUSES
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
@@ -711,19 +713,7 @@ async def _thread_context(session: AsyncSession, idea_id: str, *, limit: int = 3
         ).all()
     )
     rows.reverse()
-    return [
-        {
-            "id": row.id,
-            "role": row.role,
-            "content": row.content,
-            "attachments": row.attachments or [],
-            "metadata": _json_dict(row.metadata_),
-            "message_type": row.message_type,
-            "user_id": str(row.user_id) if row.user_id else None,
-            "created_at": _iso(row.created_at),
-        }
-        for row in rows
-    ]
+    return [_thread_message_payload(row) for row in rows]
 
 
 async def _idea_for_org(session: AsyncSession, *, idea_id: str, org_id: str) -> Idea:
@@ -945,13 +935,16 @@ async def append_artifact(
 
 
 def _thread_message_payload(message: IdeaThread) -> dict[str, Any]:
+    metadata = _json_dict(message.metadata_)
     return {
         "id": message.id,
         "idea_id": str(message.idea_id) if message.idea_id else None,
         "role": message.role,
         "content": message.content,
         "attachments": message.attachments or [],
-        "metadata": _json_dict(message.metadata_),
+        "metadata": metadata,
+        "object_references": metadata.get("object_references") or [],
+        "thread_references": metadata.get("thread_references") or [],
         "user_id": str(message.user_id) if message.user_id else None,
         "message_type": message.message_type,
         "created_at": _iso(message.created_at),
@@ -1122,13 +1115,26 @@ async def search_workspace(
         )
     ).all()
     for idea in ideas:
+        links = thread_link_payload(idea.id)
         results.append(
             {
-                "type": "idea",
+                "type": "thread",
                 "idea_id": str(idea.id),
+                "thread_id": str(idea.id),
                 "title": idea.title,
+                "display_title": idea.display_title,
                 "description": idea.description,
                 "status": idea.status,
+                "preview_summary": idea.preview_summary,
+                "preview_source": idea.preview_source,
+                **links,
+                "thread_reference": _thread_reference_snapshot(
+                    thread_id=idea.id,
+                    title=idea.display_title or idea.title,
+                    preview_summary=idea.preview_summary,
+                    preview_source=idea.preview_source,
+                    preview_updated_at=idea.preview_updated_at,
+                ),
                 "updated_at": _iso(idea.updated_at),
             }
         )
@@ -1137,7 +1143,7 @@ async def search_workspace(
     if remaining > 0:
         rows = (
             await session.execute(
-                select(IdeaThread, Idea.title.label("idea_title"))
+                select(IdeaThread, Idea)
                 .join(Idea, IdeaThread.idea_id == Idea.id)
                 .where(
                     Idea.org_id == principal.org_id,
@@ -1150,11 +1156,22 @@ async def search_workspace(
         ).all()
         for row in rows:
             thread = row[0]
+            idea = row[1]
+            links = thread_link_payload(thread.idea_id)
             results.append(
                 {
                     "type": "thread_message",
                     "idea_id": str(thread.idea_id),
-                    "idea_title": row.idea_title,
+                    "thread_id": str(thread.idea_id),
+                    "idea_title": idea.display_title or idea.title,
+                    **links,
+                    "thread_reference": _thread_reference_snapshot(
+                        thread_id=thread.idea_id,
+                        title=idea.display_title or idea.title,
+                        preview_summary=idea.preview_summary,
+                        preview_source=idea.preview_source,
+                        preview_updated_at=idea.preview_updated_at,
+                    ),
                     "thread_message_id": thread.id,
                     "role": thread.role,
                     "content": thread.content[:600],
@@ -1164,6 +1181,28 @@ async def search_workspace(
     return {"query": text, "results": results}
 
 
+def _thread_reference_snapshot(
+    *,
+    thread_id: Any,
+    title: Any,
+    preview_summary: Any = None,
+    preview_source: Any = None,
+    preview_updated_at: Any = None,
+) -> dict[str, Any]:
+    return {
+        "type": "thread_reference",
+        "object_type": "thread",
+        "object_id": str(thread_id),
+        "thread_id": str(thread_id),
+        "status": "available",
+        "title": str(title or "Untitled thread"),
+        "preview_summary": preview_summary,
+        "preview_source": preview_source,
+        "preview_updated_at": _iso(preview_updated_at),
+        **thread_link_payload(thread_id),
+    }
+
+
 async def get_thread(
     session: AsyncSession,
     principal: AgentBridgePrincipal,
@@ -1171,16 +1210,24 @@ async def get_thread(
     idea_id: str,
     limit: int = 100,
 ) -> dict[str, Any]:
-    idea = await _idea_for_org(session, idea_id=str(idea_id), org_id=principal.org_id)
+    thread_id = thread_id_from_reference(str(idea_id), allow_raw_id=True) or str(idea_id)
+    idea = await _idea_for_org(session, idea_id=thread_id, org_id=principal.org_id)
+    links = thread_link_payload(idea.id)
     return {
         "idea": {
             "id": str(idea.id),
+            "thread_id": str(idea.id),
             "title": idea.title,
+            "display_title": idea.display_title,
             "description": idea.description,
             "status": idea.status,
+            "preview_summary": idea.preview_summary,
+            "preview_source": idea.preview_source,
+            **links,
             "created_at": _iso(idea.created_at),
             "updated_at": _iso(idea.updated_at),
         },
+        "thread_reference": await thread_reference_payload(session, idea, include_handoff=True),
         "messages": await _thread_context(session, str(idea.id), limit=limit),
     }
 

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import importlib
 import json
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 from typing import Any, Mapping, Sequence
-from urllib.parse import urlsplit
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -26,6 +24,15 @@ from brain.platform.db.models.inbound import (
     InboundSourcePolicyRow,
 )
 from brain.systems.external_agents import service as external_agents
+from brain.systems.cortex.thread_links import (
+    thread_id_from_reference,
+    thread_link_payload,
+)
+from brain.systems.cortex.thread_read_model import (
+    deterministic_preview_summary,
+    refresh_thread_read_model,
+    thread_reference_payload,
+)
 from brain.systems.inbound.status import (
     STATUS_FAILED,
     STATUS_PROCESSED,
@@ -57,7 +64,6 @@ MAX_INBOUND_KIND_LENGTH = 40
 MAX_INBOUND_ORIGIN_LENGTH = 240
 MAX_TRIAGE_MESSAGE_CHARS = 8000
 MAX_TRIAGE_PAYLOAD_CHARS = 5000
-DEFAULT_PUBLIC_APP_URL = "http://localhost:8080"
 
 
 class InboundValidationError(ValueError):
@@ -1183,14 +1189,28 @@ async def _attach_context_to_thread(
     session.add(thread_message)
     await session.flush()
 
-    thread_url = _thread_url(thread)
-    thread_route = _thread_route(thread)
+    links = thread_link_payload(thread.id)
+    if not getattr(thread, "preview_summary", None):
+        preview = deterministic_preview_summary(
+            title=getattr(thread, "title", None),
+            intent=normalized.get("intent") or normalized.get("summary"),
+            source_tool=context.source_kind or context.display_name,
+        )
+        if preview:
+            await refresh_thread_read_model(
+                session,
+                thread,
+                preview_summary=preview,
+                preview_source="deterministic",
+            )
+    thread_ref = await thread_reference_payload(session, thread, include_handoff=True)
     action_result = {
         "operation": operation,
         "thread_id": str(thread.id),
-        "thread_url": thread_url,
-        "thread_route": thread_route,
-        "url": thread_url,
+        "thread_url": links["thread_url"],
+        "thread_route": links["thread_route"],
+        "url": links["thread_url"],
+        "thread_reference": thread_ref,
         "context_submission_id": str(submission.id),
         "thread_message_id": thread_message.id,
         "event_id": str(event.id),
@@ -1222,13 +1242,24 @@ async def _correlated_thread(
     context: _ConnectionContext,
     correlation: Mapping[str, Any],
 ) -> Idea | None:
-    thread_id = _clean_optional(correlation.get("thread_id") or correlation.get("idea_id"))
+    thread_id = _thread_id_from_correlation(correlation)
     if not thread_id:
         return None
     thread = await session.get(Idea, thread_id)
     if thread is None or str(thread.org_id) != str(context.org_id):
         raise InboundValidationError("correlation.thread_id does not match an accessible Thread")
     return thread
+
+
+def _thread_id_from_correlation(correlation: Mapping[str, Any]) -> str | None:
+    for key in ("thread_url", "url", "thread_route"):
+        thread_id = thread_id_from_reference(correlation.get(key))
+        if thread_id:
+            return thread_id
+    return thread_id_from_reference(
+        correlation.get("thread_id") or correlation.get("idea_id"),
+        allow_raw_id=True,
+    )
 
 
 def _context_timeline_preview(
@@ -1275,50 +1306,15 @@ def _context_part_preview(part: Any) -> str:
     return " - ".join(bits)
 
 
-def _public_app_base_url() -> str:
-    raw = (
-        os.environ.get("ILLO_PUBLIC_URL")
-        or os.environ.get("ILLO_DASHBOARD_URL")
-        or DEFAULT_PUBLIC_APP_URL
-    ).strip()
-    parsed = urlsplit(raw)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return DEFAULT_PUBLIC_APP_URL
-    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
-
-
-def _thread_route_for_id(thread_id: Any) -> str:
-    return f"/cortex?idea={thread_id}"
-
-
-def _thread_url_for_route(route: str) -> str:
-    return f"{_public_app_base_url()}{route}"
-
-
-def _thread_route(thread: Idea) -> str:
-    return _thread_route_for_id(thread.id)
-
-
-def _thread_url(thread: Idea) -> str:
-    return _thread_url_for_route(_thread_route(thread))
-
-
 def _with_thread_links(outcome: Mapping[str, Any]) -> dict[str, Any]:
     result = dict(outcome or {})
     thread_id = _clean_optional(result.get("thread_id") or result.get("idea_id"))
     if not thread_id:
         return result
-    route = _clean_optional(result.get("thread_route"))
-    existing_url = _clean_optional(result.get("url"))
-    if route is None and existing_url and existing_url.startswith("/"):
-        route = existing_url
-    route = route or _thread_route_for_id(thread_id)
-    thread_url = _clean_optional(result.get("thread_url"))
-    if thread_url is None or thread_url.startswith("/"):
-        thread_url = _thread_url_for_route(route)
-    result["thread_route"] = route
-    result["thread_url"] = thread_url
-    result["url"] = thread_url
+    links = thread_link_payload(thread_id)
+    result["thread_route"] = links["thread_route"]
+    result["thread_url"] = links["thread_url"]
+    result["url"] = links["thread_url"]
     return result
 
 

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -901,6 +901,13 @@ async def _update_thread_handoff_after_run_async(
         payload,
         user_id=user_id,
     ))
+    if run_id is not None:
+        try:
+            from brain.systems.cortex.thread_read_model import refresh_thread_read_model_for_run_id
+
+            await refresh_thread_read_model_for_run_id(run_id, payload)
+        except Exception as exc:
+            logger.debug("Agent %s: thread preview refresh failed: %s", session_id, exc)
     if fallback_error:
         logger.debug("Agent %s: post-run handoff fallback used: %s", session_id, fallback_error)
     logger.info(

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -154,6 +154,22 @@ export interface ChatAttachmentPayload {
   [key: string]: unknown;
 }
 
+export interface ObjectReferencePayload {
+  object_type: 'thread' | string;
+  status?: 'available' | 'unavailable' | string;
+  thread_id?: string | null;
+  title?: string | null;
+  preview_summary?: string | null;
+  preview_source?: string | null;
+  preview_updated_at?: string | null;
+  thread_route?: string | null;
+  thread_url?: string | null;
+  url?: string | null;
+  original_ref?: string | null;
+  handoff?: Record<string, any> | null;
+  [key: string]: unknown;
+}
+
 export interface ChatMessage {
   id: number;
   conversation_id: string;
@@ -168,6 +184,8 @@ export interface ChatMessage {
   reply_to_message_id: number | null;
   attachments: ChatAttachmentPayload[];
   metadata: Record<string, any> | null;
+  object_references: ObjectReferencePayload[];
+  thread_references: ObjectReferencePayload[];
   conversation_seq: number;
   reply_count: number;
   last_reply_at: string | null;
@@ -234,6 +252,8 @@ export interface ThreadDiscussionComment {
   body: string;
   attachments: ChatAttachmentPayload[];
   metadata: Record<string, any> | null;
+  object_references?: ObjectReferencePayload[];
+  thread_references?: ObjectReferencePayload[];
   created_at: string | null;
 }
 
@@ -969,6 +989,11 @@ export const api = {
   markAllNotificationsRead: () =>
     fetchJson<AppNotificationSummary>('/api/notifications/read-all', {
       method: 'POST',
+    }),
+  resolveLinkPreviews: (urls: string[]) =>
+    fetchJson<{ previews: ObjectReferencePayload[] }>('/api/link-previews/resolve', {
+      method: 'POST',
+      body: JSON.stringify({ urls }),
     }),
 
   // Cortex

--- a/frontend/src/lib/components/chat/ChatDock.svelte
+++ b/frontend/src/lib/components/chat/ChatDock.svelte
@@ -16,6 +16,7 @@
   import AttachmentPreviewDialog from '$lib/components/chat/AttachmentPreviewDialog.svelte';
   import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
+  import ThreadLinkPreviewCard from '$lib/features/threads/components/ThreadLinkPreviewCard.svelte';
   import type { ChatAttachmentItem, ChatAttachmentKind } from '$lib/components/chat/chatTypes';
   import {
     CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
@@ -1560,6 +1561,7 @@
                 {/if}
 
                 {@render messageLinkAttachmentList(message.body, message.attachments)}
+                {@render threadPreviewCards(message)}
               </article>
             {/each}
           {/if}
@@ -1701,6 +1703,7 @@
                 {/if}
 
                 {@render messageLinkAttachmentList(message.body, message.attachments)}
+                {@render threadPreviewCards(message)}
 
                 {#if shouldShowThreadSummary(message)}
                   <footer class="chat-thread-summary">
@@ -1847,6 +1850,7 @@
               {/if}
 
               {@render messageLinkAttachmentList(activeThreadRoot.body, activeThreadRoot.attachments)}
+              {@render threadPreviewCards(activeThreadRoot)}
             </article>
 
             {#if threadPage.hasMore}
@@ -1910,6 +1914,7 @@
                   {/if}
 
                   {@render messageLinkAttachmentList(reply.body, reply.attachments)}
+                  {@render threadPreviewCards(reply)}
                 </article>
               {/each}
             {/if}
@@ -1986,6 +1991,7 @@
     {/if}
 
     {@render messageLinkAttachmentList(message.body, message.attachments)}
+    {@render threadPreviewCards(message)}
   </article>
 {/snippet}
 
@@ -2069,6 +2075,16 @@
     <div class="chat-attachments chat-link-attachments">
       {#each linkAttachments as attachment (attachment.url)}
         {@render attachmentCard(attachment)}
+      {/each}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet threadPreviewCards(message: ChatMessage)}
+  {#if message.thread_references?.length}
+    <div class="chat-thread-link-previews">
+      {#each message.thread_references as reference (`${message.id}-${reference.thread_id ?? reference.original_ref ?? reference.url}`)}
+        <ThreadLinkPreviewCard {reference} compact />
       {/each}
     </div>
   {/if}
@@ -2178,6 +2194,12 @@
   --chat-drop-overlay-shadow:
     0 18px 42px rgba(0, 0, 0, 0.26),
     inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.chat-thread-link-previews {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .chat-dock-shell {

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -36,6 +36,7 @@
   } from '$lib/design-system/constellation';
   import type { CortexWorkspacePoint } from '$lib/features/workspace-scene/domain/workspacePoint';
   import { isLocalPreviewMemberId } from '$lib/utils/cortexLocalPreview';
+  import { threadRoute } from '$lib/features/threads/domain/threadLinks';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import { workspacePins } from '$lib/stores/workspacePins.svelte';
   import CortexLocalPreviewControls from '$lib/features/cortex/components/LocalPreviewControls.svelte';
@@ -88,8 +89,17 @@
   let workspacePageLoading = $state(false);
   let workspacePageLoadToken = 0;
   let lastRequestedIdeaId = $state<string | null>(null);
-  let initialDirectThreadIdeaId = $state<string | null>($page.url.searchParams.get('idea'));
-  let directThreadUrlPending = $state(Boolean($page.url.searchParams.get('idea')));
+  let lastSyncedThreadRoute = $state<string | null>(null);
+  function requestedThreadIdeaIdFromPage() {
+    return $page.params.threadId ?? $page.url.searchParams.get('idea');
+  }
+
+  function isThreadStageUrl() {
+    return $page.url.pathname.startsWith('/threads/') || Boolean($page.url.searchParams.get('idea'));
+  }
+
+  let initialDirectThreadIdeaId = $state<string | null>(requestedThreadIdeaIdFromPage());
+  let directThreadUrlPending = $state(Boolean(requestedThreadIdeaIdFromPage()));
   let lastAutoOpenedAppId = $state<string | null>(null);
   let threadStagePrewarmQueued = false;
   let CortexArchiveBinMenuComponent = $state<typeof import('$lib/features/cortex/components/ArchiveBinMenu.svelte').default | null>(null);
@@ -138,7 +148,7 @@
   }
 
   function runtimeReadyIntroIsDeferred() {
-    return isRuntimeReadyOnboardingUrl() && !$page.url.searchParams.get('idea');
+    return isRuntimeReadyOnboardingUrl() && !requestedThreadIdeaIdFromPage();
   }
 
   function runtimeReadyIntroOpenExisting() {
@@ -480,6 +490,14 @@
     const shouldRefreshWorkspaceSceneSidecars = directThreadActive || !workspaceSceneSidecarsReady;
     cortex.selectIdea(null);
     initialDirectThreadIdeaId = null;
+    lastSyncedThreadRoute = null;
+    if (browser && isThreadStageUrl()) {
+      void goto('/cortex', {
+        replaceState: true,
+        keepFocus: true,
+        noScroll: true,
+      });
+    }
     ensureWorkspaceRealtime();
     void cortex.loadTeamMembers();
     if (shouldRefreshWorkspaceSceneSidecars) {
@@ -880,7 +898,7 @@
   }
 
   async function maybeSelectIdeaFromUrl() {
-    const requestedIdeaId = $page.url.searchParams.get('idea');
+    const requestedIdeaId = requestedThreadIdeaIdFromPage();
     if (!requestedIdeaId) {
       directThreadUrlPending = false;
       return;
@@ -895,9 +913,24 @@
     }
     if (cortex.ideas.some((idea) => idea.id === requestedIdeaId)) {
       await cortex.selectIdea(requestedIdeaId);
+      syncCanonicalThreadUrl(requestedIdeaId);
     }
     clearRuntimeReadyOnboardingUrl();
     directThreadUrlPending = false;
+  }
+
+  function syncCanonicalThreadUrl(ideaId: string | null | undefined) {
+    if (!browser || !ideaId) return;
+    const nextRoute = threadRoute(ideaId);
+    const current = `${$page.url.pathname}${$page.url.search}${$page.url.hash}`;
+    lastSyncedThreadRoute = nextRoute;
+    if (current === nextRoute) return;
+    const replaceState = $page.url.pathname.startsWith('/threads/') || Boolean($page.url.searchParams.get('idea'));
+    void goto(nextRoute, {
+      replaceState,
+      keepFocus: true,
+      noScroll: true,
+    });
   }
 
   function ensureWorkspacePinsWs() {
@@ -935,6 +968,27 @@
   $effect(() => {
     if (
       !browser
+      || requestedThreadIdeaIdFromPage()
+      || directThreadUrlPending
+      || !cortex.panelOpen
+      || !lastSyncedThreadRoute
+    ) {
+      return;
+    }
+    lastSyncedThreadRoute = null;
+    initialDirectThreadIdeaId = null;
+    void cortex.selectIdea(null);
+    ensureWorkspaceRealtime();
+  });
+
+  $effect(() => {
+    if (!cortex.panelOpen || !cortex.selectedIdea?.id) return;
+    syncCanonicalThreadUrl(cortex.selectedIdea.id);
+  });
+
+  $effect(() => {
+    if (
+      !browser
       || runtimeReadyIntroHandled
       || runtimeReadyIntroStarting
       || !runtimeReadyIntroIsDeferred()
@@ -960,7 +1014,7 @@
   });
 
   onMount(() => {
-    const requestedIdeaId = $page.url.searchParams.get('idea');
+    const requestedIdeaId = requestedThreadIdeaIdFromPage();
     initialDirectThreadIdeaId = requestedIdeaId;
     directThreadUrlPending = Boolean(requestedIdeaId);
     cortex.setupWs();
@@ -972,6 +1026,7 @@
       if (requestedIdeaId) {
         lastRequestedIdeaId = requestedIdeaId;
         await cortex.loadDirectThread(requestedIdeaId);
+        syncCanonicalThreadUrl(requestedIdeaId);
         clearRuntimeReadyOnboardingUrl();
         directThreadUrlPending = false;
       } else {

--- a/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
+++ b/frontend/src/lib/features/cortex/realtime/cortexRealtimeEvents.ts
@@ -30,6 +30,7 @@ export const CORTEX_REALTIME_EVENT_TYPES = [
   'idea_created',
   'idea_upserted',
   'title_generated',
+  'thread_read_model_updated',
   'budget_approval_needed',
   'mention',
   'thought_split',
@@ -103,6 +104,16 @@ export type CortexRealtimePayloadByType = {
   idea_created: { idea_id?: string };
   idea_upserted: { idea?: Idea };
   title_generated: { idea_id?: string; title?: string };
+  thread_read_model_updated: {
+    idea_id?: string;
+    thread_id?: string;
+    title?: string | null;
+    preview_summary?: string | null;
+    preview_source?: string | null;
+    preview_updated_at?: string | null;
+    thread_route?: string | null;
+    thread_url?: string | null;
+  };
   budget_approval_needed: { summary?: string };
   mention: { idea_title?: string };
   thought_split: { children?: Idea[] };

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -4,6 +4,7 @@
   import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
   import ChatStateView from '$lib/components/chat/ChatStateView.svelte';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
+  import ThreadLinkPreviewCard from '$lib/features/threads/components/ThreadLinkPreviewCard.svelte';
   import {
     CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
     conversationIsNearBottom,
@@ -484,6 +485,13 @@
                 {/if}
               {/each}
             </p>
+            {#if comment.thread_references?.length}
+              <div class="discussion-thread-link-previews">
+                {#each comment.thread_references as reference (`${comment.id}-${reference.thread_id ?? reference.original_ref ?? reference.url}`)}
+                  <ThreadLinkPreviewCard {reference} compact />
+                {/each}
+              </div>
+            {/if}
           </article>
         {/each}
       </div>
@@ -660,6 +668,11 @@
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  .discussion-thread-link-previews {
+    display: grid;
+    gap: 8px;
   }
 
   .chat-mention {

--- a/frontend/src/lib/features/threads/components/ThreadLinkPreviewCard.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadLinkPreviewCard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { ConstellationIcon } from '$lib/components/constellation';
+  import type { ObjectReferencePayload } from '$lib/api/client';
+  import { threadRoute } from '$lib/features/threads/domain/threadLinks';
+
+  let {
+    reference,
+    compact = false,
+  }: {
+    reference: ObjectReferencePayload;
+    compact?: boolean;
+  } = $props();
+
+  const available = $derived(reference?.status !== 'unavailable');
+  const title = $derived(
+    available
+      ? String(reference?.title || 'Untitled thread')
+      : '',
+  );
+  const summary = $derived(
+    available
+      ? String(reference?.preview_summary || '').trim()
+      : '',
+  );
+  const href = $derived(
+    available
+      ? String(reference?.thread_route || reference?.url || (reference?.thread_id ? threadRoute(reference.thread_id) : '#'))
+      : '#',
+  );
+  const threadId = $derived(String(reference?.thread_id || '').trim());
+  const cardClass = $derived(
+    ['thread-link-preview-card', compact ? 'is-compact' : '', available ? 'is-available' : 'is-unavailable']
+      .filter(Boolean)
+      .join(' '),
+  );
+</script>
+
+{#if available}
+  <a class={cardClass} href={href} data-thread-id={threadId}>
+    <span class="thread-link-preview-icon" aria-hidden="true">
+      <ConstellationIcon name="link" size={14} stroke={1.9} />
+    </span>
+    <span class="thread-link-preview-copy">
+      <span class="thread-link-preview-kicker">Thread</span>
+      <strong>{title}</strong>
+      {#if summary}
+        <span>{summary}</span>
+      {/if}
+    </span>
+    <span class="thread-link-preview-action" aria-hidden="true">
+      <ConstellationIcon name="chevron-right" size={14} stroke={1.9} />
+    </span>
+  </a>
+{:else}
+  <div class={cardClass}>
+    <span class="thread-link-preview-icon" aria-hidden="true">
+      <ConstellationIcon name="link" size={14} stroke={1.9} />
+    </span>
+    <span class="thread-link-preview-copy">
+      <span class="thread-link-preview-kicker">Thread</span>
+      <span class="thread-link-preview-unavailable">Unavailable</span>
+    </span>
+  </div>
+{/if}
+
+<style>
+  .thread-link-preview-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    width: min(100%, 560px);
+    margin-top: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--thread-link-preview-border, rgba(255, 255, 255, 0.08));
+    border-radius: 8px;
+    background: var(--thread-link-preview-background, rgba(255, 255, 255, 0.035));
+    color: var(--thread-link-preview-text, rgba(240, 240, 250, 0.9));
+    text-decoration: none;
+    transition:
+      border-color 160ms ease,
+      background 160ms ease,
+      transform 160ms ease;
+  }
+
+  .thread-link-preview-card.is-compact {
+    padding: 9px 10px;
+    gap: 8px;
+  }
+
+  .thread-link-preview-card.is-available:hover {
+    border-color: var(--thread-link-preview-hover-border, rgba(141, 183, 255, 0.28));
+    background: var(--thread-link-preview-hover-background, rgba(141, 183, 255, 0.075));
+    transform: translateY(-1px);
+  }
+
+  .thread-link-preview-card.is-unavailable {
+    opacity: 0.72;
+  }
+
+  .thread-link-preview-icon {
+    display: inline-grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: var(--thread-link-preview-icon-background, rgba(141, 183, 255, 0.09));
+    color: var(--thread-link-preview-icon-text, rgba(171, 203, 255, 0.92));
+  }
+
+  .thread-link-preview-copy {
+    display: grid;
+    min-width: 0;
+    gap: 3px;
+  }
+
+  .thread-link-preview-kicker {
+    color: var(--thread-link-preview-muted, rgba(240, 240, 250, 0.42));
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  .thread-link-preview-copy strong {
+    overflow: hidden;
+    color: var(--thread-link-preview-title, rgba(255, 255, 255, 0.92));
+    font-size: 0.9rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .thread-link-preview-unavailable {
+    color: var(--thread-link-preview-summary, rgba(240, 240, 250, 0.58));
+    font-size: 0.86rem;
+    font-weight: 650;
+    line-height: 1.25;
+  }
+
+  .thread-link-preview-copy span:last-child:not(.thread-link-preview-kicker):not(.thread-link-preview-unavailable) {
+    display: -webkit-box;
+    overflow: hidden;
+    color: var(--thread-link-preview-summary, rgba(240, 240, 250, 0.58));
+    font-size: 0.8rem;
+    line-height: 1.35;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .thread-link-preview-action {
+    color: var(--thread-link-preview-muted, rgba(240, 240, 250, 0.42));
+  }
+
+  :global(:root[data-color-scheme='light']) .thread-link-preview-card {
+    --thread-link-preview-border: rgba(24, 35, 49, 0.08);
+    --thread-link-preview-background: rgba(255, 255, 255, 0.58);
+    --thread-link-preview-hover-border: rgba(49, 95, 214, 0.2);
+    --thread-link-preview-hover-background: rgba(255, 255, 255, 0.82);
+    --thread-link-preview-text: rgba(28, 40, 53, 0.9);
+    --thread-link-preview-title: rgba(18, 27, 36, 0.94);
+    --thread-link-preview-summary: rgba(82, 98, 111, 0.78);
+    --thread-link-preview-muted: rgba(82, 98, 111, 0.56);
+    --thread-link-preview-icon-background: rgba(49, 95, 214, 0.08);
+    --thread-link-preview-icon-text: rgba(49, 95, 214, 0.88);
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -48,6 +48,7 @@
     type ThreadStageRightDockTab,
   } from '$lib/features/threads/controllers/threadSidePanelController';
   import { threadStreamController } from '$lib/features/threads/controllers/threadStreamController';
+  import { threadUrl } from '$lib/features/threads/domain/threadLinks';
   import {
     findSlashCommandToken,
     replaceSlashCommandToken,
@@ -175,6 +176,7 @@
   let threadStageGutterPx = $state(24);
   let titleGenerating = $state(false);
   let threadArchiving = $state(false);
+  let threadLinkCopying = $state(false);
 
   const THREAD_STAGE_MIN_THREAD_WIDTH = 380;
   const THREAD_STAGE_DEFAULT_GUTTER = 24;
@@ -302,6 +304,9 @@
       title: ideaDisplayTitle(selectedIdea),
       statusLabel,
       statusState: headerStatusState,
+      linkActionLabel: threadLinkCopying ? 'Thread link copied' : 'Copy thread link',
+      linkActionLoading: threadLinkCopying,
+      onLinkAction: () => void copyThreadLink(),
       titleActionLabel: titleGenerating ? 'Generating a new thread title' : 'Generate a new thread title',
       titleActionLoading: titleGenerating,
       onTitleAction: () => void regenerateThreadTitle(),
@@ -418,6 +423,23 @@
       ui.toast(err?.detail || err?.message || 'Failed to refresh thread title', 'error');
     } finally {
       titleGenerating = false;
+    }
+  }
+
+  async function copyThreadLink() {
+    const selectedIdea = idea;
+    if (!selectedIdea?.id || threadLinkCopying) return;
+    const value = selectedIdea.thread_url || threadUrl(selectedIdea.id);
+    threadLinkCopying = true;
+    try {
+      await navigator.clipboard.writeText(value);
+      ui.toast('Thread link copied', 'success');
+    } catch {
+      ui.toast(value, 'info');
+    } finally {
+      window.setTimeout(() => {
+        threadLinkCopying = false;
+      }, 900);
     }
   }
 

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -18,6 +18,7 @@
   } from '$lib/utils/attachmentPreview';
   import StreamVisualBlock from '$lib/features/threads/components/StreamVisualBlock.svelte';
   import ThreadAuthorMark from '$lib/features/threads/components/ThreadAuthorMark.svelte';
+  import ThreadLinkPreviewCard from '$lib/features/threads/components/ThreadLinkPreviewCard.svelte';
 
   import {
     getCortexThreadRunStatusGlyph,
@@ -285,6 +286,18 @@
         />
         <h1 class="thread-header-title" title={header.title}>{header.title}</h1>
 
+        {#if header.onLinkAction}
+          <ConstellationIconButton
+            label={header.linkActionLabel ?? 'Copy thread link'}
+            title={header.linkActionLabel ?? 'Copy thread link'}
+            className={`thread-header-action-button thread-link-action-button ${header.linkActionLoading ? 'is-loading' : ''}`}
+            disabled={header.linkActionLoading}
+            onclick={header.onLinkAction}
+          >
+            <ConstellationIcon name="link" size={13} stroke={1.9} />
+          </ConstellationIconButton>
+        {/if}
+
         {#if header.onTitleAction}
           <ConstellationIconButton
             label={header.titleActionLabel ?? 'Generate a new thread title'}
@@ -459,6 +472,14 @@
                           </span>
                         </button>
                       {/if}
+                    {/each}
+                  </div>
+                {/if}
+
+                {#if item.threadReferences && item.threadReferences.length > 0}
+                  <div class="thread-message-thread-previews">
+                    {#each item.threadReferences as reference (`${reference.thread_id ?? reference.original_ref ?? reference.url}`)}
+                      <ThreadLinkPreviewCard {reference} />
                     {/each}
                   </div>
                 {/if}
@@ -1430,6 +1451,11 @@
   .thread-message-attachments {
     display: grid;
     gap: 10px;
+  }
+
+  .thread-message-thread-previews {
+    display: grid;
+    gap: 8px;
   }
 
   .thread-message-image-button {

--- a/frontend/src/lib/features/threads/domain/threadLinks.ts
+++ b/frontend/src/lib/features/threads/domain/threadLinks.ts
@@ -1,0 +1,39 @@
+import { browser } from '$app/environment';
+
+export function encodeThreadId(threadId: string | number): string {
+  return encodeURIComponent(String(threadId));
+}
+
+export function threadRoute(threadId: string | number): string {
+  return `/threads/${encodeThreadId(threadId)}`;
+}
+
+export function threadUrl(threadId: string | number): string {
+  const route = threadRoute(threadId);
+  if (!browser) return route;
+  return `${window.location.origin}${route}`;
+}
+
+export function threadIdFromPath(pathname: string): string | null {
+  const match = /^\/threads\/([^/?#]+)/.exec(pathname || '');
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function threadIdFromReference(value: string | null | undefined): string | null {
+  const text = String(value || '').trim();
+  if (!text) return null;
+  try {
+    const parsed = new URL(text, browser ? window.location.origin : 'http://illo.local');
+    const threadId = threadIdFromPath(parsed.pathname);
+    if (threadId) return threadId;
+    if (parsed.pathname === '/cortex') return parsed.searchParams.get('idea');
+  } catch {
+    if (text.startsWith('/threads/')) return threadIdFromPath(text);
+  }
+  return null;
+}

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -366,6 +366,8 @@ function mapThreadMessageItem(
     ownerColor: userAccent ? mixHex(userAccent, userOwnerText, themeMode === 'light' ? 0.22 : 0.78) : undefined,
     html: item.content ? renderReadableMarkdown(item.content) : undefined,
     attachments: attachments.length ? attachments : undefined,
+    objectReferences: Array.isArray(item.object_references) ? item.object_references : undefined,
+    threadReferences: Array.isArray(item.thread_references) ? item.thread_references : undefined,
     inlineWithWork: inlineWithWork || undefined,
   };
 }

--- a/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
@@ -2,6 +2,7 @@ import type { Snippet } from 'svelte';
 
 import type { AttachmentPreviewKind } from '$lib/utils/attachmentPreview';
 import type { RunEvidenceDebug } from '$lib/utils/runEvidenceDebug';
+import type { ObjectReferencePayload } from '$lib/types/cortex';
 import { CORTEX_THREAD_STAGE_RUN_STATUSES } from '../../../constants/statuses.ts';
 
 export const CORTEX_THREAD_STAGE_TONES = ['spectral', 'amber'] as const;
@@ -32,6 +33,9 @@ export interface CortexThreadStageHeaderConfig {
   titleActionLabel?: string;
   titleActionLoading?: boolean;
   onTitleAction?: () => void;
+  linkActionLabel?: string;
+  linkActionLoading?: boolean;
+  onLinkAction?: () => void;
   archiveActionLabel?: string;
   archiveActionLoading?: boolean;
   onArchiveAction?: () => void;
@@ -69,6 +73,8 @@ export interface CortexThreadStageMessageItem {
   paragraphs?: readonly string[];
   sections?: readonly CortexThreadStageMessageSection[];
   attachments?: readonly CortexThreadStageAttachmentItem[];
+  objectReferences?: readonly ObjectReferencePayload[];
+  threadReferences?: readonly ObjectReferencePayload[];
   inlineWithWork?: boolean;
 }
 

--- a/frontend/src/lib/stores/chat.svelte.ts
+++ b/frontend/src/lib/stores/chat.svelte.ts
@@ -110,6 +110,8 @@ function cloneUnreadSummary(summary?: Partial<ChatUnreadSummary> | null): ChatUn
 function normalizeMessage(message: ChatMessageRecord): ChatMessage {
   return {
     ...message,
+    object_references: Array.isArray(message.object_references) ? message.object_references : [],
+    thread_references: Array.isArray(message.thread_references) ? message.thread_references : [],
     optimistic: false,
     failed: false,
     error: null,
@@ -1388,6 +1390,8 @@ class ChatStore {
       reply_to_message_id: input.replyToMessageId,
       attachments: input.attachments,
       metadata: input.metadata,
+      object_references: [],
+      thread_references: [],
       conversation_seq: lastSequence + 1,
       reply_count: 0,
       last_reply_at: null,

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -623,6 +623,10 @@ class CortexStore {
     this.ideas = patchIdeaById(this.ideas, id, patch);
   }
 
+  _setIdeaReadModelPatch(id: string, patch: Partial<Idea>) {
+    this._setIdeaPatch(id, patch);
+  }
+
   private _upsertIdea(idea: Idea) {
     const normalized = this._normalizeIdea(idea);
     if (normalized.archived_at) this._registerArchivedIdea(normalized);

--- a/frontend/src/lib/stores/cortexRealtime.ts
+++ b/frontend/src/lib/stores/cortexRealtime.ts
@@ -52,6 +52,7 @@ export interface CortexRealtimeStoreBindings {
   _handleVaultSecretPrompt(msg: any): void;
   _handleVaultAgentGrantPrompt(msg: any): void;
   _upsertIdea(idea: Idea): void;
+  _setIdeaReadModelPatch(id: string, patch: Partial<Idea>): void;
   _registerArchivedIdea(idea: Pick<Idea, 'id' | 'user_id'> | null | undefined): void;
   _rememberArchivedIdea(idea: Idea | null | undefined): void;
 }
@@ -325,6 +326,21 @@ export function setupCortexRealtimeBindings(options: {
           i.id === msg.idea_id ? { ...i, display_title: msg.title } : i,
         );
       }
+    }),
+  );
+
+  unsubs.push(
+    wsClient.on('thread_read_model_updated', (msg) => {
+      const ideaId = String(msg.idea_id ?? msg.thread_id ?? '').trim();
+      if (!ideaId) return;
+      store._setIdeaReadModelPatch(ideaId, {
+        ...(msg.title ? { display_title: msg.title } : {}),
+        preview_summary: msg.preview_summary ?? null,
+        preview_source: msg.preview_source ?? null,
+        preview_updated_at: msg.preview_updated_at ?? null,
+        thread_route: msg.thread_route ?? undefined,
+        thread_url: msg.thread_url ?? undefined,
+      });
     }),
   );
 

--- a/frontend/src/lib/types/cortex.ts
+++ b/frontend/src/lib/types/cortex.ts
@@ -23,7 +23,28 @@ export interface Idea {
   _agents?: number;
   project_context?: Record<string, any> | null;
   agent_details?: Record<string, any> | null;
+  preview_summary?: string | null;
+  preview_source?: string | null;
+  preview_updated_at?: string | null;
+  thread_route?: string | null;
+  thread_url?: string | null;
   metadata?: Record<string, any> | null;
+}
+
+export interface ObjectReferencePayload {
+  object_type: 'thread' | string;
+  status?: 'available' | 'unavailable' | string;
+  thread_id?: string | null;
+  title?: string | null;
+  preview_summary?: string | null;
+  preview_source?: string | null;
+  preview_updated_at?: string | null;
+  thread_route?: string | null;
+  thread_url?: string | null;
+  url?: string | null;
+  original_ref?: string | null;
+  handoff?: Record<string, any> | null;
+  [key: string]: unknown;
 }
 
 export interface StreamItem {
@@ -35,6 +56,8 @@ export interface StreamItem {
   content?: string;
   attachments?: any[];
   metadata?: Record<string, any>;
+  object_references?: ObjectReferencePayload[];
+  thread_references?: ObjectReferencePayload[];
   user_id?: string;
   user_name?: string;
   user_color?: string;

--- a/frontend/src/routes/threads/[threadId]/+page.svelte
+++ b/frontend/src/routes/threads/[threadId]/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import CortexWorkspaceRoute from '$lib/features/cortex/components/CortexWorkspaceRoute.svelte';
+</script>
+
+<CortexWorkspaceRoute />

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -32,6 +32,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0009_org_owned_provider_credentials.py",
     # Downgrade removes only the Cycle memory tables introduced by this migration.
     "0013_cycle_memory_primitives.py",
+    # Downgrade removes only the object-reference table introduced by this migration.
+    "0016_thread_urls_object_references.py",
 }
 
 

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -500,6 +500,64 @@ async def test_hosted_mcp_filters_tools_by_bridge_token_scope():
     }
 
 
+async def test_hosted_mcp_get_thread_accepts_canonical_thread_url():
+    session = _AsyncSession()
+    thread_id = "77777777-7777-4777-8777-777777777777"
+    captured: dict[str, object] = {}
+
+    async def fake_get_thread(db, principal, *, idea_id, limit):
+        captured["db"] = db
+        captured["principal"] = principal
+        captured["idea_id"] = idea_id
+        captured["limit"] = limit
+        return {
+            "idea": {"id": idea_id, "thread_id": idea_id},
+            "thread_reference": {
+                "type": "thread_reference",
+                "object_type": "thread",
+                "object_id": idea_id,
+                "thread_id": idea_id,
+                "thread_route": f"/threads/{idea_id}",
+                "thread_url": f"https://illo.example.com/threads/{idea_id}",
+                "status": "available",
+                "title": "Shared thread",
+            },
+            "messages": [],
+        }
+
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+        return_value=_principal(),
+    ), patch(
+        "brain.app.api.routers.agent_mcp.external_agents.get_thread",
+        new=AsyncMock(side_effect=fake_get_thread),
+    ):
+        response = await _request(
+            "POST",
+            "/mcp",
+            session=session,
+            headers={"Authorization": "Bearer bridge-token"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {
+                    "name": "illo_get_thread",
+                    "arguments": {
+                        "thread_url": f"https://illo.example.com/threads/{thread_id}",
+                        "limit": 7,
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    assert captured["idea_id"] == thread_id
+    assert captured["limit"] == 7
+    assert payload["thread_reference"]["thread_route"] == f"/threads/{thread_id}"
+
+
 async def test_hosted_mcp_submit_context_builds_shared_envelope():
     session = _AsyncSession()
     captured: dict[str, object] = {}

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -914,9 +914,9 @@ async def test_context_envelope_attaches_to_correlated_thread_and_replays_idempo
 
     assert first["ilo_outcome"]["operation"] == "attached"
     assert first["ilo_outcome"]["thread_id"] == str(thread.id)
-    assert first["ilo_outcome"]["thread_url"] == f"https://illo.example.com/cortex?idea={thread.id}"
+    assert first["ilo_outcome"]["thread_url"] == f"https://illo.example.com/threads/{thread.id}"
     assert first["ilo_outcome"]["url"] == first["ilo_outcome"]["thread_url"]
-    assert first["ilo_outcome"]["thread_route"] == f"/cortex?idea={thread.id}"
+    assert first["ilo_outcome"]["thread_route"] == f"/threads/{thread.id}"
     assert replay["idempotent_replay"] is True
     assert replay["ilo_outcome"]["thread_url"] == first["ilo_outcome"]["thread_url"]
     assert replay["ilo_outcome"]["thread_route"] == first["ilo_outcome"]["thread_route"]

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -62,6 +62,7 @@ EXPECTED_TABLES = {
     "memory_summaries",
     "narrative_sessions",
     "notification_events",
+    "object_references",
     "org_api_keys",
     "org_provider_model_mappings",
     "orgs",

--- a/tests/test_thread_url_references.py
+++ b/tests/test_thread_url_references.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from brain.systems.cortex.thread_links import (
+    canonicalize_thread_reference,
+    extract_thread_reference_values,
+    thread_id_from_reference,
+    thread_link_payload,
+    thread_route_for_id,
+    thread_url_for_id,
+)
+from brain.systems.cortex.thread_read_model import (
+    compact_handoff_context,
+    preview_summary_from_handoff,
+    unavailable_thread_reference,
+)
+from brain.systems.cortex.object_references import store_object_references_for_source
+
+
+THREAD_ID = "77777777-7777-4777-8777-777777777777"
+
+
+def test_thread_link_payload_uses_canonical_thread_route(monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com/app")
+
+    assert thread_route_for_id(THREAD_ID) == f"/threads/{THREAD_ID}"
+    assert thread_url_for_id(THREAD_ID) == f"https://illo.example.com/threads/{THREAD_ID}"
+    assert thread_link_payload(THREAD_ID) == {
+        "thread_id": THREAD_ID,
+        "thread_route": f"/threads/{THREAD_ID}",
+        "thread_url": f"https://illo.example.com/threads/{THREAD_ID}",
+        "url": f"https://illo.example.com/threads/{THREAD_ID}",
+    }
+
+
+def test_thread_reference_parser_accepts_canonical_and_legacy_urls():
+    assert thread_id_from_reference(f"https://illo.example.com/threads/{THREAD_ID}") == THREAD_ID
+    assert thread_id_from_reference(f"/threads/{THREAD_ID}") == THREAD_ID
+    assert thread_id_from_reference(f"https://illo.example.com/cortex?idea={THREAD_ID}") == THREAD_ID
+    assert thread_id_from_reference(f"/cortex?idea={THREAD_ID}.") == THREAD_ID
+    assert thread_id_from_reference(THREAD_ID) is None
+    assert thread_id_from_reference(THREAD_ID, allow_raw_id=True) == THREAD_ID
+
+
+def test_canonicalize_thread_reference_preserves_original_ref(monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com")
+    payload = canonicalize_thread_reference(f"/cortex?idea={THREAD_ID}")
+
+    assert payload is not None
+    assert payload["original_ref"] == f"/cortex?idea={THREAD_ID}"
+    assert payload["thread_route"] == f"/threads/{THREAD_ID}"
+    assert payload["thread_url"] == f"https://illo.example.com/threads/{THREAD_ID}"
+
+
+def test_extract_thread_reference_values_finds_embedded_urls():
+    text = (
+        f"Compare https://illo.example.com/threads/{THREAD_ID} "
+        f"with /cortex?idea={THREAD_ID}."
+    )
+
+    assert extract_thread_reference_values(text) == [
+        f"https://illo.example.com/threads/{THREAD_ID}",
+        f"/cortex?idea={THREAD_ID}",
+    ]
+
+
+def test_preview_summary_from_handoff_compacts_runtime_checkpoint():
+    handoff = {
+        "found": True,
+        "run_id": 123,
+        "updated_at": "2026-06-01T12:00:00+00:00",
+        "message_count": 42,
+        "summary": {
+            "checkpoint": {
+                "active_objective": "Ship canonical Thread URLs.",
+                "recent_user_intent": "Make Thread references native everywhere.",
+                "current_state": "Backend read model is wired; frontend previews are next.",
+                "verification_status": "Focused checks still need to run.",
+                "current_plan": ["Wire cards across chat surfaces."],
+                "completed_work": ["Added canonical URL helpers."],
+                "open_questions": [],
+            }
+        },
+    }
+
+    assert preview_summary_from_handoff(handoff) == (
+        "Ship canonical Thread URLs. Make Thread references native everywhere. "
+        "Backend read model is wired; frontend previews are next. Focused checks still need to run."
+    )
+    assert compact_handoff_context(handoff) == {
+        "run_id": 123,
+        "updated_at": "2026-06-01T12:00:00+00:00",
+        "message_count": 42,
+        "checkpoint": {
+            "active_objective": "Ship canonical Thread URLs.",
+            "recent_user_intent": "Make Thread references native everywhere.",
+            "current_state": "Backend read model is wired; frontend previews are next.",
+            "verification_status": "Focused checks still need to run.",
+            "current_plan": ["Wire cards across chat surfaces."],
+            "completed_work": ["Added canonical URL helpers."],
+        },
+    }
+
+
+def test_unavailable_thread_reference_does_not_leak_title_or_summary():
+    payload = unavailable_thread_reference(
+        original_ref=f"https://illo.example.com/threads/{THREAD_ID}",
+        thread_id=THREAD_ID,
+    )
+
+    assert payload["type"] == "thread_reference"
+    assert payload["object_type"] == "thread"
+    assert payload["object_id"] == THREAD_ID
+    assert payload["thread_id"] == THREAD_ID
+    assert payload["status"] == "unavailable"
+    assert payload["title"] is None
+    assert payload["preview_summary"] is None
+
+
+async def test_storing_text_without_thread_links_does_not_touch_session():
+    class SessionWithoutPersistence:
+        pass
+
+    references = await store_object_references_for_source(
+        SessionWithoutPersistence(),
+        source_type="chat_message",
+        source_id="123",
+        org_id="77777777-7777-4777-8777-777777777777",
+        text="Plain message with no thread links.",
+    )
+
+    assert references == []


### PR DESCRIPTION
## Summary

- add canonical authenticated Thread URLs at `/threads/<thread_id>` with legacy `/cortex?idea=<id>` compatibility
- add backend Thread link parsing, object-reference persistence, link-preview resolution, and durable Thread preview read-model fields
- wire Thread reference payloads through Cortex APIs, native chat, Thread Discussion, inbound context, MCP/personal-agent tools, and Illo trigger context
- add shared frontend Thread preview cards across Thread Stage transcript, team chat, room-message replies, and Thread Discussion
- refresh preview summaries from deterministic Thread activity and durable handoff/run lifecycle updates

## Validation

- `PYTHONPATH=/private/tmp/illospace_pytest_deps python3 -m pytest tests/test_thread_url_references.py tests/test_inbound_webhooks.py::test_context_envelope_attaches_to_correlated_thread_and_replays_idempotently tests/test_external_agent_routes.py::test_hosted_mcp_get_thread_accepts_canonical_thread_url tests/test_external_agent_routes.py::test_hosted_mcp_create_thread_commits_before_broadcasting tests/test_external_agent_routes.py::test_hosted_mcp_create_thread_routes_trigger_when_requested`
- `python3 -m py_compile ...` for touched backend/test files
- `npm run check`
- `npm run build`
- `git diff --check`

Closes #183
