### PR TITLE
Add Slack channel inventory tool

### DIFF
--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -273,7 +273,7 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "slack",
         "name": "Slack",
         "category": "external_surface",
-        "summary": "Illo can participate in Slack conversations when a Slack source connection is registered for the workspace.",
+        "summary": "Illo can participate in Slack conversations and enumerate bot-visible Slack conversations when a Slack source connection is registered for the workspace.",
         "aliases": ("slack", "team chat", "chat teammate", "slack integration"),
         "tools": ("manage_slack", "read_slack_conversation", "post_slack_reply"),
         "status_check": {"tool": "manage_slack", "args": {"action": "status"}},

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -46,6 +46,56 @@ def _coerce_slack_limit(value: Any, default: int = 50) -> int:
         return default
 
 
+def _coerce_slack_list_limit(value: Any, default: int = 200) -> int:
+    try:
+        return max(1, min(int(value or default), 1000))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def _normalize_slack_channel_types(value: Any) -> str:
+    allowed = {"public_channel", "private_channel", "mpim", "im"}
+    if value is None:
+        requested = ["public_channel", "private_channel", "mpim", "im"]
+    elif isinstance(value, str):
+        requested = [part.strip() for part in value.split(",")]
+    else:
+        requested = [str(part).strip() for part in value]
+    normalized = [part for part in requested if part in allowed]
+    return ",".join(dict.fromkeys(normalized)) or "public_channel,private_channel,mpim,im"
+
+
+def _slack_channel_payload(channel: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": channel.get("id"),
+        "name": channel.get("name") or channel.get("user"),
+        "is_channel": channel.get("is_channel"),
+        "is_group": channel.get("is_group"),
+        "is_im": channel.get("is_im"),
+        "is_mpim": channel.get("is_mpim"),
+        "is_private": channel.get("is_private"),
+        "is_member": channel.get("is_member"),
+        "is_archived": channel.get("is_archived"),
+        "num_members": channel.get("num_members"),
+        "topic": channel.get("topic") if isinstance(channel.get("topic"), dict) else None,
+        "purpose": channel.get("purpose") if isinstance(channel.get("purpose"), dict) else None,
+    }
+
+
 async def _slack_client_from_runtime():
     from brain.systems.slack.client import SlackWebClient
     from brain.systems.vault.runtime_secrets import read_runtime_secret
@@ -232,6 +282,10 @@ async def _handle_manage_slack(
     connection_id: str | None = None,
     slack_user_id: str | None = None,
     user_id: str | None = None,
+    channel_types: str | list[str] | None = None,
+    limit: int = 200,
+    cursor: str | None = None,
+    include_archived: bool = False,
 ) -> str:
     """Inspect Slack connection health and manage minimal identity mappings."""
 
