### PR TITLE
[Illo-QA] Preflight external-agent (Codex) auth before scheduled Cycle admission

### DIFF
--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -1,0 +1,113 @@
+"""Cheap auth checks for scheduled Cycle launches."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.integrations.llm import async_resolve_llm_client
+from brain.platform.providers.model_policy import (
+    async_get_default_model,
+    infer_provider_from_model,
+)
+
+
+@dataclass(frozen=True)
+class CycleAuthPreflightResult:
+    status: str
+    provider: str | None = None
+    model: str | None = None
+    credential: str | None = None
+    repair_action: str | None = None
+    visible_message: str | None = None
+
+    @property
+    def blocked(self) -> bool:
+        return self.status == "auth_blocked"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "provider": self.provider,
+            "model": self.model,
+            "credential": self.credential,
+            "repair_action": self.repair_action,
+            "visible_message": self.visible_message,
+        }
+
+
+def _normalize_model(model: str) -> str:
+    value = str(model or "").strip()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    return value
+
+
+def _required_openai_auth_mode(model: str) -> str | None:
+    return "chatgpt" if _normalize_model(model).lower() == "gpt-5.5" else None
+
+
+def _credential_label(model: str, auth_mode: str | None, error_text: str = "") -> str:
+    normalized_model = _normalize_model(model).lower()
+    normalized_error = error_text.lower()
+    if auth_mode == "chatgpt" or "codex" in normalized_model or "codex" in normalized_error:
+        return "OpenAI Codex / ChatGPT"
+    return "OpenAI runtime"
+
+
+def _blocked_message(credential: str) -> tuple[str, str]:
+    repair_action = (
+        "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
+        "then rerun the Cycle or wait for its next scheduled run."
+    )
+    return (
+        repair_action,
+        f"Scheduled Cycle auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
+    )
+
+
+async def async_preflight_cycle_external_auth(
+    session: AsyncSession,
+    *,
+    cycle: Any,
+) -> CycleAuthPreflightResult:
+    """Validate required external auth before admitting the full agent."""
+    user_id = str(getattr(cycle, "user_id", "") or "") or None
+    org_id = str(getattr(cycle, "org_id", "") or "") or None
+    model = str(getattr(cycle, "model_override", None) or "").strip()
+    if not model:
+        model = await async_get_default_model(
+            session,
+            include_provider_prefix=True,
+            user_id=user_id,
+            org_id=org_id,
+        )
+
+    provider = infer_provider_from_model(model)
+    if provider != "openai":
+        return CycleAuthPreflightResult(status="skipped", provider=provider, model=model)
+
+    auth_mode = _required_openai_auth_mode(model)
+    try:
+        await async_resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+            auth_mode=auth_mode,
+            session=session,
+        )
+    except Exception as exc:
+        credential = _credential_label(model, auth_mode, str(exc))
+        repair_action, visible_message = _blocked_message(credential)
+        return CycleAuthPreflightResult(
+            status="auth_blocked",
+            provider=provider,
+            model=model,
+            credential=credential,
+            repair_action=repair_action,
+            visible_message=visible_message,
+        )
+
+    return CycleAuthPreflightResult(status="passed", provider=provider, model=model)

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -328,7 +328,7 @@ async def record_cycle_run_evaluation(
         error=error,
         skip_reason=skip_reason,
     )
-    score = 1 if status == "completed" else 0 if status in {"failed", "degraded"} else None
+    score = 1 if status == "completed" else 0 if status in {"failed", "degraded", "auth_blocked"} else None
     run.self_review_summary = summary
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
     session.add(
@@ -419,6 +419,9 @@ def cycle_run_evaluation_summary(
     if status == "degraded":
         detail = error or "mission result contract degraded"
         return f"Cycle run degraded and was recorded in the Cycle ledger: {detail}"
+    if status == "auth_blocked":
+        detail = error or "external auth preflight blocked the run"
+        return f"Cycle run was auth-blocked and recorded in the Cycle ledger: {detail}"
     if status == "skipped":
         detail = skip_reason or "unknown skip reason"
         return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}"

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -11,6 +11,10 @@ from sqlalchemy import select
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
+from brain.systems.cycles.auth_preflight import (
+    CycleAuthPreflightResult,
+    async_preflight_cycle_external_auth,
+)
 from brain.systems.cycles.common import (
     REUSABLE_THREAD_EXECUTION_MODE,
     THREAD_OUTPUT_TARGET_TYPE,
@@ -169,6 +173,39 @@ async def _async_append_cycle_thread_message(
         ),
         parse_message_type=lambda _content, _role: "trigger",
         lifecycle_trigger="auto_cycle_message",
+    )
+    return result.message_payload, result.status_change
+
+
+async def _async_append_cycle_auth_blocked_thread_message(
+    session,
+    idea: Idea,
+    cycle: Cycle,
+    cycle_run: CycleRun,
+    preflight: CycleAuthPreflightResult,
+) -> tuple[dict, dict | None]:
+    metadata = {
+        "source": "cycle",
+        "cycle_id": cycle.id,
+        "cycle_run_id": cycle_run.id,
+        "auth_preflight": preflight.to_dict(),
+    }
+    result = await post_thread_message(
+        session,
+        idea=idea,
+        command=ThreadMessageCommand(
+            idea_id=str(idea.id),
+            role="illo",
+            content=preflight.visible_message or "Scheduled Cycle auth blocked.",
+            actor={
+                "org_id": str(cycle.org_id) if cycle.org_id else None,
+                "name": "Illo",
+            },
+            attachments=[],
+            metadata=metadata,
+        ),
+        parse_message_type=lambda _content, _role: "agent_response",
+        lifecycle_trigger="cycle_auth_preflight_blocked",
     )
     return result.message_payload, result.status_change
 
@@ -386,40 +423,64 @@ async def async_execute_cycle_run(run_id: int) -> None:
             config={"ephemeral": target.output_target_ephemeral},
             rationale="Execution output surface for this CycleRun.",
         )
-        run.started_at = datetime.now(timezone.utc)
-        run.status = "running"
         idea_id = idea.id
-        run_metadata = _cycle_run_metadata(cycle, run)
-        run_message = _cycle_run_message(idea, cycle, run)
-        agent_run_id = await _async_admit_cycle_run(
-            uow.session,
-            idea_id=idea.id,
-            message=run_message,
-            priority=1,
-            user_id=cycle_user_id,
-            metadata=run_metadata,
-            cycle_run_id=run.id,
-        )
-        if agent_run_id is None:
+
+        preflight = await async_preflight_cycle_external_auth(uow.session, cycle=cycle)
+        if preflight.status != "skipped":
+            context_snapshot = dict(run.context_snapshot or {})
+            context_snapshot["auth_preflight"] = preflight.to_dict()
+            run.context_snapshot = context_snapshot
+
+        if preflight.blocked:
             await _finalize_cycle_run(
                 run,
                 cycle,
-                status="failed",
-                error="Cycle work admission failed before an agent run was created",
+                status="auth_blocked",
+                error=preflight.visible_message,
                 session=uow.session,
             )
-            return
-        message_payload, status_payload = await _async_append_cycle_thread_message(
-            uow.session,
-            idea,
-            cycle,
-            run,
-            owner,
-        )
-        idea_snapshot = serialize_execution_idea(idea)
-        run.run_id = agent_run_id
-        cycle.last_status = "running"
-        cycle.last_error = None
+            message_payload, status_payload = await _async_append_cycle_auth_blocked_thread_message(
+                uow.session,
+                idea,
+                cycle,
+                run,
+                preflight,
+            )
+            idea_snapshot = serialize_execution_idea(idea)
+        else:
+            run.started_at = datetime.now(timezone.utc)
+            run.status = "running"
+            run_metadata = _cycle_run_metadata(cycle, run)
+            run_message = _cycle_run_message(idea, cycle, run)
+            agent_run_id = await _async_admit_cycle_run(
+                uow.session,
+                idea_id=idea.id,
+                message=run_message,
+                priority=1,
+                user_id=cycle_user_id,
+                metadata=run_metadata,
+                cycle_run_id=run.id,
+            )
+            if agent_run_id is None:
+                await _finalize_cycle_run(
+                    run,
+                    cycle,
+                    status="failed",
+                    error="Cycle work admission failed before an agent run was created",
+                    session=uow.session,
+                )
+                return
+            message_payload, status_payload = await _async_append_cycle_thread_message(
+                uow.session,
+                idea,
+                cycle,
+                run,
+                owner,
+            )
+            idea_snapshot = serialize_execution_idea(idea)
+            run.run_id = agent_run_id
+            cycle.last_status = "running"
+            cycle.last_error = None
     if should_publish_idea and idea_snapshot:
         publish("idea_upserted", {"idea": idea_snapshot})
     if message_payload:

--- a/brain/systems/cycles/status.py
+++ b/brain/systems/cycles/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 CYCLE_RUN_ACTIVE_STATUS_VALUES = ("queued", "running", "pending_approval")
-CYCLE_RUN_TERMINAL_STATUS_VALUES = ("completed", "failed", "skipped", "degraded")
+CYCLE_RUN_TERMINAL_STATUS_VALUES = ("completed", "failed", "skipped", "degraded", "auth_blocked")
 
 CYCLE_RUN_ACTIVE_STATUSES = frozenset(CYCLE_RUN_ACTIVE_STATUS_VALUES)
 CYCLE_RUN_TERMINAL_STATUSES = frozenset(CYCLE_RUN_TERMINAL_STATUS_VALUES)

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -314,6 +315,50 @@ class _SingleRunSession:
 
 def _fail_sync_bridge(*args, **kwargs):
     raise AssertionError("sync DB bridge should not be used")
+
+
+def _cycle_execution_objects(*, model_override: str | None) -> tuple[CycleRun, Cycle, Idea]:
+    idea_id = uuid4()
+
+    run = CycleRun()
+    run.id = 12
+    run.cycle_id = 5
+    run.status = "queued"
+    run.scheduled_for = datetime(2026, 4, 28, 20, 20, tzinfo=timezone.utc)
+    run.prompt_snapshot = "Run a scheduled coding-agent check"
+
+    cycle = Cycle()
+    cycle.id = 5
+    cycle.user_id = "user-1"
+    cycle.org_id = "org-1"
+    cycle.name = "Scheduled Codex check"
+    cycle.prompt = "Run a scheduled coding-agent check"
+    cycle.schedule_expr = "20 16 * * *"
+    cycle.timezone = "America/Toronto"
+    cycle.target_idea_id = idea_id
+    cycle.deleted_at = None
+    cycle.model_override = model_override
+    cycle.thinking_override = None
+
+    idea = Idea()
+    idea.id = idea_id
+    idea.title = "Scheduled Codex check"
+    idea.display_title = None
+    idea.description = "Run a scheduled coding-agent check"
+    idea.status = "needs_input"
+    idea.origin = "cycle"
+    idea.origin_ref = "cycle:5"
+    idea.salience_score = None
+    idea.position_x = None
+    idea.position_y = None
+    idea.created_at = None
+    idea.updated_at = None
+    idea.user_id = "user-1"
+    idea.org_id = "org-1"
+    idea.archived_at = None
+    idea.active_agents = []
+    idea.attachments = []
+    return run, cycle, idea
 
 
 def test_compute_next_run_at_uses_timezone():
@@ -670,7 +715,7 @@ async def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeyp
     cycle.timezone = "America/Toronto"
     cycle.target_idea_id = idea_id
     cycle.deleted_at = None
-    cycle.model_override = None
+    cycle.model_override = "anthropic/claude-sonnet-4-6"
     cycle.thinking_override = None
 
     idea = Idea()
@@ -767,7 +812,7 @@ async def test_async_execute_cycle_run_uses_native_uow_without_sync_bridges(monk
     cycle.timezone = "America/Toronto"
     cycle.target_idea_id = idea_id
     cycle.deleted_at = None
-    cycle.model_override = None
+    cycle.model_override = "anthropic/claude-sonnet-4-6"
     cycle.thinking_override = None
 
     idea = Idea()
@@ -815,6 +860,128 @@ async def test_async_execute_cycle_run_uses_native_uow_without_sync_bridges(monk
 
 
 @pytest.mark.asyncio
+async def test_execute_cycle_run_auth_blocks_expired_codex_before_agent_admission(monkeypatch):
+    from brain.platform.integrations.openai_codex_auth import (
+        OpenAICodexCredential,
+        encode_codex_auth_payload,
+    )
+
+    run, cycle, idea = _cycle_execution_objects(model_override="openai/gpt-5.3-codex")
+    expired_payload = json.dumps(encode_codex_auth_payload(OpenAICodexCredential(
+        access_token="expired-access",
+        refresh_token="refresh-token-123",
+        account_id="acct_123",
+        expires_at=time.time() - 30,
+        auth_mode="chatgpt",
+    )))
+    session = _AsyncExecuteCycleSession(run=run, cycle=cycle, idea=idea, expected_run_id=run.id)
+
+    async def fake_resolve_key(active_session, **kwargs):
+        assert active_session is session
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["org_id"] == "org-1"
+        assert kwargs["provider"] == "openai"
+        return expired_payload, "codex_subscription"
+
+    refresh_calls = []
+
+    def fake_refresh(refresh_token):
+        refresh_calls.append(refresh_token)
+        raise RuntimeError("invalid_grant")
+
+    admissions = []
+
+    async def fail_admit(*args, **kwargs):
+        admissions.append(kwargs)
+        raise AssertionError("agent admission should not run after auth preflight blocks")
+
+    published = []
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr("brain.platform.integrations.llm._async_resolve_key_from_db", fake_resolve_key)
+    monkeypatch.setattr("brain.platform.integrations.llm.refresh_codex_access_token", fake_refresh)
+    monkeypatch.setattr(service, "_async_admit_cycle_run", fail_admit)
+    monkeypatch.setattr(service, "publish", lambda event, payload: published.append((event, payload)))
+
+    await service.async_execute_cycle_run(run.id)
+
+    assert admissions == []
+    assert refresh_calls == ["refresh-token-123"]
+    assert run.status == "auth_blocked"
+    assert run.run_id is None
+    assert run.started_at is None
+    assert cycle.last_status == "auth_blocked"
+    assert "OpenAI Codex / ChatGPT" in run.error
+    assert "Settings > Access" in run.error
+    assert "token expired and refresh failed" not in run.error
+    assert run.context_snapshot["auth_preflight"]["status"] == "auth_blocked"
+    assert run.context_snapshot["auth_preflight"]["credential"] == "OpenAI Codex / ChatGPT"
+
+    thread_msg = next(item for item in session.added if item.__class__.__name__ == "IdeaThread")
+    assert thread_msg.role == "illo"
+    assert "OpenAI Codex / ChatGPT" in thread_msg.content
+    assert "signing in to Codex / ChatGPT again" in thread_msg.content
+    evaluation = next(item for item in session.added if item.__class__.__name__ == "CycleRunEvaluation")
+    assert evaluation.details["status"] == "auth_blocked"
+    assert any(event == "thread_message" for event, _payload in published)
+
+
+@pytest.mark.asyncio
+async def test_execute_cycle_run_valid_codex_preflight_proceeds_to_agent_admission(monkeypatch):
+    from brain.platform.integrations.openai_codex_auth import (
+        OpenAICodexCredential,
+        encode_codex_auth_payload,
+    )
+
+    run, cycle, idea = _cycle_execution_objects(model_override="openai/gpt-5.3-codex")
+    valid_payload = json.dumps(encode_codex_auth_payload(OpenAICodexCredential(
+        access_token="fresh-access",
+        refresh_token="refresh-token-123",
+        account_id="acct_123",
+        expires_at=time.time() + 1800,
+        auth_mode="chatgpt",
+    )))
+    session = _AsyncExecuteCycleSession(run=run, cycle=cycle, idea=idea, expected_run_id=run.id)
+
+    async def fake_resolve_key(active_session, **kwargs):
+        assert active_session is session
+        assert kwargs["provider"] == "openai"
+        return valid_payload, "codex_subscription"
+
+    def fail_refresh(_refresh_token):
+        raise AssertionError("valid Codex token should not refresh during preflight")
+
+    codex_client_calls = []
+
+    def fake_codex_client(*args, **kwargs):
+        codex_client_calls.append((args, kwargs))
+        return object()
+
+    admissions = []
+
+    async def fake_admit(*args, **kwargs):
+        admissions.append(kwargs)
+        return 77
+
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr("brain.platform.integrations.llm._async_resolve_key_from_db", fake_resolve_key)
+    monkeypatch.setattr("brain.platform.integrations.llm.refresh_codex_access_token", fail_refresh)
+    monkeypatch.setattr("brain.platform.integrations.llm.OpenAICodexClient", fake_codex_client)
+    monkeypatch.setattr(service, "_async_admit_cycle_run", fake_admit)
+    monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
+
+    await service.async_execute_cycle_run(run.id)
+
+    assert len(admissions) == 1
+    assert run.status == "running"
+    assert run.run_id == 77
+    assert run.started_at is not None
+    assert cycle.last_status == "running"
+    assert run.context_snapshot["auth_preflight"]["status"] == "passed"
+    assert codex_client_calls[0][0][0] == "fresh-access"
+    assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
+
+
+@pytest.mark.asyncio
 async def test_execute_cycle_run_creates_execution_thread_when_target_thread_is_busy(monkeypatch):
     target_idea_id = uuid4()
 
@@ -835,7 +1002,7 @@ async def test_execute_cycle_run_creates_execution_thread_when_target_thread_is_
     cycle.timezone = "America/Toronto"
     cycle.target_idea_id = target_idea_id
     cycle.deleted_at = None
-    cycle.model_override = None
+    cycle.model_override = "anthropic/claude-sonnet-4-6"
     cycle.thinking_override = None
 
     target_idea = Idea()


### PR DESCRIPTION
## What

Scheduled Cycle runs that need an OpenAI/Codex credential currently admit the full agent even when the token is expired, wasting the entire scheduled slot on a run that can't do external work. This adds a **cheap auth preflight** that resolves the required LLM client *before* admission. On failure, the run settles into a new terminal `auth_blocked` status with a user-visible repair message instead of burning the slot.

Closes #274 (draft — do not merge yet; Reda reviews first).

## Changes
- `brain/systems/cycles/auth_preflight.py` (new) — probes the required provider/credential; returns `passed` / `skipped` (non-OpenAI) / `auth_blocked`.
- `cycles/service.py` — gates admission on the preflight; on block, finalizes the run and posts an `auth_blocked` thread message with repair guidance.
- `cycles/status.py` — adds `auth_blocked` to terminal statuses.
- `cycles/memory.py` — ledger summary + self-review score handling for `auth_blocked`.
- Regression tests in `tests/test_cycles_service.py`.

## How to review (no code reading needed)

**Run the tests:**
```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-274-preflight-auth
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_cycles_service.py -q
```
Expected: `35 passed`.

## Acceptance checks
1. A scheduled Cycle whose default/override model is OpenAI **with an expired credential** settles as `auth_blocked` (a terminal status) and never admits the full agent — no wasted run.
2. The blocked run posts an Illo thread message telling the user to reconnect OpenAI in Settings, and records `auth_blocked` in the Cycle ledger with a `0` self-review score.
3. A scheduled Cycle with **valid** OpenAI auth proceeds to normal admission (`passed` → `running`) exactly as before.
4. Non-OpenAI (e.g. Anthropic) Cycles skip the preflight entirely (`skipped`) with no behavior change; `status` is a plain `String(20)` column so `auth_blocked` needs no DB migration.

## Assumptions
- The required OpenAI auth mode for `gpt-5.5` is ChatGPT/Codex OAuth; other OpenAI models fall back to the generic runtime credential.
- `async_resolve_llm_client` raising is the correct signal for an unusable credential (matches how admission would later fail).