### PR TITLE
Fix Illo response-surface delegation

### DIFF
--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -222,6 +222,8 @@ _TERMINAL_RUN_IDEA_STATUS = {
 _AI_TIMELINE_SURFACES = {"ai_timeline", "thread_timeline", "cortex_thread", "main_thread"}
 _THREAD_DISCUSSION_SURFACE = "thread_discussion"
 _THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
+_SLACK_SURFACE = "slack"
+_SLACK_REPLY_TOOL = "post_slack_reply"
 _NON_TIMELINE_FINAL_ANSWER_TARGETS = {
     "discussion",
     "headless",
@@ -245,6 +247,13 @@ def _run_context_maps(run: AgentRunRow):
     for container in (_run_target_ref(run), _run_metadata(run)):
         if container:
             yield container
+
+
+def _run_is_headless(run: AgentRunRow) -> bool:
+    for container in _run_context_maps(run):
+        if bool(container.get("headless")):
+            return True
+    return False
 
 
 def _run_is_thread_discussion_conversation(run: AgentRunRow) -> bool:
@@ -418,6 +427,27 @@ def _run_discussion_trigger(run: AgentRunRow) -> dict[str, Any]:
     return {}
 
 
+def _run_slack_trigger(run: AgentRunRow) -> dict[str, Any]:
+    for container in _run_context_maps(run):
+        trigger = container.get("slack_trigger")
+        if isinstance(trigger, dict):
+            return dict(trigger)
+    return {}
+
+
+def _run_is_slack_origin(run: AgentRunRow) -> bool:
+    if _run_slack_trigger(run):
+        return True
+    for container in _run_context_maps(run):
+        if container.get("originating_surface") == _SLACK_SURFACE:
+            return True
+        if container.get("source_surface") == _SLACK_SURFACE:
+            return True
+        if container.get("final_answer_target_surface") == _SLACK_SURFACE:
+            return True
+    return False
+
+
 def _run_discussion_thread_id(run: AgentRunRow) -> str:
     trigger = _run_discussion_trigger(run)
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
@@ -537,12 +567,139 @@ async def _settle_thread_discussion_conversation_run_async(
     }
 
 
+async def _slack_reply_already_recorded(
+    session,
+    *,
+    run: AgentRunRow,
+) -> bool:
+    if not hasattr(session, "scalars"):
+        return False
+    try:
+        result = await session.scalars(
+            select(AgentRunEventRow)
+            .where(
+                AgentRunEventRow.run_id == int(run.id),
+                AgentRunEventRow.event_type == "run.tool_completed",
+            )
+            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+            .limit(100)
+        )
+        events = list(result.all())
+    except Exception:
+        return False
+    for event in events:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            continue
+        if str(payload.get("tool_name") or payload.get("tool") or "") != _SLACK_REPLY_TOOL:
+            continue
+        result_preview = str(payload.get("result") or "").lower()
+        if '"error"' not in result_preview and "'error'" not in result_preview:
+            return True
+    return False
+
+
+def _slack_response_target(run: AgentRunRow) -> dict[str, Any]:
+    trigger = _run_slack_trigger(run)
+    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
+    channel_id = str(response_target.get("channel_id") or trigger.get("channel_id") or "").strip()
+    thread_ts = response_target.get("thread_ts")
+    if thread_ts is not None:
+        thread_ts = str(thread_ts or "").strip() or None
+    trigger_channel_type = str(trigger.get("channel_type") or "").strip()
+    trigger_message_ts = str(trigger.get("message_ts") or "").strip()
+    if trigger_channel_type == "im":
+        thread_ts = None
+    elif not response_target.get("thread_ts") and thread_ts == trigger_message_ts:
+        thread_ts = None
+    return {
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "trigger": trigger,
+    }
+
+
+async def _slack_client_for_run(run: AgentRunRow):
+    from brain.systems.slack.client import SlackWebClient
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    token = await read_runtime_secret(
+        "SLACK_BOT_TOKEN",
+        context=RuntimeSecretContext(
+            actor_user_id=str(getattr(run, "user_id", "") or "").strip() or None,
+            org_id=str(getattr(run, "org_id", "") or "").strip() or None,
+            run_id=int(run.id),
+            idea_id=str(getattr(run, "thread_id", "") or "").strip() or None,
+        ),
+        reason="Report a completed Slack-origin Illo run back to Slack.",
+        requested_by="slack_run_settlement",
+        access="service",
+        allow_env_fallback=True,
+    )
+    return SlackWebClient(token)
+
+
+async def _clear_slack_processing_status(client: Any, trigger: dict[str, Any]) -> None:
+    set_status = getattr(client, "set_assistant_status", None)
+    if not callable(set_status):
+        return
+    channel_id = str(trigger.get("channel_id") or "").strip()
+    thread_ts = str(trigger.get("thread_ts") or trigger.get("message_ts") or "").strip()
+    if not channel_id or not thread_ts:
+        return
+    with suppress(Exception):
+        await set_status(channel_id=channel_id, thread_ts=thread_ts, status="")
+
+
+async def _settle_slack_origin_run_async(
+    session,
+    run: AgentRunRow,
+) -> dict[str, Any] | None:
+    if not _run_is_slack_origin(run):
+        return None
+    if _run_is_headless(run):
+        return None
+    final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
+    if not final_answer:
+        return None
+    if await _slack_reply_already_recorded(session, run=run):
+        return None
+
+    target = _slack_response_target(run)
+    channel_id = target["channel_id"]
+    if not channel_id:
+        return None
+    try:
+        client = await _slack_client_for_run(run)
+        response = await client.post_message(
+            channel=channel_id,
+            text=final_answer,
+            thread_ts=target["thread_ts"],
+        )
+        await _clear_slack_processing_status(client, target["trigger"])
+    except Exception as exc:
+        logger.info("slack_final_answer_settlement_failed: %s", exc, extra={"run_id": int(run.id)})
+        return None
+    return {
+        "surface": _SLACK_SURFACE,
+        "run_id": int(run.id),
+        "artifact_id": artifact_id,
+        "channel_id": channel_id,
+        "thread_ts": target["thread_ts"],
+        "slack": response,
+    }
+
+
 async def _settle_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
     run = await session.get(AgentRunRow, int(run_id))
-    if run is None or run.parent_run_id is not None:
+    if run is None:
         return None
-    if _run_is_thread_discussion_conversation(run):
+    if run.parent_run_id is None and _run_is_thread_discussion_conversation(run):
         return await _settle_thread_discussion_conversation_run_async(session, run)
+    if _run_is_slack_origin(run):
+        slack_payload = await _settle_slack_origin_run_async(session, run)
+        if run.parent_run_id is not None:
+            return slack_payload
     return await _settle_idea_for_terminal_root_run_async(session, run_id)
 
 

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -13,6 +13,7 @@ from brain.platform.providers.model_policy import get_model_for_tier
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 from brain.systems.runs.recipes.base import BaseRunRecipe
 from brain.systems.runs.recipes.shared import project_runtime_workspace_from_ref
+from brain.systems.runs.recipes.surface_guidance import response_surface_guidance
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems.personality import agent_profile_prompt_section, soul_prompt_section
 
@@ -28,8 +29,9 @@ short feedback loops.
 Runtime rules:
 - Treat the provided Target, Workspace, Context, attachments, memory, and live steering as the current run state.
 - Use later live steering to adjust the current run without discarding useful progress.
-- Prefer the smallest complete action that satisfies the request now; leave larger follow-up work explicit.
-- Fast may spawn scoped workers. If an independent investigation, implementation slice, verification pass, duplicate search, or bug/blocker report can safely progress in parallel while you continue the user-facing run, use spawn_worker.
+- Triage first: decide whether this is a direct answer, a short interactive task, or work that needs durable/parallel delegation.
+- Prefer the smallest complete action that satisfies the request now, but do not disappear into long work before giving the user a timely model-authored update on the originating surface.
+- Fast should spawn scoped workers. If an independent investigation, implementation slice, verification pass, duplicate search, or bug/blocker report can safely progress in parallel while you continue the user-facing run, use spawn_worker.
 - Use headless=true for internal blocker or bug-report workers that do not need user input and should not create visible thread content.
 - Do not spawn a worker when delegation overhead is larger than doing the step directly, when write scopes would overlap unsafely, or when your final answer depends on a multi-wave verified synthesis.
 - Use Deep when the request needs heavy verification, dependency-ordered worker waves, internal follow-ups, or formal synthesis across worker results.
@@ -156,7 +158,13 @@ class FastRecipe(BaseRunRecipe):
             root_run_id=runtime.run.root_run_id,
         )
 
-        prompt_context = context.prompt_context()
+        surface_guidance = response_surface_guidance(
+            target_ref=runtime.request.target_ref,
+            metadata=runtime.request.metadata,
+        )
+        prompt_context = "\n\n".join(
+            section for section in (surface_guidance, context.prompt_context()) if section.strip()
+        )
         system_prompt = build_fast_system_prompt(prompt_context)
         spec = build_direct_agent_invocation(
             message=context.message,

--- a/brain/systems/runs/recipes/surface_guidance.py
+++ b/brain/systems/runs/recipes/surface_guidance.py
@@ -1,0 +1,57 @@
+"""Shared response-surface guidance for agent recipes."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def response_surface_guidance(
+    *,
+    target_ref: Mapping[str, Any] | None,
+    metadata: Mapping[str, Any] | None,
+) -> str:
+    """Build generic guidance for prompt-time triage and delegated work."""
+
+    target = dict(target_ref or {})
+    meta = dict(metadata or {})
+    originating_surface = _first_text(
+        (target, meta),
+        ("originating_surface", "triggering_surface", "source_surface", "surface"),
+    )
+    response_tool = _first_text((target, meta), ("required_response_tool",))
+    final_surface = _first_text((target, meta), ("final_answer_target_surface",))
+
+    lines = ["## Response Surface and Delegation"]
+    if originating_surface:
+        lines.append(f"- Originating surface: {originating_surface}.")
+    if response_tool:
+        lines.append(f"- User-visible response tool for that surface: {response_tool}.")
+    if final_surface:
+        lines.append(f"- Final answer target surface: {final_surface}.")
+    lines.extend(
+        [
+            "- Triage before deep work: decide whether the request can be answered directly or needs durable/parallel follow-up.",
+            "- For simple requests, answer naturally on the originating surface when a response tool is available; otherwise finish with a concise final answer.",
+            "- For long, uncertain, or parallelizable work, first make the delegation durable with spawn_worker or a Cortex Thread/run via manage_idea, then promptly send a model-authored update on the originating surface when a response tool is available.",
+            "- Do not use canned acknowledgements; describe the actual decision, work started, child runs, or thread created.",
+            "- Do not wait for long-running work just to produce the first visible user update after durable dispatch.",
+            "- Use headless=true only for internal diagnostics or blocker reports that should not create visible user-facing content.",
+            "- When sharing Cortex Thread links, use a thread_url returned by a tool. Never construct a Thread URL from a Slack id, run id, or other synthetic thread key.",
+            "- When a visible delegated run completes, make its final answer suitable as a concise update back to the originating surface.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _first_text(containers: tuple[Mapping[str, Any], ...], keys: tuple[str, ...]) -> str:
+    for container in containers:
+        if not isinstance(container, Mapping):
+            continue
+        for key in keys:
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+__all__ = ["response_surface_guidance"]

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -17,6 +17,7 @@ from brain.systems.runs.tools import AsyncRunToolExecutor, ToolRecord, ToolScope
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
 from brain.platform.providers.model_policy import get_model_for_tier
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
+from brain.systems.runs.recipes.surface_guidance import response_surface_guidance
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ Rules:
 - Do not mutate forbidden or out-of-scope files. If scope is too narrow, say exactly what approval is needed.
 - Stream short progress updates while working.
 - Finish with a concise result: what changed or was learned, required evidence, artifacts produced, and remaining uncertainty.
+- If this worker is not headless and inherited a user-facing response surface, make the final result suitable as a user-visible update.
 """
 
 
@@ -114,6 +116,7 @@ class WorkerRecipe(BaseRunRecipe):
             workspace_ref=runtime.request.workspace_ref,
             context=prompt_context,
             evidence_so_far=runtime.request.metadata.get("evidence") or runtime.request.metadata.get("parent_evidence"),
+            metadata=runtime.request.metadata,
         )
         await runtime.activity("Starting scoped worker", workspace_root=workspace_root)
         spec = build_direct_agent_invocation(
@@ -220,6 +223,7 @@ def build_worker_prompt(
     workspace_ref: dict[str, Any],
     context: str = "",
     evidence_so_far: Any = None,
+    metadata: dict[str, Any] | None = None,
 ) -> str:
     context_block = context
     if not context_block:
@@ -231,6 +235,8 @@ def build_worker_prompt(
         context_block = "\n\n".join(context_parts)
     return (
         WORKER_AGENT_INSTRUCTIONS
+        + "\n\n"
+        + response_surface_guidance(target_ref=target_ref, metadata=metadata)
         + _json_block("Worker Assignment", assignment.to_payload())
         + _json_block("Parent Evidence", evidence_so_far)
         + (f"\n\n## Context\n{context_block}" if context_block else "")

--- a/brain/systems/runs/tool_catalog/definitions/workers.py
+++ b/brain/systems/runs/tool_catalog/definitions/workers.py
@@ -10,7 +10,9 @@ WORKER_SPAWN_TOOLS = [
             "Queue a scoped worker AgentRun and return immediately. Use this when an independent "
             "slice can progress in parallel while the current run continues, or when Illo should "
             "file/report an internal bug or blocker in the background. Set headless=true for "
-            "background reporting or investigation that should not create visible thread content."
+            "background reporting or investigation that should not create visible thread content; "
+            "leave headless=false when the delegated run should be able to report visible progress "
+            "or a final update back through the inherited originating surface."
         ),
         "input_schema": {
             "type": "object",
@@ -90,4 +92,3 @@ WORKER_SPAWN_TOOLS = [
         },
     },
 ]
-

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from fastapi import HTTPException
 from sqlalchemy import func, or_, select
@@ -86,13 +86,46 @@ async def _serialize_idea(idea, session) -> dict[str, Any]:
 
 def _current_tool_run_id() -> int | None:
     run = getattr(_agent_context, "run", None)
-    run_id = getattr(run, "run_id", None) or getattr(run, "id", None)
+    run_id = getattr(_agent_context, "run_id", None) or getattr(run, "run_id", None) or getattr(run, "id", None)
     execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
     run_id = run_id or execution_metadata.get("run_id")
     try:
         return int(run_id) if run_id is not None else None
     except Exception:
         return None
+
+
+def _current_response_surface_metadata() -> dict[str, Any]:
+    execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
+    execution_metadata = execution_metadata if isinstance(execution_metadata, Mapping) else {}
+    target_ref = getattr(_agent_context, "target_ref", None)
+    containers = (
+        target_ref if isinstance(target_ref, Mapping) else {},
+        execution_metadata.get("target_ref") if isinstance(execution_metadata.get("target_ref"), Mapping) else {},
+        execution_metadata.get("execution_provenance")
+        if isinstance(execution_metadata.get("execution_provenance"), Mapping)
+        else {},
+        execution_metadata,
+    )
+    inherited: dict[str, Any] = {}
+    for container in containers:
+        for key in (
+            "originating_surface",
+            "triggering_surface",
+            "source_surface",
+            "required_response_tool",
+            "slack_trigger",
+            "slack_thread_id",
+            "discussion_trigger",
+        ):
+            if key in inherited:
+                continue
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                inherited[key] = value.strip()
+            elif isinstance(value, Mapping):
+                inherited[key] = dict(value)
+    return inherited
 
 
 def _created_idea_seed_content(
@@ -127,6 +160,30 @@ def _optional_bool(value: Any) -> bool | None:
     if text in {"0", "false", "no", "n", "off"}:
         return False
     return None
+
+
+def _delegated_run_next_action(*, tool_name: str, response_tool: str | None) -> dict[str, Any]:
+    instruction = (
+        f"{tool_name} has made this delegated run durable. Do not call {tool_name} again "
+        "for the same request unless the user asks for another distinct thread/run."
+    )
+    if response_tool:
+        instruction += (
+            f" Use {response_tool} to give the waiting surface a brief model-authored update "
+            "with the returned thread/run id, then continue only with distinct follow-up work."
+        )
+    else:
+        instruction += (
+            " Give the caller a concise model-authored update with the returned thread/run id, "
+            "then continue only with distinct follow-up work."
+        )
+    return {
+        "instruction": instruction,
+        "repeat_guard": {
+            "tool": tool_name,
+            "same_request": "do_not_repeat",
+        },
+    }
 
 
 async def _seed_created_idea_thread(
@@ -188,6 +245,7 @@ async def _admit_created_idea_run(
             payload={
                 "message": _created_idea_run_message(idea, seed_content),
                 "metadata": {
+                    **_current_response_surface_metadata(),
                     "created_by_tool": "manage_idea",
                     "created_by_run_id": source_run_id,
                     "parent_idea_id": parent_id,
@@ -538,6 +596,13 @@ async def _handle_manage_idea(
                     "run_id": getattr(run_result, "run_id", None),
                     "run_started": run_result is not None,
                 }
+                if run_result is not None:
+                    response_metadata = _current_response_surface_metadata()
+                    response_tool = response_metadata.get("required_response_tool")
+                    result["next_action"] = _delegated_run_next_action(
+                        tool_name="manage_idea",
+                        response_tool=str(response_tool).strip() if response_tool else None,
+                    )
 
             else:
                 if not target_idea_id:

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -130,6 +130,35 @@ def _merge_tool_policy(tool_policy: Any, *, headless: bool) -> dict[str, Any]:
     )
 
 
+def _delegation_next_action(*, tool_name: str, response_tool: str | None, headless: bool) -> dict[str, Any]:
+    instruction = (
+        f"{tool_name} has made this delegated work durable. Do not call {tool_name} again "
+        "for the same objective unless the user asks for another distinct delegation."
+    )
+    if response_tool:
+        instruction += (
+            f" Use {response_tool} to give the waiting surface a brief model-authored update "
+            "with the returned run id/status, then continue only with distinct follow-up work."
+        )
+    elif headless:
+        instruction += (
+            " This run is headless, so settle with a concise final answer for the caller or "
+            "monitor only distinct follow-up work."
+        )
+    else:
+        instruction += (
+            " Give the caller a concise model-authored update with the returned run id/status, "
+            "then continue only with distinct follow-up work."
+        )
+    return {
+        "instruction": instruction,
+        "repeat_guard": {
+            "tool": tool_name,
+            "same_objective": "do_not_repeat",
+        },
+    }
+
+
 def _assignment_payload(
     *,
     role: str,
@@ -228,6 +257,8 @@ async def _handle_spawn_worker(
         "thread_attachment_context": inherited_metadata.get("thread_attachment_context"),
     }
     worker_metadata = {key: value for key, value in worker_metadata.items() if value is not None}
+    response_tool = _current_agent_value("required_response_tool")
+    response_tool_text = str(response_tool).strip() if response_tool else None
 
     async with UnitOfWork() as uow:
         store = AsyncAgentRunStore(uow.session)
@@ -275,6 +306,11 @@ async def _handle_spawn_worker(
             "headless": bool(headless),
             "step_key": step_key,
             "deduplicated": deduplicated,
+            "next_action": _delegation_next_action(
+                tool_name="spawn_worker",
+                response_tool=response_tool_text,
+                headless=bool(headless),
+            ),
         },
         default=str,
     )

--- a/brain/systems/runs/work_intake_slack.py
+++ b/brain/systems/runs/work_intake_slack.py
@@ -49,18 +49,34 @@ def agent_run_request_for_slack(trigger_payload: dict[str, Any] | Any) -> AgentR
     run_event = _run_event(trigger, policy)
     priority = _priority(payload, policy)
     profile = profile_from_metadata(metadata)
+    slack_thread_id = _slack_thread_id(slack_trigger, target)
+    cortex_thread_id = str(target.get("idea_id") or target.get("thread_id") or "").strip()
     target_ref = {
         **target,
         "kind": "slack_message",
         "event": str(run_event),
         "surface": slack_trigger.get("surface") or target.get("surface") or SLACK_SURFACE,
+        "slack_thread_id": slack_thread_id,
         "slack_trigger": slack_trigger,
         **surface_context,
     }
+    if cortex_thread_id:
+        target_ref["idea_id"] = cortex_thread_id
+        target_ref["thread_id"] = cortex_thread_id
+        target_ref["related_surfaces"] = {
+            "slack": {
+                "kind": "slack",
+                "thread_id": slack_thread_id,
+                "team_id": slack_trigger.get("team_id") or target.get("team_id"),
+                "channel_id": slack_trigger.get("channel_id") or target.get("channel_id"),
+                "message_ts": slack_trigger.get("message_ts") or target.get("message_ts"),
+                "thread_ts": slack_trigger.get("thread_ts") or target.get("thread_ts"),
+            }
+        }
     return AgentRunRequest(
         org_id=trigger_org_id,
         user_id=_payload_user_id(payload, trigger, org_id=trigger_org_id),
-        thread_id=_slack_thread_id(slack_trigger, target),
+        thread_id=cortex_thread_id or slack_thread_id,
         message=str(payload.get("run_message") or payload.get("message") or ""),
         profile=profile,
         recipe=recipe_for_profile(profile, metadata),

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -13,7 +13,6 @@ from typing import Any, Mapping
 from sqlalchemy import select
 
 from brain.platform.async_io import async_http_client
-from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.service import submit_inbound_envelope
@@ -27,7 +26,6 @@ from brain.systems.slack.client import (
 from brain.systems.slack.ingress import normalize_slack_socket_event
 
 logger = logging.getLogger(__name__)
-SLACK_PROCESSING_STATUS = "is working on it..."
 
 
 @dataclass(frozen=True)
@@ -315,7 +313,6 @@ async def process_socket_payload(
     )
     if envelope is None:
         return {"ack": ack, "ignored": True}
-    existing_run_for_message = await _has_slack_run_for_envelope(session, connection, envelope)
     inbound = await submit_inbound_envelope(
         session,
         connection=connection,
@@ -325,68 +322,7 @@ async def process_socket_payload(
             "envelope_id": ack.get("envelope_id"),
         },
     )
-    # Slack clears this status when the bot replies and applies a short timeout
-    # if the run fails or completes without sending a Slack message.
-    if not existing_run_for_message and _admitted_slack_run(inbound):
-        await _set_processing_status(config, envelope)
     return {"ack": ack, "ignored": False, "inbound": inbound}
-
-
-def _connection_org_id(connection: ExternalAgentConnectionRow | Mapping[str, Any]) -> str | None:
-    if isinstance(connection, Mapping):
-        return str(connection.get("org_id") or "").strip() or None
-    return str(getattr(connection, "org_id", "") or "").strip() or None
-
-
-def _envelope_idempotency_key(envelope: Mapping[str, Any]) -> str | None:
-    key = str(envelope.get("idempotency_key") or "").strip()
-    return key if key.startswith("slack:") else None
-
-
-async def _has_slack_run_for_envelope(
-    session,
-    connection: ExternalAgentConnectionRow | Mapping[str, Any],
-    envelope: Mapping[str, Any],
-) -> bool:
-    org_id = _connection_org_id(connection)
-    key = _envelope_idempotency_key(envelope)
-    if not org_id or not key:
-        return False
-    stmt = (
-        select(AgentRunRow.id)
-        .where(
-            AgentRunRow.org_id == org_id,
-            AgentRunRow.source_idempotency_scope == "slack",
-            AgentRunRow.source_idempotency_key == key,
-        )
-        .limit(1)
-    )
-    return (await session.scalar(stmt)) is not None
-
-
-def _admitted_slack_run(inbound: Mapping[str, Any]) -> bool:
-    if inbound.get("idempotent_replay"):
-        return False
-    outcome = inbound.get("ilo_outcome")
-    outcome = outcome if isinstance(outcome, Mapping) else {}
-    return outcome.get("operation") == "slack_run_admitted" and outcome.get("run_id") is not None
-
-
-async def _set_processing_status(config: SlackConnectorConfig, envelope: Mapping[str, Any]) -> None:
-    payload = envelope.get("payload") if isinstance(envelope.get("payload"), Mapping) else {}
-    channel_id = str(payload.get("channel_id") or "").strip()
-    thread_ts = str(payload.get("thread_ts") or payload.get("message_ts") or "").strip()
-    if not channel_id or not thread_ts:
-        return
-    try:
-        client = SlackWebClient(config.bot_token, timeout=2.0)
-        await client.set_assistant_status(
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-            status=SLACK_PROCESSING_STATUS,
-        )
-    except Exception as exc:
-        logger.info("slack_processing_status_failed: %s", exc)
 
 
 async def open_socket_mode_url(config: SlackConnectorConfig) -> str:

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -49,25 +49,33 @@ async def process_slack_message_envelope(
             reasoning_summary="Slack events need a connection owner for the permissive self-hosted MVP.",
         )
 
+    slack_payload = dict(normalized.get("payload") or {})
+    slack_thread_id = _slack_conversation_thread_id(slack_payload)
     trigger_payload = build_slack_work_intake_payload(
         org_id=context.org_id,
         authority_user_id=authority_user_id,
-        payload=dict(normalized.get("payload") or {}),
+        payload=slack_payload,
         inbound_event_id=str(event.id),
         connection_id=context.connection_id,
         idempotency_key=_clean_optional(normalized.get("idempotency_key")),
     )
+    trigger_metadata = dict((trigger_payload.get("payload") or {}).get("metadata") or {})
+    trigger_metadata["slack_thread_id"] = slack_thread_id
+    trigger_payload["payload"] = {
+        **dict(trigger_payload.get("payload") or {}),
+        "metadata": trigger_metadata,
+    }
     admission = await admit_work(
         session,
         WorkIntakeEvent.from_trigger_payload(trigger_payload),
     )
-    slack_payload = dict(normalized.get("payload") or {})
     target = {
         "kind": "slack_message",
         "team_id": slack_payload.get("team_id"),
         "channel_id": slack_payload.get("channel_id"),
         "message_ts": slack_payload.get("message_ts"),
         "thread_ts": slack_payload.get("thread_ts"),
+        "slack_thread_id": slack_thread_id,
     }
     if admission.ok:
         if admission.run_id is not None:
@@ -87,8 +95,15 @@ async def process_slack_message_envelope(
             },
             confidence=1.0,
             target=target,
-            tool_use={"type": "slack_teammate_run", "run_id": admission.run_id},
-            reasoning_summary="Slack mention or DM was admitted as a surface-aware Illo run.",
+            tool_use={
+                "type": "slack_teammate_run",
+                "run_id": admission.run_id,
+                "slack_thread_id": slack_thread_id,
+            },
+            reasoning_summary=(
+                "Slack mention or DM was admitted as a surface-aware Illo run. Illo decides "
+                "whether to answer directly or create durable Cortex/worker follow-up."
+            ),
             reusable_pattern_candidate={
                 "kind": SLACK_MESSAGE_ENVELOPE_KIND,
                 "origin": normalized.get("origin"),
@@ -115,6 +130,15 @@ async def process_slack_message_envelope(
         tool_use={"type": "slack_teammate_run", "status": "failed"},
         reasoning_summary=admission.skipped_reason or "Slack event could not be admitted as an Illo run.",
     )
+
+
+def _slack_conversation_thread_id(payload: Mapping[str, Any]) -> str:
+    team_id = str(payload.get("team_id") or "").strip()
+    channel_id = str(payload.get("channel_id") or "").strip()
+    thread_ts = str(payload.get("thread_ts") or payload.get("message_ts") or "").strip()
+    if not team_id or not channel_id or not thread_ts:
+        return ""
+    return f"slack:{team_id}:{channel_id}:{thread_ts}"
 
 
 async def _slack_run_user_id(

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -176,7 +176,13 @@ def slack_run_message(payload: Mapping[str, Any], slack_trigger_payload: Mapping
     lines = [
         "A teammate invoked Illo from Slack.",
         "Slack is the triggering conversation surface; use normal Illospace tools for the work.",
-        f"After acting, reply in Slack with {SLACK_REPLY_TOOL} when a visible response fits.",
+        "Decide whether this is a simple Slack reply or work that should be delegated into Cortex/worker runs.",
+        f"For simple requests, reply in Slack with {SLACK_REPLY_TOOL}.",
+        (
+            "For long-running work, make the delegation durable with manage_idea or spawn_worker, "
+            f"then send a model-authored Slack update with {SLACK_REPLY_TOOL}."
+        ),
+        "Only share Cortex Thread links returned by tools as thread_url; never build a URL from Slack ids or run ids.",
         "Use read_slack_conversation if more Slack context is needed.",
         f"Default Slack reply target: {reply_mode}",
         "",

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -45,16 +45,24 @@ Optional Slack hints:
 - `app_mention` events and every DM are actionable.
 - Top-level channel mentions reply as normal channel messages; mentions inside
   Slack threads reply back into that thread; DMs reply as normal DM messages.
-- Illo sets a best-effort Slack working status while a Slack-origin run is
-  being admitted, so teammates can see that the request was accepted. This uses
-  the existing `chat:write` scope and Slack clears the status on reply or after
-  its short timeout.
+- Socket Mode envelopes are acknowledged before durable inbound processing.
+  This is a transport acknowledgement only, not user-visible Illo speech.
+- User-visible Slack text is model-authored. Illo decides whether to answer a
+  simple request directly with `post_slack_reply`, or to make longer work
+  durable with `spawn_worker`/`manage_idea` and then post a natural Slack update
+  describing what it actually did.
+- If Illo creates or selects a Cortex Thread, it should share only the
+  `thread_url` returned by that tool. Slack ids and run ids are never converted
+  into Thread URLs.
+- When a Slack-origin run or non-headless Slack-origin child run reaches a
+  terminal final answer, the runner posts that generated final answer back to
+  Slack unless the same run already completed a successful `post_slack_reply`
+  call.
 - Regular channel messages without an Illo mention are ignored.
 - The default manifest subscribes to `app_mention` and `message.im` only. It
   keeps channel history scopes for context reads, but avoids generic channel
   message events as trigger sources because Slack can also deliver the same
   human mention as `app_mention`.
-- Socket Mode envelopes are acknowledged before durable inbound processing.
 - The connector records durable health while it connects. If the app-level
   Socket Mode token is wrong or Slack rejects the connection, `manage_slack`
   reports the connection as `error` instead of leaving it looking configured.

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -442,6 +442,9 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert captured["spec"].idea_id is None
     assert captured["spec"].workspace_root == "/tmp/work"
     assert "interactive single-agent path" in captured["spec"].system_prompt
+    assert "Triage first" in captured["spec"].system_prompt
+    assert "Response Surface and Delegation" in captured["spec"].system_prompt
+    assert "do not disappear into long work" in captured["spec"].system_prompt
     assert "spawn_worker" in captured["spec"].system_prompt
     assert "headless=true" in captured["spec"].system_prompt
     assert "write one brief task-specific assistant sentence" in captured["spec"].system_prompt
@@ -454,6 +457,143 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert any(event.event_type == "run.activity" and event.payload["label"] == "Reading files" for event in runtime.store.events)
     assert any(event.event_type == "run.tool_completed" and event.payload["tool_name"] == "read_file" for event in runtime.store.events)
     assert any(_artifact_type(artifact) == "file_observation" for artifact in runtime.store.artifacts)
+
+
+async def test_fast_discussion_run_can_ack_visibly_before_spawning_child(monkeypatch):
+    from brain.systems.runs.domain import RunRecipe
+    from brain.systems.runs.events import run_event
+    from brain.systems.runs.recipes.fast import FastRecipe
+
+    runtime = _runtime(
+        "fast",
+        message=(
+            "Please acknowledge first, then launch a child worker to inspect whether "
+            "response-surface delegation tests exist."
+        ),
+    )
+    runtime.request = replace(
+        runtime.request,
+        metadata={
+            **runtime.request.metadata,
+            "originating_surface": "thread_discussion",
+            "required_response_tool": "post_thread_discussion_reply",
+            "final_answer_target_surface": "thread_discussion",
+            "discussion_trigger": {
+                "thread_id": "idea-1",
+                "comment_id": 7,
+                "response_target": {
+                    "thread_id": "idea-1",
+                    "reply_to_comment_id": 7,
+                },
+            },
+        },
+        target_ref={
+            "kind": "thread_discussion",
+            "originating_surface": "thread_discussion",
+            "required_response_tool": "post_thread_discussion_reply",
+            "final_answer_target_surface": "thread_discussion",
+            "discussion_trigger": {
+                "thread_id": "idea-1",
+                "comment_id": 7,
+                "response_target": {
+                    "thread_id": "idea-1",
+                    "reply_to_comment_id": 7,
+                },
+            },
+        },
+    )
+    visible_comments: list[dict] = []
+
+    async def fake_reply(**kwargs):
+        visible_comments.append(dict(kwargs))
+        return {"ok": True, "comment_id": 99}
+
+    async def fake_spawn_worker(**kwargs):
+        child = await runtime.store.create_child_run(
+            runtime.run,
+            recipe=RunRecipe.WORKER,
+            message=str(kwargs["objective"]),
+            step_key="spawn_worker:response-surface-delegation-probe",
+            metadata={
+                "origin": "spawn_worker",
+                "headless": bool(kwargs.get("headless")),
+                "worker_role": kwargs.get("role") or "worker",
+            },
+        )
+        await runtime.store.append_event(
+            run_event(
+                runtime.run.id,
+                "run.worker_spawned",
+                {
+                    "child_run_id": child.id,
+                    "step_key": "spawn_worker:response-surface-delegation-probe",
+                    "headless": bool(kwargs.get("headless")),
+                    "role": kwargs.get("role") or "worker",
+                    "objective": kwargs["objective"],
+                },
+                root_run_id=runtime.run.root_run_id,
+                producer="spawn_worker",
+            )
+        )
+        return {
+            "ok": True,
+            "status": "queued",
+            "child_run_id": child.id,
+            "headless": bool(kwargs.get("headless")),
+        }
+
+    async def fake_invoke(spec):
+        assert "Response Surface and Delegation" in spec.system_prompt
+        assert "User-visible response tool for that surface: post_thread_discussion_reply." in spec.system_prompt
+        await spec.tool_handlers["post_thread_discussion_reply"](
+            body="I will launch a worker now to inspect the response-surface delegation tests.",
+        )
+        await spec.tool_handlers["spawn_worker"](
+            objective="Inspect test names for response-surface delegation coverage.",
+            role="inspect",
+            headless=False,
+        )
+        return SimpleNamespace(output="Worker queued; I will report back when it finishes.", success=True, error=None)
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_agent_tools",
+        lambda _role: [
+            {"name": "post_thread_discussion_reply"},
+            {"name": "spawn_worker"},
+        ],
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.fast.build_tool_handlers",
+        lambda **_kwargs: {
+            "post_thread_discussion_reply": fake_reply,
+            "spawn_worker": fake_spawn_worker,
+        },
+    )
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent_async", fake_invoke)
+
+    result = await FastRecipe().execute(runtime)
+
+    assert result.status.value == "completed"
+    assert visible_comments == [
+        {"body": "I will launch a worker now to inspect the response-surface delegation tests."}
+    ]
+    event_types = [event.event_type for event in runtime.store.events]
+    ack_completed_index = next(
+        i
+        for i, event in enumerate(runtime.store.events)
+        if event.event_type == "run.tool_completed"
+        and event.payload["tool_name"] == "post_thread_discussion_reply"
+    )
+    worker_spawned_index = event_types.index("run.worker_spawned")
+    spawn_completed_index = next(
+        i
+        for i, event in enumerate(runtime.store.events)
+        if event.event_type == "run.tool_completed" and event.payload["tool_name"] == "spawn_worker"
+    )
+    assert ack_completed_index < worker_spawned_index < spawn_completed_index
+    worker_event = runtime.store.events[worker_spawned_index]
+    assert worker_event.payload["headless"] is False
+    assert worker_event.payload["child_run_id"] in runtime.store.runs
 
 
 async def test_fast_recipe_uses_the_product_prompt_pipeline(monkeypatch):
@@ -1018,6 +1158,12 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
 
     assert payload["ok"] is True
     assert payload["child_run_id"] == child.id
+    assert payload["next_action"]["repeat_guard"] == {
+        "tool": "spawn_worker",
+        "same_objective": "do_not_repeat",
+    }
+    assert "Do not call spawn_worker again" in payload["next_action"]["instruction"]
+    assert "headless" in payload["next_action"]["instruction"]
     assert create_kwargs["thread_id"].startswith("headless-worker:42:")
     assert create_kwargs["metadata"]["headless"] is True
     assert set(create_kwargs["metadata"]["tool_policy"]["disabled_tools"]) >= {
@@ -2335,6 +2481,8 @@ async def test_worker_recipe_propagates_headless_tool_policy(monkeypatch):
     result = await WorkerRecipe().execute(runtime)
 
     assert result.status.value == "completed"
+    assert "Response Surface and Delegation" in captured["spec"].system_prompt
+    assert "visible delegated run completes" in captured["spec"].system_prompt
     assert captured["spec"].metadata["headless"] is True
     assert captured["spec"].metadata["tool_policy"] == {"blocked_tools": ["post_chat_message"]}
 
@@ -2834,6 +2982,250 @@ async def test_runner_does_not_duplicate_final_answer_thread_message():
 
     assert await _settle_idea_for_terminal_root_run_async(FakeSession(), 45) is None
     assert not any(isinstance(obj, IdeaThread) for obj in added)
+
+
+async def test_runner_reports_slack_origin_final_answer_back_to_slack(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=77,
+        parent_run_id=None,
+        thread_id=str(uuid.uuid4()),
+        status="completed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                },
+            },
+        },
+        metadata_={"final_answer_target_surface": "slack"},
+    )
+    final_artifact = SimpleNamespace(
+        id=101,
+        run_id=77,
+        artifact_type="final_answer",
+        text="Done. I checked the package list and posted the findings.",
+    )
+    calls = []
+
+    class FakeSession:
+        def __init__(self):
+            self.scalar_calls = 0
+
+        async def scalars(self, stmt):
+            del stmt
+            self.scalar_calls += 1
+            if self.scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([])
+
+    class FakeSlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(("message", kwargs))
+            return {"ok": True, "channel": kwargs["channel"], "ts": "1716900400.000500"}
+
+        async def set_assistant_status(self, **kwargs):
+            calls.append(("status", kwargs))
+            return {"ok": True}
+
+    async def fake_client_for_run(run_arg):
+        assert run_arg is run
+        return FakeSlackClient()
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+
+    result = await runner._settle_slack_origin_run_async(FakeSession(), run)
+
+    assert result["surface"] == "slack"
+    assert result["run_id"] == 77
+    assert result["artifact_id"] == 101
+    assert calls == [
+        (
+            "message",
+            {
+                "channel": "C456",
+                "text": "Done. I checked the package list and posted the findings.",
+                "thread_ts": None,
+            },
+        ),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "",
+            },
+        ),
+    ]
+
+
+async def test_runner_does_not_override_model_authored_slack_reply(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=78,
+        parent_run_id=None,
+        thread_id=str(uuid.uuid4()),
+        status="completed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "response_target": {"channel_id": "C456", "thread_ts": None},
+            },
+        },
+        metadata_={"final_answer_target_surface": "slack"},
+    )
+    final_artifact = SimpleNamespace(
+        id=102,
+        run_id=78,
+        artifact_type="final_answer",
+        text="Done. I checked the package list and posted the findings.",
+    )
+    posted_event = SimpleNamespace(
+        payload={
+            "tool_name": "post_slack_reply",
+            "args": {"body": "I started a Cortex thread for this and will report back there."},
+            "result": '{"ok": true, "ts": "1716900001.000200"}',
+        }
+    )
+
+    class FakeSession:
+        def __init__(self):
+            self.scalar_calls = 0
+
+        async def scalars(self, stmt):
+            del stmt
+            self.scalar_calls += 1
+            if self.scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([posted_event])
+
+    async def fail_client_for_run(_run):
+        raise AssertionError("Slack client should not be requested after post_slack_reply")
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
+
+    assert await runner._settle_slack_origin_run_async(FakeSession(), run) is None
+
+
+async def test_runner_reports_non_headless_slack_child_final_answer_back_to_slack(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=79,
+        parent_run_id=78,
+        root_run_id=78,
+        thread_id="slack:T789:C456:1716900000.000100",
+        status="completed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "response_target": {"channel_id": "C456", "thread_ts": "1716900000.000100"},
+            },
+        },
+        metadata_={"final_answer_target_surface": "slack", "headless": False},
+    )
+    final_artifact = SimpleNamespace(
+        id=103,
+        run_id=79,
+        artifact_type="final_answer",
+        text="Worker finished: the affected package was not present in the scanned manifests.",
+    )
+    calls = []
+
+    class FakeSession:
+        def __init__(self):
+            self.scalar_calls = 0
+
+        async def get(self, model, key):
+            del model, key
+            return run
+
+        async def scalars(self, stmt):
+            del stmt
+            self.scalar_calls += 1
+            if self.scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([])
+
+    class FakeSlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(("message", kwargs))
+            return {"ok": True, "channel": kwargs["channel"], "ts": "1716900400.000500"}
+
+        async def set_assistant_status(self, **kwargs):
+            calls.append(("status", kwargs))
+            return {"ok": True}
+
+    async def fake_client_for_run(run_arg):
+        assert run_arg is run
+        return FakeSlackClient()
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+
+    result = await runner._settle_terminal_root_run_async(FakeSession(), 79)
+
+    assert result["surface"] == "slack"
+    assert result["run_id"] == 79
+    assert calls[0] == (
+        "message",
+        {
+            "channel": "C456",
+            "text": "Worker finished: the affected package was not present in the scanned manifests.",
+            "thread_ts": "1716900000.000100",
+        },
+    )
+
+
+async def test_runner_keeps_headless_slack_child_silent(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=80,
+        parent_run_id=78,
+        root_run_id=78,
+        thread_id="headless-worker:78:abc",
+        status="completed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "response_target": {"channel_id": "C456", "thread_ts": "1716900000.000100"},
+            },
+        },
+        metadata_={"final_answer_target_surface": "slack", "headless": True},
+    )
+
+    async def fail_client_for_run(_run):
+        raise AssertionError("Headless child should not request a Slack client")
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
+
+    assert await runner._settle_slack_origin_run_async(object(), run) is None
 
 
 async def test_runner_does_not_mirror_after_same_run_ai_timeline_tool_message():

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -838,7 +838,14 @@ async def test_manage_idea_create_queued_admits_run_instead_of_empty_queue(monke
 
     monkeypatch.setattr(idea_tools, "_serialize_idea", serialize_idea)
 
-    with bind_agent_context({"idea_id": "parent-idea", "org_id": "org-1", "user_id": "user-1"}):
+    with bind_agent_context(
+        {
+            "idea_id": "parent-idea",
+            "org_id": "org-1",
+            "user_id": "user-1",
+            "execution_metadata": {"required_response_tool": "post_thread_discussion_reply"},
+        }
+    ):
         payload = json.loads(
             await idea_tools._handle_manage_idea(
                 action="create",
@@ -853,8 +860,74 @@ async def test_manage_idea_create_queued_admits_run_instead_of_empty_queue(monke
     assert payload["created"] is True
     assert payload["run_started"] is True
     assert payload["run_id"] == 321
+    assert payload["next_action"]["repeat_guard"] == {
+        "tool": "manage_idea",
+        "same_request": "do_not_repeat",
+    }
+    assert "Do not call manage_idea again" in payload["next_action"]["instruction"]
+    assert "post_thread_discussion_reply" in payload["next_action"]["instruction"]
     assert payload["idea"]["status"] == "working"
     assert admitted == ["idea-created"]
+
+
+async def test_manage_idea_started_run_inherits_originating_surface_without_stealing_thread_final(
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
+
+    captured = {}
+    idea = SimpleNamespace(id="idea-created", org_id="org-1", title="Check packages")
+
+    async def admit(session_arg, event):
+        del session_arg
+        captured["event"] = event
+        return SimpleNamespace(ok=True, run_id=322, skipped_reason=None)
+
+    monkeypatch.setattr(idea_tools, "admit_work", admit)
+
+    with bind_agent_context(
+        {
+            "run_id": 7,
+            "org_id": "org-1",
+            "user_id": "user-1",
+            "execution_metadata": {
+                "target_ref": {
+                    "originating_surface": "slack",
+                    "source_surface": "slack",
+                    "required_response_tool": "post_slack_reply",
+                    "final_answer_target_surface": "slack",
+                    "slack_trigger": {
+                        "channel_id": "C456",
+                        "response_target": {"channel_id": "C456", "thread_ts": "1716900000.000100"},
+                    },
+                    "slack_thread_id": "slack:T789:C456:1716900000.000100",
+                }
+            },
+        }
+    ):
+        result = await idea_tools._admit_created_idea_run(
+            object(),
+            idea=idea,
+            seed_content="Scan the repository manifests for affected packages.",
+            actor_user_id="user-1",
+            parent_id=None,
+            origin_ref="slack:T789:C456:1716900000.000100",
+            thread_message_id=43,
+        )
+
+    assert result.run_id == 322
+    event = captured["event"]
+    assert event.target == {"kind": "cortex_idea", "idea_id": "idea-created"}
+    metadata = event.payload["metadata"]
+    assert metadata["originating_surface"] == "slack"
+    assert metadata["source_surface"] == "slack"
+    assert metadata["required_response_tool"] == "post_slack_reply"
+    assert metadata["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert metadata["slack_trigger"]["channel_id"] == "C456"
+    assert "final_answer_target_surface" not in metadata
+    assert metadata["created_by_tool"] == "manage_idea"
+    assert metadata["created_by_run_id"] == 7
 
 
 def test_unified_stream_synthesizes_visible_final_answer_from_run_artifact():

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -364,7 +364,8 @@ def test_slack_adapter_builds_teammate_trigger():
         "thread_ts": None,
         "visibility": "public",
     }
-    assert "normal Illospace tools" in trigger.payload["run_message"]
+    assert "Decide whether this is a simple Slack reply" in trigger.payload["run_message"]
+    assert "thread_url" in trigger.payload["run_message"]
     assert "post_slack_reply" in trigger.payload["run_message"]
 
 
@@ -413,6 +414,45 @@ async def test_slack_work_intake_builds_surface_aware_agent_run_request():
 
 
 @pytest.mark.asyncio
+async def test_slack_work_intake_uses_backing_cortex_thread_when_provided():
+    from brain.app.triggers.adapters.slack import build_slack_message_trigger
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    trigger = build_slack_message_trigger(
+        org_id="org-1",
+        authority_user_id="owner-1",
+        payload={
+            "event_kind": "mention",
+            "origin": "slack.app_mention",
+            "team_id": "T789",
+            "channel_id": "C456",
+            "channel_type": "channel",
+            "message_ts": "1716900000.000100",
+            "thread_ts": "1716900000.000100",
+            "slack_user_id": "U123",
+            "text": "<@BILLO> ship it",
+        },
+        connection_id="conn-1",
+        idempotency_key="slack:T789:C456:1716900000.000100",
+    ).to_payload()
+    trigger["target"]["idea_id"] = "idea-123"
+    trigger["target"]["thread_id"] = "idea-123"
+    trigger["target"]["thread_url"] = "https://illo.example.com/threads/idea-123"
+
+    request = await build_agent_run_request(
+        object(),
+        WorkIntakeEvent.from_trigger_payload(trigger),
+    )
+
+    assert request.thread_id == "idea-123"
+    assert request.target_ref["idea_id"] == "idea-123"
+    assert request.target_ref["thread_id"] == "idea-123"
+    assert request.target_ref["thread_url"] == "https://illo.example.com/threads/idea-123"
+    assert request.target_ref["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert request.target_ref["related_surfaces"]["slack"]["thread_id"] == "slack:T789:C456:1716900000.000100"
+
+
+@pytest.mark.asyncio
 async def test_slack_inbound_envelope_records_event_and_admits_slack_run(session):
     from brain.systems.inbound.service import submit_inbound_envelope
     from brain.systems.slack.ingress import normalize_slack_socket_event
@@ -439,11 +479,19 @@ async def test_slack_inbound_envelope_records_event_and_admits_slack_run(session
     assert event.status == "processed"
     assert event.action_type == "slack.run_admitted"
     assert event.ingress_context["transport"] == "slack_socket_mode"
+    assert "idea_id" not in result["ilo_outcome"]
+    assert "thread_id" not in result["ilo_outcome"]
+    assert "thread_url" not in result["ilo_outcome"]
     assert run.thread_id == "slack:T789:C456:1716900000.000100"
     assert run.target_ref["kind"] == "slack_message"
+    assert run.target_ref["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
     assert run.metadata_["slack_trigger"]["channel_id"] == "C456"
+    assert run.metadata_["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert "cortex_thread" not in run.metadata_
     assert run.metadata_["inbound_event"]["event_id"] == str(event.id)
     assert receipt.target["kind"] == "slack_message"
+    assert receipt.target["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert receipt.tool_use["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
 
     replay = await submit_inbound_envelope(
         session,
@@ -493,14 +541,64 @@ async def test_duplicate_slack_events_across_connection_rows_share_one_run(sessi
 
     assert len(events) == 2
     assert len(runs) == 1
+    assert runs[0].thread_id == "slack:T789:C456:1716900000.000100"
     assert runs[0].source_idempotency_scope == "slack"
     assert runs[0].source_idempotency_key == "slack:T789:C456:1716900000.000100"
+    assert "thread_id" not in first["ilo_outcome"]
+    assert "thread_id" not in second["ilo_outcome"]
     assert first["ilo_outcome"]["run_id"] == runs[0].id
     assert second["ilo_outcome"]["run_id"] == runs[0].id
 
 
 @pytest.mark.asyncio
-async def test_slack_connector_sets_processing_status_for_actionable_payload(session, monkeypatch):
+async def test_slack_thread_followup_reuses_slack_conversation_key_with_new_run(session):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    connection = await _seed_slack_connection(session)
+    first_message = normalize_slack_socket_event(
+        _socket_mode_app_mention(text="<@BILLO> go launch a thread for this"),
+        bot_user_id="BILLO",
+    )
+    followup_message = normalize_slack_socket_event(
+        _socket_mode_app_mention(
+            text="<@BILLO> is the thread ongoing? can you share the link?",
+            ts="1716900300.000400",
+            event_ts="1716900300.000400",
+            thread_ts="1716900000.000100",
+            event_id="Ev-followup",
+        ),
+        bot_user_id="BILLO",
+    )
+
+    first = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=first_message,
+        ingress_context={"transport": "slack_socket_mode", "envelope_id": "env-1"},
+    )
+    followup = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=followup_message,
+        ingress_context={"transport": "slack_socket_mode", "envelope_id": "env-2"},
+    )
+
+    runs = (await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id.asc()))).all()
+
+    assert len(runs) == 2
+    assert runs[0].thread_id == "slack:T789:C456:1716900000.000100"
+    assert runs[1].thread_id == "slack:T789:C456:1716900000.000100"
+    assert runs[0].source_idempotency_key == "slack:T789:C456:1716900000.000100"
+    assert runs[1].source_idempotency_key == "slack:T789:C456:1716900300.000400"
+    assert first["ilo_outcome"]["slack"]["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert followup["ilo_outcome"]["slack"]["slack_thread_id"] == "slack:T789:C456:1716900000.000100"
+    assert "thread_url" not in first["ilo_outcome"]
+    assert "thread_url" not in followup["ilo_outcome"]
+
+
+@pytest.mark.asyncio
+async def test_slack_connector_does_not_send_backend_authored_ack_for_actionable_payload(session, monkeypatch):
     from brain.systems.slack import connector
 
     connection = await _seed_slack_connection(session)
@@ -513,6 +611,10 @@ async def test_slack_connector_sets_processing_status_for_actionable_payload(ses
         async def set_assistant_status(self, **kwargs):
             calls.append(("status", kwargs))
             return {"ok": True}
+
+        async def post_message(self, **kwargs):
+            calls.append(("message", kwargs))
+            return {"ok": True, "ts": "1716900001.000200", "channel": kwargs["channel"]}
 
     monkeypatch.setattr(connector, "SlackWebClient", _SlackClient, raising=False)
 
@@ -527,21 +629,11 @@ async def test_slack_connector_sets_processing_status_for_actionable_payload(ses
         ),
     )
 
-    assert calls == [
-        ("init", "xoxb-test"),
-        (
-            "status",
-            {
-                "channel_id": "C456",
-                "thread_ts": "1716900000.000100",
-                "status": "is working on it...",
-            },
-        ),
-    ]
+    assert calls == []
 
 
 @pytest.mark.asyncio
-async def test_slack_connector_does_not_reset_status_for_existing_duplicate_run(session, monkeypatch):
+async def test_slack_connector_does_not_send_backend_authored_ack_for_duplicate_run(session, monkeypatch):
     from brain.systems.slack import connector
 
     first_connection = await _seed_slack_connection(session)
@@ -555,6 +647,10 @@ async def test_slack_connector_does_not_reset_status_for_existing_duplicate_run(
         async def set_assistant_status(self, **kwargs):
             calls.append(("status", kwargs))
             return {"ok": True}
+
+        async def post_message(self, **kwargs):
+            calls.append(("message", kwargs))
+            return {"ok": True, "ts": "1716900001.000200", "channel": kwargs["channel"]}
 
     monkeypatch.setattr(connector, "SlackWebClient", _SlackClient, raising=False)
 
@@ -579,17 +675,7 @@ async def test_slack_connector_does_not_reset_status_for_existing_duplicate_run(
         ),
     )
 
-    assert calls == [
-        ("init", "xoxb-test"),
-        (
-            "status",
-            {
-                "channel_id": "C456",
-                "thread_ts": "1716900000.000100",
-                "status": "is working on it...",
-            },
-        ),
-    ]
+    assert calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes global surface triage so Illo answers simple requests on the originating surface and delegates long work durably with child runs. Adds repeat guards to delegation tool results so parent runs settle after manage_idea/spawn_worker instead of looping.\n\nVerification:\n- venv/bin/python -m pytest tests/test_slack_teammate.py tests/test_agent_run_runtime.py tests/test_work_intake.py tests/test_work_intake_full_architecture.py tests/test_triggers.py tests/test_api_cortex.py::test_manage_idea_started_run_inherits_originating_surface_without_stealing_thread_final tests/test_api_cortex.py::test_manage_idea_create_queued_admits_run_instead_of_empty_queue\n- Hosted probe a577b8e9-f165-440f-a6ac-9bfcdd27d09c confirmed deployed old behavior still loops after spawning child run 784; this PR addresses that branch code path.