### PR TITLE
Fix runtime introspection wrapper hijack

### DIFF
--- a/brain/systems/runs/direct_loop/final_reply.py
+++ b/brain/systems/runs/direct_loop/final_reply.py
@@ -5,14 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-
-def extract_latest_user_intent(message: str) -> str:
-    """Extract the latest user request from coordinator task wrappers when present."""
-    text = (message or "").strip()
-    marker = "Latest user message:"
-    if marker in text:
-        return text.split(marker, 1)[1].strip() or text
-    return text
+from brain.systems.runs.message_metadata import extract_latest_user_intent
 
 
 def parse_checker_payload(raw_output: str) -> dict | None:

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -9,7 +9,10 @@ from brain.systems.runs.capabilities import (
     registry_capability_manifests,
 )
 from brain.systems.runs.execution_context import _agent_context
-from brain.systems.runs.message_metadata import INTROSPECTION_MESSAGE_METADATA_KEYS
+from brain.systems.runs.message_metadata import (
+    INTROSPECTION_MESSAGE_METADATA_KEYS,
+    extract_latest_user_intent,
+)
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 _PERSON_ACTIVITY_PATTERNS = (
@@ -65,25 +68,34 @@ _WORKSPACE_RECORD_PHRASES = (
     "team database",
     "workspace records",
 )
-_CAPABILITY_SETUP_PATTERNS = (
+_CAPABILITY_SETUP_VERB_PATTERN = re.compile(
+    r"\b(?:set\s+(?:you|illo|it|this|that|me|us|them)\s+up|set\s*up|setup|connect|integrate|install|configure|enable)\b"
+)
+_CAPABILITY_CONTEXT_PATTERNS = (
     re.compile(
-        r"\b(?:set\s+(?:you|illo|it|this|that|me|us|them)\s+up|set\s*up|setup|connect|integrate|install|configure|enable)\b"
-    ),
-    re.compile(
-        r"\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+        r"\b(?:set\s*up|setup|connect|integrate|install|configure|enable)\b"
         r"[^?]{0,100}\b(?:you|illo|agent|integration|connector|capability|tool|plugin|app|mcp)\b"
     ),
     re.compile(
         r"\b(?:you|illo|agent|integration|connector|capability|tool|plugin|app|mcp)\b"
-        r"[^?]{0,100}\b(?:set\s*up|setup|connect|integrate|install|configure|enable|add)\b"
+        r"[^?]{0,100}\b(?:set\s*up|setup|connect|integrate|install|configure|enable)\b"
     ),
+)
+_CAPABILITY_ADD_CONTEXT_PATTERNS = (
+    re.compile(
+        r"\badd\b[^?]{0,100}\b(?:integration|connector|capability|plugin|mcp)\b"
+    ),
+    re.compile(
+        r"\b(?:integration|connector|capability|plugin|mcp)\b[^?]{0,100}\badd\b"
+    ),
+)
+_CAPABILITY_QUESTION_PATTERNS = (
     re.compile(r"\b(?:what|which)\b[^?]{0,80}\b(?:capabilities|integrations|connectors|plugins|tools)\b"),
     re.compile(r"\b(?:what|which)\b[^?]{0,80}\b(?:can|could)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:do|help)\b"),
     re.compile(r"\b(?:what|which)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:do|help)\b"),
     re.compile(r"\bhelp\b[^?]{0,80}\b(?:what|which)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:do|help)\b"),
     re.compile(r"\bhelp\b[^?]{0,80}\b(?:what|which)\b[^?]{0,40}\b(?:you|illo)\b[^?]{0,40}\b(?:can|could)\b[^?]{0,40}\b(?:do|help)\b"),
 )
-_CAPABILITY_CONTEXT_PATTERN_COUNT = 3
 
 
 def _normalized_text(message: str | None) -> str:
@@ -103,13 +115,13 @@ def _looks_like_capability_setup_question(message: str | None) -> bool:
     text = _normalized_text(message)
     if not text:
         return False
-    setup_verb = bool(_CAPABILITY_SETUP_PATTERNS[0].search(text))
-    context_patterns = _CAPABILITY_SETUP_PATTERNS[1:_CAPABILITY_CONTEXT_PATTERN_COUNT]
-    if any(pattern.search(text) for pattern in context_patterns):
+    if any(pattern.search(text) for pattern in _CAPABILITY_CONTEXT_PATTERNS):
         return True
-    if any(pattern.search(text) for pattern in _CAPABILITY_SETUP_PATTERNS[_CAPABILITY_CONTEXT_PATTERN_COUNT:]):
+    if any(pattern.search(text) for pattern in _CAPABILITY_ADD_CONTEXT_PATTERNS):
         return True
-    return setup_verb and _mentions_known_capability(text)
+    if any(pattern.search(text) for pattern in _CAPABILITY_QUESTION_PATTERNS):
+        return True
+    return bool(_CAPABILITY_SETUP_VERB_PATTERN.search(text)) and _mentions_known_capability(text)
 
 
 def _looks_like_self_context_question(message: str | None) -> bool:
@@ -172,7 +184,7 @@ def message_for_required_introspection(
             value = metadata.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
-    return message
+    return extract_latest_user_intent(message)
 
 
 def required_introspection_tool(

--- a/brain/systems/runs/message_metadata.py
+++ b/brain/systems/runs/message_metadata.py
@@ -7,3 +7,14 @@ INTROSPECTION_MESSAGE_METADATA_KEYS = (
     INTROSPECTION_MESSAGE_METADATA_KEY,
     HUMAN_MESSAGE_METADATA_KEY,
 )
+
+
+def extract_latest_user_intent(message: str | None) -> str:
+    """Extract the latest user request from coordinator task wrappers when present."""
+    text = (message or "").strip()
+    marker = "Latest user message:"
+    if marker in text:
+        return text.split(marker, 1)[1].strip() or text
+    if text.startswith("[Idea:") and "\n\n" in text:
+        return text.split("\n\n", 1)[1].strip() or text
+    return text

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1200,6 +1200,90 @@ class TestAgentLoop:
     @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
     @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))
     @patch("brain.systems.runs.direct_agent._save_session")
+    def test_thread_content_action_does_not_force_capability_detour(self, mock_save, mock_load, mock_client):
+        from brain.systems.runs.direct_agent import run_agent
+
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            self._make_response("I found JB's response and added it to the thread."),
+            self._make_response(
+                text=None,
+                stop_reason="tool_use",
+                tool_use={
+                    "name": "read_capabilities",
+                    "input": {"query": "Add JB's response to the thread."},
+                },
+            ),
+            self._make_response("I can help with threads, Slack, workspace tools, and setup."),
+        ]
+        mock_client.return_value = _mock_llm_client(client)
+
+        handler = MagicMock(return_value={"capabilities": [{"key": "threads"}]})
+
+        result = run_agent(
+            message="Add JB's response to the thread.",
+            tools=[{
+                "name": "read_capabilities",
+                "description": "test",
+                "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+            }],
+            tool_handlers={"read_capabilities": handler},
+            persist_session=False,
+        )
+
+        assert result.success
+        assert result.output == "I found JB's response and added it to the thread."
+        assert result.tool_calls == []
+        assert handler.call_count == 0
+        assert client.messages.create.call_count == 1
+
+    @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
+    @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))
+    @patch("brain.systems.runs.direct_agent._save_session")
+    def test_wrapped_thread_reply_uses_latest_message_for_introspection(self, mock_save, mock_load, mock_client):
+        from brain.systems.runs.direct_agent import run_agent
+
+        message = (
+            '[Idea: "Create a skill to analyze our db in prod and connect to postgres" | idea-1]\n\n'
+            "give me the last 10 generations in production with the company associated"
+        )
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            self._make_response("Last 10 production generations: 826324 Roman.co.uk, 826323 Roman.co.uk."),
+            self._make_response(
+                text=None,
+                stop_reason="tool_use",
+                tool_use={
+                    "name": "read_capabilities",
+                    "input": {"query": "current Illo capability and setup context"},
+                },
+            ),
+            self._make_response("I can inspect and act across the workspace: Threads, Domains, Vault, skills."),
+        ]
+        mock_client.return_value = _mock_llm_client(client)
+
+        handler = MagicMock(return_value={"capabilities": [{"key": "vault"}]})
+
+        result = run_agent(
+            message=message,
+            tools=[{
+                "name": "read_capabilities",
+                "description": "test",
+                "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+            }],
+            tool_handlers={"read_capabilities": handler},
+            persist_session=False,
+        )
+
+        assert result.success
+        assert result.output == "Last 10 production generations: 826324 Roman.co.uk, 826323 Roman.co.uk."
+        assert result.tool_calls == []
+        assert handler.call_count == 0
+        assert client.messages.create.call_count == 1
+
+    @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
+    @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))
+    @patch("brain.systems.runs.direct_agent._save_session")
     def test_provenance_question_does_not_loop_when_my_activity_is_not_exposed(self, mock_save, mock_load, mock_client):
         from brain.systems.runs.direct_agent import run_agent
 

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -517,6 +517,7 @@ def test_final_reply_helpers_parse_json_and_cache_review():
     assert payload["missing_requirements"] == ["none"]
     assert ask_payload["status"] == "blocked_on_user"
     assert extract_latest_user_intent("wrapper\nLatest user message:\nShip it") == "Ship it"
