### PR TITLE
Add interactive thread artifacts

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -154,7 +154,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
             {
                 "capability": {
                     "type": "string",
-                    "description": "Action capability name, such as thread.create, thread.post_message, handoff.create, domain.record.write, or capabilities.",
+                    "description": "Action capability name, such as thread.create, thread.post_message, thread.artifact.publish, handoff.create, domain.record.write, or capabilities.",
                 },
                 "arguments": {
                     "type": "object",
@@ -495,6 +495,26 @@ ACT_CAPABILITIES: dict[str, dict[str, Any]] = {
             "trigger_illo": "boolean",
         },
     },
+    "thread.artifact.publish": {
+        "description": "Publish or republish an interactive HTML artifact app scoped to an existing Illo thread.",
+        "arguments": {
+            "idea_id": "string",
+            "thread_id": "string",
+            "thread_url": "string",
+            "thread_route": "string",
+            "title": "string",
+            "description": "string",
+            "artifact_kind": "string",
+            "source_code": "string",
+            "app_id": "string",
+            "key": "string",
+            "update_existing": "boolean",
+            "manifest": "object",
+            "visual_spec": "object",
+            "metadata": "object",
+            "initial_state": "object",
+        },
+    },
     **agent_mcp_handoffs.ACT_CAPABILITIES,
     "domain.record.write": {
         "description": "Create, update, or archive records in Illo Domains as the user's external-agent delegate.",
@@ -674,6 +694,39 @@ async def _act_post_thread_message(
     return result
 
 
+async def _act_publish_thread_artifact(
+    db: AsyncSession,
+    principal: external_agents.AgentBridgePrincipal,
+    capability_arguments: dict[str, Any],
+) -> dict[str, Any]:
+    from brain.systems.cortex.thread_artifacts import publish_thread_artifact_app
+
+    result = await publish_thread_artifact_app(
+        db,
+        org_id=principal.org_id,
+        user_id=principal.owner_user_id,
+        thread_id=_thread_argument_id(capability_arguments),
+        title=_required_capability_string(capability_arguments, "title", capability="thread.artifact.publish"),
+        description=_clean_optional_string(capability_arguments.get("description")),
+        artifact_kind=_clean_optional_string(capability_arguments.get("artifact_kind")),
+        source_code=_required_capability_string(capability_arguments, "source_code", capability="thread.artifact.publish"),
+        app_id=_clean_optional_string(capability_arguments.get("app_id")),
+        key=_clean_optional_string(capability_arguments.get("key")),
+        update_existing=bool(capability_arguments.get("update_existing", True)),
+        manifest=_clean_dict(capability_arguments.get("manifest")),
+        visual_spec=_clean_dict(capability_arguments.get("visual_spec")),
+        metadata={
+            **_clean_dict(capability_arguments.get("metadata")),
+            "mcp_tool": ACT_TOOL_NAME,
+            "mcp_capability": "thread.artifact.publish",
+        },
+        initial_state=_clean_dict(capability_arguments.get("initial_state")),
+    )
+    result["_mutates_workspace_app"] = True
+    result["_workspace_app_change"] = {"action": result["action"], "app": result["app"]}
+    return result
+
+
 async def _tool_act(
     db: AsyncSession,
     principal: external_agents.AgentBridgePrincipal,
@@ -697,6 +750,8 @@ async def _tool_act(
             capability_arguments,
             original_arguments=arguments,
         )
+    if capability == "thread.artifact.publish":
+        return await _act_publish_thread_artifact(db, principal, capability_arguments)
     if capability == "handoff.create":
         return await agent_mcp_handoffs.create_handoff(
             db,
@@ -882,6 +937,19 @@ async def _handle_mcp_request(
             await db.commit()
         if tool_payload.pop("_mutates_handoff", False):
             await db.commit()
+        if tool_payload.pop("_mutates_workspace_app", False):
+            workspace_app_change = tool_payload.pop("_workspace_app_change", None)
+            await db.commit()
+            if isinstance(workspace_app_change, dict):
+                from brain.systems.workspace_apps.events import publish_workspace_app_change
+
+                publish_workspace_app_change(
+                    org_id=principal.org_id,
+                    action=str(workspace_app_change.get("action") or "update"),
+                    app=workspace_app_change.get("app"),
+                    app_id=workspace_app_change.get("app_id"),
+                    key=workspace_app_change.get("key"),
+                )
         mutates_thread = bool(spec.get("mutates_thread") or tool_payload.pop("_mutates_thread", False))
         if mutates_thread:
             await _add_thread_trigger_result_if_needed(

--- a/brain/systems/cortex/thread_artifacts.py
+++ b/brain/systems/cortex/thread_artifacts.py
@@ -1,0 +1,239 @@
+"""Thread-scoped interactive artifact publishing."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.idea import Idea
+from brain.systems.cortex.thread_links import thread_route_for_id, thread_url_for_route
+from brain.systems.workspace_apps.compiler import compile_workspace_app_input
+from brain.systems.workspace_apps.contracts import (
+    APP_CAPSULE_RENDERER_KEY,
+    APP_CAPSULE_SOURCE_KIND,
+    APP_KIT_NAME,
+    CONTRACT_VERSION,
+)
+from brain.systems.workspace_apps.service import (
+    WorkspaceAppNotFound,
+    a_create_app,
+    a_get_app,
+    a_serialize_app,
+    a_update_app,
+    slugify,
+)
+
+THREAD_ARTIFACT_SOURCE = "thread_artifact"
+DEFAULT_THREAD_ARTIFACT_KIND = "interactive"
+
+
+class ThreadArtifactError(ValueError):
+    """Raised when a thread artifact cannot be published."""
+
+
+def _clean_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _clean_kind(value: Any) -> str:
+    text = slugify(str(value or DEFAULT_THREAD_ARTIFACT_KIND))
+    return text or DEFAULT_THREAD_ARTIFACT_KIND
+
+
+def _thread_artifact_key(thread_id: str, title: str, artifact_kind: str) -> str:
+    thread_part = slugify(str(thread_id))[:28] or "thread"
+    title_part = slugify(title)[:48] or "artifact"
+    kind_part = slugify(artifact_kind)[:24] or DEFAULT_THREAD_ARTIFACT_KIND
+    return f"thread-{thread_part}-{kind_part}-{title_part}"[:100]
+
+
+def _default_manifest(thread_id: str, artifact_kind: str, manifest: Mapping[str, Any] | None) -> dict[str, Any]:
+    next_manifest = dict(manifest or {})
+    next_manifest.setdefault("contract_version", CONTRACT_VERSION)
+    next_manifest.setdefault("state_key", f"thread-artifact-{thread_id}"[:120])
+    next_manifest.setdefault("data_plan", {"mode": "capability", "bindings": {}})
+    next_manifest.setdefault(
+        "design_contract",
+        {"kit": APP_KIT_NAME, "theme_modes": ["dark", "light"]},
+    )
+    next_manifest["thread_artifact"] = {
+        **dict(next_manifest.get("thread_artifact") or {}),
+        "thread_id": str(thread_id),
+        "kind": artifact_kind,
+        "source": THREAD_ARTIFACT_SOURCE,
+    }
+    return next_manifest
+
+
+def _default_visual_spec(title: str, artifact_kind: str, visual_spec: Mapping[str, Any] | None) -> dict[str, Any]:
+    next_visual = dict(visual_spec or {})
+    next_visual.setdefault(
+        "thumbnail",
+        {
+            "label": title,
+            "status": "Interactive",
+            "secondary": artifact_kind.replace("-", " ").title(),
+        },
+    )
+    return next_visual
+
+
+def _artifact_metadata(
+    *,
+    thread_id: str,
+    artifact_kind: str,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    next_metadata = dict(metadata or {})
+    next_metadata["source"] = THREAD_ARTIFACT_SOURCE
+    next_metadata["artifact_scope"] = "thread"
+    next_metadata["thread_id"] = str(thread_id)
+    next_metadata["artifact_kind"] = artifact_kind
+    next_metadata["thread_artifact"] = {
+        **dict(next_metadata.get("thread_artifact") or {}),
+        "thread_id": str(thread_id),
+        "kind": artifact_kind,
+        "source": THREAD_ARTIFACT_SOURCE,
+    }
+    return next_metadata
+
+
+async def _require_thread(session: AsyncSession, *, org_id: str, thread_id: str) -> None:
+    idea_id = await session.scalar(
+        select(Idea.id).where(
+            Idea.id == str(thread_id),
+            Idea.org_id == str(org_id),
+            Idea.archived_at.is_(None),
+        )
+    )
+    if idea_id is None:
+        raise ThreadArtifactError("Thread not found for this workspace")
+
+
+async def publish_thread_artifact_app(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str | None,
+    thread_id: str,
+    title: str,
+    source_code: str,
+    description: str | None = None,
+    artifact_kind: str | None = None,
+    key: str | None = None,
+    app_id: str | None = None,
+    update_existing: bool = True,
+    manifest: Mapping[str, Any] | None = None,
+    visual_spec: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    initial_state: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create or update a thread-scoped app-capsule artifact."""
+
+    clean_thread_id = _clean_text(thread_id)
+    clean_title = _clean_text(title)
+    clean_source = str(source_code or "").strip()
+    if not clean_thread_id:
+        raise ThreadArtifactError("thread_id is required")
+    if not clean_title:
+        raise ThreadArtifactError("title is required")
+    if not clean_source:
+        raise ThreadArtifactError("source_code is required")
+
+    await _require_thread(session, org_id=org_id, thread_id=clean_thread_id)
+    clean_kind = _clean_kind(artifact_kind)
+    app_key = _clean_text(key) or _thread_artifact_key(clean_thread_id, clean_title, clean_kind)
+    route = thread_route_for_id(clean_thread_id)
+    artifact_route = f"{route}?app={app_id or app_key}"
+    thread_url = thread_url_for_route(route)
+
+    compiled = compile_workspace_app_input(
+        action="create",
+        name=clean_title,
+        key=app_key,
+        renderer_key=APP_CAPSULE_RENDERER_KEY,
+        source_kind=APP_CAPSULE_SOURCE_KIND,
+        source_code=clean_source,
+        manifest=_default_manifest(clean_thread_id, clean_kind, manifest),
+        visual_spec=_default_visual_spec(clean_title, clean_kind, visual_spec),
+        metadata=_artifact_metadata(thread_id=clean_thread_id, artifact_kind=clean_kind, metadata=metadata),
+        initial_state=dict(initial_state or {}) or None,
+    )
+
+    action = "created"
+    target_app_id = _clean_text(app_id)
+    target_key = app_key
+    if update_existing:
+        try:
+            existing = await a_get_app(session, org_id, target_app_id, key=None if target_app_id else target_key)
+        except WorkspaceAppNotFound:
+            existing = None
+        if existing is not None:
+            target_app_id = str(existing.id)
+
+    if target_app_id:
+        app = await a_update_app(
+            session,
+            org_id=org_id,
+            app_id=target_app_id,
+            name=clean_title,
+            description=description,
+            renderer_key=compiled.renderer_key,
+            source_kind=compiled.source_kind,
+            source_code=compiled.source_code,
+            manifest=compiled.manifest,
+            visual_spec=compiled.visual_spec,
+            metadata=compiled.metadata,
+            anchor_user_id=user_id,
+            updated_by_user_id=user_id,
+        )
+        action = "updated"
+    else:
+        app = await a_create_app(
+            session,
+            org_id=org_id,
+            key=target_key,
+            name=clean_title,
+            description=description,
+            renderer_key=compiled.renderer_key,
+            source_kind=compiled.source_kind,
+            source_code=compiled.source_code,
+            manifest=compiled.manifest or {},
+            visual_spec=compiled.visual_spec or {},
+            metadata=compiled.metadata or {},
+            created_by_user_id=user_id,
+            anchor_user_id=user_id,
+            initial_state=dict(initial_state or {}) or None,
+            state_key=str((compiled.manifest or {}).get("state_key") or "default"),
+        )
+
+    serialized = await a_serialize_app(session, app)
+    artifact_route = f"{route}?app={serialized['id']}"
+    return {
+        "action": action,
+        "thread_id": clean_thread_id,
+        "thread_route": route,
+        "thread_url": thread_url,
+        "artifact_route": artifact_route,
+        "artifact_url": thread_url_for_route(artifact_route),
+        "artifact_kind": clean_kind,
+        "app_id": serialized["id"],
+        "app_key": serialized["key"],
+        "app_name": serialized["name"],
+        "version": (serialized.get("active_version") or {}).get("version"),
+        "renderer_key": serialized["renderer_key"],
+        "source_kind": (serialized.get("active_version") or {}).get("source_kind"),
+        "app": serialized,
+        "compiler_repairs": list(compiled.repairs),
+        "warnings": list(compiled.warnings),
+    }
+
+
+__all__ = [
+    "DEFAULT_THREAD_ARTIFACT_KIND",
+    "THREAD_ARTIFACT_SOURCE",
+    "ThreadArtifactError",
+    "publish_thread_artifact_app",
+]

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -201,9 +201,9 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "threads",
         "name": "Threads and Discussion",
         "category": "core_workspace",
-        "summary": "Illo can work with Illospace Threads, AI Timeline messages, Thread Discussion surfaces, and generated thread assets.",
-        "aliases": ("thread", "threads", "discussion", "ai timeline", "ideas", "thread asset", "show artifact"),
-        "tools": ("manage_idea", "read_thread_discussion", "publish_thread_asset", "post_thread_discussion_reply", "post_ai_timeline_message", "post_chat_message", "cortex_reply", "cortex_visual_reply"),
+        "summary": "Illo can work with Illospace Threads, AI Timeline messages, Thread Discussion surfaces, static thread assets, and interactive thread artifacts.",
+        "aliases": ("thread", "threads", "discussion", "ai timeline", "ideas", "thread asset", "show artifact", "interactive artifact", "shareable artifact", "brainstorm board"),
+        "tools": ("manage_idea", "read_thread_discussion", "publish_thread_asset", "publish_thread_artifact", "post_thread_discussion_reply", "post_ai_timeline_message", "post_chat_message", "cortex_reply", "cortex_visual_reply"),
     },
     {
         "key": "domains",

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -112,6 +112,80 @@ CORTEX_IDEA_TOOLS = [
             "required": ["action"],
         },
     },
+    {
+        "name": "publish_thread_artifact",
+        "description": (
+            "Publish or republish an interactive, thread-scoped HTML artifact as an app-capsule. "
+            "Use this when the user asks for a shareable or visual thread view, brainstorm board, "
+            "status page, walkthrough, dashboard, checklist, comparison, or other interactive artifact. "
+            "Illo chooses the artifact shape by writing a responsive single-document HTML/CSS/JS source. "
+            "The source runs in the sandboxed app-capsule runtime and can use window.illo.state.get/set/update "
+            "for artifact-local interaction state. It must not load external scripts/styles, use browser "
+            "storage, or include secrets. The result is a versioned workspace app stamped with the current "
+            "Thread id; post the returned artifact_url or thread_url plus app_id when telling teammates where "
+            "to review it."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "thread_id": {
+                    "type": "string",
+                    "description": "Thread/idea id. Defaults to the current Thread when one is bound.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Human-readable artifact title.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Short artifact description shown in app listings.",
+                },
+                "artifact_kind": {
+                    "type": "string",
+                    "description": "Artifact type such as brainstorm, walkthrough, dashboard, checklist, comparison, incident, status, decision-room, or custom.",
+                    "default": "interactive",
+                },
+                "source_code": {
+                    "type": "string",
+                    "description": (
+                        "Responsive app-capsule HTML/CSS/JS. Use a root element with class illo-app, "
+                        "Illo App Kit classes such as illo-panel, illo-toolbar, illo-button, illo-tabs, "
+                        "illo-list, and illo-table-wrap, and window.illo.state for interactivity."
+                    ),
+                },
+                "app_id": {
+                    "type": "string",
+                    "description": "Existing artifact app id to republish/update.",
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Optional stable app key. Defaults to a thread/title-derived key.",
+                },
+                "update_existing": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "When true, update the existing app with the same key instead of creating duplicates.",
+                },
+                "manifest": {
+                    "type": "object",
+                    "description": "Optional app-capsule manifest extensions. Contract, data plan, design contract, state key, and thread metadata are defaulted.",
+                },
+                "visual_spec": {
+                    "type": "object",
+                    "description": "Optional host-rendered thumbnail/placement metadata.",
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional provenance metadata; thread_artifact fields are added automatically.",
+                },
+                "initial_state": {
+                    "type": "object",
+                    "description": "Optional initial artifact-local state. Keep durable records in Domains; use this for UI state or lightweight interaction state.",
+                },
+            },
+            "required": ["title", "source_code"],
+        },
+    },
 ]
 
 # ── Native Chat Tools ─────────────────────────────────────────

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -69,6 +69,7 @@ from brain.systems.runs.tool_catalog.handlers.slack import (
     _handle_post_slack_reply,
     _handle_read_slack_conversation,
 )
+from brain.systems.runs.tool_catalog.handlers.thread_artifacts import _handle_publish_thread_artifact
 from brain.systems.runs.tool_catalog.handlers.activity import _handle_my_activity
 from brain.systems.runs.tool_catalog.handlers.voice import _handle_transcribe_audio_attachment
 from brain.systems.runs.tool_catalog.handlers.web import _handle_web_fetch, _handle_web_search
@@ -272,6 +273,10 @@ def _get_tool_handlers(
         "publish_thread_asset": lambda **kw: _patched_private(
             "_handle_publish_thread_asset",
             _handle_publish_thread_asset,
+        )(**kw),
+        "publish_thread_artifact": lambda **kw: _patched_private(
+            "_handle_publish_thread_artifact",
+            _handle_publish_thread_artifact,
         )(**kw),
         "post_ai_timeline_message": lambda **kw: _patched_private(
             "_handle_post_ai_timeline_message",

--- a/brain/systems/runs/tool_catalog/handlers/thread_artifacts.py
+++ b/brain/systems/runs/tool_catalog/handlers/thread_artifacts.py
@@ -1,0 +1,154 @@
+"""Tool handler for thread-scoped interactive artifacts."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from brain.systems.runs.tool_catalog.handlers.common import *
+
+
+def _artifact_context() -> tuple[str | None, str | None, str | None]:
+    execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}
+    org_id = getattr(_agent_context, "org_id", None) or execution_metadata.get("org_id")
+    user_id = getattr(_agent_context, "user_id", None) or execution_metadata.get("user_id")
+
+    thread_id = getattr(_agent_context, "idea_id", None) or execution_metadata.get("idea_id")
+    run = getattr(_agent_context, "run", None)
+    if not thread_id and run is not None:
+        thread_id = getattr(run, "thread_id", None)
+    if not thread_id:
+        target_ref = execution_metadata.get("target_ref")
+        if isinstance(target_ref, Mapping):
+            thread_id = target_ref.get("thread_id") or target_ref.get("idea_id")
+    return (
+        str(org_id) if org_id else None,
+        str(user_id) if user_id else None,
+        str(thread_id) if thread_id else None,
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_bool(value: Any, *, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _optional_mapping(value: Any, field: str) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, Mapping):
+        return dict(value), None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None, None
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            return None, {"error": f"{field} must be an object or valid JSON object string: {exc.msg}"}
+        if isinstance(parsed, Mapping):
+            return dict(parsed), None
+    return None, {"error": f"{field} must be an object when provided"}
+
+
+async def _handle_publish_thread_artifact(
+    title: str,
+    source_code: str,
+    thread_id: str | None = None,
+    description: str | None = None,
+    artifact_kind: str | None = None,
+    app_id: str | None = None,
+    key: str | None = None,
+    update_existing: bool = True,
+    manifest: dict | None = None,
+    visual_spec: dict | None = None,
+    metadata: dict | None = None,
+    initial_state: dict | None = None,
+    **_ignored: Any,
+) -> str:
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+    from brain.systems.cortex.thread_artifacts import ThreadArtifactError, publish_thread_artifact_app
+    from brain.systems.workspace_apps.events import publish_workspace_app_change
+    from brain.systems.workspace_apps.service import WorkspaceAppContractError, WorkspaceAppError
+    from brain.systems.workspace_apps.compiler import contract_repair_guidance, service_error_guidance
+
+    org_id, user_id, current_thread_id = _artifact_context()
+    target_thread_id = _optional_text(thread_id) or current_thread_id
+    if not org_id:
+        return json.dumps({"error": "publish_thread_artifact could not access this workspace context"})
+    if not target_thread_id:
+        return json.dumps({"error": "publish_thread_artifact requires thread_id when no current Thread is bound"})
+
+    manifest, mapping_error = _optional_mapping(manifest, "manifest")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    visual_spec, mapping_error = _optional_mapping(visual_spec, "visual_spec")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    metadata, mapping_error = _optional_mapping(metadata, "metadata")
+    if mapping_error:
+        return json.dumps(mapping_error)
+    initial_state, mapping_error = _optional_mapping(initial_state, "initial_state")
+    if mapping_error:
+        return json.dumps(mapping_error)
+
+    try:
+        async with UnitOfWork() as uow:
+            result = await publish_thread_artifact_app(
+                uow.session,
+                org_id=org_id,
+                user_id=user_id,
+                thread_id=target_thread_id,
+                title=title,
+                description=description,
+                artifact_kind=artifact_kind,
+                source_code=source_code,
+                app_id=app_id,
+                key=key,
+                update_existing=_optional_bool(update_existing, default=True),
+                manifest=manifest,
+                visual_spec=visual_spec,
+                metadata=metadata,
+                initial_state=initial_state,
+            )
+            await uow.commit()
+            publish_workspace_app_change(org_id=org_id, action=result["action"], app=result["app"])
+            return json.dumps(result, default=str)
+    except WorkspaceAppContractError as exc:
+        return json.dumps(
+            {
+                "error": str(exc),
+                "contract_validation": exc.report,
+                "repair_guidance": contract_repair_guidance(exc.report),
+            },
+            default=str,
+        )
+    except WorkspaceAppError as exc:
+        payload: dict[str, Any] = {"error": str(exc)}
+        guidance = service_error_guidance(str(exc))
+        if guidance:
+            payload["repair_guidance"] = guidance
+        return json.dumps(payload, default=str)
+    except ThreadArtifactError as exc:
+        return json.dumps({"error": str(exc)}, default=str)
+    except Exception as exc:
+        logger.exception("publish_thread_artifact failed: %s", exc)
+        return json.dumps({"error": str(exc)}, default=str)
+
+
+__all__ = [name for name in globals() if not name.startswith("__")]

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -361,6 +361,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "publish a generated local artifact as a visible Thread upload asset",
         "output_budget_chars": 8_000,
     },
+    "publish_thread_artifact": {
+        "permission": "write_workspace_app",
+        "risk_class": "medium",
+        "side_effect_class": "workspace_app_management",
+        "reversibility": "reversible_by_archive",
+        "action_manifest": True,
+        "expected_effect": "publish a versioned interactive HTML artifact scoped to a Thread",
+        "output_budget_chars": 12_000,
+    },
     "post_ai_timeline_message": {
         "permission": "write_chat",
         "risk_class": "medium",

--- a/brain/systems/runs/tool_handlers.py
+++ b/brain/systems/runs/tool_handlers.py
@@ -22,6 +22,7 @@ from brain.systems.runs.tool_catalog.handlers.projects import *  # noqa: F401,F4
 from brain.systems.runs.tool_catalog.handlers.session_tools import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.self_context import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.skills import *  # noqa: F401,F403
+from brain.systems.runs.tool_catalog.handlers.thread_artifacts import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.voice import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.web import *  # noqa: F401,F403
 from brain.systems.runs.tool_catalog.handlers.workers import *  # noqa: F401,F403
@@ -59,6 +60,7 @@ _COMPOSITION_PATCH_NAMES = (
     "_handle_post_chat_message",
     "_handle_post_thread_discussion_reply",
     "_handle_publish_thread_asset",
+    "_handle_publish_thread_artifact",
     "_handle_read_thread_discussion",
     "_handle_read_thread_messages",
     "_handle_manage_cycle",

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import { ConstellationComposerOrb, ConstellationIcon } from '$lib/components/constellation';
   import { auth } from '$lib/stores/auth.svelte';
   import { cortex } from '$lib/stores/cortex.svelte';
@@ -180,6 +181,7 @@
   let titleGenerating = $state(false);
   let threadArchiving = $state(false);
   let threadLinkCopying = $state(false);
+  let lastAutoOpenedThreadAppId = $state<string | null>(null);
 
   const THREAD_STAGE_MIN_THREAD_WIDTH = 380;
   const THREAD_STAGE_DEFAULT_GUTTER = 24;
@@ -226,13 +228,17 @@
   const activeFilePreviewTab = $derived(activeSidePanelTab?.kind === 'file-preview' ? activeSidePanelTab : null);
   const activeFilePreviewPath = $derived(activeFilePreviewTab?.filePath ?? '');
   const activeFilePreviewRunId = $derived(activeFilePreviewTab?.runId ?? null);
+  const threadArtifactApps = $derived.by(() => workspaceApps.threadApps(idea?.id ?? null));
+  const requestedThreadAppId = $derived(
+    $page.url.searchParams.get('app') || $page.url.searchParams.get('artifact_app'),
+  );
   const selectedThreadApp = $derived(
     activeSidePanelTab?.kind === 'app' && activeSidePanelTab.appId
-      ? workspaceApps.appById(activeSidePanelTab.appId)
+      ? threadArtifactApps.find((app) => app.id === activeSidePanelTab.appId) ?? null
       : null,
   );
   const sidePanelAddMenuItems = $derived.by(() =>
-    buildThreadSidePanelAddMenuItems(sidePanelTabs, workspaceApps.visibleApps),
+    buildThreadSidePanelAddMenuItems(sidePanelTabs, threadArtifactApps),
   );
   const activeVaultSecretPrompt = $derived(
     String(cortex.vaultSecretPrompt?.idea_id ?? '') === String(idea?.id ?? '') ? cortex.vaultSecretPrompt : null,
@@ -885,7 +891,8 @@
   }
 
   function openAppTab(appId: string | null | undefined) {
-    applySidePanelState(openAppThreadSidePanelTab(sidePanelState(), appId, workspaceApps.appById(appId ?? '')));
+    const app = threadArtifactApps.find((candidate) => candidate.id === appId) ?? null;
+    applySidePanelState(openAppThreadSidePanelTab(sidePanelState(), appId, app));
   }
 
   function handleThreadAppSelect(appId: string | null) {
@@ -898,6 +905,29 @@
       closeSidePanelTab(activeSidePanelTab.id);
     }
   }
+
+  $effect(() => {
+    const appId = requestedThreadAppId;
+    if (!appId || appId === lastAutoOpenedThreadAppId) return;
+    const app = workspaceApps.appById(appId);
+    if (!app) {
+      if (!workspaceApps.loaded) void workspaceApps.load({ silent: true });
+      return;
+    }
+    if (!workspaceApps.appBelongsToThread(app, idea?.id ?? null)) return;
+    lastAutoOpenedThreadAppId = appId;
+    openAppTab(appId);
+  });
+
+  $effect(() => {
+    const appId = workspaceApps.lastChangedAppId;
+    if (!appId || appId === lastAutoOpenedThreadAppId) return;
+    if (workspaceApps.lastChangeAction !== 'create' && workspaceApps.lastChangeAction !== 'update') return;
+    const app = workspaceApps.appById(appId);
+    if (!workspaceApps.appBelongsToThread(app, idea?.id ?? null)) return;
+    lastAutoOpenedThreadAppId = appId;
+    openAppTab(appId);
+  });
 
   function closeSidePanelTab(tabId: string) {
     const closingTab = sidePanelTabs.find((tab) => tab.id === tabId);
@@ -1203,7 +1233,7 @@
 
   {#snippet appsPane()}
     <ThreadAppsPane
-      apps={workspaceApps.visibleApps}
+      apps={threadArtifactApps}
       selectedAppId={selectedThreadApp?.id ?? null}
       onSelectApp={handleThreadAppSelect}
     />

--- a/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
+++ b/frontend/src/lib/features/threads/controllers/threadSidePanelController.ts
@@ -243,8 +243,8 @@ export function buildThreadSidePanelAddMenuItems(
     items.push({
       id: 'no-apps',
       kind: 'app',
-      label: visibleApps.length > 0 ? 'All apps are open' : 'No apps available',
-      description: visibleApps.length > 0 ? 'Close an app tab to reopen it here' : 'Generated apps appear here',
+      label: visibleApps.length > 0 ? 'All artifacts are open' : 'No artifacts available',
+      description: visibleApps.length > 0 ? 'Close an artifact tab to reopen it here' : 'Thread artifacts appear here',
       disabled: true,
     });
   }

--- a/frontend/src/lib/features/workspace-apps/components/ThreadAppsPane.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/ThreadAppsPane.svelte
@@ -17,14 +17,14 @@
   const selectedApp = $derived(apps.find((app) => app.id === selectedAppId) ?? null);
 </script>
 
-<section class="thread-apps-pane" class:has-selected={!!selectedApp} aria-label="Generated apps">
+<section class="thread-apps-pane" class:has-selected={!!selectedApp} aria-label="Thread artifacts">
   {#if selectedApp}
     <div class="thread-apps-pane__selected">
       <GeneratedAppRenderer app={selectedApp} surface="dock" onclose={() => onSelectApp?.(null)} />
     </div>
   {:else}
     <header class="thread-apps-pane__header">
-      <span>Generated apps</span>
+      <span>Thread artifacts</span>
       <strong>{apps.length}</strong>
     </header>
 
@@ -46,7 +46,7 @@
     {:else}
       <div class="thread-apps-pane__empty">
         <ConstellationIcon name="code" size={18} stroke={1.8} />
-        <span>No generated apps yet.</span>
+        <span>No thread artifacts yet.</span>
       </div>
     {/if}
   {/if}

--- a/frontend/src/lib/stores/workspaceApps.svelte.ts
+++ b/frontend/src/lib/stores/workspaceApps.svelte.ts
@@ -42,6 +42,23 @@ class WorkspaceAppsStore {
     return this.apps.filter((app) => !app.archived_at);
   }
 
+  appBelongsToThread(app: WorkspaceAppRead | null | undefined, threadId: string | null | undefined) {
+    if (!app || !threadId) return false;
+    const metadata = app.metadata || {};
+    const threadArtifact = metadata.thread_artifact || {};
+    const metadataThreadId = String(
+      threadArtifact.thread_id
+        ?? metadata.thread_id
+        ?? metadata.idea_id
+        ?? '',
+    );
+    return metadata.artifact_scope === 'thread' && metadataThreadId === String(threadId);
+  }
+
+  threadApps(threadId: string | null | undefined) {
+    return this.visibleApps.filter((app) => this.appBelongsToThread(app, threadId));
+  }
+
   appById(appId: string | null | undefined) {
     if (!appId) return null;
     return this.apps.find((app) => app.id === appId) ?? null;

--- a/tests/test_thread_artifacts.py
+++ b/tests/test_thread_artifacts.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+from brain.platform.db.models.idea import Idea
+from brain.platform.db.models.org import Org, User
+from brain.platform.db.models.workspace_app import WorkspaceApp, WorkspaceAppState, WorkspaceAppVersion
+
+ORG_ID = "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"
+USER_ID = "bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb"
+THREAD_ID = "cccccccccccc4ccc8ccccccccccccccc"
+
+VALID_ARTIFACT_SOURCE = """
+<main class="illo-app">
+  <section class="illo-panel illo-stack">
+    <div class="illo-toolbar">
+      <h1 class="illo-title">Brainstorm Brief</h1>
+      <button class="illo-button" id="vote">Vote</button>
+    </div>
+    <p class="illo-copy" id="result">Ready for review.</p>
+  </section>
+</main>
+<script>
+  document.getElementById('vote').addEventListener('click', async () => {
+    const state = await window.illo.state.get();
+    const votes = Number(state.votes || 0) + 1;
+    await window.illo.state.update({ votes });
+    document.getElementById('result').textContent = votes + ' vote(s)';
+  });
+</script>
+"""
+
+
+def _register_sqlite_functions(dbapi_conn, _connection_record) -> None:
+    dbapi_conn.create_function("NOW", 0, lambda: datetime.now(timezone.utc).isoformat())
+    dbapi_conn.create_function("gen_random_uuid", 0, lambda: str(uuid.uuid4()))
+
+
+def _patch_sqlite_for_pg_types() -> None:
+    for name in ("visit_JSONB", "visit_ARRAY", "visit_UUID", "visit_VECTOR", "visit_Vector"):
+        if not hasattr(SQLiteTypeCompiler, name):
+            setattr(SQLiteTypeCompiler, name, lambda self, type_, **kw: "TEXT")
+    SQLiteTypeCompiler.visit_BIGINT = lambda self, type_, **kw: "INTEGER"
+
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_thread_artifact_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+        return result
+
+    patched._thread_artifact_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    sqlite3.register_adapter(dict, lambda value: json.dumps(value))
+    sqlite3.register_adapter(list, lambda value: json.dumps(value))
+    db = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Idea.__table__,
+            WorkspaceApp.__table__,
+            WorkspaceAppVersion.__table__,
+            WorkspaceAppState.__table__,
+        ],
+        connect_listener=_register_sqlite_functions,
+    )
+    db.add_all(
+        [
+            Org(id=ORG_ID, name="Test Org", slug="test"),
+            User(id=USER_ID, org_id=ORG_ID, name="Alex", email="alex@example.test"),
+            Idea(id=THREAD_ID, title="Artifact source thread", user_id=USER_ID, org_id=ORG_ID),
+        ]
+    )
+    await db.flush()
+    return db
+
+
+async def test_publish_thread_artifact_creates_and_republishes_app_capsule(session):
+    from brain.systems.cortex.thread_artifacts import publish_thread_artifact_app
+
+    created = await publish_thread_artifact_app(
+        session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        thread_id=THREAD_ID,
+        title="Brainstorm Brief",
+        description="Interactive team review",
+        artifact_kind="brainstorm",
+        source_code=VALID_ARTIFACT_SOURCE,
+        initial_state={"votes": 0},
+    )
+
+    assert created["action"] == "created"
+    assert created["artifact_route"] == f"/threads/{THREAD_ID}?app={created['app_id']}"
+    assert created["artifact_url"].endswith(created["artifact_route"])
+    assert created["app"]["metadata"]["artifact_scope"] == "thread"
+    assert created["app"]["metadata"]["thread_artifact"]["thread_id"] == THREAD_ID
+    assert created["app"]["active_version"]["manifest"]["thread_artifact"]["kind"] == "brainstorm"
+    assert created["app"]["active_version"]["manifest"]["state_key"] == f"thread-artifact-{THREAD_ID}"
+    assert created["app"]["active_version"]["source_kind"] == "html"
+    assert created["version"] == 1
+
+    updated = await publish_thread_artifact_app(
+        session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        thread_id=THREAD_ID,
+        title="Brainstorm Brief",
+        artifact_kind="brainstorm",
+        source_code=VALID_ARTIFACT_SOURCE.replace("Ready for review.", "Republished."),
+    )
+
+    assert updated["action"] == "updated"
+    assert updated["app_id"] == created["app_id"]
+    assert updated["version"] == 2
+    assert "Republished." in updated["app"]["active_version"]["source_code"]
+
+
+async def test_mcp_thread_artifact_publish_capability_sets_workspace_app_mutation(monkeypatch, session):
+    from brain.app.api.routers import agent_mcp
+
+    calls: list[dict] = []
+
+    async def fake_publish(db, **kwargs):
+        calls.append({"db": db, **kwargs})
+        return {
+            "action": "created",
+            "app_id": "app-1",
+            "app_key": "thread-artifact",
+            "app": {"id": "app-1", "key": "thread-artifact"},
+        }
+
+    monkeypatch.setattr(
+        "brain.systems.cortex.thread_artifacts.publish_thread_artifact_app",
+        fake_publish,
+    )
+    principal = SimpleNamespace(org_id=ORG_ID, owner_user_id=USER_ID)
+
+    result = await agent_mcp._tool_act(
+        session,
+        principal,
+        {
+            "capability": "thread.artifact.publish",
+            "arguments": {
+                "thread_id": THREAD_ID,
+                "title": "Review artifact",
+                "artifact_kind": "status",
+                "source_code": VALID_ARTIFACT_SOURCE,
+            },
+        },
+    )
+
+    assert "thread.artifact.publish" in agent_mcp.ACT_CAPABILITIES
+    assert result["_mutates_workspace_app"] is True
+    assert result["_workspace_app_change"] == {"action": "created", "app": {"id": "app-1", "key": "thread-artifact"}}
+    assert calls[0]["db"] is session
+    assert calls[0]["org_id"] == ORG_ID
+    assert calls[0]["user_id"] == USER_ID
+    assert calls[0]["thread_id"] == THREAD_ID
+    assert calls[0]["metadata"]["mcp_capability"] == "thread.artifact.publish"

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -156,6 +156,23 @@ def test_publish_thread_asset_tool_is_registered_and_exposed():
     assert registration.reversibility == "append_only"
 
 
+def test_publish_thread_artifact_tool_is_registered_and_exposed():
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    name = "publish_thread_artifact"
+    assert name in _names(COORDINATOR_TOOLS)
+    assert name in _names(WORKER_TOOLS)
+    assert name in _get_tool_handlers()
+
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert registration.permission == "write_workspace_app"
+    assert registration.side_effect_class == "workspace_app_management"
+    assert registration.reversibility == "reversible_by_archive"
+
+
 def test_ai_timeline_message_tool_is_registered_and_exposed():
     from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
     from brain.systems.runs.tool_handlers import _get_tool_handlers


### PR DESCRIPTION
## Summary
- add a thread-scoped interactive HTML artifact publisher backed by app-capsule workspace apps
- expose it through Illo tool definitions, tool registry, capability discovery, and hosted MCP `thread.artifact.publish`
- filter/open thread artifacts in the thread side panel, including `?app=` deep links and realtime app-change auto-open

## Verification
- `venv/bin/python -m py_compile brain/systems/cortex/thread_artifacts.py brain/systems/runs/tool_catalog/handlers/thread_artifacts.py brain/app/api/routers/agent_mcp.py brain/systems/runs/tool_catalog/definitions/cortex_thread.py brain/systems/runs/tool_definitions.py`
- `venv/bin/python -m pytest tests/test_thread_artifacts.py tests/test_tool_registry.py`
- `npm run check` in `frontend`
- `npm run build` in `frontend`