### PR TITLE
Lazy-load direct thread surfaces

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "check:thread-stage-bundle": "node scripts/check-thread-stage-bundle.mjs",
     "preview": "vite preview",
     "test": "node --test src/lib/utils/*.test.js",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/frontend/scripts/check-thread-stage-bundle.mjs
+++ b/frontend/scripts/check-thread-stage-bundle.mjs
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import zlib from 'node:zlib';
+
+export const THREAD_STAGE_GZIP_BUDGET_BYTES = 250_000;
+
+export function measureThreadStageStaticClosure(clientRoot) {
+  const manifestPath = path.join(clientRoot, '.vite', 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`Missing Vite manifest at ${manifestPath}. Run npm run build first.`);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const entries = Object.values(manifest);
+  const entry = entries.find(
+    (candidate) => candidate?.name === 'ThreadStageScreen' && candidate?.isDynamicEntry,
+  );
+  if (!entry) throw new Error('ThreadStageScreen dynamic entry is missing from the Vite manifest.');
+
+  const entriesByFile = new Map(entries.map((candidate) => [candidate.file, candidate]));
+  const visitedEntries = new Set();
+  const staticFiles = new Set();
+
+  function visit(candidate) {
+    if (!candidate?.file || visitedEntries.has(candidate.file)) return;
+    visitedEntries.add(candidate.file);
+    staticFiles.add(candidate.file);
+    for (const cssFile of candidate.css ?? []) staticFiles.add(cssFile);
+    for (const importedEntry of candidate.imports ?? []) {
+      visit(manifest[importedEntry] ?? entriesByFile.get(importedEntry));
+    }
+  }
+
+  visit(entry);
+
+  let rawBytes = 0;
+  let gzipBytes = 0;
+  for (const relativeFile of staticFiles) {
+    const content = fs.readFileSync(path.join(clientRoot, relativeFile));
+    rawBytes += content.byteLength;
+    gzipBytes += zlib.gzipSync(content).byteLength;
+  }
+
+  return {
+    entryFile: entry.file,
+    fileCount: staticFiles.size,
+    rawBytes,
+    gzipBytes,
+  };
+}
+
+function main() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const clientRoot = path.resolve(scriptDir, '../.svelte-kit/output/client');
+  const measurement = measureThreadStageStaticClosure(clientRoot);
+  const delta = measurement.gzipBytes - THREAD_STAGE_GZIP_BUDGET_BYTES;
+  console.log(JSON.stringify({
+    ...measurement,
+    budgetBytes: THREAD_STAGE_GZIP_BUDGET_BYTES,
+    passed: delta <= 0,
+    deltaBytes: delta,
+  }, null, 2));
+
+  if (delta > 0) {
+    console.error(`ThreadStage static closure exceeds its gzip budget by ${delta} bytes.`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
@@ -38,6 +38,7 @@
     onSecondaryIntentChange,
     secondaryIntentAriaLabel = 'Mode',
     settingsGroups,
+    onSettingsOpen,
     onSettingsChange,
     settingsAriaLabel = 'Mode, Model, and Effort',
     attachments = [],
@@ -70,7 +71,12 @@
   let settingsRootEl: HTMLDivElement | undefined = $state();
   let selectedMode = $state<string>('');
   let settingsOpen = $state(false);
-  let activeSettingsGroupKey = $state<string | null>(null);
+  let settingsOpenRequested = false;
+  let settingsMenuLoadError = $state(false);
+  let settingsMenuLoad: Promise<void> | null = null;
+  let WorkspaceComposerSettingsMenuComponent = $state<
+    typeof import('./WorkspaceComposerSettingsMenu.svelte').default | null
+  >(null);
   let settingsCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
   const isWorking = $derived(actionState === 'working');
@@ -135,16 +141,6 @@
     if (!selectModeOptions.some((option) => option.value === selectedMode)) {
       selectedMode = nextModeValue;
     }
-  });
-
-  $effect(() => {
-    if (!settingsGroups?.length) {
-      activeSettingsGroupKey = null;
-      return;
-    }
-
-    const hasActiveGroup = settingsGroups.some((group) => group.key === activeSettingsGroupKey);
-    if (!activeSettingsGroupKey || !hasActiveGroup) activeSettingsGroupKey = settingsGroups[0]?.key ?? null;
   });
 
   $effect(() => {
@@ -281,32 +277,54 @@
     return group.options.find((option) => option.value === group.value) ?? group.options[0] ?? null;
   }
 
-  function selectedSettingsLabel(group: { label: string; options: readonly { value: string; label: string }[]; value?: string }) {
-    const option = selectedSettingsOption(group);
-    return option ? `${group.label}: ${option.label}` : group.label;
-  }
-
   function cancelSettingsClose() {
     if (!settingsCloseTimer) return;
     clearTimeout(settingsCloseTimer);
     settingsCloseTimer = null;
   }
 
-  function openSettingsMenu(groupKey?: string) {
+  async function ensureSettingsMenuLoaded() {
+    if (WorkspaceComposerSettingsMenuComponent) return;
+    if (settingsMenuLoad) return settingsMenuLoad;
+
+    settingsMenuLoadError = false;
+    settingsMenuLoad = import('./WorkspaceComposerSettingsMenu.svelte')
+      .then((module) => {
+        WorkspaceComposerSettingsMenuComponent = module.default;
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load composer run settings', error);
+        settingsMenuLoadError = true;
+      })
+      .finally(() => {
+        settingsMenuLoad = null;
+      });
+    return settingsMenuLoad;
+  }
+
+  async function prepareSettingsMenu() {
+    await onSettingsOpen?.();
+    await ensureSettingsMenuLoaded();
+    if (settingsOpenRequested && WorkspaceComposerSettingsMenuComponent) settingsOpen = true;
+  }
+
+  function openSettingsMenu() {
     if (disabled || !showSettingsPicker) return;
     cancelSettingsClose();
-    activeSettingsGroupKey = groupKey ?? activeSettingsGroupKey ?? settingsGroups?.[0]?.key ?? null;
-    settingsOpen = true;
+    settingsOpenRequested = true;
+    void prepareSettingsMenu();
   }
 
   function closeSettingsMenu() {
     cancelSettingsClose();
+    settingsOpenRequested = false;
     settingsOpen = false;
   }
 
   function queueSettingsMenuClose() {
     cancelSettingsClose();
     settingsCloseTimer = setTimeout(() => {
+      settingsOpenRequested = false;
       settingsOpen = false;
       settingsCloseTimer = null;
     }, 120);
@@ -314,15 +332,11 @@
 
   function toggleSettingsOpen() {
     if (disabled || !showSettingsPicker) return;
-    if (settingsOpen) {
+    if (settingsOpen || settingsOpenRequested) {
       closeSettingsMenu();
       return;
     }
     openSettingsMenu();
-  }
-
-  function setActiveSettingsGroup(key: string) {
-    activeSettingsGroupKey = key;
   }
 
   function handleSettingsChange(key: string, nextValue: string) {
@@ -510,73 +524,18 @@
                     onclick={toggleSettingsOpen}
                   >
                     <ConstellationIcon name="settings" size={14} stroke={1.9} />
-                    <span class="composer-settings-trigger-label">{settingsSummary}</span>
+                    <span class="composer-settings-trigger-label">
+                      {settingsMenuLoadError ? 'Retry settings' : settingsSummary}
+                    </span>
                     <ConstellationIcon name="chevron-down" size={12} stroke={1.9} className="composer-settings-chevron" />
                   </button>
 
-                  {#if settingsOpen}
-                    <div role="menu" class="composer-settings-menu" aria-label={settingsAriaLabel}>
-                      <div class="composer-settings-primary" role="group" aria-label="Run setting categories">
-                        {#each settingsGroups as group (group.key)}
-                          <button
-                            type="button"
-                            class:composer-settings-group-trigger={true}
-                            class:is-active={activeSettingsGroupKey === group.key}
-                            role="menuitem"
-                            aria-haspopup="menu"
-                            aria-expanded={activeSettingsGroupKey === group.key}
-                            onpointerenter={() => setActiveSettingsGroup(group.key)}
-                            onfocus={() => setActiveSettingsGroup(group.key)}
-                            onclick={() => setActiveSettingsGroup(group.key)}
-                          >
-                            <span class="composer-settings-group-label">{group.label}</span>
-                            <span class="composer-settings-group-value">{selectedSettingsOption(group)?.label ?? ''}</span>
-                          </button>
-                        {/each}
-                      </div>
-
-                      <div class="composer-settings-secondary">
-                        {#each settingsGroups as group (group.key)}
-                          {@const isActiveGroup = activeSettingsGroupKey === group.key}
-                          <div
-                            class:composer-settings-group-panel={true}
-                            class:is-active={isActiveGroup}
-                            aria-label={group.ariaLabel ?? group.label}
-                            aria-hidden={isActiveGroup ? undefined : 'true'}
-                          >
-                            <div class="composer-settings-heading">{selectedSettingsLabel(group)}</div>
-                            <div class="composer-settings-options">
-                              {#each group.options as option}
-                                {@const isActive = option.value === (selectedSettingsOption(group)?.value ?? '')}
-                                <button
-                                  type="button"
-                                  role="menuitemradio"
-                                  aria-checked={isActive}
-                                  title={option.description ?? option.label}
-                                  class:composer-settings-option={true}
-                                  class:is-active={isActive}
-                                  tabindex={isActiveGroup ? 0 : -1}
-                                  onclick={() => handleSettingsChange(group.key, option.value)}
-                                >
-                                  <span class="composer-settings-option-main">
-                                    {#if option.icon}
-                                      <ConstellationIcon name={option.icon} size={14} stroke={1.9} />
-                                    {/if}
-                                    <span class="composer-settings-option-copy">
-                                      <span class="composer-settings-option-label">{option.label}</span>
-                                      {#if option.description}
-                                        <span class="composer-settings-option-description">{option.description}</span>
-                                      {/if}
-                                    </span>
-                                  </span>
-                                  <span class="composer-settings-option-indicator" aria-hidden="true"></span>
-                                </button>
-                              {/each}
-                            </div>
-                          </div>
-                        {/each}
-                      </div>
-                    </div>
+                  {#if settingsOpen && WorkspaceComposerSettingsMenuComponent}
+                    <WorkspaceComposerSettingsMenuComponent
+                      groups={settingsGroups}
+                      ariaLabel={settingsAriaLabel}
+                      onSettingsChange={handleSettingsChange}
+                    />
                   {/if}
                 </div>
               {/if}
@@ -984,9 +943,7 @@
     cursor: default;
   }
 
-  .composer-settings-trigger:focus-visible,
-  .composer-settings-group-trigger:focus-visible,
-  .composer-settings-option:focus-visible {
+  .composer-settings-trigger:focus-visible {
     outline: 2px solid var(--constellation-control-focus-ring);
     outline-offset: 2px;
   }
@@ -1012,184 +969,6 @@
     transform: rotate(180deg);
   }
 
-  .composer-settings-menu {
-    position: absolute;
-    left: 0;
-    bottom: calc(100% + 8px);
-    z-index: 32;
-    display: grid;
-    grid-template-columns: 128px minmax(220px, 1fr);
-    gap: 6px;
-    width: min(386px, calc(100vw - 32px));
-    max-width: min(520px, calc(100vw - 32px));
-    padding: 7px;
-    border: 1px solid var(--composer-menu-border);
-    border-radius: 14px;
-    background: var(--composer-menu-background);
-    box-shadow: var(--composer-menu-shadow);
-    color: var(--constellation-color-text-primary);
-  }
-
-  .composer-settings-primary,
-  .composer-settings-secondary {
-    min-width: 0;
-  }
-
-  .composer-settings-primary {
-    display: grid;
-    align-content: start;
-    gap: 3px;
-    padding-right: 5px;
-    border-right: 1px solid color-mix(in oklab, var(--composer-menu-border), transparent 38%);
-  }
-
-  .composer-settings-secondary {
-    position: relative;
-    display: grid;
-    align-items: start;
-    min-height: 150px;
-  }
-
-  .composer-settings-group-trigger {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
-    column-gap: 12px;
-    min-height: 32px;
-    padding: 6px 7px;
-    border: 0;
-    border-radius: 9px;
-    background: transparent;
-    color: var(--constellation-select-chip-option-text);
-    font: inherit;
-    cursor: pointer;
-    text-align: left;
-  }
-
-  .composer-settings-group-trigger:hover,
-  .composer-settings-group-trigger.is-active {
-    background: var(--composer-menu-option-hover-background);
-  }
-
-  .composer-settings-group-trigger.is-active {
-    color: var(--constellation-select-chip-trigger-hover-text);
-  }
-
-  .composer-settings-group-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 12px;
-    font-weight: 650;
-  }
-
-  .composer-settings-group-value {
-    max-width: 78px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--composer-menu-supporting-text);
-    font-size: 10.5px;
-  }
-
-  .composer-settings-group-panel {
-    display: grid;
-    gap: 4px;
-    grid-area: 1 / 1;
-    min-width: 0;
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-  }
-
-  .composer-settings-group-panel.is-active {
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible;
-  }
-
-  .composer-settings-heading {
-    padding: 0 4px;
-    color: var(--composer-menu-supporting-text);
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
-
-  .composer-settings-options {
-    display: grid;
-    gap: 3px;
-  }
-
-  .composer-settings-option {
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    min-height: 34px;
-    padding: 7px 8px;
-    border: 0;
-    border-radius: 9px;
-    background: transparent;
-    color: var(--constellation-select-chip-option-text);
-    font: inherit;
-    font-size: 12px;
-    cursor: pointer;
-    text-align: left;
-  }
-
-  .composer-settings-option:hover {
-    background: var(--composer-menu-option-hover-background);
-  }
-
-  .composer-settings-option.is-active {
-    background: var(--composer-menu-option-active-background);
-  }
-
-  .composer-settings-option-main {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    min-width: 0;
-  }
-
-  .composer-settings-option-copy {
-    display: grid;
-    gap: 1px;
-    min-width: 0;
-  }
-
-  .composer-settings-option-label,
-  .composer-settings-option-description {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .composer-settings-option-label {
-    font-weight: 650;
-  }
-
-  .composer-settings-option-description {
-    color: var(--composer-menu-supporting-text);
-    font-size: 10.5px;
-    line-height: 1.2;
-  }
-
-  .composer-settings-option-indicator {
-    width: 6px;
-    height: 6px;
-    border-radius: 999px;
-    background: transparent;
-    flex-shrink: 0;
-  }
-
-  .composer-settings-option.is-active .composer-settings-option-indicator {
-    background: var(--constellation-select-chip-indicator-active-background);
-  }
-
   @container composer-controls (max-width: 230px) {
     .composer-chip-group :global(.constellation-select-chip-trigger),
     .composer-chip-group :global(.project-context-chip),
@@ -1201,11 +980,6 @@
     .composer-settings-chip.is-open::before {
       left: -220px;
       right: -10px;
-    }
-
-    .composer-settings-menu {
-      left: auto;
-      right: 0;
     }
 
     .composer-chip-group :global(.constellation-select-chip-trigger-label),

--- a/frontend/src/lib/features/composer/components/WorkspaceComposerSettingsMenu.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposerSettingsMenu.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+  import ConstellationIcon from '$lib/components/constellation/ConstellationIcon.svelte';
+  import type { CortexWorkspaceComposerSettingsGroup } from '$lib/features/composer/domain/composerAdapter';
+
+  let {
+    groups,
+    ariaLabel,
+    onSettingsChange,
+  }: {
+    groups: readonly CortexWorkspaceComposerSettingsGroup[];
+    ariaLabel: string;
+    onSettingsChange?: (key: string, value: string) => void;
+  } = $props();
+
+  let activeGroupKey = $state<string | null>(null);
+
+  $effect(() => {
+    const hasActiveGroup = groups.some((group) => group.key === activeGroupKey);
+    if (!activeGroupKey || !hasActiveGroup) activeGroupKey = groups[0]?.key ?? null;
+  });
+
+  function selectedOption(group: CortexWorkspaceComposerSettingsGroup) {
+    return group.options.find((option) => option.value === group.value) ?? group.options[0] ?? null;
+  }
+
+  function selectedLabel(group: CortexWorkspaceComposerSettingsGroup) {
+    const option = selectedOption(group);
+    return option ? `${group.label}: ${option.label}` : group.label;
+  }
+</script>
+
+<div role="menu" class="composer-settings-menu" aria-label={ariaLabel}>
+  <div class="composer-settings-primary" role="group" aria-label="Run setting categories">
+    {#each groups as group (group.key)}
+      <button
+        type="button"
+        class:composer-settings-group-trigger={true}
+        class:is-active={activeGroupKey === group.key}
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={activeGroupKey === group.key}
+        onpointerenter={() => (activeGroupKey = group.key)}
+        onfocus={() => (activeGroupKey = group.key)}
+        onclick={() => (activeGroupKey = group.key)}
+      >
+        <span class="composer-settings-group-label">{group.label}</span>
+        <span class="composer-settings-group-value">{selectedOption(group)?.label ?? ''}</span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="composer-settings-secondary">
+    {#each groups as group (group.key)}
+      {@const isActiveGroup = activeGroupKey === group.key}
+      <div
+        class:composer-settings-group-panel={true}
+        class:is-active={isActiveGroup}
+        aria-label={group.ariaLabel ?? group.label}
+        aria-hidden={isActiveGroup ? undefined : 'true'}
+      >
+        <div class="composer-settings-heading">{selectedLabel(group)}</div>
+        <div class="composer-settings-options">
+          {#each group.options as option}
+            {@const isActive = option.value === (selectedOption(group)?.value ?? '')}
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={isActive}
+              title={option.description ?? option.label}
+              class:composer-settings-option={true}
+              class:is-active={isActive}
+              tabindex={isActiveGroup ? 0 : -1}
+              onclick={() => onSettingsChange?.(group.key, option.value)}
+            >
+              <span class="composer-settings-option-main">
+                {#if option.icon}
+                  <ConstellationIcon name={option.icon} size={14} stroke={1.9} />
+                {/if}
+                <span class="composer-settings-option-copy">
+                  <span class="composer-settings-option-label">{option.label}</span>
+                  {#if option.description}
+                    <span class="composer-settings-option-description">{option.description}</span>
+                  {/if}
+                </span>
+              </span>
+              <span class="composer-settings-option-indicator" aria-hidden="true"></span>
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .composer-settings-menu {
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 8px);
+    z-index: 32;
+    display: grid;
+    grid-template-columns: 128px minmax(220px, 1fr);
+    gap: 6px;
+    width: min(386px, calc(100vw - 32px));
+    max-width: min(520px, calc(100vw - 32px));
+    padding: 7px;
+    border: 1px solid var(--composer-menu-border);
+    border-radius: 14px;
+    background: var(--composer-menu-background);
+    box-shadow: var(--composer-menu-shadow);
+    color: var(--constellation-color-text-primary);
+  }
+
+  .composer-settings-primary,
+  .composer-settings-secondary {
+    min-width: 0;
+  }
+
+  .composer-settings-primary {
+    display: grid;
+    align-content: start;
+    gap: 3px;
+    padding-right: 5px;
+    border-right: 1px solid color-mix(in oklab, var(--composer-menu-border), transparent 38%);
+  }
+
+  .composer-settings-secondary {
+    position: relative;
+    display: grid;
+    align-items: start;
+    min-height: 150px;
+  }
+
+  .composer-settings-group-trigger {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 12px;
+    min-height: 32px;
+    padding: 6px 7px;
+    border: 0;
+    border-radius: 9px;
+    background: transparent;
+    color: var(--constellation-select-chip-option-text);
+    font: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .composer-settings-group-trigger:hover,
+  .composer-settings-group-trigger.is-active {
+    background: var(--composer-menu-option-hover-background);
+  }
+
+  .composer-settings-group-trigger.is-active {
+    color: var(--constellation-select-chip-trigger-hover-text);
+  }
+
+  .composer-settings-group-trigger:focus-visible,
+  .composer-settings-option:focus-visible {
+    outline: 2px solid var(--constellation-control-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .composer-settings-group-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    font-weight: 650;
+  }
+
+  .composer-settings-group-value {
+    max-width: 78px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--composer-menu-supporting-text);
+    font-size: 10.5px;
+  }
+
+  .composer-settings-group-panel {
+    display: grid;
+    gap: 4px;
+    grid-area: 1 / 1;
+    min-width: 0;
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+  }
+
+  .composer-settings-group-panel.is-active {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+  }
+
+  .composer-settings-heading {
+    padding: 0 4px;
+    color: var(--composer-menu-supporting-text);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .composer-settings-options {
+    display: grid;
+    gap: 3px;
+  }
+
+  .composer-settings-option {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-height: 34px;
+    padding: 7px 8px;
+    border: 0;
+    border-radius: 9px;
+    background: transparent;
+    color: var(--constellation-select-chip-option-text);
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .composer-settings-option:hover {
+    background: var(--composer-menu-option-hover-background);
+  }
+
+  .composer-settings-option.is-active {
+    background: var(--composer-menu-option-active-background);
+  }
+
+  .composer-settings-option-main {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .composer-settings-option-copy {
+    display: grid;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .composer-settings-option-label,
+  .composer-settings-option-description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .composer-settings-option-label {
+    font-weight: 650;
+  }
+
+  .composer-settings-option-description {
+    color: var(--composer-menu-supporting-text);
+    font-size: 10.5px;
+    line-height: 1.2;
+  }
+
+  .composer-settings-option-indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: transparent;
+    flex-shrink: 0;
+  }
+
+  .composer-settings-option.is-active .composer-settings-option-indicator {
+    background: var(--constellation-select-chip-indicator-active-background);
+  }
+
+  @container composer-controls (max-width: 230px) {
+    .composer-settings-menu {
+      left: auto;
+      right: 0;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/composer/domain/composerAdapter.ts
+++ b/frontend/src/lib/features/composer/domain/composerAdapter.ts
@@ -77,6 +77,7 @@ export interface WorkspaceComposerAdapterProps {
   onSecondaryIntentChange?: (value: string) => void;
   secondaryIntentAriaLabel?: string;
   settingsGroups?: readonly CortexWorkspaceComposerSettingsGroup[];
+  onSettingsOpen?: () => void | Promise<void>;
   onSettingsChange?: (key: string, value: string) => void;
   settingsAriaLabel?: string;
   attachments?: readonly CortexWorkspaceComposerAttachment[];

--- a/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
+++ b/frontend/src/lib/features/cortex/components/CortexWorkspaceRoute.svelte
@@ -119,7 +119,6 @@
   let directThreadUrlPending = $state(Boolean(requestedThreadIdeaIdFromPage()));
   let lastAutoOpenedAppId = $state<string | null>(null);
   let lastRouteOpenedWorkspaceAppId = $state<string | null>(null);
-  let threadStagePrewarmQueued = false;
   let CortexArchiveBinMenuComponent = $state<typeof import('$lib/features/cortex/components/ArchiveBinMenu.svelte').default | null>(null);
   let WorkspaceSceneComponent = $state<typeof import('$lib/features/workspace-scene/components/WorkspaceScene.svelte').default | null>(null);
   let CortexChatDockSeamComponent = $state<typeof import('$lib/features/cortex/components/chat/ChatDockSeam.svelte').default | null>(null);
@@ -916,13 +915,6 @@
   $effect(() => {
     if (!workspaceStartupStarted) return;
     if (cortexSurfaceReady) ensureCortexNotificationsMenuLoaded();
-  });
-
-  $effect(() => {
-    if (!workspaceStartupStarted) return;
-    if (!cortexSurfaceReady || ThreadStageScreenComponent || threadStagePrewarmQueued) return;
-    threadStagePrewarmQueued = true;
-    runWhenBrowserIdle(() => ensureThreadStageScreenLoaded(), 260, 1600);
   });
 
   $effect(() => {

--- a/frontend/src/lib/features/threads/components/LazyObjectReferencePreviewList.svelte
+++ b/frontend/src/lib/features/threads/components/LazyObjectReferencePreviewList.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import type { ObjectReferencePayload } from '$lib/api/client';
+
+  let {
+    objectReferences = [],
+    threadReferences = [],
+    compact = false,
+    containerClass = 'object-reference-preview-list',
+    keyPrefix = '',
+  }: {
+    objectReferences?: readonly ObjectReferencePayload[] | null;
+    threadReferences?: readonly ObjectReferencePayload[] | null;
+    compact?: boolean;
+    containerClass?: string;
+    keyPrefix?: string;
+  } = $props();
+
+  let load: Promise<void> | null = null;
+  let loadError = $state(false);
+  let ObjectReferencePreviewListComponent = $state<
+    typeof import('./ObjectReferencePreviewList.svelte').default | null
+  >(null);
+
+  const hasReferences = $derived(Boolean(objectReferences?.length || threadReferences?.length));
+
+  $effect(() => {
+    if (hasReferences) void ensureLoaded();
+  });
+
+  function ensureLoaded() {
+    if (ObjectReferencePreviewListComponent) return Promise.resolve();
+    if (load) return load;
+
+    loadError = false;
+    load = import('$lib/features/threads/controllers/threadLazyModuleRegistry')
+      .then((registry) => registry.loadObjectReferencePreviewList())
+      .then((module) => {
+        ObjectReferencePreviewListComponent = module.default;
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load thread reference previews', error);
+        loadError = true;
+      })
+      .finally(() => {
+        load = null;
+      });
+    return load;
+  }
+</script>
+
+{#if hasReferences}
+  {#if ObjectReferencePreviewListComponent}
+    <ObjectReferencePreviewListComponent
+      {objectReferences}
+      {threadReferences}
+      {compact}
+      {containerClass}
+      {keyPrefix}
+    />
+  {:else if loadError}
+    <div class="reference-preview-state is-error" role="alert">
+      <span>Reference previews could not load.</span>
+      <button type="button" onclick={() => void ensureLoaded()}>Retry</button>
+    </div>
+  {:else}
+    <div class="reference-preview-state" role="status">Loading reference previews...</div>
+  {/if}
+{/if}
+
+<style>
+  .reference-preview-state {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    color: var(--thread-message-meta, var(--constellation-color-text-muted));
+    font-size: 11px;
+  }
+
+  .reference-preview-state.is-error {
+    color: var(--constellation-negative-text, #d4808f);
+  }
+
+  .reference-preview-state button {
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/LazyStreamVisualBlock.svelte
+++ b/frontend/src/lib/features/threads/components/LazyStreamVisualBlock.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  let {
+    block,
+  }: {
+    block: { type: string; content: string; title?: string; language?: string };
+  } = $props();
+
+  let load: Promise<void> | null = null;
+  let loadError = $state(false);
+  let StreamVisualBlockComponent = $state<typeof import('./StreamVisualBlock.svelte').default | null>(null);
+
+  $effect(() => {
+    void ensureLoaded();
+  });
+
+  function ensureLoaded() {
+    if (StreamVisualBlockComponent) return Promise.resolve();
+    if (load) return load;
+
+    loadError = false;
+    load = import('$lib/features/threads/controllers/threadLazyModuleRegistry')
+      .then((registry) => registry.loadStreamVisualBlock())
+      .then((module) => {
+        StreamVisualBlockComponent = module.default;
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to load thread visual block', error);
+        loadError = true;
+      })
+      .finally(() => {
+        load = null;
+      });
+    return load;
+  }
+</script>
+
+{#if StreamVisualBlockComponent}
+  <StreamVisualBlockComponent {block} />
+{:else if loadError}
+  <div class="visual-block-load-state is-error" role="alert">
+    <span>Visual content could not load.</span>
+    <button type="button" onclick={() => void ensureLoaded()}>Retry</button>
+  </div>
+{:else}
+  <div class="visual-block-load-state" role="status">Loading visual content...</div>
+{/if}
+
+<style>
+  .visual-block-load-state {
+    padding: 12px;
+    color: var(--thread-message-meta, var(--constellation-color-text-muted));
+    font-size: 12px;
+  }
+
+  .visual-block-load-state.is-error {
+    color: var(--constellation-negative-text, #d4808f);
+  }
+
+  .visual-block-load-state button {
+    border: 0;
+    margin-left: 8px;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte
@@ -6,7 +6,7 @@
   import ChatStateView from '$lib/components/chat/ChatStateView.svelte';
   import ConversationScrollCue from '$lib/components/chat/ConversationScrollCue.svelte';
   import type { ConstellationIconName } from '$lib/components/constellation/ConstellationIcon.svelte';
-  import ObjectReferencePreviewList from '$lib/features/threads/components/ObjectReferencePreviewList.svelte';
+  import LazyObjectReferencePreviewList from '$lib/features/threads/components/LazyObjectReferencePreviewList.svelte';
   import {
     CONVERSATION_SCROLL_BOTTOM_THRESHOLD,
     conversationIsNearBottom,
@@ -576,7 +576,7 @@
                 {/each}
               </div>
             {/if}
-            <ObjectReferencePreviewList
+            <LazyObjectReferencePreviewList
               objectReferences={comment.object_references}
               threadReferences={comment.thread_references}
               compact

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import { ConstellationComposerOrb, ConstellationIcon } from '$lib/components/constellation';
   import { auth } from '$lib/stores/auth.svelte';
@@ -17,6 +18,7 @@
   import {
     buildProjectContextMessageAttachment,
     extractIdeaProjectContext,
+    validateProjectContextResources,
     type ProjectContextPickerState,
   } from '$lib/utils/projectContext';
   import { ATTACHMENT_INPUT_ACCEPT } from '$lib/utils/attachmentPreview';
@@ -49,6 +51,7 @@
     type ThreadStageRightDockAddMenuItem,
     type ThreadStageRightDockSingletonKind,
     type ThreadStageRightDockTab,
+    type ThreadStageRightDockTabKind,
   } from '$lib/features/threads/controllers/threadSidePanelController';
   import { threadStreamController } from '$lib/features/threads/controllers/threadStreamController';
   import { threadUrl } from '$lib/features/threads/domain/threadLinks';
@@ -66,32 +69,15 @@
   } from '$lib/components/chat/conversationScroll';
   import { onDestroy, onMount, tick } from 'svelte';
 
-  import BrowserThoughtPanel from '$lib/features/browser-sessions/components/BrowserThoughtPanel.svelte';
-  import ThreadCyclesPane from '$lib/features/cycles/components/ThreadCyclesPane.svelte';
-  import ProjectContextPicker from '$lib/features/composer/components/ProjectContextPicker.svelte';
-  import WorkspaceVoiceRecording from '$lib/features/composer/components/WorkspaceVoiceRecording.svelte';
-  import SkillMentionOverlay from '$lib/features/composer/components/SkillMentionOverlay.svelte';
-  import SlashAutocomplete from '$lib/features/composer/components/SlashAutocomplete.svelte';
-  import { WorkspaceVoiceDictationController } from '$lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts';
+  import type SlashAutocomplete from '$lib/features/composer/components/SlashAutocomplete.svelte';
+  import type { WorkspaceVoiceDictationController as WorkspaceVoiceDictationControllerInstance } from '$lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts';
   import { resizeComposerTextareaToContent } from '$lib/features/composer/domain/composerTextareaSizing';
-  import ThreadAttachmentPreviewPane from '$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte';
-  import ThreadCodeReviewPane from '$lib/features/threads/components/ThreadCodeReviewPane.svelte';
-  import ProjectDraftStatePanel from '$lib/features/threads/components/ProjectDraftStatePanel.svelte';
-  import ThreadProjectFilePreviewPane from '$lib/features/threads/components/ThreadProjectFilePreviewPane.svelte';
   import ThreadDiscussionPane from '$lib/features/threads/components/ThreadDiscussionPane.svelte';
   import ThreadStageShell, { type ThreadPeripherySignal } from '$lib/features/threads/components/ThreadStageShell.svelte';
   import ThreadUtilityContent from '$lib/features/threads/components/ThreadUtilityContent.svelte';
   import WorkspaceComposerAdapter from '$lib/features/composer/components/WorkspaceComposerAdapter.svelte';
-  import ThreadAppsPane from '$lib/features/workspace-apps/components/ThreadAppsPane.svelte';
-  import VaultPage from '../../../../routes/vault/+page.svelte';
   import ThreadTranscript from './ThreadTranscript.svelte';
   import ThreadStageRightDock from './ThreadStageRightDock.svelte';
-  import {
-    applyRunSetting,
-    buildRunSettingsGroups,
-    STEERING_INTENT_OPTIONS,
-    type ActiveRunMessageIntent,
-  } from '$lib/features/composer/domain/runSettings';
   import {
     accentTone,
     buildThreadTranscriptItems,
@@ -107,6 +93,13 @@
     CortexThreadStageImageAttachment,
     CortexThreadStageTranscriptItem,
   } from '$lib/features/threads/domain/threadTranscriptAdapter';
+
+  type ActiveRunMessageIntent = 'steer' | 'queue';
+
+  const STEERING_INTENT_OPTIONS = [
+    { value: 'steer', label: 'Steer', description: 'Guide the active run', icon: 'reply-thread' },
+    { value: 'queue', label: 'Queue', description: 'Run after this reply', icon: 'queue' },
+  ] as const;
 
   let {
     entering = false,
@@ -182,6 +175,206 @@
   let threadArchiving = $state(false);
   let threadLinkCopying = $state(false);
   let lastAutoOpenedThreadAppId = $state<string | null>(null);
+  let buildRunSettingsGroups = $state.raw<
+    typeof import('$lib/features/composer/domain/runSettings').buildRunSettingsGroups | null
+  >(null);
+  let threadStageDestroyed = false;
+  let voiceDictationLoading = $state(false);
+  let voiceDictation = $state.raw<WorkspaceVoiceDictationControllerInstance | null>(null);
+  let WorkspaceVoiceRecordingComponent = $state<
+    typeof import('$lib/features/composer/components/WorkspaceVoiceRecording.svelte').default | null
+  >(null);
+  let SlashAutocompleteComponent = $state<
+    typeof import('$lib/features/composer/components/SlashAutocomplete.svelte').default | null
+  >(null);
+  let SkillMentionOverlayComponent = $state<
+    typeof import('$lib/features/composer/components/SkillMentionOverlay.svelte').default | null
+  >(null);
+  let projectContextPickerRequestedOpen = $state(false);
+  let ProjectContextPickerComponent = $state<
+    typeof import('$lib/features/composer/components/ProjectContextPicker.svelte').default | null
+  >(null);
+  let BrowserThoughtPanelComponent = $state<
+    typeof import('$lib/features/browser-sessions/components/BrowserThoughtPanel.svelte').default | null
+  >(null);
+  let ThreadCyclesPaneComponent = $state<
+    typeof import('$lib/features/cycles/components/ThreadCyclesPane.svelte').default | null
+  >(null);
+  let ProjectDraftStatePanelComponent = $state<
+    typeof import('$lib/features/threads/components/ProjectDraftStatePanel.svelte').default | null
+  >(null);
+  let ThreadAttachmentPreviewPaneComponent = $state<
+    typeof import('$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte').default | null
+  >(null);
+  let ThreadCodeReviewPaneComponent = $state<
+    typeof import('$lib/features/threads/components/ThreadCodeReviewPane.svelte').default | null
+  >(null);
+  let ThreadProjectFilePreviewPaneComponent = $state<
+    typeof import('$lib/features/threads/components/ThreadProjectFilePreviewPane.svelte').default | null
+  >(null);
+  let ThreadAppsPaneComponent = $state<
+    typeof import('$lib/features/workspace-apps/components/ThreadAppsPane.svelte').default | null
+  >(null);
+  let VaultPageComponent = $state<
+    typeof import('../../../../routes/vault/+page.svelte').default | null
+  >(null);
+  let threadLazyModuleRegistryLoad: Promise<
+    typeof import('$lib/features/threads/controllers/threadLazyModuleRegistry')
+  > | null = null;
+
+  function threadLazyModuleRegistry() {
+    threadLazyModuleRegistryLoad ??=
+      import('$lib/features/threads/controllers/threadLazyModuleRegistry');
+    return threadLazyModuleRegistryLoad;
+  }
+
+  const lazyThreadModuleLoaders = {
+    'run-settings': async () => {
+      const registry = await threadLazyModuleRegistry();
+      buildRunSettingsGroups = (await registry.loadRunSettings()).buildRunSettingsGroups;
+    },
+    'composer-text-tools': async () => {
+      const registry = await threadLazyModuleRegistry();
+      const [{ default: SlashAutocomplete }, { default: SkillMentionOverlay }] =
+        await registry.loadComposerTextTools();
+      SlashAutocompleteComponent = SlashAutocomplete;
+      SkillMentionOverlayComponent = SkillMentionOverlay;
+      await tick();
+      if (slashToken) slashRef?.filter(slashToken.query);
+    },
+    'voice-dictation': async () => {
+      const registry = await threadLazyModuleRegistry();
+      const [{ WorkspaceVoiceDictationController }, { default: WorkspaceVoiceRecording }] =
+        await registry.loadVoiceDictation();
+      const controller = new WorkspaceVoiceDictationController({
+        getDraft: () => inputValue,
+        setDraft: (next) => {
+          inputValue = next;
+          void tick().then(autoGrowTextarea);
+        },
+        submit: send,
+        onError: (message) => ui.toast(message, 'error'),
+        onSettled: () => tick().then(autoGrowTextarea),
+        focusDraft: () => requestAnimationFrame(() => textareaEl?.focus()),
+      });
+      await controller.loadSettings();
+      if (threadStageDestroyed) {
+        controller.destroy();
+        return;
+      }
+      voiceDictation = controller;
+      WorkspaceVoiceRecordingComponent = WorkspaceVoiceRecording;
+    },
+    'project-context': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ProjectContextPickerComponent = (await registry.loadProjectContextPicker()).default;
+    },
+    'browser': async () => {
+      const registry = await threadLazyModuleRegistry();
+      BrowserThoughtPanelComponent = (await registry.loadBrowserThoughtPanel()).default;
+    },
+    'cycles': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ThreadCyclesPaneComponent = (await registry.loadThreadCyclesPane()).default;
+    },
+    'project': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ProjectDraftStatePanelComponent = (await registry.loadProjectDraftStatePanel()).default;
+    },
+    'preview': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ThreadAttachmentPreviewPaneComponent = (await registry.loadThreadAttachmentPreviewPane()).default;
+    },
+    'code-review': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ThreadCodeReviewPaneComponent = (await registry.loadThreadCodeReviewPane()).default;
+    },
+    'file-preview': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ThreadProjectFilePreviewPaneComponent = (
+        await registry.loadThreadProjectFilePreviewPane()
+      ).default;
+    },
+    'app': async () => {
+      const registry = await threadLazyModuleRegistry();
+      ThreadAppsPaneComponent = (await registry.loadThreadAppsPane()).default;
+    },
+    'vault': async () => {
+      const registry = await threadLazyModuleRegistry();
+      VaultPageComponent = (await registry.loadVaultPage()).default;
+    },
+  } as const;
+  type LazyThreadModuleKind = keyof typeof lazyThreadModuleLoaders;
+  type LazyThreadPaneKind = Exclude<
+    LazyThreadModuleKind,
+    'composer-text-tools' | 'project-context' | 'run-settings' | 'voice-dictation'
+  >;
+
+  const lazyThreadPaneKinds = new Set<string>([
+    'browser',
+    'cycles',
+    'project',
+    'preview',
+    'code-review',
+    'file-preview',
+    'app',
+    'vault',
+  ] satisfies LazyThreadPaneKind[]);
+  const lazyThreadModuleLabels = {
+    'run-settings': 'run settings',
+    'composer-text-tools': 'composer text tools',
+    'voice-dictation': 'voice dictation',
+    'project-context': 'project context',
+    browser: 'browser',
+    cycles: 'cycles',
+    project: 'project',
+    preview: 'attachment preview',
+    'code-review': 'code review',
+    'file-preview': 'file preview',
+    app: 'app',
+    vault: 'vault',
+  } satisfies Record<LazyThreadModuleKind, string>;
+  const activeThreadModuleLoads = new Map<LazyThreadModuleKind, Promise<void>>();
+  let loadedThreadModules = $state<Partial<Record<LazyThreadModuleKind, true>>>({});
+  let threadModuleLoadErrors = $state<Partial<Record<LazyThreadModuleKind, string>>>({});
+
+  function isLazyThreadPaneKind(
+    kind: ThreadStageRightDockTabKind | null | undefined,
+  ): kind is LazyThreadPaneKind {
+    return Boolean(kind && lazyThreadPaneKinds.has(kind));
+  }
+
+  function ensureThreadModuleLoaded(kind: LazyThreadModuleKind) {
+    if (!browser || loadedThreadModules[kind]) return Promise.resolve();
+    const activeLoad = activeThreadModuleLoads.get(kind);
+    if (activeLoad) return activeLoad;
+
+    threadModuleLoadErrors[kind] = undefined;
+    const load = lazyThreadModuleLoaders[kind]();
+    const trackedLoad = load
+      .then(() => {
+        loadedThreadModules[kind] = true;
+      })
+      .catch((error: unknown) => {
+        console.error(`Failed to load the ${lazyThreadModuleLabels[kind]} thread module`, error);
+        threadModuleLoadErrors[kind] = `The ${lazyThreadModuleLabels[kind]} module could not load.`;
+      })
+      .finally(() => {
+        activeThreadModuleLoads.delete(kind);
+      });
+
+    activeThreadModuleLoads.set(kind, trackedLoad);
+    return trackedLoad;
+  }
+
+  function ensureThreadPaneLoaded(kind: LazyThreadPaneKind) {
+    ensureThreadModuleLoaded(kind);
+  }
+
+  function openLazyProjectContextPicker() {
+    projectContextPickerRequestedOpen = true;
+    ensureThreadModuleLoaded('project-context');
+  }
 
   const THREAD_STAGE_MIN_THREAD_WIDTH = 380;
   const THREAD_STAGE_DEFAULT_GUTTER = 24;
@@ -192,8 +385,57 @@
     working: 'Working',
     done: 'Unread',
   };
+  const RUN_SETTING_MODEL_LABELS: Record<string, string> = {
+    'openai/gpt-5.6-sol': 'GPT-5.6 Sol',
+    'openai/gpt-5.5': 'GPT-5.5',
+    'openai/gpt-5.4': 'GPT-5.4',
+    'openai/gpt-5.4-mini': 'GPT-5.4 Mini',
+    'openai/gpt-5-mini': 'GPT-5 Mini',
+  };
+
+  function buildRunSettingsPlaceholderGroups(values: {
+    mode: string;
+    model: string;
+    effort: string;
+  }) {
+    return [
+      {
+        key: 'mode',
+        label: 'Mode',
+        options: [{ value: values.mode, label: values.mode === 'deep' ? 'Deep' : 'Fast' }],
+        value: values.mode,
+        ariaLabel: 'Mode',
+      },
+      {
+        key: 'model',
+        label: 'Model',
+        options: [{ value: values.model, label: RUN_SETTING_MODEL_LABELS[values.model] ?? values.model }],
+        value: values.model,
+        ariaLabel: 'Model',
+      },
+      {
+        key: 'effort',
+        label: 'Effort',
+        options: [{
+          value: values.effort,
+          label: values.effort === 'xhigh'
+            ? 'xHigh'
+            : `${values.effort.slice(0, 1).toUpperCase()}${values.effort.slice(1)}`,
+        }],
+        value: values.effort,
+        ariaLabel: 'Effort',
+      },
+    ];
+  }
 
   let idea = $derived(cortex.selectedIdea);
+  const runSettingsGroups = $derived(
+    (buildRunSettingsGroups ?? buildRunSettingsPlaceholderGroups)({
+      mode: cortex.executionProfile,
+      model: cortex.model,
+      effort: cortex.effortLevel,
+    }),
+  );
 
   const statusLabel = $derived(
     STATUS_LABELS[idea?.status ?? 'idle'] ?? (idea?.status ? idea.status.replaceAll('_', ' ') : 'Idle'),
@@ -220,6 +462,17 @@
     ].join(';'),
   );
   const activeSidePanelTab = $derived(activeThreadSidePanelTab(sidePanelTabs, activeSidePanelTabId));
+
+  $effect(() => {
+    const activeKind = activeSidePanelTab?.kind;
+    if (isLazyThreadPaneKind(activeKind)) ensureThreadPaneLoaded(activeKind);
+  });
+
+  $effect(() => {
+    if (slashToken || hasSkillMention(inputValue)) {
+      void ensureThreadModuleLoaded('composer-text-tools');
+    }
+  });
   const projectDraftRunId = $derived.by(() => {
     const run = runInfo ?? latestRun;
     const id = run?.run_id ?? run?.id ?? null;
@@ -254,19 +507,33 @@
     ),
   );
   const codeReviewSignature = $derived.by(() => codeReviewFiles.map((file) => file.path).join('|'));
-  const voiceDictation = new WorkspaceVoiceDictationController({
-    getDraft: () => inputValue,
-    setDraft: (next) => {
-      inputValue = next;
-      void tick().then(autoGrowTextarea);
-    },
-    submit: send,
-    onError: (message) => ui.toast(message, 'error'),
-    onSettled: () => tick().then(autoGrowTextarea),
-    focusDraft: () => requestAnimationFrame(() => textareaEl?.focus()),
-  });
-  const isVoiceRecording = $derived(voiceDictation.isRecording);
-  const voiceControlDisabled = $derived(sending || voiceDictation.controlDisabled);
+  const isVoiceRecording = $derived(voiceDictation?.isRecording ?? false);
+  const voiceControlLabel = $derived(
+    voiceDictation?.controlLabel ?? (voiceDictationLoading ? 'Loading voice dictation' : 'Start dictation'),
+  );
+  const voiceControlTitle = $derived(
+    voiceDictation?.controlTitle
+      ?? (voiceDictationLoading ? 'Loading voice settings...' : 'Load voice dictation'),
+  );
+  const voiceControlDisabled = $derived(
+    sending || voiceDictationLoading || Boolean(voiceDictation?.controlDisabled),
+  );
+
+  function startLoadedVoiceDictation() {
+    if (voiceDictation?.isReady) voiceDictation.toggle();
+  }
+
+  async function toggleVoiceDictation() {
+    if (voiceDictation) {
+      voiceDictation.toggle();
+      return;
+    }
+
+    voiceDictationLoading = true;
+    await ensureThreadModuleLoaded('voice-dictation');
+    voiceDictationLoading = false;
+    startLoadedVoiceDictation();
+  }
 
   function ideaDisplayTitle(source: { display_title?: string | null; title?: string | null }): string {
     return source.display_title?.trim() || source.title?.trim() || 'Untitled thread';
@@ -477,6 +744,26 @@
   const existingProjectContext = $derived(extractIdeaProjectContext(idea));
   const latestIdeaProjectContextAttachment = $derived(ideaProjectContextAttachments[0] ?? null);
   const visibleProjectContext = $derived(latestIdeaProjectContextAttachment?.snapshot ?? existingProjectContext);
+  const lazyProjectContextLabel = $derived(
+    visibleProjectContext?.selected_profile_name?.trim()
+      || visibleProjectContext?.profile_name?.trim()
+      || visibleProjectContext?.name?.trim()
+      || 'Project Context',
+  );
+
+  $effect(() => {
+    if (ProjectContextPickerComponent) return;
+
+    const snapshot = visibleProjectContext;
+    const resources = snapshot?.resources ?? snapshot?.targets ?? [];
+    const validation = validateProjectContextResources(Array.isArray(resources) ? resources : []);
+    handlePendingProjectContextState({
+      snapshot,
+      valid: validation.valid,
+      error: validation.errors[0] ?? null,
+      resourceCount: Array.isArray(resources) ? resources.length : 0,
+    });
+  });
 
   async function loadIdeaProjectContext(ideaId: string) {
     if (ideaProjectContextLoadedForIdeaId === ideaId || ideaProjectContextLoadingForIdeaId === ideaId) return;
@@ -613,11 +900,16 @@
   }
 
   function setRunSetting(key: string, value: string) {
-    applyRunSetting(key, value, {
-      setExecutionProfile: (nextValue) => cortex.setExecutionProfile(nextValue),
-      setModel: (nextValue) => cortex.setModel(nextValue),
-      setEffortLevel: (nextValue) => cortex.setEffortLevel(nextValue),
-    });
+    if (key === 'mode' && (value === 'fast' || value === 'deep')) {
+      cortex.setExecutionProfile(value);
+    }
+    if (key === 'model') cortex.setModel(value);
+    if (
+      key === 'effort'
+      && (value === 'none' || value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh')
+    ) {
+      cortex.setEffortLevel(value);
+    }
   }
 
   function setActiveRunMessageIntent(value: string) {
@@ -787,7 +1079,7 @@
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if (isVoiceRecording) {
-        void voiceDictation.send();
+        void voiceDictation?.send();
         return;
       }
       void send();
@@ -994,6 +1286,7 @@
       inputValue = '';
       void tick().then(autoGrowTextarea);
       projectContextError = '';
+      projectContextPickerRequestedOpen = false;
       ideaProjectContextAttachments = [];
       ideaProjectContextLoadedForIdeaId = null;
       ideaProjectContextLoadingForIdeaId = null;
@@ -1067,13 +1360,13 @@
     };
   });
 
-  onMount(async () => {
+  onMount(() => {
     document.addEventListener('click', handleDocClick);
-    await voiceDictation.loadSettings();
   });
 
   onDestroy(() => {
-    voiceDictation.destroy();
+    threadStageDestroyed = true;
+    voiceDictation?.destroy();
     document.removeEventListener('click', handleDocClick);
     if (transcriptScrollFrame !== null) {
       cancelAnimationFrame(transcriptScrollFrame);
@@ -1110,14 +1403,16 @@
 
       {#snippet editor()}
         <div class="thread-bridge-editor">
-          <SlashAutocomplete
-            bind:this={slashRef}
-            visible={Boolean(slashToken)}
-            anchor={textareaEl}
-            oninput={applySlashCommand}
-          />
-          {#if hasSkillMention(inputValue)}
-            <SkillMentionOverlay value={inputValue} scrollTop={textareaScrollTop} />
+          {#if SlashAutocompleteComponent}
+            <SlashAutocompleteComponent
+              bind:this={slashRef}
+              visible={Boolean(slashToken)}
+              anchor={textareaEl}
+              oninput={applySlashCommand}
+            />
+          {/if}
+          {#if SkillMentionOverlayComponent && hasSkillMention(inputValue)}
+            <SkillMentionOverlayComponent value={inputValue} scrollTop={textareaScrollTop} />
           {/if}
 
           <input
@@ -1160,18 +1455,15 @@
         disabled={sending}
         className="cortex-thread-composer-adapter"
         sendLabel={activeRunSendLabel()}
-        settingsGroups={buildRunSettingsGroups({
-          mode: cortex.executionProfile,
-          model: cortex.model,
-          effort: cortex.effortLevel,
-        })}
+        settingsGroups={runSettingsGroups}
+        onSettingsOpen={() => ensureThreadModuleLoaded('run-settings')}
         onSettingsChange={setRunSetting}
         settingsAriaLabel="Mode, Model, and Effort"
         secondaryIntentOptions={activeFastRun() ? STEERING_INTENT_OPTIONS : undefined}
         secondaryIntentValue={activeFastRun() ? activeRunMessageIntent : undefined}
         secondaryIntentAriaLabel="Message intent"
         onSecondaryIntentChange={setActiveRunMessageIntent}
-        onSubmit={() => (isVoiceRecording ? void voiceDictation.send() : void send())}
+        onSubmit={() => (isVoiceRecording ? void voiceDictation?.send() : void send())}
         onStop={() => void threadStreamController.cancelAll()}
         onAttach={() => fileInputEl?.click()}
         onRemoveAttachment={removeAttachment}
@@ -1181,30 +1473,62 @@
         editor={editor}
       >
         {#snippet extraLeadingControls()}
-          <ProjectContextPicker
-            mode="thread"
-            currentSnapshot={visibleProjectContext}
-            contextKey={idea?.id ?? ''}
-            onStateChange={handlePendingProjectContextState}
-            onOpenChange={(open) => { if (open) void ensureIdeaProjectContextLoaded(); }}
-          />
+          {#if ProjectContextPickerComponent}
+            <ProjectContextPickerComponent
+              mode="thread"
+              initialOpen={projectContextPickerRequestedOpen}
+              currentSnapshot={visibleProjectContext}
+              contextKey={idea?.id ?? ''}
+              onStateChange={handlePendingProjectContextState}
+              onOpenChange={(open) => {
+                projectContextPickerRequestedOpen = open;
+                if (open) void ensureIdeaProjectContextLoaded();
+              }}
+            />
+          {:else}
+            <button
+              class="lazy-project-context-trigger"
+              class:invalid={!pendingProjectContextState.valid}
+              class:loading={projectContextPickerRequestedOpen}
+              type="button"
+              aria-expanded="false"
+              aria-haspopup="dialog"
+              aria-label={threadModuleLoadErrors['project-context']
+                ? `Retry Project Context. ${threadModuleLoadErrors['project-context']}`
+                : lazyProjectContextLabel}
+              onclick={openLazyProjectContextPicker}
+            >
+              <ConstellationIcon name="folder" size={15} stroke={1.9} />
+              <span>
+                {threadModuleLoadErrors['project-context']
+                  ? 'Retry Project Context'
+                  : projectContextPickerRequestedOpen
+                    ? 'Loading Project Context...'
+                    : lazyProjectContextLabel}
+              </span>
+              <ConstellationIcon name="chevron-down" size={12} stroke={1.9} />
+            </button>
+          {/if}
           {#if projectContextError}
             <span class="project-context-inline-error">{projectContextError}</span>
           {/if}
         {/snippet}
         {#snippet footerStatus()}
-          {#if isVoiceRecording}
-            <WorkspaceVoiceRecording elapsedMs={voiceDictation.elapsedMs} levels={voiceDictation.audioLevels} />
+          {#if isVoiceRecording && voiceDictation && WorkspaceVoiceRecordingComponent}
+            <WorkspaceVoiceRecordingComponent
+              elapsedMs={voiceDictation.elapsedMs}
+              levels={voiceDictation.audioLevels}
+            />
           {/if}
         {/snippet}
         {#snippet extraTrailingControls()}
           <ConstellationComposerOrb
-            label={voiceDictation.controlLabel}
-            title={voiceDictation.controlTitle}
+            label={voiceControlLabel}
+            title={voiceControlTitle}
             disabled={voiceControlDisabled}
             variant="bare"
             onclick={() => {
-              if (!sending) voiceDictation.toggle();
+              if (!sending) void toggleVoiceDictation();
             }}
           >
             <ConstellationIcon name={isVoiceRecording ? 'stop' : 'mic'} size={18} stroke={2} />
@@ -1214,8 +1538,23 @@
     </div>
   {/snippet}
 
+  {#snippet lazyPaneStatus(kind: LazyThreadPaneKind)}
+    <div class="thread-lazy-pane-state" role={threadModuleLoadErrors[kind] ? 'alert' : 'status'}>
+      <span>
+        {threadModuleLoadErrors[kind] ?? `Loading ${lazyThreadModuleLabels[kind]}...`}
+      </span>
+      {#if threadModuleLoadErrors[kind]}
+        <button type="button" onclick={() => ensureThreadPaneLoaded(kind)}>Retry</button>
+      {/if}
+    </div>
+  {/snippet}
+
   {#snippet browserPane()}
-    <BrowserThoughtPanel onPreviewAttachment={openPreviewTab} />
+    {#if BrowserThoughtPanelComponent}
+      <BrowserThoughtPanelComponent onPreviewAttachment={openPreviewTab} />
+    {:else}
+      {@render lazyPaneStatus('browser')}
+    {/if}
   {/snippet}
 
   {#snippet utilityPane()}
@@ -1232,13 +1571,21 @@
   {#snippet projectPane()}
     <div class="thread-utility-surface">
       <div class="thread-utility-surface-body">
-        <ProjectDraftStatePanel {idea} runId={projectDraftRunId} />
+        {#if ProjectDraftStatePanelComponent}
+          <ProjectDraftStatePanelComponent {idea} runId={projectDraftRunId} />
+        {:else}
+          {@render lazyPaneStatus('project')}
+        {/if}
       </div>
     </div>
   {/snippet}
 
   {#snippet previewPane()}
-    <ThreadAttachmentPreviewPane attachment={dockPreviewAttachment} />
+    {#if ThreadAttachmentPreviewPaneComponent}
+      <ThreadAttachmentPreviewPaneComponent attachment={dockPreviewAttachment} />
+    {:else}
+      {@render lazyPaneStatus('preview')}
+    {/if}
   {/snippet}
 
   {#snippet discussionPane()}
@@ -1246,64 +1593,84 @@
   {/snippet}
 
   {#snippet appsPane()}
-    <ThreadAppsPane
-      apps={threadArtifactApps}
-      selectedAppId={selectedThreadApp?.id ?? null}
-      onSelectApp={handleThreadAppSelect}
-    />
+    {#if ThreadAppsPaneComponent}
+      <ThreadAppsPaneComponent
+        apps={threadArtifactApps}
+        selectedAppId={selectedThreadApp?.id ?? null}
+        onSelectApp={handleThreadAppSelect}
+      />
+    {:else}
+      {@render lazyPaneStatus('app')}
+    {/if}
   {/snippet}
 
   {#snippet codeReviewPane()}
-    <ThreadCodeReviewPane
-      files={codeReviewFiles}
-      latestRunStatus={latestRun?.status ?? null}
-      onPreviewFile={openCodeReviewFilePreview}
-    />
+    {#if ThreadCodeReviewPaneComponent}
+      <ThreadCodeReviewPaneComponent
+        files={codeReviewFiles}
+        latestRunStatus={latestRun?.status ?? null}
+        onPreviewFile={openCodeReviewFilePreview}
+      />
+    {:else}
+      {@render lazyPaneStatus('code-review')}
+    {/if}
   {/snippet}
 
   {#snippet filePreviewPane()}
-    <ThreadProjectFilePreviewPane
-      {idea}
-      runId={activeFilePreviewRunId ?? projectDraftRunId}
-      filePath={activeFilePreviewPath}
-    />
+    {#if ThreadProjectFilePreviewPaneComponent}
+      <ThreadProjectFilePreviewPaneComponent
+        {idea}
+        runId={activeFilePreviewRunId ?? projectDraftRunId}
+        filePath={activeFilePreviewPath}
+      />
+    {:else}
+      {@render lazyPaneStatus('file-preview')}
+    {/if}
   {/snippet}
 
   {#snippet vaultPane()}
     <div class="thread-vault-surface">
-      <VaultPage
-        embedded
-        initialCreatePrefill={activeVaultSecretPrompt
-          ? {
-              id: activeVaultSecretPrompt.id,
-              keyName: activeVaultSecretPrompt.key_name,
-              description: activeVaultSecretPrompt.description,
-              category: activeVaultSecretPrompt.category,
-            }
-          : null}
-        initialAgentGrantPrompt={activeVaultAgentGrantPrompt
-          ? {
-              id: activeVaultAgentGrantPrompt.id,
-              grantId: activeVaultAgentGrantPrompt.grant_id,
-              keyName: activeVaultAgentGrantPrompt.key_name,
-              reason: activeVaultAgentGrantPrompt.reason,
-            }
-          : null}
-        onInitialCreateSaved={(promptId) => {
-          if (promptId) cortex.clearVaultSecretPrompt(promptId);
-        }}
-        onInitialAgentGrantHandled={(promptId) => {
-          if (promptId) cortex.clearVaultAgentGrantPrompt(promptId);
-        }}
-      />
+      {#if VaultPageComponent}
+        <VaultPageComponent
+          embedded
+          initialCreatePrefill={activeVaultSecretPrompt
+            ? {
+                id: activeVaultSecretPrompt.id,
+                keyName: activeVaultSecretPrompt.key_name,
+                description: activeVaultSecretPrompt.description,
+                category: activeVaultSecretPrompt.category,
+              }
+            : null}
+          initialAgentGrantPrompt={activeVaultAgentGrantPrompt
+            ? {
+                id: activeVaultAgentGrantPrompt.id,
+                grantId: activeVaultAgentGrantPrompt.grant_id,
+                keyName: activeVaultAgentGrantPrompt.key_name,
+                reason: activeVaultAgentGrantPrompt.reason,
+              }
+            : null}
+          onInitialCreateSaved={(promptId) => {
+            if (promptId) cortex.clearVaultSecretPrompt(promptId);
+          }}
+          onInitialAgentGrantHandled={(promptId) => {
+            if (promptId) cortex.clearVaultAgentGrantPrompt(promptId);
+          }}
+        />
+      {:else}
+        {@render lazyPaneStatus('vault')}
+      {/if}
     </div>
   {/snippet}
 
   {#snippet cyclesPane()}
-    <ThreadCyclesPane
-      focusCycleId={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.cycleId : null}
-      refreshSerial={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.serial : null}
-    />
+    {#if ThreadCyclesPaneComponent}
+      <ThreadCyclesPaneComponent
+        focusCycleId={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.cycleId : null}
+        refreshSerial={cortex.cyclePanelSignal?.ideaId === idea?.id ? cortex.cyclePanelSignal.serial : null}
+      />
+    {:else}
+      {@render lazyPaneStatus('cycles')}
+    {/if}
   {/snippet}
 
   <ThreadStageShell
@@ -1465,6 +1832,31 @@
   .thread-utility-surface-body > :global(*) {
     flex: 1 1 auto;
     min-height: 0;
+  }
+
+  .thread-lazy-pane-state {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-width: 0;
+    min-height: 160px;
+    color: var(--constellation-utility-panel-muted-text, rgba(228, 235, 244, 0.56));
+    font-size: 12px;
+    text-align: center;
+  }
+
+  .thread-lazy-pane-state button {
+    border: 1px solid
+      var(--constellation-utility-panel-header-border, rgba(255, 255, 255, 0.1));
+    border-radius: 999px;
+    padding: 6px 12px;
+    background: rgba(255, 255, 255, 0.05);
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
   }
 
   .thread-vault-surface {
@@ -1648,6 +2040,37 @@
 
   .project-context-inline-error {
     color: #d4808f;
+  }
+
+  .lazy-project-context-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 30px;
+    max-width: 100%;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 0 4px;
+    background: transparent;
+    color: var(--constellation-select-chip-trigger-bare-text);
+    font-family: var(--constellation-font-sans);
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .lazy-project-context-trigger:hover {
+    color: var(--constellation-select-chip-trigger-hover-text);
+  }
+
+  .lazy-project-context-trigger.invalid {
+    border-color: rgba(212, 128, 143, 0.55);
+    background: rgba(212, 128, 143, 0.12);
+  }
+
+  .lazy-project-context-trigger.loading {
+    cursor: progress;
   }
 
   .thread-bridge-editor {

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -16,9 +16,9 @@
     attachmentUrl,
     normalizeServerUploadPreviewUrl,
   } from '$lib/utils/attachmentPreview';
-  import ObjectReferencePreviewList from '$lib/features/threads/components/ObjectReferencePreviewList.svelte';
-  import StreamVisualBlock from '$lib/features/threads/components/StreamVisualBlock.svelte';
+  import LazyStreamVisualBlock from '$lib/features/threads/components/LazyStreamVisualBlock.svelte';
   import ThreadAuthorMark from '$lib/features/threads/components/ThreadAuthorMark.svelte';
+  import LazyObjectReferencePreviewList from '$lib/features/threads/components/LazyObjectReferencePreviewList.svelte';
 
   import {
     getCortexThreadRunStatusGlyph,
@@ -442,7 +442,7 @@
                     {#each item.attachments as attachment, attachmentIndex (`${getAttachmentKey(attachment, attachmentIndex)}`)}
                       {#if attachment.kind === 'visual'}
                         <section class="thread-visual-surface">
-                          <StreamVisualBlock block={attachment.block} />
+                          <LazyStreamVisualBlock block={attachment.block} />
                         </section>
                       {:else if attachment.kind === 'image'}
                         <button
@@ -476,7 +476,7 @@
                   </div>
                 {/if}
 
-                <ObjectReferencePreviewList
+                <LazyObjectReferencePreviewList
                   objectReferences={item.objectReferences}
                   threadReferences={item.threadReferences}
                   containerClass="thread-message-thread-previews"
@@ -486,7 +486,7 @@
             </article>
           {:else if item.kind === 'visual'}
             <section class="thread-visual-surface">
-              <StreamVisualBlock block={item.block} />
+              <LazyStreamVisualBlock block={item.block} />
             </section>
           {:else if item.kind === 'run'}
             {@const orderedSteps = orderCortexThreadRunSteps(item.runSteps ?? [])}

--- a/frontend/src/lib/features/threads/controllers/threadLazyModuleRegistry.ts
+++ b/frontend/src/lib/features/threads/controllers/threadLazyModuleRegistry.ts
@@ -1,0 +1,61 @@
+export function loadRunSettings() {
+  return import('$lib/features/composer/domain/runSettings');
+}
+
+export function loadComposerTextTools() {
+  return Promise.all([
+    import('$lib/features/composer/components/SlashAutocomplete.svelte'),
+    import('$lib/features/composer/components/SkillMentionOverlay.svelte'),
+  ]);
+}
+
+export function loadVoiceDictation() {
+  return Promise.all([
+    import('$lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts'),
+    import('$lib/features/composer/components/WorkspaceVoiceRecording.svelte'),
+  ]);
+}
+
+export function loadProjectContextPicker() {
+  return import('$lib/features/composer/components/ProjectContextPicker.svelte');
+}
+
+export function loadBrowserThoughtPanel() {
+  return import('$lib/features/browser-sessions/components/BrowserThoughtPanel.svelte');
+}
+
+export function loadThreadCyclesPane() {
+  return import('$lib/features/cycles/components/ThreadCyclesPane.svelte');
+}
+
+export function loadProjectDraftStatePanel() {
+  return import('$lib/features/threads/components/ProjectDraftStatePanel.svelte');
+}
+
+export function loadThreadAttachmentPreviewPane() {
+  return import('$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte');
+}
+
+export function loadThreadCodeReviewPane() {
+  return import('$lib/features/threads/components/ThreadCodeReviewPane.svelte');
+}
+
+export function loadThreadProjectFilePreviewPane() {
+  return import('$lib/features/threads/components/ThreadProjectFilePreviewPane.svelte');
+}
+
+export function loadObjectReferencePreviewList() {
+  return import('$lib/features/threads/components/ObjectReferencePreviewList.svelte');
+}
+
+export function loadStreamVisualBlock() {
+  return import('$lib/features/threads/components/StreamVisualBlock.svelte');
+}
+
+export function loadThreadAppsPane() {
+  return import('$lib/features/workspace-apps/components/ThreadAppsPane.svelte');
+}
+
+export function loadVaultPage() {
+  return import('../../../../routes/vault/+page.svelte');
+}

--- a/scripts/benchmark_frontend.mjs
+++ b/scripts/benchmark_frontend.mjs
@@ -45,6 +45,36 @@ const WORKSPACE_READY_EXPRESSION = `(() => {
   );
 })()`;
 
+const THREAD_READY_EXPRESSION = `(() => {
+  const body = document.body?.textContent || '';
+  return Boolean(
+    document.querySelector('.thread-stage-shell .workspace-stage-shell.ready') &&
+    document.querySelector('[data-cortex-thread-column="main"]') &&
+    !body.includes('Loading thread...') &&
+    body.includes('Benchmark assistant reply')
+  );
+})()`;
+
+const VAULT_PANE_READY_EXPRESSION = `(() => Boolean(
+  document.querySelector('.cortex-thread-stage-right-dock[data-dock-state="vault"]') &&
+  document.querySelector('.right-dock-content[data-active-tab="vault"] .vault-list') &&
+  !document.querySelector('.right-dock-content[data-active-tab="vault"] .vault-row-skeleton')
+))()`;
+
+const VAULT_PANE_MOUNTED_EXPRESSION = `(() => Boolean(
+  document.querySelector('.cortex-thread-stage-right-dock[data-dock-state="vault"]') &&
+  document.querySelector('.right-dock-content[data-active-tab="vault"] .vault-constellation-frame') &&
+  !document.querySelector('.right-dock-content[data-active-tab="vault"] .thread-lazy-pane-state')
+))()`;
+
+const THREAD_STAGE_PREWARM_OBSERVATION_MS = 2200;
+const RARE_PANE_OPEN_BUDGET_MS = 250;
+const APP_ASSET_RESOURCE_TYPES = new Set(['Script', 'Stylesheet']);
+const VITE_CLIENT_MANIFEST_URL = new URL(
+  '../frontend/.svelte-kit/output/client/.vite/manifest.json',
+  import.meta.url,
+);
+
 const SCENARIOS = {
   workspace: {
     name: 'cortex-workspace',
@@ -54,15 +84,7 @@ const SCENARIOS = {
   thread: {
     name: 'cortex-thread-direct',
     path: '/cortex?idea=idea-1',
-    readyExpression: `(() => {
-      const body = document.body?.textContent || '';
-      return Boolean(
-        document.querySelector('.thread-stage-shell .workspace-stage-shell.ready') &&
-        document.querySelector('[data-cortex-thread-column="main"]') &&
-        !body.includes('Loading thread...') &&
-        body.includes('Benchmark assistant reply')
-      );
-    })()`,
+    readyExpression: THREAD_READY_EXPRESSION,
   },
   cycles: {
     name: 'cortex-modal-cycles',
@@ -207,14 +229,83 @@ function percentile(values, pct) {
 
 function summarizeNumbers(values) {
   if (!values.length) {
-    return { min: 0, p50: 0, avg: 0, p95: 0, max: 0 };
+    return { min: 0, p50: 0, p75: 0, avg: 0, p95: 0, max: 0 };
   }
   return {
     min: Math.min(...values),
     p50: percentile(values, 0.5),
+    p75: percentile(values, 0.75),
     avg: values.reduce((sum, value) => sum + value, 0) / values.length,
     p95: percentile(values, 0.95),
     max: Math.max(...values),
+  };
+}
+
+function manifestEntry(manifest, predicate, label) {
+  const matches = Object.entries(manifest).filter(([key, entry]) => predicate(key, entry));
+  if (matches.length !== 1) {
+    throw new Error(`Expected one ${label} entry in the Vite client manifest; found ${matches.length}`);
+  }
+  return matches[0][0];
+}
+
+function manifestAssetClosure(manifest, rootKey) {
+  const visited = new Set();
+  const assets = new Set();
+
+  function visit(key) {
+    if (visited.has(key)) return;
+    const entry = manifest[key];
+    if (!entry) throw new Error(`Vite client manifest is missing imported entry ${key}`);
+    visited.add(key);
+    if (entry.file) assets.add(`/${entry.file}`);
+    for (const css of entry.css ?? []) assets.add(`/${css}`);
+    for (const importedKey of entry.imports ?? []) visit(importedKey);
+  }
+
+  visit(rootKey);
+  return [...assets].sort();
+}
+
+function manifestEntryAssets(manifest, key) {
+  const entry = manifest[key];
+  return [entry.file ? `/${entry.file}` : null, ...(entry.css ?? []).map((css) => `/${css}`)]
+    .filter(Boolean)
+    .sort();
+}
+
+async function loadExpectedLazyAssetClosures() {
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(VITE_CLIENT_MANIFEST_URL, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `The production Vite client manifest is required for lazy asset contracts. Run the frontend build first. ${error.message}`,
+    );
+  }
+
+  const threadStageKey = manifestEntry(
+    manifest,
+    (_key, entry) => entry.name === 'ThreadStageScreen' && entry.isDynamicEntry === true,
+    'ThreadStageScreen dynamic module',
+  );
+  const vaultKey = manifestEntry(
+    manifest,
+    (_key, entry) => entry.src === 'src/routes/vault/+page.svelte' && entry.isDynamicEntry === true,
+    'Vault page dynamic module',
+  );
+
+  return {
+    threadStage: {
+      moduleId: threadStageKey,
+      assets: manifestAssetClosure(manifest, threadStageKey),
+      entryAssets: manifestEntryAssets(manifest, threadStageKey),
+    },
+    vault: {
+      moduleId: vaultKey,
+      assets: manifestAssetClosure(manifest, vaultKey),
+      entryAssets: manifestEntryAssets(manifest, vaultKey),
+    },
   };
 }
 
@@ -716,6 +807,9 @@ function mockApiResponse(method, url, fixture) {
       sidecar: true,
     });
   }
+  if (pathName === '/api/cortex/notify' && methodUpper === 'POST') {
+    return jsonResponse(200, { ok: true }, { label: 'POST /api/cortex/notify', sidecar: true });
+  }
 
   if (pathName === '/api/cycles/') {
     return jsonResponse(200, [], { label: 'GET /api/cycles/' });
@@ -770,6 +864,44 @@ function mockApiResponse(method, url, fixture) {
   const unifiedStreamMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/unified-stream$/);
   if (unifiedStreamMatch) {
     return jsonResponse(200, fixture.streamItems, { label: 'GET /api/cortex/ideas/{idea_id}/unified-stream' });
+  }
+  const threadMessageMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/thread$/);
+  if (threadMessageMatch && methodUpper === 'POST') {
+    return jsonResponse(200, {
+      id: 'benchmark-composer-message',
+      idea_id: threadMessageMatch[1],
+      role: 'user',
+      content: 'Benchmark direct-thread composer contract',
+      attachments: [],
+      metadata: {},
+      created_at: new Date().toISOString(),
+    }, { label: 'POST /api/cortex/ideas/{idea_id}/thread' });
+  }
+  const ideaStatusMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/status$/);
+  if (ideaStatusMatch && methodUpper === 'PATCH') {
+    return jsonResponse(200, {
+      ...(fixture.ideas.find((idea) => idea.id === ideaStatusMatch[1]) ?? fixture.ideas[0]),
+      status: 'queued',
+    }, { label: 'PATCH /api/cortex/ideas/{idea_id}/status', sidecar: true });
+  }
+  const discussionMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/discussion$/);
+  if (discussionMatch && methodUpper === 'GET') {
+    return jsonResponse(200, [], { label: 'GET /api/cortex/ideas/{idea_id}/discussion', sidecar: true });
+  }
+  const handoffSummaryMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/handoff-summary$/);
+  if (handoffSummaryMatch && methodUpper === 'GET') {
+    return jsonResponse(200, { found: false }, {
+      label: 'GET /api/cortex/ideas/{idea_id}/handoff-summary',
+      sidecar: true,
+    });
+  }
+  const activityTimelineMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/activity-timeline$/);
+  if (activityTimelineMatch) {
+    return jsonResponse(200, [], { label: 'GET /api/cortex/ideas/{idea_id}/activity-timeline', sidecar: true });
+  }
+  const runHistoryMatch = pathName.match(/^\/api\/cortex\/run\/history\/([^/]+)$/);
+  if (runHistoryMatch) {
+    return jsonResponse(200, [], { label: 'GET /api/cortex/run/history/{idea_id}', sidecar: true });
   }
   const browserSessionMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/browser\/session$/);
   if (browserSessionMatch && methodUpper === 'GET') {
@@ -830,6 +962,12 @@ function mockApiResponse(method, url, fixture) {
   }
   if (pathName === '/api/notifications') {
     return jsonResponse(200, [], { label: `GET /api/notifications${url.search}`, sidecar: true });
+  }
+  if (pathName === '/api/notifications/preferences') {
+    return jsonResponse(200, {
+      sound_enabled: true,
+      message_notifications_enabled: true,
+    }, { label: 'GET /api/notifications/preferences', sidecar: true });
   }
 
   if (pathName === '/api/chat/bootstrap') {
@@ -1162,9 +1300,371 @@ function assertRequestContract(condition, scenario, expectation, calls) {
   );
 }
 
-async function runScenario(client, scenarioKey, fixture, options, measured) {
+function isAppAssetRequest(params, baseUrl) {
+  if (!APP_ASSET_RESOURCE_TYPES.has(params.type)) return false;
+  try {
+    return new URL(params.request.url).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+function assetUrlSet(requests) {
+  return new Set(requests.map((request) => request.url));
+}
+
+function assetPathSet(requests) {
+  return new Set(requests.map((request) => request.path));
+}
+
+function displayAssetUrl(url, baseUrl) {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === new URL(baseUrl).origin
+      ? `${parsed.pathname}${parsed.search}`
+      : parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function verifyManifestDeferredAssets(
+  expectedClosure,
+  expectedEntryAssets,
+  assetRequests,
+  selectionStartedAt,
+) {
+  const beforeSelection = assetPathSet(
+    assetRequests.filter((request) => request.startedAt < selectionStartedAt),
+  );
+  const afterSelection = assetPathSet(
+    assetRequests.filter((request) => request.startedAt >= selectionStartedAt),
+  );
+  const sharedBeforeSelection = expectedClosure.filter((asset) => beforeSelection.has(asset));
+  const deferredBeforeSelection = expectedClosure.filter((asset) => !beforeSelection.has(asset));
+  const missingAfterSelection = deferredBeforeSelection.filter((asset) => !afterSelection.has(asset));
+  return {
+    expectedClosure,
+    expectedEntryAssets,
+    entryAssetsBeforeSelection: expectedEntryAssets.filter((asset) => beforeSelection.has(asset)),
+    entryAssetsMissingAfterSelection: expectedEntryAssets.filter((asset) => !afterSelection.has(asset)),
+    sharedBeforeSelection,
+    deferredBeforeSelection,
+    requestedAfterSelection: deferredBeforeSelection.filter((asset) => afterSelection.has(asset)),
+    missingAfterSelection,
+  };
+}
+
+function assertAssetContract(condition, scenario, expectation, assetRequests, baseUrl) {
+  if (condition) return;
+  const observed = [...assetUrlSet(assetRequests)].map((url) => displayAssetUrl(url, baseUrl));
+  throw new Error(
+    `Asset contract failed for ${scenario.name}: ${expectation}` +
+    `\nObserved app script/style assets:\n${observed.length ? observed.map((url) => `- ${url}`).join('\n') : '- none'}`,
+  );
+}
+
+async function activateDefaultThreadPane(client, label, kind, readyExpression, timeoutMs) {
+  const startedAt = performance.now();
+  const clicked = await evaluate(client, `(() => {
+    const tab = document.querySelector('button[role="tab"][title="${label}"]');
+    if (!(tab instanceof HTMLElement)) return false;
+    tab.click();
+    return true;
+  })()`);
+  if (!clicked) throw new Error(`Default thread pane tab ${label} is unavailable`);
+  await waitForExpression(
+    client,
+    `(() => Boolean(
+      document.querySelector('.right-dock-content[data-active-tab="${kind}"]') &&
+      (${readyExpression}) &&
+      !document.querySelector('.right-dock-content[data-active-tab="${kind}"] .thread-lazy-pane-state')
+    ))()`,
+    timeoutMs,
+  );
+  return { pane: kind, readyMs: performance.now() - startedAt };
+}
+
+async function waitForApiCall(calls, startIndex, predicate, timeoutMs) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    const match = calls.slice(startIndex).find(predicate);
+    if (match) return match;
+    await sleep(25);
+  }
+  throw new Error('Timed out waiting for the deterministic composer API call');
+}
+
+async function verifyDirectThreadComposer(client, apiCalls, timeoutMs) {
+  const message = 'Benchmark direct-thread composer contract';
+  const apiStartIndex = apiCalls.length;
+  const sendStartedAt = performance.now();
+  const typed = await evaluate(client, `(() => {
+    const textarea = document.querySelector('.thread-bridge-textarea');
+    if (!(textarea instanceof HTMLTextAreaElement)) return false;
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+    valueSetter?.call(textarea, ${JSON.stringify(message)});
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    return textarea.value === ${JSON.stringify(message)};
+  })()`);
+  if (!typed) throw new Error('The direct-thread composer could not type its deterministic message');
+  await waitForExpression(
+    client,
+    `(() => {
+      const send = document.querySelector('button[aria-label="Send"]');
+      return send instanceof HTMLButtonElement && !send.disabled;
+    })()`,
+    timeoutMs,
+  );
+  const submitted = await evaluate(client, `(() => {
+    const send = document.querySelector('button[aria-label="Send"]');
+    if (!(send instanceof HTMLButtonElement) || send.disabled) return false;
+    send.click();
+    return true;
+  })()`);
+  if (!submitted) throw new Error('The direct-thread composer could not type and submit its deterministic message');
+
+  await waitForApiCall(
+    apiCalls,
+    apiStartIndex,
+    (call) => call.method === 'POST' && /^\/api\/cortex\/ideas\/[^/]+\/thread$/.test(call.path),
+    timeoutMs,
+  );
+  await waitForApiCall(
+    apiCalls,
+    apiStartIndex,
+    (call) => call.method === 'GET' && /^\/api\/cortex\/ideas\/[^/]+\/unified-stream$/.test(call.path),
+    timeoutMs,
+  );
+  await waitForExpression(
+    client,
+    `(() => {
+      const textarea = document.querySelector('.thread-bridge-textarea');
+      return textarea instanceof HTMLTextAreaElement && textarea.value === '' && !textarea.disabled;
+    })()`,
+    timeoutMs,
+  );
+  return {
+    passed: true,
+    message,
+    sendReadyMs: performance.now() - sendStartedAt,
+  };
+}
+
+async function measureLazyAssetContract(
+  client,
+  scenarioKey,
+  scenario,
+  assetRequests,
+  apiCalls,
+  options,
+  lazyAssetClosures,
+) {
+  if (scenarioKey !== 'workspace' && scenarioKey !== 'thread') {
+    return { kind: 'not-applicable', passed: true };
+  }
+
+  await sleep(THREAD_STAGE_PREWARM_OBSERVATION_MS);
+
+  if (scenarioKey === 'workspace') {
+    const selectionStartedAt = performance.now();
+    const threadClicked = await evaluate(client, `(() => {
+      const thread = document.querySelector('[data-constellation-signal-id="idea-1"]');
+      if (!(thread instanceof HTMLElement)) return false;
+      thread.click();
+      return true;
+    })()`);
+    assertAssetContract(
+      threadClicked === true,
+      scenario,
+      'the deterministic workspace thread control must be available after the prewarm observation window',
+      assetRequests,
+      options.baseUrl,
+    );
+
+    await waitForExpression(client, THREAD_READY_EXPRESSION, options.timeoutMs);
+    const firstOpenMs = performance.now() - selectionStartedAt;
+    const manifestProof = verifyManifestDeferredAssets(
+      lazyAssetClosures.threadStage.assets,
+      lazyAssetClosures.threadStage.entryAssets,
+      assetRequests,
+      selectionStartedAt,
+    );
+    assertAssetContract(
+      manifestProof.entryAssetsBeforeSelection.length === 0 &&
+        manifestProof.entryAssetsMissingAfterSelection.length === 0 &&
+        manifestProof.deferredBeforeSelection.length > 0 &&
+        manifestProof.missingAfterSelection.length === 0,
+      scenario,
+      `the manifest-derived ThreadStage entry assets must remain absent for ${THREAD_STAGE_PREWARM_OBSERVATION_MS}ms and every deferred closure asset must load after thread selection; entry assets before selection: ${manifestProof.entryAssetsBeforeSelection.join(', ') || 'none'}; missing after selection: ${[...manifestProof.entryAssetsMissingAfterSelection, ...manifestProof.missingAfterSelection].join(', ') || 'none'}`,
+      assetRequests,
+      options.baseUrl,
+    );
+
+    return {
+      kind: 'thread-stage-loads-on-selection',
+      passed: true,
+      observationMs: THREAD_STAGE_PREWARM_OBSERVATION_MS,
+      assetsBeforeSelection: assetPathSet(
+        assetRequests.filter((request) => request.startedAt < selectionStartedAt),
+      ).size,
+      manifestModuleId: lazyAssetClosures.threadStage.moduleId,
+      manifestExpectedAssetCount: manifestProof.expectedClosure.length,
+      manifestExpectedAssets: manifestProof.expectedClosure,
+      manifestExpectedEntryAssets: manifestProof.expectedEntryAssets,
+      manifestEntryAssetsBeforeSelection: manifestProof.entryAssetsBeforeSelection,
+      manifestSharedAssetCountBeforeSelection: manifestProof.sharedBeforeSelection.length,
+      manifestDeferredAssetsBeforeSelection: manifestProof.deferredBeforeSelection,
+      selectionTriggeredAssetCount: manifestProof.requestedAfterSelection.length,
+      selectionTriggeredAssets: manifestProof.requestedAfterSelection,
+      threadStageFirstOpenMs: firstOpenMs,
+    };
+  }
+
+  const panelClicked = await evaluate(client, `(() => {
+    const toggle = document.querySelector('button[aria-label="Show side panel"]');
+    if (!(toggle instanceof HTMLElement)) return false;
+    toggle.click();
+    return true;
+  })()`);
+  assertAssetContract(
+    panelClicked === true,
+    scenario,
+    'the deterministic side-panel toggle must be available',
+    assetRequests,
+    options.baseUrl,
+  );
+  await waitForExpression(
+    client,
+    `Boolean(document.querySelector('.cortex-thread-stage-right-dock'))`,
+    options.timeoutMs,
+  );
+
+  const defaultPaneInteractions = [];
+  await waitForExpression(
+    client,
+    `(() => {
+      const body = document.querySelector('.right-dock-content[data-active-tab="activity"]')?.textContent || '';
+      return Boolean(
+        document.querySelector('.right-dock-content[data-active-tab="activity"] .panel-utility-content-bare') &&
+        !body.includes('Loading activity')
+      );
+    })()`,
+    options.timeoutMs,
+  );
+  defaultPaneInteractions.push({ pane: 'activity-initial', readyMs: 0 });
+  defaultPaneInteractions.push(await activateDefaultThreadPane(
+    client,
+    'Discussion',
+    'discussion',
+    `document.querySelector('.right-dock-content[data-active-tab="discussion"] .thread-discussion-pane')`,
+    options.timeoutMs,
+  ));
+  defaultPaneInteractions.push(await activateDefaultThreadPane(
+    client,
+    'Handoff',
+    'handoff-summary',
+    `document.querySelector('.right-dock-content[data-active-tab="handoff-summary"] .panel-utility-content-bare') &&
+      !(document.querySelector('.right-dock-content[data-active-tab="handoff-summary"]')?.textContent || '').includes('Loading handoff')`,
+    options.timeoutMs,
+  ));
+  defaultPaneInteractions.push(await activateDefaultThreadPane(
+    client,
+    'Activity',
+    'activity',
+    `document.querySelector('.right-dock-content[data-active-tab="activity"] .panel-utility-content-bare') &&
+      !(document.querySelector('.right-dock-content[data-active-tab="activity"]')?.textContent || '').includes('Loading activity')`,
+    options.timeoutMs,
+  ));
+
+  const addMenuClicked = await evaluate(client, `(() => {
+    const add = document.querySelector('button[aria-label="Add side panel tab"]');
+    if (!(add instanceof HTMLElement)) return false;
+    add.click();
+    return true;
+  })()`);
+  assertAssetContract(
+    addMenuClicked === true,
+    scenario,
+    'the deterministic add-pane control must be available',
+    assetRequests,
+    options.baseUrl,
+  );
+  await waitForExpression(
+    client,
+    `Boolean(document.querySelector('.right-dock-add-menu[aria-label="Add side panel tab"]'))`,
+    options.timeoutMs,
+  );
+  await sleep(120);
+
+  const selectionStartedAt = performance.now();
+  const rarePaneClicked = await evaluate(client, `(() => {
+    const items = [...document.querySelectorAll('.right-dock-add-menu [role="menuitem"]')];
+    const vault = items.find((item) => item.querySelector('strong')?.textContent?.trim() === 'Vault');
+    if (!(vault instanceof HTMLElement)) return false;
+    vault.click();
+    return true;
+  })()`);
+  assertAssetContract(
+    rarePaneClicked === true,
+    scenario,
+    'the deterministic Vault pane menu item must be available',
+    assetRequests,
+    options.baseUrl,
+  );
+
+  await waitForExpression(client, VAULT_PANE_MOUNTED_EXPRESSION, options.timeoutMs);
+  const firstOpenMs = performance.now() - selectionStartedAt;
+  const manifestProof = verifyManifestDeferredAssets(
+    lazyAssetClosures.vault.assets,
+    lazyAssetClosures.vault.entryAssets,
+    assetRequests,
+    selectionStartedAt,
+  );
+  assertAssetContract(
+    manifestProof.entryAssetsBeforeSelection.length === 0 &&
+      manifestProof.entryAssetsMissingAfterSelection.length === 0 &&
+      manifestProof.deferredBeforeSelection.length > 0 &&
+      manifestProof.missingAfterSelection.length === 0,
+    scenario,
+    `the manifest-derived Vault entry assets must be absent before selection and every deferred closure asset must be fetched by the first selection; entry assets before selection: ${manifestProof.entryAssetsBeforeSelection.join(', ') || 'none'}; missing after selection: ${[...manifestProof.entryAssetsMissingAfterSelection, ...manifestProof.missingAfterSelection].join(', ') || 'none'}`,
+    assetRequests,
+    options.baseUrl,
+  );
+  await waitForExpression(client, VAULT_PANE_READY_EXPRESSION, options.timeoutMs);
+  const dataReadyMs = performance.now() - selectionStartedAt;
+  const composerContract = await verifyDirectThreadComposer(client, apiCalls, options.timeoutMs);
+
+  return {
+    kind: 'rare-pane-loads-on-selection',
+    passed: true,
+    observationMs: THREAD_STAGE_PREWARM_OBSERVATION_MS,
+    pane: 'vault',
+    assetsBeforeSelection: assetPathSet(
+      assetRequests.filter((request) => request.startedAt < selectionStartedAt),
+    ).size,
+    manifestModuleId: lazyAssetClosures.vault.moduleId,
+    manifestExpectedAssetCount: manifestProof.expectedClosure.length,
+    manifestExpectedAssets: manifestProof.expectedClosure,
+    manifestExpectedEntryAssets: manifestProof.expectedEntryAssets,
+    manifestEntryAssetsBeforeSelection: manifestProof.entryAssetsBeforeSelection,
+    manifestSharedAssetCountBeforeSelection: manifestProof.sharedBeforeSelection.length,
+    manifestDeferredAssetsBeforeSelection: manifestProof.deferredBeforeSelection,
+    rarePaneAssetsBeforeSelection: 0,
+    selectionTriggeredAssetCount: manifestProof.requestedAfterSelection.length,
+    selectionTriggeredAssets: manifestProof.requestedAfterSelection,
+    rarePaneFirstOpenMs: firstOpenMs,
+    rarePaneDataReadyMs: dataReadyMs,
+    rarePaneFirstOpenBudgetMs: RARE_PANE_OPEN_BUDGET_MS,
+    defaultPaneInteractions,
+    composerContract,
+  };
+}
+
+async function runScenario(client, scenarioKey, fixture, options, measured, lazyAssetClosures) {
   const scenario = SCENARIOS[scenarioKey];
   const apiCalls = [];
+  const assetRequests = [];
   const unsubscribers = [];
   const requestUrls = new Map();
   const networkFailures = [];
@@ -1172,6 +1672,14 @@ async function runScenario(client, scenarioKey, fixture, options, measured) {
   unsubscribers.push(
     client.on('Network.requestWillBeSent', (params) => {
       requestUrls.set(params.requestId, params.request?.url);
+      if (isAppAssetRequest(params, options.baseUrl)) {
+        assetRequests.push({
+          url: params.request.url,
+          path: new URL(params.request.url).pathname,
+          type: params.type,
+          startedAt: performance.now(),
+        });
+      }
     }),
     client.on('Network.loadingFailed', (params) => {
       networkFailures.push({
@@ -1262,6 +1770,15 @@ async function runScenario(client, scenarioKey, fixture, options, measured) {
     const measuredApiCalls = [...apiCalls];
     const bootstrapCallsBeforeClose = workspaceBootstrapCalls(measuredApiCalls);
     const workspaceCallsBeforeClose = workspaceStartupCalls(measuredApiCalls);
+    const lazyAssetContract = await measureLazyAssetContract(
+      client,
+      scenarioKey,
+      scenario,
+      assetRequests,
+      apiCalls,
+      options,
+      lazyAssetClosures,
+    );
     let postCloseReadyMs = null;
     let postCloseApiCalls = [];
 
@@ -1323,6 +1840,7 @@ async function runScenario(client, scenarioKey, fixture, options, measured) {
       readyMs,
       postCloseReadyMs,
       requestContract,
+      lazyAssetContract,
       apiCallCount: measuredApiCalls.length,
       postCloseApiCallCount: postCloseApiCalls.length,
       totalApiCallCount: allApiCalls.length,
@@ -1388,6 +1906,36 @@ function summarizeScenario(samples) {
   const routes = routeSummaries(apiLabels);
   const allRoutes = routeSummaries(allApiLabels);
   const postCloseRoutes = routeSummaries(postCloseApiLabels);
+  const threadStageFirstOpenMs = summarizeNumbers(
+    measuredSamples
+      .map((sample) => sample.lazyAssetContract?.threadStageFirstOpenMs ?? 0)
+      .filter((value) => value > 0),
+  );
+  const rarePaneFirstOpenMs = summarizeNumbers(
+    measuredSamples
+      .map((sample) => sample.lazyAssetContract?.rarePaneFirstOpenMs ?? 0)
+      .filter((value) => value > 0),
+  );
+  const rarePaneDataReadyMs = summarizeNumbers(
+    measuredSamples
+      .map((sample) => sample.lazyAssetContract?.rarePaneDataReadyMs ?? 0)
+      .filter((value) => value > 0),
+  );
+  const selectionTriggeredAssets = [...new Set(
+    measuredSamples.flatMap((sample) => sample.lazyAssetContract?.selectionTriggeredAssets ?? []),
+  )].sort();
+  const directThreadContractSamples = measuredSamples.filter(
+    (sample) => sample.lazyAssetContract?.kind === 'rare-pane-loads-on-selection',
+  );
+  const defaultPaneKinds = ['activity-initial', 'discussion', 'handoff-summary', 'activity'];
+  const defaultPaneReadyMs = Object.fromEntries(defaultPaneKinds.map((kind) => [
+    kind,
+    summarizeNumbers(directThreadContractSamples.flatMap((sample) => (
+      sample.lazyAssetContract.defaultPaneInteractions
+        ?.filter((interaction) => interaction.pane === kind)
+        .map((interaction) => interaction.readyMs) ?? []
+    ))),
+  ]));
 
   return {
     runs: measuredSamples.length,
@@ -1424,6 +1972,71 @@ function summarizeScenario(samples) {
       measuredSamples.map((sample) => sample.requestContract?.workspaceStartupPostClose ?? 0),
     ),
     request_contract_passed: measuredSamples.every((sample) => sample.requestContract?.passed === true),
+    lazy_asset_contract_passed: measuredSamples.every((sample) => sample.lazyAssetContract?.passed === true),
+    lazy_asset_observation_ms: Math.max(
+      0,
+      ...measuredSamples.map((sample) => sample.lazyAssetContract?.observationMs ?? 0),
+    ),
+    assets_before_lazy_selection: summarizeNumbers(
+      measuredSamples
+        .map((sample) => sample.lazyAssetContract?.assetsBeforeSelection ?? 0)
+        .filter((value) => value > 0),
+    ),
+    selection_triggered_asset_count: summarizeNumbers(
+      measuredSamples
+        .map((sample) => sample.lazyAssetContract?.selectionTriggeredAssetCount ?? 0)
+        .filter((value) => value > 0),
+    ),
+    selection_triggered_assets: selectionTriggeredAssets,
+    manifest_expected_asset_count: summarizeNumbers(
+      measuredSamples
+        .map((sample) => sample.lazyAssetContract?.manifestExpectedAssetCount ?? 0)
+        .filter((value) => value > 0),
+    ),
+    manifest_expected_entry_assets: [...new Set(
+      measuredSamples.flatMap(
+        (sample) => sample.lazyAssetContract?.manifestExpectedEntryAssets ?? [],
+      ),
+    )].sort(),
+    manifest_entry_assets_before_selection: [...new Set(
+      measuredSamples.flatMap(
+        (sample) => sample.lazyAssetContract?.manifestEntryAssetsBeforeSelection ?? [],
+      ),
+    )].sort(),
+    manifest_shared_asset_count_before_selection: summarizeNumbers(
+      measuredSamples
+        .map((sample) => sample.lazyAssetContract?.manifestSharedAssetCountBeforeSelection ?? 0)
+        .filter((value) => value > 0),
+    ),
+    manifest_deferred_assets_before_selection: [...new Set(
+      measuredSamples.flatMap(
+        (sample) => sample.lazyAssetContract?.manifestDeferredAssetsBeforeSelection ?? [],
+      ),
+    )].sort(),
+    thread_stage_first_open_ms: threadStageFirstOpenMs,
+    rare_pane_assets_before_selection: summarizeNumbers(
+      measuredSamples
+        .filter((sample) => sample.lazyAssetContract?.kind === 'rare-pane-loads-on-selection')
+        .map((sample) => sample.lazyAssetContract?.rarePaneAssetsBeforeSelection ?? 0),
+    ),
+    rare_pane_first_open_ms: rarePaneFirstOpenMs,
+    rare_pane_data_ready_ms: rarePaneDataReadyMs,
+    rare_pane_first_open_budget_ms: RARE_PANE_OPEN_BUDGET_MS,
+    rare_pane_first_open_budget_passed: rarePaneFirstOpenMs.p75 === 0 || rarePaneFirstOpenMs.p75 <= RARE_PANE_OPEN_BUDGET_MS,
+    default_pane_contract_passed: directThreadContractSamples.every((sample) => (
+      defaultPaneKinds.every((kind) => (
+        sample.lazyAssetContract.defaultPaneInteractions?.some((interaction) => interaction.pane === kind)
+      ))
+    )),
+    default_pane_ready_ms: defaultPaneReadyMs,
+    composer_contract_passed: directThreadContractSamples.every(
+      (sample) => sample.lazyAssetContract.composerContract?.passed === true,
+    ),
+    composer_send_ready_ms: summarizeNumbers(
+      directThreadContractSamples
+        .map((sample) => sample.lazyAssetContract.composerContract?.sendReadyMs ?? 0)
+        .filter((value) => value > 0),
+    ),
     dom_nodes: summarizeNumbers(measuredSamples.map((sample) => sample.domNodes)),
     deep_field_feature_nodes: summarizeNumbers(measuredSamples.map((sample) => sample.deepFieldFeatureNodes ?? 0)),
     d3_shadow_nodes: summarizeNumbers(measuredSamples.map((sample) => sample.d3ShadowNodes ?? 0)),
@@ -1456,13 +2069,16 @@ function printTextReport(result) {
     routes: scenario.summary.unique_api_routes.p50.toFixed(0),
     bootstrap: `${scenario.summary.workspace_bootstrap_before_close.p50.toFixed(0)}/${scenario.summary.workspace_bootstrap_post_close.p50.toFixed(0)}`,
     close: scenario.summary.post_close_ready_ms.p50 ? scenario.summary.post_close_ready_ms.p50.toFixed(1) : '-',
+    pane75: scenario.summary.rare_pane_first_open_ms.p75
+      ? scenario.summary.rare_pane_first_open_ms.p75.toFixed(1)
+      : '-',
     long: scenario.summary.long_task_total_ms.p95.toFixed(1),
     dom: scenario.summary.dom_nodes.p50.toFixed(0),
     d3: scenario.summary.d3_shadow_nodes.p50.toFixed(0),
     links: scenario.summary.d3_shadow_connections.p50.toFixed(0),
     field: scenario.summary.deep_field_feature_nodes.p50.toFixed(0),
   }));
-  const headers = ['name', 'runs', 'p50', 'p95', 'fcp', 'api', 'routes', 'bootstrap', 'close', 'long', 'dom', 'd3', 'links', 'field'];
+  const headers = ['name', 'runs', 'p50', 'p95', 'fcp', 'api', 'routes', 'bootstrap', 'close', 'pane75', 'long', 'dom', 'd3', 'links', 'field'];
   const widths = Object.fromEntries(headers.map((header) => [
     header,
     Math.max(header.length, ...rows.map((row) => row[header].length)),
@@ -1481,6 +2097,38 @@ function printTextReport(result) {
       `${scenario.summary.workspace_bootstrap_before_close.p50.toFixed(0)}/` +
       `${scenario.summary.workspace_bootstrap_post_close.p50.toFixed(0)})`,
     );
+    if (scenario.summary.lazy_asset_observation_ms > 0) {
+      console.log(
+        `${scenario.name} lazy asset contract: ${scenario.summary.lazy_asset_contract_passed ? 'PASS' : 'FAIL'} ` +
+        `(observed ${scenario.summary.lazy_asset_observation_ms.toFixed(0)}ms; ` +
+        `manifest closure ${scenario.summary.manifest_expected_asset_count.p50.toFixed(0)}; ` +
+        `entry assets before ${scenario.summary.manifest_entry_assets_before_selection.length}; ` +
+        `shared before ${scenario.summary.manifest_shared_asset_count_before_selection.p50.toFixed(0)}; ` +
+        `deferred and fetched ${scenario.summary.selection_triggered_asset_count.p50.toFixed(0)})`,
+      );
+      for (const asset of scenario.summary.selection_triggered_assets) {
+        console.log(`  on selection: ${asset}`);
+      }
+    }
+    if (scenario.summary.rare_pane_first_open_ms.p75 > 0) {
+      console.log(
+        `${scenario.name} Vault first-open p75: ${scenario.summary.rare_pane_first_open_ms.p75.toFixed(1)}ms ` +
+        `(budget <=${scenario.summary.rare_pane_first_open_budget_ms}ms: ` +
+        `${scenario.summary.rare_pane_first_open_budget_passed ? 'PASS' : 'FAIL'}; ` +
+        `rare assets before selection ${scenario.summary.rare_pane_assets_before_selection.max.toFixed(0)}; ` +
+        `full data p75 ${scenario.summary.rare_pane_data_ready_ms.p75.toFixed(1)}ms)`,
+      );
+      console.log(
+        `${scenario.name} default pane contract: ${scenario.summary.default_pane_contract_passed ? 'PASS' : 'FAIL'} ` +
+        `(Discussion p75 ${scenario.summary.default_pane_ready_ms.discussion.p75.toFixed(1)}ms; ` +
+        `Handoff p75 ${scenario.summary.default_pane_ready_ms['handoff-summary'].p75.toFixed(1)}ms; ` +
+        `Activity p75 ${scenario.summary.default_pane_ready_ms.activity.p75.toFixed(1)}ms)`,
+      );
+      console.log(
+        `${scenario.name} composer contract: ${scenario.summary.composer_contract_passed ? 'PASS' : 'FAIL'} ` +
+        `(type, submit, POST, refresh p75 ${scenario.summary.composer_send_ready_ms.p75.toFixed(1)}ms)`,
+      );
+    }
     console.log(`${scenario.name} API routes:`);
     for (const route of scenario.summary.routes.slice(0, 20)) {
       console.log(`  ${route.avg_calls_per_run.toFixed(1)}x/run  ${route.label}`);
@@ -1528,6 +2176,7 @@ function printComparison(before, after) {
       ['FCP p50', beforeScenario.summary.fcp_ms.p50, afterScenario.summary.fcp_ms.p50, 'ms'],
       ['API calls p50', beforeScenario.summary.api_calls.p50, afterScenario.summary.api_calls.p50, ''],
       ['API KB p50', beforeScenario.summary.api_kb.p50, afterScenario.summary.api_kb.p50, 'KB'],
+      ['rare pane first-open p75', beforeScenario.summary.rare_pane_first_open_ms?.p75 ?? 0, afterScenario.summary.rare_pane_first_open_ms?.p75 ?? 0, 'ms'],
       ['DOM nodes p50', beforeScenario.summary.dom_nodes.p50, afterScenario.summary.dom_nodes.p50, ''],
       ['D3 shadow nodes p50', beforeScenario.summary.d3_shadow_nodes?.p50 ?? 0, afterScenario.summary.d3_shadow_nodes?.p50 ?? 0, ''],
       ['D3 shadow bubbles p50', beforeScenario.summary.d3_shadow_bubbles?.p50 ?? 0, afterScenario.summary.d3_shadow_bubbles?.p50 ?? 0, ''],
@@ -1565,6 +2214,7 @@ async function main() {
   }
 
   const fixture = buildFixture(options);
+  const lazyAssetClosures = await loadExpectedLazyAssetClosures();
   const chrome = await launchChrome(options);
   const client = new CdpClient(chrome.pageWsUrl);
   await client.connect();
@@ -1576,7 +2226,14 @@ async function main() {
       const totalRuns = options.warmups + options.runs;
       for (let index = 0; index < totalRuns; index += 1) {
         const measured = index >= options.warmups;
-        const sample = await runScenario(client, scenarioKey, fixture, options, measured);
+        const sample = await runScenario(
+          client,
+          scenarioKey,
+          fixture,
+          options,
+          measured,
+          lazyAssetClosures,
+        );
         samples.push(sample);
       }
       samplesByScenario.set(scenarioKey, samples);
@@ -1595,6 +2252,14 @@ async function main() {
         apiLatencyMs: options.apiLatencyMs,
         sidecarLatencyMs: options.sidecarLatencyMs,
         timeoutMs: options.timeoutMs,
+        lazyAssetManifest: {
+          threadStageModuleId: lazyAssetClosures.threadStage.moduleId,
+          threadStageAssetCount: lazyAssetClosures.threadStage.assets.length,
+          threadStageEntryAssetCount: lazyAssetClosures.threadStage.entryAssets.length,
+          vaultModuleId: lazyAssetClosures.vault.moduleId,
+          vaultAssetCount: lazyAssetClosures.vault.assets.length,
+          vaultEntryAssetCount: lazyAssetClosures.vault.entryAssets.length,
+        },
       },
       scenarios: options.scenarios.map((scenarioKey) => {
         const samples = samplesByScenario.get(scenarioKey) ?? [];
@@ -1611,6 +2276,10 @@ async function main() {
     if (unknownRoutes.length && !options.allowUnknownApi) {
       throw new Error(`Unknown mocked API routes detected:\n${unknownRoutes.map((route) => `- ${route.label}`).join('\n')}`);
     }
+    const failedPerformanceContracts = result.scenarios.filter((scenario) => (
+      scenario.summary.rare_pane_first_open_ms.p75 > 0 &&
+      scenario.summary.rare_pane_first_open_budget_passed === false
+    ));
 
     if (options.out) {
       await mkdir(path.dirname(options.out), { recursive: true });
@@ -1621,6 +2290,15 @@ async function main() {
       console.log(JSON.stringify(result, null, 2));
     } else {
       printTextReport(result);
+    }
+
+    if (failedPerformanceContracts.length) {
+      throw new Error(
+        `Rare pane first-open budget failed:\n${failedPerformanceContracts.map((scenario) => (
+          `- ${scenario.name}: p75 ${scenario.summary.rare_pane_first_open_ms.p75.toFixed(1)}ms > ` +
+          `${scenario.summary.rare_pane_first_open_budget_ms}ms`
+        )).join('\n')}`,
+      );
     }
   } finally {
     client.close();

--- a/tests/test_theme_and_workspace_app_design_contracts.py
+++ b/tests/test_theme_and_workspace_app_design_contracts.py
@@ -380,8 +380,9 @@ def test_thread_stage_open_motion_keeps_cortex_static():
     panel_open_rule = re.search(r"\.panel-open \.cortex-main\s*\{(?P<body>.*?)\}", page, re.DOTALL)
     panel_overlay_rule = re.search(r"\.panel-open \.cortex-main::after\s*\{(?P<body>.*?)\}", page, re.DOTALL)
 
-    assert "threadStagePrewarmQueued" in page
-    assert "runWhenBrowserIdle(() => ensureThreadStageScreenLoaded()" in page
+    assert "threadStagePrewarmQueued" not in page
+    assert "runWhenBrowserIdle(() => ensureThreadStageScreenLoaded()" not in page
+    assert "if (cortex.panelOpen) ensureThreadStageScreenLoaded();" in page
     assert "threadStage.syncPanelOpen(cortex.panelOpen && Boolean(ThreadStageScreenComponent))" in page
     assert "clip-path:" not in shell_style
     assert "thread-origin-bloom" not in thread_shell

--- a/tests/test_thread_lazy_pane_contract.py
+++ b/tests/test_thread_lazy_pane_contract.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STAGE_PATH = REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadStageScreen.svelte"
+REGISTRY_PATH = REPO_ROOT / "frontend/src/lib/features/threads/controllers/threadLazyModuleRegistry.ts"
+COMPOSER_ADAPTER_PATH = REPO_ROOT / "frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte"
+SETTINGS_MENU_PATH = REPO_ROOT / "frontend/src/lib/features/composer/components/WorkspaceComposerSettingsMenu.svelte"
+TRANSCRIPT_PATH = REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadTranscript.svelte"
+DISCUSSION_PATH = REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadDiscussionPane.svelte"
+LAZY_REFERENCE_PREVIEW_PATH = (
+    REPO_ROOT / "frontend/src/lib/features/threads/components/LazyObjectReferencePreviewList.svelte"
+)
+LAZY_VISUAL_BLOCK_PATH = (
+    REPO_ROOT / "frontend/src/lib/features/threads/components/LazyStreamVisualBlock.svelte"
+)
+
+RARE_THREAD_PANES = {
+    "browser": (
+        "BrowserThoughtPanel",
+        "$lib/features/browser-sessions/components/BrowserThoughtPanel.svelte",
+    ),
+    "cycles": (
+        "ThreadCyclesPane",
+        "$lib/features/cycles/components/ThreadCyclesPane.svelte",
+    ),
+    "project": (
+        "ProjectDraftStatePanel",
+        "$lib/features/threads/components/ProjectDraftStatePanel.svelte",
+    ),
+    "preview": (
+        "ThreadAttachmentPreviewPane",
+        "$lib/features/threads/components/ThreadAttachmentPreviewPane.svelte",
+    ),
+    "code-review": (
+        "ThreadCodeReviewPane",
+        "$lib/features/threads/components/ThreadCodeReviewPane.svelte",
+    ),
+    "file-preview": (
+        "ThreadProjectFilePreviewPane",
+        "$lib/features/threads/components/ThreadProjectFilePreviewPane.svelte",
+    ),
+    "app": (
+        "ThreadAppsPane",
+        "$lib/features/workspace-apps/components/ThreadAppsPane.svelte",
+    ),
+    "vault": (
+        "VaultPage",
+        "../../../../routes/vault/+page.svelte",
+    ),
+}
+
+
+def _stage_source() -> str:
+    return STAGE_PATH.read_text()
+
+
+def _registry_source() -> str:
+    return REGISTRY_PATH.read_text()
+
+
+def test_rare_thread_panes_are_dynamic_imports_only():
+    source = _stage_source()
+    registry = _registry_source()
+    script = source.split("</script>", 1)[0]
+
+    for kind, (component, module_path) in RARE_THREAD_PANES.items():
+        assert f"import {component} from '{module_path}';" not in script
+        assert f"{kind!r}: async () =>" in script
+        assert f"import('{module_path}')" in registry
+        assert f"{component}Component" in script
+
+
+def test_only_the_selected_rare_pane_triggers_loading():
+    source = _stage_source()
+
+    effect = source.split("const activeKind = activeSidePanelTab?.kind;", 1)[1].split(
+        "});",
+        1,
+    )[0]
+    assert "isLazyThreadPaneKind(activeKind)" in effect
+    assert "ensureThreadPaneLoaded(activeKind);" in effect
+    assert source.count("ensureThreadPaneLoaded(") == 3
+
+    for kind, (component, _) in RARE_THREAD_PANES.items():
+        assert f"{{#if {component}Component}}" in source
+        assert f"{{@render lazyPaneStatus('{kind}')}}" in source
+
+
+def test_default_thread_panes_remain_eager_and_lazy_failures_are_retryable():
+    source = _stage_source()
+
+    assert "import ThreadDiscussionPane from" in source
+    assert "import ThreadUtilityContent from" in source
+    assert "threadModuleLoadErrors[kind]" in source
+    assert 'onclick={() => ensureThreadPaneLoaded(kind)}' in source
+    assert ">Retry</button>" in source
+
+
+def test_project_context_picker_loads_on_interaction_without_losing_pending_context():
+    source = _stage_source()
+    registry = _registry_source()
+    module_path = "$lib/features/composer/components/ProjectContextPicker.svelte"
+
+    assert f"import ProjectContextPicker from '{module_path}';" not in source
+    assert "'project-context': async () =>" in source
+    assert f"import('{module_path}')" in registry
+    assert "onclick={openLazyProjectContextPicker}" in source
+    assert "initialOpen={projectContextPickerRequestedOpen}" in source
+
+    pending_state_effect = source.split("if (ProjectContextPickerComponent) return;", 1)[1].split(
+        "});",
+        1,
+    )[0]
+    assert "validateProjectContextResources" in pending_state_effect
+    assert "snapshot," in pending_state_effect
+    assert "resourceCount:" in pending_state_effect
+
+
+def test_voice_dictation_controller_and_recording_ui_load_on_first_use():
+    source = _stage_source()
+    registry = _registry_source()
+    controller_path = "$lib/features/composer/controllers/workspaceVoiceDictation.svelte.ts"
+    recording_path = "$lib/features/composer/components/WorkspaceVoiceRecording.svelte"
+
+    assert f"import {{ WorkspaceVoiceDictationController }} from '{controller_path}';" not in source
+    assert f"import WorkspaceVoiceRecording from '{recording_path}';" not in source
+    assert "'voice-dictation': async () =>" in source
+    assert f"import('{controller_path}')" in registry
+    assert f"import('{recording_path}')" in registry
+    assert "await ensureThreadModuleLoaded('voice-dictation');" in source
+    assert "if (voiceDictation?.isReady) voiceDictation.toggle();" in source
+    assert "WorkspaceVoiceRecordingComponent" in source
+
+
+def test_slash_and_skill_overlays_load_only_when_composer_text_needs_them():
+    source = _stage_source()
+    registry = _registry_source()
+    slash_path = "$lib/features/composer/components/SlashAutocomplete.svelte"
+    skill_path = "$lib/features/composer/components/SkillMentionOverlay.svelte"
+
+    assert f"import SlashAutocomplete from '{slash_path}';" not in source
+    assert f"import SkillMentionOverlay from '{skill_path}';" not in source
+    assert "'composer-text-tools': async () =>" in source
+    assert f"import('{slash_path}')" in registry
+    assert f"import('{skill_path}')" in registry
+    assert "if (slashToken || hasSkillMention(inputValue))" in source
+    assert "SlashAutocompleteComponent" in source
+    assert "SkillMentionOverlayComponent" in source
+
+
+def test_run_settings_menu_and_data_load_on_settings_interaction():
+    stage = _stage_source()
+    registry = _registry_source()
+    adapter = COMPOSER_ADAPTER_PATH.read_text()
+    menu = SETTINGS_MENU_PATH.read_text()
+
+    assert "import('$lib/features/composer/domain/runSettings')" in registry
+    assert "onSettingsOpen={() => ensureThreadModuleLoaded('run-settings')}" in stage
+    assert "import('./WorkspaceComposerSettingsMenu.svelte')" in adapter
+    assert "await onSettingsOpen?.();" in adapter
+    assert "WorkspaceComposerSettingsMenuComponent" in adapter
+    assert 'role="menu" class="composer-settings-menu"' in menu
+
+
+def test_reference_previews_load_only_for_messages_that_contain_references():
+    transcript = TRANSCRIPT_PATH.read_text()
+    discussion = DISCUSSION_PATH.read_text()
+    lazy_preview = LAZY_REFERENCE_PREVIEW_PATH.read_text()
+    registry = _registry_source()
+    module_path = "$lib/features/threads/components/ObjectReferencePreviewList.svelte"
+
+    assert f"import ObjectReferencePreviewList from '{module_path}';" not in transcript
+    assert f"import ObjectReferencePreviewList from '{module_path}';" not in discussion
+    assert "import LazyObjectReferencePreviewList from" in transcript
+    assert "import LazyObjectReferencePreviewList from" in discussion
+    assert "<LazyObjectReferencePreviewList" in transcript
+    assert "<LazyObjectReferencePreviewList" in discussion
+    assert f"import('{module_path}')" in registry
+    assert "const hasReferences = $derived" in lazy_preview
+    assert "if (hasReferences) void ensureLoaded();" in lazy_preview
+    assert "import('$lib/features/threads/controllers/threadLazyModuleRegistry')" in lazy_preview
+    assert "registry.loadObjectReferencePreviewList()" in lazy_preview
+    assert "ObjectReferencePreviewListComponent" in lazy_preview
+    assert "Loading reference previews" in lazy_preview
+    assert "Reference previews could not load." in lazy_preview
+    assert "function ensureLoaded()" in lazy_preview
+
+
+def test_visual_block_renderer_loads_only_when_visual_content_is_present():
+    transcript = TRANSCRIPT_PATH.read_text()
+    lazy_visual = LAZY_VISUAL_BLOCK_PATH.read_text()
+    registry = _registry_source()
+    module_path = "$lib/features/threads/components/StreamVisualBlock.svelte"
+
+    assert f"import StreamVisualBlock from '{module_path}';" not in transcript
+    assert "import LazyStreamVisualBlock from" in transcript
+    assert transcript.count("<LazyStreamVisualBlock") == 2
+    assert f"import('{module_path}')" in registry
+    assert "registry.loadStreamVisualBlock()" in lazy_visual
+    assert "StreamVisualBlockComponent" in lazy_visual
+    assert "Loading visual content" in lazy_visual
+    assert "Visual content could not load." in lazy_visual
+    assert "function ensureLoaded()" in lazy_visual

--- a/tests/test_thread_stage_bundle_budget.py
+++ b/tests/test_thread_stage_bundle_budget.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_ROOT = REPO_ROOT / "frontend"
+BUDGET_SCRIPT = FRONTEND_ROOT / "scripts/check-thread-stage-bundle.mjs"
+
+
+def test_bundle_budget_command_is_fixed_at_250kb():
+    package = json.loads((FRONTEND_ROOT / "package.json").read_text())
+    source = BUDGET_SCRIPT.read_text()
+
+    assert package["scripts"]["check:thread-stage-bundle"] == (
+        "node scripts/check-thread-stage-bundle.mjs"
+    )
+    assert "THREAD_STAGE_GZIP_BUDGET_BYTES = 250_000" in source
+    assert "candidate?.name === 'ThreadStageScreen'" in source
+    assert "candidate?.isDynamicEntry" in source
+    assert "process.exitCode = 1" in source
+
+
+def test_measurement_walks_static_imports_and_excludes_dynamic_imports(tmp_path: Path):
+    client_root = tmp_path / "client"
+    (client_root / ".vite").mkdir(parents=True)
+    manifest = {
+        "stage": {
+            "name": "ThreadStageScreen",
+            "isDynamicEntry": True,
+            "file": "stage.js",
+            "imports": ["shared"],
+            "dynamicImports": ["rare"],
+            "css": ["stage.css"],
+        },
+        "shared": {"file": "shared.js", "css": ["shared.css"]},
+        "rare": {"file": "rare.js", "isDynamicEntry": True},
+    }
+    (client_root / ".vite/manifest.json").write_text(json.dumps(manifest))
+    for filename in ["stage.js", "stage.css", "shared.js", "shared.css", "rare.js"]:
+        (client_root / filename).write_text(filename * 8)
+
+    program = f"""
+import {{ measureThreadStageStaticClosure }} from {json.dumps(BUDGET_SCRIPT.as_uri())};
+console.log(JSON.stringify(measureThreadStageStaticClosure({json.dumps(str(client_root))})));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", program],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    measurement = json.loads(result.stdout)
+
+    assert measurement["fileCount"] == 4
+    assert measurement["rawBytes"] == sum(
+        (client_root / filename).stat().st_size
+        for filename in ["stage.js", "stage.css", "shared.js", "shared.css"]
+    )


### PR DESCRIPTION
## What changed

- remove automatic post-ready ThreadStage prewarming from the workspace
- load rare thread panes and interaction-only composer features on demand
- keep Discussion, Activity, Handoff, transcript text, typing, and sending eager
- add retryable lazy wrappers for reference cards and visual blocks
- extract the composer settings menu behind first interaction
- add a production-manifest bundle budget for the ThreadStage static closure
- strengthen the Chrome benchmark with manifest-derived asset contracts, pane timings, and composer behavior coverage

## Hypothesis

Loading thread panes only when selected should reduce the direct-thread critical closure below 250,000 gzip bytes without causing more than a 5% route-ready regression or making a rare pane take more than 250 ms to become visible.

## Measured result

- direct-thread initial closure: **400,107 -> 240,471 gzip bytes** (**-39.9%**)
- enforced budget: **<=250,000 bytes** (9,529-byte margin after rebasing onto current `main`)
- workspace idle preload: **19 automatic assets -> 0**
- ThreadStage/Vault entry assets before interaction: **0**
- deferred assets requested after interaction: **5/5** for both ThreadStage and Vault
- Vault click-to-visible p75: **30.9 ms** (budget <=250 ms)
- Vault full mocked data hydration p75: **327.0 ms** at 100 ms per mocked request stage (reported separately, not hidden)

Controlled 5-warmup / 30-run route comparison at 100 ms API and sidecar latency:

| Scenario | Before p50 | After p50 | Delta | Before p95 | After p95 | Delta |
|---|---:|---:|---:|---:|---:|---:|
| Workspace | 343.9 ms | 332.9 ms | -3.20% | 418.4 ms | 380.2 ms | -9.12% |
| Direct thread | 517.1 ms | 540.6 ms | +4.55% | 615.6 ms | 588.4 ms | -4.41% |

No affected route-ready regression exceeded 5%.

## Validation

- `npm run check` - 0 errors / 0 warnings
- `npm test` - 205 passed
- `npm run build`
- `npm run check:thread-stage-bundle` - 240,471 / 250,000 PASS
- focused Python contracts - 53 passed
- `node --check scripts/benchmark_frontend.mjs`
- controlled workspace/thread Chrome profile - passed
- all-seven production benchmark smoke - passed
- independent agent-loop judge - PASS

## Scope

This is H4, the first performance-campaign slice. Cursor-paginated/windowed thread history (H2) remains a separate follow-on so its backend and transcript semantics can be judged independently.
