### PR TITLE
Fix capability introspection hijacking thread replies

### DIFF
--- a/brain/app/triggers/adapters/internal.py
+++ b/brain/app/triggers/adapters/internal.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from brain.app.api.authorization import human_identity
 from brain.app.triggers.contracts import IlloTrigger, stable_idempotency_key
+from brain.systems.runs.message_metadata import (
+    HUMAN_MESSAGE_METADATA_KEY,
+    INTROSPECTION_MESSAGE_METADATA_KEY,
+)
 
 
 def _idea_payload(idea: Any) -> dict[str, Any]:
@@ -59,6 +63,16 @@ def _discussion_mention_run_message(
     return "\n".join(lines)
 
 
+def _with_current_human_message(metadata: dict[str, Any], message: str) -> dict[str, Any]:
+    result = dict(metadata or {})
+    text = str(message or "").strip()
+    if text:
+        current_message = text[:4000]
+        result[HUMAN_MESSAGE_METADATA_KEY] = current_message
+        result[INTROSPECTION_MESSAGE_METADATA_KEY] = current_message
+    return result
+
+
 def build_cortex_notify_trigger(
     *,
     event: str,
@@ -93,9 +107,10 @@ def build_cortex_notify_trigger(
                 f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n"
                 f"New idea created.{desc_text}{att_text}"
             )
-        run_metadata = metadata
+        run_metadata = _with_current_human_message(metadata or {}, thread_message)
     else:
-        run_metadata = effective_metadata if effective_metadata is not None else metadata
+        source_metadata = effective_metadata if effective_metadata is not None else metadata
+        run_metadata = _with_current_human_message(source_metadata or {}, thread_message)
         run_message = f"[Idea: \"{idea_data['title']}\" | {idea_id}]\n\n{thread_message[:2000]}"
 
     payload = {
@@ -103,7 +118,7 @@ def build_cortex_notify_trigger(
         "idea": idea_data,
         "thread_message": thread_message[:2000],
         "run_message": run_message,
-        "metadata": dict(run_metadata or {}),
+        "metadata": run_metadata,
         "priority": int(priority),
         "user_id": user.get("id") if user else None,
     }
@@ -166,6 +181,7 @@ def build_thread_discussion_mention_trigger(
     metadata.setdefault("final_answer_target_surface", THREAD_DISCUSSION_SURFACE)
     metadata.setdefault("discussion_comment_id", comment_id)
     metadata.setdefault("discussion_trigger", discussion_trigger)
+    metadata = _with_current_human_message(metadata, body)
     thread_references = list(metadata.get("thread_references") or [])
 
     target = {

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -48,7 +48,7 @@ from brain.platform.providers.model_policy import (
     infer_provider_from_model,
     normalize_model_tier,
 )
-from brain.systems.runs.introspection import required_introspection_tool as resolve_required_introspection_tool
+from brain.systems.runs import introspection as run_introspection
 from brain.systems.runs.direct_loop.final_reply import (
     cache_final_reply_review,
     cached_final_reply_review,
@@ -1155,11 +1155,6 @@ def _check_gate_violations(
     )
 
 
-def _required_introspection_tool(message: str) -> tuple[str | None, str | None]:
-    """Return the mandatory tool for certain introspection questions."""
-    return resolve_required_introspection_tool(message)
-
-
 def _response_has_text(response) -> bool:
     """Return True when the assistant response includes any non-empty text block."""
     return _runtime_response_has_text(response)
@@ -1349,13 +1344,15 @@ async def run_agent_async(
         operation_type=operation_type,
         metadata=metadata,
     )
-    metadata_required_tool, metadata_required_msg = resolve_required_introspection_tool(
+    metadata_required_tool, metadata_required_msg = run_introspection.required_introspection_tool(
         explicit_tool=metadata.get("required_introspection_tool") if isinstance(metadata, dict) else None,
     )
     if metadata_required_tool:
         required_introspection_tool, required_introspection_msg = metadata_required_tool, metadata_required_msg
     else:
-        required_introspection_tool, required_introspection_msg = _required_introspection_tool(message)
+        required_introspection_tool, required_introspection_msg = run_introspection.required_introspection_tool(
+            run_introspection.message_for_required_introspection(message, metadata)
+        )
 
     _previous_execution_metadata = getattr(_agent_context, "execution_metadata", None)
     _previous_execution_artifacts = getattr(_agent_context, "execution_artifacts", None)

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -9,6 +9,7 @@ from brain.systems.runs.capabilities import (
     registry_capability_manifests,
 )
 from brain.systems.runs.execution_context import _agent_context
+from brain.systems.runs.message_metadata import INTROSPECTION_MESSAGE_METADATA_KEYS
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 _PERSON_ACTIVITY_PATTERNS = (
@@ -66,7 +67,7 @@ _WORKSPACE_RECORD_PHRASES = (
 )
 _CAPABILITY_SETUP_PATTERNS = (
     re.compile(
-        r"\b(?:set\s+(?:you|illo|it|this|that|me|us|them)\s+up|set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+        r"\b(?:set\s+(?:you|illo|it|this|that|me|us|them)\s+up|set\s*up|setup|connect|integrate|install|configure|enable)\b"
     ),
     re.compile(
         r"\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
@@ -159,6 +160,19 @@ def _looks_like_any_phrase(message: str | None, phrases: tuple[str, ...]) -> boo
     if not text:
         return False
     return any(phrase in text for phrase in phrases)
+
+
+def message_for_required_introspection(
+    message: str | None,
+    metadata: dict | None = None,
+) -> str | None:
+    """Prefer the original human text when a trigger decorates the run message."""
+    if isinstance(metadata, dict):
+        for key in INTROSPECTION_MESSAGE_METADATA_KEYS:
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return message
 
 
 def required_introspection_tool(

--- a/brain/systems/runs/message_metadata.py
+++ b/brain/systems/runs/message_metadata.py
@@ -1,0 +1,9 @@
+"""Shared run metadata keys for the original human message."""
+from __future__ import annotations
+
+HUMAN_MESSAGE_METADATA_KEY = "human_message"
+INTROSPECTION_MESSAGE_METADATA_KEY = "introspection_message"
+INTROSPECTION_MESSAGE_METADATA_KEYS = (
+    INTROSPECTION_MESSAGE_METADATA_KEY,
+    HUMAN_MESSAGE_METADATA_KEY,
+)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -345,6 +345,40 @@ def test_named_capability_setup_question_requires_capabilities_without_agent_men
     assert "capability/setup context" in message
 
 
+def test_work_request_that_mentions_skill_and_cycle_does_not_require_capabilities():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    message = (
+        "I want to create un dropshipping store where we will add trend products on the hot topics "
+        "we can find on the news/reddit. Idea is a collection last only something short like 2 weeks. "
+        "can you have a skill and a cyle running every week to propose trendy or funny/popular design ?"
+    )
+
+    assert required_introspection_tool(message) == (None, None)
+
+
+def test_run_introspection_uses_current_human_message_over_thread_wrapper():
+    from brain.systems.runs.introspection import (
+        message_for_required_introspection,
+        required_introspection_tool,
+    )
+
+    wrapped_message = (
+        '[Idea: "Help me set up Slack for the team" | idea-1]\n\n'
+        "where are the results ?"
+    )
+
+    assert required_introspection_tool(wrapped_message)[0] == "read_capabilities"
+
+    selected = message_for_required_introspection(
+        wrapped_message,
+        {"human_message": "where are the results ?"},
+    )
+
+    assert selected == "where are the results ?"
+    assert required_introspection_tool(selected) == (None, None)
+
+
 def test_memory_question_does_not_force_workspace_data():
     from brain.systems.runs.introspection import required_introspection_tool
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -63,7 +63,11 @@ def test_internal_adapter_builds_cortex_thread_trigger():
         idea=_idea(),
         user=_user(),
         thread_message="@illo ship it",
-        effective_metadata={"target": {"repo": "illo-brain"}},
+        effective_metadata={
+            "human_message": "stale wrapper text",
+            "introspection_message": "stale wrapper text",
+            "target": {"repo": "illo-brain"},
+        },
         priority=1,
     )
 
@@ -73,6 +77,8 @@ def test_internal_adapter_builds_cortex_thread_trigger():
     assert trigger.actor.id == "user-1"
     assert trigger.target["idea_id"] == "idea-1"
     assert trigger.payload["run_message"] == '[Idea: "Build triggers" | idea-1]\n\n@illo ship it'
+    assert trigger.payload["metadata"]["human_message"] == "@illo ship it"
+    assert trigger.payload["metadata"]["introspection_message"] == "@illo ship it"
     assert trigger.payload["metadata"]["target"]["repo"] == "illo-brain"
     assert trigger.policy["route"] == "run"
 
@@ -96,6 +102,10 @@ def test_internal_adapter_builds_thread_discussion_trigger_as_separate_surface()
         comment=SimpleNamespace(id=77, body="@illo can you see this?"),
         user=_user(),
         discussion_trigger=discussion_trigger,
+        metadata={
+            "human_message": "stale wrapper text",
+            "introspection_message": "stale wrapper text",
+        },
     )
 
     assert trigger.source == "cortex"
@@ -108,6 +118,8 @@ def test_internal_adapter_builds_thread_discussion_trigger_as_separate_surface()
         "surface": "thread_discussion",
     }
     assert trigger.payload["metadata"]["required_response_tool"] == "post_thread_discussion_reply"
+    assert trigger.payload["metadata"]["human_message"] == "@illo can you see this?"
+    assert trigger.payload["metadata"]["introspection_message"] == "@illo can you see this?"
     assert "separate Discussion conversation" in trigger.payload["run_message"]
     assert "not an AI Timeline reply" in trigger.payload["run_message"]
 

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -98,8 +98,13 @@ async def test_cortex_work_intake_builds_agent_run_request_from_normalized_trigg
         target={"idea_id": "idea-1"},
         payload={
             "user_id": "user-1",
+            "thread_message": "@illo go",
             "run_message": '[Idea: "Launch" | idea-1]\n\n@illo go',
-            "metadata": {"execution_profile": "fast"},
+            "metadata": {
+                "execution_profile": "fast",
+                "human_message": "@illo go",
+                "introspection_message": "@illo go",
+            },
         },
         policy={"priority": 1, "run_event": "thread_reply"},
         idempotency_key="cortex-idem",
@@ -116,6 +121,8 @@ async def test_cortex_work_intake_builds_agent_run_request_from_normalized_trigg
     assert request.metadata["producer"] == "trigger"
     assert request.metadata["idempotency_key"] == "cortex-idem"
     assert request.metadata["execution_profile"] == "fast"
+    assert request.metadata["human_message"] == "@illo go"
+    assert request.metadata["introspection_message"] == "@illo go"
     assert request.metadata["thread_context"]["formatted"] == "Earlier thread context"
     assert request.metadata["work_intake"]["source"] == "cortex"
     assert request.metadata["work_intake"]["actor"] == {"id": "user-1", "org_id": "org-1", "internal": False}
@@ -332,6 +339,7 @@ async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_
                 "surface": "thread_discussion",
             },
             payload={
+                "thread_message": "@illo this is what we decided, carry on",
                 "message": "[Idea: \"Launch\" | idea-1]\n\n@illo this is what we decided, carry on",
                 "metadata": {
                     "originating_surface": "thread_discussion",
@@ -339,6 +347,8 @@ async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_
                     "discussion_trigger": discussion_trigger,
                     "required_response_tool": "post_thread_discussion_reply",
                     "final_answer_target_surface": "thread_discussion",
+                    "human_message": "@illo this is what we decided, carry on",
+                    "introspection_message": "@illo this is what we decided, carry on",
                 },
             },
             policy={"priority": 0, "producer": "trigger", "run_event": "thread_discussion_mention"},
@@ -361,6 +371,8 @@ async def test_discussion_origin_cortex_work_intake_records_surface_and_trigger_
     assert request.metadata["discussion_trigger"] == discussion_trigger
     assert request.metadata["required_response_tool"] == "post_thread_discussion_reply"
     assert request.metadata["final_answer_target_surface"] == "thread_discussion"
+    assert request.metadata["human_message"] == "@illo this is what we decided, carry on"
+    assert request.metadata["introspection_message"] == "@illo this is what we decided, carry on"
 
 
 def test_legacy_routing_logic_is_removed_from_adapters():


### PR DESCRIPTION
## Summary
- preserve the current human message separately from decorated Cortex thread wrappers
- make required-introspection routing use that current message instead of the full `[Idea: ...]` wrapper/title
- tighten capability setup detection so work requests that mention adding products plus skills/cycles do not force `read_capabilities`

## Root cause
Illo was classifying the full decorated run message, including the thread title, when deciding whether to force `read_capabilities`. In the linked dropshipping thread, the title contained words like `add`, `skill`, and `cycle`, so later user replies such as `where are the results?` inherited that title and were misclassified as capability/setup questions.

## Tests
- `venv/bin/pytest tests/test_tool_registry.py`
- `venv/bin/pytest tests/test_triggers.py`
- `venv/bin/pytest tests/test_work_intake.py`
- `venv/bin/pytest tests/test_agent.py -k read_capabilities`