### PR TITLE
Add Slack graph image replies

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
+from brain.systems.slack.uploads import slack_image_upload_from_data_url
 
 
 def _execution_metadata() -> dict[str, Any]:
@@ -230,17 +231,30 @@ async def _clear_processing_status(client: Any, trigger: dict[str, Any]) -> None
 
 
 async def _handle_post_slack_reply(
-    body: str,
+    body: str = "",
     channel_id: str | None = None,
     thread_ts: str | None = None,
     visibility: str | None = None,
     user_id: str | None = None,
+    image_data: str | None = None,
+    image_filename: str | None = None,
+    image_title: str | None = None,
+    image_alt: str | None = None,
 ) -> str:
     """Post an Illo-authored reply to the originating Slack surface."""
 
     text = str(body or "").strip()
-    if not text:
-        return json.dumps({"error": "post_slack_reply requires body"})
+    try:
+        image_upload = slack_image_upload_from_data_url(
+            image_data,
+            filename=image_filename,
+            title=image_title,
+            alt_txt=image_alt,
+        )
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+    if not text and image_upload is None:
+        return json.dumps({"error": "post_slack_reply requires body or image_data"})
 
     trigger = _current_slack_trigger()
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
@@ -260,13 +274,26 @@ async def _handle_post_slack_reply(
     target_visibility = str(visibility or response_target.get("visibility") or "public").strip().lower()
     if target_visibility not in {"public", "ephemeral"}:
         return json.dumps({"error": "post_slack_reply visibility must be public or ephemeral"})
+    if image_upload is not None and target_visibility == "ephemeral":
+        return json.dumps({"error": "post_slack_reply image uploads must be public"})
     if not target_channel:
         return json.dumps({"error": "post_slack_reply requires channel_id outside a Slack-triggered run"})
 
     try:
         client = await _slack_client_from_runtime()
         target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
-        if target_visibility == "ephemeral":
+        if image_upload is not None:
+            response = await client.upload_file(
+                channel=target_channel,
+                file_bytes=image_upload.file_bytes,
+                filename=image_upload.filename,
+                title=image_upload.title,
+                initial_comment=text or None,
+                thread_ts=target_thread_ts,
+                alt_txt=image_upload.alt_txt,
+                content_type=image_upload.content_type,
+            )
+        elif target_visibility == "ephemeral":
             target_user = str(user_id or trigger.get("slack_user_id") or "").strip()
             if not target_user:
                 return json.dumps({"error": "ephemeral Slack replies require a Slack user id"})
@@ -292,6 +319,7 @@ async def _handle_post_slack_reply(
             "channel_id": target_channel,
             "thread_ts": target_thread_ts,
             "visibility": target_visibility,
+            "uploaded_image": image_upload is not None,
             "slack": response,
         },
         default=str,

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1338,7 +1338,7 @@ CHAT_TOOLS = [
             "properties": {
                 "body": {
                     "type": "string",
-                    "description": "Concise Slack markdown message to post as Illo.",
+                    "description": "Concise Slack markdown message to post as Illo. When image_data is provided, this becomes the image's initial comment.",
                 },
                 "channel_id": {
                     "type": "string",
@@ -1358,8 +1358,30 @@ CHAT_TOOLS = [
                     "type": "string",
                     "description": "Slack user id required for ephemeral replies outside a Slack-triggered run.",
                 },
+                "image_data": {
+                    "type": "string",
+                    "description": (
+                        "Optional base64 data:image URL to upload and share as a Slack image file, "
+                        "for generated graphs or charts. Prefer data:image/png;base64 for reliable Slack previews."
+                    ),
+                },
+                "image_filename": {
+                    "type": "string",
+                    "description": "Optional filename for image_data, e.g. graph.png.",
+                },
+                "image_title": {
+                    "type": "string",
+                    "description": "Optional Slack file title for image_data.",
+                },
+                "image_alt": {
+                    "type": "string",
+                    "description": "Optional alt text for image_data, used by Slack for screen readers.",
+                },
             },
-            "required": ["body"],
+            "anyOf": [
+                {"required": ["body"]},
+                {"required": ["image_data"]},
+            ],
         },
     },
     {
@@ -2169,7 +2191,7 @@ CORTEX_VISUAL_REPLY_TOOL = {
     "name": "cortex_visual_reply",
     "description": (
         "Render compact static visual content in the Cortex workspace. Use for diffs, "
-        "charts, diagrams, markdown summaries, and screenshots. For interactive or "
+        "charts, diagrams, images, markdown summaries, and screenshots. For interactive or "
         "recordful generated UI, create or update a workspace app instead."
     ),
     "input_schema": {
@@ -2177,7 +2199,7 @@ CORTEX_VISUAL_REPLY_TOOL = {
         "properties": {
             "content_type": {
                 "type": "string",
-                "enum": ["diff", "chart", "diagram", "markdown", "screenshot"],
+                "enum": ["diff", "chart", "diagram", "image", "markdown", "screenshot"],
                 "description": "Type of visual content",
             },
             "title": {
@@ -2189,7 +2211,7 @@ CORTEX_VISUAL_REPLY_TOOL = {
                 "description": (
                     "The visual content. For diff: unified diff string. "
                     "For chart: JSON {type: 'bar'|'line'|'pie'|'scatter', data: [{label, value}], title?, xlabel?, ylabel?}. "
-                    "For diagram: SVG or Mermaid syntax. For markdown: markdown string. "
+                    "For diagram: SVG or Mermaid syntax. For image: HTTP URL, data:image URL, or inert SVG markup. For markdown: markdown string. "
                     "For screenshot: an image URL or data:image URL."
                 ),
             },

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -76,6 +76,15 @@ class SlackWebClient:
             data = response.json()
         return self._coerce_response(dict(data))
 
+    async def _post_bytes(self, url: str, *, data: bytes, content_type: str) -> None:
+        async with async_http_client(timeout=self.timeout) as client:
+            response = await client.post(
+                url,
+                headers={"Content-Type": content_type or "application/octet-stream"},
+                content=data,
+            )
+            response.raise_for_status()
+
     async def post_message(
         self,
         *,
@@ -107,6 +116,44 @@ class SlackWebClient:
         if thread_ts:
             payload["thread_ts"] = thread_ts
         return await self._post("chat.postEphemeral", payload)
+
+    async def upload_file(
+        self,
+        *,
+        channel: str,
+        file_bytes: bytes,
+        filename: str,
+        title: str | None = None,
+        initial_comment: str | None = None,
+        thread_ts: str | None = None,
+        alt_txt: str | None = None,
+        content_type: str = "application/octet-stream",
+    ) -> dict[str, Any]:
+        """Upload bytes through Slack's external upload flow and share the file."""
+
+        upload_request: dict[str, Any] = {
+            "filename": filename,
+            "length": len(file_bytes),
+        }
+        if alt_txt:
+            upload_request["alt_txt"] = alt_txt[:1000]
+        upload = await self._post("files.getUploadURLExternal", upload_request)
+        upload_url = str(upload.get("upload_url") or "").strip()
+        file_id = str(upload.get("file_id") or "").strip()
+        if not upload_url or not file_id:
+            raise SlackApiError("slack_upload_ticket_missing")
+
+        await self._post_bytes(upload_url, data=file_bytes, content_type=content_type)
+
+        complete_request: dict[str, Any] = {
+            "files": [{"id": file_id, "title": title or filename}],
+            "channel_id": channel,
+        }
+        if initial_comment:
+            complete_request["initial_comment"] = initial_comment
+        if thread_ts:
+            complete_request["thread_ts"] = thread_ts
+        return await self._post("files.completeUploadExternal", complete_request)
 
     async def set_assistant_status(
         self,

--- a/brain/systems/slack/uploads.py
+++ b/brain/systems/slack/uploads.py
@@ -1,0 +1,82 @@
+"""Slack upload payload normalization."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass
+import re
+
+
+MAX_SLACK_IMAGE_BYTES = 10 * 1024 * 1024
+_IMAGE_DATA_URL_RE = re.compile(r"^data:(image/[a-z0-9.+-]+);base64,(.+)$", re.IGNORECASE | re.DOTALL)
+_IMAGE_MIME_EXTENSIONS = {
+    "image/avif": "avif",
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/svg+xml": "svg",
+    "image/webp": "webp",
+}
+
+
+@dataclass(frozen=True)
+class SlackImageUpload:
+    file_bytes: bytes
+    content_type: str
+    filename: str
+    title: str
+    alt_txt: str | None
+
+
+def _decode_image_data_url(value: str) -> tuple[bytes, str]:
+    match = _IMAGE_DATA_URL_RE.match(value)
+    if not match:
+        raise ValueError("image_data must be a base64 data:image URL")
+    mime = match.group(1).lower()
+    if mime not in _IMAGE_MIME_EXTENSIONS:
+        raise ValueError("image_data must use png, jpg, gif, webp, avif, or svg")
+    try:
+        data = base64.b64decode(re.sub(r"\s+", "", match.group(2)), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("image_data contains invalid base64") from exc
+    if not data:
+        raise ValueError("image_data is empty")
+    if len(data) > MAX_SLACK_IMAGE_BYTES:
+        raise ValueError(f"image_data is too large for Slack upload ({len(data)} bytes)")
+    return data, mime
+
+
+def _slack_image_filename(filename: str | None, content_type: str) -> str:
+    extension = _IMAGE_MIME_EXTENSIONS.get(content_type, "png")
+    raw = re.sub(r"[^A-Za-z0-9._-]+", "-", str(filename or "").strip()).strip(".-")
+    if not raw:
+        raw = f"illo-graph.{extension}"
+    if "." not in raw.rsplit("/", 1)[-1]:
+        raw = f"{raw}.{extension}"
+    return raw[:120]
+
+
+def slack_image_upload_from_data_url(
+    image_data: str | None,
+    *,
+    filename: str | None = None,
+    title: str | None = None,
+    alt_txt: str | None = None,
+) -> SlackImageUpload | None:
+    raw = str(image_data or "").strip()
+    if not raw:
+        return None
+
+    file_bytes, content_type = _decode_image_data_url(raw)
+    normalized_filename = _slack_image_filename(filename or title, content_type)
+    normalized_title = str(title or "").strip() or normalized_filename
+    normalized_alt = str(alt_txt or title or "").strip() or None
+    return SlackImageUpload(
+        file_bytes=file_bytes,
+        content_type=content_type,
+        filename=normalized_filename,
+        title=normalized_title,
+        alt_txt=normalized_alt,
+    )

--- a/frontend/src/lib/features/threads/components/StreamVisualBlock.svelte
+++ b/frontend/src/lib/features/threads/components/StreamVisualBlock.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import DOMPurify from 'dompurify';
+  import { safeVisualImageSrc } from '$lib/utils/visualImageSource';
 
   let { block }: { block: { type: string; content: string; title?: string; language?: string } } = $props();
 
@@ -114,14 +115,6 @@
   function safeHref(url: string): string {
     const trimmed = url.trim();
     if (/^https?:\/\//i.test(trimmed) || /^mailto:/i.test(trimmed)) return trimmed;
-    return '';
-  }
-
-  function safeImageSrc(url: string): string {
-    const trimmed = url.trim();
-    if (/^https?:\/\//i.test(trimmed) || /^data:image\//i.test(trimmed) || /^blob:/i.test(trimmed)) {
-      return trimmed;
-    }
     return '';
   }
 
@@ -422,12 +415,12 @@
             {@html renderMarkdown(block.content)}
           </div>
 
-        <!-- ═══ SCREENSHOT ═══ -->
-        {:else if block.type === 'screenshot'}
-          {@const imageSrc = safeImageSrc(block.content)}
+        <!-- ═══ IMAGE / SCREENSHOT ═══ -->
+        {:else if block.type === 'image' || block.type === 'screenshot'}
+          {@const imageSrc = safeVisualImageSrc(block.content)}
           {#if imageSrc}
             <figure class="screenshot-view">
-              <img src={imageSrc} alt={block.title || 'Screenshot'} />
+              <img src={imageSrc} alt={block.title || (block.type === 'image' ? 'Image' : 'Screenshot')} />
             </figure>
           {:else}
             <pre class="code-view"><code>{block.content}</code></pre>

--- a/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadStreamAdapter.ts
@@ -270,7 +270,7 @@ export function mapThreadAttachment(att: any): CortexThreadStageAttachmentItem |
   const downloadUrl = attachmentDownloadUrl(att);
 
   const kind = att.content_type || att.type || '';
-  if (['diff', 'chart', 'preview', 'diagram', 'html', 'code', 'markdown', 'screenshot'].includes(kind)) {
+  if (['diff', 'chart', 'preview', 'diagram', 'html', 'code', 'image', 'markdown', 'screenshot'].includes(kind)) {
     return {
       kind: 'visual',
       block: {

--- a/frontend/src/lib/utils/visualImageSource.test.js
+++ b/frontend/src/lib/utils/visualImageSource.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { safeVisualImageSrc } from './visualImageSource.ts';
+
+test('encodes sanitized inline svg content as an image data url', () => {
+  const source = '<svg><script>alert(1)</script><path d="M0 0h1v1z"/></svg>';
+  const imageSrc = safeVisualImageSrc(source, {
+    sanitizeSvg: (content) => content.replace(/<script[\s\S]*?<\/script>/gi, ''),
+  });
+
+  assert.ok(imageSrc.startsWith('data:image/svg+xml;charset=utf-8,'));
+  const decoded = decodeURIComponent(imageSrc.split(',')[1]);
+  assert.equal(decoded, '<svg><path d="M0 0h1v1z"/></svg>');
+});
+
+test('preserves already-addressable image urls', () => {
+  assert.equal(safeVisualImageSrc('https://example.com/chart.png'), 'https://example.com/chart.png');
+  assert.equal(safeVisualImageSrc('data:image/png;base64,cG5n'), 'data:image/png;base64,cG5n');
+  assert.equal(safeVisualImageSrc('blob:https://example.com/graph'), 'blob:https://example.com/graph');
+});
+
+test('rejects non-image content and svg sanitized into non-svg content', () => {
+  assert.equal(safeVisualImageSrc('console.log("not an image")'), '');
+  assert.equal(safeVisualImageSrc('<svg><path /></svg>', { sanitizeSvg: () => '<p>nope</p>' }), '');
+});

--- a/frontend/src/lib/utils/visualImageSource.ts
+++ b/frontend/src/lib/utils/visualImageSource.ts
@@ -1,0 +1,44 @@
+import createDOMPurify from 'dompurify';
+
+export type SvgSanitizer = (content: string) => string;
+
+export interface VisualImageSourceOptions {
+  sanitizeSvg?: SvgSanitizer;
+}
+
+type DOMPurifyLike = {
+  sanitize: (dirty: string, config?: Record<string, unknown>) => string;
+};
+
+const SVG_DATA_URL_PREFIX = 'data:image/svg+xml;charset=utf-8,';
+
+function defaultSanitizeSvg(content: string): string {
+  const purifier = createDOMPurify as unknown as DOMPurifyLike | ((window: Window) => DOMPurifyLike);
+  if (typeof (purifier as DOMPurifyLike).sanitize === 'function') {
+    return String((purifier as DOMPurifyLike).sanitize(content, { USE_PROFILES: { svg: true } }));
+  }
+  if (typeof window !== 'undefined') {
+    const windowPurifier = (purifier as (window: Window) => DOMPurifyLike)(window);
+    return String(windowPurifier.sanitize(content, { USE_PROFILES: { svg: true } }));
+  }
+  return '';
+}
+
+export function isInlineSvgImageContent(content: string): boolean {
+  return /^\s*(?:<\?xml[\s\S]*?\?>\s*)?<svg[\s>]/i.test(content);
+}
+
+export function inlineSvgImageSrc(content: string, sanitizeSvg: SvgSanitizer = defaultSanitizeSvg): string {
+  const sanitized = String(sanitizeSvg(content)).trim();
+  if (!isInlineSvgImageContent(sanitized)) return '';
+  return `${SVG_DATA_URL_PREFIX}${encodeURIComponent(sanitized)}`;
+}
+
+export function safeVisualImageSrc(content: string, options: VisualImageSourceOptions = {}): string {
+  const trimmed = content.trim();
+  if (isInlineSvgImageContent(trimmed)) return inlineSvgImageSrc(trimmed, options.sanitizeSvg);
+  if (/^https?:\/\//i.test(trimmed) || /^data:image\//i.test(trimmed) || /^blob:/i.test(trimmed)) {
+    return trimmed;
+  }
+  return '';
+}

--- a/tests/test_cortex_visual_reply.py
+++ b/tests/test_cortex_visual_reply.py
@@ -29,14 +29,16 @@ def test_cortex_visual_reply_schema_preserves_supported_content_types():
     schema = CORTEX_VISUAL_REPLY_TOOL["input_schema"]
     content_types = schema["properties"]["content_type"]["enum"]
 
-    assert content_types == ["diff", "chart", "diagram", "markdown", "screenshot"]
+    assert content_types == ["diff", "chart", "diagram", "image", "markdown", "screenshot"]
     assert schema["properties"]["display"]["enum"] == ["inline", "canvas"]
     assert schema["required"] == ["content_type", "title", "content"]
 
 
 async def test_cortex_visual_reply_persists_and_broadcasts_visual_block(monkeypatch):
     import sys
+    import brain.platform.db.models.idea as idea_models
     import brain.systems.runs.tool_catalog.handlers.cortex_reply as cortex_reply
+    from brain.systems.runs.execution_context import bind_agent_context
 
     now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
     added_blocks = []
@@ -71,22 +73,20 @@ async def test_cortex_visual_reply_persists_and_broadcasts_visual_block(monkeypa
             return False
 
     run = SimpleNamespace(run_id=123)
-    monkeypatch.setattr(cortex_reply._agent_context, "idea_id", "idea-1", raising=False)
-    monkeypatch.setattr(cortex_reply._agent_context, "run", run, raising=False)
 
     fake_events = SimpleNamespace(publish_safe=lambda event, payload: published.append((event, payload)))
     fake_uow_mod = SimpleNamespace(UnitOfWork=FakeUnitOfWork, open_unit_of_work=lambda factory: factory())
-    fake_idea_mod = SimpleNamespace(VisualBlock=FakeVisualBlock)
     monkeypatch.setitem(sys.modules, "brain.systems.cortex.events", fake_events)
     monkeypatch.setitem(sys.modules, "brain.platform.db.repositories.unit_of_work", fake_uow_mod)
-    monkeypatch.setitem(sys.modules, "brain.platform.db.models.idea", fake_idea_mod)
+    monkeypatch.setattr(idea_models, "VisualBlock", FakeVisualBlock)
 
-    result = await cortex_reply._handle_cortex_visual_reply(
-        content_type="chart",
-        title="Build health",
-        content='{"type":"bar","data":[{"label":"passed","value":3}]}',
-        display="canvas",
-    )
+    with bind_agent_context(idea_id="idea-1", run=run):
+        result = await cortex_reply._handle_cortex_visual_reply(
+            content_type="chart",
+            title="Build health",
+            content='{"type":"bar","data":[{"label":"passed","value":3}]}',
+            display="canvas",
+        )
 
     assert result == {
         "posted": True,

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from brain.systems.slack import client as slack_client_module
 from brain.systems.slack.client import SlackApiError, SlackWebClient
+from brain.systems.slack.uploads import slack_image_upload_from_data_url
 
 
 class _Response:
@@ -38,6 +39,26 @@ def _patch_http_client(
 
     monkeypatch.setattr(slack_client_module, "async_http_client", lambda **_kwargs: _HttpClient())
     return calls
+
+
+def test_slack_image_upload_normalizes_data_url_payload():
+    upload = slack_image_upload_from_data_url(
+        "data:image/svg+xml;base64,PHN2Zy8+",
+        filename="weekly active users",
+        title="Weekly active users",
+    )
+
+    assert upload is not None
+    assert upload.file_bytes == b"<svg/>"
+    assert upload.content_type == "image/svg+xml"
+    assert upload.filename == "weekly-active-users.svg"
+    assert upload.title == "Weekly active users"
+    assert upload.alt_txt == "Weekly active users"
+
+
+def test_slack_image_upload_rejects_invalid_data_url_payload():
+    with pytest.raises(ValueError, match="base64 data:image URL"):
+        slack_image_upload_from_data_url("https://example.com/graph.png")
 
 
 @pytest.mark.asyncio
@@ -94,3 +115,65 @@ async def test_slack_client_surfaces_response_metadata_errors(monkeypatch):
             "[ERROR] missing required field: ts",
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_slack_client_uploads_file_with_external_upload_flow(monkeypatch):
+    calls: list[tuple[str, str, dict[str, str], dict[str, Any] | bytes]] = []
+
+    class _HttpClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc) -> None:
+            return None
+
+        async def post(self, url: str, *, headers: dict[str, str], json=None, content=None):
+            calls.append(("post", url, headers, json if json is not None else content))
+            if url.endswith("/files.getUploadURLExternal"):
+                return _Response({"ok": True, "upload_url": "https://files.slack.test/upload", "file_id": "F123"})
+            if url == "https://files.slack.test/upload":
+                return _Response({"ok": True})
+            if url.endswith("/files.completeUploadExternal"):
+                return _Response({"ok": True, "files": [{"id": "F123", "title": "Graph"}]})
+            return _Response({"ok": False, "error": "unexpected_url"})
+
+    monkeypatch.setattr(slack_client_module, "async_http_client", lambda **_kwargs: _HttpClient())
+
+    result = await SlackWebClient("xoxb-test").upload_file(
+        channel="C456",
+        file_bytes=b"png-bytes",
+        filename="graph.png",
+        title="Graph",
+        initial_comment="Here is the graph.",
+        thread_ts="1716900000.000100",
+        alt_txt="Line chart",
+        content_type="image/png",
+    )
+
+    assert result == {"ok": True, "files": [{"id": "F123", "title": "Graph"}]}
+    assert calls == [
+        (
+            "post",
+            "https://slack.com/api/files.getUploadURLExternal",
+            {"Authorization": "Bearer xoxb-test", "Content-Type": "application/json; charset=utf-8"},
+            {"filename": "graph.png", "length": 9, "alt_txt": "Line chart"},
+        ),
+        (
+            "post",
+            "https://files.slack.test/upload",
+            {"Content-Type": "image/png"},
+            b"png-bytes",
+        ),
+        (
+            "post",
+            "https://slack.com/api/files.completeUploadExternal",
+            {"Authorization": "Bearer xoxb-test", "Content-Type": "application/json; charset=utf-8"},
+            {
+                "files": [{"id": "F123", "title": "Graph"}],
+                "channel_id": "C456",
+                "initial_comment": "Here is the graph.",
+                "thread_ts": "1716900000.000100",
+            },
+        ),
+    ]

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 import json
 import re
@@ -637,6 +638,108 @@ async def test_post_slack_reply_tool_posts_to_triggering_thread(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_post_slack_reply_tool_uploads_image_to_triggering_thread(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def upload_file(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "files": [{"id": "F123", "title": kwargs["title"]}]}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    image_data = "data:image/png;base64," + base64.b64encode(b"png-bytes").decode("ascii")
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": "1716900000.000100",
+                    "visibility": "public",
+                }
+            },
+        }
+    ):
+        result = json.loads(
+            await _handle_post_slack_reply(
+                body="Here is the chart.",
+                image_data=image_data,
+                image_filename="weekly-active-users.png",
+                image_title="Weekly active users",
+                image_alt="Line chart of weekly active users",
+            )
+        )
+
+    assert result["ok"] is True
+    assert result["uploaded_image"] is True
+    assert calls == [
+        {
+            "channel": "C456",
+            "file_bytes": b"png-bytes",
+            "filename": "weekly-active-users.png",
+            "title": "Weekly active users",
+            "initial_comment": "Here is the chart.",
+            "thread_ts": "1716900000.000100",
+            "alt_txt": "Line chart of weekly active users",
+            "content_type": "image/png",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_tool_uploads_image_without_body(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def upload_file(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "files": [{"id": "F123", "title": kwargs["title"]}]}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    image_data = "data:image/png;base64," + base64.b64encode(b"png-bytes").decode("ascii")
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": "1716900000.000100",
+                    "visibility": "public",
+                }
+            },
+        }
+    ):
+        result = json.loads(await _handle_post_slack_reply(image_data=image_data, image_title="Graph"))
+
+    assert result["ok"] is True
+    assert result["uploaded_image"] is True
+    assert calls[0]["initial_comment"] is None
+    assert calls[0]["filename"] == "Graph.png"
+
+
+@pytest.mark.asyncio
 async def test_post_slack_reply_tool_posts_top_level_mentions_to_channel(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
@@ -1145,6 +1248,15 @@ def test_slack_tools_are_available_on_normal_illo_tool_surface():
 
     names = {tool["name"] for tool in CHAT_TOOLS}
     assert {"post_slack_reply", "read_slack_conversation", "manage_slack"} <= names
+    slack_reply = next(tool for tool in CHAT_TOOLS if tool["name"] == "post_slack_reply")
+    properties = slack_reply["input_schema"]["properties"]
+    assert {"image_data", "image_filename", "image_title", "image_alt"} <= set(properties)
+    assert "data:image/png;base64" in properties["image_data"]["description"]
+    assert slack_reply["input_schema"]["anyOf"] == [
+        {"required": ["body"]},
+        {"required": ["image_data"]},
+    ]
+    assert "required" not in slack_reply["input_schema"]
 
 
 def test_manage_slack_tool_definition_has_no_operator_setup_action():


### PR DESCRIPTION
## Summary
- Allow Slack replies to upload generated graph/chart images from data:image payloads.
- Add thread-stage image visual support, including sanitized inline SVG rendering.
- Extract Slack upload and frontend image-source helpers with focused tests.

## Tests
- venv/bin/pytest tests/test_slack_client.py tests/test_slack_teammate.py tests/test_cortex_visual_reply.py
- venv/bin/python -m py_compile brain/systems/slack/uploads.py brain/systems/slack/client.py brain/systems/runs/tool_catalog/handlers/slack.py
- npm run check
- npm run test