### PR TITLE
Add thread asset publishing and SVG previews

### DIFF
--- a/brain/app/api/routers/cortex/_helpers.py
+++ b/brain/app/api/routers/cortex/_helpers.py
@@ -23,7 +23,7 @@ from brain.platform.db.repositories.skills import SkillRepository
 logger = logging.getLogger(__name__)
 
 UPLOAD_DIR = Path(__file__).resolve().parents[4] / "uploads"
-IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp", "avif"}
+IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp", "avif", "svg"}
 VIDEO_EXTENSIONS = {"mp4", "m4v", "mov", "webm"}
 TEXT_EXTENSIONS = {"txt", "md", "csv", "json", "log", "text", "tsv", "xml", "yaml", "yml"}
 DOCUMENT_EXTENSIONS = {"doc", "docx", "odt", "pdf", "ppt", "pptx", "rtf", "xls", "xlsx"}
@@ -58,6 +58,7 @@ UPLOAD_FALLBACK_CONTENT_TYPES = {
     "ppt": "application/vnd.ms-powerpoint",
     "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "rar": "application/vnd.rar",
+    "svg": "image/svg+xml",
     "rtf": "application/rtf",
     "text": "text/plain",
     "tsv": "text/tab-separated-values",

--- a/brain/systems/cortex/thread_assets.py
+++ b/brain/systems/cortex/thread_assets.py
@@ -1,0 +1,173 @@
+"""Publish generated run artifacts as previewable Cortex thread assets."""
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+from brain.systems.cortex.upload_preview import public_static_upload_url, static_upload_url_for
+
+UPLOAD_DIR = Path(__file__).resolve().parents[2] / "uploads"
+MAX_THREAD_ASSET_SIZE = 10 * 1024 * 1024
+IMAGE_EXTENSIONS = {"avif", "gif", "jpeg", "jpg", "png", "svg", "webp"}
+VIEWER_EXTENSIONS = {
+    *IMAGE_EXTENSIONS,
+    "csv",
+    "json",
+    "log",
+    "md",
+    "pdf",
+    "text",
+    "tsv",
+    "txt",
+    "xml",
+    "yaml",
+    "yml",
+}
+
+CONTENT_TYPE_BY_EXTENSION = {
+    "avif": "image/avif",
+    "csv": "text/csv",
+    "gif": "image/gif",
+    "jpeg": "image/jpeg",
+    "jpg": "image/jpeg",
+    "json": "application/json",
+    "log": "text/plain",
+    "md": "text/markdown",
+    "pdf": "application/pdf",
+    "png": "image/png",
+    "svg": "image/svg+xml",
+    "text": "text/plain",
+    "tsv": "text/tab-separated-values",
+    "txt": "text/plain",
+    "webp": "image/webp",
+    "xml": "application/xml",
+    "yaml": "application/x-yaml",
+    "yml": "application/x-yaml",
+}
+
+DEFAULT_SOURCE_ROOTS = ("/workspaces/artifacts",)
+THREAD_ASSET_PREFIX = "thread-assets"
+
+
+def _resolved_roots(source_roots: Iterable[str | Path] | None = None) -> list[Path]:
+    values = list(source_roots or [])
+    if not values:
+        configured = os.environ.get("ILLO_THREAD_ASSET_SOURCE_ROOTS", "").strip()
+        values = configured.split(os.pathsep) if configured else list(DEFAULT_SOURCE_ROOTS)
+    roots: list[Path] = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        try:
+            roots.append(Path(text).expanduser().resolve())
+        except OSError:
+            continue
+    return roots
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        return path == root or path.is_relative_to(root)
+    except AttributeError:
+        return path == root or str(path).startswith(str(root) + os.sep)
+
+
+def _source_path(file_path: str, *, source_roots: Iterable[str | Path] | None = None) -> Path:
+    raw = str(file_path or "").strip()
+    if not raw:
+        raise ValueError("file_path is required")
+    path = Path(raw).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"Thread asset source not found: {file_path}")
+
+    roots = _resolved_roots(source_roots)
+    if not any(_is_within(path, root) for root in roots):
+        allowed = ", ".join(str(root) for root in roots) or "(none configured)"
+        raise PermissionError(f"Thread assets can only be published from configured artifact roots: {allowed}")
+    return path
+
+
+def _safe_segment(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip("._-")
+    return (cleaned or fallback)[:96]
+
+
+def _content_type(path: Path, extension: str) -> str:
+    return mimetypes.guess_type(path.name)[0] or CONTENT_TYPE_BY_EXTENSION.get(extension, "application/octet-stream")
+
+
+def _asset_markdown(*, label: str, url: str, kind: str) -> str:
+    clean_label = label.replace("[", "").replace("]", "").strip() or "Thread asset"
+    if kind == "image":
+        return f"![{clean_label}]({url})"
+    return f"[{clean_label}]({url})"
+
+
+def publish_thread_asset(
+    file_path: str,
+    *,
+    thread_id: str | None = None,
+    title: str | None = None,
+    upload_dir: Path = UPLOAD_DIR,
+    source_roots: Iterable[str | Path] | None = None,
+    max_bytes: int = MAX_THREAD_ASSET_SIZE,
+) -> dict[str, Any]:
+    """Copy a generated artifact into static uploads and return a chat attachment."""
+
+    source = _source_path(file_path, source_roots=source_roots)
+    extension = source.suffix.lower().lstrip(".")
+    if extension not in VIEWER_EXTENSIONS:
+        raise ValueError(f"Thread asset type .{extension or '(none)'} is not previewable")
+
+    data = source.read_bytes()
+    if len(data) > max_bytes:
+        raise ValueError(f"Thread asset is too large ({len(data)} bytes, max {max_bytes})")
+
+    digest = hashlib.sha256(data).hexdigest()[:12]
+    stem = _safe_segment(source.stem, "asset")
+    thread_segment = _safe_segment(thread_id or "shared", "shared")
+    filename = f"{stem}-{digest}.{extension}"
+    destination_dir = (upload_dir / THREAD_ASSET_PREFIX / thread_segment).resolve()
+    upload_root = upload_dir.resolve()
+    if not _is_within(destination_dir, upload_root):
+        raise ValueError("Thread asset destination escapes upload root")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / filename
+    if not destination.exists():
+        destination.write_bytes(data)
+
+    url = static_upload_url_for(THREAD_ASSET_PREFIX, thread_segment, filename)
+    content_type = _content_type(source, extension)
+    kind = "image" if content_type.startswith("image/") or extension in IMAGE_EXTENSIONS else "file"
+    label = str(title or source.name).strip() or source.name
+    attachment = {
+        "kind": kind,
+        "url": url,
+        "download_url": public_static_upload_url(url),
+        "filename": source.name,
+        "label": label,
+        "content_type": content_type,
+        "mime_type": content_type,
+        "size": len(data),
+    }
+    return {
+        "ok": True,
+        "source_path": str(source),
+        "published_path": str(destination),
+        "url": url,
+        "public_url": attachment["download_url"],
+        "markdown": _asset_markdown(label=label, url=url, kind=kind),
+        "attachment": attachment,
+        "instruction": (
+            "To show this in Thread Discussion, call post_thread_discussion_reply with the returned "
+            "markdown in body and include the returned attachment in attachments."
+        ),
+    }
+
+
+__all__ = ["publish_thread_asset"]

--- a/brain/systems/cortex/thread_attachments.py
+++ b/brain/systems/cortex/thread_attachments.py
@@ -25,7 +25,7 @@ READABLE_TEXT_MIME_TYPES = {
     "text/xml",
     "text/yaml",
 }
-IMAGE_EXTENSIONS = {"avif", "gif", "jpeg", "jpg", "png", "webp"}
+IMAGE_EXTENSIONS = {"avif", "gif", "jpeg", "jpg", "png", "svg", "webp"}
 AUDIO_EXTENSIONS = {
     "aac",
     "aif",

--- a/brain/systems/cortex/upload_preview.py
+++ b/brain/systems/cortex/upload_preview.py
@@ -181,6 +181,7 @@ def _content_type_for_extension(extension: str) -> str:
         "ppt": "application/vnd.ms-powerpoint",
         "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         "rtf": "application/rtf",
+        "svg": "image/svg+xml",
         "xls": "application/vnd.ms-excel",
         "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     }.get(extension, "application/octet-stream")

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -201,9 +201,9 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "threads",
         "name": "Threads and Discussion",
         "category": "core_workspace",
-        "summary": "Illo can work with Illospace Threads, AI Timeline messages, and Thread Discussion surfaces.",
-        "aliases": ("thread", "threads", "discussion", "ai timeline", "ideas"),
-        "tools": ("manage_idea", "read_thread_discussion", "post_thread_discussion_reply", "post_ai_timeline_message", "post_chat_message", "cortex_reply", "cortex_visual_reply"),
+        "summary": "Illo can work with Illospace Threads, AI Timeline messages, Thread Discussion surfaces, and generated thread assets.",
+        "aliases": ("thread", "threads", "discussion", "ai timeline", "ideas", "thread asset", "show artifact"),
+        "tools": ("manage_idea", "read_thread_discussion", "publish_thread_asset", "post_thread_discussion_reply", "post_ai_timeline_message", "post_chat_message", "cortex_reply", "cortex_visual_reply"),
     },
     {
         "key": "domains",

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -141,6 +141,12 @@ def _discussion_comment_payload(comment: Any) -> dict[str, Any]:
     }
 
 
+def _clean_visible_attachments(attachments: list[Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(attachments, list):
+        return []
+    return [dict(attachment) for attachment in attachments if isinstance(attachment, dict)]
+
+
 async def _publish_chat_events(publish, summaries: dict[str, dict[str, Any]]) -> None:
     from brain.app.api.routers.chat import (
         _publish_message_events,
@@ -210,10 +216,32 @@ async def _handle_post_chat_message(
     return json.dumps({"ok": True, "message": message_payload}, default=str)
 
 
+async def _handle_publish_thread_asset(
+    file_path: str,
+    thread_id: str | None = None,
+    title: str | None = None,
+) -> str:
+    """Publish a generated local artifact as a previewable Thread attachment."""
+    from brain.systems.cortex.thread_assets import publish_thread_asset
+
+    target_thread_id = _first_nonempty(thread_id, _current_ai_timeline_thread_id(), _current_thread_id())
+    try:
+        result = publish_thread_asset(
+            file_path,
+            thread_id=target_thread_id or None,
+            title=title,
+        )
+        return json.dumps(result, default=str)
+    except Exception as exc:
+        logger.warning("publish_thread_asset failed: %s", exc)
+        return json.dumps({"error": str(exc)}, default=str)
+
+
 async def _handle_post_thread_discussion_reply(
     body: str,
     thread_id: str | None = None,
     reply_to_comment_id: int | None = None,
+    attachments: list[Any] | None = None,
 ) -> str:
     """Post an Illo-authored reply to a Thread's Discussion surface."""
     from brain.platform.db.models.idea import Idea, ThreadDiscussionComment
@@ -244,6 +272,7 @@ async def _handle_post_thread_discussion_reply(
         if reply_to_comment_id is not None
         else _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
     )
+    visible_attachments = _clean_visible_attachments(attachments)
 
     async with UnitOfWork() as uow:
         idea = await uow.session.get(Idea, target_thread_id)
@@ -266,7 +295,7 @@ async def _handle_post_thread_discussion_reply(
             author_user_id=None,
             author_kind="illo",
             body=text,
-            attachments=[],
+            attachments=visible_attachments,
             metadata_=metadata,
         )
         uow.session.add(comment)
@@ -283,6 +312,7 @@ async def _handle_post_thread_discussion_reply(
 async def _handle_post_ai_timeline_message(
     body: str,
     thread_id: str | None = None,
+    attachments: list[Any] | None = None,
 ) -> str:
     """Post an Illo-authored message to a Thread's AI Timeline surface."""
     from brain.platform.db.models.idea import Idea
@@ -305,6 +335,7 @@ async def _handle_post_ai_timeline_message(
     trigger = _current_discussion_trigger()
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
     reply_to_comment_id = _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
+    visible_attachments = _clean_visible_attachments(attachments)
 
     async with UnitOfWork() as uow:
         idea = await uow.session.get(Idea, target_thread_id)
@@ -330,6 +361,7 @@ async def _handle_post_ai_timeline_message(
                 role="illo",
                 content=text,
                 actor={"org_id": org_id},
+                attachments=visible_attachments,
                 metadata=metadata,
             ),
             lifecycle_trigger="agent_tool_ai_timeline_message",
@@ -409,6 +441,7 @@ async def _handle_read_thread_discussion(
 __all__ = [
     "_handle_post_chat_message",
     "_handle_post_ai_timeline_message",
+    "_handle_publish_thread_asset",
     "_handle_post_thread_discussion_reply",
     "_handle_read_thread_discussion",
 ]

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -35,6 +35,7 @@ from brain.systems.runs.tool_catalog.handlers.chat import (
     _handle_post_ai_timeline_message,
     _handle_post_chat_message,
     _handle_post_thread_discussion_reply,
+    _handle_publish_thread_asset,
     _handle_read_thread_discussion,
 )
 from brain.systems.runs.tool_catalog.handlers.cycles import _handle_manage_cycle
@@ -257,6 +258,10 @@ def _get_tool_handlers(
         "post_thread_discussion_reply": lambda **kw: _patched_private(
             "_handle_post_thread_discussion_reply",
             _handle_post_thread_discussion_reply,
+        )(**kw),
+        "publish_thread_asset": lambda **kw: _patched_private(
+            "_handle_publish_thread_asset",
+            _handle_publish_thread_asset,
         )(**kw),
         "post_ai_timeline_message": lambda **kw: _patched_private(
             "_handle_post_ai_timeline_message",

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -352,6 +352,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "post an Illo-authored reply to Thread Discussion",
         "output_budget_chars": 8_000,
     },
+    "publish_thread_asset": {
+        "permission": "write_workspace",
+        "risk_class": "medium",
+        "side_effect_class": "append_only",
+        "reversibility": "append_only",
+        "action_manifest": True,
+        "expected_effect": "publish a generated local artifact as a visible Thread upload asset",
+        "output_budget_chars": 8_000,
+    },
     "post_ai_timeline_message": {
         "permission": "write_chat",
         "risk_class": "medium",

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1298,6 +1298,34 @@ CHAT_TOOLS = [
         },
     },
     {
+        "name": "publish_thread_asset",
+        "description": (
+            "Publish a generated local artifact, such as an SVG, PNG, PDF, or text file, "
+            "as a previewable Thread asset under /static/uploads. Use this when a user asks "
+            "to see or download an artifact that exists only as a local file path. The tool "
+            "returns markdown and an attachment object; include both in post_thread_discussion_reply "
+            "or post_ai_timeline_message so the asset is visible in the Thread."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute local path to a generated artifact under an allowed artifact root.",
+                },
+                "thread_id": {
+                    "type": "string",
+                    "description": "Optional Thread id. Defaults to the triggering/current Thread.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional human-readable label or alt text for the asset.",
+                },
+            },
+            "required": ["file_path"],
+        },
+    },
+    {
         "name": "post_thread_discussion_reply",
         "description": (
             "Post an Illo-authored reply into the current Thread Discussion. "
@@ -1320,6 +1348,14 @@ CHAT_TOOLS = [
                 "reply_to_comment_id": {
                     "type": "integer",
                     "description": "Optional Discussion comment id being acknowledged. Defaults to the triggering comment.",
+                },
+                "attachments": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Optional visible attachments. For generated assets, pass the attachment object "
+                        "returned by publish_thread_asset."
+                    ),
                 },
             },
             "required": ["body"],
@@ -1400,6 +1436,14 @@ CHAT_TOOLS = [
                 "thread_id": {
                     "type": "string",
                     "description": "Optional Thread id. Defaults to the linked/current Thread.",
+                },
+                "attachments": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Optional visible attachments. For generated assets, pass the attachment object "
+                        "returned by publish_thread_asset."
+                    ),
                 },
             },
             "required": ["body"],

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -58,6 +58,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_post_ai_timeline_message",
     "_handle_post_chat_message",
     "_handle_post_thread_discussion_reply",
+    "_handle_publish_thread_asset",
     "_handle_read_thread_discussion",
     "_handle_read_thread_messages",
     "_handle_manage_cycle",

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { onDestroy, tick } from 'svelte';
 
+  import AttachmentPreviewDialog from '$lib/components/chat/AttachmentPreviewDialog.svelte';
   import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
   import ChatStateView from '$lib/components/chat/ChatStateView.svelte';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
+  import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
   import ObjectReferencePreviewList from '$lib/features/threads/components/ObjectReferencePreviewList.svelte';
   import {
     CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
@@ -11,7 +13,7 @@
     scrollConversationToBottom,
     shouldShowConversationScrollCue,
   } from '$lib/components/chat/conversationScroll';
-  import { ConstellationNotice, ConstellationPresenceSeed } from '$lib/components/constellation';
+  import { ConstellationIcon, ConstellationNotice, ConstellationPresenceSeed } from '$lib/components/constellation';
   import { defaultIlloMentionOption } from '$lib/features/composer/domain/mentionAutocomplete';
   import {
     listThreadDiscussion,
@@ -19,8 +21,19 @@
     type ThreadDiscussionComment,
   } from '$lib/features/threads/api/threadApi';
   import { wsClient } from '$lib/stores/ws.svelte';
+  import {
+    attachmentDetail,
+    attachmentDownloadUrl,
+    attachmentKindLabel,
+    attachmentLabel,
+    attachmentPreviewKind,
+    attachmentUrl,
+    normalizeServerUploadPreviewUrl,
+    type AttachmentPreviewKind,
+  } from '$lib/utils/attachmentPreview';
   import { buildPresenceSeedStyle, normalizeHexColor, presenceToneForColor } from '$lib/utils/constellationPresence';
   import { parseServerDate } from '$lib/utils/datetime';
+  import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
 
   let {
     ideaId = null,
@@ -38,14 +51,21 @@
   let userScrolledUp = $state(false);
   let showScrollCue = $state(false);
   let lastScrollIdeaId = $state<string | null>(null);
+  let previewAttachment = $state<PreviewableAttachment | null>(null);
+  const previewAttachmentUrl = $derived(previewAttachment?.url ?? '');
+  const previewAttachmentLabel = $derived(previewAttachment?.label ?? '');
+  const previewAttachmentDetail = $derived(previewAttachment?.detail ?? '');
+  const previewAttachmentKind = $derived(previewAttachment?.kind ?? 'file');
 
-  type MessageTextSegment = {
-    text: string;
-    mention: boolean;
+  type PreviewableAttachment = {
+    url: string;
+    downloadUrl?: string;
+    label: string;
+    detail?: string;
+    kind: AttachmentPreviewKind;
   };
 
   const MESSAGE_GROUP_WINDOW_MS = 15 * 60 * 1000;
-  const MENTION_RENDER_RE = /(^|[^A-Za-z0-9_])@([A-Za-z0-9._-]+)([.,:;!?]?)/g;
   const THREAD_DISCUSSION_RUN_PREFIX = 'thread-discussion:';
   const THREAD_DISCUSSION_REPLY_TOOL = 'post_thread_discussion_reply';
   const DISCUSSION_REPLY_RECONCILE_DELAYS_MS = [1200, 3000, 7000, 15000, 30000, 45000];
@@ -340,42 +360,80 @@
     );
   }
 
-  function messageTextSegments(bodyText: string): MessageTextSegment[] {
-    const segments: MessageTextSegment[] = [];
-    MENTION_RENDER_RE.lastIndex = 0;
-    let cursor = 0;
-    let match: RegExpExecArray | null;
+  function normalizeServerPreviewUrl(rawHref: string | null | undefined): string {
+    const base = typeof window === 'undefined' ? 'http://illo.local' : window.location.origin;
+    return normalizeServerUploadPreviewUrl(rawHref, base);
+  }
 
-    while ((match = MENTION_RENDER_RE.exec(bodyText)) !== null) {
-      const boundary = match[1] ?? '';
-      let token = match[2] ?? '';
-      let punctuation = match[3] ?? '';
-      const tokenTrailingPunctuation = token.match(/[.,:;!?]+$/)?.[0] ?? '';
-      if (tokenTrailingPunctuation) {
-        token = token.slice(0, -tokenTrailingPunctuation.length);
-        punctuation = `${tokenTrailingPunctuation}${punctuation}`;
-      }
+  function previewIconName(kind: AttachmentPreviewKind): ConstellationIconName {
+    if (kind === 'image') return 'image';
+    if (kind === 'video') return 'video';
+    if (kind === 'pdf') return 'pdf';
+    if (kind === 'link') return 'link';
+    if (kind === 'archive') return 'archive';
+    if (kind === 'text') return 'code';
+    return 'file';
+  }
 
-      const mentionStart = match.index + boundary.length;
-      if (mentionStart > cursor) {
-        segments.push({ text: bodyText.slice(cursor, mentionStart), mention: false });
-      }
+  function toPreviewAttachment(attachment: any): PreviewableAttachment | null {
+    const url = attachmentUrl(attachment);
+    if (!url) return null;
+    const kind = attachmentPreviewKind(attachment);
+    return {
+      url,
+      downloadUrl: attachmentDownloadUrl(attachment),
+      label: attachmentLabel(attachment),
+      detail: attachmentDetail(attachment),
+      kind,
+    };
+  }
 
-      const mentionText = `@${token}`;
-      segments.push({ text: mentionText, mention: true });
-      cursor = mentionStart + mentionText.length;
+  function discussionAttachments(comment: ThreadDiscussionComment): PreviewableAttachment[] {
+    const rawAttachments = Array.isArray(comment.attachments) ? comment.attachments : [];
+    return rawAttachments
+      .map((attachment) => toPreviewAttachment(attachment))
+      .filter(Boolean) as PreviewableAttachment[];
+  }
 
-      if (punctuation) {
-        segments.push({ text: punctuation, mention: false });
-        cursor += punctuation.length;
-      }
-    }
+  function previewAttachmentFromLink(anchor: HTMLAnchorElement): PreviewableAttachment | null {
+    const url = normalizeServerPreviewUrl(anchor.getAttribute('href') || anchor.href);
+    if (!url) return null;
+    const label = anchor.textContent?.trim() || attachmentLabel({ url });
+    const source = { url, filename: label };
+    return {
+      url,
+      downloadUrl: attachmentDownloadUrl(source),
+      label,
+      detail: attachmentKindLabel(source) || attachmentDetail(source),
+      kind: attachmentPreviewKind(source),
+    };
+  }
 
-    if (cursor < bodyText.length) {
-      segments.push({ text: bodyText.slice(cursor), mention: false });
-    }
+  function openAttachmentPreview(attachment: PreviewableAttachment) {
+    previewAttachment = attachment;
+  }
 
-    return segments.length > 0 ? segments : [{ text: bodyText, mention: false }];
+  function closeAttachmentPreview() {
+    previewAttachment = null;
+  }
+
+  function handleDiscussionContentClick(event: MouseEvent) {
+    const target = event.target as HTMLElement | null;
+    const anchor = target?.closest?.('a');
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    const attachment = previewAttachmentFromLink(anchor);
+    if (!attachment) return;
+    event.preventDefault();
+    openAttachmentPreview(attachment);
+  }
+
+  function previewServerFileLinks(node: HTMLElement) {
+    node.addEventListener('click', handleDiscussionContentClick);
+    return {
+      destroy() {
+        node.removeEventListener('click', handleDiscussionContentClick);
+      },
+    };
   }
 
   function syncScrollCue() {
@@ -449,6 +507,7 @@
           {@const showHeader = shouldShowMessageHeader(comments, index)}
           {@const author = authorLabel(comment)}
           {@const timestamp = timeLabel(comment.created_at)}
+          {@const attachments = discussionAttachments(comment)}
           <article
             class="discussion-message"
             class:has-header={showHeader}
@@ -476,15 +535,46 @@
               </header>
             {/if}
 
-            <p class="discussion-message-body">
-              {#each messageTextSegments(comment.body) as segment, segmentIndex (segmentIndex)}
-                {#if segment.mention}
-                  <span class="chat-mention">{segment.text}</span>
-                {:else}
-                  {segment.text}
-                {/if}
-              {/each}
-            </p>
+            <div
+              class="discussion-message-body constellation-prose"
+              use:previewServerFileLinks
+            >
+              {@html renderReadableMarkdown(comment.body)}
+            </div>
+
+            {#if attachments.length > 0}
+              <div class="discussion-attachments">
+                {#each attachments as attachment, attachmentIndex (`${attachment.url}-${attachmentIndex}`)}
+                  {#if attachment.kind === 'image'}
+                    <button
+                      type="button"
+                      class="discussion-attachment-image-button"
+                      aria-label={`Preview ${attachment.label}`}
+                      onclick={() => openAttachmentPreview(attachment)}
+                    >
+                      <img class="discussion-attachment-image" src={attachment.url} alt={attachment.label} />
+                    </button>
+                  {:else}
+                    <button
+                      type="button"
+                      class={`discussion-attachment-file is-${attachment.kind}`}
+                      aria-label={`Preview ${attachment.label}`}
+                      onclick={() => openAttachmentPreview(attachment)}
+                    >
+                      <span class="discussion-attachment-file-icon" aria-hidden="true">
+                        <ConstellationIcon name={previewIconName(attachment.kind)} size={16} stroke={1.8} />
+                      </span>
+                      <span class="discussion-attachment-file-copy">
+                        <span>{attachment.label}</span>
+                        {#if attachment.detail}
+                          <small>{attachment.detail}</small>
+                        {/if}
+                      </span>
+                    </button>
+                  {/if}
+                {/each}
+              </div>
+            {/if}
             <ObjectReferencePreviewList
               objectReferences={comment.object_references}
               threadReferences={comment.thread_references}
@@ -530,6 +620,18 @@
     />
   </div>
 </div>
+
+{#if previewAttachment && previewAttachmentUrl}
+  <AttachmentPreviewDialog
+    url={previewAttachmentUrl}
+    label={previewAttachmentLabel}
+    detail={previewAttachmentDetail}
+    kind={previewAttachmentKind}
+    openUrl={previewAttachment.downloadUrl || previewAttachmentUrl}
+    fallbackIcon={previewIconName(previewAttachmentKind)}
+    onClose={closeAttachmentPreview}
+  />
+{/if}
 
 <style>
   .thread-discussion-pane {
@@ -662,12 +764,101 @@
   }
 
   .discussion-message-body {
+    --constellation-prose-text: var(--chat-message-body-text);
+    --constellation-prose-heading: var(--constellation-thread-message-heading);
+    --constellation-prose-muted: var(--chat-message-meta-text);
+    --constellation-prose-font-size: 14px;
+    --constellation-prose-line-height: 1.6;
     margin: 0;
     color: var(--chat-message-body-text);
     font-size: 14px;
     line-height: 1.6;
-    white-space: pre-wrap;
+    white-space: normal;
     word-break: break-word;
+  }
+
+  .discussion-attachments {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .discussion-attachment-image-button {
+    appearance: none;
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: zoom-in;
+    text-align: left;
+  }
+
+  .discussion-attachment-image {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    max-height: 320px;
+    border: 1px solid var(--constellation-thread-message-image-border);
+    border-radius: 8px;
+    background: var(--constellation-thread-message-image-background);
+    object-fit: contain;
+  }
+
+  .discussion-attachment-file {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    width: min(100%, 360px);
+    max-width: 100%;
+    padding: 9px 11px;
+    border: 1px solid var(--constellation-thread-message-file-border);
+    border-radius: 8px;
+    background: var(--constellation-thread-message-file-background);
+    color: var(--constellation-thread-message-file-text);
+    cursor: zoom-in;
+    font-family: var(--constellation-font-mono, 'IBM Plex Mono', monospace);
+    font-size: 10px;
+    letter-spacing: 0;
+    text-align: left;
+  }
+
+  .discussion-attachment-file:hover,
+  .discussion-attachment-file:focus-visible,
+  .discussion-attachment-image-button:focus-visible {
+    border-color: color-mix(in srgb, var(--constellation-color-spectral) 42%, var(--constellation-thread-message-file-border));
+    outline: none;
+  }
+
+  .discussion-attachment-file-icon {
+    display: grid;
+    flex: 0 0 auto;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--constellation-color-spectral) 13%, transparent);
+    color: var(--constellation-color-spectral);
+  }
+
+  .discussion-attachment-file-copy {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .discussion-attachment-file-copy span,
+  .discussion-attachment-file-copy small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .discussion-attachment-file-copy small {
+    color: var(--chat-message-meta-text);
+    font-size: 10px;
   }
 
   .chat-mention {

--- a/frontend/src/lib/styles/components.css
+++ b/frontend/src/lib/styles/components.css
@@ -239,6 +239,27 @@
   text-decoration: underline;
 }
 
+.constellation-prose .md-readable-image-link {
+  display: block;
+  max-width: 100%;
+  width: fit-content;
+}
+
+.constellation-prose .md-readable-image-link:hover {
+  text-decoration: none;
+}
+
+.constellation-prose .md-readable-image {
+  display: block;
+  width: auto;
+  max-width: min(100%, 720px);
+  max-height: 520px;
+  border: 1px solid var(--constellation-thread-message-image-border, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  background: var(--constellation-thread-message-image-background, rgba(8, 12, 19, 0.72));
+  object-fit: contain;
+}
+
 .constellation-prose blockquote {
   border-left: 3px solid color-mix(in srgb, var(--constellation-prose-accent) 72%, transparent);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;

--- a/frontend/src/lib/utils/attachmentPreview.test.js
+++ b/frontend/src/lib/utils/attachmentPreview.test.js
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeServerUploadPreviewUrl } from './attachmentPreview.ts';
+import {
+  ATTACHMENT_INPUT_ACCEPT,
+  attachmentPreviewKind,
+  messageLinkAttachments,
+  normalizeServerUploadPreviewUrl,
+} from './attachmentPreview.ts';
 
 test('normalizes same-origin server upload preview links', () => {
   assert.equal(
@@ -19,4 +24,22 @@ test('keeps off-origin upload-looking links external', () => {
     normalizeServerUploadPreviewUrl('https://docs.example.com/static/uploads/spec.md', 'https://illo.local'),
     '',
   );
+});
+
+test('accepts and previews SVG attachments as images', () => {
+  assert.ok(ATTACHMENT_INPUT_ACCEPT.includes('image/svg+xml'));
+  assert.ok(ATTACHMENT_INPUT_ACCEPT.includes('.svg'));
+  assert.equal(attachmentPreviewKind({ url: '/static/uploads/diagram.svg' }), 'image');
+});
+
+test('promotes static upload links from message text into attachments', () => {
+  const attachments = messageLinkAttachments('See /static/uploads/thread-assets/t/diagram.svg');
+
+  assert.deepEqual(attachments, [
+    {
+      kind: 'file',
+      url: '/static/uploads/thread-assets/t/diagram.svg',
+      filename: '/static/uploads/thread-assets/t/diagram.svg',
+    },
+  ]);
 });

--- a/frontend/src/lib/utils/attachmentPreview.ts
+++ b/frontend/src/lib/utils/attachmentPreview.ts
@@ -16,6 +16,7 @@ export const ATTACHMENT_INPUT_ACCEPT = [
   'image/webp',
   'image/gif',
   'image/avif',
+  'image/svg+xml',
   'video/mp4',
   'video/webm',
   'video/quicktime',
@@ -29,6 +30,7 @@ export const ATTACHMENT_INPUT_ACCEPT = [
   '.jpg',
   '.jpeg',
   '.png',
+  '.svg',
   '.webp',
   '.m4v',
   '.mov',
@@ -77,6 +79,7 @@ const DOCUMENT_ATTACHMENT_EXTENSIONS = new Set([
 ]);
 const ARCHIVE_ATTACHMENT_EXTENSIONS = new Set(['7z', 'rar', 'tar', 'zip']);
 const MESSAGE_URL_PATTERN = /https?:\/\/[^\s<>"']+/gi;
+const MESSAGE_SERVER_UPLOAD_PATTERN = /\/static\/uploads\/[^\s<>"')]+/gi;
 
 export function attachmentUrl(attachment: any): string {
   const url = attachment?.url ?? attachment?.href ?? attachment?.previewUrl ?? attachment?.download_url ?? attachment?.downloadUrl;
@@ -218,17 +221,24 @@ export function messageLinkAttachments(
 
   const existingUrls = new Set((attachments ?? []).map((attachment) => attachmentUrl(attachment)).filter(Boolean));
   const urls: string[] = [];
-  for (const match of text.matchAll(MESSAGE_URL_PATTERN)) {
-    const url = normalizeMessageUrl(match[0]);
+  const matches = [
+    ...Array.from(text.matchAll(MESSAGE_URL_PATTERN), (match) => match[0]),
+    ...Array.from(text.matchAll(MESSAGE_SERVER_UPLOAD_PATTERN), (match) => match[0]),
+  ];
+  for (const match of matches) {
+    const url = normalizeMessageUrl(match);
     if (!url || existingUrls.has(url) || urls.includes(url)) continue;
     urls.push(url);
     if (urls.length >= 2) break;
   }
 
-  return urls.map((url) => ({
-    kind: 'link',
-    url,
-    filename: attachmentHost({ url }) || url,
-    type: 'text/uri-list',
-  }));
+  return urls.map((url) => {
+    const isServerUpload = Boolean(normalizeServerUploadPreviewUrl(url));
+    return {
+      kind: isServerUpload ? 'file' : 'link',
+      url,
+      filename: attachmentHost({ url }) || url,
+      ...(isServerUpload ? {} : { type: 'text/uri-list' }),
+    };
+  });
 }

--- a/frontend/src/lib/utils/readableMarkdown.test.js
+++ b/frontend/src/lib/utils/readableMarkdown.test.js
@@ -75,6 +75,21 @@ test('preserves server-relative markdown links', () => {
   );
 });
 
+test('renders server upload markdown images as inline preview links', () => {
+  const html = renderReadableMarkdown('![AWS mini diagram](/static/uploads/thread-assets/t/aws.svg)');
+
+  assert.equal(
+    html,
+    '<p><a class="md-readable-image-link" href="/static/uploads/thread-assets/t/aws.svg" target="_blank" rel="noopener"><img class="md-readable-image" src="/static/uploads/thread-assets/t/aws.svg" alt="AWS mini diagram" loading="lazy" decoding="async"/></a></p>',
+  );
+});
+
+test('does not render remote markdown images inline', () => {
+  const html = renderReadableMarkdown('![Remote diagram](https://example.com/aws.svg)');
+
+  assert.equal(html, '<p>Remote diagram</p>');
+});
+
 test('preserves query parameters in bare url hrefs', () => {
   const html = renderReadableMarkdown('Open https://example.com/search?q=illo&sort=new');
 

--- a/frontend/src/lib/utils/readableMarkdown.ts
+++ b/frontend/src/lib/utils/readableMarkdown.ts
@@ -48,6 +48,12 @@ function safeHref(url: string): string | null {
   return null;
 }
 
+function safeImageSrc(url: string): string | null {
+  const trimmed = decodeHrefEntities(url || '').trim();
+  if (!/^\/static\/uploads\//.test(trimmed)) return null;
+  return safeHref(trimmed);
+}
+
 export function normalizeReadableMarkdown(input: string): string {
   return (input || '')
     .replace(/\r\n?/g, '\n')
@@ -60,6 +66,12 @@ export function normalizeReadableMarkdown(input: string): string {
 function applyInlineMarkdown(text: string): string {
   const links: string[] = [];
   let output = text
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, label, url) => {
+      const safe = safeImageSrc(url);
+      if (!safe) return label;
+      const cleanLabel = String(label || 'Thread asset');
+      return `<a class="md-readable-image-link" href="${safe}" target="_blank" rel="noopener"><img class="md-readable-image" src="${safe}" alt="${cleanLabel}" loading="lazy" decoding="async"/></a>`;
+    })
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, url) => {
       const safe = safeHref(url);
       if (!safe) return label;

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -212,8 +212,8 @@ def test_thread_attachment_context_promotes_text_image_and_audio(tmp_path, monke
     note.write_text("hello attachment", encoding="utf-8")
     config = upload_dir / "config.yaml"
     config.write_text("feature: enabled", encoding="utf-8")
-    image = upload_dir / "screenshot.png"
-    image.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    image = upload_dir / "screenshot.svg"
+    image.write_text("<svg></svg>", encoding="utf-8")
     audio = upload_dir / "voice.webm"
     audio.write_bytes(b"webm audio")
     monkeypatch.setattr(thread_attachments, "UPLOAD_DIR", upload_dir)
@@ -221,7 +221,7 @@ def test_thread_attachment_context_promotes_text_image_and_audio(tmp_path, monke
     context = thread_attachments.build_thread_attachment_context([
         {"url": "/static/uploads/note.md", "filename": "note.md", "type": "text/markdown"},
         {"url": "/static/uploads/config.yaml", "filename": "config.yaml", "type": "application/x-yaml"},
-        {"url": "/static/uploads/screenshot.png", "filename": "screenshot.png", "type": "image/png"},
+        {"url": "/static/uploads/screenshot.svg", "filename": "screenshot.svg", "type": "image/svg+xml"},
         {"url": "/static/uploads/voice.webm", "filename": "voice.webm", "type": "audio/webm"},
     ])
     blocks = thread_attachments.initial_user_content_blocks("Read these", context)
@@ -236,7 +236,7 @@ def test_thread_attachment_context_promotes_text_image_and_audio(tmp_path, monke
     assert "feature: enabled" in blocks[0]["text"]
     assert "voice.webm" in blocks[0]["text"]
     assert blocks[1]["type"] == "image"
-    assert blocks[1]["source"]["media_type"] == "image/png"
+    assert blocks[1]["source"]["media_type"] == "image/svg+xml"
 
 
 def test_project_context_merge_into_idea_agent_details():
@@ -1572,17 +1572,27 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
             },
         }
     ):
-        raw = await _handle_post_thread_discussion_reply("Got it, I will carry that forward.")
+        attachment = {
+            "url": "/static/uploads/thread-assets/some-id/diagram.svg",
+            "filename": "diagram.svg",
+            "content_type": "image/svg+xml",
+        }
+        raw = await _handle_post_thread_discussion_reply(
+            "Got it, I will carry that forward.",
+            attachments=[attachment],
+        )
 
     payload = json.loads(raw)
     assert payload["ok"] is True
     assert payload["comment"]["body"] == "Got it, I will carry that forward."
     assert payload["comment"]["author_kind"] == "illo"
+    assert payload["comment"]["attachments"] == [attachment]
     assert payload["comment"]["metadata"]["created_by_run_id"] == 42
     assert payload["comment"]["metadata"]["reply_to_comment_id"] == 7
     assert created[0].thread_id == "some-id"
     assert created[0].org_id == "test-org"
     assert created[0].author_user_id is None
+    assert created[0].attachments == [attachment]
     published.assert_called_once_with(
         "thread_discussion_comment",
         {"idea_id": "some-id", "org_id": "test-org", "comment": payload["comment"]},

--- a/tests/test_thread_assets.py
+++ b/tests/test_thread_assets.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from brain.systems.cortex.thread_assets import publish_thread_asset
+
+
+def test_publish_thread_asset_copies_svg_to_static_uploads(tmp_path: Path):
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    svg_path = source_root / "aws mini.svg"
+    svg_path.write_text('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>')
+    upload_dir = tmp_path / "uploads"
+
+    result = publish_thread_asset(
+        str(svg_path),
+        thread_id="thread/one",
+        title="AWS mini diagram",
+        upload_dir=upload_dir,
+        source_roots=[source_root],
+    )
+
+    assert result["ok"] is True
+    assert result["url"].startswith("/static/uploads/thread-assets/thread-one/aws-mini-")
+    assert result["url"].endswith(".svg")
+    assert result["markdown"] == f"![AWS mini diagram]({result['url']})"
+    assert result["attachment"]["kind"] == "image"
+    assert result["attachment"]["content_type"] == "image/svg+xml"
+    assert Path(result["published_path"]).read_text() == svg_path.read_text()
+
+
+def test_publish_thread_asset_rejects_paths_outside_artifact_roots(tmp_path: Path):
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    outside = tmp_path / "secret.svg"
+    outside.write_text("<svg></svg>")
+
+    with pytest.raises(PermissionError):
+        publish_thread_asset(
+            str(outside),
+            upload_dir=tmp_path / "uploads",
+            source_roots=[source_root],
+        )

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -139,6 +139,23 @@ def test_thread_discussion_reply_tool_is_registered_and_exposed():
     assert registration.reversibility == "append_only"
 
 
+def test_publish_thread_asset_tool_is_registered_and_exposed():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "publish_thread_asset"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name in _names(WORKER_TOOLS)
+    assert name in _get_tool_handlers()
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert registration.permission == "write_workspace"
+    assert registration.side_effect_class == "append_only"
+    assert registration.reversibility == "append_only"
+
+
 def test_ai_timeline_message_tool_is_registered_and_exposed():
     from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_handlers import _get_tool_handlers


### PR DESCRIPTION
Summary: add publish_thread_asset for generated SVG/PNG/PDF/text artifacts, preserve visible attachments on Discussion and AI Timeline replies, render /static/uploads SVG/images inline in thread Discussion/transcript. Tests: venv/bin/python -m pytest tests/test_thread_assets.py tests/test_tool_registry.py tests/test_api_cortex.py::test_thread_attachment_context_promotes_text_image_and_audio tests/test_api_cortex.py::test_post_thread_discussion_reply_tool_writes_illo_comment tests/test_api_cortex.py::test_post_ai_timeline_message_tool_writes_linked_thread_message; venv/bin/python -m pytest tests/test_tool_registry.py; npm test; npm run check; npm run build.