### PR TITLE
Thread monitored-channel triage replies under the original alert

### DIFF
--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -120,17 +120,30 @@ def _surface(channel_type: str, thread_ts: str, message_ts: str) -> str:
     return "slack_channel"
 
 
-def _response_thread_ts(channel_type: str, thread_ts: str, message_ts: str) -> str | None:
+def _response_thread_ts(
+    channel_type: str,
+    thread_ts: str,
+    message_ts: str,
+    *,
+    is_monitored_channel: bool = False,
+) -> str | None:
     """Return the Slack thread timestamp Illo should use for its visible reply.
 
     Slack uses ``thread_ts=message_ts`` to create a thread under a top-level
     message. That made top-level mentions look like Illo could only answer in
     threads. The response target should only carry a thread when the user invoked
     Illo from an existing Slack thread. DMs should stay as normal DM messages.
+
+    Monitored-channel triage is the deliberate exception: a reply to an alert
+    threads *under the original alert* (its ``thread_ts`` or ``message_ts``) so
+    the alert and Illo's response stay attached, instead of landing as a detached
+    top-level message that fragments the follow-up.
     """
 
     if channel_type == "im":
         return None
+    if is_monitored_channel:
+        return thread_ts or message_ts or None
     if thread_ts and thread_ts != message_ts:
         return thread_ts
     return None
