### PR TITLE
Pass illo-lifecycle activation env vars through compose

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -42,6 +42,14 @@ x-illo-env: &illo-env
   ILLO_WORKSPACE_TOOLS_STATUS_FILE: /data/private/workspace-tools/status.json
   ILLO_WORKSPACE_TOOLS_HEARTBEAT_FILE: /data/private/workspace-tools/heartbeat.json
   ILLO_WORKSPACE_TOOLS_LOG_PATH: /data/private/logs/illo-workspace-tools.log
+  # Lifecycle activation (specs/illo-lifecycle): assignment rules, unclaimed
+  # pool, and GitHub webhook ingress. Empty default = feature off.
+  ILLO_BUSINESS_OWNER_USER_ID: ${ILLO_BUSINESS_OWNER_USER_ID:-}
+  ILLO_PRODUCT_OWNER_USER_ID: ${ILLO_PRODUCT_OWNER_USER_ID:-}
+  ILLO_REPO_OWNERS: ${ILLO_REPO_OWNERS:-}
+  ILLO_UNCLAIMED_POOL_USER_ID: ${ILLO_UNCLAIMED_POOL_USER_ID:-}
+  ILLO_GITHUB_WEBHOOK_SECRET: ${ILLO_GITHUB_WEBHOOK_SECRET:-}
+  ILLO_GITHUB_CONNECTION_ID: ${ILLO_GITHUB_CONNECTION_ID:-}
 
 x-backend-service: &backend-service
   image: ${ILLO_API_IMAGE:-ghcr.io/illospace/api:latest}


### PR DESCRIPTION
The compose `x-illo-env` anchor whitelists environment variables, so the PR #276 activation settings (`ILLO_BUSINESS_OWNER_USER_ID`, `ILLO_PRODUCT_OWNER_USER_ID`, `ILLO_REPO_OWNERS`, `ILLO_UNCLAIMED_POOL_USER_ID`, `ILLO_GITHUB_WEBHOOK_SECRET`, `ILLO_GITHUB_CONNECTION_ID`) couldn't reach the containers from `deploy/compose/.env`. This passes them through with empty defaults — unset = feature off, so merging changes nothing until a value is set in `.env`.

Compose-config only; no image rebuild needed (server picks it up via `git pull` + recreate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)