### PR TITLE
Add GPT-5.6 as a personal composer model

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -189,7 +189,8 @@ def _normalize_model(model: str) -> str:
 
 def _required_openai_auth_mode(model: str) -> str | None:
     """Return the OpenAI auth mode required by model availability."""
-    return "chatgpt" if _normalize_model(model).lower() == "gpt-5.5" else None
+    normalized = _normalize_model(model).lower()
+    return "chatgpt" if normalized == "gpt-5.5" or normalized.startswith("gpt-5.6") else None
 
 
 # ── Constants ──────────────────────────────────────────────────

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -124,7 +124,8 @@ class FinalReplyReview:
 
 
 def _required_openai_auth_mode(model: str) -> str | None:
-    return "chatgpt" if normalize_model_name(model).lower() == "gpt-5.5" else None
+    normalized = normalize_model_name(model).lower()
+    return "chatgpt" if normalized == "gpt-5.5" or normalized.startswith("gpt-5.6") else None
 
 
 def _init_llm(

--- a/frontend/src/lib/features/composer/domain/runSettings.ts
+++ b/frontend/src/lib/features/composer/domain/runSettings.ts
@@ -23,6 +23,7 @@ export const EXECUTION_PROFILE_OPTIONS = [
 ] as const satisfies readonly CortexWorkspaceComposerIntentOption[];
 
 export const MODEL_OPTIONS = [
+  { value: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'Preview model for eligible personal connections' },
   { value: 'openai/gpt-5.5', label: 'GPT-5.5', description: 'Best quality for hard reasoning' },
   { value: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'Balanced general-purpose model' },
   { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 Mini', description: 'Fast and economical' },

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -72,6 +72,13 @@ class TestModelNormalization:
 
 
 class TestProviderInference:
+    def test_direct_agent_requires_chatgpt_auth_for_subscription_models(self):
+        from brain.systems.runs.direct_agent import _required_openai_auth_mode
+
+        assert _required_openai_auth_mode("openai/gpt-5.5") == "chatgpt"
+        assert _required_openai_auth_mode("openai/gpt-5.6-sol") == "chatgpt"
+        assert _required_openai_auth_mode("openai/gpt-5.4") is None
+
     @patch("brain.systems.runs.direct_loop.final_reply_checker.get_provider")
     @patch("brain.systems.runs.direct_loop.final_reply_checker.resolve_llm_client")
     def test_init_llm_uses_provider_from_model_prefix(self, mock_resolve, mock_get_provider):
@@ -94,7 +101,7 @@ class TestProviderInference:
 
     @patch("brain.systems.runs.direct_loop.final_reply_checker.get_provider")
     @patch("brain.systems.runs.direct_loop.final_reply_checker.resolve_llm_client")
-    def test_init_llm_requires_chatgpt_auth_for_gpt_5_5(self, mock_resolve, mock_get_provider):
+    def test_init_llm_requires_chatgpt_auth_for_subscription_models(self, mock_resolve, mock_get_provider):
         from brain.systems.runs.direct_loop.final_reply_checker import _init_llm
 
         llm = MagicMock()
@@ -108,10 +115,11 @@ class TestProviderInference:
         mock_resolve.return_value = llm
         mock_get_provider.return_value = MagicMock()
 
-        _init_llm("user-1", "sess-1", "openai/gpt-5.5")
+        for model in ("openai/gpt-5.5", "openai/gpt-5.6-sol"):
+            _init_llm("user-1", "sess-1", model)
 
-        assert mock_resolve.call_args.kwargs["provider"] == "openai"
-        assert mock_resolve.call_args.kwargs["auth_mode"] == "chatgpt"
+            assert mock_resolve.call_args.kwargs["provider"] == "openai"
+            assert mock_resolve.call_args.kwargs["auth_mode"] == "chatgpt"
 
 class TestLiveGuidance:
     async def test_append_live_guidance_adds_user_message(self):


### PR DESCRIPTION
## What changed

- adds GPT-5.6 Sol to the personal composer model picker
- keeps the workspace/runtime default on GPT-5.5
- requires GPT-5.6 runs to use the originating user's ChatGPT/Codex connection instead of the shared workspace API key
- extends auth-routing coverage for GPT-5.6

## Why

GPT-5.6 is available on Reda's personal Codex connection but not on the shared `illo-team` OpenAI API key and not on every teammate connection. This enables a safe per-user opt-in without changing cycles, shared/background runs, or the owner-controlled workspace fallback.

## Validation

- `venv/bin/pytest -q tests/test_agent.py -k 'subscription_models'`
- `npm run check`
- `npm run build`
- live Reda Codex probe completed with response model `gpt-5.6-sol`
- shared workspace key returned `model_not_found`, confirming it must not be used for this preview route
