### PR TITLE
Fix illo_submit answer overwrite by forced introspection (#249)

### DIFF
--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -1128,6 +1128,12 @@ async def _queue_illo_submission(
                 "metadata": {
                     "execution_profile": "fast",
                     "origin": normalized.get("origin"),
+                    # Route required-introspection detection off the operator's actual
+                    # request, not the coordination wrapper prompt (issue #249). The
+                    # wrapper embeds boilerplate like "Source metadata:" that can trip
+                    # the self-context heuristic and hijack the final answer with a
+                    # runtime self-description.
+                    "human_message": normalized.get("message"),
                     "inbound_event": _inbound_event_metadata(context, event, normalized, None),
                     "submission": {
                         "message": normalized.get("message"),

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1346,10 +1346,12 @@ async def run_agent_async(
     )
     if metadata_required_tool:
         required_introspection_tool, required_introspection_msg = metadata_required_tool, metadata_required_msg
+        required_introspection_explicit = True
     else:
         required_introspection_tool, required_introspection_msg = run_introspection.required_introspection_tool(
             run_introspection.message_for_required_introspection(message, metadata)
         )
+        required_introspection_explicit = False
 
     _previous_execution_metadata = getattr(_agent_context, "execution_metadata", None)
     _previous_execution_artifacts = getattr(_agent_context, "execution_artifacts", None)
@@ -1701,11 +1703,21 @@ async def run_agent_async(
                 if guidance_count:
                     continue
                 output = _extract_text(state.messages)
+                # A heuristic-derived (non-explicit) required-introspection tool is a
+                # low-confidence guess. If the model already produced a substantial
+                # answer without it, forcing the detour now would discard real work and
+                # emit a runtime self-description instead (issue #249). Explicit routing
+                # metadata stays authoritative and is always honored.
+                _DERIVED_INTROSPECTION_ANSWER_LIMIT = 400
                 if (
                     required_introspection_tool
                     and _tool_is_available(tools, required_introspection_tool)
                     and required_introspection_tool in tool_handlers
                     and required_introspection_tool not in state.tool_calls_made
+                    and (
+                        required_introspection_explicit
+                        or len(output.strip()) < _DERIVED_INTROSPECTION_ANSWER_LIMIT
+                    )
                 ):
                     _append_message_with_archive(
                         state.messages,

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -51,7 +51,11 @@ _WORKSPACE_OVERVIEW_PHRASES = (
 )
 _SELF_CONTEXT_PATTERNS = (
     re.compile(r"\b(?:who are you|what is illo|what is illospace|what are you)\b"),
-    re.compile(r"\bwhere\b[^?]{0,100}\b(?:installed|running|hosted|source|code|repo|repository)\b"),
+    # Keep the "where … <runtime noun>" association within a single sentence: a period
+    # is only allowed mid-token (e.g. "illo.ai"), never as a sentence break. Otherwise an
+    # unrelated "where …" in one sentence bridges to a "source"/"code" in the next and
+    # false-positives on ordinary prose (issue #249).
+    re.compile(r"\bwhere\b(?:[^.?!]|\.(?=\S)){0,100}\b(?:installed|running|hosted|source|code|repo|repository)\b"),
     re.compile(r"\b(?:open[- ]source repo|github repo|source code|your code|own code|inspect yourself)\b"),
 )
 _PROJECT_CONTEXT_PHRASES = (

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1304,6 +1304,86 @@ class TestAgentLoop:
         assert result.tool_calls == []
         assert client.messages.create.call_count == 1
 
+    @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
+    @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))
+    @patch("brain.systems.runs.direct_agent._save_session")
+    def test_derived_introspection_does_not_overwrite_substantial_answer(self, mock_save, mock_load, mock_client):
+        # Regression for issue #249: a real task can trip the self-context heuristic
+        # (here "...where the source code is installed..."). Once the model has produced
+        # a substantial answer without the heuristically-derived tool, the end-of-run
+        # guard must NOT force a late read_self_context detour that discards the work and
+        # replaces it with a runtime self-description.
+        from brain.systems.runs.direct_agent import run_agent
+
+        long_answer = (
+            "Redirect audit complete. Every 301 resolves in a single hop to a live 200; "
+            "no chains, loops, or 404s. Rankings for the retired pages are being retained "
+            "by their redirect targets, and the hedge pages held their impressions. Search "
+            "Console shows no new coverage or indexing errors, and the sitemap was re-fetched "
+            "with the new URL structure. It is still early, so treat week-one ranking data as "
+            "noisy rather than conclusive, and re-check impressions again after a full week."
+        )
+        assert len(long_answer.strip()) >= 400
+
+        client = MagicMock()
+        client.messages.create.return_value = self._make_response(long_answer)
+        mock_client.return_value = _mock_llm_client(client)
+
+        handler = MagicMock(return_value={"ok": True, "source": "runtime_self_context"})
+
+        result = run_agent(
+            message=(
+                "Audit our deploy: confirm the redirects still work and tell me where the "
+                "source code is installed if you need it."
+            ),
+            tools=[{
+                "name": "read_self_context",
+                "description": "test",
+                "input_schema": {"type": "object", "properties": {}},
+            }],
+            tool_handlers={"read_self_context": handler},
+            persist_session=False,
+            max_turns=4,
+        )
+
+        assert result.success
+        assert result.output == long_answer
+        assert result.tool_calls == []
+        assert handler.call_count == 0
+        assert client.messages.create.call_count == 1
+
+    @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
+    @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))
+    @patch("brain.systems.runs.direct_agent._save_session")
+    def test_explicit_required_tool_forces_even_after_substantial_answer(self, mock_save, mock_load, mock_client):
+        # The #249 guard only relaxes heuristically-derived requirements. An explicit
+        # routing directive stays authoritative and must still force its tool even when
+        # the model already produced a long first answer.
+        from brain.systems.runs.direct_agent import run_agent
+
+        long_answer = "Here is a detailed answer to your question. " * 12
+        assert len(long_answer.strip()) >= 400
+
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            self._make_response(long_answer),
+            self._make_response(text=None, stop_reason="tool_use", tool_use={"name": "brain_recall", "input": {"query": "history"}}),
+            self._make_response("Grounded summary from memory."),
+        ]
+        mock_client.return_value = _mock_llm_client(client)
+
+        result = run_agent(
+            message="Summarize what we did this week.",
+            tools=[{"name": "brain_recall", "description": "test", "input_schema": {"type": "object", "properties": {}}}],
+            tool_handlers={"brain_recall": lambda **kw: {"memories": [{"content": "prior work"}]}},
+            metadata={"required_introspection_tool": "brain_recall"},
+            persist_session=False,
+        )
+
+        assert result.success
+        assert "brain_recall" in result.tool_calls
+        assert client.messages.create.call_count == 3
+
 
 class TestCallLLM:
     """Test the call_llm convenience function."""

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -217,6 +217,46 @@ async def test_language_only_preservation_match_is_prompt_hint_not_evidence_cont
     assert "Possible preservation workflow:" in run.input_message
 
 
+async def test_submission_tags_human_message_for_introspection_routing(session):
+    # Regression for issue #249: the headless submission wrapper embeds boilerplate
+    # ("Handle this external coordination submission.", "Source metadata:") that can
+    # trip the self-context heuristic and hijack the final answer with a runtime
+    # self-description. The operator's clean message must be tagged as human_message so
+    # required-introspection routing evaluates the request, not the wrapper prompt.
+    from brain.systems.runs import introspection as run_introspection
+
+    principal = await _seed_connection(session)
+    message = (
+        "Post-deploy SEO health check for uwear.ai: confirm the 301 redirects resolve "
+        "and keyword rankings are retained since the deploy."
+    )
+    result = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope={
+            "kind": "submission",
+            "origin": "claude-code.submit",
+            "desired_outcome": "seo_post_deploy_health_report",
+            "message": message,
+            "source": {"source_tool": "claude-code", "repo": "uwear-website"},
+            "idempotency_key": "claude-code:submission:seo-249",
+        },
+        ingress_context={"surface": "test"},
+    )
+
+    handling = await _assert_queued_submission(session, result["ilo_outcome"])
+    run = await session.get(AgentRunRow, handling["run_id"])
+    assert run is not None
+    # The clean operator message is tagged for introspection routing...
+    assert run.metadata_["human_message"] == message
+    # ...and routing resolves to it rather than the wrapper prompt persisted as
+    # input_message, so the coordination boilerplate can no longer force a detour.
+    assert (
+        run_introspection.message_for_required_introspection(run.input_message, run.metadata_)
+        == message
+    )
+
+
 async def test_preservation_submission_without_durable_evidence_stays_actionable(session):
     principal = await _seed_connection(session)
     result = await inbound.submit_inbound_envelope(

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -359,6 +359,26 @@ def test_source_identity_question_requires_self_context():
     assert "identity/source/runtime context" in message
 
 
+def test_where_source_across_sentences_does_not_require_self_context():
+    # Regression for issue #249: a task's ordinary "where ..." must not bridge across a
+    # sentence boundary to a "source"/"code" token elsewhere in the prompt (here the
+    # coordination wrapper's "Source metadata:" header) and force read_self_context,
+    # which then hijacks the final answer with a runtime self-description.
+    from brain.systems.runs.introspection import (
+        _looks_like_self_context_question,
+        required_introspection_tool,
+    )
+
+    message = (
+        "Post-deploy SEO health check for uwear.ai. Confirm the 301 redirects resolve and "
+        "call out where it's too soon to tell vs. where there's a real signal. Reply back "
+        'with the findings. Source metadata: {"repo": "uwear-website"}'
+    )
+
+    assert _looks_like_self_context_question(message) is False
+    assert required_introspection_tool(message) == (None, None)
+
+
 def test_capability_setup_question_requires_capabilities():
     from brain.systems.runs.introspection import required_introspection_tool
 


### PR DESCRIPTION
## Summary

Fixes #249. A task-bearing `illo_submit` submission (run 892) reported `status: completed` but returned a generic runtime self-description instead of the task result.

**The bug is not "the agent ignored the task."** Confirmed against run 892's prod trace: the agent *completed the SEO task correctly* (loaded the `uwear-seo-analyst` skill, authed to GSC/GA4, checked redirects, wrote findings to domain records). Then in the final ~6 seconds a spurious `read_self_context` was force-called and its output **overwrote** the finished answer. Prior attempts (#226/#228/#233) all targeted *"why did it introspect instead of working"* — but it did work; the answer was clobbered at the buzzer.

## Root cause (two parts)

1. **False-positive introspection routing.** The `illo_submit` headless path wraps the task in `_submission_prompt` ("Handle this external coordination submission… Source metadata:…") and never tagged `human_message`, so `required_introspection_tool()` scanned the whole wrapper. The self-context regex `\bwhere\b[^?]{0,100}\b(...|source|...)` matched **`where`** (from the task's *"call out where it's too soon to tell"*) bridging 92 chars across a sentence boundary to **`Source`** (the wrapper's own *"Source metadata:"* header) → forced `read_self_context`.
2. **End-of-run answer overwrite.** `direct_agent`'s `END_TURN` guard force-injected the required tool **after** the model had already produced the real answer; `_extract_text` then harvested the regenerated self-description, discarding the completed work.

## Fix (3 layers)

- **Primary** — `inbound/service.py`: tag `human_message` on the submission so introspection routing evaluates the operator's request, not the coordination wrapper.
- **Hardening** — `runs/direct_agent.py`: a *heuristic-derived* required-introspection tool can no longer overwrite a substantial (≥400 char) answer. Explicit `metadata["required_introspection_tool"]` routing stays authoritative and is always forced.
- **Supporting** — `runs/introspection.py`: tighten the `where … source/code` regex so it cannot bridge across a sentence boundary (genuine *"where is your source code installed?"* still matches).

## Verification

- Ran the patched router against **run 892's exact 4 KB message**: false trigger eliminated (Layers 1 and 3 each neutralize it independently); genuine self-context question still routes to `read_self_context`.
- **221 passed, 2 skipped, 0 failures** across `test_agent`, `test_tool_registry`, `test_inbound_preservation`, `test_work_intake`, `test_triggers`, `test_inbound_webhooks`, `test_external_agents_service`, `test_illo_personal_agent_mcp`, `test_agent_split`.
- 4 new regression tests, including run 892's wrapper as a golden fixture and a test proving explicit routing still forces after a long answer.

## Out of scope (optional follow-up)

The issue's suggestion to flag a `completed`-but-off-task run as `failed` in reconciliation is left out: with Layers 1+2 the run now produces the *correct* answer, making it a lower-value guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)