### PR TITLE
[Illo] Deploy-state: match the live 'ticket' object key (activation fix)

### DIFF
--- a/brain/systems/deploy_state_config.py
+++ b/brain/systems/deploy_state_config.py
@@ -33,6 +33,19 @@ def _env_duration(name: str, default: float, unit: str) -> timedelta:
     return timedelta(**{unit: max(value, 0)})
 
 
+def deploy_ticket_object_keys() -> frozenset[str]:
+    """Object-type keys that hold tracker tickets.
+
+    The live tracker's object key is runtime data, not a constant — the
+    deployed instance uses ``ticket`` while earlier code and fixtures assumed
+    ``github_ticket``. Both are matched by default; override with
+    ILLO_DEPLOY_TICKET_OBJECT_KEYS when a workspace names its type differently.
+    """
+    raw = os.environ.get("ILLO_DEPLOY_TICKET_OBJECT_KEYS", "").strip()
+    keys = frozenset(key.strip() for key in raw.split(",") if key.strip())
+    return keys or frozenset({"ticket", "github_ticket"})
+
+
 def deploy_settle_window() -> timedelta:
     return _env_duration("ILLO_DEPLOY_SETTLE_MINUTES", 30, "minutes")
 

--- a/brain/systems/deploy_state_sweep.py
+++ b/brain/systems/deploy_state_sweep.py
@@ -32,6 +32,7 @@ from brain.systems.deploy_state_config import (
     deploy_feature_enabled,
     deploy_quiet_window,
     deploy_settle_window,
+    deploy_ticket_object_keys,
 )
 from brain.systems.deploy_state_github import is_ancestor_of
 from brain.systems.user_domains.service import AsyncDomainService
@@ -94,7 +95,7 @@ def _append_progress_note(data: Mapping[str, object], line: str) -> str | None:
 
 
 async def ensure_deploy_state_fields(session, *, org_id: str) -> dict:
-    """Idempotently add optional deploy fields to every active github_ticket type."""
+    """Idempotently add optional deploy fields to every active ticket type."""
     object_types = (
         await session.scalars(
             select(DomainObjectType)
@@ -102,7 +103,7 @@ async def ensure_deploy_state_fields(session, *, org_id: str) -> dict:
             .where(
                 Domain.org_id == str(org_id),
                 Domain.archived_at.is_(None),
-                DomainObjectType.key == "github_ticket",
+                DomainObjectType.key.in_(deploy_ticket_object_keys()),
                 DomainObjectType.archived_at.is_(None),
             )
             .order_by(DomainObjectType.id)
@@ -139,7 +140,7 @@ async def _ticket_records(
     fix_pr_prefix: str | None = None,
     fix_pr: str | None = None,
 ) -> list[DomainRecord]:
-    """Select github_ticket records by deploy-state and/or fix-PR identity.
+    """Select ticket records by deploy-state and/or fix-PR identity.
 
     Selection keys on where the FIX lives (``fix_pr`` is repo-qualified), not
     on the ticket's own ``repo`` field — an app ticket fixed by a backend PR
@@ -153,7 +154,7 @@ async def _ticket_records(
             DomainRecord.org_id == str(org_id),
             DomainRecord.archived_at.is_(None),
             Domain.archived_at.is_(None),
-            DomainObjectType.key == "github_ticket",
+            DomainObjectType.key.in_(deploy_ticket_object_keys()),
             DomainObjectType.archived_at.is_(None),
         )
     )

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -492,14 +492,27 @@ async def _maybe_ensure_deploy_fields(repo_slug: str) -> None:
     org_id = _clean(getattr(_agent_context, "org_id", None))
     if not org_id:
         return
+    import logging
+
     try:
         from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
         async with UnitOfWork() as uow:
-            await ensure_deploy_state_fields(uow.session, org_id=org_id)
+            summary = await ensure_deploy_state_fields(uow.session, org_id=org_id)
+        if not summary.get("object_types"):
+            # Zero matches is a schema/config mismatch (e.g. the tracker's
+            # object key differs) — the failure mode a silent pass hides.
+            logging.getLogger("illo.deploy_state").warning(
+                "ensure_deploy_state_fields matched no ticket object types for org %s",
+                org_id,
+            )
     except Exception:
         # Schema bootstrap is best-effort for this read tool; GitHub facts remain
         # useful even if the domain database is temporarily unavailable.
+        logging.getLogger("illo.deploy_state").warning(
+            "deploy-state field bootstrap failed; continuing with GitHub facts only",
+            exc_info=True,
+        )
         return
 
 

--- a/tests/test_deploy_state_sweep.py
+++ b/tests/test_deploy_state_sweep.py
@@ -71,13 +71,13 @@ async def session(async_sqlite_session_factory):
     )
 
 
-async def _domain(session, *, name="Engineering"):
+async def _domain(session, *, name="Engineering", object_key="github_ticket"):
     return await AsyncDomainService(session).create_domain(
         ORG_ID,
         name=name,
         objects=[
             {
-                "key": "github_ticket",
+                "key": object_key,
                 "name": "GitHub Ticket",
                 "title_field": "title",
                 "fields": [
@@ -125,6 +125,34 @@ async def test_ensure_fields_is_runtime_id_agnostic_and_idempotent(session):
     deploy_fields = [field for field in fields if field.key == "deploy_state"]
     assert len(deploy_fields) == 2
     assert all(field.options == ["staging", "prod_pending", "deployed", "verified"] for field in deploy_fields)
+
+
+async def test_ensure_fields_matches_live_ticket_object_key(session, monkeypatch):
+    """The deployed tracker's object key is `ticket`, not `github_ticket` —
+    both must match by default, and the env override must narrow it."""
+    live_shaped = await _domain(session, name="Live Tracker", object_key="ticket")
+    unrelated = await _domain(session, name="Docs", object_key="doc_page")
+
+    result = await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    assert result == {"object_types": 1, "fields_added": len(DEPLOY_STATE_FIELD_DEFINITIONS)}
+    added = (
+        await session.scalars(
+            select(DomainFieldDefinition).where(DomainFieldDefinition.key == "deploy_state")
+        )
+    ).all()
+    assert [field.domain_id for field in added] == [live_shaped.id]
+
+    monkeypatch.setenv("ILLO_DEPLOY_TICKET_OBJECT_KEYS", "doc_page")
+    narrowed = await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    assert narrowed["object_types"] == 1  # now the doc_page type instead
+    assert unrelated.id in {
+        field.domain_id
+        for field in (
+            await session.scalars(
+                select(DomainFieldDefinition).where(DomainFieldDefinition.key == "deploy_state")
+            )
+        ).all()
+    }
 
 
 async def test_promotion_sweep_flips_only_confirmed_records(session, monkeypatch):


### PR DESCRIPTION
Found arming Slice 5 on illo-dev: the live Domain 1 tracker's object type is keyed `ticket`, while the code assumed `github_ticket` (inherited from a slice-4 docstring example; never validated against the live schema — and the tool handler's best-effort bootstrap swallowed the zero-match silently). `ensure_deploy_state_fields` matched nothing, so no ticket fields were provisioned.

- Ticket object keys become config: `ILLO_DEPLOY_TICKET_OBJECT_KEYS` (default `ticket,github_ticket` — covers live + existing fixtures), used by the field ensure and the sweep's record query.
- The lazy bootstrap now logs zero-match and exception cases instead of passing silently.
- Regression test for the live-shaped key + env narrowing.

Verified live before this fix: `check_fix_deploy_state` itself works end-to-end on illo-dev (run 1113: PR #860 → `prod_pending`, determinate, project-bound token) — only field provisioning was blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)