### PR TITLE
Preserve thread artifact app deep links

### DIFF
--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -50,7 +50,10 @@
     isWorkspacePageModalId,
     type WorkspacePageModalId,
   } from '$lib/features/cortex/domain/workspacePageModal';
-  import { decideThreadRouteSelection } from '$lib/features/cortex/domain/threadRouteOpening';
+  import {
+    buildSyncedThreadRouteHref,
+    decideThreadRouteSelection,
+  } from '$lib/features/cortex/domain/threadRouteOpening';
   import {
     buildCortexHrefWithoutThread,
     CORTEX_THREAD_PARAM,
@@ -1014,7 +1017,7 @@
 
   function syncCanonicalThreadUrl(ideaId: string | null | undefined): boolean {
     if (!browser || !ideaId) return false;
-    const nextRoute = threadRoute(ideaId);
+    const nextRoute = buildSyncedThreadRouteHref(ideaId, $page.url.searchParams);
     const current = `${$page.url.pathname}${$page.url.search}${$page.url.hash}`;
     lastSyncedThreadRoute = nextRoute;
     if (current === nextRoute) return false;

--- a/frontend/src/lib/features/cortex/domain/threadRouteOpening.ts
+++ b/frontend/src/lib/features/cortex/domain/threadRouteOpening.ts
@@ -1,3 +1,5 @@
+import { buildCortexThreadHref } from '../../threads/domain/threadLinks.ts';
+
 export type ThreadRouteSelectionDecision =
   | { action: 'idle'; directThreadUrlPending: false }
   | { action: 'already-open'; ideaId: string; directThreadUrlPending: false }
@@ -23,4 +25,11 @@ export function decideThreadRouteSelection({
   }
   if (requestedIdeaId === lastRequestedIdeaId) return { action: 'skip-repeat' };
   return { action: 'load-direct', ideaId: requestedIdeaId };
+}
+
+export function buildSyncedThreadRouteHref(
+  ideaId: string,
+  sourceParams?: URLSearchParams,
+): string {
+  return buildCortexThreadHref(ideaId, sourceParams);
 }

--- a/frontend/src/lib/utils/threadLinks.test.js
+++ b/frontend/src/lib/utils/threadLinks.test.js
@@ -25,6 +25,20 @@ test('builds canonical thread routes and removes transient query params', () => 
   );
 });
 
+test('canonical thread routes preserve generated app deep links', () => {
+  const params = new URLSearchParams({
+    idea: 'old-thread',
+    app: 'app-123',
+    artifact_app: 'legacy-app-456',
+    focus: 'reply',
+  });
+
+  assert.equal(
+    buildCortexThreadHref('thread:123', params),
+    '/threads/thread%3A123?app=app-123&artifact_app=legacy-app-456&focus=reply',
+  );
+});
+
 test('extracts thread ids from canonical and legacy URLs', () => {
   assert.equal(threadIdFromThreadPathname('/threads/thread%3A123'), 'thread:123');
   assert.equal(threadIdFromUrl(new URL('http://localhost:8080/threads/abc-123')), 'abc-123');

--- a/frontend/src/lib/utils/threadRouteOpening.test.js
+++ b/frontend/src/lib/utils/threadRouteOpening.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { decideThreadRouteSelection } from '../features/cortex/domain/threadRouteOpening.ts';
+import {
+  buildSyncedThreadRouteHref,
+  decideThreadRouteSelection,
+} from '../features/cortex/domain/threadRouteOpening.ts';
 
 test('thread routes load through the direct thread path', () => {
   assert.deepEqual(
@@ -48,5 +51,19 @@ test('thread routes skip duplicate unresolved requests', () => {
       lastRequestedIdeaId: 'missing-thread',
     }),
     { action: 'skip-repeat' },
+  );
+});
+
+test('thread route synchronization preserves app deep links', () => {
+  const params = new URLSearchParams({
+    idea: 'legacy-thread',
+    app: 'generated-app-1',
+    onboarding: 'runtime-ready',
+    focus: 'reply',
+  });
+
+  assert.equal(
+    buildSyncedThreadRouteHref('thread-1', params),
+    '/threads/thread-1?app=generated-app-1&focus=reply',
   );
 });


### PR DESCRIPTION
## Summary
- preserve generated app query params when syncing direct thread routes
- keep canonical thread route cleanup for transient bootstrap params
- add regression coverage for thread app deep links

## Repro
Opening /threads/:threadId?app=:appId canonicalized to /threads/:threadId, so the artifact dock never opened.

## Verification
- npm run test
- npm run check
- npm run build