### PR TITLE
Prefer public OpenAI OAuth callback for deployed hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ GEMINI_API_KEY=
 
 # Remote System tabs use the Illo server /auth/callback route for Codex sign-in.
 # Set to 0 to force the localhost bridge/manual callback flow.
-# ILLO_OPENAI_OAUTH_SERVER_CALLBACK=1
+# ILLO_OPENAI_OAUTH_SERVER_CALLBACK=0
 
 # Embeddings: api is the easiest public default; gpu/cpu are also supported.
 EMBEDDING_BACKEND=api

--- a/README.md
+++ b/README.md
@@ -141,13 +141,10 @@ restore, upgrades, logs, and status.
 - `./illo setup` creates ignored checkout-local defaults for `SECRET_KEY` and
   `VAULT_MASTER_KEY` in `.illo/runtime.env` when they are not provided, so a
   self-hosted preview can boot cleanly.
-- Codex sign-in uses OpenAI's localhost callback. On a remote/self-hosted
-  server or Docker Compose install, Illospace opens the manual fallback
-  automatically: finish sign-in, copy the final
-  `localhost:1455/auth/callback?...` URL from the sign-in tab, and paste it
-  back into Illospace. Custom server callbacks are opt-in with
-  `ILLO_OPENAI_OAUTH_SERVER_CALLBACK=1` only for OAuth clients that accept your
-  deployed callback URL.
+- Codex sign-in on public/self-hosted deployments uses your browser-facing
+  `ILLO_PUBLIC_URL` `/auth/callback` route by default. Set
+  `ILLO_OPENAI_OAUTH_SERVER_CALLBACK=0` to force the localhost bridge/manual
+  callback fallback.
 - For local file-based overrides, copy `.env.example` to `.env` and fill in the
   values you need. For production, prefer your platform's secret manager or an
   external environment file such as `~/.config/illospace/production.env`.

--- a/brain/systems/runtime_settings/auth.py
+++ b/brain/systems/runtime_settings/auth.py
@@ -193,22 +193,37 @@ def _local_bridge_enabled() -> bool:
     return _env_flag("ILLO_OPENAI_OAUTH_LOCAL_BRIDGE", True)
 
 
-def _request_origin(request: Request) -> str | None:
+def _server_callback_enabled() -> bool:
+    return _env_flag("ILLO_OPENAI_OAUTH_SERVER_CALLBACK", True)
+
+
+def _configured_public_origin() -> str | None:
+    for name in ("ILLO_PUBLIC_URL", "ILLO_DASHBOARD_URL"):
+        origin = _origin_from_header(os.getenv(name))
+        if origin and not _is_loopback_origin(origin):
+            return origin
+    return None
+
+
+def _request_header_origin(request: Request) -> str | None:
     candidates = [
         _origin_from_header(request.headers.get("origin")),
         _origin_from_header(request.headers.get("referer")),
+    ]
+    return next((candidate for candidate in candidates if candidate), None)
+
+
+def _request_origin(request: Request) -> str | None:
+    candidates = [
+        _configured_public_origin(),
+        _request_header_origin(request),
         _origin_from_header(str(request.base_url)),
     ]
     return next((candidate for candidate in candidates if candidate), None)
 
 
 def _oauth_callback_return_url(request: Request) -> str:
-    candidates = [
-        _origin_from_header(request.headers.get("origin")),
-        _origin_from_header(request.headers.get("referer")),
-        _origin_from_header(str(request.base_url)),
-    ]
-    origin = next((candidate for candidate in candidates if candidate), None)
+    origin = _request_origin(request)
     if origin is None:
         origin = "http://localhost:8000"
     return f"{origin.rstrip('/')}/auth/callback"
@@ -222,14 +237,11 @@ def _oauth_server_redirect_uri(request: Request) -> str | None:
 
 
 def _oauth_callback_mode(request: Request, requested_mode: str) -> str:
-    # The Codex OAuth client is registered for the localhost callback. A custom
-    # self-hosted callback must stay opt-in because providers can reject it
-    # before Illo receives a recoverable callback URL.
     if requested_mode == "local_bridge":
         return "local_bridge"
-    if requested_mode == "server" and _env_flag("ILLO_OPENAI_OAUTH_SERVER_CALLBACK", False):
-        return "server" if _oauth_server_redirect_uri(request) else "local_bridge"
-    return "local_bridge"
+    if not _server_callback_enabled():
+        return "local_bridge"
+    return "server" if _oauth_server_redirect_uri(request) else "local_bridge"
 
 
 def start_openai_oauth(request: Request, *, callback_mode: str = "auto") -> dict[str, object]:

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -55,12 +55,13 @@ Memory setup is also runtime-managed: choosing OpenAI/Gemini memory saves the
 non-secret embedding settings in Postgres and encrypts the embedding API key
 with `VAULT_MASTER_KEY`. The Compose app image and `/app/.env` are not mutated.
 
