### PR TITLE
Widen minted App token to serve reads (contents + pull_requests read)

### DIFF
--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -728,7 +728,16 @@ async def async_resolve_project_bound_env_tokens(
             env[env_name] = await async_mint_installation_token(
                 decrypted_blob,
                 repositories=[repo_name],
-                permissions={"issues": "write"},
+                # issues:write authors issues; contents+pull_requests read let the
+                # App also serve read_github_source (PR/repo reads) instead of 404
+                # falling back to a personal token. The App install already holds
+                # these (no re-approval) and they stay READ-only, so the write
+                # blast-radius is unchanged (the token can still only mutate issues).
+                permissions={
+                    "issues": "write",
+                    "contents": "read",
+                    "pull_requests": "read",
+                },
             )
         finally:
             decrypted_blob = None

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -400,7 +400,7 @@ async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, se
         {
             "decrypted_blob": "github-app-blob",
             "repositories": ["uwear-backend"],
-            "permissions": {"issues": "write"},
+            "permissions": {"issues": "write", "contents": "read", "pull_requests": "read"},
             "transaction_open": False,
         }
     ]
@@ -454,7 +454,7 @@ async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(pa
     async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
         assert decrypted_blob == "github-app-blob"
         assert repositories == ["uwear-backend"]
-        assert permissions == {"issues": "write"}
+        assert permissions == {"issues": "write", "contents": "read", "pull_requests": "read"}
         return "minted-installation-token"
 
     monkeypatch.setattr(
@@ -539,7 +539,7 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     access_request = next(request for request in client.requests if request["url"].endswith("/access_tokens"))
     issue_request = next(request for request in client.requests if request["url"].endswith("/issues"))
     assert access_request["json"]["repositories"] == ["uwear-backend"]
-    assert access_request["json"]["permissions"] == {"issues": "write"}
+    assert access_request["json"]["permissions"] == {"issues": "write", "contents": "read", "pull_requests": "read"}
     assert issue_request["headers"]["Authorization"] == "Bearer minted-issue-token"
 
 


### PR DESCRIPTION
## What & why

Completes the "`illo-bot` is Illo's GitHub identity" story on the **read** side. The App's installation token was minted **`issues:write` only**, so `read_github_source`'s `list_pull_requests` (and repo/code reads) got a **404 on the App token and fell back to a personal token** (Axel's / the static `GITHUB_TOKEN`). Net: `illo-bot` covered issue *authoring* but reads still rode on someone's personal PAT.

This widens the resolver's mint request to also grant **`contents:read` + `pull_requests:read`**, so the App serves those reads itself.

## Change

- `async_resolve_project_bound_env_tokens` (the App-minting site) now requests `{issues:write, contents:read, pull_requests:read}` instead of `issues:write` only.
- The App installation **already holds** these (granted at registration) → **no GitHub re-approval**.
- The added scopes are **read-only**, so the write blast-radius is unchanged — the token can still only *mutate* issues, never push code or open PRs.
- One token scope now serves both the App's reads and writes (shared cache entry per repo).

## What this does and doesn't cover

- ✅ **`read_github_source`** (list PRs, get repo, list issues) now resolves via the App — no more personal-token fallback for those.
- ⚠️ **`git clone` / file-contents in the exec sandbox** use a *separate* lane (the sync project-exec env, not this resolver), so they are **not yet** routed through the App. That's the deferred exec-lane wiring (E-exec-a). `contents:read` here is pre-positioned so the App token is ready the moment that lands.

## Testing

`240 passed` across `test_vault_project_tokens`, `test_github_app_mint`, `test_create_github_issue_tool`, `test_github_source_tool` (read path), `test_vault_hardening`, `test_runtime_secrets`, `test_agent_run_runtime`, `test_vault`, `test_vault_routes`, `test_tool_registry`, `test_builtin_skill_suite`. The resolver/contract assertions now expect the widened scope.

## Deploy note

Meant to ship **alongside #269** (already merged) in the next illo-dev deploy. After deploy, verify a `read_github_source list_pull_requests` on `uwear-backend` resolves `token_source: project_binding:GITHUB_TOKEN` with no `fallback_from_status_code`. Then the AXEL/static tokens are only needed for git-clone (exec lane) — safe to retire once that lane is wired or if clone isn't required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
