### PR TITLE
Fix workspace thread blob activation

### DIFF
--- a/frontend/src/lib/components/constellation/SignalBlob.svelte
+++ b/frontend/src/lib/components/constellation/SignalBlob.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ConstellationIcon, { type ConstellationIconName } from './ConstellationIcon.svelte';
   import ConstellationSignalStatusIndicator from './ConstellationSignalStatusIndicator.svelte';
+  import { signalBlobPointerUpAction } from './signalBlobActivation';
   import type {
     ConstellationScale,
     ConstellationShape,
@@ -70,7 +71,7 @@
     badge?: boolean;
     animated?: boolean;
     interactive?: boolean;
-    activate?: () => void;
+    activate?: (event: MouseEvent | PointerEvent) => void;
     edit?: () => void;
     longPress?: () => void;
     longPressThresholdMs?: number;
@@ -139,7 +140,9 @@
       suppressNextActivate = false;
       return;
     }
-    activate?.();
+    event.preventDefault();
+    event.stopPropagation();
+    activate?.(event);
   }
 
   function handleEdit(event: MouseEvent) {
@@ -214,11 +217,24 @@
   function handlePointerUp(event: PointerEvent) {
     if (activePointerId !== event.pointerId) return;
     clearLongPressTimer();
-    const didMove = endDrag?.(event) || pointerMoved;
-    if (didMove) {
+    const dragMoved = Boolean(endDrag?.(event));
+    const action = signalBlobPointerUpAction({
+      dragMoved,
+      pointerMoved,
+      canActivate: Boolean(activate),
+    });
+    if (action === 'suppress-click') {
       suppressNextActivate = true;
       event.preventDefault();
       event.stopPropagation();
+      window.setTimeout(() => {
+        suppressNextActivate = false;
+      }, 0);
+    } else if (action === 'activate') {
+      suppressNextActivate = true;
+      event.preventDefault();
+      event.stopPropagation();
+      activate?.(event);
       window.setTimeout(() => {
         suppressNextActivate = false;
       }, 0);

--- a/frontend/src/lib/components/constellation/signalBlobActivation.ts
+++ b/frontend/src/lib/components/constellation/signalBlobActivation.ts
@@ -1,0 +1,17 @@
+export type SignalBlobPointerUpAction = 'activate' | 'suppress-click' | 'none';
+
+export interface SignalBlobPointerUpState {
+  dragMoved: boolean;
+  pointerMoved: boolean;
+  canActivate: boolean;
+}
+
+export function signalBlobPointerUpAction({
+  dragMoved,
+  pointerMoved,
+  canActivate,
+}: SignalBlobPointerUpState): SignalBlobPointerUpAction {
+  if (dragMoved || pointerMoved) return 'suppress-click';
+  if (canActivate) return 'activate';
+  return 'none';
+}

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -1645,7 +1645,8 @@
     });
   }
 
-  function activatePrimitiveBlob(blob: PrimitiveBlobVisual) {
+  function activatePrimitiveBlob(blob: PrimitiveBlobVisual, event?: MouseEvent | PointerEvent) {
+    event?.stopPropagation();
     if (primitiveDragState?.moved) return;
     if (isPreviewIdeaId(blob.id)) return;
     const node = orbitSceneNodesById.get(blob.id);

--- a/frontend/src/lib/features/workspace-scene/renderers/WorkspaceOrbitPrimitives.svelte
+++ b/frontend/src/lib/features/workspace-scene/renderers/WorkspaceOrbitPrimitives.svelte
@@ -88,7 +88,7 @@
     beginAppDrag: (app: PrimitiveAppVisual, event: PointerEvent) => void;
     moveAppDrag: (app: PrimitiveAppVisual, event: PointerEvent) => void;
     endAppDrag: (app: PrimitiveAppVisual, event: PointerEvent) => void;
-    activateBlob: (blob: PrimitiveBlobVisual) => void;
+    activateBlob: (blob: PrimitiveBlobVisual, event: MouseEvent | PointerEvent) => void;
     editBlob: (blob: PrimitiveBlobVisual) => void;
     popBlob: (id: string) => void;
     hoverBlob: (blob: PrimitiveBlobVisual) => void;
@@ -209,7 +209,7 @@
     animated={true}
     interactive={true}
     dataId={blob.id}
-    activate={() => activateBlob(blob)}
+    activate={(event) => activateBlob(blob, event)}
     edit={() => editBlob(blob)}
     longPress={() => popBlob(blob.id)}
     longPressThresholdMs={blob.state === 'done' ? 500 : 1000}

--- a/frontend/src/lib/utils/signalBlobActivation.test.js
+++ b/frontend/src/lib/utils/signalBlobActivation.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { signalBlobPointerUpAction } from '../components/constellation/signalBlobActivation.ts';
+
+test('activates signal blobs on pointer-up when the pointer did not drag', () => {
+  assert.equal(
+    signalBlobPointerUpAction({
+      dragMoved: false,
+      pointerMoved: false,
+      canActivate: true,
+    }),
+    'activate',
+  );
+});
+
+test('suppresses signal blob click after drag movement', () => {
+  assert.equal(
+    signalBlobPointerUpAction({
+      dragMoved: true,
+      pointerMoved: false,
+      canActivate: true,
+    }),
+    'suppress-click',
+  );
+});
+
+test('suppresses signal blob click after component pointer movement', () => {
+  assert.equal(
+    signalBlobPointerUpAction({
+      dragMoved: false,
+      pointerMoved: true,
+      canActivate: true,
+    }),
+    'suppress-click',
+  );
+});
+
+test('does nothing when a non-drag pointer-up has no activation callback', () => {
+  assert.equal(
+    signalBlobPointerUpAction({
+      dragMoved: false,
+      pointerMoved: false,
+      canActivate: false,
+    }),
+    'none',
+  );
+});


### PR DESCRIPTION
## Summary
- Reproduced the deployed issue: direct thread URLs open, but clicking a workspace thread blob only focuses it.
- Activate interactive signal blobs on non-drag pointer-up, then suppress the following native click.
- Pass the pointer event through primitive blob activation and stop propagation at the activation boundary.
- Add regression coverage for the pointer-up activation decision.

## Validation
- Verified deployed server before the fix: direct thread URL works; raw click on a thread blob from `/cortex` does not open the thread.
- `node --test src/lib/utils/signalBlobActivation.test.js`
- `npm run check`
- `npm test`
- `npm run build`
- `git diff --check`