### PR TITLE
Finish killing introspection forcing: remove freshness heuristics + gate

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1702,22 +1702,17 @@ async def run_agent_async(
                     raw_archive_messages.append(copy.deepcopy(state.messages[-1]))
                 if guidance_count:
                     continue
-                output = _extract_text(state.messages)
-                # A heuristic-derived (non-explicit) required-introspection tool is a
-                # low-confidence guess. If the model already produced a substantial
-                # answer without it, forcing the detour now would discard real work and
-                # emit a runtime self-description instead (issue #249). Explicit routing
-                # metadata stays authoritative and is always honored.
-                _DERIVED_INTROSPECTION_ANSWER_LIMIT = 400
+                # Only an EXPLICIT routing directive (metadata["required_introspection_tool"])
+                # may force a hidden-context tool at end-of-turn. There is no heuristic
+                # forcing: guessed detours repeatedly hijacked completed answers with a
+                # runtime self-description (issue #249). A competent model calls its
+                # context tools voluntarily.
                 if (
-                    required_introspection_tool
+                    required_introspection_explicit
+                    and required_introspection_tool
                     and _tool_is_available(tools, required_introspection_tool)
                     and required_introspection_tool in tool_handlers
                     and required_introspection_tool not in state.tool_calls_made
-                    and (
-                        required_introspection_explicit
-                        or len(output.strip()) < _DERIVED_INTROSPECTION_ANSWER_LIMIT
-                    )
                 ):
                     _append_message_with_archive(
                         state.messages,

--- a/brain/systems/runs/introspection.py
+++ b/brain/systems/runs/introspection.py
@@ -1,80 +1,15 @@
 """Shared metadata helpers for questions that require hidden tool-backed context."""
 from __future__ import annotations
 
-import re
-
 from brain.systems.runs.message_metadata import (
     INTROSPECTION_MESSAGE_METADATA_KEYS,
     extract_latest_user_intent,
 )
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
-_PERSON_ACTIVITY_PATTERNS = (
-    re.compile(
-        r"\bwhat(?:'s| is| are| has| have| was| were| did| does)\s+"
-        r"[^?]{1,80}\s+(?:working on|been working on|doing|up to)\b"
-    ),
-    re.compile(
-        r"\bwho\s+(?:is|are|has|have|was|were)\s+[^?]{0,60}\b"
-        r"(?:working|active)\b"
-    ),
-)
-_WORKSPACE_ACTIVITY_PHRASES = (
-    "active cortex",
-    "active runs",
-    "active thoughts",
-    "latest activity",
-    "latest shared activity",
-    "latest signals",
-    "recent activity",
-    "team activity",
-    "teammate activity",
-    "workspace activity",
-)
-_WORKSPACE_OVERVIEW_PHRASES = (
-    "finish setting up this workspace",
-    "help me understand this workspace",
-    "help me finish setting up this workspace",
-    "introduce yourself",
-    "what can you see",
-    "what do you know about this workspace",
-    "what you should know about the team",
-    "what is this workspace",
-    "workspace overview",
-    "workspace setup",
-)
-_PROJECT_CONTEXT_PHRASES = (
-    "connected repo",
-    "connected repos",
-    "connected docs",
-    "project context",
-    "project contexts",
-    "what projects",
-)
-_WORKSPACE_RECORD_PHRASES = (
-    "domain records",
-    "structured records",
-    "team database",
-    "workspace records",
-)
+
 def _normalized_text(message: str | None) -> str:
     return " ".join((message or "").strip().lower().split())
-
-
-def _looks_like_workspace_activity_question(message: str | None) -> bool:
-    text = _normalized_text(message)
-    if not text:
-        return False
-    if any(pattern.search(text) for pattern in _PERSON_ACTIVITY_PATTERNS):
-        return True
-    return any(phrase in text for phrase in _WORKSPACE_ACTIVITY_PHRASES)
-
-
-def _looks_like_any_phrase(message: str | None, phrases: tuple[str, ...]) -> bool:
-    text = _normalized_text(message)
-    if not text:
-        return False
-    return any(phrase in text for phrase in phrases)
 
 
 def message_for_required_introspection(
@@ -95,62 +30,27 @@ def required_introspection_tool(
     *,
     explicit_tool: str | None = None,
 ) -> tuple[str | None, str | None]:
-    """Return a mandatory hidden-context tool from explicit routing metadata.
+    """Return a mandatory hidden-context tool ONLY from an explicit routing directive.
 
-    Explicit metadata is the preferred path. The small heuristic below is a guardrail
-    for high-risk freshness questions where answering from memory produces stale
-    workspace status.
+    There is deliberately NO heuristic/keyword forcing. A competent model calls the
+    context tools it needs — read_self_context, read_capabilities, read_team_activity,
+    read_workspace_overview, read_project_contexts, read_workspace_records — voluntarily,
+    because they are in its registry and its tool descriptions point at them.
+
+    End-of-turn forcing of *guessed* tools was the source of the recurring
+    "introspection hijack": a regex/keyword match on an ordinary work request (e.g.
+    "set … up", "where … source", "what is X working on") force-injected a tool whose
+    output then replaced the model's completed answer with the wrong thing (issue #249
+    and ~30% of production runs). Only an explicit ``required_introspection_tool``
+    metadata directive is honored here; nothing in the app currently sets one, so in
+    practice this never forces. The ``message`` argument is retained for call-site
+    compatibility.
     """
     tool = _normalized_text(explicit_tool)
-    registration = get_tool_registration(tool) if tool else None
+    if not tool:
+        return None, None
+    registration = get_tool_registration(tool)
     if registration and registration.context_route is not None:
         route = registration.context_route
         return tool, f"This question requires {tool}. {route.description}"
-    # NOTE: The self-description tools read_self_context and read_capabilities are
-    # deliberately NOT force-routed here. Their triggers ("who are you", "set … up",
-    # "where … source") also appear inside ordinary *work* requests, so forcing them at
-    # end-of-turn repeatedly hijacked completed work and replaced the answer with a
-    # runtime self-description (issue #249 and its recurrences). Both tools remain
-    # available for the model to call voluntarily when a question genuinely needs them.
-    if _looks_like_any_phrase(message, _WORKSPACE_OVERVIEW_PHRASES):
-        tool = "read_workspace_overview"
-        registration = get_tool_registration(tool)
-        if registration and registration.context_route is not None:
-            route = registration.context_route
-            return (
-                tool,
-                f"This question asks for a current workspace overview or setup status. Use {tool} "
-                f"before answering from memory. {route.description}",
-            )
-    if _looks_like_any_phrase(message, _PROJECT_CONTEXT_PHRASES):
-        tool = "read_project_contexts"
-        registration = get_tool_registration(tool)
-        if registration and registration.context_route is not None:
-            route = registration.context_route
-            return (
-                tool,
-                f"This question asks what project context is connected. Use {tool} "
-                f"before answering from memory. {route.description}",
-            )
-    if _looks_like_any_phrase(message, _WORKSPACE_RECORD_PHRASES):
-        tool = "read_workspace_records"
-        registration = get_tool_registration(tool)
-        if registration and registration.context_route is not None:
-            route = registration.context_route
-            return (
-                tool,
-                f"This question asks about structured workspace records. Use {tool} "
-                f"before answering from memory. {route.description}",
-            )
-    if _looks_like_workspace_activity_question(message):
-        tool = "read_team_activity"
-        registration = get_tool_registration(tool)
-        if registration and registration.context_route is not None:
-            route = registration.context_route
-            return (
-                tool,
-                f"This question asks for current workspace/team activity. Use {tool} "
-                f"with a recent time window and person filter when relevant before "
-                f"answering from memory. {route.description}",
-            )
     return None, None

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -329,14 +329,12 @@ def test_context_route_surface_is_registry_driven():
     assert "workspace setup" in routes["read_workspace_overview"]["domains"]
 
 
-def test_workspace_activity_question_requires_workspace_data():
+def test_workspace_activity_question_is_not_force_routed():
+    # No heuristic forcing remains: "what is X working on" is answered by the model
+    # calling read_team_activity voluntarily, not by an end-of-turn forced detour.
     from brain.systems.runs.introspection import required_introspection_tool
 
-    tool, message = required_introspection_tool("Hey illo what is Alex working on?")
-
-    assert tool == "read_team_activity"
-    assert message is not None
-    assert "current workspace/team activity" in message
+    assert required_introspection_tool("Hey illo what is Alex working on?") == (None, None)
 
 
 def test_capability_question_is_not_force_routed():
@@ -404,20 +402,19 @@ def test_work_request_that_mentions_skill_and_cycle_does_not_require_capabilitie
 
 
 def test_run_introspection_uses_current_human_message_over_thread_wrapper():
+    # message_for_required_introspection extracts the operator's latest message from a
+    # decorated thread wrapper, and prefers an explicit human_message metadata field.
+    # (Nothing is force-routed anymore regardless of content — asserted for good measure.)
     from brain.systems.runs.introspection import (
         message_for_required_introspection,
         required_introspection_tool,
     )
 
-    # The wrapper text would trip a freshness requirement (read_team_activity); the actual
-    # latest human message ("where are the results ?") should not. Routing must evaluate the
-    # human message, not the decorated wrapper.
     wrapped_message = (
         '[Idea: "what is Alex working on this week" | idea-1]\n\n'
         "where are the results ?"
     )
 
-    assert required_introspection_tool(wrapped_message)[0] == "read_team_activity"
     assert message_for_required_introspection(wrapped_message) == "where are the results ?"
 
     selected = message_for_required_introspection(
@@ -426,6 +423,7 @@ def test_run_introspection_uses_current_human_message_over_thread_wrapper():
     )
 
     assert selected == "where are the results ?"
+    assert required_introspection_tool(wrapped_message) == (None, None)
     assert required_introspection_tool(selected) == (None, None)
 
 


### PR DESCRIPTION
Follow-up to #257 (merged). #257 removed the two *self-description* tools (`read_self_context`, `read_capabilities`) from the end-of-turn forcing. This removes the **remaining** heuristic forcing so the class is closed entirely.

## What

- Deletes the freshness branches from `required_introspection_tool()` — `read_team_activity`, `read_workspace_overview`, `read_project_contexts`, `read_workspace_records` — plus all the now-dead keyword/regex predicates (`_PERSON_ACTIVITY_PATTERNS`, `_WORKSPACE_*_PHRASES`, `_looks_like_*`). `introspection.py` drops from ~270 lines to ~55.
- `required_introspection_tool()` now honors **only** an explicit `metadata["required_introspection_tool"]` directive. A grep confirms **nothing in the app sets one**, so end-of-turn forcing now never fires in practice.
- `direct_agent.py`: removes the 400-char `_DERIVED_INTROSPECTION_ANSWER_LIMIT` gate and the derived-forcing clause; the block now only forces on an explicit directive (kept as a harmless, intentional hook).

## Why

A production trace audit found the introspection hijack in **~30% of runs** (read_self_context 33, read_capabilities 12 of 150 sampled) — one daily cycle was 24-for-24 useless, and run 892's SEO check got eaten and re-run for 18 min. #257 fixed the dominant part; the freshness heuristic is the same anti-pattern (guessed tool overwrites completed work), just lower-frequency. The context tools stay fully registered and the model is guided to call them **voluntarily** — so real "what's the team doing?" questions still get grounded answers; only the *forcing* is gone.

## Tests

Freshness-forcing assertions updated to `(None, None)`; the `message_for_required_introspection` extraction test retained. **Full non-DB suite: 3138 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)