### PR TITLE
Add Uwear dependency monitor playbook guidance

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -51,6 +51,35 @@ surface the conflict and prefer the live document after verification.
 If repo-local agent instructions contradict this skill, surface the conflict
 before acting. Do not silently choose.
 
+## Dependency Monitor
+
+For selected priority issues or PRs, check likely companion surfaces before
+finalizing triage. This is part of Uwear engineering coordination, not a
+separate release watcher.
+
+Use concrete evidence first: linked GitHub issues/PRs, recent comments, touched
+files, branch targets, labels, CI failures, docs references, MCP tool names,
+payload keys, env vars, and GitHub Ticket Tracker Domain records.
+
+High-confidence examples:
+
+- Backend endpoint, payload, schema, database, agent, or runtime changes may
+  need companion checks in `uwearaiapp`, `uwear-mobile-app`, API docs, MCP
+  tools, staging verification, or downstream tests.
+- Studio/frontend changes may need companion checks for backend expectations,
+  MCP payloads, docs, mobile parity, or staging verification.
+- MCP/tooling changes may need companion checks for app Agent mode, backend
+  processing, docs, and downstream test contracts.
+- Deployment, CI, environment, or runtime changes may need companion checks for
+  staging/main promotion, EAS/mobile profiles, API env vars, and app/backend
+  integration.
+
+If companion work already exists, link it or update the existing tracker
+record. If high-confidence companion work is missing, create or update a
+generic coordination ticket in the GitHub Ticket Tracker Domain instead of
+adding a Uwear-specific object. Keep low-confidence hunches internal or as
+low-noise tracker notes.
+
 ## States
 
 - `needs-triage`: not enough signal yet to classify or assign.
@@ -98,6 +127,8 @@ Slack or team-facing summaries must be safe for teammates:
 
 - Say the priority workset is not the full backlog when relevant.
 - Show concrete next actions with ticket/PR numbers and owners.
+- Mention only high-confidence dependency blockers or missing companion work;
+  keep broader impact analysis in tracker records or internal notes.
 - Do not expose private reasoning, workload psychology, or phrases like
   "stuck", "don't stack", or "bandwidth holds".
 - For AI-written GitHub comments, begin with:
@@ -106,5 +137,5 @@ Slack or team-facing summaries must be safe for teammates:
 ## Done
 
 Triage is done when every item in scope has a state, owner or explicit reason
-for no owner, next action, and enough evidence for another agent or teammate
-to continue without re-discovering the same facts.
+for no owner, next action, dependency check, and enough evidence for another
+agent or teammate to continue without re-discovering the same facts.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.0.0"
+version = "1.0.1"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -45,6 +45,25 @@ def test_filesystem_bundle_discovery_includes_private_team_bundles():
     assert bundle.manifest.visibility == "private_local"
 
 
+def test_uwear_engineering_triage_includes_dependency_monitor():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+
+    assert bundle.manifest.version == "1.0.1"
+    procedure = bundle.skill_markdown
+    for expected in (
+        "## Dependency Monitor",
+        "selected priority issues or PRs",
+        "GitHub Ticket Tracker Domain",
+        "generic coordination ticket",
+        "only high-confidence dependency blockers or missing companion work",
+        "dependency check",
+    ):
+        assert expected in procedure
+
+
 def test_builtin_skills_have_structured_routing_metadata():
     from brain.systems.skills.builtin import BUILTIN_SKILLS
 


### PR DESCRIPTION
## Summary

- Add a Uwear-specific Dependency Monitor section to the bundled engineering triage playbook.
- Tell Illo to check companion surfaces for selected priority issues/PRs and use existing GitHub Ticket Tracker Domain records for coordination.
- Keep Slack output constrained to high-confidence dependency blockers or missing companion work.
- Bump the private skill bundle version and add a regression test for the dependency-monitor contract.

## Why

Illo should flag likely cross-repo/cross-surface dependencies during Uwear engineering triage even when humans forget. This belongs in the Uwear triage playbook/fallback skill, not in generic Cycle prompt construction, so the behavior applies to scheduled triage, manual triage, MCP probing, and future cleanup runs.

## Deployment note

The bundled skill points at Enterprise Documentation Domain 37 / doc_page 1155 (`uwear-engineering-triage`) as the live operating model when available. After merge/redeploy, verify or sync the same Dependency Monitor guidance into that live document.

## Validation

- `PYTHONPATH=/Users/redamjahed/.codex/worktrees/901e/illospace-project /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_builtin_skill_suite.py -q`
