### PR TITLE
Fix collaboration artifact postMessage cloning

### DIFF
--- a/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
@@ -21,6 +21,7 @@
   import { theme } from '$lib/stores/theme.svelte';
   import { ui } from '$lib/stores/ui.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
+  import { cloneForPostMessage } from '$lib/utils/postMessageClone';
 
   import GeneratedAppChrome from './GeneratedAppChrome.svelte';
 
@@ -92,7 +93,7 @@
   function postToFrame(type: string, payload: Record<string, any> = {}) {
     const target = frameWindow();
     if (!target) return;
-    target.postMessage({ source: 'illo-host', type, ...payload }, '*');
+    target.postMessage(cloneForPostMessage({ source: 'illo-host', type, ...payload }), '*');
   }
 
   function buildInitPayload() {

--- a/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/GeneratedHtmlAppRuntime.svelte
@@ -21,6 +21,7 @@
   import { theme } from '$lib/stores/theme.svelte';
   import { workspaceApps } from '$lib/stores/workspaceApps.svelte';
   import { ui } from '$lib/stores/ui.svelte';
+  import { cloneForPostMessage } from '$lib/utils/postMessageClone';
   import { normalizeDomainRequest, withDomainRecordAliases } from '$lib/utils/generatedAppBridge';
 
   import GeneratedAppChrome from './GeneratedAppChrome.svelte';
@@ -123,7 +124,7 @@
 
         function request(type, payload) {
           const requestId = nextId();
-          parent.postMessage({ source: 'illo-app', type, requestId, ...(payload || {}) }, '*');
+          parent.postMessage(cloneForBridge({ source: 'illo-app', type, requestId, ...(payload || {}) }), '*');
           return new Promise((resolve, reject) => {
             pending.set(requestId, { resolve, reject });
             setTimeout(() => {
@@ -132,6 +133,40 @@
               reject(new Error('Illo host bridge timed out'));
             }, 8000);
           });
+        }
+
+        function jsonRoundTrip(value) {
+          try {
+            return JSON.parse(JSON.stringify(value));
+          } catch (error) {
+            return null;
+          }
+        }
+
+        function safeJsonValue(value, seen) {
+          if (value === undefined || typeof value === 'function' || typeof value === 'symbol') return undefined;
+          if (typeof value === 'bigint') return String(value);
+          if (!value || typeof value !== 'object') return value;
+          if (value instanceof Date) return value.toISOString();
+          seen = seen || new WeakSet();
+          if (seen.has(value)) return undefined;
+          seen.add(value);
+          if (Array.isArray(value)) return value.map((item) => safeJsonValue(item, seen));
+          const output = {};
+          Object.entries(value).forEach(([key, item]) => {
+            const safeItem = safeJsonValue(item, seen);
+            if (safeItem !== undefined) output[key] = safeItem;
+          });
+          return output;
+        }
+
+        function cloneForBridge(value) {
+          if (!value || typeof value !== 'object') return value;
+          try {
+            return structuredClone(value);
+          } catch (error) {
+            return jsonRoundTrip(value) || safeJsonValue(value);
+          }
         }
 
         function applyTheme(nextTheme) {
@@ -687,7 +722,7 @@
   function postToFrame(type: string, payload: Record<string, any> = {}) {
     const target = frameWindow();
     if (!target) return;
-    target.postMessage({ source: 'illo-host', type, ...payload }, '*');
+    target.postMessage(cloneForPostMessage({ source: 'illo-host', type, ...payload }), '*');
   }
 
   function buildInitPayload() {

--- a/frontend/src/lib/features/workspace-apps/runtime/appCapsuleBridge.ts
+++ b/frontend/src/lib/features/workspace-apps/runtime/appCapsuleBridge.ts
@@ -25,7 +25,7 @@ export function appCapsuleBridgeScript(app: AppCapsuleRuntimeApp) {
 
       function request(type, payload) {
         const requestId = nextId();
-        parent.postMessage({ source: 'illo-app', type, requestId, ...(payload || {}) }, '*');
+        parent.postMessage(cloneForBridge({ source: 'illo-app', type, requestId, ...(payload || {}) }), '*');
         return new Promise((resolve, reject) => {
           pending.set(requestId, { resolve, reject });
           setTimeout(() => {
@@ -34,6 +34,40 @@ export function appCapsuleBridgeScript(app: AppCapsuleRuntimeApp) {
             reject(new Error('Illo app bridge timed out'));
           }, 8000);
         });
+      }
+
+      function jsonRoundTrip(value) {
+        try {
+          return JSON.parse(JSON.stringify(value));
+        } catch (error) {
+          return null;
+        }
+      }
+
+      function safeJsonValue(value, seen) {
+        if (value === undefined || typeof value === 'function' || typeof value === 'symbol') return undefined;
+        if (typeof value === 'bigint') return String(value);
+        if (!value || typeof value !== 'object') return value;
+        if (value instanceof Date) return value.toISOString();
+        seen = seen || new WeakSet();
+        if (seen.has(value)) return undefined;
+        seen.add(value);
+        if (Array.isArray(value)) return value.map((item) => safeJsonValue(item, seen));
+        const output = {};
+        Object.entries(value).forEach(([key, item]) => {
+          const safeItem = safeJsonValue(item, seen);
+          if (safeItem !== undefined) output[key] = safeItem;
+        });
+        return output;
+      }
+
+      function cloneForBridge(value) {
+        if (!value || typeof value !== 'object') return value;
+        try {
+          return structuredClone(value);
+        } catch (error) {
+          return jsonRoundTrip(value) || safeJsonValue(value);
+        }
       }
 
       function stableSignature(value) {

--- a/frontend/src/lib/utils/postMessageClone.test.js
+++ b/frontend/src/lib/utils/postMessageClone.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cloneForPostMessage } from './postMessageClone.ts';
+
+test('cloneForPostMessage strips proxy wrappers before browser postMessage', () => {
+  const proxiedState = new Proxy(
+    {
+      state: {
+        votes: {
+          'user:1': {
+            value: 'decision-room',
+          },
+        },
+        notes: [{ body: 'Keep the decision with the thread context.' }],
+      },
+    },
+    {},
+  );
+
+  assert.throws(() => structuredClone(proxiedState), { name: 'DataCloneError' });
+
+  const clone = cloneForPostMessage(proxiedState);
+
+  assert.deepEqual(clone, {
+    state: {
+      votes: {
+        'user:1': {
+          value: 'decision-room',
+        },
+      },
+      notes: [{ body: 'Keep the decision with the thread context.' }],
+    },
+  });
+  assert.deepEqual(structuredClone(clone), clone);
+});
+
+test('cloneForPostMessage keeps bridge payloads JSON-shaped when generated apps pass non-data values', () => {
+  const cyclic = { name: 'payload' };
+  cyclic.self = cyclic;
+
+  const clone = cloneForPostMessage({
+    eventType: 'vote.cast',
+    payload: {
+      optionId: 'decision-room',
+      callback: () => {},
+      bigint: 42n,
+      cyclic,
+    },
+  });
+
+  assert.deepEqual(clone, {
+    eventType: 'vote.cast',
+    payload: {
+      optionId: 'decision-room',
+      bigint: '42',
+      cyclic: {
+        name: 'payload',
+      },
+    },
+  });
+  assert.deepEqual(structuredClone(clone), clone);
+});

--- a/frontend/src/lib/utils/postMessageClone.ts
+++ b/frontend/src/lib/utils/postMessageClone.ts
@@ -1,0 +1,38 @@
+type JsonishRecord = Record<string, unknown>;
+
+function jsonRoundTrip<T>(value: T): T | null {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol') return undefined;
+  if (typeof value === 'bigint') return String(value);
+  if (!value || typeof value !== 'object') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (seen.has(value)) return undefined;
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => safeJsonValue(item, seen));
+
+  const output: JsonishRecord = {};
+  for (const [key, item] of Object.entries(value as JsonishRecord)) {
+    const safeItem = safeJsonValue(item, seen);
+    if (safeItem !== undefined) output[key] = safeItem;
+  }
+  return output;
+}
+
+export function cloneForPostMessage<T>(value: T): T {
+  if (!value || typeof value !== 'object') return value;
+
+  try {
+    return structuredClone(value);
+  } catch {
+    const jsonClone = jsonRoundTrip(value);
+    if (jsonClone !== null) return jsonClone;
+    return safeJsonValue(value) as T;
+  }
+}


### PR DESCRIPTION
## Summary
- clone/sanitize host-to-artifact postMessage payloads before sending them into iframe runtimes
- clone/sanitize generated app bridge payloads before sending them back to the host
- add regression coverage for proxy payloads and non-data bridge payloads

## Verification
- npm run test
- npm run check
- npm run build