### PR TITLE
fix(tracker): upsert PR records idempotently (#290)

### DIFF
--- a/brain/systems/user_domains/service.py
+++ b/brain/systems/user_domains/service.py
@@ -506,8 +506,34 @@ class AsyncDomainService:
         reason: str | None = None,
     ) -> DomainRecord:
         domain = await self.get_domain(org_id, domain_id)
-        obj = await self.get_object_type(domain.id, object_key)
+        # Serialize create/upsert decisions for this object type. Without this
+        # lock, two concurrent observations can both pass the application-level
+        # uniqueness check before either inserts its PR record.
+        obj = await self.get_object_type(domain.id, object_key, for_update=True)
         fields = await self.list_fields(obj.id)
+        natural_key = _tracker_pr_natural_key(fields, data)
+        if natural_key is not None:
+            existing = await self._find_active_tracker_pr_records(
+                org_id,
+                domain.id,
+                obj.id,
+                fields,
+                natural_key,
+            )
+            if existing:
+                return await self._merge_tracker_pr_records(
+                    org_id,
+                    domain.id,
+                    existing,
+                    data=data,
+                    title=title,
+                    actor_id=actor_id,
+                    actor_kind=actor_kind,
+                    run_id=run_id,
+                    idea_id=idea_id,
+                    reason=reason,
+                )
+
         normalized = self.validate_record_data(fields, data)
         record = DomainRecord(
             org_id=org_id,
@@ -538,6 +564,85 @@ class AsyncDomainService:
         )
         await self.session.refresh(record)
         return record
