### PR TITLE
Restore Slack processing status

### DIFF
--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -13,6 +13,7 @@ from typing import Any, Mapping
 from sqlalchemy import select
 
 from brain.platform.async_io import async_http_client
+from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.service import submit_inbound_envelope
@@ -30,6 +31,7 @@ from brain.systems.slack.ingress import (
 from brain.systems.slack.monitors import monitored_channel_ids
 
 logger = logging.getLogger(__name__)
+SLACK_PROCESSING_STATUS = "is working on it..."
 
 
 @dataclass(frozen=True)
@@ -319,6 +321,7 @@ async def process_socket_payload(
     )
     if envelope is None:
         return {"ack": ack, "ignored": True}
+    existing_run_for_message = await _has_slack_run_for_envelope(session, connection, envelope)
     if envelope.get("origin") == SLACK_CHANNEL_MESSAGE_ORIGIN:
         # Reflex acknowledgement: leave a 👀 on every observed message so the
         # channel knows Illo has seen it, independent of whether the ensuing
@@ -333,7 +336,72 @@ async def process_socket_payload(
             "envelope_id": ack.get("envelope_id"),
         },
     )
+    if (
+        envelope.get("origin") != SLACK_CHANNEL_MESSAGE_ORIGIN
+        and not existing_run_for_message
+        and _admitted_slack_run(inbound)
+    ):
+        await _set_processing_status(config, envelope)
     return {"ack": ack, "ignored": False, "inbound": inbound}
+
+
+def _connection_org_id(connection: ExternalAgentConnectionRow | Mapping[str, Any]) -> str | None:
+    if isinstance(connection, Mapping):
+        return str(connection.get("org_id") or "").strip() or None
+    return str(getattr(connection, "org_id", "") or "").strip() or None
+
+
+def _envelope_idempotency_key(envelope: Mapping[str, Any]) -> str | None:
+    key = str(envelope.get("idempotency_key") or "").strip()
+    return key if key.startswith("slack:") else None
+
+
+async def _has_slack_run_for_envelope(
+    session,
+    connection: ExternalAgentConnectionRow | Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> bool:
+    if not callable(getattr(session, "scalar", None)):
+        return False
+    org_id = _connection_org_id(connection)
+    key = _envelope_idempotency_key(envelope)
+    if not org_id or not key:
+        return False
+    stmt = (
+        select(AgentRunRow.id)
+        .where(
+            AgentRunRow.org_id == org_id,
+            AgentRunRow.source_idempotency_scope == "slack",
+            AgentRunRow.source_idempotency_key == key,
+        )
+        .limit(1)
+    )
+    return (await session.scalar(stmt)) is not None
+
+
+def _admitted_slack_run(inbound: Mapping[str, Any]) -> bool:
+    if inbound.get("idempotent_replay"):
+        return False
+    outcome = inbound.get("ilo_outcome")
+    outcome = outcome if isinstance(outcome, Mapping) else {}
+    return outcome.get("operation") == "slack_run_admitted" and outcome.get("run_id") is not None
+
+
+async def _set_processing_status(config: SlackConnectorConfig, envelope: Mapping[str, Any]) -> None:
+    payload = envelope.get("payload") if isinstance(envelope.get("payload"), Mapping) else {}
+    channel_id = str(payload.get("channel_id") or "").strip()
+    thread_ts = str(payload.get("thread_ts") or payload.get("message_ts") or "").strip()
+    if not channel_id or not thread_ts:
+        return
+    try:
+        client = SlackWebClient(config.bot_token, timeout=2.0)
+        await client.set_assistant_status(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            status=SLACK_PROCESSING_STATUS,
+        )
+    except Exception as exc:
+        logger.info("slack_processing_status_failed: %s", exc)
 
 
 async def _acknowledge_monitored_message(

--- a/docs/slack-teammate-self-hosted.md
+++ b/docs/slack-teammate-self-hosted.md
@@ -45,6 +45,10 @@ Optional Slack hints:
 - `app_mention` events and every DM are actionable.
 - Top-level channel mentions reply as normal channel messages; mentions inside
   Slack threads reply back into that thread; DMs reply as normal DM messages.
+- Illo sets Slack's native assistant thread status to `is working on it...`
+  after a mention or DM admits a fresh run. This is a transient loading
+  indicator, not a chat reply. Slack clears it when Illo replies or after the
+  platform timeout; Illo also clears it explicitly after posting a reply.
 - Socket Mode envelopes are acknowledged before durable inbound processing.
   This is a transport acknowledgement only, not user-visible Illo speech.
 - User-visible Slack text is model-authored. Illo decides whether to answer a

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -598,7 +598,7 @@ async def test_slack_thread_followup_reuses_slack_conversation_key_with_new_run(
 
 
 @pytest.mark.asyncio
-async def test_slack_connector_does_not_send_backend_authored_ack_for_actionable_payload(session, monkeypatch):
+async def test_slack_connector_sets_native_processing_status_for_actionable_payload(session, monkeypatch):
     from brain.systems.slack import connector
 
     connection = await _seed_slack_connection(session)
@@ -629,11 +629,21 @@ async def test_slack_connector_does_not_send_backend_authored_ack_for_actionable
         ),
     )
 
-    assert calls == []
+    assert calls == [
+        ("init", "xoxb-test"),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "is working on it...",
+            },
+        ),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_slack_connector_does_not_send_backend_authored_ack_for_duplicate_run(session, monkeypatch):
+async def test_slack_connector_does_not_reset_native_status_for_duplicate_run(session, monkeypatch):
     from brain.systems.slack import connector
 
     first_connection = await _seed_slack_connection(session)
@@ -675,7 +685,17 @@ async def test_slack_connector_does_not_send_backend_authored_ack_for_duplicate_
         ),
     )
 
-    assert calls == []
+    assert calls == [
+        ("init", "xoxb-test"),
+        (
+            "status",
+            {
+                "channel_id": "C456",
+                "thread_ts": "1716900000.000100",
+                "status": "is working on it...",
+            },
+        ),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- restore Slack's native `assistant.threads.setStatus` loading indicator after a fresh mention or DM admits an Illo run
- suppress duplicate status calls across duplicate Slack deliveries
- keep passive monitored-channel events excluded
- document the transient status behavior and preserve clear-on-reply handling

## Root cause

Commit `42147c7` removed the native Slack status while eliminating backend-authored acknowledgement messages. The status is provider-native transient UI, not Illo-authored chat content, so that cleanup unintentionally removed the user-visible “Illo is working on it…” signal.

## Impact

Teammates once again receive immediate visual confirmation that Illo accepted a Slack request. Duplicate deliveries do not reset the indicator, and passive channel monitoring continues to use only its existing reaction behavior.

## Validation

- `venv/bin/python -m pytest -q tests/test_slack_client.py tests/test_slack_teammate.py tests/test_slack_channel_monitor.py`
- 70 tests passed
- `git diff --check`
