### PR TITLE
Fix manage_project profile_id alias

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -447,7 +447,7 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         },
         "search_files": {
             "required": ["query"],
-            "optional": ["project_id", "paths", "glob", "limit"],
+            "optional": ["project_id/profile_id", "paths", "glob", "limit"],
             "effect": "search files in visible Projects without loading all Project contents",
             "parameters": {
                 "query": "Search text to match in files across visible Projects.",

--- a/brain/systems/runs/tool_catalog/handlers/projects.py
+++ b/brain/systems/runs/tool_catalog/handlers/projects.py
@@ -216,6 +216,7 @@ async def _handle_manage_project(
     action: str,
     operation: str | None = None,
     project_id: str | None = None,
+    profile_id: str | None = None,
     slug: str | None = None,
     name: str | None = None,
     description: str | None = None,
@@ -316,7 +317,7 @@ async def _handle_manage_project(
         "role": "owner",
         "principal_type": "human",
     }
-    selected_project_id = project_id
+    selected_project_id = project_id or profile_id
 
     try:
         async with UnitOfWork() as uow:

--- a/tests/test_manage_project_cross_references.py
+++ b/tests/test_manage_project_cross_references.py
@@ -15,6 +15,7 @@ async def test_manage_project_schema_exposes_cross_project_reference_actions():
 
     assert "search_files" in actions
     assert "mount_reference" in actions
+    assert "profile_id" in tool["input_schema"]["properties"]
     assert "query" in tool["input_schema"]["properties"]
     assert "paths" in tool["input_schema"]["properties"]
     assert "mount_path" in tool["input_schema"]["properties"]
@@ -120,7 +121,13 @@ async def test_manage_project_search_files_finds_paths_and_content_without_loadi
     _patch_project_profiles(monkeypatch, [profile])
 
     with bind_agent_context({"org_id": "org-1", "user_id": "user-1", "workspace_root": str(tmp_path / "ideas" / "thread-1")}):
-        content_payload = json.loads(await projects._handle_manage_project(action="search_files", query="stripe"))
+        content_payload = json.loads(
+            await projects._handle_manage_project(
+                action="search_files",
+                profile_id="project-payments",
+                query="stripe",
+            )
+        )
         path_payload = json.loads(await projects._handle_manage_project(action="search_files", query="onboarding pdf"))
 
     assert content_payload["results"][0]["path"] == "analysis/summary.md"


### PR DESCRIPTION
## Summary
- accept profile_id as a manage_project alias for project_id
- keep manage_project schema/help aligned with the advertised alias
- cover the alias through the existing cross-project search test

## Tests
- ./venv/bin/python -m pytest tests/test_manage_project_cross_references.py tests/test_tool_registry.py