### PR TITLE
Add a local (faster-whisper) voice dictation provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ restore, upgrades, logs, and status.
 See [docs/configuration.md](docs/configuration.md) for the production
 configuration contract.
 
+## Voice dictation
+
+Composer voice input supports two transcription providers, selectable in
+System → Voice:
+
+- **OpenAI Realtime** (default) — low-latency streaming transcription using the
+  OpenAI API key saved in AI Runtime. Words appear as you speak.
+- **Local (faster-whisper)** — on-device CPU transcription with no API key.
+  Push-to-talk: the recorded clip is transcribed when you stop. Choose a model
+  size (`tiny` / `base` / `small`, default `base`); weights download on first
+  use into `ILLO_PRIVATE_HOME/voice-models`. `faster-whisper` ships in the
+  default image and pulls no Torch/CUDA, so the provider works out of the box;
+  if it is ever absent the provider reports as unavailable and OpenAI dictation
+  is unaffected.
+
 ## Development commands
 
 ```bash

--- a/brain/systems/runtime_settings/router.py
+++ b/brain/systems/runtime_settings/router.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.api.auth import get_current_user
@@ -32,11 +32,16 @@ from .schemas import (
     RuntimeUpdateRead,
     RuntimeVoiceRead,
     RuntimeVoiceSessionRead,
+    RuntimeVoiceTranscriptRead,
     RuntimeVoiceUpdate,
 )
 from .service import async_get_runtime_settings, can_manage_runtime_settings
 from .self_update import async_get_runtime_update_status, async_start_runtime_update
-from .voice import async_create_runtime_voice_session, async_update_runtime_voice
+from .voice import (
+    async_create_runtime_voice_session,
+    async_transcribe_runtime_voice_clip,
+    async_update_runtime_voice,
+)
 
 router = APIRouter(prefix="/api/runtime-settings", tags=["runtime-settings"], dependencies=[Depends(rate_limit)])
 _OPENAI_OAUTH_CALLBACK_START_MODES = {"auto", "server", "local_bridge"}
@@ -173,6 +178,15 @@ async def create_voice_session(
     db: AsyncSession = Depends(get_db),
 ) -> RuntimeVoiceSessionRead:
     return await async_create_runtime_voice_session(db, user)
+
+
+@router.post("/voice/transcribe", response_model=RuntimeVoiceTranscriptRead)
+async def transcribe_voice_clip(
+    audio: UploadFile = File(...),
+    user: User = Depends(_runtime_user),
+    db: AsyncSession = Depends(get_db),
+) -> RuntimeVoiceTranscriptRead:
+    return await async_transcribe_runtime_voice_clip(db, user, upload=audio)
 
 
 @router.patch("/voice", response_model=RuntimeVoiceRead)

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -14,8 +14,9 @@ RuntimeUpdateStatus = Literal["idle", "running"]
 RuntimeServiceStatus = Literal["idle", "running"]
 WorkspaceToolStatus = Literal["requested", "queued", "installing", "installed", "failed", "removed"]
 WorkspaceToolQueueStatus = Literal["idle", "running"]
-VoiceProviderKey = Literal["openai", "gemini"]
+VoiceProviderKey = Literal["openai", "gemini", "local"]
 VoiceLanguageKey = Literal["auto", "en", "fr"]
+VoiceModelSizeKey = Literal["tiny", "base", "small"]
 VoiceStatus = Literal["ready", "missing", "error"]
 
 
@@ -70,10 +71,12 @@ class RuntimeVoiceRead(BaseModel):
     model: str
     source: Literal["memory"] = "memory"
     language: VoiceLanguageKey = "auto"
+    model_size: VoiceModelSizeKey = "base"
     status: VoiceStatus
     detail: str | None = None
     provider_options: list[RuntimeOption] = Field(default_factory=list)
     language_options: list[RuntimeOption] = Field(default_factory=list)
+    model_size_options: list[RuntimeOption] = Field(default_factory=list)
 
 
 class RuntimeVoiceSessionRead(BaseModel):
@@ -82,6 +85,15 @@ class RuntimeVoiceSessionRead(BaseModel):
     language: VoiceLanguageKey = "auto"
     client_secret: str
     expires_at: int | None = None
+
+
+class RuntimeVoiceTranscriptRead(BaseModel):
+    transcript: str
+    provider: str
+    model: str
+    language: str
+    transport: str
+    bytes_streamed: int = 0
 
 
 class RuntimePermissionsRead(BaseModel):
@@ -209,3 +221,4 @@ class RuntimeMemoryUpdate(BaseModel):
 class RuntimeVoiceUpdate(BaseModel):
     provider: VoiceProviderKey = "openai"
     language: VoiceLanguageKey = "auto"
+    model_size: VoiceModelSizeKey = "base"

--- a/brain/systems/runtime_settings/voice.py
+++ b/brain/systems/runtime_settings/voice.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import logging
+import os
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.async_io import async_http_post
@@ -17,7 +22,14 @@ from .memory import (
     _async_write_runtime_config_value,
     async_get_runtime_memory,
 )
-from .schemas import RuntimeMemoryRead, RuntimeOption, RuntimeVoiceRead, RuntimeVoiceSessionRead, RuntimeVoiceUpdate
+from .schemas import (
+    RuntimeMemoryRead,
+    RuntimeOption,
+    RuntimeVoiceRead,
+    RuntimeVoiceSessionRead,
+    RuntimeVoiceTranscriptRead,
+    RuntimeVoiceUpdate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +39,21 @@ OPENAI_MEMORY_KEY_REQUIRED_DETAIL = "Voice dictation needs an OpenAI API key in 
 GEMINI_LIVE_MODEL = "gemini-live"
 GEMINI_VOICE_UNAVAILABLE_DETAIL = "Gemini Live voice is not enabled yet."
 RUNTIME_VOICE_SETTINGS_KEY = "runtime_voice"
+LOCAL_WHISPER_MODEL_LABEL = "faster-whisper"
+LOCAL_WHISPER_INSTALL_DETAIL = (
+    "Local voice dictation needs faster-whisper. It ships with Illospace; "
+    "rebuild or update the API image (or run `pip install faster-whisper`) if this persists."
+)
 VOICE_PROVIDER_OPTIONS = [
     RuntimeOption(
         key="openai",
         label="OpenAI Realtime",
         description="Uses the OpenAI API key saved for AI Runtime memory.",
+    ),
+    RuntimeOption(
+        key="local",
+        label="Local (faster-whisper)",
+        description="On-device CPU transcription. No API key. Push-to-talk.",
     ),
     RuntimeOption(
         key="gemini",
@@ -49,15 +71,37 @@ VOICE_LANGUAGE_OPTIONS = [
     RuntimeOption(key="en", label="English", description="Prefer English transcription."),
     RuntimeOption(key="fr", label="French", description="Prefer French transcription."),
 ]
+VOICE_MODEL_SIZE_OPTIONS = [
+    RuntimeOption(
+        key="tiny",
+        label="Tiny",
+        description="Fastest, lowest accuracy. For weak machines or quick tests.",
+    ),
+    RuntimeOption(
+        key="base",
+        label="Base",
+        description="Balanced default. Solid English and French on CPU.",
+    ),
+    RuntimeOption(
+        key="small",
+        label="Small",
+        description="Best accuracy, notably better French. Heavier and slower.",
+    ),
+]
 
 
 @dataclass(frozen=True)
 class RuntimeVoiceConfig:
     provider: str = "openai"
     language: str = "auto"
+    model_size: str = "base"
 
     def stored_settings(self) -> dict[str, str]:
-        return {"provider": self.provider, "language": self.language}
+        return {
+            "provider": self.provider,
+            "language": self.language,
+            "model_size": self.model_size,
+        }
 
 
 async def async_get_runtime_voice(session: AsyncSession, user: User) -> RuntimeVoiceRead:
@@ -80,6 +124,7 @@ async def async_get_runtime_voice_config(session: AsyncSession) -> RuntimeVoiceC
     return RuntimeVoiceConfig(
         provider=_voice_provider(data.get("provider")),
         language=_voice_language(data.get("language")),
+        model_size=_voice_model_size(data.get("model_size")),
     )
 
 
@@ -91,6 +136,7 @@ async def async_update_runtime_voice(
     config = RuntimeVoiceConfig(
         provider=_voice_provider(update.provider),
         language=_voice_language(update.language),
+        model_size=_voice_model_size(update.model_size),
     )
     await _async_write_runtime_config_value(
         session,
@@ -106,45 +152,82 @@ def runtime_voice_from_memory(
     config: RuntimeVoiceConfig | None = None,
 ) -> RuntimeVoiceRead:
     config = config or RuntimeVoiceConfig()
+    size = _voice_model_size(config.model_size)
+
+    if config.provider == "local":
+        from brain.systems.voice.local_whisper import local_whisper_available
+
+        available = local_whisper_available()
+        return _voice_read(
+            provider="local",
+            model=f"{LOCAL_WHISPER_MODEL_LABEL}-{size}",
+            config=config,
+            size=size,
+            status="ready" if available else "missing",
+            detail=None if available else LOCAL_WHISPER_INSTALL_DETAIL,
+        )
+
     has_openai_key = bool(memory.api_key_statuses.get("openai"))
     if config.provider == "openai" and has_openai_key:
-        return RuntimeVoiceRead(
+        return _voice_read(
             provider="openai",
             model=OPENAI_REALTIME_TRANSCRIPTION_MODEL,
-            source="memory",
-            language=_voice_language(config.language),
+            config=config,
+            size=size,
             status="ready",
             detail=None,
-            provider_options=VOICE_PROVIDER_OPTIONS,
-            language_options=VOICE_LANGUAGE_OPTIONS,
         )
 
     if config.provider == "gemini":
-        return RuntimeVoiceRead(
+        return _voice_read(
             provider="gemini",
             model=GEMINI_LIVE_MODEL,
-            source="memory",
-            language=_voice_language(config.language),
+            config=config,
+            size=size,
             status="error",
             detail=GEMINI_VOICE_UNAVAILABLE_DETAIL,
-            provider_options=VOICE_PROVIDER_OPTIONS,
-            language_options=VOICE_LANGUAGE_OPTIONS,
         )
 
-    return RuntimeVoiceRead(
+    return _voice_read(
         provider="openai",
         model=OPENAI_REALTIME_TRANSCRIPTION_MODEL,
-        source="memory",
-        language=_voice_language(config.language),
+        config=config,
+        size=size,
         status="missing",
         detail=OPENAI_MEMORY_KEY_REQUIRED_DETAIL,
+    )
+
+
+def _voice_read(
+    *,
+    provider: str,
+    model: str,
+    config: RuntimeVoiceConfig,
+    size: str,
+    status: str,
+    detail: str | None,
+) -> RuntimeVoiceRead:
+    return RuntimeVoiceRead(
+        provider=provider,
+        model=model,
+        source="memory",
+        language=_voice_language(config.language),
+        model_size=size,
+        status=status,
+        detail=detail,
         provider_options=VOICE_PROVIDER_OPTIONS,
         language_options=VOICE_LANGUAGE_OPTIONS,
+        model_size_options=VOICE_MODEL_SIZE_OPTIONS,
     )
 
 
 async def async_create_runtime_voice_session(session: AsyncSession, user: User) -> RuntimeVoiceSessionRead:
     config = await async_get_runtime_voice_config(session)
+    if config.provider == "local":
+        raise HTTPException(
+            status_code=409,
+            detail="Local voice dictation uses push-to-talk transcription, not a realtime session.",
+        )
     if config.provider != "openai":
         raise HTTPException(
             status_code=409,
@@ -169,6 +252,80 @@ async def async_create_runtime_voice_session(session: AsyncSession, user: User) 
         client_secret=secret,
         expires_at=_client_secret_expires_at(payload),
     )
+
+
+async def async_transcribe_runtime_voice_clip(
+    session: AsyncSession,
+    user: User,
+    *,
+    upload: UploadFile,
+) -> RuntimeVoiceTranscriptRead:
+    """Transcribe a recorded push-to-talk audio clip using the configured provider.
+
+    Works for any server-side provider (OpenAI realtime or local faster-whisper);
+    the active provider is resolved from runtime voice settings inside
+    ``async_transcribe_audio_path``.
+    """
+
+    from brain.systems.voice.transcription import (
+        AudioTranscriptionError,
+        async_transcribe_audio_path,
+    )
+
+    filename = upload.filename or "voice-clip.webm"
+    data = await upload.read()
+    if not data:
+        raise HTTPException(status_code=422, detail="No audio was uploaded for transcription.")
+
+    suffix = Path(filename).suffix or ".webm"
+    tmp_path = await asyncio.to_thread(_write_temp_audio, data, suffix)
+    try:
+        result = await async_transcribe_audio_path(
+            session,
+            tmp_path,
+            filename=filename,
+            safety_identifier=_user_safety_identifier(user),
+        )
+    except AudioTranscriptionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    finally:
+        await asyncio.to_thread(_remove_file, tmp_path)
+
+    return RuntimeVoiceTranscriptRead(
+        transcript=result.transcript,
+        provider=result.provider,
+        model=result.model,
+        language=result.language,
+        transport=result.transport,
+        bytes_streamed=result.bytes_streamed,
+    )
+
+
+def _write_temp_audio(data: bytes, suffix: str) -> Path:
+    fd, name = tempfile.mkstemp(suffix=suffix, prefix="illo-voice-")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+    except Exception:
+        os.unlink(name)
+        raise
+    return Path(name)
+
+
+def _remove_file(path: Path) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _user_safety_identifier(user: User) -> str | None:
+    user_id = getattr(user, "id", None)
+    if not user_id:
+        return None
+    org_id = getattr(user, "org_id", None)
+    digest = hashlib.sha256(f"{org_id or ''}:{user_id}".encode("utf-8", errors="ignore")).hexdigest()[:32]
+    return f"illo-user-{digest}"
 
 
 async def _async_create_openai_realtime_client_secret(api_key: str, *, language: str = "auto") -> dict[str, Any]:
@@ -214,12 +371,19 @@ def _voice_provider(value: object) -> str:
     provider = str(value or "openai").strip().lower()
     if provider in {"gemini", "google"}:
         return "gemini"
+    if provider == "local":
+        return "local"
     return "openai"
 
 
 def _voice_language(value: object) -> str:
     language = str(value or "auto").strip().lower()
     return language if language in {"auto", "en", "fr"} else "auto"
+
+
+def _voice_model_size(value: object) -> str:
+    size = str(value or "base").strip().lower()
+    return size if size in {"tiny", "base", "small"} else "base"
 
 
 def _client_secret_value(payload: dict[str, Any]) -> str | None:

--- a/brain/systems/voice/local_whisper.py
+++ b/brain/systems/voice/local_whisper.py
@@ -1,0 +1,126 @@
+"""Local CPU speech-to-text using faster-whisper (CTranslate2).
+
+This is an optional provider. faster-whisper is not part of the slim production
+image, so every entry point imports it lazily and degrades to a clear
+``AudioTranscriptionError`` when it is missing. The existing OpenAI dictation
+path never imports this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from brain.systems.voice.transcription import AudioTranscriptionError, AudioTranscriptionResult
+
+LOCAL_WHISPER_MODEL_SIZES = ("tiny", "base", "small")
+DEFAULT_LOCAL_WHISPER_MODEL_SIZE = "base"
+LOCAL_WHISPER_TRANSPORT = "faster_whisper"
+LOCAL_WHISPER_INSTALL_DETAIL = (
+    "Local voice dictation needs faster-whisper. It ships with Illospace; "
+    "rebuild or update the API image (or run `pip install faster-whisper`) if this persists."
+)
+
+# WhisperModel instances are expensive to build (first use downloads weights),
+# so cache one per model size. faster-whisper transcription is CPU-bound and not
+# safe to run concurrently on a shared model, so a single lock serialises calls.
+_MODEL_CACHE: dict[str, object] = {}
+_MODEL_LOCK = asyncio.Lock()
+
+
+def local_whisper_available() -> bool:
+    """Return True when faster-whisper can be imported in this runtime."""
+
+    try:
+        import faster_whisper  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _normalize_model_size(value: object) -> str:
+    size = str(value or "").strip().lower()
+    return size if size in LOCAL_WHISPER_MODEL_SIZES else DEFAULT_LOCAL_WHISPER_MODEL_SIZE
+
+
+def _whisper_language(value: object) -> str | None:
+    language = str(value or "auto").strip().lower()
+    return language if language in {"en", "fr"} else None
+
+
+def _model_download_root() -> str:
+    override = os.getenv("ILLO_VOICE_MODEL_DIR")
+    if override:
+        root = Path(override)
+    else:
+        from brain.kernel.config import PRIVATE_HOME
+
+        root = Path(PRIVATE_HOME) / "voice-models"
+    root.mkdir(parents=True, exist_ok=True)
+    return str(root)
+
+
+def _load_model(model_size: str) -> object:
+    cached = _MODEL_CACHE.get(model_size)
+    if cached is not None:
+        return cached
+    try:
+        from faster_whisper import WhisperModel
+    except Exception as exc:  # pragma: no cover - import guard
+        raise AudioTranscriptionError(LOCAL_WHISPER_INSTALL_DETAIL) from exc
+    try:
+        model = WhisperModel(
+            model_size,
+            device="cpu",
+            compute_type="int8",
+            download_root=_model_download_root(),
+        )
+    except Exception as exc:
+        raise AudioTranscriptionError(f"Could not load local Whisper model '{model_size}': {exc}") from exc
+    _MODEL_CACHE[model_size] = model
+    return model
+
+
+def _transcribe_sync(model: object, path: str, language: str | None) -> tuple[str, str]:
+    segments, info = model.transcribe(  # type: ignore[attr-defined]
+        path,
+        language=language,
+        vad_filter=True,
+    )
+    transcript = "".join(segment.text for segment in segments)
+    detected = getattr(info, "language", None) or language or "auto"
+    return transcript.strip(), str(detected)
+
+
+async def async_transcribe_local_audio_path(
+    path: str | Path,
+    *,
+    language: str = "auto",
+    model_size: str = DEFAULT_LOCAL_WHISPER_MODEL_SIZE,
+) -> AudioTranscriptionResult:
+    size = _normalize_model_size(model_size)
+    whisper_language = _whisper_language(language)
+    audio_path = str(path)
+
+    async with _MODEL_LOCK:
+        model = await asyncio.to_thread(_load_model, size)
+        try:
+            transcript, detected = await asyncio.to_thread(
+                _transcribe_sync, model, audio_path, whisper_language
+            )
+        except AudioTranscriptionError:
+            raise
+        except Exception as exc:
+            raise AudioTranscriptionError(f"Local Whisper transcription failed: {exc}") from exc
+
+    if not transcript:
+        raise AudioTranscriptionError("Local Whisper did not produce any transcript from the audio.")
+
+    return AudioTranscriptionResult(
+        transcript=transcript,
+        language=detected,
+        provider="local",
+        model=f"faster-whisper-{size}",
+        transport=LOCAL_WHISPER_TRANSPORT,
+    )

--- a/brain/systems/voice/transcription.py
+++ b/brain/systems/voice/transcription.py
@@ -66,6 +66,14 @@ async def async_transcribe_audio_path(
             language=selected_language,
             safety_identifier=safety_identifier,
         )
+    if config.provider == "local":
+        from brain.systems.voice.local_whisper import async_transcribe_local_audio_path
+
+        return await async_transcribe_local_audio_path(
+            audio_path,
+            language=selected_language,
+            model_size=getattr(config, "model_size", "base"),
+        )
     if config.provider in {"gemini", "google"}:
         raise AudioTranscriptionError(
             "Gemini Live is selected, but server-side audio attachment transcription is not enabled yet."

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3,6 +3,7 @@ import type { RuntimeSettings, RuntimeVoiceSession, RuntimeVoiceTranscript } fro
 const BASE = '';
 const DEFAULT_API_TIMEOUT_MS = 20_000;
 const PROJECT_CONTEXT_UPLOAD_TIMEOUT_MS = 30_000;
+const VOICE_TRANSCRIPTION_TIMEOUT_MS = 5 * 60_000;
 
 type ApiRequestInit = RequestInit & {
   timeoutMs?: number;
@@ -1695,6 +1696,7 @@ export const api = {
     return fetchJson<RuntimeVoiceTranscript>('/api/runtime-settings/voice/transcribe', {
       method: 'POST',
       body: form,
+      timeoutMs: VOICE_TRANSCRIPTION_TIMEOUT_MS,
     });
   },
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import type { RuntimeSettings, RuntimeVoiceSession } from '$lib/types/runtimeSettings';
+import type { RuntimeSettings, RuntimeVoiceSession, RuntimeVoiceTranscript } from '$lib/types/runtimeSettings';
 
 const BASE = '';
 const DEFAULT_API_TIMEOUT_MS = 20_000;
@@ -43,10 +43,12 @@ async function fetchJson<T>(path: string, init?: ApiRequestInit): Promise<T> {
   const controller = !signal && timeoutMs > 0 ? new AbortController() : null;
   const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
   try {
+    const isFormData = typeof FormData !== 'undefined' && rest.body instanceof FormData;
+    const baseHeaders: Record<string, string> = isFormData ? {} : { 'Content-Type': 'application/json' };
     const res = await fetch(`${BASE}${path}`, {
       ...rest,
       signal: signal ?? controller?.signal,
-      headers: { 'Content-Type': 'application/json', ...(extraHeaders as Record<string, string>) },
+      headers: { ...baseHeaders, ...(extraHeaders as Record<string, string>) },
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: res.statusText }));
@@ -1678,7 +1680,7 @@ export const api = {
     fetchJson<any>('/api/runtime-settings/models', { method: 'PATCH', body: JSON.stringify(data) }),
   updateRuntimeMemory: (data: { embedder: string; embedding_model?: string | null; reranker?: string }) =>
     fetchJson<any>('/api/runtime-settings/memory', { method: 'PATCH', body: JSON.stringify(data) }),
-  updateRuntimeVoice: (data: { provider: string; language: string }) =>
+  updateRuntimeVoice: (data: { provider: string; language: string; model_size?: string }) =>
     fetchJson<RuntimeSettings['voice']>('/api/runtime-settings/voice', {
       method: 'PATCH',
       body: JSON.stringify(data),
@@ -1687,6 +1689,14 @@ export const api = {
     fetchJson<any>('/api/runtime-settings/memory/check', { method: 'POST' }),
   createRuntimeVoiceSession: () =>
     fetchJson<RuntimeVoiceSession>('/api/runtime-settings/voice/session', { method: 'POST' }),
+  transcribeRuntimeVoiceClip: (blob: Blob, filename = 'voice-clip.webm') => {
+    const form = new FormData();
+    form.append('audio', blob, filename);
+    return fetchJson<RuntimeVoiceTranscript>('/api/runtime-settings/voice/transcribe', {
+      method: 'POST',
+      body: form,
+    });
+  },
 
   // Onboarding
   runtimeReadyIntroDraft: () =>

--- a/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
@@ -148,20 +148,40 @@
   });
 
   $effect(() => {
+    const el = textareaEl;
+    if (!el) return;
+    const refresh = () => voiceDictation.maybeRefreshSettings();
+    el.addEventListener('focus', refresh);
+    return () => el.removeEventListener('focus', refresh);
+  });
+
+  $effect(() => {
     workspaceComposerMaxHeight;
     void syncComposerHeight();
   });
+
+  function refreshVoiceSettings() {
+    voiceDictation.maybeRefreshSettings();
+  }
+
+  function onVisibilityChange() {
+    if (document.visibilityState === 'visible') refreshVoiceSettings();
+  }
 
   onMount(() => {
     updateViewportHeight();
     void voiceDictation.loadSettings();
     window.addEventListener('resize', updateViewportHeight);
     window.visualViewport?.addEventListener('resize', updateViewportHeight);
+    window.addEventListener('focus', refreshVoiceSettings);
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
       voiceDictation.destroy();
       window.removeEventListener('resize', updateViewportHeight);
       window.visualViewport?.removeEventListener('resize', updateViewportHeight);
+      window.removeEventListener('focus', refreshVoiceSettings);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   });
 

--- a/frontend/src/lib/features/composer/controllers/localPushToTalkVoice.ts
+++ b/frontend/src/lib/features/composer/controllers/localPushToTalkVoice.ts
@@ -1,0 +1,98 @@
+import { api } from '$lib/api/client';
+import type {
+  VoiceDictationConnection,
+  VoiceDictationSession,
+  VoiceDictationTransportHandlers,
+} from '$lib/features/composer/domain/voiceDictation';
+
+import { createAudioLevelMonitor } from './openaiRealtimeVoice';
+
+const RECORDER_MIME_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/ogg;codecs=opus',
+  'audio/mp4',
+];
+
+/**
+ * Push-to-talk transport for the local (faster-whisper) voice provider.
+ *
+ * Unlike the OpenAI realtime transport, transcription happens server-side: we
+ * record audio in the browser and, when the user stops, upload the clip to the
+ * backend which runs faster-whisper and returns the transcript in one shot.
+ * The dictation controller flow (start/stop/send) is identical — only the
+ * transcript arrives on stop instead of streaming word by word.
+ */
+export async function createLocalPushToTalkVoiceConnection(
+  _session: VoiceDictationSession,
+  handlers: VoiceDictationTransportHandlers,
+): Promise<VoiceDictationConnection> {
+  if (typeof MediaRecorder === 'undefined') {
+    throw new Error('Local voice dictation is not supported in this browser.');
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const mimeType = pickRecorderMimeType();
+  const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+  const chunks: Blob[] = [];
+  const levelMonitor = createAudioLevelMonitor(stream, handlers.onAudioLevel);
+  let stopped = false;
+
+  recorder.ondataavailable = (event) => {
+    if (event.data && event.data.size > 0) chunks.push(event.data);
+  };
+
+  const recordingStopped = new Promise<void>((resolve) => {
+    recorder.onstop = () => resolve();
+  });
+
+  function cleanup() {
+    levelMonitor?.stop();
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+  }
+
+  recorder.start();
+
+  return {
+    async stop() {
+      if (stopped) {
+        cleanup();
+        return;
+      }
+      stopped = true;
+      try {
+        if (recorder.state !== 'inactive') {
+          recorder.stop();
+          await recordingStopped;
+        }
+        const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
+        if (blob.size > 0) {
+          const result = await api.transcribeRuntimeVoiceClip(blob, recorderFilename(blob.type));
+          if (result?.transcript) {
+            handlers.onTranscriptCompleted?.(result.transcript);
+          }
+        }
+      } finally {
+        cleanup();
+      }
+    },
+  };
+}
+
+function pickRecorderMimeType(): string | undefined {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return undefined;
+  }
+  for (const candidate of RECORDER_MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function recorderFilename(mimeType: string): string {
+  if (mimeType.includes('ogg')) return 'voice-clip.ogg';
+  if (mimeType.includes('mp4')) return 'voice-clip.mp4';
+  return 'voice-clip.webm';
+}

--- a/frontend/src/lib/features/composer/controllers/openaiRealtimeVoice.ts
+++ b/frontend/src/lib/features/composer/controllers/openaiRealtimeVoice.ts
@@ -96,7 +96,7 @@ export async function createOpenAIRealtimeVoiceConnection(
   };
 }
 
-function createAudioLevelMonitor(
+export function createAudioLevelMonitor(
   stream: MediaStream,
   onAudioLevel?: (level: number) => void,
 ): AudioLevelMonitor | null {

--- a/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
+++ b/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
@@ -34,6 +34,7 @@ export class WorkspaceVoiceDictationController {
   private controllerProvider: string | null = null;
   private startedAt = 0;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private lastSettingsLoadAt = 0;
 
   constructor(private readonly deps: WorkspaceVoiceDictationDeps) {}
 
@@ -67,12 +68,24 @@ export class WorkspaceVoiceDictationController {
   }
 
   async loadSettings() {
+    this.lastSettingsLoadAt = Date.now();
     try {
       const runtime = await api.runtimeSettings();
       this.settings = runtime.voice ?? null;
     } catch {
       this.settings = null;
     }
+  }
+
+  /**
+   * Re-sync voice settings when the provider may have changed in System → Voice,
+   * so the mic re-enables without a manual page refresh. No-op while recording or
+   * already ready, and throttled, so it never spams the API or disrupts a session.
+   */
+  maybeRefreshSettings() {
+    if (this.isBusy || this.isReady) return;
+    if (Date.now() - this.lastSettingsLoadAt < 2000) return;
+    void this.loadSettings();
   }
 
   toggle() {

--- a/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
+++ b/frontend/src/lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts
@@ -1,7 +1,9 @@
 import { api } from '$lib/api/client';
+import { createLocalPushToTalkVoiceConnection } from '$lib/features/composer/controllers/localPushToTalkVoice';
 import { createOpenAIRealtimeVoiceConnection } from '$lib/features/composer/controllers/openaiRealtimeVoice';
 import {
   createVoiceDictationController,
+  type VoiceDictationSession,
   type VoiceDictationSnapshot,
 } from '$lib/features/composer/domain/voiceDictation';
 import { appendVoiceLevel } from '$lib/features/composer/domain/voiceLevels';
@@ -29,6 +31,7 @@ export class WorkspaceVoiceDictationController {
   audioLevels = $state<number[]>([]);
 
   private controller: ReturnType<typeof createVoiceDictationController> | null = null;
+  private controllerProvider: string | null = null;
   private startedAt = 0;
   private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -126,22 +129,39 @@ export class WorkspaceVoiceDictationController {
   }
 
   private ensureController() {
-    if (this.controller && this.snapshot.status !== 'error') return this.controller;
+    const provider = this.settings?.provider ?? 'openai';
+    if (this.controller && this.controllerProvider === provider && this.snapshot.status !== 'error') {
+      return this.controller;
+    }
+    const isLocal = provider === 'local';
+    this.controllerProvider = provider;
     this.controller = createVoiceDictationController({
       getDraft: this.deps.getDraft,
       setDraft: this.deps.setDraft,
       submit: this.deps.submit,
-      createSession: () => api.createRuntimeVoiceSession(),
-      connect: (session, handlers) =>
-        createOpenAIRealtimeVoiceConnection(session, {
+      createSession: () =>
+        isLocal ? Promise.resolve(this.localSession()) : api.createRuntimeVoiceSession(),
+      connect: (session, handlers) => {
+        const wrapped = {
           ...handlers,
-          onAudioLevel: (level) => {
+          onAudioLevel: (level: number) => {
             this.audioLevels = appendVoiceLevel(this.audioLevels, level);
           },
-        }),
+        };
+        return isLocal
+          ? createLocalPushToTalkVoiceConnection(session, wrapped)
+          : createOpenAIRealtimeVoiceConnection(session, wrapped);
+      },
     });
     this.refreshSnapshot();
     return this.controller;
+  }
+
+  private localSession(): VoiceDictationSession {
+    return {
+      client_secret: '',
+      model: this.settings?.model ?? 'faster-whisper-base',
+    };
   }
 
   private refreshSnapshot() {

--- a/frontend/src/lib/types/runtimeSettings.ts
+++ b/frontend/src/lib/types/runtimeSettings.ts
@@ -1,7 +1,8 @@
 export type ModelTier = 'low' | 'medium' | 'high';
 export type EmbedderKey = 'local_gpu' | 'local_cpu' | 'openai' | 'gemini';
-export type RuntimeVoiceProvider = 'openai';
+export type RuntimeVoiceProvider = 'openai' | 'local' | 'gemini';
 export type RuntimeVoiceLanguage = 'auto' | 'en' | 'fr';
+export type RuntimeVoiceModelSize = 'tiny' | 'base' | 'small';
 
 export interface RuntimeOption {
   key: string;
@@ -51,10 +52,12 @@ export interface RuntimeVoiceSettings {
   model: string;
   source: 'memory';
   language: RuntimeVoiceLanguage;
+  model_size: RuntimeVoiceModelSize;
   status: 'ready' | 'missing' | 'error';
   detail?: string | null;
   provider_options: RuntimeOption[];
   language_options: RuntimeOption[];
+  model_size_options: RuntimeOption[];
 }
 
 export interface RuntimeVoiceSession {
@@ -63,4 +66,13 @@ export interface RuntimeVoiceSession {
   language: RuntimeVoiceLanguage;
   client_secret: string;
   expires_at?: number | null;
+}
+
+export interface RuntimeVoiceTranscript {
+  transcript: string;
+  provider: string;
+  model: string;
+  language: string;
+  transport: string;
+  bytes_streamed: number;
 }

--- a/frontend/src/lib/utils/apiClientContract.test.js
+++ b/frontend/src/lib/utils/apiClientContract.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const apiClientSource = readFileSync(
+  new URL('../api/client.ts', import.meta.url),
+  'utf8',
+);
+
+test('local voice transcription uses a long request timeout', () => {
+  assert.match(apiClientSource, /const VOICE_TRANSCRIPTION_TIMEOUT_MS = 5 \* 60_000;/);
+
+  const methodSource = apiClientSource.split('transcribeRuntimeVoiceClip:', 2)[1]?.split('\n  },', 1)[0] ?? '';
+  assert.match(methodSource, /timeoutMs:\s*VOICE_TRANSCRIPTION_TIMEOUT_MS/);
+});

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -78,6 +78,7 @@
   let voiceDraft = $state<VoiceDraft>({
     provider: 'openai',
     language: 'auto',
+    model_size: 'base',
   });
   let vaultSecrets = $state<VaultSecret[]>([]);
   let vaultLoading = $state(false);
@@ -155,6 +156,7 @@
     voiceDraft = {
       provider: next.voice.provider,
       language: next.voice.language || 'auto',
+      model_size: next.voice.model_size || 'base',
     };
   }
 
@@ -525,6 +527,7 @@
     return {
       provider: voiceDraft.provider,
       language: voiceDraft.language,
+      model_size: voiceDraft.model_size,
     };
   }
 
@@ -551,7 +554,8 @@
     if (!settings) return false;
     return (
       voiceDraft.provider !== settings.voice.provider ||
-      voiceDraft.language !== (settings.voice.language || 'auto')
+      voiceDraft.language !== (settings.voice.language || 'auto') ||
+      voiceDraft.model_size !== (settings.voice.model_size || 'base')
     );
   }
 

--- a/frontend/src/routes/system/VoiceCard.svelte
+++ b/frontend/src/routes/system/VoiceCard.svelte
@@ -55,6 +55,16 @@
         disabled={!canManageSettings}
         onValueChange={(value) => onUpdateVoice('language', value)}
       />
+      {#if voiceDraft.provider === 'local'}
+        <RuntimeSelect
+          id="voice-model-size"
+          label="Model size"
+          value={voiceDraft.model_size}
+          options={voice.model_size_options}
+          disabled={!canManageSettings}
+          onValueChange={(value) => onUpdateVoice('model_size', value)}
+        />
+      {/if}
       <label class="runtime-static-field" for="voice-model">
         <span>Transcription model</span>
         <div id="voice-model">{voice.model}</div>

--- a/frontend/src/routes/system/types.ts
+++ b/frontend/src/routes/system/types.ts
@@ -1,4 +1,9 @@
-import type { EmbedderKey, RuntimeVoiceLanguage, RuntimeVoiceProvider } from '$lib/types/runtimeSettings';
+import type {
+  EmbedderKey,
+  RuntimeVoiceLanguage,
+  RuntimeVoiceModelSize,
+  RuntimeVoiceProvider,
+} from '$lib/types/runtimeSettings';
 
 export type {
   EmbedderKey,
@@ -6,6 +11,7 @@ export type {
   RuntimeOption,
   RuntimeSettings,
   RuntimeVoiceLanguage,
+  RuntimeVoiceModelSize,
   RuntimeVoiceProvider,
   RuntimeVoiceSession,
   RuntimeVoiceSettings,
@@ -39,6 +45,7 @@ export interface MemoryDraft {
 export interface VoiceDraft {
   provider: RuntimeVoiceProvider;
   language: RuntimeVoiceLanguage;
+  model_size: RuntimeVoiceModelSize;
 }
 
 export interface NoticeState {

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -33,3 +33,9 @@ python-jose[cryptography]>=3.3
 bcrypt>=4.0
 itsdangerous>=2.1
 structlog>=24.0
+
+# Local voice dictation (CPU Whisper via CTranslate2). Unlike the embedding
+# stack this does NOT pull Torch/CUDA, so it ships in the default image and the
+# "Local" voice provider works out of the box. Model weights download on first
+# use into ILLO_PRIVATE_HOME/voice-models.
+faster-whisper>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,8 @@ structlog>=24.0
 sentence-transformers>=5.0
 transformers>=5.0
 accelerate>=1.0
+
+# Local voice dictation (CPU Whisper via CTranslate2; no torch). Ships in the
+# production image too; the "Local" voice provider degrades to unavailable if
+# this is somehow missing.
+faster-whisper>=1.0

--- a/tests/test_audio_attachment_transcription.py
+++ b/tests/test_audio_attachment_transcription.py
@@ -125,6 +125,111 @@ async def test_transcribe_audio_path_reports_gemini_boundary(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_transcribe_audio_path_routes_local_provider_to_faster_whisper(monkeypatch, tmp_path):
+    from brain.systems.voice import local_whisper, transcription
+
+    audio_path = tmp_path / "voice.webm"
+    audio_path.write_bytes(b"webm audio")
+
+    local = AsyncMock(
+        return_value=transcription.AudioTranscriptionResult(
+            transcript="bonjour",
+            language="fr",
+            provider="local",
+            model="faster-whisper-small",
+            transport="faster_whisper",
+        )
+    )
+    monkeypatch.setattr(
+        transcription,
+        "_runtime_voice_config",
+        AsyncMock(return_value=SimpleNamespace(provider="local", language="fr", model_size="small")),
+    )
+    monkeypatch.setattr(local_whisper, "async_transcribe_local_audio_path", local)
+
+    result = await transcription.async_transcribe_audio_path(object(), audio_path)
+
+    assert result.transcript == "bonjour"
+    assert result.provider == "local"
+    local.assert_awaited_once_with(audio_path, language="fr", model_size="small")
+
+
+@pytest.mark.asyncio
+async def test_local_whisper_joins_segments_and_normalizes_model_size(monkeypatch, tmp_path):
+    from brain.systems.voice import local_whisper
+
+    audio_path = tmp_path / "voice.webm"
+    audio_path.write_bytes(b"webm audio")
+
+    captured = {}
+
+    class FakeInfo:
+        language = "fr"
+
+    class FakeModel:
+        def transcribe(self, path, language=None, vad_filter=True):
+            captured["path"] = path
+            captured["language"] = language
+            captured["vad_filter"] = vad_filter
+            return iter([SimpleNamespace(text=" bon"), SimpleNamespace(text="jour")]), FakeInfo()
+
+    monkeypatch.setattr(local_whisper, "_load_model", lambda size: FakeModel())
+
+    result = await local_whisper.async_transcribe_local_audio_path(
+        audio_path,
+        language="fr",
+        model_size="not-a-size",
+    )
+
+    assert result.transcript == "bonjour"
+    assert result.provider == "local"
+    assert result.transport == "faster_whisper"
+    assert result.language == "fr"
+    # Unknown size falls back to the base default.
+    assert result.model == "faster-whisper-base"
+    assert captured["language"] == "fr"
+    assert captured["vad_filter"] is True
+
+
+@pytest.mark.asyncio
+async def test_local_whisper_auto_language_passes_none_to_model(monkeypatch, tmp_path):
+    from brain.systems.voice import local_whisper
+
+    audio_path = tmp_path / "voice.webm"
+    audio_path.write_bytes(b"webm audio")
+    captured = {}
+
+    class FakeModel:
+        def transcribe(self, path, language=None, vad_filter=True):
+            captured["language"] = language
+            return iter([SimpleNamespace(text="hello")]), SimpleNamespace(language="en")
+
+    monkeypatch.setattr(local_whisper, "_load_model", lambda size: FakeModel())
+
+    result = await local_whisper.async_transcribe_local_audio_path(audio_path, language="auto")
+
+    assert captured["language"] is None
+    assert result.language == "en"
+
+
+@pytest.mark.asyncio
+async def test_local_whisper_raises_when_no_transcript(monkeypatch, tmp_path):
+    from brain.systems.voice import local_whisper
+
+    audio_path = tmp_path / "voice.webm"
+    audio_path.write_bytes(b"webm audio")
+
+    class FakeModel:
+        def transcribe(self, path, language=None, vad_filter=True):
+            return iter([]), SimpleNamespace(language="fr")
+
+    monkeypatch.setattr(local_whisper, "_load_model", lambda size: FakeModel())
+
+    with pytest.raises(local_whisper.AudioTranscriptionError):
+        await local_whisper.async_transcribe_local_audio_path(audio_path, language="fr")
+
+
+@pytest.mark.asyncio
 async def test_transcribe_audio_attachment_handler_uses_context_audio(monkeypatch, tmp_path):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers import voice as voice_handler

--- a/tests/test_runtime_voice_settings.py
+++ b/tests/test_runtime_voice_settings.py
@@ -1,7 +1,23 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+def _memory_without_openai_key():
+    from brain.systems.runtime_settings.schemas import RuntimeMemoryRead
+
+    return RuntimeMemoryRead(
+        embedder="openai",
+        embedding_status="ready",
+        indexed_vectors=0,
+        api_key_statuses={"openai": False},
+        reranker="weighted",
+        embedder_options=[],
+        embedding_model_options=[],
+        reranker_options=[],
+    )
 
 
 @pytest.mark.asyncio
@@ -322,3 +338,167 @@ async def test_runtime_voice_session_endpoint_is_available_to_workspace_members(
 
     assert response is result
     create_session.assert_awaited_once_with(session, user)
+
+
+@pytest.mark.asyncio
+async def test_runtime_voice_local_provider_is_ready_when_faster_whisper_available(monkeypatch):
+    from brain.systems.runtime_settings import voice as voice_settings
+    from brain.systems.voice import local_whisper
+
+    monkeypatch.setattr(local_whisper, "local_whisper_available", lambda: True)
+
+    voice = voice_settings.runtime_voice_from_memory(
+        _memory_without_openai_key(),
+        voice_settings.RuntimeVoiceConfig(provider="local", language="fr", model_size="small"),
+    )
+
+    assert voice.provider == "local"
+    assert voice.model == "faster-whisper-small"
+    assert voice.model_size == "small"
+    assert voice.language == "fr"
+    assert voice.status == "ready"
+    assert voice.detail is None
+    assert [option.key for option in voice.provider_options] == ["openai", "local", "gemini"]
+    assert [option.key for option in voice.model_size_options] == ["tiny", "base", "small"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_voice_local_provider_is_missing_without_faster_whisper(monkeypatch):
+    from brain.systems.runtime_settings import voice as voice_settings
+    from brain.systems.voice import local_whisper
+
+    monkeypatch.setattr(local_whisper, "local_whisper_available", lambda: False)
+
+    voice = voice_settings.runtime_voice_from_memory(
+        _memory_without_openai_key(),
+        voice_settings.RuntimeVoiceConfig(provider="local"),
+    )
+
+    assert voice.provider == "local"
+    assert voice.model == "faster-whisper-base"
+    assert voice.model_size == "base"
+    assert voice.status == "missing"
+    assert "faster-whisper" in (voice.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_runtime_voice_update_persists_provider_and_model_size(monkeypatch):
+    from brain.systems.runtime_settings import voice as voice_settings
+    from brain.systems.runtime_settings.schemas import RuntimeVoiceUpdate
+    from brain.systems.voice import local_whisper
+
+    monkeypatch.setattr(local_whisper, "local_whisper_available", lambda: True)
+    written = {}
+
+    async def fake_write(_session, key, value):
+        written["key"] = key
+        written["value"] = value
+
+    monkeypatch.setattr(voice_settings, "_async_write_runtime_config_value", fake_write)
+    monkeypatch.setattr(
+        voice_settings,
+        "async_get_runtime_memory",
+        AsyncMock(return_value=_memory_without_openai_key()),
+    )
+
+    result = await voice_settings.async_update_runtime_voice(
+        MagicMock(),
+        SimpleNamespace(id="user-1", org_id="org-1"),
+        RuntimeVoiceUpdate(provider="local", language="fr", model_size="small"),
+    )
+
+    assert written["key"] == "runtime_voice"
+    assert '"provider": "local"' in written["value"]
+    assert '"model_size": "small"' in written["value"]
+    assert result.provider == "local"
+    assert result.model_size == "small"
+    assert result.status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_runtime_voice_session_rejects_local_provider_without_openai_lookup(monkeypatch):
+    from fastapi import HTTPException
+
+    from brain.systems.runtime_settings import voice as voice_settings
+
+    key_lookup = AsyncMock(return_value="sk-memory-openai")
+    monkeypatch.setattr(
+        voice_settings,
+        "async_get_runtime_voice_config",
+        AsyncMock(return_value=voice_settings.RuntimeVoiceConfig(provider="local")),
+    )
+    monkeypatch.setattr(voice_settings, "_async_installation_embedding_api_key", key_lookup)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await voice_settings.async_create_runtime_voice_session(MagicMock(), SimpleNamespace(id="user-1"))
+
+    assert excinfo.value.status_code == 409
+    assert "push-to-talk" in str(excinfo.value.detail)
+    key_lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_runtime_voice_clip_routes_through_configured_provider(monkeypatch):
+    from brain.systems.runtime_settings import voice as voice_settings
+    from brain.systems.voice import transcription as transcription_mod
+
+    captured = {}
+
+    async def fake_transcribe(session, path, **kwargs):
+        captured["path"] = path
+        captured["kwargs"] = kwargs
+        captured["existed_during_call"] = Path(path).is_file()
+        return transcription_mod.AudioTranscriptionResult(
+            transcript="bonjour le monde",
+            language="fr",
+            provider="local",
+            model="faster-whisper-base",
+            transport="faster_whisper",
+            bytes_streamed=11,
+        )
+
+    monkeypatch.setattr(transcription_mod, "async_transcribe_audio_path", fake_transcribe)
+
+    class FakeUpload:
+        filename = "clip.webm"
+
+        async def read(self):
+            return b"webm-audio-bytes"
+
+    result = await voice_settings.async_transcribe_runtime_voice_clip(
+        MagicMock(),
+        SimpleNamespace(id="user-1", org_id="org-1"),
+        upload=FakeUpload(),
+    )
+
+    assert result.transcript == "bonjour le monde"
+    assert result.provider == "local"
+    assert result.model == "faster-whisper-base"
+    assert result.language == "fr"
+    assert captured["kwargs"]["filename"] == "clip.webm"
+    assert str(captured["kwargs"]["safety_identifier"]).startswith("illo-user-")
+    assert captured["existed_during_call"] is True
+    # Temp file is cleaned up after transcription returns.
+    assert not Path(captured["path"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_runtime_voice_clip_rejects_empty_audio():
+    from fastapi import HTTPException
+
+    from brain.systems.runtime_settings import voice as voice_settings
+
+    class EmptyUpload:
+        filename = "clip.webm"
+
+        async def read(self):
+            return b""
+
+    with pytest.raises(HTTPException) as excinfo:
+        await voice_settings.async_transcribe_runtime_voice_clip(
+            MagicMock(),
+            SimpleNamespace(id="user-1", org_id="org-1"),
+            upload=EmptyUpload(),
+        )
+
+    assert excinfo.value.status_code == 422


### PR DESCRIPTION
## What this adds

Right now voice dictation only works through OpenAI Realtime — you need an OpenAI key and every clip leaves the machine. This PR adds a second option that runs **fully locally**: faster-whisper on CPU. Pick **Local (faster-whisper)** in System → Voice and you can dictate with no API key and nothing leaving the box.

It's deliberately additive — the OpenAI path is completely untouched. Same mic button, it just routes differently depending on the selected provider:

- **OpenAI** → existing realtime streaming, words appear as you speak.
- **Local** → push-to-talk: the browser records the clip, the server transcribes it with Whisper and drops the text in when you stop.

There's a model-size selector (`tiny` / `base` / `small`, default `base`) right next to the language one.

## Why faster-whisper

It runs Whisper through CTranslate2 with int8 quantization, so it's CPU-friendly and — unlike the embedding stack — pulls **no Torch/CUDA**. It adds ~300 MB to the image, no GPU required. Model weights download on first use into `ILLO_PRIVATE_HOME/voice-models` (on the persistent volume), so the first dictation has a one-time download and then it's instant.

## How it's wired

**Backend**
- `brain/systems/voice/local_whisper.py` — the engine: lazy import, one cached model per size, transcription run off the event loop. If the dependency is ever missing it reports the provider as unavailable instead of erroring.
- A `local` branch in the transcription router alongside `openai` / `gemini`.
- Runtime voice settings gain the `local` provider + `model_size`, plus a new `POST /api/runtime-settings/voice/transcribe` endpoint for recorded clips.
- `faster-whisper` added to the core requirements (shipped in the production image).

**Frontend**
- `Local` provider + a model-size selector in the Voice settings card; reuses the existing composer mic button.
- A push-to-talk transport (`MediaRecorder` → upload), chosen by provider.
- The composer now re-syncs voice settings on window focus / tab visibility / composer focus, so switching the provider enables the mic without a manual page refresh.

## Testing

- **26 backend tests** covering provider status, settings persistence, transcription routing, the engine itself (with a mocked model), and error handling. The existing OpenAI tests are unchanged.
- Frontend type-checks clean (`svelte-check`, 0 errors).
- Ran it **end-to-end in a real Compose deploy**: built the image, selected Local, and transcribed real English and French audio through the live API (`/voice/transcribe → 200`, correct transcripts, language auto-detected, error cases handled, models cached in the volume).

## Notes

- No DB migration — the provider and model size live in the existing `runtime_voice` JSON setting.
- If `faster-whisper` is ever absent the provider simply shows as unavailable and OpenAI dictation is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
