### PR TITLE
Route launch handoff links through API redirect

### DIFF
--- a/brain/app/api/routers/launch_handoffs.py
+++ b/brain/app/api/routers/launch_handoffs.py
@@ -96,17 +96,8 @@ async def _redirect_to_handoff_target(
     return RedirectResponse(launch_handoffs.codex_deep_link_for_handoff(row), status_code=302)
 
 
-@router.get("/codex/handoffs/{handoff_id}")
-async def redirect_codex_handoff(
-    handoff_id: str,
-    db: AsyncSession = Depends(get_db),
-    user: dict = Depends(get_current_user),
-) -> RedirectResponse:
-    return await _redirect_to_handoff_target(handoff_id, target=launch_handoffs.TARGET_CODEX, db=db, user=user)
-
-
-@router.get("/handoffs/{handoff_id}/launch")
-async def redirect_launch_handoff(
+@router.get("/api/launch-handoffs/{handoff_id}/launch")
+async def redirect_api_launch_handoff(
     handoff_id: str,
     target: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),

--- a/brain/systems/launch_handoffs.py
+++ b/brain/systems/launch_handoffs.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import parse_qs, quote, unquote, urlencode, urlsplit
+from urllib.parse import quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,13 +17,11 @@ from brain.systems.cortex.thread_links import public_app_base_url
 
 LAUNCH_HANDOFF_OBJECT_TYPE = "launch_handoff"
 TARGET_CODEX = "codex"
-CODEX_HANDOFF_ROUTE_PREFIX = "/codex/handoffs"
-LAUNCH_HANDOFF_ROUTE_PREFIX = "/handoffs"
-API_LAUNCH_HANDOFF_ROUTE_PREFIX = "/launch-handoffs"
+LAUNCH_HANDOFF_ROUTE_PREFIX = "/api/launch-handoffs"
 
 _HANDOFF_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
 _URL_CANDIDATE_RE = re.compile(
-    r"https?://[^\s<>'\"\]\)]+|/(?:codex/handoffs/|handoffs/|launch-handoffs/)[^\s<>'\"\]\)]+",
+    r"https?://[^\s<>'\"\]\)]+|/api/launch-handoffs/[^\s<>'\"\]\)]+",
     re.IGNORECASE,
 )
 _TRAILING_PUNCTUATION = ".,;:!?"
@@ -116,12 +114,9 @@ def handoff_id_from_reference(value: Any, *, allow_raw_id: bool = False) -> str 
 
     parts = urlsplit(text)
     path = parts.path or text
-    for prefix in (CODEX_HANDOFF_ROUTE_PREFIX, LAUNCH_HANDOFF_ROUTE_PREFIX, API_LAUNCH_HANDOFF_ROUTE_PREFIX):
-        if path.startswith(f"{prefix}/"):
-            tail = path[len(prefix) + 1:]
-            return _clean_handoff_id(tail.split("/", 1)[0])
-    if path == LAUNCH_HANDOFF_ROUTE_PREFIX:
-        return _clean_handoff_id(parse_qs(parts.query).get("handoff_id", [None])[0])
+    if path.startswith(f"{LAUNCH_HANDOFF_ROUTE_PREFIX}/"):
+        tail = path[len(LAUNCH_HANDOFF_ROUTE_PREFIX) + 1:]
+        return _clean_handoff_id(tail.split("/", 1)[0])
     return None
 
 
@@ -140,8 +135,6 @@ def extract_launch_handoff_reference_values(text: str) -> list[str]:
 
 def launch_handoff_route_for_id(handoff_id: Any, *, target_tool: str = TARGET_CODEX) -> str:
     target = str(target_tool or TARGET_CODEX).strip().lower()
-    if target == TARGET_CODEX:
-        return f"{CODEX_HANDOFF_ROUTE_PREFIX}/{quote(str(handoff_id), safe='')}"
     return f"{LAUNCH_HANDOFF_ROUTE_PREFIX}/{quote(str(handoff_id), safe='')}/launch?target={quote(target, safe='')}"
 
 

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -595,7 +595,7 @@ async def test_launch_handoff_redirects_to_codex_deep_link():
     ):
         response = await _request(
             "GET",
-            f"/codex/handoffs/{row.id}",
+            f"/api/launch-handoffs/{row.id}/launch?target=codex",
             follow_redirects=False,
         )
 
@@ -616,7 +616,7 @@ async def test_launch_handoff_redirect_requires_org_context():
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.get(
-                "/codex/handoffs/88888888-8888-4888-8888-888888888888",
+                "/api/launch-handoffs/88888888-8888-4888-8888-888888888888/launch?target=codex",
                 follow_redirects=False,
             )
     finally:
@@ -647,7 +647,7 @@ async def test_launch_handoff_api_create_returns_launch_url():
     assert response.status_code == 201
     payload = response.json()["handoff"]
     assert payload["id"] == row.id
-    assert payload["launch_url"].endswith(f"/codex/handoffs/{row.id}")
+    assert payload["launch_url"].endswith(f"/api/launch-handoffs/{row.id}/launch?target=codex")
     create.assert_awaited_once()
 
 
@@ -979,7 +979,7 @@ async def test_hosted_mcp_read_handoff_get_returns_context():
                     "name": "illo_read",
                     "arguments": {
                         "capability": "handoff.get",
-                        "arguments": {"url": f"https://illo.example.com/codex/handoffs/{row.id}"},
+                        "arguments": {"url": f"https://illo.example.com/api/launch-handoffs/{row.id}/launch?target=codex"},
                     },
                 },
             },