-OpenAI/Codex sign-in uses OpenAI's registered localhost callback. In this
-Compose deployment, the API runs inside a container, so the browser's
-`localhost:1455` is your workstation, not the API container. Illospace therefore
-shows the manual callback field by default: finish OpenAI sign-in, copy the
-final `localhost:1455/auth/callback?...` URL from the sign-in tab, and paste it
-back into Illospace.
+OpenAI/Codex sign-in uses `<ILLO_PUBLIC_URL>/auth/callback` automatically when
+`ILLO_PUBLIC_URL` is a public browser-facing URL. In localhost-only Compose
+access, the API runs inside a container, so the browser's `localhost:1455` is
+your workstation, not the API container; Illospace keeps the manual callback
+fallback available. Copy the final `localhost:1455/auth/callback?...` URL from
+the sign-in tab and paste it back into Illospace if automatic return is not
+available.
 
 For team-wide access, put your own reverse proxy, VPN, tunnel, or private
 network in front of `127.0.0.1:8080`, then set `ILLO_PUBLIC_URL` to that

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -75,11 +75,11 @@ ssh -L 8080:127.0.0.1:8080 <ssh-user>@<server>
 Then open `http://localhost:8080`, create the owner account, and add provider
 credentials in System/Access.
 
-For OpenAI/Codex sign-in, the manual callback fallback is expected in the
-Compose path. OpenAI redirects to `localhost:1455` in your browser, but the API
-container cannot receive that workstation-local callback. Copy the final
-`localhost:1455/auth/callback?...` URL from the sign-in tab and paste it into
-the callback field in Illospace.
+For OpenAI/Codex sign-in, a public `ILLO_PUBLIC_URL` makes OpenAI return to
+`<ILLO_PUBLIC_URL>/auth/callback` automatically. If you leave the app on a
+localhost-only SSH tunnel, Illospace keeps using the localhost bridge/manual
+callback fallback; copy the final `localhost:1455/auth/callback?...` URL from
+the sign-in tab and paste it into the callback field.
 
 For team-wide access, put your own reverse proxy, VPN, tunnel, or private
 network in front of `127.0.0.1:8080`, then update `ILLO_PUBLIC_URL` if browser

--- a/tests/test_openai_user_auth_connect.py
+++ b/tests/test_openai_user_auth_connect.py
@@ -45,7 +45,7 @@ def test_start_openai_oauth_stashes_pkce_state_in_runtime_settings_session():
     register_target.assert_called_once_with("state-123", "http://127.0.0.1:5176/auth/callback")
 
 
-def test_start_openai_oauth_uses_localhost_fallback_for_public_base_url_by_default():
+def test_start_openai_oauth_uses_server_callback_for_public_base_url_by_default():
     from brain.systems.runtime_settings.auth import OPENAI_OAUTH_SESSION_KEY, start_openai_oauth
 
     request = _RequestStub(
@@ -62,15 +62,14 @@ def test_start_openai_oauth_uses_localhost_fallback_for_public_base_url_by_defau
     ) as mock_build, patch("brain.systems.runtime_settings.auth.register_callback_target") as register_target:
         result = start_openai_oauth(request=request)
 
-    assert result["redirect_uri"] == "http://localhost:1455/auth/callback"
-    assert result["callback_available"] is False
-    assert result["callback_mode"] == "local_bridge"
-    assert "localhost:1455" in str(result["callback_detail"])
-    assert "paste" in str(result["callback_detail"]).lower()
-    assert request.session[OPENAI_OAUTH_SESSION_KEY]["redirect_uri"] == "http://localhost:1455/auth/callback"
+    assert result["redirect_uri"] == "https://illo.example.com/auth/callback"
+    assert result["callback_available"] is True
+    assert result["callback_mode"] == "server"
+    assert "Illo server" in str(result["callback_detail"])
+    assert request.session[OPENAI_OAUTH_SESSION_KEY]["redirect_uri"] == "https://illo.example.com/auth/callback"
     assert request.session[OPENAI_OAUTH_SESSION_KEY]["return_url"] == "https://illo.example.com/auth/callback"
