### PR TITLE
Loop hygiene: de-splice nudges, honest stuck notice, drop budget regex grace

### DIFF
--- a/brain/systems/budget.py
+++ b/brain/systems/budget.py
@@ -16,7 +16,6 @@ and we want to stop the bleeding, not silently degrade quality.
 
 import logging
 import os
-import re
 from datetime import datetime, timezone, timedelta
 from typing import Any, Iterable
 
@@ -50,17 +49,7 @@ MAX_TOOL_RESULT_CHARS = int(os.environ.get("BUDGET_MAX_TOOL_RESULT_CHARS", "1500
 # Context limits for run
 MAX_THREAD_SUMMARY_CHARS = int(os.environ.get("BUDGET_MAX_THREAD_SUMMARY_CHARS", "2000"))
 MAX_LAST_MESSAGES = int(os.environ.get("BUDGET_MAX_LAST_MESSAGES", "5"))
-REPAIR_GRACE_MULTIPLIER = float(os.environ.get("BUDGET_REPAIR_GRACE_MULTIPLIER", "1.75"))
-REPAIR_MAX_ESTIMATED_INPUT = int(os.environ.get("BUDGET_REPAIR_MAX_ESTIMATED_INPUT", "120000"))
 BUDGET_STATUSES = ("completed", "running")
-
-_REPAIR_TASK_RE = re.compile(
-    r"(?i)\b("
-    r"brain|memory|recall|context|migration|schema|db|database|pgvector|cursor|"
-    r"transaction|graph|guardrail|circuit breaker|budget|diagnos\w*|investigat\w*|"
-    r"debug\w*|repair|hotfix|root cause|backend"
-    r")\b"
-)
 
 
 class BudgetDecision:
@@ -77,13 +66,6 @@ class BudgetDecision:
 
     def __repr__(self):
         return f"BudgetDecision(allowed={self.allowed}, reason={self.reason!r})"
-
-
-def _looks_like_repair_task(task_description: str | None) -> bool:
-    """Return True for bounded repair/diagnostic tasks that deserve grace."""
-    if not task_description:
-        return False
-    return bool(_REPAIR_TASK_RE.search(task_description))
 
 
 def _coerce_int(value: Any) -> int:
@@ -182,8 +164,7 @@ async def _async_summarize_token_totals(
 
 
 async def check_budget(idea_id: str, estimated_input_tokens: int,
-                       model: str | None = None,
-                       task_description: str | None = None) -> BudgetDecision:
+                       model: str | None = None) -> BudgetDecision:
     """Check if a run should proceed.
 
     Normal usage: always allowed, maybe logs a warning.
@@ -213,23 +194,8 @@ async def check_budget(idea_id: str, estimated_input_tokens: int,
                     f"in last hour (warn threshold: {WARN_PER_IDEA_HOUR:,})"
                 )
 
-            repair_like = _looks_like_repair_task(task_description)
-            repair_grace_limit = int(CIRCUIT_BREAKER_PER_IDEA_HOUR * REPAIR_GRACE_MULTIPLIER)
-
             # Circuit breaker: something is catastrophically wrong
             if idea_hour_tokens > CIRCUIT_BREAKER_PER_IDEA_HOUR:
-                if repair_like and idea_hour_tokens <= repair_grace_limit and estimated_input_tokens <= REPAIR_MAX_ESTIMATED_INPUT:
-                    warning = (
-                        f"Closure mode: idea {idea_id[:8]}… is over the normal breaker "
-                        f"({idea_hour_tokens:,}/{CIRCUIT_BREAKER_PER_IDEA_HOUR:,}) but task "
-                        f"looks like bounded repair work. Allowing one more run."
-                    )
-                    logger.warning(warning)
-                    return BudgetDecision(
-                        allowed=True,
-                        warning=warning,
-                        closure_mode=True,
-                    )
                 logger.error(
                     f"CIRCUIT BREAKER: idea {idea_id[:8]}… used {idea_hour_tokens:,} tokens "
                     f"in last hour. Stopping to prevent runaway."
@@ -256,19 +222,6 @@ async def check_budget(idea_id: str, estimated_input_tokens: int,
                 )
 
             if daily_tokens > CIRCUIT_BREAKER_PER_DAY:
-                repair_grace_daily = int(CIRCUIT_BREAKER_PER_DAY * REPAIR_GRACE_MULTIPLIER)
-                if repair_like and daily_tokens <= repair_grace_daily and estimated_input_tokens <= REPAIR_MAX_ESTIMATED_INPUT:
-                    warning = (
-                        f"Closure mode: daily usage is over the normal breaker "
-                        f"({daily_tokens:,}/{CIRCUIT_BREAKER_PER_DAY:,}) but task "
-                        f"looks like bounded repair work. Allowing one more run."
-                    )
-                    logger.warning(warning)
-                    return BudgetDecision(
-                        allowed=True,
-                        warning=warning,
-                        closure_mode=True,
-                    )
                 logger.error(
                     f"CIRCUIT BREAKER: {daily_tokens:,} tokens used today. "
                     f"Stopping all runs."

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1750,14 +1750,21 @@ async def run_agent_async(
                     max_parallel_tool_calls=max_parallel_tool_calls,
                 )
 
-                # Inject system nudges
-                _inject_nudges(tool_results, state.recent_calls, response, session_id, agent_context=_agent_context)
-
                 _append_message_with_archive(
                     state.messages,
                     {"role": "user", "content": tool_results},
                     raw_archive_messages,
                 )
+
+                # Durable reminder (e.g. `cd` non-persistence), sent as its own
+                # message AFTER tool_results — never spliced into tool output.
+                reminder_message = _inject_nudges(state.recent_calls)
+                if reminder_message is not None:
+                    _append_message_with_archive(
+                        state.messages,
+                        reminder_message,
+                        raw_archive_messages,
+                    )
                 state.messages, _ = _maybe_compact_active_context(
                     state.messages,
                     session_id=session_id,

--- a/brain/systems/runs/direct_loop/loop_control.py
+++ b/brain/systems/runs/direct_loop/loop_control.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import logging
 
 logger = logging.getLogger("agent")
 
 _STUCK_WARN_THRESHOLD = 3
 _STUCK_BREAK_THRESHOLD = 5
-_CONSOLIDATION_TOOLS = {"exec_command", "search_files", "read_file", "list_files"}
 
 
 def _detect_stuck_loop(
@@ -30,77 +28,37 @@ def _detect_stuck_loop(
     repeat_count = sum(1 for fp in reversed(recent_calls) if fp == tail[0])
     if repeat_count >= break_threshold:
         logger.warning("Agent %s: stuck loop (%d identical calls). Breaking.", session_id, repeat_count)
-        messages.append({"role": "assistant", "content": [
-            {"type": "text", "text": "[Agent terminated: stuck in a loop repeating the same tool call]"},
+        messages.append({"role": "user", "content": [
+            {"type": "text", "text": "[System: Agent terminated: stuck in a loop repeating the same tool call]"},
         ]})
         return True
     return False
 
 
 def _inject_nudges(
-    tool_results: list,
     recent_calls: list[str],
-    response,
-    session_id: str,
     *,
-    agent_context=None,
     warn_threshold: int = _STUCK_WARN_THRESHOLD,
-    consolidation_tools: set[str] | frozenset[str] = _CONSOLIDATION_TOOLS,
-) -> None:
-    """Inject stuck warnings, consolidation nudges, and progress checks."""
+) -> dict | None:
+    """Return a standalone reminder message, or None if nothing to say.
 
-    if agent_context is None:
-        from brain.systems.runs.tool_handlers import _agent_context as agent_context
+    Strategy is the model's job — the harness does not second-guess it (no
+    "try a different strategy" / "consolidate into a script" / "is this reply
+    adding new information" nudges). The only thing worth surfacing here is a
+    durable, non-obvious mechanical fact that trips models up repeatedly.
+    The caller appends the returned message AFTER the tool_results message —
+    it must never be spliced into the tool_results content array.
+    """
 
-    # Stuck warning (not yet at break threshold)
     if (
         len(recent_calls) >= warn_threshold
         and len(set(recent_calls[-warn_threshold:])) == 1
     ):
-        tool_results.append({
-            "type": "text",
-            "text": (
-                "[System: You are repeating the same tool call. Try a different strategy. "
-                "NOTE: `cd` does not persist between exec_command calls; use `working_dir` or absolute paths.]"
+        return {
+            "role": "user",
+            "content": (
+                "[System: NOTE: `cd` does not persist between exec_command calls; "
+                "use `working_dir` or absolute paths.]"
             ),
-        })
-
-    # Consolidation nudge (3+ consecutive same tool)
-    if len(recent_calls) >= 3:
-        names = [fp.split(":", 1)[0] for fp in recent_calls[-3:]]
-        if (
-            len(set(names)) == 1
-            and names[0] in consolidation_tools
-            and not (
-                len(recent_calls) >= warn_threshold
-                and len(set(recent_calls[-warn_threshold:])) == 1
-            )
-        ):
-            tool_results.append({
-                "type": "text",
-                "text": (
-                    f"[System: {len(names)} consecutive {names[0]} calls — consider "
-                    "writing a single script via `run_script` instead.]"
-                ),
-            })
-
-    # Progress injection after cortex_reply
-    reply_contents = getattr(agent_context, "reply_contents", [])
-    reply_names = [block.name for block in response.content if hasattr(block, "name")]
-    if "cortex_reply" in reply_names and len(reply_contents) > 1:
-        tool_log = getattr(agent_context, "tool_calls_log", [])
-        tool_counts: dict[str, int] = {}
-        for tool_name in tool_log:
-            tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
-        previous_replies = [
-            f"  Reply {index}: {content[:150]}…"
-            for index, content in enumerate(reply_contents[:-1], 1)
-        ]
-        tool_results.append({
-            "type": "text",
-            "text": (
-                f"[System: {len(reply_contents)} replies staged. Tools: {json.dumps(tool_counts)}.\n"
-                f"Previous:\n" + "\n".join(previous_replies) + "\n"
-                "Is your latest reply adding NEW information? If done, end your turn.]"
-            ),
-        })
+        }
+    return None

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -345,7 +345,27 @@ class TestRuntimeExtractionContracts:
 
         messages = []
         assert _detect_stuck_loop(["read_file:{}"] * 5, "session-1", messages)
+        # The fabricated stuck message must not masquerade as model output.
+        assert messages[-1]["role"] == "user"
         assert "stuck in a loop" in messages[-1]["content"][0]["text"]
+
+    def test_inject_nudges_returns_only_durable_reminder(self):
+        from brain.systems.runs.direct_loop.loop_control import _inject_nudges
+
+        # Below the warn threshold: nothing to say.
+        assert _inject_nudges(["read_file:{}"]) is None
+
+        # 3 identical calls: durable `cd` reminder, no strategy second-guessing.
+        message = _inject_nudges(["read_file:{}"] * 3)
+        assert message is not None
+        assert message["role"] == "user"
+        assert "cd` does not persist" in message["content"]
+        assert "different strategy" not in message["content"]
+        assert "run_script" not in message["content"]
+        assert "adding NEW information" not in message["content"]
+
+        # Non-repeating calls: no reminder.
+        assert _inject_nudges(["read_file:{}", "write_file:{}", "list_files:{}"]) is None
 
     def test_session_effects_apply_auto_harvest_and_save(self):
         from brain.systems.runs.direct_loop.session_effects import apply_agent_session_side_effects

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -117,19 +117,6 @@ class TestCheckBudget:
         assert not result.allowed
         assert "circuit breaker" in result.reason.lower()
 
-    async def test_repair_task_gets_hourly_closure_grace(self):
-        mock_uow = _make_uow()
-        with patch("brain.systems.budget.UnitOfWork", return_value=mock_uow), \
-             _patch_budget_usage(CIRCUIT_BREAKER_PER_IDEA_HOUR + 100000):
-            result = await check_budget(
-                "test-idea-id",
-                40000,
-                task_description="Fix brain DB migration and cursor recall bug",
-            )
-        assert result.allowed
-        assert result.closure_mode
-        assert "closure mode" in result.warning.lower()
-
     async def test_circuit_breaker_daily(self):
         """Circuit breaker fires on catastrophic daily token usage."""
         mock_uow = _make_uow()
@@ -139,28 +126,14 @@ class TestCheckBudget:
         assert not result.allowed
         assert "circuit breaker" in result.reason.lower()
 
-    async def test_repair_task_gets_daily_closure_grace(self):
-        mock_uow = _make_uow()
-        with patch("brain.systems.budget.UnitOfWork", return_value=mock_uow), \
-             _patch_budget_usage(50000, CIRCUIT_BREAKER_PER_DAY + 1000000):
-            result = await check_budget(
-                "test-idea-id",
-                40000,
-                task_description="Investigate brain recall transaction failure",
-            )
-        assert result.allowed
-        assert result.closure_mode
-
-    async def test_large_repair_run_still_blocked(self):
+    async def test_circuit_breaker_hourly_ignores_task_description(self):
+        """No text-sniffing grace: any task description still trips the breaker."""
         mock_uow = _make_uow()
         with patch("brain.systems.budget.UnitOfWork", return_value=mock_uow), \
              _patch_budget_usage(CIRCUIT_BREAKER_PER_IDEA_HOUR + 100000):
-            result = await check_budget(
-                "test-idea-id",
-                250000,
-                task_description="Fix brain DB migration and cursor recall bug",
-            )
+            result = await check_budget("test-idea-id", 40000)
         assert not result.allowed
+        assert not result.closure_mode
 
     async def test_opus_never_downgraded(self):
         """Opus model is NEVER downgraded — model choice is not budget's job."""


### PR DESCRIPTION
## Summary

Three small mechanical simplifications to `brain/` loop control and budget guardrails, all under the theme "stop the harness from second-guessing a competent model's strategy."

- **Nudge splicing** (`brain/systems/runs/direct_loop/loop_control.py`, `_inject_nudges`): removed the strategy-second-guessing nudges that were spliced directly into the `tool_results` content array — "you are repeating the same tool call, try a different strategy," "consider consolidating into `run_script`," and the post-`cortex_reply` "is this reply adding new information?" progress check. Strategy is the model's job, not the harness's. The one genuinely durable, non-obvious reminder (`cd` does not persist between `exec_command` calls) is kept, but now returned by `_inject_nudges` as a standalone message appended *after* the tool_results message in `direct_agent.py`, instead of being mixed into real tool output.

- **Fabricated stuck message** (`loop_control.py`, `_detect_stuck_loop`): the stuck-loop detector (5 byte-identical tool-call fingerprints) is unchanged, but the injected `"[Agent terminated: stuck…]"` message no longer masquerades as `role: "assistant"` output — it's now a `role: "user"` system notice, since the model never said it.

- **Budget regex grace** (`brain/systems/budget.py`, `check_budget`): deleted the text-sniffing grace multiplier that relaxed the token circuit breaker by 1.75x whenever the task description matched a regex of words like `brain|debug|repair|database|backend|...`. Removed `_looks_like_repair_task`, `_REPAIR_TASK_RE`, `REPAIR_GRACE_MULTIPLIER`, and both closure-mode grace branches (hourly + daily). The real numeric circuit-breaker comparisons (`CIRCUIT_BREAKER_PER_IDEA_HOUR`, `CIRCUIT_BREAKER_PER_DAY`) are untouched — this only removes the description-matching escape hatch. `check_budget` no longer takes a `task_description` parameter since nothing consumes it.

## Test plan

- [x] Updated `tests/test_agent_split.py`: stuck-message role assertion (`user`, not `assistant`), new test asserting `_inject_nudges` returns only the durable `cd` reminder and never the removed strategy nudges.
- [x] Updated `tests/test_budget.py`: removed the repair-task closure-grace tests, added a test asserting the circuit breaker still fires regardless of task description (no more text-sniffing grace).
- [x] Full suite: `venv/bin/python -m pytest tests/ -m "not requires_db" -q --ignore=tests/test_gpu_server.py --ignore=tests/test_llm_worker.py` → **3137 passed, 59 skipped, 23 deselected**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)