### PR TITLE
Allow users to manage personal OpenAI model tokens

### DIFF
--- a/brain/app/api/routers/onboarding.py
+++ b/brain/app/api/routers/onboarding.py
@@ -46,7 +46,7 @@ def _intro_ref(user_id: str) -> str:
 def _has_personal_openai_connection(status: dict[str, Any]) -> bool:
     return bool(
         status.get("runtime_key_available")
-        and status.get("runtime_key_source") == "codex_subscription"
+        and status.get("runtime_key_source") in {"codex_subscription", "user_openai"}
     )
 
 

--- a/brain/platform/db/models/org.py
+++ b/brain/platform/db/models/org.py
@@ -125,7 +125,7 @@ class OrgApiKey(Base, CreatedAtMixin):
 
 
 class UserCodexConnection(Base, CreatedAtMixin):
-    """The only user-owned credential: a user's Codex/ChatGPT subscription."""
+    """A user's personal OpenAI runtime credential."""
 
     __tablename__ = "user_codex_connections"
 

--- a/brain/platform/integrations/llm.py
+++ b/brain/platform/integrations/llm.py
@@ -93,7 +93,7 @@ class LLMClient:
     """Resolved LLM client ready for API calls."""
     client: Any
     provider: str                     # "anthropic" or "openai"
-    source: str                       # "codex_subscription", "org_main", "env", "none"
+    source: str                       # "codex_subscription", "user_openai", "org_main", "env", "none"
     auth_mode: str | None             # "api_key", "chatgpt", etc.
     is_oauth: bool                    # True for provider OAuth-style credentials.
     extra_headers: dict[str, str]     # Per-request headers.

