### PR TITLE
Render thread asset routes as visible attachments

### DIFF
--- a/brain/systems/cortex/thread_assets.py
+++ b/brain/systems/cortex/thread_assets.py
@@ -8,7 +8,12 @@ import re
 from pathlib import Path
 from typing import Any, Iterable
 
-from brain.systems.cortex.upload_preview import public_static_upload_url, static_upload_url_for
+from brain.systems.cortex.upload_preview import (
+    normalize_static_upload_url,
+    public_static_upload_url,
+    resolve_static_upload_path,
+    static_upload_url_for,
+)
 
 UPLOAD_DIR = Path(__file__).resolve().parents[2] / "uploads"
 MAX_THREAD_ASSET_SIZE = 10 * 1024 * 1024
@@ -51,6 +56,7 @@ CONTENT_TYPE_BY_EXTENSION = {
 
 DEFAULT_SOURCE_ROOTS = ("/workspaces/artifacts",)
 THREAD_ASSET_PREFIX = "thread-assets"
+STATIC_UPLOAD_LINK_PATTERN = re.compile(r"(?:https?://[^\s<>\"')]+)?/static/uploads/[^\s<>\"')]+")
 
 
 def _resolved_roots(source_roots: Iterable[str | Path] | None = None) -> list[Path]:
@@ -101,6 +107,36 @@ def _content_type(path: Path, extension: str) -> str:
     return mimetypes.guess_type(path.name)[0] or CONTENT_TYPE_BY_EXTENSION.get(extension, "application/octet-stream")
 
 
+def _asset_attachment_from_upload(
+    value: str,
+    *,
+    title: str | None = None,
+    upload_dir: Path | None = None,
+) -> tuple[Path, str, dict[str, Any]]:
+    target_upload_dir = upload_dir or UPLOAD_DIR
+    path = resolve_static_upload_path(value, upload_dir=target_upload_dir)
+    extension = path.suffix.lower().lstrip(".")
+    if extension not in VIEWER_EXTENSIONS:
+        raise ValueError(f"Thread asset type .{extension or '(none)'} is not previewable")
+
+    url = normalize_static_upload_url(value)
+    size = path.stat().st_size
+    content_type = _content_type(path, extension)
+    kind = "image" if content_type.startswith("image/") or extension in IMAGE_EXTENSIONS else "file"
+    label = str(title or path.name).strip() or path.name
+    attachment = {
+        "kind": kind,
+        "url": url,
+        "download_url": public_static_upload_url(url),
+        "filename": path.name,
+        "label": label,
+        "content_type": content_type,
+        "mime_type": content_type,
+        "size": size,
+    }
+    return path, url, attachment
+
+
 def _asset_markdown(*, label: str, url: str, kind: str) -> str:
     clean_label = label.replace("[", "").replace("]", "").strip() or "Thread asset"
     if kind == "image":
@@ -113,11 +149,40 @@ def publish_thread_asset(
     *,
     thread_id: str | None = None,
     title: str | None = None,
-    upload_dir: Path = UPLOAD_DIR,
+    upload_dir: Path | None = None,
     source_roots: Iterable[str | Path] | None = None,
     max_bytes: int = MAX_THREAD_ASSET_SIZE,
 ) -> dict[str, Any]:
     """Copy a generated artifact into static uploads and return a chat attachment."""
+
+    target_upload_dir = upload_dir or UPLOAD_DIR
+    raw_file_path = str(file_path or "").strip()
+    if raw_file_path:
+        try:
+            published_path, url, attachment = _asset_attachment_from_upload(
+                raw_file_path,
+                title=title,
+                upload_dir=target_upload_dir,
+            )
+            return {
+                "ok": True,
+                "source_path": str(published_path),
+                "published_path": str(published_path),
+                "url": url,
+                "public_url": attachment["download_url"],
+                "markdown": _asset_markdown(label=attachment["label"], url=url, kind=attachment["kind"]),
+                "attachment": attachment,
+                "already_published": True,
+                "instruction": (
+                    "To show this in a Thread, write the returned markdown or /static/uploads route "
+                    "in post_thread_discussion_reply or post_ai_timeline_message. Valid upload routes "
+                    "are promoted to visible attachments automatically."
+                ),
+            }
+        except ValueError:
+            pass
+        except FileNotFoundError:
+            pass
 
     source = _source_path(file_path, source_roots=source_roots)
     extension = source.suffix.lower().lstrip(".")
@@ -132,8 +197,8 @@ def publish_thread_asset(
     stem = _safe_segment(source.stem, "asset")
     thread_segment = _safe_segment(thread_id or "shared", "shared")
     filename = f"{stem}-{digest}.{extension}"
-    destination_dir = (upload_dir / THREAD_ASSET_PREFIX / thread_segment).resolve()
-    upload_root = upload_dir.resolve()
+    destination_dir = (target_upload_dir / THREAD_ASSET_PREFIX / thread_segment).resolve()
+    upload_root = target_upload_dir.resolve()
     if not _is_within(destination_dir, upload_root):
         raise ValueError("Thread asset destination escapes upload root")
     destination_dir.mkdir(parents=True, exist_ok=True)
@@ -164,10 +229,71 @@ def publish_thread_asset(
         "markdown": _asset_markdown(label=label, url=url, kind=kind),
         "attachment": attachment,
         "instruction": (
-            "To show this in Thread Discussion, call post_thread_discussion_reply with the returned "
-            "markdown in body and include the returned attachment in attachments."
+            "To show this in a Thread, write the returned markdown or /static/uploads route "
+            "in post_thread_discussion_reply or post_ai_timeline_message. Valid upload routes "
+            "are promoted to visible attachments automatically."
         ),
     }
 
 
-__all__ = ["publish_thread_asset"]
+def attachment_for_published_thread_asset(
+    value: str,
+    *,
+    title: str | None = None,
+    upload_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Return a visible attachment for an existing /static/uploads artifact."""
+
+    _, _, attachment = _asset_attachment_from_upload(value, title=title, upload_dir=upload_dir)
+    return attachment
+
+
+def infer_thread_asset_attachments_from_body(
+    body: str | None,
+    *,
+    existing_attachments: list[dict[str, Any]] | None = None,
+    upload_dir: Path | None = None,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    """Promote existing /static/uploads links in message text into visible attachments."""
+
+    attachments = list(existing_attachments or [])
+    existing_urls = set()
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        existing_url = str(attachment.get("url") or attachment.get("href") or "").strip()
+        if not existing_url:
+            continue
+        try:
+            existing_urls.add(normalize_static_upload_url(existing_url))
+        except ValueError:
+            existing_urls.add(existing_url)
+    text = str(body or "")
+    if not text:
+        return attachments
+
+    for match in STATIC_UPLOAD_LINK_PATTERN.finditer(text):
+        if len(attachments) >= limit:
+            break
+        raw_url = match.group(0).rstrip("),.;!?")
+        try:
+            url = normalize_static_upload_url(raw_url)
+        except ValueError:
+            continue
+        if not url or url in existing_urls:
+            continue
+        try:
+            attachment = attachment_for_published_thread_asset(url, upload_dir=upload_dir)
+        except (FileNotFoundError, ValueError):
+            continue
+        attachments.append(attachment)
+        existing_urls.add(url)
+    return attachments
+
+
+__all__ = [
+    "attachment_for_published_thread_asset",
+    "infer_thread_asset_attachments_from_body",
+    "publish_thread_asset",
+]

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -147,6 +147,20 @@ def _clean_visible_attachments(attachments: list[Any] | None) -> list[dict[str, 
     return [dict(attachment) for attachment in attachments if isinstance(attachment, dict)]
 
 
+def _visible_attachments_for_body(body: str, attachments: list[Any] | None) -> list[dict[str, Any]]:
+    visible_attachments = _clean_visible_attachments(attachments)
+    try:
+        from brain.systems.cortex.thread_assets import infer_thread_asset_attachments_from_body
+
+        return infer_thread_asset_attachments_from_body(
+            body,
+            existing_attachments=visible_attachments,
+        )
+    except Exception as exc:
+        logger.warning("thread_asset_attachment_inference_failed: %s", exc)
+        return visible_attachments
+
+
 async def _publish_chat_events(publish, summaries: dict[str, dict[str, Any]]) -> None:
     from brain.app.api.routers.chat import (
         _publish_message_events,
@@ -272,7 +286,7 @@ async def _handle_post_thread_discussion_reply(
         if reply_to_comment_id is not None
         else _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
     )
-    visible_attachments = _clean_visible_attachments(attachments)
+    visible_attachments = _visible_attachments_for_body(text, attachments)
 
     async with UnitOfWork() as uow:
         idea = await uow.session.get(Idea, target_thread_id)
@@ -335,7 +349,7 @@ async def _handle_post_ai_timeline_message(
     trigger = _current_discussion_trigger()
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
     reply_to_comment_id = _coerce_comment_id(response_target.get("reply_to_comment_id") or trigger.get("comment_id"))
-    visible_attachments = _clean_visible_attachments(attachments)
+    visible_attachments = _visible_attachments_for_body(text, attachments)
 
     async with UnitOfWork() as uow:
         idea = await uow.session.get(Idea, target_thread_id)

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1303,15 +1303,22 @@ CHAT_TOOLS = [
             "Publish a generated local artifact, such as an SVG, PNG, PDF, or text file, "
             "as a previewable Thread asset under /static/uploads. Use this when a user asks "
             "to see or download an artifact that exists only as a local file path. The tool "
-            "returns markdown and an attachment object; include both in post_thread_discussion_reply "
-            "or post_ai_timeline_message so the asset is visible in the Thread."
+            "also accepts an existing /static/uploads/... URL returned by this tool and will "
+            "return the same attachment object idempotently. It returns markdown and an "
+            "attachment object. To show the asset in a Thread, write the returned markdown "
+            "or /static/uploads/... route in post_thread_discussion_reply or "
+            "post_ai_timeline_message; those tools persist visible attachments from valid "
+            "upload routes automatically."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Absolute local path to a generated artifact under an allowed artifact root.",
+                    "description": (
+                        "Absolute local path to a generated artifact under an allowed artifact root, "
+                        "or an existing /static/uploads/... URL for an already-published asset."
+                    ),
                 },
                 "thread_id": {
                     "type": "string",
@@ -1353,8 +1360,8 @@ CHAT_TOOLS = [
                     "type": "array",
                     "items": {"type": "object"},
                     "description": (
-                        "Optional visible attachments. For generated assets, pass the attachment object "
-                        "returned by publish_thread_asset."
+                        "Optional visible attachments. Valid /static/uploads/... links in body are "
+                        "also promoted to visible attachments automatically."
                     ),
                 },
             },
@@ -1441,8 +1448,8 @@ CHAT_TOOLS = [
                     "type": "array",
                     "items": {"type": "object"},
                     "description": (
-                        "Optional visible attachments. For generated assets, pass the attachment object "
-                        "returned by publish_thread_asset."
+                        "Optional visible attachments. Valid /static/uploads/... links in body are "
+                        "also promoted to visible attachments automatically."
                     ),
                 },
             },

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -28,6 +28,7 @@
     attachmentLabel,
     attachmentPreviewKind,
     attachmentUrl,
+    messageLinkAttachments,
     normalizeServerUploadPreviewUrl,
     type AttachmentPreviewKind,
   } from '$lib/utils/attachmentPreview';
@@ -390,7 +391,7 @@
 
   function discussionAttachments(comment: ThreadDiscussionComment): PreviewableAttachment[] {
     const rawAttachments = Array.isArray(comment.attachments) ? comment.attachments : [];
-    return rawAttachments
+    return [...rawAttachments, ...messageLinkAttachments(comment.body, rawAttachments)]
       .map((attachment) => toPreviewAttachment(attachment))
       .filter(Boolean) as PreviewableAttachment[];
   }

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1600,6 +1600,71 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_post_thread_discussion_reply_tool_infers_upload_attachments(monkeypatch, tmp_path):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_thread_discussion_reply
+    from brain.systems.cortex.upload_preview import static_upload_url_for
+
+    upload_dir = tmp_path / "uploads"
+    asset_dir = upload_dir / "thread-assets" / "some-id"
+    asset_dir.mkdir(parents=True)
+    asset = asset_dir / "diagram.png"
+    asset.write_bytes(b"png-bytes")
+    monkeypatch.setattr("brain.systems.cortex.thread_assets.UPLOAD_DIR", upload_dir)
+    url = static_upload_url_for("thread-assets", "some-id", "diagram.png")
+    created = []
+
+    class _Session:
+        async def get(self, _model, thread_id):
+            return SimpleNamespace(id=thread_id, org_id="test-org")
+
+        def add(self, obj):
+            obj.id = 10
+            obj.created_at = datetime(2026, 5, 21, 12, 6, tzinfo=timezone.utc)
+            created.append(obj)
+
+        async def flush(self):
+            return None
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    published = Mock()
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+    monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
+
+    with bind_agent_context({"org_id": "test-org", "run_id": 42, "idea_id": "some-id"}):
+        raw = await _handle_post_thread_discussion_reply(
+            f"Here it is:\n\n![Diagram]({url})",
+        )
+
+    payload = json.loads(raw)
+    assert payload["ok"] is True
+    assert payload["comment"]["attachments"] == [
+        {
+            "kind": "image",
+            "url": url,
+            "download_url": url,
+            "filename": "diagram.png",
+            "label": "diagram.png",
+            "content_type": "image/png",
+            "mime_type": "image/png",
+            "size": len(b"png-bytes"),
+        }
+    ]
+    assert created[0].attachments == payload["comment"]["attachments"]
+    published.assert_called_once_with(
+        "thread_discussion_comment",
+        {"idea_id": "some-id", "org_id": "test-org", "comment": payload["comment"]},
+    )
+
+
+@pytest.mark.asyncio
 async def test_post_ai_timeline_message_tool_writes_linked_thread_message(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_ai_timeline_message

--- a/tests/test_thread_assets.py
+++ b/tests/test_thread_assets.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from brain.systems.cortex.thread_assets import publish_thread_asset
+from brain.systems.cortex.thread_assets import (
+    infer_thread_asset_attachments_from_body,
+    publish_thread_asset,
+)
+from brain.systems.cortex.upload_preview import static_upload_url_for
 
 
 def test_publish_thread_asset_copies_svg_to_static_uploads(tmp_path: Path):
@@ -41,3 +45,54 @@ def test_publish_thread_asset_rejects_paths_outside_artifact_roots(tmp_path: Pat
             upload_dir=tmp_path / "uploads",
             source_roots=[source_root],
         )
+
+
+def test_publish_thread_asset_accepts_existing_static_upload_url(tmp_path: Path):
+    upload_dir = tmp_path / "uploads"
+    asset_dir = upload_dir / "thread-assets" / "thread-one"
+    asset_dir.mkdir(parents=True)
+    asset = asset_dir / "diagram.png"
+    asset.write_bytes(b"png-bytes")
+    url = static_upload_url_for("thread-assets", "thread-one", "diagram.png")
+
+    result = publish_thread_asset(
+        url,
+        upload_dir=upload_dir,
+        title="Published diagram",
+    )
+
+    assert result["ok"] is True
+    assert result["already_published"] is True
+    assert result["url"] == url
+    assert result["published_path"] == str(asset.resolve())
+    assert result["markdown"] == f"![Published diagram]({url})"
+    assert result["attachment"]["kind"] == "image"
+    assert result["attachment"]["url"] == url
+    assert result["attachment"]["content_type"] == "image/png"
+
+
+def test_infers_thread_asset_attachments_from_body(tmp_path: Path):
+    upload_dir = tmp_path / "uploads"
+    asset_dir = upload_dir / "thread-assets" / "thread-one"
+    asset_dir.mkdir(parents=True)
+    asset = asset_dir / "diagram.svg"
+    asset.write_text("<svg></svg>")
+    url = static_upload_url_for("thread-assets", "thread-one", "diagram.svg")
+
+    attachments = infer_thread_asset_attachments_from_body(
+        f"See this diagram: ![diagram]({url})",
+        upload_dir=upload_dir,
+    )
+
+    assert attachments == [
+        {
+            "kind": "image",
+            "url": url,
+            "download_url": url,
+            "filename": "diagram.svg",
+            "label": "diagram.svg",
+            "content_type": "image/svg+xml",
+            "mime_type": "image/svg+xml",
+            "size": len("<svg></svg>"),
+        }
+    ]


### PR DESCRIPTION
## Summary
- make published /static/uploads thread asset URLs idempotent inputs to publish_thread_asset
- promote valid /static/uploads routes in Thread Discussion and AI Timeline bodies to persisted visible attachments
- render /static/uploads links from Thread Discussion bodies as previewable attachments in the frontend
- update tool guidance so Illo can write the returned route/markdown instead of carrying attachment objects between tool calls

## Verification
- venv/bin/python3 -m pytest tests/test_tool_registry.py tests/test_thread_assets.py tests/test_api_cortex.py -k 'publish_thread_asset or post_thread_discussion_reply'
- npm test
- npm run check
- npm run build

## Illo thread
Original failure thread: https://server-rd-1.tail44d6b6.ts.net/threads/98a55210-1675-448e-affb-78b18c80a94c