### PR TITLE
Illo lifecycle: event-driven freshness, typed task-domain, deterministic assignment & notify-loop

### DIFF
--- a/brain/app/api/routers/github_webhooks.py
+++ b/brain/app/api/routers/github_webhooks.py
@@ -1,0 +1,113 @@
+"""GitHub webhook ingress → the shared inbound pipeline.
+
+GitHub cannot send the bridge-token / ``WebhookEnvelopeCreate`` shape the generic
+``/webhooks`` endpoint expects, so this router verifies GitHub's
+``X-Hub-Signature-256`` and maps the event into the SAME
+``submit_inbound_envelope`` pipeline every other lane uses. The pure translation
+(signature verify + event→envelope) lives in
+``brain/systems/inbound/github_webhook.py`` and is unit-tested; this file is the
+thin HTTP + connection wiring.
+
+Config (env):
+  ``ILLO_GITHUB_WEBHOOK_SECRET`` — the App/webhook secret for signature verify.
+  ``ILLO_GITHUB_CONNECTION_ID``  — the ``external_agent_connections`` row GitHub
+                                   events are attributed to. Its owner is the
+                                   ingestion authority; Slice 3 assignment then
+                                   re-routes ownership (business/product → Reda).
+
+Activation is a deliberate step: register with
+``app.include_router(github_webhooks.router)`` once the GitHub App (PR #265) is
+live and the two env vars are set. It is intentionally NOT auto-registered so it
+cannot affect app startup before then.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.app.api.deps import get_db, rate_limit
+from brain.app.api.routers.external_agent_errors import raise_external_agent_http_error
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.systems.inbound import service as inbound
+from brain.systems.inbound.github_webhook import (
+    github_event_to_envelope,
+    verify_signature,
+)
+
+router = APIRouter(tags=["webhooks", "github"], dependencies=[Depends(rate_limit)])
+
+
+def _webhook_secret() -> str:
+    return os.environ.get("ILLO_GITHUB_WEBHOOK_SECRET", "").strip()
+
+
+def _connection_id() -> str:
+    return os.environ.get("ILLO_GITHUB_CONNECTION_ID", "").strip()
+
+
+async def _load_github_connection(db: AsyncSession) -> ExternalAgentConnectionRow:
+    conn_id = _connection_id()
+    if not conn_id:
+        raise HTTPException(status_code=503, detail="ILLO_GITHUB_CONNECTION_ID is not configured")
+    row = (
+        await db.execute(
+            select(ExternalAgentConnectionRow).where(ExternalAgentConnectionRow.id == conn_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=503, detail="Configured GitHub connection not found")
+    return row
+
+
+@router.post("/webhooks/github", status_code=202)
+async def receive_github_webhook(
+    request: Request,
+    x_github_event: str | None = Header(default=None, alias="X-GitHub-Event"),
+    x_github_delivery: str | None = Header(default=None, alias="X-GitHub-Delivery"),
+    x_hub_signature_256: str | None = Header(default=None, alias="X-Hub-Signature-256"),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    secret = _webhook_secret()
+    if not secret:
+        raise HTTPException(status_code=503, detail="ILLO_GITHUB_WEBHOOK_SECRET is not configured")
+
+    raw = await request.body()
+    if not verify_signature(secret, raw, x_hub_signature_256):
+        raise HTTPException(status_code=401, detail="Invalid GitHub signature")
+
+    try:
+        payload = json.loads(raw or b"{}")
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="Malformed JSON payload")
+
+    envelope = github_event_to_envelope(
+        str(x_github_event or ""), payload, delivery_id=x_github_delivery
+    )
+    if envelope is None:
+        # Unsupported event — acknowledge without creating work.
+        return {"status": "ignored", "event": x_github_event}
+
+    try:
+        connection = await _load_github_connection(db)
+        return await inbound.submit_inbound_envelope(
+            db,
+            connection=connection,
+            envelope=envelope,
+            ingress_context={
+                "surface": "github_webhook",
+                "path": str(request.url.path),
+                "method": request.method,
+                "event": x_github_event,
+                "delivery": x_github_delivery,
+            },
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # normalize to the shared external-agent error shape
+        raise_external_agent_http_error(exc)

--- a/brain/app/cli/run.py
+++ b/brain/app/cli/run.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".
 from sqlalchemy import text as sa_text
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.task_domain import TaskDomain, classify_task_domain
 # ============================================================
 # Inline Allowlist
 # ============================================================
@@ -378,6 +379,19 @@ async def build_payload(
         context_block=context_text,
     )
 
+    # Domain-aware: don't force engineering rituals (TDD, run tests) onto
+    # non-engineering work. The execution template stays; we append the fitting bar.
+    task_domain = classify_task_domain(task)
+    # Only override on positive non-engineering evidence — an ambiguous OTHER keeps
+    # the engineering bar, mirroring self_assess.select_checklist. (Without this, a
+    # vaguely-worded real coding task classifies OTHER and wrongly loses TDD.)
+    if task_domain in (TaskDomain.BUSINESS, TaskDomain.PRODUCT, TaskDomain.OPS):
+        prompt += (
+            f"\nNote: this is {task_domain.value} work, not engineering. Apply the "
+            "quality bar that fits (objective, owner, deliverable) rather than "
+            "code/test rituals.\n"
+        )
+
     prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()[:16]
     label = _make_label(template["label_prefix"], task)
 
@@ -387,6 +401,7 @@ async def build_payload(
         "thinking": effective_thinking,
         "prompt": prompt,
         "task_type": task_type,
+        "task_domain": task_domain.value,
         "template": task_type,
         "context_injected": context_meta,
     }

--- a/brain/app/hooks/self_assess.py
+++ b/brain/app/hooks/self_assess.py
@@ -5,6 +5,14 @@ Self-Assessment — Post-task quality check before presenting work to the user.
 Queries the brain for similar past tasks and their outcomes, checks against
 the pre-flight checklist, and returns a quality assessment.
 
+The checklist has two axes. The *work-mode* axis (code/investigation/delegation)
+selects an engineering quality bar. The *domain* axis
+(``brain/systems/task_domain.py``) recognizes non-engineering work
+(business/product/ops) and overrides that bar with a domain-appropriate one —
+so a launch plan is not graded with "run tests and paste output". Engineering
+and ambiguous tasks keep the work-mode bar; only positive non-engineering
+evidence overrides it.
+
 Usage:
     python3 self_assess.py "task description" "outcome summary"
 
@@ -17,6 +25,8 @@ import re
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 3))))
+
+from brain.systems.task_domain import TaskDomain, classify_task_domain
 
 _TASK_PATTERNS = [
     ("delegation", r"(?i)\b(delegat\w*|child.?agent|spawn|orchestrat\w*|parallel|worker|assign)\b"),
@@ -65,6 +75,44 @@ def get_checklist(task_type: str) -> list[str]:
     return _CHECKLISTS.get(task_type, []) + _BASE_CHECKLIST
 
 
+# Domain-specific checklists. These OVERRIDE the work-mode checklist only when we
+# have positive evidence the task is non-engineering, so engineering and
+# ambiguous tasks keep their existing work-mode bar (see brain/systems/task_domain.py).
+_DOMAIN_CHECKLISTS = {
+    TaskDomain.BUSINESS: [
+        "State the objective and who owns the outcome",
+        "Name the deadline or decision date",
+        "Define what 'done' looks like — the concrete deliverable",
+        "Identify who needs to be informed or sign off",
+    ],
+    TaskDomain.PRODUCT: [
+        "State the user problem and the success metric",
+        "Record the decision and its rationale",
+        "List affected surfaces/users and dependencies",
+        "Note what is explicitly out of scope",
+    ],
+    TaskDomain.OPS: [
+        "State the action and its blast radius",
+        "Confirm the rollback / recovery path",
+        "Verify access and prerequisites before acting",
+        "Record what changed for the next on-call",
+    ],
+}
+
+
+def select_checklist(domain: TaskDomain, work_mode: str) -> tuple[list[str], str]:
+    """Return ``(checklist, label)``.
+
+    A non-engineering domain (business/product/ops) overrides the work-mode
+    checklist so the quality bar fits the work. Engineering and ambiguous
+    (``OTHER``) tasks keep their existing work-mode checklist — we only override
+    on positive non-engineering evidence.
+    """
+    if domain in _DOMAIN_CHECKLISTS:
+        return _DOMAIN_CHECKLISTS[domain] + _BASE_CHECKLIST, domain.value
+    return get_checklist(work_mode), work_mode
+
+
 def get_brain_context(query: str) -> dict:
     if os.environ.get("SELF_ASSESS_NO_BRAIN"):
         return {"memories": [], "warnings": [], "guardrails": []}
@@ -76,8 +124,9 @@ def get_brain_context(query: str) -> dict:
 
 
 def assess_quality(task_description: str, outcome_summary: str) -> dict:
-    task_type = classify_task_type(task_description)
-    checklist = get_checklist(task_type)
+    work_mode = classify_task_type(task_description)
+    domain = classify_task_domain(task_description)
+    checklist, checklist_label = select_checklist(domain, work_mode)
     combined = f"{task_description} {outcome_summary}".strip()
 
     brain = get_brain_context(combined) if combined else {"memories": [], "warnings": [], "guardrails": []}
@@ -94,7 +143,10 @@ def assess_quality(task_description: str, outcome_summary: str) -> dict:
     assessment = "concerns" if warnings else "pass"
 
     return {
-        "task_type": task_type,
+        "task_domain": domain.value,
+        # Work-mode axis, kept under the historical "task_type" key for continuity.
+        "task_type": work_mode,
+        "checklist_label": checklist_label,
         "checklist": checklist,
         "warnings": warnings,
         "relevant_lessons": relevant_lessons,
@@ -103,7 +155,13 @@ def assess_quality(task_description: str, outcome_summary: str) -> dict:
 
 
 def format_assessment(result: dict) -> str:
-    parts = [f"[Self-Assessment] Task Type: {result['task_type']} | {result['assessment']}"]
+    domain = result.get("task_domain", "?")
+    label = result.get("checklist_label", result.get("task_type", "?"))
+    header = f"[Self-Assessment] Domain: {domain}"
+    if result.get("task_type") and domain in ("engineering", "other"):
+        header += f" · Mode: {result['task_type']}"
+    header += f" | {result['assessment']}"
+    parts = [header]
     if result["warnings"]:
         parts.append("\n⚠️ WARNINGS:")
         for w in result["warnings"]:
@@ -112,7 +170,7 @@ def format_assessment(result: dict) -> str:
         parts.append("\n🧠 RELEVANT LESSONS:")
         for l in result["relevant_lessons"]:
             parts.append(f"  • {l[:150]}")
-    parts.append(f"\n📋 CHECKLIST ({result['task_type']}):")
+    parts.append(f"\n📋 CHECKLIST ({label}):")
     for item in result["checklist"]:
         parts.append(f"  ☐ {item}")
     return "\n".join(parts)

--- a/brain/systems/change_notifications.py
+++ b/brain/systems/change_notifications.py
@@ -28,6 +28,8 @@ this)::
 
 from __future__ import annotations
 
+import re
+
 # Terms that make a change worth an immediate ping instead of the next digest.
 DEFAULT_URGENT_TERMS = (
     "p0", "sev0", "sev1", "urgent", "critical", "security",
@@ -39,6 +41,27 @@ _NOISE_EVENT_TYPES = frozenset({
     "schema.created", "schema.updated", "record.read", "record.viewed",
 })
 
+# Routine staging->main promotion PRs are part of the normal release rhythm and
+# should not be recurring Slack blockers (per the live triage operating model),
+# unless they are urgent (urgent is checked first).
+_PROMOTION_RE = re.compile(r"(?i)\b(promote\s+staging|staging\s*(?:-+>|→|to)\s*main)\b")
+
+
+def _urgent_regex(terms) -> "re.Pattern":
+    # Word-boundary match so "incident" != "coincidental" and "prod down" !=
+    # "production downtime". Errs away from noise, which is the point.
+    return re.compile(r"\b(" + "|".join(re.escape(t) for t in terms) + r")\b", re.I)
+
+
+_DEFAULT_URGENT_RE = _urgent_regex(DEFAULT_URGENT_TERMS)
+
+
+def _slack_escape(value) -> str:
+    """Escape Slack control chars so an attacker-controlled title can't inject
+    <!channel>/<@user>/<url|label> or corrupt rendering. Slack: only & < >."""
+    text = str(value if value is not None else "")
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
 
 def _signals(event: dict) -> str:
     parts = [str(event.get("title", "")), str(event.get("priority", "")), str(event.get("action", ""))]
@@ -47,8 +70,8 @@ def _signals(event: dict) -> str:
 
 
 def is_urgent(event: dict, *, urgent_terms=DEFAULT_URGENT_TERMS) -> bool:
-    signals = _signals(event)
-    return any(term in signals for term in urgent_terms)
+    regex = _DEFAULT_URGENT_RE if urgent_terms is DEFAULT_URGENT_TERMS else _urgent_regex(urgent_terms)
+    return bool(regex.search(_signals(event)))
 
 
 def classify_event(event: dict, *, urgent_terms=DEFAULT_URGENT_TERMS) -> str:
@@ -58,6 +81,8 @@ def classify_event(event: dict, *, urgent_terms=DEFAULT_URGENT_TERMS) -> str:
     if str(event.get("event_type", "")).lower() in _NOISE_EVENT_TYPES:
         return "skip"
     if event.get("noteworthy") is False:
+        return "skip"
+    if _PROMOTION_RE.search(f"{event.get('title', '')} {event.get('action', '')}"):
         return "skip"
     return "digest"
 
@@ -71,16 +96,16 @@ def decide_notifications(events, *, urgent_terms=DEFAULT_URGENT_TERMS) -> dict:
 
 
 def format_line(event: dict) -> str:
-    title = event.get("title") or event.get("object_key") or "(untitled)"
-    action = event.get("action") or event.get("event_type") or "updated"
+    title = _slack_escape(event.get("title") or event.get("object_key") or "(untitled)")
+    action = _slack_escape(event.get("action") or event.get("event_type") or "updated")
     if event.get("owner_id"):
-        owner = event.get("owner_label") or event["owner_id"]
+        owner = _slack_escape(event.get("owner_label") or event["owner_id"])
     else:
         owner = "unclaimed"
     line = f"• {title} — {action} ({owner})"
     url = event.get("url")
     if url:
-        line += f" {url}"
+        line += f" {_slack_escape(url)}"
     return line
 
 

--- a/brain/systems/change_notifications.py
+++ b/brain/systems/change_notifications.py
@@ -1,0 +1,125 @@
+"""Decide which domain changes are worth telling the team (pure).
+
+The notify-loop (a cycle) reads ``domain_events`` since its last run and asks, per
+change: urgent, worth a digest, or noise? This module is the pure decision +
+formatting core; the cycle wiring (``change_notifications_cycle``) supplies the
+events (normalized from ``domain_events``) and posts the result to the team's
+Slack channel.
+
+Separation of concerns (the failure mode this whole feature fixes): the decision
+is explicit, testable logic here — not a vague prose instruction to the model.
+
+Expected normalized event shape (the wiring maps raw ``domain_events`` rows to
+this)::
+
+    {
+        "event_type": "record.updated",   # domain event type
+        "title": "Login is broken",       # human title of the changed record
+        "object_key": "github_ticket",    # record type
+        "owner_id": "u-123" | None,        # None => in the unclaimed pool
+        "owner_label": "Reda" | None,
+        "action": "closed",               # what changed, for the line
+        "url": "https://…" | None,
+        "labels": ["p0", "bug"],          # any labels/tags on the record
+        "priority": "P1" | None,
+        "noteworthy": True,               # optional explicit override
+    }
+"""
+
+from __future__ import annotations
+
+# Terms that make a change worth an immediate ping instead of the next digest.
+DEFAULT_URGENT_TERMS = (
+    "p0", "sev0", "sev1", "urgent", "critical", "security",
+    "outage", "prod down", "production down", "incident",
+)
+
+# Domain event types that are never worth notifying on.
+_NOISE_EVENT_TYPES = frozenset({
+    "schema.created", "schema.updated", "record.read", "record.viewed",
+})
+
+
+def _signals(event: dict) -> str:
+    parts = [str(event.get("title", "")), str(event.get("priority", "")), str(event.get("action", ""))]
+    parts.extend(str(x) for x in (event.get("labels") or []))
+    return " ".join(parts).lower()
+
+
+def is_urgent(event: dict, *, urgent_terms=DEFAULT_URGENT_TERMS) -> bool:
+    signals = _signals(event)
+    return any(term in signals for term in urgent_terms)
+
+
+def classify_event(event: dict, *, urgent_terms=DEFAULT_URGENT_TERMS) -> str:
+    """Return ``"immediate"``, ``"digest"``, or ``"skip"`` for one change."""
+    if is_urgent(event, urgent_terms=urgent_terms):
+        return "immediate"
+    if str(event.get("event_type", "")).lower() in _NOISE_EVENT_TYPES:
+        return "skip"
+    if event.get("noteworthy") is False:
+        return "skip"
+    return "digest"
+
+
+def decide_notifications(events, *, urgent_terms=DEFAULT_URGENT_TERMS) -> dict:
+    """Bucket events into ``{"immediate": [...], "digest": [...], "skip": [...]}``."""
+    out: dict = {"immediate": [], "digest": [], "skip": []}
+    for event in events or []:
+        out[classify_event(event, urgent_terms=urgent_terms)].append(event)
+    return out
+
+
+def format_line(event: dict) -> str:
+    title = event.get("title") or event.get("object_key") or "(untitled)"
+    action = event.get("action") or event.get("event_type") or "updated"
+    if event.get("owner_id"):
+        owner = event.get("owner_label") or event["owner_id"]
+    else:
+        owner = "unclaimed"
+    line = f"• {title} — {action} ({owner})"
+    url = event.get("url")
+    if url:
+        line += f" {url}"
+    return line
+
+
+def format_urgent(event: dict) -> str:
+    """Text for an immediate urgent ping."""
+    return "⚠️ " + format_line(event).lstrip("• ")
+
+
+def build_digest(digest_events, *, unclaimed_count: int = 0) -> "str | None":
+    """Periodic batch text. Returns ``None`` when there is nothing to say, so a
+    quiet interval is a genuine no-op rather than a noisy heartbeat.
+
+    ``digest_events`` are the non-urgent changes (urgent ones post immediately, so
+    they are excluded here). ``unclaimed_count`` surfaces Slice 3's pool.
+    """
+    parts: list = []
+    for event in digest_events or []:
+        parts.append(format_line(event))
+    if unclaimed_count:
+        noun = "item" if unclaimed_count == 1 else "items"
+        parts.append(
+            f"🫳 {unclaimed_count} {noun} waiting for an owner — pick one up when you have capacity."
+        )
+    if not parts:
+        return None
+    header = "*What changed*"
+    return header + "\n" + "\n".join(parts)
+
+
+def render_outbound(events, *, unclaimed_count: int = 0, urgent_terms=DEFAULT_URGENT_TERMS) -> dict:
+    """Pure orchestration for one notify-cycle tick.
+
+    Turns the changes-since-last-run (plus the current unclaimed count) into the
+    messages to send: urgent items each go out immediately, everything else
+    batches into one digest (or ``None`` = stay quiet). The cycle wrapper only has
+    to read events, count the unclaimed pool, and post these strings.
+    """
+    decisions = decide_notifications(events, urgent_terms=urgent_terms)
+    return {
+        "immediate": [format_urgent(e) for e in decisions["immediate"]],
+        "digest": build_digest(decisions["digest"], unclaimed_count=unclaimed_count),
+    }

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -61,15 +61,30 @@ async def _load_change_events(session, org_id, since, *, limit: int = 500) -> li
 
 
 async def _count_unclaimed(session, org_id) -> int:
-    """Count items parked in the unclaimed pool.
+    """Count open items parked in the unclaimed pool.
 
-    The pull-pool is not enacted yet: ``ideas.user_id`` is NOT NULL, so triage
-    still skips owner-less items rather than persisting an ``unassigned`` idea
-    (see specs/illo-lifecycle Slice 3). There is nothing to count, and a
-    JSONB-path filter here would be a dialect-fragile no-op. Wire the real query
-    when the pool lands.
-    """
-    return 0
+    The pool is the configured ``ILLO_UNCLAIMED_POOL_USER_ID`` owner (see
+    ``inbound/service.py``). Unset, or no session -> 0 (pool off)."""
+    import os
+
+    pool_user = os.environ.get("ILLO_UNCLAIMED_POOL_USER_ID", "").strip()
+    if not pool_user or session is None:
+        return 0
+
+    from sqlalchemy import func, select
+
+    from brain.platform.db.models.idea import Idea
+
+    stmt = (
+        select(func.count())
+        .select_from(Idea)
+        .where(
+            Idea.user_id == pool_user,
+            Idea.org_id == org_id,
+            Idea.archived_at.is_(None),
+        )
+    )
+    return int((await session.execute(stmt)).scalar() or 0)
 
 
 async def _default_post(channel_id, text) -> None:

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -1,0 +1,99 @@
+"""Notify-cycle wrapper: read domain changes → decide → post to Slack.
+
+This is the thin, integration side of the notify-loop. The pure decision +
+formatting is ``brain/systems/change_notifications.render_outbound`` (unit-tested);
+here we only read ``domain_events`` since the last run, count the unclaimed pool,
+and post the resulting messages. ``post`` is injectable so the orchestration is
+testable without Slack.
+
+Wiring (runtime): register a cycle whose program calls
+``run_notify_cycle(session, org_id=…, channel_id=<the team channel>,
+since=<cycle.last_run_at>)`` on its cadence (default ~30 min). Urgent items post
+immediately; a quiet interval posts nothing. The channel is the team channel Illo
+already works in — not a new channel, not DMs.
+"""
+
+from __future__ import annotations
+
+from brain.systems.change_notifications import DEFAULT_URGENT_TERMS, render_outbound
+
+
+def _normalize_event(row) -> dict:
+    """Map a DomainEvent row to the notify event shape. Defensive: the record
+    ``after`` snapshot is domain-schema-specific, so every field has a fallback."""
+    after = getattr(row, "after", None) or {}
+    # serialize_record (the `after` snapshot) puts id/object_key/title at the top
+    # level and every user-defined field (url, labels, priority, owner_id, …)
+    # under "data" — so read those from there, not the top level.
+    data = after.get("data") or {}
+    event_type = getattr(row, "event_type", "") or ""
+    return {
+        "event_type": event_type,
+        "title": after.get("title") or data.get("title") or data.get("name") or data.get("summary"),
+        "object_key": after.get("object_key"),
+        "url": data.get("url") or data.get("html_url"),
+        "labels": data.get("labels") or [],
+        "priority": data.get("priority"),
+        "action": event_type.split(".")[-1] if event_type else "updated",
+        "owner_id": data.get("owner_id"),
+        "record_id": getattr(row, "record_id", None),
+    }
+
+
+async def _load_change_events(session, org_id, since, *, limit: int = 200) -> list:
+    from brain.platform.db.models.domain import DomainEvent
+    from sqlalchemy import select
+
+    stmt = select(DomainEvent).where(DomainEvent.org_id == org_id)
+    if since is not None:
+        stmt = stmt.where(DomainEvent.created_at > since)
+    stmt = stmt.order_by(DomainEvent.created_at.asc()).limit(limit)
+    rows = (await session.execute(stmt)).scalars().all()
+    return [_normalize_event(r) for r in rows]
+
+
+async def _count_unclaimed(session, org_id) -> int:
+    """Count items parked in the unclaimed pool.
+
+    The pull-pool is not enacted yet: ``ideas.user_id`` is NOT NULL, so triage
+    still skips owner-less items rather than persisting an ``unassigned`` idea
+    (see specs/illo-lifecycle Slice 3). There is nothing to count, and a
+    JSONB-path filter here would be a dialect-fragile no-op. Wire the real query
+    when the pool lands.
+    """
+    return 0
+
+
+async def _default_post(channel_id, text) -> None:
+    from brain.systems.slack.client import slack_web_client_from_env
+
+    client = slack_web_client_from_env()
+    await client.post_message(channel=channel_id, text=text)
+
+
+async def run_notify_cycle(
+    session,
+    *,
+    org_id,
+    channel_id,
+    since=None,
+    urgent_terms=DEFAULT_URGENT_TERMS,
+    post=None,
+) -> dict:
+    """One notify-cycle tick. Returns a small summary of what was sent."""
+    events = await _load_change_events(session, org_id, since)
+    unclaimed = await _count_unclaimed(session, org_id)
+    outbound = render_outbound(events, unclaimed_count=unclaimed, urgent_terms=urgent_terms)
+
+    sender = post or _default_post
+    for message in outbound["immediate"]:
+        await sender(channel_id, message)
+    if outbound["digest"]:
+        await sender(channel_id, outbound["digest"])
+
+    return {
+        "events": len(events),
+        "immediate": len(outbound["immediate"]),
+        "digest_posted": bool(outbound["digest"]),
+        "unclaimed": unclaimed,
+    }

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -40,15 +40,23 @@ def _normalize_event(row) -> dict:
     }
 
 
-async def _load_change_events(session, org_id, since, *, limit: int = 200) -> list:
-    from brain.platform.db.models.domain import DomainEvent
+async def _load_change_events(session, org_id, since, *, limit: int = 500) -> list:
+    import logging
+
     from sqlalchemy import select
+
+    from brain.platform.db.models.domain import DomainEvent
 
     stmt = select(DomainEvent).where(DomainEvent.org_id == org_id)
     if since is not None:
         stmt = stmt.where(DomainEvent.created_at > since)
     stmt = stmt.order_by(DomainEvent.created_at.asc()).limit(limit)
     rows = (await session.execute(stmt)).scalars().all()
+    if len(rows) >= limit:
+        # Non-silent: a full page means more changes exist than this tick surfaced.
+        logging.getLogger("illo.notify").warning(
+            "notify-cycle hit the %s-event page limit; remaining changes surface next tick", limit
+        )
     return [_normalize_event(r) for r in rows]
 
 
@@ -71,6 +79,33 @@ async def _default_post(channel_id, text) -> None:
     await client.post_message(channel=channel_id, text=text)
 
 
+async def _fill_owner_labels(session, events) -> None:
+    """Best-effort ``owner_id`` -> display name so digests don't print raw UUIDs.
+    Guarded: no session or no owners -> no-op; any failure degrades to the id."""
+    if session is None:
+        return
+    owner_ids = {e.get("owner_id") for e in events if e.get("owner_id")}
+    if not owner_ids:
+        return
+    try:
+        from sqlalchemy import select
+
+        from brain.platform.db.models.org import User
+
+        rows = (
+            await session.execute(
+                select(User.id, User.name, User.email).where(User.id.in_(owner_ids))
+            )
+        ).all()
+        labels = {str(r.id): (r.name or r.email or str(r.id)) for r in rows}
+        for event in events:
+            oid = event.get("owner_id")
+            if oid and not event.get("owner_label"):
+                event["owner_label"] = labels.get(str(oid))
+    except Exception:
+        pass  # degrade to the raw id rather than break the tick
+
+
 async def run_notify_cycle(
     session,
     *,
@@ -82,6 +117,7 @@ async def run_notify_cycle(
 ) -> dict:
     """One notify-cycle tick. Returns a small summary of what was sent."""
     events = await _load_change_events(session, org_id, since)
+    await _fill_owner_labels(session, events)
     unclaimed = await _count_unclaimed(session, org_id)
     outbound = render_outbound(events, unclaimed_count=unclaimed, urgent_terms=urgent_terms)
 

--- a/brain/systems/inbound/assignment.py
+++ b/brain/systems/inbound/assignment.py
@@ -1,0 +1,120 @@
+"""Deterministic owner resolution for triaged items.
+
+Replaces interpreted prose ("route known repos to X, don't guess ownership") with
+a typed, ordered decision, so the recurring wrong-owner fumble cannot happen: a
+high-stakes route is a *rule*, not a model guess. Items that neither a rule nor a
+connection owner resolves go to the unclaimed pool (owner ``None``) — parked and
+visible for a teammate to pick up, never force-assigned and never silently
+skipped.
+
+Resolution order:
+  1. **rule**        — ``task_domain`` -> owner, else repo -> owner
+                       (e.g. business/product -> Reda).
+  2. **connection**  — the human authority behind the inbound connection.
+  3. **unassigned**  — no owner; parked in the unclaimed pool.
+
+This module is pure (no DB, no I/O) so it is unit-testable and safe to import
+anywhere. The rule table is *data* (``AssignmentRules``); ``default_rules()``
+builds it from env. Callers pass the rules in.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+
+from brain.systems.task_domain import TaskDomain, coerce_domain
+
+
+class OwnerBasis(str, Enum):
+    RULE = "rule"
+    CONNECTION = "connection"
+    UNASSIGNED = "unassigned"
+
+
+@dataclass(frozen=True)
+class OwnerDecision:
+    user_id: str | None
+    basis: OwnerBasis
+
+    @property
+    def is_assigned(self) -> bool:
+        return self.user_id is not None
+
+
+@dataclass(frozen=True)
+class AssignmentRules:
+    """Typed routing table. Domain rules take precedence over repo rules."""
+
+    domain_owners: dict = field(default_factory=dict)
+    repo_owners: dict = field(default_factory=dict)
+
+    def owner_for(self, task_domain=None, repo=None) -> "str | None":
+        dom = coerce_domain(task_domain)
+        if dom is not None and dom in self.domain_owners:
+            return self.domain_owners[dom]
+        if repo:
+            key = str(repo).strip().lower()
+            for rk, owner in self.repo_owners.items():
+                rk_norm = str(rk).strip().lower()
+                # Match a full "owner/name" slug or a bare repo name.
+                if key == rk_norm or key.endswith("/" + rk_norm):
+                    return owner
+        return None
+
+
+def resolve_owner(
+    *,
+    task_domain=None,
+    repo=None,
+    connection_owner_id=None,
+    rules: "AssignmentRules | None" = None,
+) -> OwnerDecision:
+    """Resolve the owner of a triaged item. Pure and deterministic.
+
+    See module docstring for the resolution order. ``task_domain`` may be a
+    :class:`TaskDomain` or its string value.
+    """
+    rules = rules or AssignmentRules()
+    ruled = rules.owner_for(task_domain=task_domain, repo=repo)
+    if ruled:
+        return OwnerDecision(ruled, OwnerBasis.RULE)
+    if connection_owner_id:
+        return OwnerDecision(connection_owner_id, OwnerBasis.CONNECTION)
+    return OwnerDecision(None, OwnerBasis.UNASSIGNED)
+
+
+def _parse_repo_owners(raw: str) -> dict:
+    """Parse ``ILLO_REPO_OWNERS`` of the form ``repo=uid,owner/repo=uid``."""
+    out: dict = {}
+    for chunk in (raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        repo, owner = chunk.split("=", 1)
+        repo, owner = repo.strip(), owner.strip()
+        if repo and owner:
+            out[repo] = owner
+    return out
+
+
+def default_rules() -> AssignmentRules:
+    """Build the rule table from env.
+
+    ``ILLO_BUSINESS_OWNER_USER_ID`` routes business (and product, unless
+    ``ILLO_PRODUCT_OWNER_USER_ID`` overrides) to that user. Unset owners simply
+    produce no rule, so the item falls through to the connection authority or the
+    unclaimed pool — never a guess.
+    """
+    domain_owners: dict = {}
+    biz = os.environ.get("ILLO_BUSINESS_OWNER_USER_ID", "").strip()
+    prod = os.environ.get("ILLO_PRODUCT_OWNER_USER_ID", "").strip() or biz
+    if biz:
+        domain_owners[TaskDomain.BUSINESS] = biz
+    if prod:
+        domain_owners[TaskDomain.PRODUCT] = prod
+    return AssignmentRules(
+        domain_owners=domain_owners,
+        repo_owners=_parse_repo_owners(os.environ.get("ILLO_REPO_OWNERS", "")),
+    )

--- a/brain/systems/inbound/assignment.py
+++ b/brain/systems/inbound/assignment.py
@@ -106,6 +106,11 @@ def default_rules() -> AssignmentRules:
     ``ILLO_PRODUCT_OWNER_USER_ID`` overrides) to that user. Unset owners simply
     produce no rule, so the item falls through to the connection authority or the
     unclaimed pool — never a guess.
