### PR TITLE
[Illo] Lifecycle Slice 5: deploy-state ladder, promotion sweep, post-deploy verification

### DIFF
--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -18,6 +18,29 @@ from __future__ import annotations
 from brain.systems.change_notifications import DEFAULT_URGENT_TERMS, render_outbound
 
 
+async def _maybe_run_deploy_verification(session, org_id) -> dict | None:
+    """Run the additive close-only verifier when deploy-state is armed."""
+    import logging
+    from datetime import datetime, timezone
+
+    from brain.systems.deploy_state_config import deploy_feature_enabled
+
+    if session is None or not deploy_feature_enabled():
+        return None
+    try:
+        from brain.systems.deploy_state_sweep import run_deploy_verification
+
+        async with session.begin_nested():
+            return await run_deploy_verification(
+                session,
+                org_id=org_id,
+                now=datetime.now(timezone.utc),
+            )
+    except Exception:
+        logging.getLogger("illo.notify").exception("deploy verification failed safely")
+        return None
+
+
 def _normalize_event(row) -> dict:
     """Map a DomainEvent row to the notify event shape. Defensive: the record
     ``after`` snapshot is domain-schema-specific, so every field has a fallback."""
@@ -131,6 +154,7 @@ async def run_notify_cycle(
     post=None,
 ) -> dict:
     """One notify-cycle tick. Returns a small summary of what was sent."""
+    verification = await _maybe_run_deploy_verification(session, org_id)
     events = await _load_change_events(session, org_id, since)
     await _fill_owner_labels(session, events)
     unclaimed = await _count_unclaimed(session, org_id)
