### PR TITLE
Make final-reply checker advisory instead of a hard gate

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
+++ b/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
@@ -138,6 +138,9 @@ def _stage_cortex_reply(content: str, *, run_id: int | None, review: dict) -> di
     }
     if run_id:
         result["run_id"] = run_id
+    checker_note = review.get("rationale")
+    if checker_note:
+        result["checker_note"] = checker_note
     if review.get("override"):
         result["checker_override"] = review["override"]
     if reply_count > 1:
@@ -188,35 +191,9 @@ def _handle_cortex_reply(content: str) -> dict:
         user_id=getattr(_agent_context, "user_id", None),
         session_id=getattr(_agent_context, "session_id", None),
     )
-    if review["status"] not in {"resolved", "blocked_on_user"} and _looks_like_concrete_blocker_reply(
-        proposed_reply,
-        execution_context,
-    ):
-        review = {
-            "status": "blocked_on_user",
-            "approved": True,
-            "rationale": (
-                "The candidate reports a concrete backend/tool dependency blocker, "
-                "so continuing the agent loop would not make progress."
-            ),
-            "missing_requirements": [],
-            "raw_output": review.get("raw_output", ""),
-            "override": "concrete_dependency_blocker",
-        }
-    if review["status"] not in {"resolved", "blocked_on_user"}:
-        return {
-            "blocked": True,
-            "error": "Final reply checker rejected cortex_reply.",
-            "checker_status": review["status"],
-            "checker_reason": review.get("rationale") or "The proposed final reply does not show the work is finished.",
-            "missing_requirements": review.get("missing_requirements") or [],
-            "instruction": (
-                "Do not send this as the final reply yet. Continue working. "
-                "If more execution is required, use the normal project tools or let the AgentRun recipe escalate. "
-                "Only call cortex_reply after the user goal is complete or concretely blocked by user input, "
-                "credentials, an unavailable service, or a backend/tool dependency."
-            ),
-        }
+    # The checker is advisory: its verdict is surfaced as a non-blocking warning so
+    # the model can decide for itself whether to continue or reply again. It no longer
+    # vetoes a reply the model considers final.
 
     run_id = getattr(getattr(_agent_context, "run", None), "run_id", None)
     if run_id:
@@ -234,6 +211,9 @@ def _handle_cortex_reply(content: str) -> dict:
         if run_id:
             result["run_id"] = run_id
         result["checker_status"] = review["status"]
+        checker_note = review.get("rationale")
+        if checker_note:
+            result["checker_note"] = checker_note
         if review.get("override"):
             result["checker_override"] = review["override"]
         if reply_count > 1:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2209,7 +2209,9 @@ class TestCortexReplyHandler:
             _agent_context.intent_satisfaction = None
 
     @patch("brain.systems.runs.direct_agent.review_final_reply_once")
-    def test_cortex_reply_blocks_unresolved_final_message(self, mock_review):
+    def test_cortex_reply_stages_reply_with_advisory_warning_when_checker_unresolved(self, mock_review):
+        """An 'unresolved' checker verdict is advisory: the reply still stages, and the
+        verdict is surfaced as a non-blocking warning instead of vetoing the reply."""
         from brain.systems.runs.direct_agent import _handle_cortex_reply, _agent_context
 
         class _Run:
@@ -2234,49 +2236,16 @@ class TestCortexReplyHandler:
                     "I got it materially closer, but I cannot honestly say we are fully ready yet."
                 )
 
-            assert result["blocked"] is True
-            assert result["checker_status"] == "continue"
-            assert "AgentRun recipe escalate" in result["instruction"]
-            mock_reply.assert_not_called()
-            assert _agent_context.reply_contents == []
-        finally:
-            _agent_context.idea_id = None
-            _agent_context.run = None
-            _agent_context.user_request = None
-            _agent_context.reply_contents = []
-            _agent_context.final_reply_review = None
-
-    @patch("brain.systems.runs.direct_agent.review_final_reply_once")
-    def test_cortex_reply_allows_concrete_dependency_blocker(self, mock_review):
-        from brain.systems.runs.direct_agent import _handle_cortex_reply, _agent_context
-
-        class _Run:
-            run_id = 42
-
-        mock_review.return_value = {
-            "status": "continue",
-            "approved": False,
-            "rationale": "The proposed reply does not complete the requested listing.",
-            "missing_requirements": ["List the cycles"],
-            "raw_output": "",
-        }
-        _agent_context.idea_id = "idea-123"
-        _agent_context.run = _Run()
-        _agent_context.user_request = "List my cycles"
-        _agent_context.reply_contents = []
-        _agent_context.final_reply_review = None
-
-        try:
-            with patch("brain.systems.cortex.reply.reply_to_cortex") as mock_reply:
-                result = _handle_cortex_reply(
-                    "I couldn't list your cycles because the cycles database migration is missing."
-                )
-
+            assert "blocked" not in result
             assert result["staged"] is True
             assert result["posted"] is False
-            assert result["checker_status"] == "blocked_on_user"
-            assert result["checker_override"] == "concrete_dependency_blocker"
+            assert result["checker_status"] == "continue"
+            assert result["checker_note"] == "The proposed reply admits the work is not ready yet."
+            assert "settlement" in result["instruction"]
             mock_reply.assert_not_called()
+            assert _agent_context.reply_contents == [
+                "I got it materially closer, but I cannot honestly say we are fully ready yet."
+            ]
         finally:
             _agent_context.idea_id = None
             _agent_context.run = None


### PR DESCRIPTION
## Problem

`_handle_cortex_reply` (in `brain/systems/runs/tool_catalog/handlers/cortex_reply.py`) called `review_final_reply_once` and, when the checker's status was not in `{resolved, blocked_on_user}`, **rejected** the reply with `{"blocked": True, "error": "Final reply checker rejected cortex_reply."}`.

This was an unappealable second-LLM veto: a complete, correct answer got bounced because a different model disagreed, forcing the agent into guess-and-retry loops that burn turns and tokens. A bolted-on `_looks_like_concrete_blocker_reply` escape hatch existed only to work around the gate misfiring on genuine dependency blockers.

## Change

The checker is now **advisory, not a gate**:

- `cortex_reply` always stages (run-scoped) or posts the reply — the checker can no longer veto it.
- The checker's verdict is surfaced as a **non-blocking warning** in the tool result via `checker_status` and a new `checker_note` (the checker's reasoning), so the model can decide for itself whether to continue or reply again.
- Removed the rejection/blocking branch and the now-unnecessary `_looks_like_concrete_blocker_reply` escape-hatch branch.

The checker is still **called**, and what it computes is unchanged (`final_reply_checker.py` untouched) — only its power to VETO is removed. The empty-reply guard (a separate deterministic check, not the LLM veto) is intentionally left in place.

## Tests

- Rewrote `test_cortex_reply_blocks_unresolved_final_message` → `test_cortex_reply_stages_reply_with_advisory_warning_when_checker_unresolved`: asserts an `unresolved` verdict now stages the reply and surfaces `checker_status`/`checker_note` instead of returning `blocked`.
- Removed `test_cortex_reply_allows_concrete_dependency_blocker` (validated the deleted escape hatch).
- Full suite green: **3137 passed, 59 skipped** (`pytest tests/ -m "not requires_db"`, torch tests excluded per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)