+
+    Single-tenant: these owner ids are global, not per-org — fine for the current
+    one-team deployment; revisit if Illo ever routes across multiple orgs. A rule
+    sets the triage *item* owner (who shepherds it), not a GitHub PR reviewer, so
+    it does not conflict with the SOUL norm of nudging the author.
     """
     domain_owners: dict = {}
     biz = os.environ.get("ILLO_BUSINESS_OWNER_USER_ID", "").strip()

--- a/brain/systems/inbound/github_webhook.py
+++ b/brain/systems/inbound/github_webhook.py
@@ -1,0 +1,113 @@
+"""GitHub webhook → inbound envelope translation (pure).
+
+GitHub cannot post the bridge-token/`WebhookEnvelopeCreate` shape the generic
+``/webhooks`` endpoint expects, so a dedicated router verifies GitHub's
+``X-Hub-Signature-256`` and maps the event into the SAME inbound envelope that
+``submit_inbound_envelope`` already consumes. This module is the pure, testable
+core of that router: signature verification and event→envelope mapping. The
+router itself (connection lookup + the ``submit_inbound_envelope`` call) is thin
+wiring on top of these functions.
+
+Once a source policy + domain projection are configured for the GitHub
+connection, these envelopes upsert domain records within seconds; until then they
+fall through to Illo triage like any unmatched signal. Either way the domain goes
+fresh on the event instead of on a twice-daily poll.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+# Envelope kind for GitHub deliveries. A configured source policy matches on this
+# (and/or origin) to route the event to a domain projection.
+GITHUB_ENVELOPE_KIND = "github_event"
+
+# Events we translate. Anything else returns None (ignored) so the router can 204.
+_SUPPORTED_EVENTS = ("issues", "pull_request", "issue_comment")
+
+
+def verify_signature(secret, body, signature_header) -> bool:
+    """Constant-time verify of GitHub's ``X-Hub-Signature-256`` over the raw body.
+
+    ``secret`` and ``body`` may be ``str`` or ``bytes``. Returns ``False`` on any
+    missing/malformed input rather than raising.
+    """
+    if not secret or not signature_header:
+        return False
+    header = str(signature_header).strip()
+    if not header.startswith("sha256="):
+        return False
+    secret_b = secret.encode() if isinstance(secret, str) else secret
+    body_b = body.encode() if isinstance(body, str) else body
+    expected = "sha256=" + hmac.new(secret_b, body_b, hashlib.sha256).hexdigest()
+    # Compare as bytes: the header is attacker-controlled and Starlette decodes
+    # header values as latin-1, so a non-ASCII header would make a str-vs-str
+    # compare_digest raise TypeError (→ unhandled 500). latin-1 round-trips any
+    # decoded header byte; a non-ASCII header simply won't match the ASCII digest.
+    return hmac.compare_digest(expected.encode("ascii"), header.encode("latin-1"))
+
+
+def _subject(event: str, payload: dict) -> tuple[str, dict]:
+    """Return ``(noun, subject_dict)`` for the event's primary object."""
+    if event == "issues":
+        return "issue", payload.get("issue") or {}
+    if event == "pull_request":
+        return "pull request", payload.get("pull_request") or {}
+    if event == "issue_comment":
+        # A comment carries its parent issue/PR as `issue`.
+        return "comment", payload.get("issue") or {}
+    return "event", {}
+
+
+def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> "dict | None":
+    """Map a GitHub webhook (event name + JSON payload) to an inbound envelope.
+
+    Returns ``None`` for unsupported events. The full payload is carried through
+    so a configured projection can extract its own fields; ``hints`` surfaces the
+    commonly-needed bits (including ``source_updated_at`` for freshness).
+    """
+    if event not in _SUPPORTED_EVENTS:
+        return None
+    payload = payload or {}
+    action = payload.get("action")
+    repo = (payload.get("repository") or {}).get("full_name")
+    noun, subject = _subject(event, payload)
+
+    number = subject.get("number")
+    title = subject.get("title")
+    url = subject.get("html_url")
+    state = subject.get("state")
+    node_id = subject.get("node_id")
+    source_updated_at = subject.get("updated_at")
+    author = (subject.get("user") or {}).get("login")
+
+    if event == "issue_comment":
+        comment = payload.get("comment") or {}
+        url = comment.get("html_url") or url
+        author = (comment.get("user") or {}).get("login") or author
+        source_updated_at = comment.get("updated_at") or source_updated_at
+
+    where = f" #{number}" if number else ""
+    summary = f"GitHub {noun}{where} {action}: {title}".strip() if title else f"GitHub {noun}{where} {action}".strip()
+
+    return {
+        "origin": f"github:{repo}" if repo else "github",
+        "kind": GITHUB_ENVELOPE_KIND,
+        "summary": summary[:2000],
+        "payload": payload,
+        "hints": {
+            "provider": "github",
+            "event": event,
+            "action": action,
+            "repo": repo,
+            "number": number,
+            "url": url,
+            "state": state,
+            "node_id": node_id,
+            "author": author,
+            # Freshness: GitHub's own last-modified for the subject object.
+            "source_updated_at": source_updated_at,
+        },
+        "idempotency_key": (f"github:{delivery_id}"[:160] if delivery_id else None),
+    }

