### PR TITLE
Run updater daemon from mounted repo

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -169,6 +169,7 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/updater.Dockerfile
+    command: ["bash", "/repo/deploy/scripts/self-update-daemon.sh"]
     restart: unless-stopped
     environment:
       ILLO_SELF_UPDATE_REPO: /repo

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -299,6 +299,7 @@ def test_compose_deploy_stays_private_without_builtin_public_ingress():
     assert 'ILLO_WORKER_ENABLE_CYCLE_SCHEDULER: "1"' in compose
     assert 'ILLO_WORKER_DISABLE_CYCLE_SCHEDULER: "0"' in compose
     assert "deploy/docker/updater.Dockerfile" in compose
+    assert 'command: ["bash", "/repo/deploy/scripts/self-update-daemon.sh"]' in compose
     assert "illo-self-update-healthcheck" in compose
     assert "/var/run/docker.sock:/var/run/docker.sock" in compose
     assert "../..:/repo" in compose


### PR DESCRIPTION
## Summary
- run the updater sidecar daemon from /repo/deploy/scripts/self-update-daemon.sh instead of the image-baked copy
- keep the existing updater image as the bootstrap/runtime, but make host_controller restarts pick up the latest repo daemon after a deploy
- add a deploy safety regression assertion for the compose command

## Why
Live verification after PR #212 showed manage_runtime_services can list and restart host_controller, but manage_workspace_tools still waits for the workspace-tools heartbeat. That points at the updater container still running a stale image-baked daemon. Running the mounted daemon lets the existing runtime-services restart path activate the newest workspace-tools loop immediately after the repo updates.

## Tests
- bash -n deploy/scripts/self-update-daemon.sh
- bash -n deploy/scripts/runtime-services.sh
- bash -n deploy/scripts/upgrade.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_runtime_settings.py tests/test_workspace_tools.py -q