### PR TITLE
Fix Uwear triage skill registration

### DIFF
--- a/brain/platform/db/repositories/skills.py
+++ b/brain/platform/db/repositories/skills.py
@@ -43,6 +43,7 @@ _SKILL_READ_COLUMNS = (
     Skill.graduated_steps,
     Skill.auto_emerged,
     Skill.builtin,
+    Skill.archived,
     Skill.thinking_tier,
     Skill.skill_installation_id,
     Skill.bundle_version_id,

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -13,7 +13,13 @@ from brain.systems.cortex.project_context.github import (
     parse_github_repo_slug,
 )
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
-from brain.systems.vault import async_get_secret
+from brain.systems.vault import (
+    VAULT_AGENT_ACCESS_AVAILABLE,
+    async_get_secret,
+    async_list_secrets,
+    async_resolve_project_bound_env_tokens,
+    normalize_agent_access_level,
+)
 
 
 def _clean(value: Any) -> str | None:
@@ -52,6 +58,137 @@ async def _github_token_from_secret(token_secret_key: str | None) -> str | None:
     )
 
 
+async def _github_token_candidates(
+    *,
+    repo_slug: str,
+    token_secret_key: str | None,
+) -> list[dict[str, str | None]]:
+    """Return safe token candidates for a GitHub repo read.
+
+    A bad explicit key should not strand a read when the org has a project-bound
+    or default GitHub token that can see the target repo.
+    """
+
+    user_id = _clean(getattr(_agent_context, "user_id", None))
+    org_id = _clean(getattr(_agent_context, "org_id", None))
+    if token_secret_key and not user_id:
+        raise ValueError("token_secret_key requires a run user_id context")
+
+    candidates: list[dict[str, str | None]] = []
+    seen_keys: set[str] = set()
+    seen_tokens: set[str] = set()
+
+    async def add_secret_key(key_name: str | None, source: str) -> None:
+        key = _clean(key_name)
+        if not key or key in seen_keys:
+            return
+        seen_keys.add(key)
+        token = await _github_token_from_secret(key)
+        if not token or token in seen_tokens:
+            return
+        seen_tokens.add(token)
+        candidates.append({"key_name": key, "token": token, "source": source})
+
+    async def add_token(token: str | None, source: str) -> None:
+        value = _clean(token)
+        if not value or value in seen_tokens:
+            return
+        seen_tokens.add(value)
+        candidates.append({"key_name": None, "token": value, "source": source})
+
+    await add_secret_key(token_secret_key, "explicit")
+
+    if user_id and org_id:
+        try:
+            bound_env = await async_resolve_project_bound_env_tokens(
+                actor_user_id=user_id,
+                org_id=org_id,
+                project_slug=repo_slug,
+            )
+        except Exception:
+            bound_env = {}
+        for env_name in ("GITHUB_TOKEN", "GH_TOKEN"):
+            await add_token(bound_env.get(env_name), f"project_binding:{env_name}")
+        for env_name, token in sorted(bound_env.items()):
+            await add_token(token, f"project_binding:{env_name}")
+
+        try:
+            secrets = await async_list_secrets(actor_user_id=user_id, org_id=org_id)
+        except Exception:
+            secrets = []
+
+        def priority(secret: dict[str, Any]) -> tuple[int, str]:
+            key = str(secret.get("key_name") or "")
+            if key == "GITHUB_TOKEN":
+                return (0, key)
+            if str(secret.get("category") or "").lower() == "github":
+                return (1, key)
+            return (2, key)
+
+        github_like = [
+            secret
+            for secret in secrets
+            if normalize_agent_access_level(secret.get("agent_access_level"))
+            == VAULT_AGENT_ACCESS_AVAILABLE
+            and (
+                str(secret.get("key_name") or "") == "GITHUB_TOKEN"
+                or "github" in str(secret.get("key_name") or "").lower()
+                or str(secret.get("category") or "").lower() == "github"
+            )
+        ]
+        for secret in sorted(github_like, key=priority):
+            await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
+
+    if not candidates:
+        candidates.append({"key_name": None, "token": None, "source": "public"})
+    return candidates
+
+
+async def _read_with_token(
+    *,
+    action: str,
+    repo_slug: str,
+    state: str,
+    labels: list[str] | str | None,
+    assignee: str | None,
+    creator: str | None,
+    mentioned: str | None,
+    since: str | None,
+    include_pull_requests: bool,
+    head: str | None,
+    base: str | None,
+    limit: int,
+    token: str | None,
+) -> dict[str, Any]:
+    if action in {"repo", "get_repo"}:
+        return {
+            "repo": await async_get_repo_by_slug(repo_slug, token=token),
+        }
+    if action in {"list_issues", "issues"}:
+        return await async_list_repo_issues(
+            repo_slug,
+            token=token,
+            state=state,
+            labels=_string_list(labels),
+            assignee=_clean(assignee),
+            creator=_clean(creator),
+            mentioned=_clean(mentioned),
+            since=_clean(since),
+            include_pull_requests=bool(include_pull_requests),
+            limit=_limit(limit),
+        )
+    if action in {"list_pull_requests", "pull_requests", "prs"}:
+        return await async_list_repo_pull_requests(
+            repo_slug,
+            token=token,
+            state=state,
+            head=_clean(head),
+            base=_clean(base),
+            limit=_limit(limit),
+        )
+    raise ValueError("read_github_source action must be get_repo, list_issues, or list_pull_requests")
+
+
 async def _handle_read_github_source(
     action: str = "list_issues",
     repo: str | None = None,
@@ -72,43 +209,56 @@ async def _handle_read_github_source(
     repo_slug = parse_github_repo_slug(repo or "")
     if not repo_slug:
         return json.dumps({"error": "read_github_source requires repo as owner/name or a GitHub URL"})
-    token = await _github_token_from_secret(token_secret_key)
     clean_action = (action or "list_issues").strip().lower()
-    try:
-        if clean_action in {"repo", "get_repo"}:
-            payload = {
-                "repo": await async_get_repo_by_slug(repo_slug, token=token),
-                "token_secret_key_used": bool(token_secret_key),
-            }
-        elif clean_action in {"list_issues", "issues"}:
-            payload = await async_list_repo_issues(
-                repo_slug,
-                token=token,
+    valid_actions = {
+        "repo",
+        "get_repo",
+        "list_issues",
+        "issues",
+        "list_pull_requests",
+        "pull_requests",
+        "prs",
+    }
+    if clean_action not in valid_actions:
+        return json.dumps({"error": "read_github_source action must be get_repo, list_issues, or list_pull_requests"})
+
+    candidates = await _github_token_candidates(
+        repo_slug=repo_slug,
+        token_secret_key=token_secret_key,
+    )
+    last_error: GitHubConnectorError | None = None
+    auth_statuses = {401, 403, 404}
+    for index, candidate in enumerate(candidates):
+        try:
+            payload = await _read_with_token(
+                action=clean_action,
+                repo_slug=repo_slug,
                 state=state,
-                labels=_string_list(labels),
-                assignee=_clean(assignee),
-                creator=_clean(creator),
-                mentioned=_clean(mentioned),
-                since=_clean(since),
-                include_pull_requests=bool(include_pull_requests),
-                limit=_limit(limit),
+                labels=labels,
+                assignee=assignee,
+                creator=creator,
+                mentioned=mentioned,
+                since=since,
+                include_pull_requests=include_pull_requests,
+                head=head,
+                base=base,
+                limit=limit,
+                token=candidate["token"],
             )
-            payload["token_secret_key_used"] = bool(token_secret_key)
-        elif clean_action in {"list_pull_requests", "pull_requests", "prs"}:
-            payload = await async_list_repo_pull_requests(
-                repo_slug,
-                token=token,
-                state=state,
-                head=_clean(head),
-                base=_clean(base),
-                limit=_limit(limit),
-            )
-            payload["token_secret_key_used"] = bool(token_secret_key)
-        else:
-            return json.dumps({"error": "read_github_source action must be get_repo, list_issues, or list_pull_requests"})
-    except GitHubConnectorError as exc:
-        return json.dumps({"error": exc.message, "status_code": exc.status_code})
-    return json.dumps(payload, default=str)
+        except GitHubConnectorError as exc:
+            last_error = exc
+            if exc.status_code in auth_statuses and index < len(candidates) - 1:
+                continue
+            return json.dumps({"error": exc.message, "status_code": exc.status_code})
+        payload["token_secret_key_used"] = bool(candidate.get("key_name"))
+        payload["token_source"] = candidate["source"]
+        if last_error is not None:
+            payload["fallback_from_status_code"] = last_error.status_code
+        return json.dumps(payload, default=str)
+
+    if last_error is not None:
+        return json.dumps({"error": last_error.message, "status_code": last_error.status_code})
+    return json.dumps({"error": "No GitHub token candidates were available"})
 
 
 __all__ = ["_handle_read_github_source"]

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -84,6 +84,22 @@ def _skill_from_bundle(name: str, *, maturity: str = "emerging") -> dict[str, An
     )
 
 
+def _filesystem_skill_bundle_names() -> list[str]:
+    """Return all complete filesystem bundle directories shipped with this build."""
+
+    if not BUILTIN_SKILL_BUNDLE_ROOT.exists():
+        return []
+    names: list[str] = []
+    for child in BUILTIN_SKILL_BUNDLE_ROOT.iterdir():
+        if (
+            child.is_dir()
+            and (child / "skill.toml").is_file()
+            and (child / "SKILL.md").is_file()
+        ):
+            names.append(child.name)
+    return sorted(names)
+
+
 BUILTIN_SKILLS: dict[str, dict[str, Any]] = {
     "coordinate": _skill(
         name="coordinate",
@@ -1071,9 +1087,9 @@ async def _ensure_builtin_skill_bundles() -> None:
         logger.warning("ensure_builtin_skill_bundles unavailable: %s", exc)
         return
 
-    for name in BUILTIN_SKILLS:
+    for name in _filesystem_skill_bundle_names():
         bundle_dir = BUILTIN_SKILL_BUNDLE_ROOT / name
-        if not bundle_dir.is_dir():
+        if name in BUILTIN_SKILLS and not bundle_dir.is_dir():
             logger.warning("Missing built-in skill bundle: %s", bundle_dir)
             continue
 
@@ -1083,16 +1099,22 @@ async def _ensure_builtin_skill_bundles() -> None:
                     SkillRepository(uow.session),
                     SkillBundleRepository(uow.session),
                 )
-                await service.import_bundle(
-                    bundle_dir,
-                    namespace="illo_core",
-                    enabled_scope="system",
-                    update_policy="pinned",
-                    review_status="approved",
-                    trust_level=ILLO_CORE_TRUST_LEVEL,
-                    source_kind=ILLO_CORE_SOURCE_KIND,
-                    auto_bump_conflicting_semver=True,
-                )
+                import_kwargs: dict[str, Any] = {
+                    "namespace": "self_hosted",
+                    "enabled_scope": "system",
+                    "update_policy": "pinned",
+                    "review_status": "approved",
+                    "auto_bump_conflicting_semver": True,
+                }
+                if name in BUILTIN_SKILLS:
+                    import_kwargs.update(
+                        {
+                            "namespace": "illo_core",
+                            "trust_level": ILLO_CORE_TRUST_LEVEL,
+                            "source_kind": ILLO_CORE_SOURCE_KIND,
+                        }
+                    )
+                await service.import_bundle(bundle_dir, **import_kwargs)
         except Exception as exc:
             logger.warning(
                 "ensure_builtin_skill_bundle_failed skill=%s error=%s",
@@ -1106,4 +1128,5 @@ __all__ = [
     "BUILTIN_SKILL_BUNDLE_ROOT",
     "ensure_builtin_skills",
     "ensure_builtin_skills_cached",
+    "_filesystem_skill_bundle_names",
 ]

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -4,8 +4,8 @@ display_name = "Uwear Engineering Triage"
 version = "1.0.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
-source = "uwear"
-visibility = "private"
+source = "self_hosted"
+visibility = "private_local"
 
 [routing]
 triggers = [

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -27,6 +27,24 @@ def test_builtin_skills_are_limited_to_product_primitives():
     assert not hasattr(module, "BUILTIN_SKILL_RETIREMENTS")
 
 
+def test_filesystem_bundle_discovery_includes_private_team_bundles():
+    from brain.systems.skills.builtin import (
+        BUILTIN_SKILL_BUNDLE_ROOT,
+        BUILTIN_SKILLS,
+        _filesystem_skill_bundle_names,
+    )
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    names = set(_filesystem_skill_bundle_names())
+    assert CORE_BUILTINS <= names
+    assert "uwear-engineering-triage" in names
+    assert "uwear-engineering-triage" not in BUILTIN_SKILLS
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    assert bundle.manifest.source == "self_hosted"
+    assert bundle.manifest.visibility == "private_local"
+
+
 def test_builtin_skills_have_structured_routing_metadata():
     from brain.systems.skills.builtin import BUILTIN_SKILLS
 

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from brain.systems.cortex.project_context.github import _issue_payload
+from brain.systems.cortex.project_context.github import GitHubConnectorError, _issue_payload
+from brain.systems.runs.execution_context import bind_agent_context
 from brain.systems.runs.tool_catalog.handlers.github import _handle_read_github_source
 
 
@@ -53,9 +54,121 @@ async def test_read_github_source_handler_lists_issues_with_canonical_repo_and_b
         "repo": "uwear-ai/uwear-backend",
         "issues": [],
         "token_secret_key_used": False,
+        "token_source": "public",
     }
     list_issues.assert_awaited_once()
     assert list_issues.await_args.args == ("uwear-ai/uwear-backend",)
     assert list_issues.await_args.kwargs["labels"] == ["bug"]
     assert list_issues.await_args.kwargs["assignee"] == "redawear"
     assert list_issues.await_args.kwargs["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_read_github_source_falls_back_from_bad_explicit_token_to_available_github_token():
+    async def fake_get_secret(key_name, *args, **kwargs):
+        return {
+            "BAD_GITHUB_TOKEN": "bad-token",
+            "GITHUB_TOKEN": "good-token",
+        }.get(key_name)
+
+    async def fake_list_secrets(*args, **kwargs):
+        return [
+            {
+                "key_name": "GITHUB_TOKEN",
+                "category": "general",
+                "agent_access_level": "available",
+            }
+        ]
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_secret",
+        new=AsyncMock(side_effect=fake_get_secret),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(side_effect=fake_list_secrets),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_repo_issues",
+        new=AsyncMock(
+            side_effect=[
+                GitHubConnectorError(
+                    status_code=404,
+                    message="Repository not found or not visible to this token.",
+                ),
+                {"repo": "uwear-ai/uwear-backend", "issues": []},
+            ]
+        ),
+    ) as list_issues:
+        result = await _handle_read_github_source(
+            repo="uwear-ai/uwear-backend",
+            token_secret_key="BAD_GITHUB_TOKEN",
+        )
+
+    payload = json.loads(result)
+    assert payload == {
+        "repo": "uwear-ai/uwear-backend",
+        "issues": [],
+        "token_secret_key_used": True,
+        "token_source": "vault_inventory",
+        "fallback_from_status_code": 404,
+    }
+    assert [call.kwargs["token"] for call in list_issues.await_args_list] == [
+        "bad-token",
+        "good-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_read_github_source_falls_back_from_project_binding_to_available_github_token():
+    async def fake_get_secret(key_name, *args, **kwargs):
+        return {"GITHUB_TOKEN": "good-token"}.get(key_name)
+
+    async def fake_list_secrets(*args, **kwargs):
+        return [
+            {
+                "key_name": "GITHUB_TOKEN",
+                "category": "general",
+                "agent_access_level": "available",
+            }
+        ]
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_secret",
+        new=AsyncMock(side_effect=fake_get_secret),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(side_effect=fake_list_secrets),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={"GH_TOKEN": "expired-token"}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_repo_pull_requests",
+        new=AsyncMock(
+            side_effect=[
+                GitHubConnectorError(
+                    status_code=401,
+                    message="GitHub rejected this Vault token.",
+                ),
+                {"repo": "uwear-ai/uwear-backend", "pull_requests": []},
+            ]
+        ),
+    ) as list_prs:
+        result = await _handle_read_github_source(
+            action="list_pull_requests",
+            repo="uwear-ai/uwear-backend",
+        )
+
+    payload = json.loads(result)
+    assert payload == {
+        "repo": "uwear-ai/uwear-backend",
+        "pull_requests": [],
+        "token_secret_key_used": True,
+        "token_source": "vault_inventory",
+        "fallback_from_status_code": 401,
+    }
+    assert [call.kwargs["token"] for call in list_prs.await_args_list] == [
+        "expired-token",
+        "good-token",
+    ]


### PR DESCRIPTION
## Summary
- discover shipped filesystem skill bundles beyond the core BUILTIN_SKILLS map so private team bundles can be seeded on boot
- fix the Uwear engineering triage bundle manifest to use accepted self_hosted/private_local enum values
- eager-load Skill.archived for skill list payloads to avoid async lazy-load errors in manage_skill list
- make read_github_source fall back from a bad/insufficient GitHub Vault key to project-bound or available GitHub-like Vault candidates

## Why
Live no-Slack Illo acceptance tests found two blockers:

1. Domain 37 guidance was visible, but the deployed skill registry could not load uwear-engineering-triage via skill_view.
2. A coordinator dry run used read_github_source with a legacy Illospace-only token and received 404s for Uwear repos, even though an available org GitHub token can see the target repos.

This keeps the repair generic: filesystem bundle discovery works for any shipped private team bundle, and the GitHub reader now behaves like a resilient read-only connector instead of requiring the model to choose the one perfect token.

## Tests
- uv run python -m pytest tests/test_builtin_skill_suite.py tests/test_skill_bundles.py tests/test_create_skill_tool.py tests/test_skill_repository.py tests/test_github_source_tool.py

