### PR TITLE
Encode Codex auth timestamps as RFC3339

### DIFF
--- a/brain/platform/integrations/openai_codex_auth.py
+++ b/brain/platform/integrations/openai_codex_auth.py
@@ -193,7 +193,7 @@ def encode_codex_auth_payload(cred: OpenAICodexCredential) -> dict[str, Any]:
         payload["auth_mode"] = auth_mode
 
     if cred.last_refresh is not None:
-        payload["last_refresh"] = cred.last_refresh
+        payload["last_refresh"] = _format_auth_timestamp(cred.last_refresh)
 
     if auth_mode == "api_key" and cred.access_token:
         payload["OPENAI_API_KEY"] = cred.access_token
@@ -213,7 +213,7 @@ def encode_codex_auth_payload(cred: OpenAICodexCredential) -> dict[str, Any]:
     if cred.plan_type:
         tokens["plan_type"] = cred.plan_type
     if cred.expires_at is not None:
-        tokens["expires_at"] = cred.expires_at
+        tokens["expires_at"] = _format_auth_timestamp(cred.expires_at)
 
     if tokens:
         payload["tokens"] = tokens
@@ -506,6 +506,10 @@ def _coerce_timestamp(*values: Any) -> int | float | None:
                 continue
             return int(number) if number.is_integer() else number
     return None
+
+
+def _format_auth_timestamp(value: int | float) -> str:
+    return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _merged_token_claims(id_token: str | None, access_token: str | None) -> dict[str, Any]:

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1866,6 +1866,8 @@ async def test_runtime_tool_executor_materializes_workspace_tool_auth_for_instal
         refresh_token="refresh-token-secret",
         account_id="acct_123",
         email="reda@uwear.ai",
+        expires_at=2_222_222_222,
+        last_refresh=1_700_000_000,
         auth_mode="chatgpt",
     )))
     catalog = [
@@ -1932,7 +1934,9 @@ async def test_runtime_tool_executor_materializes_workspace_tool_auth_for_instal
 
     assert result["exit_code"] == 0
     assert seen["auth_payload"]["auth_mode"] == "chatgpt"
+    assert seen["auth_payload"]["last_refresh"] == "2023-11-14T22:13:20Z"
     assert seen["auth_payload"]["tokens"]["account_id"] == "acct_123"
+    assert seen["auth_payload"]["tokens"]["expires_at"] == "2040-06-02T03:57:02Z"
     assert "access-token-secret" in seen["sensitive_values"]
     assert not tmp_path.__class__(seen["codex_home"]).exists()
     public_payload = json.dumps([event.payload for event in runtime.store.events], default=str)

--- a/tests/test_openai_codex_auth.py
+++ b/tests/test_openai_codex_auth.py
@@ -58,8 +58,10 @@ def test_parse_codex_auth_payload_extracts_nested_tokens_and_jwt_metadata():
 
     encoded = encode_codex_auth_payload(cred)
     assert encoded["auth_mode"] == "chatgpt"
+    assert encoded["last_refresh"] == "2023-11-14T22:13:20Z"
     assert encoded["tokens"]["account_id"] == "acct_123"
     assert encoded["tokens"]["id_token"] == id_token
+    assert encoded["tokens"]["expires_at"] == "2040-06-02T03:57:02Z"
 
 
 def test_load_codex_auth_json_prefers_codex_home_over_home(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- encode materialized Codex auth `last_refresh` and `tokens.expires_at` as RFC3339 UTC strings
- keep parsing flexible for numeric or ISO timestamp input
- add runtime materialization coverage so generated `CODEX_HOME/auth.json` matches the current Codex CLI expectation

## Live finding
Child run 734 proved `workspace_tool_auth=["codex-cli"]` injected `CODEX_HOME`, but `codex exec` rejected numeric auth timestamps with: `invalid type: floating point ..., expected an RFC 3339 formatted date and time string`.

## Tests
- `./venv/bin/pytest tests/test_openai_codex_auth.py tests/test_agent_run_runtime.py::test_runtime_tool_executor_materializes_workspace_tool_auth_for_installed_command tests/test_agent_run_runtime.py::test_runtime_tool_executor_supports_explicit_workspace_tool_auth_for_script tests/test_vault_project_tokens.py::test_exec_command_uses_workspace_tool_runtime_env_and_redacts_file_secrets`
- `./venv/bin/pytest tests/test_workspace_tools.py tests/test_safe_deploy.py::test_compose_self_update_sidecar_can_bootstrap_from_api_queue`
- `git diff --check`