--- a/brain/systems/runs/workspace_tool_runtime.py
+++ b/brain/systems/runs/workspace_tool_runtime.py
@@ -227,8 +227,8 @@ async def _resolve_provider_connection(source: dict[str, Any], *, context: dict[
             provider=provider,
             auth_mode="api_key",
         )
-        if resolved_source not in {"org_main", "env"} or not raw:
-            raise PermissionError(f"Workspace tool requires a {provider} workspace API key")
+        if resolved_source not in {"user_openai", "org_main", "env"} or not raw:
+            raise PermissionError(f"Workspace tool requires a {provider} user or workspace API key")
         return raw
 
     raise ValueError(f"Unsupported workspace tool provider credential: {credential or '<empty>'}")

--- a/brain/systems/runtime_settings/auth.py
+++ b/brain/systems/runtime_settings/auth.py
@@ -133,20 +133,13 @@ async def async_store_openai_connection(
         raise HTTPException(status_code=400, detail=f"OpenAI credential verification failed: {exc}") from exc
 
     try:
-        if method == "chatgpt":
+        if method in {"chatgpt", "api_key"}:
             await async_set_user_codex_connection(
                 str(user.id),
                 api_token,
                 label=label or _connection_label(method),
                 session=session,
             )
-        elif method == "api_key":
-            stored = await _async_store_org_openai_api_key(session, user, api_token)
-            if not stored:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only workspace owners and admins can connect an org OpenAI API key.",
-                )
         else:
             raise HTTPException(status_code=400, detail="Unsupported OpenAI credential method")
     except RuntimeError as exc:
@@ -158,10 +151,6 @@ async def async_store_openai_connection(
         raise HTTPException(status_code=404, detail="User not found")
     await session.flush()
     await session.refresh(refreshed)
-    if method == "api_key" and _can_manage_installation_memory(refreshed):
-        from .memory import async_configure_openai_embedding_api_key
-
-        await async_configure_openai_embedding_api_key(session, api_token)
     return await async_get_openai_connection(session, refreshed)
 
 

--- a/brain/systems/runtime_settings/auth.py
+++ b/brain/systems/runtime_settings/auth.py
@@ -112,6 +112,8 @@ async def async_get_openai_connection(session: AsyncSession, user: User) -> Runt
         source=source,
         label=_connection_label(method),
         detail=None if connected else "Connect Codex or an OpenAI API key to run models.",
+        has_personal_connection=bool(status.get("has_codex_subscription")),
+        has_org_key=bool(status.get("has_org_db_key")),
     )
 
 
@@ -319,6 +321,35 @@ async def async_connect_openai_api_key(
     api_key: str,
 ) -> RuntimeConnectionRead:
     return await async_store_openai_connection(session, user, api_key.strip(), label="OpenAI API key")
+
+
+async def async_connect_openai_org_api_key(
+    session: AsyncSession,
+    user: User,
+    api_key: str,
+) -> RuntimeConnectionRead:
+    if not _can_manage_installation_memory(user):
+        raise HTTPException(
+            status_code=403,
+            detail="You need owner or admin access to manage the workspace OpenAI key",
+        )
+    token = (api_key or "").strip()
+    if not token:
+        raise HTTPException(status_code=400, detail="Paste an OpenAI API key")
+    try:
+        api_token, method = parse_provider_connect_token(token, OPENAI_PROVIDER)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if method != "api_key" or not api_token.startswith("sk-"):
+        raise HTTPException(status_code=400, detail="Workspace runtime needs a standard OpenAI API key")
+    try:
+        verify_provider_api_key(api_token, OPENAI_PROVIDER)
+    except Exception as exc:  # pragma: no cover - exact SDK exception type varies.
+        logger.warning("OpenAI workspace credential verification failed: %s", exc)
+        raise HTTPException(status_code=400, detail=f"OpenAI credential verification failed: {exc}") from exc
+
+    await _async_store_org_openai_api_key(session, user, api_token)
+    return await async_get_openai_connection(session, user)
 
 
 async def async_connect_openai_embedding_api_key(

--- a/brain/systems/runtime_settings/router.py
+++ b/brain/systems/runtime_settings/router.py
@@ -13,6 +13,7 @@ from .auth import (
     async_connect_gemini_api_key,
     async_connect_openai_api_key,
     async_connect_openai_embedding_api_key,
+    async_connect_openai_org_api_key,
     async_exchange_openai_oauth,
     start_openai_oauth,
 )
@@ -75,6 +76,16 @@ async def connect_openai_key(
     db: AsyncSession = Depends(get_db),
 ) -> RuntimeConnectionRead:
     return await async_connect_openai_api_key(db, user, payload.api_key)
+
+
+@router.post("/connection/openai/org-api-key", response_model=RuntimeConnectionRead)
+async def connect_openai_org_key(
+    payload: OpenAIKeyConnectRequest,
+    user: User = Depends(_runtime_user),
+    db: AsyncSession = Depends(get_db),
+) -> RuntimeConnectionRead:
+    _require_settings_admin(user)
+    return await async_connect_openai_org_api_key(db, user, payload.api_key)
 
 
 @router.post("/connection/openai/embedding-api-key", response_model=RuntimeMemoryRead)

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -34,6 +34,8 @@ class RuntimeConnectionRead(BaseModel):
     source: str | None = None
     label: str | None = None
     detail: str | None = None
+    has_personal_connection: bool = False
+    has_org_key: bool = False
 
 
 class RuntimeModelsRead(BaseModel):

--- a/brain/systems/services/runtime_introspection.py
+++ b/brain/systems/services/runtime_introspection.py
@@ -58,6 +58,7 @@ def _provider_auth_payload(
     is_selected_provider = provider == effective_provider
     runtime_scope = (
         "codex_subscription" if runtime_source == "codex_subscription"
+        else "user" if runtime_source == "user_openai"
         else "org" if runtime_source == "org_main"
         else "external" if runtime_source == "codex_cache"
         else "env" if runtime_source in {"env", "dotenv"}
@@ -73,6 +74,7 @@ def _provider_auth_payload(
 
     runtime_label = (
         "your Codex subscription" if runtime_scope == "codex_subscription"
+        else "your OpenAI API key" if runtime_scope == "user"
         else "the org default credential" if runtime_scope == "org"
         else "a local Codex session fallback" if runtime_scope == "external"
         else "an environment credential" if runtime_scope == "env"
@@ -96,7 +98,7 @@ def _provider_auth_payload(
         "runtime_key_label": runtime_label,
         "runtime_credential_id": runtime_credential_id,
         "runtime_credential_name": runtime_credential_name,
-        "runtime_uses_db_key": runtime_source in ("codex_subscription", "org_main"),
+        "runtime_uses_db_key": runtime_source in ("codex_subscription", "user_openai", "org_main"),
         "runtime_uses_external_auth": runtime_uses_external_auth,
         "setup_required": not runtime_available and not (has_codex_subscription or has_org_key),
         "supports_db_api_keys": provider in {"anthropic", "openai"},
@@ -193,15 +195,16 @@ async def async_get_provider_auth_status(
 
     runtime_scope = (
         "codex_subscription" if runtime_source == "codex_subscription"
+        else "user" if runtime_source == "user_openai"
         else "org" if runtime_source == "org_main"
         else "external" if runtime_source == "codex_cache"
         else "env" if runtime_source in {"env", "dotenv"}
         else "none"
     )
 
-    if user_id and runtime_scope in {"codex_subscription", "org"}:
+    if user_id and runtime_scope in {"codex_subscription", "user", "org"}:
         try:
-            if runtime_scope == "codex_subscription":
+            if runtime_scope in {"codex_subscription", "user"}:
                 stmt = (
                     select(UserCodexConnection)
                     .where(
@@ -213,7 +216,10 @@ async def async_get_provider_auth_status(
                 key_row = (await session.scalars(stmt)).first()
                 if key_row:
                     runtime_credential_id = key_row.id
-                    runtime_credential_name = key_row.label or "Codex / ChatGPT"
+                    runtime_credential_name = (
+                        key_row.label
+                        or ("OpenAI API key" if runtime_scope == "user" else "Codex / ChatGPT")
+                    )
             elif runtime_scope == "org" and org_id:
                 stmt = (
                     select(OrgApiKey)

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -30,6 +30,9 @@ from brain.platform.vault_crypto import _decrypt, _encrypt, _get_fernet
 
 logger = logging.getLogger(__name__)
 
+USER_OPENAI_API_KEY_SOURCE = "user_openai"
+USER_OPENAI_CODEX_SOURCE = "codex_subscription"
+
 VAULT_UNLOCK_HEADER = "X-Vault-Token"
 VAULT_SESSION_TTL = timedelta(minutes=15)
 VAULT_LOCKOUT_AFTER_FAILURES = 3
@@ -696,6 +699,28 @@ async def async_resolve_project_bound_env_tokens(
 # Runtime provider credentials
 # ---------------------------------------------------------------------------
 
+def _openai_user_connection_source(credential_payload: str) -> str | None:
+    """Classify a stored OpenAI connection without treating ChatGPT as an API key."""
+    payload = (credential_payload or "").strip()
+    if not payload:
+        return None
+    if payload.startswith("sk-"):
+        return USER_OPENAI_API_KEY_SOURCE
+
+    try:
+        from brain.platform.integrations.openai_codex_auth import parse_codex_auth_payload
+
+        credential = parse_codex_auth_payload(payload, source="vault")
+    except Exception:
+        return None
+
+    if credential.auth_mode == "api_key" and credential.access_token:
+        return USER_OPENAI_API_KEY_SOURCE
+    if credential.auth_mode == "chatgpt":
+        return USER_OPENAI_CODEX_SOURCE
+    return None
+
+
 async def resolve_api_key(
     user_id: str | None = None,
     org_id: str | None = None,
@@ -704,8 +729,8 @@ async def resolve_api_key(
 ) -> tuple[str | None, str]:
     """Resolve a runtime provider credential.
 
-    Provider API keys are org-owned. The only user-owned credential lane is a
-    user's OpenAI Codex/ChatGPT subscription connection.
+    Provider API keys are org-owned except for a user's own OpenAI model
+    connection, which may be either a Codex/ChatGPT session or an API key.
 
     Returns (key, source) where source describes which level resolved.
     """
@@ -729,7 +754,7 @@ async def async_resolve_api_key(
 
     async def _resolve(active_session: AsyncSession) -> tuple[str | None, str]:
         normalized_provider = provider.strip().lower()
-        if normalized_provider == "openai" and auth_mode != "api_key" and user_id:
+        if normalized_provider == "openai" and user_id:
             stmt = (
                 select(UserCodexConnection)
                 .where(
@@ -740,7 +765,16 @@ async def async_resolve_api_key(
             )
             codex_connection = (await active_session.scalars(stmt)).first()
             if codex_connection:
-                return _decrypt(bytes(codex_connection.encrypted_credential)), "codex_subscription"
+                credential = _decrypt(bytes(codex_connection.encrypted_credential))
+                user_source = _openai_user_connection_source(credential)
+                if auth_mode == "api_key":
+                    if user_source == USER_OPENAI_API_KEY_SOURCE:
+                        return credential, user_source
+                elif auth_mode == "chatgpt":
+                    if user_source == USER_OPENAI_CODEX_SOURCE:
+                        return credential, user_source
+                elif user_source:
+                    return credential, user_source
 
         effective_org_id = org_id
         if not effective_org_id and user_id:
@@ -800,14 +834,18 @@ async def async_update_resolved_api_key(
     session: AsyncSession | None = None,
 ) -> bool:
     """Update the credential row selected by ``async_resolve_api_key``."""
-    if source not in {"codex_subscription", "org_main"}:
+    if source not in {USER_OPENAI_CODEX_SOURCE, USER_OPENAI_API_KEY_SOURCE, "org_main"}:
         return False
 
     encrypted = _encrypt(api_key)
 
     async def _update(active_session: AsyncSession) -> bool:
         normalized_provider = provider.strip().lower()
-        if source == "codex_subscription" and user_id and normalized_provider == "openai":
+        if (
+            source in {USER_OPENAI_CODEX_SOURCE, USER_OPENAI_API_KEY_SOURCE}
+            and user_id
+            and normalized_provider == "openai"
+        ):
             stmt = (
                 select(UserCodexConnection)
                 .where(
@@ -906,7 +944,7 @@ async def set_user_codex_connection(
     *,
     label: str = "Codex / ChatGPT",
 ) -> int:
-    """Store the one supported user-owned credential: Codex subscription auth."""
+    """Store a user's personal OpenAI runtime credential."""
     return await async_set_user_codex_connection(user_id, credential_payload, label=label)
 
 
@@ -917,7 +955,7 @@ async def async_set_user_codex_connection(
     label: str = "Codex / ChatGPT",
     session: AsyncSession | None = None,
 ) -> int:
-    """Store the one supported user-owned credential using async DB access."""
+    """Store a user's personal OpenAI runtime credential using async DB access."""
     clean_user_id = _require_actor_user_id(user_id)
     encrypted = _encrypt(credential_payload)
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1660,6 +1660,11 @@ export const api = {
     fetchJson<any>('/api/runtime-settings/update', { method: 'POST' }),
   connectRuntimeOpenAIKey: (data: { api_key: string }) =>
     fetchJson<any>('/api/runtime-settings/connection/openai/api-key', { method: 'POST', body: JSON.stringify(data) }),
+  connectRuntimeOpenAIOrgKey: (data: { api_key: string }) =>
+    fetchJson<any>('/api/runtime-settings/connection/openai/org-api-key', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   connectRuntimeOpenAIEmbeddingKey: (data: { api_key: string }) =>
     fetchJson<any>('/api/runtime-settings/connection/openai/embedding-api-key', {
       method: 'POST',

--- a/frontend/src/lib/types/runtimeSettings.ts
+++ b/frontend/src/lib/types/runtimeSettings.ts
@@ -19,6 +19,8 @@ export interface RuntimeSettings {
     source?: string | null;
     label?: string | null;
     detail?: string | null;
+    has_personal_connection?: boolean;
+    has_org_key?: boolean;
   };
   models: {
     low: string;

--- a/frontend/src/lib/utils/runtimeOnboarding.ts
+++ b/frontend/src/lib/utils/runtimeOnboarding.ts
@@ -9,7 +9,7 @@ type RuntimeSettingsLike = {
 
 export function hasPersonalOpenAIRuntimeConnection(runtime: RuntimeSettingsLike) {
   const connection = runtime?.connection;
-  return connection?.status === 'connected' && connection?.source === 'codex_subscription';
+  return connection?.status === 'connected' && ['codex_subscription', 'user_openai'].includes(connection?.source || '');
 }
 
 export function requiresPersonalOpenAIOnboarding(runtime: RuntimeSettingsLike) {

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -65,6 +65,12 @@
   let oauthChannel: BroadcastChannel | null = null;
   let oauthExchangeInFlight = false;
   let savingConnection = $state(false);
+  let personalOpenAIKey = $state('');
+  let orgOpenAIKey = $state('');
+  let memoryApiKey = $state('');
+  let savingPersonalApiKey = $state(false);
+  let savingOrgApiKey = $state(false);
+  let savingMemoryApiKey = $state(false);
   let savingChanges = $state(false);
   let checkingMemory = $state(false);
   let memoryCheck = $state<MemoryCheck | null>(null);
@@ -102,6 +108,7 @@
 
   const canManageSettings = $derived(settings?.permissions?.can_manage_settings ?? false);
   const hasPersonalOpenAIConnection = $derived(hasPersonalOpenAIRuntimeConnection(settings));
+  const hasOrgOpenAIConnection = $derived(Boolean(settings?.connection?.has_org_key));
   const connectionStatus = $derived(settings?.connection?.status ?? 'missing');
   const modelOptions = $derived(settings?.models?.options ?? []);
   const setupMode = $derived($page.url.searchParams.get('setup') === '1');
@@ -255,6 +262,40 @@
     } finally {
       oauthExchangeInFlight = false;
       savingConnection = false;
+    }
+  }
+
+  async function savePersonalOpenAIKey() {
+    const value = personalOpenAIKey.trim();
+    if (!value || !settings) return;
+    savingPersonalApiKey = true;
+    notice = null;
+    try {
+      const connection = await api.connectRuntimeOpenAIKey({ api_key: value });
+      settings = { ...settings, connection };
+      personalOpenAIKey = '';
+      notice = { tone: 'success', title: 'Personal OpenAI key saved.' };
+    } catch (error) {
+      notice = errorNotice('Personal OpenAI key was not saved.', error, 'Check the key and try again.');
+    } finally {
+      savingPersonalApiKey = false;
+    }
+  }
+
+  async function saveOrgOpenAIKey() {
+    const value = orgOpenAIKey.trim();
+    if (!value || !settings || !canManageSettings) return;
+    savingOrgApiKey = true;
+    notice = null;
+    try {
+      const connection = await api.connectRuntimeOpenAIOrgKey({ api_key: value });
+      settings = { ...settings, connection };
+      orgOpenAIKey = '';
+      notice = { tone: 'success', title: 'Workspace OpenAI key rotated.' };
+    } catch (error) {
+      notice = errorNotice('Workspace OpenAI key was not rotated.', error, 'Check the key and try again.');
+    } finally {
+      savingOrgApiKey = false;
     }
   }
 
@@ -749,6 +790,32 @@
     }
   }
 
+  async function saveMemoryApiKey() {
+    const value = memoryApiKey.trim();
+    if (!value || !settings || !canManageSettings || !usesApiEmbedder(memoryDraft.embedder)) return;
+    const provider = memoryVaultProvider;
+    savingMemoryApiKey = true;
+    notice = null;
+    try {
+      const memory = provider === 'gemini'
+        ? await api.connectRuntimeGeminiKey({ api_key: value })
+        : await api.connectRuntimeOpenAIEmbeddingKey({ api_key: value });
+      settings = { ...settings, memory };
+      memoryApiKey = '';
+      selectedMemoryVaultKey = '';
+      memoryCheck = null;
+      notice = {
+        tone: 'success',
+        title: 'Memory key rotated.',
+        detail: `${providerLabel(provider)} is available for memory.`,
+      };
+    } catch (error) {
+      notice = errorNotice('Memory key was not rotated.', error, 'Check the key and try again.');
+    } finally {
+      savingMemoryApiKey = false;
+    }
+  }
+
   function memoryNotice(): MemoryNoticeState | null {
     if (!settings) return null;
     if (memoryChangeNeedsRebuild()) {
@@ -831,11 +898,21 @@
           oauthPending={Boolean(oauthUrl)}
           {oauthCallbackMode}
           hasPersonalConnection={hasPersonalOpenAIConnection}
+          hasOrgConnection={hasOrgOpenAIConnection}
+          {canManageSettings}
+          personalApiKey={personalOpenAIKey}
+          orgApiKey={orgOpenAIKey}
           {savingConnection}
+          {savingPersonalApiKey}
+          {savingOrgApiKey}
           onCallbackChange={(value) => (oauthCallback = value)}
+          onPersonalApiKeyChange={(value) => (personalOpenAIKey = value)}
+          onOrgApiKeyChange={(value) => (orgOpenAIKey = value)}
           onStartCodexSignIn={() => startCodexSignIn()}
           onStartLocalCodexSignIn={() => startCodexSignIn('local_bridge')}
           onFinishCodexSignIn={finishCodexSignIn}
+          onSavePersonalApiKey={savePersonalOpenAIKey}
+          onSaveOrgApiKey={saveOrgOpenAIKey}
         />
 
         <ModelsCard
@@ -853,13 +930,17 @@
           embeddingModelOptions={embeddingModelOptions()}
           vaultKeyOptions={memoryVaultKeyOptions}
           selectedVaultKey={selectedMemoryVaultKey}
+          {memoryApiKey}
           notice={memoryNotice()}
           {memoryCheck}
           {canManageSettings}
           {vaultLoading}
           syncingVaultKey={syncingMemoryVaultKey}
+          {savingMemoryApiKey}
           onUpdateMemory={updateMemoryDraft}
           onSelectVaultKey={handleMemoryVaultKeyChange}
+          onMemoryApiKeyChange={(value) => (memoryApiKey = value)}
+          onSaveMemoryApiKey={saveMemoryApiKey}
         />
 
         <VoiceCard

--- a/frontend/src/routes/system/MemoryCard.svelte
+++ b/frontend/src/routes/system/MemoryCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ConstellationNotice } from '$lib/components/constellation';
+  import { ConstellationButton, ConstellationNotice, ConstellationTextInput } from '$lib/components/constellation';
 
   import RuntimeSelect from './RuntimeSelect.svelte';
   import type { MemoryCheck, MemoryDraft, MemoryNoticeState, RuntimeOption, RuntimeSettings } from './types';
@@ -10,31 +10,42 @@
     embeddingModelOptions,
     vaultKeyOptions,
     selectedVaultKey,
+    memoryApiKey,
     notice,
     memoryCheck,
     canManageSettings,
     vaultLoading,
     syncingVaultKey,
+    savingMemoryApiKey,
     onUpdateMemory,
     onSelectVaultKey,
+    onMemoryApiKeyChange,
+    onSaveMemoryApiKey,
   }: {
     memory: RuntimeSettings['memory'];
     memoryDraft: MemoryDraft;
     embeddingModelOptions: RuntimeSettings['memory']['embedding_model_options'];
     vaultKeyOptions: RuntimeOption[];
     selectedVaultKey: string;
+    memoryApiKey: string;
     notice: MemoryNoticeState | null;
     memoryCheck: MemoryCheck | null;
     canManageSettings: boolean;
     vaultLoading: boolean;
     syncingVaultKey: boolean;
+    savingMemoryApiKey: boolean;
     onUpdateMemory: (key: keyof MemoryDraft, value: string) => void;
     onSelectVaultKey: (value: string) => void;
+    onMemoryApiKeyChange: (value: string) => void;
+    onSaveMemoryApiKey: () => void;
   } = $props();
 
   const localModelLabel = $derived(memoryDraft.embedder === 'local_cpu' ? 'Local CPU model' : 'Local GPU model');
   const usesApiModel = $derived(memoryDraft.embedder === 'openai' || memoryDraft.embedder === 'gemini');
   const showReranker = $derived(memory.reranker_options.length > 1);
+  const memoryKeyLabel = $derived(memoryDraft.embedder === 'gemini' ? 'Gemini key' : 'OpenAI key');
+  const memoryKeyPlaceholder = $derived(memoryDraft.embedder === 'gemini' ? 'AIza...' : 'sk-...');
+  const memoryKeyConnected = $derived(Boolean(memory.api_key_statuses?.[memoryDraft.embedder === 'gemini' ? 'gemini' : 'openai']));
 </script>
 
 <section class="runtime-section memory-runtime" aria-labelledby="memory-runtime-heading">
@@ -106,6 +117,34 @@
         />
       {/if}
     </div>
+
+    {#if usesApiModel}
+      <div class="memory-key-row">
+        <div class="memory-key-copy">
+          <span>{memoryKeyLabel}</span>
+          <strong>{memoryKeyConnected ? 'Connected' : 'Missing'}</strong>
+        </div>
+        <ConstellationTextInput
+          id="memory-api-key"
+          type="password"
+          placeholder={memoryKeyPlaceholder}
+          value={memoryApiKey}
+          autocomplete="off"
+          mono
+          disabled={!canManageSettings || savingMemoryApiKey}
+          oninput={(event) => onMemoryApiKeyChange((event.currentTarget as HTMLInputElement).value)}
+        />
+        <ConstellationButton
+          variant="secondary"
+          size="sm"
+          onclick={onSaveMemoryApiKey}
+          loading={savingMemoryApiKey}
+          disabled={!canManageSettings || !memoryApiKey.trim() || syncingVaultKey}
+        >
+          Rotate
+        </ConstellationButton>
+      </div>
+    {/if}
   </div>
 </section>
 
@@ -185,5 +224,45 @@
     background: color-mix(in srgb, var(--constellation-control-input-background) 72%, transparent);
     color: var(--constellation-text-primary);
     padding: 0 12px;
+  }
+
+  .memory-key-row {
+    display: grid;
+    grid-template-columns: minmax(120px, 0.34fr) minmax(180px, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    padding-top: 2px;
+  }
+
+  .memory-key-copy {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .memory-key-copy span,
+  .memory-key-copy strong {
+    min-width: 0;
+    font-family: var(--constellation-font-mono);
+    font-size: var(--constellation-type-meta);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .memory-key-copy span {
+    color: var(--constellation-color-text-secondary);
+    font-weight: 700;
+  }
+
+  .memory-key-copy strong {
+    color: var(--constellation-color-text-primary);
+    font-weight: 700;
+  }
+
+  @media (max-width: 760px) {
+    .memory-key-row {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/frontend/src/routes/system/ProviderConnections.svelte
+++ b/frontend/src/routes/system/ProviderConnections.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ConstellationButton, ConstellationIcon } from '$lib/components/constellation';
+  import { ConstellationButton, ConstellationIcon, ConstellationTextInput } from '$lib/components/constellation';
 
   let {
     oauthUrl,
@@ -7,22 +7,42 @@
     oauthPending,
     oauthCallbackMode,
     hasPersonalConnection,
+    hasOrgConnection,
+    canManageSettings,
+    personalApiKey,
+    orgApiKey,
     savingConnection,
+    savingPersonalApiKey,
+    savingOrgApiKey,
     onCallbackChange,
+    onPersonalApiKeyChange,
+    onOrgApiKeyChange,
     onStartCodexSignIn,
     onStartLocalCodexSignIn,
     onFinishCodexSignIn,
+    onSavePersonalApiKey,
+    onSaveOrgApiKey,
   }: {
     oauthUrl: string;
     oauthCallback: string;
     oauthPending: boolean;
     oauthCallbackMode: 'server' | 'local_bridge' | 'manual';
     hasPersonalConnection: boolean;
+    hasOrgConnection: boolean;
+    canManageSettings: boolean;
+    personalApiKey: string;
+    orgApiKey: string;
     savingConnection: boolean;
+    savingPersonalApiKey: boolean;
+    savingOrgApiKey: boolean;
     onCallbackChange: (value: string) => void;
+    onPersonalApiKeyChange: (value: string) => void;
+    onOrgApiKeyChange: (value: string) => void;
     onStartCodexSignIn: () => void;
     onStartLocalCodexSignIn: () => void;
     onFinishCodexSignIn: () => void;
+    onSavePersonalApiKey: () => void;
+    onSaveOrgApiKey: () => void;
   } = $props();
 
   const openAiActionLabel = $derived(openAiConnectionActionLabel());
@@ -77,6 +97,72 @@
         <span>ChatGPT / Codex sign-in</span>
       </span>
     </button>
+
+    <article class="provider-token-row">
+      <div class="provider-copy">
+        <h3>Personal API key</h3>
+        <p>Your model runs</p>
+      </div>
+
+      <div class="provider-token-controls">
+        <span class:connected={hasPersonalConnection} class="provider-token-status">
+          {hasPersonalConnection ? 'Connected' : 'Missing'}
+        </span>
+        <ConstellationTextInput
+          id="personal-openai-api-key"
+          type="password"
+          placeholder="sk-..."
+          value={personalApiKey}
+          autocomplete="off"
+          mono
+          disabled={savingPersonalApiKey}
+          oninput={(event) => onPersonalApiKeyChange((event.currentTarget as HTMLInputElement).value)}
+        />
+        <ConstellationButton
+          variant="secondary"
+          size="sm"
+          onclick={onSavePersonalApiKey}
+          loading={savingPersonalApiKey}
+          disabled={!personalApiKey.trim() || savingConnection}
+        >
+          Save
+        </ConstellationButton>
+      </div>
+    </article>
+
+    {#if canManageSettings}
+      <article class="provider-token-row">
+        <div class="provider-copy">
+          <h3>Workspace API key</h3>
+          <p>Org default</p>
+        </div>
+
+        <div class="provider-token-controls">
+          <span class:connected={hasOrgConnection} class="provider-token-status">
+            {hasOrgConnection ? 'Connected' : 'Missing'}
+          </span>
+          <ConstellationTextInput
+            id="workspace-openai-api-key"
+            type="password"
+            placeholder="sk-..."
+            value={orgApiKey}
+            autocomplete="off"
+            mono
+            disabled={savingOrgApiKey}
+            oninput={(event) => onOrgApiKeyChange((event.currentTarget as HTMLInputElement).value)}
+          />
+          <ConstellationButton
+            variant="secondary"
+            size="sm"
+            onclick={onSaveOrgApiKey}
+            loading={savingOrgApiKey}
+            disabled={!orgApiKey.trim() || savingConnection}
+          >
+            Rotate
+          </ConstellationButton>
+        </div>
+      </article>
+    {/if}
   </div>
 
   {#if oauthPending && !hasPersonalConnection}
@@ -159,7 +245,8 @@
   }
 
   .provider-row,
-  .connect-provider-row {
+  .connect-provider-row,
+  .provider-token-row {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
@@ -170,6 +257,12 @@
 
   .provider-row {
     padding: 2px 0;
+  }
+
+  .provider-token-row {
+    grid-template-columns: minmax(140px, 0.42fr) minmax(0, 1fr);
+    padding: 10px 0;
+    border-top: 1px solid var(--constellation-surface-panel-separator);
   }
 
   .provider-mark {
@@ -249,6 +342,35 @@
     line-height: 1.2;
   }
 
+  .provider-token-controls {
+    display: grid;
+    grid-template-columns: auto minmax(180px, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .provider-token-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24px;
+    padding: 0 8px;
+    border: 1px solid var(--constellation-control-input-border);
+    border-radius: 999px;
+    color: var(--constellation-color-text-secondary);
+    font-family: var(--constellation-font-mono);
+    font-size: var(--constellation-type-meta);
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .provider-token-status.connected {
+    color: var(--constellation-color-success, var(--constellation-color-text-primary));
+  }
+
   .oauth-callback-row {
     display: grid;
     grid-template-columns: auto minmax(86px, 118px) minmax(0, 1fr) auto;
@@ -314,6 +436,17 @@
     .provider-mark {
       width: 44px;
       height: 44px;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .provider-token-row,
+    .provider-token-controls {
+      grid-template-columns: 1fr;
+    }
+
+    .provider-token-status {
+      justify-self: start;
     }
   }
 </style>

--- a/frontend/src/routes/vault/+page.svelte
+++ b/frontend/src/routes/vault/+page.svelte
@@ -1009,6 +1009,14 @@
     try {
       if (normalized === 'OPENAI_API_KEY') {
         await api.connectRuntimeOpenAIKey({ api_key: value });
+        if (canManageRuntimeSettings()) {
+          await api.connectRuntimeOpenAIOrgKey({ api_key: value });
+          await api.connectRuntimeOpenAIEmbeddingKey({ api_key: value });
+        }
+        return true;
+      }
+      if (normalized === 'OPENAI_ORG_API_KEY' || normalized === 'OPENAI_WORKSPACE_API_KEY') {
+        await api.connectRuntimeOpenAIOrgKey({ api_key: value });
         return true;
       }
       if (normalized === 'OPENAI_EMBEDDING_API_KEY') {
@@ -1023,6 +1031,10 @@
       ui.toast(err?.message || 'Secret saved, but runtime did not accept the key.', 'error');
     }
     return false;
+  }
+
+  function canManageRuntimeSettings() {
+    return ['owner', 'admin'].includes(String(auth.user?.role || ''));
   }
 
   async function submitCreate() {

--- a/tests/test_api_key_management.py
+++ b/tests/test_api_key_management.py
@@ -1,4 +1,5 @@
-"""Tests for org-owned provider keys and user Codex subscription storage."""
+"""Tests for org-owned provider keys and user OpenAI connection storage."""
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -38,37 +39,78 @@ class TestResolveApiKey:
         assert key == "sk-org-main"
         assert source == "org_main"
 
-    @patch("brain.systems.vault._decrypt", return_value="codex-json")
     @patch("brain.systems.vault.UnitOfWork")
-    async def test_openai_can_resolve_user_codex_subscription(self, mock_uow_cls, mock_decrypt):
+    async def test_openai_can_resolve_user_codex_subscription(self, mock_uow_cls):
         uow_cls, sess, uow = _make_uow_mock()
         mock_uow_cls.return_value = uow
         uow.session = sess
 
+        chatgpt_payload = json.dumps({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "access-token",
+                "account_id": "acct_123",
+            },
+        })
         codex_connection = SimpleNamespace(encrypted_credential=b"codex-enc")
         sess.scalars.return_value.first.return_value = codex_connection
 
         from brain.systems.vault import resolve_api_key
 
-        key, source = await resolve_api_key(user_id="user-1", provider="openai")
+        with patch("brain.systems.vault._decrypt", return_value=chatgpt_payload):
+            key, source = await resolve_api_key(user_id="user-1", provider="openai")
 
-        assert key == "codex-json"
+        assert key == chatgpt_payload
         assert source == "codex_subscription"
 
-    @patch("brain.systems.vault._decrypt", return_value="sk-org-openai")
     @patch("brain.systems.vault.UnitOfWork")
-    async def test_openai_api_key_mode_skips_user_codex_subscription(self, mock_uow_cls, mock_decrypt):
+    async def test_openai_api_key_mode_resolves_user_api_key_before_org(self, mock_uow_cls):
         uow_cls, sess, uow = _make_uow_mock()
         mock_uow_cls.return_value = uow
         uow.session = sess
 
-        sess.get.return_value = SimpleNamespace(org_id="org-1")
-        org_key = SimpleNamespace(encrypted_key=b"org-enc")
-        sess.scalars.return_value.first.return_value = org_key
+        user_connection = SimpleNamespace(encrypted_credential=b"user-api-enc")
+        sess.scalars.return_value.first.return_value = user_connection
 
         from brain.systems.vault import resolve_api_key
 
-        key, source = await resolve_api_key(user_id="user-1", provider="openai", auth_mode="api_key")
+        with patch("brain.systems.vault._decrypt", return_value="sk-user-openai"):
+            key, source = await resolve_api_key(user_id="user-1", provider="openai", auth_mode="api_key")
+
+        assert key == "sk-user-openai"
+        assert source == "user_openai"
+
+    @patch("brain.systems.vault.UnitOfWork")
+    async def test_openai_api_key_mode_skips_user_codex_subscription(self, mock_uow_cls):
+        uow_cls, sess, uow = _make_uow_mock()
+        mock_uow_cls.return_value = uow
+        uow.session = sess
+
+        chatgpt_payload = json.dumps({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "access-token",
+                "account_id": "acct_123",
+            },
+        })
+        user_connection = SimpleNamespace(encrypted_credential=b"codex-enc")
+        org_key = SimpleNamespace(encrypted_key=b"org-enc")
+        user_result = MagicMock()
+        user_result.first.return_value = user_connection
+        org_result = MagicMock()
+        org_result.first.return_value = org_key
+        sess.scalars = AsyncMock(side_effect=[user_result, org_result])
+        sess.get.return_value = SimpleNamespace(org_id="org-1")
+
+        from brain.systems.vault import resolve_api_key
+
+        def decrypt(value):
+            if value == b"codex-enc":
+                return chatgpt_payload
+            return "sk-org-openai"
+
+        with patch("brain.systems.vault._decrypt", side_effect=decrypt):
+            key, source = await resolve_api_key(user_id="user-1", provider="openai", auth_mode="api_key")
 
         assert key == "sk-org-openai"
         assert source == "org_main"

--- a/tests/test_openai_oauth_ui_contract.py
+++ b/tests/test_openai_oauth_ui_contract.py
@@ -31,9 +31,35 @@ def test_system_provider_connection_is_not_admin_gated():
 
     assert "hasPersonalOpenAIRuntimeConnection(settings)" in page
     assert "hasPersonalConnection={hasPersonalOpenAIConnection}" in page
-    assert "canManageSettings: boolean;" not in card
-    assert "disabled={!canManageSettings}" not in card
-    assert "disabled={!canManageSettings || savingConnection}" not in card
+    assert "Personal API key" in card
+    assert "onSavePersonalApiKey={savePersonalOpenAIKey}" in page
+    assert "disabled={!personalApiKey.trim() || savingConnection}" in card
+    assert "disabled={!canManageSettings || !personalApiKey.trim()" not in card
+
+
+def test_system_provider_connection_exposes_admin_org_key_rotation():
+    card = (ROOT / "frontend/src/routes/system/ProviderConnections.svelte").read_text()
+    page = (ROOT / "frontend/src/routes/system/+page.svelte").read_text()
+    client = (ROOT / "frontend/src/lib/api/client.ts").read_text()
+
+    assert "Workspace API key" in card
+    assert "{#if canManageSettings}" in card
+    assert "onSaveOrgApiKey={saveOrgOpenAIKey}" in page
+    assert "connectRuntimeOpenAIOrgKey" in client
+    assert "/api/runtime-settings/connection/openai/org-api-key" in client
+
+
+def test_system_memory_card_exposes_memory_key_rotation():
+    card = (ROOT / "frontend/src/routes/system/MemoryCard.svelte").read_text()
+    page = (ROOT / "frontend/src/routes/system/+page.svelte").read_text()
+    vault = (ROOT / "frontend/src/routes/vault/+page.svelte").read_text()
+
+    assert "onSaveMemoryApiKey" in card
+    assert "onSaveMemoryApiKey={saveMemoryApiKey}" in page
+    assert "connectRuntimeOpenAIEmbeddingKey" in page
+    assert "connectRuntimeGeminiKey" in page
+    assert "connectRuntimeOpenAIOrgKey" in vault
+    assert "OPENAI_ORG_API_KEY" in vault
 
 
 def test_system_oauth_start_keeps_page_open_when_popup_is_blocked():

--- a/tests/test_openai_oauth_ui_contract.py
+++ b/tests/test_openai_oauth_ui_contract.py
@@ -58,7 +58,7 @@ def test_onboarding_routes_require_personal_openai_connection():
     layout = (ROOT / "frontend/src/routes/+layout.svelte").read_text()
     onboarding = (ROOT / "frontend/src/routes/onboarding/+page.svelte").read_text()
 
-    assert "connection?.source === 'codex_subscription'" in helper
+    assert "['codex_subscription', 'user_openai'].includes" in helper
     assert "requiresPersonalOpenAIOnboarding(runtime)" in login
     assert "requiresPersonalOpenAIOnboarding(runtime)" in layout
     assert "hasPersonalOpenAIRuntimeConnection(runtime)" in onboarding

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -35,6 +35,41 @@ async def test_provider_auth_status_reports_openai_codex_runtime():
 
 
 @pytest.mark.asyncio
+async def test_provider_auth_status_reports_user_openai_api_key_runtime():
+    from types import SimpleNamespace
+
+    from brain.platform.db.models.org import UserCodexConnection
+    from brain.systems.services.runtime_introspection import async_get_provider_auth_status
+
+    mock_session = MagicMock()
+    mock_session.scalars = AsyncMock(
+        side_effect=[
+            SimpleNamespace(first=lambda: 1),
+            SimpleNamespace(first=lambda: None),
+            SimpleNamespace(first=lambda: SimpleNamespace(id=321, label="Personal OpenAI")),
+        ]
+    )
+
+    mock_llm = MagicMock(source="user_openai", auth_mode="api_key", is_oauth=False)
+
+    with patch("brain.systems.services.runtime_introspection.async_resolve_llm_client", AsyncMock(return_value=mock_llm)), \
+         patch("brain.systems.services.runtime_introspection.async_resolve_default_provider", AsyncMock(return_value="openai")):
+        data = await async_get_provider_auth_status(mock_session, user_id="user-1", org_id="org-1", provider="openai")
+
+    assert data["provider"] == "openai"
+    assert data["status"] == "in_use"
+    assert data["method"] == "api_key"
+    assert data["runtime_key_source"] == "user_openai"
+    assert data["runtime_key_scope"] == "user"
+    assert data["runtime_key_label"] == "your OpenAI API key"
+    assert data["runtime_uses_db_key"] is True
+    assert data["runtime_credential_id"] == 321
+    assert data["runtime_credential_name"] == "Personal OpenAI"
+    stmt = mock_session.scalars.await_args_list[-1].args[0]
+    assert UserCodexConnection.__tablename__ in str(stmt)
+
+
+@pytest.mark.asyncio
 async def test_runtime_settings_tool_returns_model_mappings_and_active_status():
     import brain.systems.services.runtime_introspection as runtime_settings_service
     from brain.app.mcp.server import tool_runtime_settings
@@ -329,6 +364,46 @@ async def test_store_openai_connection_reports_invalid_format():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["member", "owner"])
+async def test_store_openai_api_key_uses_personal_runtime_connection(monkeypatch, role):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.auth as auth_settings
+    from brain.systems.runtime_settings.schemas import RuntimeConnectionRead
+
+    user = SimpleNamespace(id="user-1", org_id="org-1", role=role)
+    session = MagicMock()
+    session.get = AsyncMock(return_value=user)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    store_user_connection = AsyncMock(return_value=7)
+    store_org_connection = AsyncMock(side_effect=AssertionError("model keys must stay user-scoped"))
+    read_connection = AsyncMock(return_value=RuntimeConnectionRead(
+        status="connected",
+        setup_required=False,
+        method="api_key",
+        source="user_openai",
+        label="OpenAI API key",
+    ))
+
+    monkeypatch.setattr(auth_settings, "verify_provider_api_key", lambda *args, **kwargs: None)
+    monkeypatch.setattr(auth_settings, "async_set_user_codex_connection", store_user_connection)
+    monkeypatch.setattr(auth_settings, "_async_store_org_openai_api_key", store_org_connection)
+    monkeypatch.setattr(auth_settings, "async_get_openai_connection", read_connection)
+
+    result = await auth_settings.async_store_openai_connection(session, user, "sk-test")
+
+    assert result.source == "user_openai"
+    store_user_connection.assert_awaited_once()
+    assert store_user_connection.await_args.args[:2] == ("user-1", "sk-test")
+    assert store_user_connection.await_args.kwargs["label"] == "OpenAI API key"
+    assert store_user_connection.await_args.kwargs["session"] is session
+    store_org_connection.assert_not_called()
+    session.flush.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(user)
+
+
+@pytest.mark.asyncio
 async def test_store_openai_connection_reports_missing_vault_master_key(monkeypatch):
     from types import SimpleNamespace
 
@@ -338,7 +413,7 @@ async def test_store_openai_connection_reports_missing_vault_master_key(monkeypa
         raise RuntimeError("VAULT_MASTER_KEY is required. Refusing to auto-generate a vault key.")
 
     monkeypatch.setattr(auth_settings, "verify_provider_api_key", lambda *args, **kwargs: None)
-    monkeypatch.setattr(auth_settings, "async_set_org_api_key", raise_missing_vault_key)
+    monkeypatch.setattr(auth_settings, "async_set_user_codex_connection", raise_missing_vault_key)
 
     with pytest.raises(Exception) as exc:
         await auth_settings.async_store_openai_connection(

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -70,6 +70,35 @@ async def test_provider_auth_status_reports_user_openai_api_key_runtime():
 
 
 @pytest.mark.asyncio
+async def test_openai_connection_reports_personal_and_org_key_flags(monkeypatch):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.auth as auth_settings
+
+    monkeypatch.setattr(
+        auth_settings,
+        "async_get_provider_auth_status",
+        AsyncMock(return_value={
+            "runtime_key_available": True,
+            "method": "api_key",
+            "runtime_key_source": "user_openai",
+            "has_codex_subscription": True,
+            "has_org_db_key": True,
+        }),
+    )
+
+    connection = await auth_settings.async_get_openai_connection(
+        MagicMock(),
+        SimpleNamespace(id="user-1", org_id="org-1"),
+    )
+
+    assert connection.status == "connected"
+    assert connection.source == "user_openai"
+    assert connection.has_personal_connection is True
+    assert connection.has_org_key is True
+
+
+@pytest.mark.asyncio
 async def test_runtime_settings_tool_returns_model_mappings_and_active_status():
     import brain.systems.services.runtime_introspection as runtime_settings_service
     from brain.app.mcp.server import tool_runtime_settings
@@ -401,6 +430,62 @@ async def test_store_openai_api_key_uses_personal_runtime_connection(monkeypatch
     store_org_connection.assert_not_called()
     session.flush.assert_awaited_once()
     session.refresh.assert_awaited_once_with(user)
+
+
+@pytest.mark.asyncio
+async def test_store_openai_org_api_key_rotates_workspace_runtime_key(monkeypatch):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.auth as auth_settings
+    from brain.systems.runtime_settings.schemas import RuntimeConnectionRead
+
+    session = MagicMock()
+    store_org_connection = AsyncMock(return_value=True)
+    store_user_connection = AsyncMock(side_effect=AssertionError("org key must not replace personal key"))
+    read_connection = AsyncMock(return_value=RuntimeConnectionRead(
+        status="connected",
+        setup_required=False,
+        method="api_key",
+        source="org_main",
+        label="OpenAI API key",
+        has_org_key=True,
+    ))
+
+    monkeypatch.setattr(auth_settings, "parse_provider_connect_token", lambda token, provider: (token, "api_key"))
+    monkeypatch.setattr(auth_settings, "verify_provider_api_key", lambda *args, **kwargs: None)
+    monkeypatch.setattr(auth_settings, "_async_store_org_openai_api_key", store_org_connection)
+    monkeypatch.setattr(auth_settings, "async_set_user_codex_connection", store_user_connection)
+    monkeypatch.setattr(auth_settings, "async_get_openai_connection", read_connection)
+
+    user = SimpleNamespace(id="owner-1", org_id="org-1", role="owner")
+
+    result = await auth_settings.async_connect_openai_org_api_key(session, user, "sk-org-rotated")
+
+    assert result.has_org_key is True
+    store_org_connection.assert_awaited_once()
+    assert store_org_connection.await_args.args == (session, user, "sk-org-rotated")
+    store_user_connection.assert_not_called()
+    read_connection.assert_awaited_once_with(session, user)
+
+
+@pytest.mark.asyncio
+async def test_store_openai_org_api_key_rejects_members(monkeypatch):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.auth as auth_settings
+
+    store_org_connection = AsyncMock()
+    monkeypatch.setattr(auth_settings, "_async_store_org_openai_api_key", store_org_connection)
+
+    with pytest.raises(Exception) as exc:
+        await auth_settings.async_connect_openai_org_api_key(
+            MagicMock(),
+            SimpleNamespace(id="member-1", org_id="org-1", role="member"),
+            "sk-org-rotated",
+        )
+
+    assert exc.value.status_code == 403
+    store_org_connection.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -140,6 +140,30 @@ async def test_workspace_tool_catalog_includes_codex_runtime_auth_profile():
     }
 
 
+async def test_workspace_tool_provider_api_key_accepts_user_openai_connection(monkeypatch):
+    from brain.systems.runs import workspace_tool_runtime
+
+    async def fake_resolve_api_key(**kwargs):
+        assert kwargs["user_id"] == USER_ID
+        assert kwargs["org_id"] == ORG_ID
+        assert kwargs["provider"] == "openai"
+        assert kwargs["auth_mode"] == "api_key"
+        return "sk-user-openai", "user_openai"
+
+    monkeypatch.setattr("brain.systems.vault.async_resolve_api_key", fake_resolve_api_key)
+
+    raw = await workspace_tool_runtime._resolve_provider_connection(
+        {
+            "provider": "openai",
+            "credential": "api_key",
+            "scope": "originating_user",
+        },
+        context={"actor_id": USER_ID, "org_id": ORG_ID},
+    )
+
+    assert raw == "sk-user-openai"
+
+
 async def test_workspace_tool_install_persists_and_queues_request(seeded_session, monkeypatch, tmp_path):
     request_file, status_file, _root = _workspace_tool_queue(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## Summary

- Store runtime OpenAI model API keys on the calling user connection instead of the org key.
- Resolve user-owned API keys as `user_openai` while keeping ChatGPT/Codex auth separate from API-key auth.
- Add a separate admin-only workspace OpenAI key rotation endpoint and System UI control.
- Add System UI controls for rotating memory embedding keys directly, and keep Vault `OPENAI_API_KEY` sync updating personal, org, and OpenAI memory keys for admins.
- Treat `user_openai` as a personal OpenAI connection for runtime status, onboarding, and workspace-tool API-key materialization.

## Testing

- [x] Backend tests: `python3 -m pytest tests/test_api_key_management.py tests/test_runtime_settings.py tests/test_openai_oauth_ui_contract.py tests/test_workspace_tools.py -q`
- [x] Frontend checks/build: `npm run check` from `frontend/`
- [x] Manual verification: Vite smoke on `http://127.0.0.1:5174/system`; local backend was not running, so the app redirected to login, but the current page booted without console errors.

## Public Release Hygiene

- [x] No secrets, logs, database dumps, uploads, private operator notes, or personal paths.
- [x] New environment variables are documented in `.env.example`. N/A; none added.
- [x] New public-facing behavior is documented in `README.md` or `docs/`. N/A; runtime settings behavior only.
- [x] License/notice impact has been considered. N/A.