### PR TITLE
Teach Illo runtime Thread URLs

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -405,21 +405,21 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
     },
     "manage_idea": {
         "list": {"required": [], "optional": ["status", "search", "include_archived", "limit"], "effect": "read Cortex thoughts"},
-        "get": {"required": ["idea_id unless a current thread is bound"], "optional": [], "effect": "read one thought"},
+        "get": {"required": ["idea_id/thread_url unless a current thread is bound"], "optional": [], "effect": "read one thought"},
         "create": {
             "required": ["title"],
             "optional": ["thread_message", "description", "status", "start_run", "parent_id", "user_id"],
             "effect": "create a Cortex thought with an Illo-authored seed message; user_id assigns the owner",
         },
         "update": {
-            "required": ["idea_id unless a current thread is bound", "at least one changed field"],
+            "required": ["idea_id/thread_url unless a current thread is bound", "at least one changed field"],
             "optional": ["title", "display_title", "description", "status", "position_x", "position_y", "user_id"],
             "effect": "update thought metadata",
         },
-        "archive": {"required": ["idea_id unless a current thread is bound"], "optional": [], "effect": "archive a thought"},
-        "restore": {"required": ["idea_id"], "optional": [], "effect": "restore an archived thought"},
-        "set_status": {"required": ["idea_id unless a current thread is bound", "status"], "optional": [], "effect": "change status"},
-        "mark_read": {"required": ["idea_id unless a current thread is bound"], "optional": [], "effect": "mark a thought read"},
+        "archive": {"required": ["idea_id/thread_url unless a current thread is bound"], "optional": [], "effect": "archive a thought"},
+        "restore": {"required": ["idea_id/thread_url"], "optional": [], "effect": "restore an archived thought"},
+        "set_status": {"required": ["idea_id/thread_url unless a current thread is bound", "status"], "optional": [], "effect": "change status"},
+        "mark_read": {"required": ["idea_id/thread_url unless a current thread is bound"], "optional": [], "effect": "mark a thought read"},
     },
     "manage_project": {
         "list": {"required": [], "optional": ["query", "limit", "include_inactive"], "effect": "read project context profiles, optionally filtered by project name, description, aliases, or resources"},

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -61,8 +61,21 @@ async def _require_idea_for_actor(session, idea_id: str, actor: dict[str, Any]):
     return await _a_require_idea_for_user(session, idea_id, actor)
 
 
-def _target_idea_id(idea_id: str | None, thread_id: str | None, context_idea_id: str | None) -> str | None:
-    return str(idea_id or thread_id or context_idea_id).strip() or None
+def _target_idea_id(
+    idea_id: str | None,
+    thread_id: str | None,
+    thread_url: str | None,
+    url: str | None,
+    thread_route: str | None,
+    context_idea_id: str | None,
+) -> str | None:
+    from brain.systems.cortex.thread_links import thread_id_from_reference
+
+    for value in (thread_url, url, thread_route, idea_id, thread_id, context_idea_id):
+        parsed = thread_id_from_reference(value, allow_raw_id=True)
+        if parsed:
+            return parsed
+    return None
 
 
 async def _serialize_idea(idea, session) -> dict[str, Any]:
@@ -396,6 +409,9 @@ async def _handle_manage_idea(
     operation: str | None = None,
     idea_id: str | None = None,
     thread_id: str | None = None,
+    thread_url: str | None = None,
+    url: str | None = None,
+    thread_route: str | None = None,
     title: str | None = None,
     thread_message: str | None = None,
     start_run: bool | None = None,
@@ -426,7 +442,7 @@ async def _handle_manage_idea(
 
     org_id, actor_user_id, context_idea_id = _idea_tool_context()
     actor = _idea_actor(org_id=org_id, actor_user_id=actor_user_id)
-    target_idea_id = _target_idea_id(idea_id, thread_id, context_idea_id)
+    target_idea_id = _target_idea_id(idea_id, thread_id, thread_url, url, thread_route, context_idea_id)
     event: tuple[str, dict[str, Any]] | None = None
 
     try:

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 
 from sqlalchemy import String, and_, cast, func, or_, select
 
+from brain.systems.cortex.thread_links import thread_id_from_reference, thread_link_payload
 from brain.systems.runs.tool_definitions import WORKSPACE_OVERVIEW_SPARSE_GUIDANCE
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
 
@@ -203,6 +204,17 @@ def _optional_text(value: Any) -> str | None:
     return text or None
 
 
+def _thread_id_from_first_reference(*values: Any) -> str | None:
+    for value in values:
+        text = _optional_text(value)
+        if not text:
+            continue
+        parsed = thread_id_from_reference(text, allow_raw_id=True)
+        if parsed:
+            return parsed
+    return None
+
+
 def _normalize_postgres_uuid_filter(
     payload: dict[str, Any],
     *,
@@ -278,6 +290,34 @@ def _idea_title(idea: Any) -> str | None:
     if not idea:
         return None
     return idea.display_title or idea.title
+
+
+def _thread_reference_for_idea(idea: Any, idea_id: Any = None) -> dict[str, Any] | None:
+    resolved_id = str(idea_id or getattr(idea, "id", "") or "").strip()
+    if not resolved_id:
+        return None
+    return {
+        "type": "thread_reference",
+        "object_type": "thread",
+        "object_id": resolved_id,
+        "thread_id": resolved_id,
+        "status": "available",
+        "title": _idea_title(idea) or "Untitled thread",
+        "preview_summary": getattr(idea, "preview_summary", None),
+        "preview_source": getattr(idea, "preview_source", None),
+        "preview_updated_at": _serialize_dt(getattr(idea, "preview_updated_at", None)),
+        **thread_link_payload(resolved_id),
+    }
+
+
+def _thread_link_fields(idea: Any, idea_id: Any = None) -> dict[str, Any]:
+    reference = _thread_reference_for_idea(idea, idea_id)
+    if not reference:
+        return {}
+    return {
+        **thread_link_payload(reference["thread_id"]),
+        "thread_reference": reference,
+    }
 
 
 def _add_error(payload: dict[str, Any], source: str, exc: Exception) -> None:
@@ -444,6 +484,7 @@ async def _query_runs(
             "idea_id": str(run.thread_id),
             "thread_id": str(run.thread_id),
             "idea_title": _idea_title(idea),
+            **_thread_link_fields(idea, run.thread_id),
             "user_id": str(run.user_id) if run.user_id is not None else None,
             "user_name": user.name if user else None,
             "skill": (((run.metadata_ or {}).get("routing") or {}).get("selected_skill"))
@@ -512,22 +553,26 @@ async def _query_threads(
         stmt = stmt.where(text_match)
 
     rows = await _session_execute_all(session, stmt)
-    payload["sources"]["threads"] = [
-        {
+    thread_rows: list[dict[str, Any]] = []
+    for thread, idea, user in rows:
+        links = thread_link_payload(thread.idea_id) if thread.idea_id is not None else {}
+        thread_rows.append({
             "id": int(thread.id),
             "type": "thread_message",
             "created_at": _serialize_dt(thread.created_at),
             "idea_id": str(thread.idea_id) if thread.idea_id is not None else None,
+            "thread_id": str(thread.idea_id) if thread.idea_id is not None else None,
             "idea_title": _idea_title(idea),
+            **links,
+            "thread_reference": _thread_reference_for_idea(idea, thread.idea_id),
             "role": thread.role,
             "message_type": thread.message_type,
             "user_id": str(thread.user_id) if thread.user_id is not None else None,
             "user_name": user.name if user else None,
             "content": _snippet(thread.content, 520),
             "provenance": {"table": "idea_threads", "id": int(thread.id)},
-        }
-        for thread, idea, user in rows
-    ]
+        })
+    payload["sources"]["threads"] = thread_rows
 
 
 async def _query_ideas(
@@ -560,23 +605,30 @@ async def _query_ideas(
         stmt = stmt.where(text_match)
 
     rows = await _session_scalars_all(session, stmt)
-    payload["sources"]["ideas"] = [
-        {
+    idea_rows: list[dict[str, Any]] = []
+    for idea in rows:
+        links = thread_link_payload(idea.id)
+        idea_rows.append({
             "id": str(idea.id),
             "type": "idea",
             "created_at": _serialize_dt(idea.created_at),
             "updated_at": _serialize_dt(idea.updated_at),
             "status": idea.status,
             "title": idea.display_title or idea.title,
+            "thread_id": str(idea.id),
+            **links,
+            "thread_reference": _thread_reference_for_idea(idea),
             "description": _snippet(idea.description),
+            "preview_summary": getattr(idea, "preview_summary", None),
+            "preview_source": getattr(idea, "preview_source", None),
+            "preview_updated_at": _serialize_dt(getattr(idea, "preview_updated_at", None)),
             "user_id": str(idea.user_id) if idea.user_id is not None else None,
             "org_id": str(idea.org_id) if idea.org_id is not None else None,
             "active_agents": idea.active_agents,
             "working_memory": _snippet(idea.working_memory, 360),
             "provenance": {"table": "ideas", "id": str(idea.id)},
-        }
-        for idea in rows
-    ]
+        })
+    payload["sources"]["ideas"] = idea_rows
 
 
 async def _query_tool_calls(
@@ -627,6 +679,7 @@ async def _query_tool_calls(
             "called_at": _serialize_dt(event.created_at),
             "run_id": int(event.run_id),
             "idea_id": str(run.thread_id),
+            **_thread_link_fields(idea, run.thread_id),
             "idea_title": _idea_title(idea),
             "run_status": run.status if run else None,
             "tool_name": (event.payload or {}).get("tool_name"),
@@ -758,6 +811,7 @@ async def _query_project_attachments(
             "type": "project_attachment",
             "created_at": _serialize_dt(attachment.created_at),
             "idea_id": str(attachment.idea_id),
+            **_thread_link_fields(idea, attachment.idea_id),
             "idea_title": _idea_title(idea),
             "project_profile_id": str(attachment.project_profile_id) if attachment.project_profile_id else None,
             "project_name": profile.name if profile else None,
@@ -936,6 +990,7 @@ async def _query_domain_events(
             "actor_id": event.actor_id,
             "run_id": event.run_id,
             "idea_id": str(event.idea_id) if event.idea_id else None,
+            **_thread_link_fields(None, event.idea_id),
             "reason": _snippet(event.reason),
             "provenance": {"table": "domain_events", "id": int(event.id)},
         }
@@ -1122,6 +1177,7 @@ async def _query_cycles(
             "enabled": bool(cycle.enabled),
             "target_idea_id": str(cycle.target_idea_id) if cycle.target_idea_id else None,
             "idea_id": str(cycle.target_idea_id) if cycle.target_idea_id else None,
+            **_thread_link_fields(idea, cycle.target_idea_id),
             "idea_title": _idea_title(idea),
             "next_run_at": _serialize_dt(cycle.next_run_at),
             "last_run_at": _serialize_dt(cycle.last_run_at),
@@ -1197,6 +1253,7 @@ async def _query_cycle_runs(
             "error": _snippet(run.error),
             "skip_reason": run.skip_reason,
             "idea_id": str(run.idea_id) if run.idea_id else None,
+            **_thread_link_fields(idea, run.idea_id),
             "idea_title": _idea_title(idea),
             "run_id": int(run.run_id) if run.run_id is not None else None,
             "prompt_snapshot": _snippet(run.prompt_snapshot, 520),
@@ -1329,6 +1386,11 @@ def _build_activity_items(payload: Mapping[str, Any], *, limit: int = 30) -> lis
                 "user_name": record.get("user_name"),
                 "idea_id": record.get("idea_id"),
                 "idea_title": record.get("idea_title"),
+                "thread_id": record.get("thread_id") or record.get("idea_id"),
+                "thread_route": record.get("thread_route"),
+                "thread_url": record.get("thread_url") or record.get("url"),
+                "url": record.get("url") or record.get("thread_url"),
+                "thread_reference": record.get("thread_reference"),
                 "provenance": record.get("provenance"),
             })
     items.sort(key=_activity_sort_key, reverse=True)
@@ -1673,7 +1735,7 @@ async def query_workspace_data(
 
     org_id = _optional_text(org_id)
     user_id = _optional_text(user_id)
-    idea_id = _optional_text(idea_id)
+    idea_id = _thread_id_from_first_reference(idea_id)
     object_key = _optional_text(object_key)
     source_names = _normalize_sources(sources)
     start, end, resolved_window = _time_bounds(time_window, start_at=start_at, end_at=end_at)
@@ -1793,6 +1855,7 @@ async def query_workspace_data(
 def _workspace_query_scope(
     *,
     idea_id: str | None = None,
+    thread_url: str | None = None,
     domain_id: int | None = None,
     object_key: str | None = None,
     include_archived: bool = False,
@@ -1800,12 +1863,13 @@ def _workspace_query_scope(
 ) -> dict[str, Any]:
     run = getattr(_agent_context, "run", None)
     execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
-    if idea_id is None and default_current_idea:
-        scoped_idea_id = _optional_text(
+    explicit_thread_scope = thread_url is not None or idea_id is not None
+    if not explicit_thread_scope and default_current_idea:
+        scoped_idea_id = _thread_id_from_first_reference(
             getattr(_agent_context, "idea_id", None) or execution_metadata.get("idea_id")
         )
     else:
-        scoped_idea_id = _optional_text(idea_id)
+        scoped_idea_id = _thread_id_from_first_reference(thread_url, idea_id)
     return {
         "idea_id": scoped_idea_id,
         "domain_id": domain_id,
@@ -1820,6 +1884,7 @@ def _workspace_query_scope(
 async def _query_workspace_data_for_agent(**kwargs: Any) -> dict[str, Any]:
     scope_kwargs = _workspace_query_scope(
         idea_id=kwargs.pop("idea_id", None),
+        thread_url=kwargs.pop("thread_url", None),
         domain_id=kwargs.pop("domain_id", None),
         object_key=kwargs.pop("object_key", None),
         include_archived=bool(kwargs.pop("include_archived", False)),
@@ -1902,6 +1967,7 @@ async def _handle_query_workspace_data(
     end_at: str | None = None,
     limit: int = 20,
     idea_id: str | None = None,
+    thread_url: str | None = None,
     domain_id: int | None = None,
     object_key: str | None = None,
     include_archived: bool = False,
@@ -1916,6 +1982,7 @@ async def _handle_query_workspace_data(
         end_at=end_at,
         limit=limit,
         idea_id=idea_id,
+        thread_url=thread_url,
         domain_id=domain_id,
         object_key=object_key,
         include_archived=include_archived,
@@ -1967,6 +2034,7 @@ async def _handle_read_team_activity(
     end_at: str | None = None,
     limit: int = 20,
     idea_id: str | None = None,
+    thread_url: str | None = None,
 ) -> str:
     payload = await _query_workspace_data_for_agent(
         sources=["activity"],
@@ -1978,10 +2046,12 @@ async def _handle_read_team_activity(
         end_at=end_at,
         limit=limit,
         idea_id=idea_id,
+        thread_url=thread_url,
     )
     payload = _workspace_view_payload("team_activity", payload)
     payload["answering_guidance"] = [
         "Base recaps on activity_items first, then use per-source rows for detail.",
+        "When pointing someone to existing work in a Cortex Thread, include the returned thread_url with the Thread title.",
         "When results are empty, say what was checked instead of guessing from memory.",
     ]
     return json.dumps(payload, default=str)

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -574,6 +574,7 @@ BRAIN_TOOLS = [
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
                 "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter."},
+                "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL or /threads/{id} route filter."},
                 "domain_id": {"type": "integer", "description": "Optional Domain id filter."},
                 "object_key": {"type": "string", "description": "Optional Domain object key filter."},
                 "include_archived": {"type": "boolean", "default": False},
@@ -606,7 +607,9 @@ BRAIN_TOOLS = [
             "Read recent human and Illo activity in this workspace: Cortex thread messages, ideas, agent runs, "
             "tool-call summaries, Domain events, Project Context attachments, workspace app updates, and Cycle runs. "
             "Use before answering questions like 'what happened?', 'what is the team working on?', "
-            "'what did Illo do?', or 'what changed recently?'."
+            "'what did Illo do?', 'did someone work on this?', or 'what changed recently?'. "
+            "Thread and idea results include thread_url/thread_reference; cite the Thread title plus thread_url "
+            "when pointing a teammate to prior work."
         ),
         "input_schema": {
             "type": "object",
@@ -622,6 +625,7 @@ BRAIN_TOOLS = [
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
                 "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter."},
+                "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL or /threads/{id} route filter."},
             },
         },
     },
@@ -1172,7 +1176,9 @@ CORTEX_IDEA_TOOLS = [
             "'archive this thread', 'rename this thought', 'mark this resolved', or "
             "'restore that idea'. This is the action/exact-thread tool. For recent team-wide thread "
             "activity, prefer read_team_activity first. idea_id defaults to the current Cortex "
-            "thread/idea when one is bound. Use action='help' or action='schema' with operation to inspect "
+            "thread/idea when one is bound. For exact-thread actions, pass idea_id, thread_id, "
+            "thread_url, or thread_route. Results include thread_url; share it when the user needs "
+            "to open or hand off the Thread. Use action='help' or action='schema' with operation to inspect "
             "arguments before mutating."
         ),
         "input_schema": {
@@ -1205,6 +1211,18 @@ CORTEX_IDEA_TOOLS = [
                 "thread_id": {
                     "type": "string",
                     "description": "Alias for idea_id, for user wording that says thread.",
+                },
+                "thread_url": {
+                    "type": "string",
+                    "description": "Canonical Illo Thread URL identifying the target thread.",
+                },
+                "thread_route": {
+                    "type": "string",
+                    "description": "Canonical /threads/{id} route identifying the target thread.",
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Alias for thread_url when a Thread link is passed as a generic URL.",
                 },
                 "title": {"type": "string", "description": "Raw idea title for create/update."},
                 "thread_message": {

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -565,7 +565,24 @@ def test_manage_idea_tool_is_available_to_agents():
     tool = next(item for item in WORKER_TOOLS if item["name"] == "manage_idea")
 
     assert "archive this thread" in tool["description"]
+    assert "thread_url" in tool["input_schema"]["properties"]
     assert "manage_idea" in _get_tool_handlers()
+
+
+def test_manage_idea_target_accepts_thread_url():
+    from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
+
+    assert (
+        idea_tools._target_idea_id(
+            idea_id=None,
+            thread_id=None,
+            thread_url="https://illo.example.com/threads/idea-1",
+            url=None,
+            thread_route=None,
+            context_idea_id="current-idea",
+        )
+        == "idea-1"
+    )
 
 
 async def test_manage_idea_archive_defaults_to_current_thread(monkeypatch):

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -234,6 +234,21 @@ def test_workspace_query_scope_omitted_idea_defaults_to_current_thread():
     assert scope["org_id"] == "org-1"
 
 
+def test_workspace_query_scope_accepts_thread_url():
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+    from brain.systems.runs.execution_context import bind_agent_context
+
+    with bind_agent_context({"idea_id": "current-idea", "user_id": "user-1", "org_id": "org-1"}):
+        scope = workspace_data._workspace_query_scope(
+            thread_url="https://illo.example.com/threads/shared-thread-1",
+            default_current_idea=True,
+        )
+
+    assert scope["idea_id"] == "shared-thread-1"
+    assert scope["user_id"] == "user-1"
+    assert scope["org_id"] == "org-1"
+
+
 async def test_workspace_data_runs_include_latest_final_answer_artifact():
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 
@@ -290,6 +305,8 @@ async def test_workspace_data_runs_include_latest_final_answer_artifact():
         payload["sources"]["runs"][0]["output"]
         == "Alex has been actively polishing the Cortex thread flow."
     )
+    assert payload["sources"]["runs"][0]["thread_url"].endswith("/threads/idea-1")
+    assert payload["sources"]["runs"][0]["thread_reference"]["title"] == "Current planning"
 
 
 def test_workspace_data_activity_items_sort_newest_signals_first():
@@ -314,7 +331,16 @@ def test_workspace_data_activity_items_sort_newest_signals_first():
                     "type": "thread_message",
                     "created_at": "2026-05-06T18:00:00+00:00",
                     "idea_id": "idea-2",
+                    "thread_id": "idea-2",
                     "idea_title": "Live Cortex polish",
+                    "thread_url": "https://illo.example.com/threads/idea-2",
+                    "thread_route": "/threads/idea-2",
+                    "thread_reference": {
+                        "type": "thread_reference",
+                        "thread_id": "idea-2",
+                        "title": "Live Cortex polish",
+                        "thread_url": "https://illo.example.com/threads/idea-2",
+                    },
                     "content": "Let's fix the current thread activity answer.",
                     "user_id": "user-1",
                     "user_name": "Alex",
@@ -329,3 +355,5 @@ def test_workspace_data_activity_items_sort_newest_signals_first():
     assert [item["source"] for item in items] == ["threads", "workspace_apps"]
     assert items[0]["title"] == "Live Cortex polish"
     assert items[0]["summary"] == "Let's fix the current thread activity answer."
+    assert items[0]["thread_url"] == "https://illo.example.com/threads/idea-2"
+    assert items[0]["thread_reference"]["thread_id"] == "idea-2"


### PR DESCRIPTION
## Summary
- let native Illo runtime tools accept canonical Thread URLs/routes as thread targets
- include thread_url and thread_reference on workspace activity rows for ideas, thread messages, agent runs, tool calls, project attachments, domain events, and cycles
- update runtime tool guidance so Illo cites Thread title plus URL when pointing teammates to prior work

## Tests
- python3 -m compileall -q brain/systems/runs/tool_catalog/handlers/ideas.py brain/systems/runs/tool_catalog/handlers/workspace_data.py brain/systems/runs/tool_definitions.py
- PYTHONPATH=/private/tmp/illospace-thread-url-object-references /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python3 -m pytest tests/test_workspace_data_query.py tests/test_api_cortex.py::test_manage_idea_tool_is_available_to_agents tests/test_api_cortex.py::test_manage_idea_target_accepts_thread_url -q
- PYTHONPATH=/private/tmp/illospace-thread-url-object-references /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python3 -m pytest tests/test_thread_url_references.py tests/test_api_schemas.py tests/test_tool_registry.py -q