### PR TITLE
[Illo] Widen GitHub App mint scope to checks:read

### DIFF
--- a/brain/systems/vault/github_app_mint.py
+++ b/brain/systems/vault/github_app_mint.py
@@ -20,17 +20,19 @@ from brain.systems.cortex.project_context.github import (
 from brain.systems.vault.runtime_secrets import RuntimeSecretUnavailable
 
 # Minted installation tokens carry issues:write (to file issues) plus read-only
-# contents + pull_requests, so the same App token serves read_github_source
-# PR-listing and project-bound git-clone/source reads. This lets the legacy
+# contents, pull_requests, and checks, so the same App token serves
+# read_github_source PR-listing/detail (including check-runs) and project-bound
+# git-clone/source reads. This lets the legacy
 # personal-PAT read fallbacks (GITHUB_TOKEN__AXEL_LEGACY via GH_TOKEN, and the
 # static GITHUB_TOKEN) be retired. The added scopes are read-only: the App can
-# read PRs/contents but cannot push or open PRs, so the write blast-radius stays
+# read PRs/contents/check-runs but cannot push or open PRs, so the write blast-radius stays
 # issues-only and no GitHub re-approval is required (the installation already
-# holds Contents/Pull-requests read&write).
+# holds Contents/Pull-requests read&write and Checks read).
 DEFAULT_INSTALLATION_PERMISSIONS: dict[str, str] = {
     "issues": "write",
     "contents": "read",
     "pull_requests": "read",
+    "checks": "read",
 }
 _CACHE_FRESHNESS_WINDOW = timedelta(minutes=5)
 _PEM_HASH_PREFIX_LENGTH = 16

--- a/tests/test_github_app_mint.py
+++ b/tests/test_github_app_mint.py
@@ -206,7 +206,7 @@ async def test_mint_cache_separates_repositories_and_permissions(monkeypatch, rs
         permissions={"metadata": "read"},
     ) == "metadata-token"
 
-    default_scope = {"issues": "write", "contents": "read", "pull_requests": "read"}
+    default_scope = {"issues": "write", "contents": "read", "pull_requests": "read", "checks": "read"}
     assert [request["json"] for request in requests] == [
         {"repositories": ["uwear-backend"], "permissions": default_scope},
         {"repositories": ["uwear-mobile"], "permissions": default_scope},

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -400,7 +400,7 @@ async def test_github_app_project_binding_mints_before_manual_skip(patch_uow, se
         {
             "decrypted_blob": "github-app-blob",
             "repositories": ["uwear-backend"],
-            "permissions": {"issues": "write", "contents": "read", "pull_requests": "read"},
+            "permissions": {"issues": "write", "contents": "read", "pull_requests": "read", "checks": "read"},
             "transaction_open": False,
         }
     ]
@@ -454,7 +454,7 @@ async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(pa
     async def async_mint_installation_token(decrypted_blob, *, repositories, permissions):
         assert decrypted_blob == "github-app-blob"
         assert repositories == ["uwear-backend"]
-        assert permissions == {"issues": "write", "contents": "read", "pull_requests": "read"}
+        assert permissions == {"issues": "write", "contents": "read", "pull_requests": "read", "checks": "read"}
         return "minted-installation-token"
 
     monkeypatch.setattr(
@@ -539,7 +539,7 @@ async def test_create_github_issue_uses_minted_github_app_project_binding(
     access_request = next(request for request in client.requests if request["url"].endswith("/access_tokens"))
     issue_request = next(request for request in client.requests if request["url"].endswith("/issues"))
     assert access_request["json"]["repositories"] == ["uwear-backend"]
-    assert access_request["json"]["permissions"] == {"issues": "write", "contents": "read", "pull_requests": "read"}
+    assert access_request["json"]["permissions"] == {"issues": "write", "contents": "read", "pull_requests": "read", "checks": "read"}
     assert issue_request["headers"]["Authorization"] == "Bearer minted-issue-token"
 
 


### PR DESCRIPTION
## Why

During the 2026-07-10 coordinator dry run (run 1100), `read_github_source get_pull_request` on uwear-ai/uwear-backend#859 returned 403 "Resource not accessible by integration". The PR-detail reader (#288) fetches `/commits/{head_sha}/check-runs` after the PR itself, and that endpoint needs the `checks:read` installation permission — missing from both the illo-bot App grant and the mint scope. The coordinator's promotion gate degraded honestly (CI unknown) but could never verify a promotion PR as green.

Live repro with the minted token pinned it exactly:
- `GET /pulls/859` → 200 (PR detail + mergeability fine under `pull_requests:read`)
- `GET /commits/85cb0145/check-runs` → 403, `X-Accepted-GitHub-Permissions: checks=read`

## What

- Add `"checks": "read"` to `DEFAULT_INSTALLATION_PERMISSIONS` (mirrors #270's widening; resolver passes this constant, so no other call-site changes).
- Sync the four pinned mint-scope test assertions (`tests/test_github_app_mint.py`, `tests/test_vault_project_tokens.py`). Explicit issues-only mints unchanged.
- `statuses:read` deliberately NOT added: uwear CI posts check-runs only (zero legacy commit statuses on the live promotion PR head) and the connector never reads `/status`.

## Order-of-operations safety

The illo-bot App now holds Checks: Read-only and the uwear-ai installation accepted the update (done + verified live before this PR merges: a mint requesting the widened scope succeeds and check-runs returns 200 with CI state). Deploying this without that grant would have 422'd every mint.

Implemented by Codex (gpt-5.6-sol), reviewed by Claude. 44/44 vault mint/token tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)