### PR TITLE
Add soul rule for person-directed delivery

### DIFF
--- a/brain/systems/personality/soul.py
+++ b/brain/systems/personality/soul.py
@@ -63,6 +63,15 @@ Choose the lightest visible coordination surface that fits the work:
 - reply in the current thread when the current audience is enough;
 - name or mention teammates in the current thread when they should share the same context;
 - create teammate-owned threads when each person needs their own action, follow-up, or handoff.
+
+When someone asks you to share, send, hand off, or pass information to a specific
+person, treat delivery as part of the task. Use the best available channel for
+that person in the current context: an Illo thread or handoff if that is where
+they are reachable, or an available team channel such as Slack DM if that is the
+clearest path. Do not overbuild the decision. Only use external channels when
+the request is explicitly about reaching that person. Prefer a short pointer or
+link over copying sensitive content into external tools. If no reliable channel
+is available, say so and create the best durable Illo-visible handoff you can.
 """
 
 SOUL_MAX_CHARS = int(os.getenv("ILLO_SOUL_MAX_CHARS", "6000"))

--- a/tests/test_agent_soul.py
+++ b/tests/test_agent_soul.py
@@ -33,6 +33,9 @@ def test_default_soul_is_team_workspace_specific(monkeypatch, tmp_path):
     assert "connected\npersonal agent acting for that member" in soul.content
     assert "not only as a reply to the current user" in soul.content
     assert "teammate-owned threads" in soul.content
+    assert "treat delivery as part of the task" in soul.content
+    assert "Only use external channels" in soul.content
+    assert "short pointer or\nlink" in soul.content
 
 
 def test_manage_soul_replace_writes_bounded_soul(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Add a concise default soul rule that treats person-directed sharing/handoff requests as including delivery.
- Keep the behavior channel-agnostic: prefer Illo-visible handoffs, use available team channels such as Slack DM only when explicitly reaching that person is the task, and prefer links/pointers over copying sensitive content.

## Verification
- `python3 -m py_compile brain/systems/personality/soul.py tests/test_agent_soul.py`
- `git diff --check`
- `python3 -m pytest tests/test_agent_soul.py -q` could not run in this environment: `No module named pytest`.