+    assert extract_latest_user_intent('[Idea: "Setup context" | idea-1]\n\nShip it') == "Ship it"
     assert "Ship it" in continuation_gate_nudge("Latest user message:\nShip it")
 
     ctx = SimpleNamespace()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -369,6 +369,7 @@ def test_run_introspection_uses_current_human_message_over_thread_wrapper():
     )
 
     assert required_introspection_tool(wrapped_message)[0] == "read_capabilities"
+    assert message_for_required_introspection(wrapped_message) == "where are the results ?"
 
     selected = message_for_required_introspection(
         wrapped_message,
@@ -377,6 +378,34 @@ def test_run_introspection_uses_current_human_message_over_thread_wrapper():
 
     assert selected == "where are the results ?"
     assert required_introspection_tool(selected) == (None, None)
+
+
+def test_thread_content_action_does_not_require_capabilities():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Add JB's response to the thread.")
+
+    assert tool is None
+    assert message is None
+
+
+def test_app_content_action_does_not_require_capabilities():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Add JB's response to the app.")
+
+    assert tool is None
+    assert message is None
+
+
+def test_add_integration_action_still_requires_capabilities():
+    from brain.systems.runs.introspection import required_introspection_tool
+
+    tool, message = required_introspection_tool("Add the Slack integration.")
+
+    assert tool == "read_capabilities"
+    assert message is not None
+    assert "capability/setup context" in message
 
 
 def test_memory_question_does_not_force_workspace_data():


### PR DESCRIPTION
Root cause: mandatory introspection scanned the full Cortex idea wrapper, so stale header words like skill/connect forced read_capabilities after the model had already produced the useful answer. The final output then came from the post-tool capabilities detour.

Fix: share latest-user-intent extraction between final reply handling and required introspection selection, strip Idea wrappers before deciding whether a hidden context tool is mandatory, and narrow generic add matching so thread/app content actions do not force capability setup context.

Tests:
- venv/bin/pytest tests/test_agent.py tests/test_agent_runtime_modules.py tests/test_tool_registry.py -q
- venv/bin/python -m compileall -q brain/systems/runs/direct_loop/final_reply.py brain/systems/runs/direct_agent.py brain/systems/runs/introspection.py brain/systems/runs/message_metadata.py
- direct probe for the production-generations wrapper selects the latest user request and returns (None, None)