### PR TITLE
Add reusable thread collaboration app

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -524,6 +524,23 @@ ACT_CAPABILITIES: dict[str, dict[str, Any]] = {
             "initial_state": "object",
         },
     },
+    "thread.collaboration.start": {
+        "description": (
+            "Start or update a reusable team collaboration board for a thread. "
+            "Use this for brainstorms, votes, async team opinions, decision rooms, and status collection "
+            "instead of generating throwaway HTML apps."
+        ),
+        "arguments": {
+            "idea_id": "string",
+            "thread_id": "string",
+            "title": "string",
+            "prompt": "string",
+            "mode": "string",
+            "options": "object[]",
+            "session_key": "string",
+            "metadata": "object",
+        },
+    },
     **agent_mcp_handoffs.ACT_CAPABILITIES,
     "domain.record.write": {
         "description": "Create, update, or archive records in Illo Domains as the user's external-agent delegate.",
@@ -745,6 +762,34 @@ async def _act_publish_thread_artifact(
     return result
 
 
+async def _act_start_thread_collaboration(
+    db: AsyncSession,
+    principal: external_agents.AgentBridgePrincipal,
+    capability_arguments: dict[str, Any],
+) -> dict[str, Any]:
+    from brain.systems.cortex.thread_artifacts import publish_thread_collaboration_app
+
+    result = await publish_thread_collaboration_app(
+        db,
+        org_id=principal.org_id,
+        user_id=principal.owner_user_id,
+        thread_id=_thread_argument_id(capability_arguments),
+        title=_required_capability_string(capability_arguments, "title", capability="thread.collaboration.start"),
+        prompt=_required_capability_string(capability_arguments, "prompt", capability="thread.collaboration.start"),
+        mode=_clean_optional_string(capability_arguments.get("mode")),
+        options=capability_arguments.get("options") if isinstance(capability_arguments.get("options"), list) else [],
+        session_key=_clean_optional_string(capability_arguments.get("session_key")),
+        metadata={
+            **_clean_dict(capability_arguments.get("metadata")),
+            "mcp_tool": ACT_TOOL_NAME,
+            "mcp_capability": "thread.collaboration.start",
+        },
+    )
+    result["_mutates_workspace_app"] = True
+    result["_workspace_app_change"] = {"action": result["action"], "app": result["app"]}
+    return result
+
+
 async def _tool_act(
     db: AsyncSession,
     principal: external_agents.AgentBridgePrincipal,
@@ -770,6 +815,8 @@ async def _tool_act(
         )
     if capability == "thread.artifact.publish":
         return await _act_publish_thread_artifact(db, principal, capability_arguments)
+    if capability == "thread.collaboration.start":
+        return await _act_start_thread_collaboration(db, principal, capability_arguments)
     if capability == "handoff.create":
         return await agent_mcp_handoffs.create_handoff(
             db,

--- a/brain/systems/cortex/thread_artifacts.py
+++ b/brain/systems/cortex/thread_artifacts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Mapping
+from urllib.parse import urlencode
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,15 +18,21 @@ from brain.systems.workspace_apps.contracts import (
 )
 from brain.systems.workspace_apps.service import (
     WorkspaceAppNotFound,
+    a_active_version,
     a_create_app,
     a_get_app,
+    a_get_or_create_state,
     a_serialize_app,
     a_update_app,
     slugify,
 )
 
 THREAD_ARTIFACT_SOURCE = "thread_artifact"
+THREAD_COLLABORATION_SOURCE = "system_thread_collaboration"
 DEFAULT_THREAD_ARTIFACT_KIND = "interactive"
+SYSTEM_COLLABORATION_APP_KEY = "system-team-collaboration-board"
+SYSTEM_COLLABORATION_APP_NAME = "Team Collaboration Board"
+SYSTEM_COLLABORATION_STATE_PREFIX = "thread-collab"
 
 
 class ThreadArtifactError(ValueError):
@@ -47,6 +54,12 @@ def _thread_artifact_key(thread_id: str, title: str, artifact_kind: str) -> str:
     title_part = slugify(title)[:48] or "artifact"
     kind_part = slugify(artifact_kind)[:24] or DEFAULT_THREAD_ARTIFACT_KIND
     return f"thread-{thread_part}-{kind_part}-{title_part}"[:100]
+
+
+def _thread_collaboration_state_key(thread_id: str, session_key: str | None = None) -> str:
+    thread_part = slugify(str(thread_id))[:72] or "thread"
+    session_part = slugify(str(session_key or "default"))[:32] or "default"
+    return f"{SYSTEM_COLLABORATION_STATE_PREFIX}-{thread_part}-{session_part}"[:120]
 
 
 def _default_manifest(thread_id: str, artifact_kind: str, manifest: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -100,6 +113,300 @@ def _artifact_metadata(
     return next_metadata
 
 
+def _system_collaboration_metadata(metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    next_metadata = dict(metadata or {})
+    next_metadata["source"] = THREAD_COLLABORATION_SOURCE
+    next_metadata["system_app"] = True
+    next_metadata["artifact_scope"] = "thread"
+    next_metadata.setdefault(
+        "description",
+        "Product-owned reusable collaboration board for thread-scoped votes, notes, and decisions.",
+    )
+    return next_metadata
+
+
+def _system_collaboration_manifest() -> dict[str, Any]:
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "state_key": "default",
+        "data_plan": {"mode": "capability", "bindings": {}},
+        "collaboration": {
+            "mode": "event_sourced",
+            "state_key": "default",
+            "actions": {
+                "vote.cast": {
+                    "label": "Cast vote",
+                    "description": "Record or update one participant vote.",
+                    "reducer": {
+                        "type": "choice_by_actor",
+                        "state_path": "votes",
+                        "value_field": "optionId",
+                    },
+                },
+                "note.add": {
+                    "label": "Add note",
+                    "description": "Append one participant note.",
+                    "reducer": {"type": "append", "state_path": "notes"},
+                },
+                "status.change": {
+                    "label": "Change status",
+                    "description": "Set the current collaboration status or decision.",
+                    "reducer": {"type": "set", "state_path": "status"},
+                },
+            },
+        },
+        "design_contract": {"kit": APP_KIT_NAME, "theme_modes": ["dark", "light"]},
+    }
+
+
+def _system_collaboration_visual_spec() -> dict[str, Any]:
+    return {
+        "accent": "teal",
+        "thumbnail": {
+            "label": "Collaboration",
+            "value": "Live",
+            "secondary": "Votes, notes, decisions",
+        },
+    }
+
+
+def _clean_collaboration_options(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    options: list[dict[str, str]] = []
+    for index, item in enumerate(value[:12], start=1):
+        if isinstance(item, Mapping):
+            label = _clean_text(item.get("label") or item.get("title") or item.get("name"))
+            option_id = _clean_text(item.get("id") or item.get("key") or label)
+            description = _clean_text(item.get("description") or item.get("body") or item.get("text"))
+        else:
+            label = _clean_text(item)
+            option_id = label
+            description = None
+        if not label:
+            continue
+        options.append(
+            {
+                "id": slugify(option_id or label)[:80] or f"option-{index}",
+                "label": label[:120],
+                "description": (description or "")[:280],
+            }
+        )
+    return options
+
+
+def _collaboration_initial_data(
+    *,
+    title: str,
+    prompt: str,
+    mode: str,
+    options: list[dict[str, str]],
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "config": {
+            "title": title,
+            "prompt": prompt,
+            "mode": mode,
+            "options": options,
+            "allow_notes": True,
+            "metadata": dict(metadata or {}),
+        },
+        "votes": {},
+        "notes": [],
+        "status": {"phase": "collecting_signal", "decision": None},
+    }
+
+
+SYSTEM_COLLABORATION_APP_SOURCE = r"""
+<main class="illo-app">
+  <style>
+    .illo-app { box-sizing: border-box; min-height: 100%; padding: 28px; background: #f7f4ec; color: #182724; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .wrap { max-width: 880px; margin: 0 auto; display: grid; gap: 18px; }
+    .eyebrow { margin: 0; color: #2d877b; font-size: 13px; font-weight: 800; letter-spacing: 0; text-transform: uppercase; }
+    h1 { margin: 4px 0 0; font-size: clamp(30px, 5vw, 46px); line-height: 1.03; letter-spacing: 0; }
+    .prompt { margin: 0; color: #61706c; font-size: 18px; line-height: 1.48; }
+    .metrics { display: flex; flex-wrap: wrap; gap: 10px; }
+    .pill { border: 1px solid #ddd4c7; background: #fffdf8; border-radius: 999px; padding: 9px 13px; color: #66736f; font-size: 14px; white-space: nowrap; }
+    .pill strong { color: #1d2d2a; }
+    .options, .notes { display: grid; gap: 12px; }
+    .option, .note-panel { border: 1px solid #ded6ca; background: #fffdf8; border-radius: 8px; padding: 18px; }
+    .option { border-left: 7px solid var(--accent); display: grid; gap: 14px; }
+    .option.selected { outline: 3px solid rgba(45,135,123,.24); border-color: #8abdb5; }
+    .option-top, .option-meta, .note-form { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+    .option h2, .note-panel h2 { margin: 0; font-size: 20px; line-height: 1.15; letter-spacing: 0; }
+    .option p { margin: 7px 0 0; color: #65736f; line-height: 1.42; }
+    .bar { height: 12px; border-radius: 999px; background: #e5e4df; overflow: hidden; }
+    .fill { height: 100%; width: var(--pct); background: var(--accent); border-radius: inherit; transition: width .18s ease; }
+    button { border: 0; border-radius: 7px; background: #162724; color: white; cursor: pointer; font-size: 15px; font-weight: 800; min-width: 78px; padding: 11px 16px; }
+    button:hover { background: #24403b; }
+    button:disabled { cursor: wait; opacity: .58; }
+    textarea { min-height: 62px; resize: vertical; border: 1px solid #d6cec0; border-radius: 7px; padding: 12px; font: inherit; background: white; color: #182724; flex: 1; }
+    ul { display: grid; gap: 8px; list-style: none; margin: 0; padding: 0; }
+    li { border: 1px solid #ebe4d8; border-radius: 7px; padding: 10px 12px; color: #43504d; background: #fff; }
+    .muted { color: #7a8581; }
+    @media (max-width: 620px) { .illo-app { padding: 20px; } .option-top, .option-meta, .note-form { display: grid; } button { width: 100%; } }
+  </style>
+  <section class="wrap">
+    <header>
+      <p class="eyebrow" id="modeLabel">Team collaboration</p>
+      <h1 id="title">Team Collaboration Board</h1>
+      <p class="prompt" id="prompt">Loading...</p>
+    </header>
+    <div class="metrics" id="metrics"></div>
+    <section class="options" id="options"></section>
+    <section class="note-panel">
+      <h2>Notes</h2>
+      <div class="note-form">
+        <textarea id="noteText" placeholder="Add a note, concern, or rationale..."></textarea>
+        <button id="noteButton" type="button">Add note</button>
+      </div>
+      <ul id="notes"></ul>
+    </section>
+  </section>
+  <script>
+    const FALLBACK_OPTIONS = [
+      { id: 'option-a', label: 'Option A', description: '' },
+      { id: 'option-b', label: 'Option B', description: '' }
+    ];
+    const ACCENTS = ['#68aaa0', '#ee8c70', '#8a92e6', '#d1a64d', '#5c9ed6'];
+    let snapshot = null;
+    let busy = false;
+    let runtimeStatus = 'loading';
+
+    function object(value) {
+      return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+    }
+    function dataFrom(value) {
+      const snap = object(value);
+      const state = object(snap.state);
+      if (state.data && typeof state.data === 'object') return state.data;
+      return snap;
+    }
+    function config() {
+      return object(dataFrom(snapshot).config);
+    }
+    function options() {
+      const items = Array.isArray(config().options) ? config().options : [];
+      return items.length ? items : FALLBACK_OPTIONS;
+    }
+    function votes() {
+      const raw = object(dataFrom(snapshot).votes);
+      return Object.values(raw).map((entry) => {
+        if (typeof entry === 'string') return entry;
+        const item = object(entry);
+        return item.value || object(item.payload).optionId || null;
+      }).filter(Boolean);
+    }
+    function notes() {
+      const raw = dataFrom(snapshot).notes;
+      return (Array.isArray(raw) ? raw : []).map((note) => {
+        if (typeof note === 'string') return note;
+        return object(note).body || object(note).text || '';
+      }).filter(Boolean);
+    }
+    function stateVersion() {
+      return Number(object(object(snapshot).state).version || 0);
+    }
+    function escapeHtml(value) {
+      return String(value == null ? '' : value).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[char]));
+    }
+    function render() {
+      const cfg = config();
+      const allVotes = votes();
+      const total = allVotes.length;
+      document.getElementById('modeLabel').textContent = `${cfg.mode || 'team'} collaboration`;
+      document.getElementById('title').textContent = cfg.title || 'Team Collaboration Board';
+      document.getElementById('prompt').textContent = cfg.prompt || 'Collect signal from the team.';
+      document.getElementById('metrics').innerHTML = [
+        `<span class="pill">Runtime: <strong>${escapeHtml(runtimeStatus)}</strong></span>`,
+        `<span class="pill">Participants: <strong>${total}</strong></span>`,
+        `<span class="pill">Notes: <strong>${notes().length}</strong></span>`,
+        `<span class="pill">State version: <strong>${stateVersion()}</strong></span>`
+      ].join('');
+      document.getElementById('options').innerHTML = options().map((option, index) => {
+        const count = allVotes.filter((vote) => vote === option.id).length;
+        const pct = total ? Math.round((count / total) * 100) : 0;
+        return `<article class="option" style="--accent:${ACCENTS[index % ACCENTS.length]}">
+          <div class="option-top">
+            <div><h2>${escapeHtml(option.label)}</h2><p>${escapeHtml(option.description || '')}</p></div>
+            <button type="button" data-vote="${escapeHtml(option.id)}" ${busy ? 'disabled' : ''}>Vote</button>
+          </div>
+          <div class="bar"><div class="fill" style="--pct:${pct}%"></div></div>
+          <div class="option-meta"><span>${count} vote${count === 1 ? '' : 's'} / ${pct}%</span></div>
+        </article>`;
+      }).join('');
+      document.getElementById('notes').innerHTML = notes().length
+        ? notes().slice(-8).reverse().map((note) => `<li>${escapeHtml(note)}</li>`).join('')
+        : '<li class="muted">No notes yet.</li>';
+      document.querySelectorAll('[data-vote]').forEach((button) => {
+        button.addEventListener('click', () => castVote(button.getAttribute('data-vote')));
+      });
+    }
+    async function refresh() {
+      try {
+        snapshot = await window.illo.collab.get({ limit: 100 });
+        runtimeStatus = 'ready';
+      } catch (error) {
+        runtimeStatus = error && error.message ? error.message : 'refresh failed';
+      }
+      render();
+    }
+    async function castVote(optionId) {
+      if (!optionId || busy) return;
+      busy = true;
+      runtimeStatus = 'saving vote';
+      render();
+      try {
+        snapshot = await window.illo.collab.event('vote.cast', { optionId, at: new Date().toISOString() });
+        runtimeStatus = 'vote saved';
+      } catch (error) {
+        runtimeStatus = error && error.message ? error.message : 'vote failed';
+      } finally {
+        busy = false;
+        render();
+      }
+    }
+    async function addNote() {
+      const input = document.getElementById('noteText');
+      const body = input.value.trim();
+      if (!body || busy) return;
+      busy = true;
+      runtimeStatus = 'saving note';
+      render();
+      try {
+        snapshot = await window.illo.collab.event('note.add', { body, at: new Date().toISOString() });
+        input.value = '';
+        runtimeStatus = 'note saved';
+      } catch (error) {
+        runtimeStatus = error && error.message ? error.message : 'note failed';
+      } finally {
+        busy = false;
+        render();
+      }
+    }
+    document.getElementById('noteButton').addEventListener('click', addNote);
+    window.addEventListener('illo:collab', (event) => {
+      snapshot = event.detail;
+      runtimeStatus = 'synced';
+      render();
+    });
+    if (window.illo && window.illo.collab) {
+      window.illo.collab.subscribe((nextSnapshot) => {
+        snapshot = nextSnapshot;
+        runtimeStatus = 'synced';
+        render();
+      }, { intervalMs: 3000 });
+      refresh();
+    } else {
+      runtimeStatus = 'bridge unavailable';
+      render();
+    }
+  </script>
+</main>
+""".strip()
+
+
 async def _require_thread(session: AsyncSession, *, org_id: str, thread_id: str) -> None:
     idea_id = await session.scalar(
         select(Idea.id).where(
@@ -110,6 +417,158 @@ async def _require_thread(session: AsyncSession, *, org_id: str, thread_id: str)
     )
     if idea_id is None:
         raise ThreadArtifactError("Thread not found for this workspace")
+
+
+async def _ensure_system_collaboration_app(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str | None,
+) -> tuple[str, dict[str, Any], str]:
+    manifest = _system_collaboration_manifest()
+    visual_spec = _system_collaboration_visual_spec()
+    metadata = _system_collaboration_metadata()
+    action = "created"
+
+    try:
+        app = await a_get_app(session, org_id, None, key=SYSTEM_COLLABORATION_APP_KEY)
+    except WorkspaceAppNotFound:
+        app = await a_create_app(
+            session,
+            org_id=org_id,
+            key=SYSTEM_COLLABORATION_APP_KEY,
+            name=SYSTEM_COLLABORATION_APP_NAME,
+            description="Reusable system collaboration board for thread-scoped team input.",
+            renderer_key=APP_CAPSULE_RENDERER_KEY,
+            source_kind=APP_CAPSULE_SOURCE_KIND,
+            source_code=SYSTEM_COLLABORATION_APP_SOURCE,
+            manifest=manifest,
+            visual_spec=visual_spec,
+            metadata=metadata,
+            created_by_user_id=user_id,
+            anchor_user_id=user_id,
+        )
+    else:
+        action = "reused"
+        version = await a_active_version(session, app.id)
+        if (
+            version is None
+            or version.source_code != SYSTEM_COLLABORATION_APP_SOURCE
+            or version.manifest != manifest
+            or app.visual_spec != visual_spec
+        ):
+            app = await a_update_app(
+                session,
+                org_id=org_id,
+                app_id=str(app.id),
+                name=SYSTEM_COLLABORATION_APP_NAME,
+                description="Reusable system collaboration board for thread-scoped team input.",
+                renderer_key=APP_CAPSULE_RENDERER_KEY,
+                source_kind=APP_CAPSULE_SOURCE_KIND,
+                source_code=SYSTEM_COLLABORATION_APP_SOURCE,
+                manifest=manifest,
+                visual_spec=visual_spec,
+                metadata=metadata,
+                anchor_user_id=user_id,
+                updated_by_user_id=user_id,
+            )
+            action = "updated"
+
+    return action, await a_serialize_app(session, app), str(app.id)
+
+
+async def publish_thread_collaboration_app(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    user_id: str | None,
+    thread_id: str,
+    title: str,
+    prompt: str,
+    mode: str | None = None,
+    options: list[Any] | None = None,
+    session_key: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Start or update a thread-scoped session on the reusable collaboration board."""
+
+    clean_thread_id = _clean_text(thread_id)
+    clean_title = _clean_text(title)
+    clean_prompt = _clean_text(prompt)
+    if not clean_thread_id:
+        raise ThreadArtifactError("thread_id is required")
+    if not clean_title:
+        raise ThreadArtifactError("title is required")
+    if not clean_prompt:
+        raise ThreadArtifactError("prompt is required")
+
+    await _require_thread(session, org_id=org_id, thread_id=clean_thread_id)
+    action, app, app_id = await _ensure_system_collaboration_app(
+        session,
+        org_id=org_id,
+        user_id=user_id,
+    )
+    state_key = _thread_collaboration_state_key(clean_thread_id, session_key)
+    collaboration_options = _clean_collaboration_options(options or [])
+    state = await a_get_or_create_state(
+        session,
+        org_id=org_id,
+        app_id=app_id,
+        key=state_key,
+        user_id=user_id,
+    )
+    current_data = dict(state.data or {})
+    next_data = {
+        **_collaboration_initial_data(
+            title=clean_title,
+            prompt=clean_prompt,
+            mode=slugify(mode or "decision") or "decision",
+            options=collaboration_options,
+            metadata={
+                **dict(metadata or {}),
+                "thread_id": clean_thread_id,
+                "session_key": state_key,
+            },
+        ),
+        **current_data,
+        "config": _collaboration_initial_data(
+            title=clean_title,
+            prompt=clean_prompt,
+            mode=slugify(mode or "decision") or "decision",
+            options=collaboration_options,
+            metadata={
+                **dict(metadata or {}),
+                "thread_id": clean_thread_id,
+                "session_key": state_key,
+            },
+        )["config"],
+    }
+    state.data = next_data
+    state.version = int(state.version or 0) + 1
+    state.updated_by_user_id = user_id
+    await session.flush()
+
+    route = thread_route_for_id(clean_thread_id)
+    artifact_route = f"{route}?{urlencode({'app': app_id, 'state_key': state_key})}"
+    return {
+        "action": action,
+        "thread_id": clean_thread_id,
+        "thread_route": route,
+        "thread_url": thread_url_for_route(route),
+        "artifact_route": artifact_route,
+        "artifact_url": thread_url_for_route(artifact_route),
+        "artifact_kind": "collaboration",
+        "app_id": app_id,
+        "app_key": app["key"],
+        "app_name": app["name"],
+        "state_key": state_key,
+        "state": {
+            "key": state.key,
+            "version": int(state.version or 0),
+            "data": state.data or {},
+        },
+        "app": app,
+    }
 
 
 async def publish_thread_artifact_app(
@@ -233,7 +692,10 @@ async def publish_thread_artifact_app(
 
 __all__ = [
     "DEFAULT_THREAD_ARTIFACT_KIND",
+    "SYSTEM_COLLABORATION_APP_KEY",
     "THREAD_ARTIFACT_SOURCE",
+    "THREAD_COLLABORATION_SOURCE",
     "ThreadArtifactError",
+    "publish_thread_collaboration_app",
     "publish_thread_artifact_app",
 ]

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -232,9 +232,11 @@
   const requestedThreadAppId = $derived(
     $page.url.searchParams.get('app') || $page.url.searchParams.get('artifact_app'),
   );
+  const requestedThreadAppStateKey = $derived($page.url.searchParams.get('state_key'));
   const selectedThreadApp = $derived(
     activeSidePanelTab?.kind === 'app' && activeSidePanelTab.appId
-      ? threadArtifactApps.find((app) => app.id === activeSidePanelTab.appId) ?? null
+      ? threadArtifactApps.find((app) => app.id === activeSidePanelTab.appId)
+        ?? workspaceApps.appById(activeSidePanelTab.appId)
       : null,
   );
   const sidePanelAddMenuItems = $derived.by(() =>
@@ -891,8 +893,17 @@
   }
 
   function openAppTab(appId: string | null | undefined) {
-    const app = threadArtifactApps.find((candidate) => candidate.id === appId) ?? null;
+    const app = threadArtifactApps.find((candidate) => candidate.id === appId) ?? workspaceApps.appById(appId);
     applySidePanelState(openAppThreadSidePanelTab(sidePanelState(), appId, app));
+  }
+
+  function isStateKeyScopedSystemCollaborationApp(app: ReturnType<typeof workspaceApps.appById>): boolean {
+    const metadata = app?.metadata || {};
+    return Boolean(
+      requestedThreadAppStateKey
+        && metadata.system_app === true
+        && metadata.source === 'system_thread_collaboration',
+    );
   }
 
   function handleThreadAppSelect(appId: string | null) {
@@ -914,7 +925,10 @@
       if (!workspaceApps.loaded) void workspaceApps.load({ silent: true });
       return;
     }
-    if (!workspaceApps.appBelongsToThread(app, idea?.id ?? null)) return;
+    if (
+      !workspaceApps.appBelongsToThread(app, idea?.id ?? null)
+      && !isStateKeyScopedSystemCollaborationApp(app)
+    ) return;
     lastAutoOpenedThreadAppId = appId;
     openAppTab(appId);
   });

--- a/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
+++ b/frontend/src/lib/features/workspace-apps/components/AppCapsuleRenderer.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { browser } from '$app/environment';
+  import { page } from '$app/stores';
   import { onMount } from 'svelte';
 
   import { ConstellationIcon, ConstellationPill } from '$lib/components/constellation';
   import type { GeneratedAppSurface } from '$lib/features/workspace-apps/domain/generatedAppSurface';
+  import { resolveWorkspaceAppStateKey } from '$lib/features/workspace-apps/domain/workspaceAppStateKey';
   import {
     appendWorkspaceAppEvent,
     getWorkspaceAppCollaboration,
@@ -71,7 +73,7 @@
 
   const activeVersion = $derived(app.active_version);
   const manifest = $derived(activeVersion?.manifest ?? {});
-  const stateKey = $derived(String(manifest.state_key || 'default'));
+  const stateKey = $derived(resolveWorkspaceAppStateKey($page.url.searchParams, manifest.state_key));
   const sourceCode = $derived(activeVersion?.source_code || fallbackAppCapsuleSource(app.name));
   const appAccent = $derived(String(app.visual_spec?.accent || app.visual_spec?.thumbnail?.accent || '#4BACB8'));
   const srcdoc = $derived(
@@ -185,7 +187,7 @@
   async function handleCollaborationGet(message: RuntimeMessage) {
     try {
       const result = await getWorkspaceAppCollaboration(app.id, {
-        state_key: message.stateKey || undefined,
+        state_key: message.stateKey || stateKey || undefined,
         after_event_id: message.afterEventId ?? undefined,
         limit: message.limit ?? undefined,
       });
@@ -217,7 +219,7 @@
         event_type: eventType,
         payload: message.payload || {},
         state_patch: message.statePatch || message.patch || null,
-        state_key: message.stateKey || undefined,
+        state_key: message.stateKey || stateKey || undefined,
         idempotency_key: message.idempotencyKey || undefined,
         expected_state_version: message.expectedStateVersion ?? undefined,
         metadata: message.metadata || {},

--- a/frontend/src/lib/features/workspace-apps/domain/workspaceAppStateKey.ts
+++ b/frontend/src/lib/features/workspace-apps/domain/workspaceAppStateKey.ts
@@ -1,0 +1,21 @@
+export const WORKSPACE_APP_STATE_KEY_PARAM = 'state_key';
+
+const MAX_STATE_KEY_LENGTH = 120;
+
+export function normalizeWorkspaceAppStateKey(value: unknown, fallback = 'default'): string {
+  const fallbackText = String(fallback || 'default').trim() || 'default';
+  const text = String(value || '').trim();
+  if (!text) return fallbackText;
+  if (text.length > MAX_STATE_KEY_LENGTH) return fallbackText;
+  return text;
+}
+
+export function resolveWorkspaceAppStateKey(
+  searchParams: URLSearchParams | null | undefined,
+  manifestStateKey: unknown,
+): string {
+  return normalizeWorkspaceAppStateKey(
+    searchParams?.get(WORKSPACE_APP_STATE_KEY_PARAM),
+    normalizeWorkspaceAppStateKey(manifestStateKey),
+  );
+}

--- a/frontend/src/lib/utils/threadLinks.test.js
+++ b/frontend/src/lib/utils/threadLinks.test.js
@@ -30,12 +30,13 @@ test('canonical thread routes preserve generated app deep links', () => {
     idea: 'old-thread',
     app: 'app-123',
     artifact_app: 'legacy-app-456',
+    state_key: 'thread-collab-789',
     focus: 'reply',
   });
 
   assert.equal(
     buildCortexThreadHref('thread:123', params),
-    '/threads/thread%3A123?app=app-123&artifact_app=legacy-app-456&focus=reply',
+    '/threads/thread%3A123?app=app-123&artifact_app=legacy-app-456&state_key=thread-collab-789&focus=reply',
   );
 });
 

--- a/frontend/src/lib/utils/workspaceAppStateKey.test.js
+++ b/frontend/src/lib/utils/workspaceAppStateKey.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeWorkspaceAppStateKey,
+  resolveWorkspaceAppStateKey,
+} from '../features/workspace-apps/domain/workspaceAppStateKey.ts';
+
+test('workspace app state key routing prefers a route state_key over the manifest default', () => {
+  const params = new URLSearchParams({ state_key: 'thread-collab-123' });
+
+  assert.equal(resolveWorkspaceAppStateKey(params, 'default'), 'thread-collab-123');
+});
+
+test('workspace app state key routing falls back to the manifest key when route key is absent or invalid', () => {
+  assert.equal(resolveWorkspaceAppStateKey(new URLSearchParams(), 'manifest-key'), 'manifest-key');
+  assert.equal(
+    resolveWorkspaceAppStateKey(new URLSearchParams({ state_key: 'x'.repeat(121) }), 'manifest-key'),
+    'manifest-key',
+  );
+});
+
+test('workspace app state key routing normalizes blank values to default', () => {
+  assert.equal(normalizeWorkspaceAppStateKey('   '), 'default');
+  assert.equal(normalizeWorkspaceAppStateKey(null, 'fallback'), 'fallback');
+});

--- a/tests/test_thread_artifacts.py
+++ b/tests/test_thread_artifacts.py
@@ -17,6 +17,7 @@ from brain.platform.db.models.workspace_app import WorkspaceApp, WorkspaceAppSta
 ORG_ID = "aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa"
 USER_ID = "bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb"
 THREAD_ID = "cccccccccccc4ccc8ccccccccccccccc"
+SECOND_THREAD_ID = "dddddddddddd4ddd8ddddddddddddddd"
 
 VALID_ARTIFACT_SOURCE = """
 <main class="illo-app">
@@ -86,6 +87,7 @@ async def session(async_sqlite_session_factory):
             Org(id=ORG_ID, name="Test Org", slug="test"),
             User(id=USER_ID, org_id=ORG_ID, name="Alex", email="alex@example.test"),
             Idea(id=THREAD_ID, title="Artifact source thread", user_id=USER_ID, org_id=ORG_ID),
+            Idea(id=SECOND_THREAD_ID, title="Second source thread", user_id=USER_ID, org_id=ORG_ID),
         ]
     )
     await db.flush()
@@ -133,6 +135,50 @@ async def test_publish_thread_artifact_creates_and_republishes_app_capsule(sessi
     assert "Republished." in updated["app"]["active_version"]["source_code"]
 
 
+async def test_publish_thread_collaboration_reuses_system_app_with_thread_state_keys(session):
+    from brain.systems.cortex.thread_artifacts import (
+        SYSTEM_COLLABORATION_APP_KEY,
+        publish_thread_collaboration_app,
+    )
+
+    first = await publish_thread_collaboration_app(
+        session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        thread_id=THREAD_ID,
+        title="Pick the next artifact",
+        prompt="Which collaborative surface should Illo share first?",
+        mode="decision",
+        options=[
+            {"id": "vote", "label": "Vote board"},
+            {"id": "brainstorm", "label": "Brainstorm board"},
+        ],
+    )
+    second = await publish_thread_collaboration_app(
+        session,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        thread_id=SECOND_THREAD_ID,
+        title="Choose review style",
+        prompt="How should the team review the proposal?",
+        mode="brainstorm",
+        options=["Async notes", "Live vote"],
+    )
+
+    assert first["action"] == "created"
+    assert second["action"] == "reused"
+    assert first["app_id"] == second["app_id"]
+    assert first["app_key"] == SYSTEM_COLLABORATION_APP_KEY
+    assert first["state_key"] != second["state_key"]
+    assert f"state_key={first['state_key']}" in first["artifact_route"]
+    assert f"state_key={second['state_key']}" in second["artifact_route"]
+    assert first["state"]["data"]["config"]["prompt"] == "Which collaborative surface should Illo share first?"
+    assert second["state"]["data"]["config"]["options"][0]["id"] == "async-notes"
+    assert first["app"]["active_version"]["manifest"]["collaboration"]["actions"]["vote.cast"]["reducer"][
+        "state_path"
+    ] == "votes"
+
+
 async def test_mcp_thread_artifact_publish_capability_sets_workspace_app_mutation(monkeypatch, session):
     from brain.app.api.routers import agent_mcp
 
@@ -175,3 +221,51 @@ async def test_mcp_thread_artifact_publish_capability_sets_workspace_app_mutatio
     assert calls[0]["user_id"] == USER_ID
     assert calls[0]["thread_id"] == THREAD_ID
     assert calls[0]["metadata"]["mcp_capability"] == "thread.artifact.publish"
+
+
+async def test_mcp_thread_collaboration_start_uses_system_publisher(monkeypatch, session):
+    from brain.app.api.routers import agent_mcp
+
+    calls: list[dict] = []
+
+    async def fake_publish(db, **kwargs):
+        calls.append({"db": db, **kwargs})
+        return {
+            "action": "reused",
+            "app_id": "system-app",
+            "app_key": "system-team-collaboration-board",
+            "state_key": "thread-collab-1",
+            "app": {"id": "system-app", "key": "system-team-collaboration-board"},
+        }
+
+    monkeypatch.setattr(
+        "brain.systems.cortex.thread_artifacts.publish_thread_collaboration_app",
+        fake_publish,
+    )
+    principal = SimpleNamespace(org_id=ORG_ID, owner_user_id=USER_ID)
+
+    result = await agent_mcp._tool_act(
+        session,
+        principal,
+        {
+            "capability": "thread.collaboration.start",
+            "arguments": {
+                "thread_id": THREAD_ID,
+                "title": "Team decision",
+                "prompt": "Which option should we pick?",
+                "mode": "decision",
+                "options": [{"id": "a", "label": "A"}],
+            },
+        },
+    )
+
+    assert "thread.collaboration.start" in agent_mcp.ACT_CAPABILITIES
+    assert result["_mutates_workspace_app"] is True
+    assert result["_workspace_app_change"] == {
+        "action": "reused",
+        "app": {"id": "system-app", "key": "system-team-collaboration-board"},
+    }
+    assert calls[0]["db"] is session
+    assert calls[0]["thread_id"] == THREAD_ID
+    assert calls[0]["prompt"] == "Which option should we pick?"
+    assert calls[0]["metadata"]["mcp_capability"] == "thread.collaboration.start"


### PR DESCRIPTION
## Summary
- add thread.collaboration.start MCP capability for reusable team collaboration boards
- create a product-owned system collaboration app with per-thread state_key sessions
- route app capsule state/collab calls through ?state_key and allow deep-linked system collaboration apps to open in thread panels

## Tests
- venv/bin/pytest tests/test_thread_artifacts.py
- npm run check
- npm run test
- venv/bin/python -m py_compile brain/systems/cortex/thread_artifacts.py brain/app/api/routers/agent_mcp.py