### PR TITLE
Restart worker on stalled AgentRun queue

### DIFF
--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -8,7 +8,12 @@ import os
 import signal
 import time
 
-from brain.systems.runs.cortex.runner import runner_health_snapshot, start_runner, stop_runner
+from brain.systems.runs.cortex.queue_health import QueueStallMonitor, queued_backlog_health_snapshot
+from brain.systems.runs.cortex.runner import (
+    runner_health_snapshot,
+    start_runner,
+    stop_runner,
+)
 from brain.systems.cycles import start_cycle_scheduler, stop_cycle_scheduler
 
 logging.basicConfig(
@@ -59,6 +64,20 @@ def _runner_health_grace_seconds() -> float:
         return 15.0
 
 
+def _queue_health_check_interval_seconds() -> float:
+    try:
+        return max(1.0, float(os.getenv("ILLO_AGENT_RUN_QUEUE_HEALTH_CHECK_SECONDS", "5")))
+    except Exception:
+        return 5.0
+
+
+def _queue_stall_grace_seconds() -> float:
+    try:
+        return max(5.0, float(os.getenv("ILLO_AGENT_RUN_QUEUE_STALL_GRACE_SECONDS", "45")))
+    except Exception:
+        return 45.0
+
+
 def _require_embedding_backend_ready() -> None:
     """Block worker startup until the configured GPU embedding worker is ready."""
     import brain.kernel.config as cfg
@@ -96,17 +115,39 @@ def main() -> None:
     start_runner()
     last_healthy = time.monotonic()
     health_grace_seconds = _runner_health_grace_seconds()
+    queue_stall_monitor = QueueStallMonitor(
+        check_interval_seconds=_queue_health_check_interval_seconds(),
+        stall_grace_seconds=_queue_stall_grace_seconds(),
+    )
     try:
         while _running:
+            now = time.monotonic()
             health = runner_health_snapshot()
             if health.get("runner_running"):
-                last_healthy = time.monotonic()
-            elif time.monotonic() - last_healthy > health_grace_seconds:
+                last_healthy = now
+            elif now - last_healthy > health_grace_seconds:
                 logger.error(
                     "agent-run worker runner supervisor unhealthy; exiting for restart",
                     extra={"runner_health": health},
                 )
                 raise SystemExit(1)
+
+            if queue_stall_monitor.should_check(now=now):
+                try:
+                    queue_health = queued_backlog_health_snapshot()
+                except Exception as exc:
+                    logger.warning("agent-run worker queue health check failed: %s", exc)
+                else:
+                    stale_for_seconds = queue_stall_monitor.observe(queue_health, now=now)
+                    if stale_for_seconds is not None:
+                        logger.error(
+                            "agent-run worker queue stalled; exiting for restart",
+                            extra={
+                                "queue_health": queue_health,
+                                "stale_for_seconds": stale_for_seconds,
+                            },
+                        )
+                        raise SystemExit(1)
             time.sleep(_poll_interval())
     finally:
         stop_runner(drain_timeout_seconds=_shutdown_drain_timeout_seconds())

--- a/brain/systems/runs/cortex/queue_health.py
+++ b/brain/systems/runs/cortex/queue_health.py
@@ -1,0 +1,155 @@
+"""Queue health helpers for the standalone AgentRun worker."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+
+from brain.contracts.statuses import PROCESSING_RUN_STATUS_VALUES
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.systems.runs.status import RunStatus
+
+UnitOfWork = None
+
+_DEFAULT_RUNNER_CONCURRENCY = 4
+_MAX_RUNNER_CONCURRENCY = 32
+_DEFAULT_QUEUED_WATCHDOG_AFTER_SEC = 15.0
+
+
+def _unit_of_work_factory():
+    global UnitOfWork
+    if UnitOfWork is None:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork as _UnitOfWork
+
+        UnitOfWork = _UnitOfWork
+    return UnitOfWork
+
+
+def _coerce_concurrency(value: Any, *, default: int | None = None) -> int | None:
+    try:
+        if value is None or value == "":
+            return default
+        return max(1, min(_MAX_RUNNER_CONCURRENCY, int(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, *, default: float, minimum: float) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return max(float(minimum), float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def runner_concurrency() -> int:
+    return _coerce_concurrency(
+        os.getenv("ILLO_AGENT_RUNNER_CONCURRENCY"),
+        default=_DEFAULT_RUNNER_CONCURRENCY,
+    ) or _DEFAULT_RUNNER_CONCURRENCY
+
+
+def queued_watchdog_after_seconds() -> float:
+    return _coerce_float(
+        os.getenv("ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS"),
+        default=_DEFAULT_QUEUED_WATCHDOG_AFTER_SEC,
+        minimum=1.0,
+    )
+
+
+async def queued_backlog_snapshot_async() -> tuple[int, datetime | None, int]:
+    async with _unit_of_work_factory()() as uow:
+        queued_result = await uow.session.execute(
+            select(func.count(AgentRunRow.id), func.min(AgentRunRow.created_at)).where(
+                AgentRunRow.status == RunStatus.QUEUED.value
+            )
+        )
+        queued_count, oldest_created_at = queued_result.one()
+        active_count = await uow.session.scalar(
+            select(func.count(AgentRunRow.id)).where(
+                AgentRunRow.status.in_(PROCESSING_RUN_STATUS_VALUES)
+            )
+        )
+    return int(queued_count or 0), _normalize_datetime(oldest_created_at), int(active_count or 0)
+
+
+def _normalize_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def queued_backlog_health_snapshot_async() -> dict[str, Any]:
+    queued_count, oldest_queued_at, active_count = await queued_backlog_snapshot_async()
+    configured_concurrency = runner_concurrency()
+    watchdog_after_seconds = queued_watchdog_after_seconds()
+    oldest_queued_age_seconds = None
+    if oldest_queued_at is not None:
+        oldest_queued_age_seconds = max(
+            0.0,
+            (datetime.now(timezone.utc) - oldest_queued_at).total_seconds(),
+        )
+    stale_queued_backlog = (
+        queued_count > 0
+        and oldest_queued_age_seconds is not None
+        and oldest_queued_age_seconds >= watchdog_after_seconds
+        and active_count < configured_concurrency
+    )
+    return {
+        "queued": queued_count,
+        "active_runs": active_count,
+        "configured_concurrency": configured_concurrency,
+        "oldest_queued_at": oldest_queued_at.isoformat() if oldest_queued_at else None,
+        "oldest_queued_age_seconds": int(oldest_queued_age_seconds)
+        if oldest_queued_age_seconds is not None
+        else None,
+        "watchdog_after_seconds": int(watchdog_after_seconds),
+        "stale_queued_backlog": stale_queued_backlog,
+    }
+
+
+def queued_backlog_health_snapshot() -> dict[str, Any]:
+    return asyncio.run(queued_backlog_health_snapshot_async())
+
+
+@dataclass
+class QueueStallMonitor:
+    check_interval_seconds: float
+    stall_grace_seconds: float
+    last_checked_at: float = 0.0
+    stale_since: float | None = None
+
+    def should_check(self, *, now: float) -> bool:
+        return now - self.last_checked_at >= self.check_interval_seconds
+
+    def observe(self, queue_health: dict[str, Any], *, now: float) -> int | None:
+        self.last_checked_at = now
+        if not queue_health.get("stale_queued_backlog"):
+            self.stale_since = None
+            return None
+        if self.stale_since is None:
+            self.stale_since = now
+        stale_for_seconds = now - self.stale_since
+        if stale_for_seconds < self.stall_grace_seconds:
+            return None
+        return int(stale_for_seconds)
+
+
+__all__ = [
+    "QueueStallMonitor",
+    "queued_backlog_health_snapshot",
+    "queued_backlog_health_snapshot_async",
+    "queued_backlog_snapshot_async",
+    "queued_watchdog_after_seconds",
+    "runner_concurrency",
+]

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -25,6 +25,11 @@ from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.stream import RunStream
+from brain.systems.runs.cortex.queue_health import (
+    queued_backlog_snapshot_async as _shared_queued_backlog_snapshot_async,
+    queued_watchdog_after_seconds as _shared_queued_watchdog_after_seconds,
+    runner_concurrency as _shared_runner_concurrency,
+)
 from brain.systems.runs.ui_events import run_event_to_ui_message
 from brain.systems.cortex.events import publish_live_safe, publish_safe
 from brain.systems.cortex.project_context.materializer import (
@@ -62,26 +67,14 @@ _runner_thread_index = 0
 _poll_interval_sec = 0.5
 _runner_reconcile_interval_sec = 2.0
 _stale_reconcile_interval_sec = 30.0
-_default_runner_concurrency = 4
-_max_runner_concurrency = 32
 _default_heartbeat_interval_sec = 10.0
 _default_stale_run_sec = 300.0
-_default_queued_watchdog_after_sec = 15.0
 _queued_watchdog_interval_sec = 5.0
 _last_stale_reconcile_monotonic = 0.0
 _last_queued_watchdog_monotonic = 0.0
 _queued_watchdog_tasks: set[asyncio.Task[int]] = set()
 
 _PROCESS_ACTIVE_STATUS_VALUES = PROCESSING_RUN_STATUS_VALUES
-
-
-def _coerce_concurrency(value: Any, *, default: int | None = None) -> int | None:
-    try:
-        if value is None or value == "":
-            return default
-        return max(1, min(_max_runner_concurrency, int(value)))
-    except (TypeError, ValueError):
-        return default
 
 
 def _coerce_float(value: Any, *, default: float, minimum: float) -> float:
@@ -114,18 +107,11 @@ def _stale_run_seconds() -> float:
 
 
 def _queued_watchdog_after_seconds() -> float:
-    return _coerce_float(
-        os.getenv("ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS"),
-        default=_default_queued_watchdog_after_sec,
-        minimum=1.0,
-    )
+    return _shared_queued_watchdog_after_seconds()
 
 
 def _runner_concurrency() -> int:
-    return _coerce_concurrency(
-        os.getenv("ILLO_AGENT_RUNNER_CONCURRENCY"),
-        default=_default_runner_concurrency,
-    ) or _default_runner_concurrency
+    return _shared_runner_concurrency()
 
 
 def _active_runner_count() -> int:
@@ -796,19 +782,7 @@ async def _reap_stale_runs_if_due_async(*, force: bool = False) -> int:
 
 
 async def _queued_backlog_snapshot_async() -> tuple[int, datetime | None, int]:
-    async with _unit_of_work_factory()() as uow:
-        queued_result = await uow.session.execute(
-            select(func.count(AgentRunRow.id), func.min(AgentRunRow.created_at)).where(
-                AgentRunRow.status == RunStatus.QUEUED.value
-            )
-        )
-        queued_count, oldest_created_at = queued_result.one()
-        active_count = await uow.session.scalar(
-            select(func.count(AgentRunRow.id)).where(
-                AgentRunRow.status.in_(_PROCESS_ACTIVE_STATUS_VALUES)
-            )
-        )
-    return int(queued_count or 0), _normalize_datetime(oldest_created_at), int(active_count or 0)
+    return await _shared_queued_backlog_snapshot_async()
 
 
 def _forget_queued_watchdog_task(task: asyncio.Task[int]) -> None:

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -153,6 +153,44 @@ def test_runner_health_snapshot_requires_supervisor_and_slots(monkeypatch):
     assert runner.runner_health_snapshot()["runner_running"] is False
 
 
+async def test_queued_backlog_health_snapshot_marks_stale_queue(monkeypatch):
+    from brain.systems.runs.cortex import queue_health
+
+    oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
+
+    async def fake_snapshot():
+        return 2, oldest, 0
+
+    monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
+    monkeypatch.setattr(queue_health, "queued_watchdog_after_seconds", lambda: 10)
+    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
+
+    health = await queue_health.queued_backlog_health_snapshot_async()
+
+    assert health["queued"] == 2
+    assert health["active_runs"] == 0
+    assert health["stale_queued_backlog"] is True
+
+
+async def test_queued_backlog_health_snapshot_respects_full_capacity(monkeypatch):
+    from brain.systems.runs.cortex import queue_health
+
+    oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
+
+    async def fake_snapshot():
+        return 2, oldest, 4
+
+    monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
+    monkeypatch.setattr(queue_health, "queued_watchdog_after_seconds", lambda: 10)
+    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
+
+    health = await queue_health.queued_backlog_health_snapshot_async()
+
+    assert health["queued"] == 2
+    assert health["active_runs"] == 4
+    assert health["stale_queued_backlog"] is False
+
+
 async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(monkeypatch):
     from brain.systems.runs.cortex import runner
 

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -59,6 +59,47 @@ def test_runner_health_grace_has_safe_minimum(monkeypatch):
     assert _runner_health_grace_seconds() == 1.0
 
 
+def test_queue_health_check_interval_accepts_numeric_override(monkeypatch):
+    from brain.systems.cortex.worker import _queue_health_check_interval_seconds
+
+    monkeypatch.setenv("ILLO_AGENT_RUN_QUEUE_HEALTH_CHECK_SECONDS", "2.5")
+
+    assert _queue_health_check_interval_seconds() == 2.5
+
+
+def test_queue_stall_grace_has_safe_minimum(monkeypatch):
+    from brain.systems.cortex.worker import _queue_stall_grace_seconds
+
+    monkeypatch.setenv("ILLO_AGENT_RUN_QUEUE_STALL_GRACE_SECONDS", "0")
+
+    assert _queue_stall_grace_seconds() == 5.0
+
+
+def test_queue_stall_monitor_checks_on_interval():
+    from brain.systems.runs.cortex.queue_health import QueueStallMonitor
+
+    monitor = QueueStallMonitor(check_interval_seconds=5.0, stall_grace_seconds=10.0)
+
+    assert monitor.should_check(now=4.0) is False
+    assert monitor.should_check(now=5.0) is True
+    monitor.observe({"stale_queued_backlog": False}, now=5.0)
+    assert monitor.should_check(now=9.0) is False
+    assert monitor.should_check(now=10.0) is True
+
+
+def test_queue_stall_monitor_tracks_stale_backlog():
+    from brain.systems.runs.cortex.queue_health import QueueStallMonitor
+
+    monitor = QueueStallMonitor(check_interval_seconds=5.0, stall_grace_seconds=10.0)
+
+    assert monitor.observe({"stale_queued_backlog": True}, now=10.0) is None
+    assert monitor.stale_since == 10.0
+    assert monitor.observe({"stale_queued_backlog": True}, now=19.0) is None
+    assert monitor.observe({"stale_queued_backlog": True}, now=20.0) == 10
+    assert monitor.observe({"stale_queued_backlog": False}, now=21.0) is None
+    assert monitor.stale_since is None
+
+
 def test_cycle_scheduler_can_be_disabled_for_handoff_worker(monkeypatch):
     from brain.systems.cortex.worker import _cycle_scheduler_enabled
 


### PR DESCRIPTION
## Summary
- add a runner queue-backlog health snapshot that reports stale queued work when capacity is available
- make the standalone worker exit for Docker restart if stale queued work persists past a grace window
- cover the new queue-health and worker stall helpers with focused tests

## Verification
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_cortex_worker.py tests/test_agent_run_runner.py
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m compileall brain/systems/cortex/worker.py brain/systems/runs/cortex/runner.py
- git diff --check

Live server check after restart: queued=0 active=0, and Slack replies posted successfully for runs 532 and 533.