### PR TITLE
Fix Slack response targeting

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -93,6 +93,15 @@ async def _handle_post_slack_reply(
     target_thread_ts = thread_ts if thread_ts is not None else response_target.get("thread_ts")
     if target_thread_ts is not None:
         target_thread_ts = str(target_thread_ts or "").strip() or None
+    trigger_channel_id = str(trigger.get("channel_id") or "").strip()
+    trigger_message_ts = str(trigger.get("message_ts") or "").strip()
+    trigger_channel_type = str(trigger.get("channel_type") or "").strip()
+    response_target_thread_ts = response_target.get("thread_ts")
+    if target_channel == trigger_channel_id:
+        if trigger_channel_type == "im":
+            target_thread_ts = None
+        elif not response_target_thread_ts and target_thread_ts == trigger_message_ts:
+            target_thread_ts = None
     target_visibility = str(visibility or response_target.get("visibility") or "public").strip().lower()
     if target_visibility not in {"public", "ephemeral"}:
         return json.dumps({"error": "post_slack_reply visibility must be public or ephemeral"})

--- a/brain/systems/runs/tool_definitions.py
+++ b/brain/systems/runs/tool_definitions.py
@@ -1312,7 +1312,8 @@ CHAT_TOOLS = [
         "description": (
             "Post an Illo-authored reply into Slack. Use this when a run was "
             "triggered by a Slack mention or DM and the visible answer belongs "
-            "back in Slack. Defaults to the originating Slack channel, thread, or DM."
+            "back in Slack. Defaults to the originating Slack channel, existing "
+            "thread, or DM; top-level mentions and DMs are not threaded."
         ),
         "input_schema": {
             "type": "object",
@@ -1327,7 +1328,7 @@ CHAT_TOOLS = [
                 },
                 "thread_ts": {
                     "type": "string",
-                    "description": "Optional Slack thread timestamp. Defaults to the triggering response target.",
+                    "description": "Optional Slack thread timestamp. Defaults to the triggering response target; omit for top-level channel replies and DMs.",
                 },
                 "visibility": {
                     "type": "string",

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -78,9 +78,19 @@ def _surface(channel_type: str, thread_ts: str, message_ts: str) -> str:
 
 
 def _response_thread_ts(channel_type: str, thread_ts: str, message_ts: str) -> str | None:
-    if channel_type == "im" and thread_ts == message_ts:
+    """Return the Slack thread timestamp Illo should use for its visible reply.
+
+    Slack uses ``thread_ts=message_ts`` to create a thread under a top-level
+    message. That made top-level mentions look like Illo could only answer in
+    threads. The response target should only carry a thread when the user invoked
+    Illo from an existing Slack thread. DMs should stay as normal DM messages.
+    """
+
+    if channel_type == "im":
         return None
-    return thread_ts or message_ts or None
+    if thread_ts and thread_ts != message_ts:
+        return thread_ts
+    return None
 
 
 def normalize_slack_socket_event(
@@ -110,7 +120,13 @@ def normalize_slack_socket_event(
     thread_ts = str(event.get("thread_ts") or message_ts).strip()
     slack_user_id = str(event.get("user") or "").strip()
     event_id = str(payload.get("event_id") or "").strip()
-    idempotency_key = f"slack:{team_id}:{event_id}" if event_id else f"slack:{team_id}:{channel_id}:{message_ts}"
+    # Slack may deliver both an app_mention event and a message.* event for the
+    # same user-visible mention. Use the Slack message identity, not Slack's
+    # per-event id, so one Slack message admits at most one Illo run.
+    if channel_id and message_ts:
+        idempotency_key = f"slack:{team_id}:{channel_id}:{message_ts}"
+    else:
+        idempotency_key = f"slack:{team_id}:{event_id}"
     surface = _surface(channel_type, thread_ts, message_ts)
     response_target = {
         "channel_id": channel_id,

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -131,30 +131,54 @@ def slack_surface(payload: Mapping[str, Any]) -> str:
 
 def slack_response_target(payload: Mapping[str, Any]) -> dict[str, Any]:
     existing = payload.get("response_target")
-    if isinstance(existing, Mapping):
-        return {
-            "channel_id": _clean(existing.get("channel_id") or payload.get("channel_id")),
-            "thread_ts": existing.get("thread_ts"),
-            "visibility": _clean(existing.get("visibility")) or "public",
-        }
     channel_type = _clean(payload.get("channel_type"))
     message_ts = _clean(payload.get("message_ts"))
+    if isinstance(existing, Mapping):
+        thread_ts = _response_thread_ts(
+            channel_type,
+            _clean(existing.get("thread_ts")),
+            message_ts,
+        )
+        return {
+            "channel_id": _clean(existing.get("channel_id") or payload.get("channel_id")),
+            "thread_ts": thread_ts,
+            "visibility": _clean(existing.get("visibility")) or "public",
+        }
     thread_ts = _clean(payload.get("thread_ts") or message_ts)
     return {
         "channel_id": _clean(payload.get("channel_id")),
-        "thread_ts": None if channel_type == "im" and thread_ts == message_ts else thread_ts,
+        "thread_ts": _response_thread_ts(channel_type, thread_ts, message_ts),
         "visibility": "public",
     }
+
+
+def _response_thread_ts(channel_type: str, thread_ts: str, message_ts: str) -> str | None:
+    if channel_type == "im":
+        return None
+    if thread_ts and thread_ts != message_ts:
+        return thread_ts
+    return None
 
 
 def slack_run_message(payload: Mapping[str, Any], slack_trigger_payload: Mapping[str, Any]) -> str:
     text = _clean(payload.get("text"))[:2000]
     surface = _clean(slack_trigger_payload.get("surface"))
+    response_target = slack_trigger_payload.get("response_target")
+    response_target = response_target if isinstance(response_target, Mapping) else {}
+    reply_thread_ts = _clean(response_target.get("thread_ts"))
+    channel_type = _clean(slack_trigger_payload.get("channel_type"))
+    if channel_type == "im":
+        reply_mode = "Slack DM normal message; do not pass thread_ts."
+    elif reply_thread_ts:
+        reply_mode = f"Slack thread reply using thread_ts {reply_thread_ts}."
+    else:
+        reply_mode = "Top-level Slack channel message; do not pass thread_ts."
     lines = [
         "A teammate invoked Illo from Slack.",
         "Slack is the triggering conversation surface; use normal Illospace tools for the work.",
         f"After acting, reply in Slack with {SLACK_REPLY_TOOL} when a visible response fits.",
         "Use read_slack_conversation if more Slack context is needed.",
+        f"Default Slack reply target: {reply_mode}",
         "",
         f"Slack surface: {surface}",
         f"Team: {slack_trigger_payload.get('team_id')}",

--- a/deploy/slack/illo-self-hosted-manifest.yml
+++ b/deploy/slack/illo-self-hosted-manifest.yml
@@ -13,6 +13,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - chat:write.public
       - files:read
       - files:write
       - groups:history

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -8,7 +8,8 @@ public Slack Events API endpoint.
 
 1. Create a Slack app from `deploy/slack/illo-self-hosted-manifest.yml`.
 2. Enable Socket Mode in Slack.
-3. Install the app to your Slack workspace.
+3. Install the app to your Slack workspace. Existing installations should be
+   reinstalled after manifest scope changes so `chat:write.public` is granted.
 4. Save `SLACK_BOT_TOKEN` to Illospace Vault, or set it as an environment
    variable for the connector process.
 5. Save `SLACK_APP_TOKEN` to Illospace Vault, or set it as an environment
@@ -41,6 +42,8 @@ Optional Slack hints:
 ## Runtime Behavior
 
 - `app_mention` events and every DM are actionable.
+- Top-level channel mentions reply as normal channel messages; mentions inside
+  Slack threads reply back into that thread; DMs reply as normal DM messages.
 - Regular channel messages without an Illo mention are ignored.
 - Socket Mode envelopes are acknowledged before durable inbound processing.
 - Actionable Slack events are stored as inbound events with kind

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -99,6 +99,7 @@ def test_self_hosted_slack_manifest_supports_illo_teammate_loop():
         "channels:history",
         "channels:read",
         "chat:write",
+        "chat:write.public",
         "files:read",
         "files:write",
         "groups:history",
@@ -198,7 +199,7 @@ def test_socket_mode_app_mention_normalizes_to_slack_surface_envelope():
     assert envelope is not None
     assert envelope["kind"] == "slack_message"
     assert envelope["origin"] == "slack.app_mention"
-    assert envelope["idempotency_key"] == "slack:T789:Ev222"
+    assert envelope["idempotency_key"] == "slack:T789:C456:1716900000.000100"
     assert envelope["payload"]["team_id"] == "T789"
     assert envelope["payload"]["channel_id"] == "C456"
     assert envelope["payload"]["channel_type"] == "channel"
@@ -209,7 +210,7 @@ def test_socket_mode_app_mention_normalizes_to_slack_surface_envelope():
     assert envelope["hints"]["surface"]["kind"] == "slack"
     assert envelope["hints"]["response_target"] == {
         "channel_id": "C456",
-        "thread_ts": "1716900000.000100",
+        "thread_ts": None,
         "visibility": "public",
     }
 
@@ -226,6 +227,68 @@ def test_socket_mode_ignores_non_dm_messages_without_illo_mention():
     )
 
     assert ignored is None
+
+
+def test_socket_mode_thread_mention_keeps_thread_reply_target():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_app_mention(thread_ts="1716899999.000001"),
+        bot_user_id="BILLO",
+    )
+
+    assert envelope is not None
+    assert envelope["payload"]["surface"] == "slack_thread"
+    assert envelope["hints"]["response_target"] == {
+        "channel_id": "C456",
+        "thread_ts": "1716899999.000001",
+        "visibility": "public",
+    }
+
+
+def test_socket_mode_dm_response_target_never_threads():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_app_mention(
+            type="message",
+            channel="D123",
+            channel_type="im",
+            text="can you help?",
+            thread_ts="1716899999.000001",
+        ),
+        bot_user_id="BILLO",
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.direct_message"
+    assert envelope["payload"]["surface"] == "slack_dm"
+    assert envelope["hints"]["response_target"] == {
+        "channel_id": "D123",
+        "thread_ts": None,
+        "visibility": "public",
+    }
+
+
+def test_socket_mode_duplicate_slack_events_share_message_idempotency_key():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    app_mention = normalize_slack_socket_event(
+        _socket_mode_app_mention(event_id="Ev-app-mention"),
+        bot_user_id="BILLO",
+    )
+    message_event = normalize_slack_socket_event(
+        _socket_mode_app_mention(
+            type="message",
+            event_id="Ev-message-channel",
+        ),
+        bot_user_id="BILLO",
+    )
+
+    assert app_mention is not None
+    assert message_event is not None
+    assert app_mention["idempotency_key"] == message_event["idempotency_key"]
+    assert app_mention["idempotency_key"] == "slack:T789:C456:1716900000.000100"
 
 
 def test_slack_adapter_builds_teammate_trigger():
@@ -264,7 +327,7 @@ def test_slack_adapter_builds_teammate_trigger():
     assert trigger.payload["metadata"]["inbound_event"]["event_id"] == "inbound-1"
     assert trigger.payload["metadata"]["slack_trigger"]["response_target"] == {
         "channel_id": "C456",
-        "thread_ts": "1716900000.000100",
+        "thread_ts": None,
         "visibility": "public",
     }
     assert "normal Illospace tools" in trigger.payload["run_message"]
@@ -400,6 +463,112 @@ async def test_post_slack_reply_tool_posts_to_triggering_thread(monkeypatch):
             "channel": "C456",
             "text": "On it.",
             "thread_ts": "1716900000.000100",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_tool_posts_top_level_mentions_to_channel(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "ts": "1716900200.000300", "channel": kwargs["channel"]}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                },
+            },
+        }
+    ):
+        result = json.loads(
+            await _handle_post_slack_reply(
+                body="On it.",
+                thread_ts="1716900000.000100",
+            )
+        )
+
+    assert result["ok"] is True
+    assert calls == [
+        {
+            "channel": "C456",
+            "text": "On it.",
+            "thread_ts": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_tool_never_threads_originating_dm(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    calls = []
+
+    class _SlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "ts": "1716900200.000300", "channel": kwargs["channel"]}
+
+    async def slack_client():
+        return _SlackClient()
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "channel_id": "D123",
+                "channel_type": "im",
+                "message_ts": "1716900100.000200",
+                "response_target": {
+                    "channel_id": "D123",
+                    "thread_ts": None,
+                    "visibility": "public",
+                },
+            },
+        }
+    ):
+        result = json.loads(
+            await _handle_post_slack_reply(
+                body="Hi.",
+                thread_ts="1716900100.000200",
+            )
+        )
+
+    assert result["ok"] is True
+    assert calls == [
+        {
+            "channel": "D123",
+            "text": "Hi.",
+            "thread_ts": None,
         }
     ]
 


### PR DESCRIPTION
## Summary
- stop treating top-level Slack mentions as thread replies
- preserve thread replies only when the mention is already inside a Slack thread
- keep DMs unthreaded and make duplicate Slack event deliveries share one message idempotency key
- document/re-scope Slack install behavior with `chat:write.public`

## Tests
- Not run here: this runtime does not have pytest installed (`python -m pytest tests/test_slack_teammate.py -q` -> `No module named pytest`).
