### PR TITLE
Simplify inbound submission: preservation hint + raw operator message

### DIFF
--- a/brain/systems/inbound/preservation.py
+++ b/brain/systems/inbound/preservation.py
@@ -207,22 +207,7 @@ def submission_preservation_contract(normalized: Mapping[str, Any]) -> dict[str,
 
 
 def submission_preservation_prompt_lines(contract: Mapping[str, Any]) -> list[str]:
-    if contract.get("requires_durable_evidence"):
-        visibility = contract.get("visibility_hint") or "the narrowest visibility that preserves future utility"
-        return [
-            "",
-            "Preservation workflow:",
-            "- This submission explicitly asks Illo to preserve knowledge or work material.",
-            "- The inbound event is only raw source evidence; by itself it is not enough to satisfy preservation.",
-            "- First inspect the full event with manage_inbound(action='get_event', event_id=..., include_receipts=true) if the preview is insufficient.",
-            "- Decide the right durable surface: reconstructive memory for reusable lessons/procedures, a Domain/doc/project record for canonical structured knowledge, a handoff when this should launch future work, or a thread note when team visibility matters.",
-            "- Prefer memory_ingest_source with source_kind='inbound_submission', source_ref equal to the inbound event id, and visibility set to "
-            f"{visibility}.",
-            "- Use manage_domain/manage_project/create_launch_handoff/thread tools when those are the better Illo-owned storage surfaces.",
-            "- Avoid direct source duplication when a matching durable record already exists; update or link to the existing object instead.",
-            "- Final answer must list what Illo decided, every durable handle created or updated, and any reason no durable write was appropriate.",
-        ]
-    if contract.get("intent") == "possible_preservation":
+    if contract.get("requires_durable_evidence") or contract.get("intent") == "possible_preservation":
         return [
             "",
             "Possible preservation workflow:",

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -1103,7 +1103,7 @@ async def _queue_illo_submission(
 
     source_name = context.display_name or context.source_kind or "external source"
     preservation = submission_preservation_contract(normalized)
-    message = _submission_prompt(context=context, event=event, normalized=normalized)
+    message = _submission_prompt(normalized=normalized)
     result = await admit_work(
         session,
         WorkIntakeEvent(
@@ -1129,10 +1129,10 @@ async def _queue_illo_submission(
                     "execution_profile": "fast",
                     "origin": normalized.get("origin"),
                     # Route required-introspection detection off the operator's actual
-                    # request, not the coordination wrapper prompt (issue #249). The
-                    # wrapper embeds boilerplate like "Source metadata:" that can trip
-                    # the self-context heuristic and hijack the final answer with a
-                    # runtime self-description.
+                    # request rather than any surrounding coordination text (issue #249).
+                    # The run message now leads with the raw operator message and origin/
+                    # source/constraints live in metadata, but keep this tag as the
+                    # authoritative human-message signal for introspection routing.
                     "human_message": normalized.get("message"),
                     "inbound_event": _inbound_event_metadata(context, event, normalized, None),
                     "submission": {
@@ -1164,36 +1164,19 @@ async def _queue_illo_submission(
     return handling
 
 
-def _submission_prompt(
-    *,
-    context: _ConnectionContext,
-    event: InboundEventRow,
-    normalized: Mapping[str, Any],
-) -> str:
-    source_name = context.display_name or context.source_kind or "external source"
+def _submission_prompt(*, normalized: Mapping[str, Any]) -> str:
+    """Build the run message with the operator's raw request as the primary content.
+
+    Origin, source, constraints, and correlation are NOT embedded as authoritative
+    prompt text (that "Source metadata:" envelope is what tripped issue #249). They
+    are carried as structured run metadata in the ``submission`` payload instead.
+    """
+
     preservation = submission_preservation_contract(normalized)
-    lines = [
-        "Handle this external coordination submission.",
-        "",
-        f"Inbound event: {event.id}",
-        f"Origin: {normalized.get('origin') or event.origin}",
-        f"Source: {source_name}",
-        "",
-        "Message:",
-        str(normalized.get("message") or normalized.get("summary") or ""),
-    ]
+    lines = [str(normalized.get("message") or normalized.get("summary") or "")]
     parts = list(normalized.get("parts") or [])
     if parts:
         lines.extend(["", f"Context parts: {len(parts)}", _json_preview(parts, limit=MAX_TRIAGE_PAYLOAD_CHARS)])
-    for label, key in (
-        ("Source metadata", "source"),
-        ("Constraints", "constraints"),
-        ("Correlation", "correlation"),
-        ("Response hints", "response"),
-    ):
-        value = normalized.get(key)
-        if value:
-            lines.extend(["", f"{label}:", _json_preview(value, limit=1200)])
     lines.extend(submission_preservation_prompt_lines(preservation))
     lines.extend(
         [

--- a/tests/test_inbound_preservation.py
+++ b/tests/test_inbound_preservation.py
@@ -182,12 +182,21 @@ async def test_preservation_submission_gets_curator_prompt_and_contract(session)
     event = await session.get(InboundEventRow, result["event_id"])
 
     assert run is not None
-    assert "Preservation workflow:" in run.input_message
-    assert "memory_ingest_source" in run.input_message
+    # The mandatory preservation preamble is now a soft hint, not a storage mandate,
+    # so the operator's real request is no longer buried under ceremony.
+    assert "Possible preservation workflow:" in run.input_message
+    assert "Treat this as a hint, not a storage mandate." in run.input_message
+    assert "Final answer must list" not in run.input_message
+    # The raw operator message leads the run prompt; source/constraints are metadata only.
+    assert run.input_message.startswith(envelope["message"])
+    assert "Source metadata:" not in run.input_message
     preservation = run.metadata_["submission"]["preservation"]
     assert preservation["requires_durable_evidence"] is True
     assert preservation["intent"] == "preserve_knowledge"
     assert preservation["detection_source"] == "desired_outcome"
+    # Origin/source/constraints are carried as structured run metadata, not prompt text.
+    assert run.metadata_["submission"]["source"] == envelope["source"]
+    assert run.metadata_["submission"]["constraints"] == envelope["constraints"]
     assert event is not None
     assert event.action_result["preservation"]["requires_durable_evidence"] is True
 
@@ -218,11 +227,12 @@ async def test_language_only_preservation_match_is_prompt_hint_not_evidence_cont
 
 
 async def test_submission_tags_human_message_for_introspection_routing(session):
-    # Regression for issue #249: the headless submission wrapper embeds boilerplate
-    # ("Handle this external coordination submission.", "Source metadata:") that can
-    # trip the self-context heuristic and hijack the final answer with a runtime
-    # self-description. The operator's clean message must be tagged as human_message so
-    # required-introspection routing evaluates the request, not the wrapper prompt.
+    # Regression for issue #249: the headless submission wrapper used to embed
+    # boilerplate ("Handle this external coordination submission.", "Source metadata:")
+    # that could trip the self-context heuristic and hijack the final answer with a
+    # runtime self-description. The prompt now leads with the operator's raw message and
+    # keeps origin/source in metadata, and the clean message is still tagged as
+    # human_message so required-introspection routing evaluates the request.
     from brain.systems.runs import introspection as run_introspection
 
     principal = await _seed_connection(session)
@@ -247,6 +257,11 @@ async def test_submission_tags_human_message_for_introspection_routing(session):
     handling = await _assert_queued_submission(session, result["ilo_outcome"])
     run = await session.get(AgentRunRow, handling["run_id"])
     assert run is not None
+    # The wrapper envelope is gone: the run prompt leads with the raw operator message
+    # and no longer embeds the "Source metadata:" boilerplate that caused the false-match.
+    assert run.input_message.startswith(message)
+    assert "Handle this external coordination submission." not in run.input_message
+    assert "Source metadata:" not in run.input_message
     # The clean operator message is tagged for introspection routing...
     assert run.metadata_["human_message"] == message
     # ...and routing resolves to it rather than the wrapper prompt persisted as


### PR DESCRIPTION
## Why

Two coupled over-engineered surfaces in the inbound submission path were burying the operator's real coordination request under harness ceremony.

## Changes

**1. Preservation mandate → soft hint** (`brain/systems/inbound/preservation.py`)
When `requires_durable_evidence=True`, `submission_preservation_prompt_lines` prepended a multi-line MANDATORY preamble ("Final answer must list what Illo decided, every durable handle created or updated, and any reason no durable write was appropriate"). This forced operators to invent a durable record or pad the final answer justifying its omission, burying the real answer. It now reuses the softer `possible_preservation` phrasing ("Treat this as a hint, not a storage mandate. If durable storage is appropriate, list the durable handle").

`preservation_evidence_result()` is kept unchanged as telemetry. Reconciliation (`reconciliation.py`) still escalates a genuinely-missing required write to `review_required` and records the reason on the event — nothing is silently swallowed.

**2. Submission wrapper → raw operator message** (`brain/systems/inbound/service.py`)
`_submission_prompt` wrapped the operator's message in a `Message:/Source metadata:/Constraints:/Correlation:/Response hints:` envelope that the model (and historically the introspection heuristics) treated as authoritative — the exact `Source metadata:` surface behind issue #249, previously patched with the `human_message` metadata band-aid. The run message now leads with the raw `normalized["message"]`; origin/source/constraints/correlation are carried only as structured run metadata (the `submission` payload in `_queue_illo_submission` already holds them). The `human_message` metadata tag stays for introspection routing. The now-unused `context`/`event` params were dropped from `_submission_prompt`.

## Tests

`tests/test_inbound_preservation.py` updated to assert the soft-hint behavior and raw-message-first prompt. Full non-DB suite green: **3138 passed, 59 skipped, 23 deselected**.

Run: `venv/bin/python -m pytest tests/ -m "not requires_db" -q --ignore=tests/test_gpu_server.py --ignore=tests/test_llm_worker.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)