### PR TITLE
Fix Project Context vault credential materialization

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -35,7 +35,7 @@ from brain.systems.cortex.project_context.workspace_manifest import (
     ThreadDraftIdentity,
     normalize_project_workspace_manifest,
 )
-from brain.systems.vault import get_secret, list_secrets
+from brain.systems.vault import async_get_secret, list_secrets
 
 
 _REPO_RESOURCE_KINDS = {
@@ -210,11 +210,22 @@ async def _github_secret_names(user_id: str, org_id: str | None) -> list[str]:
     return names[:5]
 
 
-async def _token_candidates(resource: dict[str, Any], user_id: str | None, org_id: str | None) -> list[tuple[str | None, str | None]]:
+def _vault_read_error_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    return message or exc.__class__.__name__
+
+
+async def _token_candidates(
+    resource: dict[str, Any],
+    user_id: str | None,
+    org_id: str | None,
+) -> list[tuple[str | None, str | None, str | None]]:
     explicit_key = _vault_key_from_resource(resource)
-    candidates: list[tuple[str | None, str | None]] = []
+    candidates: list[tuple[str | None, str | None, str | None]] = []
     if not user_id:
-        return [(None, None)]
+        if explicit_key:
+            return [(explicit_key, None, "Vault credential requires a run user_id context.")]
+        return [(None, None, None)]
 
     key_names = []
     if explicit_key:
@@ -228,17 +239,21 @@ async def _token_candidates(resource: dict[str, Any], user_id: str | None, org_i
             continue
         seen.add(key_name)
         try:
-            token = await _maybe_await(get_secret(
+            token = await async_get_secret(
                 key_name,
                 actor_user_id=user_id,
                 org_id=org_id,
-                accessed_by="api",
-            ))
-        except Exception:
-            token = None
+                accessed_by="github_runtime_tool",
+            )
+        except Exception as exc:
+            candidates.append((key_name, None, _vault_read_error_message(exc)))
+            continue
         if token:
-            candidates.append((key_name, token.strip()))
-    candidates.append((None, None))
+            candidates.append((key_name, token.strip(), None))
+        else:
+            candidates.append((key_name, None, "Vault secret was not found or is empty."))
+    if not explicit_key:
+        candidates.append((None, None, None))
     return candidates
 
 
@@ -688,7 +703,13 @@ async def _materialize_resource(
         return None, message
 
     errors: list[str] = []
-    for key_name, token in await _token_candidates(resource, user_id, org_id):
+    for candidate in await _token_candidates(resource, user_id, org_id):
+        key_name, token = candidate[:2]
+        token_error = candidate[2] if len(candidate) > 2 else None
+        if token_error:
+            prefix = f"Vault key {key_name}: " if key_name else "GitHub credential: "
+            errors.append(prefix + token_error)
+            continue
         try:
             clone = _clone_github_repo(slug, destination, token=token, branch=branch)
         except Exception as exc:

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -277,11 +277,11 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
 
     clone_calls = []
 
-    def fake_get_secret(key_name, **kwargs):
+    async def fake_get_secret(key_name, **kwargs):
         assert key_name == "GITHUB_EXAMPLE_TOKEN"
         assert kwargs["actor_user_id"] == "user-1"
         assert kwargs["org_id"] == "org-1"
-        assert kwargs["accessed_by"] == "api"
+        assert kwargs["accessed_by"] == "github_runtime_tool"
         return "test-private-token"
 
     def fake_clone(slug, destination, *, token, branch):
@@ -290,7 +290,7 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
         return {"path": str(destination), "branch": branch, "commit": "abc123"}
 
     monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
-    monkeypatch.setattr(materializer, "get_secret", fake_get_secret)
+    monkeypatch.setattr(materializer, "async_get_secret", fake_get_secret)
     monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
 
     result = await materialize_project_context_workspaces(
@@ -324,6 +324,80 @@ async def test_materialize_github_project_context_uses_vault_key_without_persist
     assert run.metadata_["workspaces"] == result.workspaces
     assert "test-private-token" not in str(run.metadata_)
     assert "test-private-token" not in str(run.target_metadata)
+
+
+async def test_materialize_github_project_context_reports_explicit_vault_failure(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=55,
+        user_id="user-1",
+        metadata_={"org_id": "org-1"},
+        target_metadata={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "name": "example-org/private-repo",
+                        "repo": "example-org/private-repo",
+                        "uri": "https://github.com/example-org/private-repo",
+                        "branch": "main",
+                        "credential_ref": {
+                            "type": "vault_secret",
+                            "provider": "github",
+                            "key_name": "GITHUB_EXAMPLE_TOKEN",
+                        },
+                    },
+                ],
+            },
+        },
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    async def fake_get_secret(key_name, **kwargs):
+        assert key_name == "GITHUB_EXAMPLE_TOKEN"
+        assert kwargs["actor_user_id"] == "user-1"
+        assert kwargs["org_id"] == "org-1"
+        assert kwargs["accessed_by"] == "github_runtime_tool"
+        return None
+
+    def fake_clone(*_args, **_kwargs):
+        raise AssertionError("explicit vault credentials should not fall through to public clone")
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "async_get_secret", fake_get_secret)
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(
+        55,
+        workspace_root=str(tmp_path),
+        user_id="user-1",
+        org_id="org-1",
+    )
+
+    assert not result.ok
+    assert len(result.errors) == 1
+    assert "Vault key GITHUB_EXAMPLE_TOKEN: Vault secret was not found or is empty." in result.errors[0]
+    assert "public clone" not in result.errors[0]
+    resource = run.target_metadata["project_context_snapshot"]["resources"][1]
+    assert resource["materialization"]["error"] == "Vault key GITHUB_EXAMPLE_TOKEN: Vault secret was not found or is empty."
+    assert run.target_status == "invalid"
 
 
 async def test_materialize_github_folder_uri_mounts_repo_subpath(tmp_path, monkeypatch):
@@ -448,11 +522,11 @@ async def test_materialize_github_project_context_finds_general_github_token(tmp
             {"key_name": "GITHUB_TOKEN", "category": "general"},
         ]
 
-    def fake_get_secret(key_name, **kwargs):
+    async def fake_get_secret(key_name, **kwargs):
         assert key_name == "GITHUB_TOKEN"
         assert kwargs["actor_user_id"] == "user-1"
         assert kwargs["org_id"] == "org-1"
-        assert kwargs["accessed_by"] == "api"
+        assert kwargs["accessed_by"] == "github_runtime_tool"
         return "general-github-token"
 
     clone_calls = []
@@ -464,7 +538,7 @@ async def test_materialize_github_project_context_finds_general_github_token(tmp
 
     monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
     monkeypatch.setattr(materializer, "list_secrets", fake_list_secrets)
-    monkeypatch.setattr(materializer, "get_secret", fake_get_secret)
+    monkeypatch.setattr(materializer, "async_get_secret", fake_get_secret)
     monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
 
     result = await materialize_project_context_workspaces(


### PR DESCRIPTION
## Summary
- read Project Context GitHub vault credentials through the async vault path used by runtime GitHub tooling
- preserve explicit vault credential failures in materialization errors instead of masking them as public clone failures
- avoid falling through to unauthenticated public clone when a repo resource explicitly declares a vault credential

## Tests
- ./venv/bin/python -m pytest tests/test_project_context_materializer.py -q
- ./venv/bin/python -m pytest tests/test_project_context_root_materializer.py tests/test_github_source_tool.py -q
- ./venv/bin/python -m pytest tests/test_project_context_materializer.py tests/test_project_context_root_materializer.py tests/test_github_source_tool.py -q
- ./venv/bin/python -m pytest tests/ -m "not requires_db" -q (fails only in local torch-dependent GPU/LLM worker tests because venv torch is missing libtorch_cpu.dylib; 3153 passed, 8 failed, 58 skipped, 23 deselected)
