### PR TITLE
Bridge generated app iframe wheel scrolling

### DIFF
--- a/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
@@ -140,6 +140,58 @@
           document.documentElement.style.colorScheme = mode;
         }
 
+        function normalizeWheelDelta(event, axis) {
+          const raw = axis === 'x' ? event.deltaX : event.deltaY;
+          if (!raw) return 0;
+          if (event.deltaMode === 1) return raw * 16;
+          if (event.deltaMode === 2) {
+            return raw * Math.max(window.innerHeight || 0, document.documentElement.clientHeight || 0, 1);
+          }
+          return raw;
+        }
+
+        function canScrollElement(element, deltaX, deltaY, allowsX, allowsY) {
+          const maxTop = Math.max(0, element.scrollHeight - element.clientHeight);
+          const maxLeft = Math.max(0, element.scrollWidth - element.clientWidth);
+          return (
+            (allowsY && deltaY < 0 && element.scrollTop > 0) ||
+            (allowsY && deltaY > 0 && element.scrollTop < maxTop) ||
+            (allowsX && deltaX < 0 && element.scrollLeft > 0) ||
+            (allowsX && deltaX > 0 && element.scrollLeft < maxLeft)
+          );
+        }
+
+        function wheelScrollTarget(start, deltaX, deltaY) {
+          let element = start && start.nodeType === Node.ELEMENT_NODE ? start : start && start.parentElement;
+          while (element && element !== document.body && element !== document.documentElement) {
+            const style = window.getComputedStyle(element);
+            const allowsY = style.overflowY !== 'visible' && style.overflowY !== 'hidden' && style.overflowY !== 'clip';
+            const allowsX = style.overflowX !== 'visible' && style.overflowX !== 'hidden' && style.overflowX !== 'clip';
+            if (canScrollElement(element, deltaX, deltaY, allowsX, allowsY)) return element;
+            element = element.parentElement;
+          }
+          const root = document.scrollingElement || document.documentElement || document.body;
+          return root && canScrollElement(root, deltaX, deltaY, true, true) ? root : null;
+        }
+
+        function installWheelScrollBridge() {
+          window.addEventListener('wheel', (event) => {
+            if (event.defaultPrevented || event.ctrlKey) return;
+            const deltaX = normalizeWheelDelta(event, 'x');
+            const deltaY = normalizeWheelDelta(event, 'y');
+            if (!deltaX && !deltaY) return;
+            const target = wheelScrollTarget(event.target, deltaX, deltaY);
+            if (!target) return;
+            const previousTop = target.scrollTop;
+            const previousLeft = target.scrollLeft;
+            target.scrollTop += deltaY;
+            target.scrollLeft += deltaX;
+            if (target.scrollTop !== previousTop || target.scrollLeft !== previousLeft) {
+              event.preventDefault();
+            }
+          }, { passive: false });
+        }
+
         function stableSignature(value) {
           try {
             return JSON.stringify(value || {});
@@ -296,6 +348,7 @@
         } else {
           setTimeout(ready, 0);
         }
+        installWheelScrollBridge();
       })();
     <\/script>`;
   }

--- a/frontend/src/lib/features/workspace-apps/runtime/appCapsuleBridge.ts
+++ b/frontend/src/lib/features/workspace-apps/runtime/appCapsuleBridge.ts
@@ -48,6 +48,58 @@ export function appCapsuleBridgeScript(app: AppCapsuleRuntimeApp) {
         document.documentElement.style.colorScheme = mode;
       }
 
+      function normalizeWheelDelta(event, axis) {
+        const raw = axis === 'x' ? event.deltaX : event.deltaY;
+        if (!raw) return 0;
+        if (event.deltaMode === 1) return raw * 16;
+        if (event.deltaMode === 2) {
+          return raw * Math.max(window.innerHeight || 0, document.documentElement.clientHeight || 0, 1);
+        }
+        return raw;
+      }
+
+      function canScrollElement(element, deltaX, deltaY, allowsX, allowsY) {
+        const maxTop = Math.max(0, element.scrollHeight - element.clientHeight);
+        const maxLeft = Math.max(0, element.scrollWidth - element.clientWidth);
+        return (
+          (allowsY && deltaY < 0 && element.scrollTop > 0) ||
+          (allowsY && deltaY > 0 && element.scrollTop < maxTop) ||
+          (allowsX && deltaX < 0 && element.scrollLeft > 0) ||
+          (allowsX && deltaX > 0 && element.scrollLeft < maxLeft)
+        );
+      }
+
+      function wheelScrollTarget(start, deltaX, deltaY) {
+        let element = start && start.nodeType === Node.ELEMENT_NODE ? start : start && start.parentElement;
+        while (element && element !== document.body && element !== document.documentElement) {
+          const style = window.getComputedStyle(element);
+          const allowsY = style.overflowY !== 'visible' && style.overflowY !== 'hidden' && style.overflowY !== 'clip';
+          const allowsX = style.overflowX !== 'visible' && style.overflowX !== 'hidden' && style.overflowX !== 'clip';
+          if (canScrollElement(element, deltaX, deltaY, allowsX, allowsY)) return element;
+          element = element.parentElement;
+        }
+        const root = document.scrollingElement || document.documentElement || document.body;
+        return root && canScrollElement(root, deltaX, deltaY, true, true) ? root : null;
+      }
+
+      function installWheelScrollBridge() {
+        window.addEventListener('wheel', (event) => {
+          if (event.defaultPrevented || event.ctrlKey) return;
+          const deltaX = normalizeWheelDelta(event, 'x');
+          const deltaY = normalizeWheelDelta(event, 'y');
+          if (!deltaX && !deltaY) return;
+          const target = wheelScrollTarget(event.target, deltaX, deltaY);
+          if (!target) return;
+          const previousTop = target.scrollTop;
+          const previousLeft = target.scrollLeft;
+          target.scrollTop += deltaY;
+          target.scrollLeft += deltaX;
+          if (target.scrollTop !== previousTop || target.scrollLeft !== previousLeft) {
+            event.preventDefault();
+          }
+        }, { passive: false });
+      }
+
       function binding(alias) {
         const normalizedAlias = String(alias || '').trim();
         if (!normalizedAlias) throw new Error('window.illo.data(alias) requires an alias');
@@ -161,6 +213,7 @@ export function appCapsuleBridgeScript(app: AppCapsuleRuntimeApp) {
       } else {
         setTimeout(ready, 0);
       }
+      installWheelScrollBridge();
     })();
   <\/script>`;
 }