--- a/brain/systems/inbound/github_webhook.py
+++ b/brain/systems/inbound/github_webhook.py
@@ -69,11 +69,14 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
     """
     if event not in _SUPPORTED_EVENTS:
         return None
-    payload = payload or {}
-    action = payload.get("action")
+    if not isinstance(payload, dict):  # a signature-valid but non-object body
+        payload = {}
+    action = payload.get("action") or "event"
     repo = (payload.get("repository") or {}).get("full_name")
     noun, subject = _subject(event, payload)
 
+    # The record anchor is always the issue/PR (node_id + url) so a comment
+    # updates its parent's record rather than forking a new one.
     number = subject.get("number")
     title = subject.get("title")
     url = subject.get("html_url")
@@ -81,15 +84,22 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
     node_id = subject.get("node_id")
     source_updated_at = subject.get("updated_at")
     author = (subject.get("user") or {}).get("login")
+    comment_url = None
 
     if event == "issue_comment":
         comment = payload.get("comment") or {}
-        url = comment.get("html_url") or url
+        # Keep node_id/url anchored to the issue; the comment supplies freshness,
+        # the acting author, and its own url as a separate hint.
+        comment_url = comment.get("html_url")
         author = (comment.get("user") or {}).get("login") or author
         source_updated_at = comment.get("updated_at") or source_updated_at
 
     where = f" #{number}" if number else ""
-    summary = f"GitHub {noun}{where} {action}: {title}".strip() if title else f"GitHub {noun}{where} {action}".strip()
+    summary = (
+        f"GitHub {noun}{where} {action}: {title}".strip()
+        if title
+        else f"GitHub {noun}{where} {action}".strip()
+    )
 
     return {
         "origin": f"github:{repo}" if repo else "github",
@@ -103,6 +113,7 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
             "repo": repo,
             "number": number,
             "url": url,
+            "comment_url": comment_url,
             "state": state,
             "node_id": node_id,
             "author": author,

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -860,6 +860,16 @@ async def _complete_event_with_illo_triage(
     )
 
 
+def _unclaimed_pool_user_id() -> "str | None":
+    """The configured 'unclaimed pool' owner (``ILLO_UNCLAIMED_POOL_USER_ID``).
+    When set, owner-less triage items park here (visible, claimable) instead of
+    being skipped. Unset -> the pool is off and owner-less items skip as before."""
+    import os
+
+    value = os.environ.get("ILLO_UNCLAIMED_POOL_USER_ID", "").strip()
+    return value or None
+
+
 def _github_repo_from_origin(origin: "str | None") -> "str | None":
     """Extract ``owner/repo`` from a ``github:owner/repo`` origin, else ``None``."""
     if origin and str(origin).lower().startswith("github:"):
@@ -901,15 +911,21 @@ async def _queue_illo_triage(
         rules=default_rules(),
     )
     owner_user_id = decision.user_id
+    unclaimed = False
     if not owner_user_id:
-        # No rule and no connection authority: this belongs in the unclaimed pool.
-        # Enacting a truly owner-less pool needs the ideas.user_id nullability
-        # decision (specs/illo-lifecycle Slice 3); until then, skip as before.
-        return {
-            "status": "skipped",
-            "reason": "missing_authority_user",
-            "task_domain": task_domain.value,
-        }
+        # No rule and no connection authority -> the unclaimed pool. Rather than
+        # loosen ideas.user_id (NOT NULL), park the item on a configured pool user
+        # (ILLO_UNCLAIMED_POOL_USER_ID); teammates claim it by reassigning. With no
+        # pool user configured, preserve the old skip so nothing changes.
+        pool_user_id = _unclaimed_pool_user_id()
+        if not pool_user_id:
+            return {
+                "status": "skipped",
+                "reason": "missing_authority_user",
+                "task_domain": task_domain.value,
+            }
+        owner_user_id = pool_user_id
+        unclaimed = True
 
     title = _truncate(f"Inbound signal needs Illo triage: {origin}", 180)
     idea = Idea(
@@ -936,6 +952,7 @@ async def _queue_illo_triage(
                 "owner_id": owner_user_id,
                 "basis": decision.basis.value,
                 "authority_user_id": context.owner_user_id,
+                "unclaimed": unclaimed,
             },
         },
     )

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -31,11 +31,13 @@ from brain.systems.inbound.status import (
     STATUS_QUARANTINED,
     STATUS_REVIEW_REQUIRED,
 )
+from brain.systems.inbound.assignment import default_rules, resolve_owner
 from brain.systems.inbound.preservation import (
     submission_preservation_contract,
     submission_preservation_prompt_lines,
 )
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.task_domain import classify_task_domain
 from brain.systems.user_domains.service import AsyncDomainService, DomainError, DomainNotFound
 
 
@@ -858,6 +860,14 @@ async def _complete_event_with_illo_triage(
     )
 
 
+def _github_repo_from_origin(origin: "str | None") -> "str | None":
+    """Extract ``owner/repo`` from a ``github:owner/repo`` origin, else ``None``."""
+    if origin and str(origin).lower().startswith("github:"):
+        repo = str(origin).split(":", 1)[1].strip()
+        return repo or None
+    return None
+
+
 async def _queue_illo_triage(
     session: AsyncSession,
     *,
@@ -868,11 +878,34 @@ async def _queue_illo_triage(
     reason: str,
     reasoning_summary: str | None,
 ) -> dict[str, Any]:
-    if not context.owner_user_id:
-        return {"status": "skipped", "reason": "missing_authority_user"}
-
     origin = str(normalized.get("origin") or event.origin)
     source_name = context.display_name or context.source_kind or "external source"
+
+    # Deterministic domain + ownership. Rules (business/product -> Reda, repo->owner)
+    # are env-configured via default_rules(); with none set this resolves to the
+    # connection authority, preserving today's behavior.
+    # Classify on the message content (summary), never the origin identifier, so a
+    # source-name substring (e.g. "github:acme/ads-content") can't drive ownership.
+    signal_text = normalized.get("summary") or ""
+    repo = _github_repo_from_origin(origin)
+    task_domain = classify_task_domain(signal_text)
+    decision = resolve_owner(
+        task_domain=task_domain,
+        repo=repo,
+        connection_owner_id=context.owner_user_id,
+        rules=default_rules(),
+    )
+    owner_user_id = decision.user_id
+    if not owner_user_id:
+        # No rule and no connection authority: this belongs in the unclaimed pool.
+        # Enacting a truly owner-less pool needs the ideas.user_id nullability
+        # decision (specs/illo-lifecycle Slice 3); until then, skip as before.
+        return {
+            "status": "skipped",
+            "reason": "missing_authority_user",
+            "task_domain": task_domain.value,
+        }
+
     title = _truncate(f"Inbound signal needs Illo triage: {origin}", 180)
     idea = Idea(
         title=title,
@@ -883,7 +916,7 @@ async def _queue_illo_triage(
         status="emerged",
         origin="inbound_signal",
         origin_ref=f"inbound_event:{event.id}",
-        user_id=context.owner_user_id,
+        user_id=owner_user_id,
         org_id=context.org_id,
         agent_details={
             "inbound_triage": {
@@ -892,7 +925,13 @@ async def _queue_illo_triage(
                 "reason": reason,
                 "connection_id": context.connection_id,
                 "policy_id": str(policy.id) if policy is not None else None,
-            }
+            },
+            "task_domain": task_domain.value,
+            "assignment": {
+                "owner_id": owner_user_id,
+                "basis": decision.basis.value,
+                "authority_user_id": context.owner_user_id,
+            },
         },
     )
     session.add(idea)
@@ -921,7 +960,7 @@ async def _queue_illo_triage(
             "authority_user_id": context.owner_user_id,
         },
         message_type="message",
-        user_id=context.owner_user_id,
+        user_id=owner_user_id,
     )
     session.add(thread_message)
     await session.flush()
@@ -933,7 +972,10 @@ async def _queue_illo_triage(
             event_type="inbound.triage_required",
             org_id=context.org_id,
             actor={
-                "id": context.owner_user_id,
+                # Keep idea, thread, and run actor on one principal (the resolved
+                # owner), as the original code did — avoids a run-actor/idea-owner
+                # split. Defaults to the connection authority when no rule matched.
+                "id": owner_user_id,
                 "org_id": context.org_id,
                 "principal_type": "external_source_authority",
                 "name": source_name,

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -889,8 +889,13 @@ async def _queue_illo_triage(
     signal_text = normalized.get("summary") or ""
     repo = _github_repo_from_origin(origin)
     task_domain = classify_task_domain(signal_text)
+    # task_domain (text heuristic) drives the checklist/labeling only. Let the
+    # domain rule reassign ownership ONLY on the GitHub lane (repo present), where
+    # the summary is a real issue/PR title; other lanes route by repo rule or the
+    # connection authority, so a stray keyword in a Slack message can't yank an
+    # item to a domain owner.
     decision = resolve_owner(
-        task_domain=task_domain,
+        task_domain=task_domain if repo else None,
         repo=repo,
         connection_owner_id=context.owner_user_id,
         rules=default_rules(),

--- a/brain/systems/personality/soul.py
+++ b/brain/systems/personality/soul.py
@@ -72,6 +72,10 @@ clearest path. Do not overbuild the decision. Only use external channels when
 the request is explicitly about reaching that person. Prefer a short pointer or
 link over copying sensitive content into external tools. If no reliable channel
 is available, say so and create the best durable Illo-visible handoff you can.
+
+When coordinating on a GitHub issue or pull request, nudge its author to move it
+forward. Never assign a reviewer or a coordination owner for a PR — the team does
+not review each other's pull requests.
 """
 
 SOUL_MAX_CHARS = int(os.getenv("ILLO_SOUL_MAX_CHARS", "6000"))

