### PR TITLE
[Illo-QA] Gate scheduled-Cycle final answer on mission result contract (#272)

### DIFF
--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -1,0 +1,682 @@
+"""Runtime result-contract gate for scheduled Cycle visible finalization."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any
+
+from sqlalchemy import select
+
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.cycle import Cycle, CycleRun
+
+logger = logging.getLogger(__name__)
+
+MISSION_RESULT_CONTRACT_VERDICT_KEY = "mission_result_contract_verdict"
+_CONTRACT_KIND = "autonomous_cycle_run_result"
+_FINAL_ANSWER_TYPE = "final_answer"
+
+_INTROSPECTION_MARKERS = (
+    "verified current runtime facts",
+    "i'm illo, the agent inside an illospace workspace",
+    "runtime scope: workspace-bound",
+    "source root / working directory",
+    "git metadata is unavailable",
+)
+
+_EVIDENCE_HEALTH_TERMS = (
+    "evidence_health",
+    "evidence health",
+)
+_EVIDENCE_HEALTH_VALUES = (
+    "ok",
+    "healthy",
+    "degraded",
+    "partial",
+    "sparse",
+    "failed",
+    "unavailable",
+    "unknown",
+)
+
+_MISSION_OUTPUT_ALIASES: dict[str, tuple[str, ...]] = {
+    "24h readout": (
+        "24h readout",
+        "24-hour readout",
+        "24 hour readout",
+        "last 24h",
+        "last 24 hours",
+    ),
+    "failure map": ("failure map", "failure-map", "failure modes", "failures"),
+    "codebase implications": (
+        "codebase implications",
+        "code implications",
+        "implementation implications",
+    ),
+    "proposals": ("proposals", "proposal"),
+    "tracking summary": ("tracking summary", "tracking", "domain tracking"),
+    "impact loop": ("impact loop", "impact-loop"),
+    "next action": ("next action", "next step", "blocker"),
+}
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).lower()
+
+
+def _candidate_summary(value: Any, *, limit: int = 320) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
+
+
+def _json_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _json_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        key = str(value or "").strip()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(key)
+    return deduped
+
+
+def _looks_like_introspection_boilerplate(text: str) -> bool:
+    normalized = _normalize_text(text)
+    return any(marker in normalized for marker in _INTROSPECTION_MARKERS)
+
+
+def _contains_any(normalized_text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in normalized_text for term in terms)
+
+
+def _mission_required_output_labels(mission: str) -> list[str]:
+    normalized = _normalize_text(mission)
+    labels = [
+        label
+        for label, aliases in _MISSION_OUTPUT_ALIASES.items()
+        if _contains_any(normalized, aliases)
+    ]
+    return _dedupe(labels)
+
+
+def _domain_tracking_required(mission: str, evidence_packet: dict[str, Any]) -> bool:
+    if bool(evidence_packet.get("domain_side_effects_succeeded")):
+        return True
+    normalized = _normalize_text(mission)
+    return "domain" in normalized and ("record" in normalized or "tracking" in normalized)
+
+
+def _satisfies_required_output(
+    requirement: str,
+    *,
+    normalized_candidate: str,
+) -> bool:
+    if requirement == "answer_the_cycle_mission":
+        return (
+            len(normalized_candidate) >= 80
+            and not _looks_like_introspection_boilerplate(normalized_candidate)
+        )
+    if requirement == "summarize_workspace_evidence_or_explicit_gaps":
+        return _contains_any(
+            normalized_candidate,
+            (
+                "evidence",
+                "gap",
+                "gaps",
+                "source",
+                "sources",
+                "readout",
+                "reviewed",
+                "observed",
+                "workspace",
+            ),
+        )
+    if requirement == "report_evidence_health":
+        return _contains_any(normalized_candidate, _EVIDENCE_HEALTH_TERMS) and _contains_any(
+            normalized_candidate,
+            _EVIDENCE_HEALTH_VALUES,
+        )
+    if requirement == "record_next_action_or_blocker":
+        return _contains_any(normalized_candidate, ("next action", "next step", "blocker"))
+    if requirement == "short_self_review_summary":
+        return _contains_any(
+            normalized_candidate,
+            ("self-review", "self review", "review summary", "self review summary"),
+        )
+    return requirement.replace("_", " ") in normalized_candidate
+
+
+def evaluate_cycle_result_contract(
+    *,
+    candidate_answer: str,
+    result_contract: dict[str, Any],
+    mission: str,
+    evidence_packet: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic verdict for a candidate scheduled-Cycle visible answer."""
+
+    evidence_packet = _json_dict(evidence_packet)
+    normalized_candidate = _normalize_text(candidate_answer)
+    missing: list[str] = []
+
+    if not normalized_candidate:
+        missing.append("visible_final_answer")
+    if _looks_like_introspection_boilerplate(candidate_answer):
+        missing.append("candidate_is_runtime_introspection")
+
+    for requirement in _json_list(result_contract.get("required_outputs")):
+        requirement_name = str(requirement or "").strip()
+        if not requirement_name:
+            continue
+        if not _satisfies_required_output(
+            requirement_name,
+            normalized_candidate=normalized_candidate,
+        ):
+            missing.append(requirement_name)
+
+    for label in _mission_required_output_labels(mission):
+        if not _contains_any(normalized_candidate, _MISSION_OUTPUT_ALIASES[label]):
+            missing.append(label)
+
+    if _domain_tracking_required(mission, evidence_packet):
+        has_domain_tracking = "domain" in normalized_candidate and _contains_any(
+            normalized_candidate,
+            ("record", "records", "tracking", "ledger"),
+        )
+        if not has_domain_tracking:
+            missing.append("domain_tracking_summary")
+
+    missing = _dedupe(missing)
+    return {
+        "approved": not missing,
+        "missing_outputs": missing,
+        "candidate_summary": _candidate_summary(candidate_answer),
+    }
+
+
+def _metadata_result_contract(agent_run: AgentRunRow | None) -> dict[str, Any]:
+    metadata = _json_dict(getattr(agent_run, "metadata_", None))
+    contract = _json_dict(metadata.get("contract")).get("result")
+    if isinstance(contract, dict):
+        return dict(contract)
+    launch_envelope = _json_dict(metadata.get("launch_envelope"))
+    contract = launch_envelope.get("result_contract")
+    if isinstance(contract, dict):
+        return dict(contract)
+    launch_receipt = _json_dict(metadata.get("launch_receipt"))
+    contract = launch_receipt.get("result_contract")
+    if isinstance(contract, dict):
+        return dict(contract)
+    return {}
+
+
+def cycle_result_contract_for_run(
+    agent_run: AgentRunRow | None,
+    cycle_run: CycleRun | None,
+) -> dict[str, Any]:
+    context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
+    contract = context_snapshot.get("result_contract")
+    if isinstance(contract, dict):
+        return dict(contract)
+    return _metadata_result_contract(agent_run)
+
+
+def _is_result_contract(contract: dict[str, Any]) -> bool:
+    return contract.get("kind") == _CONTRACT_KIND
+
+
+def _is_cycle_agent_run(agent_run: AgentRunRow | None) -> bool:
+    metadata = _json_dict(getattr(agent_run, "metadata_", None))
+    return metadata.get("source") == "cycle" and bool(metadata.get("cycle_run_id"))
+
+
+def _cycle_run_id_for_agent_run(agent_run: AgentRunRow) -> int | None:
+    metadata = _json_dict(getattr(agent_run, "metadata_", None))
+    try:
+        return int(metadata.get("cycle_run_id"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _mission_text(agent_run: AgentRunRow | None, cycle_run: CycleRun | None, cycle: Cycle | None) -> str:
+    for value in (
+        getattr(cycle_run, "prompt_snapshot", None),
+        getattr(cycle, "prompt", None),
+        getattr(agent_run, "input_message", None),
+    ):
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def persisted_cycle_contract_verdict(cycle_run: CycleRun | None) -> dict[str, Any] | None:
+    context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
+    verdict = context_snapshot.get(MISSION_RESULT_CONTRACT_VERDICT_KEY)
+    return dict(verdict) if isinstance(verdict, dict) else None
+
+
+def _persist_cycle_contract_verdict(cycle_run: CycleRun, verdict: dict[str, Any]) -> None:
+    context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
+    context_snapshot[MISSION_RESULT_CONTRACT_VERDICT_KEY] = dict(verdict)
+    cycle_run.context_snapshot = context_snapshot
+
+
+async def _latest_final_answer_artifact(
+    session: Any,
+    *,
+    run_id: int,
+) -> AgentRunArtifactRow | None:
+    result = await session.scalars(
+        select(AgentRunArtifactRow)
+        .where(
+            AgentRunArtifactRow.run_id == int(run_id),
+            AgentRunArtifactRow.artifact_type == _FINAL_ANSWER_TYPE,
+        )
+        .order_by(AgentRunArtifactRow.created_at.desc(), AgentRunArtifactRow.id.desc())
+        .limit(1)
+    )
+    return result.first()
+
+
+async def _append_final_answer_artifact_once(
+    session: Any,
+    agent_run: AgentRunRow,
+    text: str,
+    *,
+    payload: dict[str, Any],
+) -> AgentRunArtifactRow:
+    text_value = str(text or "")
+    existing = (
+        await session.scalars(
+            select(AgentRunArtifactRow)
+            .where(
+                AgentRunArtifactRow.run_id == int(agent_run.id),
+                AgentRunArtifactRow.artifact_type == _FINAL_ANSWER_TYPE,
+                AgentRunArtifactRow.text == text_value,
+            )
+            .order_by(AgentRunArtifactRow.id.asc())
+            .limit(1)
+        )
+    ).first()
+    if existing is not None:
+        return existing
+
+    row = AgentRunArtifactRow(
+        run_id=int(agent_run.id),
+        root_run_id=getattr(agent_run, "root_run_id", None) or int(agent_run.id),
+        artifact_type=_FINAL_ANSWER_TYPE,
+        title="Cycle contract final answer",
+        payload=dict(payload or {}),
+        text=text_value,
+        uri=None,
+        visibility="public",
+    )
+    session.add(row)
+    flush = getattr(session, "flush", None)
+    if callable(flush):
+        await flush()
+    return row
+
+
+def _event_tool_name(event: AgentRunEventRow) -> str:
+    payload = _json_dict(getattr(event, "payload", None))
+    return str(payload.get("tool_name") or payload.get("tool") or "").strip()
+
+
+def _event_result_preview(event: AgentRunEventRow, *, limit: int = 600) -> str:
+    payload = _json_dict(getattr(event, "payload", None))
+    value = payload.get("result") or payload.get("result_preview") or payload.get("error") or ""
+    return _candidate_summary(value, limit=limit)
+
+
+async def _cycle_contract_evidence_packet(
+    session: Any,
+    *,
+    agent_run: AgentRunRow,
+    cycle_run: CycleRun,
+    cycle: Cycle | None,
+) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    side_effects_succeeded = False
+    domain_side_effects_succeeded = False
+
+    try:
+        result = await session.scalars(
+            select(AgentRunEventRow)
+            .where(AgentRunEventRow.run_id == int(agent_run.id))
+            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+            .limit(40)
+        )
+        event_rows = list(result.all())
+    except Exception:
+        logger.debug("cycle_contract_gate_event_packet_failed", exc_info=True)
+        event_rows = []
+
+    for event in reversed(event_rows):
+        event_type = str(getattr(event, "event_type", "") or "")
+        payload = _json_dict(getattr(event, "payload", None))
+        tool_name = _event_tool_name(event)
+        result_preview = _event_result_preview(event)
+        is_error = bool(payload.get("is_error")) or event_type == "run.tool_failed"
+        if event_type == "run.tool_completed" and not is_error:
+            side_effects_succeeded = True
+            domain_blob = _normalize_text(f"{tool_name} {result_preview}")
+            if "domain" in domain_blob:
+                domain_side_effects_succeeded = True
+        events.append(
+            {
+                "event_type": event_type,
+                "tool_name": tool_name,
+                "is_error": is_error,
+                "result_preview": result_preview,
+            }
+        )
+
+    context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
+    return {
+        "cycle_id": getattr(cycle, "id", None) or getattr(cycle_run, "cycle_id", None),
+        "cycle_run_id": getattr(cycle_run, "id", None),
+        "agent_run_id": getattr(agent_run, "id", None),
+        "scheduled_review_window": context_snapshot.get("scheduled_review_window"),
+        "evidence_health": context_snapshot.get("evidence_health"),
+        "side_effects_succeeded": side_effects_succeeded,
+        "domain_side_effects_succeeded": domain_side_effects_succeeded,
+        "recent_events": events[-20:],
+    }
+
+
+def _repair_prompt(
+    *,
+    mission: str,
+    result_contract: dict[str, Any],
+    evidence_packet: dict[str, Any],
+    missing_outputs: list[str],
+    candidate_answer: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are repairing one scheduled Cycle final answer before it becomes visible. "
+                "Use only the supplied mission, result contract, evidence packet, and candidate. "
+                "Do not claim fresh tool access. Produce the corrected visible final answer only. "
+                "If evidence is insufficient, say evidence_health=degraded and name the gap."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Original Cycle mission:\n"
+                f"{mission[:4000]}\n\n"
+                "Result contract:\n"
+                f"{json.dumps(result_contract, ensure_ascii=True, sort_keys=True, default=str)[:3000]}\n\n"
+                "Evidence packet:\n"
+                f"{json.dumps(evidence_packet, ensure_ascii=True, sort_keys=True, default=str)[:5000]}\n\n"
+                "Missing required outputs:\n"
+                f"{json.dumps(missing_outputs, ensure_ascii=True)}\n\n"
+                "Candidate visible answer:\n"
+                f"{candidate_answer[:4000]}"
+            ),
+        },
+    ]
+
+
+def _repair_model(agent_run: AgentRunRow) -> str:
+    model_policy = _json_dict(getattr(agent_run, "model_policy", None))
+    metadata = _json_dict(getattr(agent_run, "metadata_", None))
+    for container in (model_policy, metadata):
+        for key in ("model", "model_override"):
+            value = str(container.get(key) or "").strip()
+            if value:
+                return value
+    from brain.platform.providers.model_policy import get_default_model, resolve_default_provider
+
+    provider = resolve_default_provider(
+        user_id=str(getattr(agent_run, "user_id", "") or "") or None,
+        org_id=str(getattr(agent_run, "org_id", "") or "") or None,
+    )
+    return get_default_model(
+        provider=provider,
+        include_provider_prefix=False,
+        user_id=str(getattr(agent_run, "user_id", "") or "") or None,
+    )
+
+
+async def _async_repair_cycle_contract_answer(
+    *,
+    agent_run: AgentRunRow,
+    mission: str,
+    result_contract: dict[str, Any],
+    evidence_packet: dict[str, Any],
+    missing_outputs: list[str],
+    candidate_answer: str,
+) -> str | None:
+    """Run exactly one bounded LLM repair pass for a failed Cycle contract answer."""
+
+    try:
+        from brain.platform.integrations.llm import resolve_llm_client
+        from brain.platform.integrations.providers import get_provider
+        from brain.platform.providers.model_policy import infer_provider_from_model, resolve_default_provider
+        from brain.systems.runs.direct_loop.request import build_api_request
+        from brain.systems.sessions import _content_to_dicts
+        from brain.systems.sessions.harvest import _extract_text
+
+        user_id = str(getattr(agent_run, "user_id", "") or "") or None
+        org_id = str(getattr(agent_run, "org_id", "") or "") or None
+        model = _repair_model(agent_run)
+        default_provider = resolve_default_provider(user_id=user_id, org_id=org_id)
+        requested_provider = infer_provider_from_model(model, default=default_provider)
+        llm = resolve_llm_client(user_id=user_id, org_id=org_id, provider=requested_provider)
+        provider = get_provider(llm.provider, llm.client)
+        session_id = f"cycle-contract-repair-{int(agent_run.id)}"
+        request = build_api_request(
+            model=model,
+            messages=_repair_prompt(
+                mission=mission,
+                result_contract=result_contract,
+                evidence_packet=evidence_packet,
+                missing_outputs=missing_outputs,
+                candidate_answer=candidate_answer,
+            ),
+            max_tokens=1200,
+            system=None,
+            tools=None,
+            reasoning_effort=None,
+            extra_headers=llm.build_request_headers(session_id=session_id),
+            provider_name=llm.provider,
+            session_id=session_id,
+            persist_session=False,
+            cache_tools=False,
+            operation_type="verifier",
+        )
+        response = await asyncio.to_thread(provider.create, request)
+        text = _extract_text([{"role": "assistant", "content": _content_to_dicts(response.content)}])
+        return str(text or "").strip() or None
+    except Exception:
+        logger.exception("cycle_contract_repair_failed", extra={"run_id": getattr(agent_run, "id", None)})
+        return None
+
+
+def _degraded_visible_answer(missing_outputs: list[str]) -> str:
+    missing = ", ".join(missing_outputs[:8]) if missing_outputs else "required Cycle outputs"
+    return (
+        "Cycle run degraded: mission_contract_failed. The run completed side effects, "
+        f"but its visible final answer did not satisfy the Cycle result contract. Missing: {missing}."
+    )
+
+
+def _base_verdict(
+    *,
+    candidate_answer: str,
+    candidate_artifact_id: Any,
+    initial_review: dict[str, Any],
+    evidence_packet: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "kind": "cycle_result_contract_verdict",
+        "schema_version": 1,
+        "candidate_artifact_id": candidate_artifact_id,
+        "candidate_summary": initial_review.get("candidate_summary") or _candidate_summary(candidate_answer),
+        "missing_outputs": list(initial_review.get("missing_outputs") or []),
+        "final_missing_outputs": list(initial_review.get("missing_outputs") or []),
+        "repair_attempted": False,
+        "repair_succeeded": False,
+        "settlement_status": (
+            "mission_success" if initial_review.get("approved") else "mission_contract_failed"
+        ),
+        "visible_answer_source": "candidate" if initial_review.get("approved") else None,
+        "side_effects_succeeded": bool(evidence_packet.get("side_effects_succeeded")),
+        "domain_side_effects_succeeded": bool(evidence_packet.get("domain_side_effects_succeeded")),
+    }
+
+
+async def async_prepare_cycle_run_visible_finalization(
+    session: Any,
+    agent_run_id: int,
+) -> dict[str, Any] | None:
+    """Ensure a scheduled Cycle final answer satisfies its result contract before visibility."""
+
+    agent_run = await session.get(AgentRunRow, int(agent_run_id))
+    if not _is_cycle_agent_run(agent_run):
+        return None
+    cycle_run_id = _cycle_run_id_for_agent_run(agent_run)
+    if cycle_run_id is None:
+        return None
+    cycle_run = await session.get(CycleRun, cycle_run_id)
+    cycle = await session.get(Cycle, cycle_run.cycle_id) if cycle_run else None
+    if cycle_run is None or cycle is None:
+        return None
+
+    existing = persisted_cycle_contract_verdict(cycle_run)
+    if existing is not None:
+        return existing
+
+    result_contract = cycle_result_contract_for_run(agent_run, cycle_run)
+    if not _is_result_contract(result_contract):
+        return None
+
+    artifact = await _latest_final_answer_artifact(session, run_id=int(agent_run.id))
+    candidate_answer = str(getattr(artifact, "text", None) or "").strip()
+    mission = _mission_text(agent_run, cycle_run, cycle)
+    evidence_packet = await _cycle_contract_evidence_packet(
+        session,
+        agent_run=agent_run,
+        cycle_run=cycle_run,
+        cycle=cycle,
+    )
+    initial_review = evaluate_cycle_result_contract(
+        candidate_answer=candidate_answer,
+        result_contract=result_contract,
+        mission=mission,
+        evidence_packet=evidence_packet,
+    )
+    verdict = _base_verdict(
+        candidate_answer=candidate_answer,
+        candidate_artifact_id=getattr(artifact, "id", None),
+        initial_review=initial_review,
+        evidence_packet=evidence_packet,
+    )
+
+    if initial_review["approved"]:
+        _persist_cycle_contract_verdict(cycle_run, verdict)
+        return verdict
+
+    verdict["repair_attempted"] = True
+    try:
+        repair_answer = await _async_repair_cycle_contract_answer(
+            agent_run=agent_run,
+            mission=mission,
+            result_contract=result_contract,
+            evidence_packet=evidence_packet,
+            missing_outputs=list(initial_review["missing_outputs"]),
+            candidate_answer=candidate_answer,
+        )
+    except Exception:
+        logger.exception("cycle_contract_repair_call_failed", extra={"run_id": int(agent_run.id)})
+        repair_answer = None
+    if repair_answer:
+        repair_review = evaluate_cycle_result_contract(
+            candidate_answer=repair_answer,
+            result_contract=result_contract,
+            mission=mission,
+            evidence_packet=evidence_packet,
+        )
+        if repair_review["approved"]:
+            repaired_artifact = await _append_final_answer_artifact_once(
+                session,
+                agent_run,
+                repair_answer,
+                payload={
+                    "source": "cycle_result_contract_gate",
+                    "repair_for_artifact_id": getattr(artifact, "id", None),
+                    "initial_missing_outputs": list(initial_review["missing_outputs"]),
+                },
+            )
+            verdict.update(
+                {
+                    "repair_succeeded": True,
+                    "settlement_status": "mission_success_after_repair",
+                    "visible_answer_source": "repair",
+                    "repaired_artifact_id": getattr(repaired_artifact, "id", None),
+                    "repaired_summary": repair_review["candidate_summary"],
+                    "final_missing_outputs": [],
+                }
+            )
+            _persist_cycle_contract_verdict(cycle_run, verdict)
+            return verdict
+        verdict["repair_missing_outputs"] = list(repair_review["missing_outputs"])
+        verdict["final_missing_outputs"] = list(repair_review["missing_outputs"])
+
+    missing_outputs = list(verdict.get("final_missing_outputs") or verdict["missing_outputs"])
+    degraded_answer = _degraded_visible_answer(missing_outputs)
+    degraded_artifact = await _append_final_answer_artifact_once(
+        session,
+        agent_run,
+        degraded_answer,
+        payload={
+            "source": "cycle_result_contract_gate",
+            "settlement_status": "mission_contract_failed",
+            "missing_outputs": missing_outputs,
+        },
+    )
+    verdict.update(
+        {
+            "settlement_status": "mission_contract_failed",
+            "visible_answer_source": "degraded_explanation",
+            "degraded_artifact_id": getattr(degraded_artifact, "id", None),
+            "degraded_summary": _candidate_summary(degraded_answer),
+            "final_missing_outputs": missing_outputs,
+        }
+    )
+    _persist_cycle_contract_verdict(cycle_run, verdict)
+    return verdict
+
+
+def cycle_finalization_status_from_verdict(
+    requested_status: str,
+    *,
+    verdict: dict[str, Any] | None,
+    error: str | None = None,
+) -> tuple[str, str | None]:
+    if requested_status != "completed":
+        return requested_status, error
+    if _json_dict(verdict).get("settlement_status") == "mission_contract_failed":
+        missing = _json_list(_json_dict(verdict).get("final_missing_outputs"))
+        detail = ", ".join(str(item) for item in missing[:8]) or "required Cycle outputs"
+        return "degraded", f"mission_contract_failed: missing {detail}"
+    return requested_status, error

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -21,6 +21,7 @@ from brain.systems.cycles.common import (
     string_or_none,
     validate_nonempty_trimmed,
 )
+from brain.systems.cycles.contract_gate import MISSION_RESULT_CONTRACT_VERDICT_KEY
 from brain.systems.cycles.contracts import (
     cycle_launch_receipt,
     cycle_result_contract,
@@ -327,6 +328,7 @@ async def record_cycle_run_evaluation(
         error=error,
         skip_reason=skip_reason,
     )
+    score = 1 if status == "completed" else 0 if status in {"failed", "degraded"} else None
     run.self_review_summary = summary
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
     session.add(
@@ -336,7 +338,7 @@ async def record_cycle_run_evaluation(
             evaluator_type=evaluator_type,
             evaluator_id=actor_id(evaluator_id),
             summary=summary,
-            score=1 if status == "completed" else 0 if status == "failed" else None,
+            score=score,
             details={
                 "status": status,
                 "error": error,
@@ -347,6 +349,9 @@ async def record_cycle_run_evaluation(
                 "result_contract": context_snapshot.get("result_contract"),
                 "evidence_health": context_snapshot.get("evidence_health"),
                 "launch_receipts": context_snapshot.get("launch_receipts", []),
+                MISSION_RESULT_CONTRACT_VERDICT_KEY: context_snapshot.get(
+                    MISSION_RESULT_CONTRACT_VERDICT_KEY
+                ),
             },
         )
     )
@@ -411,6 +416,9 @@ def cycle_run_evaluation_summary(
     if status == "failed":
         detail = error or "unknown failure"
         return f"Cycle run failed and was recorded in the Cycle ledger: {detail}"
+    if status == "degraded":
+        detail = error or "mission result contract degraded"
+        return f"Cycle run degraded and was recorded in the Cycle ledger: {detail}"
     if status == "skipped":
         detail = skip_reason or "unknown skip reason"
         return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}"

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -19,6 +19,11 @@ from brain.systems.cycles.common import (
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
+from brain.systems.cycles.contract_gate import (
+    async_prepare_cycle_run_visible_finalization,
+    cycle_finalization_status_from_verdict,
+    persisted_cycle_contract_verdict,
+)
 from brain.systems.cycles.memory import (
     append_cycle_run_output_target_snapshot,
     async_add_cycle_guidance,
@@ -450,11 +455,19 @@ async def async_finalize_cycle_run_from_run(
         cycle = await uow.session.get(Cycle, run.cycle_id) if run else None
         if not run or not cycle or run.status in TERMINAL_RUN_STATUSES:
             return
+        verdict = persisted_cycle_contract_verdict(run)
+        if status == "completed" and verdict is None:
+            verdict = await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
+        final_status, final_error = cycle_finalization_status_from_verdict(
+            status,
+            verdict=verdict,
+            error=error if status == "failed" else None,
+        )
         await _finalize_cycle_run(
             run,
             cycle,
-            status=status,
-            error=error if status == "failed" else None,
+            status=final_status,
+            error=final_error,
             session=uow.session,
         )
 

--- a/brain/systems/cycles/status.py
+++ b/brain/systems/cycles/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 CYCLE_RUN_ACTIVE_STATUS_VALUES = ("queued", "running", "pending_approval")
-CYCLE_RUN_TERMINAL_STATUS_VALUES = ("completed", "failed", "skipped")
+CYCLE_RUN_TERMINAL_STATUS_VALUES = ("completed", "failed", "skipped", "degraded")
 
 CYCLE_RUN_ACTIVE_STATUSES = frozenset(CYCLE_RUN_ACTIVE_STATUS_VALUES)
 CYCLE_RUN_TERMINAL_STATUSES = frozenset(CYCLE_RUN_TERMINAL_STATUS_VALUES)

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -1198,6 +1198,12 @@ async def _run_queued_once_async(*, limit: int = 1) -> int:
                 async with _unit_of_work_factory()() as uow:
                     completed_run = await _engine_for_session(uow.session).run_existing(int(run_id))
                     completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
+                    if completed_status == "completed":
+                        from brain.systems.cycles.contract_gate import (
+                            async_prepare_cycle_run_visible_finalization,
+                        )
+
+                        await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
                     status_payload = await _settle_terminal_root_run_async(uow.session, int(run_id))
                 await _finalize_cycle_run_if_needed_async(int(run_id), status=completed_status)
             if status_payload:

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1303,6 +1303,17 @@ async def test_runner_delegates_cycle_settlement_for_terminal_run(monkeypatch):
     assert calls == [(99, "completed", None), (101, "failed", "boom")]
 
 
+def test_runner_prepares_cycle_contract_before_visible_terminal_settlement():
+    from brain.systems.runs.cortex import runner
+
+    source = inspect.getsource(runner._run_queued_once_async)
+
+    assert "async_prepare_cycle_run_visible_finalization" in source
+    assert source.index("async_prepare_cycle_run_visible_finalization") < source.index(
+        "_settle_terminal_root_run_async"
+    )
+
+
 async def test_deep_recipe_uses_native_child_runs(monkeypatch):
     import brain.systems.runs.recipes.deep as deep_module
     from brain.systems.runs.domain import AgentRunArtifact

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -13,15 +13,18 @@ from brain.systems.cycles import execution as cycle_execution
 from brain.systems.cycles import service
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea
 
 
 class _FakeSession:
-    def __init__(self, agent_run=None, run=None, cycle=None):
+    def __init__(self, agent_run=None, run=None, cycle=None, artifacts=None, events=None):
         self._agent_run = agent_run
         self._run = run
         self._cycle = cycle
+        self._artifacts = list(artifacts or [])
+        self._events = list(events or [])
         self.added = []
 
     def get(self, model, value):
@@ -33,13 +36,53 @@ class _FakeSession:
             return self._cycle
         return None
 
+    def scalars(self, statement):
+        text = str(statement)
+        if "agent_run_artifacts" in text:
+            rows = list(self._artifacts)
+            if "agent_run_artifacts.text =" in text:
+                params = statement.compile().params
+                text_value = next(
+                    (value for key, value in params.items() if key.startswith("text_")),
+                    None,
+                )
+                rows = [row for row in rows if row.text == text_value]
+            rows.sort(
+                key=lambda row: (
+                    row.created_at or datetime.min.replace(tzinfo=timezone.utc),
+                    row.id or 0,
+                ),
+                reverse=True,
+            )
+            return _AllResult(rows)
+        if "agent_run_events" in text:
+            rows = sorted(
+                self._events,
+                key=lambda row: (row.sequence_no or 0, row.id or 0),
+                reverse=True,
+            )
+            return _AllResult(rows)
+        return _AllResult([])
+
     def add(self, value):
         self.added.append(value)
+        if isinstance(value, AgentRunArtifactRow):
+            if value.id is None:
+                value.id = 100 + len(self._artifacts) + 1
+            if value.created_at is None:
+                value.created_at = datetime(2026, 4, 28, 20, 30, tzinfo=timezone.utc)
+            self._artifacts.append(value)
 
 
 class _AsyncFakeSession(_FakeSession):
     async def get(self, model, value):
         return super().get(model, value)
+
+    async def scalars(self, statement):
+        return super().scalars(statement)
+
+    async def flush(self):
+        return None
 
 
 class _ScalarResult:
@@ -994,6 +1037,12 @@ async def test_cycle_busy_thread_detection_uses_agent_run_open_statuses():
 
 def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
     agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = "Run the Cycle mission"
+    agent_run.model_policy = {}
     agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
 
     cycle_run = CycleRun()
@@ -1012,11 +1061,29 @@ def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
 
     cycle = Cycle()
     cycle.id = 5
+    cycle.prompt = "Run the smoke test. Report evidence health, next action, and self-review."
     cycle.last_status = None
     cycle.last_error = "old"
     cycle.last_run_at = None
 
-    fake_session = _AsyncFakeSession(agent_run=agent_run, run=cycle_run, cycle=cycle)
+    final_answer = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text=(
+            "I completed the Cycle mission. Evidence health: ok. Workspace evidence "
+            "showed the smoke test was clean. Next action: continue monitoring. "
+            "Self-review summary: contract satisfied."
+        ),
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    fake_session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[final_answer],
+    )
     monkeypatch.setattr(
         service,
         "UnitOfWork",
@@ -1038,6 +1105,213 @@ def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
     assert evaluation.details["launch_receipts"] == [
         {"kind": "cycle_launch_receipt", "cycle_run_id": 12}
     ]
+    verdict = evaluation.details["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_success"
+    assert verdict["candidate_artifact_id"] == 8
+
+
+@pytest.mark.asyncio
+async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = "Daily Illo Conversation Improvements"
+    agent_run.model_policy = {}
+    agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = 5
+    cycle_run.status = "running"
+    cycle_run.prompt_snapshot = (
+        "Daily Illo Conversation Improvements. Produce: 24h readout, failure map, "
+        "codebase implications, proposals, tracking summary, impact loop, next action. "
+        "Include Domain tracking, evidence health, and a short self-review summary."
+    )
+    cycle_run.context_snapshot = {
+        "result_contract": {
+            "kind": "autonomous_cycle_run_result",
+            "required_outputs": [
+                "answer_the_cycle_mission",
+                "summarize_workspace_evidence_or_explicit_gaps",
+                "report_evidence_health",
+                "record_next_action_or_blocker",
+                "short_self_review_summary",
+            ],
+        },
+        "evidence_health": {"status": "pending"},
+    }
+
+    cycle = Cycle()
+    cycle.id = 5
+    cycle.prompt = cycle_run.prompt_snapshot
+
+    bad_answer = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text=(
+            "Verified current runtime facts:\n"
+            "- I'm Illo, the agent inside an Illospace workspace.\n"
+            "- Runtime scope: workspace-bound, user-bound, and thread-bound."
+        ),
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    domain_event = AgentRunEventRow(
+        id=4,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=4,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "create_domain_record",
+            "result": {"status": "ok", "record_id": 26},
+        },
+    )
+    session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[bad_answer],
+        events=[domain_event],
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return (
+            "24h readout: reviewed workspace evidence and Domain records.\n"
+            "Failure map: the visible answer was runtime introspection.\n"
+            "Codebase implications: enforce the Cycle contract before finalization.\n"
+            "Proposals: keep the contract gate and one repair pass.\n"
+            "Tracking summary: Domain record 26 captured the work.\n"
+            "Impact loop: future runs can compare repaired answers to outcomes.\n"
+            "Next action: monitor the next scheduled run.\n"
+            "evidence_health=ok.\n"
+            "Self-review summary: mission result contract satisfied after repair."
+        )
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+
+    verdict = await contract_gate.async_prepare_cycle_run_visible_finalization(session, 44)
+
+    assert len(repair_calls) == 1
+    assert repair_calls[0]["candidate_answer"] == bad_answer.text
+    assert "24h readout" in repair_calls[0]["missing_outputs"]
+    assert verdict["repair_attempted"] is True
+    assert verdict["repair_succeeded"] is True
+    assert verdict["settlement_status"] == "mission_success_after_repair"
+    assert verdict["side_effects_succeeded"] is True
+    assert verdict["domain_side_effects_succeeded"] is True
+    latest_answer = session._artifacts[-1]
+    assert latest_answer.artifact_type == "final_answer"
+    assert latest_answer.text.startswith("24h readout")
+    assert "Verified current runtime facts" not in latest_answer.text
+    assert cycle_run.context_snapshot["mission_result_contract_verdict"] == verdict
+
+
+def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = "Daily Illo Conversation Improvements"
+    agent_run.model_policy = {}
+    agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = 5
+    cycle_run.status = "running"
+    cycle_run.error = None
+    cycle_run.skip_reason = None
+    cycle_run.prompt_snapshot = (
+        "Daily Illo Conversation Improvements. Produce: 24h readout, failure map, "
+        "codebase implications, proposals, tracking summary, impact loop, next action. "
+        "Include Domain tracking, evidence health, and a short self-review summary."
+    )
+    cycle_run.context_snapshot = {
+        "result_contract": {
+            "kind": "autonomous_cycle_run_result",
+            "required_outputs": [
+                "answer_the_cycle_mission",
+                "summarize_workspace_evidence_or_explicit_gaps",
+                "report_evidence_health",
+                "record_next_action_or_blocker",
+                "short_self_review_summary",
+            ],
+        },
+        "evidence_health": {"status": "pending"},
+    }
+
+    cycle = Cycle()
+    cycle.id = 5
+    cycle.prompt = cycle_run.prompt_snapshot
+    cycle.last_status = None
+    cycle.last_error = None
+    cycle.last_run_at = None
+
+    bad_answer = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text="Verified current runtime facts:\n- Runtime scope: workspace-bound.",
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    domain_event = AgentRunEventRow(
+        id=4,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=4,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "create_domain_record",
+            "result": {"status": "ok", "record_id": 26},
+        },
+    )
+    fake_session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[bad_answer],
+        events=[domain_event],
+    )
+
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return "Verified current runtime facts: Git metadata is unavailable right now."
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([fake_session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert len(repair_calls) == 1
+    assert cycle_run.status == "degraded"
+    assert cycle.last_status == "degraded"
+    assert cycle_run.error.startswith("mission_contract_failed: missing")
+    latest_answer = fake_session._artifacts[-1].text
+    assert latest_answer.startswith("Cycle run degraded: mission_contract_failed")
+    assert "Verified current runtime facts" not in latest_answer
+    evaluation = next(
+        item for item in fake_session.added if item.__class__.__name__ == "CycleRunEvaluation"
+    )
+    verdict = evaluation.details["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_contract_failed"
+    assert verdict["repair_attempted"] is True
+    assert verdict["side_effects_succeeded"] is True
+    assert "24h readout" in verdict["missing_outputs"]
 
 
 def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch):


### PR DESCRIPTION
## What & why

Scheduled **Cycle** runs could ship a user-visible final answer unrelated to the mission — the `Verified current runtime facts` / "I'm Illo…" introspection boilerplate — even though the run's real Domain side effects (daily_analysis, improvement proposals) succeeded. Issue #272 documents 10 consecutive scheduled replies in the "Daily Illo Conversation Improvements" thread all overwritten this way. Illo's own accepted Domain-26 proposals converged on: **prompt-only guidance is exhausted; the fix must be runtime settlement enforcement.**

This PR adds that enforcement as a **result-contract gate before visible terminal settlement**.

## How it works

New module `brain/systems/cycles/contract_gate.py`, invoked from `cortex/runner.py` right before `_settle_terminal_root_run_async` (and idempotently re-read in `cycles/service.py` finalization):

1. For a completed scheduled-Cycle AgentRun with a `result_contract`, validate the latest `final_answer` artifact against the contract's required outputs, mission-required outputs (24h readout, failure map, codebase implications, proposals, tracking summary, impact loop, next action), evidence health, and Domain tracking — **rejecting introspection boilerplate outright**.
2. On failure, run **exactly one** bounded LLM repair pass, re-prompted with the mission, evidence packet, missing outputs, and candidate. If the repaired answer passes, it's appended as the newest `final_answer` artifact (what reaches the thread).
3. If repair still fails, append a concise `mission_contract_failed` degraded explanation naming the missing outputs — never the identity boilerplate — and settle the CycleRun as `degraded` (new terminal status).
4. Persist a structured `mission_result_contract_verdict` (candidate summary, missing outputs, repair status, side-effect success, settlement status) so `side_effects_succeeded` no longer implies `mission_success`.

## Acceptance checks (issue #272) → covered by tests

| # | Check | Test |
|---|-------|------|
| 1 | Side effects present but candidate omits required outputs → fails gate, not `mission_success` | `test_finalize_cycle_run_degrades_when_contract_repair_fails` |
| 2 | Exactly one bounded repair pass; successful repair is what reaches the thread | `test_cycle_contract_gate_repairs_bad_visible_answer_once` |
| 3 | Failed repair → `degraded`/`mission_contract_failed` explanation naming missing outputs, not "Verified current runtime facts" | `test_finalize_cycle_run_degrades_when_contract_repair_fails` |
| 4 | Gate runs before visible settlement; persisted verdict distinguishes side-effect vs mission-visible success | `test_runner_prepares_cycle_contract_before_visible_terminal_settlement` + verdict persistence |

## Verification

- `python -m pytest tests/test_cycles_service.py tests/test_agent_run_runtime.py -q` → **105 passed** (venv: sqlalchemy 2.0.49, pytest 9.0.3).
- New module imports cleanly.

Closes #272

---
🤖 Draft opened by Routine 3 (Illospace ticket worker). Implementation by Codex (gpt-5.5); reviewed, committed, tested & PR-opened by the Claude orchestrator. Not marking ready — Reda reviews & merges.