### PR TITLE
Refine Illo inbound preservation handling

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -25,6 +25,7 @@ from brain.systems.cortex.thread_links import thread_id_from_reference
 from brain.systems.cortex.project_context.search import search_project_contexts
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
+from brain.systems.inbound.results import read_inbound_submission_result
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
 
 
@@ -59,6 +60,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
             (
                 "Submit instructions, context, traces, decisions, or work material to Illo. "
                 "Use this when the request needs Illo's judgment, memory, or coordination. "
+                "Use it for preserve/store/remember requests so Illo can choose the durable memory or workspace surface. "
                 "The call is async-first: Illo stores an inbound event, queues headless handling, "
                 f"and returns an event id that can be read with {RESULT_TOOL_NAME}."
             ),
@@ -66,6 +68,10 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
                 "message": {
                     "type": "string",
                     "description": "Natural-language instruction or context for Illo to handle.",
+                },
+                "desired_outcome": {
+                    "type": "string",
+                    "description": "Explicit outcome request, such as preserve_knowledge when Illo should create durable memory or workspace state.",
                 },
                 "origin": {
                     "type": "string",
@@ -180,6 +186,7 @@ MCP_TOOLS: dict[str, dict[str, Any]] = {
         **_tool_schema(
             (
                 "Read the current status and receipts for an async Illo submission. "
+                "For preservation requests, returns whether durable evidence is pending, satisfied, or missing. "
                 "Prefer webhook callbacks when configured; this tool is the polling fallback."
             ),
             {
@@ -291,6 +298,7 @@ def _build_submit_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
     source_tool = _clean_optional_string(source.get("source_tool")) or "external"
     source.setdefault("source_tool", source_tool)
     origin = _clean_optional_string(arguments.get("origin")) or f"{source_tool}.submit"
+    desired_outcome = _clean_optional_string(arguments.get("desired_outcome"))
     constraints = _clean_dict(arguments.get("constraints"))
     correlation = _clean_dict(arguments.get("correlation"))
     response = _clean_dict(arguments.get("response"))
@@ -303,7 +311,7 @@ def _build_submit_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
         "correlation": correlation,
         "response": response,
     }
-    return {
+    envelope = {
         "kind": "submission",
         "origin": origin,
         "payload": payload,
@@ -316,6 +324,9 @@ def _build_submit_envelope(arguments: dict[str, Any]) -> dict[str, Any]:
         "response": response,
         "idempotency_key": _clean_optional_string(arguments.get("idempotency_key")),
     }
+    if desired_outcome:
+        envelope["desired_outcome"] = desired_outcome
+    return envelope
 
 
 def _submission_connection(principal: external_agents.AgentBridgePrincipal) -> dict[str, Any]:
@@ -844,34 +855,17 @@ async def _tool_get_result(
     )
     if not event_id:
         raise ValueError(f"{RESULT_TOOL_NAME} requires event_id, submission_id, or result_id")
-    event = await inbound_admin.require_event_for_org(db, org_id=principal.org_id, event_id=event_id)
-    if str(event.connection_id) != str(principal.connection_id):
-        raise ValueError("Inbound event not found")
-    receipts = await inbound_admin.list_receipts(
+    result = await read_inbound_submission_result(
         db,
         org_id=principal.org_id,
-        event_id=str(event.id),
+        connection_id=principal.connection_id,
+        event_id=event_id,
+        include_payload=bool(arguments.get("include_payload", True)),
         limit=int(arguments.get("limit") or 25),
     )
-    receipt_payloads = [inbound_admin.serialize_receipt(receipt) for receipt in receipts]
-    event_payload = inbound_admin.serialize_event(
-        event,
-        include_payload=bool(arguments.get("include_payload", True)),
-    )
-    action_result = dict(event.action_result or {})
-    handling = dict(action_result.get("handling") or {})
-    latest_receipt = receipt_payloads[0] if receipt_payloads else None
-    return {
-        "event_id": str(event.id),
-        "submission_id": str(event.id),
-        "result_id": str(event.id),
-        "status": event.status,
-        "handling_status": handling.get("status"),
-        "run_id": handling.get("run_id"),
-        "event": event_payload,
-        "latest_receipt": latest_receipt,
-        "receipts": receipt_payloads,
-    }
+    if result.mutated_inbound:
+        await db.commit()
+    return result.payload
 
 
 async def _add_thread_trigger_result_if_needed(

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -27,6 +27,14 @@ _SUMMARY_OPERATION_TAGS = {
     "refreshed",
     "posted",
 }
+_EXPLICIT_REF_KEYS = frozenset(
+    {
+        "target_refs",
+        "mutated_target_refs",
+        "durable_refs",
+        "durable_target_refs",
+    }
+)
 
 _DIRECT_REF_KINDS = {
     "idea_id": "idea",
@@ -35,6 +43,20 @@ _DIRECT_REF_KINDS = {
     "message_id": "message",
     "domain_id": "domain",
     "record_id": "domain_record",
+    "project_id": "project_context",
+    "project_profile_id": "project_context",
+    "handoff_id": "launch_handoff",
+    "source_id": "memory_source",
+    "span_id": "memory_span",
+    "span_ids": "memory_span",
+    "content_node_id": "memory_node",
+    "cue_node_id": "memory_node",
+    "cue_node_ids": "memory_node",
+    "tag_node_id": "memory_node",
+    "tag_node_ids": "memory_node",
+    "assertion_id": "memory_assertion",
+    "edge_id": "memory_edge",
+    "edge_ids": "memory_edge",
     "connection_id": "external_source_connection",
     "policy_id": "inbound_source_policy",
     "projection_id": "inbound_domain_projection",
@@ -50,6 +72,9 @@ _OBJECT_REF_KINDS = {
     "message": "message",
     "domain": "domain",
     "record": "domain_record",
+    "project": "project_context",
+    "handoff": "launch_handoff",
+    "attachment": "project_context_attachment",
     "connection": "external_source_connection",
     "policy": "inbound_source_policy",
     "projection": "inbound_domain_projection",
@@ -129,14 +154,70 @@ def _add_ref(refs: list[dict[str, str]], seen: set[tuple[str, str]], *, kind: st
     refs.append({"kind": kind, "id": text, "source": source})
 
 
+def _add_ref_values(
+    refs: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    kind: str,
+    value: Any,
+    source: str,
+) -> None:
+    if isinstance(value, list | tuple | set):
+        for item in value:
+            _add_ref(refs, seen, kind=kind, value=item, source=source)
+        return
+    _add_ref(refs, seen, kind=kind, value=value, source=source)
+
+
+def _add_explicit_ref(
+    refs: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    value: Any,
+    source: str,
+) -> None:
+    if not isinstance(value, Mapping):
+        return
+    kind = str(value.get("kind") or value.get("type") or "").strip()
+    ref_id = value.get("id") or value.get("ref") or value.get("value")
+    if not ref_id and kind:
+        ref_id = value.get(f"{kind}_id")
+    if not kind or ref_id is None:
+        return
+    _add_ref(
+        refs,
+        seen,
+        kind=kind,
+        value=ref_id,
+        source=str(value.get("source") or source),
+    )
+
+
+def _add_explicit_ref_values(
+    refs: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    value: Any,
+    source: str,
+) -> None:
+    if isinstance(value, list | tuple | set):
+        for item in value:
+            _add_explicit_ref(refs, seen, value=item, source=source)
+        return
+    _add_explicit_ref(refs, seen, value=value, source=source)
+
+
 def _collect_refs(value: Any, refs: list[dict[str, str]], seen: set[tuple[str, str]], *, source: str) -> None:
     if len(refs) >= _MAX_TARGET_REFS:
         return
     if isinstance(value, Mapping):
         for key, child in value.items():
             key_text = str(key)
+            if key_text in _EXPLICIT_REF_KEYS:
+                _add_explicit_ref_values(refs, seen, value=child, source=source)
+                continue
             if key_text in _DIRECT_REF_KINDS:
-                _add_ref(refs, seen, kind=_DIRECT_REF_KINDS[key_text], value=child, source=source)
+                _add_ref_values(refs, seen, kind=_DIRECT_REF_KINDS[key_text], value=child, source=source)
             if key_text in _OBJECT_REF_KINDS and isinstance(child, Mapping):
                 _add_ref(refs, seen, kind=_OBJECT_REF_KINDS[key_text], value=child.get("id"), source=source)
             if isinstance(child, Mapping | list):

--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -1,0 +1,294 @@
+"""Preservation intent and evidence policy for inbound submissions."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+PRESERVATION_INTENT_KEYWORDS = frozenset(
+    {
+        "archive",
+        "durable",
+        "knowledge trace",
+        "methodology",
+        "preserve",
+        "remember",
+        "save",
+        "store",
+        "storage",
+    }
+)
+PRESERVATION_INTENT_FIELDS = frozenset(
+    {
+        "preserve_as",
+        "storage",
+        "store_as",
+        "memory",
+        "knowledge",
+        "durable",
+        "retention",
+    }
+)
+PRESERVATION_OUTCOME_VALUES = frozenset(
+    {
+        "preserve",
+        "preserve_knowledge",
+        "store",
+        "store_knowledge",
+        "durable_storage",
+        "remember",
+        "archive",
+    }
+)
+PRESERVATION_ACCEPTABLE_TOOLS = (
+    "memory_ingest_source",
+    "brain_encode",
+    "manage_domain",
+    "manage_project",
+    "create_launch_handoff",
+    "post_thread_discussion_reply",
+    "post_ai_timeline_message",
+    "publish_thread_artifact",
+    "manage_workspace_app",
+)
+PRESERVATION_ACCEPTABLE_TARGET_KINDS = (
+    "memory_source",
+    "memory_node",
+    "memory_assertion",
+    "domain_record",
+    "domain",
+    "project_context",
+    "project_context_attachment",
+    "thread_message",
+    "launch_handoff",
+    "workspace_app",
+)
+PRESERVATION_MISSING_REASON = (
+    "Preservation was requested, but the completed Illo run did not produce durable storage evidence."
+)
+
+
+@dataclass(frozen=True)
+class PreservationContract:
+    requires_durable_evidence: bool
+    intent: str
+    reason: str | None
+    detection_source: str | None
+    visibility_hint: str | None
+    preserve_as: str | None
+    acceptable_tools: tuple[str, ...] = PRESERVATION_ACCEPTABLE_TOOLS
+    acceptable_target_kinds: tuple[str, ...] = PRESERVATION_ACCEPTABLE_TARGET_KINDS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "requires_durable_evidence": self.requires_durable_evidence,
+            "intent": self.intent,
+            "reason": self.reason,
+            "detection_source": self.detection_source,
+            "acceptable_tools": list(self.acceptable_tools),
+            "acceptable_target_kinds": list(self.acceptable_target_kinds),
+            "visibility_hint": self.visibility_hint,
+            "preserve_as": self.preserve_as,
+        }
+
+
+def _clean_optional(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _intent_text(value: Any) -> str:
+    if value in (None, "", [], {}):
+        return ""
+    if isinstance(value, str):
+        return value.lower()
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str).lower()
+    except Exception:
+        return str(value).lower()
+
+
+def _contains_preservation_keyword(text: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9_]+", " ", text.lower())
+    for keyword in PRESERVATION_INTENT_KEYWORDS:
+        pattern = r"\b" + re.escape(keyword).replace(r"\ ", r"\s+") + r"\b"
+        if re.search(pattern, normalized):
+            return True
+    return False
+
+
+def _has_preservation_field(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for key, child in value.items():
+        key_text = str(key or "").strip().lower()
+        if key_text in PRESERVATION_INTENT_FIELDS:
+            return True
+        if isinstance(child, Mapping) and _has_preservation_field(child):
+            return True
+    return False
+
+
+def _explicit_outcome_requests_preservation(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return False
+    normalized = re.sub(r"[^a-z0-9_]+", "_", text).strip("_")
+    return normalized in PRESERVATION_OUTCOME_VALUES or _contains_preservation_keyword(text)
+
+
+def submission_preservation_contract(normalized: Mapping[str, Any]) -> dict[str, Any]:
+    constraints = _json_dict(normalized.get("constraints"))
+    response = _json_dict(normalized.get("response"))
+    source = _json_dict(normalized.get("source"))
+    parts = list(normalized.get("parts") or [])
+    part_headers = [
+        {"type": part.get("type"), "title": part.get("title")}
+        for part in parts
+        if isinstance(part, Mapping)
+    ]
+    desired_outcome = _clean_optional(
+        normalized.get("desired_outcome")
+        or constraints.get("desired_outcome")
+        or response.get("desired_outcome")
+        or source.get("desired_outcome")
+    )
+    preserve_as = _clean_optional(constraints.get("preserve_as") or response.get("preserve_as"))
+    visibility_hint = _clean_optional(constraints.get("visibility"))
+    scanned = "\n".join(
+        [
+            _intent_text(normalized.get("message")),
+            _intent_text(normalized.get("summary")),
+            _intent_text(desired_outcome),
+            _intent_text(constraints),
+            _intent_text(response),
+            _intent_text(source),
+            _intent_text(part_headers),
+        ]
+    )
+    explicit_outcome = _explicit_outcome_requests_preservation(desired_outcome)
+    explicit_field = any(_has_preservation_field(value) for value in (constraints, response, source))
+    language_hint = _contains_preservation_keyword(scanned)
+    required = explicit_outcome or explicit_field
+    if explicit_outcome:
+        reason = "preservation requested by desired_outcome"
+        detection_source = "desired_outcome"
+    elif explicit_field:
+        reason = "preservation field present in submission metadata"
+        detection_source = "metadata"
+    elif language_hint:
+        reason = "preservation language present in submission"
+        detection_source = "language_hint"
+    else:
+        reason = None
+        detection_source = None
+
+    if required:
+        intent = "preserve_knowledge"
+    elif language_hint:
+        intent = "possible_preservation"
+    else:
+        intent = "general_coordination"
+    return PreservationContract(
+        requires_durable_evidence=required,
+        intent=intent,
+        reason=reason,
+        detection_source=detection_source,
+        visibility_hint=visibility_hint,
+        preserve_as=preserve_as,
+    ).to_dict()
+
+
+def submission_preservation_prompt_lines(contract: Mapping[str, Any]) -> list[str]:
+    if contract.get("requires_durable_evidence"):
+        visibility = contract.get("visibility_hint") or "the narrowest visibility that preserves future utility"
+        return [
+            "",
+            "Preservation workflow:",
+            "- This submission explicitly asks Illo to preserve knowledge or work material.",
+            "- The inbound event is only raw source evidence; by itself it is not enough to satisfy preservation.",
+            "- First inspect the full event with manage_inbound(action='get_event', event_id=..., include_receipts=true) if the preview is insufficient.",
+            "- Decide the right durable surface: reconstructive memory for reusable lessons/procedures, a Domain/doc/project record for canonical structured knowledge, a handoff when this should launch future work, or a thread note when team visibility matters.",
+            "- Prefer memory_ingest_source with source_kind='inbound_submission', source_ref equal to the inbound event id, and visibility set to "
+            f"{visibility}.",
+            "- Use manage_domain/manage_project/create_launch_handoff/thread tools when those are the better Illo-owned storage surfaces.",
+            "- Avoid direct source duplication when a matching durable record already exists; update or link to the existing object instead.",
+            "- Final answer must list what Illo decided, every durable handle created or updated, and any reason no durable write was appropriate.",
+        ]
+    if contract.get("intent") == "possible_preservation":
+        return [
+            "",
+            "Possible preservation workflow:",
+            "- The wording may indicate a preservation request. Treat this as a hint, not a storage mandate.",
+            "- If durable storage is appropriate, choose an Illo-owned memory, domain, project, handoff, thread, artifact, or workspace-app surface and list the durable handle in the final answer.",
+        ]
+    return []
+
+
+def preservation_contract_from_run_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    submission = _json_dict(metadata.get("submission"))
+    return _json_dict(submission.get("preservation"))
+
+
+def preservation_evidence_result(
+    contract: Mapping[str, Any] | None,
+    *,
+    run_status: Any,
+    attribution: Mapping[str, Any],
+) -> dict[str, Any]:
+    contract = _json_dict(contract)
+    required = bool(contract.get("requires_durable_evidence"))
+    result: dict[str, Any] = {
+        "required": required,
+        "status": "not_required",
+        "acceptable_tools": list(contract.get("acceptable_tools") or PRESERVATION_ACCEPTABLE_TOOLS),
+        "acceptable_target_kinds": list(
+            contract.get("acceptable_target_kinds") or PRESERVATION_ACCEPTABLE_TARGET_KINDS
+        ),
+    }
+    if not required:
+        return result
+
+    run_status_value = str(getattr(run_status, "value", run_status) or "").strip()
+    if run_status_value != "completed":
+        result["status"] = run_status_value
+        return result
+
+    acceptable_kinds = {str(kind) for kind in result["acceptable_target_kinds"]}
+    acceptable_tools = {str(tool) for tool in result["acceptable_tools"]}
+    mutated_refs = [
+        dict(ref)
+        for ref in attribution.get("mutated_target_refs", [])
+        if str(ref.get("kind") or "") in acceptable_kinds
+    ]
+    tool_names = [str(tool) for tool in attribution.get("tool_names", [])]
+    matching_tools = [tool for tool in tool_names if tool in acceptable_tools]
+    if mutated_refs:
+        result["status"] = "satisfied"
+        result["mutated_target_refs"] = mutated_refs
+        result["tool_names"] = matching_tools or tool_names
+        return result
+
+    result["status"] = "missing"
+    result["reason"] = PRESERVATION_MISSING_REASON
+    result["tool_names"] = matching_tools or tool_names
+    result["mutated_target_refs"] = []
+    return result
+
+
+__all__ = [
+    "PRESERVATION_ACCEPTABLE_TARGET_KINDS",
+    "PRESERVATION_ACCEPTABLE_TOOLS",
+    "PRESERVATION_MISSING_REASON",
+    "submission_preservation_contract",
+    "submission_preservation_prompt_lines",
+    "preservation_contract_from_run_metadata",
+    "preservation_evidence_result",
+]

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -11,6 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.systems.inbound.attribution import summarize_inbound_run_attribution
+from brain.systems.inbound.preservation import (
+    PRESERVATION_MISSING_REASON,
+    preservation_contract_from_run_metadata,
+    preservation_evidence_result,
+)
+from brain.systems.inbound.status import STATUS_REVIEW_REQUIRED
 from brain.systems.runs.domain import AgentRun, ArtifactType
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 
@@ -164,7 +170,14 @@ async def reconcile_inbound_triage_run(
     terminal_at = _run_datetime(row, status)
     final_answer = await _latest_final_answer(session, run_id)
     attribution = await summarize_inbound_run_attribution(session, run_id=run_id, status=status)
-    terminal_status = _receipt_terminal_status(status)
+    evidence_contract = preservation_evidence_result(
+        preservation_contract_from_run_metadata(metadata),
+        run_status=status,
+        attribution=attribution,
+    )
+    evidence_missing = evidence_contract.get("status") == "missing"
+    terminal_status = STATUS_REVIEW_REQUIRED if evidence_missing else _receipt_terminal_status(status)
+    outcome_status = "needs_action" if evidence_missing else status.value
     triage_terminal = _triage_terminal_payload(
         run_id=run_id,
         status=status,
@@ -172,27 +185,40 @@ async def reconcile_inbound_triage_run(
         terminal_at=terminal_at,
         final_answer=final_answer,
     )
+    triage_terminal["status"] = outcome_status
+    triage_terminal["evidence_contract"] = evidence_contract
 
     outcome = _json_dict(receipt.outcome)
     tool_use = _json_dict(receipt.tool_use)
     outcome_key = "handling" if tool_use.get("type") == "illo_submit" else "triage"
     handling = _json_dict(outcome.get(outcome_key))
+    result_payload = _triage_result(status, final_answer)
+    if evidence_missing:
+        result_payload = {
+            **result_payload,
+            "status": outcome_status,
+            "reason": evidence_contract.get("reason") or PRESERVATION_MISSING_REASON,
+        }
     outcome[outcome_key] = {
         **handling,
         **triage_terminal,
-        "result": _triage_result(status, final_answer),
+        "result": result_payload,
         "attribution": attribution,
     }
 
     receipt.status = terminal_status
     receipt.outcome = outcome
+    tool_terminal = _tool_use_terminal_payload(
+        status=status,
+        reconciled_at=now,
+        terminal_at=terminal_at,
+    )
+    if evidence_missing:
+        tool_terminal["status"] = outcome_status
+    tool_terminal["evidence_contract"] = evidence_contract
     receipt.tool_use = {
         **tool_use,
-        **_tool_use_terminal_payload(
-            status=status,
-            reconciled_at=now,
-            terminal_at=terminal_at,
-        ),
+        **tool_terminal,
         "attribution": attribution,
     }
 
@@ -202,7 +228,9 @@ async def reconcile_inbound_triage_run(
         outcome_key: outcome[outcome_key],
     }
     event.processed_at = event.processed_at or now
-    if status == RunStatus.COMPLETED:
+    if evidence_missing:
+        event.error = evidence_contract.get("reason") or PRESERVATION_MISSING_REASON
+    elif status == RunStatus.COMPLETED:
         event.error = None
     else:
         event.error = final_answer or f"Illo triage run ended with status {status.value}"

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -1,0 +1,93 @@
+"""Read async inbound submission results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.systems.inbound import admin as inbound_admin
+from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+
+
+@dataclass(frozen=True)
+class InboundSubmissionResult:
+    payload: dict[str, Any]
+    mutated_inbound: bool = False
+
+
+async def read_inbound_submission_result(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    connection_id: str,
+    event_id: str,
+    include_payload: bool = True,
+    limit: int = 25,
+) -> InboundSubmissionResult:
+    event = await inbound_admin.require_event_for_org(session, org_id=org_id, event_id=event_id)
+    if str(event.connection_id) != str(connection_id):
+        raise ValueError("Inbound event not found")
+
+    action_result = dict(event.action_result or {})
+    handling = dict(action_result.get("handling") or {})
+    reconciled = False
+    current_run_status = None
+    if handling.get("run_id") is not None:
+        try:
+            run_id = int(handling["run_id"])
+        except (TypeError, ValueError):
+            run_id = None
+        if run_id is not None:
+            run = await session.get(AgentRunRow, run_id)
+            current_run_status = getattr(run, "status", None) if run is not None else None
+            receipt = await reconcile_inbound_triage_run(session, run_id)
+            reconciled = receipt is not None
+            if reconciled:
+                await session.refresh(event)
+
+    receipts = await inbound_admin.list_receipts(
+        session,
+        org_id=org_id,
+        event_id=str(event.id),
+        limit=limit,
+    )
+    receipt_payloads = [inbound_admin.serialize_receipt(receipt) for receipt in receipts]
+    event_payload = inbound_admin.serialize_event(event, include_payload=include_payload)
+
+    action_result = dict(event.action_result or {})
+    handling = dict(action_result.get("handling") or {})
+    preservation = dict(action_result.get("preservation") or {})
+    evidence_contract = dict(handling.get("evidence_contract") or {})
+    requires_evidence = bool(
+        evidence_contract.get("required")
+        or preservation.get("requires_durable_evidence")
+    )
+    evidence_status = str(
+        evidence_contract.get("status")
+        or ("pending" if requires_evidence else "not_required")
+    )
+    latest_receipt = receipt_payloads[0] if receipt_payloads else None
+    return InboundSubmissionResult(
+        payload={
+            "event_id": str(event.id),
+            "submission_id": str(event.id),
+            "result_id": str(event.id),
+            "status": event.status,
+            "handling_status": handling.get("status"),
+            "run_id": handling.get("run_id"),
+            "run_status": handling.get("run_status") or current_run_status,
+            "requires_durable_evidence": requires_evidence,
+            "evidence_status": evidence_status,
+            "evidence_contract": evidence_contract or preservation or None,
+            "event": event_payload,
+            "latest_receipt": latest_receipt,
+            "receipts": receipt_payloads,
+        },
+        mutated_inbound=reconciled,
+    )
+
+
+__all__ = ["InboundSubmissionResult", "read_inbound_submission_result"]

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -31,6 +31,10 @@ from brain.systems.inbound.status import (
     STATUS_QUARANTINED,
     STATUS_REVIEW_REQUIRED,
 )
+from brain.systems.inbound.preservation import (
+    submission_preservation_contract,
+    submission_preservation_prompt_lines,
+)
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.systems.user_domains.service import AsyncDomainService, DomainError, DomainNotFound
 
@@ -1073,6 +1077,7 @@ async def _process_submission_envelope(
             "message": "Submission accepted and queued for Illo handling.",
             "event_id": str(event.id),
             "handling": handling,
+            "preservation": submission_preservation_contract(normalized),
         },
         confidence=None,
         target=_submission_target(handling, event=event),
@@ -1097,6 +1102,7 @@ async def _queue_illo_submission(
         return {"status": "skipped", "reason": "missing_authority_user", "event_id": str(event.id)}
 
     source_name = context.display_name or context.source_kind or "external source"
+    preservation = submission_preservation_contract(normalized)
     message = _submission_prompt(context=context, event=event, normalized=normalized)
     result = await admit_work(
         session,
@@ -1130,6 +1136,7 @@ async def _queue_illo_submission(
                         "correlation": dict(normalized.get("correlation") or {}),
                         "response": dict(normalized.get("response") or {}),
                         "part_count": len(list(normalized.get("parts") or [])),
+                        "preservation": preservation,
                     },
                 },
             },
@@ -1158,6 +1165,7 @@ def _submission_prompt(
     normalized: Mapping[str, Any],
 ) -> str:
     source_name = context.display_name or context.source_kind or "external source"
+    preservation = submission_preservation_contract(normalized)
     lines = [
         "Handle this external coordination submission.",
         "",
@@ -1180,6 +1188,7 @@ def _submission_prompt(
         value = normalized.get(key)
         if value:
             lines.extend(["", f"{label}:", _json_preview(value, limit=1200)])
+    lines.extend(submission_preservation_prompt_lines(preservation))
     lines.extend(
         [
             "",

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -696,6 +696,7 @@ async def test_hosted_mcp_submit_builds_submission_envelope():
                     "arguments": {
                         "message": "Ask Illo to review the implementation context and decide next steps.",
                         "origin": "codex.submit",
+                        "desired_outcome": "preserve_knowledge",
                         "source_tool": "codex",
                         "repo": "illospace-project",
                         "branch": "codex/mcp-submit",
@@ -734,6 +735,7 @@ async def test_hosted_mcp_submit_builds_submission_envelope():
     assert captured["envelope"] == {
         "kind": "submission",
         "origin": "codex.submit",
+        "desired_outcome": "preserve_knowledge",
         "payload": {
             "message": "Ask Illo to review the implementation context and decide next steps.",
             "parts": [{"type": "text", "text": "Implemented the submit tool."}],

--- a/tests/test_illo_personal_agent_mcp.py
+++ b/tests/test_illo_personal_agent_mcp.py
@@ -29,6 +29,7 @@ def test_tool_catalog_contains_behavior_guidance():
     assert {"illo_submit", "illo_read", "illo_act", "illo_get_result"} == set(tools)
     assert "queues headless handling" in tools["illo_submit"]["description"]
     assert "message" in tools["illo_submit"]["inputSchema"]["properties"]
+    assert "desired_outcome" in tools["illo_submit"]["inputSchema"]["properties"]
     assert tools["illo_submit"]["inputSchema"]["required"] == ["message"]
     assert "named capability" in tools["illo_read"]["description"]
     assert tools["illo_read"]["inputSchema"]["required"] == ["capability"]
@@ -63,6 +64,7 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
 
     submit_result = client.submit(
         "Ask the team to review the implementation context",
+        desired_outcome="preserve_knowledge",
         parts=[{"type": "text", "text": "Implemented MCP submission"}],
         repo="illospace-project",
         branch="codex/mcp-submit-context",
@@ -102,6 +104,7 @@ def test_client_routes_and_auth_header_are_stable(monkeypatch):
     context_payload = calls[0]["payload"]
     assert context_payload["method"] == "tools/call"
     assert context_payload["params"]["arguments"]["message"] == "Ask the team to review the implementation context"
+    assert context_payload["params"]["arguments"]["desired_outcome"] == "preserve_knowledge"
     assert context_payload["params"]["arguments"]["parts"] == [
         {"type": "text", "text": "Implemented MCP submission"}
     ]

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.external_agent import (
+    ExternalAgentConnectionRow,
+    ExternalAgentConnectionTokenRow,
+)
+from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.db.models.org import Org, User
+from brain.systems.external_agents import service as external_agents
+from brain.systems.inbound import service as inbound
+from brain.systems.runs.events import run_event
+from brain.systems.runs.status import RunStatus
+from brain.systems.runs.store import AsyncAgentRunStore
+
+
+pytestmark = pytest.mark.asyncio
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+USER_ID = "22222222-2222-4222-8222-222222222222"
+CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
+TOKEN_ID = "44444444-4444-4444-8444-444444444444"
+RAW_TOKEN = "illo_conn_test_webhook_token"
+
+
+def _patch_sqlite_for_pg_types():
+    if not hasattr(SQLiteTypeCompiler, "visit_JSONB"):
+        SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_BIGINT = lambda self, type_, **kw: "INTEGER"
+    for name in ("visit_VECTOR", "visit_Vector"):
+        if not hasattr(SQLiteTypeCompiler, name):
+            setattr(SQLiteTypeCompiler, name, lambda self, type_, **kw: "TEXT")
+
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_inbound_preservation_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+            result = result.replace("TRUE", "1").replace("FALSE", "0")
+        return result
+
+    patched._inbound_preservation_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    return await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            ExternalAgentConnectionRow.__table__,
+            ExternalAgentConnectionTokenRow.__table__,
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+            InboundEventRow.__table__,
+            InboundDecisionReceiptRow.__table__,
+        ]
+    )
+
+
+async def _seed_connection(session) -> external_agents.AgentBridgePrincipal:
+    if await session.get(Org, ORG_ID) is None:
+        session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    if await session.get(User, USER_ID) is None:
+        session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    session.add_all(
+        [
+            ExternalAgentConnectionRow(
+                id=CONNECTION_ID,
+                org_id=ORG_ID,
+                owner_user_id=USER_ID,
+                display_name="Codex",
+                agent_kind="codex",
+                transport="mcp",
+                status="online",
+                remote_agent_card={},
+                capabilities={
+                    "illo_submit": True,
+                    "illo_read": True,
+                    "illo_act": True,
+                    "illo_get_result": True,
+                },
+                auth_metadata={},
+                metadata_={},
+            ),
+            ExternalAgentConnectionTokenRow(
+                id=TOKEN_ID,
+                connection_id=CONNECTION_ID,
+                org_id=ORG_ID,
+                owner_user_id=USER_ID,
+                token_hash=external_agents.hash_connection_token(RAW_TOKEN),
+                token_prefix=external_agents.token_prefix(RAW_TOKEN),
+                name="MCP token",
+                scopes=[external_agents.SCOPE_SIGNAL_SUBMIT],
+            ),
+        ]
+    )
+    await session.flush()
+    return external_agents.AgentBridgePrincipal(
+        connection_id=CONNECTION_ID,
+        org_id=ORG_ID,
+        owner_user_id=USER_ID,
+        token_id=TOKEN_ID,
+        scopes=frozenset([external_agents.SCOPE_SIGNAL_SUBMIT]),
+        connection_display_name="Codex",
+        agent_kind="codex",
+    )
+
+
+async def _assert_queued_submission(session, outcome: dict) -> dict:
+    assert outcome["operation"] == "queued"
+    assert outcome["message"] == "Submission accepted and queued for Illo handling."
+    handling = outcome["handling"]
+    assert handling["status"] == "queued"
+    assert handling["event_id"]
+    assert handling["run_id"]
+
+    run = await session.get(AgentRunRow, handling["run_id"])
+    assert run is not None
+    assert run.thread_id == f"inbound:{CONNECTION_ID}:{handling['event_id']}"
+    assert run.status == "queued"
+    assert run.metadata_["producer"] == "inbound"
+    assert run.target_ref["kind"] == "inbound_submission"
+    assert run.target_ref["event_id"] == handling["event_id"]
+    assert run.metadata_["submission"]["message"]
+    return handling
+
+
+async def _finish_triage_run(
+    session,
+    triage: dict,
+    *,
+    status: RunStatus,
+    final_answer: str,
+) -> None:
+    store = AsyncAgentRunStore(session)
+    run_id = int(triage["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_final_answer_once(run_id, final_answer, root_run_id=run_id)
+    await store.set_status(run_id, status)
+
+
+async def test_preservation_submission_gets_curator_prompt_and_contract(session):
+    principal = await _seed_connection(session)
+    envelope = {
+        "kind": "submission",
+        "origin": "codex.submit",
+        "desired_outcome": "preserve_knowledge",
+        "message": "Please preserve this Roman methodology note as durable Illo knowledge.",
+        "parts": [{"type": "text", "title": "Roman methodology", "content": "# Roman PDP Methodology"}],
+        "source": {"source_tool": "codex", "repo": "uwear-backend"},
+        "constraints": {"preserve_as": "durable methodology note", "visibility": "org"},
+        "idempotency_key": "codex:submission:preserve-contract",
+    }
+
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=envelope,
+        ingress_context={"surface": "test"},
+    )
+
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run = await session.get(AgentRunRow, handling["run_id"])
+    event = await session.get(InboundEventRow, result["event_id"])
+
+    assert run is not None
+    assert "Preservation workflow:" in run.input_message
+    assert "memory_ingest_source" in run.input_message
+    preservation = run.metadata_["submission"]["preservation"]
+    assert preservation["requires_durable_evidence"] is True
+    assert preservation["intent"] == "preserve_knowledge"
+    assert preservation["detection_source"] == "desired_outcome"
+    assert event is not None
+    assert event.action_result["preservation"]["requires_durable_evidence"] is True
+
+
+async def test_language_only_preservation_match_is_prompt_hint_not_evidence_contract(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.submit",
+            "message": "Store this process note so Illo can reuse it later.",
+            "parts": [{"type": "text", "content": "Long enough process note for a future workflow."}],
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:language-hint",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run = await session.get(AgentRunRow, handling["run_id"])
+    assert run is not None
+
+    preservation = run.metadata_["submission"]["preservation"]
+    assert preservation["intent"] == "possible_preservation"
+    assert preservation["requires_durable_evidence"] is False
+    assert "Possible preservation workflow:" in run.input_message
+
+
+async def test_preservation_submission_without_durable_evidence_stays_actionable(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.submit",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Store this process note so Illo can reuse it later.",
+            "parts": [{"type": "text", "content": "Long enough process note for a future workflow."}],
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:missing-evidence",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+
+    await _finish_triage_run(
+        session,
+        handling,
+        status=RunStatus.COMPLETED,
+        final_answer="I reviewed the note and decided it was useful.",
+    )
+
+    event = await session.get(InboundEventRow, result["event_id"])
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert event is not None
+    assert event.status == "review_required"
+    assert event.action_result["handling"]["status"] == "needs_action"
+    assert event.action_result["handling"]["run_status"] == "completed"
+    assert event.action_result["handling"]["evidence_contract"]["status"] == "missing"
+    assert "did not produce durable storage evidence" in event.error
+    assert receipt.status == "review_required"
+    assert receipt.tool_use["status"] == "needs_action"
+    assert receipt.tool_use["evidence_contract"]["status"] == "missing"
+
+
+async def test_preservation_submission_with_explicit_memory_evidence_reconciles_processed(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.submit",
+            "desired_outcome": "preserve_knowledge",
+            "message": "Preserve this reusable ArtDirection playbook in Illo memory.",
+            "parts": [{"type": "text", "content": "A reusable playbook with enough detail for ingestion."}],
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:memory-evidence",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    store = AsyncAgentRunStore(session)
+    run_id = int(handling["run_id"])
+    await store.set_status(run_id, RunStatus.STARTING)
+    await store.set_status(run_id, RunStatus.RUNNING)
+    await store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "memory_ingest_source",
+                "args": {"content_kind": "procedure", "source_kind": "inbound_submission"},
+                "result": json.dumps(
+                    {
+                        "operation": "created",
+                        "mutated_target_refs": [
+                            {"kind": "memory_source", "id": 91},
+                            {"kind": "memory_node", "id": 93},
+                        ],
+                    }
+                ),
+            },
+            root_run_id=run_id,
+        )
+    )
+    await store.append_final_answer_once(run_id, "Stored the playbook in reconstructive memory.", root_run_id=run_id)
+    await store.set_status(run_id, RunStatus.COMPLETED)
+
+    event = await session.get(InboundEventRow, result["event_id"])
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert event is not None
+    assert event.status == "processed"
+    assert event.error is None
+    evidence = event.action_result["handling"]["evidence_contract"]
+    assert evidence["status"] == "satisfied"
+    assert {"kind": "memory_source", "id": "91", "source": "memory_ingest_source"} in evidence["mutated_target_refs"]
+    assert receipt.status == "processed"
+    assert "memory_source" in {ref["kind"] for ref in receipt.tool_use["attribution"]["mutated_target_refs"]}
+
+
+async def test_get_result_lazily_reconciles_completed_submission_run(session):
+    principal = await _seed_connection(session)
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "codex.submit",
+            "message": "Review this context and decide what to do.",
+            "source": {"source_tool": "codex"},
+            "idempotency_key": "codex:submission:lazy-reconcile",
+        },
+        ingress_context={"surface": "test"},
+    )
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run = await session.get(AgentRunRow, handling["run_id"])
+    assert run is not None
+    run.status = RunStatus.COMPLETED.value
+    run.completed_at = datetime.now(timezone.utc)
+    await session.flush()
+
+    from brain.app.api.routers.agent_mcp import _tool_get_result
+
+    payload = await _tool_get_result(session, principal, {"event_id": result["event_id"]})
+
+    assert "_mutates_inbound" not in payload
+    assert payload["status"] == "processed"
+    assert payload["handling_status"] == "completed"
+    assert payload["run_status"] == "completed"
+    assert payload["evidence_status"] == "not_required"

--- a/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
+++ b/tools/illo-personal-agent-mcp/illo_personal_agent_mcp/server.py
@@ -160,6 +160,7 @@ class IlloBridgeClient:
         message: str,
         *,
         origin: str = "codex.submit",
+        desired_outcome: str | None = None,
         parts: list[dict[str, Any]] | None = None,
         source: dict[str, Any] | None = None,
         constraints: dict[str, Any] | None = None,
@@ -182,6 +183,7 @@ class IlloBridgeClient:
                 **extra,
                 "message": str(message),
                 "origin": str(origin or "codex.submit"),
+                "desired_outcome": desired_outcome,
                 "parts": list(parts or []),
                 "source": dict(source or {}),
                 "constraints": dict(constraints or {}),
@@ -267,6 +269,7 @@ def _client() -> IlloBridgeClient:
 def tool_illo_submit(
     message: str,
     origin: str = "codex.submit",
+    desired_outcome: str | None = None,
     parts: list[dict[str, Any]] | None = None,
     source: dict[str, Any] | None = None,
     constraints: dict[str, Any] | None = None,
@@ -286,6 +289,7 @@ def tool_illo_submit(
     return _client().submit(
         message=message,
         origin=origin,
+        desired_outcome=desired_outcome,
         parts=parts,
         source=source,
         constraints=constraints,
@@ -361,6 +365,7 @@ TOOLS: dict[str, dict[str, Any]] = {
         "description": (
             "Submit instructions, context, traces, decisions, or work material to Illo. "
             "Use this when the request needs Illo's judgment, memory, or coordination. "
+            "Use it for preserve/store/remember requests so Illo can choose the durable memory or workspace surface. "
             "The call is async-first: Illo stores an inbound event, queues headless handling, "
             "and returns an event id that can be read with illo_get_result."
         ),
@@ -372,6 +377,10 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "description": "Natural-language instruction or context for Illo to handle.",
                 },
                 "origin": {"type": "string", "description": "Stable event name.", "default": "codex.submit"},
+                "desired_outcome": {
+                    "type": "string",
+                    "description": "Explicit outcome request, for example preserve_knowledge for durable Illo storage.",
+                },
                 "parts": {
                     "type": "array",
                     "items": {"type": "object"},
@@ -464,8 +473,9 @@ TOOLS: dict[str, dict[str, Any]] = {
         "function": tool_illo_get_result,
         "description": (
             "Retrieve or poll the outcome of an asynchronous Illo operation returned by "
-            "illo_submit, illo_read, or illo_act. Use this for result_id receipts instead of "
-            "repeating the original request."
+            "illo_submit, illo_read, or illo_act. Preservation results include whether durable "
+            "evidence is pending, satisfied, or missing. Use this for result_id receipts instead "
+            "of repeating the original request."
         ),
         "inputSchema": {
             "type": "object",


### PR DESCRIPTION
## Summary
- Extract inbound preservation policy/evidence into shared modules
- Add explicit desired_outcome=preserve_knowledge lane for MCP submissions
- Move lazy result reconciliation out of the hosted MCP router and add focused preservation tests

## Tests
- venv/bin/python -m pytest tests/test_inbound_preservation.py tests/test_inbound_webhooks.py tests/test_illo_personal_agent_mcp.py tests/test_external_agent_routes.py tests/test_reconstructive_memory.py -q