### PR TITLE
Fix Slack private channel inventory

### DIFF
--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -281,7 +281,7 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "slack",
         "name": "Slack",
         "category": "external_surface",
-        "summary": "Illo can participate in Slack conversations and enumerate bot-visible Slack conversations when a Slack source connection is registered for the workspace.",
+        "summary": "Illo can participate in Slack conversations and enumerate bot-visible or previously observed Slack conversations when a Slack source connection is registered for the workspace.",
         "aliases": ("slack", "team chat", "chat teammate", "slack integration"),
         "tools": ("manage_slack", "read_slack_conversation", "post_slack_reply"),
         "status_check": {"tool": "manage_slack", "args": {"action": "status"}},

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -96,6 +96,97 @@ def _slack_channel_payload(channel: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _slack_connection_online(connection: Any) -> bool:
+    return str(getattr(connection, "status", "") or "").strip().lower() in {"connected", "online"}
+
+
+def _slack_event_type_to_channel_type(channel_type: str, channel_id: str = "") -> str:
+    normalized = str(channel_type or "").strip().lower()
+    if normalized in {"public_channel", "private_channel", "mpim", "im"}:
+        return normalized
+    if normalized == "channel":
+        return "public_channel"
+    if normalized == "group":
+        return "private_channel"
+    if normalized:
+        return normalized
+    if channel_id.startswith("D"):
+        return "im"
+    if channel_id.startswith("G"):
+        return "private_channel"
+    return "public_channel"
+
+
+def _observed_slack_channel_payload(event: Any) -> dict[str, Any] | None:
+    payload = getattr(event, "raw_payload", None)
+    if not isinstance(payload, dict):
+        return None
+    channel_id = str(payload.get("channel_id") or "").strip()
+    if not channel_id:
+        return None
+    channel_type = str(payload.get("channel_type") or "").strip()
+    slack_channel_type = _slack_event_type_to_channel_type(channel_type, channel_id)
+    is_private_channel = slack_channel_type == "private_channel"
+    observed_at = getattr(event, "created_at", None)
+    return {
+        "id": channel_id,
+        "name": str(payload.get("channel_name") or "").strip() or None,
+        "is_channel": slack_channel_type in {"public_channel", "private_channel"},
+        "is_group": is_private_channel,
+        "is_im": slack_channel_type == "im",
+        "is_mpim": slack_channel_type == "mpim",
+        "is_private": is_private_channel,
+        "is_member": True,
+        "is_archived": None,
+        "num_members": None,
+        "topic": None,
+        "purpose": None,
+        "source": "observed_slack_event",
+        "channel_type": channel_type or None,
+        "slack_channel_type": slack_channel_type,
+        "permalink": payload.get("permalink") or None,
+        "observed_at": observed_at.isoformat() if observed_at else None,
+    }
+
+
+async def _observed_slack_channels_for_connection(
+    session,
+    *,
+    org_id: str,
+    connection_id: str,
+    requested_types: set[str],
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    from sqlalchemy import select
+
+    from brain.platform.db.models.inbound import InboundEventRow
+
+    stmt = (
+        select(InboundEventRow)
+        .where(
+            InboundEventRow.org_id == str(org_id),
+            InboundEventRow.connection_id == str(connection_id),
+            InboundEventRow.kind == "slack_message",
+        )
+        .order_by(InboundEventRow.created_at.desc(), InboundEventRow.id.desc())
+        .limit(max(1, min(int(limit or 100), 500)))
+    )
+    observed: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for event in list((await session.scalars(stmt)).all()):
+        channel = _observed_slack_channel_payload(event)
+        if not channel:
+            continue
+        channel_id = str(channel.get("id") or "")
+        if channel_id in seen_ids:
+            continue
+        if str(channel.get("slack_channel_type") or "") not in requested_types:
+            continue
+        seen_ids.add(channel_id)
+        observed.append(channel)
+    return observed
+
+
 async def _slack_client_from_runtime():
     from brain.systems.slack.client import SlackWebClient
     from brain.systems.vault.runtime_secrets import read_runtime_secret
@@ -285,6 +376,9 @@ async def _slack_connection_for_tool(session, *, org_id: str, connection_id: str
     if not rows:
         return None, "Slack connection not found"
     if not connection_id and len(rows) > 1:
+        online_rows = [row for row in rows if _slack_connection_online(row)]
+        if len(online_rows) == 1:
+            return online_rows[0], None
         return None, "connection_id is required when multiple Slack connections exist"
     return rows[0], None
 
@@ -371,8 +465,9 @@ async def _handle_manage_slack(
         if normalized_action == "list_channels":
             try:
                 client = await _slack_client_from_runtime()
+                normalized_channel_types = _normalize_slack_channel_types(channel_types)
                 response = await client.conversations_list(
-                    types=_normalize_slack_channel_types(channel_types),
+                    types=normalized_channel_types,
                     limit=_coerce_slack_list_limit(limit),
                     cursor=str(cursor or "").strip() or None,
                     exclude_archived=not _coerce_bool(include_archived, default=False),
@@ -384,6 +479,19 @@ async def _handle_manage_slack(
                 for channel in list(response.get("channels") or [])
                 if isinstance(channel, dict)
             ]
+            observed_channels = await _observed_slack_channels_for_connection(
+                uow.session,
+                org_id=org_id,
+                connection_id=str(connection.id),
+                requested_types={part for part in normalized_channel_types.split(",") if part},
+            )
+            existing_channel_ids = {str(channel.get("id") or "") for channel in channels}
+            observed_channels = [
+                channel
+                for channel in observed_channels
+                if str(channel.get("id") or "") and str(channel.get("id") or "") not in existing_channel_ids
+            ]
+            channels.extend(observed_channels)
             metadata = response.get("response_metadata") if isinstance(response.get("response_metadata"), dict) else {}
             return json.dumps(
                 {
@@ -391,10 +499,13 @@ async def _handle_manage_slack(
                     "connection": _slack_connection_payload(connection),
                     "count": len(channels),
                     "channels": channels,
+                    "requested_channel_types": normalized_channel_types,
+                    "observed_channel_count": len(observed_channels),
                     "next_cursor": str(metadata.get("next_cursor") or "") or None,
                     "visibility_note": (
                         "Slack only returns conversations visible to the configured bot token; "
-                        "private channels may require the bot to be invited and the app to have the right scopes."
+                        "private channels may require the bot to be invited and the app to have the right scopes. "
+                        "Slack-origin mentions are also surfaced as observed_slack_event channels when Slack listing omits them."
                     ),
                 },
                 default=str,

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -382,7 +382,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "inbound_configuration",
         "reversibility": "variable",
         "action_manifest": True,
-        "expected_effect": "inspect Slack connection health, list bot-visible Slack conversations, or update Slack-to-Illospace identity mappings",
+        "expected_effect": "inspect Slack connection health, list bot-visible or observed Slack conversations, or update Slack-to-Illospace identity mappings",
         "output_budget_chars": 12_000,
     },
     "manage_project": {

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1444,10 +1444,12 @@ CHAT_TOOLS = [
     {
         "name": "manage_slack",
         "description": (
-            "Inspect Slack connection health, list Slack conversations visible to Illo's bot, "
+            "Inspect Slack connection health, list Slack conversations visible to Illo's bot or observed from "
+            "Slack-origin mentions, "
             "and manage Slack-to-Illospace identity mappings. Use action='status' to check "
             "whether Slack is connected, action='list_channels' to see channels/DMs the "
-            "configured bot token can enumerate, and identity mapping actions to link Slack users "
+            "configured bot token can enumerate plus Slack surfaces Illo has already seen, "
+            "and identity mapping actions to link Slack users "
             "to Illospace users."
         ),
         "input_schema": {

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -175,10 +175,7 @@ class SlackWebClient:
         }
         if cursor:
             payload["cursor"] = cursor
-        post = getattr(self, "_post", None)
-        if callable(post):
-            return await post("conversations.list", payload)
-        return await self.api_call("conversations.list", payload)
+        return await self._get("conversations.list", payload)
 
     async def auth_test(self) -> dict[str, Any]:
         return await self._post("auth.test", {})

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -115,6 +115,7 @@ def normalize_slack_socket_event(
     team_id = str(payload.get("team_id") or event.get("team") or "").strip()
     enterprise_id = str(payload.get("enterprise_id") or event.get("enterprise") or "").strip() or None
     channel_id = str(event.get("channel") or "").strip()
+    channel_name = str(event.get("channel_name") or event.get("channel_name_normalized") or "").strip() or None
     channel_type = str(event.get("channel_type") or "").strip()
     message_ts = str(event.get("ts") or event.get("event_ts") or "").strip()
     thread_ts = str(event.get("thread_ts") or message_ts).strip()
@@ -140,6 +141,7 @@ def normalize_slack_socket_event(
         "team_id": team_id,
         "enterprise_id": enterprise_id,
         "channel_id": channel_id,
+        "channel_name": channel_name,
         "channel_type": channel_type,
         "message_ts": message_ts,
         "thread_ts": thread_ts,
@@ -164,6 +166,7 @@ def normalize_slack_socket_event(
                 "surface": surface,
                 "team_id": team_id,
                 "channel_id": channel_id,
+                "channel_name": channel_name,
                 "channel_type": channel_type,
                 "message_ts": message_ts,
                 "thread_ts": thread_ts,

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -77,4 +77,4 @@ from that Slack user are attributed to the mapped Illospace user.
 
 ## Channel inventory
 
-Illo can list Slack conversations through `manage_slack(action="list_channels")`. The result is bounded by Slack itself: public channels require `channels:read`, private channels require `groups:read` and may only appear when the app/bot can see them, MPIMs require `mpim:read`, and DMs require `im:read`. Posting into public channels the bot has not joined requires `chat:write.public`; private channels still require inviting the bot.
+Illo can list Slack conversations through `manage_slack(action="list_channels")`. The result includes Slack API inventory plus Slack-origin channels Illo has already observed from mentions or DMs. Slack API inventory is bounded by Slack itself: public channels require `channels:read`, private channels require `groups:read` and may only appear when the app/bot can see them, MPIMs require `mpim:read`, and DMs require `im:read`. Posting into public channels the bot has not joined requires `chat:write.public`; private channels still require inviting the bot, but an observed private channel can still expose the channel id needed for posting.

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -86,7 +86,7 @@ async def _seed_slack_connection(session):
     return connection
 
 
-async def _seed_second_slack_connection(session):
+async def _seed_second_slack_connection(session, *, status: str = "online"):
     connection = ExternalAgentConnectionRow(
         id="44444444-4444-4444-8444-444444444444",
         org_id=ORG_ID,
@@ -94,7 +94,7 @@ async def _seed_second_slack_connection(session):
         display_name="Slack duplicate connector",
         agent_kind="slack",
         transport="slack_socket_mode",
-        status="online",
+        status=status,
         remote_agent_id="T789",
         remote_agent_card={},
         capabilities={"slack": {"socket_mode": True}},
@@ -232,6 +232,20 @@ def test_socket_mode_app_mention_normalizes_to_slack_surface_envelope():
         "thread_ts": None,
         "visibility": "public",
     }
+
+
+def test_socket_mode_preserves_channel_name_when_present():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_app_mention(channel="G456", channel_name="4_software", channel_type="group"),
+        bot_user_id="BILLO",
+    )
+
+    assert envelope is not None
+    assert envelope["payload"]["channel_id"] == "G456"
+    assert envelope["payload"]["channel_name"] == "4_software"
+    assert envelope["hints"]["surface"]["channel_name"] == "4_software"
 
 
 def test_socket_mode_ignores_non_dm_messages_without_illo_mention():
@@ -1226,8 +1240,8 @@ async def test_slack_web_client_lists_conversations_with_safe_defaults(monkeypat
         async def __aexit__(self, *_exc):
             return None
 
-        async def post(self, url, *, headers, json):
-            calls.append({"url": url, "headers": headers, "json": json})
+        async def get(self, url, *, headers, params):
+            calls.append({"url": url, "headers": headers, "params": params})
             return _Response()
 
     monkeypatch.setattr("httpx.AsyncClient", _AsyncClient)
@@ -1245,9 +1259,8 @@ async def test_slack_web_client_lists_conversations_with_safe_defaults(monkeypat
             "url": "https://slack.com/api/conversations.list",
             "headers": {
                 "Authorization": "Bearer xoxb-test",
-                "Content-Type": "application/json; charset=utf-8",
             },
-            "json": {
+            "params": {
                 "types": "public_channel,private_channel",
                 "limit": 1000,
                 "exclude_archived": True,
@@ -1345,7 +1358,153 @@ async def test_manage_slack_list_channels_returns_bot_visible_conversations(sess
         }
     ]
     assert result["next_cursor"] == "next-1"
+    assert result["requested_channel_types"] == "public_channel,private_channel"
+    assert result["observed_channel_count"] == 0
     assert "visible to the configured bot token" in result["visibility_note"]
+
+
+@pytest.mark.asyncio
+async def test_manage_slack_list_channels_auto_selects_single_live_connection(session, monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+
+    live_connection = await _seed_slack_connection(session)
+    await _seed_second_slack_connection(session, status="error")
+    calls = []
+
+    class _SlackClient:
+        async def conversations_list(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "channels": [], "response_metadata": {}}
+
+    async def slack_client():
+        return _SlackClient()
+
+    class _UnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, _exc, _tb):
+            if exc_type is None:
+                await session.flush()
+            return None
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        result = json.loads(await _handle_manage_slack(action="list_channels"))
+
+    assert result["ok"] is True
+    assert result["connection"]["id"] == str(live_connection.id)
+    assert calls == [
+        {
+            "types": "public_channel,private_channel,mpim,im",
+            "limit": 200,
+            "cursor": None,
+            "exclude_archived": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manage_slack_list_channels_includes_observed_private_slack_surfaces(session, monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+
+    connection = await _seed_slack_connection(session)
+    session.add(
+        InboundEventRow(
+            org_id=ORG_ID,
+            connection_id=str(connection.id),
+            kind="slack_message",
+            origin="slack.app_mention",
+            idempotency_key="slack:T789:G4SOFTWARE:1716901111.000100",
+            raw_payload={
+                "team_id": "T789",
+                "channel_id": "G4SOFTWARE",
+                "channel_name": "4_software",
+                "channel_type": "group",
+                "message_ts": "1716901111.000100",
+                "permalink": "https://example.slack.com/archives/G4SOFTWARE/p1716901111000100",
+            },
+            normalized_payload={},
+            envelope={},
+            ingress_context={},
+            source_actor={},
+            authority_user_id=USER_ID,
+            status="processed",
+        )
+    )
+    await session.flush()
+
+    calls = []
+
+    class _SlackClient:
+        async def conversations_list(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "ok": True,
+                "channels": [],
+                "response_metadata": {},
+            }
+
+    async def slack_client():
+        return _SlackClient()
+
+    class _UnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, _exc, _tb):
+            if exc_type is None:
+                await session.flush()
+            return None
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        result = json.loads(await _handle_manage_slack(action="list_channels", channel_types="private_channel"))
+
+    assert calls[0]["types"] == "private_channel"
+    assert result["count"] == 1
+    assert result["observed_channel_count"] == 1
+    observed_channel = result["channels"][0]
+    assert observed_channel.pop("observed_at")
+    assert result["channels"] == [
+        {
+            "id": "G4SOFTWARE",
+            "name": "4_software",
+            "is_channel": True,
+            "is_group": True,
+            "is_im": False,
+            "is_mpim": False,
+            "is_private": True,
+            "is_member": True,
+            "is_archived": None,
+            "num_members": None,
+            "topic": None,
+            "purpose": None,
+            "source": "observed_slack_event",
+            "channel_type": "group",
+            "slack_channel_type": "private_channel",
+            "permalink": "https://example.slack.com/archives/G4SOFTWARE/p1716901111000100",
+        }
+    ]
+    assert "observed_slack_event" in result["visibility_note"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix Slack conversations.list to send query params via GET so requested conversation types apply
- Merge observed Slack-origin channels into manage_slack inventory and preserve channel names
- Auto-select the single live Slack connection when stale duplicates exist

## Tests
- venv/bin/python3 -m pytest tests/test_slack_teammate.py -q
- venv/bin/python3 -m compileall brain/systems/slack/client.py brain/systems/runs/tool_catalog/handlers/slack.py brain/systems/slack/ingress.py brain/systems/runs/tool_definitions.py brain/systems/runs/capabilities.py brain/systems/runs/tool_catalog/registry.py
- git diff --check