### PR TITLE
Add share links for collaborative workspace apps

### DIFF
--- a/brain/app/api/schemas/workspace_apps.py
+++ b/brain/app/api/schemas/workspace_apps.py
@@ -34,6 +34,11 @@ class WorkspaceAppRead(BaseModel):
     updated_at: datetime
     active_version: WorkspaceAppVersionRead | None = None
     contract_validation: dict[str, Any] = Field(default_factory=dict)
+    app_route: str
+    app_url: str
+    share_url: str
+    url: str
+    thread_id: str | None = None
 
 
 class WorkspaceAppCreate(BaseModel):

--- a/brain/systems/workspace_apps/collaboration.py
+++ b/brain/systems/workspace_apps/collaboration.py
@@ -114,6 +114,25 @@ def _value_from_payload(payload: Mapping[str, Any], reducer: Mapping[str, Any]) 
     return dict(payload)
 
 
+def _reducer_object(action: Mapping[str, Any]) -> dict[str, Any]:
+    reducer = action.get("reducer")
+    if isinstance(reducer, str):
+        state_path = (
+            action.get("state_path")
+            or action.get("list_key")
+            or action.get("map_key")
+            or action.get("state_key")
+        )
+        normalized = {
+            "type": reducer.strip(),
+            "state_path": state_path,
+        }
+        if action.get("value_field") is not None:
+            normalized["value_field"] = action.get("value_field")
+        return normalized
+    return _as_mapping(reducer)
+
+
 def _top_level_patch(before: Mapping[str, Any], after: Mapping[str, Any]) -> dict[str, Any]:
     return {
         key: value
@@ -135,7 +154,7 @@ def _apply_reducer(
     payload: Mapping[str, Any],
     actor_key: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    reducer = _as_mapping(action.get("reducer"))
+    reducer = _reducer_object(action)
     if not reducer:
         return data, {}
 

--- a/brain/systems/workspace_apps/contracts.py
+++ b/brain/systems/workspace_apps/contracts.py
@@ -238,12 +238,31 @@ def _validate_collaboration(value: Mapping[str, Any], errors: list[str]) -> None
         reducer = raw_action.get("reducer")
         if reducer is None:
             continue
-        reducer_obj = _as_mapping(reducer)
+        reducer_obj = _collaboration_reducer_object(raw_action)
         reducer_type = str(reducer_obj.get("type") or "").strip()
         if reducer_type not in {"choice_by_actor", "append", "set"}:
             errors.append(f"{prefix}.reducer.type must be one of: append, choice_by_actor, set")
         if not str(reducer_obj.get("state_path") or "").strip():
             errors.append(f"{prefix}.reducer.state_path is required")
+
+
+def _collaboration_reducer_object(action: Mapping[str, Any]) -> dict[str, Any]:
+    reducer = action.get("reducer")
+    if isinstance(reducer, str):
+        state_path = (
+            action.get("state_path")
+            or action.get("list_key")
+            or action.get("map_key")
+            or action.get("state_key")
+        )
+        normalized = {
+            "type": reducer.strip(),
+            "state_path": state_path,
+        }
+        if action.get("value_field") is not None:
+            normalized["value_field"] = action.get("value_field")
+        return normalized
+    return _as_mapping(reducer)
 
 
 def _validate_domain_binding(alias: str, value: Any, errors: list[str]) -> None:

--- a/brain/systems/workspace_apps/links.py
+++ b/brain/systems/workspace_apps/links.py
@@ -1,0 +1,58 @@
+"""Canonical share links for generated workspace apps."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+from urllib.parse import quote
+
+from brain.systems.cortex.thread_links import LEGACY_CORTEX_ROUTE, thread_route_for_id, thread_url_for_route
+
+WORKSPACE_APP_QUERY_PARAM = "app"
+
+
+def thread_id_from_app_metadata(metadata: Mapping[str, Any] | None) -> str | None:
+    data = dict(metadata or {})
+    thread_artifact = data.get("thread_artifact")
+    candidates = [
+        data.get("thread_id"),
+        thread_artifact.get("thread_id") if isinstance(thread_artifact, Mapping) else None,
+    ]
+    for value in candidates:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return None
+
+
+def workspace_app_route_for_id(app_id: Any, *, thread_id: Any | None = None) -> str:
+    encoded_app_id = quote(str(app_id), safe="")
+    base_route = thread_route_for_id(thread_id) if thread_id else LEGACY_CORTEX_ROUTE
+    separator = "&" if "?" in base_route else "?"
+    return f"{base_route}{separator}{WORKSPACE_APP_QUERY_PARAM}={encoded_app_id}"
+
+
+def workspace_app_url_for_id(app_id: Any, *, thread_id: Any | None = None) -> str:
+    return thread_url_for_route(workspace_app_route_for_id(app_id, thread_id=thread_id))
+
+
+def workspace_app_link_payload(app_id: Any, *, metadata: Mapping[str, Any] | None = None) -> dict[str, str]:
+    thread_id = thread_id_from_app_metadata(metadata)
+    route = workspace_app_route_for_id(app_id, thread_id=thread_id)
+    url = thread_url_for_route(route)
+    payload = {
+        "app_route": route,
+        "app_url": url,
+        "share_url": url,
+        "url": url,
+    }
+    if thread_id:
+        payload["thread_id"] = thread_id
+    return payload
+
+
+__all__ = [
+    "WORKSPACE_APP_QUERY_PARAM",
+    "thread_id_from_app_metadata",
+    "workspace_app_link_payload",
+    "workspace_app_route_for_id",
+    "workspace_app_url_for_id",
+]

--- a/brain/systems/workspace_apps/service.py
+++ b/brain/systems/workspace_apps/service.py
@@ -18,6 +18,7 @@ from brain.systems.workspace_apps.contracts import (
     build_contract_validation_report,
     record_like_state_keys,
 )
+from brain.systems.workspace_apps.links import workspace_app_link_payload
 
 DEFAULT_RENDERER_KEY = APP_CAPSULE_RENDERER_KEY
 DEFAULT_SOURCE_KIND = APP_CAPSULE_SOURCE_KIND
@@ -386,6 +387,7 @@ async def a_serialize_app(
     version: WorkspaceAppVersion | None | object = _VERSION_MISSING,
 ) -> dict[str, Any]:
     resolved_version = await a_active_version(session, app.id) if version is _VERSION_MISSING else version
+    links = workspace_app_link_payload(app.id, metadata=app.app_metadata or {})
     return {
         "id": app.id,
         "org_id": app.org_id,
@@ -402,6 +404,7 @@ async def a_serialize_app(
         "updated_at": app.updated_at,
         "active_version": serialize_version(resolved_version),
         "contract_validation": contract_validation_report_for_app(app, resolved_version),
+        **links,
     }
 
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -563,6 +563,11 @@ export interface WorkspaceAppRead {
   updated_at: string;
   active_version: WorkspaceAppVersionRead | null;
   contract_validation: Record<string, any>;
+  app_route: string;
+  app_url: string;
+  share_url: string;
+  url: string;
+  thread_id?: string | null;
 }
 
 export interface WorkspaceAppStateRead {

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -60,6 +60,7 @@
   } from '$lib/features/threads/domain/threadLinks';
 
   const RUNTIME_READY_ONBOARDING_PARAM = 'runtime-ready';
+  const WORKSPACE_APP_QUERY_PARAM = 'app';
   const WORKSPACE_ARRIVAL_DURATION_MS = 1320;
   const RUNTIME_READY_INTRO_DELAY_MS = 1560;
   type RuntimeReadyComposerDraft = {
@@ -101,6 +102,10 @@
     return threadIdFromUrl($page.url);
   }
 
+  function requestedWorkspaceAppIdFromPage() {
+    return ($page.url.searchParams.get(WORKSPACE_APP_QUERY_PARAM) || '').trim() || null;
+  }
+
   function isThreadStageUrl() {
     return isThreadRoutePathname($page.url.pathname) || Boolean($page.url.searchParams.get(CORTEX_THREAD_PARAM));
   }
@@ -108,6 +113,7 @@
   let initialDirectThreadIdeaId = $state<string | null>(requestedThreadIdeaIdFromPage());
   let directThreadUrlPending = $state(Boolean(requestedThreadIdeaIdFromPage()));
   let lastAutoOpenedAppId = $state<string | null>(null);
+  let lastRouteOpenedWorkspaceAppId = $state<string | null>(null);
   let threadStagePrewarmQueued = false;
   let CortexArchiveBinMenuComponent = $state<typeof import('$lib/features/cortex/components/ArchiveBinMenu.svelte').default | null>(null);
   let WorkspaceSceneComponent = $state<typeof import('$lib/features/workspace-scene/components/WorkspaceScene.svelte').default | null>(null);
@@ -266,6 +272,23 @@
   });
 
   $effect(() => {
+    if (isThreadStageUrl()) return;
+    const requestedAppId = requestedWorkspaceAppIdFromPage();
+    if (!requestedAppId) {
+      lastRouteOpenedWorkspaceAppId = null;
+      return;
+    }
+    const app = workspaceApps.appById(requestedAppId);
+    if (!app) {
+      if (!workspaceApps.loaded) void workspaceApps.load({ silent: true });
+      return;
+    }
+    if (requestedAppId === lastRouteOpenedWorkspaceAppId && workspaceOverlay.activeWorkspaceAppId === requestedAppId) return;
+    lastRouteOpenedWorkspaceAppId = requestedAppId;
+    void openWorkspaceAppFromRoute(requestedAppId);
+  });
+
+  $effect(() => {
     const modalId = activeWorkspacePageModalId;
     if (!modalId) {
       workspacePageLoadToken += 1;
@@ -323,6 +346,14 @@
 
   async function handleWorkspaceAppOpen(origin: { x: number; y: number; appId: string }) {
     workspaceOverlay.openWorkspaceAppOverlay(origin.appId);
+    threadStage.setCenteredOrigin('50%', '50%');
+    if (cortex.panelOpen) {
+      await cortex.selectIdea(null);
+    }
+  }
+
+  async function openWorkspaceAppFromRoute(appId: string) {
+    workspaceOverlay.openWorkspaceAppOverlay(appId);
     threadStage.setCenteredOrigin('50%', '50%');
     if (cortex.panelOpen) {
       await cortex.selectIdea(null);

--- a/tests/test_workspace_app_collaboration.py
+++ b/tests/test_workspace_app_collaboration.py
@@ -174,6 +174,56 @@ async def test_collaboration_event_applies_declared_reducer_and_lists_events(ses
     assert snapshot["events"][0]["id"] == result["events"][0]["id"]
 
 
+async def test_collaboration_accepts_reducer_shorthand_manifest(session):
+    manifest = _collaboration_manifest()
+    manifest["collaboration"]["actions"]["vote.cast"] = {
+        "description": "Record or update one participant vote.",
+        "reducer": "choice_by_actor",
+        "state_key": "votes",
+        "value_field": "optionId",
+    }
+    manifest["collaboration"]["actions"]["note.add"] = {
+        "description": "Append one participant note.",
+        "reducer": "append",
+        "list_key": "notes",
+    }
+
+    app = await a_create_app(
+        session,
+        org_id=ORG_ID,
+        key="shorthand-decision-board",
+        name="Shorthand Decision Board",
+        renderer_key="app-capsule",
+        source_kind="html",
+        source_code=VALID_SOURCE,
+        manifest=manifest,
+        visual_spec={"thumbnail": {"label": "Decision", "value": "Open"}},
+        initial_state={"votes": {}, "notes": []},
+        state_key="decision-board",
+        created_by_user_id=USER_ID,
+    )
+
+    vote = await a_append_collaboration_event(
+        session,
+        org_id=ORG_ID,
+        app_id=app.id,
+        event_type="vote.cast",
+        payload={"optionId": "decision-board"},
+        user_id=USER_ID,
+    )
+    note = await a_append_collaboration_event(
+        session,
+        org_id=ORG_ID,
+        app_id=app.id,
+        event_type="note.add",
+        payload={"text": "The board makes feedback concrete."},
+        user_id=USER_ID,
+    )
+
+    assert vote["state"]["data"]["votes"][f"user:{USER_ID}"]["value"] == "decision-board"
+    assert note["state"]["data"]["notes"] == [{"text": "The board makes feedback concrete."}]
+
+
 async def test_collaboration_event_idempotency_returns_existing_event(session):
     app = await _create_collaboration_app(session)
 

--- a/tests/test_workspace_apps_service.py
+++ b/tests/test_workspace_apps_service.py
@@ -31,6 +31,7 @@ from brain.systems.workspace_apps.service import (
     a_delete_archived_apps,
     a_list_archived_apps,
     a_restore_app,
+    a_serialize_app,
     a_update_app,
 )
 from brain.systems.workspace_apps.bindings import WorkspaceAppBindingError, async_run_workspace_app_binding
@@ -305,6 +306,54 @@ async def test_app_capsule_capability_manifest_saves(session):
     assert version.renderer_key == "app-capsule"
     assert version.source_kind == "html"
     assert version.manifest["data_plan"]["mode"] == "capability"
+
+
+async def test_serialized_workspace_app_includes_share_url(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com/app")
+
+    app = await a_create_app(
+        session,
+        org_id=ORG_ID,
+        key="team-feedback",
+        name="Team Feedback",
+        renderer_key="app-capsule",
+        source_kind="html",
+        source_code=VALID_SOURCE,
+        manifest=_app_local_manifest(),
+        visual_spec=VALID_VISUAL_SPEC,
+        created_by_user_id=USER_ID,
+    )
+
+    serialized = await a_serialize_app(session, app)
+
+    assert serialized["app_route"] == f"/cortex?app={app.id}"
+    assert serialized["app_url"] == f"https://illo.example.com/cortex?app={app.id}"
+    assert serialized["share_url"] == serialized["app_url"]
+    assert serialized["url"] == serialized["app_url"]
+
+
+async def test_serialized_thread_workspace_app_uses_thread_share_url(session, monkeypatch):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com/app")
+
+    app = await a_create_app(
+        session,
+        org_id=ORG_ID,
+        key="thread-feedback",
+        name="Thread Feedback",
+        renderer_key="app-capsule",
+        source_kind="html",
+        source_code=VALID_SOURCE,
+        manifest=_app_local_manifest(),
+        visual_spec=VALID_VISUAL_SPEC,
+        metadata={"thread_artifact": {"thread_id": "thread:123"}},
+        created_by_user_id=USER_ID,
+    )
+
+    serialized = await a_serialize_app(session, app)
+
+    assert serialized["thread_id"] == "thread:123"
+    assert serialized["app_route"] == f"/threads/thread%3A123?app={app.id}"
+    assert serialized["app_url"] == f"https://illo.example.com/threads/thread%3A123?app={app.id}"
 
 
 async def test_workspace_app_binding_broker_routes_domain_operations(session):


### PR DESCRIPTION
## Summary
- include canonical app/share URLs in workspace app API and tool serialization
- support /cortex?app=<id> direct opening for workspace-level generated apps
- accept reducer shorthand in collaborative workspace app manifests so agent-authored apps can use intuitive action specs

## Why
A live Illo collaboration run successfully created a reusable team feedback app, then stalled when the tool result exposed only an app id. Illo had to guess the route instead of receiving a canonical share URL. The same run also generated natural reducer shorthand, which failed validation before self-repairing. These changes make the generic collaborative artifact runtime easier for Illo to use without coding for one specific brainstorming board.

## Verification
- ./venv/bin/python3 -m pytest tests/test_workspace_apps_service.py tests/test_workspace_app_collaboration.py tests/test_thread_artifacts.py tests/test_workspace_app_contract.py tests/test_tool_registry.py tests/test_thread_url_references.py -q
- npm run check