### PR TITLE
Widen GitHub App mint scope to contents:read + pull_requests:read

### DIFF
--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -721,14 +721,17 @@ async def async_resolve_project_bound_env_tokens(
             assert value is not None
             env[env_name] = value
             continue
-        from brain.systems.vault.github_app_mint import async_mint_installation_token
+        from brain.systems.vault.github_app_mint import (
+            DEFAULT_INSTALLATION_PERMISSIONS,
+            async_mint_installation_token,
+        )
 
         assert repo_name is not None
         try:
             env[env_name] = await async_mint_installation_token(
                 decrypted_blob,
                 repositories=[repo_name],
-                permissions={"issues": "write"},
+                permissions=DEFAULT_INSTALLATION_PERMISSIONS,
             )
         finally:
             decrypted_blob = None

--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -19,7 +19,19 @@ from brain.systems.cortex.project_context.github import (
 )
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
-DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {"issues": "write"}
+# Minted installation tokens carry issues:write (to file issues) plus read-only
+# contents + pull_requests, so the same App token serves read_github_source
+# PR-listing and project-bound git-clone/source reads. This lets the legacy
+# personal-PAT read fallbacks (GITHUB_TOKEN__AXEL_LEGACY via GH_TOKEN, and the
+# static GITHUB_TOKEN) be retired. The added scopes are read-only: the App can
+# read PRs/contents but cannot push or open PRs, so the write blast-radius stays
+# issues-only and no GitHub re-approval is required (the installation already
+# holds Contents/Pull-requests read&write).
+DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {
+    "issues": "write",
+    "contents": "read",
+    "pull_requests": "read",
+}
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
 _PEM_HASH_PREFIX_LENGTH = 16
 

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -206,9 +206,10 @@ async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rs
         permissions={"metadata": "read"},
     ) == "metadata-token"
 
+    default_scope = {"issues": "write", "contents": "read", "pull_requests": "read"}
     assert [request["json"] for request in requests] == [
-        {"repositories": ["uwear-backend"], "permissions": {"issues": "write"}},
-        {"repositories": ["uwear-mobile"], "permissions": {"issues": "write"}},
+        {"repositories": ["uwear-backend"], "permissions": default_scope},
+        {"repositories": ["uwear-mobile"], "permissions": default_scope},
         {"repositories": ["uwear-backend"], "permissions": {"metadata": "read"}},
     ]
 

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -400,7 +400,7 @@ async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, se
         {
             "decrypted_blob": "github-app-blob",
             "repositories": ["uwear-backend"],
-            "permissions": {"issues": "write"},
+            "permissions": {"issues": "write", "contents": "read", "pull_requests": "read"},
             "transaction_open": False,
         }
     ]
@@ -454,7 +454,7 @@ async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(pa
     async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
         assert decrypted_blob == "github-app-blob"
         assert repositories == ["uwear-backend"]
-        assert permissions == {"issues": "write"}
+        assert permissions == {"issues": "write", "contents": "read", "pull_requests": "read"}
         return "minted-installation-token"
 
     monkeypatch.setattr(
@@ -539,7 +539,7 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     access_request = next(request for request in client.requests if request["url"].endswith("/access_tokens"))
     issue_request = next(request for request in client.requests if request["url"].endswith("/issues"))
     assert access_request["json"]["repositories"] == ["uwear-backend"]
-    assert access_request["json"]["permissions"] == {"issues": "write"}
+    assert access_request["json"]["permissions"] == {"issues": "write", "contents": "read", "pull_requests": "read"}
     assert issue_request["headers"]["Authorization"] == "Bearer minted-issue-token"
 
 


### PR DESCRIPTION
## Why

Illo's GitHub App (`illo-bot[bot]`, #265) mints an installation token that is the confirmed **sole issue-write path** for the 4 tracked repos (verified: run 953 filed `uwear-ai/uwear-backend#888` as `illo-bot[bot]`). But the mint was scoped **`issues:write` only**, so:

- `read_github_source` → `list_pull_requests` and project-bound **git-clone / source reads** 404 on the App token and fall back to the legacy personal PATs (`GITHUB_TOKEN__AXEL_LEGACY` via the `GH_TOKEN` binding, or the static `GITHUB_TOKEN`).
- That read fallback is the residual dependency keeping the legacy PATs alive, and it's the mechanism behind the run-947 non-deterministic-token 404 (a PR-list read fell back through a `404` to a vault-inventory PAT: `token_source: vault_inventory, fallback_from_status_code: 404`).

## What

- `DEFAULT_INSTALLATION_PERMISSIONS` widened to add read-only `contents:read` + `pull_requests:read`.
- The project-bound env resolver (`async_resolve_project_bound_env_tokens`) now mints at that default scope instead of a hardcoded `{"issues": "write"}`.

## Safety

- The added scopes are **read-only**. The App can read PRs/contents but still **cannot push or open PRs** — the **write blast-radius stays issues-only** and branch protection is unaffected.
- **No GitHub re-approval needed:** the `illo-bot` installation already holds Contents + Pull-requests **read & write**; this only widens what the *minted token* requests.
- Scope is part of the mint cache key, so tokens re-mint cleanly at the new scope.

## Relationship to #269

Complementary, independent diffs. #269 hardens the **write** path (App-only issue writes). This PR lets the **read** path move onto the App too, which is what actually unblocks retiring the legacy read PATs.

## Rollout / legacy-PAT retirement sequencing

- ✅ **Tier 1 (done):** `GITHUB_TOKEN__JB_LEGACY` (`public_repo`-only, 404s on private repos) deleted from Vault — closes the run-947 read-404.
- **This PR (Tier 2 prereq):** widen mint scope → merge → deploy.
- **After deploy, verify** for each of `uwear-backend` / `uwearaiapp` / `uwear-mobile-app` / `uwear-website`:
  - `read_github_source` `list_pull_requests` returns `token_source: project_binding:GITHUB_TOKEN` with **no** `fallback_from_status_code`;
  - a project-bound `git clone` of a private repo succeeds via the injected `GITHUB_TOKEN`.
- **Then retire** `GITHUB_TOKEN__AXEL_LEGACY` (id 2) + its `GH_TOKEN` bindings + the static `GITHUB_TOKEN` (id 1). After that the App is the sole path for **reads and writes**.

## Tests

Updated the four assertions that pinned the old `issues`-only default mint scope (`test_github_app_mint.py`, `test_vault_project_tokens.py`); the explicit-scope `_exchange_installation_token` tests are intentionally unchanged. Files byte-compile clean; I could not run the suite locally (needs the full app dependency tree) — **CI is the gate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
