### PR TITLE
Fix project workspace mount resolution

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -392,6 +392,24 @@ def _workspace_entry_from_resource(resource: dict[str, Any], path: Path | str) -
     return {"name": _resource_workspace_name(resource, workspace_path), "path": str(workspace_path)}
 
 
+def _default_workspace_path(
+    workspaces: list[dict[str, str]],
+    *,
+    root_workspace: dict[str, str],
+    root_empty: bool,
+) -> str | None:
+    root_path = _clean_text(root_workspace.get("path"))
+    if root_empty:
+        for workspace in workspaces:
+            path = _clean_text(workspace.get("path"))
+            if path and path != root_path:
+                return path
+    return root_path or next(
+        (_clean_text(workspace.get("path")) for workspace in workspaces if _clean_text(workspace.get("path"))),
+        None,
+    )
+
+
 def _repo_workspace_path(resource: dict[str, Any], repo_path: Path) -> tuple[Path | None, str | None]:
     subpath = _github_subpath_from_resource(resource)
     if not subpath:
@@ -837,7 +855,8 @@ async def materialize_project_context_workspaces(
     workspaces.append(root_workspace)
     result.resources_checked += 1
     root_materialization = root_resource.get("materialization") if isinstance(root_resource.get("materialization"), dict) else {}
-    result.empty_project = bool(root_materialization.get("root_empty", True))
+    root_empty = bool(root_materialization.get("root_empty", True))
+    result.empty_project = root_empty
 
     for resource in resources:
         if _is_project_root_resource(resource):
@@ -867,6 +886,14 @@ async def materialize_project_context_workspaces(
         thread_workspace_root=root,
     )
     workspace_manifest_payload = workspace_manifest.to_dict()
+    default_workspace = _default_workspace_path(
+        workspaces,
+        root_workspace=root_workspace,
+        root_empty=root_empty,
+    )
+    if default_workspace:
+        workspace_manifest_payload["workspace_root"] = default_workspace
+        workspace_manifest_payload["resolved_workspace_root"] = default_workspace
     snapshot["project_workspace_manifest"] = workspace_manifest_payload
     result.workspaces = workspaces
     status = "materialized" if not result.errors else "failed"
@@ -910,8 +937,7 @@ async def materialize_project_context_workspaces(
         current_workspace_payload["project_context_permission_scope"] = permission_scope
         current_workspace_payload["project_workspace_manifest"] = workspace_manifest_payload
         current_workspace_payload["workspaces"] = _merge_workspaces(current_workspace_payload.get("workspaces"), workspaces)
-        if workspaces:
-            default_workspace = workspaces[0]["path"]
+        if default_workspace:
             current_workspace_payload["workspace_root"] = default_workspace
             current_workspace_payload["resolved_workspace_root"] = default_workspace
         current_workspace_payload["project_context_materialization"] = project_context_materialization

--- a/brain/systems/cortex/project_context/workspace_manifest.py
+++ b/brain/systems/cortex/project_context/workspace_manifest.py
@@ -172,6 +172,8 @@ def _normalise_agent_path(path: Any) -> str | None:
     text = _clean_text(path)
     if not text:
         return None
+    if not text.startswith("/"):
+        return None
     return _normalise_mount_path(text, fallback="/")
 
 

--- a/brain/systems/runs/recipes/shared.py
+++ b/brain/systems/runs/recipes/shared.py
@@ -109,7 +109,14 @@ def project_runtime_workspace_from_ref(workspace_ref: dict[str, Any]) -> Project
                     item.get("name"),
                     item.get("label"),
                 )
-        workspace_root = _workspace_directory_path(workspace_manifest.get("workspace_root"))
+        workspace_root = None
+        for key in _WORKSPACE_ROOT_KEYS:
+            path = _workspace_directory_path(workspace_ref.get(key))
+            if path:
+                workspace_root = path
+                break
+        if workspace_root is None:
+            workspace_root = _workspace_directory_path(workspace_manifest.get("workspace_root"))
         if workspace_root is None and allowed_workspaces:
             workspace_root = allowed_workspaces[0]["path"]
         if workspace_root is not None:

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -715,13 +715,20 @@ def _build_workspace_registry(
     """Return a deduplicated list of accessible workspace roots."""
     registry: list[dict[str, str]] = []
     seen_paths: set[str] = set()
+    entries_by_path: dict[str, dict[str, str]] = {}
 
     for raw in ([workspace_root] if workspace_root else []) + list(allowed_workspaces or []):
         item = _normalize_workspace_entry(raw)
-        if not item or item["path"] in seen_paths:
+        if not item:
+            continue
+        if item["path"] in seen_paths:
+            existing = entries_by_path.get(item["path"])
+            if existing and isinstance(raw, dict):
+                existing["name"] = item["name"]
             continue
         registry.append(item)
         seen_paths.add(item["path"])
+        entries_by_path[item["path"]] = item
 
     return registry
 
@@ -745,7 +752,16 @@ def _select_workspace(
     if path_matches:
         return path_matches[0]["path"]
 
-    name_matches = [item for item in registry if item["name"] == requested or os.path.basename(item["path"]) == requested]
+    def name_candidates(item: dict[str, str]) -> set[str]:
+        name = item["name"]
+        candidates = {name, os.path.basename(item["path"])}
+        if name != "/" and name.startswith("/"):
+            candidates.add(name.lstrip("/"))
+        elif "/" in name:
+            candidates.add("/" + name.lstrip("/"))
+        return {candidate for candidate in candidates if candidate}
+
+    name_matches = [item for item in registry if requested in name_candidates(item)]
     if len(name_matches) == 1:
         return name_matches[0]["path"]
     if len(name_matches) > 1:

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -172,13 +172,22 @@ def _current_project_workspace_manifest() -> ProjectWorkspaceManifest | None:
     return _first_project_workspace_manifest(workspace_payloads, include_workspace_entries=True)
 
 
-def _project_mount_resolution(path: str) -> tuple[str, object] | None:
+def _project_mount_resolution(path: str, *, base: str | None = None) -> tuple[str, object] | None:
+    if not isinstance(path, str) or not path.startswith("/"):
+        return None
+    if os.path.isabs(path) and os.path.exists(os.path.expanduser(path)):
+        return None
     manifest = _current_project_workspace_manifest()
     if manifest is None:
         return None
     mount = manifest.mount_for_agent_path(path)
     if mount is None:
         return None
+    if getattr(mount, "mount_path", None) == "/":
+        workspace_real = os.path.realpath(getattr(mount, "workspace_path", "") or "")
+        base_real = os.path.realpath(base) if base else ""
+        if not workspace_real or not base_real or not _path_is_within(base_real, workspace_real):
+            return None
     resolved = mount.resolve_agent_path(path)
     if not resolved:
         return None
@@ -304,7 +313,7 @@ def _resolve_path(path: str, working_dir: str | None = None, *, for_write: bool 
         working_dir: Override workspace root (used by worktree isolation).
     """
     base = os.path.realpath(working_dir or _patched_workspace_root())
-    project_resolution = _project_mount_resolution(path)
+    project_resolution = _project_mount_resolution(path, base=base)
     if project_resolution is not None:
         resolved, _mount = project_resolution
         _block_project_internal_path(resolved)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1440,6 +1440,28 @@ class TestExecToolHandlers:
         result = handlers["read_file"]("app.ts", workspace="frontend")
         assert "FRONTEND" in result["content"]
 
+    def test_workspace_selector_preserves_allowed_name_for_default_workspace(self, tmp_path):
+        from brain.systems.runs.tool_handlers import _get_tool_handlers
+
+        project_root = tmp_path / "project-root"
+        backend = tmp_path / "github" / "uwear-ai" / "uwear-backend"
+        project_root.mkdir(parents=True)
+        backend.mkdir(parents=True)
+        (backend / "api.py").write_text("BACKEND = True\n")
+
+        handlers = _get_tool_handlers(
+            workspace_root=str(backend),
+            allowed_workspaces=[
+                {"name": "/", "path": str(project_root)},
+                {"name": "/uwear-ai/uwear-backend", "path": str(backend)},
+            ],
+        )
+
+        without_slash = handlers["read_file"]("api.py", workspace="uwear-ai/uwear-backend")
+        with_slash = handlers["read_file"]("api.py", workspace="/uwear-ai/uwear-backend")
+        assert "BACKEND" in without_slash["content"]
+        assert "BACKEND" in with_slash["content"]
+
     def test_workspace_selector_accepts_project_mount_path(self, tmp_path):
         from brain.systems.runs.tool_handlers import _get_tool_handlers
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -819,6 +819,24 @@ def test_workspace_root_from_ref_uses_thread_project_context_snapshot():
         {"name": "/reports", "path": "/tmp/projects/p1/reports-a"},
         {"name": "/reports-2", "path": "/tmp/projects/p1/reports-b"},
     ]
+    runtime_workspace = project_runtime_workspace_from_ref(
+        {
+            "workspace_root": "/tmp/projects/p1/repos/backend",
+            "resolved_workspace_root": "/tmp/projects/p1/repos/backend",
+            "project_workspace_manifest": {
+                "workspace_root": "/tmp/projects/p1/project-root",
+                "workspaces": [
+                    {"name": "/", "path": "/tmp/projects/p1/project-root"},
+                    {"name": "/uwear-ai/uwear-backend", "path": "/tmp/projects/p1/repos/backend"},
+                ],
+            },
+        }
+    )
+    assert runtime_workspace.workspace_root == "/tmp/projects/p1/repos/backend"
+    assert runtime_workspace.allowed_workspaces == [
+        {"name": "/", "path": "/tmp/projects/p1/project-root"},
+        {"name": "/uwear-ai/uwear-backend", "path": "/tmp/projects/p1/repos/backend"},
+    ]
 
 
 async def test_fast_recipe_infers_workspace_root_from_project_context_snapshot(monkeypatch):

--- a/tests/test_file_tool_project_mount_paths.py
+++ b/tests/test_file_tool_project_mount_paths.py
@@ -56,6 +56,45 @@ def _project_context(source_dir, draft_dir, *, manifest_mounts=True):
     }
 
 
+def _root_and_repo_context(project_root, repo_root):
+    manifest = {
+        "workspace_root": str(repo_root),
+        "resolved_workspace_root": str(repo_root),
+        "workspaces": [
+            {"name": "/", "path": str(project_root)},
+            {"name": "/uwear-ai/uwear-backend", "path": str(repo_root)},
+        ],
+        "mounts": [
+            {
+                "id": "/",
+                "resource_id": "project-root",
+                "kind": "project_root",
+                "mount_path": "/",
+                "workspace_path": str(project_root),
+                "resource_path": str(project_root),
+            },
+            {
+                "id": "/uwear-ai/uwear-backend",
+                "resource_id": "uwear-backend",
+                "kind": "repo",
+                "mount_path": "/uwear-ai/uwear-backend",
+                "workspace_path": str(repo_root),
+                "resource_path": str(repo_root),
+            },
+        ],
+    }
+    workspace_ref = {
+        "workspace_root": str(repo_root),
+        "resolved_workspace_root": str(repo_root),
+        "workspaces": manifest["workspaces"],
+        "project_workspace_manifest": manifest,
+    }
+    return {
+        "workspace_ref": workspace_ref,
+        "run": SimpleNamespace(id=456, workspace_ref=workspace_ref, target_ref={}, metadata_={}),
+    }
+
+
 def test_read_file_resolves_project_mount_path_to_draft_workspace(tmp_path):
     source_dir = tmp_path / "source" / "reports"
     draft_dir = tmp_path / "thread" / ".illo-project-context" / "local" / "reports"
@@ -73,6 +112,60 @@ def test_read_file_resolves_project_mount_path_to_draft_workspace(tmp_path):
     assert result["path"] == str(draft_dir / "brief.md")
     assert "draft copy" in result["content"]
     assert "source copy" not in result["content"]
+
+
+def test_read_file_relative_path_uses_selected_repo_workspace_when_root_mount_exists(tmp_path):
+    project_root = tmp_path / "thread" / ".illo-project-context" / "local" / "project-root"
+    repo_root = tmp_path / "thread" / ".illo-project-context" / "github" / "uwear-ai" / "uwear-backend"
+    project_file = project_root / "api" / "src" / "uwear_api" / "models" / "ai_model.py"
+    repo_file = repo_root / "api" / "src" / "uwear_api" / "models" / "ai_model.py"
+    project_file.parent.mkdir(parents=True)
+    repo_file.parent.mkdir(parents=True)
+    project_file.write_text("project root copy\n", encoding="utf-8")
+    repo_file.write_text("backend repo copy\n", encoding="utf-8")
+
+    with bind_agent_context(_root_and_repo_context(project_root, repo_root)):
+        relative_result = files._handle_read_file(
+            "api/src/uwear_api/models/ai_model.py",
+            _workspace=str(repo_root),
+        )
+        absolute_result = files._handle_read_file(str(repo_file), _workspace=str(repo_root))
+        mounted_result = files._handle_read_file(
+            "/uwear-ai/uwear-backend/api/src/uwear_api/models/ai_model.py",
+            _workspace=str(project_root),
+        )
+        write_result = files._handle_write_file(
+            "api/src/uwear_api/models/new_model.py",
+            "backend write\n",
+            _workspace=str(repo_root),
+        )
+
+    assert "error" not in relative_result
+    assert relative_result["path"] == str(repo_file)
+    assert "backend repo copy" in relative_result["content"]
+    assert "project root copy" not in relative_result["content"]
+    assert "backend repo copy" in absolute_result["content"]
+    assert mounted_result["path"] == str(repo_file)
+    assert "backend repo copy" in mounted_result["content"]
+    assert write_result["path"] == str(repo_root / "api" / "src" / "uwear_api" / "models" / "new_model.py")
+    assert (repo_root / "api" / "src" / "uwear_api" / "models" / "new_model.py").read_text(encoding="utf-8") == "backend write\n"
+    assert not (project_root / "api" / "src" / "uwear_api" / "models" / "new_model.py").exists()
+
+
+def test_root_mount_only_resolves_against_selected_project_root_workspace(tmp_path):
+    project_root = tmp_path / "thread" / ".illo-project-context" / "local" / "project-root"
+    repo_root = tmp_path / "thread" / ".illo-project-context" / "github" / "uwear-ai" / "uwear-backend"
+    project_root.mkdir(parents=True)
+    repo_root.mkdir(parents=True)
+    (project_root / "README.md").write_text("project readme\n", encoding="utf-8")
+
+    with bind_agent_context(_root_and_repo_context(project_root, repo_root)):
+        project_result = files._handle_read_file("/README.md", _workspace=str(project_root))
+        repo_result = files._handle_read_file("/README.md", _workspace=str(repo_root))
+
+    assert "project readme" in project_result["content"]
+    assert "error" in repo_result
+    assert "Path escapes workspace" in repo_result["error"]
 
 
 def test_write_file_resolves_project_mount_path_to_draft_workspace(tmp_path):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -589,11 +589,16 @@ async def test_materialize_agent_run_workspace_ref_project_context_updates_works
     result = await materialize_project_context_workspaces(44, workspace_root=str(tmp_path), user_id="user-1")
 
     assert result.ok
-    assert result.workspaces
-    assert run.workspace_ref["workspace_root"] == result.workspaces[0]["path"]
-    assert run.workspace_ref["resolved_workspace_root"] == result.workspaces[0]["path"]
+    assert len(result.workspaces) == 2
+    assert result.workspaces[0]["name"] == "/"
+    assert result.workspaces[1]["name"] == "example-org/example-backend"
+    assert run.workspace_ref["workspace_root"] == result.workspaces[1]["path"]
+    assert run.workspace_ref["resolved_workspace_root"] == result.workspaces[1]["path"]
+    assert run.workspace_ref["project_workspace_manifest"]["workspace_root"] == result.workspaces[1]["path"]
     assert run.workspace_ref["project_context_snapshot"]["resources"][0]["path"] == result.workspaces[0]["path"]
+    assert run.workspace_ref["project_context_snapshot"]["resources"][1]["path"] == result.workspaces[1]["path"]
     assert run.target_ref["project_context_snapshot"]["resources"][0]["path"] == result.workspaces[0]["path"]
+    assert run.target_ref["project_context_snapshot"]["resources"][1]["path"] == result.workspaces[1]["path"]
 
 
 async def test_materialize_reuses_existing_thread_checkout_without_reclone(tmp_path, monkeypatch):

--- a/tests/test_project_context_workspace_manifest.py
+++ b/tests/test_project_context_workspace_manifest.py
@@ -34,6 +34,7 @@ def test_workspace_manifest_disambiguates_duplicate_mount_paths():
         {"name": "/reports", "path": "/tmp/materialized/reports-a"},
         {"name": "/reports-2", "path": "/tmp/materialized/reports-b"},
     ]
+    assert manifest.resolve_agent_path("reports/summary.md") is None
     assert manifest.resolve_agent_path("/reports/summary.md") == "/tmp/materialized/reports-a/summary.md"
     assert manifest.resolve_agent_path("/reports-2/summary.md") == "/tmp/materialized/reports-b/summary.md"
     assert manifest.to_dict()["workspaces"] == [


### PR DESCRIPTION
## Summary
- make relative file paths resolve inside the selected/default workspace instead of Project mounts
- prevent the synthetic Project root mount `/` from hijacking repo workspace reads/writes
- preserve and accept repo workspace names with or without a leading slash
- default repo-only Projects with empty synthetic roots to the repo workspace

## Tests
- `./venv/bin/pytest tests/test_project_context_materializer.py tests/test_project_context_root_materializer.py tests/test_project_context_workspace_manifest.py tests/test_file_tool_project_mount_paths.py tests/test_agent_run_runtime.py tests/test_agent.py`
- `git diff --check`