### PR TITLE
[Illo] Compose passthrough for Slice 5 deploy-state env vars

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -50,6 +50,11 @@ x-illo-env: &illo-env
   ILLO_UNCLAIMED_POOL_USER_ID: ${ILLO_UNCLAIMED_POOL_USER_ID:-}
   ILLO_GITHUB_WEBHOOK_SECRET: ${ILLO_GITHUB_WEBHOOK_SECRET:-}
   ILLO_GITHUB_CONNECTION_ID: ${ILLO_GITHUB_CONNECTION_ID:-}
+  # Slice 5 deploy-state: watched repos arm the promotion sweep, ladder
+  # fields, and check_fix_deploy_state tool. Empty default = feature off.
+  ILLO_DEPLOY_SWEEP_REPOS: ${ILLO_DEPLOY_SWEEP_REPOS:-}
+  ILLO_DEPLOY_SETTLE_MINUTES: ${ILLO_DEPLOY_SETTLE_MINUTES:-}
+  ILLO_DEPLOY_QUIET_HOURS: ${ILLO_DEPLOY_QUIET_HOURS:-}
 
 x-backend-service: &backend-service
   image: ${ILLO_API_IMAGE:-ghcr.io/illospace/api:latest}

--- a/specs/illo-lifecycle/README.md
+++ b/specs/illo-lifecycle/README.md
@@ -11,9 +11,10 @@ Claude-reviewed, fast suite green (3438 passed, 9 pre-existing
 READ-ONLY illo-dev dry runs (952-pattern): run 1088 pre-promotion → expected
 noise / zero refiles / zero pings + promotion recommendation; run 1089
 post-promotion → reopen #904 + escalate to the builder (axel-havard). Live
-activation gates below; the doc-1155 delta
-([slices/05-doc-1155-delta.md](slices/05-doc-1155-delta.md)) awaits approval
-and must merge after/with the parallel digest-contract edit to record 1155.
+activation gates below. The doc-1155 delta
+([slices/05-doc-1155-delta.md](slices/05-doc-1155-delta.md)) is **applied**:
+live doc v6 (2026-07-10) carries both this slice's ladder and the parallel
+digest-contract edits, verified identical to the bundled SKILL.md.
 
 **Prior status (2026-07-09):** All five slices **implemented and shipped in PR #276**
 (2 commits). Pure logic cores are unit-tested (**105 focused tests green**); an
@@ -61,10 +62,11 @@ enumerated per slice below.
   `ILLO_DEPLOY_QUIET_HOURS` overrides); ensure the Slice-1 source
   policy/projection **covers `pull_request` events** — the sweep hook runs on
   the post-projection ingest path, so unprojected merge envelopes never reach
-  it; apply the deploy-state ladder delta to live doc 1155
-  (**coordinate with the parallel digest-contract edit to the same doc**);
-  verification tick rides Slice 4's cycle registration; decide the optional
-  Rollbar read-only token (Vault) for API-backed quiet checks.
+  it; ~~apply the deploy-state ladder delta to live doc 1155~~ **done — doc
+  v6 (2026-07-10) carries it**; verification tick rides Slice 4's cycle
+  registration; optional Rollbar read-only token (Vault) for API-backed quiet
+  checks — **Reda decided 2026-07-10: skip for now**, Slack-inference default
+  stands.
 
 **Before ending your pass:** update this section.
 

--- a/specs/illo-lifecycle/slices/05-doc-1155-delta.md
+++ b/specs/illo-lifecycle/slices/05-doc-1155-delta.md
@@ -1,5 +1,10 @@
 # Slice 5 activation artifact — live doc 1155 delta
 
+> **APPLIED 2026-07-10 16:37 UTC as doc 1155 v6.** The digest-contract session
+> wrote v6 from the post-merge bundled SKILL.md, which already contained every
+> edit below (verified byte-identical modulo trailing whitespace). Do NOT
+> re-apply. This file stays as the record of what changed and why.
+
 The runtime source of truth for triage prose is Enterprise Documentation
 (Domain 37) record **1155**, slug `uwear-engineering-triage`. The bundled
 [SKILL.md](../../../brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md)


### PR DESCRIPTION
Follow-up to #293: the compose file never exposed `ILLO_DEPLOY_SWEEP_REPOS` / `ILLO_DEPLOY_SETTLE_MINUTES` / `ILLO_DEPLOY_QUIET_HOURS` to the containers, so the activation switch couldn't reach the code. Three lines in the existing lifecycle-activation block, empty defaults — zero behavior change until `.env` sets them. Needed before arming the deploy-state feature on illo-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)