### PR TITLE
Allow personal OpenAI provider sign-in

### DIFF
--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -18,6 +18,7 @@
     navigateOpenAIOAuthPopup,
     openOpenAIOAuthPopup,
   } from '$lib/utils/oauthPopup';
+  import { hasPersonalOpenAIRuntimeConnection } from '$lib/utils/runtimeOnboarding';
   import { auth } from '$lib/stores/auth.svelte';
 
   import MemoryCard from './MemoryCard.svelte';
@@ -100,6 +101,7 @@
   });
 
   const canManageSettings = $derived(settings?.permissions?.can_manage_settings ?? false);
+  const hasPersonalOpenAIConnection = $derived(hasPersonalOpenAIRuntimeConnection(settings));
   const connectionStatus = $derived(settings?.connection?.status ?? 'missing');
   const modelOptions = $derived(settings?.models?.options ?? []);
   const setupMode = $derived($page.url.searchParams.get('setup') === '1');
@@ -824,12 +826,11 @@
     <div class="runtime-config-layout">
       <div class="runtime-primary-column">
         <ProviderConnections
-          {connectionStatus}
           {oauthUrl}
           {oauthCallback}
           oauthPending={Boolean(oauthUrl)}
           {oauthCallbackMode}
-          {canManageSettings}
+          hasPersonalConnection={hasPersonalOpenAIConnection}
           {savingConnection}
           onCallbackChange={(value) => (oauthCallback = value)}
           onStartCodexSignIn={() => startCodexSignIn()}

--- a/frontend/src/routes/system/ProviderConnections.svelte
+++ b/frontend/src/routes/system/ProviderConnections.svelte
@@ -2,24 +2,22 @@
   import { ConstellationButton, ConstellationIcon } from '$lib/components/constellation';
 
   let {
-    connectionStatus,
     oauthUrl,
     oauthCallback,
     oauthPending,
     oauthCallbackMode,
-    canManageSettings,
+    hasPersonalConnection,
     savingConnection,
     onCallbackChange,
     onStartCodexSignIn,
     onStartLocalCodexSignIn,
     onFinishCodexSignIn,
   }: {
-    connectionStatus: string;
     oauthUrl: string;
     oauthCallback: string;
     oauthPending: boolean;
     oauthCallbackMode: 'server' | 'local_bridge' | 'manual';
-    canManageSettings: boolean;
+    hasPersonalConnection: boolean;
     savingConnection: boolean;
     onCallbackChange: (value: string) => void;
     onStartCodexSignIn: () => void;
@@ -27,11 +25,10 @@
     onFinishCodexSignIn: () => void;
   } = $props();
 
-  const hasModelAccess = $derived(connectionStatus === 'connected');
   const openAiActionLabel = $derived(openAiConnectionActionLabel());
 
   function openAiConnectionActionLabel() {
-    if (hasModelAccess) return 'Manage';
+    if (hasPersonalConnection) return 'Manage';
     return oauthPending ? 'Open again' : 'Connect';
   }
 </script>
@@ -60,7 +57,7 @@
         size="sm"
         onclick={onStartCodexSignIn}
         loading={savingConnection}
-        disabled={!canManageSettings}
+        disabled={savingConnection}
       >
         {openAiActionLabel}
       </ConstellationButton>
@@ -69,20 +66,20 @@
     <button
       type="button"
       class="connect-provider-row"
-      disabled={!canManageSettings || savingConnection}
+      disabled={savingConnection}
       onclick={onStartCodexSignIn}
     >
       <span class="connect-provider-icon" aria-hidden="true">
         <ConstellationIcon name="plus" size={15} />
       </span>
       <span class="connect-provider-copy">
-        <strong>Connect provider</strong>
-        <span>API key, OAuth, or custom endpoint</span>
+        <strong>Connect personal account</strong>
+        <span>ChatGPT / Codex sign-in</span>
       </span>
     </button>
   </div>
 
-  {#if oauthPending && !hasModelAccess}
+  {#if oauthPending && !hasPersonalConnection}
     <div class="oauth-callback-row">
       {#if oauthUrl}
         <a class="oauth-sign-in-link" href={oauthUrl} target="_blank" rel="noreferrer">

--- a/tests/test_openai_oauth_ui_contract.py
+++ b/tests/test_openai_oauth_ui_contract.py
@@ -20,9 +20,20 @@ def test_onboarding_shows_manual_callback_escape_hatch_while_oauth_is_pending():
 def test_system_access_card_expands_manual_callback_while_oauth_is_pending():
     source = (ROOT / "frontend/src/routes/system/ProviderConnections.svelte").read_text()
 
-    assert "{#if oauthPending && !hasModelAccess}" in source
+    assert "{#if oauthPending && !hasPersonalConnection}" in source
     assert "oauthUrl: string;" in source
     assert 'href={oauthUrl}' in source
+
+
+def test_system_provider_connection_is_not_admin_gated():
+    card = (ROOT / "frontend/src/routes/system/ProviderConnections.svelte").read_text()
+    page = (ROOT / "frontend/src/routes/system/+page.svelte").read_text()
+
+    assert "hasPersonalOpenAIRuntimeConnection(settings)" in page
+    assert "hasPersonalConnection={hasPersonalOpenAIConnection}" in page
+    assert "canManageSettings: boolean;" not in card
+    assert "disabled={!canManageSettings}" not in card
+    assert "disabled={!canManageSettings || savingConnection}" not in card
 
 
 def test_system_oauth_start_keeps_page_open_when_popup_is_blocked():


### PR DESCRIPTION
## Summary
- allow authenticated users to start personal ChatGPT/Codex sign-in from AI Runtime without owner/admin runtime-setting permissions
- keep org/runtime settings gated behind canManageSettings
- use the existing personal OpenAI connection helper so manual OAuth fallback is based on personal connection state

## Verification
- venv/bin/python -m pytest tests/test_openai_oauth_ui_contract.py
- npm run check
- npm test
- thermo-nuclear-code-quality-review: passed, no structural blockers