### PR TITLE
Preserve final answer image attachments

### DIFF
--- a/brain/systems/cortex/thought_lifecycle.py
+++ b/brain/systems/cortex/thought_lifecycle.py
@@ -79,6 +79,7 @@ class TerminalRunSettlementCommand:
     run_status: str
     final_answer: str | None = None
     artifact_id: int | str | None = None
+    attachments: list[dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True)
@@ -598,6 +599,19 @@ def _final_answer_metadata(command: TerminalRunSettlementCommand) -> dict[str, A
     }
 
 
+def _visible_final_answer_attachments(command: TerminalRunSettlementCommand) -> list[dict[str, Any]]:
+    attachments = [dict(attachment) for attachment in command.attachments or [] if isinstance(attachment, dict)]
+    try:
+        from brain.systems.cortex.thread_assets import infer_thread_asset_attachments_from_body
+
+        return infer_thread_asset_attachments_from_body(
+            str(command.final_answer or ""),
+            existing_attachments=attachments,
+        )
+    except Exception:
+        return attachments
+
+
 async def mirror_run_final_answer(
     session: Any,
     *,
@@ -612,7 +626,7 @@ async def mirror_run_final_answer(
         idea_id=str(getattr(idea, "id", "") or ""),
         role="illo",
         content=text,
-        attachments=[],
+        attachments=_visible_final_answer_attachments(command),
         metadata=_final_answer_metadata(command),
         user_id=None,
         message_type="agent_response",

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -283,7 +283,93 @@ def _message_belongs_to_run(message: IdeaThread, run_id: int) -> bool:
     metadata = getattr(message, "metadata_", None)
     if not isinstance(metadata, dict):
         return False
-    return str(metadata.get("run_id") or "") == str(run_id)
+    return str(metadata.get("run_id") or metadata.get("created_by_run_id") or "") == str(run_id)
+
+
+def _message_surface(message: IdeaThread) -> str:
+    metadata = getattr(message, "metadata_", None)
+    if not isinstance(metadata, dict):
+        return ""
+    surface = metadata.get("surface") or metadata.get("target_surface")
+    return str(surface or "").strip()
+
+
+def _message_is_visible_run_timeline_output(message: IdeaThread, run_id: int) -> bool:
+    if not _message_belongs_to_run(message, run_id):
+        return False
+    if str(getattr(message, "message_type", "") or "") == "agent_response":
+        return True
+    return _message_surface(message) in _AI_TIMELINE_SURFACES
+
+
+def _attachment_key(attachment: dict[str, Any]) -> str:
+    return str(
+        attachment.get("url")
+        or attachment.get("download_url")
+        or attachment.get("public_url")
+        or attachment.get("filename")
+        or ""
+    )
+
+
+def _append_unique_attachments(target: list[dict[str, Any]], attachments: Any, seen: set[str]) -> None:
+    if not isinstance(attachments, list):
+        return
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        key = _attachment_key(attachment)
+        if key and key in seen:
+            continue
+        if key:
+            seen.add(key)
+        target.append(dict(attachment))
+
+
+async def _same_run_visible_attachments(session, *, run: AgentRunRow, thread_id: str) -> list[dict[str, Any]]:
+    """Carry attachments created by tools in this run into the mirrored final answer."""
+    if not hasattr(session, "scalars"):
+        return []
+
+    run_id = int(run.id)
+    attachments: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    try:
+        comments_result = await session.scalars(
+            select(ThreadDiscussionComment)
+            .where(
+                ThreadDiscussionComment.thread_id == str(thread_id),
+                ThreadDiscussionComment.author_kind == "illo",
+            )
+            .order_by(ThreadDiscussionComment.created_at.desc(), ThreadDiscussionComment.id.desc())
+            .limit(100)
+        )
+        comments = list(comments_result.all())
+    except Exception:
+        comments = []
+    for comment in comments:
+        if _comment_belongs_to_run(comment, run_id):
+            _append_unique_attachments(attachments, getattr(comment, "attachments", None), seen)
+
+    try:
+        messages_result = await session.scalars(
+            select(IdeaThread)
+            .where(
+                IdeaThread.idea_id == str(thread_id),
+                IdeaThread.role.in_(("illo", "assistant")),
+            )
+            .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
+            .limit(100)
+        )
+        messages = list(messages_result.all())
+    except Exception:
+        messages = []
+    for message in messages:
+        if _message_belongs_to_run(message, run_id):
+            _append_unique_attachments(attachments, getattr(message, "attachments", None), seen)
+
+    return attachments
 
 
 async def _latest_final_answer_artifact(session, *, run: AgentRunRow) -> tuple[str | None, int | None]:
@@ -314,11 +400,12 @@ async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Id
             .where(
                 IdeaThread.idea_id == str(idea.id),
                 IdeaThread.role.in_(("illo", "assistant")),
-                IdeaThread.message_type == "agent_response",
             )
+            .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
+            .limit(100)
         )
     ).all()