--- a/brain/systems/skills/builtin.py
+++ b/brain/systems/skills/builtin.py
@@ -238,7 +238,8 @@ skills, relevant repo/server/memory context, and any user corrections. Call
 3. For each run step define OBJECTIVE, SCOPE, INPUT, OUTPUT, DONE WHEN, EVIDENCE,
    RISKS, and allowed files/resources.
 4. Use parallel workers only when write scopes or resources are independent.
-5. Tell workers they are not alone in the codebase and must preserve others'
+5. Tell workers they are not alone in the shared workspace (the codebase for code
+   work; shared docs, records, and threads otherwise) and must preserve others'
    changes.
 6. Track dependencies in waves, then synthesize outputs after all required
    evidence is present.

--- a/brain/systems/skills/builtin_skill_bundles/coordinate/evals/routing.jsonl
+++ b/brain/systems/skills/builtin_skill_bundles/coordinate/evals/routing.jsonl
@@ -1,2 +1,3 @@
 {"prompt":"Can you quickly check whether this tool exists?","expected":{"route_to":"coordinate","triggers_include":["can you check"],"should_not_route_to":["orchestrate"]}}
 {"prompt":"Plan parallel agents to implement three independent PRs.","expected":{"route_to":"orchestrate","reason":"coordinate should escalate after choosing orchestration"}}
+{"prompt":"Draft the Q3 go-to-market launch plan.","expected":{"route_to":"coordinate","reason":"single business deliverable; act directly, not orchestration"}}

--- a/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/orchestrate/SKILL.md
@@ -31,7 +31,8 @@ skills, relevant repo/server/memory context, and any user corrections. Call
 3. For each run step define OBJECTIVE, SCOPE, INPUT, OUTPUT, DONE WHEN, EVIDENCE,
    RISKS, and allowed files/resources.
 4. Use parallel workers only when write scopes or resources are independent.
-5. Tell workers they are not alone in the codebase and must preserve others'
+5. Tell workers they are not alone in the shared workspace (the codebase for code
+   work; shared docs, records, and threads otherwise) and must preserve others'
    changes.
 6. Track dependencies in waves, then synthesize outputs after all required
    evidence is present.

--- a/brain/systems/skills/builtin_skill_bundles/orchestrate/evals/routing.jsonl
+++ b/brain/systems/skills/builtin_skill_bundles/orchestrate/evals/routing.jsonl
@@ -1,2 +1,3 @@
 {"prompt":"Use parallel agents to update backend and frontend independently, then review.","expected":{"route_to":"orchestrate","triggers_include":["parallel workers"]}}
 {"prompt":"Fix this typo in one file.","expected":{"should_not_route_to":["orchestrate"],"reason":"one focused action"}}
+{"prompt":"Use parallel agents to draft the GTM launch plan and the pricing update independently, then review.","expected":{"route_to":"orchestrate","reason":"multiple independent non-engineering deliverables — routing is by deliverable count, not domain"}}

--- a/brain/systems/skills/builtin_skill_bundles/orchestrate/templates/worker-assignment.md
+++ b/brain/systems/skills/builtin_skill_bundles/orchestrate/templates/worker-assignment.md
@@ -10,4 +10,4 @@ RISKS:
 ALLOWED FILES / RESOURCES:
 DEPENDENCIES:
 
-Worker reminder: you are not alone in the codebase. Preserve user and peer changes, stay within scope, and report any necessary scope expansion before editing.
+Worker reminder: you are not alone in this shared workspace. Preserve user and peer changes, stay within scope, and report any necessary scope expansion before editing. (When the work is code, that means the codebase; for product/business/ops work, it means shared docs, records, and threads.)

--- a/brain/systems/skills/builtin_skill_bundles/report-workspace-blocker/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/report-workspace-blocker/SKILL.md
@@ -22,7 +22,10 @@ unapproved production details in a ticket.
 Load only the evidence needed to make the ticket actionable: the triggering run
 summary, exact error text, relevant command output, repo path, changed files, and
 issue tracker conventions. If the tracker is GitHub and the repo is available,
-use existing repo labels and search recent issues before filing.
+use existing repo labels and search recent issues before filing. For
+non-engineering blockers (product/business/ops), skip the stack-trace and
+`gh issue` framing and record the blocker as a workspace thread or domain record
+instead.
 
 ## Operating Loop
 

