### PR TITLE
Fix workspace tool manifest JSON defaults

### DIFF
--- a/deploy/scripts/workspace-tools.sh
+++ b/deploy/scripts/workspace-tools.sh
@@ -80,8 +80,10 @@ write_manifest() {
   local bin_path="$7"
   local status="$8"
   local detail="$9"
-  local health_json="${10:-{}}"
-  local metadata_json="${11:-{}}"
+  local health_json="${10:-}"
+  local metadata_json="${11:-}"
+  [ -n "$health_json" ] || health_json="{}"
+  [ -n "$metadata_json" ] || metadata_json="{}"
   mkdir -p "$(dirname "$manifest_path")"
   jq -n \
     --arg bundle_id "$bundle_id" \

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -326,6 +326,10 @@ def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
     assert "WORKSPACE_TOOLS_HEARTBEAT_FILE" in self_update_daemon
     assert "write_workspace_tools_heartbeat" in self_update_daemon
     assert "deploy/scripts/workspace-tools.sh" in self_update_daemon
+    workspace_tools = (root / "deploy" / "scripts" / "workspace-tools.sh").read_text()
+    assert '${10:-{}}' not in workspace_tools
+    assert '[ -n "$health_json" ] || health_json="{}"' in workspace_tools
+    assert '[ -n "$metadata_json" ] || metadata_json="{}"' in workspace_tools
 
 
 def test_compose_doctor_can_skip_host_local_http_probes_from_sidecars():


### PR DESCRIPTION
## Summary
- fix Bash positional-argument default handling in workspace-tools manifest writes
- avoid appending an extra brace to health/metadata JSON passed to jq --argjson
- add a deploy safety assertion for the regression

## Why
Live aws-diagrams install reached the manifest write step after Java/Graphviz/PlantUML setup, then failed with:

jq: invalid JSON text passed to --argjson

Tracing showed Bash expanded ${10:-{}} and ${11:-{}} into argument JSON plus an extra closing brace. Explicit defaults keep jq input valid.

## Tests
- bash -n deploy/scripts/workspace-tools.sh
- bash -n deploy/scripts/self-update-daemon.sh
- venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_workspace_tools.py -q
- direct Bash positional argument + jq --argjson expansion check