### PR TITLE
[Illo-QA][coordinator] Fix chronic GitHub read degradation: legacy token + exact counts (#282)

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -218,6 +218,60 @@ def _pull_request_payload(pr: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _pull_request_detail_payload(pr: dict[str, Any]) -> dict[str, Any]:
+    payload = _pull_request_payload(pr)
+    payload.update({
+        "mergeable": pr.get("mergeable"),
+        "mergeable_state": pr.get("mergeable_state"),
+        "merged": bool(pr.get("merged")),
+        "commits": pr.get("commits"),
+        "changed_files": pr.get("changed_files"),
+        "additions": pr.get("additions"),
+        "deletions": pr.get("deletions"),
+    })
+    return payload
+
+
+def _check_runs_payload(data: Any) -> dict[str, Any]:
+    raw_runs = data.get("check_runs") if isinstance(data, dict) else []
+    runs = [run for run in raw_runs if isinstance(run, dict)] if isinstance(raw_runs, list) else []
+    check_runs = [
+        {
+            "name": run.get("name"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "details_url": run.get("details_url"),
+            "started_at": run.get("started_at"),
+            "completed_at": run.get("completed_at"),
+        }
+        for run in runs
+    ]
+    failure_conclusions = {
+        "action_required",
+        "cancelled",
+        "failure",
+        "stale",
+        "startup_failure",
+        "timed_out",
+    }
+    if not check_runs:
+        status = "none"
+    elif any(run.get("status") != "completed" for run in check_runs):
+        status = "pending"
+    elif any(run.get("conclusion") in failure_conclusions for run in check_runs):
+        status = "failure"
+    elif all(run.get("conclusion") in {"success", "neutral", "skipped"} for run in check_runs):
+        status = "success"
+    else:
+        status = "unknown"
+    total_count = data.get("total_count") if isinstance(data, dict) else None
+    return {
+        "status": status,
+        "total_count": int(total_count) if isinstance(total_count, int) else len(check_runs),
+        "check_runs": check_runs,
+    }
+
+
 def _merge_repos(*groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
     seen: set[str] = set()
     merged: list[dict[str, Any]] = []
@@ -406,6 +460,95 @@ async def async_list_repo_pull_requests(
         "repo": slug,
         "state": params["state"],
         "pull_requests": [_pull_request_payload(item) for item in items[:max_items] if isinstance(item, dict)],
+    }
+
+
+async def async_get_pull_request(
+    slug: str,
+    pull_number: int,
+    *,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Read one pull request and its head commit's check runs with one identity."""
+
+    owner, repo = slug.split("/", 1)
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        pr = await _async_request(
+            client,
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{pull_number}",
+            token=token,
+        )
+        head = pr.get("head") if isinstance(pr, dict) else None
+        head_sha = head.get("sha") if isinstance(head, dict) else None
+        if not head_sha:
+            raise GitHubConnectorError(status_code=502, message="GitHub pull request response omitted the head SHA.")
+        checks = await _async_request(
+            client,
+            "GET",
+            f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
+            token=token,
+            params={"per_page": GITHUB_ITEM_LIMIT, "page": 1},
+        )
+        total_checks = checks.get("total_count") if isinstance(checks, dict) else None
+        check_runs = checks.get("check_runs") if isinstance(checks, dict) else None
+        if isinstance(total_checks, int) and isinstance(check_runs, list):
+            page_count = (total_checks + GITHUB_ITEM_LIMIT - 1) // GITHUB_ITEM_LIMIT
+            for page in range(2, page_count + 1):
+                page_data = await _async_request(
+                    client,
+                    "GET",
+                    f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
+                    token=token,
+                    params={"per_page": GITHUB_ITEM_LIMIT, "page": page},
+                )
+                page_runs = page_data.get("check_runs") if isinstance(page_data, dict) else None
+                if isinstance(page_runs, list):
+                    check_runs.extend(page_runs)
+    return {
+        "repo": slug,
+        "pull_request": _pull_request_detail_payload(pr if isinstance(pr, dict) else {}),
+        "checks": _check_runs_payload(checks),
+    }
+
+
+async def async_get_repo_counts(
+    slug: str,
+    *,
+    token: str | None = None,
+    state: str = "open",
+) -> dict[str, Any]:
+    """Return exact issue and pull-request counts from authenticated GitHub Search."""
+
+    clean_state = (state or "open").strip().lower()
+    if clean_state not in {"open", "closed", "all"}:
+        raise GitHubConnectorError(status_code=422, message="Count state must be open, closed, or all.")
+    state_qualifier = "" if clean_state == "all" else f" is:{clean_state}"
+    counts: dict[str, int] = {}
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        for result_key, kind in (("issues", "issue"), ("pull_requests", "pr")):
+            data = await _async_request(
+                client,
+                "GET",
+                "/search/issues",
+                token=token,
+                params={
+                    "q": f"repo:{slug} is:{kind}{state_qualifier}",
+                    "per_page": 1,
+                },
+            )
+            raw_count = data.get("total_count") if isinstance(data, dict) else None
+            if not isinstance(raw_count, int):
+                raise GitHubConnectorError(
+                    status_code=502,
+                    message="GitHub search response omitted total_count.",
+                )
+            counts[result_key] = raw_count
+    return {
+        "repo": slug,
+        "state": clean_state,
+        "counts": counts,
+        "total_count": sum(counts.values()),
     }
 
 

--- a/brain/systems/runs/execution_context.py
+++ b/brain/systems/runs/execution_context.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from contextlib import contextmanager
 import contextvars
 from dataclasses import dataclass, field, fields
-from typing import Iterator, Mapping
+from typing import Callable, Iterator, Mapping, TypeVar, cast
+
+
+_StateT = TypeVar("_StateT")
+
+
+@dataclass
+class _AgentRunState:
+    """Mutable namespaces intentionally shared by cloned tool-call contexts."""
+
+    values: dict[str, object] = field(default_factory=dict)
 
 
 def _clone_context_value(value: object) -> object:
@@ -109,6 +119,17 @@ def get_agent_context_value(name: str, default=None):
     return getattr(_agent_context, name, default)
 
 
+def get_or_create_agent_run_state(namespace: str, factory: Callable[[], _StateT]) -> _StateT:
+    """Return state shared by tool calls in one bound agent run, never globally."""
+
+    holder = getattr(_agent_context, "_run_state", None)
+    if not isinstance(holder, _AgentRunState):
+        return factory()
+    if namespace not in holder.values:
+        holder.values[namespace] = factory()
+    return cast(_StateT, holder.values[namespace])
+
+
 def snapshot_agent_context() -> dict:
     """Capture the current task's bound AgentRun context attributes."""
     return _agent_context._copy()
@@ -130,6 +151,11 @@ def bind_agent_context(
 
     next_values = clone_agent_context_mapping(_context_values.get())
     next_values.update(clone_agent_context_mapping(attrs))
+    # A fresh explicit binding starts a new run-local scope. Runtime tool-call
+    # propagation includes the existing holder in ``attrs`` and therefore
+    # deliberately shares it with nested/cloned contexts.
+    if not isinstance(attrs.get("_run_state"), _AgentRunState):
+        next_values["_run_state"] = _AgentRunState()
     token = _context_values.set(next_values)
     try:
         yield _agent_context
@@ -143,5 +169,6 @@ __all__ = [
     "clone_agent_context_mapping",
     "current_agent_context",
     "get_agent_context_value",
+    "get_or_create_agent_run_state",
     "snapshot_agent_context",
 ]

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -7,19 +7,28 @@ GITHUB_TOOLS = [
     {
         "name": "read_github_source",
         "description": (
-            "Read bounded GitHub repository source data such as repo metadata, issues, and pull requests. "
-            "Use this as a generic source reader before writing findings into Domains, Cycles, Slack updates, "
-            "or inbound projections. This tool is read-only and accepts owner/name, GitHub URL, or git remote "
-            "repo values."
+            "Read bounded GitHub repository source data such as repo metadata, issues, pull requests, exact "
+            "issue/PR counts, and pull-request CI check status. Use this as a generic source reader before "
+            "writing findings into Domains, Cycles, Slack updates, or inbound projections. This tool is "
+            "read-only and accepts owner/name, GitHub URL, or git remote repo values."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["get_repo", "list_issues", "list_pull_requests"],
+                    "enum": [
+                        "get_repo",
+                        "list_issues",
+                        "list_pull_requests",
+                        "get_pull_request",
+                        "get_counts",
+                    ],
                     "default": "list_issues",
-                    "description": "Which GitHub source data to read.",
+                    "description": (
+                        "Which GitHub source data to read. get_pull_request includes mergeability and CI "
+                        "check runs; get_counts returns exact issue and PR counts for the requested state."
+                    ),
                 },
                 "repo": {
                     "type": "string",
@@ -47,6 +56,11 @@ GITHUB_TOOLS = [
                 },
                 "head": {"type": "string", "description": "Optional pull request head filter."},
                 "base": {"type": "string", "description": "Optional pull request base branch filter."},
+                "pull_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Pull request number required by get_pull_request.",
+                },
                 "limit": {"type": "integer", "default": 30, "description": "Maximum items to return, 1-100."},
                 "token_secret_key": {
                     "type": "string",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import json
 from typing import Any
 
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_create_repo_issue,
+    async_get_pull_request,
+    async_get_repo_counts,
     async_get_repo_by_slug,
     async_list_repo_issues,
     async_list_repo_pull_requests,
     parse_github_repo_slug,
 )
+from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 from brain.systems.vault import (
     VAULT_AGENT_ACCESS_AVAILABLE,
@@ -41,6 +45,40 @@ def _limit(value: Any) -> int:
         return max(1, min(int(value or 30), 100))
     except (TypeError, ValueError):
         return 30
+
+
+def _is_known_legacy_token_key(value: Any) -> bool:
+    key = str(value or "").strip().upper()
+    return "__" in key and key.endswith("_LEGACY")
+
+
+@dataclass
+class _GitHubReadState:
+    rejected: dict[tuple[str | None, str], GitHubConnectorError] = field(default_factory=dict)
+    preferred: dict[str, str | None] = field(default_factory=dict)
+
+
+def _github_read_state() -> _GitHubReadState:
+    """Return context-local token history for the current agent run."""
+
+    return get_or_create_agent_run_state("github_read", _GitHubReadState)
+
+
+def _ordered_read_candidates(
+    candidates: list[dict[str, str | None]],
+    *,
+    repo_slug: str,
+    state: _GitHubReadState,
+) -> list[dict[str, str | None]]:
+    available = [
+        candidate
+        for candidate in candidates
+        if (candidate.get("token"), repo_slug) not in state.rejected
+    ]
+    if repo_slug in state.preferred:
+        preferred_token = state.preferred[repo_slug]
+        available.sort(key=lambda candidate: candidate.get("token") != preferred_token)
+    return available
 
 
 async def _github_token_from_secret(token_secret_key: str | None) -> str | None:
@@ -86,7 +124,7 @@ async def _github_token_candidates(
 
     async def add_secret_key(key_name: str | None, source: str) -> None:
         key = _clean(key_name)
-        if not key or key in seen_keys:
+        if not key or key in seen_keys or _is_known_legacy_token_key(key):
             return
         seen_keys.add(key)
         token = await _github_token_from_secret(key)
@@ -116,9 +154,8 @@ async def _github_token_candidates(
             bound_env = {}
         for env_name in ("GITHUB_TOKEN", "GH_TOKEN"):
             await add_token(bound_env.get(env_name), f"project_binding:{env_name}")
-        for env_name, token in sorted(bound_env.items()):
-            await add_token(token, f"project_binding:{env_name}")
 
+        sorted_secrets: list[dict[str, Any]] = []
         if not for_write:
             try:
                 secrets = await async_list_secrets(actor_user_id=user_id, org_id=org_id)
@@ -144,7 +181,21 @@ async def _github_token_candidates(
                     or str(secret.get("category") or "").lower() == "github"
                 )
             ]
-            for secret in sorted(github_like, key=priority):
+            sorted_secrets = sorted(github_like, key=priority)
+            for secret in sorted_secrets:
+                if str(secret.get("key_name") or "") != "GITHUB_TOKEN":
+                    continue
+                await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
+
+        for env_name, token in sorted(bound_env.items()):
+            if env_name in {"GITHUB_TOKEN", "GH_TOKEN"} or _is_known_legacy_token_key(env_name):
+                continue
+            await add_token(token, f"project_binding:{env_name}")
+
+        if not for_write:
+            for secret in sorted_secrets:
+                if str(secret.get("key_name") or "") == "GITHUB_TOKEN":
+                    continue
                 await add_secret_key(str(secret.get("key_name") or ""), "vault_inventory")
 
     if not candidates:
@@ -167,11 +218,13 @@ async def _read_with_token(
     base: str | None,
     limit: int,
     token: str | None,
+    pull_number: int | None,
 ) -> dict[str, Any]:
     if action in {"repo", "get_repo"}:
-        return {
-            "repo": await async_get_repo_by_slug(repo_slug, token=token),
-        }
+        repo = await async_get_repo_by_slug(repo_slug, token=token)
+        if repo is None:
+            raise GitHubConnectorError(status_code=404, message="Repository not found or not visible to this token.")
+        return {"repo": repo}
     if action in {"list_issues", "issues"}:
         return await async_list_repo_issues(
             repo_slug,
@@ -194,7 +247,22 @@ async def _read_with_token(
             base=_clean(base),
             limit=_limit(limit),
         )
-    raise ValueError("read_github_source action must be get_repo, list_issues, or list_pull_requests")
+    if action in {"pull_request", "get_pull_request", "pr"}:
+        return await async_get_pull_request(
+            repo_slug,
+            int(pull_number or 0),
+            token=token,
+        )
+    if action in {"counts", "get_counts", "exact_counts"}:
+        return await async_get_repo_counts(
+            repo_slug,
+            token=token,
+            state=state,
+        )
+    raise ValueError(
+        "read_github_source action must be get_repo, list_issues, list_pull_requests, "
+        "get_pull_request, or get_counts"
+    )
 
 
 async def _handle_read_github_source(
@@ -209,10 +277,11 @@ async def _handle_read_github_source(
     include_pull_requests: bool = False,
     head: str | None = None,
     base: str | None = None,
+    pull_number: int | None = None,
     limit: int = 30,
     token_secret_key: str | None = None,
 ) -> str:
-    """Read GitHub repo metadata, issues, or pull requests."""
+    """Read GitHub repo metadata, issues, pull requests, counts, or CI checks."""
 
     repo_slug = parse_github_repo_slug(repo or "")
     if not repo_slug:
@@ -226,17 +295,58 @@ async def _handle_read_github_source(
         "list_pull_requests",
         "pull_requests",
         "prs",
+        "pull_request",
+        "get_pull_request",
+        "pr",
+        "counts",
+        "get_counts",
+        "exact_counts",
     }
     if clean_action not in valid_actions:
-        return json.dumps({"error": "read_github_source action must be get_repo, list_issues, or list_pull_requests"})
+        return json.dumps({
+            "error": (
+                "read_github_source action must be get_repo, list_issues, list_pull_requests, "
+                "get_pull_request, or get_counts"
+            )
+        })
+    if clean_action in {"pull_request", "get_pull_request", "pr"}:
+        try:
+            clean_pull_number = int(pull_number or 0)
+        except (TypeError, ValueError):
+            clean_pull_number = 0
+        if clean_pull_number < 1:
+            return json.dumps({"error": "get_pull_request requires a positive pull_number"})
+    else:
+        clean_pull_number = None
 
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,
         token_secret_key=token_secret_key,
     )
+    read_state = _github_read_state()
+    read_candidates = _ordered_read_candidates(
+        candidates,
+        repo_slug=repo_slug,
+        state=read_state,
+    )
+    if not read_candidates:
+        cached_errors = [
+            error
+            for (token, rejected_repo), error in read_state.rejected.items()
+            if rejected_repo == repo_slug and any(candidate.get("token") == token for candidate in candidates)
+        ]
+        if cached_errors:
+            cached_error = cached_errors[-1]
+            return json.dumps({"error": cached_error.message, "status_code": cached_error.status_code})
+        return json.dumps({"error": "No GitHub token candidates were available"})
     last_error: GitHubConnectorError | None = None
-    auth_statuses = {401, 403, 404}
-    for index, candidate in enumerate(candidates):
+    retry_statuses = {401, 403, 404}
+    if clean_action in {"counts", "get_counts", "exact_counts"}:
+        # The generated query is valid, so GitHub Search's 422 can mean that
+        # this candidate cannot search the private repository.
+        retry_statuses.add(422)
+    negative_cache_statuses = {401, 404}
+    for index, candidate in enumerate(read_candidates):
         try:
             payload = await _read_with_token(
                 action=clean_action,
@@ -252,12 +362,16 @@ async def _handle_read_github_source(
                 base=base,
                 limit=limit,
                 token=candidate["token"],
+                pull_number=clean_pull_number,
             )
         except GitHubConnectorError as exc:
             last_error = exc
-            if exc.status_code in auth_statuses and index < len(candidates) - 1:
+            if exc.status_code in negative_cache_statuses:
+                read_state.rejected[(candidate.get("token"), repo_slug)] = exc
+            if exc.status_code in retry_statuses and index < len(read_candidates) - 1:
                 continue
             return json.dumps({"error": exc.message, "status_code": exc.status_code})
+        read_state.preferred[repo_slug] = candidate.get("token")
         payload["token_secret_key_used"] = bool(candidate.get("key_name"))
         payload["token_source"] = candidate["source"]
         if last_error is not None:

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -312,7 +312,9 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "risk_class": "low",
         "side_effect_class": "read_only",
         "reversibility": "none",
-        "expected_effect": "read bounded GitHub repository metadata, issues, or pull requests",
+        "expected_effect": (
+            "read bounded GitHub repository metadata, issues, pull requests, exact counts, or CI checks"
+        ),
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
     },

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -6,8 +6,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from brain.systems.cortex.project_context.github import GitHubConnectorError, _issue_payload
-from brain.systems.runs.execution_context import bind_agent_context
-from brain.systems.runs.tool_catalog.handlers.github import _handle_read_github_source
+from brain.systems.runs.execution_context import bind_agent_context, snapshot_agent_context
+from brain.systems.runs.tool_catalog.handlers.github import (
+    _github_token_candidates,
+    _handle_read_github_source,
+)
 
 
 def test_issue_payload_normalizes_github_issue_shape():
@@ -172,3 +175,387 @@ async def test_read_github_source_falls_back_from_project_binding_to_available_g
         "expired-token",
         "good-token",
     ]
+
+
+@pytest.mark.asyncio
+async def test_github_token_candidates_drop_known_legacy_and_put_primary_before_aliases():
+    async def fake_get_secret(key_name, *args, **kwargs):
+        return {"GITHUB_TOKEN": "primary-token"}.get(key_name)
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_secret",
+        new=AsyncMock(side_effect=fake_get_secret),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "key_name": "GITHUB_TOKEN",
+                    "category": "github",
+                    "agent_access_level": "available",
+                }
+            ]
+        ),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(
+            return_value={
+                "GITHUB_TOKEN__JB_LEGACY": "legacy-token",
+                "GITHUB_TOKEN__AXEL": "secondary-token",
+            }
+        ),
+    ):
+        candidates = await _github_token_candidates(
+            repo_slug="uwear-ai/uwear-backend",
+            token_secret_key=None,
+        )
+
+    assert [candidate["token"] for candidate in candidates] == [
+        "primary-token",
+        "secondary-token",
+    ]
+    assert all("LEGACY" not in candidate["source"] for candidate in candidates)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 404])
+async def test_read_github_source_does_not_retry_rejected_token_within_run(status_code: int):
+    attempts: list[str | None] = []
+
+    async def fake_list_issues(*args, token=None, **kwargs):
+        attempts.append(token)
+        if token == "bad-token":
+            raise GitHubConnectorError(status_code=status_code, message="Not visible")
+        return {"repo": "uwear-ai/uwear-backend", "issues": []}
+
+    bound_tokens = {
+        "GITHUB_TOKEN": "bad-token",
+        "GITHUB_TOKEN__AXEL": "good-token",
+    }
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value=bound_tokens),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_repo_issues",
+        new=AsyncMock(side_effect=fake_list_issues),
+    ):
+        tool_context = snapshot_agent_context()
+        with bind_agent_context(tool_context):
+            first = json.loads(await _handle_read_github_source(repo="uwear-ai/uwear-backend"))
+        with bind_agent_context(tool_context):
+            second = json.loads(await _handle_read_github_source(repo="uwear-ai/uwear-backend"))
+
+    assert first["fallback_from_status_code"] == status_code
+    assert "fallback_from_status_code" not in second
+    assert attempts == ["bad-token", "good-token", "good-token"]
+
+
+@pytest.mark.asyncio
+async def test_read_github_source_prefers_repo_winner_for_follow_up_pull_checks():
+    attempts: list[tuple[str, str | None]] = []
+
+    async def fake_list_prs(*args, token=None, **kwargs):
+        attempts.append(("list", token))
+        if token == "explicit-token":
+            raise GitHubConnectorError(status_code=403, message="Forbidden")
+        return {"repo": "uwear-ai/uwear-backend", "pull_requests": [{"number": 42}]}
+
+    async def fake_get_pull(*args, token=None, **kwargs):
+        attempts.append(("detail", token))
+        return {
+            "repo": "uwear-ai/uwear-backend",
+            "pull_request": {"number": 42},
+            "checks": {"status": "success", "total_count": 1, "check_runs": []},
+        }
+
+    async def fake_get_secret(key_name, *args, **kwargs):
+        return {"EXPLICIT_TOKEN": "explicit-token"}.get(key_name)
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_secret",
+        new=AsyncMock(side_effect=fake_get_secret),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={"GITHUB_TOKEN": "winning-token"}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_repo_pull_requests",
+        new=AsyncMock(side_effect=fake_list_prs),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_pull_request",
+        new=AsyncMock(side_effect=fake_get_pull),
+    ):
+        listed = json.loads(
+            await _handle_read_github_source(
+                action="list_pull_requests",
+                repo="uwear-ai/uwear-backend",
+                token_secret_key="EXPLICIT_TOKEN",
+            )
+        )
+        detailed = json.loads(
+            await _handle_read_github_source(
+                action="get_pull_request",
+                repo="uwear-ai/uwear-backend",
+                pull_number=42,
+                token_secret_key="EXPLICIT_TOKEN",
+            )
+        )
+
+    assert listed["fallback_from_status_code"] == 403
+    assert detailed["checks"]["status"] == "success"
+    assert attempts == [
+        ("list", "explicit-token"),
+        ("list", "winning-token"),
+        ("detail", "winning-token"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pull_check_read_uses_primary_without_trying_bound_legacy_token():
+    attempts: list[str | None] = []
+
+    async def fake_get_secret(key_name, *args, **kwargs):
+        return {"GITHUB_TOKEN": "primary-token"}.get(key_name)
+
+    async def fake_get_pull(*args, token=None, **kwargs):
+        attempts.append(token)
+        if token == "legacy-token":
+            raise GitHubConnectorError(status_code=404, message="Not visible")
+        return {
+            "repo": "uwear-ai/uwear-backend",
+            "pull_request": {"number": 42, "mergeable": True},
+            "checks": {"status": "success", "total_count": 2, "check_runs": []},
+        }
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_secret",
+        new=AsyncMock(side_effect=fake_get_secret),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={"GITHUB_TOKEN__JB_LEGACY": "legacy-token"}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "key_name": "GITHUB_TOKEN",
+                    "category": "github",
+                    "agent_access_level": "available",
+                }
+            ]
+        ),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_pull_request",
+        new=AsyncMock(side_effect=fake_get_pull),
+    ):
+        result = json.loads(
+            await _handle_read_github_source(
+                action="get_pull_request",
+                repo="uwear-ai/uwear-backend",
+                pull_number=42,
+            )
+        )
+
+    assert result["checks"]["status"] == "success"
+    assert result["pull_request"]["mergeable"] is True
+    assert "fallback_from_status_code" not in result
+    assert attempts == ["primary-token"]
+
+
+@pytest.mark.asyncio
+async def test_read_github_source_still_falls_back_to_normal_secondary_token():
+    attempts: list[str | None] = []
+
+    async def fake_list_prs(*args, token=None, **kwargs):
+        attempts.append(token)
+        if token == "primary-token":
+            raise GitHubConnectorError(status_code=401, message="Expired")
+        return {"repo": "uwear-ai/uwear-backend", "pull_requests": []}
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(
+            return_value={
+                "GITHUB_TOKEN": "primary-token",
+                "GITHUB_TOKEN__AXEL": "secondary-token",
+            }
+        ),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_repo_pull_requests",
+        new=AsyncMock(side_effect=fake_list_prs),
+    ):
+        result = json.loads(
+            await _handle_read_github_source(
+                action="list_pull_requests",
+                repo="uwear-ai/uwear-backend",
+            )
+        )
+
+    assert result["token_source"] == "project_binding:GITHUB_TOKEN__AXEL"
+    assert attempts == ["primary-token", "secondary-token"]
+
+
+@pytest.mark.asyncio
+async def test_pull_request_reader_fetches_details_and_checks_with_same_token():
+    from brain.systems.cortex.project_context.github import async_get_pull_request
+
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(
+            side_effect=[
+                {
+                    "number": 42,
+                    "state": "open",
+                    "mergeable": True,
+                    "mergeable_state": "clean",
+                    "head": {"ref": "fix-ci", "sha": "abc123"},
+                    "base": {"ref": "staging", "sha": "def456"},
+                },
+                {
+                    "total_count": 2,
+                    "check_runs": [
+                        {"name": "unit", "status": "completed", "conclusion": "success"},
+                        {"name": "lint", "status": "completed", "conclusion": "failure"},
+                    ],
+                },
+            ]
+        ),
+    ) as request:
+        result = await async_get_pull_request(
+            "uwear-ai/uwear-backend",
+            42,
+            token="primary-token",
+        )
+
+    assert result["pull_request"]["mergeable"] is True
+    assert result["pull_request"]["mergeable_state"] == "clean"
+    assert result["checks"]["status"] == "failure"
+    assert result["checks"]["total_count"] == 2
+    assert [call.args[2] for call in request.await_args_list] == [
+        "/repos/uwear-ai/uwear-backend/pulls/42",
+        "/repos/uwear-ai/uwear-backend/commits/abc123/check-runs",
+    ]
+    assert [call.kwargs["token"] for call in request.await_args_list] == [
+        "primary-token",
+        "primary-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_github_search_reader_returns_exact_repo_counts():
+    from brain.systems.cortex.project_context.github import async_get_repo_counts
+
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(
+            side_effect=[
+                {"total_count": 17, "items": []},
+                {"total_count": 4, "items": []},
+            ]
+        ),
+    ) as request:
+        result = await async_get_repo_counts(
+            "uwear-ai/uwear-backend",
+            token="primary-token",
+            state="open",
+        )
+
+    assert result == {
+        "repo": "uwear-ai/uwear-backend",
+        "state": "open",
+        "counts": {"issues": 17, "pull_requests": 4},
+        "total_count": 21,
+    }
+    assert [call.kwargs["token"] for call in request.await_args_list] == [
+        "primary-token",
+        "primary-token",
+    ]
+    assert [call.kwargs["params"]["q"] for call in request.await_args_list] == [
+        "repo:uwear-ai/uwear-backend is:issue is:open",
+        "repo:uwear-ai/uwear-backend is:pr is:open",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_read_github_source_exact_counts_action_uses_authenticated_reader():
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={"GITHUB_TOKEN": "primary-token"}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_repo_counts",
+        new=AsyncMock(
+            return_value={
+                "repo": "uwear-ai/uwear-backend",
+                "state": "open",
+                "counts": {"issues": 17, "pull_requests": 4},
+                "total_count": 21,
+            }
+        ),
+    ) as get_counts:
+        result = json.loads(
+            await _handle_read_github_source(
+                action="get_counts",
+                repo="uwear-ai/uwear-backend",
+            )
+        )
+
+    assert result["counts"] == {"issues": 17, "pull_requests": 4}
+    assert result["total_count"] == 21
+    get_counts.assert_awaited_once_with(
+        "uwear-ai/uwear-backend",
+        token="primary-token",
+        state="open",
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_counts_retry_search_422_with_healthy_secondary_token():
+    attempts: list[str | None] = []
+
+    async def fake_get_counts(repo, *, token, state):
+        attempts.append(token)
+        if token == "primary-token":
+            raise GitHubConnectorError(status_code=422, message="Validation Failed")
+        return {
+            "repo": repo,
+            "state": state,
+            "counts": {"issues": 17, "pull_requests": 4},
+            "total_count": 21,
+        }
+
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(
+            return_value={
+                "GITHUB_TOKEN": "primary-token",
+                "GITHUB_TOKEN__AXEL": "secondary-token",
+            }
+        ),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_repo_counts",
+        new=AsyncMock(side_effect=fake_get_counts),
+    ):
+        result = json.loads(
+            await _handle_read_github_source(
+                action="get_counts",
+                repo="uwear-ai/uwear-backend",
+            )
+        )
+
+    assert result["counts"] == {"issues": 17, "pull_requests": 4}
+    assert result["fallback_from_status_code"] == 422
+    assert attempts == ["primary-token", "secondary-token"]