@@ -282,6 +336,38 @@ async def _handle_manage_slack(
         if error:
             return json.dumps({"error": error})
 
+        if normalized_action == "list_channels":
+            try:
+                client = await _slack_client_from_runtime()
+                response = await client.conversations_list(
+                    types=_normalize_slack_channel_types(channel_types),
+                    limit=_coerce_slack_list_limit(limit),
+                    cursor=str(cursor or "").strip() or None,
+                    exclude_archived=not _coerce_bool(include_archived, default=False),
+                )
+            except Exception as exc:
+                return json.dumps({"error": str(exc)})
+            channels = [
+                _slack_channel_payload(channel)
+                for channel in list(response.get("channels") or [])
+                if isinstance(channel, dict)
+            ]
+            metadata = response.get("response_metadata") if isinstance(response.get("response_metadata"), dict) else {}
+            return json.dumps(
+                {
+                    "ok": True,
+                    "connection": _slack_connection_payload(connection),
+                    "count": len(channels),
+                    "channels": channels,
+                    "next_cursor": str(metadata.get("next_cursor") or "") or None,
+                    "visibility_note": (
+                        "Slack only returns conversations visible to the configured bot token; "
+                        "private channels may require the bot to be invited and the app to have the right scopes."
+                    ),
+                },
+                default=str,
+            )
+
         if normalized_action == "list_mappings":
             mappings = await list_slack_identity_mappings(
                 uow.session,
@@ -307,7 +393,7 @@ async def _handle_manage_slack(
             )
             return json.dumps({"ok": True, "mapping": mapping}, default=str)
 
-    return json.dumps({"error": "manage_slack action must be status, list_mappings, link_identity, or unlink_identity"})
+    return json.dumps({"error": "manage_slack action must be status, list_channels, list_mappings, link_identity, or unlink_identity"})
 
 
 __all__ = [

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -372,7 +372,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "inbound_configuration",
         "reversibility": "variable",
         "action_manifest": True,
-        "expected_effect": "inspect Slack connection health or update Slack-to-Illospace identity mappings",
+        "expected_effect": "inspect Slack connection health, list bot-visible Slack conversations, or update Slack-to-Illospace identity mappings",
         "output_budget_chars": 12_000,
     },
     "manage_project": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1425,9 +1425,11 @@ CHAT_TOOLS = [
     {
         "name": "manage_slack",
         "description": (
-            "Inspect Slack connection health and Slack-to-Illospace identity mappings. "
-            "Use action='status' to check whether Slack is connected, and use "
-            "identity mapping actions to link Slack users to Illospace users."
+            "Inspect Slack connection health, list Slack conversations visible to Illo's bot, "
+            "and manage Slack-to-Illospace identity mappings. Use action='status' to check "
+            "whether Slack is connected, action='list_channels' to see channels/DMs the "
+            "configured bot token can enumerate, and identity mapping actions to link Slack users "
+            "to Illospace users."
         ),
         "input_schema": {
             "type": "object",
@@ -1436,6 +1438,7 @@ CHAT_TOOLS = [
                     "type": "string",
                     "enum": [
                         "status",
+                        "list_channels",
                         "list_mappings",
                         "link_identity",
                         "unlink_identity",
@@ -1453,6 +1456,27 @@ CHAT_TOOLS = [
                 "user_id": {
                     "type": "string",
                     "description": "Illospace user id, required for link_identity.",
+                },
+                "channel_types": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "string"}},
+                    ],
+                    "description": "Conversation types for list_channels: public_channel, private_channel, mpim, im. Defaults to all supported types.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum Slack conversations to return for list_channels, up to Slack's page limit.",
+                    "default": 200,
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Slack pagination cursor for list_channels.",
+                },
+                "include_archived": {
+                    "type": "boolean",
+                    "description": "Include archived Slack conversations in list_channels results.",
+                    "default": False,
                 },
             },
             "required": ["action"],

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -114,6 +114,23 @@ class SlackWebClient:
             payload["inclusive"] = True
         return await self.api_call("conversations.history", payload)
 
+    async def conversations_list(
+        self,
+        *,
+        types: str = "public_channel,private_channel,mpim,im",
+        limit: int = 200,
+        cursor: str | None = None,
+        exclude_archived: bool = True,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "types": types,
+            "limit": max(1, min(int(limit or 200), 1000)),
+            "exclude_archived": bool(exclude_archived),
+        }
+        if cursor:
+            payload["cursor"] = cursor
+        return await self.api_call("conversations.list", payload)
+
     async def auth_test(self) -> dict[str, Any]:
         return await self.api_call("auth.test", {})
 

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -129,6 +129,9 @@ class SlackWebClient:
         }
         if cursor:
             payload["cursor"] = cursor
+        post = getattr(self, "_post", None)
+        if callable(post):
+            return await post("conversations.list", payload)
         return await self.api_call("conversations.list", payload)
 
     async def auth_test(self) -> dict[str, Any]:

--- a/deploy/slack/illo-self-hosted-manifest.yml
+++ b/deploy/slack/illo-self-hosted-manifest.yml
@@ -13,6 +13,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - chat:write.public
       - files:read
       - files:write
       - groups:history
@@ -20,6 +21,8 @@ oauth_config:
       - im:history
       - im:read
       - im:write
+      - mpim:history
+      - mpim:read
       - users:read
 settings:
   event_subscriptions:

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -58,3 +58,8 @@ Slack connection owner as the authority user while preserving Slack provenance.
 When identity matters, Illo can use `manage_slack` to inspect connection health
 and link a Slack user id to an Illospace user id. Once linked, later Slack runs
 from that Slack user are attributed to the mapped Illospace user.
+
+
+## Channel inventory
+
+Illo can list Slack conversations through `manage_slack(action="list_channels")`. The result is bounded by Slack itself: public channels require `channels:read`, private channels require `groups:read` and may only appear when the app/bot can see them, MPIMs require `mpim:read`, and DMs require `im:read`. Posting into public channels the bot has not joined requires `chat:write.public`; private channels still require inviting the bot.

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -99,6 +99,7 @@ def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
         "channels:history",
         "channels:read",
         "chat:write",
+        "chat:write.public",
         "files:read",
         "files:write",
         "groups:history",
@@ -106,6 +107,8 @@ def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
         "im:history",
         "im:read",
         "im:write",
+        "mpim:history",
+        "mpim:read",
         "users:read",
     }.issubset(bot_scopes)
 
@@ -609,7 +612,7 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
     actions = tool["input_schema"]["properties"]["action"]["enum"]
     serialized_tool = json.dumps(tool)
 
-    assert actions == ["status", "list_mappings", "link_identity", "unlink_identity"]
+    assert actions == ["status", "list_channels", "list_mappings", "link_identity", "unlink_identity"]
     assert "setup_instructions" not in serialized_tool
     assert "SLACK_" not in serialized_tool
     assert "docker" not in serialized_tool
@@ -670,6 +673,138 @@ async def test_manage_slack_status_returns_connection_facts_not_setup_guidance(m
     assert "server secret store" not in serialized
     invented_surface = "Illospace Slack " + "connection setup"
     assert invented_surface not in serialized
+
+
+@pytest.mark.asyncio
+async def test_slack_web_client_lists_conversations_with_safe_defaults(monkeypatch):
+    from brain.systems.slack.client import SlackWebClient
+
+    calls = []
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True, "channels": []}
+
+    class _AsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        async def post(self, url, *, headers, json):
+            calls.append({"url": url, "headers": headers, "json": json})
+            return _Response()
+
+    monkeypatch.setattr("httpx.AsyncClient", _AsyncClient)
+
+    client = SlackWebClient("xoxb-test")
+    await client.conversations_list(
+        types="public_channel,private_channel",
+        limit=5000,
+        cursor="cursor-1",
+        exclude_archived=True,
+    )
+
+    assert calls == [
+        {
+            "url": "https://slack.com/api/conversations.list",
+            "headers": {
+                "Authorization": "Bearer xoxb-test",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            "json": {
+                "types": "public_channel,private_channel",
+                "limit": 1000,
+                "exclude_archived": True,
+                "cursor": "cursor-1",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manage_slack_list_channels_returns_bot_visible_conversations(session, monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+
+    connection = await _seed_slack_connection(session)
+    calls = []
+
+    class _SlackClient:
+        async def conversations_list(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "ok": True,
+                "channels": [
+                    {
+                        "id": "C456",
+                        "name": "team",
+                        "is_channel": True,
+                        "is_private": False,
+                        "is_member": True,
+                        "is_archived": False,
+                        "num_members": 12,
+                    }
+                ],
+                "response_metadata": {"next_cursor": "next-1"},
+            }
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        result = json.loads(
+            await _handle_manage_slack(
+                action="list_channels",
+                connection_id=str(connection.id),
+                channel_types=["public_channel", "bogus", "private_channel"],
+                limit=5000,
+                cursor="cursor-1",
+                include_archived=False,
+            )
+        )
+
+    assert calls == [
+        {
+            "types": "public_channel,private_channel",
+            "limit": 1000,
+            "cursor": "cursor-1",
+            "exclude_archived": True,
+        }
+    ]
+    assert result["ok"] is True
+    assert result["connection"]["id"] == str(connection.id)
+    assert result["count"] == 1
+    assert result["channels"] == [
+        {
+            "id": "C456",
+            "name": "team",
+            "is_channel": True,
+            "is_group": None,
+            "is_im": None,
+            "is_mpim": None,
+            "is_private": False,
+            "is_member": True,
+            "is_archived": False,
+            "num_members": 12,
+            "topic": None,
+            "purpose": None,
+        }
+    ]
+    assert result["next_cursor"] == "next-1"
+    assert "visible to the configured bot token" in result["visibility_note"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -759,10 +759,23 @@ async def test_manage_slack_list_channels_returns_bot_visible_conversations(sess
     async def slack_client():
         return _SlackClient()
 
+    class _UnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, _exc, _tb):
+            if exc_type is None:
+                await session.flush()
+            return None
+
     monkeypatch.setattr(
         "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
         slack_client,
     )
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
 
     with bind_agent_context({"org_id": ORG_ID}):
         result = json.loads(


### PR DESCRIPTION
Adds Slack channel inventory support so Illo can enumerate conversations visible to the configured Slack bot token.

Changes:
- Adds Slack Web API `conversations.list` wrapper.
- Adds `manage_slack(action="list_channels")` with pagination/type filters and a visibility caveat.
- Updates tool schema, capability summary, registry effect, self-hosted manifest scopes, docs, and Slack tests.

Validation:
- `python -m compileall -q brain/systems/slack/client.py brain/systems/runs/tool_catalog/handlers/slack.py brain/systems/runs/tool_definitions.py brain/systems/runs/capabilities.py tests/test_slack_teammate.py`
- `git diff --check`
- Source assertions for tool/schema/docs/manifest

Note: `python -m pytest tests/test_slack_teammate.py -q` could not run in this worktree because pytest is not installed in the runtime image.