### PR TITLE
Fix Slack thread context reads

### DIFF
--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -15,6 +15,17 @@ class SlackConfigurationError(RuntimeError):
 class SlackApiError(RuntimeError):
     """Raised when Slack Web API returns an error."""
 
+    def __init__(self, error: str, *, response_metadata: dict[str, Any] | None = None) -> None:
+        self.error = error
+        self.response_metadata = dict(response_metadata or {})
+        messages = self.response_metadata.get("messages")
+        details = (
+            "; ".join(str(message) for message in messages if message)
+            if isinstance(messages, list)
+            else ""
+        )
+        super().__init__(f"{error}: {details}" if details else error)
+
 
 class SlackWebClient:
     def __init__(
@@ -31,7 +42,16 @@ class SlackWebClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
 
-    async def api_call(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+    def _coerce_response(self, data: dict[str, Any]) -> dict[str, Any]:
+        if not data.get("ok"):
+            metadata = data.get("response_metadata")
+            raise SlackApiError(
+                str(data.get("error") or "slack_api_error"),
+                response_metadata=metadata if isinstance(metadata, dict) else None,
+            )
+        return dict(data)
+
+    async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
         async with async_http_client(timeout=self.timeout) as client:
             response = await client.post(
                 f"{self.base_url}/{method}",
@@ -43,9 +63,18 @@ class SlackWebClient:
             )
             response.raise_for_status()
             data = response.json()
-        if not data.get("ok"):
-            raise SlackApiError(str(data.get("error") or "slack_api_error"))
-        return dict(data)
+        return self._coerce_response(dict(data))
+
+    async def _get(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        async with async_http_client(timeout=self.timeout) as client:
+            response = await client.get(
+                f"{self.base_url}/{method}",
+                headers={"Authorization": f"Bearer {self.bot_token}"},
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+        return self._coerce_response(dict(data))
 
     async def post_message(
         self,
@@ -60,7 +89,7 @@ class SlackWebClient:
         }
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return await self.api_call("chat.postMessage", payload)
+        return await self._post("chat.postMessage", payload)
 
     async def post_ephemeral(
         self,
@@ -77,7 +106,7 @@ class SlackWebClient:
         }
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return await self.api_call("chat.postEphemeral", payload)
+        return await self._post("chat.postEphemeral", payload)
 
     async def set_assistant_status(
         self,
@@ -94,10 +123,10 @@ class SlackWebClient:
         }
         if loading_messages:
             payload["loading_messages"] = loading_messages[:10]
-        return await self.api_call("assistant.threads.setStatus", payload)
+        return await self._post("assistant.threads.setStatus", payload)
 
     async def open_conversation(self, *, users: str) -> dict[str, Any]:
-        return await self.api_call("conversations.open", {"users": users})
+        return await self._post("conversations.open", {"users": users})
 
     async def conversation_replies(
         self,
@@ -106,7 +135,7 @@ class SlackWebClient:
         thread_ts: str,
         limit: int = 50,
     ) -> dict[str, Any]:
-        return await self.api_call(
+        return await self._get(
             "conversations.replies",
             {
                 "channel": channel,
@@ -129,10 +158,10 @@ class SlackWebClient:
         if latest:
             payload["latest"] = latest
             payload["inclusive"] = True
-        return await self.api_call("conversations.history", payload)
+        return await self._post("conversations.history", payload)
 
     async def auth_test(self) -> dict[str, Any]:
-        return await self.api_call("auth.test", {})
+        return await self._post("auth.test", {})
 
 
 def slack_bot_token_from_env() -> str:

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from brain.systems.slack import client as slack_client_module
+from brain.systems.slack.client import SlackApiError, SlackWebClient
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+def _patch_http_client(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, Any],
+) -> list[tuple[str, str, dict[str, str], dict[str, Any]]]:
+    calls: list[tuple[str, str, dict[str, str], dict[str, Any]]] = []
+
+    class _HttpClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc) -> None:
+            return None
+
+        async def get(self, url: str, *, headers: dict[str, str], params: dict[str, Any]):
+            calls.append(("get", url, headers, params))
+            return _Response(payload)
+
+    monkeypatch.setattr(slack_client_module, "async_http_client", lambda **_kwargs: _HttpClient())
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_slack_client_reads_thread_context_with_query_params(monkeypatch):
+    calls = _patch_http_client(
+        monkeypatch,
+        {"ok": True, "messages": [{"ts": "1716900000.000100", "text": "Root"}]},
+    )
+
+    result = await SlackWebClient("xoxb-test").conversation_replies(
+        channel="C456",
+        thread_ts="1716900000.000100",
+        limit=500,
+    )
+
+    assert result["ok"] is True
+    assert calls == [
+        (
+            "get",
+            "https://slack.com/api/conversations.replies",
+            {"Authorization": "Bearer xoxb-test"},
+            {"channel": "C456", "ts": "1716900000.000100", "limit": 200},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slack_client_surfaces_response_metadata_errors(monkeypatch):
+    _patch_http_client(
+        monkeypatch,
+        {
+            "ok": False,
+            "error": "invalid_arguments",
+            "response_metadata": {
+                "messages": [
+                    "[ERROR] missing required field: channel",
+                    "[ERROR] missing required field: ts",
+                ]
+            },
+        },
+    )
+
+    with pytest.raises(SlackApiError, match="missing required field: channel") as caught:
+        await SlackWebClient("xoxb-test").conversation_replies(
+            channel="C456",
+            thread_ts="1716900000.000100",
+            limit=10,
+        )
+
+    assert caught.value.error == "invalid_arguments"
+    assert caught.value.response_metadata == {
+        "messages": [
+            "[ERROR] missing required field: channel",
+            "[ERROR] missing required field: ts",
+        ]
+    }


### PR DESCRIPTION
## Summary
- call Slack conversations.replies with GET/query params instead of the shared JSON POST helper
- preserve Slack response_metadata.messages in SlackApiError so invalid_arguments includes useful diagnostics
- add regression coverage for thread context reads and detailed Slack API errors

## Production evidence
- Run 558 failed read_slack_conversation(scope=thread) for channel C082SUKQKJL / thread_ts 1780407070.081239 with invalid_arguments.
- Direct Slack POST JSON reproduced Slack response_metadata: missing required field channel and ts.
- Direct Slack GET/query params against the same channel/thread returned ok=true with 6 messages.

## Tests
- /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_slack_teammate.py -q