### PR TITLE
[Illo-QA][project-context] Degrade instead of fail-closed on partial multi-repo materialization (#281)

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -55,16 +55,59 @@ _MAX_GIT_CLONE_TIMEOUT_SECONDS = 1800
 class ProjectContextMaterializationResult:
     workspaces: list[dict[str, str]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    degraded_resources: list[dict[str, str]] = field(default_factory=list)
     resources_checked: int = 0
     empty_project: bool = False
 
     @property
-    def ok(self) -> bool:
+    def ready(self) -> bool:
         return (bool(self.workspaces) or self.empty_project) and not self.errors
+
+    @property
+    def ok(self) -> bool:
+        return self.ready
+
+    @property
+    def status(self) -> str:
+        if not self.ready:
+            return "failed"
+        if self.warnings:
+            return "degraded"
+        return "materialized"
+
+    @property
+    def evidence_health(self) -> dict[str, Any]:
+        if self.status == "degraded":
+            return {
+                "status": "degraded",
+                "warnings": self.warnings[:10],
+                "degraded_resources": self.degraded_resources[:10],
+            }
+        if self.status == "failed":
+            return {"status": "unavailable", "errors": self.errors[:10]}
+        return {"status": "ok"}
 
     def fail(self, message: str) -> "ProjectContextMaterializationResult":
         self.errors.append(message)
         return self
+
+    def degrade(
+        self,
+        message: str,
+        *,
+        resource: dict[str, str],
+    ) -> "ProjectContextMaterializationResult":
+        self.warnings.append(message)
+        self.degraded_resources.append(resource)
+        return self
+
+    def fail_if_no_usable_workspace(self, usable_workspace_count: int) -> None:
+        if usable_workspace_count or not self.warnings:
+            return
+        self.errors.extend(self.warnings)
+        self.warnings.clear()
+        self.degraded_resources.clear()
 
 
 def _clean_text(value: Any) -> str | None:
@@ -115,6 +158,22 @@ def _github_slug_from_resource(resource: dict[str, Any]) -> str | None:
             if slug:
                 return slug
     return None
+
+
+def _resource_failure_is_soft(resource: dict[str, Any]) -> bool:
+    return bool(_github_slug_from_resource(resource)) and resource.get("required") is not True
+
+
+def _degraded_resource_payload(resource: dict[str, Any], error: str) -> dict[str, str]:
+    payload = {"kind": _resource_kind(resource), "error": error}
+    for key, value in (
+        ("id", _clean_text(resource.get("id"))),
+        ("name", _clean_text(resource.get("name") or resource.get("label"))),
+        ("repo", _github_slug_from_resource(resource)),
+    ):
+        if value:
+            payload[key] = value
+    return payload
 
 
 def _normalise_repo_subpath(value: Any) -> str | None:
@@ -901,6 +960,7 @@ async def materialize_project_context_workspaces(
     root_materialization = root_resource.get("materialization") if isinstance(root_resource.get("materialization"), dict) else {}
     root_empty = bool(root_materialization.get("root_empty", True))
     result.empty_project = root_empty
+    usable_workspace_count = 0 if root_empty else 1
 
     for resource in resources:
         if _is_project_root_resource(resource):
@@ -919,8 +979,14 @@ async def materialize_project_context_workspaces(
             materialized_resources.append(resource)
         if workspace:
             workspaces.append(workspace)
+            usable_workspace_count += 1
         if error:
-            result.errors.append(error)
+            if _resource_failure_is_soft(resource):
+                result.degrade(error, resource=_degraded_resource_payload(resource, error))
+            else:
+                result.fail(error)
+
+    result.fail_if_no_usable_workspace(usable_workspace_count)
 
     snapshot["resources"] = materialized_resources
 
@@ -940,12 +1006,14 @@ async def materialize_project_context_workspaces(
         workspace_manifest_payload["resolved_workspace_root"] = default_workspace
     snapshot["project_workspace_manifest"] = workspace_manifest_payload
     result.workspaces = workspaces
-    status = "materialized" if not result.errors else "failed"
     project_context_materialization = {
-        "status": status,
+        "status": result.status,
         "workspaces": workspaces,
         "workspace_manifest": workspace_manifest_payload,
         "errors": result.errors[:10],
+        "warnings": result.warnings[:10],
+        "degraded_resources": result.degraded_resources[:10],
+        "evidence_health": result.evidence_health,
         "empty_project": result.empty_project,
         "seed_resource_count": len(resources),
         "project_root_path_count": int(root_materialization.get("root_path_count") or 0),

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -2,6 +2,34 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+
+def test_project_context_materialization_result_is_ready_when_evidence_is_degraded():
+    from brain.systems.cortex.project_context.materializer import ProjectContextMaterializationResult
+
+    result = ProjectContextMaterializationResult(
+        workspaces=[
+            {"name": "/", "path": "/tmp/project-root"},
+            {"name": "repo-a", "path": "/tmp/repo-a"},
+            {"name": "repo-b", "path": "/tmp/repo-b"},
+        ],
+        warnings=["Could not materialize GitHub repository example-org/missing: clone timed out."],
+        degraded_resources=[
+            {
+                "kind": "repo",
+                "name": "example-org/missing",
+                "repo": "example-org/missing",
+                "error": "Could not materialize GitHub repository example-org/missing: clone timed out.",
+            }
+        ],
+    )
+
+    assert result.ready is True
+    assert result.ok is True
+    assert result.status == "degraded"
+    assert result.evidence_health["status"] == "degraded"
+    assert result.evidence_health["degraded_resources"][0]["repo"] == "example-org/missing"
+
+
 def test_thread_attachment_file_is_not_materialized_as_github_workspace():
     from brain.systems.cortex.project_context.materializer import _github_slug_from_resource
 
@@ -297,6 +325,70 @@ def test_runner_materializes_placeholder_projects_as_empty_roots(monkeypatch):
     assert context_ready is True
     assert status_payload is None
     runner.materialize_project_context_workspaces.assert_called_once()
+
+
+def test_runner_starts_when_project_context_materialization_is_degraded(monkeypatch):
+    from brain.systems.cortex.project_context.materializer import ProjectContextMaterializationResult
+    from brain.systems.runs.cortex import runner
+
+    run = SimpleNamespace(
+        id=281,
+        root_run_id=None,
+        user_id="user-1",
+        org_id="org-1",
+        thread_id="idea-281",
+        target_ref={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {"kind": "repo", "repo": "example-org/repo-a"},
+                    {"kind": "repo", "repo": "example-org/missing-repo"},
+                ],
+            }
+        },
+        workspace_ref={},
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    result = ProjectContextMaterializationResult(
+        workspaces=[
+            {"name": "/", "path": "/tmp/project-root"},
+            {"name": "example-org/repo-a", "path": "/tmp/repo-a"},
+        ],
+        warnings=["Could not materialize GitHub repository example-org/missing-repo: clone timed out."],
+        degraded_resources=[
+            {
+                "kind": "repo",
+                "repo": "example-org/missing-repo",
+                "error": "Could not materialize GitHub repository example-org/missing-repo: clone timed out.",
+            }
+        ],
+    )
+    mark_failed = AsyncMock()
+
+    monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
+    monkeypatch.setattr(runner, "materialize_project_context_workspaces", AsyncMock(return_value=result))
+    monkeypatch.setattr(runner, "_mark_run_failed_after_runner_error_async", mark_failed)
+
+    context_ready, status_payload = runner._materialize_project_context(281)
+
+    assert context_ready is True
+    assert status_payload is None
+    assert result.status == "degraded"
+    mark_failed.assert_not_awaited()
 
 
 async def test_materialize_github_project_context_uses_vault_key_without_persisting_token(tmp_path, monkeypatch):
@@ -680,6 +772,213 @@ async def test_materialize_github_project_context_fails_closed_when_clone_unavai
     assert "Could not materialize GitHub repository example-org/private" in result.errors[0]
     assert run.target_status == "invalid"
     assert run.target_metadata["project_context_snapshot"]["status"] == "invalid"
+    assert run.metadata_["project_context_materialization"]["status"] == "failed"
+
+
+async def test_materialize_multi_repo_context_degrades_when_one_clone_is_unavailable(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    repos = [
+        "example-org/repo-a",
+        "example-org/repo-b",
+        "example-org/missing-repo",
+        "example-org/repo-c",
+    ]
+    run = SimpleNamespace(
+        id=281,
+        user_id="user-1",
+        metadata_={"org_id": "org-1"},
+        target_metadata={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "name": repo,
+                        "repo": repo,
+                        "uri": f"https://github.com/{repo}",
+                    }
+                    for repo in repos
+                ],
+            },
+        },
+        workspace_ref={},
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def fake_clone(slug, destination, *, token, branch):
+        if slug == "example-org/missing-repo":
+            raise RuntimeError("clone timed out")
+        destination.mkdir(parents=True)
+        return {"path": str(destination), "branch": branch or "main", "commit": f"commit-{slug[-1]}"}
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "list_secrets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(281, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert result.ready is True
+    assert result.ok is True
+    assert result.status == "degraded"
+    assert result.errors == []
+    assert len(result.workspaces) == 4
+    assert "example-org/missing-repo" in result.warnings[0]
+    assert result.degraded_resources[0]["repo"] == "example-org/missing-repo"
+    assert run.target_status == "resolved"
+    assert run.target_validation_error is None
+    assert run.target_metadata["project_context_snapshot"]["status"] == "validated"
+
+    materialization_payload = run.metadata_["project_context_materialization"]
+    assert materialization_payload["status"] == "degraded"
+    assert materialization_payload["evidence_health"]["status"] == "degraded"
+    assert materialization_payload["degraded_resources"][0]["repo"] == "example-org/missing-repo"
+    assert (
+        run.target_metadata["project_context_snapshot"]["resources"][3]["materialization"]["status"]
+        == "failed"
+    )
+
+    runtime_materialization = run.workspace_ref["project_runtime_context"]["project_context_materialization"]
+    assert runtime_materialization["evidence_health"]["status"] == "degraded"
+    assert runtime_materialization["degraded_resources"][0]["repo"] == "example-org/missing-repo"
+
+
+async def test_materialize_multi_repo_context_stays_materialized_when_all_clones_succeed(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    repos = [f"example-org/repo-{suffix}" for suffix in ("a", "b", "c", "d")]
+    run = SimpleNamespace(
+        id=282,
+        user_id="user-1",
+        metadata_={"org_id": "org-1"},
+        target_metadata={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "name": repo,
+                        "repo": repo,
+                        "uri": f"https://github.com/{repo}",
+                    }
+                    for repo in repos
+                ],
+            },
+        },
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def fake_clone(slug, destination, *, token, branch):
+        destination.mkdir(parents=True)
+        return {"path": str(destination), "branch": branch or "main", "commit": f"commit-{slug[-1]}"}
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "list_secrets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(282, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert result.ready is True
+    assert result.status == "materialized"
+    assert result.warnings == []
+    assert result.degraded_resources == []
+    assert len(result.workspaces) == 5
+    assert run.metadata_["project_context_materialization"]["status"] == "materialized"
+    assert run.metadata_["project_context_materialization"]["evidence_health"] == {"status": "ok"}
+
+
+async def test_materialize_required_repo_failure_stays_fail_closed_with_other_usable_repo(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=283,
+        user_id="user-1",
+        metadata_={"org_id": "org-1"},
+        target_metadata={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "name": "example-org/required-repo",
+                        "repo": "example-org/required-repo",
+                        "uri": "https://github.com/example-org/required-repo",
+                        "required": True,
+                    },
+                    {
+                        "kind": "repo",
+                        "name": "example-org/healthy-repo",
+                        "repo": "example-org/healthy-repo",
+                        "uri": "https://github.com/example-org/healthy-repo",
+                    },
+                ],
+            },
+        },
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    def fake_clone(slug, destination, *, token, branch):
+        if slug == "example-org/required-repo":
+            raise RuntimeError("repository unavailable")
+        destination.mkdir(parents=True)
+        return {"path": str(destination), "branch": branch or "main", "commit": "healthy123"}
+
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "list_secrets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(283, workspace_root=str(tmp_path), user_id="user-1")
+
+    assert result.ready is False
+    assert result.status == "failed"
+    assert "example-org/required-repo" in result.errors[0]
+    assert len(result.workspaces) == 2
+    assert run.target_status == "invalid"
     assert run.metadata_["project_context_materialization"]["status"] == "failed"
 
 


### PR DESCRIPTION
## What
Scheduled multi-repo Cycle runs currently **fail-closed** when a single secondary repo fails to clone — one bad/unreachable repo aborts the whole run with "did not provide a usable workspace", even when the root workspace and every other repo materialized fine.

This makes partial materialization a **graceful degradation** instead: the run starts and completes its mission on the healthy workspaces, and surfaces which repos it couldn't reach.

## How
- Per-resource failures are classified **once**: a secondary GitHub repo (`required` not True) that fails → **soft** (`degrade`); the root/required workspace failing → **hard** (`fail`, still fail-closed).
- `ready`, `status` (`materialized` / `degraded` / `failed`), and a new `evidence_health` payload all derive from that single classification — no scattered `and not self.errors` checks.
- `fail_if_no_usable_workspace()` re-promotes soft warnings to hard errors when **nothing** usable exists (root failed and no repos came up), preserving the fail-closed guarantee.
- `ok` kept as a back-compat alias for `ready`.
- Materialization snapshot now carries `warnings`, `degraded_resources`, and `evidence_health`.

All-healthy and total-failure paths are behaviorally unchanged.

## Review surface (no diff-reading required)
Run the tests:
```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-281-partial-materialization
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_project_context_materializer.py tests/test_project_context_root_materializer.py \
  tests/test_project_context_merge.py -q
```
Result: **45 passed**.

## Acceptance checks
- [x] 4-repo context, 1 repo clone fails → run starts & completes on the 3 healthy repos; no "did not provide a usable workspace".
- [x] Result surfaces `evidence_health: degraded` and names the specific repo that failed.
- [x] Root/primary workspace itself fails → still aborts (fail-closed only when nothing usable exists).
- [x] Fully-healthy 4-repo context → `status="materialized"`, no spurious degraded flag.
- [x] `workspaces=[root, repoA, repoB]` + one soft error ⇒ `ready is True`, `status == "degraded"`.

🤖 Draft opened by autonomous routine R3. Do not merge/ready without review.