--- a/tests/test_theme_and_workspace_app_design_contracts.py
+++ b/tests/test_theme_and_workspace_app_design_contracts.py
@@ -202,6 +202,9 @@ def test_iframe_generated_app_runtime_allows_vertical_scroll():
     capsule_runtime = (
         REPO_ROOT / "frontend/src/lib/features/workspace-apps/runtime/appCapsuleStyle.ts"
     ).read_text()
+    capsule_bridge = (
+        REPO_ROOT / "frontend/src/lib/features/workspace-apps/runtime/appCapsuleBridge.ts"
+    ).read_text()
 
     html_document_rule = _css_rule(html_runtime, "html,\n      body {")
     capsule_document_rule = _css_rule(capsule_runtime, "html,\n    body {")
@@ -210,6 +213,12 @@ def test_iframe_generated_app_runtime_allows_vertical_scroll():
         assert "overflow-x: hidden !important;" in rule
         assert "overflow-y: auto !important;" in rule
         assert "overflow: hidden;" not in rule
+
+    for runtime_source in [html_runtime, capsule_bridge]:
+        assert "function installWheelScrollBridge()" in runtime_source
+        assert "window.addEventListener('wheel'" in runtime_source
+        assert "{ passive: false }" in runtime_source
+        assert "target.scrollTop += deltaY" in runtime_source
 
 
 def test_app_capsule_runtime_uses_new_bridge_and_responsive_surface():


### PR DESCRIPTION
## Summary

- Bridge wheel and trackpad events inside generated app iframes so already-scrollable app documents respond to normal scrolling.
- Apply the bridge to current app-capsule apps and legacy sandboxed HTML generated apps.
- Extend the generated app design contract so iframe runtimes keep the wheel bridge.

## Existing app impact

This is a frontend runtime/renderer fix. Existing generated apps should gain mouse-wheel and trackpad scrolling after this deploys and clients reload. The main caveat is an individual app that intentionally intercepts wheel events or blocks its own nested scroll container.

## Tests

- `venv/bin/python -m pytest tests/test_theme_and_workspace_app_design_contracts.py -q`
- `npm run check` in `frontend/`
