### PR TITLE
Report Slack socket token failures

### DIFF
--- a/brain/app/cli/slack_connector.py
+++ b/brain/app/cli/slack_connector.py
@@ -8,7 +8,11 @@ import json
 import logging
 import sys
 
-from brain.systems.slack.connector import SlackConnectorConfig, run_forever
+from brain.systems.slack.connector import (
+    SlackConnectorConfig,
+    run_forever,
+    validate_slack_connector_tokens,
+)
 
 
 def _redacted(value: str) -> str:
@@ -34,8 +38,12 @@ def build_parser() -> argparse.ArgumentParser:
 async def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
-    config = await SlackConnectorConfig.from_runtime()
     if args.check:
+        config = await SlackConnectorConfig.from_runtime()
+        validate_slack_connector_tokens(
+            bot_token=config.bot_token,
+            app_token=config.app_token,
+        )
         print(
             json.dumps(
                 {

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -104,6 +104,19 @@ class SlackConnectorConfig:
         )
 
 
+def validate_slack_connector_tokens(*, bot_token: str, app_token: str) -> None:
+    bot = str(bot_token or "").strip()
+    app = str(app_token or "").strip()
+    if bot.startswith("xapp-"):
+        raise SlackConfigurationError(
+            "Slack bot token must be a bot token, not an app-level Socket Mode token"
+        )
+    if app.startswith(("xoxb-", "xoxp-")):
+        raise SlackConfigurationError(
+            "Slack app-level Socket Mode token must be an app-level token, not a bot/user token"
+        )
+
+
 def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -413,7 +426,21 @@ async def run_socket_mode_loop(
         session_factory=session_factory,
         connection_factory=connection_factory,
     )
-    socket_url = config.socket_mode_url or await open_socket_mode_url(config)
+    try:
+        validate_slack_connector_tokens(
+            bot_token=config.bot_token,
+            app_token=config.app_token,
+        )
+        socket_url = config.socket_mode_url or await open_socket_mode_url(config)
+    except Exception as exc:
+        await _ensure_runtime_connection(
+            config,
+            status="error",
+            last_error=str(exc),
+            session_factory=session_factory,
+            connection_factory=connection_factory,
+        )
+        raise
     logger.info("slack_socket_mode_connecting")
     async with websockets.connect(socket_url) as websocket:
         logger.info("slack_socket_mode_connected")
@@ -443,6 +470,7 @@ async def _ensure_runtime_connection(
     config: SlackConnectorConfig,
     *,
     status: str,
+    last_error: str | None = None,
     session_factory=None,
     connection_factory=None,
 ) -> tuple[ExternalAgentConnectionRow, SlackConnectorConfig]:
@@ -453,12 +481,22 @@ async def _ensure_runtime_connection(
                 if connection is None:
                     raise SlackConfigurationError("Slack connection factory returned no connection")
                 return connection, config
-            return await ensure_slack_connection_for_config(session, config, status=status)
+            return await ensure_slack_connection_for_config(
+                session,
+                config,
+                status=status,
+                last_error=last_error,
+            )
 
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
     async with UnitOfWork() as uow:
-        return await ensure_slack_connection_for_config(uow.session, config, status=status)
+        return await ensure_slack_connection_for_config(
+            uow.session,
+            config,
+            status=status,
+            last_error=last_error,
+        )
 
 
 async def _process_runtime_socket_payload(
@@ -539,4 +577,5 @@ __all__ = [
     "open_socket_mode_url",
     "run_socket_mode_loop",
     "run_forever",
+    "validate_slack_connector_tokens",
 ]

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -13,7 +13,8 @@ public Slack Events API endpoint.
 4. Save `SLACK_BOT_TOKEN` to Illospace Vault, or set it as an environment
    variable for the connector process.
 5. Save `SLACK_APP_TOKEN` to Illospace Vault, or set it as an environment
-   variable for the connector process.
+   variable for the connector process. This must be a Slack app-level Socket
+   Mode token, usually prefixed `xapp-`; do not reuse the bot token here.
 6. Start the connector process:
 
 ```bash
@@ -54,6 +55,9 @@ Optional Slack hints:
   message events as trigger sources because Slack can also deliver the same
   human mention as `app_mention`.
 - Socket Mode envelopes are acknowledged before durable inbound processing.
+- The connector records durable health while it connects. If the app-level
+  Socket Mode token is wrong or Slack rejects the connection, `manage_slack`
+  reports the connection as `error` instead of leaving it looking configured.
 - Actionable Slack events are stored as inbound events with kind
   `slack_message`.
 - Slack-origin runs receive normal Illospace tools plus:

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -947,6 +947,88 @@ def test_slack_connector_config_requires_socket_mode_tokens(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slack_connector_marks_connection_error_when_socket_open_fails(session, monkeypatch):
+    from brain.systems.slack import connector
+    from brain.systems.slack.client import SlackApiError
+
+    session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    await session.flush()
+
+    class _SessionFactory:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        def __call__(self):
+            return self
+
+    async def open_socket_mode_url(_config):
+        raise SlackApiError("not_allowed_token_type")
+
+    monkeypatch.setattr(connector, "open_socket_mode_url", open_socket_mode_url)
+
+    with pytest.raises(SlackApiError, match="not_allowed_token_type"):
+        await connector.run_socket_mode_loop(
+            config=connector.SlackConnectorConfig(
+                bot_token="xoxb-test",
+                app_token="xapp-test",
+                org_id=ORG_ID,
+                owner_user_id=USER_ID,
+                team_id="T789",
+                bot_user_id="BILLO",
+            ),
+            session_factory=_SessionFactory(),
+        )
+
+    connection = (await session.scalars(select(ExternalAgentConnectionRow))).one()
+    assert connection.status == "error"
+    assert connection.last_error == "not_allowed_token_type"
+    assert connection.metadata_["health"]["status"] == "error"
+    assert connection.metadata_["health"]["last_error"] == "not_allowed_token_type"
+
+
+@pytest.mark.asyncio
+async def test_slack_connector_reports_bot_token_used_as_app_token(session):
+    from brain.systems.slack import connector
+    from brain.systems.slack.client import SlackConfigurationError
+
+    session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    await session.flush()
+
+    class _SessionFactory:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        def __call__(self):
+            return self
+
+    with pytest.raises(SlackConfigurationError, match="app-level Socket Mode token"):
+        await connector.run_socket_mode_loop(
+            config=connector.SlackConnectorConfig(
+                bot_token="xoxb-test",
+                app_token="xoxb-wrong-token",
+                org_id=ORG_ID,
+                owner_user_id=USER_ID,
+                team_id="T789",
+                bot_user_id="BILLO",
+            ),
+            session_factory=_SessionFactory(),
+        )
+
+    connection = (await session.scalars(select(ExternalAgentConnectionRow))).one()
+    assert connection.status == "error"
+    assert "app-level Socket Mode token" in str(connection.last_error)
+    assert connection.metadata_["health"]["status"] == "error"
+
+
+@pytest.mark.asyncio
 async def test_slack_connection_health_record_uses_env_backed_tokens(session):
     from brain.systems.slack.connector import ensure_slack_connection
 


### PR DESCRIPTION
## Summary
- validate Slack token roles before opening Socket Mode, especially bot tokens accidentally saved as app-level tokens
- persist connector health as error when Socket Mode open fails so manage_slack no longer reports a deaf connector as merely configured
- let the long-running connector retry instead of doing a one-time preflight load in the CLI startup path

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py -q
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_runtime_settings.py tests/test_safe_deploy.py -q