### PR TITLE
Add passive Slack channel monitoring (👀 ack + headless triage)

### DIFF
--- a/brain/app/triggers/contracts.py
+++ b/brain/app/triggers/contracts.py
@@ -43,6 +43,7 @@ ILLO_NATIVE_EVENTS = frozenset({
     "chat.room_thread_mention",
     "slack.app_mention",
     "slack.direct_message",
+    "slack.channel_message",
 })
 
 

--- a/brain/app/triggers/router.py
+++ b/brain/app/triggers/router.py
@@ -13,7 +13,7 @@ _CORTEX_TRIGGER_EVENTS = {
     "cortex.thread_discussion_mention",
 }
 _CHAT_TRIGGER_EVENTS = {"chat.room_message_mention", "chat.room_thread_mention"}
-_SLACK_TRIGGER_EVENTS = {"slack.app_mention", "slack.direct_message"}
+_SLACK_TRIGGER_EVENTS = {"slack.app_mention", "slack.direct_message", "slack.channel_message"}
 _RUN_TRIGGER_EVENTS = _CORTEX_TRIGGER_EVENTS | _CHAT_TRIGGER_EVENTS | _SLACK_TRIGGER_EVENTS
 
 

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -442,12 +442,15 @@ CHAT_TOOLS = [
         "name": "manage_slack",
         "description": (
             "Inspect Slack connection health, list Slack conversations visible to Illo's bot or observed from "
-            "Slack-origin mentions, "
-            "and manage Slack-to-Illospace identity mappings. Use action='status' to check "
-            "whether Slack is connected, action='list_channels' to see channels/DMs the "
-            "configured bot token can enumerate plus Slack surfaces Illo has already seen, "
-            "and identity mapping actions to link Slack users "
-            "to Illospace users."
+            "Slack-origin mentions, manage Slack-to-Illospace identity mappings, and configure which channels "
+            "Illo passively monitors. Use action='status' to check whether Slack is connected, "
+            "action='list_channels' to see channels/DMs the configured bot token can enumerate plus Slack "
+            "surfaces Illo has already seen, and identity mapping actions to link Slack users to Illospace "
+            "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
+            "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
+            "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
+            "bot must be a member of the channel and the Slack app needs the channels:history and "
+            "reactions:write scopes."
         ),
         "input_schema": {
             "type": "object",
@@ -460,6 +463,9 @@ CHAT_TOOLS = [
                         "list_mappings",
                         "link_identity",
                         "unlink_identity",
+                        "list_monitored",
+                        "monitor_channel",
+                        "unmonitor_channel",
                     ],
                     "description": "Slack management action.",
                 },
@@ -474,6 +480,14 @@ CHAT_TOOLS = [
                 "user_id": {
                     "type": "string",
                     "description": "Illospace user id, required for link_identity.",
+                },
+                "channel_id": {
+                    "type": "string",
+                    "description": "Slack channel id (e.g. C0123ABCD), required for monitor_channel and unmonitor_channel.",
+                },
+                "channel_name": {
+                    "type": "string",
+                    "description": "Optional human-readable channel name stored alongside a monitored channel for readability.",
                 },
                 "channel_types": {
                     "oneOf": [

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -429,11 +429,13 @@ async def _handle_manage_slack(
     slack_user_id: str | None = None,
     user_id: str | None = None,
     channel_types: str | list[str] | None = None,
+    channel_id: str | None = None,
+    channel_name: str | None = None,
     limit: int = 200,
     cursor: str | None = None,
     include_archived: bool = False,
 ) -> str:
-    """Inspect Slack connection health and manage minimal identity mappings."""
+    """Inspect Slack connection health, identity mappings, and channel monitors."""
 
     normalized_action = str(action or "").strip().lower()
     org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
@@ -446,6 +448,12 @@ async def _handle_manage_slack(
         link_slack_identity,
         list_slack_identity_mappings,
         unlink_slack_identity,
+    )
+    from brain.systems.slack.monitors import (
+        SlackMonitorConfigError,
+        add_monitored_channel,
+        list_monitored_channels,
+        remove_monitored_channel,
     )
 
     async with UnitOfWork() as uow:
@@ -564,7 +572,57 @@ async def _handle_manage_slack(
             )
             return json.dumps({"ok": True, "mapping": mapping}, default=str)
 
-    return json.dumps({"error": "manage_slack action must be status, list_channels, list_mappings, link_identity, or unlink_identity"})
+        if normalized_action == "list_monitored":
+            channels = await list_monitored_channels(
+                uow.session,
+                connection_id=str(connection.id),
+                org_id=org_id,
+            )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "connection": _slack_connection_payload(connection),
+                    "monitored_channels": channels,
+                },
+                default=str,
+            )
+        if normalized_action == "monitor_channel":
+            if not str(channel_id or "").strip():
+                return json.dumps({"error": "monitor_channel requires: channel_id"})
+            try:
+                result = await add_monitored_channel(
+                    uow.session,
+                    connection_id=str(connection.id),
+                    channel_id=str(channel_id),
+                    org_id=org_id,
+                    channel_name=channel_name,
+                )
+            except SlackMonitorConfigError as exc:
+                return json.dumps({"error": str(exc)})
+            return json.dumps({"ok": True, **result}, default=str)
+        if normalized_action == "unmonitor_channel":
+            if not str(channel_id or "").strip():
+                return json.dumps({"error": "unmonitor_channel requires: channel_id"})
+            try:
+                result = await remove_monitored_channel(
+                    uow.session,
+                    connection_id=str(connection.id),
+                    channel_id=str(channel_id),
+                    org_id=org_id,
+                )
+            except SlackMonitorConfigError as exc:
+                return json.dumps({"error": str(exc)})
+            return json.dumps({"ok": True, **result}, default=str)
+
+    return json.dumps(
+        {
+            "error": (
+                "manage_slack action must be status, list_channels, list_mappings, "
+                "link_identity, unlink_identity, list_monitored, monitor_channel, "
+                "or unmonitor_channel"
+            )
+        }
+    )
 
 
 __all__ = [

--- a/brain/systems/runs/work_intake_slack.py
+++ b/brain/systems/runs/work_intake_slack.py
@@ -35,13 +35,24 @@ def agent_run_request_for_slack(trigger_payload: dict[str, Any] | Any) -> AgentR
         payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None,
     )
     slack_trigger = dict(metadata.get("slack_trigger") or payload.get("slack") or {})
-    surface_context = {
-        "originating_surface": SLACK_SURFACE,
-        "triggering_surface": SLACK_SURFACE,
-        "source_surface": SLACK_SURFACE,
-        "required_response_tool": SLACK_REPLY_TOOL,
-        "final_answer_target_surface": SLACK_SURFACE,
-    }
+    if metadata.get("slack_monitor"):
+        # Passive channel monitoring runs headless: no forced response tool and no
+        # auto-settled Slack post. Illo replies only if it calls post_slack_reply.
+        surface_context = {
+            "originating_surface": SLACK_SURFACE,
+            "triggering_surface": SLACK_SURFACE,
+            "source_surface": SLACK_SURFACE,
+            "final_answer_target_surface": "headless",
+            "headless": True,
+        }
+    else:
+        surface_context = {
+            "originating_surface": SLACK_SURFACE,
+            "triggering_surface": SLACK_SURFACE,
+            "source_surface": SLACK_SURFACE,
+            "required_response_tool": SLACK_REPLY_TOOL,
+            "final_answer_target_surface": SLACK_SURFACE,
+        }
     for key, value in surface_context.items():
         metadata.setdefault(key, value)
     metadata["slack_trigger"] = slack_trigger

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -172,6 +172,28 @@ class SlackWebClient:
             payload["loading_messages"] = loading_messages[:10]
         return await self._post("assistant.threads.setStatus", payload)
 
+    async def add_reaction(
+        self,
+        *,
+        channel: str,
+        timestamp: str,
+        name: str = "eyes",
+    ) -> dict[str, Any]:
+        """Add an emoji reaction to a Slack message.
+
+        Slack returns ``already_reacted`` when the emoji is already present; the
+        caller may treat that as success. Requires the ``reactions:write`` scope.
+        """
+
+        return await self._post(
+            "reactions.add",
+            {
+                "channel": channel,
+                "timestamp": timestamp,
+                "name": str(name or "eyes").strip().strip(":"),
+            },
+        )
+
     async def open_conversation(self, *, users: str) -> dict[str, Any]:
         return await self._post("conversations.open", {"users": users})
 

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -23,7 +23,11 @@ from brain.systems.slack.client import (
     slack_app_token_from_env,
     slack_bot_token_from_env,
 )
-from brain.systems.slack.ingress import normalize_slack_socket_event
+from brain.systems.slack.ingress import (
+    SLACK_CHANNEL_MESSAGE_ORIGIN,
+    normalize_slack_socket_event,
+)
+from brain.systems.slack.monitors import monitored_channel_ids
 
 logger = logging.getLogger(__name__)
 
@@ -307,12 +311,19 @@ async def process_socket_payload(
     """Normalize and process a Socket Mode payload after its ack is sent."""
 
     ack = socket_mode_ack(socket_payload)
+    monitored_channels = monitored_channel_ids(connection)
     envelope = normalize_slack_socket_event(
         socket_payload,
         bot_user_id=config.bot_user_id,
+        monitored_channels=monitored_channels,
     )
     if envelope is None:
         return {"ack": ack, "ignored": True}
+    if envelope.get("origin") == SLACK_CHANNEL_MESSAGE_ORIGIN:
+        # Reflex acknowledgement: leave a 👀 on every observed message so the
+        # channel knows Illo has seen it, independent of whether the ensuing
+        # triage run decides to reply.
+        await _acknowledge_monitored_message(config, envelope)
     inbound = await submit_inbound_envelope(
         session,
         connection=connection,
@@ -323,6 +334,32 @@ async def process_socket_payload(
         },
     )
     return {"ack": ack, "ignored": False, "inbound": inbound}
+
+
+async def _acknowledge_monitored_message(
+    config: SlackConnectorConfig,
+    envelope: Mapping[str, Any],
+) -> None:
+    """Add the 👀 reaction to an observed monitored-channel message.
+
+    Best-effort: a missing ``reactions:write`` scope or an already-present
+    reaction must not break inbound processing.
+    """
+
+    payload = dict(envelope.get("payload") or {})
+    channel_id = str(payload.get("channel_id") or "").strip()
+    message_ts = str(payload.get("message_ts") or "").strip()
+    if not channel_id or not message_ts:
+        return
+    try:
+        client = SlackWebClient(config.bot_token)
+        await client.add_reaction(channel=channel_id, timestamp=message_ts, name="eyes")
+    except SlackApiError as exc:
+        if exc.error == "already_reacted":
+            return
+        logger.info("slack_monitor_reaction_failed: %s", exc)
+    except Exception as exc:
+        logger.info("slack_monitor_reaction_failed: %s", exc)
 
 
 async def open_socket_mode_url(config: SlackConnectorConfig) -> str:

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 SLACK_MESSAGE_ENVELOPE_KIND = "slack_message"
+SLACK_CHANNEL_MESSAGE_ORIGIN = "slack.channel_message"
 MAX_SLACK_TEXT_CHARS = 4000
 
 _IGNORED_MESSAGE_SUBTYPES = {
@@ -45,27 +46,69 @@ def _bot_user_id(socket_payload: Mapping[str, Any], explicit_bot_user_id: str | 
     return None
 
 
-def _event_origin(event: Mapping[str, Any], *, bot_user_id: str | None) -> str | None:
+def _is_own_slack_message(
+    event: Mapping[str, Any],
+    *,
+    bot_user_id: str | None,
+    api_app_id: str | None,
+) -> bool:
+    """Return True when a message was authored by Illo's own Slack app.
+
+    Guards against Illo reacting to or triaging its own posts, which would loop
+    on a monitored channel.
+    """
+
+    if bot_user_id and str(event.get("user") or "").strip() == str(bot_user_id):
+        return True
+    event_app_id = str(event.get("app_id") or "").strip()
+    if event_app_id and api_app_id and event_app_id == str(api_app_id).strip():
+        return True
+    return False
+
+
+def _event_origin(
+    event: Mapping[str, Any],
+    *,
+    bot_user_id: str | None,
+    api_app_id: str | None = None,
+    monitored_channels: frozenset[str] | set[str] | None = None,
+) -> str | None:
     event_type = str(event.get("type") or "")
     subtype = str(event.get("subtype") or "")
     channel_type = str(event.get("channel_type") or "")
     text = str(event.get("text") or "")
-    if event.get("bot_id") or subtype in _IGNORED_MESSAGE_SUBTYPES:
+    channel_id = str(event.get("channel") or "").strip()
+    if subtype in _IGNORED_MESSAGE_SUBTYPES:
         return None
-    if event_type == "app_mention":
-        return "slack.app_mention"
-    if event_type != "message":
+    if _is_own_slack_message(event, bot_user_id=bot_user_id, api_app_id=api_app_id):
         return None
-    if channel_type == "im":
-        return "slack.direct_message"
-    if bot_user_id and f"<@{bot_user_id}>" in text:
-        return "slack.app_mention"
+    is_bot = bool(event.get("bot_id"))
+    # Direct human invitations to participate: explicit mentions and DMs.
+    if not is_bot:
+        if event_type == "app_mention":
+            return "slack.app_mention"
+        if event_type == "message" and channel_type == "im":
+            return "slack.direct_message"
+        if event_type == "message" and bot_user_id and f"<@{bot_user_id}>" in text:
+            return "slack.app_mention"
+    # Passive monitoring: every message in an explicitly monitored channel,
+    # including third-party bots (Sentry, Rollbar) posting automated alerts.
+    if (
+        event_type == "message"
+        and channel_type != "im"
+        and channel_id
+        and monitored_channels
+        and channel_id in monitored_channels
+    ):
+        return SLACK_CHANNEL_MESSAGE_ORIGIN
     return None
 
 
 def _event_kind(origin: str) -> str:
     if origin == "slack.direct_message":
         return "direct_message"
+    if origin == SLACK_CHANNEL_MESSAGE_ORIGIN:
+        return "channel_message"
     return "mention"
 
 
@@ -97,18 +140,29 @@ def normalize_slack_socket_event(
     socket_payload: Mapping[str, Any],
     *,
     bot_user_id: str | None = None,
+    monitored_channels: frozenset[str] | set[str] | list[str] | None = None,
 ) -> dict[str, Any] | None:
     """Return a shared inbound envelope for actionable Slack Socket Mode events.
 
-    Only explicit mentions and DMs are actionable in the self-hosted MVP. Other
-    channel messages may be visible to the bot, but they are not invitations for
-    Illo to participate.
+    Explicit mentions and DMs are always actionable. In addition, every message
+    posted to an explicitly *monitored* channel (``monitored_channels``) is
+    admitted as a ``slack.channel_message`` so Illo can observe and triage the
+    channel; other channel messages remain non-actionable.
     """
 
     payload = _socket_payload(socket_payload)
     event = _slack_event(socket_payload)
     resolved_bot_user_id = _bot_user_id(socket_payload, bot_user_id)
-    origin = _event_origin(event, bot_user_id=resolved_bot_user_id)
+    api_app_id = str(payload.get("api_app_id") or "").strip() or None
+    monitored = frozenset(
+        str(channel).strip() for channel in (monitored_channels or ()) if str(channel).strip()
+    )
+    origin = _event_origin(
+        event,
+        bot_user_id=resolved_bot_user_id,
+        api_app_id=api_app_id,
+        monitored_channels=monitored,
+    )
     if origin is None:
         return None
 

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -1,0 +1,177 @@
+"""Slack channel monitoring configuration helpers.
+
+A "monitored" Slack channel is one where Illo passively observes *every* message
+(not just @-mentions/DMs), acknowledges each with a lightweight reaction, and
+decides per-message whether the content is ticket-worthy. The set of monitored
+channels lives on the Slack connection's ``metadata_["slack"]["monitored_channels"]``
+so it can be configured at runtime by Illo (via ``manage_slack``) and picked up by
+the connector on the next event with no restart.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+
+
+class SlackMonitorConfigError(ValueError):
+    """Raised when a Slack channel monitor cannot be configured."""
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _connection_metadata(connection: Any) -> dict[str, Any]:
+    metadata = getattr(connection, "metadata_", None)
+    if metadata is None and isinstance(connection, Mapping):
+        metadata = connection.get("metadata_") or connection.get("metadata")
+    return dict(metadata or {})
+
+
+def _slack_metadata(connection: Any) -> dict[str, Any]:
+    slack_metadata = _connection_metadata(connection).get("slack")
+    return dict(slack_metadata or {}) if isinstance(slack_metadata, Mapping) else {}
+
+
+def _normalize_entries(raw: Any) -> list[dict[str, Any]]:
+    """Normalize stored monitored-channel entries into a list of dicts.
+
+    Accepts either a list of channel-id strings or a list of dicts so older or
+    hand-edited configurations keep working.
+    """
+
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in raw or []:
+        if isinstance(item, Mapping):
+            channel_id = _clean(item.get("channel_id") or item.get("id"))
+            if not channel_id or channel_id in seen:
+                continue
+            entry = {"channel_id": channel_id}
+            channel_name = _clean(item.get("channel_name") or item.get("name"))
+            if channel_name:
+                entry["channel_name"] = channel_name
+            entry["enabled"] = item.get("enabled") is not False
+            entries.append(entry)
+            seen.add(channel_id)
+        else:
+            channel_id = _clean(item)
+            if not channel_id or channel_id in seen:
+                continue
+            entries.append({"channel_id": channel_id, "enabled": True})
+            seen.add(channel_id)
+    return entries
+
+
+def monitored_channel_ids(connection: ExternalAgentConnectionRow) -> set[str]:
+    """Return the set of enabled monitored channel ids for a connection.
+
+    Pure read helper (no session) used by the connector on the hot path.
+    """
+
+    entries = _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+    return {entry["channel_id"] for entry in entries if entry.get("enabled", True)}
+
+
+async def _connection_for_org(
+    session,
+    connection_id: str,
+    org_id: str | None,
+) -> ExternalAgentConnectionRow:
+    connection = await session.get(ExternalAgentConnectionRow, str(connection_id))
+    if connection is None:
+        raise SlackMonitorConfigError("Slack connection not found")
+    if connection.agent_kind != "slack" or connection.transport != "slack_socket_mode":
+        raise SlackMonitorConfigError("Connection is not a Slack Socket Mode connection")
+    if org_id and str(connection.org_id) != str(org_id):
+        raise SlackMonitorConfigError("Slack connection is outside this org")
+    return connection
+
+
+def _write_entries(connection: ExternalAgentConnectionRow, entries: list[dict[str, Any]]) -> None:
+    root = dict(connection.metadata_ or {})
+    slack_metadata = _slack_metadata(connection)
+    slack_metadata["monitored_channels"] = entries
+    root["slack"] = slack_metadata
+    connection.metadata_ = root
+
+
+async def list_monitored_channels(
+    session,
+    *,
+    connection_id: str,
+    org_id: str | None = None,
+) -> list[dict[str, Any]]:
+    connection = await _connection_for_org(session, connection_id, org_id)
+    return _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+
+
+async def add_monitored_channel(
+    session,
+    *,
+    connection_id: str,
+    channel_id: str,
+    org_id: str | None = None,
+    channel_name: str | None = None,
+) -> dict[str, Any]:
+    clean_channel_id = _clean(channel_id)
+    if not clean_channel_id:
+        raise SlackMonitorConfigError("channel_id is required")
+    connection = await _connection_for_org(session, connection_id, org_id)
+    entries = _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+    clean_channel_name = _clean(channel_name) or None
+    updated = False
+    for entry in entries:
+        if entry["channel_id"] == clean_channel_id:
+            entry["enabled"] = True
+            if clean_channel_name:
+                entry["channel_name"] = clean_channel_name
+            updated = True
+            break
+    if not updated:
+        entry = {"channel_id": clean_channel_id, "enabled": True}
+        if clean_channel_name:
+            entry["channel_name"] = clean_channel_name
+        entries.append(entry)
+    _write_entries(connection, entries)
+    await session.flush()
+    return {
+        "channel_id": clean_channel_id,
+        "channel_name": clean_channel_name,
+        "monitored": True,
+        "monitored_channels": entries,
+    }
+
+
+async def remove_monitored_channel(
+    session,
+    *,
+    connection_id: str,
+    channel_id: str,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    clean_channel_id = _clean(channel_id)
+    if not clean_channel_id:
+        raise SlackMonitorConfigError("channel_id is required")
+    connection = await _connection_for_org(session, connection_id, org_id)
+    entries = _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+    remaining = [entry for entry in entries if entry["channel_id"] != clean_channel_id]
+    removed = len(remaining) != len(entries)
+    _write_entries(connection, remaining)
+    await session.flush()
+    return {
+        "channel_id": clean_channel_id,
+        "removed": removed,
+        "monitored_channels": remaining,
+    }
+
+
+__all__ = [
+    "SlackMonitorConfigError",
+    "add_monitored_channel",
+    "list_monitored_channels",
+    "monitored_channel_ids",
+    "remove_monitored_channel",
+]

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 SLACK_MESSAGE_ENVELOPE_KIND = "slack_message"
 SLACK_SURFACE = "slack"
 SLACK_REPLY_TOOL = "post_slack_reply"
+SLACK_CHANNEL_MESSAGE_ORIGIN = "slack.channel_message"
 
 
 def build_slack_work_intake_payload(
@@ -23,16 +24,29 @@ def build_slack_work_intake_payload(
     trigger = slack_trigger(slack_payload)
     event_type = slack_event_type(slack_payload)
     target = slack_target(trigger)
+    is_monitor = event_type == SLACK_CHANNEL_MESSAGE_ORIGIN
     metadata = {
-        "origin": "slack_teammate",
+        "origin": "slack_channel_monitor" if is_monitor else "slack_teammate",
         "originating_surface": SLACK_SURFACE,
         "triggering_surface": SLACK_SURFACE,
         "source_surface": SLACK_SURFACE,
-        "required_response_tool": SLACK_REPLY_TOOL,
-        "final_answer_target_surface": SLACK_SURFACE,
         "slack_trigger": trigger,
         "slack_connection_id": connection_id,
     }
+    if is_monitor:
+        # Passive observation of a monitored channel: run headless so the
+        # settlement layer never auto-posts the final answer, and do not force a
+        # response tool. Illo replies only when it explicitly chooses to via
+        # post_slack_reply (e.g. after creating a ticket).
+        metadata["slack_monitor"] = True
+        metadata["headless"] = True
+        metadata["final_answer_target_surface"] = "headless"
+        metadata["execution_profile"] = "fast"
+        run_message = slack_channel_monitor_message(slack_payload, trigger)
+    else:
+        metadata["required_response_tool"] = SLACK_REPLY_TOOL
+        metadata["final_answer_target_surface"] = SLACK_SURFACE
+        run_message = slack_run_message(slack_payload, trigger)
     if inbound_event_id:
         metadata["inbound_event"] = {
             "event_id": inbound_event_id,
@@ -61,7 +75,7 @@ def build_slack_work_intake_payload(
         "payload": {
             "slack": trigger,
             "thread_message": _clean(slack_payload.get("text"))[:2000],
-            "run_message": slack_run_message(slack_payload, trigger),
+            "run_message": run_message,
             "metadata": metadata,
             "priority": int(priority),
             "user_id": str(authority_user_id),
@@ -108,10 +122,13 @@ def slack_target(slack_trigger_payload: Mapping[str, Any]) -> dict[str, Any]:
 
 def slack_event_type(payload: Mapping[str, Any]) -> str:
     origin = _clean(payload.get("origin"))
-    if origin in {"slack.app_mention", "slack.direct_message"}:
+    if origin in {"slack.app_mention", "slack.direct_message", SLACK_CHANNEL_MESSAGE_ORIGIN}:
         return origin
-    if _clean(payload.get("event_kind")) == "direct_message":
+    event_kind = _clean(payload.get("event_kind"))
+    if event_kind == "direct_message":
         return "slack.direct_message"
+    if event_kind == "channel_message":
+        return SLACK_CHANNEL_MESSAGE_ORIGIN
     return "slack.app_mention"
 
 
@@ -198,15 +215,59 @@ def slack_run_message(payload: Mapping[str, Any], slack_trigger_payload: Mapping
     return "\n".join(lines)
 
 
+def slack_channel_monitor_message(
+    payload: Mapping[str, Any],
+    slack_trigger_payload: Mapping[str, Any],
+) -> str:
+    """Frame a monitored-channel message as a passive triage decision.
+
+    The message has already been acknowledged with a 👀 reaction at ingest, so
+    the run's job is only to decide whether the content is ticket-worthy — and to
+    stay silent otherwise.
+    """
+
+    text = _clean(payload.get("text"))[:2000]
+    channel_id = _clean(slack_trigger_payload.get("channel_id"))
+    channel_name = _clean(payload.get("channel_name"))
+    channel_label = f"#{channel_name}" if channel_name else f"channel {channel_id}"
+    author = _clean(slack_trigger_payload.get("slack_user_id")) or "unknown (may be an app/bot)"
+    lines = [
+        f"You are passively monitoring Slack {channel_label}. A new message was posted "
+        "and has already been acknowledged with a 👀 reaction — do not acknowledge it again.",
+        "",
+        "Classify this message and act accordingly:",
+        "- Casual chatter, or discussion about an existing alert: take NO visible action. Do not reply.",
+        "- A genuine automated alert (Sentry, Rollbar, CI) or a user-reported problem that is "
+        "ticket-worthy: create/route a ticket by loading the 'uwear-engineering-triage' skill "
+        "(brain_skills then skill_view), then optionally post a brief Slack note with post_slack_reply.",
+        "- Ambiguous or low-signal: prefer no visible action; the 👀 already confirms you saw it.",
+        "",
+        "Silence is the correct default. Only use post_slack_reply when you have opened/flagged a "
+        "ticket or must surface something important. Use read_slack_conversation "
+        "(scope=recent_channel or thread) for more context before deciding.",
+        "",
+        f"Channel: {channel_id}" + (f" ({channel_name})" if channel_name else ""),
+        f"Team: {slack_trigger_payload.get('team_id')}",
+        f"Message ts: {slack_trigger_payload.get('message_ts')}",
+        f"Author (Slack id): {author}",
+    ]
+    if slack_trigger_payload.get("permalink"):
+        lines.append(f"Permalink: {slack_trigger_payload.get('permalink')}")
+    lines.extend(["", f"Message text: {text}"])
+    return "\n".join(lines)
+
+
 def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
 __all__ = [
+    "SLACK_CHANNEL_MESSAGE_ORIGIN",
     "SLACK_MESSAGE_ENVELOPE_KIND",
     "SLACK_REPLY_TOOL",
     "SLACK_SURFACE",
     "build_slack_work_intake_payload",
+    "slack_channel_monitor_message",
     "slack_event_type",
     "slack_response_target",
     "slack_run_message",

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -1,0 +1,500 @@
+"""Tests for passive Slack channel monitoring (Route A).
+
+Covers the full path: ingress admission of monitored-channel messages, the 👀
+reflex reaction, headless triage run framing (no forced reply), and the
+``manage_slack`` self-configuration surface for monitored channels.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _socket_mode_channel_message(**event_overrides):
+    """A Socket Mode ``message`` event posted to a channel (no @-mention)."""
+
+    event = {
+        "type": "message",
+        "user": "U123",
+        "text": "Payments API is throwing 500s in prod",
+        "ts": "1716900000.000200",
+        "event_ts": "1716900000.000200",
+        "channel": "C_ALERTS",
+        "channel_type": "channel",
+    }
+    event.update(event_overrides)
+    return {
+        "type": "events_api",
+        "envelope_id": "env-2",
+        "payload": {
+            "team_id": "T789",
+            "api_app_id": "A111",
+            "event_id": "Ev333",
+            "event_time": 1716900000,
+            "event": event,
+            "authorizations": [{"team_id": "T789", "user_id": "BILLO", "is_bot": True}],
+        },
+    }
+
+
+def _channel_monitor_payload() -> dict[str, Any]:
+    """A normalized Slack payload for a monitored-channel message."""
+
+    return {
+        "origin": "slack.channel_message",
+        "event_kind": "channel_message",
+        "team_id": "T789",
+        "channel_id": "C_ALERTS",
+        "channel_name": "alerts",
+        "channel_type": "channel",
+        "message_ts": "1716900000.000200",
+        "thread_ts": "1716900000.000200",
+        "slack_user_id": "U123",
+        "text": "Payments API 500s in prod",
+        "response_target": {"channel_id": "C_ALERTS", "thread_ts": None, "visibility": "public"},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Ingress: which channel messages become actionable                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_monitored_channel_plain_message_admitted_as_channel_message():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.channel_message"
+    assert envelope["payload"]["event_kind"] == "channel_message"
+    assert envelope["payload"]["channel_id"] == "C_ALERTS"
+    assert envelope["payload"]["surface"] == "slack_channel"
+    assert envelope["idempotency_key"] == "slack:T789:C_ALERTS:1716900000.000200"
+
+
+def test_unmonitored_channel_plain_message_is_ignored():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    assert (
+        normalize_slack_socket_event(
+            _socket_mode_channel_message(),
+            bot_user_id="BILLO",
+            monitored_channels=set(),
+        )
+        is None
+    )
+    assert (
+        normalize_slack_socket_event(
+            _socket_mode_channel_message(),
+            bot_user_id="BILLO",
+            monitored_channels={"C_OTHER"},
+        )
+        is None
+    )
+
+
+def test_monitored_channel_ignores_illo_own_message_by_user():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    assert (
+        normalize_slack_socket_event(
+            _socket_mode_channel_message(user="BILLO"),
+            bot_user_id="BILLO",
+            monitored_channels={"C_ALERTS"},
+        )
+        is None
+    )
+
+
+def test_monitored_channel_ignores_illo_own_app_message():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    # A message authored by Illo's own Slack app (event.app_id == payload.api_app_id).
+    assert (
+        normalize_slack_socket_event(
+            _socket_mode_channel_message(user="", bot_id="B_ILLO", app_id="A111"),
+            bot_user_id="BILLO",
+            monitored_channels={"C_ALERTS"},
+        )
+        is None
+    )
+
+
+def test_monitored_channel_admits_third_party_bot_alert():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(
+            user="",
+            bot_id="B_SENTRY",
+            app_id="A_SENTRY",
+            text="New Sentry issue: TypeError in checkout",
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.channel_message"
+
+
+def test_monitored_channel_mention_still_routes_as_mention():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(text="<@BILLO> please take a look"),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.app_mention"
+
+
+def test_monitored_channel_ignores_edit_subtype():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    assert (
+        normalize_slack_socket_event(
+            _socket_mode_channel_message(subtype="message_changed"),
+            bot_user_id="BILLO",
+            monitored_channels={"C_ALERTS"},
+        )
+        is None
+    )
+
+
+def test_dm_is_never_treated_as_channel_message():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(channel="D1", channel_type="im", text="hi"),
+        bot_user_id="BILLO",
+        monitored_channels={"D1"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.direct_message"
+
+
+# --------------------------------------------------------------------------- #
+# Trigger shaping: monitored messages become headless triage runs              #
+# --------------------------------------------------------------------------- #
+
+
+def test_slack_event_type_detects_channel_message():
+    from brain.systems.slack.triggers import slack_event_type
+
+    assert slack_event_type({"origin": "slack.channel_message"}) == "slack.channel_message"
+    assert slack_event_type({"event_kind": "channel_message"}) == "slack.channel_message"
+
+
+def test_build_payload_for_channel_message_is_headless_and_not_forced_reply():
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+        inbound_event_id="evt1",
+        connection_id="conn1",
+        idempotency_key="idem1",
+    )
+
+    assert payload["event_type"] == "slack.channel_message"
+    metadata = payload["payload"]["metadata"]
+    assert metadata["slack_monitor"] is True
+    assert metadata["headless"] is True
+    assert metadata["final_answer_target_surface"] == "headless"
+    assert "required_response_tool" not in metadata
+    run_message = payload["payload"]["run_message"]
+    assert "monitoring Slack #alerts" in run_message
+    assert "👀" in run_message
+
+
+def test_build_payload_for_mention_still_forces_reply():
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload={
+            "origin": "slack.app_mention",
+            "event_kind": "mention",
+            "team_id": "T789",
+            "channel_id": "C1",
+            "channel_type": "channel",
+            "message_ts": "1716900000.000100",
+            "thread_ts": "1716900000.000100",
+            "slack_user_id": "U1",
+            "text": "<@BILLO> hi",
+            "response_target": {"channel_id": "C1", "thread_ts": None, "visibility": "public"},
+        },
+    )
+
+    metadata = payload["payload"]["metadata"]
+    assert metadata["required_response_tool"] == "post_slack_reply"
+    assert metadata["final_answer_target_surface"] == "slack"
+    assert "headless" not in metadata
+
+
+def test_agent_run_request_for_monitor_is_headless_without_forced_tool():
+    from brain.systems.runs.work_intake_slack import agent_run_request_for_slack
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    trigger_payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+        inbound_event_id="evt1",
+        connection_id="conn1",
+        idempotency_key="idem1",
+    )
+
+    request = agent_run_request_for_slack(trigger_payload)
+
+    assert request.metadata.get("headless") is True
+    assert request.metadata.get("slack_monitor") is True
+    assert not request.metadata.get("required_response_tool")
+    assert request.metadata.get("final_answer_target_surface") == "headless"
+    assert request.target_ref.get("headless") is True
+    assert request.target_ref.get("slack_trigger", {}).get("channel_id") == "C_ALERTS"
+
+
+# --------------------------------------------------------------------------- #
+# Client: the 👀 reaction call                                                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_posts_normalized_eyes(monkeypatch):
+    from brain.systems.slack import client as slack_client_module
+    from brain.systems.slack.client import SlackWebClient
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    class _HttpClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc) -> None:
+            return None
+
+        async def post(self, url: str, *, headers, json=None):
+            calls.append((url, json))
+            return _Response()
+
+    monkeypatch.setattr(slack_client_module, "async_http_client", lambda **_kwargs: _HttpClient())
+
+    result = await SlackWebClient("xoxb-test").add_reaction(
+        channel="C_ALERTS", timestamp="1716900000.000200", name=":eyes:"
+    )
+
+    assert result["ok"] is True
+    assert calls == [
+        (
+            "https://slack.com/api/reactions.add",
+            {"channel": "C_ALERTS", "timestamp": "1716900000.000200", "name": "eyes"},
+        )
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Connector: the reflex reaction fires only for monitored channel messages      #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeConnection:
+    def __init__(self, metadata=None, org_id="org1"):
+        self.id = "conn1"
+        self.org_id = org_id
+        self.agent_kind = "slack"
+        self.transport = "slack_socket_mode"
+        self.metadata_ = dict(metadata or {})
+
+
+class _FakeSession:
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def get(self, _model, _id):
+        return self._connection
+
+    async def flush(self):
+        return None
+
+
+def _patch_connector(monkeypatch):
+    from brain.systems.slack import connector as connector_module
+
+    reactions: list[tuple[str, str, str]] = []
+    submitted: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        def __init__(self, token):
+            self.token = token
+
+        async def add_reaction(self, *, channel, timestamp, name):
+            reactions.append((channel, timestamp, name))
+            return {"ok": True}
+
+    async def _fake_submit(session, *, connection, envelope, ingress_context):
+        submitted.append(envelope)
+        return {"status": "processed"}
+
+    monkeypatch.setattr(connector_module, "SlackWebClient", _FakeClient)
+    monkeypatch.setattr(connector_module, "submit_inbound_envelope", _fake_submit)
+    return connector_module, reactions, submitted
+
+
+@pytest.mark.asyncio
+async def test_process_socket_payload_reacts_to_monitored_message(monkeypatch):
+    connector_module, reactions, submitted = _patch_connector(monkeypatch)
+    connection = _FakeConnection(metadata={"slack": {"monitored_channels": ["C_ALERTS"]}})
+    config = connector_module.SlackConnectorConfig(
+        bot_token="xoxb-x", app_token="xapp-x", bot_user_id="BILLO"
+    )
+
+    result = await connector_module.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=_socket_mode_channel_message(),
+        config=config,
+    )
+
+    assert result["ignored"] is False
+    assert reactions == [("C_ALERTS", "1716900000.000200", "eyes")]
+    assert submitted and submitted[0]["origin"] == "slack.channel_message"
+
+
+@pytest.mark.asyncio
+async def test_process_socket_payload_does_not_react_to_mention(monkeypatch):
+    connector_module, reactions, submitted = _patch_connector(monkeypatch)
+    connection = _FakeConnection(metadata={"slack": {"monitored_channels": ["C_ALERTS"]}})
+    config = connector_module.SlackConnectorConfig(
+        bot_token="xoxb-x", app_token="xapp-x", bot_user_id="BILLO"
+    )
+
+    await connector_module.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=_socket_mode_channel_message(text="<@BILLO> hey"),
+        config=config,
+    )
+
+    assert reactions == []
+    assert submitted and submitted[0]["origin"] == "slack.app_mention"
+
+
+@pytest.mark.asyncio
+async def test_process_socket_payload_ignores_unmonitored_channel(monkeypatch):
+    connector_module, reactions, submitted = _patch_connector(monkeypatch)
+    connection = _FakeConnection(metadata={"slack": {"monitored_channels": []}})
+    config = connector_module.SlackConnectorConfig(
+        bot_token="xoxb-x", app_token="xapp-x", bot_user_id="BILLO"
+    )
+
+    result = await connector_module.process_socket_payload(
+        None,
+        connection=connection,
+        socket_payload=_socket_mode_channel_message(),
+        config=config,
+    )
+
+    assert result["ignored"] is True
+    assert reactions == []
+    assert submitted == []
+
+
+# --------------------------------------------------------------------------- #
+# Self-configuration: manage_slack monitored-channel helpers                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_monitor_channel_add_list_remove_roundtrip():
+    from brain.systems.slack.monitors import (
+        add_monitored_channel,
+        list_monitored_channels,
+        monitored_channel_ids,
+        remove_monitored_channel,
+    )
+
+    connection = _FakeConnection()
+    session = _FakeSession(connection)
+
+    await add_monitored_channel(
+        session, connection_id="conn1", channel_id="C_ALERTS", org_id="org1", channel_name="alerts"
+    )
+    listed = await list_monitored_channels(session, connection_id="conn1", org_id="org1")
+    assert listed == [{"channel_id": "C_ALERTS", "channel_name": "alerts", "enabled": True}]
+    assert monitored_channel_ids(connection) == {"C_ALERTS"}
+
+    # Re-adding is idempotent.
+    await add_monitored_channel(session, connection_id="conn1", channel_id="C_ALERTS", org_id="org1")
+    assert len(await list_monitored_channels(session, connection_id="conn1", org_id="org1")) == 1
+
+    removed = await remove_monitored_channel(
+        session, connection_id="conn1", channel_id="C_ALERTS", org_id="org1"
+    )
+    assert removed["removed"] is True
+    assert monitored_channel_ids(connection) == set()
+
+
+def test_monitored_channel_ids_supports_legacy_strings_and_disabled():
+    from brain.systems.slack.monitors import monitored_channel_ids
+
+    connection = _FakeConnection(
+        metadata={
+            "slack": {
+                "monitored_channels": [
+                    "C1",
+                    {"channel_id": "C2", "enabled": False},
+                    {"channel_id": "C3"},
+                ]
+            }
+        }
+    )
+
+    assert monitored_channel_ids(connection) == {"C1", "C3"}
+
+
+@pytest.mark.asyncio
+async def test_add_monitored_channel_rejects_non_slack_connection():
+    from brain.systems.slack.monitors import SlackMonitorConfigError, add_monitored_channel
+
+    connection = _FakeConnection()
+    connection.agent_kind = "github"
+
+    with pytest.raises(SlackMonitorConfigError):
+        await add_monitored_channel(
+            _FakeSession(connection), connection_id="conn1", channel_id="C1", org_id="org1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_monitor_channel_preserves_identity_map_metadata():
+    from brain.systems.slack.monitors import add_monitored_channel
+
+    connection = _FakeConnection(metadata={"slack": {"identity_map": {"U1": "user-1"}}})
+    session = _FakeSession(connection)
+
+    await add_monitored_channel(session, connection_id="conn1", channel_id="C_ALERTS", org_id="org1")
+
+    # Adding a monitor must not clobber the existing identity map.
+    assert connection.metadata_["slack"]["identity_map"] == {"U1": "user-1"}
+    assert connection.metadata_["slack"]["monitored_channels"][0]["channel_id"] == "C_ALERTS"

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1359,7 +1359,16 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
     actions = tool["input_schema"]["properties"]["action"]["enum"]
     serialized_tool = json.dumps(tool)
 
-    assert actions == ["status", "list_channels", "list_mappings", "link_identity", "unlink_identity"]
+    assert actions == [
+        "status",
+        "list_channels",
+        "list_mappings",
+        "link_identity",
+        "unlink_identity",
+        "list_monitored",
+        "monitor_channel",
+        "unmonitor_channel",
+    ]
     assert "setup_instructions" not in serialized_tool
     assert "SLACK_" not in serialized_tool
     assert "docker" not in serialized_tool


### PR DESCRIPTION
## What & why

Illo could only see Slack **@-mentions and DMs** — every other channel message was dropped at ingress (*"not an invitation to participate"*). So it can't watch a channel like `#alerts`, where the important signals (Sentry/Rollbar alerts, user-reported issues) never mention the bot.

This adds a **general "monitored channel" primitive**: Illo sees every message in a monitored channel, acknowledges each with a 👀 reaction, and only replies / creates a ticket when a message is genuinely worthy — chatter stays silent.

The design deliberately separates a **one-time platform primitive** (this PR) from **runtime self-configuration** (Illo decides *which* channels and the triage rules itself, no deploy):

| Piece | Behavior |
|---|---|
| **Ingest** | `ingress.normalize_slack_socket_event` admits plain channel messages (incl. third-party bots like Sentry/Rollbar) for channels in a monitored set as a new `slack.channel_message` origin. Illo's **own** posts (by bot-user-id or own app-id) are never admitted → no self-loop. Explicit mentions still win over passive observation. |
| **👀 reflex** | The connector calls `reactions.add(eyes)` immediately on ingest for monitored messages, independent of the run. Best-effort: a missing scope or `already_reacted` never breaks intake. |
| **Selective reply** | A monitored message admits a **headless** triage run that carries the `slack_trigger` (so the agent *may* `post_slack_reply` / `read_slack_conversation`) but sets **no** `required_response_tool` and is **not** auto-settled to Slack. Silence is the default; the run is framed to route a ticket via the existing `uwear-engineering-triage` skill only when warranted. |
| **Self-config** | `manage_slack` gains `monitor_channel` / `unmonitor_channel` / `list_monitored`, persisted on the Slack connection metadata beside `identity_map`. The connector reads it fresh per event → configure at runtime, no restart. |

## ⚠️ Deploy prerequisite (Slack app)

For a monitored channel the bot must be **a member of the channel**, and the Slack app needs the **`channels:history`** (see messages) and **`reactions:write`** (👀) scopes. Existing mention/DM behavior is unchanged and needs nothing new.

## Known v1 tradeoff

Every monitored message admits **one fast-profile triage run** (which usually no-ops for chatter). Intentional for v1 to keep the decision in Illo's hands per-message; a cheaper pre-classifier can be layered in later if a channel's volume warrants it. Called out rather than silently capped.

## Testing

- New `tests/test_slack_channel_monitor.py` (20 tests): ingress admission + own-message/third-party-bot/mention/edit-subtype/DM edge cases; the 👀 reflex firing **only** for monitored channel messages; headless non-forced-reply run framing; the `add_reaction` client call; and the `manage_slack` monitor helpers (add/list/remove, legacy formats, identity-map preservation, non-Slack rejection).
- Full non-DB suite: **3185 passed** (the only failures are pre-existing `torch`/GPU env import errors, unrelated to this change).

## How to test once deployed

1. Invite the Illo bot to `#alerts`; confirm the app has `channels:history` + `reactions:write`.
2. Ask Illo (via MCP `illo_submit` or a DM): *"monitor the #alerts channel"* → it resolves the channel id (`manage_slack list_channels`) and calls `manage_slack monitor_channel`.
3. Post a plain message in `#alerts` → expect an immediate 👀 and **no reply** for chatter.
4. Post a Sentry/Rollbar-style alert or a user issue → expect 👀 **and** a ticket + a brief reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)