### PR TITLE
Fix thread artifact deep links

### DIFF
--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -51,6 +51,7 @@
     type ThreadStageRightDockTab,
   } from '$lib/features/threads/controllers/threadSidePanelController';
   import { threadStreamController } from '$lib/features/threads/controllers/threadStreamController';
+  import { decideThreadArtifactDeepLink } from '$lib/features/threads/domain/threadArtifactDeepLink';
   import { threadUrl } from '$lib/features/threads/domain/threadLinks';
   import {
     findSlashCommandToken,
@@ -182,6 +183,7 @@
   let threadArchiving = $state(false);
   let threadLinkCopying = $state(false);
   let lastAutoOpenedThreadAppId = $state<string | null>(null);
+  let requestedThreadAppLoadRequestedFor = $state<string | null>(null);
 
   const THREAD_STAGE_MIN_THREAD_WIDTH = 380;
   const THREAD_STAGE_DEFAULT_GUTTER = 24;
@@ -908,15 +910,30 @@
 
   $effect(() => {
     const appId = requestedThreadAppId;
-    if (!appId || appId === lastAutoOpenedThreadAppId) return;
+    if (requestedThreadAppLoadRequestedFor && requestedThreadAppLoadRequestedFor !== appId) {
+      requestedThreadAppLoadRequestedFor = null;
+    }
     const app = workspaceApps.appById(appId);
-    if (!app) {
-      if (!workspaceApps.loaded) void workspaceApps.load({ silent: true });
+    const decision = decideThreadArtifactDeepLink({
+      requestedAppId: appId,
+      lastAutoOpenedAppId: lastAutoOpenedThreadAppId,
+      appExists: Boolean(app),
+      appBelongsToCurrentThread: workspaceApps.appBelongsToThread(app, idea?.id ?? null),
+      currentThreadLoaded: Boolean(idea?.id),
+      loadRequestedForAppId: requestedThreadAppLoadRequestedFor,
+      appsLoading: workspaceApps.loading,
+    });
+
+    if (decision.action === 'request-refresh') {
+      requestedThreadAppLoadRequestedFor = decision.appId;
+      void workspaceApps.load({ silent: true, force: true });
       return;
     }
-    if (!workspaceApps.appBelongsToThread(app, idea?.id ?? null)) return;
-    lastAutoOpenedThreadAppId = appId;
-    openAppTab(appId);
+    if (decision.action !== 'open') return;
+
+    requestedThreadAppLoadRequestedFor = null;
+    lastAutoOpenedThreadAppId = decision.appId;
+    openAppTab(decision.appId);
   });
 
   $effect(() => {

--- a/frontend/src/lib/features/threads/domain/threadArtifactDeepLink.ts
+++ b/frontend/src/lib/features/threads/domain/threadArtifactDeepLink.ts
@@ -1,0 +1,43 @@
+export type ThreadArtifactDeepLinkDecision =
+  | { action: 'idle' }
+  | { action: 'already-opened'; appId: string }
+  | { action: 'request-refresh'; appId: string }
+  | { action: 'wait-for-app'; appId: string }
+  | { action: 'wait-for-thread'; appId: string }
+  | { action: 'ignore-wrong-thread'; appId: string }
+  | { action: 'open'; appId: string };
+
+export interface ThreadArtifactDeepLinkInput {
+  requestedAppId?: string | null;
+  lastAutoOpenedAppId?: string | null;
+  appExists: boolean;
+  appBelongsToCurrentThread: boolean;
+  currentThreadLoaded: boolean;
+  loadRequestedForAppId?: string | null;
+  appsLoading: boolean;
+}
+
+export function decideThreadArtifactDeepLink({
+  requestedAppId,
+  lastAutoOpenedAppId,
+  appExists,
+  appBelongsToCurrentThread,
+  currentThreadLoaded,
+  loadRequestedForAppId,
+  appsLoading,
+}: ThreadArtifactDeepLinkInput): ThreadArtifactDeepLinkDecision {
+  const appId = String(requestedAppId ?? '').trim();
+  if (!appId) return { action: 'idle' };
+  if (appId === lastAutoOpenedAppId) return { action: 'already-opened', appId };
+
+  if (!appExists) {
+    if (appsLoading || loadRequestedForAppId === appId) {
+      return { action: 'wait-for-app', appId };
+    }
+    return { action: 'request-refresh', appId };
+  }
+
+  if (!currentThreadLoaded) return { action: 'wait-for-thread', appId };
+  if (!appBelongsToCurrentThread) return { action: 'ignore-wrong-thread', appId };
+  return { action: 'open', appId };
+}

--- a/frontend/src/lib/utils/threadArtifactDeepLink.test.js
+++ b/frontend/src/lib/utils/threadArtifactDeepLink.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decideThreadArtifactDeepLink } from '../features/threads/domain/threadArtifactDeepLink.ts';
+
+test('thread artifact deep links force one refresh when the requested app is missing from cache', () => {
+  assert.deepEqual(
+    decideThreadArtifactDeepLink({
+      requestedAppId: 'artifact-app',
+      lastAutoOpenedAppId: null,
+      appExists: false,
+      appBelongsToCurrentThread: false,
+      currentThreadLoaded: true,
+      loadRequestedForAppId: null,
+      appsLoading: false,
+    }),
+    { action: 'request-refresh', appId: 'artifact-app' },
+  );
+});
+
+test('thread artifact deep links wait while a forced app refresh is already in flight', () => {
+  assert.deepEqual(
+    decideThreadArtifactDeepLink({
+      requestedAppId: 'artifact-app',
+      lastAutoOpenedAppId: null,
+      appExists: false,
+      appBelongsToCurrentThread: false,
+      currentThreadLoaded: true,
+      loadRequestedForAppId: 'artifact-app',
+      appsLoading: true,
+    }),
+    { action: 'wait-for-app', appId: 'artifact-app' },
+  );
+});
+
+test('thread artifact deep links open only after the app belongs to the current thread', () => {
+  assert.deepEqual(
+    decideThreadArtifactDeepLink({
+      requestedAppId: 'artifact-app',
+      lastAutoOpenedAppId: null,
+      appExists: true,
+      appBelongsToCurrentThread: true,
+      currentThreadLoaded: true,
+      loadRequestedForAppId: 'artifact-app',
+      appsLoading: false,
+    }),
+    { action: 'open', appId: 'artifact-app' },
+  );
+});
+
+test('thread artifact deep links ignore apps scoped to a different thread', () => {
+  assert.deepEqual(
+    decideThreadArtifactDeepLink({
+      requestedAppId: 'artifact-app',
+      lastAutoOpenedAppId: null,
+      appExists: true,
+      appBelongsToCurrentThread: false,
+      currentThreadLoaded: true,
+      loadRequestedForAppId: null,
+      appsLoading: false,
+    }),
+    { action: 'ignore-wrong-thread', appId: 'artifact-app' },
+  );
+});


### PR DESCRIPTION
## Summary
- Force one silent workspace app refresh when a thread artifact deep link points at an app missing from the current frontend cache
- Open the artifact panel only after the app belongs to the current thread
- Add regression coverage for the missing-cache deep-link path

## Verification
- npm run test
- npm run check
- npm run build