### PR TITLE
Fix scoped workspace tool status sync

### DIFF
--- a/brain/systems/runtime_settings/workspace_tools.py
+++ b/brain/systems/runtime_settings/workspace_tools.py
@@ -105,7 +105,12 @@ async def async_get_workspace_tools_status(
         running = available and _WORKSPACE_TOOLS_QUEUE.status_is_running(request_file, status_data)
 
     rows = await _installation_rows(session, org_id=org_id, bundle_id=normalized_bundle_id)
-    await _sync_installations_from_manifests(session, rows, org_id=org_id, catalog_by_id=catalog_by_id)
+    sync_catalog_by_id = (
+        {normalized_bundle_id: catalog_by_id[normalized_bundle_id]}
+        if normalized_bundle_id
+        else catalog_by_id
+    )
+    await _sync_installations_from_manifests(session, rows, org_id=org_id, catalog_by_id=sync_catalog_by_id)
     rows = await _installation_rows(session, org_id=org_id, bundle_id=normalized_bundle_id)
     installations = [_serialize_installation(row) for row in rows]
 

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -15,6 +15,7 @@ from brain.systems.runs.execution_context import AgentExecutionContext, bind_age
 from brain.systems.runs.project_execution_env import prepare_project_execution_env
 from brain.systems.runs.tool_catalog.handlers.workspace_tools import _handle_manage_workspace_tools
 from brain.systems.runtime_settings.workspace_tools import (
+    async_get_workspace_tools_status,
     async_get_workspace_tool_user_config,
     async_install_workspace_tool,
     async_set_workspace_tool_user_config,
@@ -167,6 +168,51 @@ async def test_workspace_tool_install_persists_and_queues_request(seeded_session
     assert row.status == "queued"
     assert row.requested_by_user_id == USER_ID
     assert row.bin_path.endswith("/aws-diagrams/current/bin")
+
+
+async def test_scoped_workspace_tool_status_does_not_duplicate_other_manifest_rows(
+    seeded_session,
+    monkeypatch,
+    tmp_path,
+):
+    _request_file, _status_file, root = _workspace_tool_queue(monkeypatch, tmp_path)
+    aws_paths_root = root / "orgs" / ORG_ID / "aws-diagrams" / "current"
+    aws_bin = aws_paths_root / "bin"
+    aws_bin.mkdir(parents=True)
+    (aws_paths_root / "illo-tool.json").write_text(
+        json.dumps({
+            "bundle_id": "aws-diagrams",
+            "name": "AWS Architecture Diagrams",
+            "status": "installed",
+            "path_entries": [str(aws_bin)],
+        }),
+        encoding="utf-8",
+    )
+    seeded_session.add(
+        WorkspaceToolInstallation(
+            org_id=ORG_ID,
+            bundle_id="aws-diagrams",
+            display_name="AWS Architecture Diagrams",
+            status="installed",
+            bin_path=str(aws_bin),
+        )
+    )
+    await seeded_session.flush()
+
+    status = await async_get_workspace_tools_status(
+        seeded_session,
+        org_id=ORG_ID,
+        bundle_id="codex-cli",
+    )
+    await seeded_session.flush()
+    rows = (
+        await seeded_session.execute(
+            select(WorkspaceToolInstallation).where(WorkspaceToolInstallation.bundle_id == "aws-diagrams")
+        )
+    ).scalars().all()
+
+    assert status.catalog[0].id == "aws-diagrams"
+    assert [row.bundle_id for row in rows] == ["aws-diagrams"]
 
 
 async def test_manage_workspace_tools_handler_queues_install(


### PR DESCRIPTION
## Summary
- limit manifest sync to the requested bundle when workspace tool status is scoped
- add a regression test for existing aws-diagrams rows when checking codex-cli status

## Why
Live verification of the generic workspace-tool auth work reached codex-cli installation, but manage_workspace_tools status/install was blocked by an autoflush duplicate row for aws-diagrams. The scoped status call loaded only codex-cli installation rows while still syncing every manifest in the catalog.

## Tests
- ./venv/bin/pytest tests/test_workspace_tools.py
- ./venv/bin/pytest tests/test_agent_run_runtime.py::test_runtime_tool_executor_materializes_workspace_tool_auth_for_installed_command tests/test_agent_run_runtime.py::test_runtime_tool_executor_supports_explicit_workspace_tool_auth_for_script tests/test_vault_project_tokens.py::test_exec_command_uses_workspace_tool_runtime_env_and_redacts_file_secrets
- git diff --check
- ./venv/bin/python -m py_compile brain/systems/runtime_settings/workspace_tools.py