### PR DESCRIPTION
## What
The coordinator chronically defers CI status and backlog counts every run because GitHub reads degrade in two ways:
1. A **legacy Vault token** (`GITHUB_TOKEN__JB_LEGACY`) gets tried first and 404s, spamming logs and pushing the human to "re-check CI in GitHub".
2. Backlog counts fall back to an inexact path (`gh` missing / Search `422` "avoided exact counts").

## How
- **Token ordering:** exclude the known-legacy alias pattern (`*__*_LEGACY`) from the read candidate list; put the primary `GITHUB_TOKEN` first, then normal `GH_TOKEN` / non-legacy secondaries.
- **Per-run negative cache:** a `(token, repo)` pair that 401/404s once is recorded and skipped for the rest of the run; a preferred-token memory reuses the first identity that worked. State is **context-local** to the bound agent run (`get_or_create_agent_run_state`), never global mutable state that leaks across runs.
- **Exact counts, gh-free:** new authenticated `async_get_repo_counts` using the Search API `total_count` (no `gh` dependency). Search `422` is treated as a retryable per-candidate signal, not a hard inexact fallback.
- **PR detail + CI:** new single-identity `async_get_pull_request` reads the PR and its head commit's check-runs (with pagination) in one token, exposing a normalized `checks.status`.

Secondary **non-legacy** tokens still resolve; healthy `GITHUB_TOKEN`/`GH_TOKEN` ordering is unchanged.

## Review surface (no diff-reading required)
Run the tests:
```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-282-github-read-degradation
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_github_source_tool.py -q
```
Result: **14 passed**.

## Acceptance checks
- [x] Repo readable via primary `GITHUB_TOKEN` → CI status without a `__JB_LEGACY` 404 and without "re-check CI in GitHub" (legacy not tried first).
- [x] A `(token, repo)` that 404s once is not retried again in the same run (call-count asserted).
- [x] Exact open-issue/open-PR counts via authenticated Search `total_count` — no `gh`, no `422` fallback.
- [x] A repo needing a genuine secondary token still resolves; exclusion is scoped to the legacy alias + negative cache, not a blanket drop.

🤖 Draft opened by autonomous routine R3. Do not merge/ready without review.
