### PR TITLE
Fix npm workspace tool installer health checks

### DIFF
--- a/deploy/scripts/workspace-tools.sh
+++ b/deploy/scripts/workspace-tools.sh
@@ -272,14 +272,24 @@ install_npm_package_cli() {
         package_spec="${NPM_PACKAGE}@${NPM_PACKAGE_VERSION}"
       fi
 
-      npm install --prefix "$npm_prefix" --cache "$npm_cache" "$package_spec"
+      npm install --global --prefix "$npm_prefix" --cache "$npm_cache" "$package_spec"
+      if [ ! -x "$npm_prefix/bin/$TOOL_BIN" ]; then
+        echo "Workspace tool target missing after npm install: $npm_prefix/bin/$TOOL_BIN" >&2
+        ls -la "$npm_prefix/bin" >&2 || true
+        exit 1
+      fi
 
       cat > "$install_bin_path/$TOOL_BIN" <<'"'"'WRAPPER'"'"'
 #!/usr/bin/env bash
 set -euo pipefail
 TOOL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOOL_BIN_NAME="$(basename "$0")"
-exec "$TOOL_ROOT/npm-prefix/bin/$TOOL_BIN_NAME" "$@"
+TARGET="$TOOL_ROOT/npm-prefix/bin/$TOOL_BIN_NAME"
+if [ ! -x "$TARGET" ]; then
+  echo "Workspace tool target missing: $TARGET" >&2
+  exit 127
+fi
+exec "$TARGET" "$@"
 WRAPPER
       chmod +x "$install_bin_path/$TOOL_BIN"
 
@@ -288,16 +298,28 @@ WRAPPER
       chown -R "$APP_UID:$APP_GID" "$INSTALL_ROOT" "$(dirname "$CURRENT_ROOT")"
     '
 
-  local tool_version node_version npm_version
-  tool_version="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$BIN_PATH/$tool_bin\" --version" 2>&1 | head -n 1 || true)"
+  local tool_output tool_status tool_version node_version npm_version
+  set +e
+  tool_output="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$BIN_PATH/$tool_bin\" --version" 2>&1)"
+  tool_status=$?
+  set -e
+  tool_version="${tool_output%%$'\n'*}"
   node_version="$(docker run --rm "$builder_image" node --version 2>&1 | head -n 1 || true)"
   npm_version="$(docker run --rm "$builder_image" npm --version 2>&1 | head -n 1 || true)"
   health_json="$(jq -n \
     --arg tool_bin "$tool_bin" \
     --arg tool "$tool_version" \
+    --arg tool_status "$tool_status" \
     --arg node "$node_version" \
     --arg npm "$npm_version" \
-    '{($tool_bin): $tool, node: $node, npm: $npm}')"
+    '{($tool_bin): $tool, cli_exit_code: ($tool_status | tonumber), node: $node, npm: $npm}')"
+
+  if [ "$tool_status" -ne 0 ] || [ -z "$tool_version" ]; then
+    write_manifest "$manifest_path" "$bundle_id" "$name" "$version" "$INSTALL_ROOT" "$CURRENT_ROOT" "$BIN_PATH" \
+      "failed" "Workspace tool bundle health check failed." "$health_json" "$metadata_json"
+    echo "Workspace tool bundle health check failed for $bundle_id: ${tool_version:-no output}" >&2
+    exit 1
+  fi
 
   write_manifest "$manifest_path" "$bundle_id" "$name" "$version" "$INSTALL_ROOT" "$CURRENT_ROOT" "$BIN_PATH" \
     "installed" "Workspace tool bundle installed." "$health_json" "$metadata_json"
@@ -354,14 +376,18 @@ check_npm_package_cli() {
       "failed" "Workspace tool bundle is not installed or ${tool_bin} is missing." "$health_json" "$metadata_json"
     exit 1
   fi
-  local tool_version node_version npm_version
-  tool_version="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$bin_path/$tool_bin\" --version" 2>&1 | head -n 1 || true)"
+  local tool_output tool_status tool_version node_version npm_version
+  set +e
+  tool_output="$(docker run --rm -v "$PRIVATE_VOLUME:/data/private" "$builder_image" bash -lc "\"$bin_path/$tool_bin\" --version" 2>&1)"
+  tool_status=$?
+  set -e
+  tool_version="${tool_output%%$'\n'*}"
   node_version="$(docker run --rm "$builder_image" node --version 2>&1 | head -n 1 || true)"
   npm_version="$(docker run --rm "$builder_image" npm --version 2>&1 | head -n 1 || true)"
-  health_json="$(jq -n --arg tool_bin "$tool_bin" --arg tool "$tool_version" --arg node "$node_version" --arg npm "$npm_version" '{($tool_bin): $tool, node: $node, npm: $npm}')"
+  health_json="$(jq -n --arg tool_bin "$tool_bin" --arg tool "$tool_version" --arg tool_status "$tool_status" --arg node "$node_version" --arg npm "$npm_version" '{($tool_bin): $tool, cli_exit_code: ($tool_status | tonumber), node: $node, npm: $npm}')"
   status="installed"
   detail="Workspace tool bundle health check passed."
-  if [ -z "$tool_version" ]; then
+  if [ "$tool_status" -ne 0 ] || [ -z "$tool_version" ]; then
     status="failed"
     detail="Workspace tool bundle health check failed."
   fi

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -330,6 +330,10 @@ def test_compose_self_update_sidecar_can_bootstrap_from_api_queue():
     assert '${10:-{}}' not in workspace_tools
     assert '[ -n "$health_json" ] || health_json="{}"' in workspace_tools
     assert '[ -n "$metadata_json" ] || metadata_json="{}"' in workspace_tools
+    assert 'npm install --global --prefix "$npm_prefix"' in workspace_tools
+    assert "Workspace tool target missing" in workspace_tools
+    assert "tool_status=$?" in workspace_tools
+    assert 'if [ "$tool_status" -ne 0 ] || [ -z "$tool_version" ]; then' in workspace_tools
 
 
 def test_compose_doctor_can_skip_host_local_http_probes_from_sidecars():


### PR DESCRIPTION
## Summary
- install npm workspace-tool bundles with a global prefix so wrappers resolve the expected bin path
- fail npm bundle health when the CLI exits nonzero, instead of accepting stderr as a version string
- add deploy-script regression assertions for the generic npm install profile

## Tests
- bash -n deploy/scripts/workspace-tools.sh
- git diff --check
- ./venv/bin/pytest tests/test_safe_deploy.py tests/test_workspace_tools.py
- ./venv/bin/pytest tests/test_agent_run_runtime.py::test_runtime_tool_executor_materializes_workspace_tool_auth_for_installed_command tests/test_agent_run_runtime.py::test_runtime_tool_executor_supports_explicit_workspace_tool_auth_for_script tests/test_vault_project_tokens.py::test_exec_command_uses_workspace_tool_runtime_env_and_redacts_file_secrets