### PR TITLE
Retire personal/legacy tokens from the GitHub write path

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -65,17 +65,14 @@ async def _github_token_candidates(
     token_secret_key: str | None,
     for_write: bool = False,
 ) -> list[dict[str, str | None]]:
-    """Return safe token candidates for a GitHub repo read.
+    """Return safe token candidates for a GitHub repo operation.
 
     A bad explicit key should not strand a read when the org has a project-bound
     or default GitHub token that can see the target repo.
 
-    ``for_write`` narrows the vault-inventory fallback to the canonical
-    ``GITHUB_TOKEN``/``GH_TOKEN`` default. A read may fall back to any available
-    github-ish secret, but an irreversible public write must not silently author
-    an issue under an arbitrary teammate's personal token — write identity is
-    limited to an explicit key, a repo project-binding, or the designated
-    default token.
+    ``for_write`` restricts automatic identity selection to GitHub App project
+    bindings. Writes may also use an explicit ``token_secret_key``. Reads keep
+    the broader project-binding and vault-inventory fallback behavior.
     """
 
     user_id = _clean(getattr(_agent_context, "user_id", None))
@@ -113,6 +110,7 @@ async def _github_token_candidates(
                 actor_user_id=user_id,
                 org_id=org_id,
                 project_slug=repo_slug,
+                github_app_only=for_write,
             )
         except Exception:
             bound_env = {}
@@ -121,36 +119,33 @@ async def _github_token_candidates(
         for env_name, token in sorted(bound_env.items()):
             await add_token(token, f"project_binding:{env_name}")
 
-        try:
-            secrets = await async_list_secrets(actor_user_id=user_id, org_id=org_id)
-        except Exception:
-            secrets = []
+        if not for_write:
+            try:
+                secrets = await async_list_secrets(actor_user_id=user_id, org_id=org_id)
+            except Exception:
+                secrets = []
 
-        def priority(secret: dict[str, Any]) -> tuple[int, str]:
-            key = str(secret.get("key_name") or "")
-            if key == "GITHUB_TOKEN":
-                return (0, key)
-            if str(secret.get("category") or "").lower() == "github":
-                return (1, key)
-            return (2, key)
+            def priority(secret: dict[str, Any]) -> tuple[int, str]:
+                key = str(secret.get("key_name") or "")
+                if key == "GITHUB_TOKEN":
+                    return (0, key)
+                if str(secret.get("category") or "").lower() == "github":
+                    return (1, key)
+                return (2, key)
 
-        github_like = [
-            secret
-            for secret in secrets
-            if normalize_agent_access_level(secret.get("agent_access_level"))
-            == VAULT_AGENT_ACCESS_AVAILABLE
-            and (
-                str(secret.get("key_name") or "") in {"GITHUB_TOKEN", "GH_TOKEN"}
-                if for_write
-                else (
+            github_like = [
+                secret
+                for secret in secrets
+                if normalize_agent_access_level(secret.get("agent_access_level"))
+                == VAULT_AGENT_ACCESS_AVAILABLE
+                and (
                     str(secret.get("key_name") or "") == "GITHUB_TOKEN"
                     or "github" in str(secret.get("key_name") or "").lower()
                     or str(secret.get("category") or "").lower() == "github"
                 )
-            )
-        ]
-        for secret in sorted(github_like, key=priority):
-            await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
+            ]
+            for secret in sorted(github_like, key=priority):
+                await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
 
     if not candidates:
         candidates.append({"key_name": None, "token": None, "source": "public"})
@@ -308,9 +303,8 @@ async def _handle_create_github_issue(
     if not write_candidates:
         return json.dumps({
             "error": (
-                "No write-capable GitHub token could reach this repo. Ask for clarification "
-                "(which repo, or a write-capable token) or fall back to an internal tracker "
-                "record + handoff — do not claim a GitHub issue was filed."
+                f"No GitHub App identity is connected for {repo_slug}. Connect the GitHub App "
+                "for this repo (or pass token_secret_key) so Illo can write as its own bot."
             ),
             "status_code": 401,
             "no_write_token": True,

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -660,6 +660,7 @@ async def async_resolve_project_bound_env_tokens(
     project_slug: str | None = None,
     project_slugs: list[str] | tuple[str, ...] | set[str] | None = None,
     target_registry_id: int | None = None,
+    github_app_only: bool = False,
 ) -> dict[str, str]:
     """Return env-name/token pairs for matching org project bindings."""
     if not project_slug and not project_slugs and target_registry_id is None:
@@ -678,6 +679,8 @@ async def async_resolve_project_bound_env_tokens(
                 target_registry_id=target_registry_id,
             )
         ]:
+            if github_app_only and getattr(secret, "category", None) != "github_app":
+                continue
             if getattr(secret, "category", None) == "github_app":
                 secret.last_accessed_at = datetime.now(timezone.utc)
                 secret.access_count = (secret.access_count or 0) + 1

--- a/tests/test_create_github_issue_tool.py
+++ b/tests/test_create_github_issue_tool.py
@@ -67,9 +67,12 @@ async def test_create_github_issue_returns_no_write_token_when_no_token_resolves
         )
 
     payload = json.loads(result)
+    # Contract, not copy: a write with no App identity is flagged no_write_token,
+    # returns a non-empty actionable error, and never opens an issue. The exact
+    # wording is free to change without breaking this test.
     assert payload["no_write_token"] is True
     assert payload["repo"] == "uwear-ai/uwear-backend"
-    assert "GitHub App" in payload["error"]
+    assert isinstance(payload.get("error"), str) and payload["error"].strip()
     create.assert_not_awaited()
 
 

--- a/tests/test_create_github_issue_tool.py
+++ b/tests/test_create_github_issue_tool.py
@@ -69,7 +69,7 @@ async def test_create_github_issue_returns_no_write_token_when_no_token_resolves
     payload = json.loads(result)
     assert payload["no_write_token"] is True
     assert payload["repo"] == "uwear-ai/uwear-backend"
-    assert "clarification" in payload["error"]
+    assert "GitHub App" in payload["error"]
     create.assert_not_awaited()
 
 

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -421,6 +421,67 @@ async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, se
     }
 
 
+async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(patch_uow, session, monkeypatch):
+    from brain.systems.vault import async_resolve_project_bound_env_tokens
+
+    github_app = await _secret(
+        session,
+        "GITHUB_APP__ILLO",
+        "github-app-blob",
+        access_level="manual",
+        category="github_app",
+    )
+    await _binding(
+        session,
+        github_app,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GITHUB_TOKEN",
+    )
+    personal = await _secret(
+        session,
+        "AXEL_LEGACY",
+        "personal-token",
+        access_level="ask",
+        category="github",
+    )
+    await _binding(
+        session,
+        personal,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GH_TOKEN",
+    )
+
+    async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
+        assert decrypted_blob == "github-app-blob"
+        assert repositories == ["uwear-backend"]
+        assert permissions == {"issues": "write"}
+        return "minted-installation-token"
+
+    monkeypatch.setattr(
+        "brain.systems.vault.github_app_mint.async_mint_installation_token",
+        async_mint_installation_token,
+    )
+
+    app_only = await async_resolve_project_bound_env_tokens(
+        actor_user_id=OTHER_USER_ID,
+        org_id=ORG_ID,
+        project_slug="uwear-ai/uwear-backend",
+        github_app_only=True,
+    )
+    all_bound = await async_resolve_project_bound_env_tokens(
+        actor_user_id=OTHER_USER_ID,
+        org_id=ORG_ID,
+        project_slug="uwear-ai/uwear-backend",
+        github_app_only=False,
+    )
+
+    assert app_only == {"GITHUB_TOKEN": "minted-installation-token"}
+    assert all_bound == {
+        "GITHUB_TOKEN": "minted-installation-token",
+        "GH_TOKEN": "personal-token",
+    }
+
+
 async def test_create_github_issue_uses_minted_github_app_project_binding(
     patch_uow,
     session,
@@ -480,6 +541,185 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     assert access_request["json"]["repositories"] == ["uwear-backend"]
     assert access_request["json"]["permissions"] == {"issues": "write"}
     assert issue_request["headers"]["Authorization"] == "Bearer minted-issue-token"
+
+
+async def test_create_github_issue_does_not_use_personal_project_binding(
+    patch_uow,
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.github import _handle_create_github_issue
+
+    personal = await _secret(
+        session,
+        "AXEL_LEGACY",
+        "personal-token",
+        access_level="ask",
+        category="github",
+    )
+    await _binding(
+        session,
+        personal,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GH_TOKEN",
+    )
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("personal token must not be used for GitHub writes")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.github.async_create_repo_issue",
+        fail_if_called,
+    )
+
+    with bind_agent_context({"user_id": USER_ID, "org_id": ORG_ID}):
+        result = await _handle_create_github_issue(
+            repo="uwear-ai/uwear-backend",
+            title="Backend incident",
+        )
+
+    payload = json.loads(result)
+    assert payload["repo"] == "uwear-ai/uwear-backend"
+    assert payload["status_code"] == 401
+    assert payload["no_write_token"] is True
+    assert "No GitHub App identity is connected for uwear-ai/uwear-backend" in payload["error"]
+
+
+async def test_create_github_issue_does_not_use_canonical_inventory_personal_token(
+    patch_uow,
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.github import _handle_create_github_issue
+
+    await _secret(
+        session,
+        "GITHUB_TOKEN",
+        "personal-inventory-token",
+        access_level="available",
+        category="github",
+    )
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("inventory token must not be used for GitHub writes")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.github.async_create_repo_issue",
+        fail_if_called,
+    )
+
+    with bind_agent_context({"user_id": USER_ID, "org_id": ORG_ID}):
+        result = await _handle_create_github_issue(
+            repo="uwear-ai/uwear-backend",
+            title="Backend incident",
+        )
+
+    payload = json.loads(result)
+    assert payload["repo"] == "uwear-ai/uwear-backend"
+    assert payload["status_code"] == 401
+    assert payload["no_write_token"] is True
+    assert "No GitHub App identity is connected for uwear-ai/uwear-backend" in payload["error"]
+
+
+async def test_create_github_issue_honors_explicit_token_secret_key_for_write(
+    patch_uow,
+    session,
+    monkeypatch,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.github import _handle_create_github_issue
+
+    await _secret(
+        session,
+        "CUSTOM_WRITE_TOKEN",
+        "explicit-write-token",
+        access_level="available",
+        category="github",
+    )
+    issued_with = {}
+
+    async def fake_create_repo_issue(repo_slug, *, title, body, labels, assignees, token):
+        issued_with["repo_slug"] = repo_slug
+        issued_with["token"] = token
+        return {
+            "repo": repo_slug,
+            "issue": {
+                "number": 123,
+                "html_url": "https://github.com/uwear-ai/uwear-backend/issues/123",
+                "title": title,
+                "state": "open",
+            },
+        }
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.github.async_create_repo_issue",
+        fake_create_repo_issue,
+    )
+
+    with bind_agent_context({"user_id": USER_ID, "org_id": ORG_ID}):
+        result = await _handle_create_github_issue(
+            repo="uwear-ai/uwear-backend",
+            title="Backend incident",
+            token_secret_key="CUSTOM_WRITE_TOKEN",
+        )
+
+    payload = json.loads(result)
+    assert payload["repo"] == "uwear-ai/uwear-backend"
+    assert payload["issue"]["number"] == 123
+    assert payload["token_secret_key_used"] is True
+    assert payload["token_source"] == "explicit"
+    assert payload["token_key_name"] == "CUSTOM_WRITE_TOKEN"
+    assert payload.get("no_write_token") is not True
+    assert issued_with == {
+        "repo_slug": "uwear-ai/uwear-backend",
+        "token": "explicit-write-token",
+    }
+
+
+async def test_read_token_candidates_still_use_personal_binding_and_inventory(
+    patch_uow,
+    session,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.github import _github_token_candidates
+
+    personal = await _secret(
+        session,
+        "AXEL_LEGACY",
+        "personal-bound-token",
+        access_level="ask",
+        category="github",
+    )
+    await _binding(
+        session,
+        personal,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GH_TOKEN",
+    )
+    await _secret(
+        session,
+        "GITHUB_TOKEN",
+        "personal-inventory-token",
+        access_level="available",
+        category="github",
+    )
+
+    with bind_agent_context({"user_id": USER_ID, "org_id": ORG_ID}):
+        candidates = await _github_token_candidates(
+            repo_slug="uwear-ai/uwear-backend",
+            token_secret_key=None,
+            for_write=False,
+        )
+
+    assert {
+        (candidate["source"], candidate["token"])
+        for candidate in candidates
+    } == {
+        ("project_binding:GH_TOKEN", "personal-bound-token"),
+        ("vault_inventory", "personal-inventory-token"),
+    }
 
 
 async def test_project_bindings_require_org_scope(patch_uow, session):


### PR DESCRIPTION
## What & why

Now that the GitHub App (`illo-bot`) is the proven write identity ([#265](https://github.com/Illospace/illospace/pull/265), live in prod), this retires **personal/legacy tokens from the write path** so Illo never silently authors a GitHub issue under a teammate's personal token.

Before this, the write-candidate list still fell back to personal tokens: the `GH_TOKEN → *_LEGACY` project bindings and the canonical available `GITHUB_TOKEN` inventory secret. After this, **GitHub writes auto-select only a GitHub App identity or an explicit key.**

## Change

- **`async_resolve_project_bound_env_tokens`** — new `github_app_only` flag that skips non-`github_app` bindings (only App-minted tokens resolve when set). Default `False` → existing callers unchanged.
- **`_github_token_candidates`** — for writes: resolve bindings with `github_app_only=for_write`, and gate the vault-inventory fallback behind `if not for_write`. The explicit `token_secret_key` path is kept for both. Net write identity = **App-backed binding or explicit key only**.
- **`no_write_token`** message is now honest/actionable ("No GitHub App identity is connected for `<repo>`…").

## Reads are unchanged

`for_write=False` still returns personal project-binding tokens **and** the inventory `github`-ish secrets exactly as before — Illo keeps reading private repos via existing tokens. This is write-identity only.

## Consequence to know

Auto-creating an issue in a repo with **no App binding** — notably `Illospace/illospace` (a different org the `uwear-ai` App can't reach) — now returns `no_write_token` until an App is connected there or an explicit `token_secret_key` is passed. **Reads there are unaffected.** The four bound `uwear-ai` repos are unchanged (App already covers them).

## Testing

`176 passed` across `test_vault_project_tokens.py`, `test_vault_hardening.py`, `test_runtime_secrets.py`, `test_vault_async.py`, `test_github_app_mint.py`, `test_agent_run_runtime.py`, `test_vault.py`, `test_vault_routes.py`. New coverage: the `github_app_only` resolver filter, write-retirement (personal-only → `no_write_token`, token not used), read-preservation (personal tokens still selected for reads), and the explicit-key path.

Implemented by Codex gpt-5.5 (xhigh); it's a fail-safe restriction (removes write candidates, never adds capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