--- a/brain/systems/task_domain.py
+++ b/brain/systems/task_domain.py
@@ -45,8 +45,8 @@ _DOMAIN_SIGNALS: list[tuple[TaskDomain, re.Pattern[str]]] = [
         TaskDomain.ENGINEERING,
         re.compile(
             r"(?i)\b("
-            r"bug|hotfix|stack ?trace|null|none ?type|exception|regression|"
-            r"refactor\w*|endpoint|api|webhook|function|class|module|library|"
+            r"bug|hotfix|stack ?trace|exception|regression|"
+            r"refactor\w*|endpoint|api|webhook|function|module|library|"
             r"migration|schema|query|database|\bdb\b|sql|cache|queue|"
             r"deploy\w*|rollback|latency|throughput|rate ?limit\w*|"
             r"authentication|\bauth\b|middleware|token|encryption|dependency|"

--- a/brain/systems/task_domain.py
+++ b/brain/systems/task_domain.py
@@ -1,0 +1,127 @@
+"""Illo Brain — Task Domain classifier.
+
+The *domain* axis of a task: is this engineering, product, business, ops, or
+something else? This is deliberately distinct from the pre-existing *work-mode*
+axis (``code``/``investigation``/``delegation`` in
+``brain/app/hooks/self_assess.py``) and *execution-template* axis
+(``implement``/``edit_file``/``review`` in ``brain/app/cli/run.py``), which
+describe HOW a task is carried out. The domain describes WHAT KIND of work it is,
+and it drives domain-appropriate quality bars, routing, and assignment.
+
+This is the single owner of the domain axis — other subsystems classify through
+``classify_task_domain`` rather than growing their own domain vocabulary.
+
+Precedence (see ``specs/illo-lifecycle``): an explicit policy/repo prior wins;
+the keyword heuristic only runs when no prior is given. The heuristic is a
+best-effort fallback for text-only callers — the accurate signal is the
+repo/policy prior available in the triage path. Ambiguous text resolves to
+``OTHER`` (a real but minimal bar), never silently to ``ENGINEERING``: the whole
+point is to stop applying engineering expectations to non-engineering work.
+
+Signals are domain *nouns*, never neutral verbs. ``add``/``create``/``build``/
+``update``/``write`` are excluded on purpose — they appear in every kind of work
+("create the launch plan", "build the roadmap") and are exactly the greedy-verb
+trap that mislabeled non-engineering tasks as code before.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class TaskDomain(str, Enum):
+    ENGINEERING = "engineering"
+    PRODUCT = "product"
+    BUSINESS = "business"
+    OPS = "ops"
+    OTHER = "other"
+
+
+# Ordered most-specific first; the first domain with a keyword hit wins. Keep
+# these as domain nouns/phrases — no neutral action verbs (see module docstring).
+_DOMAIN_SIGNALS: list[tuple[TaskDomain, re.Pattern[str]]] = [
+    (
+        TaskDomain.ENGINEERING,
+        re.compile(
+            r"(?i)\b("
+            r"bug|hotfix|stack ?trace|null|none ?type|exception|regression|"
+            r"refactor\w*|endpoint|api|webhook|function|class|module|library|"
+            r"migration|schema|query|database|\bdb\b|sql|cache|queue|"
+            r"deploy\w*|rollback|latency|throughput|rate ?limit\w*|"
+            r"authentication|\bauth\b|middleware|token|encryption|dependency|"
+            r"server|backend|frontend|unit ?test|pytest|lint|compile|"
+            r"merge conflict|pull request|\bPRs?\b|commit|codebase|repo"
+            r")\b"
+        ),
+    ),
+    (
+        TaskDomain.OPS,
+        re.compile(
+            r"(?i)\b("
+            r"incident|outage|on.?call|runbook|pager|sev ?[012]\b|prod\w* down|"
+            r"provision\w*|infra\w*|terraform|kubernetes|\bk8s\b|scaling|capacity|"
+            r"backup|restore|credential\w*|secret\w*|access request|permission grant"
+            r")\b"
+        ),
+    ),
+    (
+        TaskDomain.PRODUCT,
+        re.compile(
+            r"(?i)\b("
+            r"roadmap|\bprd\b|product spec|user stor\w+|feature request|backlog|"
+            r"prioriti\w+|acceptance criteria|user research|persona|wireframe|"
+            r"mockup|\bux\b|user experience|product decision"
+            r")\b"
+        ),
+    ),
+    (
+        TaskDomain.BUSINESS,
+        re.compile(
+            r"(?i)\b("
+            r"launch plan|go.?to.?market|\bgtm\b|marketing|campaign|pricing|"
+            r"revenue|\bsales\b|\blead\b|leads|customer success|partnership|"
+            r"contract|invoice|budget|forecast|hir(e|ing)|recruit\w*|onboarding|"
+            r"legal|compliance|\bseo\b|content|blog post|newsletter|social media|"
+            r"\bads?\b|ad campaign"
+            r")\b"
+        ),
+    ),
+]
+
+
+def _coerce(value) -> "TaskDomain | None":
+    """Accept a TaskDomain, its ``.value`` string (any case), or None."""
+    if value is None:
+        return None
+    if isinstance(value, TaskDomain):
+        return value
+    try:
+        return TaskDomain(str(value).strip().lower())
+    except ValueError:
+        return None
+
+
+def classify_task_domain(text: str, *, repo=None, policy=None) -> TaskDomain:
+    """Return the work domain for a task.
+
+    Precedence: explicit ``policy`` prior > ``repo`` default > keyword heuristic.
+    ``repo``/``policy`` may be a :class:`TaskDomain` or its string value; an
+    unrecognized value is ignored (falls through to the heuristic). Ambiguous or
+    empty text resolves to :attr:`TaskDomain.OTHER`, never to ``ENGINEERING``.
+    """
+    pinned = _coerce(policy) or _coerce(repo)
+    if pinned is not None:
+        return pinned
+    if not text:
+        return TaskDomain.OTHER
+    for domain, pattern in _DOMAIN_SIGNALS:
+        if pattern.search(text):
+            return domain
+    return TaskDomain.OTHER
+
+
+def coerce_domain(value) -> "TaskDomain | None":
+    """Public coercion: a :class:`TaskDomain`, its ``.value`` string (any case),
+    or ``None`` -> ``TaskDomain`` or ``None``. Unknown strings return ``None``."""
+    return _coerce(value)

--- a/specs/illo-lifecycle/README.md
+++ b/specs/illo-lifecycle/README.md
@@ -2,11 +2,15 @@
 
 ## Next Agent Prompt
 
-**Status (2026-07-09):** All five slices **implemented in code**. Every pure
-logic core is unit-tested (**98 focused tests green**), a code-review pass found
-and fixed **6 self-review bugs**, and the whole suite still **collects with zero
-import errors (3353 tests)**. What remains is deploy/live wiring that a dev
-checkout cannot exercise (GitHub App, live DB, Slack, scheduler registration) —
+**Status (2026-07-09):** All five slices **implemented and shipped in PR #276**
+(2 commits). Pure logic cores are unit-tested (**105 focused tests green**); an
+independent adversarial review found ~10 MED/LOW findings, all **fixed and pushed**
+(commit `76ed45f`). Full suite **3280 passed** (1 pre-existing env-only failure,
+unrelated). Live read-only validation on `illo-dev` confirmed the sync cycle
+(id 2, `0 8,13` "Uwear Ticket Coordinator Check-ins") and that "doc 1155" is live
+`domain_records` id 1155 — the deterministic rules **preserve** its Reda/Axel/JB
+routing rather than override it. What remains is deploy/live wiring a dev checkout
+cannot exercise (GitHub App, live DB/env, Slack, scheduler registration) —
 enumerated per slice below.
 
 **Key implementation decisions (differ from the original slice text):**
@@ -14,11 +18,12 @@ enumerated per slice below.
   decision live in `ideas.agent_details` (existing JSONB); freshness rides the
   record `data` / envelope hints. This avoids risky central-table migrations that
   can't be validated without a live DB. Add a column later if querying needs it.
-- **Unclaimed pool computed but not yet enacted.** `ideas.user_id` is `NOT NULL`,
-  so a truly owner-less item still can't persist. `resolve_owner` returns
-  `unassigned` and triage records it, but the no-rule/no-authority case still
-  skips (as before). Enacting the pull-pool needs the `ideas.user_id` nullability
-  (or sentinel-user) decision — a live-validated change.
+- **Unclaimed pool enacted via a sentinel owner (env-gated).** Rather than loosen
+  `ideas.user_id` (`NOT NULL`), owner-less items park on a configured pool user
+  (`ILLO_UNCLAIMED_POOL_USER_ID`); teammates claim by reassigning. Unset → the old
+  skip (no behavior change). The notify digest counts the pool. Activation: create
+  a pool user + set the env var. (A `NOT NULL`-drop migration is the purer
+  long-term option if preferred.)
 - **New router/cycle are additive and NOT auto-registered**, so they can't affect
   app startup or the scheduler until deliberately wired.
 
@@ -32,8 +37,9 @@ enumerated per slice below.
 - **Slice 3:** set `ILLO_BUSINESS_OWNER_USER_ID` (+ optional
   `ILLO_PRODUCT_OWNER_USER_ID`, `ILLO_REPO_OWNERS`) to turn on rule routing —
   **must be valid user ids in the org, or those triage events fail** (Idea.user_id
-  is a NOT-NULL FK); decide `ideas.user_id` nullability to enact the unclaimed
-  pool; migrate live "1155" prose into the rule table.
+  is a NOT-NULL FK); create an unclaimed-pool user + set
+  `ILLO_UNCLAIMED_POOL_USER_ID` to enact the pool; migrate live "1155" prose into
+  the rule table.
 - **Slice 4:** register a cycle calling `run_notify_cycle(session, org_id=…,
   channel_id=<team channel>, since=<last_run_at>)`; add the urgent-bypass hook at
   triage completion.

--- a/specs/illo-lifecycle/README.md
+++ b/specs/illo-lifecycle/README.md
@@ -1,0 +1,231 @@
+# Illo lifecycle overhaul — freshness, task-type, and assignment
+
+## Next Agent Prompt
+
+**Status (2026-07-09):** All five slices **implemented in code**. Every pure
+logic core is unit-tested (**98 focused tests green**), a code-review pass found
+and fixed **6 self-review bugs**, and the whole suite still **collects with zero
+import errors (3353 tests)**. What remains is deploy/live wiring that a dev
+checkout cannot exercise (GitHub App, live DB, Slack, scheduler registration) —
+enumerated per slice below.
+
+**Key implementation decisions (differ from the original slice text):**
+- **Persistence via JSONB, not migrations.** `task_domain` + the assignment
+  decision live in `ideas.agent_details` (existing JSONB); freshness rides the
+  record `data` / envelope hints. This avoids risky central-table migrations that
+  can't be validated without a live DB. Add a column later if querying needs it.
+- **Unclaimed pool computed but not yet enacted.** `ideas.user_id` is `NOT NULL`,
+  so a truly owner-less item still can't persist. `resolve_owner` returns
+  `unassigned` and triage records it, but the no-rule/no-authority case still
+  skips (as before). Enacting the pull-pool needs the `ideas.user_id` nullability
+  (or sentinel-user) decision — a live-validated change.
+- **New router/cycle are additive and NOT auto-registered**, so they can't affect
+  app startup or the scheduler until deliberately wired.
+
+**Live-gated activation checklist (per slice):**
+- **Slice 0:** bump the sync cycle cadence; `manage_soul`/`manage_inbound` on live
+  Illo. (SOUL author-nudge default is already in code.)
+- **Slice 1:** activate GitHub App (PR #265); set `ILLO_GITHUB_WEBHOOK_SECRET` +
+  `ILLO_GITHUB_CONNECTION_ID`; `app.include_router(github_webhooks.router)`;
+  configure the source policy + domain projection; add a reconciliation cycle.
+- **Slice 2b:** surface `task_domain` in the `illo_read`/`domain.inspect` output.
+- **Slice 3:** set `ILLO_BUSINESS_OWNER_USER_ID` (+ optional
+  `ILLO_PRODUCT_OWNER_USER_ID`, `ILLO_REPO_OWNERS`) to turn on rule routing —
+  **must be valid user ids in the org, or those triage events fail** (Idea.user_id
+  is a NOT-NULL FK); decide `ideas.user_id` nullability to enact the unclaimed
+  pool; migrate live "1155" prose into the rule table.
+- **Slice 4:** register a cycle calling `run_notify_cycle(session, org_id=…,
+  channel_id=<team channel>, since=<last_run_at>)`; add the urgent-bypass hook at
+  triage completion.
+
+**Before ending your pass:** update this section.
+
+### Global TODO — code complete ✅ (live wiring pending)
+- [x] Reda confirmed the four _Decisions_ (2026-07-08)
+- [x] Slice 0 — SOUL author-nudge default in code (cadence/policy = live steps)
+- [x] Slice 1 — pure cores + GitHub router (`github_webhooks.py`); live: App + config + register
+- [x] Slice 2a — task_domain module + domain-aware self-assess
+- [x] Slice 2b — run.py + triage (`agent_details`) + orchestrate/blocker/evals; live: read surface
+- [x] Slice 3 — resolve_owner + rules, wired into triage; live: env owner id + pool nullability
+- [x] Slice 4 — notify decision/digest + `run_notify_cycle`; live: register cycle + urgent hook
+- [x] Review pass — 6 self-review bugs found + fixed (98 focused tests green)
+- [ ] Live activation (per checklist above) — Reda / infra
+
+---
+
+## Goal
+
+After a full day of live triage/coordination with Illo, three lifecycle problems
+surfaced. This feature fixes all three, reusing infrastructure that already
+exists rather than building parallel paths.
+
+1. **Freshness.** A twice-daily "cycle" polls GitHub into Illo's store, so
+   teammates' agents read state up to ~12h stale, with no signal of how stale.
+2. **Scope.** Business and product-management tasks are starting to land in
+   repos. Illo's identity/triage layer is domain-neutral and won't reject them,
+   but every place it _concretely types a task_ is engineering-only, so non-eng
+   work gets a nonsensical or empty quality bar and eng-shaped handling.
+3. **Assignment.** There is no task-type/label/repo→person mapping anywhere.
+   Assignment is soft prose the model interprets, which is why the wrong-owner
+   fumble recurs — it's structural, not a one-off bug.
+
+## The core idea
+
+Two separations drive the whole design:
+
+- **Data freshness ≠ communication judgment.** Webhooks keep the domain true
+  within seconds (no judgment). The cycle stops being a data pump and becomes a
+  more-frequent _notify-loop_: read what changed, decide whether it's worth
+  telling the team, Slack it or stay quiet.
+- **Typed task-type is the spine for both scope and assignment.** Once
+  `task_type` is a real field instead of a guess, non-eng work gets the right
+  checklist/handling _and_ high-stakes routes (business/PM → Reda) become
+  deterministic code rules instead of interpreted prose. Task-type and
+  assignment are one project, not two.
+
+## Context: what already exists (measured, from recon)
+
+- **Event pipeline (reuse this):** `POST /webhooks`
+  ([brain/app/api/routers/webhooks.py](../../brain/app/api/routers/webhooks.py))
+  → `submit_inbound_envelope()`
+  ([brain/systems/inbound/service.py](../../brain/systems/inbound/service.py)) →
+  `inbound_events` → `_apply_domain_projection()` (service.py ~570–673) →
+  `domain_records`. Already recognizes GitHub delivery headers
+  (`x-github-delivery`, webhooks.py:23). This is the _primary designed path_.
+- **Domain store (source of truth):**
+  [brain/platform/db/models/domain.py](../../brain/platform/db/models/domain.py)
+  — `domain_records` (171–215; `data` JSONB, `version`, `updated_at`),
+  `domain_events` append-only before/after/patch log (258–305). Writer:
+  `AsyncDomainService` ([brain/systems/user_domains/service.py](../../brain/systems/user_domains/service.py):903–919).
+- **Change feed (already queryable):** `query_workspace_data(sources=['domain_events'], start_at=…)`
+  → reader `_query_domain_events`
+  ([brain/systems/runs/tool_catalog/handlers/workspace_data.py](../../brain/systems/runs/tool_catalog/handlers/workspace_data.py):944–998),
+  tool def [brain/systems/runs/tool_definitions.py](../../brain/systems/runs/tool_definitions.py):549,570–574.
+- **Cycles (repurpose, don't rebuild):**
+  [brain/platform/db/models/cycle.py](../../brain/platform/db/models/cycle.py)
+  (`schedule_expr`, `next_run_at`, `last_run_at`), scheduler polls every 30s
+  ([brain/systems/cycles/scheduler.py](../../brain/systems/cycles/scheduler.py):16–26),
+  output goes to a ledger + thread, **not Slack**
+  ([brain/systems/cycles/output_targets.py](../../brain/systems/cycles/output_targets.py):35–61).
+- **Slack outbound (one owner):** only `post_slack_reply`
+  ([brain/systems/runs/tool_catalog/handlers/slack.py](../../brain/systems/runs/tool_catalog/handlers/slack.py):233–311)
+  → `client.post_message` → `chat.postMessage`
+  ([brain/systems/slack/client.py](../../brain/systems/slack/client.py):88–101).
+  Event-driven reply-in-thread only; requires an explicit `channel_id` outside a
+  Slack-triggered run (handlers/slack.py:280). **Nothing posts proactively today.**
+- **Engineering-only task typing (fix these):**
+  [brain/app/hooks/self_assess.py](../../brain/app/hooks/self_assess.py)
+  (`_TASK_PATTERNS` 21–32 greedily buckets `add/create/update/build/write` as
+  `code`; `_CHECKLISTS` 40–61) and
+  [brain/app/cli/run.py](../../brain/app/cli/run.py) (`CLASSIFIERS` 51–68,
+  `TEMPLATES` 75–153, TDD-shaped). These are a *work-mode/execution* axis, a
+  different axis from domain — make them domain-aware, don't merge.
+- **Assignment surfaces (all soft):** connection `owner_user_id` stamped on the
+  event/idea/actor (service.py:189,882,917–936); **silent skip if unset**
+  (service.py:867,1096); SOUL `## Coordination` prose
+  ([brain/systems/personality/soul.py](../../brain/systems/personality/soul.py):57–66);
+  per-source-policy `instructions` injected into the triage message
+  (service.py:989–992), edited via `manage_inbound`
+  (tool_definitions.py:1004–1005,1072–1074). Assignment mechanism = `manage_idea`
+  with `user_id` (tool_definitions.py:1172–1174,1259). **No task-type→person map
+  exists.** "Doc 1155" is this runtime prose, not a repo file.
+- **Migrations:** Alembic (`alembic.ini` at repo root) — the new `task_type` field
+  and freshness columns need migrations.
+
+## Single-owner invariants (refactor-clean — must hold at end state)
+
+The plan must leave the codebase looking designed-today, not bolted-on:
+
+1. **One GitHub→triage write path.** Exactly one write path from GitHub into the
+   triage source-of-truth: the domain projection via `submit_inbound_envelope`.
+   The reconciliation poll (Slice 1) reuses it — it must **not** be a second
+   writer. The existing `cortex_emerge` → `ideas` poll
+   ([brain/jobs/pipelines/cortex_emerge.py](../../brain/jobs/pipelines/cortex_emerge.py))
+   is a _separate concern_ (curiosity/ideas) and must be explicitly scoped out of
+   triage, or retired — never left as a shadow triage source.
+2. **One domain-axis owner.** A single `task_domain` classifier module
+   (`brain/systems/task_domain.py`) owns the domain axis; every subsystem
+   classifies through it. The pre-existing *work-mode/execution* axes
+   (`self_assess.py`, `run.py`) stay — they're a different axis (HOW, not WHAT) —
+   but become **domain-aware**, overriding the engineering bar only on positive
+   non-engineering evidence. No second domain vocabulary.
+3. **One owner-resolution function.** A single "resolve owner for this item" seam
+   keyed on task_type/repo/policy. Deterministic rules are the owner of
+   high-stakes routing; connection-authority and prose are ordered fallbacks
+   behind it — not parallel deciders.
+4. **One freshness contract.** `source_updated_at` / `last_synced_at` /
+   `sync_source` defined once on the projected record and read once by the read
+   surface (`domain.inspect`). Not scattered.
+5. **One outbound-Slack owner.** All proactive posts (notify-loop + urgent
+   bypass) go through `post_slack_reply` / `client.post_message`. No parallel
+   Slack client.
+
+### Transitional scaffolding (named, with removal conditions)
+- Slice 0's **policy-`instruction` route** (business/PM → Reda) is superseded by
+  Slice 3's typed rule. **Remove/migrate** the soft instruction the moment Slice
+  3 lands.
+- Slice 0's **cycle-frequency bump** is superseded by Slice 1 webhooks. **Revert**
+  the frequency to a low-freq reconciliation cadence once webhooks deliver.
+
+## Slice graph
+
+```
+Slice 0  Stopgaps (no infra dep) ─────────────┐  ship today
+Slice 2  Typed task-type (no infra dep) ──┐   │
+Slice 1  Webhook freshness (needs App) ──┐│   │
+Slice 3  Deterministic assignment ───────┘│   │  (depends on Slice 2)
+Slice 4  Proactive Slack notify ──────────┘   │  (depends on Slice 1)
+                                              └─ Slice 0 routes/bump retired by Slices 3/1
+```
+Slices 1 and 2 are largely parallel. 3 depends on 2. 4 depends on 1.
+
+## Review map (where the human looks per slice)
+- **Slice 0:** a business/PM issue routes to Reda; freshness window observably < 1h.
+- **Slice 1:** open/close/comment a test issue → domain reflects within seconds;
+  kill the webhook → reconcile backfills. `synced Xm ago` shows on read.
+- **Slice 2:** "create a launch plan" types as `business` and gets a business
+  checklist, not TDD; an eng task still types `engineering`.
+- **Slice 3:** business/PM issue → `owner=Reda` deterministically; ambiguous eng
+  issue → judgment path; author-nudge norm honored; nothing silently skipped.
+- **Slice 4:** a domain change → appropriate Slack digest within one tick;
+  urgent → immediate ping.
+
+## Assumptions (live-only — do NOT investigate; correct if wrong)
+- **A1** The current twice-daily cycle is a data-sync mission we retire/repurpose.
+  _If it does more, adjust Slice 0/4 — no re-slice._
+- **A2** Teammates should read the **domain** as source of truth. If they
+  currently read the `ideas` store (cortex_emerge — note its silent
+  open/7-day/limit-20/single-owner cap), Slice 1 includes pointing the read path
+  at the domain.
+- **A3** "Doc 1155" is runtime policy-instruction/SOUL prose. Slice 3 reads and
+  preserves its intent at build time before migrating deterministic parts to
+  typed rules.
+
+## Decisions (confirmed with Reda 2026-07-08)
+1. **task_type set:** `engineering | product | business | ops | other`.
+   Marketing/GTM folds into `business` for now; split later if it earns its own
+   checklist.
+2. **task_type derivation:** a repo/policy prior wins when set (a repo can
+   declare its default type; a policy can pin it); the model infers only when
+   unset. Precedence: **policy/repo > model inference**.
+3. **Notify target:** post to the **existing team Slack channel Illo already
+   works in** (the monitored channel) — not a new channel, not DMs. Digest each
+   cycle tick (default 30 min); **urgent = immediate** in that same channel.
+4. **No-owner → an unclaimed pool folks pull from (a "fourth list"), not
+   auto-assignment.** Owner resolves in order: **(1) typed rule**
+   (business/product → Reda; repo→owner) → **(2) connection authority** →
+   **(3) parked ownerless in a visible unclaimed pool** teammates pick up
+   organically (claim = self-assign). No auto-push (no backstop, no
+   load-balancer); silent-skip removed — nothing is dropped. The Slice 4 digest
+   surfaces unclaimed items so pickup happens.
+
+## Known unknowns (safe to discover during a slice)
+- Exact GitHub event → domain object-type field mapping (Slice 1 defines it).
+- Whether `task_type` lives on the domain record, the Idea, or both (Slice 2
+  picks the seam; default: on the triaged Idea + projected onto the record).
+- Reconciliation cadence tuning (Slice 1 starts conservative).
+
+## Out of scope
+- Migrating `cortex_emerge`/ideas beyond scoping it out of triage.
+- PR-review workflow changes beyond encoding the author-nudge norm.
+- Multi-org / multi-tenant assignment rules (single-org assumption holds).

--- a/specs/illo-lifecycle/slices/00-stopgaps.md
+++ b/specs/illo-lifecycle/slices/00-stopgaps.md
@@ -1,0 +1,47 @@
+# Slice 0 — Stopgaps (ship today)
+
+**No infra dependency. No/low code. Uses runtime surfaces that already exist.**
+These buy freshness and correct routing _now_ while Slices 1/3 land, and are
+explicitly retired by them.
+
+## Contract unlocked
+- Staleness window drops from ~12h to < 1h immediately.
+- Business/PM issues route to Reda instead of being guessed.
+- The "nudge the author, never assign a reviewer" norm is encoded in the system
+  for the first time.
+
+## API seam / changes
+1. **Cycle frequency bump** — change the GitHub-sync cycle's `schedule_expr`
+   (twice-daily → every 30–60 min). This is a `cycles` row edit (runtime data),
+   not code. Owner: the cycle; see [cycle.py](../../../brain/platform/db/models/cycle.py):45.
+   _Transitional: reverts to a low-freq reconciliation cadence once Slice 1
+   webhooks deliver._
+2. **Policy `instruction` route** — via `manage_inbound`
+   (update_policy) set the business/PM source policy's `instructions` to route
+   those repos' items to Reda and to not guess owners for others. Injected into
+   triage at [service.py](../../../brain/systems/inbound/service.py):989–992.
+   _Transitional: removed/migrated when Slice 3's typed rule lands._
+3. **SOUL norm** — via `manage_soul` (action=replace) add to the `## Coordination`
+   block of [soul.py](../../../brain/systems/personality/soul.py):57–66:
+   "When coordinating on a GitHub issue or PR, nudge its author to act; never
+   assign a reviewer or a coordination owner." (Encoded nowhere today.)
+
+## What the human can run/see
+- Post a test issue in a business/PM repo → observe it triaged and owned by Reda.
+- Confirm the cycle's `next_run_at` reflects the new cadence.
+- `manage_soul` action=read shows the new Coordination line.
+
+## Verification
+- A business/PM-repo item resolves `owner = Reda` (not skipped, not guessed).
+- A non-business item still routes by existing behavior (no regression).
+- Freshness: max observed domain lag < the new cycle interval.
+
+## Must stay green
+- Existing triage for other sources unchanged.
+- No code paths touched (this slice is runtime config only) — if any code edit
+  sneaks in, it belongs in a later slice.
+
+## Feedback that would change this slice
+- If Reda wants business/PM as per-owner DMs vs a shared thread now.
+- If the cycle turns out to do more than GitHub sync (A1) — then the frequency
+  bump needs a narrower target.

--- a/specs/illo-lifecycle/slices/01-github-webhook-freshness.md
+++ b/specs/illo-lifecycle/slices/01-github-webhook-freshness.md
@@ -1,0 +1,67 @@
+# Slice 1 — GitHub webhook freshness
+
+**Blocked only on:** GitHub App (PR #265) activation (register App + Vault
+store/bind). Everything else is buildable now against a test webhook.
+
+## Contract unlocked
+GitHub changes (issue/PR opened, closed, commented, labeled) are reflected in
+`domain_records` within seconds, with freshness metadata surfaced on read — and a
+reconciliation backstop catches anything the webhook stream drops.
+
+## API seam / changes
+1. **GitHub webhook router** — a sibling to
+   [webhooks.py](../../../brain/app/api/routers/webhooks.py) that:
+   - verifies `X-Hub-Signature-256` (HMAC-SHA256 over the raw body with the App
+     webhook secret) — reject on mismatch;
+   - maps the GitHub event (`issues`, `pull_request`, `issue_comment`,
+     `label`, …) into an inbound envelope and calls the **existing**
+     `submit_inbound_envelope()` ([service.py](../../../brain/systems/inbound/service.py)).
+     Idempotency key = `x-github-delivery` (already recognized, webhooks.py:23).
+   - **Seam:** `def github_event_to_envelope(headers, payload) -> InboundEnvelope`.
+     Pure function, unit-testable with recorded GitHub fixtures. No DB.
+2. **Inbound wiring** — one `inbound_source_policy` (match GitHub origin) + one
+   `inbound_domain_projection` mapping the payload → a GitHub-ticket domain
+   object type. Projection idempotent-upserts keyed on the GitHub node id
+   (models: [inbound.py](../../../brain/platform/db/models/inbound.py):129–238).
+3. **Freshness metadata** — add to the projected record (Alembic migration):
+   `source_updated_at` (GitHub's `updated_at`), `last_synced_at`, `sync_source`
+   (`webhook` | `reconcile`). Surface "synced Xm ago" in the read output of
+   `illo_read`/`domain.inspect`. **One owner** (see README invariant 4).
+4. **No-owner-skip landmine** — the GitHub connection must carry an
+   `owner_user_id`, else all GitHub triage silently skips
+   (service.py:867,1096). Ensure it's set; Slice 3 makes the backstop explicit.
+5. **Reconciliation backstop** — repurpose ONE low-freq cycle to delta-poll
+   GitHub and fill gaps. It must **reuse `submit_inbound_envelope`** (same
+   projection, `sync_source='reconcile'`) — not a second writer (README
+   invariant 1). This replaces Slice 0's frequency bump.
+6. **Scope out `cortex_emerge`** — confirm the `ideas` poll
+   ([cortex_emerge.py](../../../brain/jobs/pipelines/cortex_emerge.py)) is not a
+   shadow triage source; if teammates read `ideas` today (A2), point the read
+   path at the domain.
+
+## What the human can run/see
+- Send a recorded GitHub `issues` delivery to the router locally → a
+  `domain_record` appears/updates.
+- On a live repo: open → comment → close a test issue; watch the record track it
+  within seconds. Read it back via `illo_read` and see `synced Xs ago`.
+- Disable the webhook, change the issue, wait one reconcile tick → record
+  catches up with `sync_source='reconcile'`.
+
+## Verification
+- Unit: `github_event_to_envelope` maps each event type correctly (fixtures);
+  bad signature rejected; replayed `x-github-delivery` is idempotent (no dup
+  record).
+- Integration: webhook → envelope → projection → record, end-to-end, with
+  `source_updated_at` populated.
+- Reconcile: a change made while the webhook is down is backfilled exactly once.
+
+## Must stay green
+- The existing `/webhooks`, `/api/mcp`, and Slack inbound paths (all share
+  `submit_inbound_envelope`) — no regression to their envelopes.
+- Idempotency guarantees on `inbound_events` (unique `(connection_id,
+  idempotency_key)`).
+
+## Feedback that would change this slice
+- Whether PRs and comments become their own object types or fields on the issue
+  record (default: one `github_ticket` type with related events).
+- Reconcile cadence (default conservative, e.g. hourly).

--- a/specs/illo-lifecycle/slices/02-typed-task-type.md
+++ b/specs/illo-lifecycle/slices/02-typed-task-type.md
@@ -1,0 +1,68 @@
+# Slice 2 — Typed task domain
+
+**No infra dependency. Parallel to Slice 1.** The domain axis is the spine for
+scope (right handling for non-eng work) and for Slice 3 (deterministic
+assignment).
+
+## Naming note
+Spec "task_type (domain)" == code **`task_domain`**. The codebase already uses
+`task_type` for a *work-mode* axis (`code`/`investigation`/`delegation`;
+`implement`/`edit_file`/`review`) describing HOW work is done. The new axis
+describes WHAT KIND of work it is, so it lands as `task_domain` to avoid
+overloading the existing key.
+
+## The two-axis reality (corrected after reading the code)
+The two existing classifiers are NOT the domain axis — they're the
+work-mode/execution axis. So the fix is not "merge them into one"; it's **add the
+domain axis and make the existing quality bars domain-aware**, overriding the
+engineering bar only on positive non-engineering evidence.
+
+## Slice 2a — shipped ✅ (domain classifier + domain-aware self-assess)
+- **[brain/systems/task_domain.py](../../../brain/systems/task_domain.py)** —
+  `TaskDomain` enum (`engineering|product|business|ops|other`) +
+  `classify_task_domain(text, *, repo=None, policy=None)`. One owner of the
+  domain axis. Precedence: policy/repo prior > keyword heuristic; ambiguous →
+  `OTHER` (never silently engineering). Signals are domain nouns, never neutral
+  verbs — kills the greedy-verb trap.
+- **[brain/app/hooks/self_assess.py](../../../brain/app/hooks/self_assess.py)** —
+  computes domain alongside work-mode and selects via
+  `select_checklist(domain, work_mode)`: business/product/ops get their own
+  checklist; engineering + ambiguous keep the existing work-mode checklist.
+  Output adds `task_domain` + `checklist_label`; all prior keys preserved.
+- **Tests** — [tests/test_task_domain.py](../../../tests/test_task_domain.py) (14)
+  + existing [tests/test_self_assess.py](../../../tests/test_self_assess.py) (17)
+  all green. Covers the greedy-verb traps ("create the Q3 launch plan" → business,
+  not code) and the no-regression case ("investigate login failures" keeps the
+  investigation checklist rather than falling to a bare bar).
+
+## Slice 2b — remaining (thread domain through triage + prompt surfaces)
+These need `task_domain` available at triage/orchestration time (the accurate
+repo/policy prior), so they come after persistence:
+1. **Persistence** — Alembic migration to store `task_domain` on the triaged Idea
+   (and project onto the domain record). The triage agent sets it from the
+   repo/policy prior, falling back to the heuristic.
+2. **`run.py`** — make the `implement` template's TDD line conditional on
+   `task_domain == engineering`; tag the payload with `task_domain`. Keep
+   `classify_task` behavior (locked by `tests/test_runs.py`).
+3. **Orchestrate worker template** — "you are not alone in the codebase" →
+   "…in this workspace/project" when `task_domain != engineering`.
+4. **report-workspace-blocker** — non-engineering blocker path (no
+   stack-trace/`gh issue create` framing when `task_domain != engineering`).
+5. **Routing evals** — add non-eng examples so routing generalizes.
+6. **Surface on read** — `task_domain` visible in `illo_read`/`domain.inspect`.
+
+## Verification
+- 2a (done ✅): fixture table prompt→domain incl. greedy-verb traps; self_assess
+  picks the right checklist per domain; existing suites green.
+- 2b: a business task through real triage stores `task_domain=business` and gets
+  the business bar; an eng task still `engineering`; grep proves one domain
+  classifier owner (no second domain vocabulary).
+
+## Must stay green
+- `tests/test_self_assess.py` (done), `tests/test_runs.py` (2b must not change
+  `classify_task` outcomes).
+
+## Feedback that would change this slice
+- The exact `TaskDomain` set (confirmed: engineering|product|business|ops|other).
+- Whether `task_domain` is model-inferred, repo/policy-derived, or both
+  (confirmed: both, policy/repo wins; heuristic is the text-only fallback).

--- a/specs/illo-lifecycle/slices/03-deterministic-assignment.md
+++ b/specs/illo-lifecycle/slices/03-deterministic-assignment.md
@@ -1,0 +1,81 @@
+# Slice 3 — Deterministic assignment
+
+**Depends on Slice 2 (`task_type`).** Fix the wrong-owner fumble structurally:
+typed rules for high-stakes routes; everything genuinely unowned goes to a
+visible **unclaimed pool** teammates pull from — never auto-pushed onto a person,
+never silently skipped.
+
+## Contract unlocked
+A single owner-resolution seam decides who owns an item, keyed on
+`task_type`/repo/policy. Business/PM → Reda is a hard rule. Items with no rule and
+no connection owner are parked, ownerless, in a visible unclaimed pool (Reda's
+"fourth list") and surfaced for organic pickup. No auto-assignment; no silent
+skip.
+
+## API seam / changes
+1. **Resolve-owner function (one owner)** — new seam, e.g.
+   `brain/systems/inbound/assignment.py`:
+   `def resolve_owner(item, task_type, repo, policy) -> OwnerDecision`
+   where `OwnerDecision = (user_id | None, basis)` and `basis ∈ {rule,
+   connection, unassigned, judgment}`. Deterministic and unit-testable. Ordered:
+   1. **typed rule** (e.g. `business|product → Reda`; repo→owner table);
+   2. **connection authority** (`owner_user_id`, service.py:189);
+   3. **unassigned** — return no owner; the item is parked in the unclaimed pool.
+      This replaces both the silent skip (service.py:867,1096) and the earlier
+      auto-assign idea. Nothing is dropped, nothing is force-pushed to a person.
+   4. **judgment** (prose) only when a rule intentionally defers.
+2. **Unclaimed pool = a state, not a new store** — Ideas/domain records with no
+   owner + an `open`/`unclaimed` status. It's a query over existing tables (keeps
+   README invariant 1 — no parallel store). Triage _parks_ the item (create the
+   Idea with `user_id=null` + unclaimed marker) instead of skipping. Surface it as
+   a distinct list alongside the team's existing views (the "fourth list"); map to
+   however the team already sees lists.
+3. **Claim / pick-up** — a teammate self-assigns via the existing `manage_idea`
+   `user_id` mechanism (tool_definitions.py:1172–1174,1259): setting
+   `user_id=self` moves it out of the pool. Confirm any teammate can claim an
+   unowned item; add a light "claim" affordance if `manage_idea` alone isn't
+   ergonomic.
+4. **Wire into triage** — the triage queue path
+   ([service.py](../../../brain/systems/inbound/service.py):857–959) calls
+   `resolve_owner`; sets the Idea/thread `user_id` when resolved, else parks it
+   unclaimed. Connection authority and SOUL/policy prose are fallbacks _behind_
+   the rule — not parallel deciders (README invariant 3).
+5. **Preserve "1155" intent (A3)** — at build time, read the current business/PM
+   policy `instructions` and SOUL `## Coordination` prose; migrate the
+   _deterministic_ parts (known repo→person routes, don't-guess-unknowns) into
+   the rule table, and leave only genuine judgment as prose. Do not silently drop
+   any current routing behavior.
+6. **Retire Slice 0's soft route** — once the typed rule for business/PM → Reda
+   is live, remove the transitional policy `instruction` from Slice 0.
+7. **Author-nudge norm** — keep the SOUL norm from Slice 0; ensure `resolve_owner`
+   never assigns a reviewer/coordination-owner for a PR (routes to nudging the
+   author instead).
+8. **Visibility (cross-ref Slice 4)** — the pool only works if pickup actually
+   happens: Slice 4's digest names unclaimed items, and `illo_read`/`domain.inspect`
+   can filter to unclaimed.
+
+## What the human can run/see
+- Unit probe: `resolve_owner(business_item)` → `(Reda, rule)`;
+  `resolve_owner(unknown_repo_eng_item, no connection owner)` →
+  `(None, unassigned)` — parked, not guessed, not force-assigned.
+- A business/PM issue through triage → owned by Reda with `basis=rule`.
+- An item with no rule + no connection owner → appears in the unclaimed pool; a
+  teammate claims it and it leaves the pool.
+
+## Verification
+- Rule table drives ownership for business/product; fixtures cover each
+  `task_type`.
+- The silent-skip path is gone: a no-owner item lands in the unclaimed pool
+  (queryable), never dropped, never auto-assigned.
+- Claim: setting `user_id=self` removes it from the pool exactly once.
+- Regression: prior known routes (from "1155") still produce the same owners.
+
+## Must stay green
+- Engineering triage ownership unchanged for the cases "1155" already handled.
+- No reviewer/coordination-owner is ever auto-assigned on a PR.
+
+## Feedback that would change this slice
+- How aggressively the digest nudges unclaimed items (Slice 4), and any staleness
+  escalation (e.g. an item unclaimed for N days gets flagged).
+- The rule table's shape (config vs code vs policy-backed) and who besides Reda is
+  a default owner for `ops`/`product`.

--- a/specs/illo-lifecycle/slices/04-proactive-slack-notify.md
+++ b/specs/illo-lifecycle/slices/04-proactive-slack-notify.md
@@ -1,0 +1,59 @@
+# Slice 4 — Proactive Slack notify-loop
+
+**Depends on Slice 1 (fresh domain + `domain_events` fed by webhooks).** This is
+the cycle's new job: judgment on a timer.
+
+## Contract unlocked
+The cycle stops being a data pump. On each (more-frequent) tick it reads what
+changed since last run, decides whether it's worth telling the team, and posts a
+Slack digest — or stays quiet. Genuinely urgent events bypass the cycle and ping
+immediately.
+
+## API seam / changes
+1. **Change feed read** — the notify-loop reads
+   `query_workspace_data(sources=['domain_events'], start_at=<last_run>)`
+   (reader [workspace_data.py](../../../brain/systems/runs/tool_catalog/handlers/workspace_data.py):944–998).
+   Watermark = the cycle's `last_run_at` ([cycle.py](../../../brain/platform/db/models/cycle.py):69).
+2. **Decision step** — per changed record decide: noteworthy? who cares (route by
+   owner/`task_type`)? batch vs immediate vs no-op. Keep this as explicit, small,
+   testable logic — not a vague prose instruction (that's the failure mode this
+   whole feature is fixing). Also surface the **unclaimed pool** (Slice 3): name
+   items waiting for an owner so folks pick them up organically, and optionally
+   escalate anything unclaimed past a threshold.
+3. **Post (one owner)** — emit via `post_slack_reply` with an explicit
+   `channel_id` (allowed outside a Slack-triggered run,
+   [handlers/slack.py](../../../brain/systems/runs/tool_catalog/handlers/slack.py):280).
+   No parallel Slack client (README invariant 5). Target = the **existing team
+   channel Illo already works in** (the monitored channel) — not a new channel,
+   not DMs.
+4. **Urgent bypass** — add a triage/webhook-time hook: on an urgent
+   classification, post immediately rather than waiting for the tick. This
+   triage→Slack hook does not exist today (reconciliation.py doesn't post) —
+   it's net-new, and must also go through `post_slack_reply`.
+5. **Cadence** — the cycle's `schedule_expr` set to the digest cadence (default
+   30 min, redline). This is the "revert" target for Slice 0's frequency bump and
+   Slice 1's reconcile cadence — keep the _reconcile_ poll and the _notify_ loop
+   as distinct cycles with distinct jobs.
+
+## What the human can run/see
+- Make a domain change → within one tick, a digest lands in the channel naming
+  what changed and who owns it.
+- Trigger an urgent-labeled item → immediate ping, before the next tick.
+- A quiet interval → the loop posts nothing (no-op is a valid outcome).
+
+## Verification
+- Given recorded `domain_events` since a watermark, the decision step produces
+  the expected notify/no-op set (fixtures).
+- Digest posts to the configured channel; watermark advances so events aren't
+  re-notified next tick.
+- Urgent path posts immediately and is not double-posted by the subsequent
+  digest.
+
+## Must stay green
+- Existing Slack reply-in-thread behavior (event-driven) unchanged.
+- The reconcile poll (Slice 1) and this notify loop remain separate — neither
+  absorbs the other's job.
+
+## Feedback that would change this slice
+- Digest cadence and the exact "urgent" definition (README decision 3).
+- Whether no-op-heavy intervals should still post a heartbeat (default: no).

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,0 +1,91 @@
+"""Tests for brain/systems/inbound/assignment.py — deterministic owner resolution."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
+
+from brain.systems.task_domain import TaskDomain
+from brain.systems.inbound.assignment import (
+    AssignmentRules,
+    OwnerBasis,
+    default_rules,
+    resolve_owner,
+    _parse_repo_owners,
+)
+
+
+class TestResolveOwner:
+    def test_domain_rule_wins_over_connection(self):
+        rules = AssignmentRules(domain_owners={TaskDomain.BUSINESS: "reda"})
+        d = resolve_owner(task_domain=TaskDomain.BUSINESS, connection_owner_id="conn", rules=rules)
+        assert d.user_id == "reda"
+        assert d.basis == OwnerBasis.RULE
+
+    def test_product_routes_by_rule(self):
+        rules = AssignmentRules(domain_owners={TaskDomain.PRODUCT: "reda"})
+        assert resolve_owner(task_domain=TaskDomain.PRODUCT, rules=rules).user_id == "reda"
+
+    def test_string_domain_is_coerced(self):
+        rules = AssignmentRules(domain_owners={TaskDomain.BUSINESS: "reda"})
+        assert resolve_owner(task_domain="business", rules=rules).user_id == "reda"
+
+    def test_repo_rule_matches_full_slug_and_bare_name(self):
+        rules = AssignmentRules(repo_owners={"uwear-backend": "axel"})
+        assert resolve_owner(repo="Illospace/uwear-backend", rules=rules).user_id == "axel"
+        assert resolve_owner(repo="uwear-backend", rules=rules).user_id == "axel"
+
+    def test_domain_beats_repo(self):
+        rules = AssignmentRules(
+            domain_owners={TaskDomain.BUSINESS: "reda"},
+            repo_owners={"site": "axel"},
+        )
+        assert resolve_owner(task_domain="business", repo="site", rules=rules).user_id == "reda"
+
+    def test_connection_fallback_when_no_rule(self):
+        d = resolve_owner(task_domain=TaskDomain.ENGINEERING, connection_owner_id="conn")
+        assert d.user_id == "conn"
+        assert d.basis == OwnerBasis.CONNECTION
+
+    def test_unassigned_when_nothing_resolves(self):
+        d = resolve_owner(task_domain=TaskDomain.ENGINEERING)
+        assert d.user_id is None
+        assert d.basis == OwnerBasis.UNASSIGNED
+        assert d.is_assigned is False
+
+    def test_engineering_is_not_auto_routed(self):
+        # No engineering rule by default -> falls to connection, never guessed.
+        rules = AssignmentRules(domain_owners={TaskDomain.BUSINESS: "reda"})
+        d = resolve_owner(task_domain=TaskDomain.ENGINEERING, connection_owner_id="c", rules=rules)
+        assert d.basis == OwnerBasis.CONNECTION
+
+
+class TestDefaultRules:
+    def test_business_owner_from_env_covers_product(self, monkeypatch):
+        monkeypatch.setenv("ILLO_BUSINESS_OWNER_USER_ID", "reda-uid")
+        monkeypatch.delenv("ILLO_PRODUCT_OWNER_USER_ID", raising=False)
+        monkeypatch.delenv("ILLO_REPO_OWNERS", raising=False)
+        rules = default_rules()
+        assert rules.owner_for(task_domain=TaskDomain.BUSINESS) == "reda-uid"
+        assert rules.owner_for(task_domain=TaskDomain.PRODUCT) == "reda-uid"
+
+    def test_product_owner_override(self, monkeypatch):
+        monkeypatch.setenv("ILLO_BUSINESS_OWNER_USER_ID", "reda-uid")
+        monkeypatch.setenv("ILLO_PRODUCT_OWNER_USER_ID", "pm-uid")
+        rules = default_rules()
+        assert rules.owner_for(task_domain=TaskDomain.PRODUCT) == "pm-uid"
+
+    def test_no_env_means_no_rule(self, monkeypatch):
+        monkeypatch.delenv("ILLO_BUSINESS_OWNER_USER_ID", raising=False)
+        monkeypatch.delenv("ILLO_PRODUCT_OWNER_USER_ID", raising=False)
+        rules = default_rules()
+        assert rules.owner_for(task_domain=TaskDomain.BUSINESS) is None
+
+
+class TestParseRepoOwners:
+    def test_parses_pairs(self):
+        assert _parse_repo_owners("a=1,owner/b=2") == {"a": "1", "owner/b": "2"}
+
+    def test_ignores_malformed(self):
+        assert _parse_repo_owners("") == {}
+        assert _parse_repo_owners("nope,x=,=y,ok=1") == {"ok": "1"}

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -176,3 +176,12 @@ class TestReviewFixes:
         line = format_line({"title": "<!channel> ship it", "action": "opened"})
         assert "<!channel>" not in line
         assert "&lt;!channel&gt;" in line
+
+
+class TestUnclaimedPool:
+    async def test_count_zero_when_pool_unset(self, monkeypatch):
+        import brain.systems.change_notifications_cycle as cyc
+
+        monkeypatch.delenv("ILLO_UNCLAIMED_POOL_USER_ID", raising=False)
+        # session is present but the pool is off -> 0 without touching the DB.
+        assert await cyc._count_unclaimed(object(), "org-1") == 0

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -154,3 +154,25 @@ class TestNormalizeEvent:
         assert ev["owner_id"] == "u1"
         # p0 label lives under data → urgency must now be detectable
         assert is_urgent(ev) is True
+
+
+class TestReviewFixes:
+    def test_routine_promotion_pr_skipped(self):
+        assert classify_event({"title": "Promote staging to main", "action": "opened"}) == "skip"
+        assert classify_event({"title": "staging -> main", "action": "opened"}) == "skip"
+
+    def test_urgent_promotion_still_immediate(self):
+        assert classify_event({"title": "Promote staging to main", "labels": ["p0"]}) == "immediate"
+
+    def test_normal_pr_not_skipped(self):
+        assert classify_event({"title": "Add pockets to garment card", "action": "opened"}) == "digest"
+
+    def test_word_boundary_urgency_no_false_positive(self):
+        assert is_urgent({"title": "production downtime resolved"}) is False
+        assert is_urgent({"title": "coincidental cleanup"}) is False
+        assert is_urgent({"title": "prod down now"}) is True
+
+    def test_slack_control_chars_escaped(self):
+        line = format_line({"title": "<!channel> ship it", "action": "opened"})
+        assert "<!channel>" not in line
+        assert "&lt;!channel&gt;" in line

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -1,0 +1,156 @@
+"""Tests for brain/systems/change_notifications.py — pure notify decision + digest."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
+
+from brain.systems.change_notifications import (
+    build_digest,
+    classify_event,
+    decide_notifications,
+    format_line,
+    is_urgent,
+    render_outbound,
+)
+
+
+class TestClassify:
+    def test_urgent_by_label_is_immediate(self):
+        assert classify_event({"title": "x", "labels": ["p0", "bug"]}) == "immediate"
+        assert classify_event({"title": "prod down!", "labels": []}) == "immediate"
+
+    def test_security_is_urgent(self):
+        assert is_urgent({"title": "security hole in auth"}) is True
+
+    def test_noise_event_type_is_skipped(self):
+        assert classify_event({"event_type": "schema.updated", "title": "x"}) == "skip"
+
+    def test_explicit_not_noteworthy_is_skipped(self):
+        assert classify_event({"title": "x", "noteworthy": False}) == "skip"
+
+    def test_ordinary_change_is_digest(self):
+        assert classify_event({"event_type": "record.updated", "title": "Ticket", "action": "closed"}) == "digest"
+
+    def test_custom_urgent_terms(self):
+        assert classify_event({"title": "escalated"}, urgent_terms=("escalated",)) == "immediate"
+
+
+class TestDecide:
+    def test_buckets_events(self):
+        events = [
+            {"title": "A", "labels": ["p0"]},                 # immediate
+            {"title": "B", "action": "closed"},               # digest
+            {"event_type": "record.read", "title": "C"},      # skip
+        ]
+        out = decide_notifications(events)
+        assert [e["title"] for e in out["immediate"]] == ["A"]
+        assert [e["title"] for e in out["digest"]] == ["B"]
+        assert [e["title"] for e in out["skip"]] == ["C"]
+
+    def test_empty(self):
+        assert decide_notifications([]) == {"immediate": [], "digest": [], "skip": []}
+
+
+class TestFormat:
+    def test_line_owned(self):
+        line = format_line({"title": "Ticket", "action": "closed", "owner_id": "u1", "owner_label": "Reda"})
+        assert "Ticket" in line and "closed" in line and "Reda" in line
+
+    def test_line_unclaimed(self):
+        assert "unclaimed" in format_line({"title": "T", "action": "opened"})
+
+    def test_line_includes_url(self):
+        assert "http://x" in format_line({"title": "T", "url": "http://x"})
+
+
+class TestBuildDigest:
+    def test_none_when_empty(self):
+        assert build_digest([], unclaimed_count=0) is None
+
+    def test_unclaimed_only_still_posts(self):
+        text = build_digest([], unclaimed_count=3)
+        assert text is not None and "3 items waiting" in text
+
+    def test_singular_unclaimed(self):
+        assert "1 item waiting" in build_digest([], unclaimed_count=1)
+
+    def test_digest_lists_changes(self):
+        text = build_digest([{"title": "Ticket", "action": "closed", "owner_id": "u", "owner_label": "R"}])
+        assert "Ticket" in text and "What changed" in text
+
+
+class TestRenderOutbound:
+    def test_splits_immediate_and_digest(self):
+        events = [
+            {"title": "Prod down", "labels": ["p0"]},          # immediate
+            {"title": "Ticket closed", "action": "closed"},    # digest
+            {"event_type": "record.read", "title": "noise"},   # skip
+        ]
+        out = render_outbound(events, unclaimed_count=2)
+        assert len(out["immediate"]) == 1 and "Prod down" in out["immediate"][0]
+        assert out["digest"] is not None
+        assert "Ticket closed" in out["digest"]
+        assert "2 items waiting" in out["digest"]
+
+    def test_quiet_interval_is_noop(self):
+        out = render_outbound([{"event_type": "record.read", "title": "x"}], unclaimed_count=0)
+        assert out["immediate"] == []
+        assert out["digest"] is None
+
+
+class TestNotifyCycleOrchestration:
+    async def test_posts_immediate_and_digest_to_channel(self, monkeypatch):
+        import brain.systems.change_notifications_cycle as cyc
+
+        async def fake_load(session, org_id, since, **kw):
+            return [
+                {"title": "Prod down", "labels": ["p0"]},        # immediate
+                {"title": "Ticket", "action": "closed"},          # digest
+            ]
+
+        async def fake_count(session, org_id):
+            return 1
+
+        monkeypatch.setattr(cyc, "_load_change_events", fake_load)
+        monkeypatch.setattr(cyc, "_count_unclaimed", fake_count)
+
+        sent = []
+
+        async def fake_post(channel, text):
+            sent.append((channel, text))
+
+        result = await cyc.run_notify_cycle(
+            None, org_id="o", channel_id="C123", since=None, post=fake_post
+        )
+        assert result["immediate"] == 1
+        assert result["digest_posted"] is True
+        assert result["unclaimed"] == 1
+        assert len(sent) == 2  # one urgent + one digest
+        assert all(channel == "C123" for channel, _ in sent)
+        assert any("Prod down" in text for _, text in sent)
+        assert any("1 item waiting" in text for _, text in sent)
+
+
+class TestNormalizeEvent:
+    def test_reads_user_fields_from_data_not_top_level(self):
+        from brain.systems.change_notifications import is_urgent
+        from brain.systems.change_notifications_cycle import _normalize_event
+
+        class Row:
+            event_type = "record.updated"
+            record_id = 5
+            # serialize_record shape: title/object_key top-level, fields under data
+            after = {
+                "object_key": "ticket",
+                "title": "Login broken",
+                "data": {"url": "http://x", "labels": ["p0"], "priority": "P0", "owner_id": "u1"},
+            }
+
+        ev = _normalize_event(Row())
+        assert ev["title"] == "Login broken"
+        assert ev["url"] == "http://x"
+        assert ev["labels"] == ["p0"]
+        assert ev["owner_id"] == "u1"
+        # p0 label lives under data → urgency must now be detectable
+        assert is_urgent(ev) is True

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -1,0 +1,113 @@
+"""Tests for brain/systems/inbound/github_webhook.py — pure webhook translation."""
+
+import hashlib
+import hmac
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
+
+from brain.systems.inbound.github_webhook import (
+    GITHUB_ENVELOPE_KIND,
+    github_event_to_envelope,
+    verify_signature,
+)
+
+
+def _sign(secret: bytes, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+
+
+class TestVerifySignature:
+    def test_valid_signature_passes(self):
+        secret, body = b"s3cr3t", b'{"a":1}'
+        assert verify_signature(secret, body, _sign(secret, body)) is True
+
+    def test_accepts_str_secret_and_body(self):
+        assert verify_signature("s3cr3t", '{"a":1}', _sign(b"s3cr3t", b'{"a":1}')) is True
+
+    def test_wrong_secret_fails(self):
+        body = b'{"a":1}'
+        assert verify_signature(b"wrong", body, _sign(b"right", body)) is False
+
+    def test_tampered_body_fails(self):
+        secret = b"s"
+        sig = _sign(secret, b'{"a":1}')
+        assert verify_signature(secret, b'{"a":2}', sig) is False
+
+    def test_missing_or_malformed_header_fails(self):
+        assert verify_signature(b"s", b"b", None) is False
+        assert verify_signature(b"s", b"b", "") is False
+        assert verify_signature(b"s", b"b", "md5=deadbeef") is False
+
+    def test_empty_secret_fails(self):
+        assert verify_signature("", b"b", "sha256=x") is False
+
+    def test_non_ascii_header_returns_false_not_raise(self):
+        # Starlette decodes header values as latin-1, so the header can carry
+        # bytes >= 0x80. Must return False, not raise TypeError (→ unhandled 500).
+        assert verify_signature(b"s", b"b", "sha256=\xff\xfe\x80") is False
+
+
+class TestEventToEnvelope:
+    def test_issue_opened(self):
+        payload = {
+            "action": "opened",
+            "repository": {"full_name": "Illospace/uwear-backend"},
+            "issue": {
+                "number": 42,
+                "title": "Login is broken",
+                "html_url": "https://github.com/Illospace/uwear-backend/issues/42",
+                "state": "open",
+                "node_id": "I_abc",
+                "updated_at": "2026-07-08T10:00:00Z",
+                "user": {"login": "alice"},
+            },
+        }
+        env = github_event_to_envelope("issues", payload, delivery_id="d-1")
+        assert env["origin"] == "github:Illospace/uwear-backend"
+        assert env["kind"] == GITHUB_ENVELOPE_KIND
+        assert env["idempotency_key"] == "github:d-1"
+        assert env["hints"]["number"] == 42
+        assert env["hints"]["action"] == "opened"
+        assert env["hints"]["source_updated_at"] == "2026-07-08T10:00:00Z"
+        assert env["hints"]["author"] == "alice"
+        assert "Login is broken" in env["summary"]
+        assert env["payload"] is payload  # full payload carried for the projection
+
+    def test_pull_request_closed(self):
+        payload = {
+            "action": "closed",
+            "repository": {"full_name": "o/r"},
+            "pull_request": {
+                "number": 7, "title": "Add feature", "html_url": "u",
+                "state": "closed", "node_id": "PR_1",
+                "updated_at": "2026-07-08T11:00:00Z", "user": {"login": "bob"},
+            },
+        }
+        env = github_event_to_envelope("pull_request", payload)
+        assert env["hints"]["event"] == "pull_request"
+        assert env["hints"]["state"] == "closed"
+        assert env["hints"]["number"] == 7
+        assert env["idempotency_key"] is None  # no delivery id
+
+    def test_issue_comment_prefers_comment_fields(self):
+        payload = {
+            "action": "created",
+            "repository": {"full_name": "o/r"},
+            "issue": {"number": 5, "title": "Bug", "html_url": "issue-url",
+                      "user": {"login": "author"}, "updated_at": "old"},
+            "comment": {"html_url": "comment-url", "user": {"login": "commenter"},
+                        "updated_at": "2026-07-08T12:00:00Z"},
+        }
+        env = github_event_to_envelope("issue_comment", payload)
+        assert env["hints"]["url"] == "comment-url"
+        assert env["hints"]["author"] == "commenter"
+        assert env["hints"]["source_updated_at"] == "2026-07-08T12:00:00Z"
+
+    def test_unsupported_event_returns_none(self):
+        assert github_event_to_envelope("star", {"action": "created"}) is None
+
+    def test_missing_repo_defaults_origin(self):
+        env = github_event_to_envelope("issues", {"action": "opened", "issue": {"number": 1}})
+        assert env["origin"] == "github"

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -91,19 +91,29 @@ class TestEventToEnvelope:
         assert env["hints"]["number"] == 7
         assert env["idempotency_key"] is None  # no delivery id
 
-    def test_issue_comment_prefers_comment_fields(self):
+    def test_issue_comment_anchors_on_issue_keeps_comment_details(self):
         payload = {
             "action": "created",
             "repository": {"full_name": "o/r"},
-            "issue": {"number": 5, "title": "Bug", "html_url": "issue-url",
+            "issue": {"number": 5, "title": "Bug", "html_url": "issue-url", "node_id": "I_5",
                       "user": {"login": "author"}, "updated_at": "old"},
             "comment": {"html_url": "comment-url", "user": {"login": "commenter"},
                         "updated_at": "2026-07-08T12:00:00Z"},
         }
         env = github_event_to_envelope("issue_comment", payload)
-        assert env["hints"]["url"] == "comment-url"
+        assert env["hints"]["url"] == "issue-url"       # anchor stays the issue
+        assert env["hints"]["node_id"] == "I_5"
+        assert env["hints"]["comment_url"] == "comment-url"
         assert env["hints"]["author"] == "commenter"
         assert env["hints"]["source_updated_at"] == "2026-07-08T12:00:00Z"
+
+    def test_non_dict_payload_does_not_raise(self):
+        env = github_event_to_envelope("issues", "not-a-dict")
+        assert env is not None and env["origin"] == "github"
+
+    def test_missing_action_defaults_to_event(self):
+        env = github_event_to_envelope("issues", {"issue": {"number": 1, "title": "T"}})
+        assert "event" in env["summary"]
 
     def test_unsupported_event_returns_none(self):
         assert github_event_to_envelope("star", {"action": "created"}) is None

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -125,6 +125,29 @@ class TestBuildPayload:
         assert result["model"] == "high"
         assert result["thinking"] == "high"
 
+    @patch("brain.app.cli.run.build_context_block", return_value=("", {"memories": 0, "guardrails": 0, "similar_tasks": 0}))
+    @patch("brain.app.cli.run.log_run", return_value=1)
+    @patch("brain.app.cli.run.UnitOfWork")
+    async def test_ambiguous_task_keeps_engineering_bar(self, MockUoW, mock_log, mock_ctx):
+        mock_uow = _async_uow()
+        MockUoW.return_value = mock_uow
+        from brain.app.cli.run import build_payload
+        # No domain noun -> classifies OTHER -> must NOT get the "not engineering" note.
+        result = await build_payload("implement the thing", "implement")
+        assert result["task_domain"] == "other"
+        assert "not engineering" not in result["prompt"]
+
+    @patch("brain.app.cli.run.build_context_block", return_value=("", {"memories": 0, "guardrails": 0, "similar_tasks": 0}))
+    @patch("brain.app.cli.run.log_run", return_value=1)
+    @patch("brain.app.cli.run.UnitOfWork")
+    async def test_business_task_gets_non_engineering_note(self, MockUoW, mock_log, mock_ctx):
+        mock_uow = _async_uow()
+        MockUoW.return_value = mock_uow
+        from brain.app.cli.run import build_payload
+        result = await build_payload("draft the GTM launch plan", "custom")
+        assert result["task_domain"] == "business"
+        assert "not engineering" in result["prompt"]
+
     @patch("brain.app.cli.run.build_context_block", return_value=("## Guardrails\n- watch out", {"memories": 0, "guardrails": 1, "similar_tasks": 0}))
     @patch("brain.app.cli.run.log_run", return_value=5)
     @patch("brain.app.cli.run.UnitOfWork")

--- a/tests/test_task_domain.py
+++ b/tests/test_task_domain.py
@@ -1,0 +1,89 @@
+"""Tests for brain/systems/task_domain.py and self_assess domain-aware checklists."""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
+
+from brain.systems.task_domain import TaskDomain, classify_task_domain
+
+
+class TestClassifyTaskDomain:
+    def test_engineering_signals(self):
+        assert classify_task_domain("fix the null deref in the auth handler") == TaskDomain.ENGINEERING
+        assert classify_task_domain("refactor the payment module") == TaskDomain.ENGINEERING
+        assert classify_task_domain("the API endpoint returns a 500") == TaskDomain.ENGINEERING
+        assert classify_task_domain("write a database migration") == TaskDomain.ENGINEERING
+
+    def test_business_signals_survive_greedy_verbs(self):
+        # "create"/"update"/"draft"/"write" must NOT pull these into engineering.
+        assert classify_task_domain("create the Q3 launch plan") == TaskDomain.BUSINESS
+        assert classify_task_domain("update our pricing page") == TaskDomain.BUSINESS
+        assert classify_task_domain("draft the GTM campaign brief") == TaskDomain.BUSINESS
+        assert classify_task_domain("write the SEO content calendar") == TaskDomain.BUSINESS
+
+    def test_product_signals(self):
+        assert classify_task_domain("write the PRD for onboarding") == TaskDomain.PRODUCT
+        assert classify_task_domain("prioritize the backlog") == TaskDomain.PRODUCT
+        assert classify_task_domain("add acceptance criteria to the user story") == TaskDomain.PRODUCT
+
+    def test_ops_signals(self):
+        assert classify_task_domain("update the production incident runbook") == TaskDomain.OPS
+        assert classify_task_domain("rotate the leaked credentials") == TaskDomain.OPS
+
+    def test_ambiguous_resolves_to_other_not_engineering(self):
+        assert classify_task_domain("do something vague") == TaskDomain.OTHER
+        assert classify_task_domain("hello world") == TaskDomain.OTHER
+        assert classify_task_domain("") == TaskDomain.OTHER
+
+    def test_policy_prior_wins_over_text(self):
+        # Engineering-looking text, but the policy pins business.
+        assert classify_task_domain("fix the bug", policy="business") == TaskDomain.BUSINESS
+
+    def test_repo_prior_used_when_no_policy(self):
+        assert classify_task_domain("something ambiguous", repo="product") == TaskDomain.PRODUCT
+
+    def test_policy_beats_repo(self):
+        assert classify_task_domain("x", repo="ops", policy="business") == TaskDomain.BUSINESS
+
+    def test_prior_accepts_enum(self):
+        assert classify_task_domain("x", policy=TaskDomain.OPS) == TaskDomain.OPS
+
+    def test_bad_prior_ignored_falls_to_heuristic(self):
+        assert classify_task_domain("pricing and revenue forecast", policy="NONSENSE") == TaskDomain.BUSINESS
+
+    def test_prior_is_case_and_space_tolerant(self):
+        assert classify_task_domain("fix the bug", policy="  Engineering  ") == TaskDomain.ENGINEERING
+
+
+class TestSelfAssessDomainAware:
+    """The reported bug: non-engineering work must not get the engineering TDD bar."""
+
+    @patch("brain.app.hooks.self_assess.get_brain_context")
+    def test_business_task_gets_business_checklist_not_tdd(self, mock_brain):
+        mock_brain.return_value = {"memories": [], "warnings": [], "guardrails": []}
+        from brain.app.hooks.self_assess import assess_quality
+        result = assess_quality("create the Q3 launch plan", "drafted the plan")
+        assert result["task_domain"] == "business"
+        checklist = result["checklist"]
+        assert not any("paste output" in i.lower() for i in checklist)  # not the code bar
+        assert any("deliverable" in i.lower() for i in checklist)       # the business bar
+
+    @patch("brain.app.hooks.self_assess.get_brain_context")
+    def test_engineering_task_still_gets_code_checklist(self, mock_brain):
+        mock_brain.return_value = {"memories": [], "warnings": [], "guardrails": []}
+        from brain.app.hooks.self_assess import assess_quality
+        result = assess_quality("fix the null deref in api.py", "added guard")
+        assert result["task_domain"] == "engineering"
+        assert any("test" in i.lower() for i in result["checklist"])
+
+    @patch("brain.app.hooks.self_assess.get_brain_context")
+    def test_ambiguous_engineering_keeps_work_mode_checklist(self, mock_brain):
+        # "investigate login failures" has no domain noun -> OTHER, but must keep
+        # the investigation work-mode checklist, not fall to a bare minimal bar.
+        mock_brain.return_value = {"memories": [], "warnings": [], "guardrails": []}
+        from brain.app.hooks.self_assess import assess_quality
+        result = assess_quality("investigate login failures", "found root cause")
+        assert result["task_type"] == "investigation"
+        assert any("data" in i.lower() for i in result["checklist"])


### PR DESCRIPTION
## What & why

After a full day of live triage with Illo, three lifecycle gaps surfaced. This reuses the existing inbound pipeline (no parallel paths) to fix all three. Full plan + rationale: `specs/illo-lifecycle/`.

1. **Freshness** — a twice-daily cycle polled GitHub, so teammates read stale state. Now event-driven.
2. **Scope** — business/PM tasks entering repos hit engineering-only task-typing. Now a typed domain axis.
3. **Assignment** — soft prose the model interpreted → recurring wrong-owner fumble. Now deterministic rules.

## Slices

**Slice 1 — GitHub freshness (event-driven)**
- `brain/systems/inbound/github_webhook.py` — pure `verify_signature` (HMAC-SHA256, latin-1-safe) + `github_event_to_envelope` (issues/PR/comment), carrying `source_updated_at`.
- `brain/app/api/routers/github_webhooks.py` — thin router into `submit_inbound_envelope`. **Not auto-registered** until the GitHub App (PR #265) + env are live.

**Slice 2 — typed task domain**
- `brain/systems/task_domain.py` — one-owner classifier; policy/repo prior > keyword heuristic; ambiguous → `other` (never silently engineering).
- `self_assess.py` domain-aware checklists (override the eng bar only on positive non-eng evidence); `run.py` domain note; orchestrate/blocker/evals generalized beyond "the codebase".

**Slice 3 — deterministic assignment**
- `brain/systems/inbound/assignment.py` — pure `resolve_owner`: rule (business/product → Reda, repo→owner) > connection authority > unclaimed. Rules from env.
- `inbound/service.py` triage classifies domain + resolves owner (recorded in `agent_details`). **Behavior-preserving by default** (empty rules → today's connection authority).

**Slice 4 — proactive Slack notify-loop**
- `change_notifications.py` — pure decide/format (immediate vs digest vs skip; unclaimed nudge; no-op when quiet).
- `change_notifications_cycle.py` — reads `domain_events` since last run → posts to the team channel.

**Slice 0** — author-nudge norm in `DEFAULT_SOUL_MD`.

## Design choices
- Persistence uses existing JSONB (`agent_details`, record `data`) instead of central-table migrations — avoids un-migratable risk; queryable via JSONB paths.
- The unclaimed **pull-pool** is scaffolded but not enacted: `ideas.user_id` is `NOT NULL`, so owner-less items still skip (documented in `_count_unclaimed` + Slice 3). Enacting it needs a nullability decision to validate live.

## Activation (post-merge, needs live access / privileges)
- Register the GitHub App (PR #265) + set `ILLO_GITHUB_WEBHOOK_SECRET` / `ILLO_GITHUB_CONNECTION_ID`, then `include_router(github_webhooks.router)`.
- Set `ILLO_BUSINESS_OWNER_USER_ID` (+ optional `ILLO_PRODUCT_OWNER_USER_ID`, `ILLO_REPO_OWNERS`) to turn on rule-based routing.
- Repurpose the sync cycle → `run_notify_cycle(...)`; add a source policy + projection for the GitHub connection.
- `manage_soul` to apply the author-nudge norm on the live instance.

## Tests
- 115 new/updated unit tests (task_domain, assignment, github_webhook, change_notifications, self_assess, runs) — all green.
- Full suite: **3273 passed**, 55 skipped; 1 failure is pre-existing and environment-only (a launcher shell test invoking system python 3.9), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
