### PR TITLE
Make GitHub Project Context clones more resilient

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -46,6 +46,9 @@ _REPO_RESOURCE_KINDS = {
     "github_repository",
 }
 _LOCAL_FIRST_RESOURCE_KINDS = {"file", "folder", "directory", "workspace", "docs", "doc"}
+_DEFAULT_GIT_CLONE_TIMEOUT_SECONDS = 600
+_MIN_GIT_CLONE_TIMEOUT_SECONDS = 30
+_MAX_GIT_CLONE_TIMEOUT_SECONDS = 1800
 
 
 @dataclass
@@ -311,6 +314,17 @@ def _askpass_script(parent: Path) -> Path:
     return path
 
 
+def _git_clone_timeout_seconds() -> int:
+    raw = os.getenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return _DEFAULT_GIT_CLONE_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_GIT_CLONE_TIMEOUT_SECONDS
+    return max(_MIN_GIT_CLONE_TIMEOUT_SECONDS, min(value, _MAX_GIT_CLONE_TIMEOUT_SECONDS))
+
+
 def _clone_github_repo(
     slug: str,
     destination: Path,
@@ -334,7 +348,16 @@ def _clone_github_repo(
     try:
         last_error = ""
         for selected_branch in dict.fromkeys(branches):
-            command = ["git", "clone", "--depth", "1"]
+            command = [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--single-branch",
+                "--no-tags",
+                "--filter",
+                "blob:none",
+            ]
             if selected_branch:
                 command.extend(["--branch", selected_branch])
             command.extend([f"https://github.com/{slug}.git", str(destination)])
@@ -344,7 +367,7 @@ def _clone_github_repo(
                 command,
                 capture_output=True,
                 text=True,
-                timeout=180,
+                timeout=_git_clone_timeout_seconds(),
                 env=env,
             )
             if proc.returncode == 0:

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -40,6 +40,74 @@ def test_project_context_materializable_resources_include_empty_project_roots():
     }) is True
 
 
+def test_github_clone_uses_lightweight_command_and_configurable_timeout(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import _clone_github_repo
+
+    calls = []
+
+    def fake_run_subprocess(command, **kwargs):
+        kwargs = {**kwargs, "env": dict(kwargs.get("env") or {})}
+        calls.append({"command": command, **kwargs})
+        Path(command[-1]).mkdir(parents=True)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_git_output(_cwd, *args):
+        if args == ("branch", "--show-current"):
+            return "main"
+        if args == ("rev-parse", "HEAD"):
+            return "abc123"
+        return None
+
+    monkeypatch.setenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", "900")
+    monkeypatch.setattr(materializer, "run_subprocess_sync", fake_run_subprocess)
+    monkeypatch.setattr(materializer, "_git_output", fake_git_output)
+
+    destination = tmp_path / "repo"
+    result = _clone_github_repo(
+        "example-org/private-repo",
+        destination,
+        token="secret-token",
+        branch="main",
+    )
+
+    assert result == {"path": str(destination), "branch": "main", "commit": "abc123"}
+    assert len(calls) == 1
+    assert calls[0]["command"] == [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--single-branch",
+        "--no-tags",
+        "--filter",
+        "blob:none",
+        "--branch",
+        "main",
+        "https://github.com/example-org/private-repo.git",
+        str(destination),
+    ]
+    assert calls[0]["timeout"] == 900
+    assert calls[0]["capture_output"] is True
+    assert calls[0]["text"] is True
+    assert calls[0]["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert calls[0]["env"]["ILLO_GITHUB_PROJECT_CONTEXT_TOKEN"] == "secret-token"
+    assert "secret-token" not in " ".join(calls[0]["command"])
+
+
+def test_github_clone_timeout_env_is_bounded(monkeypatch):
+    from brain.systems.cortex.project_context.materializer import _git_clone_timeout_seconds
+
+    monkeypatch.delenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", raising=False)
+    assert _git_clone_timeout_seconds() == 600
+    monkeypatch.setenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", "5")
+    assert _git_clone_timeout_seconds() == 30
+    monkeypatch.setenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", "3600")
+    assert _git_clone_timeout_seconds() == 1800
+    monkeypatch.setenv("ILLO_PROJECT_CONTEXT_GIT_CLONE_TIMEOUT_SECONDS", "not-an-int")
+    assert _git_clone_timeout_seconds() == 600
+
+
 def test_project_root_key_uses_canonical_project_key():
     from brain.systems.cortex.project_context.project_root import project_key_from_context
 


### PR DESCRIPTION
## Summary
- increase the Project Context GitHub clone timeout from a fixed 180s to a bounded configurable default of 600s
- make GitHub Project Context clones lighter with --single-branch, --no-tags, and --filter blob:none
- add regression coverage for the clone command shape and timeout bounds

## Live evidence
- Post-deploy smoke for PR #247 confirmed the credential bug is fixed: run 886 used Vault key GITHUB_TOKEN for uwear-ai/uwear-website instead of falling back to public clone.
- The remaining blocker was a generic authenticated clone timeout: git clone --depth 1 --branch main ... timed out after 180 seconds.

## Tests
- ./venv/bin/python -m pytest tests/test_project_context_materializer.py -q
- ./venv/bin/python -m pytest tests/test_project_context_root_materializer.py tests/test_github_source_tool.py -q
