### PR TITLE
Add GPT-5.6 workspace default with fallback

### DIFF
--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -12,6 +12,7 @@ from brain.platform.integrations.providers import get_active_provider
 
 
 DEFAULT_RUNTIME_PROVIDER = "openai"
+DEFAULT_THINKING_TIER = "high"
 DEFAULT_PROVIDER_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
     "openai": "gpt-5.5",
@@ -23,6 +24,7 @@ PROVIDER_MODEL_OPTIONS: dict[str, tuple[str, ...]] = {
         "claude-haiku-4-5",
     ),
     "openai": (
+        "gpt-5.6-sol",
         "gpt-5.5",
         "gpt-5.4-pro",
         "gpt-5.4",
@@ -369,6 +371,11 @@ def _configured_default_model(config: dict[str, Any], provider: str) -> str | No
     return None
 
 
+def _configured_default_thinking(config: dict[str, Any]) -> str | None:
+    value = str(config.get("default_thinking") or "").strip().lower()
+    return value if value in THINKING_MAP else None
+
+
 def get_default_model(
     provider: str | None = None,
     *,
@@ -410,6 +417,36 @@ async def async_get_default_model(
         except Exception:
             pass
     return f"{provider}/{model}" if include_provider_prefix else model
+
+
+async def async_get_default_thinking(
+    session: AsyncSession,
+    *,
+    user_id: str | None = None,
+    org_id: str | None = None,
+) -> str:
+    """Return the workspace default reasoning effort."""
+    effective_org_id = await async_resolve_effective_org_id(
+        session,
+        user_id=user_id,
+        org_id=org_id,
+    )
+    if effective_org_id:
+        try:
+            row = (
+                await session.execute(
+                    text("SELECT memory_model_config FROM orgs WHERE id = :org_id LIMIT 1"),
+                    {"org_id": effective_org_id},
+                )
+            ).mappings().first()
+            configured = _configured_default_thinking(
+                dict((row or {}).get("memory_model_config") or {})
+            )
+            if configured:
+                return configured
+        except Exception:
+            pass
+    return DEFAULT_THINKING_TIER
 
 
 def resolve_skill_runtime(

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -91,6 +91,11 @@ from brain.systems.runs.direct_loop.context_recovery import (
 from brain.systems.runs.direct_loop.retry import (
     async_api_call_with_retry as _runtime_async_api_call_with_retry,
 )
+from brain.systems.runs.direct_loop.model_fallback import (
+    fallback_model_for,
+    is_missing_required_model_auth,
+    is_model_unavailable_error,
+)
 from brain.systems.runs.direct_loop.session_effects import (
     async_apply_agent_session_side_effects as _runtime_async_apply_agent_session_side_effects,
 )
@@ -192,6 +197,9 @@ def _required_openai_auth_mode(model: str) -> str | None:
     """Return the OpenAI auth mode required by model availability."""
     normalized = _normalize_model(model).lower()
     return "chatgpt" if normalized == "gpt-5.5" or normalized.startswith("gpt-5.6") else None
+
+
+_AUTO_OPENAI_AUTH_MODE = object()
 
 
 # ── Constants ──────────────────────────────────────────────────
@@ -431,15 +439,21 @@ async def _init_llm_async(
     *,
     org_id: str | None = None,
     resolved_llm=None,
+    auth_mode_override: str | None | object = _AUTO_OPENAI_AUTH_MODE,
 ):
     """Resolve LLM client from async runtime code without sync DB access."""
     if resolved_llm is None:
         requested_provider = infer_provider_from_model(model)
+        auth_mode = (
+            _required_openai_auth_mode(model)
+            if auth_mode_override is _AUTO_OPENAI_AUTH_MODE
+            else auth_mode_override
+        )
         llm = await async_resolve_llm_client(
             user_id=user_id,
             org_id=org_id,
             provider=requested_provider,
-            auth_mode=_required_openai_auth_mode(model) if requested_provider == "openai" else None,
+            auth_mode=auth_mode if requested_provider == "openai" else None,
         )
     else:
         llm = resolved_llm
@@ -1482,16 +1496,43 @@ async def run_agent_async(
             org_id=effective_org_id,
         )
         model = _normalize_model(model)
+        model_fallback_used = False
+        fallback_activity: str | None = None
 
         # Resolve LLM client
-        llm, state.provider, _runtime_extra_headers = await _init_llm_async(
-            effective_user_id,
-            session_id,
-            model,
-            org_id=effective_org_id,
-            resolved_llm=resolved_llm,
-        )
+        try:
+            llm, state.provider, _runtime_extra_headers = await _init_llm_async(
+                effective_user_id,
+                session_id,
+                model,
+                org_id=effective_org_id,
+                resolved_llm=resolved_llm,
+            )
+        except Exception as exc:
+            fallback = fallback_model_for(model)
+            if not fallback or not is_missing_required_model_auth(exc):
+                raise
+            preferred_model = model
+            model = _normalize_model(fallback)
+            llm, state.provider, _runtime_extra_headers = await _init_llm_async(
+                effective_user_id,
+                session_id,
+                model,
+                org_id=effective_org_id,
+                resolved_llm=resolved_llm,
+                auth_mode_override=None,
+            )
+            model_fallback_used = True
+            fallback_activity = f"{preferred_model} requires a personal Codex connection; using {model}"
+            logger.info(
+                "Agent %s: preferred model auth unavailable; falling back %s -> %s",
+                session_id,
+                preferred_model,
+                model,
+            )
         state.provider_name = llm.provider
+        owns_semantic_compactor = semantic_compactor is None
+        owns_thread_handoff_compactor = thread_handoff_compactor is None
         if semantic_compactor is None:
             semantic_compactor = _llm_context_checkpoint_compactor(
                 provider=state.provider,
@@ -1507,7 +1548,9 @@ async def run_agent_async(
                 model=model,
                 provider_name=state.provider_name,
                 session_id=session_id,
-        )
+            )
+        if fallback_activity and on_stream_activity:
+            await _call_optional_async(on_stream_activity, fallback_activity)
 
         # Load existing raw session archive, then use durable handoff + recent messages as active context.
         load_session = load_session or _session_store.async_load_session
@@ -1630,6 +1673,70 @@ async def run_agent_async(
                     )
                     break
                 except Exception as exc:
+                    fallback = fallback_model_for(model)
+                    if (
+                        not model_fallback_used
+                        and fallback
+                        and is_model_unavailable_error(exc)
+                    ):
+                        preferred_model = model
+                        model = _normalize_model(fallback)
+                        model_fallback_used = True
+                        logger.warning(
+                            "Agent %s turn %d: model unavailable; falling back %s -> %s",
+                            session_id,
+                            turn,
+                            preferred_model,
+                            model,
+                        )
+                        await _async_record_api_call(
+                            session_id=session_id,
+                            run_id=run_id,
+                            turn=turn,
+                            model=preferred_model,
+                            context_messages=len(state.messages),
+                            system_prompt_chars=len(json.dumps(system)) if system else 0,
+                            status="model_unavailable",
+                            error=str(exc)[:500],
+                            latency_ms=int((time.time() - _call_start) * 1000),
+                        )
+                        if on_stream_activity:
+                            await _call_optional_async(
+                                on_stream_activity,
+                                f"{preferred_model} is unavailable for this connection; using {model}",
+                            )
+                        if owns_semantic_compactor:
+                            semantic_compactor = _llm_context_checkpoint_compactor(
+                                provider=state.provider,
+                                llm=llm,
+                                model=model,
+                                provider_name=state.provider_name,
+                                session_id=session_id,
+                            )
+                        if owns_thread_handoff_compactor:
+                            thread_handoff_compactor = _llm_thread_handoff_compactor(
+                                provider=state.provider,
+                                llm=llm,
+                                model=model,
+                                provider_name=state.provider_name,
+                                session_id=session_id,
+                            )
+                        request = _build_api_request(
+                            model,
+                            state.messages,
+                            max_tokens,
+                            system,
+                            tools,
+                            reasoning_effort,
+                            _runtime_extra_headers,
+                            state.provider_name,
+                            session_id,
+                            persist_session,
+                            cache_tools=cache_system_prompt,
+                            operation_type=state.operation_type,
+                        )
+                        _call_start = time.time()
+                        continue
                     if overflow_retry_used or not is_context_overflow_error(exc, provider_name=state.provider_name):
                         raise
                     overflow_retry_used = True

--- a/brain/systems/runs/direct_loop/model_fallback.py
+++ b/brain/systems/runs/direct_loop/model_fallback.py
@@ -1,0 +1,82 @@
+"""Deterministic model fallback policy for limited-availability models."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+_MODEL_FALLBACKS = {
+    "openai/gpt-5.6": "openai/gpt-5.5",
+    "openai/gpt-5.6-sol": "openai/gpt-5.5",
+}
+_UNAVAILABLE_TERMS = (
+    "model_not_found",
+    "model is not available",
+    "model is unavailable",
+    "model does not exist",
+    "model is not supported",
+    "not supported when using codex",
+    "limited preview",
+    "not available on this account",
+    "do not have access to the model",
+)
+
+
+def _canonical_model(model: str | None) -> str:
+    value = str(model or "").strip().lower().replace(":", "/", 1)
+    return value if "/" in value else f"openai/{value}"
+
+
+def fallback_model_for(model: str | None) -> str | None:
+    """Return the next configured model for a limited-availability model."""
+    return _MODEL_FALLBACKS.get(_canonical_model(model))
+
+
+def _error_text(exc: Any) -> str:
+    values = [str(exc)]
+    for attr in ("response_body", "body", "message", "detail"):
+        value = getattr(exc, attr, None)
+        if value is None:
+            continue
+        if isinstance(value, (dict, list)):
+            values.append(json.dumps(value, default=str))
+        else:
+            values.append(str(value))
+    response = getattr(exc, "response", None)
+    if response is not None:
+        for attr in ("text", "content"):
+            value = getattr(response, attr, None)
+            if value:
+                values.append(str(value))
+    return " ".join(values).lower()
+
+
+def _status_code(exc: Any) -> int | None:
+    value = getattr(exc, "status_code", None)
+    if value is None:
+        value = getattr(getattr(exc, "response", None), "status_code", None)
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def is_model_unavailable_error(exc: Any) -> bool:
+    """Classify entitlement/model-catalog failures without hiding auth errors."""
+    if _status_code(exc) not in {400, 403, 404}:
+        return False
+    text = _error_text(exc)
+    return any(term in text for term in _UNAVAILABLE_TERMS)
+
+
+def is_missing_required_model_auth(exc: Any) -> bool:
+    """Return true when the preferred subscription route is simply absent."""
+    return str(exc).startswith("No OpenAI auth found.")
+
+
+__all__ = [
+    "fallback_model_for",
+    "is_missing_required_model_auth",
+    "is_model_unavailable_error",
+]

--- a/brain/systems/runs/recipes/deep.py
+++ b/brain/systems/runs/recipes/deep.py
@@ -23,7 +23,11 @@ from brain.systems.runs.recipes.phase_barrier import (
     review_completed_phase,
 )
 from brain.systems.runs.recipes.scout import ScoutHandoff, scout_request
-from brain.systems.runs.recipes.shared import default_run_model, workspace_root_from_ref
+from brain.systems.runs.recipes.shared import (
+    default_run_model,
+    default_run_thinking,
+    workspace_root_from_ref,
+)
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.verification.evidence import (
     artifact_payloads,
@@ -788,7 +792,12 @@ async def _coordinator_model_and_thinking(runtime: RunRuntime) -> tuple[str, str
             user_id=runtime.request.user_id,
             org_id=runtime.request.org_id,
         )
-    thinking = model_policy.get("coordinator_thinking") or model_policy.get("thinking") or "high"
+    thinking = model_policy.get("coordinator_thinking") or model_policy.get("thinking")
+    if not thinking:
+        thinking = await default_run_thinking(
+            user_id=runtime.request.user_id,
+            org_id=runtime.request.org_id,
+        )
     return str(model), str(thinking)
 
 

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -11,7 +11,11 @@ from brain.systems.runs.status import RunStatus
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 from brain.systems.runs.recipes.base import BaseRunRecipe
-from brain.systems.runs.recipes.shared import default_run_model, project_runtime_workspace_from_ref
+from brain.systems.runs.recipes.shared import (
+    default_run_model,
+    default_run_thinking,
+    project_runtime_workspace_from_ref,
+)
 from brain.systems.runs.recipes.surface_guidance import response_surface_guidance
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems.personality import agent_profile_prompt_section, soul_prompt_section
@@ -128,7 +132,10 @@ class FastRecipe(BaseRunRecipe):
             user_id=runtime.request.user_id,
             org_id=runtime.request.org_id,
         )
-        thinking = model_policy.get("thinking") or "high"
+        thinking = model_policy.get("thinking") or await default_run_thinking(
+            user_id=runtime.request.user_id,
+            org_id=runtime.request.org_id,
+        )
 
         async def _activity(label: str) -> None:
             await runtime.activity(label)

--- a/brain/systems/runs/recipes/phase_barrier.py
+++ b/brain/systems/runs/recipes/phase_barrier.py
@@ -14,7 +14,11 @@ from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
 from brain.systems.runs.events import run_event
 from brain.systems.runs.graph import DeepPlan, RunNode
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
-from brain.systems.runs.recipes.shared import default_run_model, workspace_root_from_ref
+from brain.systems.runs.recipes.shared import (
+    default_run_model,
+    default_run_thinking,
+    workspace_root_from_ref,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +144,12 @@ async def review_completed_phase(
             user_id=getattr(runtime.request, "user_id", None),
             org_id=getattr(runtime.request, "org_id", None),
         )
-    thinking = model_policy.get("coordinator_thinking") or model_policy.get("thinking") or "high"
+    thinking = model_policy.get("coordinator_thinking") or model_policy.get("thinking")
+    if not thinking:
+        thinking = await default_run_thinking(
+            user_id=getattr(runtime.request, "user_id", None),
+            org_id=getattr(runtime.request, "org_id", None),
+        )
 
     await runtime.store.append_event(
         run_event(

--- a/brain/systems/runs/recipes/shared.py
+++ b/brain/systems/runs/recipes/shared.py
@@ -242,8 +242,27 @@ async def default_run_model(
         )
 
 
+async def default_run_thinking(
+    *,
+    user_id: str | None = None,
+    org_id: str | None = None,
+) -> str:
+    """Return the configured workspace reasoning effort for a run."""
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+    from brain.platform.providers.model_policy import async_get_default_thinking
+
+    async with UnitOfWork() as uow:
+        return await async_get_default_thinking(
+            uow.session,
+            user_id=user_id,
+            org_id=org_id,
+        )
+
+
 __all__ = [
     "ProjectRuntimeWorkspace",
+    "default_run_model",
+    "default_run_thinking",
     "project_runtime_workspace_from_ref",
     "workspace_root_from_ref",
 ]

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -11,7 +11,11 @@ from brain.systems.runs.context import compact_project_reference
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
 from brain.systems.runs.recipes.base import BaseRunRecipe
-from brain.systems.runs.recipes.shared import default_run_model, project_runtime_workspace_from_ref
+from brain.systems.runs.recipes.shared import (
+    default_run_model,
+    default_run_thinking,
+    project_runtime_workspace_from_ref,
+)
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.tools import AsyncRunToolExecutor, ToolRecord, ToolScope, wrap_tool_handlers
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
@@ -90,7 +94,10 @@ class WorkerRecipe(BaseRunRecipe):
             user_id=runtime.request.user_id,
             org_id=runtime.request.org_id,
         )
-        thinking = model_policy.get("thinking") or "high"
+        thinking = model_policy.get("thinking") or await default_run_thinking(
+            user_id=runtime.request.user_id,
+            org_id=runtime.request.org_id,
+        )
         streamed_output = False
 
         async def _activity(label: str) -> None:

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -16,7 +16,7 @@ from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
 from brain.systems.runs.store import AsyncAgentRunStore
 
-_VALID_EFFORT_LEVELS = {"low", "medium", "high", "xhigh"}
+_VALID_EFFORT_LEVELS = {"none", "low", "medium", "high", "xhigh"}
 _VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
@@ -178,14 +178,15 @@ def metadata_choice(
 
 def model_policy_from_metadata(metadata: dict[str, Any] | None) -> dict[str, str]:
     metadata = metadata or {}
-    policy = {
-        "thinking": metadata_choice(
-            metadata,
-            ("thinking_tier", "effort", "effort_level", "thinking"),
-            _VALID_EFFORT_LEVELS,
-            "high",
-        ),
-    }
+    policy: dict[str, str] = {}
+    thinking = metadata_choice(
+        metadata,
+        ("thinking_tier", "effort", "effort_level", "thinking"),
+        _VALID_EFFORT_LEVELS,
+        "",
+    )
+    if thinking:
+        policy["thinking"] = thinking
     raw_model = metadata.get("model") or metadata.get("model_name")
     if isinstance(raw_model, str) and raw_model.strip():
         policy["model"] = raw_model.strip().replace(":", "/", 1)

--- a/brain/systems/runtime_settings/models.py
+++ b/brain/systems/runtime_settings/models.py
@@ -7,11 +7,13 @@ from brain.platform.db.models.org import Org, User
 from brain.platform.providers.model_policy import (
     PROVIDER_MODEL_OPTIONS,
     async_get_default_model,
+    async_get_default_thinking,
 )
 
 from .schemas import RuntimeModelsRead, RuntimeModelsUpdate, RuntimeOption
 
 OPENAI_MODEL_OPTIONS = [
+    RuntimeOption(key="gpt-5.6-sol", label="GPT-5.6 Sol", description="Latest model; falls back to GPT-5.5 when unavailable."),
     RuntimeOption(key="gpt-5.5", label="GPT-5.5", description="Default model for hard reasoning."),
     RuntimeOption(key="gpt-5.4-pro", label="GPT-5.4 Pro", description="Previous maximum-quality route."),
     RuntimeOption(key="gpt-5.4", label="GPT-5.4", description="Balanced general-purpose model."),
@@ -23,6 +25,14 @@ OPENAI_MODEL_OPTIONS = [
     RuntimeOption(key="gpt-5.2", label="GPT-5.2", description="Stable professional-work model."),
     RuntimeOption(key="gpt-4.1", label="GPT-4.1", description="Legacy high-quality fallback."),
     RuntimeOption(key="gpt-4.1-mini", label="GPT-4.1 Mini", description="Legacy lightweight fallback."),
+]
+
+THINKING_OPTIONS = [
+    RuntimeOption(key="none", label="None", description="No additional reasoning effort."),
+    RuntimeOption(key="low", label="Low", description="Faster responses with light reasoning."),
+    RuntimeOption(key="medium", label="Medium", description="Balanced reasoning effort."),
+    RuntimeOption(key="high", label="High", description="More reasoning for difficult work."),
+    RuntimeOption(key="xhigh", label="Extra High", description="Maximum supported reasoning effort."),
 ]
 
 
@@ -49,7 +59,17 @@ async def async_get_runtime_models(session: AsyncSession, user: User) -> Runtime
         org_id=user.org_id,
         user_id=user.id,
     )
-    return RuntimeModelsRead(default=_normalize_model(default), options=OPENAI_MODEL_OPTIONS)
+    thinking = await async_get_default_thinking(
+        session,
+        org_id=user.org_id,
+        user_id=user.id,
+    )
+    return RuntimeModelsRead(
+        default=_normalize_model(default),
+        thinking=thinking,
+        options=OPENAI_MODEL_OPTIONS,
+        thinking_options=THINKING_OPTIONS,
+    )
 
 
 async def async_update_runtime_models(
@@ -63,6 +83,8 @@ async def async_update_runtime_models(
         config = dict(org.memory_model_config or {})
         config["default_provider"] = "openai"
         config["default_model"] = f"openai/{model}"
+        if update.thinking is not None:
+            config["default_thinking"] = update.thinking
         for stale_key in (
             "session_harvest",
             "depth_0",

--- a/brain/systems/runtime_settings/schemas.py
+++ b/brain/systems/runtime_settings/schemas.py
@@ -40,7 +40,9 @@ class RuntimeConnectionRead(BaseModel):
 
 class RuntimeModelsRead(BaseModel):
     default: str
+    thinking: Literal["none", "low", "medium", "high", "xhigh"] = "high"
     options: list[RuntimeOption]
+    thinking_options: list[RuntimeOption] = Field(default_factory=list)
 
 
 class RuntimeMemoryRead(BaseModel):
@@ -207,6 +209,7 @@ class OpenAIOAuthStartResponse(BaseModel):
 
 class RuntimeModelsUpdate(BaseModel):
     default: str = Field(min_length=1)
+    thinking: Literal["none", "low", "medium", "high", "xhigh"] | None = None
 
 
 class RuntimeMemoryUpdate(BaseModel):

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1762,7 +1762,7 @@ export const api = {
     }),
   exchangeRuntimeOpenAIOAuth: (data: { callback: string }) =>
     fetchJson<any>('/api/runtime-settings/connection/openai/oauth/exchange', { method: 'POST', body: JSON.stringify(data) }),
-  updateRuntimeModels: (data: { default: string }) =>
+  updateRuntimeModels: (data: { default: string; thinking: string }) =>
     fetchJson<any>('/api/runtime-settings/models', { method: 'PATCH', body: JSON.stringify(data) }),
   updateRuntimeMemory: (data: { embedder: string; embedding_model?: string | null; reranker?: string }) =>
     fetchJson<any>('/api/runtime-settings/memory', { method: 'PATCH', body: JSON.stringify(data) }),

--- a/frontend/src/lib/features/composer/domain/runSettings.ts
+++ b/frontend/src/lib/features/composer/domain/runSettings.ts
@@ -31,6 +31,7 @@ export const MODEL_OPTIONS = [
 ] as const satisfies readonly CortexWorkspaceComposerIntentOption[];
 
 export const EFFORT_OPTIONS = [
+  { value: 'none', label: 'None', description: 'No additional reasoning effort' },
   { value: 'low', label: 'Low', description: 'Quick reasoning pass' },
   { value: 'medium', label: 'Medium', description: 'Balanced reasoning depth' },
   { value: 'high', label: 'High', description: 'Deeper reasoning for hard work' },

--- a/frontend/src/lib/features/cortex/controllers/runSettingsController.ts
+++ b/frontend/src/lib/features/cortex/controllers/runSettingsController.ts
@@ -16,7 +16,7 @@ export type CortexRunSettingsInput = {
 
 export type RunSettingsStorage = Pick<Storage, 'getItem' | 'setItem'>;
 
-export const DEFAULT_RUN_MODEL = 'openai/gpt-5.5';
+export const DEFAULT_RUN_MODEL = 'openai/gpt-5.6-sol';
 
 export const CORTEX_RUN_SETTINGS_STORAGE_KEYS = {
   executionProfile: 'illo:cortex:execution-profile',
@@ -27,7 +27,7 @@ export const CORTEX_RUN_SETTINGS_STORAGE_KEYS = {
 export const DEFAULT_CORTEX_RUN_SETTINGS: CortexRunSettings = {
   executionProfile: 'fast',
   model: DEFAULT_RUN_MODEL,
-  effortLevel: 'high',
+  effortLevel: 'xhigh',
 };
 
 export function normalizeExecutionProfile(value: unknown): CortexExecutionProfile {
@@ -41,7 +41,7 @@ export function normalizeModel(value: unknown, fallback = DEFAULT_RUN_MODEL): st
 
 export function normalizeEffortLevel(value: unknown): CortexEffortLevel {
   const normalized = String(value || '').trim().toLowerCase();
-  return normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh'
+  return normalized === 'none' || normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh'
     ? normalized
     : 'high';
 }
@@ -101,10 +101,21 @@ export function persistRunSettings(
 ): boolean {
   if (!storage) return false;
   try {
-    const normalized = normalizeRunSettings(settings);
-    storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.executionProfile, normalized.executionProfile);
-    storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model, normalized.model);
-    storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel, normalized.effortLevel);
+    if (settings.executionProfile !== undefined) {
+      storage.setItem(
+        CORTEX_RUN_SETTINGS_STORAGE_KEYS.executionProfile,
+        normalizeExecutionProfile(settings.executionProfile),
+      );
+    }
+    if (settings.model !== undefined) {
+      storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model, normalizeModel(settings.model));
+    }
+    if (settings.effortLevel !== undefined) {
+      storage.setItem(
+        CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel,
+        normalizeEffortLevel(settings.effortLevel),
+      );
+    }
     return true;
   } catch {
     return false;

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -2,6 +2,7 @@ import { browser, dev } from '$app/environment';
 import { api, type CortexBootstrapPayload } from '$lib/api/client';
 import { auth } from '$lib/stores/auth.svelte';
 import {
+  CORTEX_RUN_SETTINGS_STORAGE_KEYS,
   loadRunSettings,
   normalizeRunOptions as normalizeCortexRunOptions,
   normalizeRunSettings,
@@ -116,8 +117,8 @@ class CortexStore {
   teamMembersLoaded = $state(false);
   view = $state<'canvas' | 'list'>('canvas');
   executionProfile = $state<CortexExecutionProfile>('fast');
-  model = $state<string>('openai/gpt-5.5');
-  effortLevel = $state<CortexEffortLevel>('high');
+  model = $state<string>('openai/gpt-5.6-sol');
+  effortLevel = $state<CortexEffortLevel>('xhigh');
   constellationMode = $state(false);
   canvasOpen = $state(false);
   browserSession = $state<BrowserSessionState | null>(null);
@@ -206,24 +207,35 @@ class CortexStore {
     this.effortLevel = settings.effortLevel;
   }
 
-  private _persistRunSettings() {
-    if (typeof localStorage === 'undefined') return;
-    persistRunSettings(localStorage, this.runSettingsOptions());
-  }
-
   setExecutionProfile(profile: CortexExecutionProfile) {
     this.executionProfile = this._normalizeExecutionProfile(profile);
-    this._persistRunSettings();
+    if (typeof localStorage !== 'undefined') {
+      persistRunSettings(localStorage, { executionProfile: this.executionProfile });
+    }
   }
 
   setModel(model: string) {
     this.model = this._normalizeModel(model);
-    this._persistRunSettings();
+    if (typeof localStorage !== 'undefined') {
+      persistRunSettings(localStorage, { model: this.model });
+    }
   }
 
   setEffortLevel(level: CortexEffortLevel) {
     this.effortLevel = this._normalizeEffortLevel(level);
-    this._persistRunSettings();
+    if (typeof localStorage !== 'undefined') {
+      persistRunSettings(localStorage, { effortLevel: this.effortLevel });
+    }
+  }
+
+  applyWorkspaceRunDefaults(model: string, effortLevel: unknown) {
+    if (typeof localStorage === 'undefined') return;
+    if (localStorage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model) === null) {
+      this.model = this._normalizeModel(model);
+    }
+    if (localStorage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel) === null) {
+      this.effortLevel = this._normalizeEffortLevel(effortLevel);
+    }
   }
 
   runSettingsOptions(): Pick<AgentRunOptions, 'executionProfile' | 'model' | 'effortLevel'> {

--- a/frontend/src/lib/types/cortex.ts
+++ b/frontend/src/lib/types/cortex.ts
@@ -228,7 +228,7 @@ export interface VaultAgentGrantPrompt {
 }
 
 export type CortexExecutionProfile = 'fast' | 'deep';
-export type CortexEffortLevel = 'low' | 'medium' | 'high' | 'xhigh';
+export type CortexEffortLevel = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface AgentRunOptions {
   executionProfile?: CortexExecutionProfile;

--- a/frontend/src/lib/types/runtimeSettings.ts
+++ b/frontend/src/lib/types/runtimeSettings.ts
@@ -2,6 +2,7 @@ export type EmbedderKey = 'local_gpu' | 'local_cpu' | 'openai' | 'gemini';
 export type RuntimeVoiceProvider = 'openai' | 'local' | 'gemini';
 export type RuntimeVoiceLanguage = 'auto' | 'en' | 'fr';
 export type RuntimeVoiceModelSize = 'tiny' | 'base' | 'small';
+export type RuntimeThinking = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface RuntimeOption {
   key: string;
@@ -24,7 +25,9 @@ export interface RuntimeSettings {
   };
   models: {
     default: string;
+    thinking: RuntimeThinking;
     options: RuntimeOption[];
+    thinking_options: RuntimeOption[];
   };
   memory: {
     scope?: 'installation';

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import GlobalSearch from '$lib/components/layout/GlobalSearch.svelte';
   import { api } from '$lib/api/client';
   import { auth } from '$lib/stores/auth.svelte';
+  import { cortex } from '$lib/stores/cortex.svelte';
   import { theme } from '$lib/stores/theme.svelte';
   import { wsClient } from '$lib/stores/ws.svelte';
   import { requiresPersonalOpenAIOnboarding } from '$lib/utils/runtimeOnboarding';
@@ -96,6 +97,13 @@
 
         try {
           const runtime = await api.runtimeSettings();
+          const workspaceModel = String(runtime.models?.default || '').includes('/')
+            ? String(runtime.models.default)
+            : `openai/${String(runtime.models?.default || 'gpt-5.6-sol')}`;
+          cortex.applyWorkspaceRunDefaults(
+            workspaceModel,
+            runtime.models?.thinking || 'xhigh',
+          );
           if (requiresPersonalOpenAIOnboarding(runtime) && !isSystemPage) {
             goto('/onboarding');
           }

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -20,6 +20,7 @@
   } from '$lib/utils/oauthPopup';
   import { hasPersonalOpenAIRuntimeConnection } from '$lib/utils/runtimeOnboarding';
   import { auth } from '$lib/stores/auth.svelte';
+  import { cortex } from '$lib/stores/cortex.svelte';
 
   import MemoryCard from './MemoryCard.svelte';
   import ModelsCard from './ModelsCard.svelte';
@@ -75,7 +76,7 @@
   let memoryCheck = $state<MemoryCheck | null>(null);
   let notice = $state<NoticeState | null>(null);
   let startingIntro = $state(false);
-  let modelDraft = $state<{ default: string }>({ default: '' });
+  let modelDraft = $state<{ default: string; thinking: string }>({ default: '', thinking: 'high' });
   let memoryDraft = $state<MemoryDraft>({
     embedder: 'local_gpu',
     embedding_model: 'text-embedding-3-small',
@@ -111,6 +112,7 @@
   const hasOrgOpenAIConnection = $derived(Boolean(settings?.connection?.has_org_key));
   const connectionStatus = $derived(settings?.connection?.status ?? 'missing');
   const modelOptions = $derived(settings?.models?.options ?? []);
+  const thinkingOptions = $derived(settings?.models?.thinking_options ?? []);
   const setupMode = $derived($page.url.searchParams.get('setup') === '1');
   const setupCanContinue = $derived(setupMode && connectionStatus === 'connected');
   const memoryVaultProvider = $derived<MemoryVaultProvider>(embeddingProvider(memoryDraft.embedder));
@@ -153,6 +155,7 @@
     settings = next;
     modelDraft = {
       default: next.models.default,
+      thinking: next.models.thinking || 'high',
     };
     memoryDraft = {
       embedder: next.memory.embedder,
@@ -436,6 +439,10 @@
       if (shouldSaveModels) {
         const models = await api.updateRuntimeModels(modelDraft);
         nextSettings = { ...nextSettings, models };
+        cortex.applyWorkspaceRunDefaults(
+          `openai/${models.default}`,
+          models.thinking,
+        );
         saved.push('Model');
       }
       if (shouldSaveMemory) {
@@ -467,6 +474,10 @@
 
   function updateModel(value: string) {
     modelDraft = { ...modelDraft, default: value };
+  }
+
+  function updateThinking(value: string) {
+    modelDraft = { ...modelDraft, thinking: value };
   }
 
   function updateMemoryDraft(key: keyof MemoryDraft, value: string) {
@@ -573,7 +584,10 @@
 
   function modelDraftDirty() {
     if (!settings) return false;
-    return modelDraft.default !== settings.models.default;
+    return (
+      modelDraft.default !== settings.models.default ||
+      modelDraft.thinking !== settings.models.thinking
+    );
   }
 
   function memoryDraftDirty() {
@@ -915,8 +929,10 @@
         <ModelsCard
           {modelDraft}
           {modelOptions}
+          {thinkingOptions}
           {canManageSettings}
           onUpdateModel={updateModel}
+          onUpdateThinking={updateThinking}
         />
       </div>
 

--- a/frontend/src/routes/system/ModelsCard.svelte
+++ b/frontend/src/routes/system/ModelsCard.svelte
@@ -6,13 +6,17 @@
   let {
     modelDraft,
     modelOptions,
+    thinkingOptions,
     canManageSettings,
     onUpdateModel,
+    onUpdateThinking,
   }: {
-    modelDraft: { default: string };
+    modelDraft: { default: string; thinking: string };
     modelOptions: RuntimeOption[];
+    thinkingOptions: RuntimeOption[];
     canManageSettings: boolean;
     onUpdateModel: (value: string) => void;
+    onUpdateThinking: (value: string) => void;
   } = $props();
 </script>
 
@@ -38,6 +42,23 @@
       options={modelOptions}
       disabled={!canManageSettings}
       onValueChange={onUpdateModel}
+    />
+  </div>
+
+  <div class="model-row">
+    <div class="model-copy">
+      <h3>Default effort</h3>
+      <p>Reasoning effort used for new runs unless a composer selection overrides it.</p>
+    </div>
+
+    <RuntimeSelect
+      id="model-thinking"
+      label="Default reasoning effort"
+      labelHidden
+      value={modelDraft.thinking}
+      options={thinkingOptions}
+      disabled={!canManageSettings}
+      onValueChange={onUpdateThinking}
     />
   </div>
 </section>

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -79,6 +79,28 @@ class TestProviderInference:
         assert _required_openai_auth_mode("openai/gpt-5.6-sol") == "chatgpt"
         assert _required_openai_auth_mode("openai/gpt-5.4") is None
 
+    def test_preview_model_falls_back_only_for_model_availability_errors(self):
+        from brain.systems.runs.direct_loop.model_fallback import (
+            fallback_model_for,
+            is_model_unavailable_error,
+        )
+
+        unsupported = SimpleNamespace(
+            status_code=400,
+            response_body="The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        )
+        missing = SimpleNamespace(
+            status_code=404,
+            body={"error": {"code": "model_not_found", "message": "Model is not available on this account"}},
+        )
+        expired = SimpleNamespace(status_code=401, response_body="access token expired")
+
+        assert fallback_model_for("openai/gpt-5.6-sol") == "openai/gpt-5.5"
+        assert fallback_model_for("gpt-5.5") is None
+        assert is_model_unavailable_error(unsupported) is True
+        assert is_model_unavailable_error(missing) is True
+        assert is_model_unavailable_error(expired) is False
+
     @patch("brain.systems.runs.direct_loop.final_reply_checker.get_provider")
     @patch("brain.systems.runs.direct_loop.final_reply_checker.resolve_llm_client")
     def test_init_llm_uses_provider_from_model_prefix(self, mock_resolve, mock_get_provider):
@@ -120,6 +142,107 @@ class TestProviderInference:
 
             assert mock_resolve.call_args.kwargs["provider"] == "openai"
             assert mock_resolve.call_args.kwargs["auth_mode"] == "chatgpt"
+
+
+@pytest.mark.asyncio
+async def test_agent_retries_gpt_5_6_on_gpt_5_5_when_account_lacks_entitlement(monkeypatch):
+    from brain.platform.integrations.openai_codex_client import OpenAICodexError
+    from brain.platform.integrations.providers import LLMResponse, TextContentBlock, Usage
+    from brain.systems.runs.direct_agent import run_agent_async
+
+    llm = _mock_llm_client(MagicMock(), provider="openai")
+    llm.auth_mode = "chatgpt"
+    llm.is_oauth = True
+    requests = []
+
+    async def fake_api_call(_provider, request, *_args, **_kwargs):
+        requests.append(request)
+        if len(requests) == 1:
+            raise OpenAICodexError(
+                "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                status_code=400,
+            )
+        return LLMResponse(
+            content=[TextContentBlock("Fallback succeeded")],
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=3, output_tokens=2),
+            model="gpt-5.5",
+        )
+
+    monkeypatch.setattr("brain.systems.runs.direct_agent.get_provider", lambda *_args: MagicMock())
+    monkeypatch.setattr("brain.systems.runs.direct_agent._api_call_with_retry_async", fake_api_call)
+    monkeypatch.setattr("brain.systems.runs.direct_agent._async_record_api_call", AsyncMock())
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
+        AsyncMock(),
+    )
+
+    activity = []
+    result = await run_agent_async(
+        "Test fallback",
+        model="openai/gpt-5.6-sol",
+        thinking="xhigh",
+        tools=[],
+        tool_handlers={},
+        persist_session=False,
+        skip_harvest=True,
+        resolved_llm=llm,
+        on_stream_activity=activity.append,
+    )
+
+    assert result.success is True
+    assert result.output == "Fallback succeeded"
+    assert [request.model for request in requests] == ["gpt-5.6-sol", "gpt-5.5"]
+    assert any("unavailable" in item and "gpt-5.5" in item for item in activity)
+
+
+@pytest.mark.asyncio
+async def test_agent_uses_shared_key_fallback_when_personal_codex_connection_is_missing(monkeypatch):
+    from brain.platform.integrations.providers import LLMResponse, TextContentBlock, Usage
+    from brain.systems.runs.direct_agent import run_agent_async
+
+    llm = _mock_llm_client(MagicMock(), provider="openai")
+    resolve = AsyncMock(
+        side_effect=[
+            RuntimeError("No OpenAI auth found. Connect a Codex subscription or add an org OpenAI key in Illo."),
+            llm,
+        ]
+    )
+    seen_models = []
+
+    async def fake_api_call(_provider, request, *_args, **_kwargs):
+        seen_models.append(request.model)
+        return LLMResponse(
+            content=[TextContentBlock("Shared fallback succeeded")],
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=3, output_tokens=2),
+            model="gpt-5.5",
+        )
+
+    monkeypatch.setattr("brain.systems.runs.direct_agent.async_resolve_llm_client", resolve)
+    monkeypatch.setattr("brain.systems.runs.direct_agent.get_provider", lambda *_args: MagicMock())
+    monkeypatch.setattr("brain.systems.runs.direct_agent._api_call_with_retry_async", fake_api_call)
+    monkeypatch.setattr("brain.systems.runs.direct_agent._async_record_api_call", AsyncMock())
+    monkeypatch.setattr(
+        "brain.systems.runs.direct_agent._runtime_async_apply_agent_session_side_effects",
+        AsyncMock(),
+    )
+
+    result = await run_agent_async(
+        "Test shared fallback",
+        model="openai/gpt-5.6-sol",
+        thinking="xhigh",
+        tools=[],
+        tool_handlers={},
+        persist_session=False,
+        skip_harvest=True,
+        user_id="user-1",
+        org_id="org-1",
+    )
+
+    assert result.success is True
+    assert seen_models == ["gpt-5.5"]
+    assert [call.kwargs["auth_mode"] for call in resolve.await_args_list] == ["chatgpt", None]
 
 class TestLiveGuidance:
     async def test_append_live_guidance_adds_user_message(self):

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2896,7 +2896,7 @@ async def _build_cortex_intake_run_request(
     )
 
 
-async def test_work_intake_keeps_fast_high_effort_by_default():
+async def test_work_intake_defers_unspecified_effort_to_workspace_default():
 
     session = _async_work_intake_session(SimpleNamespace(id="idea-1", org_id="org-1", user_id="u1", title="Thread"))
 
@@ -2911,7 +2911,7 @@ async def test_work_intake_keeps_fast_high_effort_by_default():
 
     assert request.profile == "fast"
     assert request.recipe == "fast"
-    assert request.model_policy == {"thinking": "high"}
+    assert request.model_policy == {}
     assert request.metadata["event"] == "thread_reply"
 
 
@@ -3126,10 +3126,24 @@ async def test_work_intake_applies_explicit_model_override():
     )
 
     assert request.model_policy == {
-        "thinking": "high",
         "model": "openai/gpt-5.5",
         "provider": "openai",
     }
+
+
+async def test_work_intake_preserves_explicit_none_effort():
+    session = _async_work_intake_session(SimpleNamespace(id="idea-1", org_id="org-1", user_id="u1", title="Thread"))
+
+    request = await _build_cortex_intake_run_request(
+        session,
+        idea_id="idea-1",
+        event="thread_reply",
+        message="Use no extra reasoning",
+        user_id="u1",
+        metadata={"execution_profile": "fast", "effort": "none"},
+    )
+
+    assert request.model_policy == {"thinking": "none"}
 
 
 async def test_runner_settles_root_run_idea_status():

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -39,9 +39,31 @@ class TestModelPolicy:
         from brain.platform.providers.model_policy import get_provider_model_options
 
         options = get_provider_model_options("openai")
+        assert "gpt-5.6-sol" in options
         assert "gpt-5.5" in options
         assert "gpt-5.4" in options
         assert "gpt-5-mini" in options
+
+    @pytest.mark.asyncio
+    async def test_org_default_thinking_overrides_runtime_default(self):
+        from brain.platform.providers.model_policy import async_get_default_thinking
+
+        def execute_side_effect(stmt, params=None):
+            sql = str(stmt)
+            if "SELECT org_id FROM users" in sql:
+                return _AsyncMappingResult(first={"org_id": "org-1"})
+            if "SELECT memory_model_config FROM orgs" in sql:
+                return _AsyncMappingResult(
+                    first={"memory_model_config": {"default_thinking": "xhigh"}}
+                )
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+        thinking = await async_get_default_thinking(
+            _AsyncPolicySession(execute_side_effect),
+            user_id="user-1",
+        )
+
+        assert thinking == "xhigh"
 
     @pytest.mark.asyncio
     async def test_org_default_model_overrides_default(self):

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -519,11 +519,51 @@ async def test_runtime_models_default_uses_configured_model(monkeypatch):
     import brain.systems.runtime_settings.models as runtime_models
 
     monkeypatch.setattr(runtime_models, "async_get_default_model", AsyncMock(return_value="gpt-5.5"), raising=False)
+    monkeypatch.setattr(runtime_models, "async_get_default_thinking", AsyncMock(return_value="xhigh"), raising=False)
 
     data = await runtime_models.async_get_runtime_models(MagicMock(), SimpleNamespace(id="user-1", org_id="org-1"))
 
     assert data.default == "gpt-5.5"
+    assert data.thinking == "xhigh"
+    assert any(option.key == "gpt-5.6-sol" for option in data.options)
     assert any(option.key == "gpt-5.5" for option in data.options)
+    assert any(option.key == "none" for option in data.thinking_options)
+    assert any(option.key == "xhigh" for option in data.thinking_options)
+
+
+@pytest.mark.asyncio
+async def test_runtime_models_update_persists_workspace_model_and_effort(monkeypatch):
+    from types import SimpleNamespace
+
+    import brain.systems.runtime_settings.models as runtime_models
+    from brain.systems.runtime_settings.schemas import RuntimeModelsUpdate
+
+    org = SimpleNamespace(memory_model_config={"default_provider": "openai"})
+
+    class FakeSession:
+        async def get(self, _model, identifier):
+            assert identifier == "org-1"
+            return org
+
+        async def flush(self):
+            return None
+
+    expected = SimpleNamespace(default="gpt-5.6-sol", thinking="xhigh")
+    monkeypatch.setattr(
+        runtime_models,
+        "async_get_runtime_models",
+        AsyncMock(return_value=expected),
+    )
+
+    result = await runtime_models.async_update_runtime_models(
+        FakeSession(),
+        SimpleNamespace(id="user-1", org_id="org-1"),
+        RuntimeModelsUpdate(default="gpt-5.6-sol", thinking="xhigh"),
+    )
+
+    assert result is expected
+    assert org.memory_model_config["default_model"] == "openai/gpt-5.6-sol"
+    assert org.memory_model_config["default_thinking"] == "xhigh"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Adds GPT-5.6 Sol to AI Runtime and the composer model options.
- Adds a workspace-level default reasoning effort, including Extra High.
- Lets owners configure GPT-5.6 Sol plus Extra High as workspace defaults while retaining per-user overrides.
- Falls back from GPT-5.6 Sol to GPT-5.5 only for confirmed model entitlement or availability errors.
- Keeps stable background helpers on GPT-5.5 unless they use the fallback-aware agent path.

## Why

GPT-5.6 Sol is a limited preview. Eligible Codex-connected users can use it, while teammates whose ChatGPT account is not entitled to the preview should continue on GPT-5.5 automatically.

## Validation

- 3,276 backend tests passed; 80 skipped. The two excluded local GPU files require a missing libtorch_cpu.dylib and are unrelated.
- 348 focused model/runtime tests passed.
- Frontend type check: 0 errors and 0 warnings.
- Frontend production build completed successfully.
- Live credential probes confirmed GPT-5.6 success for an eligible connection and the expected unsupported-model response plus GPT-5.5 success for an ineligible connection.