-    if any(_message_belongs_to_run(message, int(run.id)) for message in recent_responses):
+    if any(_message_is_visible_run_timeline_output(message, int(run.id)) for message in recent_responses):
         return None, None
     return text, artifact_id
 
@@ -481,6 +568,7 @@ async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict
     if old_status in PROTECTED_IDEA_STATUSES:
         return None
     final_answer, artifact_id = await _latest_unmirrored_final_answer(session, run=run, idea=idea)
+    attachments = await _same_run_visible_attachments(session, run=run, thread_id=str(idea.id))
     settlement = await settle_terminal_run(
         session,
         idea=idea,
@@ -489,6 +577,7 @@ async def _settle_idea_for_terminal_root_run_async(session, run_id: int) -> dict
             run_status=str(run.status or ""),
             final_answer=final_answer,
             artifact_id=artifact_id,
+            attachments=attachments,
         ),
     )
     return settlement.status_change

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -41,6 +41,9 @@ Runtime rules:
 """
 
 _FAST_HIDDEN_TOOL_NAMES = {"cortex_reply", "cortex_visual_reply"}
+_THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
+_THREAD_DISCUSSION_SURFACE = "thread_discussion"
+_THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
 
 
 def build_fast_system_prompt(prompt_context: str = "") -> str:
@@ -58,8 +61,35 @@ def _disabled_tool_names(runtime: RunRuntime) -> set[str]:
     return disabled_tool_names_from_metadata(runtime.request.metadata)
 
 
+def _runtime_context_maps(runtime: RunRuntime):
+    for container in (
+        getattr(runtime.request, "metadata", None),
+        getattr(runtime.request, "target_ref", None),
+    ):
+        if isinstance(container, dict):
+            yield container
+
+
+def _runtime_originated_from_thread_discussion(runtime: RunRuntime) -> bool:
+    for container in _runtime_context_maps(runtime):
+        if container.get("kind") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("originating_surface") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("triggering_surface") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("source_surface") == _THREAD_DISCUSSION_SURFACE:
+            return True
+        if isinstance(container.get("discussion_trigger"), dict):
+            return True
+    thread_id = str(getattr(runtime.request, "thread_id", "") or "")
+    return thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
+
+
 def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
     hidden = _FAST_HIDDEN_TOOL_NAMES | _disabled_tool_names(runtime)
+    if not _runtime_originated_from_thread_discussion(runtime):
+        hidden.add(_THREAD_DISCUSSION_REPLY_TOOL)
     return [
         tool
         for tool in build_agent_tools("coordinator")

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -125,6 +125,24 @@ def _current_ai_timeline_thread_id(explicit_thread_id: str | None = None) -> str
     return _thread_id_from_discussion_conversation(parent_thread_id)
 
 
+def _discussion_reply_allowed() -> bool:
+    if _current_discussion_trigger():
+        return True
+    for container in (_execution_metadata(), _current_target_ref()):
+        if container.get("kind") == THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("originating_surface") == THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("triggering_surface") == THREAD_DISCUSSION_SURFACE:
+            return True
+        if container.get("source_surface") == THREAD_DISCUSSION_SURFACE:
+            return True
+        if isinstance(container.get("discussion_trigger"), dict):
+            return True
+    current_thread_id = str(_current_thread_id() or "").strip()
+    return current_thread_id.startswith(THREAD_DISCUSSION_CONVERSATION_PREFIX)
+
+
 def _discussion_comment_payload(comment: Any) -> dict[str, Any]:
     return {
         "id": comment.id,
@@ -265,15 +283,25 @@ async def _handle_post_thread_discussion_reply(
     text = str(body or "").strip()
     if not text:
         return json.dumps({"error": "post_thread_discussion_reply requires body"})
+    if not _discussion_reply_allowed():
+        return json.dumps(
+            {
+                "error": (
+                    "post_thread_discussion_reply is only available for Thread "
+                    "Discussion-triggered runs; use post_ai_timeline_message for "
+                    "the Thread AI Timeline."
+                )
+            }
+        )
 
     trigger = _current_discussion_trigger()
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
-    target_thread_id = _first_nonempty(
+    target_thread_id = _thread_id_from_discussion_conversation(_first_nonempty(
         thread_id,
         response_target.get("thread_id"),
         trigger.get("thread_id"),
         _current_thread_id(),
-    )
+    ))
     if not target_thread_id:
         return json.dumps({"error": "post_thread_discussion_reply requires a Thread id or active Thread run"})
 

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1336,10 +1336,10 @@ CHAT_TOOLS = [
         "name": "post_thread_discussion_reply",
         "description": (
             "Post an Illo-authored reply into the current Thread Discussion. "
-            "Use this when a run was summoned from Discussion, or when the natural "
-            "answer belongs in Discussion rather than the AI Timeline. This does not "
-            "post to the AI Timeline. Discussion and AI Timeline are separate "
-            "conversation surfaces linked by Thread context."
+            "Use this only when the run was summoned from Thread Discussion. "
+            "This does not post to the AI Timeline, and non-Discussion-origin "
+            "runs must use post_ai_timeline_message for visible Thread output. "
+            "Discussion is a team comment surface, not the default response channel."
         ),
         "input_schema": {
             "type": "object",

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -664,6 +664,30 @@ def test_fast_discussion_origin_surface_keeps_timeline_reply_tools_hidden(monkey
     ]
 
 
+def test_fast_timeline_origin_hides_discussion_reply_tool(monkeypatch):
+    from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_agent_tools",
+        lambda role: [
+            {"name": "post_thread_discussion_reply"},
+            {"name": "post_ai_timeline_message"},
+        ],
+    )
+
+    runtime = SimpleNamespace(
+        request=SimpleNamespace(
+            thread_id="idea-1",
+            metadata={},
+            target_ref={"originating_surface": "ai_timeline"},
+        )
+    )
+
+    assert [tool["name"] for tool in _agent_tools_for_runtime(runtime)] == [
+        "post_ai_timeline_message",
+    ]
+
+
 def test_discussion_origin_run_does_not_auto_mirror_final_answer_to_timeline():
     from brain.systems.runs.cortex.runner import _run_should_mirror_final_answer_to_timeline
 
@@ -2635,7 +2659,7 @@ async def test_runner_does_not_duplicate_final_answer_thread_message():
     run = SimpleNamespace(id=45, parent_run_id=None, thread_id=idea_id, status="completed")
     idea = SimpleNamespace(id=idea_id, status="unread_reply", updated_at=None)
     final_artifact = SimpleNamespace(id=100, run_id=45, artifact_type="final_answer", text="Already visible")
-    existing_message = SimpleNamespace(metadata_={"run_id": 45})
+    existing_message = SimpleNamespace(message_type="agent_response", metadata_={"run_id": 45})
     added = []
     scalar_calls = 0
 
@@ -2661,6 +2685,62 @@ async def test_runner_does_not_duplicate_final_answer_thread_message():
             pass
 
     assert await _settle_idea_for_terminal_root_run_async(FakeSession(), 45) is None
+    assert not any(isinstance(obj, IdeaThread) for obj in added)
+
+
+async def test_runner_does_not_mirror_after_same_run_ai_timeline_tool_message():
+    from sqlalchemy.sql import visitors
+
+    from brain.systems.runs.cortex.runner import _settle_idea_for_terminal_root_run_async
+    from brain.platform.db.models.agent_run import AgentRunRow
+    from brain.platform.db.models.idea import Idea, IdeaThread
+
+    idea_id = str(uuid.uuid4())
+    run = SimpleNamespace(id=48, parent_run_id=None, thread_id=idea_id, status="completed")
+    idea = SimpleNamespace(id=idea_id, status="unread_reply", updated_at=None)
+    final_artifact = SimpleNamespace(id=103, run_id=48, artifact_type="final_answer", text="Already posted")
+    existing_message = SimpleNamespace(
+        message_type="message",
+        metadata_={"created_by_run_id": 48, "surface": "ai_timeline"},
+    )
+    added = []
+    scalar_calls = 0
+
+    def _filters_on_message_type(stmt) -> bool:
+        found = False
+
+        def visit_binary(binary):
+            nonlocal found
+            if "message_type" in str(getattr(binary, "left", "")):
+                found = True
+
+        visitors.traverse(stmt, {}, {"binary": visit_binary})
+        return found
+
+    class FakeSession:
+        async def get(self, model, key):
+            if model is AgentRunRow and int(key) == 48:
+                return run
+            if model is Idea and str(key) == idea_id:
+                return idea
+            return None
+
+        def add(self, obj):
+            added.append(obj)
+
+        async def scalars(self, stmt):
+            nonlocal scalar_calls
+            scalar_calls += 1
+            if scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            if scalar_calls == 2 and not _filters_on_message_type(stmt):
+                return _ScalarRows([existing_message])
+            return _ScalarRows([])
+
+        async def flush(self):
+            pass
+
+    assert await _settle_idea_for_terminal_root_run_async(FakeSession(), 48) is None
     assert not any(isinstance(obj, IdeaThread) for obj in added)
 
 
@@ -2786,3 +2866,80 @@ async def test_runner_settles_discussion_origin_run_into_discussion_not_timeline
     }
     assert published[0][0] == "thread_discussion_comment"
     assert published[0][1]["idea_id"] == "idea-1"
+
+
+async def test_runner_carries_same_run_discussion_attachments_into_timeline_final_answer(monkeypatch):
+    from brain.systems.runs.cortex.runner import _settle_idea_for_terminal_root_run_async
+    from brain.systems.cortex.thought_lifecycle import TerminalRunSettlementCommand
+    from brain.platform.db.models.agent_run import AgentRunRow
+    from brain.platform.db.models.idea import Idea
+
+    thread_id = "550e8400-e29b-41d4-a716-446655440000"
+    run = SimpleNamespace(
+        id=47,
+        parent_run_id=None,
+        thread_id=thread_id,
+        status="completed",
+        target_ref={"originating_surface": "ai_timeline"},
+        metadata_={},
+    )
+    idea = SimpleNamespace(
+        id=thread_id,
+        status="working",
+        org_id="org-1",
+        user_id="owner-1",
+        agent_details=None,
+    )
+    final_artifact = SimpleNamespace(
+        id=102,
+        run_id=47,
+        artifact_type="final_answer",
+        text="Done - I attached both PNGs in the thread.",
+    )
+    attachment = {
+        "url": f"/static/uploads/thread-assets/{thread_id}/diagram.png",
+        "kind": "image",
+        "content_type": "image/png",
+    }
+    same_run_comment = SimpleNamespace(
+        id=28,
+        thread_id=thread_id,
+        author_kind="illo",
+        body="Corrected version",
+        attachments=[attachment],
+        metadata_={"created_by_run_id": 47},
+    )
+    scalar_calls = 0
+    captured_command = None
+
+    class FakeSession:
+        async def get(self, model, key):
+            if model is AgentRunRow and int(key) == 47:
+                return run
+            if model is Idea and str(key) == thread_id:
+                return idea
+            return None
+
+        async def scalars(self, _stmt):
+            nonlocal scalar_calls
+            scalar_calls += 1
+            if scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            if scalar_calls == 2:
+                return _ScalarRows([])
+            if scalar_calls == 3:
+                return _ScalarRows([same_run_comment])
+            return _ScalarRows([])
+
+    async def fake_settle_terminal_run(_session, *, idea, command, publish=None):
+        nonlocal captured_command
+        captured_command = command
+        return SimpleNamespace(status_change={"ok": True})
+
+    monkeypatch.setattr("brain.systems.runs.cortex.runner.settle_terminal_run", fake_settle_terminal_run)
+
+    payload = await _settle_idea_for_terminal_root_run_async(FakeSession(), 47)
+
+    assert payload == {"ok": True}
+    assert isinstance(captured_command, TerminalRunSettlementCommand)
+    assert captured_command.attachments == [attachment]

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1600,6 +1600,29 @@ async def test_post_thread_discussion_reply_tool_writes_illo_comment(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_post_thread_discussion_reply_tool_rejects_timeline_origin(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_thread_discussion_reply
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            raise AssertionError("timeline-origin run must not write to Thread Discussion")
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
+
+    with bind_agent_context({"org_id": "test-org", "run_id": 42, "idea_id": "some-id"}):
+        raw = await _handle_post_thread_discussion_reply("This belongs in the main thread.")
+
+    payload = json.loads(raw)
+    assert "error" in payload
+    assert "Thread Discussion-triggered" in payload["error"]
+    assert "post_ai_timeline_message" in payload["error"]
+
+
+@pytest.mark.asyncio
 async def test_post_thread_discussion_reply_tool_infers_upload_attachments(monkeypatch, tmp_path):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.chat import _handle_post_thread_discussion_reply
@@ -1638,7 +1661,24 @@ async def test_post_thread_discussion_reply_tool_infers_upload_attachments(monke
     monkeypatch.setattr("brain.platform.db.repositories.unit_of_work.UnitOfWork", _UnitOfWork)
     monkeypatch.setattr("brain.systems.cortex.events.publish_safe", published)
 
-    with bind_agent_context({"org_id": "test-org", "run_id": 42, "idea_id": "some-id"}):
+    with bind_agent_context(
+        {
+            "org_id": "test-org",
+            "run_id": 42,
+            "target_ref": {
+                "discussion_trigger": {
+                    "surface": "thread_discussion",
+                    "thread_id": "some-id",
+                    "comment_id": 7,
+                    "response_target": {
+                        "surface": "thread_discussion",
+                        "thread_id": "some-id",
+                        "reply_to_comment_id": 7,
+                    },
+                }
+            },
+        }
+    ):
         raw = await _handle_post_thread_discussion_reply(
             f"Here it is:\n\n![Diagram]({url})",
         )

--- a/tests/test_cortex_thought_full_architecture.py
+++ b/tests/test_cortex_thought_full_architecture.py
@@ -219,6 +219,52 @@ async def test_terminal_run_settlement_mirrors_final_answer_once_and_transitions
 
 
 @pytest.mark.asyncio
+async def test_terminal_run_settlement_promotes_static_upload_links_to_attachments(monkeypatch, tmp_path):
+    from brain.systems.cortex.thought_lifecycle import (
+        TerminalRunSettlementCommand,
+        settle_terminal_run,
+    )
+    from brain.systems.cortex import thread_assets
+
+    upload_file = tmp_path / "thread-assets" / "idea-1" / "architecture.png"
+    upload_file.parent.mkdir(parents=True)
+    upload_file.write_bytes(b"png")
+    monkeypatch.setattr(thread_assets, "UPLOAD_DIR", tmp_path)
+
+    session = _Session()
+    idea = _idea(status="working")
+    body = (
+        "Here is the diagram:\n\n"
+        "![Architecture](/static/uploads/thread-assets/idea-1/architecture.png)"
+    )
+
+    result = await settle_terminal_run(
+        session,
+        idea=idea,
+        command=TerminalRunSettlementCommand(
+            run_id=18,
+            run_status="completed",
+            final_answer=body,
+            artifact_id=902,
+        ),
+    )
+
+    assert result.thread_message_payload is not None
+    assert result.thread_message_payload["attachments"] == [
+        {
+            "url": "/static/uploads/thread-assets/idea-1/architecture.png",
+            "download_url": "/static/uploads/thread-assets/idea-1/architecture.png",
+            "filename": "architecture.png",
+            "label": "architecture.png",
+            "kind": "image",
+            "content_type": "image/png",
+            "mime_type": "image/png",
+            "size": 3,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_thought_status_transition_is_the_only_status_log_writer():
     from brain.systems.cortex.thought_lifecycle import (
         ThoughtStatusCommand,


### PR DESCRIPTION
## Summary
- infer visible attachments from /static/uploads links in mirrored final-answer timeline messages
- carry same-run visible tool attachments into the mirrored final answer so Discussion-only asset posts are not lost from the main timeline
- add regressions for route-linked final answers and same-run Discussion attachment carryover

## Tests
- venv/bin/python3 -m pytest tests/test_cortex_thought_full_architecture.py tests/test_agent_run_runtime.py -k 'terminal_run_settlement or settle or ai_timeline or discussion_origin or attachments'
- venv/bin/python3 -m pytest tests/test_thread_assets.py tests/test_api_cortex.py -k 'thread_asset or post_ai_timeline_message or post_thread_discussion_reply'