-    assert request.session[OPENAI_OAUTH_SESSION_KEY]["callback_mode"] == "local_bridge"
-    mock_build.assert_called_once_with(redirect_uri="http://localhost:1455/auth/callback")
+    assert request.session[OPENAI_OAUTH_SESSION_KEY]["callback_mode"] == "server"
+    mock_build.assert_called_once_with(redirect_uri="https://illo.example.com/auth/callback")
     ensure_callback.assert_not_called()
     register_target.assert_not_called()
 
@@ -105,9 +104,10 @@ def test_start_openai_oauth_disables_local_bridge_for_compose_loopback_origin(mo
     register_target.assert_not_called()
 
 
-def test_start_openai_oauth_requires_opt_in_for_server_callback_for_public_base_url():
+def test_start_openai_oauth_can_disable_server_callback_for_public_base_url(monkeypatch):
     from brain.systems.runtime_settings.auth import OPENAI_OAUTH_SESSION_KEY, start_openai_oauth
 
+    monkeypatch.setenv("ILLO_OPENAI_OAUTH_SERVER_CALLBACK", "0")
     request = _RequestStub(
         headers={"origin": "https://illo.example.com"},
         base_url="https://illo.example.com/",
@@ -130,10 +130,9 @@ def test_start_openai_oauth_requires_opt_in_for_server_callback_for_public_base_
     register_target.assert_not_called()
 
 
-def test_start_openai_oauth_can_opt_in_server_callback_for_public_base_url(monkeypatch):
+def test_start_openai_oauth_accepts_explicit_server_callback_for_public_base_url():
     from brain.systems.runtime_settings.auth import OPENAI_OAUTH_SESSION_KEY, start_openai_oauth
 
-    monkeypatch.setenv("ILLO_OPENAI_OAUTH_SERVER_CALLBACK", "1")
     request = _RequestStub(
         headers={"origin": "https://illo.example.com"},
         base_url="https://illo.example.com/",
@@ -159,6 +158,34 @@ def test_start_openai_oauth_can_opt_in_server_callback_for_public_base_url(monke
     ensure_callback.assert_not_called()
     register_target.assert_not_called()
 
+
+
+def test_start_openai_oauth_uses_configured_public_url_when_request_origin_is_loopback(monkeypatch):
+    from brain.systems.runtime_settings.auth import OPENAI_OAUTH_SESSION_KEY, start_openai_oauth
+
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://team.example.com")
+    request = _RequestStub(
+        headers={"origin": "http://localhost:8080"},
+        base_url="http://localhost:8080/",
+        session={},
+    )
+
+    with patch(
+        "brain.systems.runtime_settings.auth.ensure_callback_server",
+    ) as ensure_callback, patch(
+        "brain.systems.runtime_settings.auth.build_codex_oauth_authorize_url",
+        return_value=("https://auth.openai.com/oauth/authorize?state=state-123", "state-123", "verifier-123"),
+    ) as mock_build, patch("brain.systems.runtime_settings.auth.register_callback_target") as register_target:
+        result = start_openai_oauth(request=request)
+
+    assert result["redirect_uri"] == "https://team.example.com/auth/callback"
+    assert result["callback_available"] is True
+    assert result["callback_mode"] == "server"
+    assert request.session[OPENAI_OAUTH_SESSION_KEY]["redirect_uri"] == "https://team.example.com/auth/callback"
+    assert request.session[OPENAI_OAUTH_SESSION_KEY]["return_url"] == "https://team.example.com/auth/callback"
+    mock_build.assert_called_once_with(redirect_uri="https://team.example.com/auth/callback")
+    ensure_callback.assert_not_called()
+    register_target.assert_not_called()
 
 def test_start_openai_oauth_can_force_localhost_fallback_for_public_base_url():
     from brain.systems.runtime_settings.auth import OPENAI_OAUTH_SESSION_KEY, start_openai_oauth


### PR DESCRIPTION
## Summary
- default OpenAI/Codex OAuth to the deployed server callback when a public origin is available
- prefer `ILLO_PUBLIC_URL`/`ILLO_DASHBOARD_URL` over loopback request origins when building `/auth/callback`
- keep localhost/manual fallback for loopback-only access or `ILLO_OPENAI_OAUTH_SERVER_CALLBACK=0`
- update docs and tests for the new callback behavior

## Validation
- `python3 -m compileall brain/systems/runtime_settings/auth.py tests/test_openai_user_auth_connect.py tests/test_runtime_settings_oauth_start_route.py`
- direct behavioral script covering public origin default, disabled server callback, `ILLO_PUBLIC_URL` over loopback, and loopback fallback

Note: `pytest` is not installed in this runtime (`python3: No module named pytest`), so full pytest execution could not run here.
