### PR TITLE
Add workspace tool runtime auth profiles

### DIFF
--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -1350,6 +1350,8 @@ async def tool_manage_runtime_services(
 async def tool_manage_workspace_tools(
     action: str = "list",
     bundle_id: str | None = None,
+    preferences: dict[str, Any] | None = None,
+    credential_refs: dict[str, Any] | None = None,
     user_id: str | None = None,
     org_id: str | None = None,
 ) -> dict:
@@ -1357,14 +1359,19 @@ async def tool_manage_workspace_tools(
     from brain.platform.db.models.org import User
     from brain.systems.runtime_settings.workspace_tools import (
         async_check_workspace_tool,
+        async_get_workspace_tool_user_config,
         async_get_workspace_tools_status,
         async_install_workspace_tool,
+        async_set_workspace_tool_user_config,
         workspace_tool_catalog,
     )
 
     normalized_action = str(action or "list").strip().lower()
-    if normalized_action not in {"catalog", "list", "status", "install", "check"}:
-        raise ValueError("manage_workspace_tools action must be 'catalog', 'list', 'status', 'install', or 'check'.")
+    if normalized_action not in {"catalog", "list", "status", "install", "check", "get_config", "set_config"}:
+        raise ValueError(
+            "manage_workspace_tools action must be 'catalog', 'list', 'status', 'install', "
+            "'check', 'get_config', or 'set_config'."
+        )
 
     if normalized_action == "catalog":
         return {
@@ -1407,6 +1414,32 @@ async def tool_manage_workspace_tools(
                 org_id=effective_org_id,
                 bundle_id=bundle_id,
             )
+        elif normalized_action == "get_config":
+            if not bundle_id:
+                raise ValueError("get_config requires bundle_id.")
+            config = await async_get_workspace_tool_user_config(
+                uow.session,
+                org_id=effective_org_id,
+                user_id=str(user.id),
+                bundle_id=bundle_id,
+            )
+            return {
+                "action": normalized_action,
+                "bundle_id": bundle_id,
+                "config": config.model_dump(mode="json") if config else None,
+            }
+        elif normalized_action == "set_config":
+            if not bundle_id:
+                raise ValueError("set_config requires bundle_id.")
+            config = await async_set_workspace_tool_user_config(
+                uow.session,
+                org_id=effective_org_id,
+                user_id=str(user.id),
+                bundle_id=bundle_id,
+                preferences=preferences if preferences is not None else {},
+                credential_refs=credential_refs if credential_refs is not None else {},
+            )
+            return {"action": normalized_action, "config": config.model_dump(mode="json")}
         else:
             tool_status = await async_get_workspace_tools_status(
                 uow.session,
@@ -1668,13 +1701,27 @@ TOOLS = {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["catalog", "list", "status", "install", "check"],
+                    "enum": ["catalog", "list", "status", "install", "check", "get_config", "set_config"],
                     "default": "list",
-                    "description": "Inspect catalog/status, queue install, or refresh persisted health.",
+                    "description": (
+                        "Inspect catalog/status, queue install, refresh persisted health, or manage "
+                        "the originating user's non-secret tool config."
+                    ),
                 },
                 "bundle_id": {
                     "type": "string",
-                    "description": "Tool bundle id, e.g. aws-diagrams. Required for install and check.",
+                    "description": (
+                        "Tool bundle id, e.g. aws-diagrams. Required for install, check, "
+                        "get_config, and set_config."
+                    ),
+                },
+                "preferences": {
+                    "type": "object",
+                    "description": "Non-secret per-user preferences for set_config.",
+                },
+                "credential_refs": {
+                    "type": "object",
+                    "description": "Per-user credential references for set_config. Never include raw secrets.",
                 },
             },
             "required": ["action"],

--- a/brain/platform/db/alembic/versions/0019_workspace_tool_user_configs.py
+++ b/brain/platform/db/alembic/versions/0019_workspace_tool_user_configs.py
@@ -1,0 +1,105 @@
+"""Add per-user workspace tool configs.
+
+Revision ID: 0019_workspace_tool_user_configs
+Revises: 0018_workspace_tool_installations
+Create Date: 2026-06-05
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0019_workspace_tool_user_configs"
+down_revision = "0018_workspace_tool_installations"
+branch_labels = None
+depends_on = None
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema=_schema()))
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name, schema=_schema())}
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    constraints = _inspector().get_unique_constraints(table_name, schema=_schema())
+    constraints += _inspector().get_foreign_keys(table_name, schema=_schema())
+    return constraint_name in {constraint["name"] for constraint in constraints}
+
+
+def _json_default(value: str) -> sa.TextClause:
+    return sa.text(f"'{value}'::jsonb") if op.get_bind().dialect.name == "postgresql" else sa.text(f"'{value}'")
+
+
+def _json_type():
+    return postgresql.JSONB() if op.get_bind().dialect.name == "postgresql" else sa.JSON()
+
+
+def _uuid_type():
+    return postgresql.UUID(as_uuid=False) if op.get_bind().dialect.name == "postgresql" else sa.String()
+
+
+def _create_index_if_missing(name: str, columns: list[str]) -> None:
+    if _table_exists("workspace_tool_user_configs") and not _index_exists("workspace_tool_user_configs", name):
+        op.create_index(name, "workspace_tool_user_configs", columns)
+
+
+def upgrade() -> None:
+    if not _table_exists("workspace_tool_user_configs"):
+        op.create_table(
+            "workspace_tool_user_configs",
+            sa.Column("id", _uuid_type(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", _uuid_type(), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("user_id", _uuid_type(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("bundle_id", sa.String(length=120), nullable=False),
+            sa.Column("preferences", _json_type(), nullable=False, server_default=_json_default("{}")),
+            sa.Column("credential_refs", _json_type(), nullable=False, server_default=_json_default("{}")),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+            sa.UniqueConstraint(
+                "org_id",
+                "user_id",
+                "bundle_id",
+                name="uq_workspace_tool_user_configs_org_user_bundle",
+            ),
+        )
+
+    _create_index_if_missing("ix_workspace_tool_user_configs_org_user", ["org_id", "user_id"])
+    _create_index_if_missing(
+        "ix_workspace_tool_user_configs_org_bundle",
+        ["org_id", "bundle_id"],
+    )
+
+
+def downgrade() -> None:
+    if not _table_exists("workspace_tool_user_configs"):
+        return
+    for name in (
+        "ix_workspace_tool_user_configs_org_bundle",
+        "ix_workspace_tool_user_configs_org_user",
+    ):
+        if _index_exists("workspace_tool_user_configs", name):
+            op.drop_index(name, table_name="workspace_tool_user_configs")
+    if _constraint_exists("workspace_tool_user_configs", "uq_workspace_tool_user_configs_org_user_bundle"):
+        op.drop_constraint(
+            "uq_workspace_tool_user_configs_org_user_bundle",
+            "workspace_tool_user_configs",
+            type_="unique",
+        )

--- a/brain/platform/db/models/workspace_tool.py
+++ b/brain/platform/db/models/workspace_tool.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from brain.platform.db.base import Base
 
-__all__ = ["WorkspaceToolInstallation"]
+__all__ = ["WorkspaceToolInstallation", "WorkspaceToolUserConfig"]
 
 
 class WorkspaceToolInstallation(Base):
@@ -55,4 +55,36 @@ class WorkspaceToolInstallation(Base):
 
     __table_args__ = (
         UniqueConstraint("org_id", "bundle_id", name="uq_workspace_tool_installations_org_bundle"),
+    )
+
+
+class WorkspaceToolUserConfig(Base):
+    """Per-user preferences and credential references for a shared workspace tool."""
+
+    __tablename__ = "workspace_tool_user_configs"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+        default=lambda: str(uuid.uuid4()),
+    )
+    org_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    bundle_id: Mapped[str] = mapped_column(String(120), nullable=False)
+    preferences: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    credential_refs: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=text("NOW()"))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=text("NOW()"))
+
+    __table_args__ = (
+        UniqueConstraint("org_id", "user_id", "bundle_id", name="uq_workspace_tool_user_configs_org_user_bundle"),
     )

--- a/brain/systems/runs/project_execution_env.py
+++ b/brain/systems/runs/project_execution_env.py
@@ -334,7 +334,10 @@ def _prepend_path_entries(env: dict[str, str], path_entries: list[str]) -> None:
     env["ILLO_WORKSPACE_TOOLS_PATH"] = os.pathsep.join(path_entries)
 
 
-def prepare_project_execution_env(extra_env: Mapping[str, str] | None = None) -> ProjectExecutionEnv:
+def prepare_project_execution_env(
+    extra_env: Mapping[str, str] | None = None,
+    extra_sensitive_values: list[str] | tuple[str, ...] | None = None,
+) -> ProjectExecutionEnv:
     injected_env = current_project_bound_env()
     injected_env.update(_resolved_extra_env(extra_env))
     workspace_tool_paths = _current_workspace_tool_bin_paths()
@@ -343,7 +346,7 @@ def prepare_project_execution_env(extra_env: Mapping[str, str] | None = None) ->
             env=None,
             injected_env=[],
             git_auth_hosts=[],
-            sensitive_values=[],
+            sensitive_values=list(extra_sensitive_values or []),
         )
 
     run_env = os.environ.copy()
@@ -356,11 +359,14 @@ def prepare_project_execution_env(extra_env: Mapping[str, str] | None = None) ->
         env=run_env,
         injected_env=sorted([*injected_env, *(["ILLO_WORKSPACE_TOOLS_PATH"] if workspace_tool_paths else [])]),
         git_auth_hosts=git_auth_hosts,
-        sensitive_values=list(injected_env.values()) + git_sensitive_values,
+        sensitive_values=list(injected_env.values()) + git_sensitive_values + list(extra_sensitive_values or []),
     )
 
 
-async def async_prepare_project_execution_env(extra_env: Mapping[str, str] | None = None) -> ProjectExecutionEnv:
+async def async_prepare_project_execution_env(
+    extra_env: Mapping[str, str] | None = None,
+    extra_sensitive_values: list[str] | tuple[str, ...] | None = None,
+) -> ProjectExecutionEnv:
     injected_env = await async_current_project_bound_env()
     injected_env.update(_resolved_extra_env(extra_env))
     workspace_tool_paths = _current_workspace_tool_bin_paths()
@@ -369,7 +375,7 @@ async def async_prepare_project_execution_env(extra_env: Mapping[str, str] | Non
             env=None,
             injected_env=[],
             git_auth_hosts=[],
-            sensitive_values=[],
+            sensitive_values=list(extra_sensitive_values or []),
         )
 
     run_env = os.environ.copy()
@@ -382,7 +388,7 @@ async def async_prepare_project_execution_env(extra_env: Mapping[str, str] | Non
         env=run_env,
         injected_env=sorted([*injected_env, *(["ILLO_WORKSPACE_TOOLS_PATH"] if workspace_tool_paths else [])]),
         git_auth_hosts=git_auth_hosts,
-        sensitive_values=list(injected_env.values()) + git_sensitive_values,
+        sensitive_values=list(injected_env.values()) + git_sensitive_values + list(extra_sensitive_values or []),
     )
 
 

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -136,6 +136,16 @@ def _resolved_secret_env_arg(secret_env=None, _resolved_secret_env=None):
     return _resolved_secret_env
 
 
+def _resolved_workspace_tool_runtime_args(
+    workspace_tool_auth=None,
+    _resolved_workspace_tool_env=None,
+    _resolved_workspace_tool_sensitive_values=None,
+):
+    if workspace_tool_auth not in (None, {}, []):
+        raise ValueError("workspace_tool_auth specs must be resolved by the runtime before invoking tool handlers")
+    return _resolved_workspace_tool_env, _resolved_workspace_tool_sensitive_values
+
+
 def _get_tool_handlers(
     workspace_root: str | None = None,
     allowed_workspaces: list[str | dict] | None = None,
@@ -385,14 +395,24 @@ def _get_tool_handlers(
         timeout=60,
         workspace=None,
         secret_env=None,
+        workspace_tool_auth=None,
         _resolved_secret_env=None,
+        _resolved_workspace_tool_env=None,
+        _resolved_workspace_tool_sensitive_values=None,
     ):
+        workspace_tool_env, workspace_tool_sensitive_values = _resolved_workspace_tool_runtime_args(
+            workspace_tool_auth,
+            _resolved_workspace_tool_env,
+            _resolved_workspace_tool_sensitive_values,
+        )
         return _handle_exec_command(
             command,
             working_dir=working_dir,
             timeout=timeout,
             _workspace=_select_workspace(workspace, ws, allowed_workspaces),
             _resolved_secret_env=_resolved_secret_env_arg(secret_env, _resolved_secret_env),
+            _resolved_workspace_tool_env=workspace_tool_env,
+            _resolved_workspace_tool_sensitive_values=workspace_tool_sensitive_values,
         )
 
     def _run_script_handler(
@@ -401,14 +421,24 @@ def _get_tool_handlers(
         timeout=60,
         workspace=None,
         secret_env=None,
+        workspace_tool_auth=None,
         _resolved_secret_env=None,
+        _resolved_workspace_tool_env=None,
+        _resolved_workspace_tool_sensitive_values=None,
     ):
+        workspace_tool_env, workspace_tool_sensitive_values = _resolved_workspace_tool_runtime_args(
+            workspace_tool_auth,
+            _resolved_workspace_tool_env,
+            _resolved_workspace_tool_sensitive_values,
+        )
         return _handle_run_script(
             script,
             description,
             timeout,
             _workspace=_select_workspace(workspace, ws, allowed_workspaces),
             _resolved_secret_env=_resolved_secret_env_arg(secret_env, _resolved_secret_env),
+            _resolved_workspace_tool_env=workspace_tool_env,
+            _resolved_workspace_tool_sensitive_values=workspace_tool_sensitive_values,
         )
 
     handlers.update({
@@ -490,13 +520,29 @@ def _get_tool_handlers(
             "file_summary",
             _file_summary_with_workspace,
         )
-        def _test_runner_handler(target, pattern=None, verbose=False, secret_env=None, _resolved_secret_env=None):
+        def _test_runner_handler(
+            target,
+            pattern=None,
+            verbose=False,
+            secret_env=None,
+            workspace_tool_auth=None,
+            _resolved_secret_env=None,
+            _resolved_workspace_tool_env=None,
+            _resolved_workspace_tool_sensitive_values=None,
+        ):
+            workspace_tool_env, workspace_tool_sensitive_values = _resolved_workspace_tool_runtime_args(
+                workspace_tool_auth,
+                _resolved_workspace_tool_env,
+                _resolved_workspace_tool_sensitive_values,
+            )
             return extended_handlers["test_runner"](
                 target,
                 pattern=pattern,
                 verbose=verbose,
                 workspace_root=_workspace_hint(),
                 _resolved_secret_env=_resolved_secret_env_arg(secret_env, _resolved_secret_env),
+                _resolved_workspace_tool_env=workspace_tool_env,
+                _resolved_workspace_tool_sensitive_values=workspace_tool_sensitive_values,
             )
 
         handlers["test_runner"] = _test_runner_handler

--- a/brain/systems/runs/tool_catalog/handlers/files.py
+++ b/brain/systems/runs/tool_catalog/handlers/files.py
@@ -351,6 +351,8 @@ def _handle_exec_command(
     timeout: int = 60,
     _workspace: str | None = None,
     _resolved_secret_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_sensitive_values: list[str] | tuple[str, ...] | None = None,
 ) -> dict:
     """Execute a shell command with safety limits."""
     import subprocess
@@ -383,7 +385,12 @@ def _handle_exec_command(
     # Otherwise split into a list for safer execution.
     _SHELL_CHARS = {'|', '>', '<', '&&', '||', ';', '`', '$(' }
     needs_shell = any(ch in command for ch in _SHELL_CHARS)
-    project_execution = _prepare_project_execution_env(extra_env=_resolved_secret_env)
+    extra_env = dict(_resolved_secret_env or {})
+    extra_env.update(dict(_resolved_workspace_tool_env or {}))
+    project_execution = _prepare_project_execution_env(
+        extra_env=extra_env,
+        extra_sensitive_values=_resolved_workspace_tool_sensitive_values,
+    )
 
     try:
         if needs_shell:
@@ -444,6 +451,8 @@ def _handle_run_script(
     timeout: int = 60,
     _workspace: str | None = None,
     _resolved_secret_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_sensitive_values: list[str] | tuple[str, ...] | None = None,
 ) -> dict:
     """Write a Python script to a tempfile and execute it."""
     import subprocess
@@ -453,7 +462,12 @@ def _handle_run_script(
     if _workspace and os.path.exists(_workspace) and not os.path.isdir(_workspace):
         _workspace = None
     cwd = _workspace or _patched_workspace_root()
-    project_execution = _prepare_project_execution_env(extra_env=_resolved_secret_env)
+    extra_env = dict(_resolved_secret_env or {})
+    extra_env.update(dict(_resolved_workspace_tool_env or {}))
+    project_execution = _prepare_project_execution_env(
+        extra_env=extra_env,
+        extra_sensitive_values=_resolved_workspace_tool_sensitive_values,
+    )
 
     try:
         _block_project_source_command_write(script, operation="script", cwd=cwd)

--- a/brain/systems/runs/tool_catalog/handlers/workspace_tools.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_tools.py
@@ -27,6 +27,8 @@ async def _handle_manage_workspace_tools(
     action: str = "list",
     operation: str | None = None,
     bundle_id: str | None = None,
+    preferences: dict[str, Any] | None = None,
+    credential_refs: dict[str, Any] | None = None,
 ) -> str:
     action = str(action or "list").strip().lower()
     if action in {"help", "schema"}:
@@ -35,8 +37,10 @@ async def _handle_manage_workspace_tools(
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
     from brain.systems.runtime_settings.workspace_tools import (
         async_check_workspace_tool,
+        async_get_workspace_tool_user_config,
         async_get_workspace_tools_status,
         async_install_workspace_tool,
+        async_set_workspace_tool_user_config,
         workspace_tool_catalog,
     )
 
@@ -83,6 +87,38 @@ async def _handle_manage_workspace_tools(
                     bundle_id=bundle_id,
                 )
                 return _dump({"action": action, **status.model_dump(mode="json")})
+
+            if action == "get_config":
+                if not user_id:
+                    return _error("get_config requires authenticated user context")
+                if not bundle_id:
+                    return _error("get_config requires: bundle_id")
+                config = await async_get_workspace_tool_user_config(
+                    session,
+                    org_id=org_id,
+                    user_id=user_id,
+                    bundle_id=bundle_id,
+                )
+                return _dump({
+                    "action": action,
+                    "bundle_id": bundle_id,
+                    "config": config.model_dump(mode="json") if config else None,
+                })
+
+            if action == "set_config":
+                if not user_id:
+                    return _error("set_config requires authenticated user context")
+                if not bundle_id:
+                    return _error("set_config requires: bundle_id")
+                config = await async_set_workspace_tool_user_config(
+                    session,
+                    org_id=org_id,
+                    user_id=user_id,
+                    bundle_id=bundle_id,
+                    preferences=preferences if preferences is not None else {},
+                    credential_refs=credential_refs if credential_refs is not None else {},
+                )
+                return _dump({"action": action, "config": config.model_dump(mode="json")})
     except Exception as exc:
         logger.exception("manage_workspace_tools failed: %s", exc)
         return _error(str(exc))

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -14,6 +14,7 @@ from brain.systems.inbound.status import (
 )
 from brain.systems.runs.tool_catalog.definitions.workers import WORKER_SPAWN_TOOLS
 from brain.systems.runs.secret_mounts import SECRET_ENV_SCHEMA
+from brain.systems.runs.workspace_tool_runtime import WORKSPACE_TOOL_AUTH_SCHEMA
 
 
 _WORKSPACE_TIME_WINDOW_VALUES = [
@@ -2007,6 +2008,7 @@ EXEC_TOOLS = [
                 "working_dir": {"type": "string", "description": "Working directory (optional, defaults to workspace)"},
                 "timeout": {"type": "integer", "description": "Timeout in seconds (default 60, max 300)", "default": 60},
                 "secret_env": SECRET_ENV_SCHEMA,
+                "workspace_tool_auth": WORKSPACE_TOOL_AUTH_SCHEMA,
             },
             "required": ["command"],
         },
@@ -2126,6 +2128,7 @@ EXEC_TOOLS = [
                 },
                 "timeout": {"type": "integer", "description": "Timeout in seconds (default 60, max 300)", "default": 60},
                 "secret_env": SECRET_ENV_SCHEMA,
+                "workspace_tool_auth": WORKSPACE_TOOL_AUTH_SCHEMA,
             },
             "required": ["script"],
         },
@@ -2808,11 +2811,23 @@ WORKSPACE_TOOL_TOOLS = [
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["help", "schema", "catalog", "list", "status", "install", "check"],
+                    "enum": [
+                        "help",
+                        "schema",
+                        "catalog",
+                        "list",
+                        "status",
+                        "install",
+                        "check",
+                        "get_config",
+                        "set_config",
+                    ],
                     "default": "list",
                     "description": (
                         "Use catalog to see installable bundles, list/status to inspect current workspace state, "
-                        "install to queue an approved bundle install, and check to refresh persisted health."
+                        "install to queue an approved bundle install, check to refresh persisted health, "
+                        "and get_config/set_config for the originating user's non-secret tool preferences "
+                        "and credential references."
                     ),
                 },
                 "operation": {
@@ -2821,7 +2836,21 @@ WORKSPACE_TOOL_TOOLS = [
                 },
                 "bundle_id": {
                     "type": "string",
-                    "description": "Tool bundle id, e.g. aws-diagrams. Required for install and check; optional for status.",
+                    "description": (
+                        "Tool bundle id, e.g. aws-diagrams. Required for install, check, get_config, "
+                        "and set_config; optional for status."
+                    ),
+                },
+                "preferences": {
+                    "type": "object",
+                    "description": "Non-secret per-user preferences for set_config, such as default profile or flags.",
+                },
+                "credential_refs": {
+                    "type": "object",
+                    "description": (
+                        "Per-user credential references for set_config. Store references such as provider "
+                        "connection ids or Vault key names, never raw secret values."
+                    ),
                 },
             },
             "required": ["action"],

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -26,6 +26,10 @@ from brain.systems.runs.secret_mounts import (
 )
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.tool_catalog.metadata import ActionPolicyResult
+from brain.systems.runs.workspace_tool_runtime import (
+    handler_args_with_resolved_workspace_tool_runtime,
+    resolve_workspace_tool_runtime,
+)
 
 
 SECRET_TOOL_NAMES = frozenset({"brain_vault", "vault", "secrets"})
@@ -178,12 +182,26 @@ class AsyncRunToolExecutor:
                 run_id=run_id,
                 context=action_context,
             )
+            workspace_tool_runtime = await resolve_workspace_tool_runtime(
+                tool.name,
+                tool.args,
+                run_id=run_id,
+                context=action_context,
+            )
             handler = _runtime_policy_handler(tool.handler)
             handler_args = handler_args_with_resolved_secret_env(tool.name, tool.args, secret_env)
-            with bind_agent_context(_handler_context_from_action_context(action_context)):
-                result = handler(**handler_args)
-                if inspect.isawaitable(result):
-                    result = await result
+            handler_args = handler_args_with_resolved_workspace_tool_runtime(
+                tool.name,
+                handler_args,
+                workspace_tool_runtime,
+            )
+            try:
+                with bind_agent_context(_handler_context_from_action_context(action_context)):
+                    result = handler(**handler_args)
+                    if inspect.isawaitable(result):
+                        result = await result
+            finally:
+                workspace_tool_runtime.cleanup()
         except Exception as exc:
             error_text = str(exc)
             if manifest_id:

--- a/brain/systems/runs/workspace_tool_runtime.py
+++ b/brain/systems/runs/workspace_tool_runtime.py
@@ -1,0 +1,362 @@
+"""Run-scoped credential materialization for managed workspace tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import shutil
+import shlex
+import tempfile
+from typing import Any
+
+from brain.platform.integrations.openai_codex_auth import (
+    encode_codex_auth_payload,
+    parse_codex_auth_payload,
+)
+
+
+WORKSPACE_TOOL_AUTH_TOOLS = frozenset({"exec_command", "run_script", "test_runner"})
+RESOLVED_WORKSPACE_TOOL_ENV_ARG = "_resolved_workspace_tool_env"
+RESOLVED_WORKSPACE_TOOL_SENSITIVE_VALUES_ARG = "_resolved_workspace_tool_sensitive_values"
+WORKSPACE_TOOL_AUTH_SCHEMA = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "Optional workspace tool bundle ids or runtime auth profile ids whose declared credentials "
+        "should be materialized for this call. exec_command also auto-detects installed workspace "
+        "tool profiles from command names. This is a hint/reference only; never include raw secrets."
+    ),
+}
+
+
+@dataclass
+class WorkspaceToolRuntimeMaterialization:
+    env: dict[str, str] = field(default_factory=dict)
+    sensitive_values: list[str] = field(default_factory=list)
+    activated_profiles: list[dict[str, str]] = field(default_factory=list)
+    cleanup_paths: list[Path] = field(default_factory=list)
+
+    def cleanup(self) -> None:
+        for path in self.cleanup_paths:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def normalize_workspace_tool_auth(raw: Any) -> set[str]:
+    if raw in (None, {}, []):
+        return set()
+    if isinstance(raw, str):
+        return {_normalize_ref(raw)}
+    if isinstance(raw, (list, tuple, set)):
+        return {_normalize_ref(item) for item in raw if str(item or "").strip()}
+    if isinstance(raw, dict):
+        values: list[Any] = []
+        for key in ("bundle_id", "bundle", "profile_id", "profile", "tool"):
+            if raw.get(key):
+                values.append(raw[key])
+        for key in ("bundle_ids", "bundles", "profile_ids", "profiles", "tools"):
+            if isinstance(raw.get(key), (list, tuple, set)):
+                values.extend(raw[key])
+        return {_normalize_ref(item) for item in values if str(item or "").strip()}
+    raise ValueError("workspace_tool_auth must be a string, array, or object of bundle/profile references")
+
+
+async def resolve_workspace_tool_runtime(
+    tool_name: str,
+    args: dict[str, Any],
+    *,
+    run_id: int,
+    context: dict[str, Any],
+) -> WorkspaceToolRuntimeMaterialization:
+    raw_auth = args.get("workspace_tool_auth")
+    if tool_name not in WORKSPACE_TOOL_AUTH_TOOLS:
+        if raw_auth not in (None, {}, []):
+            raise ValueError(f"{tool_name} does not support workspace_tool_auth")
+        return WorkspaceToolRuntimeMaterialization()
+
+    explicit_refs = normalize_workspace_tool_auth(raw_auth)
+    command_names = _command_names_for_tool_call(tool_name, args)
+    if not explicit_refs and not command_names:
+        return WorkspaceToolRuntimeMaterialization()
+
+    profiles = _matching_auth_profiles(
+        explicit_refs=explicit_refs,
+        command_names=command_names,
+        org_id=str(context.get("org_id") or "").strip() or None,
+    )
+    if not profiles:
+        return WorkspaceToolRuntimeMaterialization()
+
+    materialized = WorkspaceToolRuntimeMaterialization()
+    try:
+        for bundle_id, profile in profiles:
+            credential = await _resolve_credential(profile, context=context, run_id=run_id)
+            _materialize_profile(bundle_id, profile, credential, materialized)
+            materialized.activated_profiles.append({
+                "bundle_id": bundle_id,
+                "profile_id": str(profile.get("id") or "default"),
+            })
+        return materialized
+    except Exception:
+        materialized.cleanup()
+        raise
+
+
+def handler_args_with_resolved_workspace_tool_runtime(
+    tool_name: str,
+    args: dict[str, Any],
+    materialized: WorkspaceToolRuntimeMaterialization,
+) -> dict[str, Any]:
+    handler_args = dict(args)
+    handler_args.pop("workspace_tool_auth", None)
+    if tool_name in WORKSPACE_TOOL_AUTH_TOOLS:
+        if materialized.env:
+            handler_args[RESOLVED_WORKSPACE_TOOL_ENV_ARG] = dict(materialized.env)
+        if materialized.sensitive_values:
+            handler_args[RESOLVED_WORKSPACE_TOOL_SENSITIVE_VALUES_ARG] = list(materialized.sensitive_values)
+    return handler_args
+
+
+def _normalize_ref(value: Any) -> str:
+    return str(value or "").strip().lower().replace("_", "-")
+
+
+def _command_names_for_tool_call(tool_name: str, args: dict[str, Any]) -> set[str]:
+    if tool_name != "exec_command":
+        return set()
+    command = str(args.get("command") or "").strip()
+    if not command:
+        return set()
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.replace("&&", " ").replace("||", " ").replace(";", " ").split()
+    names: set[str] = set()
+    for token in tokens:
+        cleaned = token.strip()
+        if not cleaned or cleaned in {"&&", "||", "|", ";", "(", ")"} or cleaned.startswith("-"):
+            continue
+        names.add(Path(cleaned).name)
+    return names
+
+
+def _matching_auth_profiles(
+    *,
+    explicit_refs: set[str],
+    command_names: set[str],
+    org_id: str | None,
+) -> list[tuple[str, dict[str, Any]]]:
+    from brain.systems.runtime_settings.workspace_tools import (
+        installed_workspace_tool_bundle_ids,
+        workspace_tool_catalog,
+    )
+
+    installed_bundle_ids = {_normalize_ref(item) for item in installed_workspace_tool_bundle_ids(org_id)}
+    matches: list[tuple[str, dict[str, Any]]] = []
+    for bundle in workspace_tool_catalog():
+        bundle_id = _normalize_ref(bundle.id)
+        profiles = _auth_profiles(bundle.runtime)
+        for profile in profiles:
+            profile_id = _normalize_ref(profile.get("id") or "")
+            commands = {_normalize_ref(item) for item in _string_list(profile.get("commands"))}
+            if not commands:
+                commands = {_normalize_ref(item) for item in bundle.provided_commands}
+            explicit_match = bundle_id in explicit_refs or (profile_id and profile_id in explicit_refs)
+            auto_match = bool(commands & {_normalize_ref(item) for item in command_names})
+            if explicit_match or (auto_match and bundle_id in installed_bundle_ids):
+                matches.append((bundle.id, profile))
+    return matches
+
+
+def _auth_profiles(runtime: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = runtime.get("auth_profiles") if isinstance(runtime, dict) else None
+    if not isinstance(raw, list):
+        raw = runtime.get("credential_profiles") if isinstance(runtime, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+async def _resolve_credential(
+    profile: dict[str, Any],
+    *,
+    context: dict[str, Any],
+    run_id: int,
+) -> str:
+    source = profile.get("source")
+    if not isinstance(source, dict):
+        raise ValueError(f"Workspace tool auth profile {profile.get('id') or '<default>'} is missing source")
+
+    source_type = str(source.get("type") or "").strip().lower()
+    if source_type == "provider_connection":
+        return await _resolve_provider_connection(source, context=context)
+    if source_type == "vault_secret":
+        return await _resolve_vault_secret(source, profile=profile, context=context, run_id=run_id)
+    raise ValueError(f"Unsupported workspace tool credential source type: {source_type or '<empty>'}")
+
+
+async def _resolve_provider_connection(source: dict[str, Any], *, context: dict[str, Any]) -> str:
+    provider = str(source.get("provider") or "").strip().lower()
+    credential = str(source.get("credential") or source.get("source") or "").strip().lower()
+    scope = str(source.get("scope") or "originating_user").strip().lower()
+    user_id = str(context.get("actor_id") or "").strip() or None
+    org_id = str(context.get("org_id") or "").strip() or None
+    if scope in {"originating_user", "user"} and not user_id:
+        raise PermissionError("Workspace tool provider credentials require an originating user")
+
+    from brain.systems.vault import async_resolve_api_key
+
+    if credential in {"codex_subscription", "user_codex_connection"}:
+        if provider != "openai":
+            raise ValueError("codex_subscription provider credentials are only supported for OpenAI")
+        raw, resolved_source = await async_resolve_api_key(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+            auth_mode="chatgpt",
+        )
+        if resolved_source != "codex_subscription" or not raw:
+            raise PermissionError("Workspace tool requires the originating user's Codex/OpenAI connection")
+        return raw
+
+    if credential in {"org_main", "org_api_key", "api_key"}:
+        raw, resolved_source = await async_resolve_api_key(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+            auth_mode="api_key",
+        )
+        if resolved_source not in {"org_main", "env"} or not raw:
+            raise PermissionError(f"Workspace tool requires a {provider} workspace API key")
+        return raw
+
+    raise ValueError(f"Unsupported workspace tool provider credential: {credential or '<empty>'}")
+
+
+async def _resolve_vault_secret(
+    source: dict[str, Any],
+    *,
+    profile: dict[str, Any],
+    context: dict[str, Any],
+    run_id: int,
+) -> str:
+    vault_key = str(source.get("vault_key") or source.get("key") or "").strip()
+    if not vault_key:
+        raise ValueError("vault_secret workspace tool source requires vault_key")
+
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    return await read_runtime_secret(
+        vault_key,
+        context=RuntimeSecretContext(
+            actor_user_id=str(context.get("actor_id") or "").strip() or None,
+            org_id=str(context.get("org_id") or "").strip() or None,
+            run_id=run_id,
+            idea_id=str(context.get("idea_id") or "").strip() or None,
+            project_slug=context.get("project_slug"),
+            project_slugs=context.get("project_slugs"),
+            target_registry_id=context.get("target_registry_id"),
+        ),
+        reason=str(profile.get("reason") or f"Run workspace tool auth profile {profile.get('id') or '<default>'}"),
+        requested_by="workspace_tool_runtime",
+    )
+
+
+def _materialize_profile(
+    bundle_id: str,
+    profile: dict[str, Any],
+    credential: str,
+    materialized: WorkspaceToolRuntimeMaterialization,
+) -> None:
+    specs = profile.get("materialize")
+    if isinstance(specs, dict):
+        specs = [specs]
+    if not isinstance(specs, list) or not specs:
+        raise ValueError(f"Workspace tool auth profile {profile.get('id') or '<default>'} has no materialize spec")
+
+    for spec in specs:
+        if not isinstance(spec, dict):
+            continue
+        materialize_type = str(spec.get("type") or "").strip().lower()
+        if materialize_type == "env":
+            env_name = _require_env_name(spec.get("name") or spec.get("env"))
+            value = _format_credential(credential, str(spec.get("format") or "raw"))
+            materialized.env[env_name] = value
+            materialized.sensitive_values.extend(_sensitive_values(value))
+            continue
+        if materialize_type == "file":
+            env_name = _require_env_name(spec.get("env")) if spec.get("env") else None
+            relative_path = str(spec.get("path") or "credential").strip()
+            if not relative_path or Path(relative_path).is_absolute() or ".." in Path(relative_path).parts:
+                raise ValueError("Workspace tool file materialization path must be relative and contained")
+            temp_root = Path(tempfile.mkdtemp(prefix=f"illo-{_normalize_ref(bundle_id)}-auth-"))
+            os.chmod(temp_root, 0o700)
+            target = temp_root / relative_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            value = _format_credential(credential, str(spec.get("format") or "raw"))
+            target.write_text(value, encoding="utf-8")
+            os.chmod(target, 0o600)
+            if env_name:
+                materialized.env[env_name] = str(temp_root)
+            materialized.sensitive_values.extend(_sensitive_values(value))
+            materialized.cleanup_paths.append(temp_root)
+            continue
+        raise ValueError(f"Unsupported workspace tool materialization type: {materialize_type or '<empty>'}")
+
+
+def _format_credential(raw: str, format_name: str) -> str:
+    normalized = str(format_name or "raw").strip().lower()
+    if normalized == "raw":
+        return str(raw)
+    if normalized == "json":
+        parsed = json.loads(raw) if isinstance(raw, str) else raw
+        return json.dumps(parsed, separators=(",", ":"))
+    if normalized == "codex_auth_json":
+        cred = parse_codex_auth_payload(raw, source="workspace_tool_runtime")
+        return json.dumps(encode_codex_auth_payload(cred), separators=(",", ":"))
+    raise ValueError(f"Unsupported workspace tool credential format: {normalized}")
+
+
+def _sensitive_values(value: Any) -> list[str]:
+    return list(dict.fromkeys(_collect_sensitive_values(value, include_string=True)))
+
+
+def _collect_sensitive_values(value: Any, *, include_string: bool = False, key_name: str | None = None) -> list[str]:
+    values: list[str] = []
+    if isinstance(value, str):
+        stripped = value.strip()
+        key = str(key_name or "").lower()
+        sensitive_key = any(part in key for part in ("token", "key", "secret", "credential", "email", "account"))
+        if len(stripped) >= 6 and (include_string or sensitive_key):
+            values.append(stripped)
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            return values
+        values.extend(_collect_sensitive_values(parsed))
+        return values
+    if isinstance(value, dict):
+        for key, item in value.items():
+            values.extend(_collect_sensitive_values(item, key_name=str(key)))
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            values.extend(_collect_sensitive_values(item))
+    return values
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values = value.replace(",", " ").split()
+    elif isinstance(value, (list, tuple, set)):
+        values = list(value)
+    else:
+        values = []
+    return [str(item).strip() for item in values if str(item or "").strip()]
+
+
+def _require_env_name(value: Any) -> str:
+    name = str(value or "").strip()
+    if not name or not name.replace("_", "A").isalnum() or name[0].isdigit():
+        raise ValueError(f"Invalid workspace tool env name: {name or '<empty>'}")
+    return name

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -125,6 +125,19 @@ class WorkspaceToolBundleRead(BaseModel):
     skill_dependencies: list[str] = Field(default_factory=list)
     install_profile: str | None = None
     optional: bool = False
+    metadata: dict = Field(default_factory=dict)
+    runtime: dict = Field(default_factory=dict)
+
+
+class WorkspaceToolUserConfigRead(BaseModel):
+    id: str | None = None
+    org_id: str
+    user_id: str
+    bundle_id: str
+    preferences: dict = Field(default_factory=dict)
+    credential_refs: dict = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 class WorkspaceToolInstallationRead(BaseModel):

--- a/brain/systems/runtime_settings/workspace_tools.py
+++ b/brain/systems/runtime_settings/workspace_tools.py
@@ -12,11 +12,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.kernel import config as cfg
-from brain.platform.db.models.workspace_tool import WorkspaceToolInstallation
+from brain.platform.db.models.workspace_tool import WorkspaceToolInstallation, WorkspaceToolUserConfig
 
 from .schemas import (
     WorkspaceToolBundleRead,
     WorkspaceToolInstallationRead,
+    WorkspaceToolUserConfigRead,
     WorkspaceToolsRead,
 )
 from .sidecar_queue import (
@@ -73,6 +74,8 @@ def workspace_tool_catalog() -> list[WorkspaceToolBundleRead]:
                 skill_dependencies=_string_list(item.get("skill_dependencies")),
                 install_profile=_optional_text(item.get("install_profile") or item.get("installer")),
                 optional=bool(item.get("optional", False)),
+                metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
+                runtime=item.get("runtime") if isinstance(item.get("runtime"), dict) else {},
             )
         )
     return bundles
@@ -284,6 +287,79 @@ def installed_workspace_tool_bin_paths(org_id: str | None) -> list[str]:
     return _dedupe(paths)
 
 
+def installed_workspace_tool_bundle_ids(org_id: str | None) -> list[str]:
+    if not org_id:
+        return []
+    org_root = workspace_tool_root() / "orgs" / _safe_path_part(org_id)
+    if not org_root.exists():
+        return []
+    bundle_ids: list[str] = []
+    for manifest_path in sorted(org_root.glob("*/current/illo-tool.json")):
+        manifest = read_json(manifest_path)
+        if str(manifest.get("status") or "").lower() != "installed":
+            continue
+        bundle_id = _optional_text(manifest.get("bundle_id")) or manifest_path.parent.parent.name
+        if bundle_id:
+            bundle_ids.append(bundle_id)
+    return _dedupe(bundle_ids)
+
+
+async def async_get_workspace_tool_user_config(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str,
+    bundle_id: str,
+) -> WorkspaceToolUserConfigRead | None:
+    normalized_bundle_id = normalize_bundle_id(bundle_id)
+    row = await _user_config_row(
+        session,
+        org_id=org_id,
+        user_id=user_id,
+        bundle_id=normalized_bundle_id,
+    )
+    return _serialize_user_config(row) if row else None
+
+
+async def async_set_workspace_tool_user_config(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str,
+    bundle_id: str,
+    preferences: dict[str, Any] | None = None,
+    credential_refs: dict[str, Any] | None = None,
+) -> WorkspaceToolUserConfigRead:
+    bundle = require_workspace_tool_bundle(bundle_id)
+    row = await _user_config_row(
+        session,
+        org_id=org_id,
+        user_id=user_id,
+        bundle_id=bundle.id,
+    )
+    now = datetime.now(timezone.utc)
+    if row is None:
+        row = WorkspaceToolUserConfig(
+            org_id=str(org_id),
+            user_id=str(user_id),
+            bundle_id=bundle.id,
+            preferences={},
+            credential_refs={},
+        )
+        session.add(row)
+    if preferences is not None:
+        if not isinstance(preferences, dict):
+            raise HTTPException(status_code=400, detail="preferences must be an object.")
+        row.preferences = dict(preferences)
+    if credential_refs is not None:
+        if not isinstance(credential_refs, dict):
+            raise HTTPException(status_code=400, detail="credential_refs must be an object.")
+        row.credential_refs = dict(credential_refs)
+    row.updated_at = now
+    await session.flush()
+    return _serialize_user_config(row)
+
+
 def normalize_bundle_id(value: str | None) -> str:
     normalized = str(value or "").strip().lower().replace("_", "-")
     if not normalized:
@@ -306,6 +382,25 @@ async def _installation_rows(
         stmt = stmt.where(WorkspaceToolInstallation.bundle_id == bundle_id)
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+async def _user_config_row(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str,
+    bundle_id: str,
+) -> WorkspaceToolUserConfig | None:
+    stmt = (
+        select(WorkspaceToolUserConfig)
+        .where(
+            WorkspaceToolUserConfig.org_id == str(org_id),
+            WorkspaceToolUserConfig.user_id == str(user_id),
+            WorkspaceToolUserConfig.bundle_id == str(bundle_id),
+        )
+        .limit(1)
+    )
+    return (await session.scalars(stmt)).first()
 
 
 async def _upsert_requested_installation(
@@ -387,6 +482,19 @@ def _serialize_installation(row: WorkspaceToolInstallation) -> WorkspaceToolInst
         last_error=row.last_error,
         health=row.health or {},
         metadata=row.metadata_ or {},
+    )
+
+
+def _serialize_user_config(row: WorkspaceToolUserConfig) -> WorkspaceToolUserConfigRead:
+    return WorkspaceToolUserConfigRead(
+        id=str(row.id) if row.id is not None else None,
+        org_id=str(row.org_id),
+        user_id=str(row.user_id),
+        bundle_id=str(row.bundle_id),
+        preferences=row.preferences or {},
+        credential_refs=row.credential_refs or {},
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -552,6 +552,8 @@ def handle_test_runner(
     verbose: bool = False,
     workspace_root: str | None = None,
     _resolved_secret_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_env: Mapping[str, str] | None = None,
+    _resolved_workspace_tool_sensitive_values: list[str] | tuple[str, ...] | None = None,
 ) -> dict:
     """Run tests and return structured results."""
     cmd = [sys.executable, "-m", "pytest", target, "--tb=short", "-q"]
@@ -560,7 +562,12 @@ def handle_test_runner(
     if verbose:
         cmd.append("-v")
 
-    project_execution = prepare_project_execution_env(extra_env=_resolved_secret_env)
+    extra_env = dict(_resolved_secret_env or {})
+    extra_env.update(dict(_resolved_workspace_tool_env or {}))
+    project_execution = prepare_project_execution_env(
+        extra_env=extra_env,
+        extra_sensitive_values=_resolved_workspace_tool_sensitive_values,
+    )
 
     try:
         proc = run_subprocess_sync(

--- a/deploy/compose/workspace-tools.json
+++ b/deploy/compose/workspace-tools.json
@@ -15,6 +15,44 @@
         "installer_runtime": "micromamba",
         "package_channel": "conda-forge"
       }
+    },
+    {
+      "id": "codex-cli",
+      "name": "Codex CLI",
+      "description": "OpenAI Codex command-line coding agent installed as a shared workspace tool, with per-run user auth materialization.",
+      "version": "latest",
+      "install_profile": "npm_package_cli",
+      "provided_commands": ["codex"],
+      "skill_dependencies": [],
+      "optional": true,
+      "metadata": {
+        "npm_package": "@openai/codex",
+        "package_version": "latest",
+        "bin": "codex",
+        "installer_runtime": "npm"
+      },
+      "runtime": {
+        "auth_profiles": [
+          {
+            "id": "originating-user-openai-codex",
+            "description": "Use the originating user's OpenAI Codex/ChatGPT connection for this one tool invocation.",
+            "commands": ["codex"],
+            "required": true,
+            "source": {
+              "type": "provider_connection",
+              "provider": "openai",
+              "credential": "codex_subscription",
+              "scope": "originating_user"
+            },
+            "materialize": {
+              "type": "file",
+              "env": "CODEX_HOME",
+              "path": "auth.json",
+              "format": "codex_auth_json"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/deploy/scripts/workspace-tools.sh
+++ b/deploy/scripts/workspace-tools.sh
@@ -230,7 +230,81 @@ WRAPPER
   echo "Installed $bundle_id for org $org_id at $CURRENT_ROOT"
 }
 
-check_tool() {
+install_npm_package_cli() {
+  local bundle_id="$1"
+  local org_id="$2"
+  local version="$3"
+  local paths name metadata_json health_json package_name package_version tool_bin builder_image
+
+  paths="$(tool_paths_json "$bundle_id" "$org_id" "$version")"
+  INSTALL_ROOT="$(jq -r '.install_root' <<<"$paths")"
+  CURRENT_ROOT="$(jq -r '.current_root' <<<"$paths")"
+  BIN_PATH="$(jq -r '.bin_path' <<<"$paths")"
+  local manifest_path
+  manifest_path="$(jq -r '.manifest_path' <<<"$paths")"
+  name="$(bundle_field "$bundle_id" '.name')"
+  package_name="$(bundle_field "$bundle_id" '.metadata.npm_package')"
+  package_version="$(bundle_field "$bundle_id" '.metadata.package_version // "latest"')"
+  tool_bin="$(bundle_field "$bundle_id" '.metadata.bin // .provided_commands[0]')"
+  metadata_json="$(bundle_json "$bundle_id" | jq -c '.metadata // {}')"
+  builder_image="${ILLO_NPM_WORKSPACE_TOOL_BUILDER_IMAGE:-node:22-bookworm-slim}"
+
+  docker run --rm \
+    -e APP_UID="$APP_UID" \
+    -e APP_GID="$APP_GID" \
+    -e INSTALL_ROOT="$INSTALL_ROOT" \
+    -e CURRENT_ROOT="$CURRENT_ROOT" \
+    -e BIN_PATH="$BIN_PATH" \
+    -e NPM_PACKAGE="$package_name" \
+    -e NPM_PACKAGE_VERSION="$package_version" \
+    -e TOOL_BIN="$tool_bin" \
+    -v "$PRIVATE_VOLUME:/data/private" \
+    "$builder_image" \
+    bash -lc '
+      set -euo pipefail
+      install_bin_path="$INSTALL_ROOT/bin"
+      npm_prefix="$INSTALL_ROOT/npm-prefix"
+      npm_cache="$INSTALL_ROOT/npm-cache"
+      mkdir -p "$INSTALL_ROOT" "$install_bin_path" "$npm_prefix" "$npm_cache"
+
+      package_spec="$NPM_PACKAGE"
+      if [ -n "${NPM_PACKAGE_VERSION:-}" ] && [ "$NPM_PACKAGE_VERSION" != "latest" ]; then
+        package_spec="${NPM_PACKAGE}@${NPM_PACKAGE_VERSION}"
+      fi
+
+      npm install --prefix "$npm_prefix" --cache "$npm_cache" "$package_spec"
+
+      cat > "$install_bin_path/$TOOL_BIN" <<'"'"'WRAPPER'"'"'
+#!/usr/bin/env bash
+set -euo pipefail
+TOOL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOL_BIN_NAME="$(basename "$0")"
+exec "$TOOL_ROOT/npm-prefix/bin/$TOOL_BIN_NAME" "$@"
+WRAPPER
+      chmod +x "$install_bin_path/$TOOL_BIN"
+
+      rm -rf "$CURRENT_ROOT"
+      ln -s "$INSTALL_ROOT" "$CURRENT_ROOT"
+      chown -R "$APP_UID:$APP_GID" "$INSTALL_ROOT" "$(dirname "$CURRENT_ROOT")"
+    '
+
+  local tool_version node_version npm_version
+  tool_version="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$BIN_PATH/$tool_bin\" --version" 2>&1 | head -n 1 || true)"
+  node_version="$(docker run --rm "$builder_image" node --version 2>&1 | head -n 1 || true)"
+  npm_version="$(docker run --rm "$builder_image" npm --version 2>&1 | head -n 1 || true)"
+  health_json="$(jq -n \
+    --arg tool_bin "$tool_bin" \
+    --arg tool "$tool_version" \
+    --arg node "$node_version" \
+    --arg npm "$npm_version" \
+    '{($tool_bin): $tool, node: $node, npm: $npm}')"
+
+  write_manifest "$manifest_path" "$bundle_id" "$name" "$version" "$INSTALL_ROOT" "$CURRENT_ROOT" "$BIN_PATH" \
+    "installed" "Workspace tool bundle installed." "$health_json" "$metadata_json"
+  echo "Installed $bundle_id for org $org_id at $CURRENT_ROOT"
+}
+
+check_aws_diagrams() {
   local bundle_id="$1"
   local org_id="$2"
   local version="$3"
@@ -262,6 +336,58 @@ check_tool() {
   [ "$status" = "installed" ]
 }
 
+check_npm_package_cli() {
+  local bundle_id="$1"
+  local org_id="$2"
+  local version="$3"
+  local paths manifest_path bin_path name metadata_json health_json status detail tool_bin builder_image
+  paths="$(tool_paths_json "$bundle_id" "$org_id" "$version")"
+  manifest_path="$(jq -r '.manifest_path' <<<"$paths")"
+  bin_path="$(jq -r '.bin_path' <<<"$paths")"
+  name="$(bundle_field "$bundle_id" '.name')"
+  metadata_json="$(bundle_json "$bundle_id" | jq -c '.metadata // {}')"
+  tool_bin="$(bundle_field "$bundle_id" '.metadata.bin // .provided_commands[0]')"
+  builder_image="${ILLO_NPM_WORKSPACE_TOOL_BUILDER_IMAGE:-node:22-bookworm-slim}"
+  if [ ! -x "$bin_path/$tool_bin" ]; then
+    health_json="$(jq -n --arg tool_bin "$tool_bin" '{($tool_bin): "missing"}')"
+    write_manifest "$manifest_path" "$bundle_id" "$name" "$version" "$(jq -r '.install_root' <<<"$paths")" "$(jq -r '.current_root' <<<"$paths")" "$bin_path" \
+      "failed" "Workspace tool bundle is not installed or ${tool_bin} is missing." "$health_json" "$metadata_json"
+    exit 1
+  fi
+  local tool_version node_version npm_version
+  tool_version="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$bin_path/$tool_bin\" --version" 2>&1 | head -n 1 || true)"
+  node_version="$(docker run --rm "$builder_image" node --version 2>&1 | head -n 1 || true)"
+  npm_version="$(docker run --rm "$builder_image" npm --version 2>&1 | head -n 1 || true)"
+  health_json="$(jq -n --arg tool_bin "$tool_bin" --arg tool "$tool_version" --arg node "$node_version" --arg npm "$npm_version" '{($tool_bin): $tool, node: $node, npm: $npm}')"
+  status="installed"
+  detail="Workspace tool bundle health check passed."
+  if [ -z "$tool_version" ]; then
+    status="failed"
+    detail="Workspace tool bundle health check failed."
+  fi
+  write_manifest "$manifest_path" "$bundle_id" "$name" "$version" "$(jq -r '.install_root' <<<"$paths")" "$(jq -r '.current_root' <<<"$paths")" "$bin_path" \
+    "$status" "$detail" "$health_json" "$metadata_json"
+  [ "$status" = "installed" ]
+}
+
+check_tool() {
+  local bundle_id="$1"
+  local org_id="$2"
+  local version="$3"
+  case "$(bundle_field "$bundle_id" '.install_profile')" in
+    aws_diagrams_micromamba)
+      check_aws_diagrams "$bundle_id" "$org_id" "$version"
+      ;;
+    npm_package_cli)
+      check_npm_package_cli "$bundle_id" "$org_id" "$version"
+      ;;
+    *)
+      echo "Bundle $bundle_id has no supported install_profile" >&2
+      exit 2
+      ;;
+  esac
+}
+
 main() {
   local action="${1:-}"
   case "$action" in
@@ -278,6 +404,9 @@ main() {
       case "$(bundle_field "$bundle_id" '.install_profile')" in
         aws_diagrams_micromamba)
           install_aws_diagrams "$bundle_id" "$org_id" "$version"
+          ;;
+        npm_package_cli)
+          install_npm_package_cli "$bundle_id" "$org_id" "$version"
           ;;
         *)
           echo "Bundle $bundle_id has no supported install_profile" >&2

--- a/docs/workspace-tools.md
+++ b/docs/workspace-tools.md
@@ -9,6 +9,10 @@ base worker image for every team.
 - Bundles are cataloged in `deploy/compose/workspace-tools.json`.
 - Illo manages them through `manage_workspace_tools`.
 - Installs are workspace-scoped by `org_id`.
+- Bundle catalog entries may declare `runtime.auth_profiles` for tools that
+  need credentials at execution time.
+- Per-user workspace tool config is keyed by `org_id + user_id + bundle_id`
+  and stores non-secret preferences plus credential references only.
 - Installed files live under `ILLO_WORKSPACE_TOOLS_ROOT`, defaulting to
   `/data/private/workspace-tools`.
 - The updater sidecar watches `ILLO_WORKSPACE_TOOLS_REQUEST_FILE` and executes
@@ -20,8 +24,31 @@ base worker image for every team.
   metadata.
 - Agent command environments prepend installed bundle `bin` paths for the active
   workspace.
+- Agent subprocess tools can materialize declared runtime auth profiles for a
+  single invocation through `workspace_tool_auth`; `exec_command` also
+  auto-detects installed workspace tool profiles from command names.
 
-## First Bundle
+## Runtime Auth Profiles
+
+Workspace tool installs are shared team state; credentials are not. A bundle
+that needs authentication declares a runtime auth profile instead of storing
+secrets on the installation record.
+
+Runtime profiles describe:
+
+- which commands they apply to, for example `codex`;
+- where credentials come from, such as an originating user's provider
+  connection, a workspace API key, or a Vault secret reference;
+- how to project that credential into the tool, such as an env var or a
+  temporary config file;
+- whether the credential is user-scoped or workspace-scoped.
+
+At execution time, trusted runtime code resolves the active `actor_user_id`,
+materializes the credential into a temporary environment or file, runs the
+tool, redacts secret values from output/artifacts, and deletes temporary files.
+The model sees only references and status, never raw secret values.
+
+## Bundles
 
 `aws-diagrams` installs:
 
@@ -32,13 +59,27 @@ base worker image for every team.
 This supports skills such as `aws-architecture-diagrams` without making Java,
 Graphviz, or PlantUML mandatory for every Illospace team.
 
+`codex-cli` installs:
+
+- OpenAI Codex CLI through the generic `npm_package_cli` installer profile
+  and npm package `@openai/codex`
+- a `codex` wrapper in the workspace tool `bin` path
+- a runtime auth profile that resolves the originating user's OpenAI
+  Codex/ChatGPT connection and writes a temporary `CODEX_HOME/auth.json` for
+  that one subprocess call
+
 ## Agent Flow
 
 1. `manage_workspace_tools(action="catalog")`
 2. `manage_workspace_tools(action="status", bundle_id="aws-diagrams")`
 3. With user approval, `manage_workspace_tools(action="install", bundle_id="aws-diagrams")`
 4. Later runs get the installed bundle on `PATH`.
-5. Skills can call `manage_workspace_tools(action="check", bundle_id="aws-diagrams")`
+5. Skills can call `manage_workspace_tools(action="get_config", bundle_id="...")`
+   or `set_config` to read/write non-secret user preferences and credential
+   references for shared tools.
+6. Skills can pass `workspace_tool_auth=["codex-cli"]` to subprocess tools when
+   a runtime auth profile should be materialized explicitly.
+7. Skills can call `manage_workspace_tools(action="check", bundle_id="aws-diagrams")`
    before claiming rendered artifacts are available.
 
 ## Security Boundary
@@ -46,3 +87,7 @@ Graphviz, or PlantUML mandatory for every Illospace team.
 The model cannot submit arbitrary installer scripts. It can only request a
 cataloged bundle id. The host controller runs curated installer profiles, writes
 status/log files, and stores tools in the shared private volume.
+
+Runtime auth materialization follows the same boundary. The model can request a
+bundle/profile reference, but only trusted runtime code may resolve provider
+connections or Vault secrets and write temporary env/files for a subprocess.

--- a/frontend/src/lib/utils/attachmentPreview.test.js
+++ b/frontend/src/lib/utils/attachmentPreview.test.js
@@ -43,3 +43,24 @@ test('promotes static upload links from message text into attachments', () => {
     },
   ]);
 });
+
+test('does not promote inline markdown image uploads into duplicate attachments', () => {
+  const body = [
+    '[docs/GENERATION_DISPATCHER_PRD.md](https://github.com/uwear-ai/uwear-backend/blob/docs/generation-dispatcher-prd/docs/GENERATION_DISPATCHER_PRD.md)',
+    '',
+    '![Current Generation Architecture](/static/uploads/thread-assets/t/current-generation-architecture.png)',
+    '',
+    '![Target Generation Dispatcher Architecture](/static/uploads/thread-assets/t/target-generation-dispatcher-architecture.png)',
+  ].join('\n');
+
+  const attachments = messageLinkAttachments(body);
+
+  assert.deepEqual(attachments, [
+    {
+      kind: 'link',
+      url: 'https://github.com/uwear-ai/uwear-backend/blob/docs/generation-dispatcher-prd/docs/GENERATION_DISPATCHER_PRD.md',
+      filename: 'github.com',
+      type: 'text/uri-list',
+    },
+  ]);
+});

--- a/frontend/src/lib/utils/attachmentPreview.ts
+++ b/frontend/src/lib/utils/attachmentPreview.ts
@@ -80,6 +80,7 @@ const DOCUMENT_ATTACHMENT_EXTENSIONS = new Set([
 const ARCHIVE_ATTACHMENT_EXTENSIONS = new Set(['7z', 'rar', 'tar', 'zip']);
 const MESSAGE_URL_PATTERN = /https?:\/\/[^\s<>"']+/gi;
 const MESSAGE_SERVER_UPLOAD_PATTERN = /\/static\/uploads\/[^\s<>"')]+/gi;
+const MESSAGE_MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
 
 export function attachmentUrl(attachment: any): string {
   const url = attachment?.url ?? attachment?.href ?? attachment?.previewUrl ?? attachment?.download_url ?? attachment?.downloadUrl;
@@ -212,6 +213,15 @@ export function normalizeMessageUrl(rawUrl: string): string {
   return rawUrl.replace(/[),.;!?]+$/g, '');
 }
 
+function inlineMarkdownImageUploadUrls(text: string): Set<string> {
+  const urls = new Set<string>();
+  for (const match of text.matchAll(MESSAGE_MARKDOWN_IMAGE_PATTERN)) {
+    const url = normalizeMessageUrl(match[1] ?? '');
+    if (url.startsWith(SERVER_UPLOAD_PREVIEW_PATH_PREFIX)) urls.add(url);
+  }
+  return urls;
+}
+
 export function messageLinkAttachments(
   body: string | null | undefined,
   attachments: any[] | null | undefined = [],
@@ -220,6 +230,7 @@ export function messageLinkAttachments(
   if (!text) return [];
 
   const existingUrls = new Set((attachments ?? []).map((attachment) => attachmentUrl(attachment)).filter(Boolean));
+  const inlineImageUrls = inlineMarkdownImageUploadUrls(text);
   const urls: string[] = [];
   const matches = [
     ...Array.from(text.matchAll(MESSAGE_URL_PATTERN), (match) => match[0]),
@@ -227,7 +238,7 @@ export function messageLinkAttachments(
   ];
   for (const match of matches) {
     const url = normalizeMessageUrl(match);
-    if (!url || existingUrls.has(url) || urls.includes(url)) continue;
+    if (!url || existingUrls.has(url) || inlineImageUrls.has(url) || urls.includes(url)) continue;
     urls.push(url);
     if (urls.length >= 2) break;
   }

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1856,6 +1856,150 @@ async def test_runtime_tool_executor_resolves_secret_env_mount_without_public_va
     assert secret_value not in artifact_payload
 
 
+async def test_runtime_tool_executor_materializes_workspace_tool_auth_for_installed_command(monkeypatch, tmp_path):
+    from brain.platform.integrations.openai_codex_auth import OpenAICodexCredential, encode_codex_auth_payload
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+    from brain.systems.runtime_settings.schemas import WorkspaceToolBundleRead
+
+    credential_payload = json.dumps(encode_codex_auth_payload(OpenAICodexCredential(
+        access_token="access-token-secret",
+        refresh_token="refresh-token-secret",
+        account_id="acct_123",
+        email="reda@uwear.ai",
+        auth_mode="chatgpt",
+    )))
+    catalog = [
+        WorkspaceToolBundleRead(
+            id="codex-cli",
+            name="Codex CLI",
+            description="test bundle",
+            version="latest",
+            provided_commands=["codex"],
+            runtime={
+                "auth_profiles": [{
+                    "id": "originating-user-openai-codex",
+                    "commands": ["codex"],
+                    "source": {
+                        "type": "provider_connection",
+                        "provider": "openai",
+                        "credential": "codex_subscription",
+                        "scope": "originating_user",
+                    },
+                    "materialize": {
+                        "type": "file",
+                        "env": "CODEX_HOME",
+                        "path": "auth.json",
+                        "format": "codex_auth_json",
+                    },
+                }],
+            },
+        )
+    ]
+
+    async def fake_resolve_api_key(**kwargs):
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["org_id"] == "org-1"
+        assert kwargs["provider"] == "openai"
+        assert kwargs["auth_mode"] == "chatgpt"
+        return credential_payload, "codex_subscription"
+
+    monkeypatch.setattr("brain.systems.runtime_settings.workspace_tools.workspace_tool_catalog", lambda: catalog)
+    monkeypatch.setattr("brain.systems.runtime_settings.workspace_tools.installed_workspace_tool_bundle_ids", lambda org_id: ["codex-cli"])
+    monkeypatch.setattr("brain.systems.vault.async_resolve_api_key", fake_resolve_api_key)
+
+    runtime = _runtime("worker")
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+    seen = {}
+
+    def handler(**kwargs):
+        codex_home = kwargs["_resolved_workspace_tool_env"]["CODEX_HOME"]
+        auth_path = tmp_path.__class__(codex_home) / "auth.json"
+        auth_payload = json.loads(auth_path.read_text(encoding="utf-8"))
+        seen["codex_home"] = codex_home
+        seen["auth_payload"] = auth_payload
+        seen["sensitive_values"] = kwargs["_resolved_workspace_tool_sensitive_values"]
+        return {"exit_code": 0, "stdout": "ok", "stderr": ""}
+
+    result = await executor.execute(
+        42,
+        ToolExecution(
+            name="exec_command",
+            args={"command": "codex --version"},
+            handler=handler,
+        ),
+        root_run_id=42,
+    )
+
+    assert result["exit_code"] == 0
+    assert seen["auth_payload"]["auth_mode"] == "chatgpt"
+    assert seen["auth_payload"]["tokens"]["account_id"] == "acct_123"
+    assert "access-token-secret" in seen["sensitive_values"]
+    assert not tmp_path.__class__(seen["codex_home"]).exists()
+    public_payload = json.dumps([event.payload for event in runtime.store.events], default=str)
+    artifact_payload = json.dumps([artifact.text for artifact in runtime.store.artifacts], default=str)
+    assert "access-token-secret" not in public_payload
+    assert "access-token-secret" not in artifact_payload
+
+
+async def test_runtime_tool_executor_supports_explicit_workspace_tool_auth_for_script(monkeypatch):
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+    from brain.systems.runtime_settings.schemas import WorkspaceToolBundleRead
+
+    catalog = [
+        WorkspaceToolBundleRead(
+            id="generic-token-tool",
+            name="Generic Token Tool",
+            description="test bundle",
+            provided_commands=["generic-token-tool"],
+            runtime={
+                "auth_profiles": [{
+                    "id": "workspace-api-token",
+                    "source": {
+                        "type": "provider_connection",
+                        "provider": "openai",
+                        "credential": "org_api_key",
+                        "scope": "workspace",
+                    },
+                    "materialize": {
+                        "type": "env",
+                        "name": "GENERIC_TOOL_TOKEN",
+                        "format": "raw",
+                    },
+                }],
+            },
+        )
+    ]
+
+    async def fake_resolve_api_key(**kwargs):
+        assert kwargs["auth_mode"] == "api_key"
+        return "sk-workspace-secret", "org_main"
+
+    monkeypatch.setattr("brain.systems.runtime_settings.workspace_tools.workspace_tool_catalog", lambda: catalog)
+    monkeypatch.setattr("brain.systems.runtime_settings.workspace_tools.installed_workspace_tool_bundle_ids", lambda org_id: [])
+    monkeypatch.setattr("brain.systems.vault.async_resolve_api_key", fake_resolve_api_key)
+
+    runtime = _runtime("worker")
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+    seen = {}
+
+    def handler(**kwargs):
+        seen.update(kwargs)
+        return {"exit_code": 0, "stdout": "ok", "stderr": ""}
+
+    await executor.execute(
+        42,
+        ToolExecution(
+            name="run_script",
+            args={"script": "print('ok')", "workspace_tool_auth": ["generic-token-tool"]},
+            handler=handler,
+        ),
+        root_run_id=42,
+    )
+
+    assert seen["_resolved_workspace_tool_env"] == {"GENERIC_TOOL_TOKEN": "sk-workspace-secret"}
+    assert seen["_resolved_workspace_tool_sensitive_values"] == ["sk-workspace-secret"]
+
+
 async def test_runtime_tool_executor_rejects_secret_env_on_unsupported_tool():
     from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
 

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -117,6 +117,7 @@ EXPECTED_TABLES = {
     "workspace_pins",
     "workspace_pool_entries",
     "workspace_tool_installations",
+    "workspace_tool_user_configs",
 }
 
 

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -598,6 +598,31 @@ def test_exec_command_uses_resolved_secret_env_without_returning_values(tmp_path
     assert result["stdout"].count("[secret redacted]") == 2
 
 
+def test_exec_command_uses_workspace_tool_runtime_env_and_redacts_file_secrets(tmp_path):
+    from brain.systems.runs.tool_catalog.handlers.files import _handle_exec_command
+
+    token = "codex-access-token-secret"
+    proc = SimpleNamespace(
+        returncode=0,
+        stdout=f"token={token}\n",
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=proc) as run:
+        result = _handle_exec_command(
+            "codex --version",
+            working_dir=str(tmp_path),
+            _resolved_workspace_tool_env={"CODEX_HOME": str(tmp_path / "codex-home")},
+            _resolved_workspace_tool_sensitive_values=[token],
+        )
+
+    run_env = run.call_args.kwargs["env"]
+    assert run_env["CODEX_HOME"] == str(tmp_path / "codex-home")
+    assert result["injected_env"] == ["CODEX_HOME"]
+    assert token not in str(result)
+    assert result["stdout"].count("[secret redacted]") == 1
+
+
 def test_exec_command_rejects_non_string_resolved_secret_env_values(tmp_path):
     from brain.systems.runs.tool_catalog.handlers.files import _handle_exec_command
 

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -10,12 +10,15 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.workspace_tool import WorkspaceToolInstallation
+from brain.platform.db.models.workspace_tool import WorkspaceToolInstallation, WorkspaceToolUserConfig
 from brain.systems.runs.execution_context import AgentExecutionContext, bind_agent_context
 from brain.systems.runs.project_execution_env import prepare_project_execution_env
 from brain.systems.runs.tool_catalog.handlers.workspace_tools import _handle_manage_workspace_tools
 from brain.systems.runtime_settings.workspace_tools import (
+    async_get_workspace_tool_user_config,
     async_install_workspace_tool,
+    async_set_workspace_tool_user_config,
+    installed_workspace_tool_bundle_ids,
     workspace_tool_catalog,
 )
 
@@ -53,6 +56,7 @@ async def session(async_sqlite_session_factory):
             Org.__table__,
             User.__table__,
             WorkspaceToolInstallation.__table__,
+            WorkspaceToolUserConfig.__table__,
         ]
     )
 
@@ -112,6 +116,27 @@ async def test_workspace_tool_catalog_includes_aws_diagrams():
     assert "aws-diagrams" in bundles
     assert "plantuml" in bundles["aws-diagrams"].provided_commands
     assert "aws-architecture-diagrams" in bundles["aws-diagrams"].skill_dependencies
+
+
+async def test_workspace_tool_catalog_includes_codex_runtime_auth_profile():
+    bundles = {bundle.id: bundle for bundle in workspace_tool_catalog()}
+
+    codex = bundles["codex-cli"]
+    profile = codex.runtime["auth_profiles"][0]
+    assert "codex" in codex.provided_commands
+    assert codex.metadata["npm_package"] == "@openai/codex"
+    assert profile["source"] == {
+        "type": "provider_connection",
+        "provider": "openai",
+        "credential": "codex_subscription",
+        "scope": "originating_user",
+    }
+    assert profile["materialize"] == {
+        "type": "file",
+        "env": "CODEX_HOME",
+        "path": "auth.json",
+        "format": "codex_auth_json",
+    }
 
 
 async def test_workspace_tool_install_persists_and_queues_request(seeded_session, monkeypatch, tmp_path):
@@ -181,3 +206,44 @@ async def test_installed_workspace_tool_paths_are_injected_into_command_env(monk
     assert execution_env.env is not None
     assert execution_env.env["PATH"].split(os.pathsep)[0] == str(bin_path)
     assert execution_env.env["ILLO_WORKSPACE_TOOLS_PATH"] == str(bin_path)
+
+
+async def test_installed_workspace_tool_bundle_ids_read_installed_manifests(monkeypatch, tmp_path):
+    root = tmp_path / "tools"
+    bin_path = root / "orgs" / ORG_ID / "codex-cli" / "current" / "bin"
+    bin_path.mkdir(parents=True)
+    manifest_path = bin_path.parent / "illo-tool.json"
+    manifest_path.write_text(
+        json.dumps({
+            "bundle_id": "codex-cli",
+            "status": "installed",
+            "path_entries": [str(bin_path)],
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ILLO_WORKSPACE_TOOLS_ROOT", str(root))
+
+    assert installed_workspace_tool_bundle_ids(ORG_ID) == ["codex-cli"]
+
+
+async def test_workspace_tool_user_config_persists_non_secret_refs(seeded_session):
+    saved = await async_set_workspace_tool_user_config(
+        seeded_session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        bundle_id="codex-cli",
+        preferences={"default_model": "gpt-5.1-codex", "approval_mode": "suggest"},
+        credential_refs={"openai": {"type": "provider_connection", "credential": "codex_subscription"}},
+    )
+
+    loaded = await async_get_workspace_tool_user_config(
+        seeded_session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        bundle_id="codex-cli",
+    )
+
+    assert loaded is not None
+    assert saved.id == loaded.id
+    assert loaded.preferences["approval_mode"] == "suggest"
+    assert loaded.credential_refs["openai"]["credential"] == "codex_subscription"


### PR DESCRIPTION
## Summary
- add generic runtime auth profiles for workspace tool bundles
- add per-user workspace tool config records for non-secret preferences and credential refs
- add a generic npm_package_cli installer profile and Codex CLI as an example bundle
- materialize declared tool auth per subprocess invocation with temp env/files and cleanup/redaction

## Tests
- ./venv/bin/pytest tests/test_workspace_tools.py tests/test_safe_deploy.py tests/test_agent_run_runtime.py::test_runtime_tool_executor_materializes_workspace_tool_auth_for_installed_command tests/test_agent_run_runtime.py::test_runtime_tool_executor_supports_explicit_workspace_tool_auth_for_script tests/test_vault_project_tokens.py::test_exec_command_uses_workspace_tool_runtime_env_and_redacts_file_secrets
- ./venv/bin/pytest tests/test_tool_registry.py tests/test_models_org.py
- bash -n deploy/scripts/workspace-tools.sh
- ./venv/bin/python -m json.tool deploy/compose/workspace-tools.json
- git diff --check