### PR TITLE
Fix workspace tools host controller refresh

### DIFF
--- a/deploy/compose/runtime-services.json
+++ b/deploy/compose/runtime-services.json
@@ -25,6 +25,13 @@
       "description": "Illospace browser interface."
     },
     {
+      "id": "host_controller",
+      "compose_service": "updater",
+      "name": "Host controller",
+      "description": "Updater sidecar that handles self-updates, runtime-service restarts, and workspace tool installs.",
+      "include_in_all": false
+    },
+    {
       "id": "slack_connector",
       "compose_service": "slack-connector",
       "name": "Slack connector",

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -14,6 +14,10 @@ runtime_service_ids() {
   jq -r '.services[].id' "$RUNTIME_SERVICE_CATALOG"
 }
 
+runtime_service_ids_for_all() {
+  jq -r '.services[] | select(.include_in_all != false) | .id' "$RUNTIME_SERVICE_CATALOG"
+}
+
 runtime_service_name() {
   local service="$1"
   local compose_name
@@ -58,7 +62,7 @@ expand_runtime_services() {
   if [ "$include_all" = "1" ]; then
     while IFS= read -r service; do
       append_unique_service "$service"
-    done < <(runtime_service_ids)
+    done < <(runtime_service_ids_for_all)
   fi
 
   printf '%s\n' "${expanded_services[@]}"

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -70,15 +70,16 @@ all_runtime_services() {
 }
 
 schedule_updater_refresh_after_self_update() {
-  local delay
+  local delay job_name
   [ "$SKIP_UPDATER_RESTART" = "1" ] || return 0
   delay="${ILLO_COMPOSE_UPDATER_SELF_REFRESH_DELAY_SECONDS:-15}"
   if [[ ! "$delay" =~ ^[0-9]+$ ]]; then
     delay="15"
   fi
+  job_name="${COMPOSE_PROJECT_NAME:-illospace}-updater-self-refresh-$(date -u +%Y%m%d%H%M%S)"
   echo "Updater: scheduling self-refresh in ${delay}s so the host controller runs the latest code."
-  compose run -d --rm --no-deps --entrypoint sh updater -lc \
-    "sleep $delay; docker compose --env-file \"\${ILLO_COMPOSE_ENV_FILE:-/repo/deploy/compose/.env}\" -f /repo/deploy/compose/docker-compose.yml up -d --force-recreate --no-deps updater" \
+  compose run -d --name "$job_name" --no-deps --entrypoint sh updater -lc \
+    "sleep $delay; docker compose --env-file \"\${ILLO_COMPOSE_ENV_FILE:-/repo/deploy/compose/.env}\" -f /repo/deploy/compose/docker-compose.yml up -d --force-recreate --no-deps updater; docker rm -f \"$job_name\" >/dev/null 2>&1 || true" \
     >/dev/null || echo "Updater: could not schedule delayed self-refresh; restart updater manually after this update." >&2
 }
 

--- a/docs/workspace-tools.md
+++ b/docs/workspace-tools.md
@@ -13,6 +13,9 @@ base worker image for every team.
   `/data/private/workspace-tools`.
 - The updater sidecar watches `ILLO_WORKSPACE_TOOLS_REQUEST_FILE` and executes
   curated installer profiles through `deploy/scripts/workspace-tools.sh`.
+- The updater sidecar is exposed as the `host_controller` runtime service; if a
+  workspace tool status says it is waiting for the host controller, restart
+  `host_controller` through `manage_runtime_services`.
 - Successful installs write `illo-tool.json` with status, health, bin paths, and
   metadata.
 - Agent command environments prepend installed bundle `bin` paths for the active

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -349,6 +349,8 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
     assert "schedule_updater_refresh_after_self_update" in upgrade
     assert "ILLO_COMPOSE_UPDATER_SELF_REFRESH_DELAY_SECONDS" in upgrade
+    assert "--name \"$job_name\"" in upgrade
+    assert 'docker rm -f \\"$job_name\\"' in upgrade
     assert "up -d --force-recreate --no-deps updater" in upgrade
     assert "start_worker_handoff" in runtime_lib
     assert "ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1" in runtime_lib
@@ -374,6 +376,9 @@ def test_compose_runtime_service_restart_supports_one_many_or_all_services():
     assert "runtime_service_ids" in runtime_services
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in runtime_services
     assert "expand_runtime_services" in runtime_lib
+    assert "runtime_service_ids_for_all" in runtime_lib
+    assert "host_controller" in catalog
+    assert '"include_in_all": false' in catalog
     assert "slack_connector" in catalog
     assert "slack-connector" in catalog
     assert "runtime-services.json" in runtime_lib


### PR DESCRIPTION
## Summary
- expose the updater sidecar as the restartable host_controller runtime service
- keep host_controller out of broad runtime-service all restarts
- harden the delayed updater self-refresh job so it does not use detached --rm
- document the host-controller recovery path for workspace tools

## Why
Live acceptance testing of PR #211 showed manage_workspace_tools was deployed and catalog/status worked, but installs failed because the workspace-tools heartbeat was missing: the updater host controller was still not running the new workspace-tools loop.

## Tests
- bash -n deploy/scripts/upgrade.sh
- bash -n deploy/scripts/compose-runtime-lib.sh
- bash -n deploy/scripts/runtime-services.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_runtime_settings.py tests/test_workspace_tools.py -q