@@ -142,9 +166,12 @@ async def run_notify_cycle(
     if outbound["digest"]:
         await sender(channel_id, outbound["digest"])
 
-    return {
+    summary = {
         "events": len(events),
         "immediate": len(outbound["immediate"]),
         "digest_posted": bool(outbound["digest"]),
         "unclaimed": unclaimed,
     }
+    if verification is not None:
+        summary["verification"] = verification
+    return summary

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -224,6 +224,7 @@ def _pull_request_detail_payload(pr: dict[str, Any]) -> dict[str, Any]:
         "mergeable": pr.get("mergeable"),
         "mergeable_state": pr.get("mergeable_state"),
         "merged": bool(pr.get("merged")),
+        "merge_commit_sha": pr.get("merge_commit_sha"),
         "commits": pr.get("commits"),
         "changed_files": pr.get("changed_files"),
         "additions": pr.get("additions"),
@@ -510,6 +511,53 @@ async def async_get_pull_request(
         "pull_request": _pull_request_detail_payload(pr if isinstance(pr, dict) else {}),
         "checks": _check_runs_payload(checks),
     }
+
+
+async def async_get_pull_request_deploy_info(
+    slug: str,
+    pull_number: int,
+    *,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Read only the PR facts needed for deploy-state ancestry checks."""
+    owner, repo = slug.split("/", 1)
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        pr = await _async_request(
+            client,
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{pull_number}",
+            token=token,
+        )
+    detail = _pull_request_detail_payload(pr if isinstance(pr, dict) else {})
+    return {
+        "repo": slug,
+        "pull_request": detail,
+    }
+
+
+async def async_compare_commits(
+    slug: str,
+    base: str,
+    head: str,
+    *,
+    token: str | None = None,
+) -> str:
+    """Return GitHub's compare status for ``base...head``."""
+    owner, repo = slug.split("/", 1)
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        payload = await _async_request(
+            client,
+            "GET",
+            f"/repos/{owner}/{repo}/compare/{base}...{head}",
+            token=token,
+        )
+    status = payload.get("status") if isinstance(payload, dict) else None
+    if status not in {"identical", "behind", "ahead", "diverged"}:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub compare response omitted a recognized status.",
+        )
+    return str(status)
 
 
 async def async_get_repo_counts(

--- a/brain/systems/deploy_state.py
+++ b/brain/systems/deploy_state.py
@@ -1,0 +1,216 @@
+"""Pure deploy-state decisions for alert-linked GitHub tickets.
+
+``deploy_state`` describes the latest fix attempt, independently of the
+ticket's workflow status.  This module is the single owner of that axis: Slack
+alert parsing, re-fire classification, promotion recommendations, merge-event
+classification, and mechanical state derivation all live here.  Database,
+GitHub, and Slack wiring supply facts but do not reinterpret them.
+
+Indeterminate infrastructure reads are intentionally represented outside this
+module as ``None``.  Callers must degrade open by leaving persisted state
+unchanged rather than guessing that a fix did or did not ship.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+from typing import Mapping
+
+
+class DeployState(StrEnum):
+    """Where the latest fix attempt is in the release lifecycle."""
+
+    STAGING = "staging"
+    PROD_PENDING = "prod_pending"
+    DEPLOYED = "deployed"
+    VERIFIED = "verified"
+
+
+class LadderAction(StrEnum):
+    """Action for an alert occurrence matched to an existing ticket."""
+
+    NOTE_OCCURRENCE = "note_occurrence"
+    EXPECTED_NOISE = "expected_noise"
+    REOPEN_ESCALATE = "reopen_escalate"
+
+
+class RefireSignal(StrEnum):
+    """Additional signal emitted beside the main ladder action."""
+
+    RECOMMEND_PROMOTION = "recommend_promotion"
+
+
+class MergeKind(StrEnum):
+    PROMOTION = "promotion"
+    HOTFIX = "hotfix"
+    FIX_TO_STAGING = "fix_to_staging"
+    OTHER = "other"
+
+
+@dataclass(frozen=True, slots=True)
+class AlertSignature:
+    """Structured identity and occurrence information from a Rollbar alert."""
+
+    project: str
+    item_number: int
+    title: str
+    occurrence_milestone: int | None = None
+
+    @property
+    def signature(self) -> str:
+        return f"{self.project}#{self.item_number}"
+
+    @property
+    def milestone(self) -> int | None:
+        """Short alias used by triage callers."""
+        return self.occurrence_milestone
+
+
+_ROLLBAR_ITEM_RE = re.compile(
+    r"https?://app\.rollbar\.com/[^\s|>]+/item/"
+    r"(?P<project>[^/\s|>]+)/(?P<item>\d+)"
+    r"(?:[^|>]*\|(?P<label>[^>]*))?",
+    re.IGNORECASE,
+)
+_MILESTONE_RE = re.compile(
+    r"\b(?P<count>\d+)(?:st|nd|rd|th)\s+(?:error|occurrence)\s*:\s*",
+    re.IGNORECASE,
+)
+_NEW_ITEM_RE = re.compile(r"\bnew\s+item\b\s*:?\s*", re.IGNORECASE)
+_ITEM_PREFIX_RE = re.compile(r"^\s*#?\d+\s*")
+
+
+def parse_rollbar_alert(text: str | None) -> AlertSignature | None:
+    """Parse Rollbar's Slack attachment fallback into a stable signature.
+
+    The caller assembles the text (including attachment fallback/title text).
+    Messages without a Rollbar item URL return ``None`` even if they contain an
+    issue-like ``#123`` fragment, avoiding false matches on ordinary Slack text.
+    """
+    if not text:
+        return None
+    match = _ROLLBAR_ITEM_RE.search(str(text))
+    if not match:
+        return None
+
+    label = (match.group("label") or "").strip()
+    label = _ITEM_PREFIX_RE.sub("", label, count=1)
+    milestone_match = _MILESTONE_RE.search(label)
+    milestone = int(milestone_match.group("count")) if milestone_match else None
+    if milestone_match:
+        title = label[milestone_match.end():]
+    else:
+        title = _NEW_ITEM_RE.sub("", label, count=1)
+    title = title.strip().rstrip("> ")
+
+    return AlertSignature(
+        project=match.group("project"),
+        item_number=int(match.group("item")),
+        title=title,
+        occurrence_milestone=milestone,
+    )
+
+
+def as_utc_datetime(value: datetime | str | None) -> datetime | None:
+    """Normalize a datetime/ISO value to aware UTC, or return ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _coerce_deploy_state(value: DeployState | str | None) -> DeployState | None:
+    if value is None or value == "":
+        return None
+    try:
+        return DeployState(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_refire(
+    *,
+    deploy_state: DeployState | str | None,
+    ticket_status: str | None,
+    deployed_at: datetime | None,
+    now: datetime,
+    settle: timedelta,
+) -> LadderAction:
+    """Classify an alert re-fire against the latest known fix attempt."""
+    state = _coerce_deploy_state(deploy_state)
+    if str(ticket_status or "").casefold() == "done":
+        return LadderAction.REOPEN_ESCALATE
+    if state is DeployState.VERIFIED:
+        return LadderAction.REOPEN_ESCALATE
+    if state in {DeployState.STAGING, DeployState.PROD_PENDING}:
+        return LadderAction.EXPECTED_NOISE
+    if state is DeployState.DEPLOYED:
+        deployed = as_utc_datetime(deployed_at)
+        current = as_utc_datetime(now)
+        if deployed is not None and current is not None and current < deployed + settle:
+            return LadderAction.EXPECTED_NOISE
+        return LadderAction.REOPEN_ESCALATE
+    return LadderAction.NOTE_OCCURRENCE
+
+
+def promotion_recommendation_signal(
+    *,
+    deploy_state: DeployState | str | None,
+    occurrence_milestone: int | None,
+    promotion_recommended_at: datetime | None,
+    now: datetime,
+) -> RefireSignal | None:
+    """Return the once-per-UTC-day early-promotion signal, when warranted."""
+    if _coerce_deploy_state(deploy_state) is not DeployState.PROD_PENDING:
+        return None
+    if occurrence_milestone is None or occurrence_milestone <= 0:
+        return None
+    current = as_utc_datetime(now)
+    previous = as_utc_datetime(promotion_recommended_at)
+    if current is None:
+        return None
+    if previous is not None and previous.date() == current.date():
+        return None
+    return RefireSignal.RECOMMEND_PROMOTION
+
+
+def classify_merge_event(hints: Mapping[str, object] | None) -> MergeKind:
+    """Classify a merged pull request from normalized webhook hints."""
+    values = hints or {}
+    if values.get("merged") is not True:
+        return MergeKind.OTHER
+    base = str(values.get("base_ref") or "").removeprefix("refs/heads/").casefold()
+    head = str(values.get("head_ref") or "").removeprefix("refs/heads/").casefold()
+    if base == "main" and head == "staging":
+        return MergeKind.PROMOTION
+    if base == "main":
+        return MergeKind.HOTFIX
+    if base == "staging":
+        return MergeKind.FIX_TO_STAGING
+    return MergeKind.OTHER
+
+
+def derive_deploy_state(
+    *,
+    merged: bool | None,
+    base_ref: str | None,
+    in_staging: bool | None,
+    in_main: bool | None,
+) -> DeployState | None:
+    """Derive the mechanical state shared by the sweep and agent tool."""
+    if in_main is True:
+        return DeployState.DEPLOYED
+    if in_staging is True and in_main is False:
+        return DeployState.PROD_PENDING
+    if merged is True and str(base_ref or "").casefold() == "staging":
+        return DeployState.STAGING
+    return None

--- a/brain/systems/deploy_state.py
+++ b/brain/systems/deploy_state.py
@@ -145,14 +145,20 @@ def classify_refire(
     now: datetime,
     settle: timedelta,
 ) -> LadderAction:
-    """Classify an alert re-fire against the latest known fix attempt."""
+    """Classify an alert re-fire against the latest known fix attempt.
+
+    A merely-staged fix wins over a stale ``Done``: re-firing while the fix
+    awaits promotion is expected noise even when the ticket was closed
+    prematurely — the caller normalizes the invalid status quietly instead of
+    escalating to a builder who has nothing new to act on.
+    """
     state = _coerce_deploy_state(deploy_state)
+    if state in {DeployState.STAGING, DeployState.PROD_PENDING}:
+        return LadderAction.EXPECTED_NOISE
     if str(ticket_status or "").casefold() == "done":
         return LadderAction.REOPEN_ESCALATE
     if state is DeployState.VERIFIED:
         return LadderAction.REOPEN_ESCALATE
-    if state in {DeployState.STAGING, DeployState.PROD_PENDING}:
-        return LadderAction.EXPECTED_NOISE
     if state is DeployState.DEPLOYED:
         deployed = as_utc_datetime(deployed_at)
         current = as_utc_datetime(now)

--- a/brain/systems/deploy_state_config.py
+++ b/brain/systems/deploy_state_config.py
@@ -1,0 +1,41 @@
+"""Runtime activation and timing settings for deploy-state wiring."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import timedelta
+
+
+logger = logging.getLogger("illo.deploy_state")
+
+
+def watched_deploy_repos() -> frozenset[str]:
+    return frozenset(
+        repo.strip().casefold()
+        for repo in os.environ.get("ILLO_DEPLOY_SWEEP_REPOS", "").split(",")
+        if repo.strip()
+    )
+
+
+def deploy_feature_enabled(repo: str | None = None) -> bool:
+    watched = watched_deploy_repos()
+    return bool(watched) and (repo is None or str(repo).casefold() in watched)
+
+
+def _env_duration(name: str, default: float, unit: str) -> timedelta:
+    raw = os.environ.get(name, "").strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        logger.warning("invalid %s=%r; using %s", name, raw, default)
+        value = default
+    return timedelta(**{unit: max(value, 0)})
+
+
+def deploy_settle_window() -> timedelta:
+    return _env_duration("ILLO_DEPLOY_SETTLE_MINUTES", 30, "minutes")
+
+
+def deploy_quiet_window() -> timedelta:
+    return _env_duration("ILLO_DEPLOY_QUIET_HOURS", 24, "hours")

--- a/brain/systems/deploy_state_github.py
+++ b/brain/systems/deploy_state_github.py
@@ -1,0 +1,48 @@
+"""Best-effort GitHub reads for deploy-state ancestry checks."""
+
+from __future__ import annotations
+
+import logging
+
+from brain.systems.cortex.project_context.github import (
+    async_compare_commits,
+    parse_github_repo_slug,
+)
+
+
+logger = logging.getLogger("illo.deploy_state.github")
+
+
+async def is_ancestor_of(
+    repo: str,
+    sha: str,
+    branch: str,
+    *,
+    token: str | None = None,
+) -> bool | None:
+    """Whether ``sha`` is an ancestor of ``branch``; ``None`` is indeterminate.
+
+    GitHub's ``branch...sha`` status is ``behind`` when the SHA is behind (and
+    therefore contained by) the branch.  Failures deliberately degrade open.
+    """
+    slug = parse_github_repo_slug(repo)
+    clean_sha = str(sha or "").strip()
+    clean_branch = str(branch or "").strip()
+    if not slug or not clean_sha or not clean_branch:
+        return None
+    try:
+        status = await async_compare_commits(slug, clean_branch, clean_sha, token=token)
+    except Exception as exc:
+        logger.warning(
+            "deploy ancestry check indeterminate for %s %s...%s: %s",
+            slug,
+            clean_branch,
+            clean_sha,
+            exc,
+        )
+        return None
+    if status in {"identical", "behind"}:
+        return True
+    if status in {"ahead", "diverged"}:
+        return False
+    return None

--- a/brain/systems/deploy_state_sweep.py
+++ b/brain/systems/deploy_state_sweep.py
@@ -1,0 +1,489 @@
+"""Deterministic persistence wiring for the deploy-state lifecycle.
+
+The pure axis and ladder live in :mod:`brain.systems.deploy_state`.  This module
+owns best-effort reads of GitHub-ticket records plus optimistic writes through
+``AsyncDomainService``.  It never posts to Slack and never lets GitHub or record
+conflicts fail webhook ingestion / notification ticks.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from datetime import datetime
+from typing import Awaitable, Mapping, Protocol, Sequence
+
+from sqlalchemy import func, or_, select
+
+from brain.platform.db.models.domain import (
+    Domain,
+    DomainFieldDefinition,
+    DomainObjectType,
+    DomainRecord,
+)
+from brain.systems.deploy_state import (
+    DeployState,
+    MergeKind,
+    as_utc_datetime,
+    classify_merge_event,
+    derive_deploy_state,
+)
+from brain.systems.deploy_state_config import (
+    deploy_feature_enabled,
+    deploy_quiet_window,
+    deploy_settle_window,
+)
+from brain.systems.deploy_state_github import is_ancestor_of
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+logger = logging.getLogger("illo.deploy_state")
+
+DEPLOY_STATE_FIELD_DEFINITIONS: tuple[dict, ...] = (
+    {"key": "rollbar_item", "name": "Rollbar Item", "field_type": "text"},
+    {"key": "alert_last_seen_at", "name": "Alert Last Seen At", "field_type": "datetime"},
+    {"key": "alert_occurrences", "name": "Alert Occurrences", "field_type": "number"},
+    {"key": "fix_pr", "name": "Fix PR", "field_type": "text"},
+    {"key": "fix_merge_sha", "name": "Fix Merge SHA", "field_type": "text"},
+    {"key": "fix_merged_at", "name": "Fix Merged At", "field_type": "datetime"},
+    {
+        "key": "deploy_state",
+        "name": "Deploy State",
+        "field_type": "enum",
+        "options": [state.value for state in DeployState],
+    },
+    {"key": "deployed_at", "name": "Deployed At", "field_type": "datetime"},
+    {"key": "verified_at", "name": "Verified At", "field_type": "datetime"},
+    {
+        "key": "promotion_recommended_at",
+        "name": "Promotion Recommended At",
+        "field_type": "datetime",
+    },
+)
+
+
+class QuietCheck(Protocol):
+    """Replaceable quiet-check seam; a future Rollbar implementation fits here."""
+
+    def __call__(
+        self,
+        *,
+        data: Mapping[str, object],
+        deployed_at: datetime,
+        settle_until: datetime,
+        now: datetime,
+    ) -> bool | None | Awaitable[bool | None]: ...
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if not isinstance(value, datetime | str):
+        return None
+    return as_utc_datetime(value)
+
+
+def _iso(value: datetime | str | object) -> str | None:
+    parsed = _parse_datetime(value)
+    return parsed.isoformat() if parsed else None
+
+
+def _append_progress_note(data: Mapping[str, object], line: str) -> str | None:
+    if "progress_note" not in data:
+        return None
+    current = str(data.get("progress_note") or "").rstrip()
+    return f"{current}\n{line}".lstrip()
+
+
+async def ensure_deploy_state_fields(session, *, org_id: str) -> dict:
+    """Idempotently add optional deploy fields to every active github_ticket type."""
+    object_types = (
+        await session.scalars(
+            select(DomainObjectType)
+            .join(Domain, Domain.id == DomainObjectType.domain_id)
+            .where(
+                Domain.org_id == str(org_id),
+                Domain.archived_at.is_(None),
+                DomainObjectType.key == "github_ticket",
+                DomainObjectType.archived_at.is_(None),
+            )
+            .order_by(DomainObjectType.id)
+        )
+    ).all()
+    service = AsyncDomainService(session)
+    added = 0
+    for object_type in object_types:
+        existing = {
+            field.key
+            for field in await service.list_fields(object_type.id)
+        }
+        for payload in DEPLOY_STATE_FIELD_DEFINITIONS:
+            if payload["key"] in existing:
+                continue
+            await service.add_field_definition(object_type, dict(payload), emit_event=False)
+            existing.add(str(payload["key"]))
+            added += 1
+    return {"object_types": len(object_types), "fields_added": added}
+
+
+def _json_text(session, key: str):
+    bind = session.get_bind()
+    if bind is not None and bind.dialect.name == "sqlite":
+        return func.json_extract(DomainRecord.data, f"$.{key}")
+    return DomainRecord.data[key].as_string()
+
+
+async def _ticket_records(
+    session,
+    *,
+    org_id: str,
+    repo: str | None = None,
+    states: set[str] | None = None,
+    fix_pr: str | None = None,
+) -> list[DomainRecord]:
+    stmt = (
+        select(DomainRecord)
+        .join(DomainObjectType, DomainObjectType.id == DomainRecord.object_type_id)
+        .join(Domain, Domain.id == DomainRecord.domain_id)
+        .where(
+            DomainRecord.org_id == str(org_id),
+            DomainRecord.archived_at.is_(None),
+            Domain.archived_at.is_(None),
+            DomainObjectType.key == "github_ticket",
+            DomainObjectType.archived_at.is_(None),
+        )
+    )
+    if repo is not None:
+        stmt = stmt.where(_json_text(session, "repo") == repo)
+    conditions = []
+    if states:
+        conditions.append(_json_text(session, "deploy_state").in_(states))
+    if fix_pr:
+        conditions.append(_json_text(session, "fix_pr") == fix_pr)
+    if conditions:
+        stmt = stmt.where(or_(*conditions))
+    return list((await session.scalars(stmt.order_by(DomainRecord.id))).all())
+
+
+async def _update_record(
+    session,
+    record: DomainRecord,
+    patch: dict,
+    *,
+    reason: str,
+) -> None:
+    async with session.begin_nested():
+        await AsyncDomainService(session).update_record(
+            str(record.org_id),
+            record.domain_id,
+            record.id,
+            data_patch=patch,
+            expected_version=record.version,
+            actor_kind="system",
+            reason=reason,
+        )
+
+
+async def _check_ancestry(
+    repo: str,
+    sha: str,
+    branch: str,
+    tokens: Sequence[str | None],
+) -> bool | None:
+    """Try ordered read identities until ancestry is determinate."""
+    for token in tokens:
+        if token is None:
+            result = await is_ancestor_of(repo, sha, branch)
+        else:
+            result = await is_ancestor_of(repo, sha, branch, token=token)
+        if result is not None:
+            return result
+    return None
+
+
+def _new_summary(kind: MergeKind | str) -> dict:
+    return {
+        "merge_kind": str(kind),
+        "examined": 0,
+        "updated": 0,
+        "deployed": 0,
+        "prod_pending": 0,
+        "staging": 0,
+        "indeterminate": 0,
+        "skipped": 0,
+        "errors": [],
+    }
+
+
+async def _sweep_main_merge(
+    session,
+    *,
+    org_id: str,
+    repo: str,
+    event: Mapping,
+    ancestry_tokens: Sequence[str | None],
+    summary: dict,
+) -> None:
+    kind = classify_merge_event(event)
+    fix_pr = f"{repo}#{event.get('number')}" if kind is MergeKind.HOTFIX and event.get("number") else None
+    records = await _ticket_records(
+        session,
+        org_id=org_id,
+        repo=repo,
+        states={DeployState.STAGING.value, DeployState.PROD_PENDING.value},
+        fix_pr=fix_pr,
+    )
+    for record in records:
+        summary["examined"] += 1
+        data = record.data or {}
+        sha = str(data.get("fix_merge_sha") or "").strip()
+        if fix_pr and data.get("fix_pr") == fix_pr and event.get("merge_commit_sha"):
+            sha = str(event["merge_commit_sha"])
+        if not sha:
+            summary["skipped"] += 1
+            continue
+        in_main = await _check_ancestry(repo, sha, "main", ancestry_tokens)
+        if in_main is None:
+            summary["indeterminate"] += 1
+            continue
+        patch: dict = {}
+        if in_main:
+            deployed_at = _iso(event.get("merged_at"))
+            if not deployed_at:
+                summary["skipped"] += 1
+                continue
+            patch.update({"deploy_state": DeployState.DEPLOYED.value, "deployed_at": deployed_at})
+            if fix_pr and data.get("fix_pr") == fix_pr:
+                patch.update({"fix_merge_sha": sha, "fix_merged_at": deployed_at})
+            note = _append_progress_note(data, f"deployed to main at {deployed_at}")
+            if note is not None:
+                patch["progress_note"] = note
+            bucket = "deployed"
+        elif data.get("deploy_state") == DeployState.STAGING.value:
+            in_staging = await _check_ancestry(repo, sha, "staging", ancestry_tokens)
+            if in_staging is None:
+                summary["indeterminate"] += 1
+                continue
+            if not in_staging:
+                summary["skipped"] += 1
+                continue
+            patch["deploy_state"] = DeployState.PROD_PENDING.value
+            note = _append_progress_note(data, "fix confirmed on staging; awaiting promotion")
+            if note is not None:
+                patch["progress_note"] = note
+            bucket = "prod_pending"
+        else:
+            summary["skipped"] += 1
+            continue
+        try:
+            await _update_record(session, record, patch, reason=f"deploy_sweep:{kind.value}")
+        except Exception as exc:
+            logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
+            summary["errors"].append(record.id)
+            continue
+        summary["updated"] += 1
+        summary[bucket] += 1
+
+
+async def _sweep_staging_merge(
+    session,
+    *,
+    org_id: str,
+    repo: str,
+    event: Mapping,
+    ancestry_tokens: Sequence[str | None],
+    summary: dict,
+) -> None:
+    number = event.get("number")
+    sha = str(event.get("merge_commit_sha") or "").strip()
+    merged_at = _iso(event.get("merged_at"))
+    if not number or not sha or not merged_at:
+        summary["skipped"] += 1
+        return
+    fix_pr = f"{repo}#{number}"
+    records = await _ticket_records(session, org_id=org_id, fix_pr=fix_pr)
+    for record in records:
+        summary["examined"] += 1
+        data = record.data or {}
+        in_main = await _check_ancestry(repo, sha, "main", ancestry_tokens)
+        state = derive_deploy_state(
+            merged=True,
+            base_ref="staging",
+            in_staging=True,
+            in_main=in_main,
+        )
+        if state is None:
+            state = DeployState.STAGING
+        patch = {
+            "fix_merge_sha": sha,
+            "fix_merged_at": merged_at,
+            "deploy_state": state.value,
+        }
+        if state is DeployState.DEPLOYED:
+            patch["deployed_at"] = merged_at
+        note = _append_progress_note(data, f"fix {fix_pr} merged to staging at {merged_at}")
+        if note is not None:
+            patch["progress_note"] = note
+        try:
+            await _update_record(session, record, patch, reason="deploy_sweep:fix_to_staging")
+        except Exception as exc:
+            logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
+            summary["errors"].append(record.id)
+            continue
+        summary["updated"] += 1
+        summary[state.value] += 1
+        if in_main is None:
+            summary["indeterminate"] += 1
+
+
+async def run_deploy_sweep(
+    session,
+    *,
+    org_id: str,
+    repo: str,
+    merge_event: Mapping,
+    ancestry_tokens: Sequence[str | None] | None = None,
+) -> dict:
+    """Apply one merged-PR event, returning telemetry and never raising."""
+    kind = classify_merge_event(merge_event)
+    summary = _new_summary(kind)
+    if not deploy_feature_enabled(repo):
+        summary["disabled"] = True
+        return summary
+    try:
+        tokens = tuple(ancestry_tokens or (None,))
+        summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
+        if kind in {MergeKind.PROMOTION, MergeKind.HOTFIX}:
+            await _sweep_main_merge(
+                session,
+                org_id=org_id,
+                repo=repo,
+                event=merge_event,
+                ancestry_tokens=tokens,
+                summary=summary,
+            )
+        elif kind is MergeKind.FIX_TO_STAGING:
+            await _sweep_staging_merge(
+                session,
+                org_id=org_id,
+                repo=repo,
+                event=merge_event,
+                ancestry_tokens=tokens,
+                summary=summary,
+            )
+    except Exception as exc:
+        logger.exception("deploy sweep failed safely for %s", repo)
+        summary["errors"].append(str(exc))
+    return summary
+
+
+def infer_quiet_from_record(
+    *,
+    data: Mapping[str, object],
+    deployed_at: datetime,
+    settle_until: datetime,
+    now: datetime,
+) -> bool | None:
+    """Default quiet check: infer from the last alert occurrence we ingested."""
+    raw_last_seen = data.get("alert_last_seen_at")
+    if raw_last_seen in {None, ""}:
+        return True
+    last_seen = _parse_datetime(raw_last_seen)
+    if last_seen is None:
+        return None
+    return last_seen <= settle_until
+
+
+async def _check_quiet(check: QuietCheck, **kwargs) -> bool | None:
+    result = check(**kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def run_deploy_verification(
+    session,
+    *,
+    org_id: str,
+    now: datetime,
+    quiet_check: QuietCheck = infer_quiet_from_record,
+) -> dict:
+    """Close only deployed tickets that stayed quiet through the full window."""
+    summary = {
+        "examined": 0,
+        "eligible": 0,
+        "verified": 0,
+        "not_quiet": 0,
+        "indeterminate": 0,
+        "skipped": 0,
+        "errors": [],
+    }
+    if not deploy_feature_enabled():
+        summary["disabled"] = True
+        return summary
+    try:
+        summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
+        records = await _ticket_records(
+            session,
+            org_id=org_id,
+            states={DeployState.DEPLOYED.value},
+        )
+    except Exception as exc:
+        logger.exception("deploy verification setup failed safely")
+        summary["errors"].append(str(exc))
+        return summary
+
+    current = _parse_datetime(now)
+    if current is None:
+        summary["errors"].append("invalid now")
+        return summary
+    settle = deploy_settle_window()
+    quiet_window = deploy_quiet_window()
+    for record in records:
+        summary["examined"] += 1
+        data = record.data or {}
+        deployed_at = _parse_datetime(data.get("deployed_at"))
+        if deployed_at is None:
+            summary["skipped"] += 1
+            continue
+        settle_until = deployed_at + settle
+        if current < settle_until + quiet_window:
+            summary["skipped"] += 1
+            continue
+        summary["eligible"] += 1
+        try:
+            quiet = await _check_quiet(
+                quiet_check,
+                data=data,
+                deployed_at=deployed_at,
+                settle_until=settle_until,
+                now=current,
+            )
+        except Exception as exc:
+            logger.warning("quiet check failed for record %s: %s", record.id, exc)
+            summary["indeterminate"] += 1
+            continue
+        if quiet is None:
+            summary["indeterminate"] += 1
+            continue
+        if quiet is False:
+            summary["not_quiet"] += 1
+            continue
+        deployed_iso = deployed_at.isoformat()
+        patch = {
+            "deploy_state": DeployState.VERIFIED.value,
+            "verified_at": current.isoformat(),
+            "status": "Done",
+        }
+        note = _append_progress_note(
+            data,
+            f"verified quiet since deploy at {deployed_iso}",
+        )
+        if note is not None:
+            patch["progress_note"] = note
+        try:
+            await _update_record(session, record, patch, reason="deploy_verification")
+        except Exception as exc:
+            logger.warning("deploy verification skipped record %s: %s", record.id, exc)
+            summary["errors"].append(record.id)
+            continue
+        summary["verified"] += 1
+    return summary

--- a/brain/systems/deploy_state_sweep.py
+++ b/brain/systems/deploy_state_sweep.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 from typing import Awaitable, Mapping, Protocol, Sequence
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 
 from brain.platform.db.models.domain import (
     Domain,
@@ -135,10 +135,16 @@ async def _ticket_records(
     session,
     *,
     org_id: str,
-    repo: str | None = None,
     states: set[str] | None = None,
+    fix_pr_prefix: str | None = None,
     fix_pr: str | None = None,
 ) -> list[DomainRecord]:
+    """Select github_ticket records by deploy-state and/or fix-PR identity.
+
+    Selection keys on where the FIX lives (``fix_pr`` is repo-qualified), not
+    on the ticket's own ``repo`` field — an app ticket fixed by a backend PR
+    must be swept by the backend promotion, not the app one.
+    """
     stmt = (
         select(DomainRecord)
         .join(DomainObjectType, DomainObjectType.id == DomainRecord.object_type_id)
@@ -151,11 +157,15 @@ async def _ticket_records(
             DomainObjectType.archived_at.is_(None),
         )
     )
-    if repo is not None:
-        stmt = stmt.where(_json_text(session, "repo") == repo)
     conditions = []
     if states:
-        conditions.append(_json_text(session, "deploy_state").in_(states))
+        state_arm = _json_text(session, "deploy_state").in_(states)
+        if fix_pr_prefix:
+            state_arm = and_(
+                state_arm,
+                _json_text(session, "fix_pr").like(f"{fix_pr_prefix}%"),
+            )
+        conditions.append(state_arm)
     if fix_pr:
         conditions.append(_json_text(session, "fix_pr") == fix_pr)
     if conditions:
@@ -227,8 +237,8 @@ async def _sweep_main_merge(
     records = await _ticket_records(
         session,
         org_id=org_id,
-        repo=repo,
         states={DeployState.STAGING.value, DeployState.PROD_PENDING.value},
+        fix_pr_prefix=f"{repo}#",
         fix_pr=fix_pr,
     )
     for record in records:

--- a/brain/systems/inbound/github_webhook.py
+++ b/brain/systems/inbound/github_webhook.py
@@ -94,6 +94,16 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
         author = (comment.get("user") or {}).get("login") or author
         source_updated_at = comment.get("updated_at") or source_updated_at
 
+    merge_hints = {}
+    if event == "pull_request":
+        merge_hints = {
+            "merged": subject.get("merged") is True,
+            "base_ref": (subject.get("base") or {}).get("ref"),
+            "head_ref": (subject.get("head") or {}).get("ref"),
+            "merge_commit_sha": subject.get("merge_commit_sha"),
+            "merged_at": subject.get("merged_at"),
+        }
+
     where = f" #{number}" if number else ""
     summary = (
         f"GitHub {noun}{where} {action}: {title}".strip()
@@ -119,6 +129,7 @@ def github_event_to_envelope(event: str, payload: dict, *, delivery_id=None) -> 
             "author": author,
             # Freshness: GitHub's own last-modified for the subject object.
             "source_updated_at": source_updated_at,
+            **merge_hints,
         },
         "idempotency_key": (f"github:{delivery_id}"[:160] if delivery_id else None),
     }

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
@@ -277,6 +279,12 @@ async def submit_inbound_envelope(
             envelope=normalized,
             projection=projection,
         )
+        await _maybe_run_deploy_sweep(
+            session,
+            org_id=context.org_id,
+            actor_user_id=context.owner_user_id,
+            normalized=normalized,
+        )
         return await _complete_event(
             session,
             event,
@@ -335,6 +343,61 @@ async def submit_inbound_envelope(
             error=str(exc),
             reasoning_summary=str(exc),
         )
+
+
+async def _maybe_run_deploy_sweep(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    actor_user_id: str | None = None,
+    normalized: Mapping[str, Any],
+) -> dict | None:
+    """Best-effort deploy hook; never lets lifecycle wiring fail ingestion."""
+    if normalized.get("kind") != "github_event":
+        return None
+    hints = normalized.get("hints") or {}
+    if not isinstance(hints, Mapping):
+        return None
+    repo = str(hints.get("repo") or "").strip()
+    from brain.systems.deploy_state_config import deploy_feature_enabled
+
+    if (
+        not deploy_feature_enabled(repo)
+        or hints.get("event") != "pull_request"
+        or hints.get("merged") is not True
+    ):
+        return None
+    try:
+        from brain.systems.deploy_state_sweep import run_deploy_sweep
+        from brain.systems.runs.execution_context import bind_agent_context
+        from brain.systems.runs.tool_catalog.handlers.github import _github_token_candidates
+
+        try:
+            with bind_agent_context({"user_id": actor_user_id, "org_id": org_id}):
+                candidates = await _github_token_candidates(
+                    repo_slug=repo,
+                    token_secret_key=None,
+                )
+        except Exception:
+            logging.getLogger("illo.inbound").exception(
+                "GitHub read-token selection failed; deploy sweep will try public access"
+            )
+            candidates = [{"token": None}]
+        ancestry_tokens = [candidate.get("token") for candidate in candidates]
+
+        async with session.begin_nested():
+            return await run_deploy_sweep(
+                session,
+                org_id=str(org_id),
+                repo=repo,
+                merge_event=hints,
+                ancestry_tokens=ancestry_tokens,
+            )
+    except Exception:
+        logging.getLogger("illo.inbound").exception(
+            "deploy sweep failed safely for inbound GitHub event"
+        )
+        return None
 
 
 async def match_source_policy(

--- a/brain/systems/runs/capabilities.py
+++ b/brain/systems/runs/capabilities.py
@@ -233,9 +233,9 @@ _FIRST_PARTY_CAPABILITY_SPECS: tuple[dict[str, Any], ...] = (
         "key": "github_source",
         "name": "GitHub Source",
         "category": "integrations",
-        "summary": "Illo can read bounded GitHub repository metadata, issues, and pull requests, and open real GitHub issues when a write-capable token can reach the repo.",
+        "summary": "Illo can read bounded GitHub repository metadata, issues, pull requests, and fix deploy ancestry, and open real GitHub issues when a write-capable token can reach the repo.",
         "aliases": ("github", "issues", "pull requests", "prs", "repo tickets", "source repo", "create issue", "open issue", "file a ticket"),
-        "tools": ("read_github_source", "create_github_issue"),
+        "tools": ("read_github_source", "check_fix_deploy_state", "create_github_issue"),
     },
     {
         "key": "workspace_apps",

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -117,6 +117,37 @@ GITHUB_TOOLS = [
             "required": ["repo", "title"],
         },
     },
+    {
+        "name": "check_fix_deploy_state",
+        "description": (
+            "Read GitHub commit ancestry to check whether a fix PR or commit is merged, on staging, "
+            "or deployed to main. Returns an indeterminate result when GitHub cannot be reached or "
+            "no available read token can see the repository; it never guesses closed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository as owner/name, GitHub URL, or git remote URL.",
+                },
+                "pr_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Fix pull request number. Provide this or sha, not both.",
+                },
+                "sha": {
+                    "type": "string",
+                    "description": "Fix merge commit SHA. Provide this or pr_number, not both.",
+                },
+                "token_secret_key": {
+                    "type": "string",
+                    "description": "Optional Vault secret key containing a GitHub read token.",
+                },
+            },
+            "required": ["repo"],
+        },
+    },
 ]
 
 

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -42,6 +42,7 @@ from brain.systems.runs.tool_catalog.handlers.cycles import _handle_manage_cycle
 from brain.systems.runs.tool_catalog.handlers.domains import _handle_manage_domain
 from brain.systems.runs.tool_catalog.handlers.inbound import _handle_manage_inbound
 from brain.systems.runs.tool_catalog.handlers.github import (
+    _handle_check_fix_deploy_state,
     _handle_create_github_issue,
     _handle_read_github_source,
 )
@@ -272,6 +273,10 @@ def _get_tool_handlers(
         "create_github_issue": lambda **kw: _patched_private(
             "_handle_create_github_issue",
             _handle_create_github_issue,
+        )(**kw),
+        "check_fix_deploy_state": lambda **kw: _patched_private(
+            "_handle_check_fix_deploy_state",
+            _handle_check_fix_deploy_state,
         )(**kw),
         "read_thread_messages": _handle_read_thread_messages,
         "post_chat_message": lambda **kw: _patched_private(

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 import json
 from typing import Any
 
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_create_repo_issue,
+    async_get_pull_request_deploy_info,
     async_get_pull_request,
     async_get_repo_counts,
     async_get_repo_by_slug,
@@ -16,6 +18,17 @@ from brain.systems.cortex.project_context.github import (
     async_list_repo_pull_requests,
     parse_github_repo_slug,
 )
+from brain.systems.deploy_state import (
+    DeployState,
+    as_utc_datetime,
+    classify_refire,
+    derive_deploy_state,
+)
+from brain.systems.deploy_state_config import (
+    deploy_feature_enabled,
+    deploy_settle_window,
+)
+from brain.systems.deploy_state_github import is_ancestor_of
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 from brain.systems.vault import (
@@ -470,4 +483,169 @@ async def _handle_create_github_issue(
     return json.dumps({"error": "No GitHub token candidates were available", "no_write_token": True})
 
 
-__all__ = ["_handle_read_github_source", "_handle_create_github_issue"]
+async def _maybe_ensure_deploy_fields(repo_slug: str) -> None:
+    """Lazily provision runtime fields when this env-gated feature is armed."""
+    from brain.systems.deploy_state_sweep import ensure_deploy_state_fields
+
+    if not deploy_feature_enabled(repo_slug):
+        return
+    org_id = _clean(getattr(_agent_context, "org_id", None))
+    if not org_id:
+        return
+    try:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+        async with UnitOfWork() as uow:
+            await ensure_deploy_state_fields(uow.session, org_id=org_id)
+    except Exception:
+        # Schema bootstrap is best-effort for this read tool; GitHub facts remain
+        # useful even if the domain database is temporarily unavailable.
+        return
+
+
+def _parse_github_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, datetime | str):
+        return None
+    return as_utc_datetime(value)
+
+
+def _indeterminate_deploy_result(repo_slug: str, *, error: GitHubConnectorError | None = None) -> str:
+    action = classify_refire(
+        deploy_state=None,
+        ticket_status="Todo",
+        deployed_at=None,
+        now=datetime.now(timezone.utc),
+        settle=deploy_settle_window(),
+    )
+    payload: dict[str, Any] = {
+        "repo": repo_slug,
+        "merged": None,
+        "base_ref": None,
+        "in_staging": None,
+        "in_main": None,
+        "deploy_state": None,
+        "recommended_action": action.value,
+        "indeterminate": True,
+    }
+    if error is not None:
+        payload.update({"error": error.message, "status_code": error.status_code})
+    return json.dumps(payload)
+
+
+async def _handle_check_fix_deploy_state(
+    repo: str | None = None,
+    pr_number: int | None = None,
+    sha: str | None = None,
+    token_secret_key: str | None = None,
+) -> str:
+    """Return the ancestry-derived deploy state for a PR or commit SHA."""
+    repo_slug = parse_github_repo_slug(repo or "")
+    if not repo_slug:
+        return json.dumps({"error": "check_fix_deploy_state requires repo as owner/name or a GitHub URL"})
+    if not deploy_feature_enabled(repo_slug):
+        return json.dumps({
+            "error": "deploy-state checks are disabled for this repository",
+            "repo": repo_slug,
+            "disabled": True,
+        })
+    clean_sha = _clean(sha)
+    try:
+        clean_pr = int(pr_number) if pr_number is not None else None
+    except (TypeError, ValueError):
+        clean_pr = None
+    if (clean_pr is None) == (clean_sha is None):
+        return json.dumps({"error": "check_fix_deploy_state requires exactly one of pr_number or sha"})
+    if clean_pr is not None and clean_pr < 1:
+        return json.dumps({"error": "check_fix_deploy_state requires a positive pr_number"})
+
+    await _maybe_ensure_deploy_fields(repo_slug)
+    candidates = await _github_token_candidates(
+        repo_slug=repo_slug,
+        token_secret_key=token_secret_key,
+    )
+    read_state = _github_read_state()
+    read_candidates = _ordered_read_candidates(candidates, repo_slug=repo_slug, state=read_state)
+    last_error: GitHubConnectorError | None = None
+    for index, candidate in enumerate(read_candidates):
+        token = candidate.get("token")
+        merged: bool | None = None
+        base_ref: str | None = None
+        merged_at: datetime | None = None
+        candidate_sha = clean_sha
+        if clean_pr is not None:
+            try:
+                info = await async_get_pull_request_deploy_info(
+                    repo_slug,
+                    clean_pr,
+                    token=token,
+                )
+            except GitHubConnectorError as exc:
+                last_error = exc
+                if exc.status_code in {401, 404}:
+                    read_state.rejected[(token, repo_slug)] = exc
+                if exc.status_code in {401, 403, 404} and index < len(read_candidates) - 1:
+                    continue
+                return _indeterminate_deploy_result(repo_slug, error=exc)
+            pr = info.get("pull_request") or {}
+            merged = pr.get("merged") if isinstance(pr.get("merged"), bool) else None
+            base_ref = _clean((pr.get("base") or {}).get("ref"))
+            merged_at = _parse_github_datetime(pr.get("merged_at"))
+            head_sha = _clean((pr.get("head") or {}).get("sha"))
+            candidate_sha = (
+                _clean(pr.get("merge_commit_sha")) or head_sha
+                if merged is True
+                else head_sha
+            )
+        if not candidate_sha:
+            return _indeterminate_deploy_result(repo_slug)
+
+        in_staging = await is_ancestor_of(repo_slug, candidate_sha, "staging", token=token)
+        in_main = await is_ancestor_of(repo_slug, candidate_sha, "main", token=token)
+        if (in_staging is None or in_main is None) and index < len(read_candidates) - 1:
+            continue
+        state = derive_deploy_state(
+            merged=merged,
+            base_ref=base_ref,
+            in_staging=in_staging,
+            in_main=in_main,
+        )
+        observed_at = datetime.now(timezone.utc)
+        # A staging PR's merged_at is not the production deploy time, and a
+        # raw SHA has no deploy timestamp. Treat a newly observed main ancestor
+        # as inside settle rather than falsely escalating an unknown timeline.
+        classified_deployed_at = None
+        if state is DeployState.DEPLOYED:
+            classified_deployed_at = (
+                merged_at if str(base_ref or "").casefold() == "main" else observed_at
+            )
+        action = classify_refire(
+            deploy_state=state,
+            ticket_status="Todo",
+            deployed_at=classified_deployed_at,
+            now=observed_at,
+            settle=deploy_settle_window(),
+        )
+        read_state.preferred[repo_slug] = token
+        payload = {
+            "repo": repo_slug,
+            "merged": merged,
+            "base_ref": base_ref,
+            "in_staging": in_staging,
+            "in_main": in_main,
+            "deploy_state": state.value if state else None,
+            "recommended_action": action.value,
+            "indeterminate": in_staging is None or in_main is None,
+            "token_secret_key_used": bool(candidate.get("key_name")),
+            "token_source": candidate.get("source"),
+        }
+        if last_error is not None:
+            payload["fallback_from_status_code"] = last_error.status_code
+        return json.dumps(payload)
+    return _indeterminate_deploy_result(repo_slug, error=last_error)
+
+
+__all__ = [
+    "_handle_check_fix_deploy_state",
+    "_handle_create_github_issue",
+    "_handle_read_github_source",
+]

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -318,6 +318,15 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
     },
+    "check_fix_deploy_state": {
+        "permission": "read_workspace",
+        "risk_class": "low",
+        "side_effect_class": "read_only",
+        "reversibility": "none",
+        "expected_effect": "read GitHub ancestry to classify a fix's deploy state",
+        "output_budget_chars": 8_000,
+        "evidence_emitter": True,
+    },
     "create_github_issue": {
         "permission": "write_workspace",
         "risk_class": "high",

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -97,10 +97,11 @@ Decide as follows:
 
 - **One problem = one issue — check before filing.** Before calling
   `create_github_issue`, search open AND recently-closed GitHub issues and
-  Domain 1 tracker records for the same error signature, Rollbar id, endpoint,
-  profile id, or root cause. If a match exists — even if closed — comment on or
-  reopen it instead of filing a new one. Never file a second issue for a symptom
-  already tracked, and never split one error/Rollbar alert into multiple issues.
+  Domain 1 tracker records for the same error signature, Rollbar id (prefer
+  the structured `rollbar_item` field), endpoint, profile id, or root cause.
+  If a match exists — even if closed or `Done` — do NOT file a new issue and
+  do NOT blindly skip: follow the **Deploy-State Ladder** below. Never split
+  one error/Rollbar alert into multiple issues.
 - **Repo and incident are both clear and a write-capable token can reach the
   repo:** open a real GitHub issue with `create_github_issue` in the correct
   repo (`uwear-ai/uwearaiapp`, `uwear-ai/uwear-backend`,
@@ -119,6 +120,59 @@ Never describe an internal tracker record as a GitHub issue. Only say a GitHub
 issue was opened when `create_github_issue` succeeded and you can cite its
 number and URL.
 
+## Deploy-State Ladder (re-firing alerts)
+
+Uwear merges fixes to `staging` and promotes to prod roughly weekly (an
+evergreen staging→main promotion PR) unless urgent, so prod alerts re-fire
+for already-fixed bugs. When an incoming alert matches an existing ticket,
+branch on the fix's deploy-state — never binary-skip, never refile:
+
+1. **No fix merged yet:** append an occurrence/freshness note to the ticket
+   (update `alert_last_seen_at`, `alert_occurrences`). On a rate spike
+   (a Rollbar Nth-error milestone: 10th/100th/500th…), raise `priority` and
+   say why in `progress_note`.
+2. **Fix merged to staging but not in prod** (`deploy_state` is `staging` or
+   `prod_pending`): **expected noise.** Annotate the ticket; optionally reply
+   once in the alert thread "known — fixed by PR #X merged to staging, ships
+   with the next weekly promotion". Never refile and never re-ping the owner.
+   If the alert is an occurrence milestone, also apply **Urgent Promotion**
+   below.
+3. **Fix deployed to prod** (`deploy_state` is `deployed` or `verified`, or
+   the ticket is `Done`) **and the alert still fires past the settle window**
+   (default 30 minutes after deploy): **the fix did not work.** Reopen the
+   ticket — status back to `Todo`, note the failed attempt in
+   `progress_note`, clear `deploy_state` — and escalate to the builder (the
+   fix PR's author) by name. This case is why blind dedup-suppression is
+   unacceptable.
+
+Determine deploy-state mechanically, never by assumption: the fix PR's merge
+commit must be an ancestor of `main` to count as deployed (GitHub compare
+`main...SHA`; use the `check_fix_deploy_state` tool when available). A fix
+merged to staging after the promotion PR's cutoff is NOT in that promotion.
+Hotfix PRs targeting `main` directly count as deployed on merge. If GitHub
+cannot confirm, leave the recorded state unchanged and say so — degrade open,
+never guess.
+
+For an alert-linked ticket, `Done` means **deployed to prod AND verified
+quiet** in Rollbar since the deploy (settle window, then a quiet window —
+default 24 h), with evidence such as "verified quiet since deploy at T".
+Merged-to-staging is never `Done`.
+
+When you file or link a fix, stamp the structured fields on the tracker
+record — `rollbar_item` (e.g. `Uwear-API#2206`), `fix_pr` (repo-qualified,
+e.g. `uwear-ai/uwear-backend#905`), `fix_merge_sha`, `fix_merged_at`,
+`deploy_state` — instead of burying them in prose. The ladder only works if
+these are data.
+
+## Urgent Promotion
+
+When a `prod_pending` fix keeps accumulating occurrences (successive Rollbar
+Nth-error milestones), RECOMMEND early promotion in the team channel, for
+example: "fix for #904 (PR #905) is merged and waiting; #2206 hit its 500th
+occurrence today; recommend promoting now." Recommend at most once per ticket
+per day (stamp `promotion_recommended_at`). Recommend only — NEVER merge the
+promotion PR or any PR yourself; promotion is a human action.
+
 ## States
 
 - `needs-triage`: not enough signal yet to classify or assign.
@@ -133,8 +187,12 @@ number and URL.
 - `In Review`: non-draft PR is open and awaiting review, CI, or merge.
 - `Blocked`: failing CI, requested changes, unclear owner, missing info, or
   external dependency.
-- `Done`: linked PR merged or issue closed. A `Done` item must not appear in
-  anyone's priority workset — see **Before Posting** and **Public Output**.
+- `Done`: linked PR merged or issue closed. For an alert-linked ticket (one
+  with a `rollbar_item`), `Done` additionally requires the fix deployed to
+  prod AND verified quiet (`deploy_state` = `verified`) per the
+  **Deploy-State Ladder** — merged-to-staging is not done. A `Done` item must
+  not appear in anyone's priority workset — see **Before Posting** and
+  **Public Output**.
 - `Canceled` / `wontfix`: obsolete, duplicate, invalid, intentionally closed,
   or not worth doing.
 
@@ -231,6 +289,9 @@ fix any that fail:
    pre-assigned.
 3. **Dedup gate:** no two items describe the same underlying problem under
    different issue numbers.
+4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2) re-pings
+   an owner or appears as new work; every reopened ticket (Ladder case 3)
+   names the builder and the failed fix.
 
 ## Public Output
 

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -96,12 +96,13 @@ Two different places can hold work, and they are NOT the same thing:
 Decide as follows:
 
 - **One problem = one issue — check before filing.** Before calling
-  `create_github_issue`, search open AND recently-closed GitHub issues and
-  Domain 1 tracker records for the same error signature, Rollbar id (prefer
-  the structured `rollbar_item` field), endpoint, profile id, or root cause.
-  If a match exists — even if closed or `Done` — do NOT file a new issue and
-  do NOT blindly skip: follow the **Deploy-State Ladder** below. Never split
-  one error/Rollbar alert into multiple issues.
+  `create_github_issue`, search open AND closed GitHub issues and Domain 1
+  tracker records for the same error signature, Rollbar id (prefer the
+  structured `rollbar_item` field — an exact `rollbar_item`/signature match
+  has no recency cutoff), endpoint, profile id, or root cause. If a match
+  exists — even if closed or `Done` — do NOT file a new issue and do NOT
+  blindly skip: follow the **Deploy-State Ladder** below. Never split one
+  error/Rollbar alert into multiple issues.
 - **Repo and incident are both clear and a write-capable token can reach the
   repo:** open a real GitHub issue with `create_github_issue` in the correct
   repo (`uwear-ai/uwearaiapp`, `uwear-ai/uwear-backend`,
@@ -125,33 +126,45 @@ number and URL.
 Uwear merges fixes to `staging` and promotes to prod roughly weekly (an
 evergreen staging→main promotion PR) unless urgent, so prod alerts re-fire
 for already-fixed bugs. When an incoming alert matches an existing ticket,
-branch on the fix's deploy-state — never binary-skip, never refile:
+first update `alert_last_seen_at` and `alert_occurrences` on the record —
+every matched re-fire, all cases; the post-deploy verifier infers "quiet"
+from these fields — then branch on the fix's deploy-state — never
+binary-skip, never refile:
 
-1. **No fix merged yet:** append an occurrence/freshness note to the ticket
-   (update `alert_last_seen_at`, `alert_occurrences`). On a rate spike
-   (a Rollbar Nth-error milestone: 10th/100th/500th…), raise `priority` and
-   say why in `progress_note`.
+1. **No fix merged yet:** append an occurrence/freshness note to the ticket.
+   On a rate spike (a Rollbar Nth-error milestone: 10th/100th/500th…), raise
+   `priority` and say why in `progress_note`.
 2. **Fix merged to staging but not in prod** (`deploy_state` is `staging` or
    `prod_pending`): **expected noise.** Annotate the ticket; optionally reply
    once in the alert thread "known — fixed by PR #X merged to staging, ships
    with the next weekly promotion". Never refile and never re-ping the owner.
-   If the alert is an occurrence milestone, also apply **Urgent Promotion**
-   below.
+   This holds even if the ticket was prematurely closed or `Done`: quietly
+   normalize the status (back to `In Review`/`Blocked`) with the annotation
+   and flag the premature close — still no refile, still no owner ping. A
+   re-fire while a deployed fix is inside the settle window (default
+   30 minutes after deploy) is the same expected drain noise — annotate
+   only. If the alert is an occurrence milestone, also apply **Urgent
+   Promotion** below.
 3. **Fix deployed to prod** (`deploy_state` is `deployed` or `verified`, or
-   the ticket is `Done`) **and the alert still fires past the settle window**
-   (default 30 minutes after deploy): **the fix did not work.** Reopen the
+   the ticket is `Done` with no merely-staged fix) **and the alert still
+   fires past the settle window**: **the fix did not work.** Reopen the
    ticket — status back to `Todo`, note the failed attempt in
    `progress_note`, clear `deploy_state` — and escalate to the builder (the
-   fix PR's author) by name. This case is why blind dedup-suppression is
+   fix PR's author) by name. Escalation is a named mention and a next
+   action, never a reassignment — do not change the GitHub assignee (the
+   **Ownership** rules stand). This case is why blind dedup-suppression is
    unacceptable.
 
 Determine deploy-state mechanically, never by assumption: the fix PR's merge
 commit must be an ancestor of `main` to count as deployed (GitHub compare
 `main...SHA`; use the `check_fix_deploy_state` tool when available). A fix
 merged to staging after the promotion PR's cutoff is NOT in that promotion.
-Hotfix PRs targeting `main` directly count as deployed on merge. If GitHub
-cannot confirm, leave the recorded state unchanged and say so — degrade open,
-never guess.
+Hotfix PRs targeting `main` directly count as deployed on merge.
+`deployed_at` is the promotion/hotfix merge-to-main time — never the earlier
+staging `fix_merged_at`. A reverted fix still passes the ancestry check: when
+a revert of the fix is linked or discovered, clear `deploy_state` (treat as
+not merged) and say so. If GitHub cannot confirm, leave the recorded state
+unchanged and say so — degrade open, never guess.
 
 For an alert-linked ticket, `Done` means **deployed to prod AND verified
 quiet** in Rollbar since the deploy (settle window, then a quiet window —
@@ -160,18 +173,24 @@ Merged-to-staging is never `Done`.
 
 When you file or link a fix, stamp the structured fields on the tracker
 record — `rollbar_item` (e.g. `Uwear-API#2206`), `fix_pr` (repo-qualified,
-e.g. `uwear-ai/uwear-backend#905`), `fix_merge_sha`, `fix_merged_at`,
-`deploy_state` — instead of burying them in prose. The ladder only works if
-these are data.
+e.g. `uwear-ai/uwear-backend#905` — the promotion sweep matches tickets by
+the fix's repo, so cross-repo fixes only work when this is stamped),
+`fix_merge_sha`, `fix_merged_at`, `deploy_state` — instead of burying them in
+prose. The fields track the latest fix attempt believed to govern
+production; when a newer fix PR supersedes an older one, restamp all of them
+and note the supersession in `progress_note`. The ladder only works if these
+are data.
 
 ## Urgent Promotion
 
-When a `prod_pending` fix keeps accumulating occurrences (successive Rollbar
-Nth-error milestones), RECOMMEND early promotion in the team channel, for
+When a `prod_pending` fix's alert hits a Rollbar Nth-error milestone
+(10th/100th/500th…), RECOMMEND early promotion in the team channel, for
 example: "fix for #904 (PR #905) is merged and waiting; #2206 hit its 500th
 occurrence today; recommend promoting now." Recommend at most once per ticket
 per day (stamp `promotion_recommended_at`). Recommend only — NEVER merge the
-promotion PR or any PR yourself; promotion is a human action.
+promotion PR or any PR yourself; promotion is a human action. This never-merge
+rule is absolute for the staging→main promotion PR: no delegated merge or
+closure authority (Workflow step 5) overrides it.
 
 ## States
 
@@ -258,7 +277,8 @@ Classify stale work by next action:
 - `Blocked`: blocked by CI, review changes, branch drift, or external
   dependency.
 - `Backlog`: valid but not selected for near-term work.
-- `Done`: already merged, closed, or otherwise complete.
+- `Done`: already merged, closed, or otherwise complete (alert-linked
+  tickets: only once deploy-verified — see **Deploy-State Ladder**).
 - `Canceled` / `wontfix`: explicitly obsolete, duplicate, invalid, or not
   worth doing after approval.
 
@@ -282,28 +302,33 @@ fix any that fail:
 
 1. **State gate:** no `Done` item is in the priority list. A merged PR whose
    issue is still open goes to the `Cleanup — safe to close` batch or gets
-   closed — never listed as active work.
+   closed — never listed as active work. Exception: an alert-linked ticket
+   whose fix is merely merged (not deploy-verified) is NOT cleanup — it stays
+   active as `prod_pending` per the **Deploy-State Ladder**.
 2. **Owner gate:** every PR is owned by its GitHub author with a "merge or close"
    nudge and no other name attached. Every issue owner is the GitHub assignee, or
    the area fallback only if unassigned. No customer-generation issue is
    pre-assigned.
 3. **Dedup gate:** no two items describe the same underlying problem under
    different issue numbers.
-4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2) re-pings
-   an owner or appears as new work; every reopened ticket (Ladder case 3)
-   names the builder and the failed fix.
+4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2, including
+   a within-settle deploy drain) re-pings an owner or appears as new work;
+   every reopened ticket (Ladder case 3) names the builder and the failed fix
+   without reassigning the issue.
 
 ## Public Output
 
 Slack or team-facing summaries must be safe for teammates:
 
 - Say the priority workset is not the full backlog when relevant.
-- A `Done` item (linked PR merged) must never appear in a person's priority
-  workset, even if its GitHub issue is still open. If the PR is merged but the
-  issue is open, either close the issue (when closure authority is delegated and
-  the PR clearly resolves it) or list it **once** in a separate
-  `Cleanup — safe to close` batch at the end. Never carry a `Done` item across
-  check-ins as active work.
+- A `Done` item (linked PR merged — and, for an alert-linked ticket,
+  deploy-verified per the **Deploy-State Ladder**) must never appear in a
+  person's priority workset, even if its GitHub issue is still open. If the PR
+  is merged but the issue is open, either close the issue (when closure
+  authority is delegated and the PR clearly resolves it — never for an
+  alert-linked ticket that is not yet deploy-verified) or list it **once** in
+  a separate `Cleanup — safe to close` batch at the end. Never carry a `Done`
+  item across check-ins as active work.
 - Never list the same underlying problem under two numbers. If a bug was re-filed
   (a closed issue reopened under a new number, or one alert split into several),
   collapse to the single active item and note the rest as duplicates.

--- a/brain/systems/slack/ingress.py
+++ b/brain/systems/slack/ingress.py
@@ -7,6 +7,8 @@ from typing import Any, Mapping
 SLACK_MESSAGE_ENVELOPE_KIND = "slack_message"
 SLACK_CHANNEL_MESSAGE_ORIGIN = "slack.channel_message"
 MAX_SLACK_TEXT_CHARS = 4000
+MAX_SLACK_ATTACHMENT_PREVIEW_CHARS = 500
+MAX_SLACK_ATTACHMENT_PREVIEWS = 2
 
 _IGNORED_MESSAGE_SUBTYPES = {
     "bot_message",
@@ -20,6 +22,28 @@ _IGNORED_MESSAGE_SUBTYPES = {
 
 def _bounded_text(value: Any, *, limit: int = MAX_SLACK_TEXT_CHARS) -> str:
     return str(value or "")[:limit]
+
+
+def _event_text(event: Mapping[str, Any]) -> str:
+    """Surface attachment-only bot alerts without changing ordinary messages."""
+    text = _bounded_text(event.get("text"))
+    if text.strip():
+        return text
+    previews: list[str] = []
+    attachments = event.get("attachments")
+    if not isinstance(attachments, list):
+        return text
+    for attachment in attachments[:MAX_SLACK_ATTACHMENT_PREVIEWS]:
+        if not isinstance(attachment, Mapping):
+            continue
+        preview = attachment.get("fallback") or attachment.get("title")
+        bounded = _bounded_text(
+            preview,
+            limit=MAX_SLACK_ATTACHMENT_PREVIEW_CHARS,
+        ).strip()
+        if bounded:
+            previews.append(bounded)
+    return _bounded_text("\n".join(previews))
 
 
 def _socket_payload(socket_payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -207,6 +231,7 @@ def normalize_slack_socket_event(
         "visibility": "public",
     }
     permalink = str(event.get("permalink") or "").strip() or None
+    message_text = _event_text(event)
     normalized_payload = {
         "event_kind": _event_kind(origin),
         "origin": origin,
@@ -219,7 +244,7 @@ def normalize_slack_socket_event(
         "thread_ts": thread_ts,
         "slack_user_id": slack_user_id,
         "bot_user_id": resolved_bot_user_id,
-        "text": _bounded_text(event.get("text")),
+        "text": message_text,
         "permalink": permalink,
         "event_id": event_id or None,
         "event_time": payload.get("event_time"),
@@ -231,7 +256,7 @@ def normalize_slack_socket_event(
         "kind": SLACK_MESSAGE_ENVELOPE_KIND,
         "origin": origin,
         "payload": normalized_payload,
-        "summary": _bounded_text(event.get("text"), limit=500),
+        "summary": _bounded_text(message_text, limit=500),
         "hints": {
             "surface": {
                 "kind": "slack",

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -262,8 +262,10 @@ def slack_channel_monitor_message(
         "- An alert that matches an EXISTING ticket or issue (same Rollbar id/error signature): "
         "do NOT refile and do NOT blindly skip — follow the triage skill's Deploy-State Ladder: "
         "note occurrences while unfixed; a fix merged to staging but not promoted is expected "
-        "noise (annotate, no owner re-ping); a fix deployed to prod that still fires means the "
-        "fix did not work — reopen the ticket and escalate to the fix author.",
+        "noise (annotate, no owner re-ping, even if the ticket was closed early); a fix deployed "
+        "to prod that still fires PAST the settle window (~30 min after deploy) means the fix "
+        "did not work — reopen the ticket and escalate to the fix author (re-fires inside the "
+        "settle window are expected drain noise).",
         "- Ticket-worthy but the repo/incident is unclear, or create_github_issue reports "
         "no write-capable token can reach the repo (no_write_token / 403 / 404): do NOT claim a "
         "GitHub issue was filed. Ask for clarification with post_slack_reply, or record an internal "

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -259,6 +259,11 @@ def slack_channel_monitor_message(
         "with create_github_issue in the correct uwear-ai repo. Load the 'uwear-engineering-triage' "
         "skill (brain_skills then skill_view) first for routing/ownership rules, then optionally "
         "post a brief Slack note with post_slack_reply citing the issue number and URL.",
+        "- An alert that matches an EXISTING ticket or issue (same Rollbar id/error signature): "
+        "do NOT refile and do NOT blindly skip — follow the triage skill's Deploy-State Ladder: "
+        "note occurrences while unfixed; a fix merged to staging but not promoted is expected "
+        "noise (annotate, no owner re-ping); a fix deployed to prod that still fires means the "
+        "fix did not work — reopen the ticket and escalate to the fix author.",
         "- Ticket-worthy but the repo/incident is unclear, or create_github_issue reports "
         "no write-capable token can reach the repo (no_write_token / 403 / 404): do NOT claim a "
         "GitHub issue was filed. Ask for clarification with post_slack_reply, or record an internal "

--- a/specs/illo-lifecycle/README.md
+++ b/specs/illo-lifecycle/README.md
@@ -43,6 +43,12 @@ enumerated per slice below.
 - **Slice 4:** register a cycle calling `run_notify_cycle(session, org_id=…,
   channel_id=<team channel>, since=<last_run_at>)`; add the urgent-bypass hook at
   triage completion.
+- **Slice 5:** set `ILLO_DEPLOY_SWEEP_REPOS` (watched repos) to arm the
+  promotion sweep (+ optional `ILLO_DEPLOY_SETTLE_MINUTES` /
+  `ILLO_DEPLOY_QUIET_HOURS` overrides); apply the deploy-state ladder delta to
+  live doc 1155 (**coordinate with the parallel digest-contract edit to the
+  same doc**); verification tick rides Slice 4's cycle registration; decide
+  the optional Rollbar read-only token (Vault) for API-backed quiet checks.
 
 **Before ending your pass:** update this section.
 
@@ -55,6 +61,9 @@ enumerated per slice below.
 - [x] Slice 3 — resolve_owner + rules, wired into triage; live: env owner id + pool nullability
 - [x] Slice 4 — notify decision/digest + `run_notify_cycle`; live: register cycle + urgent hook
 - [x] Review pass — 6 self-review bugs found + fixed (98 focused tests green)
+- [ ] Slice 5 — deploy-state & post-deploy verification (spec authored
+  2026-07-10 after the Rollbar #2206 → #904 re-fire case; implementation in
+  progress)
 - [ ] Live activation (per checklist above) — Reda / infra
 
 ---
@@ -181,9 +190,12 @@ Slice 2  Typed task-type (no infra dep) ──┐   │
 Slice 1  Webhook freshness (needs App) ──┐│   │
 Slice 3  Deterministic assignment ───────┘│   │  (depends on Slice 2)
 Slice 4  Proactive Slack notify ──────────┘   │  (depends on Slice 1)
+Slice 5  Deploy-state & verification ─────┘   │  (composes with 1 + 4)
                                               └─ Slice 0 routes/bump retired by Slices 3/1
 ```
 Slices 1 and 2 are largely parallel. 3 depends on 2. 4 depends on 1.
+Slice 5's sweep rides Slice 1's webhook lane and its verification tick rides
+Slice 4's cycle; its pure cores and prose are independent of both.
 
 ## Review map (where the human looks per slice)
 - **Slice 0:** a business/PM issue routes to Reda; freshness window observably < 1h.

--- a/specs/illo-lifecycle/README.md
+++ b/specs/illo-lifecycle/README.md
@@ -2,7 +2,20 @@
 
 ## Next Agent Prompt
 
-**Status (2026-07-09):** All five slices **implemented and shipped in PR #276**
+**Status (2026-07-10):** Slice 5 (deploy-state & post-deploy verification,
+[slices/05-deploy-state.md](slices/05-deploy-state.md)) is **code-complete on
+this branch**: pure core + sweep + verification + `check_fix_deploy_state`
+tool + prose ladder (SKILL.md/monitor prompt), Codex-implemented and
+Claude-reviewed, fast suite green (3438 passed, 9 pre-existing
+`test_llm_worker` env failures), and the ladder **verified live** by two
+READ-ONLY illo-dev dry runs (952-pattern): run 1088 pre-promotion → expected
+noise / zero refiles / zero pings + promotion recommendation; run 1089
+post-promotion → reopen #904 + escalate to the builder (axel-havard). Live
+activation gates below; the doc-1155 delta
+([slices/05-doc-1155-delta.md](slices/05-doc-1155-delta.md)) awaits approval
+and must merge after/with the parallel digest-contract edit to record 1155.
+
+**Prior status (2026-07-09):** All five slices **implemented and shipped in PR #276**
 (2 commits). Pure logic cores are unit-tested (**105 focused tests green**); an
 independent adversarial review found ~10 MED/LOW findings, all **fixed and pushed**
 (commit `76ed45f`). Full suite **3280 passed** (1 pre-existing env-only failure,
@@ -45,10 +58,13 @@ enumerated per slice below.
   triage completion.
 - **Slice 5:** set `ILLO_DEPLOY_SWEEP_REPOS` (watched repos) to arm the
   promotion sweep (+ optional `ILLO_DEPLOY_SETTLE_MINUTES` /
-  `ILLO_DEPLOY_QUIET_HOURS` overrides); apply the deploy-state ladder delta to
-  live doc 1155 (**coordinate with the parallel digest-contract edit to the
-  same doc**); verification tick rides Slice 4's cycle registration; decide
-  the optional Rollbar read-only token (Vault) for API-backed quiet checks.
+  `ILLO_DEPLOY_QUIET_HOURS` overrides); ensure the Slice-1 source
+  policy/projection **covers `pull_request` events** — the sweep hook runs on
+  the post-projection ingest path, so unprojected merge envelopes never reach
+  it; apply the deploy-state ladder delta to live doc 1155
+  (**coordinate with the parallel digest-contract edit to the same doc**);
+  verification tick rides Slice 4's cycle registration; decide the optional
+  Rollbar read-only token (Vault) for API-backed quiet checks.
 
 **Before ending your pass:** update this section.
 
@@ -61,9 +77,10 @@ enumerated per slice below.
 - [x] Slice 3 — resolve_owner + rules, wired into triage; live: env owner id + pool nullability
 - [x] Slice 4 — notify decision/digest + `run_notify_cycle`; live: register cycle + urgent hook
 - [x] Review pass — 6 self-review bugs found + fixed (98 focused tests green)
-- [ ] Slice 5 — deploy-state & post-deploy verification (spec authored
-  2026-07-10 after the Rollbar #2206 → #904 re-fire case; implementation in
-  progress)
+- [x] Slice 5 — deploy-state & post-deploy verification (spec + code +
+  prose, 2026-07-10, from the Rollbar #2206 → #904 re-fire case; ladder
+  dry-run-verified on illo-dev, runs 1088/1089); live: env + doc 1155 delta
+  + Rollbar-token decision
 - [ ] Live activation (per checklist above) — Reda / infra
 
 ---

--- a/specs/illo-lifecycle/slices/05-deploy-state.md
+++ b/specs/illo-lifecycle/slices/05-deploy-state.md
@@ -22,6 +22,16 @@ between "merged" and `Done`. Record 1238 shows the data gap: Rollbar #2206 and
 fix PR #905 exist only as prose in `body`/`progress_note` — nothing structured
 for a dedup ladder to key on.
 
+The case study then advanced to exactly the state this slice models, while the
+spec was being written: Axel confirmed #2206 as **deployment drift** — the
+real fix is PR #860, merged to *staging* 2026-07-07 (merge `d9980489`,
+compare `main...d9980489` = diverged ⇒ not in prod) — closed hotfix #905
+unmerged as unnecessary, and closed issue #904 as "known". Under this slice
+that ticket is `deploy_state=prod_pending` with `fix_pr=uwear-ai/uwear-backend#860`
+and **cannot be `Done`** (not deployed, not verified); today, closed-with-
+live-alert is precisely the armed done-reappeared trap: the next #2206
+re-fire meets a closed ticket and binary dedup would refile it.
+
 ## Contract unlocked
 
 A re-firing alert is never blindly skipped and never refiled. Triage branches

--- a/specs/illo-lifecycle/slices/05-deploy-state.md
+++ b/specs/illo-lifecycle/slices/05-deploy-state.md
@@ -95,12 +95,16 @@ degrade open, never fail closed (the PR #287 convention).
      - `staging`/`prod_pending` → `EXPECTED_NOISE` (annotate the ticket,
        optional one-time thread reply "known — fixed by PR #X merged to
        staging, ships with next weekly promotion"; **never refile, never
-       re-ping the owner**; milestone here additionally yields
-       `RECOMMEND_PROMOTION`);
+       re-ping the owner** — and a merely-staged fix wins over a stale `Done`:
+       the prematurely closed ticket is quietly normalized, never escalated;
+       a milestone on a `prod_pending` fix additionally yields
+       `RECOMMEND_PROMOTION`, `staging` having upgraded to `prod_pending` on
+       the triage touch);
      - `deployed` within settle → `EXPECTED_NOISE` (deploy draining);
-     - `deployed` past settle, or `verified`, or ticket already `Done` →
-       `REOPEN_ESCALATE` (this is why blind dedup-suppression is unacceptable,
-       and it retires the done-reappeared refile bug).
+     - `deployed` past settle, or `verified`, or ticket `Done` with no
+       merely-staged fix → `REOPEN_ESCALATE` (this is why blind
+       dedup-suppression is unacceptable, and it retires the done-reappeared
+       refile bug).
    - `classify_merge_event(hints) -> MergeKind` — `promotion` (base main, head
      staging), `hotfix` (base main, other head), `fix_to_staging`, `other`.
 2. **Record fields (runtime rows, no migration)** — the domain writer rejects
@@ -127,7 +131,9 @@ degrade open, never fail closed (the PR #287 convention).
    inbound path right after projection when an envelope carries
    merged-to-main hints for a watched repo (`ILLO_DEPLOY_SWEEP_REPOS`,
    comma-separated; unset = off, the standing inert-until-wired convention).
-   For each Domain-1 record of that repo with `deploy_state` in
+   For each Domain-1 record **whose `fix_pr` lives in that repo** (fix-repo
+   identity, not the ticket's own `repo` field — an app ticket fixed by a
+   backend PR is swept by the backend promotion) with `deploy_state` in
    {`staging`,`prod_pending`}: ancestry-check its `fix_merge_sha` against
    main; flip to `deployed` + `deployed_at` when confirmed. Writes go through
    `AsyncDomainService` (the one domain writer) with `expected_version`; the
@@ -249,3 +255,7 @@ degrade open, never fail closed (the PR #287 convention).
   a DM after N ignored recommendations.
 - The Rollbar read-token decision (item 9) — with it, verification can also
   run occurrence-count deltas instead of pure quiet/not-quiet.
+- Revert detection: ancestry can't see reverts (a reverted fix still passes
+  the compare check). Today the prose handles it (clear `deploy_state` when a
+  revert is linked); mechanical revert detection would need commit-message or
+  linked-PR heuristics.

--- a/specs/illo-lifecycle/slices/05-deploy-state.md
+++ b/specs/illo-lifecycle/slices/05-deploy-state.md
@@ -1,0 +1,241 @@
+# Slice 5 — Deploy-state & post-deploy verification
+
+**Composes with Slice 1 (merge events arrive via the GitHub webhook lane) and
+Slice 4 (the notify cycle carries the verification tick; posts go through the
+one Slack owner).** Both are code-complete awaiting live wiring; this slice's
+pure cores, prose, and tests are buildable and verifiable now, and its runtime
+pieces are inert behind the same activation gates.
+
+## The problem observed live (2026-07-10, Rollbar #2206 → #904)
+
+Uwear merges fixes to `staging` but promotes to prod roughly weekly (evergreen
+staging→main promotion PR, e.g. uwear-backend #859) unless urgent. Prod Rollbar
+alerts therefore **re-fire for already-fixed bugs**, and the lifecycle has no
+representation of this. Intake works (alert → monitored channel → headless
+triage → real issue #904 / tracker record 1238, PR #905 opened as a main
+hotfix), but dedup is **binary**: ticket exists → skip. So a re-firing alert
+for a staging-fixed bug is either silently skipped (no annotation, no
+occurrence awareness) or — if the ticket closed at merge — refiled as a
+duplicate (the "done-reappeared" fumble class). Nothing verifies an error
+actually **stopped** after the promotion deploy; tracker `status` has nothing
+between "merged" and `Done`. Record 1238 shows the data gap: Rollbar #2206 and
+fix PR #905 exist only as prose in `body`/`progress_note` — nothing structured
+for a dedup ladder to key on.
+
+## Contract unlocked
+
+A re-firing alert is never blindly skipped and never refiled. Triage branches
+on the fix's **deploy-state**: not-merged → occurrence note; merged-awaiting-
+promotion → expected noise, annotated, owner NOT re-pinged; deployed-and-still-
+firing → the fix didn't work, ticket **reopened** and the builder escalated.
+`Done` for alert-linked tickets means **deployed to prod AND verified quiet in
+Rollbar**, not merely merged — with evidence ("verified quiet since deploy at
+T"). When a waiting fix keeps accumulating occurrences, Illo recommends early
+promotion in the team channel (recommend only — never merges).
+
+## Deploy-state model (one axis, one owner)
+
+`deploy_state` tracks the ticket's **latest fix attempt**, not the ticket
+itself; ticket `status` is untouched as an axis. Values (absent = no fix
+merged):
+
+- `staging` — fix PR merged to the repo's staging branch; promotion state not
+  yet confirmed. Set on the fix-PR merge event (base = staging) or at
+  triage-time backfill.
+- `prod_pending` — ancestry-confirmed on staging and **not** an ancestor of
+  main; awaiting the weekly promotion. (`staging` upgrades to `prod_pending`
+  on any sweep/triage touch. The ladder treats both identically — the split is
+  bookkeeping precision, not behavior.)
+- `deployed` — the fix's merge commit is an ancestor of main (promotion merged
+  **or** direct-to-main hotfix like #905 — both paths, one check).
+  `deployed_at` stamps the merge time; the verification window runs.
+- `verified` — the Rollbar item stayed quiet from `deployed_at` (+ settle)
+  through the quiet window; `verified_at` stamped; ticket may close `Done`.
+
+On a post-deploy re-fire past the settle window the ladder **reopens**: status
+back to `Todo`, `deploy_state` cleared (the fix is no longer believed), the
+failed attempt recorded in `progress_note` prose. A new fix PR restarts the
+ladder.
+
+The mechanical "is this fix in prod" check is commit ancestry — GitHub compare
+`main...SHA` (status `identical`/`behind` ⇒ ancestor) — NOT "was the promotion
+PR merged": a fix merged to staging after the promotion PR's cutoff is not in
+that promotion. Per-ticket ancestry at sweep time is correctness, not
+optimization. Indeterminate reads (API down, no token) leave state unchanged —
+degrade open, never fail closed (the PR #287 convention).
+
+## API seam / changes
+
+1. **Pure core (one owner of the axis)** — new `brain/systems/deploy_state.py`,
+   patterned on [change_notifications.py](../../../brain/systems/change_notifications.py)
+   (explicit, testable logic — not prose):
+   - `DeployState` str-enum: `staging | prod_pending | deployed | verified`.
+   - `parse_rollbar_alert(text) -> AlertSignature | None` — from a Rollbar
+     Slack attachment/fallback text (live shape:
+     `<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2206|#2206 100th
+     error: ClientError: 400 INVALID_ARGUMENT…>`), extract project + item
+     number (the signature, e.g. `Uwear-API#2206`), error title, and the
+     **occurrence milestone** ("100th error" → 100) that drives rate-spike
+     escalation. Note: Rollbar posts have empty `text` — content rides
+     attachments; parse whatever text the caller fetched.
+   - `classify_refire(*, deploy_state, ticket_status, deployed_at, now,
+     settle) -> LadderAction` — the ladder, pure:
+     - no merged fix → `NOTE_OCCURRENCE` (append freshness/occurrence note;
+       milestone alert also raises `priority`);
+     - `staging`/`prod_pending` → `EXPECTED_NOISE` (annotate the ticket,
+       optional one-time thread reply "known — fixed by PR #X merged to
+       staging, ships with next weekly promotion"; **never refile, never
+       re-ping the owner**; milestone here additionally yields
+       `RECOMMEND_PROMOTION`);
+     - `deployed` within settle → `EXPECTED_NOISE` (deploy draining);
+     - `deployed` past settle, or `verified`, or ticket already `Done` →
+       `REOPEN_ESCALATE` (this is why blind dedup-suppression is unacceptable,
+       and it retires the done-reappeared refile bug).
+   - `classify_merge_event(hints) -> MergeKind` — `promotion` (base main, head
+     staging), `hotfix` (base main, other head), `fix_to_staging`, `other`.
+2. **Record fields (runtime rows, no migration)** — the domain writer rejects
+   unknown `data` keys ([service.py](../../../brain/systems/user_domains/service.py):57–66),
+   so the new keys are `DomainFieldDefinition` rows added via the existing
+   `add_field_definition` (service.py:364) by an idempotent
+   `ensure_deploy_state_fields(...)` keyed on object key `github_ticket` (the
+   Domain-1 id is runtime data, not a constant). Flat, all optional:
+   `rollbar_item` (text, `Uwear-API#2206`), `alert_last_seen_at` (datetime),
+   `alert_occurrences` (number, highest milestone seen), `fix_pr` (text,
+   repo-qualified `uwear-ai/uwear-backend#905` — cross-repo fixes exist),
+   `fix_merge_sha` (text), `fix_merged_at` (datetime), `deploy_state` (enum),
+   `deployed_at`, `verified_at`, `promotion_recommended_at` (datetime).
+   History stays in `progress_note` prose; fields hold the latest attempt.
+   Called lazily by the sweep/tool (both gated), so activation stays
+   deliberate.
+3. **Merge hints on the webhook envelope** — extend `github_event_to_envelope`
+   ([github_webhook.py](../../../brain/systems/inbound/github_webhook.py):63):
+   for `pull_request` closed events also stamp `hints.merged` (the bool it
+   drops today), `base_ref`, `head_ref`, `merge_commit_sha`, `merged_at`.
+   Additive; existing envelope fields untouched.
+4. **Promotion-event sweep (deterministic, no LLM)** — new
+   `run_deploy_sweep(session, *, org_id, repo, merge_event)` invoked from the
+   inbound path right after projection when an envelope carries
+   merged-to-main hints for a watched repo (`ILLO_DEPLOY_SWEEP_REPOS`,
+   comma-separated; unset = off, the standing inert-until-wired convention).
+   For each Domain-1 record of that repo with `deploy_state` in
+   {`staging`,`prod_pending`}: ancestry-check its `fix_merge_sha` against
+   main; flip to `deployed` + `deployed_at` when confirmed. Writes go through
+   `AsyncDomainService` (the one domain writer) with `expected_version`; the
+   resulting `domain_events` feed the Slice-4 digest for free ("shipped,
+   verifying: …"). Also backfills `staging → prod_pending` confirmations.
+5. **Verification pass (timer side, close-half only)** — a
+   `run_deploy_verification(session, org_id, now)` step on the Slice-4 notify
+   tick ([change_notifications_cycle](../../../brain/systems/change_notifications_cycle.py)):
+   records with `deploy_state=deployed` and `deployed_at + settle + quiet
+   window` elapsed and no `alert_last_seen_at` past settle → flip `verified`,
+   close `Done` with evidence ("verified quiet since deploy at T"). The
+   **reopen half is event-driven** (a re-fire flows through triage → ladder →
+   `REOPEN_ESCALATE` immediately) — the timer only ever closes, so an
+   unregistered cycle degrades safe: tickets merely stay `deployed`. Quiet is
+   derived from our own record data (every re-fire passes the monitored
+   channel → ladder → `alert_last_seen_at`), so **no Rollbar API is
+   required** for the default path. Defaults `ILLO_DEPLOY_SETTLE_MINUTES=30`,
+   `ILLO_DEPLOY_QUIET_HOURS=24`.
+6. **Agent tool: `check_fix_deploy_state`** — read-only sibling of
+   `create_github_issue` (same registration pattern:
+   [definitions/github.py](../../../brain/systems/runs/tool_catalog/definitions/github.py),
+   handler, [registry.py](../../../brain/systems/runs/tool_catalog/registry.py)
+   toolsets; risk: read). Input repo + PR number (or SHA); output `{merged,
+   base_ref, in_staging, in_main, deploy_state, recommended_action}` —
+   computed by the **same pure core** the sweep uses, so prose and code cannot
+   drift. The ancestry helper reuses the project-context GitHub client
+   (token-aware, degrade-open on `None`).
+7. **Prose ladder (the dedup rule's new text)** — rewrite the binary
+   "One problem = one issue" rule in
+   [uwear-engineering-triage/SKILL.md](../../../brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md)
+   into the deploy-state ladder (match by `rollbar_item`/signature first, then
+   fuzzy; branch per `classify_refire`; stamp the structured fields when
+   filing/linking), redefine `Done` for alert-linked tickets (deployed AND
+   verified quiet), and add the recommend-early-promotion norm (**recommend
+   only; never merge the promotion PR**). Mirror the same ladder into the
+   monitored-channel prompt
+   ([triggers.py](../../../brain/systems/slack/triggers.py):235 —
+   `slack_channel_monitor_message`) as one branch line. The live doc (Domain
+   37 record 1155, currently v5) gets the same delta as an activation step —
+   coordinate with the parallel digest-contract edit to the same doc.
+8. **Urgent-promotion recommendation** — when the ladder yields
+   `RECOMMEND_PROMOTION` (milestone re-fire on a `prod_pending` fix), the
+   triage run posts to the team channel via `post_slack_reply` (invariant 5):
+   "fix for #904 (PR #905) is merged and waiting; #2206 hit its Nth occurrence
+   today; recommend promoting now." Deduped by `promotion_recommended_at`
+   (max one per ticket per day). Matches the weekly-unless-urgent policy;
+   merging remains a human action.
+9. **Optional enabler (decision for Reda — do not block):** a Rollbar
+   **read-only** API token in Vault (the runtime-authored
+   `PROD_POSTGRES_READONLY_URL` / skill-46 pattern) would let the
+   verification pass query item occurrence counts deterministically instead
+   of inferring quiet from Slack recurrence (catches sub-threshold fires that
+   never reach the channel). The quiet-check is a seam with the internal
+   inference as default impl; the API impl slots in when the token exists.
+10. **Alert text at ingest (small)** — surface Slack attachment
+    fallback/preview text into the monitor envelope/message
+    ([ingress.py](../../../brain/systems/slack/ingress.py) /
+    triggers.py): run 1073's "Message text:" was **empty** because Rollbar
+    posts attachment-only; the signature should be visible without a fetch
+    (the agent still reads the thread for full context).
+
+## What the human can run/see
+
+- Unit probe: `classify_refire(deploy_state=prod_pending, …)` →
+  `EXPECTED_NOISE`; same ticket after promotion + settle →
+  `REOPEN_ESCALATE`; `parse_rollbar_alert` on the recorded #2206 fallback →
+  `Uwear-API#2206`, milestone 100.
+- Feed a recorded promotion-merge webhook delivery locally → a
+  `prod_pending` fixture record flips to `deployed` with `deployed_at`, and a
+  `domain_event` shows the flip.
+- Dry-run pattern (run 952 style, READ-ONLY, no posts): synthetic re-fire of
+  Rollbar #2206 with the fix framed merged-to-staging → the triage run
+  classifies "expected — awaiting promotion", files **zero** new issues,
+  pings **zero** owners. Synthetic post-promotion re-fire (live truth: #905
+  IS in main) → reports it would reopen #904 and escalate to the builder.
+- `check_fix_deploy_state(repo=uwear-ai/uwear-backend, pr=905)` →
+  `in_main=true, deploy_state=deployed` (live read).
+
+## Verification
+
+- Unit: ladder truth table (every `deploy_state` × settle/milestone/status
+  combination → action); parser fixtures from the real #2206 attachment incl.
+  new-item vs Nth-error forms and non-Rollbar text → `None`;
+  `classify_merge_event` promotion vs hotfix vs staging-fix; sweep flips only
+  ancestry-confirmed records (fix-after-promotion-cutoff stays
+  `prod_pending`); verification closes only quiet-through-window records;
+  recommendation dedup (second milestone same day → no second post).
+- Integration (test-DB, `submit_inbound_envelope` pattern of
+  [test_inbound_webhooks.py](../../../tests/test_inbound_webhooks.py)): a
+  merged-to-main `pull_request` envelope with `ILLO_DEPLOY_SWEEP_REPOS` set
+  triggers exactly one sweep; idempotent on delivery replay; unset env → no
+  sweep (inert).
+- Ensure-fields: idempotent (second call adds nothing); unknown-key rejection
+  gone once fields exist.
+- The two dry-run scenarios above on illo-dev, non-posting, after the prose
+  ships.
+
+## Must stay green
+
+- Existing webhook envelope mapping and idempotency
+  ([test_github_webhook.py](../../../tests/test_github_webhook.py)) — hints
+  are additive.
+- Ordinary (non-alert-linked) ticket flow: no new required fields, `Done`
+  semantics unchanged, triage prompt still fits its current decision shape.
+- Slack monitor ack/headless behavior
+  ([test_slack_channel_monitor.py](../../../tests/test_slack_channel_monitor.py)).
+- One domain writer, one Slack owner, one GitHub→triage write path (README
+  invariants) — the sweep writes via `AsyncDomainService` and posts nothing
+  itself.
+
+## Feedback that would change this slice
+
+- Grace defaults (settle 30m / quiet 24h) and whether quiet should also
+  require a minimum number of prod requests (traffic-aware verification needs
+  the Rollbar API enabler).
+- Whether `staging` vs `prod_pending` earns its keep or collapses to one
+  value.
+- Recommendation cadence (once/day/ticket) and whether it should escalate to
+  a DM after N ignored recommendations.
+- The Rollbar read-token decision (item 9) — with it, verification can also
+  run occurrence-count deltas instead of pure quiet/not-quiet.

--- a/specs/illo-lifecycle/slices/05-doc-1155-delta.md
+++ b/specs/illo-lifecycle/slices/05-doc-1155-delta.md
@@ -1,0 +1,64 @@
+# Slice 5 activation artifact — live doc 1155 delta
+
+The runtime source of truth for triage prose is Enterprise Documentation
+(Domain 37) record **1155**, slug `uwear-engineering-triage`. The bundled
+[SKILL.md](../../../brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md)
+already carries these edits (kept in sync per the PR #268 pattern); this file
+is the exact delta to apply to the **live doc** at activation, written as
+anchored edits so it composes with other in-flight edits to the same record
+(the coordinator digest-contract redesign also edits 1155 — whichever lands
+second must re-read the doc first and apply onto the latest content).
+
+**Apply mechanics:** `manage_domain` → `update_record` on record 1155 with a
+`data.content` patch and `expected_version` = the version just read (v5 as of
+2026-07-10 before either edit; expect it higher if the digest edit landed
+first). Requires explicit approval — this is a live-runtime write.
+
+## Edit 1 — dedup rule routes through the ladder
+
+In **## Creating Work Items**, replace the bullet beginning
+`**One problem = one issue — check before filing.**` … ending
+`…never split one error/Rollbar alert into multiple issues.` with:
+
+> - **One problem = one issue — check before filing.** Before calling
+>   `create_github_issue`, search open AND recently-closed GitHub issues and
+>   Domain 1 tracker records for the same error signature, Rollbar id (prefer
+>   the structured `rollbar_item` field), endpoint, profile id, or root cause.
+>   If a match exists — even if closed or `Done` — do NOT file a new issue and
+>   do NOT blindly skip: follow the **Deploy-State Ladder** below. Never split
+>   one error/Rollbar alert into multiple issues.
+
+## Edit 2 — insert two sections before `## States`
+
+Insert the full text of the bundled SKILL.md's
+**## Deploy-State Ladder (re-firing alerts)** and **## Urgent Promotion**
+sections (copy verbatim from the bundled skill — they are the canonical text)
+immediately before `## States`.
+
+## Edit 3 — `Done` redefinition
+
+In **## States**, replace the `Done` bullet with:
+
+> - `Done`: linked PR merged or issue closed. For an alert-linked ticket (one
+>   with a `rollbar_item`), `Done` additionally requires the fix deployed to
+>   prod AND verified quiet (`deploy_state` = `verified`) per the
+>   **Deploy-State Ladder** — merged-to-staging is not done. A `Done` item must
+>   not appear in anyone's priority workset — see **Before Posting** and
+>   **Public Output**.
+
+## Edit 4 — Before Posting gate
+
+In **## Before Posting**, append gate 4 after the dedup gate:
+
+> 4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2) re-pings
+>    an owner or appears as new work; every reopened ticket (Ladder case 3)
+>    names the builder and the failed fix.
+
+## After applying
+
+- Re-read the record; confirm the new sections render and the version bumped.
+- The bundled SKILL.md and the live doc must say the same thing — if the doc
+  has diverged elsewhere (e.g. digest-contract edits), leave those parts
+  alone; these four edits are self-contained.
+- Verify with the run-952-style READ-ONLY dry runs in the slice spec
+  ([05-deploy-state.md](05-deploy-state.md) → Verification).

--- a/specs/illo-lifecycle/slices/05-doc-1155-delta.md
+++ b/specs/illo-lifecycle/slices/05-doc-1155-delta.md
@@ -21,12 +21,13 @@ In **## Creating Work Items**, replace the bullet beginning
 `…never split one error/Rollbar alert into multiple issues.` with:
 
 > - **One problem = one issue — check before filing.** Before calling
->   `create_github_issue`, search open AND recently-closed GitHub issues and
->   Domain 1 tracker records for the same error signature, Rollbar id (prefer
->   the structured `rollbar_item` field), endpoint, profile id, or root cause.
->   If a match exists — even if closed or `Done` — do NOT file a new issue and
->   do NOT blindly skip: follow the **Deploy-State Ladder** below. Never split
->   one error/Rollbar alert into multiple issues.
+>   `create_github_issue`, search open AND closed GitHub issues and Domain 1
+>   tracker records for the same error signature, Rollbar id (prefer the
+>   structured `rollbar_item` field — an exact `rollbar_item`/signature match
+>   has no recency cutoff), endpoint, profile id, or root cause. If a match
+>   exists — even if closed or `Done` — do NOT file a new issue and do NOT
+>   blindly skip: follow the **Deploy-State Ladder** below. Never split one
+>   error/Rollbar alert into multiple issues.
 
 ## Edit 2 — insert two sections before `## States`
 
@@ -50,9 +51,28 @@ In **## States**, replace the `Done` bullet with:
 
 In **## Before Posting**, append gate 4 after the dedup gate:
 
-> 4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2) re-pings
->    an owner or appears as new work; every reopened ticket (Ladder case 3)
->    names the builder and the failed fix.
+> 4. **Deploy-state gate:** no expected-noise re-fire (Ladder case 2, including
+>    a within-settle deploy drain) re-pings an owner or appears as new work;
+>    every reopened ticket (Ladder case 3) names the builder and the failed fix
+>    without reassigning the issue.
+
+## Edit 5 — legacy "merged = Done" clauses gain the deploy-verified qualifier
+
+Three older clauses equate a merged PR with done and would let an agent close
+or hide a staging-only alert ticket; qualify each exactly as the bundled
+SKILL.md now does:
+
+- **## Backlog Hygiene**, the `Done` classification bullet → append
+  "(alert-linked tickets: only once deploy-verified — see **Deploy-State
+  Ladder**)".
+- **## Before Posting** gate 1 (state gate) → append the exception sentence:
+  "Exception: an alert-linked ticket whose fix is merely merged (not
+  deploy-verified) is NOT cleanup — it stays active as `prod_pending` per the
+  **Deploy-State Ladder**."
+- **## Public Output**, the `Done` item bullet → "(linked PR merged — and,
+  for an alert-linked ticket, deploy-verified per the **Deploy-State
+  Ladder**)", and the close-the-issue parenthetical gains "— never for an
+  alert-linked ticket that is not yet deploy-verified".
 
 ## After applying
 

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -131,6 +131,44 @@ class TestNotifyCycleOrchestration:
         assert any("Prod down" in text for _, text in sent)
         assert any("1 item waiting" in text for _, text in sent)
 
+    async def test_verification_is_inert_when_deploy_feature_unset(self, monkeypatch):
+        import brain.systems.change_notifications_cycle as cyc
+
+        monkeypatch.delenv("ILLO_DEPLOY_SWEEP_REPOS", raising=False)
+        monkeypatch.setattr(cyc, "_load_change_events", lambda *a, **k: _async_value([]))
+        monkeypatch.setattr(cyc, "_count_unclaimed", lambda *a, **k: _async_value(0))
+
+        result = await cyc.run_notify_cycle(
+            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None)
+        )
+        assert result == {
+            "events": 0,
+            "immediate": 0,
+            "digest_posted": False,
+            "unclaimed": 0,
+        }
+
+    async def test_verification_is_additive_and_safe(self, monkeypatch):
+        import brain.systems.change_notifications_cycle as cyc
+
+        monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", "o/r")
+        monkeypatch.setattr(cyc, "_load_change_events", lambda *a, **k: _async_value([]))
+        monkeypatch.setattr(cyc, "_count_unclaimed", lambda *a, **k: _async_value(0))
+        monkeypatch.setattr(
+            cyc,
+            "_maybe_run_deploy_verification",
+            lambda *a, **k: _async_value({"verified": 2}),
+        )
+
+        result = await cyc.run_notify_cycle(
+            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None)
+        )
+        assert result["verification"] == {"verified": 2}
+
+
+async def _async_value(value):
+    return value
+
 
 class TestNormalizeEvent:
     def test_reads_user_fields_from_data_not_top_level(self):

--- a/tests/test_check_fix_deploy_state_tool.py
+++ b/tests/test_check_fix_deploy_state_tool.py
@@ -1,0 +1,191 @@
+"""Read-only check_fix_deploy_state tool tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from brain.systems.cortex.project_context.github import GitHubConnectorError
+from brain.systems.deploy_state_github import is_ancestor_of
+from brain.systems.runs.tool_catalog.handlers.github import _handle_check_fix_deploy_state
+
+
+_H = "brain.systems.runs.tool_catalog.handlers.github"
+
+
+@pytest.mark.asyncio
+async def test_check_fix_deploy_state_uses_pr_merge_sha_and_shared_ladder(monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", "uwear-ai/uwear-backend")
+
+    async def ancestry(repo, sha, branch, *, token=None):
+        assert repo == "uwear-ai/uwear-backend"
+        assert sha == "merge-sha"
+        assert token is None
+        return branch == "staging"
+
+    with patch(f"{_H}._maybe_ensure_deploy_fields", new=AsyncMock()), patch(
+        f"{_H}.async_get_pull_request_deploy_info",
+        new=AsyncMock(
+            return_value={
+                "repo": "uwear-ai/uwear-backend",
+                "pull_request": {
+                    "merged": True,
+                    "merge_commit_sha": "merge-sha",
+                    "merged_at": "2026-07-01T00:00:00Z",
+                    "base": {"ref": "staging"},
+                    "head": {"sha": "head-sha"},
+                },
+            }
+        ),
+    ), patch(f"{_H}.is_ancestor_of", new=AsyncMock(side_effect=ancestry)):
+        payload = json.loads(
+            await _handle_check_fix_deploy_state(
+                repo="https://github.com/uwear-ai/uwear-backend.git",
+                pr_number=905,
+            )
+        )
+
+    assert payload["merged"] is True
+    assert payload["base_ref"] == "staging"
+    assert payload["in_staging"] is True
+    assert payload["in_main"] is False
+    assert payload["deploy_state"] == "prod_pending"
+    assert payload["recommended_action"] == "expected_noise"
+
+
+@pytest.mark.asyncio
+async def test_check_fix_deploy_state_sha_in_main_degrades_open_on_unknown_deploy_time(monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", "uwear-ai/uwear-backend")
+
+    async def ancestry(repo, sha, branch, *, token=None):
+        return True
+
+    with patch(f"{_H}._maybe_ensure_deploy_fields", new=AsyncMock()), patch(
+        f"{_H}.is_ancestor_of", new=AsyncMock(side_effect=ancestry)
+    ):
+        payload = json.loads(
+            await _handle_check_fix_deploy_state(
+                repo="uwear-ai/uwear-backend",
+                sha="abc123",
+            )
+        )
+
+    assert payload["merged"] is None
+    assert payload["in_main"] is True
+    assert payload["deploy_state"] == "deployed"
+    assert payload["recommended_action"] == "expected_noise"
+
+
+@pytest.mark.asyncio
+async def test_staging_pr_now_in_main_does_not_use_old_staging_merge_as_deploy_time(monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", "uwear-ai/uwear-backend")
+
+    async def ancestry(repo, sha, branch, *, token=None):
+        return True
+
+    with patch(f"{_H}._maybe_ensure_deploy_fields", new=AsyncMock()), patch(
+        f"{_H}.async_get_pull_request_deploy_info",
+        new=AsyncMock(
+            return_value={
+                "pull_request": {
+                    "merged": True,
+                    "merge_commit_sha": "merge-sha",
+                    "merged_at": "2026-01-01T00:00:00Z",
+                    "base": {"ref": "staging"},
+                    "head": {"sha": "head-sha"},
+                }
+            }
+        ),
+    ), patch(f"{_H}.is_ancestor_of", new=AsyncMock(side_effect=ancestry)):
+        payload = json.loads(
+            await _handle_check_fix_deploy_state(
+                repo="uwear-ai/uwear-backend",
+                pr_number=905,
+            )
+        )
+
+    assert payload["deploy_state"] == "deployed"
+    assert payload["recommended_action"] == "expected_noise"
+
+
+@pytest.mark.asyncio
+async def test_check_fix_deploy_state_no_token_visibility_degrades_open(monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", "uwear-ai/uwear-backend")
+    with patch(f"{_H}._maybe_ensure_deploy_fields", new=AsyncMock()), patch(
+        f"{_H}.async_get_pull_request_deploy_info",
+        new=AsyncMock(
+            side_effect=GitHubConnectorError(
+                status_code=404,
+                message="Repository not found or not visible to this token.",
+            )
+        ),
+    ):
+        payload = json.loads(
+            await _handle_check_fix_deploy_state(
+                repo="uwear-ai/uwear-backend",
+                pr_number=905,
+            )
+        )
+
+    assert payload["merged"] is None
+    assert payload["in_staging"] is None
+    assert payload["in_main"] is None
+    assert payload["deploy_state"] is None
+    assert payload["recommended_action"] == "note_occurrence"
+    assert payload["indeterminate"] is True
+    assert payload["status_code"] == 404
+
+
+@pytest.mark.asyncio
+async def test_check_fix_deploy_state_is_env_gated(monkeypatch):
+    monkeypatch.delenv("ILLO_DEPLOY_SWEEP_REPOS", raising=False)
+    payload = json.loads(
+        await _handle_check_fix_deploy_state(repo="uwear-ai/uwear-backend", sha="abc123")
+    )
+    assert payload["disabled"] is True
+
+
+def test_check_fix_deploy_state_tool_is_registered_and_read_only():
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+    from brain.systems.runs.tool_definitions import COORDINATOR_TOOLS, WORKER_TOOLS
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+
+    name = "check_fix_deploy_state"
+    assert name in {tool["name"] for tool in COORDINATOR_TOOLS}
+    assert name in {tool["name"] for tool in WORKER_TOOLS}
+    assert name in _get_tool_handlers()
+    registration = get_tool_registration(name)
+    assert registration is not None
+    assert registration.risk_class == "low"
+    assert registration.side_effect_class == "read_only"
+    assert registration.action_manifest is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [("identical", True), ("behind", True), ("ahead", False), ("diverged", False)],
+)
+async def test_ancestry_helper_maps_github_compare_status(status, expected):
+    with patch(
+        "brain.systems.deploy_state_github.async_compare_commits",
+        new=AsyncMock(return_value=status),
+    ) as compare:
+        assert await is_ancestor_of("uwear-ai/uwear-backend", "abc123", "main") is expected
+    compare.assert_awaited_once_with(
+        "uwear-ai/uwear-backend",
+        "main",
+        "abc123",
+        token=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ancestry_helper_failure_is_indeterminate():
+    with patch(
+        "brain.systems.deploy_state_github.async_compare_commits",
+        new=AsyncMock(side_effect=GitHubConnectorError(503, "offline")),
+    ):
+        assert await is_ancestor_of("uwear-ai/uwear-backend", "abc123", "main") is None

--- a/tests/test_deploy_state.py
+++ b/tests/test_deploy_state.py
@@ -1,0 +1,186 @@
+"""Pure deploy-state core tests."""
+
+from datetime import datetime, timedelta, timezone
+from itertools import product
+
+import pytest
+
+from brain.systems.deploy_state import (
+    DeployState,
+    LadderAction,
+    MergeKind,
+    RefireSignal,
+    classify_merge_event,
+    classify_refire,
+    derive_deploy_state,
+    parse_rollbar_alert,
+    promotion_recommendation_signal,
+)
+
+
+NOW = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+SETTLE = timedelta(minutes=30)
+
+
+@pytest.mark.parametrize(
+    ("state", "status", "deployed_at", "expected"),
+    [
+        (None, "Todo", None, LadderAction.NOTE_OCCURRENCE),
+        (DeployState.STAGING, "Todo", None, LadderAction.EXPECTED_NOISE),
+        (DeployState.PROD_PENDING, "In Progress", None, LadderAction.EXPECTED_NOISE),
+        (DeployState.DEPLOYED, "Todo", NOW - timedelta(minutes=29), LadderAction.EXPECTED_NOISE),
+        (DeployState.DEPLOYED, "Todo", NOW - SETTLE, LadderAction.REOPEN_ESCALATE),
+        (DeployState.DEPLOYED, "Todo", None, LadderAction.REOPEN_ESCALATE),
+        (DeployState.VERIFIED, "Todo", NOW - timedelta(days=2), LadderAction.REOPEN_ESCALATE),
+        (None, "Done", None, LadderAction.REOPEN_ESCALATE),
+        (DeployState.STAGING, "Done", None, LadderAction.REOPEN_ESCALATE),
+        (DeployState.PROD_PENDING, "Done", None, LadderAction.REOPEN_ESCALATE),
+        (DeployState.DEPLOYED, "Done", NOW - timedelta(minutes=1), LadderAction.REOPEN_ESCALATE),
+        (DeployState.VERIFIED, "Done", NOW, LadderAction.REOPEN_ESCALATE),
+    ],
+)
+def test_refire_ladder_truth_table(state, status, deployed_at, expected):
+    assert classify_refire(
+        deploy_state=state,
+        ticket_status=status,
+        deployed_at=deployed_at,
+        now=NOW,
+        settle=SETTLE,
+    ) is expected
+
+
+@pytest.mark.parametrize(
+    ("state", "inside_settle", "milestone", "status"),
+    list(
+        product(
+            [None, *list(DeployState)],
+            [False, True],
+            [None, 100],
+            ["Todo", "Done"],
+        )
+    ),
+)
+def test_full_state_settle_milestone_status_matrix(state, inside_settle, milestone, status):
+    deployed_at = NOW - (timedelta(minutes=1) if inside_settle else timedelta(hours=2))
+    action = classify_refire(
+        deploy_state=state,
+        ticket_status=status,
+        deployed_at=deployed_at,
+        now=NOW,
+        settle=SETTLE,
+    )
+    if status == "Done" or state is DeployState.VERIFIED:
+        expected = LadderAction.REOPEN_ESCALATE
+    elif state in {DeployState.STAGING, DeployState.PROD_PENDING}:
+        expected = LadderAction.EXPECTED_NOISE
+    elif state is DeployState.DEPLOYED:
+        expected = (
+            LadderAction.EXPECTED_NOISE
+            if inside_settle
+            else LadderAction.REOPEN_ESCALATE
+        )
+    else:
+        expected = LadderAction.NOTE_OCCURRENCE
+    assert action is expected
+    signal = promotion_recommendation_signal(
+        deploy_state=state,
+        occurrence_milestone=milestone,
+        promotion_recommended_at=None,
+        now=NOW,
+    )
+    assert (signal is RefireSignal.RECOMMEND_PROMOTION) is (
+        state is DeployState.PROD_PENDING and milestone is not None
+    )
+
+
+def test_milestone_does_not_change_primary_ladder_action():
+    assert classify_refire(
+        deploy_state=DeployState.PROD_PENDING,
+        ticket_status="Todo",
+        deployed_at=None,
+        now=NOW,
+        settle=SETTLE,
+    ) is LadderAction.EXPECTED_NOISE
+    assert promotion_recommendation_signal(
+        deploy_state=DeployState.PROD_PENDING,
+        occurrence_milestone=100,
+        promotion_recommended_at=None,
+        now=NOW,
+    ) is RefireSignal.RECOMMEND_PROMOTION
+
+
+def test_promotion_recommendation_is_deduped_per_utc_day():
+    assert promotion_recommendation_signal(
+        deploy_state="prod_pending",
+        occurrence_milestone=100,
+        promotion_recommended_at=NOW - timedelta(hours=1),
+        now=NOW,
+    ) is None
+    assert promotion_recommendation_signal(
+        deploy_state="prod_pending",
+        occurrence_milestone=200,
+        promotion_recommended_at=NOW - timedelta(days=1),
+        now=NOW,
+    ) is RefireSignal.RECOMMEND_PROMOTION
+    assert promotion_recommendation_signal(
+        deploy_state="staging",
+        occurrence_milestone=100,
+        promotion_recommended_at=None,
+        now=NOW,
+    ) is None
+
+
+def test_parse_real_rollbar_fallback():
+    parsed = parse_rollbar_alert(
+        "<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2206|"
+        "#2206 100th error: ClientError: 400 INVALID_ARGUMENT. {'err...>"
+    )
+    assert parsed is not None
+    assert parsed.signature == "Uwear-API#2206"
+    assert parsed.milestone == 100
+    assert parsed.title.startswith("ClientError: 400 INVALID_ARGUMENT")
+
+
+@pytest.mark.parametrize(
+    ("label", "milestone", "title"),
+    [
+        ("#17 New item: RuntimeError: exploded", None, "RuntimeError: exploded"),
+        ("#17 New item RuntimeError: exploded", None, "RuntimeError: exploded"),
+        ("#17 21st error: RuntimeError: exploded", 21, "RuntimeError: exploded"),
+        ("#17 2nd occurrence: RuntimeError: exploded", 2, "RuntimeError: exploded"),
+    ],
+)
+def test_parse_rollbar_forms(label, milestone, title):
+    parsed = parse_rollbar_alert(
+        f"<https://app.rollbar.com/a/acme/fix/item/worker/17|{label}>"
+    )
+    assert parsed is not None
+    assert parsed.signature == "worker#17"
+    assert parsed.milestone == milestone
+    assert parsed.title == title
+
+
+@pytest.mark.parametrize("text", [None, "", "#2206 100th error: nope", "Sentry item #2206"])
+def test_non_rollbar_text_returns_none(text):
+    assert parse_rollbar_alert(text) is None
+
+
+@pytest.mark.parametrize(
+    ("hints", "expected"),
+    [
+        ({"merged": True, "base_ref": "main", "head_ref": "staging"}, MergeKind.PROMOTION),
+        ({"merged": True, "base_ref": "main", "head_ref": "fix/urgent"}, MergeKind.HOTFIX),
+        ({"merged": True, "base_ref": "staging", "head_ref": "fix/bug"}, MergeKind.FIX_TO_STAGING),
+        ({"merged": False, "base_ref": "main", "head_ref": "staging"}, MergeKind.OTHER),
+        ({"merged": True, "base_ref": "develop", "head_ref": "fix/bug"}, MergeKind.OTHER),
+    ],
+)
+def test_classify_merge_event(hints, expected):
+    assert classify_merge_event(hints) is expected
+
+
+def test_derive_deploy_state_is_shared_mechanical_axis():
+    assert derive_deploy_state(merged=True, base_ref="staging", in_staging=True, in_main=True) is DeployState.DEPLOYED
+    assert derive_deploy_state(merged=True, base_ref="staging", in_staging=True, in_main=False) is DeployState.PROD_PENDING
+    assert derive_deploy_state(merged=True, base_ref="staging", in_staging=None, in_main=None) is DeployState.STAGING
+    assert derive_deploy_state(merged=None, base_ref=None, in_staging=None, in_main=None) is None

--- a/tests/test_deploy_state.py
+++ b/tests/test_deploy_state.py
@@ -33,8 +33,11 @@ SETTLE = timedelta(minutes=30)
         (DeployState.DEPLOYED, "Todo", None, LadderAction.REOPEN_ESCALATE),
         (DeployState.VERIFIED, "Todo", NOW - timedelta(days=2), LadderAction.REOPEN_ESCALATE),
         (None, "Done", None, LadderAction.REOPEN_ESCALATE),
-        (DeployState.STAGING, "Done", None, LadderAction.REOPEN_ESCALATE),
-        (DeployState.PROD_PENDING, "Done", None, LadderAction.REOPEN_ESCALATE),
+        # A merely-staged fix wins over a stale Done: re-firing before
+        # promotion is expected noise even on a prematurely closed ticket
+        # (the caller normalizes the status quietly; no builder escalation).
+        (DeployState.STAGING, "Done", None, LadderAction.EXPECTED_NOISE),
+        (DeployState.PROD_PENDING, "Done", None, LadderAction.EXPECTED_NOISE),
         (DeployState.DEPLOYED, "Done", NOW - timedelta(minutes=1), LadderAction.REOPEN_ESCALATE),
         (DeployState.VERIFIED, "Done", NOW, LadderAction.REOPEN_ESCALATE),
     ],
@@ -69,10 +72,11 @@ def test_full_state_settle_milestone_status_matrix(state, inside_settle, milesto
         now=NOW,
         settle=SETTLE,
     )
-    if status == "Done" or state is DeployState.VERIFIED:
-        expected = LadderAction.REOPEN_ESCALATE
-    elif state in {DeployState.STAGING, DeployState.PROD_PENDING}:
+    if state in {DeployState.STAGING, DeployState.PROD_PENDING}:
+        # Pre-promotion fixes are expected noise even on a stale Done ticket.
         expected = LadderAction.EXPECTED_NOISE
+    elif status == "Done" or state is DeployState.VERIFIED:
+        expected = LadderAction.REOPEN_ESCALATE
     elif state is DeployState.DEPLOYED:
         expected = (
             LadderAction.EXPECTED_NOISE

--- a/tests/test_deploy_state_sweep.py
+++ b/tests/test_deploy_state_sweep.py
@@ -1,0 +1,371 @@
+"""Deploy-state persistence, verification, and safe-hook tests."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+from brain.platform.db.models.domain import (
+    Domain,
+    DomainEvent,
+    DomainFieldDefinition,
+    DomainObjectType,
+    DomainRecord,
+    DomainRelation,
+    DomainRelationType,
+)
+from brain.systems.deploy_state_sweep import (
+    DEPLOY_STATE_FIELD_DEFINITIONS,
+    ensure_deploy_state_fields,
+    run_deploy_sweep,
+    run_deploy_verification,
+)
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+pytestmark = pytest.mark.asyncio
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+REPO = "uwear-ai/uwear-backend"
+NOW = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+
+
+def _patch_sqlite_for_pg_types():
+    if not hasattr(SQLiteTypeCompiler, "visit_JSONB"):
+        SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_deploy_state_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+            result = result.replace("TRUE", "1").replace("FALSE", "0")
+        return result
+
+    patched._deploy_state_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    return await async_sqlite_session_factory(
+        [
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainFieldDefinition.__table__,
+            DomainRelationType.__table__,
+            DomainRecord.__table__,
+            DomainRelation.__table__,
+            DomainEvent.__table__,
+        ]
+    )
+
+
+async def _domain(session, *, name="Engineering"):
+    return await AsyncDomainService(session).create_domain(
+        ORG_ID,
+        name=name,
+        objects=[
+            {
+                "key": "github_ticket",
+                "name": "GitHub Ticket",
+                "title_field": "title",
+                "fields": [
+                    {"key": "title", "field_type": "text", "required": True},
+                    {"key": "repo", "field_type": "text"},
+                    {
+                        "key": "status",
+                        "field_type": "enum",
+                        "options": ["Todo", "In Progress", "Done"],
+                    },
+                    {"key": "progress_note", "field_type": "long_text"},
+                ],
+            }
+        ],
+    )
+
+
+async def _record(session, domain, *, title, **data):
+    return await AsyncDomainService(session).create_record(
+        ORG_ID,
+        domain.id,
+        "github_ticket",
+        title=title,
+        data={
+            "title": title,
+            "repo": REPO,
+            "status": "Todo",
+            "progress_note": "investigating",
+            **data,
+        },
+    )
+
+
+async def test_ensure_fields_is_runtime_id_agnostic_and_idempotent(session):
+    first_domain = await _domain(session, name="First")
+    second_domain = await _domain(session, name="Second")
+    assert first_domain.id != second_domain.id
+
+    first = await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    second = await ensure_deploy_state_fields(session, org_id=ORG_ID)
+
+    assert first == {"object_types": 2, "fields_added": 2 * len(DEPLOY_STATE_FIELD_DEFINITIONS)}
+    assert second == {"object_types": 2, "fields_added": 0}
+    fields = (await session.scalars(select(DomainFieldDefinition))).all()
+    deploy_fields = [field for field in fields if field.key == "deploy_state"]
+    assert len(deploy_fields) == 2
+    assert all(field.options == ["staging", "prod_pending", "deployed", "verified"] for field in deploy_fields)
+
+
+async def test_promotion_sweep_flips_only_confirmed_records(session, monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", REPO)
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    shipped = await _record(
+        session, domain, title="Shipped", deploy_state="prod_pending", fix_merge_sha="in-main"
+    )
+    post_cutoff = await _record(
+        session, domain, title="Post cutoff", deploy_state="prod_pending", fix_merge_sha="after-cutoff"
+    )
+    unknown = await _record(
+        session, domain, title="Unknown", deploy_state="prod_pending", fix_merge_sha="unknown"
+    )
+    staging = await _record(
+        session, domain, title="Staging", deploy_state="staging", fix_merge_sha="on-staging"
+    )
+
+    async def fake_ancestry(repo, sha, branch):
+        return {
+            ("in-main", "main"): True,
+            ("after-cutoff", "main"): False,
+            ("unknown", "main"): None,
+            ("on-staging", "main"): False,
+            ("on-staging", "staging"): True,
+        }[(sha, branch)]
+
+    monkeypatch.setattr("brain.systems.deploy_state_sweep.is_ancestor_of", fake_ancestry)
+    summary = await run_deploy_sweep(
+        session,
+        org_id=ORG_ID,
+        repo=REPO,
+        merge_event={
+            "merged": True,
+            "base_ref": "main",
+            "head_ref": "staging",
+            "number": 900,
+            "merge_commit_sha": "promotion",
+            "merged_at": NOW.isoformat(),
+        },
+    )
+
+    await session.refresh(shipped)
+    await session.refresh(post_cutoff)
+    await session.refresh(unknown)
+    await session.refresh(staging)
+    assert shipped.data["deploy_state"] == "deployed"
+    assert shipped.data["deployed_at"] == NOW.isoformat()
+    assert post_cutoff.data["deploy_state"] == "prod_pending"
+    assert unknown.data["deploy_state"] == "prod_pending"
+    assert staging.data["deploy_state"] == "prod_pending"
+    assert summary["deployed"] == 1
+    assert summary["prod_pending"] == 1
+    assert summary["indeterminate"] == 1
+
+
+async def test_fix_to_staging_stamps_only_matching_ticket(session, monkeypatch):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", REPO)
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    matched = await _record(session, domain, title="Matched", fix_pr=f"{REPO}#905")
+    other = await _record(session, domain, title="Other", fix_pr=f"{REPO}#906")
+
+    async def not_in_main(repo, sha, branch):
+        assert (repo, sha, branch) == (REPO, "fix-sha", "main")
+        return False
+
+    monkeypatch.setattr("brain.systems.deploy_state_sweep.is_ancestor_of", not_in_main)
+    summary = await run_deploy_sweep(
+        session,
+        org_id=ORG_ID,
+        repo=REPO,
+        merge_event={
+            "merged": True,
+            "base_ref": "staging",
+            "head_ref": "fix/905",
+            "number": 905,
+            "merge_commit_sha": "fix-sha",
+            "merged_at": NOW.isoformat(),
+        },
+    )
+
+    await session.refresh(matched)
+    await session.refresh(other)
+    assert matched.data["fix_merge_sha"] == "fix-sha"
+    assert matched.data["fix_merged_at"] == NOW.isoformat()
+    assert matched.data["deploy_state"] == "prod_pending"
+    assert other.data["fix_merge_sha"] is None
+    assert summary["updated"] == 1
+
+
+async def test_env_unset_makes_sweep_inert(session, monkeypatch):
+    monkeypatch.delenv("ILLO_DEPLOY_SWEEP_REPOS", raising=False)
+    summary = await run_deploy_sweep(
+        session,
+        org_id=ORG_ID,
+        repo=REPO,
+        merge_event={"merged": True, "base_ref": "main", "head_ref": "staging"},
+    )
+    assert summary["disabled"] is True
+    assert summary["examined"] == 0
+    assert (await session.scalars(select(DomainFieldDefinition))).all() == []
+
+
+async def test_verification_closes_only_quiet_through_window_and_never_reopens(
+    session, monkeypatch
+):
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", REPO)
+    monkeypatch.setenv("ILLO_DEPLOY_SETTLE_MINUTES", "30")
+    monkeypatch.setenv("ILLO_DEPLOY_QUIET_HOURS", "24")
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    deployed_at = NOW - timedelta(hours=25)
+    quiet = await _record(
+        session,
+        domain,
+        title="Quiet",
+        deploy_state="deployed",
+        deployed_at=deployed_at.isoformat(),
+    )
+    before_settle = await _record(
+        session,
+        domain,
+        title="Seen during settle",
+        deploy_state="deployed",
+        deployed_at=deployed_at.isoformat(),
+        alert_last_seen_at=(deployed_at + timedelta(minutes=20)).isoformat(),
+    )
+    refired = await _record(
+        session,
+        domain,
+        title="Refired",
+        deploy_state="deployed",
+        deployed_at=deployed_at.isoformat(),
+        alert_last_seen_at=(deployed_at + timedelta(hours=2)).isoformat(),
+    )
+    too_recent = await _record(
+        session,
+        domain,
+        title="Recent",
+        deploy_state="deployed",
+        deployed_at=(NOW - timedelta(hours=2)).isoformat(),
+    )
+    already_verified = await _record(
+        session,
+        domain,
+        title="Already verified",
+        deploy_state="verified",
+        deployed_at=(NOW - timedelta(days=2)).isoformat(),
+        verified_at=(NOW - timedelta(days=1)).isoformat(),
+        alert_last_seen_at=NOW.isoformat(),
+        status="Done",
+    )
+
+    summary = await run_deploy_verification(session, org_id=ORG_ID, now=NOW)
+
+    for record in (quiet, before_settle, refired, too_recent, already_verified):
+        await session.refresh(record)
+    assert quiet.data["deploy_state"] == "verified"
+    assert quiet.data["status"] == "Done"
+    assert f"verified quiet since deploy at {deployed_at.isoformat()}" in quiet.data["progress_note"]
+    assert before_settle.data["deploy_state"] == "verified"
+    assert refired.data["deploy_state"] == "deployed"
+    assert refired.data["status"] == "Todo"
+    assert too_recent.data["deploy_state"] == "deployed"
+    assert already_verified.data["deploy_state"] == "verified"
+    assert already_verified.data["status"] == "Done"
+    assert summary["verified"] == 2
+    assert summary["not_quiet"] == 1
+
+
+async def test_sweep_exception_does_not_propagate_from_inbound_hook(session, monkeypatch):
+    import brain.systems.deploy_state_sweep as sweep
+    from brain.systems.inbound.service import _maybe_run_deploy_sweep
+
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", REPO)
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("github unavailable")
+
+    monkeypatch.setattr(sweep, "run_deploy_sweep", fail)
+    result = await _maybe_run_deploy_sweep(
+        session,
+        org_id=ORG_ID,
+        normalized={
+            "kind": "github_event",
+            "hints": {
+                "event": "pull_request",
+                "merged": True,
+                "repo": REPO,
+                "base_ref": "main",
+                "head_ref": "staging",
+            },
+        },
+    )
+    assert result is None
+
+
+async def test_inbound_hook_env_unset_is_noop_without_session(monkeypatch):
+    from brain.systems.inbound.service import _maybe_run_deploy_sweep
+
+    monkeypatch.delenv("ILLO_DEPLOY_SWEEP_REPOS", raising=False)
+    result = await _maybe_run_deploy_sweep(
+        object(),
+        org_id=ORG_ID,
+        normalized={"kind": "github_event", "hints": {"merged": True, "repo": REPO}},
+    )
+    assert result is None
+
+
+async def test_inbound_hook_passes_selected_read_tokens_to_sweep(session, monkeypatch):
+    import brain.systems.deploy_state_sweep as sweep
+    import brain.systems.runs.tool_catalog.handlers.github as github_handlers
+    from brain.systems.inbound.service import _maybe_run_deploy_sweep
+
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", REPO)
+    selected = AsyncMock(
+        return_value=[
+            {"token": "bound-read-token", "source": "project_binding:GITHUB_TOKEN"},
+            {"token": None, "source": "public"},
+        ]
+    )
+    run = AsyncMock(return_value={"updated": 0})
+    monkeypatch.setattr(github_handlers, "_github_token_candidates", selected)
+    monkeypatch.setattr(sweep, "run_deploy_sweep", run)
+
+    await _maybe_run_deploy_sweep(
+        session,
+        org_id=ORG_ID,
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+        normalized={
+            "kind": "github_event",
+            "hints": {
+                "event": "pull_request",
+                "merged": True,
+                "repo": REPO,
+                "base_ref": "main",
+                "head_ref": "staging",
+            },
+        },
+    )
+
+    assert run.await_args.kwargs["ancestry_tokens"] == ["bound-read-token", None]

--- a/tests/test_deploy_state_sweep.py
+++ b/tests/test_deploy_state_sweep.py
@@ -132,16 +132,33 @@ async def test_promotion_sweep_flips_only_confirmed_records(session, monkeypatch
     domain = await _domain(session)
     await ensure_deploy_state_fields(session, org_id=ORG_ID)
     shipped = await _record(
-        session, domain, title="Shipped", deploy_state="prod_pending", fix_merge_sha="in-main"
+        session, domain, title="Shipped", deploy_state="prod_pending",
+        fix_merge_sha="in-main", fix_pr=f"{REPO}#801",
     )
     post_cutoff = await _record(
-        session, domain, title="Post cutoff", deploy_state="prod_pending", fix_merge_sha="after-cutoff"
+        session, domain, title="Post cutoff", deploy_state="prod_pending",
+        fix_merge_sha="after-cutoff", fix_pr=f"{REPO}#802",
     )
     unknown = await _record(
-        session, domain, title="Unknown", deploy_state="prod_pending", fix_merge_sha="unknown"
+        session, domain, title="Unknown", deploy_state="prod_pending",
+        fix_merge_sha="unknown", fix_pr=f"{REPO}#803",
     )
     staging = await _record(
-        session, domain, title="Staging", deploy_state="staging", fix_merge_sha="on-staging"
+        session, domain, title="Staging", deploy_state="staging",
+        fix_merge_sha="on-staging", fix_pr=f"{REPO}#804",
+    )
+    # An app-repo ticket fixed by a PR in THIS repo: swept by fix_pr identity,
+    # not the ticket's own repo field.
+    cross_repo = await _record(
+        session, domain, title="Cross repo", repo="uwear-ai/uwearaiapp",
+        deploy_state="prod_pending", fix_merge_sha="in-main",
+        fix_pr=f"{REPO}#805",
+    )
+    # A ticket whose fix lives in ANOTHER repo must not be touched by this
+    # repo's promotion even though its own repo field matches.
+    other_fix_repo = await _record(
+        session, domain, title="Other fix repo", deploy_state="prod_pending",
+        fix_merge_sha="in-main", fix_pr="uwear-ai/uwearaiapp#42",
     )
 
     async def fake_ancestry(repo, sha, branch):
@@ -172,12 +189,17 @@ async def test_promotion_sweep_flips_only_confirmed_records(session, monkeypatch
     await session.refresh(post_cutoff)
     await session.refresh(unknown)
     await session.refresh(staging)
+    await session.refresh(cross_repo)
+    await session.refresh(other_fix_repo)
     assert shipped.data["deploy_state"] == "deployed"
     assert shipped.data["deployed_at"] == NOW.isoformat()
     assert post_cutoff.data["deploy_state"] == "prod_pending"
     assert unknown.data["deploy_state"] == "prod_pending"
     assert staging.data["deploy_state"] == "prod_pending"
-    assert summary["deployed"] == 1
+    assert cross_repo.data["deploy_state"] == "deployed"
+    assert other_fix_repo.data["deploy_state"] == "prod_pending"
+    assert other_fix_repo.data["deployed_at"] is None
+    assert summary["deployed"] == 2
     assert summary["prod_pending"] == 1
     assert summary["indeterminate"] == 1
 

--- a/tests/test_github_webhook.py
+++ b/tests/test_github_webhook.py
@@ -83,12 +83,19 @@ class TestEventToEnvelope:
                 "number": 7, "title": "Add feature", "html_url": "u",
                 "state": "closed", "node_id": "PR_1",
                 "updated_at": "2026-07-08T11:00:00Z", "user": {"login": "bob"},
+                "merged": True, "base": {"ref": "main"}, "head": {"ref": "staging"},
+                "merge_commit_sha": "abc123", "merged_at": "2026-07-08T11:01:00Z",
             },
         }
         env = github_event_to_envelope("pull_request", payload)
         assert env["hints"]["event"] == "pull_request"
         assert env["hints"]["state"] == "closed"
         assert env["hints"]["number"] == 7
+        assert env["hints"]["merged"] is True
+        assert env["hints"]["base_ref"] == "main"
+        assert env["hints"]["head_ref"] == "staging"
+        assert env["hints"]["merge_commit_sha"] == "abc123"
+        assert env["hints"]["merged_at"] == "2026-07-08T11:01:00Z"
         assert env["idempotency_key"] is None  # no delivery id
 
     def test_issue_comment_anchors_on_issue_keeps_comment_details(self):

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -121,6 +122,9 @@ async def _seed_connection(
         session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
     if await session.get(User, USER_ID) is None:
         session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    # Flush so the org/user rows exist before the connection's FKs reference
+    # them — Postgres enforces the ordering; SQLite's no-FK default hides it.
+    await session.flush()
     connection = ExternalAgentConnectionRow(
         id=connection_id,
         org_id=ORG_ID,
@@ -1127,6 +1131,230 @@ async def test_domain_projection_creates_updates_and_dedupes_domain_records(sess
     domain_events = await domain_service.list_events(ORG_ID, domain.id, record_id=record_id)
     assert [event.event_type for event in domain_events] == ["record.updated", "record.created"]
     assert all(str(event.reason).startswith("inbound_event:") for event in domain_events)
+
+
+@pytest.mark.requires_db
+async def test_merged_github_projection_triggers_one_deploy_sweep_and_replay_is_inert(
+    session, monkeypatch
+):
+    import brain.systems.deploy_state_sweep as deploy_sweep
+
+    repo = "uwear-ai/uwear-backend"
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", repo)
+    principal = await _seed_connection(session)
+    domain_service = AsyncDomainService(session)
+    domain = await domain_service.create_domain(
+        ORG_ID,
+        name="GitHub Tickets",
+        objects=[
+            {
+                "key": "github_ticket",
+                "title_field": "external_id",
+                "fields": [
+                    {"key": "external_id", "field_type": "text", "required": True},
+                    {"key": "repo", "field_type": "text"},
+                ],
+            }
+        ],
+    )
+    policy = await inbound.create_source_policy(
+        session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        name="GitHub events to Domain",
+        origin_patterns=["github:*"],
+        envelope_kinds=["github_event"],
+        allowed_actions=["domain_projection.upsert"],
+    )
+    await inbound.create_domain_projection(
+        session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        policy_id=str(policy.id),
+        domain_id=domain.id,
+        object_key="github_ticket",
+        external_id_path="hints.node_id",
+        external_id_field="external_id",
+        field_mapping={"repo": "hints.repo"},
+    )
+    calls = []
+
+    async def fake_sweep(session_arg, *, org_id, repo, merge_event, ancestry_tokens):
+        calls.append((session_arg, org_id, repo, dict(merge_event), ancestry_tokens))
+        return {"updated": 0}
+
+    monkeypatch.setattr(deploy_sweep, "run_deploy_sweep", fake_sweep)
+    envelope = {
+        "origin": f"github:{repo}",
+        "kind": "github_event",
+        "payload": {"pull_request": {"number": 859}},
+        "hints": {
+            "provider": "github",
+            "event": "pull_request",
+            "action": "closed",
+            "repo": repo,
+            "number": 859,
+            "node_id": "PR_859",
+            "merged": True,
+            "base_ref": "main",
+            "head_ref": "staging",
+            "merge_commit_sha": "promotion-sha",
+            "merged_at": "2026-07-10T12:00:00Z",
+        },
+        "idempotency_key": "github:delivery-859",
+    }
+
+    first = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=envelope,
+    )
+    replay = await inbound.submit_inbound_envelope(
+        session,
+        connection=principal,
+        envelope=envelope,
+    )
+
+    assert first["status"] == "processed"
+    assert replay["idempotent_replay"] is True
+    assert len(calls) == 1
+    assert calls[0][1:3] == (ORG_ID, repo)
+    assert calls[0][4] == [None]
+
+
+@pytest.mark.requires_db
+async def test_postgres_merged_main_envelope_flips_record_and_emits_domain_event(
+    db_session, monkeypatch
+):
+    import brain.systems.deploy_state_sweep as deploy_sweep
+    import brain.systems.runs.tool_catalog.handlers.github as github_handlers
+
+    repo = "uwear-ai/uwear-backend"
+    monkeypatch.setenv("ILLO_DEPLOY_SWEEP_REPOS", repo)
+    monkeypatch.setattr(
+        github_handlers,
+        "_github_token_candidates",
+        AsyncMock(return_value=[{"token": None, "source": "public"}]),
+    )
+    monkeypatch.setattr(
+        deploy_sweep,
+        "is_ancestor_of",
+        AsyncMock(return_value=True),
+    )
+    principal = await _seed_connection(db_session)
+    domain_service = AsyncDomainService(db_session)
+    domain = await domain_service.create_domain(
+        ORG_ID,
+        name="Deploy Sweep Integration",
+        slug="deploy-sweep-integration",
+        objects=[
+            {
+                "key": "github_ticket",
+                "title_field": "title",
+                "fields": [
+                    {"key": "external_id", "field_type": "text", "required": True},
+                    {"key": "title", "field_type": "text", "required": True},
+                    {"key": "repo", "field_type": "text"},
+                    {
+                        "key": "status",
+                        "field_type": "enum",
+                        "options": ["Todo", "In Progress", "Done"],
+                    },
+                    {"key": "progress_note", "field_type": "long_text"},
+                ],
+            }
+        ],
+    )
+    from brain.systems.deploy_state_sweep import ensure_deploy_state_fields
+
+    first_fields = await ensure_deploy_state_fields(db_session, org_id=ORG_ID)
+    second_fields = await ensure_deploy_state_fields(db_session, org_id=ORG_ID)
+    assert first_fields["fields_added"] == 10
+    assert second_fields["fields_added"] == 0
+    record = await domain_service.create_record(
+        ORG_ID,
+        domain.id,
+        "github_ticket",
+        title="Production alert",
+        data={
+            "external_id": "PR_859",
+            "title": "Production alert",
+            "repo": repo,
+            "status": "Todo",
+            "progress_note": "fix merged to staging",
+            "fix_pr": f"{repo}#905",
+            "fix_merge_sha": "fix-sha",
+            "fix_merged_at": "2026-07-09T12:00:00Z",
+            "deploy_state": "prod_pending",
+        },
+    )
+    policy = await inbound.create_source_policy(
+        db_session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        name="GitHub deploy projection",
+        origin_patterns=["github:*"],
+        envelope_kinds=["github_event"],
+        allowed_actions=["domain_projection.upsert"],
+    )
+    await inbound.create_domain_projection(
+        db_session,
+        org_id=ORG_ID,
+        connection_id=CONNECTION_ID,
+        policy_id=str(policy.id),
+        domain_id=domain.id,
+        object_key="github_ticket",
+        external_id_path="hints.node_id",
+        external_id_field="external_id",
+        field_mapping={"repo": "hints.repo"},
+    )
+    envelope = {
+        "origin": f"github:{repo}",
+        "kind": "github_event",
+        "payload": {"pull_request": {"number": 859}},
+        "hints": {
+            "event": "pull_request",
+            "action": "closed",
+            "repo": repo,
+            "number": 859,
+            "node_id": "PR_859",
+            "merged": True,
+            "base_ref": "main",
+            "head_ref": "staging",
+            "merge_commit_sha": "promotion-sha",
+            "merged_at": "2026-07-10T12:00:00Z",
+        },
+        "idempotency_key": "github:deploy-integration-859",
+    }
+
+    first = await inbound.submit_inbound_envelope(
+        db_session,
+        connection=principal,
+        envelope=envelope,
+    )
+    version_after_first = record.version
+    replay = await inbound.submit_inbound_envelope(
+        db_session,
+        connection=principal,
+        envelope=envelope,
+    )
+
+    await db_session.refresh(record)
+    assert first["status"] == "processed"
+    assert replay["idempotent_replay"] is True
+    assert record.version == version_after_first
+    assert record.data["deploy_state"] == "deployed"
+    assert record.data["deployed_at"] == "2026-07-10T12:00:00+00:00"
+    sweep_events = (
+        await db_session.scalars(
+            select(DomainEvent).where(
+                DomainEvent.record_id == record.id,
+                DomainEvent.reason == "deploy_sweep:promotion",
+            )
+        )
+    ).all()
+    assert len(sweep_events) == 1
+    assert sweep_events[0].patch["deploy_state"] == "deployed"
 
 
 async def test_domain_projection_requires_explicit_policy_action_permission(session):

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -183,6 +183,68 @@ def test_monitored_channel_admits_third_party_bot_alert():
     assert envelope["origin"] == "slack.channel_message"
 
 
+def test_attachment_only_bot_alert_surfaces_fallback_into_monitor_prompt():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    fallback = (
+        "<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2206|"
+        "#2206 100th error: ClientError: 400 INVALID_ARGUMENT>"
+    )
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(
+            user="",
+            bot_id="B_ROLLBAR",
+            app_id="A_ROLLBAR",
+            text="",
+            attachments=[
+                {"fallback": fallback},
+                {"title": "secondary alert context"},
+                {"fallback": "ignored third attachment"},
+            ],
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert fallback in envelope["payload"]["text"]
+    assert "secondary alert context" in envelope["payload"]["text"]
+    assert "ignored third attachment" not in envelope["payload"]["text"]
+    assert fallback in envelope["summary"]
+
+    work = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=envelope["payload"],
+    )
+    assert fallback in work["payload"]["thread_message"]
+    assert f"Message text: {fallback}" in work["payload"]["run_message"]
+
+
+def test_attachment_previews_are_bounded_to_two_by_500_chars():
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(
+            user="",
+            bot_id="B_ROLLBAR",
+            app_id="A_ROLLBAR",
+            text="",
+            attachments=[
+                {"fallback": "a" * 600},
+                {"title": "b" * 600},
+                {"fallback": "c" * 600},
+            ],
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["payload"]["text"] == f"{'a' * 500}\n{'b' * 500}"
+
+
 def test_monitored_channel_mention_still_routes_as_mention():
     from brain.systems.slack.ingress import normalize_slack_socket_event
 


### PR DESCRIPTION
## What

Implements `specs/illo-lifecycle/slices/05-deploy-state.md` (authored in this PR): the lifecycle answer to prod Rollbar alerts re-firing for staging-fixed bugs. Grew out of the live 2026-07-10 case: Rollbar #2206 → issue #904 → hotfix #905 closed unmerged because the real fix (PR #860) was already on staging — and #904 is now closed while the error still fires in prod, which is exactly the armed "done-reappeared" trap this slice retires.

**Three touchpoints:**
1. **Triage/dedup ladder** (prose in `uwear-engineering-triage/SKILL.md` + monitor prompt, deterministic core in `brain/systems/deploy_state.py`): a re-firing alert branches on the fix's deploy-state — not merged → occurrence note (+priority on Rollbar Nth-error milestones); merged-but-unpromoted → expected noise (annotate, optional one thread reply, never refile, **never re-ping the owner**); deployed and still firing past settle → **reopen + escalate to the fix PR's author**. Done for alert-linked tickets now means *deployed AND verified quiet*, never merely merged.
2. **State model**: `deploy_state` (`staging → prod_pending → deployed → verified`) + structured `rollbar_item` / `fix_pr` / `fix_merge_sha` / timestamps as **runtime `DomainFieldDefinition` rows** on `github_ticket` object types (`ensure_deploy_state_fields`, idempotent — the domain writer rejects unknown JSONB keys, and no Alembic migration per the spec's standing decision). Mechanical truth = commit ancestry (`compare branch...sha`), handling both promotion and direct-to-main hotfix paths; indeterminate reads degrade open.
3. **Promotion sweep + verification**: merged-PR webhook envelopes (new additive hints) trigger a savepoint-guarded, never-raising sweep hook in `submit_inbound_envelope` — per-ticket ancestry flips `prod_pending → deployed` (post-cutoff fixes correctly stay pending). The verification step rides the Slice-4 notify tick and **only closes** ("verified quiet since deploy at T"); reopening is event-driven through the ladder, so an unregistered cycle degrades safe.

Plus: `check_fix_deploy_state` read-only agent tool (shares the pure core so prose and code cannot drift), urgent-promotion recommendation signal (once per ticket per UTC day; **recommend only, never merge**), and attachment-fallback text surfacing at Slack ingest (Rollbar posts have empty `text`).

## Verification

- **Live dry runs (952 pattern, READ-ONLY, zero mutations confirmed from run receipts):** illo-dev run **1088** — synthetic 500th-occurrence #2206 re-fire against the real prod_pending state → classified expected-noise, zero new issues, zero owner pings, correct promotion recommendation, and surfaced (without silently flipping) the premature-Done violation on record 1238. Run **1089** — synthetic post-promotion re-fire → would reopen #904/record 1238 and escalate to `axel-havard` (PR #860's real author) by name.
- **Tests:** fast suite 3438 passed (9 pre-existing `test_llm_worker` env failures, unchanged from baseline). All 178 tests in the touched files green against real Postgres, including the new envelope→hook→record-flip integration test (its fixture FK ordering fixed for Postgres — SQLite's no-FK default had hidden it).
- Inert by default: with `ILLO_DEPLOY_SWEEP_REPOS` unset, behavior is today's byte-for-byte apart from additive webhook hints.

## Activation (spec README checklist)

Set `ILLO_DEPLOY_SWEEP_REPOS` (+ optional `ILLO_DEPLOY_SETTLE_MINUTES`/`ILLO_DEPLOY_QUIET_HOURS`); ensure the Slice-1 source policy/projection covers `pull_request` events (the sweep hook is post-projection); apply `specs/illo-lifecycle/slices/05-doc-1155-delta.md` to live doc 1155 — **coordinate merge order with the parallel digest-contract edit to the same record (v5 before either)**; verification tick arrives with Slice-4 cycle registration.

## Decision for Reda (non-blocking)

Optional Rollbar **read-only** API token in Vault (PROD_POSTGRES_READONLY_URL pattern) — the quiet check is a seam with internal inference as default; an API impl would catch sub-threshold fires that never reach Slack.

## Review notes (non-blocking, from the Claude review of the Codex implementation)

- `inbound/service.py` imports the private `_github_token_candidates` from the github handler for token selection — reuse over duplication; promote to a shared helper in a later cleanup.
- The sweep's progress-note append keys on the record's data having a `progress_note` key (over-conservative; state flips still land when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)