### PR TITLE
Fix workspace blob thread opening

### DIFF
--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -280,10 +280,11 @@
     void ensureWorkspacePageComponent(modalId);
   });
 
-  function handleThreadOpen(origin: { x: number; y: number; id: string }) {
+  async function handleThreadOpen(origin: { x: number; y: number; id: string }) {
     workspaceOverlay.closeWorkspaceApp();
     workspaceOverlay.closeWorkspaceAndPinMenus();
     threadStage.setOriginFromClient(workspaceEl, origin.x, origin.y);
+    await openDirectThreadAndSyncUrl(origin.id);
   }
 
   function handleArchiveDragState(state: { active: boolean; over: boolean }) {
@@ -962,28 +963,43 @@
     if (decision.action === 'skip-repeat') return;
 
     lastRequestedIdeaId = decision.ideaId;
-    const opened = await cortex.loadDirectThread(decision.ideaId);
-    if (opened) {
-      syncCanonicalThreadUrl(decision.ideaId);
-    } else {
-      cleanupUnresolvedThreadUrl(decision.ideaId);
-    }
+    await openDirectThreadAndSyncUrl(decision.ideaId);
     clearRuntimeReadyOnboardingUrl();
-    directThreadUrlPending = false;
   }
 
-  function syncCanonicalThreadUrl(ideaId: string | null | undefined) {
-    if (!browser || !ideaId) return;
+  async function openDirectThreadAndSyncUrl(ideaId: string): Promise<boolean> {
+    directThreadUrlPending = true;
+    const opened = await cortex.loadDirectThread(ideaId);
+    if (opened) {
+      const navigationStarted = syncCanonicalThreadUrl(ideaId);
+      if (!navigationStarted) directThreadUrlPending = false;
+      return true;
+    }
+
+    directThreadUrlPending = false;
+    cleanupUnresolvedThreadUrl(ideaId);
+    return false;
+  }
+
+  function syncCanonicalThreadUrl(ideaId: string | null | undefined): boolean {
+    if (!browser || !ideaId) return false;
     const nextRoute = threadRoute(ideaId);
     const current = `${$page.url.pathname}${$page.url.search}${$page.url.hash}`;
     lastSyncedThreadRoute = nextRoute;
-    if (current === nextRoute) return;
+    if (current === nextRoute) return false;
     const replaceState = $page.url.pathname.startsWith('/threads/') || Boolean($page.url.searchParams.get('idea'));
+    directThreadUrlPending = true;
     void goto(nextRoute, {
       replaceState,
       keepFocus: true,
       noScroll: true,
+    }).catch(() => {
+      if (lastSyncedThreadRoute === nextRoute) {
+        lastSyncedThreadRoute = null;
+        directThreadUrlPending = false;
+      }
     });
+    return true;
   }
 
   function ensureWorkspacePinsWs() {
@@ -1078,14 +1094,8 @@
     void (async () => {
       if (requestedIdeaId) {
         lastRequestedIdeaId = requestedIdeaId;
-        const opened = await cortex.loadDirectThread(requestedIdeaId);
-        if (opened) {
-          syncCanonicalThreadUrl(requestedIdeaId);
-        } else {
-          cleanupUnresolvedThreadUrl(requestedIdeaId);
-        }
+        await openDirectThreadAndSyncUrl(requestedIdeaId);
         clearRuntimeReadyOnboardingUrl();
-        directThreadUrlPending = false;
       } else {
         await loadWorkspaceSceneSidecars();
         await maybeSelectIdeaFromUrl();

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -1645,20 +1645,23 @@
     });
   }
 
+  function openWorkspaceThread(id: string, x: number, y: number) {
+    if (isPreviewIdeaId(id)) return;
+    if (onthreadopen) {
+      onthreadopen({ x, y, id });
+      return;
+    }
+    void cortex.selectIdea(id);
+  }
+
   function activatePrimitiveBlob(blob: PrimitiveBlobVisual, event?: MouseEvent | PointerEvent) {
     event?.stopPropagation();
     if (primitiveDragState?.moved) return;
-    if (isPreviewIdeaId(blob.id)) return;
     const node = orbitSceneNodesById.get(blob.id);
     const position = node ? renderedIdeaPosition(node) : { x: blob.x, y: blob.y };
     const rect = containerEl?.getBoundingClientRect();
     const [localX, localY] = currentZoomTransform.apply([position.x, position.y]);
-    onthreadopen?.({
-      x: (rect?.left ?? 0) + localX,
-      y: (rect?.top ?? 0) + localY,
-      id: blob.id,
-    });
-    cortex.selectIdea(blob.id);
+    openWorkspaceThread(blob.id, (rect?.left ?? 0) + localX, (rect?.top ?? 0) + localY);
   }
 
   function refreshShadowBubbleTitle(node: OrbitNode) {
@@ -3669,10 +3672,8 @@
       bubbleSel
         .on('click', (e: Event, d: any) => {
           e.stopPropagation();
-          if (isPreviewIdeaId(d?.id)) return;
           const mouse = e as MouseEvent;
-          onthreadopen?.({ x: mouse.clientX, y: mouse.clientY, id: d.id });
-          cortex.selectIdea(d.id);
+          openWorkspaceThread(d.id, mouse.clientX, mouse.clientY);
         })
         .on('mouseover', function(e: any, d: any) {
           d3.select(this).raise();
@@ -3900,10 +3901,8 @@
     bubble
       .on('click', (e: Event) => {
         e.stopPropagation();
-        if (isPreviewIdeaId(sceneNode?.id)) return;
         const mouse = e as MouseEvent;
-        onthreadopen?.({ x: mouse.clientX, y: mouse.clientY, id: sceneNode.id });
-        cortex.selectIdea(sceneNode.id);
+        openWorkspaceThread(sceneNode.id, mouse.clientX, mouse.clientY);
       })
       .on('mouseover', function(e: any) {
         d3.select(this).raise();

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -1199,7 +1199,8 @@ class CortexStore {
         this.teamMembers = this._normalizeTeamMembers(this.teamMembers);
         this.teamMembersLoaded = true;
       }
-      return this._applyLoadedStream(id, version, bootstrap.direct_thread.stream);
+      const applied = this._applyLoadedStream(id, version, bootstrap.direct_thread.stream);
+      return applied || this.selectedIdeaId === id;
     } catch {
       await this._load({ loadTeamMembers: false });
       const activeIdea = this.ideas.find((idea) => idea.id === id && !idea.archived_at);


### PR DESCRIPTION
## Summary

- route workspace blob opens through the direct thread loader before syncing the canonical `/threads/:id` URL
- keep direct-thread URL navigation marked pending while the thread is loading so cleanup effects do not close it mid-flight
- treat stale same-thread direct loads as successful when the selected thread is still active

## Verification

- `npm test`
- `npm run check`
- local headless Chrome repro: created a real local idea, clicked its workspace blob, confirmed `/threads/:id`, `panelOpen=true`, and `.thread-stage-panel` mounted
