### PR TITLE
Add Project Context search to Illo MCP

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -22,6 +22,7 @@ from brain.app.api.routers.agent_mcp_domains import DOMAIN_TOOL_HANDLERS
 from brain.app.api.routers.external_agent_errors import raise_external_agent_http_error
 from brain.app.mentions import classify_mention_intent
 from brain.systems.cortex.thread_links import thread_id_from_reference
+from brain.systems.cortex.project_context.search import search_project_contexts
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
@@ -133,7 +134,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
             {
                 "capability": {
                     "type": "string",
-                    "description": "Read capability name, such as workspace.search, thread.get, handoff.get, team.members.list, domain.inspect, or capabilities.",
+                    "description": "Read capability name, such as workspace.search, project_contexts.search, thread.get, handoff.get, team.members.list, domain.inspect, or capabilities.",
                 },
                 "arguments": {
                     "type": "object",
@@ -443,8 +444,16 @@ async def _tool_submit(
 
 READ_CAPABILITIES: dict[str, dict[str, Any]] = {
     "workspace.search": {
-        "description": "Search the Illo workspace for related ideas, threads, and shared work.",
+        "description": "Search the Illo workspace for related Project Contexts, ideas, threads, and shared work.",
         "arguments": {"query": "string", "limit": "integer"},
+    },
+    "project_contexts.search": {
+        "description": "Search reusable Project Context profiles and attached project context resources visible to the bridge user.",
+        "arguments": {
+            "query": "string",
+            "limit": "integer",
+            "include_inactive": "boolean",
+        },
     },
     "thread.get": {
         "description": "Read messages from an existing Illo idea/thread.",
@@ -581,6 +590,15 @@ async def _tool_read(
             principal,
             query=_required_capability_string(capability_arguments, "query", capability=capability),
             limit=int(capability_arguments.get("limit") or 10),
+        )
+    if capability == "project_contexts.search":
+        return await search_project_contexts(
+            db,
+            org_id=principal.org_id,
+            user_id=principal.owner_user_id,
+            query=capability_arguments.get("query"),
+            limit=int(capability_arguments.get("limit") or 10),
+            include_inactive=bool(capability_arguments.get("include_inactive", False)),
         )
     if capability == "thread.get":
         return await external_agents.get_thread(

--- a/brain/systems/cortex/project_context/search.py
+++ b/brain/systems/cortex/project_context/search.py
@@ -1,0 +1,209 @@
+"""Search Project Context profiles and attachments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sqlalchemy import String, and_, cast, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.idea import Idea, IdeaProjectAttachment, ProjectProfile, ProjectProfileAccess
+from brain.platform.db.models.org import User
+from brain.systems.cortex.project_context.access import project_profile_visible_predicate
+from brain.systems.cortex.thread_links import thread_link_payload
+
+
+def _iso(value: Any) -> str | None:
+    return value.isoformat() if hasattr(value, "isoformat") else (str(value) if value else None)
+
+
+def _compact_text(text: str | None, *, limit: int = 160) -> str | None:
+    normalized = " ".join((text or "").split())
+    if not normalized:
+        return None
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: max(limit - 3, 0)].rstrip() + "..."
+
+
+def project_context_resource_summary(context: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(context, Mapping):
+        return {"count": 0, "items": []}
+    resources = [item for item in (context.get("resources") or []) if isinstance(item, Mapping)]
+    return {
+        "count": len(resources),
+        "items": [
+            {
+                "id": item.get("id"),
+                "kind": item.get("kind") or item.get("type"),
+                "label": item.get("label") or item.get("name"),
+                "path": item.get("path"),
+                "repo": item.get("repo"),
+                "uri": item.get("uri"),
+            }
+            for item in resources[:10]
+        ],
+    }
+
+
+def _search_terms(value: str | None) -> list[str]:
+    normalized = " ".join(str(value or "").lower().split())
+    if not normalized:
+        return []
+    return [term for term in normalized.split(" ") if term][:12]
+
+
+def _match_all_terms(terms: Sequence[str], *columns: Any) -> Any | None:
+    if not terms:
+        return None
+    return and_(
+        *[
+            or_(*[func.lower(column).like(f"%{term}%") for column in columns])
+            for term in terms
+        ]
+    )
+
+
+def _thread_reference_snapshot(
+    *,
+    thread_id: Any,
+    title: Any,
+    preview_summary: Any = None,
+    preview_source: Any = None,
+    preview_updated_at: Any = None,
+) -> dict[str, Any]:
+    return {
+        "type": "thread_reference",
+        "object_type": "thread",
+        "object_id": str(thread_id),
+        "thread_id": str(thread_id),
+        "status": "available",
+        "title": str(title or "Untitled thread"),
+        "preview_summary": preview_summary,
+        "preview_source": preview_source,
+        "preview_updated_at": _iso(preview_updated_at),
+        **thread_link_payload(thread_id),
+    }
+
+
+def _profile_result(profile: ProjectProfile, user: User | None) -> dict[str, Any]:
+    return {
+        "type": "project_context_profile",
+        "project_profile_id": str(profile.id),
+        "id": str(profile.id),
+        "slug": profile.slug,
+        "name": profile.name,
+        "description": _compact_text(profile.description, limit=520),
+        "active": bool(profile.active),
+        "visibility": profile.visibility,
+        "owner_user_id": str(profile.user_id) if profile.user_id is not None else None,
+        "owner_name": user.name if user else None,
+        "resources": project_context_resource_summary(profile.project_context),
+        "created_at": _iso(profile.created_at),
+        "provenance": {"table": "project_profiles", "id": str(profile.id)},
+    }
+
+
+def _attachment_result(
+    attachment: IdeaProjectAttachment,
+    idea: Idea,
+    profile: ProjectProfile | None,
+    user: User | None,
+) -> dict[str, Any]:
+    links = thread_link_payload(attachment.idea_id)
+    return {
+        "type": "project_context_attachment",
+        "id": int(attachment.id),
+        "idea_id": str(attachment.idea_id),
+        "thread_id": str(attachment.idea_id),
+        **links,
+        "thread_reference": _thread_reference_snapshot(
+            thread_id=attachment.idea_id,
+            title=idea.display_title or idea.title,
+            preview_summary=idea.preview_summary,
+            preview_source=idea.preview_source,
+            preview_updated_at=idea.preview_updated_at,
+        ),
+        "idea_title": idea.display_title or idea.title,
+        "project_profile_id": str(attachment.project_profile_id) if attachment.project_profile_id else None,
+        "project_slug": profile.slug if profile else None,
+        "project_name": profile.name if profile else None,
+        "status": attachment.status,
+        "attached_by": str(attachment.attached_by) if attachment.attached_by else None,
+        "attached_by_name": user.name if user else None,
+        "resources": project_context_resource_summary(attachment.snapshot),
+        "created_at": _iso(attachment.created_at),
+        "provenance": {"table": "idea_project_attachments", "id": int(attachment.id)},
+    }
+
+
+async def search_project_contexts(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str | None,
+    query: str | None = None,
+    limit: int = 10,
+    include_inactive: bool = False,
+) -> dict[str, Any]:
+    """Search Project Context profiles and attachments visible to a user."""
+
+    text = str(query or "").strip()
+    max_results = max(1, min(int(limit or 10), 25))
+    results: list[dict[str, Any]] = []
+    terms = _search_terms(text)
+
+    profile_stmt = (
+        select(ProjectProfile, User)
+        .outerjoin(User, User.id == ProjectProfile.user_id)
+        .where(ProjectProfile.org_id == org_id)
+        .where(project_profile_visible_predicate(ProjectProfile, ProjectProfileAccess, user_id))
+        .order_by(ProjectProfile.created_at.desc(), ProjectProfile.id.desc())
+        .limit(max_results)
+    )
+    if not include_inactive:
+        profile_stmt = profile_stmt.where(ProjectProfile.active.is_(True))
+    profile_match = _match_all_terms(
+        terms,
+        ProjectProfile.slug,
+        ProjectProfile.name,
+        ProjectProfile.description,
+        cast(ProjectProfile.project_context, String),
+    )
+    if profile_match is not None:
+        profile_stmt = profile_stmt.where(profile_match)
+
+    for profile, user in (await session.execute(profile_stmt)).all():
+        results.append(_profile_result(profile, user))
+
+    remaining = max_results - len(results)
+    if remaining <= 0:
+        return {"query": text, "results": results}
+
+    attachment_stmt = (
+        select(IdeaProjectAttachment, Idea, ProjectProfile, User)
+        .join(Idea, Idea.id == IdeaProjectAttachment.idea_id)
+        .outerjoin(ProjectProfile, ProjectProfile.id == IdeaProjectAttachment.project_profile_id)
+        .outerjoin(User, User.id == IdeaProjectAttachment.attached_by)
+        .where(Idea.org_id == org_id)
+        .where(Idea.archived_at.is_(None))
+        .where(IdeaProjectAttachment.status != "invalid")
+        .order_by(IdeaProjectAttachment.created_at.desc(), IdeaProjectAttachment.id.desc())
+        .limit(remaining)
+    )
+    attachment_match = _match_all_terms(
+        terms,
+        Idea.title,
+        Idea.display_title,
+        ProjectProfile.slug,
+        ProjectProfile.name,
+        cast(IdeaProjectAttachment.snapshot, String),
+    )
+    if attachment_match is not None:
+        attachment_stmt = attachment_stmt.where(attachment_match)
+
+    for attachment, idea, profile, user in (await session.execute(attachment_stmt)).all():
+        results.append(_attachment_result(attachment, idea, profile, user))
+
+    return {"query": text, "results": results}

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -37,6 +37,7 @@ from brain.systems.cortex.thought_lifecycle import (
 )
 from brain.systems.cortex.thread_links import thread_id_from_reference, thread_link_payload
 from brain.systems.cortex.thread_read_model import thread_reference_payload
+from brain.systems.cortex.project_context.search import search_project_contexts
 from brain.systems.cortex.status import EXTERNAL_TASK_STARTABLE_IDEA_STATUSES
 from brain.systems.external_agents.status import EXTERNAL_AGENT_TASK_TERMINAL_STATUSES
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
@@ -1104,6 +1105,19 @@ async def search_workspace(
     max_results = max(1, min(int(limit or 10), 25))
     results: list[dict[str, Any]] = []
 
+    project_contexts = await search_project_contexts(
+        session,
+        org_id=principal.org_id,
+        user_id=principal.owner_user_id,
+        query=text,
+        limit=max_results,
+    )
+    results.extend(project_contexts["results"][:max_results])
+
+    remaining = max_results - len(results)
+    if remaining <= 0:
+        return {"query": text, "results": results}
+
     ideas = (
         await session.scalars(
             select(Idea)
@@ -1113,7 +1127,7 @@ async def search_workspace(
                 or_(Idea.title.ilike(pattern), Idea.description.ilike(pattern)),
             )
             .order_by(Idea.updated_at.desc(), Idea.id.desc())
-            .limit(max_results)
+            .limit(remaining)
         )
     ).all()
     for idea in ideas:

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -113,6 +113,16 @@
       "reason": "Platform code calls system behavior; replace with callback, event, or interface owned outside the adapter."
     },
     {
+      "source": "brain/platform/db/repositories/reconstructive_memory.py",
+      "import": "brain.systems.reconstructive_memory.ingestion",
+      "source_layer": "brain.platform",
+      "target_layer": "brain.systems",
+      "allowed_occurrences": 1,
+      "owner": "architecture-boundaries",
+      "planned_removal": "Move the compatibility write facade out of the platform repository layer or extract a lower-layer ingestion contract.",
+      "reason": "Compatibility repository delegates legacy writes into the reconstructive-memory system ingestion path."
+    },
+    {
       "source": "brain/platform/db/repositories/skill_bundles.py",
       "import": "brain.systems.skills.bundles",
       "source_layer": "brain.platform",

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -21,7 +21,14 @@ from brain.platform.db.models.external_agent import (
     ExternalAgentTaskRow,
 )
 from brain.systems.external_agents import service
-from brain.platform.db.models.idea import Idea, IdeaThread, UserMention
+from brain.platform.db.models.idea import (
+    Idea,
+    IdeaProjectAttachment,
+    IdeaThread,
+    ProjectProfile,
+    ProjectProfileAccess,
+    UserMention,
+)
 from brain.platform.db.models.notification import (
     NOTIFICATION_KIND_WORKSPACE_MENTION,
     NotificationEvent,
@@ -364,6 +371,74 @@ async def test_headless_ask_serializes_after_run_admission_without_lazy_loading(
     assert payload["illo_run_id"] is not None
     assert payload["updated_at"]
     assert [event["event_type"] for event in payload["events"]] == ["external_task.ask_illo_submitted"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_search_returns_visible_project_context_profiles(async_sqlite_session_factory):
+    _patch_sqlite_for_external_agent_tables()
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Idea.__table__,
+            IdeaThread.__table__,
+            ProjectProfile.__table__,
+            ProjectProfileAccess.__table__,
+            IdeaProjectAttachment.__table__,
+        ]
+    )
+    session.add_all(
+        [
+            Org(id=ORG_ID, name="Org", slug="org"),
+            User(id=OWNER_ID, org_id=ORG_ID, name="User", email="user@example.com", approved=True),
+        ]
+    )
+    await session.flush()
+    profile = ProjectProfile(
+        id="cccccccc-cccc-4ccc-8ccc-ccccccccccc1",
+        org_id=ORG_ID,
+        user_id=OWNER_ID,
+        slug="aritzia-uwear-client-project",
+        name="Aritzia / Uwear Client Project",
+        description="85K asset pilot with QA retry proof and delivery package.",
+        visibility="private",
+        active=True,
+        project_context={
+            "resources": [
+                {
+                    "id": "delivery-package",
+                    "kind": "folder",
+                    "label": "Delivery package",
+                    "path": "/projects/aritzia/delivery",
+                }
+            ]
+        },
+    )
+    session.add(profile)
+    await session.flush()
+
+    principal = service.AgentBridgePrincipal(
+        connection_id="conn-1",
+        org_id=ORG_ID,
+        owner_user_id=OWNER_ID,
+        token_id="token-1",
+        scopes=frozenset(service.DEFAULT_BRIDGE_SCOPES),
+        connection_display_name="Codex",
+        agent_kind="codex",
+    )
+
+    payload = await service.search_workspace(
+        session,
+        principal,
+        query="Aritzia 85K asset pilot",
+        limit=5,
+    )
+
+    assert payload["query"] == "Aritzia 85K asset pilot"
+    assert payload["results"][0]["type"] == "project_context_profile"
+    assert payload["results"][0]["slug"] == "aritzia-uwear-client-project"
+    assert payload["results"][0]["resources"]["count"] == 1
+    assert payload["results"][0]["resources"]["items"][0]["path"] == "/projects/aritzia/delivery"
 
 
 class _ScalarResult:

--- a/tests/test_hosted_mcp_project_contexts.py
+++ b/tests/test_hosted_mcp_project_contexts.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from brain.app.api.auth import get_current_user
+from brain.app.api.deps import get_db, rate_limit
+from brain.app.api.main import app
+from brain.systems.external_agents import service as external_agents
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AsyncSession:
+    def __init__(self):
+        self.sync_session = MagicMock()
+
+    async def run_sync(self, fn):
+        return fn(self.sync_session)
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+    async def close(self):
+        return None
+
+
+def _principal() -> external_agents.AgentBridgePrincipal:
+    return external_agents.AgentBridgePrincipal(
+        connection_id="conn-1",
+        org_id="org-1",
+        owner_user_id="user-1",
+        token_id="token-1",
+        scopes=frozenset(external_agents.DEFAULT_BRIDGE_SCOPES),
+        connection_display_name="Hermes",
+        agent_kind="hermes",
+    )
+
+
+async def _request(method: str, path: str, *, session: _AsyncSession | None = None, **kwargs):
+    overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = lambda: session or _AsyncSession()
+    app.dependency_overrides[get_current_user] = lambda: {
+        "id": "user-1",
+        "org_id": "org-1",
+        "role": "member",
+    }
+    app.dependency_overrides[rate_limit] = lambda: None
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.request(method, path, **kwargs)
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(overrides)
+
+
+async def test_hosted_mcp_read_capabilities_include_project_context_search():
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+        return_value=_principal(),
+    ):
+        response = await _request(
+            "POST",
+            "/mcp",
+            headers={"Authorization": "Bearer bridge-token"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "tools/call",
+                "params": {
+                    "name": "illo_read",
+                    "arguments": {"capability": "capabilities"},
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    names = {capability["name"] for capability in payload["capabilities"]}
+    assert "project_contexts.search" in names
+    details = next(capability for capability in payload["capabilities"] if capability["name"] == "project_contexts.search")
+    assert "Project Context" in details["description"]
+
+
+async def test_hosted_mcp_read_project_contexts_search_uses_bridge_principal_scope():
+    session = _AsyncSession()
+    captured: dict[str, object] = {}
+
+    async def fake_search_project_contexts(db, *, org_id, user_id, query, limit, include_inactive):
+        captured["db"] = db
+        captured["org_id"] = org_id
+        captured["user_id"] = user_id
+        captured["query"] = query
+        captured["limit"] = limit
+        captured["include_inactive"] = include_inactive
+        return {
+            "query": query,
+            "results": [
+                {
+                    "type": "project_context_profile",
+                    "slug": "aritzia-uwear-client-project",
+                    "name": "Aritzia / Uwear Client Project",
+                    "resources": {"count": 2, "items": []},
+                }
+            ],
+        }
+
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+        return_value=_principal(),
+    ), patch(
+        "brain.app.api.routers.agent_mcp.search_project_contexts",
+        new=AsyncMock(side_effect=fake_search_project_contexts),
+    ):
+        response = await _request(
+            "POST",
+            "/mcp",
+            session=session,
+            headers={"Authorization": "Bearer bridge-token"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "tools/call",
+                "params": {
+                    "name": "illo_read",
+                    "arguments": {
+                        "capability": "project_contexts.search",
+                        "arguments": {
+                            "query": "Aritzia 85K asset pilot",
+                            "limit": 7,
+                            "include_inactive": True,
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    assert payload["results"][0]["slug"] == "aritzia-uwear-client-project"
+    assert captured == {
+        "db": session,
+        "org_id": "org-1",
+        "user_id": "user-1",
+        "query": "Aritzia 85K asset pilot",
+        "limit": 7,
+        "include_inactive": True,
+    }

--- a/tests/test_illo_personal_agent_mcp.py
+++ b/tests/test_illo_personal_agent_mcp.py
@@ -32,6 +32,7 @@ def test_tool_catalog_contains_behavior_guidance():
     assert tools["illo_submit"]["inputSchema"]["required"] == ["message"]
     assert "named capability" in tools["illo_read"]["description"]
     assert tools["illo_read"]["inputSchema"]["required"] == ["capability"]
+    assert "project_contexts.search" in tools["illo_read"]["inputSchema"]["properties"]["capability"]["description"]
     assert "user's delegate" in tools["illo_act"]["description"]
     assert tools["illo_act"]["inputSchema"]["required"] == ["capability"]
     assert "result_id" in tools["illo_get_result"]["description"]

--- a/tools/illo-personal-agent-mcp/README.md
+++ b/tools/illo-personal-agent-mcp/README.md
@@ -156,6 +156,19 @@ A typical payload:
 }
 ```
 
+For saved project packets, docs, folders, or customer context, prefer the
+Project Context read capability:
+
+```json
+{
+  "capability": "project_contexts.search",
+  "arguments": {
+    "query": "aritzia client project",
+    "limit": 10
+  }
+}
+```
+
 ## Act
 
 Use `illo_act` only when the user has asked for a visible team action or for

--- a/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
+++ b/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
@@ -428,7 +428,7 @@ TOOLS: dict[str, dict[str, Any]] = {
             "properties": {
                 "capability": {
                     "type": "string",
-                    "description": "Read capability name, such as workspace.search, thread.get, handoff.get, team.members.list, domain.inspect, or capabilities.",
+                    "description": "Read capability name, such as workspace.search, project_contexts.search, thread.get, handoff.get, team.members.list, domain.inspect, or capabilities.",
                 },
                 "arguments": {"type": "object", "description": "Capability-specific arguments.", "default": {}},
             },


### PR DESCRIPTION
Summary:
- Add a canonical Project Context search module for profile and attachment discovery.
- Surface Project Context results through workspace.search and project_contexts.search in hosted MCP.
- Update the local MCP package docs/schema and add focused regression coverage.

Tests:
- git diff --check
- venv/bin/python -m py_compile brain/systems/cortex/project_context/search.py brain/systems/external_agents/service.py brain/app/api/routers/agent_mcp.py tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
- venv/bin/python -m pytest tests/test_external_agent_routes.py tests/test_external_agents_service.py tests/test_hosted_mcp_project_contexts.py tests/test_illo_personal_agent_mcp.py