### PR TITLE
Add uwear-generation-investigation skill for customer-generation triage

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-generation-investigation/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-generation-investigation/SKILL.md
@@ -1,0 +1,151 @@
+## Role
+
+You investigate **customer-reported generation-quality complaints** for Uwear,
+read-only. Given a customer `profile_id` (and a complaint such as "the garment
+has no pockets", wrong color, missing detail), you fetch the customer's recent
+garment generation(s) from the production database, read the prompt, inputs,
+model, and QA/status, and produce a concrete, evidence-backed **hypothesis** for
+why the customer got that result. This is the mechanical first-pass triage that
+precedes any engineering ticket.
+
+## Use When
+
+- A customer support alert reports an unexpected or wrong generation and carries
+  a `Profile ID` (for example a Retool "New: Issue" with a profile id and an
+  attachment).
+- Someone asks "why did this user get this generation?", "investigate the
+  generation for profile X", or to explain an unexpected garment result.
+- You already have a `generation_id` or `profile_id` and need the payload behind
+  a result.
+
+## Do Not Use When
+
+- The task is generic production-database analysis (use `prod-postgres-analysis`
+  directly) or unrelated data.
+- Any write, migration, backfill, schema change, or bulk export.
+- Exporting customer PII. You need technical generation facts, not personal data.
+
+## Credential Boundary And Safety
+
+This skill is a specialization of `prod-postgres-analysis`; obey its full
+safety contract. In short:
+
+- Connect read-only with the Vault key **`PROD_POSTGRES_READONLY_URL`**, mounted
+  as a `secret_env` for the single tool call. Never print, echo, log, or persist
+  the connection URL or password.
+- The run image has **`psycopg2`** (no `psql`, no `psycopg`). Query via Python +
+  psycopg2.
+- Every session: `SET default_transaction_read_only = on;` (or
+  `BEGIN READ ONLY;`), `SET statement_timeout = '15s';`,
+  `SET lock_timeout = '2s';`, `SET idle_in_transaction_session_timeout = '30s';`.
+- `LIMIT` every row query (default 10, hard max 100). No DDL/DML/admin commands.
+  Stop immediately on any write capability, permission error, or timeout loop.
+
+Example mount:
+
+```json
+"secret_env": {
+  "DATABASE_URL": {
+    "vault_key": "PROD_POSTGRES_READONLY_URL",
+    "reason": "Read-only generation investigation for a customer complaint"
+  }
+}
+```
+
+## The Canonical Join (profile_id → generation)
+
+A customer profile owns generations through the **polymorphic owner columns**,
+NOT the legacy batch path:
+
+```sql
+-- recent generations for a customer profile
+SELECT g.generation_id, g.status, g.created_at, g.model_id,
+       g.generation_setting, g.payload
+FROM generation g
+WHERE g.user_id = :profile_id
+  AND g.user_type = 'profile'
+ORDER BY g.generation_id DESC
+LIMIT 10;
+```
+
+- `generation.user_type` is `varchar` (observed values include `profile` and
+  `shopper`); customer generations are `user_type = 'profile'` with
+  `user_id = profile.profile_id`.
+- Do **not** use `generation.batch_id -> batch.profile_id`. That path is
+  **legacy**: recent profiles bypass batches entirely (the newest generations
+  carry no `batch_id`, and `batch.profile_id` stops at older ids), so it returns
+  zero rows for recent customers even when they have generations.
+- Choose the generation(s) relevant to the complaint by recency and the
+  complaint's description/timeframe. A complaint's attached image is an output,
+  so correlate via `generation_result` / `generation_result_origin` when a
+  specific result is referenced.
+
+## What To Read For The Hypothesis
+
+For the relevant generation(s), gather the payload with these supporting joins:
+
+```sql
+LEFT JOIN ai_model am
+       ON am.model_id = g.model_id                       -- am.slug, am.display_name, am.model_family, am.provider
+LEFT JOIN clothing_generation_association cga
+       ON cga.generation_id = g.generation_id
+LEFT JOIN clothing_item ci
+       ON ci.clothing_item_id = cga.clothing_item_id      -- ci.tryon_prompt  (NULL => item semantics not carried through)
+LEFT JOIN generation_result_origin gro
+       ON gro.generation_id = g.generation_id             -- gro.status  (watch for 'non_compliant')
+LEFT JOIN generation_result_qa grq
+       ON grq.generation_result_id = gro.generation_result_id   -- QA status + decision
+```
+
+Key fields:
+
+- **Composed prompt / inputs:** `generation.generation_setting` (jsonb; keys
+  include `model_name`, `operations`, `qa`, `reference_attachments`,
+  `img_ref_urls`, `subject_detection`, `resolution`, `upscale_factor`,
+  `face_enhancement`) and `generation.payload`.
+- **Garment try-on prompt:** `clothing_item.tryon_prompt`. A NULL here means the
+  item-level garment semantics (pockets, cuffs, etc.) were not carried through
+  the canonical field — a common root cause of missing-detail complaints.
+- **Model:** `ai_model.slug` / `display_name` / `provider`.
+- **Outcome vs QA:** `generation_result_origin.status` (e.g. `non_compliant`)
+  versus the `generation_result_qa` decision. A `non_compliant` result that
+  still passed QA is a QA-gap signal worth calling out.
+
+## Forming The Hypothesis
+
+State one concrete, evidence-backed cause. Common patterns:
+
+- **Prompt / detail preservation:** the composed prompt or `tryon_prompt` never
+  specified the missing detail, or `tryon_prompt` was NULL so the model inferred
+  from images.
+- **Reference-image gap:** `reference_attachments` / `img_ref_urls` lacked the
+  detail.
+- **Model behavior:** the model (`ai_model.slug`) dropped the detail.
+- **QA gap:** `generation_result_origin.status = non_compliant` but QA passed —
+  the failure was not caught.
+
+## Output Contract
+
+Return, with no customer PII (no email/name):
+
+- **Hypothesis:** one sentence, the most likely cause.
+- **Evidence:** the relevant prompt/settings text, `tryon_prompt` (or that it was
+  NULL), model slug, `generation.status`, `generation_result_origin.status`, and
+  the QA decision. Cite the `generation_id`(s).
+- **Recommended issue:** a ready-to-file body for a `uwear-ai/uwear-backend`
+  GitHub issue that points the owner at the payload to confirm or deny, prefixed
+  with `> *This was generated by AI during triage.*`.
+- If the profile has **no** generations via the canonical path, say so plainly
+  and ask support for the `generation_id` or asset id — do not guess.
+
+## Failure Modes
+
+- **Vault key missing:** stop and request `PROD_POSTGRES_READONLY_URL` through
+  Vault; never accept a pasted DSN.
+- **No generations for the profile:** report it plainly; the alert's `profile_id`
+  may be wrong, or a specific result id is needed. Do not fall back to the legacy
+  batch path and conclude "no generations".
+- **Ambiguous which generation:** list the recent candidates with timestamps and
+  ask which, rather than asserting.
+- **Sensitive content:** aggregate/technical facts only; never expose personal
+  data.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-generation-investigation/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-generation-investigation/skill.toml
@@ -1,0 +1,31 @@
+schema_version = 1
+name = "uwear-generation-investigation"
+display_name = "Uwear Generation Investigation"
+version = "1.0.0"
+description = "Read-only recipe for investigating a customer-reported generation-quality complaint: given a profile_id, fetch the generation payload (prompt, inputs, model, QA/status) from production Postgres and form an evidence-backed hypothesis for why the customer got that result."
+license = "UNLICENSED"
+source = "self_hosted"
+visibility = "private_local"
+maturity = "emerging"
+
+[routing]
+triggers = [
+  { pattern = "why did the customer get this generation", direction = "for" },
+  { pattern = "customer reported a bad generation", direction = "for" },
+  { pattern = "investigate a generation for a profile", direction = "for" },
+  { pattern = "garment generation quality issue", direction = "for" },
+  { pattern = "generation quality complaint", direction = "for" },
+  { pattern = "unexpected generation result", direction = "for" },
+  { pattern = "customer support generation issue", direction = "for" },
+  { pattern = "explain this generation for a profile_id", direction = "for" },
+]
+
+[runtime]
+default_thinking_tier = "high"
+
+[permissions]
+toolsets = ["brain"]
+
+[loading]
+summary = "SKILL.md#role"
+procedure = "SKILL.md"

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -260,6 +260,40 @@ def test_report_workspace_blocker_routes_to_headless_worker():
     assert any("Search for duplicates" in guardrail["text"] for guardrail in skill["guardrails"])
 
 
+def test_uwear_generation_investigation_bundle_uses_canonical_join():
+    from brain.systems.skills.builtin import (
+        BUILTIN_SKILL_BUNDLE_ROOT,
+        BUILTIN_SKILLS,
+        _filesystem_skill_bundle_names,
+    )
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    names = set(_filesystem_skill_bundle_names())
+    assert "uwear-generation-investigation" in names
+    # Filesystem team bundle, not a core product primitive.
+    assert "uwear-generation-investigation" not in BUILTIN_SKILLS
+
+    bundle = load_skill_bundle(
+        BUILTIN_SKILL_BUNDLE_ROOT / "uwear-generation-investigation"
+    )
+    assert bundle.manifest.source == "self_hosted"
+    assert bundle.manifest.visibility == "private_local"
+
+    procedure = bundle.skill_markdown
+    # The validated CANONICAL owner join, read-only credential, and the payload
+    # fields the hypothesis depends on.
+    assert "user_type = 'profile'" in procedure
+    assert "PROD_POSTGRES_READONLY_URL" in procedure
+    assert "tryon_prompt" in procedure
+    assert "generation_result_origin" in procedure
+    # Must actively warn off the legacy batch path that silently misses recent
+    # profiles (the trap that would have produced a wrong recipe).
+    assert "legacy" in procedure.lower()
+    assert "batch" in procedure.lower()
+    # Read-only safety must be spelled out, not assumed.
+    assert "read-only" in procedure.lower()
+
+
 def _has_text_items(items: Any, key: str) -> bool:
     if not isinstance(items, list) or not items:
         return False


### PR DESCRIPTION
## What
A builtin skill bundle **`uwear-generation-investigation`** giving Illo a read-only recipe to investigate customer-reported generation-quality complaints.

## Why
When a customer reports a bad generation ("the garment has no pockets"), the mechanical first-pass triage is: given a `profile_id`, fetch the generation payload (prompt, inputs, model, QA/status) from prod and form a hypothesis for why they got that result. Illo had the generic `prod-postgres-analysis` skill and read-only prod access (`PROD_POSTGRES_READONLY_URL`), but **no uwear-specific recipe** — so monitored-channel triage flagged the alert and stopped instead of investigating (the #alerts "it got lost" failure).

## What's in it
- The **canonical owner join**, validated end-to-end against production (read-only): `generation.user_id = profile.profile_id AND generation.user_type = 'profile'`.
- An explicit warning that the **legacy** `generation.batch_id → batch.profile_id` path silently misses recent profiles (0/1000 newest generations carry a `batch_id`; `batch.profile_id` stops at an older id) — the trap that would have produced a wrong recipe.
- The payload fields the hypothesis depends on: `generation.generation_setting`, `clothing_item.tryon_prompt`, `ai_model`, `generation_result_origin.status`, `generation_result_qa`.
- The `prod-postgres-analysis` read-only safety contract + `PROD_POSTGRES_READONLY_URL` Vault mount (psycopg2; `BEGIN READ ONLY`; timeouts; `LIMIT`; no DDL/DML).

## Validation
The join and hypothesis were validated by running the actual investigation against prod (read-only) for the real incident, profile **157748**: 8 generations found via the canonical path (0 via the legacy batch path). Hypothesis = a detail-preservation gap (the composed prompt said "side pockets" but every `clothing_item.tryon_prompt` was NULL) **plus** a QA gap (`generation_result_origin.status = non_compliant` yet QA passed with `decision=true`).

## Notes
- Auto-discovered as a filesystem bundle — no registry change needed.
- Pairs with a routing update to the live triage doc (record 1155) that points customer-support alerts to this skill; applied separately.
- 15/15 builtin skill suite tests pass (incl. a new test locking the canonical join, the read-only credential, and the anti-legacy-batch warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
