### PR TITLE
Add GitHub App minted-credential Vault primitive

### DIFF
--- a/brain/app/api/routers/vault.py
+++ b/brain/app/api/routers/vault.py
@@ -1,6 +1,7 @@
 """Vault router — org secret management, lock state, and audit."""
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -16,6 +17,7 @@ from brain.app.api.schemas.vault import (
     SecretReveal,
     VaultProjectBindingCreate,
     VaultProjectBindingRead,
+    validate_github_app_secret_value,
 )
 
 
@@ -33,6 +35,7 @@ class SecretUpdate(BaseModel):
     description: str | None = None
     category: str | None = None
     agent_access_level: str | None = Field(default=None, pattern="^(available|ask|manual)$")
+    model_config = {"hide_input_in_errors": True}
 
 
 class AgentGrantApproval(BaseModel):
@@ -80,6 +83,35 @@ def _raise_if_vault_not_configured(exc: RuntimeError) -> None:
         status_code=503,
         detail="Vault master key is not configured. Set VAULT_MASTER_KEY before saving or revealing secrets.",
     ) from exc
+
+
+def _masked_github_app_reveal(value: str) -> str:
+    try:
+        payload = json.loads(value)
+        if not isinstance(payload, dict):
+            raise ValueError
+        app_id = str(int(str(payload.get("app_id") or "").strip()))
+        installation_id = str(int(str(payload.get("installation_id") or "").strip()))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        raise HTTPException(
+            status_code=422,
+            detail="GitHub App credential cannot be revealed because the stored value is invalid.",
+        ) from None
+
+    masked = {
+        "app_id": app_id,
+        "installation_id": installation_id,
+    }
+    client_id = payload.get("client_id")
+    if isinstance(client_id, str):
+        clean_client_id = client_id.strip()
+        if clean_client_id and "\n" not in clean_client_id and len(clean_client_id) <= 128:
+            masked["client_id"] = clean_client_id
+    return json.dumps(masked, sort_keys=True)
+
+
+def _github_app_update_422(detail: str) -> HTTPException:
+    return HTTPException(status_code=422, detail=detail)
 
 
 async def _async_require_unlocked(request: Request, user: dict[str, Any]) -> None:
@@ -150,6 +182,20 @@ async def update_secret(
     if not secret:
         raise HTTPException(status_code=404, detail="Secret not found")
     updates = body.model_dump(exclude_unset=True)
+    effective_category = updates.get("category", getattr(secret, "category", None))
+    effective_level = updates.get("agent_access_level", getattr(secret, "agent_access_level", None))
+    if effective_category == "github_app":
+        try:
+            normalized_level = normalize_agent_access_level(effective_level)
+        except ValueError as exc:
+            raise _github_app_update_422(str(exc)) from exc
+        if normalized_level != "manual":
+            raise _github_app_update_422("github_app secrets must be stored with agent_access_level 'manual'")
+        if "value" in updates:
+            try:
+                validate_github_app_secret_value(updates["value"])
+            except ValueError as exc:
+                raise _github_app_update_422(str(exc)) from exc
     if "value" in updates:
         try:
             await async_set_secret(
@@ -329,16 +375,19 @@ async def reveal_secret(
     user: dict[str, Any] = Depends(get_current_user),
 ):
     await _async_require_unlocked(request, user)
-    from brain.systems.vault import async_reveal_secret as _reveal
+    from brain.systems.vault import async_get_secret_record, async_reveal_secret as _reveal
 
     org_id, actor_user_id = _vault_identity(user)
     try:
+        secret = await async_get_secret_record(key_name, actor_user_id, org_id=org_id)
         value = await _reveal(key_name, actor_user_id=actor_user_id, org_id=org_id)
     except RuntimeError as exc:
         _raise_if_vault_not_configured(exc)
         raise
     if value is None:
         raise HTTPException(status_code=404, detail="Secret not found")
+    if getattr(secret, "category", None) == "github_app":
+        value = _masked_github_app_reveal(value)
     return SecretReveal(key_name=key_name, value=value)
 
 

--- a/brain/app/api/schemas/vault.py
+++ b/brain/app/api/schemas/vault.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, model_validator
+
+
+def validate_github_app_secret_value(value: str) -> None:
+    try:
+        payload = json.loads(value)
+    except Exception:
+        raise ValueError("github_app value must be valid JSON") from None
+    if not isinstance(payload, dict):
+        raise ValueError("github_app value must be a JSON object")
+    for field in ("app_id", "installation_id", "private_key_pem"):
+        raw_value = payload.get(field)
+        if field == "private_key_pem":
+            valid = isinstance(raw_value, str) and bool(raw_value.strip())
+        else:
+            valid = (
+                raw_value is not None
+                and raw_value is not True
+                and raw_value is not False
+                and bool(str(raw_value).strip())
+            )
+        if not valid:
+            raise ValueError(f"github_app value requires non-empty {field}")
+    private_key_pem = str(payload.get("private_key_pem") or "").strip()
+    if not private_key_pem.startswith("-----BEGIN"):
+        raise ValueError("github_app private_key_pem must start with a PEM header")
 
 
 class SecretRead(BaseModel):
@@ -33,6 +59,16 @@ class SecretCreate(BaseModel):
     description: str = ""
     category: str = "general"
     agent_access_level: str = Field(default="ask", pattern="^(available|ask|manual)$")
+    model_config = {"hide_input_in_errors": True}
+
+    @model_validator(mode="after")
+    def validate_github_app_value(self) -> "SecretCreate":
+        if self.category != "github_app":
+            return self
+        if self.agent_access_level != "manual":
+            raise ValueError("github_app secrets must be stored with agent_access_level 'manual'")
+        validate_github_app_secret_value(self.value)
+        return self
 
 
 class SecretReveal(BaseModel):

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -666,8 +666,8 @@ async def async_resolve_project_bound_env_tokens(
         return {}
     clean_org_id = _require_org_id(org_id)
     clean_actor_user_id = _require_actor_user_id(actor_user_id)
+    env_assignments: list[tuple[str, str | None, str | None, str | None]] = []
     async with UnitOfWork() as uow:
-        env: dict[str, str] = {}
         for binding, secret in [
             (binding, secret)
             for binding, secret in await _async_project_binding_rows(uow, org_id=clean_org_id)
@@ -678,6 +678,24 @@ async def async_resolve_project_bound_env_tokens(
                 target_registry_id=target_registry_id,
             )
         ]:
+            if getattr(secret, "category", None) == "github_app":
+                secret.last_accessed_at = datetime.now(timezone.utc)
+                secret.access_count = (secret.access_count or 0) + 1
+                await _async_log_access(
+                    org_id=clean_org_id,
+                    actor_user_id=clean_actor_user_id,
+                    secret_id=secret.id,
+                    key_name=secret.key_name,
+                    action="read",
+                    # github_app mint reads audit as agent on the binding lane.
+                    accessed_by="agent",
+                    uow=uow,
+                )
+                repo_name = binding.project_slug.split("/")[-1]
+                decrypted = _decrypt(bytes(secret.encrypted_value))
+                env_assignments.append((binding.env_name, None, repo_name, decrypted))
+                decrypted = None
+                continue
             if normalize_agent_access_level(getattr(secret, "agent_access_level", None)) == VAULT_AGENT_ACCESS_MANUAL:
                 continue
             secret.last_accessed_at = datetime.now(timezone.utc)
@@ -691,8 +709,27 @@ async def async_resolve_project_bound_env_tokens(
                 accessed_by="agent",
                 uow=uow,
             )
-            env[binding.env_name] = _decrypt(bytes(secret.encrypted_value))
-        return env
+            env_assignments.append((binding.env_name, _decrypt(bytes(secret.encrypted_value)), None, None))
+
+    env: dict[str, str] = {}
+    while env_assignments:
+        env_name, value, repo_name, decrypted_blob = env_assignments.pop(0)
+        if decrypted_blob is None:
+            assert value is not None
+            env[env_name] = value
+            continue
+        from brain.systems.vault.github_app_mint import async_mint_installation_token
+
+        assert repo_name is not None
+        try:
+            env[env_name] = await async_mint_installation_token(
+                decrypted_blob,
+                repositories=[repo_name],
+                permissions={"issues": "write"},
+            )
+        finally:
+            decrypted_blob = None
+    return env
 
 
 # ---------------------------------------------------------------------------

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -1,0 +1,341 @@
+"""GitHub App installation-token minting for Vault-stored credentials."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+from jose import jwt
+
+from brain.platform.async_io import async_http_client
+from brain.systems.cortex.project_context.github import (
+    GITHUB_API_BASE,
+    GitHubConnectorError,
+    _headers,
+)
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
+
+DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {"issues": "write"}
+_CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
+_PEM_HASH_PREFIX_LENGTH = 16
+
+
+@dataclass(frozen=True)
+class GitHubAppCredential:
+    app_id: str
+    installation_id: str
+    private_key_pem: str
+    client_id: str | None = None
+
+    @classmethod
+    def from_blob(cls, decrypted_value: str) -> "GitHubAppCredential":
+        try:
+            payload = json.loads(decrypted_value)
+        except Exception:
+            raise RuntimeSecretUnavailable(
+                "GitHub App credential field 'value' must be valid JSON"
+            ) from None
+        if not isinstance(payload, dict):
+            raise RuntimeSecretUnavailable(
+                "GitHub App credential field 'value' must be a JSON object"
+            )
+
+        app_id = _required_int_string(payload, "app_id")
+        installation_id = _required_int_string(payload, "installation_id")
+        private_key_pem = _required_string(payload, "private_key_pem")
+        pem_lines = private_key_pem.splitlines()
+        first_line = pem_lines[0] if pem_lines else ""
+        if not private_key_pem.startswith("-----BEGIN") or "PRIVATE KEY-----" not in first_line:
+            raise RuntimeSecretUnavailable(
+                "GitHub App credential field 'private_key_pem' must be a PEM private key"
+            )
+
+        raw_client_id = payload.get("client_id")
+        client_id = str(raw_client_id).strip() if raw_client_id is not None else None
+        return cls(
+            app_id=app_id,
+            installation_id=installation_id,
+            private_key_pem=private_key_pem,
+            client_id=client_id or None,
+        )
+
+
+@dataclass(frozen=True)
+class MintedInstallationToken:
+    token: str
+    expires_at: datetime
+    installation_id: str
+    scope_key: str
+
+
+_TOKEN_CACHE: dict[str, MintedInstallationToken] = {}
+_MINT_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _required_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeSecretUnavailable(
+            f"GitHub App credential field '{field}' is required"
+        )
+    return value.strip()
+
+
+def _required_int_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if value is None or value is True or value is False or not str(value).strip():
+        raise RuntimeSecretUnavailable(
+            f"GitHub App credential field '{field}' is required"
+        )
+    try:
+        return str(int(str(value).strip()))
+    except (TypeError, ValueError):
+        raise RuntimeSecretUnavailable(
+            f"GitHub App credential field '{field}' must be an integer"
+        ) from None
+
+
+def _utc_datetime(value: datetime | int | float | None) -> datetime:
+    current = _now() if value is None else value
+    if isinstance(current, datetime):
+        if current.tzinfo is None:
+            return current.replace(tzinfo=timezone.utc)
+        return current.astimezone(timezone.utc)
+    return datetime.fromtimestamp(float(current), tz=timezone.utc)
+
+
+def _timestamp(value: datetime | int | float | None) -> int:
+    return int(_utc_datetime(value).timestamp())
+
+
+def _build_app_jwt(
+    cred: GitHubAppCredential,
+    *,
+    now: datetime | int | float | None = None,
+) -> str:
+    issued_at = _timestamp(now)
+    claims = {
+        "iss": cred.client_id or cred.app_id,
+        "iat": issued_at - 60,
+        "exp": issued_at + 540,
+    }
+    try:
+        return jwt.encode(claims, cred.private_key_pem, algorithm="RS256")
+    except Exception:
+        raise RuntimeSecretUnavailable(
+            "GitHub App credential field 'private_key_pem' could not sign an app JWT"
+        ) from None
+
+
+def _normalize_repositories(repositories: list[str] | tuple[str, ...]) -> list[str]:
+    cleaned: list[str] = []
+    for repo in repositories:
+        name = str(repo or "").strip()
+        if not name:
+            continue
+        if "/" in name:
+            raise RuntimeSecretUnavailable(
+                "GitHub App token field 'repositories' must contain bare repository names"
+            )
+        if name not in cleaned:
+            cleaned.append(name)
+    if not cleaned:
+        raise RuntimeSecretUnavailable(
+            "GitHub App token field 'repositories' is required"
+        )
+    return cleaned
+
+
+def _normalize_permissions(permissions: dict[str, str] | None) -> dict[str, str]:
+    if permissions is None:
+        raise RuntimeSecretUnavailable(
+            "GitHub App token field 'permissions' is required"
+        )
+    cleaned = {
+        str(key).strip(): str(value).strip()
+        for key, value in permissions.items()
+        if str(key).strip() and str(value).strip()
+    }
+    if not cleaned:
+        raise RuntimeSecretUnavailable(
+            "GitHub App token field 'permissions' is required"
+        )
+    return cleaned
+
+
+def _scope_key(
+    cred: GitHubAppCredential,
+    *,
+    repositories: list[str],
+    permissions: dict[str, str],
+) -> str:
+    private_key_hash = hashlib.sha256(cred.private_key_pem.encode("utf-8")).hexdigest()
+    payload = {
+        "installation_id": cred.installation_id,
+        "repositories": sorted(repositories),
+        "permissions": sorted(permissions.items()),
+        "private_key_sha256": private_key_hash[:_PEM_HASH_PREFIX_LENGTH],
+    }
+    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _lock_for_scope(scope_key: str) -> asyncio.Lock:
+    lock = _MINT_LOCKS.get(scope_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _MINT_LOCKS[scope_key] = lock
+    return lock
+
+
+def _cache_is_fresh(
+    minted: MintedInstallationToken | None,
+    *,
+    now: datetime,
+) -> bool:
+    if minted is None:
+        return False
+    return minted.expires_at - now > _CACHE_FRESHNESS_WINDOW
+
+
+def _parse_expires_at(value: Any) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response was missing expires_at.",
+        )
+    try:
+        expires_at = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response had an invalid expires_at.",
+        ) from None
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at.astimezone(timezone.utc)
+
+
+def _mint_error(response: httpx.Response) -> GitHubConnectorError:
+    messages = {
+        401: "GitHub rejected the GitHub App JWT.",
+        403: "GitHub denied the GitHub App installation token request.",
+        404: "GitHub App installation was not found.",
+        422: "GitHub could not mint an installation token for the requested repositories or permissions.",
+    }
+    return GitHubConnectorError(
+        status_code=response.status_code,
+        message=messages.get(
+            response.status_code,
+            f"GitHub returned {response.status_code} while minting an installation token.",
+        ),
+    )
+
+
+async def _exchange_installation_token(
+    cred: GitHubAppCredential,
+    *,
+    repositories: list[str],
+    permissions: dict[str, str],
+    now: datetime | int | float | None = None,
+) -> MintedInstallationToken:
+    clean_repositories = _normalize_repositories(repositories)
+    clean_permissions = _normalize_permissions(permissions)
+    scope_key = _scope_key(
+        cred,
+        repositories=clean_repositories,
+        permissions=clean_permissions,
+    )
+    app_jwt = _build_app_jwt(cred, now=now)
+    path = f"/app/installations/{cred.installation_id}/access_tokens"
+    try:
+        async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+            response = await client.request(
+                "POST",
+                f"{GITHUB_API_BASE}{path}",
+                headers=_headers(app_jwt),
+                json={
+                    "repositories": clean_repositories,
+                    "permissions": clean_permissions,
+                },
+            )
+    except httpx.HTTPError:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="Could not reach GitHub.",
+        ) from None
+
+    if response.status_code != 201:
+        raise _mint_error(response)
+    try:
+        payload = response.json()
+    except Exception:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response was not valid JSON.",
+        ) from None
+    token = payload.get("token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token.strip():
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub installation token response was missing token.",
+        )
+    return MintedInstallationToken(
+        token=token.strip(),
+        expires_at=_parse_expires_at(payload.get("expires_at")),
+        installation_id=cred.installation_id,
+        scope_key=scope_key,
+    )
+
+
+async def async_mint_installation_token(
+    decrypted_blob: str,
+    *,
+    repositories: list[str],
+    permissions: dict[str, str] = DEFAULT_INSTALLATION_PERMISSIONS,
+) -> str:
+    cred = GitHubAppCredential.from_blob(decrypted_blob)
+    clean_repositories = _normalize_repositories(repositories)
+    clean_permissions = _normalize_permissions(permissions)
+    scope_key = _scope_key(
+        cred,
+        repositories=clean_repositories,
+        permissions=clean_permissions,
+    )
+
+    current = _utc_datetime(None)
+    cached = _TOKEN_CACHE.get(scope_key)
+    if _cache_is_fresh(cached, now=current):
+        return cached.token
+
+    async with _lock_for_scope(scope_key):
+        current = _utc_datetime(None)
+        cached = _TOKEN_CACHE.get(scope_key)
+        if _cache_is_fresh(cached, now=current):
+            return cached.token
+        minted = await _exchange_installation_token(
+            cred,
+            repositories=clean_repositories,
+            permissions=clean_permissions,
+            now=current,
+        )
+        _TOKEN_CACHE[scope_key] = minted
+        return minted.token
+
+
+__all__ = [
+    "DEFAULT_INSTALLATION_PERMISSIONS",
+    "GitHubAppCredential",
+    "MintedInstallationToken",
+    "_build_app_jwt",
+    "_exchange_installation_token",
+    "async_mint_installation_token",
+]

--- a/brain/systems/vault/runtime_secrets.py
+++ b/brain/systems/vault/runtime_secrets.py
@@ -109,13 +109,22 @@ async def read_runtime_secret(
 
     if access == "service":
         if actor_user_id and org_id:
-            from brain.systems.vault import get_secret
+            from brain.systems.vault import async_get_secret_record, get_secret
 
             candidate = await _select_existing_vault_key_candidate(
                 key_candidates,
                 actor_user_id=actor_user_id,
                 org_id=org_id,
             )
+            record = await async_get_secret_record(
+                candidate,
+                actor_user_id=actor_user_id,
+                org_id=org_id,
+            )
+            if getattr(record, "category", None) == "github_app":
+                raise RuntimeSecretUnavailable(
+                    f"Vault secret '{candidate}' is a GitHub App credential and cannot be read by service runtimes"
+                )
             value = await get_secret(
                 candidate,
                 actor_user_id=actor_user_id,
@@ -140,6 +149,7 @@ async def read_runtime_secret(
     if context.run_id is None:
         raise RuntimeSecretUnavailable("Runtime secret reads require an AgentRun id")
 
+    from brain.systems.vault import async_get_secret_record
     from brain.systems.vault.agent_access import read_agent_secret_for_runtime
 
     candidate = await _select_existing_vault_key_candidate(
@@ -147,6 +157,15 @@ async def read_runtime_secret(
         actor_user_id=actor_user_id,
         org_id=org_id,
     )
+    record = await async_get_secret_record(
+        candidate,
+        actor_user_id=actor_user_id,
+        org_id=org_id,
+    )
+    if getattr(record, "category", None) == "github_app":
+        raise RuntimeSecretUnavailable(
+            f"Vault secret '{candidate}' is a GitHub App credential and cannot be read by agents"
+        )
     response = await read_agent_secret_for_runtime(
         candidate,
         reason=reason,

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2208,7 +2208,11 @@ async def test_runtime_tool_executor_stops_before_command_when_secret_mount_fail
     async def fake_runtime_secret_read(key, **kwargs):
         return {"error": "Vault grant required before this agent can read the secret", "key_name": key}
 
+    async def fake_secret_record(*_args, **_kwargs):
+        return None
+
     monkeypatch.setattr("brain.systems.vault.agent_access.read_agent_secret_for_runtime", fake_runtime_secret_read)
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", fake_secret_record)
 
     runtime = _runtime("worker")
     executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import jwt
+
+from brain.systems.cortex.project_context.github import GITHUB_API_BASE, GitHubConnectorError
+from brain.systems.vault import github_app_mint as mint
+from brain.systems.vault.github_app_mint import (
+    GitHubAppCredential,
+    _build_app_jwt,
+    _exchange_installation_token,
+    async_mint_installation_token,
+)
+from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
+
+NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def clear_mint_cache():
+    mint._TOKEN_CACHE.clear()
+    mint._MINT_LOCKS.clear()
+    yield
+    mint._TOKEN_CACHE.clear()
+    mint._MINT_LOCKS.clear()
+
+
+@pytest.fixture
+def rsa_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    return private_pem, public_pem
+
+
+class _HTTPClient:
+    def __init__(self, responses: list[httpx.Response], requests: list[dict], *, delay: float = 0) -> None:
+        self._responses = responses
+        self._requests = requests
+        self._delay = delay
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def request(self, method, url, *, headers=None, json=None, params=None):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        self._requests.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "json": json,
+            "params": params,
+        })
+        return self._responses.pop(0)
+
+
+def _blob(private_key_pem: str, *, app_id=123, installation_id=456, client_id="Iv23.client") -> str:
+    payload = {
+        "app_id": app_id,
+        "client_id": client_id,
+        "installation_id": installation_id,
+        "private_key_pem": private_key_pem,
+    }
+    return json.dumps(payload)
+
+
+def _token_response(token: str, expires_at: datetime) -> httpx.Response:
+    return httpx.Response(
+        201,
+        json={"token": token, "expires_at": expires_at.isoformat().replace("+00:00", "Z")},
+    )
+
+
+def _patch_http(monkeypatch, responses: list[httpx.Response], *, delay: float = 0) -> list[dict]:
+    requests: list[dict] = []
+    client = _HTTPClient(responses, requests, delay=delay)
+    monkeypatch.setattr(mint, "async_http_client", lambda **_kwargs: client)
+    return requests
+
+
+def _decode(token: str, public_pem: str) -> dict:
+    return jwt.decode(
+        token,
+        public_pem,
+        algorithms=["RS256"],
+        options={"verify_aud": False, "verify_exp": False},
+    )
+
+
+def test_build_app_jwt_claims_and_signature_use_client_id(rsa_keypair):
+    private_pem, public_pem = rsa_keypair
+    cred = GitHubAppCredential.from_blob(_blob(private_pem, client_id="Iv23.client"))
+
+    token = _build_app_jwt(cred, now=NOW)
+    claims = _decode(token, public_pem)
+
+    now_ts = int(NOW.timestamp())
+    assert jwt.get_unverified_header(token)["alg"] == "RS256"
+    assert claims["iss"] == "Iv23.client"
+    assert claims["iat"] == now_ts - 60
+    assert claims["exp"] == now_ts + 540
+    assert claims["exp"] - now_ts < 600
+    assert claims["exp"] - claims["iat"] == 600
+
+
+def test_build_app_jwt_uses_app_id_when_client_id_absent(rsa_keypair):
+    private_pem, public_pem = rsa_keypair
+    cred = GitHubAppCredential.from_blob(_blob(private_pem, client_id=None))
+
+    token = _build_app_jwt(cred, now=NOW)
+
+    assert _decode(token, public_pem)["iss"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_exchange_installation_token_request_shape(monkeypatch, rsa_keypair):
+    private_pem, public_pem = rsa_keypair
+    cred = GitHubAppCredential.from_blob(_blob(private_pem))
+    requests = _patch_http(
+        monkeypatch,
+        [_token_response("minted-token", NOW + timedelta(hours=1))],
+    )
+
+    minted = await _exchange_installation_token(
+        cred,
+        repositories=["uwear-backend"],
+        permissions={"issues": "write"},
+        now=NOW,
+    )
+
+    assert minted.token == "minted-token"
+    assert len(requests) == 1
+    request = requests[0]
+    assert request["method"] == "POST"
+    assert request["url"] == f"{GITHUB_API_BASE}/app/installations/456/access_tokens"
+    assert request["headers"]["Accept"] == "application/vnd.github+json"
+    assert request["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
+    assert request["json"] == {
+        "repositories": ["uwear-backend"],
+        "permissions": {"issues": "write"},
+    }
+    app_jwt = request["headers"]["Authorization"].removeprefix("Bearer ")
+    assert _decode(app_jwt, public_pem)["iss"] == "Iv23.client"
+
+
+@pytest.mark.asyncio
+async def test_mint_cache_reuses_until_expiry_window_then_remints(monkeypatch, rsa_keypair):
+    private_pem, _public_pem = rsa_keypair
+    current = {"now": NOW}
+    monkeypatch.setattr(mint, "_now", lambda: current["now"])
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _token_response("token-1", NOW + timedelta(hours=1)),
+            _token_response("token-2", NOW + timedelta(hours=2)),
+        ],
+    )
+    blob = _blob(private_pem)
+
+    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-1"
+    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-1"
+    assert len(requests) == 1
+
+    current["now"] = NOW + timedelta(minutes=56)
+    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "token-2"
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rsa_keypair):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _token_response("issues-token", NOW + timedelta(hours=1)),
+            _token_response("other-repo-token", NOW + timedelta(hours=1)),
+            _token_response("metadata-token", NOW + timedelta(hours=1)),
+        ],
+    )
+    blob = _blob(private_pem)
+
+    assert await async_mint_installation_token(blob, repositories=["uwear-backend"]) == "issues-token"
+    assert await async_mint_installation_token(blob, repositories=["uwear-mobile"]) == "other-repo-token"
+    assert await async_mint_installation_token(
+        blob,
+        repositories=["uwear-backend"],
+        permissions={"metadata": "read"},
+    ) == "metadata-token"
+
+    assert [request["json"] for request in requests] == [
+        {"repositories": ["uwear-backend"], "permissions": {"issues": "write"}},
+        {"repositories": ["uwear-mobile"], "permissions": {"issues": "write"}},
+        {"repositories": ["uwear-backend"], "permissions": {"metadata": "read"}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_mint_calls_share_one_http_exchange(monkeypatch, rsa_keypair):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [_token_response("shared-token", NOW + timedelta(hours=1))],
+        delay=0.01,
+    )
+    blob = _blob(private_pem)
+
+    tokens = await asyncio.gather(*[
+        async_mint_installation_token(blob, repositories=["uwear-backend"])
+        for _ in range(8)
+    ])
+
+    assert tokens == ["shared-token"] * 8
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_pem_rotation_misses_cache(monkeypatch, rsa_keypair):
+    first_private_pem, _public_pem = rsa_keypair
+    second_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    second_private_pem = second_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [
+            _token_response("token-before-rotation", NOW + timedelta(hours=1)),
+            _token_response("token-after-rotation", NOW + timedelta(hours=1)),
+        ],
+    )
+
+    assert await async_mint_installation_token(_blob(first_private_pem), repositories=["uwear-backend"]) == "token-before-rotation"
+    assert await async_mint_installation_token(_blob(second_private_pem), repositories=["uwear-backend"]) == "token-after-rotation"
+    assert len(requests) == 2
+
+
+def test_from_blob_fails_closed_without_echoing_bad_secret_values():
+    non_pem_blob = json.dumps({
+        "app_id": "123",
+        "installation_id": "456",
+        "private_key_pem": "not-a-pem-secret-value",
+    })
+    wrong_key_type = json.dumps({
+        "app_id": "123",
+        "installation_id": "456",
+        "private_key_pem": "-----BEGIN CERTIFICATE-----\nsecret-cert\n-----END CERTIFICATE-----",
+    })
+    public_key = json.dumps({
+        "app_id": "123",
+        "installation_id": "456",
+        "private_key_pem": "-----BEGIN PUBLIC KEY-----\nsecret-public\n-----END PUBLIC KEY-----",
+    })
+
+    for blob, forbidden in [
+        (non_pem_blob, "not-a-pem-secret-value"),
+        (wrong_key_type, "secret-cert"),
+        (public_key, "secret-public"),
+    ]:
+        with pytest.raises(RuntimeSecretUnavailable) as exc:
+            GitHubAppCredential.from_blob(blob)
+        message = str(exc.value)
+        assert "private_key_pem" in message
+        assert forbidden not in message
+        assert blob not in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403, 404, 422])
+async def test_exchange_errors_are_sanitized(monkeypatch, rsa_keypair, status_code):
+    private_pem, _public_pem = rsa_keypair
+    cred = GitHubAppCredential.from_blob(_blob(private_pem))
+    forbidden_token = "minted-token-that-must-not-leak"
+    requests = _patch_http(
+        monkeypatch,
+        [httpx.Response(status_code, json={"message": forbidden_token})],
+    )
+
+    with pytest.raises(GitHubConnectorError) as exc:
+        await _exchange_installation_token(
+            cred,
+            repositories=["uwear-backend"],
+            permissions={"issues": "write"},
+            now=NOW,
+        )
+
+    assert exc.value.status_code == status_code
+    assert forbidden_token not in exc.value.message
+    assert private_pem not in exc.value.message
+    assert requests
+
+
+@pytest.mark.asyncio
+async def test_mint_does_not_log_pem_jwt_or_minted_token(monkeypatch, caplog, rsa_keypair):
+    private_pem, _public_pem = rsa_keypair
+    monkeypatch.setattr(mint, "_now", lambda: NOW)
+    requests = _patch_http(
+        monkeypatch,
+        [_token_response("minted-token-secret", NOW + timedelta(hours=1))],
+    )
+
+    with caplog.at_level("DEBUG"):
+        token = await async_mint_installation_token(_blob(private_pem), repositories=["uwear-backend"])
+
+    app_jwt = requests[0]["headers"]["Authorization"].removeprefix("Bearer ")
+    assert token == "minted-token-secret"
+    assert private_pem not in caplog.text
+    assert app_jwt not in caplog.text
+    assert "minted-token-secret" not in caplog.text

--- a/tests/test_runtime_secrets.py
+++ b/tests/test_runtime_secrets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 import re
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,6 +26,10 @@ async def test_agent_tool_runtime_secret_uses_central_agent_access(monkeypatch):
         kwargs["key_name"] = key_name
         return await read_agent_secret_for_runtime(**kwargs)
 
+    async def async_get_secret_record(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
     monkeypatch.setattr(
         "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
         read_agent_secret_for_runtime_with_key,
@@ -77,7 +82,11 @@ async def test_service_runtime_secret_prefers_vault_before_env(monkeypatch):
         )
         return "vault-token"
 
+    async def async_get_secret_record(*_args, **_kwargs):
+        return None
+
     monkeypatch.setenv("SERVICE_TOKEN", "env-token")
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
     monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
 
     value = await read_runtime_secret(
@@ -107,7 +116,11 @@ async def test_service_runtime_secret_can_fall_back_to_env(monkeypatch):
     async def get_secret(key_name, actor_user_id, *, org_id, accessed_by):
         return None
 
+    async def async_get_secret_record(*_args, **_kwargs):
+        return None
+
     monkeypatch.setenv("SERVICE_TOKEN", "env-token")
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
     monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
 
     value = await read_runtime_secret(
@@ -120,6 +133,82 @@ async def test_service_runtime_secret_can_fall_back_to_env(monkeypatch):
     )
 
     assert value == "env-token"
+
+
+@pytest.mark.asyncio
+async def test_service_runtime_secret_denies_github_app_secret_before_decrypt(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, RuntimeSecretUnavailable, read_runtime_secret
+
+    calls = []
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        return SimpleNamespace(category="github_app")
+
+    async def get_secret(key_name, actor_user_id, *, org_id, accessed_by):
+        calls.append(key_name)
+        return "-----BEGIN RSA PRIVATE KEY-----\nsecret-key-material\n-----END RSA PRIVATE KEY-----"
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr("brain.systems.vault.get_secret", get_secret)
+
+    with pytest.raises(RuntimeSecretUnavailable) as exc:
+        await read_runtime_secret(
+            "GITHUB_APP__ILLO",
+            context=RuntimeSecretContext(actor_user_id="user-1", org_id="org-1"),
+            reason="Service callers must not read GitHub App private keys.",
+            requested_by="service_tool",
+            access="service",
+        )
+
+    assert calls == []
+    assert "GitHub App credential" in str(exc.value)
+    assert "secret-key-material" not in str(exc.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agent_access_level", ["available", "ask"])
+async def test_agent_tool_runtime_secret_denies_github_app_secret_before_agent_read(
+    monkeypatch,
+    agent_access_level,
+):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, RuntimeSecretUnavailable, read_runtime_secret
+
+    raw_blob = (
+        '{"app_id":"123","installation_id":"456",'
+        '"private_key_pem":"-----BEGIN RSA PRIVATE KEY-----\\nsecret-key-material\\n-----END RSA PRIVATE KEY-----"}'
+    )
+    read_calls = []
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        return SimpleNamespace(category="github_app", agent_access_level=agent_access_level)
+
+    async def read_agent_secret_for_runtime(key_name, **kwargs):
+        read_calls.append(key_name)
+        return {"value": raw_blob}
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr(
+        "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
+        read_agent_secret_for_runtime,
+    )
+
+    with pytest.raises(RuntimeSecretUnavailable) as exc:
+        await read_runtime_secret(
+            "GITHUB_APP__ILLO",
+            context=RuntimeSecretContext(
+                actor_user_id="user-1",
+                org_id="org-1",
+                run_id=42,
+            ),
+            reason="Agent-controlled secret_env mount must not expose GitHub App credentials.",
+            requested_by="secret_env_mount",
+            access="agent_tool",
+        )
+
+    assert read_calls == []
+    assert "cannot be read by agents" in str(exc.value)
+    assert "secret-key-material" not in str(exc.value)
+    assert raw_blob not in str(exc.value)
 
 
 def _string_arg(node: ast.Call) -> str | None:
@@ -259,6 +348,8 @@ async def test_agent_tool_runtime_secret_falls_back_to_uppercase_legacy_key_when
     assert record_calls == [
         ("DataForSeoLogin", "user-1", "org-1"),
         ("DATAFORSEOLOGIN", "user-1", "org-1"),
+        # agent_tool github_app guard re-reads the selected candidate's record.
+        ("DATAFORSEOLOGIN", "user-1", "org-1"),
     ]
     assert read_calls == ["DATAFORSEOLOGIN"]
 
@@ -323,6 +414,7 @@ async def test_service_runtime_secret_falls_back_to_uppercase_legacy_vault_key(m
     assert value == "legacy-service-token"
     assert record_calls == [
         ("service_token", "user-1", "org-1"),
+        ("SERVICE_TOKEN", "user-1", "org-1"),
         ("SERVICE_TOKEN", "user-1", "org-1"),
     ]
     assert calls == [("SERVICE_TOKEN", "user-1", "org-1", "service_tool")]

--- a/tests/test_vault_async.py
+++ b/tests/test_vault_async.py
@@ -78,6 +78,43 @@ async def test_async_set_secret_creates_secret_without_sync_uow_bridge(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_async_set_and_get_github_app_secret_preserves_category_and_manual_access(monkeypatch):
+    blob = '{"app_id":"123","installation_id":"456","private_key_pem":"-----BEGIN KEY-----\\nsecret\\nKEY-----"}'
+    session = _Session()
+    _patch_uow(monkeypatch, session)
+    secret_holder = {"secret": None}
+
+    async def fake_secret_by_key(*_args, **_kwargs):
+        return secret_holder["secret"]
+
+    monkeypatch.setattr(vault, "_async_secret_by_key", fake_secret_by_key)
+    monkeypatch.setattr(vault, "_encrypt", lambda value: b"ciphertext")
+    monkeypatch.setattr(vault, "_decrypt", lambda value: blob)
+
+    async def fake_resolve_missing(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(vault, "async_resolve_missing", fake_resolve_missing)
+
+    await vault.async_set_secret(
+        "GITHUB_APP__ILLO",
+        blob,
+        ACTOR_ID,
+        org_id=ORG_ID,
+        category="github_app",
+        agent_access_level="manual",
+    )
+    secret = next(obj for obj in session.added if isinstance(obj, Secret))
+    secret_holder["secret"] = secret
+
+    value = await vault.async_get_secret("GITHUB_APP__ILLO", ACTOR_ID, org_id=ORG_ID)
+
+    assert value == blob
+    assert secret.category == "github_app"
+    assert secret.agent_access_level == "manual"
+
+
+@pytest.mark.asyncio
 async def test_async_get_secret_reads_and_audits_actor(monkeypatch):
     secret = SimpleNamespace(
         id=9,

--- a/tests/test_vault_hardening.py
+++ b/tests/test_vault_hardening.py
@@ -1,10 +1,13 @@
 """Regression tests for vault hardening boundaries."""
 from __future__ import annotations
 
+import json
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from brain.app.api.main import app
@@ -56,6 +59,77 @@ def test_reveal_requires_personal_pin_setup_before_unlock():
     reveal.assert_not_called()
 
 
+def test_reveal_github_app_secret_omits_private_key_pem():
+    pem = "-----BEGIN RSA PRIVATE KEY-----\nsecret-key-material\n-----END RSA PRIVATE KEY-----"
+    raw_value = json.dumps({
+        "app_id": 123,
+        "client_id": "Iv23.client",
+        "installation_id": "456",
+        "private_key_pem": pem,
+    })
+    with _client() as client, \
+         patch("brain.systems.vault.async_has_pin", return_value=True), \
+         patch("brain.systems.vault.async_validate_vault_token", return_value=True), \
+         patch(
+             "brain.systems.vault.async_get_secret_record",
+             return_value=SimpleNamespace(category="github_app"),
+         ), \
+         patch("brain.systems.vault.async_reveal_secret", return_value=raw_value):
+        response = client.get("/api/vault/GITHUB_APP__ILLO", headers={"X-Vault-Token": "ok"})
+
+    assert response.status_code == 200
+    value = json.loads(response.json()["value"])
+    assert value == {
+        "app_id": "123",
+        "client_id": "Iv23.client",
+        "installation_id": "456",
+    }
+    assert "private_key_pem" not in response.text
+    assert "secret-key-material" not in response.text
+
+
+def test_secret_create_validates_github_app_blob_without_affecting_other_categories():
+    from pydantic import ValidationError
+
+    from brain.app.api.schemas.vault import SecretCreate
+
+    SecretCreate(
+        key_name="GITHUB_APP__ILLO",
+        value=json.dumps({
+            "app_id": "123",
+            "installation_id": "456",
+            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----",
+        }),
+        category="github_app",
+        agent_access_level="manual",
+    )
+    SecretCreate(key_name="PLAIN", value="not-json", category="general")
+
+    for access_level in ("available", "ask"):
+        with pytest.raises(ValidationError) as exc:
+            SecretCreate(
+                key_name="GITHUB_APP__ILLO",
+                value=json.dumps({
+                    "app_id": "123",
+                    "installation_id": "456",
+                    "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----",
+                }),
+                category="github_app",
+                agent_access_level=access_level,
+            )
+        assert "github_app secrets must be stored with agent_access_level 'manual'" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        SecretCreate(
+            key_name="GITHUB_APP__ILLO",
+            value="not-json-secret",
+            category="github_app",
+            agent_access_level="manual",
+        )
+    assert "valid JSON" in str(exc.value)
+    assert "not-json-secret" not in str(exc.value)
+
+
 def test_list_returns_metadata_without_unlock_when_pin_is_configured():
     secret = {
         "id": 1,
@@ -82,6 +156,45 @@ def test_list_returns_metadata_without_unlock_when_pin_is_configured():
     assert payload[0]["key_name"] == "OPENAI_API_KEY"
     assert "value" not in payload[0]
     list_secrets.assert_called_once_with(USER["id"], category=None, org_id=USER["org_id"])
+
+
+async def test_github_app_manual_secret_is_denied_on_agent_tool_runtime_lane(monkeypatch):
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, RuntimeSecretUnavailable, read_runtime_secret
+
+    pem = "-----BEGIN RSA PRIVATE KEY-----\nsecret-key-material\n-----END RSA PRIVATE KEY-----"
+
+    async def async_get_secret_record(key_name, actor_user_id, *, org_id):
+        return SimpleNamespace(category="github_app", agent_access_level="manual")
+
+    read_calls = []
+
+    async def read_agent_secret_for_runtime(key_name, **kwargs):
+        read_calls.append(key_name)
+        return {"error": "secret is marked manual and cannot be auto-read by agents"}
+
+    monkeypatch.setattr("brain.systems.vault.async_get_secret_record", async_get_secret_record)
+    monkeypatch.setattr(
+        "brain.systems.vault.agent_access.read_agent_secret_for_runtime",
+        read_agent_secret_for_runtime,
+    )
+
+    with pytest.raises(RuntimeSecretUnavailable) as exc:
+        await read_runtime_secret(
+            "GITHUB_APP__ILLO",
+            context=RuntimeSecretContext(
+                actor_user_id=USER["id"],
+                org_id=USER["org_id"],
+                run_id=42,
+            ),
+            reason="Agent-controlled secret_env mount must not expose GitHub App credentials.",
+            requested_by="secret_env_mount",
+            access="agent_tool",
+        )
+
+    assert read_calls == []
+    assert "GitHub App credential" in str(exc.value)
+    assert "secret-key-material" not in str(exc.value)
+    assert pem not in str(exc.value)
 
 
 def test_unlock_rejects_bad_pin_and_returns_session_token_for_good_pin():

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -2,13 +2,17 @@
 from __future__ import annotations
 
 import base64
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy import func, select
 
 from brain.platform.db.models.environment import TargetRegistry  # noqa: F401 - resolves project binding FK target
@@ -85,12 +89,14 @@ async def _secret(
     actor_user_id=USER_ID,
     org_id: str | None = None,
     access_level="ask",
+    category="general",
 ) -> Secret:
     from brain.systems.vault import _encrypt
 
     secret = Secret(
         key_name=key_name,
         encrypted_value=_encrypt(value),
+        category=category,
         org_id=org_id or ORG_ID,
         created_by_user_id=actor_user_id,
         updated_by_user_id=actor_user_id,
@@ -121,6 +127,54 @@ async def _binding(
     session.add(binding)
     await session.flush()
     return binding
+
+
+class _MockGitHubClient:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def request(self, method, url, *, headers=None, params=None, json=None):
+        self.requests.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "json": json,
+            "params": params,
+        })
+        if url.endswith("/app/installations/456/access_tokens"):
+            return httpx.Response(
+                201,
+                json={
+                    "token": "minted-issue-token",
+                    "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+                },
+            )
+        if url.endswith("/repos/uwear-ai/uwear-backend/issues"):
+            return httpx.Response(
+                201,
+                json={
+                    "number": 321,
+                    "html_url": "https://github.com/uwear-ai/uwear-backend/issues/321",
+                    "title": json["title"],
+                    "state": "open",
+                },
+            )
+        return httpx.Response(404, json={"message": "unexpected mocked URL"})
+
+
+def _test_private_key_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("ascii")
 
 
 async def _grant_count(session) -> int:
@@ -271,6 +325,161 @@ async def test_resolve_project_bound_env_tokens_returns_org_bound_tokens_for_mem
     assert env == {"GITHUB_TOKEN": "ghp-test"}
     await session.refresh(github)
     assert github.access_count == 1
+
+
+async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, session, monkeypatch):
+    from brain.systems.vault import async_resolve_project_bound_env_tokens
+
+    github_app = await _secret(
+        session,
+        "GITHUB_APP__ILLO",
+        "github-app-blob",
+        access_level="manual",
+        category="github_app",
+    )
+    await _binding(
+        session,
+        github_app,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GITHUB_TOKEN",
+    )
+    normal = await _secret(session, "NORMAL_TOKEN", "plain-token", access_level="ask")
+    await _binding(
+        session,
+        normal,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="NORMAL_TOKEN",
+    )
+    manual = await _secret(session, "MANUAL_TOKEN", "manual-token", access_level="manual")
+    await _binding(
+        session,
+        manual,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="MANUAL_TOKEN",
+    )
+    transaction_state = {"open": False}
+    mint_calls = []
+
+    class TrackingUoW(_TestUoW):
+        async def __aenter__(self):
+            transaction_state["open"] = True
+            return await super().__aenter__()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            try:
+                return await super().__aexit__(exc_type, exc, tb)
+            finally:
+                transaction_state["open"] = False
+
+    async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
+        mint_calls.append({
+            "decrypted_blob": decrypted_blob,
+            "repositories": repositories,
+            "permissions": permissions,
+            "transaction_open": transaction_state["open"],
+        })
+        return "minted-installation-token"
+
+    monkeypatch.setattr("brain.systems.vault.UnitOfWork", lambda: TrackingUoW(session))
+    monkeypatch.setattr(
+        "brain.systems.vault.github_app_mint.async_mint_installation_token",
+        async_mint_installation_token,
+    )
+
+    env = await async_resolve_project_bound_env_tokens(
+        actor_user_id=OTHER_USER_ID,
+        org_id=ORG_ID,
+        project_slug="uwear-ai/uwear-backend",
+    )
+
+    assert env == {
+        "GITHUB_TOKEN": "minted-installation-token",
+        "NORMAL_TOKEN": "plain-token",
+    }
+    assert mint_calls == [
+        {
+            "decrypted_blob": "github-app-blob",
+            "repositories": ["uwear-backend"],
+            "permissions": {"issues": "write"},
+            "transaction_open": False,
+        }
+    ]
+    await session.refresh(github_app)
+    await session.refresh(normal)
+    await session.refresh(manual)
+    assert github_app.access_count == 1
+    assert normal.access_count == 1
+    assert manual.access_count == 0
+    logs = (await session.scalars(select(VaultAccessLog).order_by(VaultAccessLog.key_name))).all()
+    assert {
+        log.key_name: log.accessed_by
+        for log in logs
+        if log.action == "read"
+    } == {
+        "GITHUB_APP__ILLO": "agent",
+        "NORMAL_TOKEN": "agent",
+    }
+
+
+async def test_create_github_issue_uses_minted_github_app_project_binding(
+    patch_uow,
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.github import _handle_create_github_issue
+    from brain.systems.vault import github_app_mint
+
+    github_app_mint._TOKEN_CACHE.clear()
+    github_app_mint._MINT_LOCKS.clear()
+    app_blob = json.dumps({
+        "app_id": "123",
+        "client_id": "Iv23.client",
+        "installation_id": "456",
+        "private_key_pem": _test_private_key_pem(),
+    })
+    github_app = await _secret(
+        session,
+        "GITHUB_APP__ILLO",
+        app_blob,
+        access_level="manual",
+        category="github_app",
+    )
+    await _binding(
+        session,
+        github_app,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GITHUB_TOKEN",
+    )
+    client = _MockGitHubClient()
+    monkeypatch.setattr(
+        "brain.systems.vault.github_app_mint.async_http_client",
+        lambda **_kwargs: client,
+    )
+    monkeypatch.setattr(
+        "brain.systems.cortex.project_context.github.async_http_client",
+        lambda **_kwargs: client,
+    )
+
+    with bind_agent_context({"user_id": USER_ID, "org_id": ORG_ID}):
+        result = await _handle_create_github_issue(
+            repo="uwear-ai/uwear-backend",
+            title="Backend incident",
+            body="Details",
+            labels=["bug"],
+        )
+
+    payload = json.loads(result)
+    assert payload["repo"] == "uwear-ai/uwear-backend"
+    assert payload["issue"]["number"] == 321
+    assert payload["token_source"] == "project_binding:GITHUB_TOKEN"
+    assert "token_key_name" in payload
+    assert payload.get("no_write_token") is not True
+    access_request = next(request for request in client.requests if request["url"].endswith("/access_tokens"))
+    issue_request = next(request for request in client.requests if request["url"].endswith("/issues"))
+    assert access_request["json"]["repositories"] == ["uwear-backend"]
+    assert access_request["json"]["permissions"] == {"issues": "write"}
+    assert issue_request["headers"]["Authorization"] == "Bearer minted-issue-token"
 
 
 async def test_project_bindings_require_org_scope(patch_uow, session):

--- a/tests/test_vault_routes.py
+++ b/tests/test_vault_routes.py
@@ -1,10 +1,12 @@
 """FastAPI route coverage for the org-owned vault."""
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from fastapi import HTTPException
 import pytest
 from starlette.testclient import TestClient
 
@@ -56,6 +58,14 @@ def _secret():
     )
 
 
+def _github_app_blob() -> str:
+    return json.dumps({
+        "app_id": "123",
+        "installation_id": "456",
+        "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----",
+    })
+
+
 class TestVaultOrgRoutes:
     def test_list_secrets_returns_org_metadata(self, client):
         with patch("brain.systems.vault.async_list_secrets", return_value=[]) as mock_list:
@@ -85,7 +95,8 @@ class TestVaultOrgRoutes:
         assert "VAULT_MASTER_KEY" in resp.json()["detail"]
 
     def test_reveal_passes_actor_and_org(self, client):
-        with patch("brain.systems.vault.async_reveal_secret", return_value="secret_value") as mock_reveal:
+        with patch("brain.systems.vault.async_get_secret_record", return_value=SimpleNamespace(category="general")), \
+             patch("brain.systems.vault.async_reveal_secret", return_value="secret_value") as mock_reveal:
             resp = client.get("/api/vault/MY_KEY")
 
         assert resp.status_code == 200
@@ -131,3 +142,110 @@ class TestVaultOrgRoutes:
         assert secret.description == "new"
         assert secret.agent_access_level == "available"
         db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_secret_rejects_flipping_to_github_app_without_manual(self):
+        from brain.app.api.routers import vault as vault_router
+
+        secret = SimpleNamespace(description="old", category="general", agent_access_level="ask")
+        db = MagicMock()
+        db.flush = AsyncMock()
+
+        with patch.object(vault_router, "_async_require_unlocked", new=AsyncMock()), \
+             patch("brain.platform.db.repositories.vault.VaultRepository.a_get_by_key", new=AsyncMock(return_value=secret)), \
+             patch("brain.systems.vault.async_set_secret", new=AsyncMock()) as set_secret, \
+             pytest.raises(HTTPException) as exc:
+            await vault_router.update_secret(
+                "MY_KEY",
+                vault_router.SecretUpdate(category="github_app"),
+                request=MagicMock(headers={}),
+                db=db,
+                user=USER_A,
+            )
+
+        assert exc.value.status_code == 422
+        assert "agent_access_level 'manual'" in exc.value.detail
+        set_secret.assert_not_awaited()
+        db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_secret_rejects_github_app_level_downgrade(self):
+        from brain.app.api.routers import vault as vault_router
+
+        secret = SimpleNamespace(description="old", category="github_app", agent_access_level="manual")
+        db = MagicMock()
+        db.flush = AsyncMock()
+
+        with patch.object(vault_router, "_async_require_unlocked", new=AsyncMock()), \
+             patch("brain.platform.db.repositories.vault.VaultRepository.a_get_by_key", new=AsyncMock(return_value=secret)), \
+             patch("brain.systems.vault.async_set_secret", new=AsyncMock()) as set_secret, \
+             pytest.raises(HTTPException) as exc:
+            await vault_router.update_secret(
+                "GITHUB_APP__ILLO",
+                vault_router.SecretUpdate(agent_access_level="available"),
+                request=MagicMock(headers={}),
+                db=db,
+                user=USER_A,
+            )
+
+        assert exc.value.status_code == 422
+        assert "agent_access_level 'manual'" in exc.value.detail
+        set_secret.assert_not_awaited()
+        db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_secret_rejects_invalid_github_app_value_update(self):
+        from brain.app.api.routers import vault as vault_router
+
+        secret = SimpleNamespace(description="old", category="github_app", agent_access_level="manual")
+        db = MagicMock()
+        db.flush = AsyncMock()
+
+        with patch.object(vault_router, "_async_require_unlocked", new=AsyncMock()), \
+             patch("brain.platform.db.repositories.vault.VaultRepository.a_get_by_key", new=AsyncMock(return_value=secret)), \
+             patch("brain.systems.vault.async_set_secret", new=AsyncMock()) as set_secret, \
+             pytest.raises(HTTPException) as exc:
+            await vault_router.update_secret(
+                "GITHUB_APP__ILLO",
+                vault_router.SecretUpdate(value="not-json-secret"),
+                request=MagicMock(headers={}),
+                db=db,
+                user=USER_A,
+            )
+
+        assert exc.value.status_code == 422
+        assert "valid JSON" in exc.value.detail
+        assert "not-json-secret" not in exc.value.detail
+        set_secret.assert_not_awaited()
+        db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_secret_accepts_valid_manual_github_app_update(self):
+        from brain.app.api.routers import vault as vault_router
+
+        secret = SimpleNamespace(description="old", category="general", agent_access_level="ask")
+        db = MagicMock()
+        db.flush = AsyncMock()
+
+        with patch.object(vault_router, "_async_require_unlocked", new=AsyncMock()), \
+             patch("brain.platform.db.repositories.vault.VaultRepository.a_get_by_key", new=AsyncMock(return_value=secret)), \
+             patch("brain.systems.vault.async_set_secret", new=AsyncMock()) as set_secret:
+            result = await vault_router.update_secret(
+                "GITHUB_APP__ILLO",
+                vault_router.SecretUpdate(
+                    value=_github_app_blob(),
+                    category="github_app",
+                    agent_access_level="manual",
+                ),
+                request=MagicMock(headers={}),
+                db=db,
+                user=USER_A,
+            )
+
+        assert result == {"updated": True}
+        set_secret.assert_awaited_once()
+        _, kwargs = set_secret.await_args
+        assert kwargs["key_name"] == "GITHUB_APP__ILLO"
+        assert kwargs["category"] == "github_app"
+        assert kwargs["agent_access_level"] == "manual"
+        db.flush.assert_not_awaited()


### PR DESCRIPTION
## What & why

Gives Illo its **own GitHub identity** by teaching the Vault to store a **GitHub App** credential and **mint short-lived installation tokens on demand**, instead of authoring under a person's legacy PAT. This is the Vault's first *minted credential* (value is computed at read time, not stored), and it unblocks `create_github_issue` for private repos (e.g. `uwear-ai/uwear-backend`) — where it currently degrades to `no_write_token`.

Storage is already org-owned, so no schema change: the App credential lives as **one org secret** `GITHUB_APP__ILLO` (`category='github_app'`, `agent_access_level='manual'`), surfaced to the write path via a project binding that resolves through the minting seam.

## What's in this PR (backend only)

- **`brain/systems/vault/github_app_mint.py`** (new) — parse the `{app_id, client_id?, installation_id, private_key_pem}` blob, sign a short RS256 app-JWT (`iss=client_id or app_id`, ≤10-min), exchange it at `POST /app/installations/{id}/access_tokens` for a ~1h token **down-scoped to `[repo] + {issues:write}`**. In-process cache (~55m) keyed by a scope fingerprint that includes a PEM hash (rotation-safe); mint-on-miss guarded by an `asyncio.Lock`.
- **Mint branch** in `async_resolve_project_bound_env_tokens` — a `github_app` binding resolves to a freshly minted token as `GITHUB_TOKEN`. The mint HTTP call runs **outside the DB transaction** (only the audit row + access-count are written in-txn).
- **Fail-closed posture** — the raw PEM never leaves the resolver:
  - both agent-facing read seams (**service** + **agent_tool**) hard-deny `github_app`;
  - `reveal_secret` **masks** the private key (returns metadata only);
  - `SecretCreate` **and** the update path enforce `agent_access_level='manual'` and validate the blob, with input hidden from validation errors.
- Mint failures (bad blob, GitHub 4xx/5xx) degrade to `no_write_token` (caller already catches), never crash.

## Testing

`172 passed, 1 skipped` across the full vault surface. New coverage: JWT claims/signature, exchange request shape (bare repo name, headers, perms), cache hit/miss/rotation/concurrency, `from_blob` fail-closed, agent_tool + service denial (incl. `available`/`ask`), reveal masking, create/update `manual` enforcement, mint-before-manual-skip, and an end-to-end mocked-GitHub `create_github_issue` contract test.

## Not in this PR (by design)

- **Part A (org owner, manual):** register the `illo` GitHub App under `uwear-ai`, permissions **Issues: R&W**, install on `uwear-backend`, generate the private key. No GitHub review needed (private app, "only this account").
- **Data step:** store `GITHUB_APP__ILLO` + create the `uwear-backend → GITHUB_TOKEN` binding in Vault (PIN-unlocked API).
- Frontend `github_app` add-secret form; the sync shell/exec token lane (deliberately scoped out — `files.py` untouched).

## Process

Design plan drafted via a multi-agent workflow; implemented by **Codex gpt-5.5 (xhigh)**; independently reviewed by a **fable-5** pass that caught a real PEM-exfiltration hole (agent-facing seam relied on an unenforced `manual` level) — now fixed and regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