@@ -1032,7 +1032,7 @@ async def test_hosted_mcp_create_handoff_commits_and_returns_launch_url():
     assert response.status_code == 200
     payload = json.loads(response.json()["result"]["content"][0]["text"])
     assert payload["handoff"]["id"] == row.id
-    assert payload["launch_url"].endswith(f"/codex/handoffs/{row.id}")
+    assert payload["launch_url"].endswith(f"/api/launch-handoffs/{row.id}/launch?target=codex")
     assert order == ["commit"]
     create.assert_awaited_once()
 

--- a/tests/test_thread_url_references.py
+++ b/tests/test_thread_url_references.py
@@ -75,15 +75,15 @@ def test_extract_thread_reference_values_finds_embedded_urls():
 def test_launch_handoff_links_use_codex_route_and_origin_url(monkeypatch):
     monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com/app")
 
-    assert launch_handoff_route_for_id(HANDOFF_ID) == f"/codex/handoffs/{HANDOFF_ID}"
-    assert launch_handoff_url_for_id(HANDOFF_ID) == f"https://illo.example.com/codex/handoffs/{HANDOFF_ID}"
-    assert handoff_id_from_reference(f"https://illo.example.com/codex/handoffs/{HANDOFF_ID}") == HANDOFF_ID
-    assert handoff_id_from_reference(f"/handoffs/{HANDOFF_ID}/launch?target=codex") == HANDOFF_ID
+    launch_route = f"/api/launch-handoffs/{HANDOFF_ID}/launch?target=codex"
+    assert launch_handoff_route_for_id(HANDOFF_ID) == launch_route
+    assert launch_handoff_url_for_id(HANDOFF_ID) == f"https://illo.example.com{launch_route}"
+    assert handoff_id_from_reference(f"https://illo.example.com{launch_route}") == HANDOFF_ID
     assert handoff_id_from_reference(HANDOFF_ID) is None
     assert handoff_id_from_reference(HANDOFF_ID, allow_raw_id=True) == HANDOFF_ID
     assert extract_launch_handoff_reference_values(
-        f"Open https://illo.example.com/codex/handoffs/{HANDOFF_ID}."
-    ) == [f"https://illo.example.com/codex/handoffs/{HANDOFF_ID}"]
+        f"Open https://illo.example.com{launch_route}."
+    ) == [f"https://illo.example.com{launch_route}"]
 
 
 def test_launch_handoff_preview_and_codex_prompt_are_compact(monkeypatch):
@@ -113,11 +113,14 @@ def test_launch_handoff_preview_and_codex_prompt_are_compact(monkeypatch):
         created_at = None
         updated_at = None
 
-    payload = launch_handoff_reference_payload(Row(), original_ref=f"/codex/handoffs/{HANDOFF_ID}")
+    payload = launch_handoff_reference_payload(
+        Row(),
+        original_ref=f"/api/launch-handoffs/{HANDOFF_ID}/launch?target=codex",
+    )
     deep_link = codex_deep_link_for_handoff(Row())
 
     assert payload["object_type"] == "launch_handoff"
-    assert payload["launch_url"] == f"https://illo.example.com/codex/handoffs/{HANDOFF_ID}"
+    assert payload["launch_url"] == f"https://illo.example.com/api/launch-handoffs/{HANDOFF_ID}/launch?target=codex"
     assert payload["preview_summary"] == "Create a generic handoff link for Codex."
     assert "codex://threads/new?" in deep_link
     assert "originUrl=git%40github.com" in deep_link


### PR DESCRIPTION
## Summary
- change generated Codex handoff launch URLs from frontend-caught /codex/handoffs/:id to backend-routed /api/launch-handoffs/:id/launch?target=codex
- make /api/launch-handoffs/:id/launch the only supported handoff URL shape
- remove the dead /codex/handoffs and /handoffs redirect/parser compatibility paths

## Root cause
Production serves /codex/handoffs/:id as the Svelte app shell, so Slack links returned HTML instead of a 302 to codex://. The MCP handoff read path worked, but the click-to-launch URL did not reach FastAPI.

## Validation
- venv/bin/python3 -m pytest tests/test_thread_url_references.py tests/test_external_agent_routes.py tests/test_tool_registry.py
- git diff --check