+
+    async def _find_active_tracker_pr_records(
+        self,
+        org_id: str,
+        domain_id: int,
+        object_type_id: int,
+        fields: Sequence[DomainFieldDefinition],
+        natural_key: tuple[str, str],
+    ) -> list[DomainRecord]:
+        stmt = (
+            select(DomainRecord)
+            .where(
+                DomainRecord.org_id == org_id,
+                DomainRecord.domain_id == domain_id,
+                DomainRecord.object_type_id == object_type_id,
+                DomainRecord.archived_at.is_(None),
+            )
+            .order_by(DomainRecord.id)
+        )
+        records = (await self.session.scalars(stmt)).all()
+        return [
+            record
+            for record in records
+            if _tracker_pr_natural_key(fields, record.data or {}) == natural_key
+        ]
+
+    async def _merge_tracker_pr_records(
+        self,
+        org_id: str,
+        domain_id: int,
+        records: Sequence[DomainRecord],
+        *,
+        data: dict[str, Any],
+        title: str | None,
+        actor_id: str | None,
+        actor_kind: str,
+        run_id: int | None,
+        idea_id: str | None,
+        reason: str | None,
+    ) -> DomainRecord:
+        # Domain record ids are monotonically assigned, so the lowest id is the
+        # deterministic proxy for the earliest-created canonical row.
+        canonical, *duplicates = sorted(records, key=lambda record: record.id)
+        merged_data = dict(canonical.data or {})
+        for duplicate in duplicates:
+            for key, value in (duplicate.data or {}).items():
+                if _is_empty(merged_data.get(key)) and not _is_empty(value):
+                    merged_data[key] = value
+        # The current observation is authoritative for every field it supplies.
+        merged_data.update(data)
+
+        canonical = await self.update_record(
+            org_id,
+            domain_id,
+            canonical.id,
+            data_patch=merged_data,
+            title=title,
+            actor_id=actor_id,
+            actor_kind=actor_kind,
+            run_id=run_id,
+            idea_id=idea_id,
+            reason=reason,
+        )
+        for duplicate in duplicates:
+            merge_reason = f"Merged duplicate PR record into record {canonical.id}"
+            if reason:
+                merge_reason = f"{reason} | {merge_reason}"
+            await self.remove_record(
+                org_id,
+                domain_id,
+                duplicate.id,
+                mode="archive",
+                actor_id=actor_id,
+                actor_kind=actor_kind,
+                run_id=run_id,
+                idea_id=idea_id,
+                reason=merge_reason,
+            )
+        return canonical
 
     async def update_record(
         self,
@@ -799,13 +904,21 @@ class AsyncDomainService:
         stmt = stmt.order_by(DomainEvent.created_at.desc(), DomainEvent.id.desc()).limit(max(1, min(limit, 200)))
         return (await self.session.scalars(stmt)).all()
 
-    async def get_object_type(self, domain_id: int, object_key: str) -> DomainObjectType:
+    async def get_object_type(
+        self,
+        domain_id: int,
+        object_key: str,
+        *,
+        for_update: bool = False,
+    ) -> DomainObjectType:
         key = _normalize_key(object_key, "object key")
         stmt = select(DomainObjectType).where(
             DomainObjectType.domain_id == domain_id,
             DomainObjectType.key == key,
             DomainObjectType.archived_at.is_(None),
         )
+        if for_update:
+            stmt = stmt.with_for_update()
         obj = (await self.session.scalars(stmt)).first()
         if obj is None:
             raise DomainNotFound(f"Object type '{key}' not found")
@@ -1111,6 +1224,67 @@ def _title_from_key(key: str) -> str:
 
 def _is_empty(value: Any) -> bool:
     return value is None or value == ""
+
+
+def _tracker_pr_natural_key(
+    fields: Iterable[DomainFieldDefinition],
+    data: Mapping[str, Any],
+) -> tuple[str, str] | None:
+    field_keys = {field.key for field in fields}
+    if not {"repo", "pr_number"}.issubset(field_keys):
+        return None
+
+    repo = _normalize_repo_identity(data.get("repo"))
+    pr_number = _normalize_pr_number(data.get("pr_number"))
+    if repo and pr_number:
+        return repo, pr_number
+
+    if "pr_url" in field_keys:
+        return _github_pr_key_from_url(data.get("pr_url"))
+    return None
+
+
+def _normalize_repo_identity(value: Any) -> str | None:
+    repo = str(value or "").strip().rstrip("/")
+    if not repo:
+        return None
+    repo = re.sub(r"^git@github\.com:", "", repo, flags=re.IGNORECASE)
+    repo = re.sub(r"^(?:https?://)?github\.com/", "", repo, flags=re.IGNORECASE)
+    repo = repo.rstrip("/")
+    if repo.lower().endswith(".git"):
+        repo = repo[:-4]
+    return repo.casefold() or None
+
+
+def _normalize_pr_number(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    pr_number = str(value).strip().removeprefix("#").strip()
+    if not pr_number:
+        return None
+    if pr_number.isdigit():
+        return str(int(pr_number))
+    return pr_number.casefold()
+
+
+def _github_pr_key_from_url(value: Any) -> tuple[str, str] | None:
+    pr_url = str(value or "").strip()
+    match = re.match(
+        r"^https?://github\.com/([^/]+)/([^/]+)/pull/([^/?#]+)",
+        pr_url,
+        flags=re.IGNORECASE,
+    )
+    if match is None:
+        return None
+    repo = _normalize_repo_identity(f"{match.group(1)}/{match.group(2)}")
+    pr_number = _normalize_pr_number(match.group(3))
+    if not repo or not pr_number:
+        return None
+    return repo, pr_number
 
 
 def _coerce_field_value(field: DomainFieldDefinition, value: Any) -> Any:

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -165,6 +165,264 @@ async def test_list_records_filters_by_data_fields_and_record_metadata(session):
     assert [record.id for record in records] == [reda.id]
 
 
+async def _create_pr_tracker(service: AsyncDomainService) -> Domain:
+    return await service.create_domain(
+        ORG_ID,
+        name="GitHub Pull Request Tracker",
+        objects=[
+            {
+                "key": "pull_request",
+                "name": "Pull Request",
+                "title_field": "title",
+                "fields": [
+                    {"key": "title", "field_type": "text", "required": True},
+                    {"key": "repo", "field_type": "text", "required": True},
+                    {"key": "pr_number", "field_type": "number", "required": True},
+                    {"key": "pr_url", "field_type": "url"},
+                    {
+                        "key": "status",
+                        "field_type": "enum",
+                        "options": ["open", "in_review", "merged"],
+                    },
+                    {"key": "sync_source", "field_type": "text"},
+                    {"key": "reviewer", "field_type": "text"},
+                ],
+            }
+        ],
+    )
+
+
+async def _insert_legacy_pr_record(
+    session,
+    service: AsyncDomainService,
+    domain: Domain,
+    *,
+    title: str,
+    repo: str,
+    pr_number: int,
+    **data,
+) -> DomainRecord:
+    obj = await service.get_object_type(domain.id, "pull_request")
+    fields = await service.list_fields(obj.id)
+    normalized = service.validate_record_data(
+        fields,
+        {"title": title, "repo": repo, "pr_number": pr_number, **data},
+    )
+    record = DomainRecord(
+        org_id=ORG_ID,
+        domain_id=domain.id,
+        object_type_id=obj.id,
+        title=title,
+        data=normalized,
+        search_text=title.lower(),
+    )
+    session.add(record)
+    await session.flush()
+    await session.refresh(record)
+    return record
+
+
+async def test_pr_tracker_create_record_upserts_repo_and_pr_number(session):
+    service = AsyncDomainService(session)
+    domain = await _create_pr_tracker(service)
+
+    created = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "Illospace/illospace",
+            "pr_number": 84,
+            "status": "open",
+            "sync_source": "mission-control",
+        },
+    )
+    observed_again = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "Illospace/illospace",
+            "pr_number": 84,
+            "status": "in_review",
+            "sync_source": "mission-control",
+        },
+    )
+
+    records = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="pull_request",
+    )
+    assert [record.id for record in records] == [created.id]
+    assert observed_again.id == created.id
+    assert observed_again.version == 2
+    assert observed_again.data["status"] == "in_review"
+
+
+async def test_pr_tracker_upsert_normalizes_two_evidence_sources(session):
+    service = AsyncDomainService(session)
+    domain = await _create_pr_tracker(service)
+
+    from_sync = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "https://github.com/Illospace/illospace.git",
+            "pr_number": "84",
+            "pr_url": "https://github.com/Illospace/illospace/pull/84",
+            "status": "open",
+            "sync_source": "mission-control",
+        },
+    )
+    from_live_github = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "illospace/illospace",
+            "pr_number": 84,
+            "pr_url": "https://github.com/illospace/illospace/pull/84",
+            "status": "in_review",
+            "sync_source": "live-github",
+        },
+    )
+
+    records = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="pull_request",
+    )
+    assert len(records) == 1
+    assert from_live_github.id == from_sync.id
+    assert records[0].data["sync_source"] == "live-github"
+
+
+async def test_pr_tracker_write_merges_legacy_duplicates_into_lowest_id(session):
+    service = AsyncDomainService(session)
+    domain = await _create_pr_tracker(service)
+    canonical = await _insert_legacy_pr_record(
+        session,
+        service,
+        domain,
+        title="Fix coordinator writes",
+        repo="Illospace/illospace",
+        pr_number=84,
+        status="open",
+        sync_source="mission-control",
+    )
+    duplicate = await _insert_legacy_pr_record(
+        session,
+        service,
+        domain,
+        title="PR #84",
+        repo="illospace/illospace",
+        pr_number=84,
+        status="in_review",
+        sync_source="live-github",
+        reviewer="Reda",
+    )
+
+    merged = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "Illospace/illospace",
+            "pr_number": 84,
+            "status": "merged",
+            "sync_source": "github-event",
+        },
+    )
+
+    active = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="pull_request",
+    )
+    assert [record.id for record in active] == [canonical.id]
+    assert merged.id == canonical.id < duplicate.id
+    assert merged.data["status"] == "merged"
+    assert merged.data["reviewer"] == "Reda"
+    assert (await session.get(DomainRecord, duplicate.id)).archived_at is not None
+
+
+async def test_legacy_pr_duplicates_can_still_be_archived_explicitly(session):
+    service = AsyncDomainService(session)
+    domain = await _create_pr_tracker(service)
+    canonical = await _insert_legacy_pr_record(
+        session,
+        service,
+        domain,
+        title="Fix coordinator writes",
+        repo="Illospace/illospace",
+        pr_number=84,
+    )
+    duplicate = await _insert_legacy_pr_record(
+        session,
+        service,
+        domain,
+        title="PR #84",
+        repo="Illospace/illospace",
+        pr_number=84,
+    )
+
+    repair = await service.remove_record(
+        ORG_ID,
+        domain.id,
+        duplicate.id,
+        mode="archive",
+        reason="Legacy duplicate repair",
+    )
+
+    active = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="pull_request",
+    )
+    assert repair["archived"] is True
+    assert [record.id for record in active] == [canonical.id]
+
+
+async def test_pr_tracker_distinct_pr_numbers_create_distinct_records(session):
+    service = AsyncDomainService(session)
+    domain = await _create_pr_tracker(service)
+
+    first = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Fix coordinator writes",
+            "repo": "Illospace/illospace",
+            "pr_number": 84,
+        },
+    )
+    second = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "pull_request",
+        data={
+            "title": "Keep archive repair",
+            "repo": "Illospace/illospace",
+            "pr_number": 85,
+        },
+    )
+
+    records = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="pull_request",
+    )
+    assert {record.id for record in records} == {first.id, second.id}
+
+
 async def test_domain_events_drop_non_uuid_idea_ids(session):
     service = AsyncDomainService(session)
     domain = await service.create_domain(


### PR DESCRIPTION
Closes #290

## What
The coordinator was creating **duplicate tracker PR rows** for the same GitHub PR across runs — PR-record creation was not idempotent.

This makes `create_record` upsert on the normalized `(repo, pr_number)` natural key for tracker PR object types:
- an object-type **row lock** (`get_object_type(..., for_update=True)`) serializes concurrent create decisions so two observations can't both pass the uniqueness check;
- the **lowest-id** matching row is treated as canonical;
- missing fields are merged from duplicates, the current observation is authoritative for the fields it supplies;
- extra duplicate rows are archived (with a merge reason).

Scoped narrowly: `_tracker_pr_natural_key` returns `None` unless the object type has both `repo` and `pr_number` fields, so all other domain object creation is unchanged. Legacy archive/repair paths keep working.

## Review surface
- Run tests: `cd <worktree> && venv/bin/python -m pytest tests/test_domains_service.py -q` → **12 passed** locally.

## Acceptance checks
- Two runs observing the same PR → a single active tracker row, not duplicates.
- Concurrent create for the same `(repo, pr_number)` → serialized by the row lock; one canonical row.
- Pre-existing duplicates → merged into the lowest-id canonical row, extras archived.
- Non-tracker domain object creation → unchanged.

Draft — Reda reviews and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