@@ -185,7 +198,12 @@ def normalize_slack_socket_event(
     surface = _surface(channel_type, thread_ts, message_ts)
     response_target = {
         "channel_id": channel_id,
-        "thread_ts": _response_thread_ts(channel_type, thread_ts, message_ts),
+        "thread_ts": _response_thread_ts(
+            channel_type,
+            thread_ts,
+            message_ts,
+            is_monitored_channel=origin == SLACK_CHANNEL_MESSAGE_ORIGIN,
+        ),
         "visibility": "public",
     }
     permalink = str(event.get("permalink") or "").strip() or None

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -150,11 +150,13 @@ def slack_response_target(payload: Mapping[str, Any]) -> dict[str, Any]:
     existing = payload.get("response_target")
     channel_type = _clean(payload.get("channel_type"))
     message_ts = _clean(payload.get("message_ts"))
+    is_monitored_channel = _clean(payload.get("origin")) == SLACK_CHANNEL_MESSAGE_ORIGIN
     if isinstance(existing, Mapping):
         thread_ts = _response_thread_ts(
             channel_type,
             _clean(existing.get("thread_ts")),
             message_ts,
+            is_monitored_channel=is_monitored_channel,
         )
         return {
             "channel_id": _clean(existing.get("channel_id") or payload.get("channel_id")),
@@ -164,14 +166,29 @@ def slack_response_target(payload: Mapping[str, Any]) -> dict[str, Any]:
     thread_ts = _clean(payload.get("thread_ts") or message_ts)
     return {
         "channel_id": _clean(payload.get("channel_id")),
-        "thread_ts": _response_thread_ts(channel_type, thread_ts, message_ts),
+        "thread_ts": _response_thread_ts(
+            channel_type,
+            thread_ts,
+            message_ts,
+            is_monitored_channel=is_monitored_channel,
+        ),
         "visibility": "public",
     }
 
 
-def _response_thread_ts(channel_type: str, thread_ts: str, message_ts: str) -> str | None:
+def _response_thread_ts(
+    channel_type: str,
+    thread_ts: str,
+    message_ts: str,
+    *,
+    is_monitored_channel: bool = False,
+) -> str | None:
     if channel_type == "im":
         return None
+    if is_monitored_channel:
+        # Monitored-channel triage replies thread under the original alert so the
+        # alert and Illo's response stay attached. See ingress._response_thread_ts.
+        return thread_ts or message_ts or None
     if thread_ts and thread_ts != message_ts:
         return thread_ts
     return None

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -79,6 +79,44 @@ def test_monitored_channel_plain_message_admitted_as_channel_message():
     assert envelope["idempotency_key"] == "slack:T789:C_ALERTS:1716900000.000200"
 
 
+def test_monitored_channel_reply_threads_under_alert():
+    """A monitored-channel triage reply must thread UNDER the original alert.
+
+    Regression: monitored alerts are top-level (thread_ts == message_ts). The
+    default reply-target logic drops thread_ts for top-level messages (so Illo
+    does not force threads on plain mentions), which sent Illo's monitored-channel
+    reply as a detached top-level message instead of a threaded reply under the
+    alert. The monitored-channel origin is the deliberate exception.
+    """
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.channel_message"
+    # Threads under the alert's own ts, in both mirrors of response_target.
+    assert envelope["hints"]["response_target"]["thread_ts"] == "1716900000.000200"
+    assert envelope["payload"]["response_target"]["thread_ts"] == "1716900000.000200"
+
+
+def test_monitored_channel_reply_threads_under_existing_parent_thread():
+    """If the monitored alert is itself already threaded, reply under its parent."""
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(thread_ts="1716899999.000001"),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["hints"]["response_target"]["thread_ts"] == "1716899999.000001"
+
+
 def test_unmonitored_channel_plain_message_is_ignored():
     from brain.systems.slack.ingress import normalize_slack_socket_event
 
@@ -243,6 +281,9 @@ def test_build_payload_for_mention_still_forces_reply():
     assert metadata["required_response_tool"] == "post_slack_reply"
     assert metadata["final_answer_target_surface"] == "slack"
     assert "headless" not in metadata
+    # Origin-scoped: the monitored-channel threading exception must NOT change
+    # mention behavior — a top-level mention still replies top-level (no thread).
+    assert metadata["slack_trigger"]["response_target"]["thread_ts"] is None
 
 
 def test_agent_run_request_for_monitor_is_headless_without_forced_tool():
@@ -266,6 +307,26 @@ def test_agent_run_request_for_monitor_is_headless_without_forced_tool():
     assert request.metadata.get("final_answer_target_surface") == "headless"
     assert request.target_ref.get("headless") is True
     assert request.target_ref.get("slack_trigger", {}).get("channel_id") == "C_ALERTS"
+
+
+def test_channel_monitor_reply_target_threads_under_alert():
+    """The trigger built for a monitored message carries a thread anchor so an
+    explicit post_slack_reply (the only reply path in a headless monitor run)
+    threads under the alert rather than posting a detached channel message.
+    """
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+        inbound_event_id="evt1",
+        connection_id="conn1",
+        idempotency_key="idem1",
+    )
+
+    slack_trigger = payload["payload"]["metadata"]["slack_trigger"]
+    assert slack_trigger["response_target"]["thread_ts"] == "1716900000.000200"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What
Monitored-channel triage replies now thread **under the original alert** instead of posting as a detached top-level channel message.

## Why
When Illo triages an alert in a monitored channel (`slack.channel_message`, from #256), it replied as a new top-level message. `_response_thread_ts` intentionally drops `thread_ts` when `thread_ts == message_ts` (so plain @-mentions aren't forced into threads) — but a monitored alert *is* top-level, so `thread_ts == message_ts` and the reply anchor was nulled. Result: Illo's response detached from the alert, and human follow-ups formed a second thread that fragmented context (the "it got lost" failure mode from the #alerts customer-support incident).

## How
Origin-scoped exception in both `_response_thread_ts` copies (ingress + triggers): for `slack.channel_message`, thread under the alert's `thread_ts or message_ts`. Mentions and DMs are unchanged. Fixing the normalized `response_target` upstream also neutralizes the redundant strip guard in the `post_slack_reply` handler (its `not response_target_thread_ts` condition is now false).

## Tests
- New: thread-under-alert (ingress **and** trigger level), thread-under-existing-parent-thread, and a guard asserting a top-level mention still stays unthreaded (locks the origin-scoping so this change can't regress mention/DM behavior).
- 74/74 slack/trigger tests green against current `main`. (Unrelated `torch`-install failures in `test_gpu_server`/`test_llm_worker` are pre-existing environment issues, untouched by this change.)

## Scope
This is the threading half of the #alerts customer-support fix. The investigation-capability wiring (routing customer-generation alerts to a read-only prod-DB investigation) and the triage-doc (record 1155) instruction updates are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
