### PR TITLE
fix(cycles): contain provider error answers (#289)

### DIFF
--- a/brain/platform/integrations/provider_error_sentinel.py
+++ b/brain/platform/integrations/provider_error_sentinel.py
@@ -1,0 +1,67 @@
+"""Detection and safe serialization for provider errors returned as model text."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+PROVIDER_ERROR_SENTINEL_PREFIX = "upstream_provider_error:"
+
+_PROVIDER_ERROR_KINDS = (
+    "server_error",
+    "overloaded_error",
+    "rate_limit_error",
+)
+_PROVIDER_ERROR_KIND_VALUES = frozenset((*_PROVIDER_ERROR_KINDS, "provider_error"))
+
+
+def provider_error_kind(
+    candidate: Any,
+    *,
+    provider_exception: BaseException | str | None = None,
+) -> str | None:
+    """Classify known provider-error text without retaining its request details."""
+
+    text = str(candidate or "").strip()
+    normalized = text.lower()
+    if (
+        normalized.startswith("cycle run degraded: mission_contract_failed.")
+        and "help.openai.com" not in normalized
+    ):
+        return None
+    if normalized.startswith(PROVIDER_ERROR_SENTINEL_PREFIX):
+        sentinel_kind = normalized.removeprefix(PROVIDER_ERROR_SENTINEL_PREFIX).strip()
+        return sentinel_kind if sentinel_kind in _PROVIDER_ERROR_KIND_VALUES else "provider_error"
+    for kind in _PROVIDER_ERROR_KINDS:
+        if re.search(rf"\b{re.escape(kind)}\b", normalized):
+            return kind
+    if "help.openai.com" in normalized:
+        return "provider_error"
+    if text:
+        return None
+    if provider_exception is None:
+        return None
+
+    exception_text = str(provider_exception or "").strip().lower()
+    if not exception_text:
+        return None
+    for kind in _PROVIDER_ERROR_KINDS:
+        if re.search(rf"\b{re.escape(kind)}\b", exception_text):
+            return kind
+    return "provider_error"
+
+
+def safe_provider_error_sentinel(kind: str | None) -> str:
+    """Return a request-ID-free marker safe for internal persistence."""
+
+    normalized_kind = str(kind or "provider_error").strip().lower()
+    if normalized_kind not in _PROVIDER_ERROR_KIND_VALUES:
+        normalized_kind = "provider_error"
+    return f"{PROVIDER_ERROR_SENTINEL_PREFIX} {normalized_kind}"
+
+
+__all__ = [
+    "PROVIDER_ERROR_SENTINEL_PREFIX",
+    "provider_error_kind",
+    "safe_provider_error_sentinel",
+]

--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -10,6 +10,10 @@ from typing import Any
 
 from sqlalchemy import select
 
+from brain.platform.integrations.provider_error_sentinel import (
+    provider_error_kind,
+    safe_provider_error_sentinel,
+)
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.cycle import Cycle, CycleRun
 
@@ -162,18 +166,23 @@ def _satisfies_required_output(
 
 def evaluate_cycle_result_contract(
     *,
-    candidate_answer: str,
+    candidate_answer: str | None,
     result_contract: dict[str, Any],
     mission: str,
     evidence_packet: dict[str, Any] | None = None,
+    provider_exception: BaseException | str | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic verdict for a candidate scheduled-Cycle visible answer."""
 
     evidence_packet = _json_dict(evidence_packet)
     normalized_candidate = _normalize_text(candidate_answer)
+    detected_provider_error = provider_error_kind(
+        candidate_answer,
+        provider_exception=provider_exception,
+    )
     missing: list[str] = []
 
-    if not normalized_candidate:
+    if not normalized_candidate or detected_provider_error:
         missing.append("visible_final_answer")
     if _looks_like_introspection_boilerplate(candidate_answer):
         missing.append("candidate_is_runtime_introspection")
@@ -204,7 +213,12 @@ def evaluate_cycle_result_contract(
     return {
         "approved": not missing,
         "missing_outputs": missing,
-        "candidate_summary": _candidate_summary(candidate_answer),
+        "candidate_summary": (
+            safe_provider_error_sentinel(detected_provider_error)
+            if detected_provider_error
+            else _candidate_summary(candidate_answer)
+        ),
+        "provider_error": detected_provider_error,
     }
 
 
@@ -301,6 +315,14 @@ async def _append_final_answer_artifact_once(
     payload: dict[str, Any],
 ) -> AgentRunArtifactRow:
     text_value = str(text or "")
+    detected_provider_error = provider_error_kind(text_value)
+    if detected_provider_error:
+        logger.error(
+            "cycle_provider_error_final_answer_append_blocked run_id=%s raw_error=%s",
+            getattr(agent_run, "id", None),
+            text_value,
+        )
+        text_value = safe_provider_error_sentinel(detected_provider_error)
     existing = (
         await session.scalars(
             select(AgentRunArtifactRow)
@@ -342,6 +364,17 @@ def _event_result_preview(event: AgentRunEventRow, *, limit: int = 600) -> str:
     payload = _json_dict(getattr(event, "payload", None))
     value = payload.get("result") or payload.get("result_preview") or payload.get("error") or ""
     return _candidate_summary(value, limit=limit)
+
+
+def _captured_provider_error(evidence_packet: dict[str, Any]) -> str | None:
+    for event in reversed(_json_list(evidence_packet.get("recent_events"))):
+        event_data = _json_dict(event)
+        if event_data.get("event_type") != "run.failed":
+            continue
+        error = str(event_data.get("result_preview") or "").strip()
+        if provider_error_kind(error):
+            return error
+    return None
 
 
 async def _cycle_contract_evidence_packet(
@@ -512,7 +545,37 @@ async def _async_repair_cycle_contract_answer(
         return None
 
 
-def _degraded_visible_answer(missing_outputs: list[str]) -> str:
+def _completed_side_effect_names(evidence_packet: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for event in _json_list(evidence_packet.get("recent_events")):
+        event_data = _json_dict(event)
+        if event_data.get("event_type") != "run.tool_completed" or event_data.get("is_error"):
+            continue
+        name = str(event_data.get("tool_name") or "").strip()
+        if name:
+            names.append(name)
+    return _dedupe(names)
+
+
+def _degraded_visible_answer(
+    missing_outputs: list[str],
+    *,
+    provider_error: str | None = None,
+    evidence_packet: dict[str, Any] | None = None,
+) -> str:
+    if provider_error:
+        side_effect_names = _completed_side_effect_names(_json_dict(evidence_packet))
+        side_effect_sentence = (
+            "Side effects completed before the provider failure remain applied: "
+            f"{', '.join(side_effect_names[:8])}."
+            if side_effect_names
+            else "No completed side effects were recorded before the provider failure."
+        )
+        return (
+            "Cycle run degraded: mission_contract_failed. The upstream model provider failed "
+            f"with {provider_error} after a bounded retry, so no safe visible mission answer "
+            f"was produced. {side_effect_sentence}"
+        )
     missing = ", ".join(missing_outputs[:8]) if missing_outputs else "required Cycle outputs"
     return (
         "Cycle run degraded: mission_contract_failed. The run completed side effects, "
@@ -542,12 +605,16 @@ def _base_verdict(
         "visible_answer_source": "candidate" if initial_review.get("approved") else None,
         "side_effects_succeeded": bool(evidence_packet.get("side_effects_succeeded")),
         "domain_side_effects_succeeded": bool(evidence_packet.get("domain_side_effects_succeeded")),
+        "provider_error": initial_review.get("provider_error"),
     }
 
 
 async def async_prepare_cycle_run_visible_finalization(
     session: Any,
     agent_run_id: int,
+    *,
+    provider_exception: BaseException | str | None = None,
+    provider_errors_only: bool = False,
 ) -> dict[str, Any] | None:
     """Ensure a scheduled Cycle final answer satisfies its result contract before visibility."""
 
@@ -579,11 +646,39 @@ async def async_prepare_cycle_run_visible_finalization(
         cycle_run=cycle_run,
         cycle=cycle,
     )
+    captured_provider_exception = provider_exception or _captured_provider_error(evidence_packet)
+    detected_provider_error = provider_error_kind(
+        candidate_answer,
+        provider_exception=captured_provider_exception,
+    )
+    if provider_errors_only and not detected_provider_error:
+        return None
+    if detected_provider_error:
+        raw_provider_error = candidate_answer or str(captured_provider_exception or "")
+        logger.error(
+            "cycle_provider_error_final_answer_blocked run_id=%s artifact_id=%s raw_error=%s",
+            int(agent_run.id),
+            getattr(artifact, "id", None),
+            raw_provider_error,
+        )
+        candidate_answer = safe_provider_error_sentinel(detected_provider_error)
+        if artifact is not None:
+            artifact.text = candidate_answer
+            artifact.visibility = "internal"
+            artifact_payload = _json_dict(getattr(artifact, "payload", None))
+            artifact_payload.update(
+                {
+                    "provider_error": detected_provider_error,
+                    "blocked_from_visibility": True,
+                }
+            )
+            artifact.payload = artifact_payload
     initial_review = evaluate_cycle_result_contract(
         candidate_answer=candidate_answer,
         result_contract=result_contract,
         mission=mission,
         evidence_packet=evidence_packet,
+        provider_exception=captured_provider_exception,
     )
     verdict = _base_verdict(
         candidate_answer=candidate_answer,
@@ -616,6 +711,12 @@ async def async_prepare_cycle_run_visible_finalization(
             mission=mission,
             evidence_packet=evidence_packet,
         )
+        if repair_review.get("provider_error"):
+            logger.error(
+                "cycle_contract_repair_provider_error run_id=%s raw_error=%s",
+                int(agent_run.id),
+                repair_answer,
+            )
         if repair_review["approved"]:
             repaired_artifact = await _append_final_answer_artifact_once(
                 session,
@@ -643,7 +744,11 @@ async def async_prepare_cycle_run_visible_finalization(
         verdict["final_missing_outputs"] = list(repair_review["missing_outputs"])
 
     missing_outputs = list(verdict.get("final_missing_outputs") or verdict["missing_outputs"])
-    degraded_answer = _degraded_visible_answer(missing_outputs)
+    degraded_answer = _degraded_visible_answer(
+        missing_outputs,
+        provider_error=verdict.get("provider_error"),
+        evidence_packet=evidence_packet,
+    )
     degraded_artifact = await _append_final_answer_artifact_once(
         session,
         agent_run,
@@ -673,10 +778,15 @@ def cycle_finalization_status_from_verdict(
     verdict: dict[str, Any] | None,
     error: str | None = None,
 ) -> tuple[str, str | None]:
-    if requested_status != "completed":
-        return requested_status, error
-    if _json_dict(verdict).get("settlement_status") == "mission_contract_failed":
-        missing = _json_list(_json_dict(verdict).get("final_missing_outputs"))
+    verdict_data = _json_dict(verdict)
+    contract_failed = verdict_data.get("settlement_status") == "mission_contract_failed"
+    provider_error = str(verdict_data.get("provider_error") or "").strip()
+    if contract_failed and (requested_status == "completed" or provider_error):
+        missing = _json_list(verdict_data.get("final_missing_outputs"))
+        if provider_error:
+            return "degraded", f"mission_contract_failed: upstream provider {provider_error}"
         detail = ", ".join(str(item) for item in missing[:8]) or "required Cycle outputs"
         return "degraded", f"mission_contract_failed: missing {detail}"
+    if requested_status != "completed":
+        return requested_status, error
     return requested_status, error

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -505,8 +505,8 @@ async def async_finalize_cycle_run_from_run(
     if status not in {"completed", "failed"}:
         return
     async with UnitOfWork() as uow:
-        run = await uow.session.get(AgentRun, run_id)
-        metadata = run.metadata_ if run else None
+        agent_run = await uow.session.get(AgentRun, run_id)
+        metadata = agent_run.metadata_ if agent_run else None
         if not isinstance(metadata, dict) or metadata.get("source") != "cycle":
             return
         cycle_run_id = metadata.get("cycle_run_id")
@@ -519,6 +519,12 @@ async def async_finalize_cycle_run_from_run(
         verdict = persisted_cycle_contract_verdict(run)
         if status == "completed" and verdict is None:
             verdict = await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
+        elif status == "failed" and verdict is None:
+            verdict = await async_prepare_cycle_run_visible_finalization(
+                uow.session,
+                int(run_id),
+                provider_errors_only=True,
+            )
         final_status, final_error = cycle_finalization_status_from_verdict(
             status,
             verdict=verdict,

--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -267,7 +267,7 @@ class RunContextLoader:
         )
 
 
-def has_scheduled_result_contract(metadata: dict[str, Any]) -> bool:
+def _has_scheduled_result_contract(metadata: dict[str, Any]) -> bool:
     if not isinstance(metadata, dict):
         return False
     contract = metadata.get("contract")
@@ -291,6 +291,17 @@ def has_scheduled_result_contract(metadata: dict[str, Any]) -> bool:
         str(launch_envelope.get("origin") or "").strip().lower() == "scheduled_cycle",
         str(context_policy.get("current_instruction_role") or "").strip().lower() == "scheduled_prompt",
     ))
+
+
+def has_scheduled_result_contract(metadata: dict[str, Any]) -> bool:
+    """Recognize Cycle contracts at intake and inside recipe execution metadata."""
+
+    if _has_scheduled_result_contract(metadata):
+        return True
+    execution_provenance = metadata.get("execution_provenance") if isinstance(metadata, dict) else None
+    return isinstance(execution_provenance, dict) and _has_scheduled_result_contract(
+        execution_provenance
+    )
 
 
 __all__ = [

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -1198,12 +1198,16 @@ async def _run_queued_once_async(*, limit: int = 1) -> int:
                 async with _unit_of_work_factory()() as uow:
                     completed_run = await _engine_for_session(uow.session).run_existing(int(run_id))
                     completed_status = str(getattr(completed_run.status, "value", completed_run.status) or "")
-                    if completed_status == "completed":
+                    if completed_status in {"completed", "failed"}:
                         from brain.systems.cycles.contract_gate import (
                             async_prepare_cycle_run_visible_finalization,
                         )
 
-                        await async_prepare_cycle_run_visible_finalization(uow.session, int(run_id))
+                        await async_prepare_cycle_run_visible_finalization(
+                            uow.session,
+                            int(run_id),
+                            provider_errors_only=completed_status == "failed",
+                        )
                     status_payload = await _settle_terminal_root_run_async(uow.session, int(run_id))
                 await _finalize_cycle_run_if_needed_async(int(run_id), status=completed_status)
             if status_payload:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -42,6 +42,10 @@ from brain.platform.integrations.llm import (
 from brain.platform.async_io import run_blocking
 from brain.platform.integrations.providers import get_provider
 from brain.platform.integrations.providers import ContentBlockType, LLMRequest, MessageRole, StopReason
+from brain.platform.integrations.provider_error_sentinel import (
+    provider_error_kind,
+    safe_provider_error_sentinel,
+)
 from brain.platform.providers.model_policy import (
     async_get_default_model,
     infer_provider_from_model,
@@ -1227,6 +1231,7 @@ def _tool_is_available(tools: list[dict] | None, tool_name: str | None) -> bool:
 # ── API Call ──────────────────────────────────────────────────
 
 _API_RETRY_DELAYS = (2, 5, 10)
+_PROVIDER_ERROR_TEXT_RETRY_DELAYS = (1,)
 
 
 async def _api_call_with_retry_async(
@@ -1665,12 +1670,45 @@ async def run_agent_async(
 
             # API call with retry on transient 500s, plus one emergency context compaction retry.
             overflow_retry_used = False
+            provider_error_text_attempt = 0
+            detected_provider_error = None
             while True:
                 try:
+                    # Scheduled Cycles settle through the contract gate; withholding live text
+                    # deltas keeps an upstream error body from becoming a public interim answer.
+                    visible_stream_delta = None if scheduled_result_contract else on_stream_delta
                     response = await _api_call_with_retry_async(
-                        state.provider, request, llm, cancel_event, on_stream_activity, on_stream_delta,
+                        state.provider, request, llm, cancel_event, on_stream_activity, visible_stream_delta,
                         session_id, turn, state.tokens, start_time, state.tool_calls_made, _call_start,
                     )
+                    response_text = _extract_text(
+                        [{"role": "assistant", "content": _content_to_dicts(response.content)}]
+                    ).strip()
+                    detected_provider_error = (
+                        provider_error_kind(response_text) if scheduled_result_contract else None
+                    )
+                    if detected_provider_error:
+                        logger.error(
+                            "Agent %s turn %d: Cycle provider error text blocked "
+                            "(kind=%s, attempt=%d/%d): %s",
+                            session_id,
+                            turn,
+                            detected_provider_error,
+                            provider_error_text_attempt + 1,
+                            len(_PROVIDER_ERROR_TEXT_RETRY_DELAYS) + 1,
+                            response_text,
+                        )
+                        if provider_error_text_attempt < len(_PROVIDER_ERROR_TEXT_RETRY_DELAYS):
+                            delay = _PROVIDER_ERROR_TEXT_RETRY_DELAYS[provider_error_text_attempt]
+                            provider_error_text_attempt += 1
+                            if on_stream_activity:
+                                await _call_optional_async(
+                                    on_stream_activity,
+                                    f"Upstream model provider failed; retrying in {delay}s…",
+                                )
+                            await asyncio.sleep(max(0.0, float(delay)))
+                            _call_start = time.time()
+                            continue
                     break
                 except Exception as exc:
                     fallback = fallback_model_for(model)
@@ -1821,11 +1859,22 @@ async def run_agent_async(
                 cache_write=getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
                 context_messages=len(state.messages),
                 system_prompt_chars=len(json.dumps(system)) if system else 0,
-                status="tool_use" if response.stop_reason == StopReason.TOOL_USE else "success",
+                status=(
+                    "provider_error_text"
+                    if detected_provider_error
+                    else "tool_use" if response.stop_reason == StopReason.TOOL_USE else "success"
+                ),
                 stop_reason=str(response.stop_reason), latency_ms=_call_ms,
             )
 
             content_dicts = _content_to_dicts(response.content)
+            if detected_provider_error:
+                content_dicts = [
+                    {
+                        "type": "text",
+                        "text": safe_provider_error_sentinel(detected_provider_error),
+                    }
+                ]
             if (
                 response.stop_reason == StopReason.END_TURN
                 and getattr(response.usage, "output_tokens", 0) > 0

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -289,10 +289,20 @@ class AsyncAgentRunEngine:
             return await self.store.set_status(run.id, result_status)
         if result_status == RunStatus.FAILED:
             if result.output:
-                await self.store.append_final_answer_once(run.id, result.output, root_run_id=run.root_run_id)
+                artifact = await self.store.append_final_answer_once(
+                    run.id,
+                    result.output,
+                    root_run_id=run.root_run_id,
+                )
+                safe_output = str(getattr(artifact, "text", None) or result.output)
                 if not await self.store.has_event_type(run.id, "run.text_delta"):
                     await self.store.append_event(
-                        run_event(run.id, "run.text_completed", {"text": result.output}, root_run_id=run.root_run_id)
+                        run_event(
+                            run.id,
+                            "run.text_completed",
+                            {"text": safe_output},
+                            root_run_id=run.root_run_id,
+                        )
                     )
             return await self.fail(run.id, result.output or "recipe_failed")
         if result_status == RunStatus.CANCELED:
@@ -313,10 +323,20 @@ class AsyncAgentRunEngine:
         if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
             return to_domain(row)
         if output:
-            await self.store.append_final_answer_once(run_id, output, root_run_id=row.root_run_id)
+            artifact = await self.store.append_final_answer_once(
+                run_id,
+                output,
+                root_run_id=row.root_run_id,
+            )
+            safe_output = str(getattr(artifact, "text", None) or output)
             if not await self.store.has_event_type(run_id, "run.text_delta"):
                 await self.store.append_event(
-                    run_event(run_id, "run.text_completed", {"text": output}, root_run_id=row.root_run_id)
+                    run_event(
+                        run_id,
+                        "run.text_completed",
+                        {"text": safe_output},
+                        root_run_id=row.root_run_id,
+                    )
                 )
         await self.store.append_event(
             run_event(run_id, "run.completed", {"status": status.value}, root_run_id=row.root_run_id)
@@ -327,8 +347,11 @@ class AsyncAgentRunEngine:
         row = await self.store.require_run(run_id)
         if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
             return to_domain(row)
-        await self.store.append_event(run_event(run_id, "run.failed", {"error": error}, root_run_id=row.root_run_id))
-        return await self.store.set_status(run_id, RunStatus.FAILED, reason=error)
+        safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
+        await self.store.append_event(
+            run_event(run_id, "run.failed", {"error": safe_error}, root_run_id=row.root_run_id)
+        )
+        return await self.store.set_status(run_id, RunStatus.FAILED, reason=safe_error)
 
     async def cancel(self, run_id: int, *, reason: str | None = None) -> AgentRun:
         row = await self.store.require_run(run_id)

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 import threading
 from typing import Any
 
@@ -10,6 +11,11 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.integrations.provider_error_sentinel import (
+    PROVIDER_ERROR_SENTINEL_PREFIX,
+    provider_error_kind,
+    safe_provider_error_sentinel,
+)
 from brain.systems.runs.domain import (
     AgentRun,
     AgentRunArtifact,
@@ -29,6 +35,8 @@ from brain.platform.db.models.agent_run import (
     AgentRunEventRow,
     AgentRunRow,
 )
+
+logger = logging.getLogger(__name__)
 
 _STEERING_SUBMITTED_EVENT = "run.steering_submitted"
 _STEERING_CURSOR_METADATA_KEY = "steering_cursor_sequence_no"
@@ -600,19 +608,42 @@ class AsyncAgentRunStore:
                 await self.session.commit()
             return row
 
+    async def safe_cycle_provider_error_text(self, run_id: int, text_value: str) -> str:
+        if text_value.startswith(PROVIDER_ERROR_SENTINEL_PREFIX):
+            return text_value
+        detected_provider_error = provider_error_kind(text_value)
+        if not detected_provider_error:
+            return text_value
+        run = await self.session.get(AgentRunRow, int(run_id))
+        metadata = dict(getattr(run, "metadata_", None) or {}) if run is not None else {}
+        if metadata.get("source") != "cycle" and not metadata.get("cycle_run_id"):
+            return text_value
+        logger.error(
+            "cycle_provider_error_text_blocked run_id=%s raw_error=%s",
+            run_id,
+            text_value,
+        )
+        return safe_provider_error_sentinel(detected_provider_error)
+
     async def append_artifact(self, artifact: AgentRunArtifact) -> AgentRunArtifactRow:
         artifact_type = (
             artifact.artifact_type.value
             if isinstance(artifact.artifact_type, ArtifactType)
             else str(artifact.artifact_type)
         )
+        artifact_text = artifact.text
+        if artifact_type == ArtifactType.FINAL_ANSWER.value and artifact_text is not None:
+            artifact_text = await self.safe_cycle_provider_error_text(
+                int(artifact.run_id),
+                str(artifact_text),
+            )
         row = AgentRunArtifactRow(
             run_id=artifact.run_id,
             root_run_id=artifact.root_run_id or artifact.run_id,
             artifact_type=artifact_type,
             title=artifact.title,
             payload=dict(artifact.payload or {}),
-            text=artifact.text,
+            text=artifact_text,
             uri=artifact.uri,
             visibility=(
                 artifact.visibility.value
@@ -642,6 +673,7 @@ class AsyncAgentRunStore:
         text_value = str(text_value or "")
         if not text_value:
             return None
+        text_value = await self.safe_cycle_provider_error_text(int(run_id), text_value)
         existing = (
             await self.session.scalars(
                 select(AgentRunArtifactRow)

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -152,6 +152,83 @@ async def test_claim_and_completion_are_idempotent(session_factory):
     assert events.count("run.completed") == 1
 
 
+async def test_cycle_final_answer_store_never_persists_raw_provider_error(session_factory):
+    from brain.systems.runs.artifacts import final_answer_artifact
+
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(
+        _run_request(
+            thread_id="thread-1",
+            message="scheduled mission",
+            metadata={
+                "source": "cycle",
+                "cycle_run_id": 12,
+                "contract": {"result": {"kind": "autonomous_cycle_run_result"}},
+            },
+        )
+    )
+    raw_provider_error = (
+        "An error occurred while processing your request. Contact help.openai.com with request ID "
+        "req-store-guard. | server_error | server_error"
+    )
+
+    artifact = await store.append_final_answer_once(run.id, raw_provider_error)
+    direct_artifact = await store.append_artifact(final_answer_artifact(run.id, raw_provider_error))
+
+    assert artifact is not None
+    assert artifact.text == "upstream_provider_error: server_error"
+    assert "help.openai.com" not in artifact.text
+    assert direct_artifact.text == "upstream_provider_error: server_error"
+    assert "help.openai.com" not in direct_artifact.text
+
+
+async def test_failed_cycle_engine_events_do_not_surface_raw_provider_error(session_factory):
+    raw_provider_error = (
+        "An error occurred while processing your request. Contact help.openai.com with request ID "
+        "req-engine-guard. | server_error | server_error"
+    )
+
+    class ProviderFailureRecipe:
+        async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+            return RunRecipeResult(output=raw_provider_error, status=RunStatus.FAILED)
+
+    session = session_factory()
+    result = await AsyncAgentRunEngine(
+        session,
+        recipes={"fast": ProviderFailureRecipe()},
+    ).run(
+        _run_request(
+            thread_id="thread-1",
+            message="scheduled mission",
+            metadata={
+                "source": "cycle",
+                "cycle_run_id": 12,
+                "contract": {"result": {"kind": "autonomous_cycle_run_result"}},
+            },
+        )
+    )
+
+    artifacts = list(
+        (
+            await session.scalars(
+                select(AgentRunArtifactRow).where(AgentRunArtifactRow.run_id == result.id)
+            )
+        ).all()
+    )
+    events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow).where(AgentRunEventRow.run_id == result.id)
+            )
+        ).all()
+    )
+
+    assert result.status == RunStatus.FAILED
+    assert artifacts[-1].text == "upstream_provider_error: server_error"
+    assert all("help.openai.com" not in str(event.payload) for event in events)
+
+
 async def test_post_completion_tasks_run_after_terminal_completion(session_factory):
     session = session_factory()
     started = asyncio.Event()

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -19,6 +19,13 @@ from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea
 
 
+RAW_PROVIDER_ERROR = (
+    "An error occurred while processing your request. You can retry your request, or contact us "
+    "through our help center at help.openai.com if the error persists. Please include the request "
+    "ID `a7dd7556-test` in your message. | server_error | server_error"
+)
+
+
 class _FakeSession:
     def __init__(self, agent_run=None, run=None, cycle=None, artifacts=None, events=None):
         self._agent_run = agent_run
@@ -1279,6 +1286,38 @@ def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
     assert verdict["candidate_artifact_id"] == 8
 
 
+def test_cycle_contract_rejects_raw_provider_error_as_visible_answer():
+    from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
+
+    review = evaluate_cycle_result_contract(
+        candidate_answer=RAW_PROVIDER_ERROR,
+        result_contract={"kind": "autonomous_cycle_run_result", "required_outputs": []},
+        mission="",
+        evidence_packet={},
+    )
+
+    assert review["approved"] is False
+    assert review["missing_outputs"] == ["visible_final_answer"]
+    assert review["provider_error"] == "server_error"
+    assert "help.openai.com" not in review["candidate_summary"]
+
+
+def test_cycle_contract_rejects_empty_answer_with_captured_provider_exception():
+    from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
+
+    review = evaluate_cycle_result_contract(
+        candidate_answer=None,
+        result_contract={"kind": "autonomous_cycle_run_result", "required_outputs": []},
+        mission="",
+        evidence_packet={},
+        provider_exception=RuntimeError("upstream request failed | overloaded_error"),
+    )
+
+    assert review["approved"] is False
+    assert review["missing_outputs"] == ["visible_final_answer"]
+    assert review["provider_error"] == "overloaded_error"
+
+
 @pytest.mark.asyncio
 async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
     from brain.systems.cycles import contract_gate
@@ -1481,6 +1520,85 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
     assert verdict["repair_attempted"] is True
     assert verdict["side_effects_succeeded"] is True
     assert "24h readout" in verdict["missing_outputs"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_contract_provider_error_degrades_without_leaking_and_preserves_side_effects(
+    monkeypatch,
+):
+    from brain.systems.cycles import contract_gate
+
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = "Record the daily tracker update."
+    agent_run.model_policy = {}
+    agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = 5
+    cycle_run.status = "running"
+    cycle_run.prompt_snapshot = "Record the daily tracker update."
+    cycle_run.context_snapshot = {
+        "result_contract": {
+            "kind": "autonomous_cycle_run_result",
+            "required_outputs": [],
+        }
+    }
+
+    cycle = Cycle()
+    cycle.id = 5
+    cycle.prompt = cycle_run.prompt_snapshot
+
+    provider_error_artifact = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text=RAW_PROVIDER_ERROR,
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    tracker_event = AgentRunEventRow(
+        id=4,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=4,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "create_domain_record",
+            "result": {"status": "ok", "record_id": 26},
+        },
+    )
+    session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[provider_error_artifact],
+        events=[tracker_event],
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return RAW_PROVIDER_ERROR
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+
+    verdict = await contract_gate.async_prepare_cycle_run_visible_finalization(session, 44)
+
+    assert len(repair_calls) == 1
+    assert verdict["settlement_status"] == "mission_contract_failed"
+    assert verdict["provider_error"] == "server_error"
+    assert verdict["side_effects_succeeded"] is True
+    assert verdict["domain_side_effects_succeeded"] is True
+    degraded_answer = session._artifacts[-1].text
+    assert "upstream model provider failed with server_error" in degraded_answer
+    assert "create_domain_record" in degraded_answer
+    assert "remain applied" in degraded_answer
+    assert all("help.openai.com" not in str(artifact.text or "") for artifact in session._artifacts)
 
 
 def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch):

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -31,6 +31,75 @@ def _response(text: str):
     return SimpleNamespace(stop_reason="end_turn", content=[block], usage=usage)
 
 
+async def test_scheduled_cycle_retries_provider_error_text_before_returning_safe_sentinel(
+    monkeypatch,
+):
+    from brain.systems.runs import direct_agent
+
+    raw_provider_error = (
+        "An error occurred while processing your request. Contact help.openai.com with request ID "
+        "req-primary-cycle. | server_error | server_error"
+    )
+    provider_calls = []
+    streamed_deltas = []
+
+    class FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def __iter__(self):
+            yield SimpleNamespace(type="text", text=raw_provider_error)
+
+        def get_final_message(self):
+            return _response(raw_provider_error)
+
+    class FakeProvider:
+        def stream(self, request):
+            provider_calls.append(request)
+            return FakeStream()
+
+        def create(self, _request):
+            raise AssertionError("Cycle primary calls with activity hooks should use streaming")
+
+        def is_api_error(self, _exc):
+            return False
+
+        def is_retryable_error(self, _exc):
+            return False
+
+    monkeypatch.setattr(direct_agent, "get_provider", lambda *_args, **_kwargs: FakeProvider())
+    monkeypatch.setattr(direct_agent, "_PROVIDER_ERROR_TEXT_RETRY_DELAYS", (0,))
+
+    result = await direct_agent.run_agent_async(
+        message="Run the scheduled Cycle mission",
+        model="claude-sonnet-4-6",
+        tools=[],
+        persist_session=False,
+        session_id="cycle-provider-error-retry",
+        resolved_llm=_FakeLLM(),
+        on_stream_activity=lambda _label: None,
+        on_stream_delta=streamed_deltas.append,
+        metadata={
+            "execution_provenance": {
+                "source": "cycle",
+                "contract": {
+                    "kind": "autonomous_cycle_run",
+                    "result": {"kind": "autonomous_cycle_run_result"},
+                },
+            }
+        },
+    )
+
+    assert len(provider_calls) == 2
+    assert result.success is True
+    assert result.output == "upstream_provider_error: server_error"
+    assert "help.openai.com" not in result.output
+    assert streamed_deltas == []
+
+
 async def test_run_agent_async_basic_completion_uses_async_session_hooks(monkeypatch):
     from brain.systems.runs import direct_agent
 


### PR DESCRIPTION
Closes #289

## What
Raw upstream provider errors (e.g. `server_error`, `overloaded_error`, `rate_limit_error`, or an `help.openai.com` blurb) were leaking through as a scheduled Cycle's **visible final answer**, bypassing the mission-contract degrade and with no retry.

This adds a provider-error **sentinel**: a small classifier (`brain/platform/integrations/provider_error_sentinel.py`) that recognizes those responses, plus contract-gate wiring that blocks them from streaming and from final-answer artifacts, retries the primary Cycle model call once, and then degrades to a structured `mission_contract_failed` answer that **preserves and names the completed side effects**. The raw provider string is never surfaced or persisted as a visible answer.

## Review surface
- Run tests: `cd <worktree> && venv/bin/python -m pytest tests/test_agent_run_state_machine.py tests/test_cycles_service.py tests/test_direct_agent_async_contract.py -q` → **63 passed** locally.

## Acceptance checks
- Provider `server_error` as the model's text → classified as invalid visible answer; contract gate rejects, no `mission_success`.
- Bounded single retry on the primary Cycle model call; still failing → structured degrade.
- Degrade answer names the provider failure kind and lists side effects completed before it — never the raw `help.openai.com` / `server_error` string.
- Soft-contract behavior for non-provider-error answers is unchanged.

Draft — Reda reviews and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
