### PR TITLE
Paginate direct thread history

### DIFF
--- a/brain/app/api/routers/cortex/_bootstrap.py
+++ b/brain/app/api/routers/cortex/_bootstrap.py
@@ -61,7 +61,6 @@ def _dump_payload(value: Any) -> Any:
 async def cortex_bootstrap(
     include: str | None = "core",
     idea_id: str | None = None,
-    include_debug: bool = False,
     provider: str | None = None,
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
@@ -113,14 +112,10 @@ async def cortex_bootstrap(
     if "direct_thread" in include_set:
         if not idea_id:
             raise HTTPException(status_code=400, detail="idea_id is required when include contains direct_thread")
-        payload["direct_thread"] = {
-            "idea_id": idea_id,
-            "stream": await unified_stream_payload(
-                idea_id=idea_id,
-                include_debug=include_debug,
-                user=user,
-            ),
-        }
+        payload["direct_thread"] = await unified_stream_payload(
+            idea_id=idea_id,
+            user=user,
+        )
     if "auth_status" in include_set:
         try:
             payload["auth_status"] = await async_get_provider_auth_status(

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -1,15 +1,17 @@
 """Cortex idea operations — threads, mentions, presence, unified stream."""
 from __future__ import annotations
 
+import base64
+import binascii
+import copy
 import json
 import logging
-import copy
 from datetime import datetime, timezone
-from typing import Any
+from typing import Annotated, Any, NamedTuple
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select, union
 from sqlalchemy.orm import aliased
 
 from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
@@ -26,7 +28,6 @@ from brain.app.api.services.notifications import (
     async_build_notification_summary,
 )
 from brain.systems.runs.cortex.read_models import run_stream_payload
-from brain.systems.runs.visibility import fetch_visible_run_rows
 from brain.app.api.routers.cortex._helpers import (
     _infer_feedback_tags,
     _parse_message_type,
@@ -56,7 +57,7 @@ from brain.systems.cortex.project_context.snapshot import (
 )
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
 from brain.platform.db.models.run import AgentRun
-from brain.platform.db.models.idea import IdeaThread
+from brain.platform.db.models.idea import IdeaThread, VisualBlock
 from brain.platform.db.models.org import User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 
@@ -661,56 +662,270 @@ async def update_agent_status(idea_id: str, request: Request, user: dict[str, An
 
 # ── Unified stream ─────────────────────────────────────────────
 
+
+_STREAM_PAGE_LIMIT = 200
+# Head-only active roots are bounded independently of the physical page size.
+_STREAM_ACTIVE_ROOT_LIMIT = 20
+_STREAM_KIND_RANK = {"message": 0, "run": 1, "visual_block": 2}
+
+
+class _StreamKey(NamedTuple):
+    created_at: datetime
+    kind_rank: int
+    row_id: int
+
+
+class _StreamCandidate(NamedTuple):
+    key: _StreamKey
+    kind: str
+    row: Any
+
+
+def _utc_datetime(value: Any) -> datetime:
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not isinstance(value, datetime):
+        raise ValueError("Stream timestamp must be a datetime")
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _stream_candidate(kind: str, row: Any) -> _StreamCandidate:
+    physical_row = row[0] if kind == "message" else row
+    return _StreamCandidate(
+        key=_StreamKey(
+            _utc_datetime(physical_row.created_at),
+            _STREAM_KIND_RANK[kind],
+            int(physical_row.id),
+        ),
+        kind=kind,
+        row=row,
+    )
+
+
+def _encode_stream_cursor(key: _StreamKey) -> str:
+    payload = "|".join((
+        "v1",
+        key.created_at.isoformat(timespec="microseconds"),
+        str(key.kind_rank),
+        str(key.row_id),
+    )).encode("ascii")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_stream_cursor(value: str | None) -> _StreamKey | None:
+    if value is None:
+        return None
+    try:
+        padding = "=" * (-len(value) % 4)
+        raw = base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+        version, timestamp, raw_kind_rank, raw_row_id = raw.decode("ascii").split("|")
+        if version != "v1":
+            raise ValueError
+        kind_rank = int(raw_kind_rank)
+        row_id = int(raw_row_id)
+        if (
+            (raw_kind_rank, raw_row_id) != (str(kind_rank), str(row_id))
+            or kind_rank not in _STREAM_KIND_RANK.values() or row_id <= 0
+        ):
+            raise ValueError
+        parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        if parsed_timestamp.tzinfo is None:
+            raise ValueError
+        return _StreamKey(_utc_datetime(parsed_timestamp), kind_rank, row_id)
+    except (ValueError, TypeError, UnicodeError, binascii.Error):
+        raise HTTPException(status_code=400, detail="Invalid unified stream cursor") from None
+
+
+def _stream_before_clause(model: Any, kind: str, cursor: _StreamKey | None):
+    if cursor is None:
+        return None
+    rank = _STREAM_KIND_RANK[kind]
+    if rank < cursor.kind_rank:
+        return model.created_at <= cursor.created_at
+    if rank > cursor.kind_rank:
+        return model.created_at < cursor.created_at
+    return or_(
+        model.created_at < cursor.created_at,
+        and_(model.created_at == cursor.created_at, model.id < cursor.row_id),
+    )
+
+
+def _stream_messages_stmt(
+    idea_id: str,
+    cursor: _StreamKey | None,
+    candidate_limit: int,
+):
+    stmt = (
+        select(IdeaThread, User.name.label("user_name"), User.color.label("user_color"))
+        .outerjoin(User, IdeaThread.user_id == User.id)
+        .where(IdeaThread.idea_id == idea_id)
+    )
+    before_clause = _stream_before_clause(IdeaThread, "message", cursor)
+    if before_clause is not None:
+        stmt = stmt.where(before_clause)
+    return stmt.order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc()).limit(candidate_limit)
+
+
+def _visible_run_clause():
+    return AgentRun.metadata_["headless"].as_boolean().is_not(True)
+
+
+def _stream_runs_stmt(
+    idea_id: str,
+    cursor: _StreamKey | None,
+    candidate_limit: int,
+):
+    recent = select(AgentRun.id).where(
+        AgentRun.thread_id == idea_id,
+        _visible_run_clause(),
+    )
+    before_clause = _stream_before_clause(AgentRun, "run", cursor)
+    if before_clause is not None:
+        recent = recent.where(before_clause)
+    recent = recent.order_by(AgentRun.created_at.desc(), AgentRun.id.desc()).limit(candidate_limit)
+    recent_ids = recent.cte("recent_stream_runs")
+    selected_ids = select(recent_ids.c.id)
+    if cursor is None:
+        active_roots = (
+            select(AgentRun.id)
+            .where(
+                AgentRun.thread_id == idea_id,
+                AgentRun.parent_run_id.is_(None),
+                AgentRun.status.in_(OPEN_RUN_STATUS_VALUES),
+                _visible_run_clause(),
+            )
+            .order_by(AgentRun.created_at.desc(), AgentRun.id.desc())
+            .limit(_STREAM_ACTIVE_ROOT_LIMIT)
+            .cte("active_stream_roots")
+        )
+        selected_ids = union(selected_ids, select(active_roots.c.id))
+    return (
+        select(AgentRun)
+        .where(AgentRun.id.in_(selected_ids))
+        .order_by(AgentRun.created_at.desc(), AgentRun.id.desc())
+    )
+
+
+def _stream_visuals_stmt(
+    idea_id: str,
+    cursor: _StreamKey | None,
+    candidate_limit: int,
+):
+    stmt = select(VisualBlock).where(VisualBlock.idea_id == idea_id)
+    before_clause = _stream_before_clause(VisualBlock, "visual_block", cursor)
+    if before_clause is not None:
+        stmt = stmt.where(before_clause)
+    return stmt.order_by(VisualBlock.created_at.desc(), VisualBlock.id.desc()).limit(candidate_limit)
+
+
+def _select_stream_page(
+    candidates: list[_StreamCandidate],
+    limit: int,
+) -> tuple[list[_StreamCandidate], bool, str | None]:
+    newest = sorted(candidates, key=lambda candidate: candidate.key, reverse=True)[: limit + 1]
+    has_more = len(newest) > limit
+    selected = sorted(newest[:limit], key=lambda candidate: candidate.key)
+    next_before = _encode_stream_cursor(selected[0].key) if has_more else None
+    return selected, has_more, next_before
+
+
+def _active_root_injections(
+    run_rows: list[Any],
+    selected: list[_StreamCandidate],
+) -> list[_StreamCandidate]:
+    if not selected:
+        return []
+    oldest_key = selected[0].key
+    selected_run_ids = {
+        candidate.key.row_id for candidate in selected if candidate.kind == "run"
+    }
+    injections: list[_StreamCandidate] = []
+    for run in run_rows:
+        if (
+            int(run.id) in selected_run_ids
+            or run.parent_run_id is not None
+            or run.status not in OPEN_RUN_STATUS_VALUES
+        ):
+            continue
+        candidate = _stream_candidate("run", run)
+        if candidate.key < oldest_key:
+            injections.append(candidate)
+    return sorted(injections, key=lambda candidate: candidate.key)
+
+
+def _serialize_stream_candidate(candidate: _StreamCandidate) -> dict[str, Any]:
+    if candidate.kind == "run":
+        return run_stream_payload(candidate.row)
+    if candidate.kind == "visual_block":
+        visual = candidate.row
+        return {
+            "type": "visual_block",
+            "timestamp": visual.created_at.isoformat() if visual.created_at else "",
+            "id": f"vb-{visual.id}",
+            "content_type": visual.content_type,
+            "title": visual.title,
+            "content": visual.content,
+            "display_mode": visual.display_mode or "inline",
+            "run_id": visual.run_id,
+            "position_after": visual.position_after,
+        }
+    row = candidate.row
+    message = row[0]
+    return {
+        "type": "message",
+        "timestamp": message.created_at.isoformat() if message.created_at else "",
+        "id": str(message.id),
+        "role": message.role,
+        "content": message.content,
+        "attachments": message.attachments or [],
+        "metadata": message.metadata_ or {},
+        "message_type": message.message_type,
+        "user_name": row.user_name,
+        "user_color": row.user_color,
+    }
+
+
 async def unified_stream_payload(
     idea_id: str,
-    include_debug: bool = False,
+    *,
+    limit: int = _STREAM_PAGE_LIMIT,
+    before: str | None = None,
     user: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     if user is None:
         raise HTTPException(status_code=401, detail="Not authenticated")
-    items = []
+    cursor = _decode_stream_cursor(before)
+    candidate_limit = limit + 1
 
     async with UnitOfWork() as uow:
         await _require_idea_for_user(uow.session, idea_id, user)
-        stmt = (
-            select(IdeaThread, User.name.label("user_name"), User.color.label("user_color"))
-            .outerjoin(User, IdeaThread.user_id == User.id)
-            .where(IdeaThread.idea_id == idea_id)
-            .order_by(IdeaThread.created_at)
+        message_rows = list(
+            (await uow.session.execute(_stream_messages_stmt(idea_id, cursor, candidate_limit))).all()
         )
-        for row in (await uow.session.execute(stmt)).all():
-            t = row[0]
-            items.append({
-                "type": "message",
-                "timestamp": t.created_at.isoformat() if t.created_at else "",
-                "id": str(t.id),
-                "role": t.role,
-                "content": t.content,
-                "attachments": t.attachments or [],
-                "metadata": t.metadata_ or {},
-                "message_type": t.message_type,
-                "user_name": row.user_name,
-                "user_color": row.user_color,
-            })
+        all_run_rows = list((await uow.session.scalars(
+            _stream_runs_stmt(idea_id, cursor, candidate_limit)
+        )).all())
+        recent_run_rows = sorted(
+            all_run_rows,
+            key=lambda run: _stream_candidate("run", run).key,
+            reverse=True,
+        )[:candidate_limit]
+        visual_rows = list((await uow.session.scalars(
+            _stream_visuals_stmt(idea_id, cursor, candidate_limit)
+        )).all())
 
-        if include_debug:
-            from brain.systems.runs.cortex.read_models import serialize_run_history_async
-
-            for dp in await serialize_run_history_async(idea_id, include_debug=True, uow_factory=UnitOfWork):
-                ts = dp.get("started_at") or dp.get("created_at")
-                items.append({
-                    "type": "run",
-                    "timestamp": ts.isoformat() if hasattr(ts, 'isoformat') else str(ts),
-                    **dp,
-                })
-        else:
-            stmt = (
-                select(AgentRun)
-                .where(AgentRun.thread_id == idea_id)
-                .order_by(AgentRun.created_at.desc(), AgentRun.id.desc())
-            )
-            for run in await fetch_visible_run_rows(uow.session, stmt, limit=20):
-                items.append(run_stream_payload(run))
+        candidates = [
+            *(_stream_candidate("message", row) for row in message_rows),
+            *(_stream_candidate("run", row) for row in recent_run_rows),
+            *(_stream_candidate("visual_block", row) for row in visual_rows),
+        ]
+        selected, has_more, next_before = _select_stream_page(candidates, limit)
+        if cursor is None:
+            selected.extend(_active_root_injections(all_run_rows, selected))
+        selected.sort(key=lambda candidate: candidate.key)
+        items = [_serialize_stream_candidate(candidate) for candidate in selected]
 
         run_ids = [int(item["id"]) for item in items if item.get("type") == "run"]
         for item in items:
@@ -723,10 +938,10 @@ async def unified_stream_payload(
         if run_ids:
             children_stmt = (
                 select(AgentRun)
-                .where(AgentRun.parent_run_id.in_(run_ids))
+                .where(AgentRun.parent_run_id.in_(run_ids), _visible_run_clause())
                 .order_by(AgentRun.created_at.asc(), AgentRun.id.asc())
             )
-            for child in await fetch_visible_run_rows(uow.session, children_stmt):
+            for child in (await uow.session.scalars(children_stmt)).all():
                 if child.parent_run_id is None:
                     continue
                 child_runs.setdefault(int(child.parent_run_id), []).append(run_stream_payload(child))
@@ -766,38 +981,25 @@ async def unified_stream_payload(
 
         _append_final_answer_messages(items)
 
-        # Include visual blocks in the stream
-        from brain.platform.db.models.idea import VisualBlock
-        vb_stmt = (
-            select(VisualBlock)
-            .where(VisualBlock.idea_id == idea_id)
-            .order_by(VisualBlock.created_at)
-        )
-        for vb in (await uow.session.scalars(vb_stmt)).all():
-            items.append({
-                "type": "visual_block",
-                "timestamp": vb.created_at.isoformat() if vb.created_at else "",
-                "id": f"vb-{vb.id}",
-                "content_type": vb.content_type,
-                "title": vb.title,
-                "content": vb.content,
-                "display_mode": vb.display_mode or "inline",
-                "run_id": vb.run_id,
-                "position_after": vb.position_after,
-            })
-
-    items.sort(key=lambda x: x.get("timestamp", ""))
-    return items
+    items.sort(key=lambda item: _utc_datetime(item["timestamp"]))
+    return {
+        "idea_id": idea_id,
+        "items": items,
+        "has_more": has_more,
+        "next_before": next_before,
+    }
 
 
 @router.get("/ideas/{idea_id}/unified-stream")
 async def idea_unified_stream(
     idea_id: str,
-    include_debug: bool = False,
+    limit: Annotated[int, Query(ge=1, le=_STREAM_PAGE_LIMIT)] = _STREAM_PAGE_LIMIT,
+    before: str | None = None,
     user: dict[str, Any] = Depends(get_current_user),
 ):
     return await unified_stream_payload(
         idea_id=idea_id,
-        include_debug=include_debug,
+        limit=limit,
+        before=before,
         user=user,
     )

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import type { RuntimeSettings, RuntimeVoiceSession, RuntimeVoiceTranscript } from '$lib/types/runtimeSettings';
+import type { StreamItem } from '$lib/types/cortex';
 
 const BASE = '';
 const DEFAULT_API_TIMEOUT_MS = 20_000;
@@ -717,7 +718,7 @@ export interface CortexBootstrapPayload {
   workspace_apps: WorkspaceAppRead[] | null;
   workspace_pins: WorkspacePinRead[] | null;
   selected_idea?: any | null;
-  direct_thread?: { idea_id: string; stream: any[] } | null;
+  direct_thread?: ThreadStreamPage | null;
   auth_status: any | null;
   meta?: Record<string, any>;
 }
@@ -725,8 +726,18 @@ export interface CortexBootstrapPayload {
 export interface CortexBootstrapOptions {
   include?: string | string[];
   ideaId?: string | null;
-  includeDebug?: boolean;
   provider?: string | null;
+}
+
+export interface ThreadStreamPage {
+  idea_id: string;
+  items: StreamItem[];
+  has_more: boolean;
+  next_before: string | null;
+}
+
+export interface ThreadStreamPageOptions {
+  before?: string | null;
 }
 
 export type ProjectDraftChangeKey =
@@ -1057,7 +1068,6 @@ export const api = {
     return fetchJson<CortexBootstrapPayload>(withQuery('/api/cortex/bootstrap', {
       include,
       idea_id: options.ideaId,
-      include_debug: options.includeDebug,
       provider: options.provider,
     }));
   },
@@ -1264,12 +1274,10 @@ export const api = {
     fetchJson<any>(`/api/cortex/ideas/${id}`, { method: 'DELETE' }),
   restoreIdea: (id: string) =>
     fetchJson<any>(`/api/cortex/ideas/${id}/restore`, { method: 'POST' }),
-  unifiedStream: (ideaId: string, includeDebug = false) =>
-    fetchJson<any[]>(
-      includeDebug
-        ? `/api/cortex/ideas/${ideaId}/unified-stream?include_debug=true`
-        : `/api/cortex/ideas/${ideaId}/unified-stream`
-    ),
+  unifiedStream: (ideaId: string, options: ThreadStreamPageOptions = {}) =>
+    fetchJson<ThreadStreamPage>(withQuery(`/api/cortex/ideas/${ideaId}/unified-stream`, {
+      before: options.before,
+    })),
   addThreadMessage: (ideaId: string, data: { content: string; role?: string; attachments?: ChatAttachmentPayload[]; metadata?: Record<string, any> }) =>
     fetchJson<any>(`/api/cortex/ideas/${ideaId}/thread`, { method: 'POST', body: JSON.stringify(data) }),
   updatePosition: (ideaId: string, x: number, y: number) =>
@@ -1277,12 +1285,8 @@ export const api = {
   batchPositions: (positions: { id: string; x: number; y: number }[]) =>
     fetchJson<any>('/api/cortex/ideas/positions', { method: 'PUT', body: JSON.stringify({ positions }) }),
   runStatus: () => fetchJson<any>('/api/cortex/run/status'),
-  runHistory: (ideaId: string, includeDebug = false) =>
-    fetchJson<any[]>(
-      includeDebug
-        ? `/api/cortex/run/history/${ideaId}?include_debug=true`
-        : `/api/cortex/run/history/${ideaId}`
-    ),
+  runHistory: (ideaId: string) =>
+    fetchJson<any[]>(`/api/cortex/run/history/${ideaId}`),
   approveRun: (id: number) =>
     fetchJson<any>(`/api/cortex/run/${id}/approve`, { method: 'POST' }),
   denyRun: (id: number) =>

--- a/frontend/src/lib/features/threads/api/threadApi.ts
+++ b/frontend/src/lib/features/threads/api/threadApi.ts
@@ -1,6 +1,6 @@
-import { api } from '$lib/api/client';
+import { api, type ThreadStreamPage, type ThreadStreamPageOptions } from '$lib/api/client';
 import { pickTypedApiMethods } from '$lib/api/featureApi';
-import type { Connection, Idea, StreamItem } from '$lib/types/cortex';
+import type { Connection, Idea } from '$lib/types/cortex';
 
 export type ThreadMessageInput = Parameters<typeof api.addThreadMessage>[1];
 export type ThreadMessage = Awaited<ReturnType<typeof api.addThreadMessage>>;
@@ -30,9 +30,9 @@ export type ThreadDiscussionCreateInput = Parameters<typeof api.postThreadDiscus
 export type ThreadDiscussionCreateResult = Awaited<ReturnType<typeof api.postThreadDiscussionComment>>;
 
 type ThreadApiMethods = {
-  unifiedStream: (ideaId: string, includeDebug?: boolean) => Promise<StreamItem[]>;
+  unifiedStream: (ideaId: string, options?: ThreadStreamPageOptions) => Promise<ThreadStreamPage>;
   addThreadMessage: (ideaId: string, data: ThreadMessageInput) => Promise<ThreadMessage>;
-  runHistory: (ideaId: string, includeDebug?: boolean) => Promise<ThreadRunHistoryItem[]>;
+  runHistory: (ideaId: string) => Promise<ThreadRunHistoryItem[]>;
   approveRun: typeof api.approveRun;
   denyRun: typeof api.denyRun;
   steerRun: typeof api.steerRun;

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -87,11 +87,12 @@
     timeAgo,
     visibleThreadStreamItems,
   } from '$lib/features/threads/domain/threadStreamAdapter';
-  import type {
-    CortexThreadStageFileAttachment,
-    CortexThreadStageHeaderStatusState,
-    CortexThreadStageImageAttachment,
-    CortexThreadStageTranscriptItem,
+  import {
+    canShowEarlierThreadHistory,
+    type CortexThreadStageFileAttachment,
+    type CortexThreadStageHeaderStatusState,
+    type CortexThreadStageImageAttachment,
+    type CortexThreadStageTranscriptItem,
   } from '$lib/features/threads/domain/threadTranscriptAdapter';
 
   type ActiveRunMessageIntent = 'steer' | 'queue';
@@ -154,7 +155,8 @@
   let threadDragOver = $state(false);
   let userScrolledUp = $state(false);
   let threadStreamWindowState = $state<{ ideaId: string; cursor: ThreadStreamWindowCursor } | null>(null);
-  let programmaticScroll = false;
+  let threadHistoryOperationToken = 0;
+  let programmaticScroll = $state(false);
   let showTranscriptScrollCue = $state(false);
   let transcriptScrollFrame: number | null = null;
   let projectContextError = $state('');
@@ -792,13 +794,23 @@
     if (state.valid) projectContextError = '';
   }
 
+  const selectedThreadId = $derived(idea?.id == null ? null : String(idea.id));
   const threadStreamWindow = $derived.by(() =>
     buildThreadStreamWindow(
       visibleStreamItems,
-      String(idea?.id ?? '') === threadStreamWindowState?.ideaId
+      selectedThreadId === threadStreamWindowState?.ideaId
         ? threadStreamWindowState.cursor
         : null,
     ),
+  );
+  const remoteHistoryHasMore = $derived(Boolean(selectedThreadId && cortex.threadHistoryHasMore(selectedThreadId)));
+  const canShowEarlierHistory = $derived(
+    programmaticScroll && userScrolledUp
+    || canShowEarlierThreadHistory(threadStreamWindow.previousCursor, remoteHistoryHasMore),
+  );
+  const earlierHistoryState = $derived(
+    selectedThreadId && ((programmaticScroll && userScrolledUp) || cortex.threadHistoryLoadingOlder(selectedThreadId)) ? 'loading'
+      : selectedThreadId && !threadStreamWindow.previousCursor && cortex.threadHistoryError(selectedThreadId) ? 'error' : 'idle',
   );
 
   const transcriptItems = $derived.by((): CortexThreadStageTranscriptItem[] =>
@@ -865,28 +877,46 @@
   async function showEarlierHistory() {
     const cursor = threadStreamWindow.previousCursor;
     const element = transcriptEl;
-    const threadId = idea?.id == null ? null : String(idea.id);
-    if (programmaticScroll || !cursor || !element || !threadId) return;
-    const previousScrollTop = element.scrollTop;
-    const previousScrollHeight = element.scrollHeight;
+    const threadId = selectedThreadId;
+    if (programmaticScroll || earlierHistoryState === 'loading' || !element || !threadId
+      || !canShowEarlierHistory) return;
+    const operationToken = ++threadHistoryOperationToken;
+    const scrollBottom = element.scrollHeight - element.scrollTop;
+    const anchor = element.querySelector<HTMLElement>('.thread-history-window-control + *');
+    const anchorTop = anchor?.getBoundingClientRect().top ?? 0;
     programmaticScroll = true;
     userScrolledUp = true;
     if (transcriptScrollFrame !== null) {
       cancelAnimationFrame(transcriptScrollFrame);
       transcriptScrollFrame = null;
     }
-    threadStreamWindowState = { ideaId: threadId, cursor };
 
     try {
-      await tick();
-      if (String(idea?.id ?? '') !== threadId || transcriptEl !== element) return;
-      element.scrollTop = Math.max(0, previousScrollTop + element.scrollHeight - previousScrollHeight);
+      threadStreamWindowState = { ideaId: threadId, cursor: cursor ?? threadStreamWindow.startCursor };
+      if (!cursor) await cortex.loadOlderThreadHistory(threadId);
     } finally {
-      programmaticScroll = false;
-      if (String(idea?.id ?? '') === threadId && transcriptEl === element) {
-        userScrolledUp = !conversationIsNearBottom(element, CONVERSATION_SCROLL_BOTTOM_THRESHOLD);
-        syncTranscriptScrollCue();
-      }
+      await tick();
+      requestAnimationFrame(() => {
+        if (operationToken !== threadHistoryOperationToken || selectedThreadId !== threadId) return;
+        if (transcriptEl === element) {
+          if (anchor?.isConnected) {
+            element.scrollTop += anchor.getBoundingClientRect().top - anchorTop;
+          } else {
+            element.scrollTop = element.scrollHeight - scrollBottom;
+          }
+        }
+        requestAnimationFrame(() => {
+          if (operationToken !== threadHistoryOperationToken || selectedThreadId !== threadId) return;
+          if (transcriptEl === element) {
+            if (anchor?.isConnected) {
+              element.scrollTop += anchor.getBoundingClientRect().top - anchorTop;
+            }
+            userScrolledUp = !conversationIsNearBottom(element, CONVERSATION_SCROLL_BOTTOM_THRESHOLD);
+            syncTranscriptScrollCue();
+          }
+          programmaticScroll = false;
+        });
+      });
     }
   }
 
@@ -1318,6 +1348,8 @@
   $effect(() => {
     const currentIdeaId = idea?.id ?? null;
     if (currentIdeaId !== lastSelectedIdeaId) {
+      threadHistoryOperationToken += 1;
+      programmaticScroll = false;
       if (currentIdeaId && String(currentIdeaId) !== threadStreamWindowState?.ideaId) {
         threadStreamWindowState = null;
       }
@@ -1406,6 +1438,7 @@
 
   onDestroy(() => {
     threadStageDestroyed = true;
+    threadHistoryOperationToken += 1;
     voiceDictation?.destroy();
     document.removeEventListener('click', handleDocClick);
     if (transcriptScrollFrame !== null) {
@@ -1739,7 +1772,8 @@
             replyDock={replyDock}
             onTranscriptScroll={handleScrollEvent}
             onScrollToBottom={() => scrollToBottom(true)}
-            onShowEarlierHistory={threadStreamWindow.previousCursor ? showEarlierHistory : undefined}
+            onShowEarlierHistory={canShowEarlierHistory ? showEarlierHistory : undefined}
+            {earlierHistoryState}
             onPreviewAttachment={openPreviewTab}
             onTranscriptReady={(element) => {
               transcriptEl = element;

--- a/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadTranscript.svelte
@@ -89,6 +89,7 @@
     onTranscriptReady,
     onScrollToBottom,
     onShowEarlierHistory,
+    earlierHistoryState = 'idle',
     onPreviewAttachment,
   }: ThreadTranscriptProps = $props();
 
@@ -360,16 +361,17 @@
         {@render transcriptSlot()}
       {:else if loading}
         <div class="thread-empty-state thread-loading-state">{loadingLabel}</div>
-      {:else if hasTranscript}
+      {:else}
         {#if onShowEarlierHistory}
-          <div class="thread-history-window-control">
-            <ConstellationButton variant="quiet" size="sm" onclick={onShowEarlierHistory}>
-              Show earlier history
+          <div class="thread-history-window-control" aria-live="polite">
+            <ConstellationButton variant="quiet" size="sm" loading={earlierHistoryState === 'loading'} loadingLabel="Loading earlier history" onclick={onShowEarlierHistory}>
+              {earlierHistoryState === 'error' ? 'Retry earlier history' : 'Show earlier history'}
             </ConstellationButton>
           </div>
         {/if}
 
-        {#each transcriptItems as item, index (`${item.kind}-${item.id ?? index}`)}
+        {#if hasTranscript}
+          {#each transcriptItems as item, index (`${item.kind}-${item.id ?? index}`)}
           {#if renderTranscriptItem}
             {@render renderTranscriptItem(item)}
           {:else if item.kind === 'message'}
@@ -929,9 +931,10 @@
               {/if}
             </section>
           {/if}
-        {/each}
-      {:else}
-        <div class="thread-empty-state">{emptyLabel}</div>
+          {/each}
+        {:else}
+          <div class="thread-empty-state">{emptyLabel}</div>
+        {/if}
       {/if}
     </div>
 

--- a/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
+++ b/frontend/src/lib/features/threads/domain/threadTranscriptAdapter.ts
@@ -251,8 +251,14 @@ export interface ThreadTranscriptProps {
   onTranscriptReady?: (element: HTMLDivElement | undefined) => void;
   onScrollToBottom?: () => void;
   onShowEarlierHistory?: () => void;
+  earlierHistoryState?: 'idle' | 'loading' | 'error';
   onPreviewAttachment?: (attachment: CortexThreadStageImageAttachment | CortexThreadStageFileAttachment) => void;
 }
+
+export const canShowEarlierThreadHistory = (localCursor: unknown, remoteHasMore: boolean) => Boolean(localCursor || remoteHasMore);
+
+export const ownsThreadHistoryOperation = (operation: { threadId: string; token: number }, threadId: string | null, token: number) =>
+  operation.threadId === threadId && operation.token === token;
 
 export function getCortexThreadRunStatusLabel(status: CortexThreadStageRunStatus): string {
   switch (status) {

--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -1761,8 +1761,10 @@
     const duration = 220;
     archivingIdeaId = nodeId;
     archivingIdeaProgress = 0;
+    void cortex.deleteIdea(nodeId);
 
     function tick(now: number) {
+      if (destroyed) return;
       const progress = Math.min((now - startedAt) / duration, 1);
       archivingIdeaProgress = d3.easeCubicOut(progress);
       syncPrimitiveDragVisuals();
@@ -1772,7 +1774,6 @@
       }
       archivingIdeaId = null;
       archivingIdeaProgress = 0;
-      cortex.deleteIdea(nodeId);
     }
 
     requestAnimationFrame(tick);
@@ -1870,7 +1871,7 @@
     state.node.y = point.y;
     dragging({ active: false, x: point.x, y: point.y, clientX: event.clientX, clientY: event.clientY }, state.node);
     syncPrimitiveDragVisuals();
-    if (simulation) simulation.alpha(0.18).restart();
+    heatOrbit(0.18);
     return true;
   }
 
@@ -1953,17 +1954,25 @@
     const startTime = performance.now();
     archivingPinId = pin.pinId;
     archivingPinProgress = 0;
+    const deletion = onpindelete
+      ? Promise.resolve().then(() => onpindelete({ pinId: pin.pinId })).then(
+          () => true,
+          () => false,
+        )
+      : null;
 
     function finish() {
+      if (destroyed) return;
       archivingPinId = null;
       archivingPinProgress = 0;
       resetArchiveDragInteraction();
       localPinPositions.delete(pin.pinId);
       syncPrimitiveOrbitVisuals();
-      if (simulation) simulation.alpha(0.16).restart();
+      heatOrbit(0.16);
     }
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -1979,17 +1988,19 @@
         return;
       }
 
-      if (!onpindelete) {
+      if (!deletion) {
         patchPrimitivePinPosition(pin.pinId, fallbackPosition.x, fallbackPosition.y);
         finish();
         return;
       }
 
-      Promise.resolve(onpindelete({ pinId: pin.pinId }))
-        .catch(() => {
+      void deletion.then((deleted) => {
+        if (destroyed) return;
+        if (!deleted) {
           patchPrimitivePinPosition(pin.pinId, fallbackPosition.x, fallbackPosition.y);
-        })
-        .finally(finish);
+        }
+        finish();
+      });
     }
 
     requestAnimationFrame(archiveTick);
@@ -2104,7 +2115,7 @@
     dragTargetAnchorId = null;
     archiveDropAppId = archiveTarget ? app.id : null;
     setArchiveDragState(true, Boolean(archiveTarget));
-    if (simulation) simulation.alpha(0.08).restart();
+    heatOrbit(0.08);
     return true;
   }
 
@@ -2120,8 +2131,13 @@
     const startTime = performance.now();
     archivingAppId = app.id;
     archivingAppProgress = 0;
+    const archive = Promise.resolve().then(() => onapparchive?.({ appId: app.id })).then(
+      () => true,
+      () => false,
+    );
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -2137,18 +2153,18 @@
         return;
       }
 
-      Promise.resolve(onapparchive?.({ appId: app.id }))
-        .catch(() => {
+      void archive.then((archived) => {
+        if (destroyed) return;
+        if (!archived) {
           patchPrimitiveAppPosition(app.id, fallbackPosition.x, fallbackPosition.y);
-        })
-        .finally(() => {
-          archivingAppId = null;
-          archivingAppProgress = 0;
-          resetArchiveDragInteraction();
-          localAppPositions.delete(app.id);
-          syncPrimitiveOrbitVisuals();
-          if (simulation) simulation.alpha(0.16).restart();
-        });
+        }
+        archivingAppId = null;
+        archivingAppProgress = 0;
+        resetArchiveDragInteraction();
+        localAppPositions.delete(app.id);
+        syncPrimitiveOrbitVisuals();
+        heatOrbit(0.16);
+      });
     }
 
     requestAnimationFrame(archiveTick);
@@ -2176,7 +2192,7 @@
           x: state.previousX,
           y: state.previousY,
         });
-        if (simulation) simulation.alpha(0.16).restart();
+        heatOrbit(0.16);
         return didMove;
       }
 
@@ -2189,7 +2205,7 @@
           localAppPositions.delete(app.id);
           syncPrimitiveOrbitVisuals();
         });
-      if (simulation) simulation.alpha(0.16).restart();
+      heatOrbit(0.16);
 
       return didMove;
     }
@@ -2259,6 +2275,9 @@
   let orbitAnchorLookup: AttractorLookup = { byId: new Map(), byName: new Map(), byAnchorKey: new Map() };
   let sunLayoutKey = '';
   let pinLayoutKey = '';
+  let appLayoutKey = '';
+  let connectionTopologyKey = '';
+  let presenceMotionKey: string | null = null;
   let sunPulseFrame: number | null = null;
   let breathingFrame: number | null = null;
   let particleFrame: number | null = null;
@@ -2268,20 +2287,16 @@
   let primitiveSyncLastAt = 0;
   let simulationPaintLastAt = 0;
   let renderOwnerWarningIssued = false;
-  let workspaceMotionSuspended = false;
+  let destroyed = false;
   let _isDragging = false;
-  let lastOrbitTickAt = 0;
   const PREVIEW_MEMBER_PREFIX = '__cortex-preview-user__';
   const PREVIEW_IDEA_PREFIX = '__cortex-preview-idea__';
   const PRIMITIVE_SYNC_INTERVAL_MS = 16;
   const SIMULATION_PAINT_INTERVAL_MS = 16;
-  const ORBIT_WAKE_CHECK_INTERVAL_MS = 4_000;
-  const ORBIT_STALE_AFTER_MS = 6_500;
 
   type SimulationPerformanceProfile = {
     alphaDecay: number;
     alphaMin: number;
-    idleAlphaTarget: number;
     collideIterations: number;
     velocityDecay: number;
   };
@@ -2296,10 +2311,6 @@
 
   function activeSimulationProfile() {
     return simulationPerformanceProfile(activeSimulationNodeCount());
-  }
-
-  function idleOrbitAlphaTarget() {
-    return activeSimulationProfile().idleAlphaTarget;
   }
 
   function primitiveSyncIntervalMs() {
@@ -2359,6 +2370,21 @@
     primitiveSyncNodes = null;
   }
 
+  function heatOrbit(alpha: number) {
+    if (!simulation || paused) return;
+
+    simulation
+      .alphaTarget(0)
+      .alpha(Math.max(simulation.alpha(), alpha));
+
+    if (document.visibilityState !== 'visible') return;
+
+    primitiveSyncLastAt = 0;
+    simulationPaintLastAt = 0;
+    schedulePrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
+    simulation.restart();
+  }
+
   function stopActiveSimulation() {
     if (!simulation) return;
     simulation.on('tick', null);
@@ -2383,42 +2409,13 @@
     cancelPrimitiveOrbitVisualSync();
   }
 
-  function suspendWorkspaceMotion() {
-    if (workspaceMotionSuspended) return;
-    workspaceMotionSuspended = true;
-    if (simulation) {
-      simulation.alphaTarget(0);
-      simulation.stop();
-      syncPrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
-    }
-    cancelRenderFrames();
-    g?.selectAll('*').interrupt();
-  }
-
-  function resumeWorkspaceMotion() {
-    if (!workspaceMotionSuspended) return;
-    workspaceMotionSuspended = false;
-    if (!simulation) {
-      renderCanvas({ preserveViewport: true });
-      return;
-    }
-    const nodes = simulation.nodes() as OrbitNode[];
-    clearAttractionCache(nodes);
-    simulation
-      .alphaTarget(idleOrbitAlphaTarget())
-      .alpha(Math.max(simulation.alpha(), 0.14))
-      .restart();
-    syncPrimitiveMotionVisuals(nodes);
-  }
-
   function resetRenderRuntime() {
     renderGeneration += 1;
-    workspaceMotionSuspended = false;
+    restoreThreadAnchorState(simulation?.nodes() as OrbitNode[] | undefined);
     stopActiveSimulation();
     cancelRenderFrames();
     primitiveSyncLastAt = 0;
     simulationPaintLastAt = 0;
-    lastOrbitTickAt = 0;
     coreGroup = undefined as any;
   }
 
@@ -2510,11 +2507,7 @@
     if (!simulation) return;
     const profile = activeSimulationProfile();
     simulation.force('collide', d3.forceCollide().radius((d: any) => bubbleCollisionRadius(d)).strength(0.84).iterations(profile.collideIterations));
-    if (workspaceMotionSuspended) {
-      syncPrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
-      return;
-    }
-    simulation.alpha(alpha).restart();
+    heatOrbit(alpha);
   }
 
   // ── SVG Defs (from cortex-physics.js createDefs) ───────────
@@ -2589,7 +2582,7 @@
     return d3.forceSimulation(nodes)
       .alphaDecay(profile.alphaDecay)
       .alphaMin(profile.alphaMin)
-      .alphaTarget(profile.idleAlphaTarget)
+      .alphaTarget(0)
       .velocityDecay(profile.velocityDecay)
       .force('center', orbitAnchors.length > 0 ? null : d3.forceCenter(w / 2, h / 2).strength(0.02))
       .force('collide', d3.forceCollide().radius((d: any) => bubbleCollisionRadius(d)).strength(0.84).iterations(profile.collideIterations))
@@ -2652,13 +2645,6 @@
         for (const n of nodes) {
           // Subtle upward float for high-salience nodes (reduced to avoid directional bias)
           n.vy -= ((n.salience_score || 5) / 10) * 0.03 * alpha;
-        }
-      })
-      .force('brownian', () => {
-        for (const n of nodes) {
-          // Gentle random perturbation keeps motion organic (not alpha-dependent)
-          n.vx += (Math.random() - 0.5) * 0.15;
-          n.vy += (Math.random() - 0.5) * 0.15;
         }
       });
   }
@@ -3073,8 +3059,7 @@
   }
 
   function restartOrbitSettle() {
-    if (!simulation) return;
-    simulation.alpha(Math.max(simulation.alpha(), 0.22)).restart();
+    heatOrbit(0.22);
   }
 
   function dragStart(e: any, d: any) {
@@ -3083,7 +3068,7 @@
     dragTargetAnchorId = null;
     archiveDropIdeaId = null;
     setArchiveDragState(canArchiveNode(d), false);
-    if (!e.active && simulation) simulation.alphaTarget(0.1).restart();
+    if (!e.active) heatOrbit(0.1);
     d.fx = d.x; d.fy = d.y;
     d._dragOrigX = d.x; d._dragOrigY = d.y;
   }
@@ -3132,8 +3117,10 @@
     const startTime = performance.now();
     archivingIdeaId = d.id;
     archivingIdeaProgress = 0;
+    void cortex.deleteIdea(d.id);
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -3154,9 +3141,8 @@
       archivingIdeaId = null;
       archivingIdeaProgress = 0;
       resetArchiveDragInteraction();
-      cortex.deleteIdea(d.id);
       el.remove();
-      if (simulation) simulation.alpha(0.3).restart();
+      heatOrbit(0.3);
     }
 
     requestAnimationFrame(archiveTick);
@@ -3169,8 +3155,7 @@
       _isDragging = false;
       dragTargetAnchorId = null;
       resetArchiveDragInteraction();
-      if (!e.active && simulation) simulation.alphaTarget(idleOrbitAlphaTarget());
-      if (simulation) simulation.alpha(0.1).restart();
+      heatOrbit(0.1);
       return;
     }
 
@@ -3178,7 +3163,6 @@
     _isDragging = false;
     dragTargetAnchorId = null;
     resetArchiveDragInteraction();
-    if (!e.active && simulation) simulation.alphaTarget(idleOrbitAlphaTarget());
     if (coreGroup) coreGroup.select('.core-circle').attr('filter', 'url(#core-glow)');
 
     const dragDx = d.x - (d._dragOrigX || d.x);
@@ -3194,7 +3178,7 @@
       el.select('.bubble-cloud').transition().duration(200).attr('transform', 'scale(1)');
       el.transition().duration(200).attr('opacity', (dd: any) => bubbleOpacity(dd.status));
       syncPrimitiveDragVisuals();
-      if (simulation) simulation.alpha(0.22).restart();
+      heatOrbit(0.22);
       return;
     }
 
@@ -3229,7 +3213,7 @@
       if (dragDist > 20) {
         cortex.updateIdeaPosition(d.id, d.x, d.y);
       }
-      if (simulation) simulation.alpha(0.15).restart();
+      heatOrbit(0.15);
     }
   }
 
@@ -3309,7 +3293,7 @@
     setTimeout(() => {
       cortex.deleteIdea(d.id);
       el.remove();
-      if (simulation) { simulation.alpha(0.3).restart(); }
+      heatOrbit(0.3);
     }, 250);
   }
 
@@ -3547,6 +3531,41 @@
     });
   }
 
+  function workspaceConnectionLinkData(visible: any[]) {
+    const visibleIds = new Set(visible.map((idea: any) => idea.id));
+    const visibleById = new Map(visible.map((idea: any) => [idea.id, idea] as const));
+    return cortex.connections
+      .filter((connection: any) => visibleIds.has(connection.source_id) && visibleIds.has(connection.target_id))
+      .map((connection: any) => {
+        const sourceIdea = visibleById.get(connection.source_id);
+        const targetIdea = visibleById.get(connection.target_id);
+
+        return {
+          ...connection,
+          source: connection.source_id,
+          target: connection.target_id,
+          sourceUserId: sourceIdea?.user_id,
+          targetUserId: targetIdea?.user_id,
+          sourceAccent: sourceIdea ? ownerColor(sourceIdea) : undefined,
+          targetAccent: targetIdea ? ownerColor(targetIdea) : undefined,
+        };
+      });
+  }
+
+  function workspaceConnectionTopologyKey(visible: any[]) {
+    const visibleIds = new Set(visible.map((idea: any) => idea.id));
+    const ownership = visible
+      .map((idea: any) => `${idea.id}:${idea.user_id ?? ''}`)
+      .sort()
+      .join('|');
+    const connections = cortex.connections
+      .filter((connection: any) => visibleIds.has(connection.source_id) && visibleIds.has(connection.target_id))
+      .map((connection: any) => `${connection.id}:${connection.source_id}:${connection.target_id}`)
+      .sort()
+      .join('|');
+    return `${ownership}::${connections}`;
+  }
+
   function renderCanvas({ preserveViewport = false }: { preserveViewport?: boolean } = {}) {
     if (!containerEl) return;
     const preservedTransform = preserveViewport ? untrack(() => currentZoomTransform) : null;
@@ -3618,26 +3637,11 @@
     const visible = syncSceneNodes(cortex.filteredIdeas);
     clearAttractionCache(visible);
 
-    const visibleIds = new Set(visible.map((i: any) => i.id));
-    const visibleById = new Map(visible.map((idea: any) => [idea.id, idea] as const));
-    const linkData = cortex.connections
-      .filter((c: any) => visibleIds.has(c.source_id) && visibleIds.has(c.target_id))
-      .map((c: any) => {
-        const sourceIdea = visibleById.get(c.source_id);
-        const targetIdea = visibleById.get(c.target_id);
-
-        return {
-          ...c,
-          source: c.source_id,
-          target: c.target_id,
-          sourceUserId: sourceIdea?.user_id,
-          targetUserId: targetIdea?.user_id,
-          sourceAccent: sourceIdea ? ownerColor(sourceIdea) : undefined,
-          targetAccent: targetIdea ? ownerColor(targetIdea) : undefined,
-        };
-      });
+    const linkData = workspaceConnectionLinkData(visible);
+    connectionTopologyKey = workspaceConnectionTopologyKey(visible);
 
     simulation = createSim(visible, linkData, canvasW, canvasH);
+    if (paused || document.visibilityState !== 'visible') simulation.stop();
 
     const linkSel = USE_D3_SHADOW_SCENE
       ? g.selectAll('.connection-path').data(linkData, (d: any) => d.id)
@@ -3696,7 +3700,6 @@
     simulation.on('tick', () => {
       if (renderToken !== renderGeneration) return;
       const now = performance.now();
-      lastOrbitTickAt = now;
       if (simulationPaintLastAt && now - simulationPaintLastAt < simulationPaintIntervalMs()) return;
       simulationPaintLastAt = now;
       if (linkSel) linkSel.attr('d', curvedLinkPath);
@@ -3736,7 +3739,7 @@
           pair.target.vy -= (dy / dist) * strength;
         }
       });
-      simulation.alpha(0.18).restart();
+      heatOrbit(0.18);
     };
 
     // Semantic clustering is progressive enhancement: keep the initial orbit
@@ -3759,33 +3762,40 @@
     // Save positions when simulation settles
     simulation.on('end', () => {
       if (renderToken !== renderGeneration) return;
-      const positions = collectSceneIdeaPositions(
-        simulation?.nodes() as OrbitNode[] ?? [],
-        isPreviewIdeaId,
-      );
+      const nodes = simulation?.nodes() as OrbitNode[] ?? [];
+      cancelPrimitiveOrbitVisualSync();
+      syncPrimitiveMotionVisuals(nodes);
+      const positions = collectSceneIdeaPositions(nodes, isPreviewIdeaId);
       persistSceneIdeaPositions(positions).catch(() => {});
     });
+    untrack(syncThreadAnchor);
   }
 
   // ── Lifecycle ──────────────────────────────────────────────
   let paused = false;
   let flowState = $state(false);
-  let flowCheckInterval: any = null;
-  let orbitWakeCheckInterval: ReturnType<typeof setInterval> | null = null;
 
-  function checkFlowState() {
+  function updateFlowState() {
+    if (destroyed) return;
     const panelOpen = cortex.panelOpen;
     const activeInput = document.activeElement?.tagName === 'TEXTAREA';
-    if (panelOpen && activeInput && !flowState) {
-      flowState = true;
+    const nextFlowState = panelOpen && activeInput;
+    if (nextFlowState === flowState) return;
+
+    flowState = nextFlowState;
+    if (nextFlowState) {
       g?.selectAll('.bubble-group')
         .filter((d: any) => d.id !== cortex.selectedIdeaId)
         .transition().duration(600).attr('opacity', 0.38);
-    } else if ((!panelOpen || !activeInput) && flowState) {
-      flowState = false;
+    } else {
       g?.selectAll('.bubble-group').transition().duration(600)
         .attr('opacity', (d: any) => bubbleOpacity(d.status));
     }
+  }
+
+  function handleFlowFocusChange() {
+    if (destroyed) return;
+    queueMicrotask(updateFlowState);
   }
 
   function handleFitView() {
@@ -3797,6 +3807,7 @@
   function handleTogglePause() {
     paused = !paused;
     if (paused) {
+      restoreThreadAnchorState(simulation?.nodes() as OrbitNode[] | undefined);
       renderGeneration += 1;
       cancelRenderFrames();
       stopActiveSimulation();
@@ -3805,28 +3816,15 @@
     }
   }
 
-  function ensureOrbitMotionActive() {
-    if (!simulation || paused || workspaceMotionSuspended) return;
-    const nodes = simulation.nodes() as OrbitNode[];
-    clearAttractionCache(nodes);
-    simulation
-      .alphaTarget(idleOrbitAlphaTarget())
-      .alpha(Math.max(simulation.alpha(), 0.14))
-      .restart();
-    schedulePrimitiveOrbitVisuals(nodes);
-  }
-
   function handleVisibilityChange() {
-    if (document.visibilityState !== 'visible') return;
-    ensureOrbitMotionActive();
-  }
-
-  function checkOrbitMotionHealth() {
-    if (!simulation || paused || workspaceMotionSuspended || document.visibilityState === 'hidden') return;
-    const now = performance.now();
-    if (!lastOrbitTickAt || now - lastOrbitTickAt > ORBIT_STALE_AFTER_MS) {
-      ensureOrbitMotionActive();
+    if (!simulation || paused) return;
+    if (document.visibilityState === 'hidden') {
+      simulation.stop();
+      cancelPrimitiveOrbitVisualSync();
+      return;
     }
+    if (simulation.alpha() < simulation.alphaMin()) return;
+    heatOrbit(0);
   }
 
   // Track rendered idea IDs to detect new ones
@@ -3857,14 +3855,9 @@
       nodes.push(sceneNode);
       simulation.nodes(nodes);
     }
-    if (!workspaceMotionSuspended) {
-      simulation.alpha(0.5).restart();
-    }
+    heatOrbit(0.5);
 
     if (!USE_D3_SHADOW_SCENE) {
-      if (workspaceMotionSuspended) {
-        collapseBirthAnimation(sceneNode);
-      }
       syncPrimitiveOrbitVisuals(Array.from(orbitSceneNodesById.values()));
       syncPrimitiveMotionVisuals(simulation.nodes() as OrbitNode[]);
       return;
@@ -3882,21 +3875,14 @@
     renderBubbleContent(bubble, qPosMap);
     syncPrimitiveOrbitVisuals(Array.from(orbitSceneNodesById.values()));
 
-    if (workspaceMotionSuspended) {
-      bubble.select('.bubble-cloud')
-        .attr('opacity', bubbleOpacity(sceneNode.status))
-        .attr('transform', 'scale(1)');
-      bubble.select('.bubble-label').attr('opacity', 1);
-    } else {
-      bubble.select('.bubble-cloud')
-        .attr('opacity', 0).attr('transform', 'scale(0)')
-        .transition('bubble-birth-cloud').duration(600).ease(d3.easeCubicOut)
-        .attr('opacity', bubbleOpacity(sceneNode.status))
-        .attr('transform', 'scale(1)');
-      bubble.select('.bubble-label')
-        .attr('opacity', 0)
-        .transition('bubble-birth-label').delay(300).duration(400).attr('opacity', 1);
-    }
+    bubble.select('.bubble-cloud')
+      .attr('opacity', 0).attr('transform', 'scale(0)')
+      .transition('bubble-birth-cloud').duration(600).ease(d3.easeCubicOut)
+      .attr('opacity', bubbleOpacity(sceneNode.status))
+      .attr('transform', 'scale(1)');
+    bubble.select('.bubble-label')
+      .attr('opacity', 0)
+      .transition('bubble-birth-label').delay(300).duration(400).attr('opacity', 1);
 
     bubble
       .on('click', (e: Event) => {
@@ -3936,8 +3922,9 @@
     window.addEventListener('cortex-fit-view', handleFitView);
     window.addEventListener('cortex-toggle-pause', handleTogglePause);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    flowCheckInterval = setInterval(checkFlowState, 2000);
-    orbitWakeCheckInterval = setInterval(checkOrbitMotionHealth, ORBIT_WAKE_CHECK_INTERVAL_MS);
+    document.addEventListener('focusin', handleFlowFocusChange);
+    document.addEventListener('focusout', handleFlowFocusChange);
+    handleFlowFocusChange();
   });
 
   // Re-initialize attractors when teamMembers loads or user-owned cluster loads change.
@@ -4005,7 +3992,7 @@
     const nodes = simulation?.nodes() as OrbitNode[] | undefined;
     if (nodes) clearAttractionCache(nodes);
     refreshOrbitVisualState();
-    if (simulation) simulation.alpha(0.24).restart();
+    heatOrbit(0.24);
   });
 
   $effect(() => {
@@ -4016,23 +4003,27 @@
   });
 
   $effect(() => {
-    const appLayoutKey = apps
-      .map((app) => [
-        app.id,
-        app.updated_at,
-        app.anchor_user_id ?? '',
-        app.visual_spec?.orbit_anchor_type ?? '',
-        app.visual_spec?.orbit_anchor_id ?? '',
-        app.visual_spec?.position_x ?? '',
-        app.visual_spec?.position_y ?? '',
-      ].join(':'))
+    const nextAppLayoutKey = apps
+      .filter((app) => !app.archived_at)
+      .map((app) => {
+        const position = workspaceAppStoredPosition(app);
+        return [
+          app.id,
+          app.created_at,
+          workspaceAppAnchorId(app),
+          workspaceAppOrbitOrder(app) ?? '',
+          position?.x ?? '',
+          position?.y ?? '',
+        ].join(':');
+      })
+      .sort()
       .join('|');
+    const layoutChanged = nextAppLayoutKey !== appLayoutKey;
+    appLayoutKey = nextAppLayoutKey;
     activeAppId;
     if (svg) {
       syncPrimitiveOrbitVisuals();
-      if (simulation && !workspaceMotionSuspended) {
-        simulation.alpha(Math.max(simulation.alpha(), 0.12)).restart();
-      }
+      if (layoutChanged) heatOrbit(0.12);
     }
   });
 
@@ -4066,11 +4057,26 @@
     }
   });
 
-  $effect(() => {
+  function restoreThreadAnchorState(nodes: OrbitNode[] = []) {
+    const previous = threadAnchorState;
+    if (!previous) return false;
+
+    const previousNode = nodes.find((node) => node.id === previous.id)
+      ?? orbitSceneNodesById.get(previous.id);
+    if (previousNode) {
+      previousNode.fx = previous.fx;
+      previousNode.fy = previous.fy;
+      delete previousNode._threadAnchorPinned;
+    }
+    threadAnchorState = null;
+    return true;
+  }
+
+  function syncThreadAnchor() {
     const panelOpen = cortex.panelOpen;
     const selectedId = cortex.selectedIdeaId;
 
-    if (!simulation) return;
+    if (destroyed || !simulation) return;
     const nodes = simulation.nodes() as OrbitNode[];
 
     if (panelOpen && selectedId) {
@@ -4079,15 +4085,7 @@
       collapseBirthAnimation(anchorNode);
 
       if (!threadAnchorState || threadAnchorState.id !== selectedId) {
-        const prevAnchorState = threadAnchorState;
-        if (prevAnchorState) {
-          const prevNode = nodes.find((node) => node.id === prevAnchorState.id);
-          if (prevNode) {
-            prevNode.fx = prevAnchorState.fx;
-            prevNode.fy = prevAnchorState.fy;
-            delete prevNode._threadAnchorPinned;
-          }
-        }
+        restoreThreadAnchorState(nodes);
 
         threadAnchorState = {
           id: selectedId,
@@ -4103,27 +4101,15 @@
       return;
     }
 
-    if (threadAnchorState) {
-      const prevNode = nodes.find((node) => node.id === threadAnchorState?.id);
-      if (prevNode) {
-        prevNode.fx = threadAnchorState.fx;
-        prevNode.fy = threadAnchorState.fy;
-        delete prevNode._threadAnchorPinned;
-      }
-      threadAnchorState = null;
+    if (restoreThreadAnchorState(nodes)) {
       refreshCollisionForce(0.14);
       handleFocusMode(currentZoomTransform);
     }
 
     releaseThreadAnchors(nodes);
-  });
+  }
 
-  $effect(() => {
-    const panelOpen = cortex.panelOpen;
-    const selectedId = cortex.selectedIdeaId;
-    if (!svg || !simulation || !panelOpen || !selectedId) return;
-    ensureOrbitMotionActive();
-  });
+  $effect(syncThreadAnchor);
 
   // Track node properties for change detection
   let nodeSnapshotMap = new Map<string, WorkspaceSceneNodeSnapshot>();
@@ -4225,27 +4211,58 @@
           const nodes = (simulation.nodes() as OrbitNode[]).filter((n) => n.id !== id);
           simulation.nodes(nodes);
           clearAttractionCache(nodes);
-          simulation.alpha(0.2).restart();
+          heatOrbit(0.2);
         }
       }
     }
   });
 
   $effect(() => {
-    const typingEntries = Array.from(cortex.typingUsers.values()).map((entry) => `${entry.user_id}:${entry.idea_id}`).join('|');
-    typingEntries;
+    const visible = (cortex.filteredIdeas as WorkspaceSceneIdeaSnapshot[]).filter((idea) => !idea?.archived_at);
+    const nextTopologyKey = workspaceConnectionTopologyKey(visible);
+    if (!simulation || nextTopologyKey === connectionTopologyKey) return;
+
+    connectionTopologyKey = nextTopologyKey;
+    const linkForce = simulation.force('link') as d3.ForceLink<OrbitNode, any> | undefined;
+    linkForce?.links(workspaceConnectionLinkData(visible));
+    heatOrbit(0.18);
+  });
+
+  $effect(() => {
+    const typingEntries = Array.from(cortex.typingUsers.values())
+      .map((entry) => `${entry.user_id}:${entry.idea_id}`)
+      .sort()
+      .join('|');
+    const viewerEntries = Array.from(new Set(
+      presenceStore.viewers.map((entry) => entry.user_id),
+    ))
+      .sort()
+      .join('|');
+    const nextPresenceMotionKey = `${typingEntries}::${viewerEntries}`;
+    const initialPresence = presenceMotionKey === null;
+    const presenceChanged = nextPresenceMotionKey !== presenceMotionKey;
+    if (!presenceChanged) return;
+
+    presenceMotionKey = nextPresenceMotionKey;
     refreshOrbitVisualState();
+    if (!initialPresence) heatOrbit(0.08);
+  });
+
+  $effect(() => {
+    cortex.panelOpen;
+    handleFlowFocusChange();
   });
 
   onDestroy(() => {
+    destroyed = true;
     resetArchiveDragInteraction();
     resetRenderRuntime();
-    if (flowCheckInterval) clearInterval(flowCheckInterval);
-    if (orbitWakeCheckInterval) clearInterval(orbitWakeCheckInterval);
     cortex.setBirthContext(null);
     window.removeEventListener('cortex-fit-view', handleFitView);
     window.removeEventListener('cortex-toggle-pause', handleTogglePause);
     document.removeEventListener('visibilitychange', handleVisibilityChange);
+    document.removeEventListener('focusin', handleFlowFocusChange);
+    document.removeEventListener('focusout', handleFlowFocusChange);
   });
 </script>
 

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -1,5 +1,5 @@
 import { browser, dev } from '$app/environment';
-import { api, type CortexBootstrapPayload } from '$lib/api/client';
+import { api, type CortexBootstrapPayload, type ThreadStreamPage } from '$lib/api/client';
 import { auth } from '$lib/stores/auth.svelte';
 import {
   CORTEX_RUN_SETTINGS_STORAGE_KEYS,
@@ -53,6 +53,7 @@ import {
   applyAgentTextDeltaToStream,
   applyRunCompletedToStream,
   mergeLiveStreamState,
+  mergeThreadStreamPageItems,
   runUiEventKey,
   type CortexRunStreamItem,
 } from '$lib/utils/cortexRunStream';
@@ -106,6 +107,8 @@ export interface CortexCreateIdeaOptions {
   displayTitle?: string | null;
 }
 
+type ThreadHistoryState = { nextBefore?: string | null; loadingOlder?: boolean; error?: string | null };
+
 class CortexStore {
   ideas = $state<Idea[]>([]);
   connections = $state<Connection[]>([]);
@@ -147,7 +150,9 @@ class CortexStore {
   archivedIdeasLoading = $state(false);
 
   private _wsUnsubs: (() => void)[] = [];
-  private _streamVersion = 0;
+  private _selectionEpoch = 0;
+  private _headStreamRequest = 0;
+  private _threadHistory = $state<ThreadHistoryState>({});
   private _pendingStreamRefresh: ReturnType<typeof setTimeout> | null = null;
   private _selectedIdeaReconcile: ReturnType<typeof setInterval> | null = null;
   private _ideasSnapshotReconcile: ReturnType<typeof setInterval> | null = null;
@@ -293,10 +298,10 @@ class CortexStore {
 
   private _hydrateSelectedIdeaSidecars(id: string, version: number) {
     this._runWhenIdle(() => {
-      if (this.selectedIdeaId !== id || this._streamVersion !== version) return;
+      if (this.selectedIdeaId !== id || this._selectionEpoch !== version) return;
 
       api.getBrowserSession(id).then((browserSession) => {
-        if (this.selectedIdeaId !== id || this._streamVersion !== version) return;
+        if (this.selectedIdeaId !== id || this._selectionEpoch !== version) return;
         this.browserSession = browserSession;
         this.browserFrame = null;
         this.browserDiscovery = null;
@@ -530,16 +535,16 @@ class CortexStore {
   private _scheduleSelectedBrowserSessionRefresh(delayMs = 450) {
     if (!this.selectedIdeaId || this.browserSession?.id || this._pendingBrowserSessionRefresh) return;
     const ideaId = this.selectedIdeaId;
-    const version = this._streamVersion;
+    const version = this._selectionEpoch;
     this._pendingBrowserSessionRefresh = setTimeout(() => {
       this._pendingBrowserSessionRefresh = null;
-      if (this.selectedIdeaId !== ideaId || this._streamVersion !== version || this.browserSession?.id) {
+      if (this.selectedIdeaId !== ideaId || this._selectionEpoch !== version || this.browserSession?.id) {
         return;
       }
       api.getBrowserSession(ideaId).then((browserSession) => {
         if (
           this.selectedIdeaId !== ideaId
-          || this._streamVersion !== version
+          || this._selectionEpoch !== version
           || !browserSession?.id
           || this.browserSession?.id
         ) {
@@ -702,6 +707,75 @@ class CortexStore {
       (item) => this._isActiveRunItem(item as StreamItem),
       mergeRunProgressSnapshot,
     ) as StreamItem[];
+  }
+
+  threadHistoryHasMore(ideaId: string): boolean {
+    return this.selectedIdeaId === ideaId && typeof this._threadHistory.nextBefore === 'string';
+  }
+
+  threadHistoryLoadingOlder(ideaId: string): boolean {
+    return this.selectedIdeaId === ideaId && this._threadHistory.loadingOlder === true;
+  }
+
+  threadHistoryError(ideaId: string): string | null {
+    return this.selectedIdeaId === ideaId ? this._threadHistory.error ?? null : null;
+  }
+
+  private _resetThreadHistory(): number {
+    this._selectionEpoch += 1;
+    this._threadHistory = {};
+    return this._selectionEpoch;
+  }
+
+  private _currentThreadRequest(ideaId: string, epoch: number, pageIdeaId = ideaId): boolean {
+    return pageIdeaId === ideaId && this.selectedIdeaId === ideaId && this._selectionEpoch === epoch;
+  }
+
+  private _applyThreadStreamPage(
+    ideaId: string,
+    epoch: number,
+    page: Pick<ThreadStreamPage, 'idea_id' | 'items' | 'next_before'>,
+    mode: 'initial' | 'head' | 'older',
+  ): boolean {
+    if (!this._currentThreadRequest(ideaId, epoch, page.idea_id)) return false;
+
+    const effectiveMode = this._threadHistory.nextBefore === undefined ? 'initial' : mode;
+    const pagedItems = mergeThreadStreamPageItems(
+      this.stream as CortexRunStreamItem[],
+      page.items as CortexRunStreamItem[],
+      effectiveMode,
+    );
+    const mergedItems = this._mergeLiveStreamState(pagedItems as StreamItem[], ideaId);
+    this.stream = mergedItems;
+
+    if (effectiveMode !== 'head') {
+      this._threadHistory = { nextBefore: page.next_before, loadingOlder: false, error: null };
+    }
+
+    this._reconcileIdeaStatusFromStream(ideaId, mergedItems);
+    if (this._hasActiveRuns(mergedItems) || this._selectedIdeaLooksWorking(ideaId)) {
+      this._ensureSelectedIdeaReconcile();
+    } else {
+      this._stopSelectedIdeaReconcile();
+    }
+    if (this._hasWorkingIdeas()) this._ensureIdeasSnapshotReconcile();
+    else this._stopIdeasSnapshotReconcile();
+
+    if (effectiveMode === 'initial') {
+      this._maybeApplyVaultSecretPromptFromStream(ideaId, mergedItems);
+      this._maybeApplyVaultAgentGrantPromptFromStream(ideaId, mergedItems);
+      this.browserFrame = null;
+      this.browserDiscovery = null;
+      this.browserExtraction = null;
+      const selected = this.ideas.find((idea) => idea.id === ideaId);
+      if (selected?.status === 'done' && !this._isLocalPreviewIdeaId(ideaId)) {
+        this._markIdeaSeen(ideaId, this._ideaRevision(selected));
+        this._setIdeaPatch(ideaId, { status: 'idle' });
+      }
+      this.streamLoading = false;
+      this._hydrateSelectedIdeaSidecars(ideaId, epoch);
+    }
+    return true;
   }
 
   private _selectedIdeaLooksWorking(id: string): boolean {
@@ -980,12 +1054,6 @@ class CortexStore {
     return this.ideas.find((i) => i.id === this.selectedIdeaId);
   }
 
-  typingInIdea(ideaId: string): string[] {
-    return [...this.typingUsers.values()]
-      .filter((t) => t.idea_id === ideaId)
-      .map((t) => t.user_id);
-  }
-
   get filteredIdeas(): Idea[] {
     let result = this.ideas;
     if (this.filters.statuses.size > 0) {
@@ -1135,35 +1203,13 @@ class CortexStore {
     }
   }
 
-  private _applyLoadedStream(id: string, version: number, items: StreamItem[]) {
-    if (this.selectedIdeaId !== id || this._streamVersion !== version) return false;
-    const mergedItems = this._mergeLiveStreamState(items, id);
-    this.stream = mergedItems;
-    this._maybeApplyVaultSecretPromptFromStream(id, mergedItems);
-    this._maybeApplyVaultAgentGrantPromptFromStream(id, mergedItems);
-    this._reconcileIdeaStatusFromStream(id, mergedItems);
-    this.browserFrame = null;
-    this.browserDiscovery = null;
-    this.browserExtraction = null;
-    const selected = this.ideas.find((i) => i.id === id);
-    if (selected?.status === 'done' && !this._isLocalPreviewIdeaId(id)) {
-      this._markIdeaSeen(id, this._ideaRevision(selected));
-      this._setIdeaPatch(id, { status: 'idle' });
-    }
-    if (this._hasActiveRuns(mergedItems) || this._selectedIdeaLooksWorking(id)) {
-      this._ensureSelectedIdeaReconcile();
-    } else {
-      this._stopSelectedIdeaReconcile();
-    }
-    if (this._hasWorkingIdeas()) this._ensureIdeasSnapshotReconcile();
-    else this._stopIdeasSnapshotReconcile();
-    this.streamLoading = false;
-
-    this._hydrateSelectedIdeaSidecars(id, version);
-    return true;
-  }
-
   async loadDirectThread(id: string): Promise<boolean> {
+    if (this.selectedIdeaId === id && this._threadHistory.nextBefore !== undefined) {
+      this.panelOpen = true;
+      this.canvasOpen = false;
+      await this._refreshSelectedStream();
+      return this.selectedIdeaId === id;
+    }
     if (this._isLocalPreviewIdeaId(id)) {
       await this.selectIdea(id);
       return this.selectedIdeaId === id;
@@ -1177,7 +1223,7 @@ class CortexStore {
       this.browserDiscovery = null;
       this.browserExtraction = null;
     }
-    const version = ++this._streamVersion;
+    const epoch = this._resetThreadHistory();
     this._seenRunUiEvents.clear();
     if (this.vaultSecretPrompt?.idea_id && this.vaultSecretPrompt.idea_id !== id) {
       this.vaultSecretPrompt = null;
@@ -1196,12 +1242,10 @@ class CortexStore {
         include: ['selected_idea', 'direct_thread'],
         ideaId: id,
       });
-      if (
-        !bootstrap?.selected_idea
-        || !Array.isArray(bootstrap?.direct_thread?.stream)
-      ) {
-        throw new Error('Incomplete cortex direct-thread bootstrap');
+      if (!bootstrap?.selected_idea || !bootstrap.direct_thread) {
+        throw Error();
       }
+      if (bootstrap.direct_thread.idea_id !== id) throw Error();
       const selectedIdea = this._normalizeIdea(bootstrap.selected_idea);
       const remainingIdeas = this.ideas.filter((idea) => idea.id !== selectedIdea.id);
       this.ideas = [selectedIdea, ...remainingIdeas];
@@ -1209,10 +1253,12 @@ class CortexStore {
         this.teamMembers = this._normalizeTeamMembers(this.teamMembers);
         this.teamMembersLoaded = true;
       }
-      const applied = this._applyLoadedStream(id, version, bootstrap.direct_thread.stream);
+      const applied = this._applyThreadStreamPage(id, epoch, bootstrap.direct_thread, 'initial');
       return applied || this.selectedIdeaId === id;
     } catch {
+      if (!this._currentThreadRequest(id, epoch)) return this.selectedIdeaId === id;
       await this._load({ loadTeamMembers: false });
+      if (!this._currentThreadRequest(id, epoch)) return this.selectedIdeaId === id;
       const activeIdea = this.ideas.find((idea) => idea.id === id && !idea.archived_at);
       if (activeIdea) {
         await this.selectIdea(id);
@@ -1223,7 +1269,7 @@ class CortexStore {
     } finally {
       this.loading = false;
       this._initialLoadDone = true;
-      if (this.selectedIdeaId === id && this._streamVersion === version) {
+      if (this._currentThreadRequest(id, epoch)) {
         this.streamLoading = false;
       }
     }
@@ -1231,7 +1277,7 @@ class CortexStore {
 
   async selectIdea(id: string | null) {
     if (id === null) {
-      this._streamVersion += 1;
+      this._resetThreadHistory();
       if (this.browserSession?.id) {
         wsClient.send('browser_unsubscribe', { session_id: this.browserSession.id });
       }
@@ -1258,6 +1304,12 @@ class CortexStore {
       this.stream = [];
       return;
     }
+    if (this.selectedIdeaId === id && this._threadHistory.nextBefore !== undefined) {
+      this.panelOpen = true;
+      this.canvasOpen = false;
+      await this._refreshSelectedStream();
+      return;
+    }
     if (this.browserSession?.id && this.browserSession.idea_id !== id) {
       wsClient.send('browser_unsubscribe', { session_id: this.browserSession.id });
       this.browserSession = null;
@@ -1265,7 +1317,7 @@ class CortexStore {
       this.browserDiscovery = null;
       this.browserExtraction = null;
     }
-    const version = ++this._streamVersion;
+    const epoch = this._resetThreadHistory();
     this._seenRunUiEvents.clear();
     if (this.vaultSecretPrompt?.idea_id && this.vaultSecretPrompt.idea_id !== id) {
       this.vaultSecretPrompt = null;
@@ -1288,11 +1340,11 @@ class CortexStore {
     if (this._isLocalPreviewIdeaId(id)) {
       const idea = selectedIdea;
       if (idea) {
-        this._applyLoadedStream(
-          id,
-          version,
-          buildLocalPreviewThreadStream(idea, this.teamMembers) as StreamItem[],
-        );
+        this._applyThreadStreamPage(id, epoch, {
+          idea_id: id,
+          items: buildLocalPreviewThreadStream(idea, this.teamMembers) as StreamItem[],
+          next_before: null,
+        }, 'initial');
       } else {
         this.streamLoading = false;
       }
@@ -1300,13 +1352,16 @@ class CortexStore {
     }
 
     try {
-      const items = await api.unifiedStream(id);
-      // Guard: user may have switched ideas while we were fetching
-      this._applyLoadedStream(id, version, items);
+      const page = await api.unifiedStream(id);
+      if (!this._applyThreadStreamPage(id, epoch, page, 'initial')) {
+        throw Error();
+      }
     } catch (err: any) {
-      ui.toast(err.detail || 'Failed to load thread', 'error');
+      if (this._currentThreadRequest(id, epoch)) {
+        ui.toast(err.detail || 'Failed to load thread', 'error');
+      }
     } finally {
-      if (this.selectedIdeaId === id && this._streamVersion === version) {
+      if (this._currentThreadRequest(id, epoch)) {
         this.streamLoading = false;
       }
     }
@@ -1637,9 +1692,7 @@ class CortexStore {
       this.ideas = this.ideas.filter((i) => i.id !== id);
       if (!this._hasWorkingIdeas()) this._stopIdeasSnapshotReconcile();
       if (this.selectedIdeaId === id) {
-        this.selectedIdeaId = null;
-        this.panelOpen = false;
-        this.stream = [];
+        await this.selectIdea(null);
       }
     } catch (err: any) {
       ui.toast(err.detail || 'Failed to delete idea', 'error');
@@ -1663,17 +1716,6 @@ class CortexStore {
       const idea = this.ideas.find((i) => i.id === id);
       if (idea) { idea.position_x = x; idea.position_y = y; }
     } catch { /* silent — position is best-effort */ }
-  }
-
-  async updateIdeaOwner(id: string, userId: string) {
-    try {
-      const updated = await api.updateIdea(id, { user_id: userId });
-      this._upsertIdea(updated);
-      return updated;
-    } catch (e) {
-      console.error('Failed to update idea owner:', e);
-      throw e;
-    }
   }
 
   async updateIdeaOrbitAnchor(id: string, anchorType: string | null, anchorId: string | null) {
@@ -1709,23 +1751,44 @@ class CortexStore {
   }
 
   private async _refreshSelectedStream() {
-    if (!this.selectedIdeaId) return;
-    if (this._isLocalPreviewIdeaId(this.selectedIdeaId)) return;
-    const version = ++this._streamVersion;
+    const ideaId = this.selectedIdeaId;
+    if (!ideaId || this.streamLoading || this._isLocalPreviewIdeaId(ideaId)) return;
+    const epoch = this._selectionEpoch;
+    const headRequest = ++this._headStreamRequest;
     try {
-      const items = await api.unifiedStream(this.selectedIdeaId);
-      // Only apply if no newer request has been issued
-      if (this._streamVersion === version) {
-        const mergedItems = this._mergeLiveStreamState(items, this.selectedIdeaId);
-        this.stream = mergedItems;
-        this._reconcileIdeaStatusFromStream(this.selectedIdeaId, mergedItems);
-        const hasActiveRun = this._hasActiveRuns(mergedItems);
-        if (hasActiveRun || this._selectedIdeaLooksWorking(this.selectedIdeaId)) this._ensureSelectedIdeaReconcile();
-        else this._stopSelectedIdeaReconcile();
-        if (this._hasWorkingIdeas()) this._ensureIdeasSnapshotReconcile();
-        else this._stopIdeasSnapshotReconcile();
-      }
+      const page = await api.unifiedStream(ideaId);
+      if (headRequest !== this._headStreamRequest) return;
+      this._applyThreadStreamPage(ideaId, epoch, page, 'head');
     } catch { /* silent */ }
+  }
+
+  async loadOlderThreadHistory(ideaId: string): Promise<boolean> {
+    const before = this._threadHistory.nextBefore;
+    if (
+      this.selectedIdeaId !== ideaId ||
+      typeof before !== 'string' ||
+      this._threadHistory.loadingOlder
+    ) return false;
+
+    const epoch = this._selectionEpoch;
+    this._threadHistory = { nextBefore: before, loadingOlder: true, error: null };
+    try {
+      const page = await api.unifiedStream(ideaId, { before });
+      const applied = this._applyThreadStreamPage(ideaId, epoch, page, 'older');
+      if (!applied && this._currentThreadRequest(ideaId, epoch)) {
+        throw Error();
+      }
+      return applied;
+    } catch (error: any) {
+      if (this._currentThreadRequest(ideaId, epoch)) {
+        this._threadHistory = {
+          nextBefore: before,
+          loadingOlder: false,
+          error: error?.detail || 'Failed to load older thread history',
+        };
+      }
+      return false;
+    }
   }
 
   private _scheduleSelectedStreamRefresh(delayMs = 250) {
@@ -1826,16 +1889,6 @@ class CortexStore {
     this._wsUnsubs = [];
   }
 
-  toggleFilter(status: string) {
-    const next = new Set(this.filters.statuses);
-    if (next.has(status)) next.delete(status);
-    else next.add(status);
-    this.filters = { ...this.filters, statuses: next };
-  }
-
-  setSearch(q: string) {
-    this.filters = { ...this.filters, search: q };
-  }
 }
 
 export const cortex = new CortexStore();

--- a/frontend/src/lib/utils/cortexOrbitPhysics.test.js
+++ b/frontend/src/lib/utils/cortexOrbitPhysics.test.js
@@ -1,20 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { forceSimulation } from 'd3-force';
 
 import { cortexOrbitPerformanceProfile } from './cortexOrbitPhysics.ts';
 
-test('orbit performance profiles keep a nonzero idle alpha target above alphaMin', () => {
+test('orbit performance profiles cool naturally with a zero alpha target', () => {
   for (const nodeCount of [1, 60, 120, 220]) {
     const profile = cortexOrbitPerformanceProfile(nodeCount);
-    assert.ok(
-      profile.idleAlphaTarget > profile.alphaMin,
-      `nodeCount=${nodeCount} should not let the orbit simulation cool below alphaMin`,
-    );
-  }
-});
+    assert.equal('idleAlphaTarget' in profile, false, `nodeCount=${nodeCount} must not encode perpetual heat`);
 
-test('orbit idle heat tapers down for dense workspaces', () => {
-  assert.ok(cortexOrbitPerformanceProfile(1).idleAlphaTarget > cortexOrbitPerformanceProfile(60).idleAlphaTarget);
-  assert.ok(cortexOrbitPerformanceProfile(60).idleAlphaTarget > cortexOrbitPerformanceProfile(120).idleAlphaTarget);
-  assert.ok(cortexOrbitPerformanceProfile(120).idleAlphaTarget > cortexOrbitPerformanceProfile(220).idleAlphaTarget);
+    for (const initialAlpha of [1, 0.14]) {
+      const simulation = forceSimulation([])
+        .stop()
+        .alpha(initialAlpha)
+        .alphaDecay(profile.alphaDecay)
+        .alphaMin(profile.alphaMin)
+        .alphaTarget(0);
+      for (let ticks = 0; simulation.alpha() >= profile.alphaMin && ticks < 1600; ticks += 1) {
+        simulation.tick();
+      }
+      assert.ok(simulation.alpha() < profile.alphaMin, `nodeCount=${nodeCount} alpha=${initialAlpha} did not converge`);
+    }
+  }
 });

--- a/frontend/src/lib/utils/cortexOrbitPhysics.ts
+++ b/frontend/src/lib/utils/cortexOrbitPhysics.ts
@@ -1,7 +1,6 @@
 export type CortexOrbitPerformanceProfile = {
   alphaDecay: number;
   alphaMin: number;
-  idleAlphaTarget: number;
   collideIterations: number;
   velocityDecay: number;
 };
@@ -23,7 +22,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.018,
       alphaMin: 0.003,
-      idleAlphaTarget: 0.004,
       collideIterations: 1,
       velocityDecay: 0.38,
     };
@@ -32,7 +30,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.012,
       alphaMin: 0.002,
-      idleAlphaTarget: 0.006,
       collideIterations: 2,
       velocityDecay: 0.36,
     };
@@ -41,7 +38,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.008,
       alphaMin: 0.0015,
-      idleAlphaTarget: 0.009,
       collideIterations: 2,
       velocityDecay: 0.35,
     };
@@ -49,7 +45,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
   return {
     alphaDecay: 0.0045,
     alphaMin: 0.001,
-    idleAlphaTarget: 0.012,
     collideIterations: 3,
     velocityDecay: 0.34,
   };

--- a/frontend/src/lib/utils/cortexRunStream.test.js
+++ b/frontend/src/lib/utils/cortexRunStream.test.js
@@ -6,10 +6,26 @@ import {
   applyAgentTextDeltaToStream,
   applyRunCompletedToStream,
   mergeLiveStreamState,
+  mergeThreadStreamPageItems,
   runUiEventKey,
   shouldRenderLiveAgentTextItem,
 } from './cortexRunStream.ts';
 import { mergeRunProgressSnapshot } from './cortexRunPresentation.ts';
+
+const message = (id, content = id, timestamp = /^\d+$/.test(id)
+  ? new Date(Number(id) * 1000).toISOString()
+  : undefined) => ({ type: 'message', id, idea_id: 'idea-1', content, timestamp });
+
+function reconcilePage(current, page, mode) {
+  const paged = mergeThreadStreamPageItems(current, page, mode);
+  return mergeLiveStreamState(
+    paged,
+    current,
+    'idea-1',
+    (item) => ['starting', 'running', 'queued'].includes(item.status),
+    mergeRunProgressSnapshot,
+  );
+}
 
 test('merges live run progress into persisted stream snapshots', () => {
   const persisted = [{
@@ -210,4 +226,174 @@ test('settles run completion summaries', () => {
 test('deduplicates run UI events by event cursor', () => {
   assert.equal(runUiEventKey({ type: 'tool_started', run_id: 1, event_cursor: 20 }), 'tool_started:1:20');
   assert.equal(runUiEventKey({ type: 'tool_started', run_id: 1, event_cursor: 0 }), null);
+});
+
+test('prepends overlapping older pages by typed identity without replacing newer items', () => {
+  const current = [message('3', 'newer three'), message('4'), message('5')];
+  const merged = reconcilePage(
+    current,
+    [message('1'), message('2'), message('3', 'stale three')],
+    'older',
+  );
+
+  assert.deepEqual(merged.map((item) => `${item.type}:${item.id}`), [
+    'message:1', 'message:2', 'message:3', 'message:4', 'message:5',
+  ]);
+  assert.equal(merged[2].content, 'newer three');
+  assert.deepEqual(
+    mergeThreadStreamPageItems(
+      [{ type: 'run', id: 'shared' }, message('shared')],
+      [],
+      'older',
+    ).map((item) => `${item.type}:${item.id}`),
+    ['message:shared', 'run:shared'],
+  );
+});
+
+test('concurrent head and older pages converge regardless of response order', () => {
+  const initial = [message('3'), message('4'), message('5')];
+  const older = [message('1'), message('2'), message('3')];
+  const head = [message('4'), message('5'), message('6')];
+
+  const headThenOlder = reconcilePage(reconcilePage(initial, head, 'head'), older, 'older');
+  const olderThenHead = reconcilePage(reconcilePage(initial, older, 'older'), head, 'head');
+  for (const result of [headThenOlder, olderThenHead]) {
+    assert.deepEqual(result.map((item) => item.id), ['1', '2', '3', '4', '5', '6']);
+  }
+});
+
+test('keeps websocket items and live progress that arrive while a page is loading', () => {
+  const websocketMessage = message('6', 'arrived live');
+  const initial = reconcilePage([websocketMessage], [
+    message('1'), message('2'), message('3'), message('4'), message('5'),
+  ], 'initial');
+  assert.deepEqual(initial.map((item) => item.id), ['1', '2', '3', '4', '5', '6']);
+
+  const liveRun = {
+    type: 'run', id: '7', run_id: 7, idea_id: 'idea-1', status: 'running',
+    tool_calls: [{ tool: 'read_file', status: 'running' }],
+  };
+  const refreshed = reconcilePage([liveRun], [{
+    type: 'run', id: '7', run_id: 7, idea_id: 'idea-1', status: 'starting', tool_calls: [],
+  }], 'head');
+  assert.equal(refreshed[0].status, 'running');
+  assert.equal(refreshed[0].tool_calls.length, 1);
+
+  const noOverlapHead = reconcilePage([
+    message('old', 'old', '2026-01-01T00:00:00Z'),
+    message('websocket', 'live', '2026-01-03T00:00:00Z'),
+  ], [message('head', 'head', '2026-01-02T00:00:00Z')], 'head');
+  assert.deepEqual(noOverlapHead.map((item) => item.id), ['old', 'head', 'websocket']);
+});
+
+test('sorts a head page around an injected active root instead of its first item', () => {
+  const merged = reconcilePage([
+    message('history', 'history', '2026-01-01T12:00:00Z'),
+    message('websocket', 'live', '2026-01-04T00:00:00Z'),
+  ], [{
+    type: 'run', id: 'old-root', run_id: 'old-root', idea_id: 'idea-1', status: 'running',
+    timestamp: '2026-01-01T00:00:00Z',
+  },
+  message('head-2', 'head 2', '2026-01-02T00:00:00Z'),
+  message('head-3', 'head 3', '2026-01-03T00:00:00Z')], 'head');
+
+  assert.deepEqual(merged.map((item) => item.id), [
+    'old-root', 'history', 'head-2', 'head-3', 'websocket',
+  ]);
+});
+
+test('sorts a later synthetic final from an older run by its own timestamp', () => {
+  const merged = reconcilePage(
+    [message('current', 'current', '2026-01-05T00:00:00Z')],
+    [{
+      type: 'run', id: '9', run_id: 9, idea_id: 'idea-1', status: 'completed',
+      timestamp: '2026-01-01T00:00:00Z',
+    }, {
+      type: 'message', id: 'run-final-9-artifact', idea_id: 'idea-1', content: 'Synthetic',
+      timestamp: '2026-01-06T00:00:00Z',
+      metadata: { run_id: 9, synthetic_from_run_artifact: true },
+    }],
+    'older',
+  );
+
+  assert.deepEqual(merged.map((item) => item.id), ['9', 'current', 'run-final-9-artifact']);
+});
+
+test('uses kind rank and numeric persisted ids for equal timestamps', () => {
+  const timestamp = '2026-01-01T00:00:00Z';
+  const merged = mergeThreadStreamPageItems([], [
+    { type: 'visual_block', id: 'vb-2', timestamp },
+    { type: 'message', id: '10', timestamp },
+    { type: 'run', id: '10', timestamp },
+    { type: 'visual_block', id: 'vb-10', timestamp },
+    { type: 'run', id: '2', timestamp },
+    { type: 'message', id: '2', timestamp },
+  ], 'initial');
+
+  assert.deepEqual(merged.map((item) => `${item.type}:${item.id}`), [
+    'message:2', 'message:10', 'run:2', 'run:10',
+    'visual_block:vb-2', 'visual_block:vb-10',
+  ]);
+});
+
+test('uses deterministic lexical order for equal-time noncanonical ids', () => {
+  const timestamp = '2026-01-01T00:00:00Z';
+  const merged = mergeThreadStreamPageItems([], [
+    { type: 'message', id: 'live-run-2', timestamp },
+    { type: 'message', id: 'live-run-10', timestamp },
+  ], 'initial');
+
+  assert.deepEqual(merged.map((item) => item.id), ['live-run-10', 'live-run-2']);
+});
+
+test('never regresses a terminal run to stale live state', () => {
+  const terminal = {
+    type: 'run', id: '7', run_id: 7, idea_id: 'idea-1', status: 'completed',
+    timestamp: '2026-01-01T00:00:00Z', completed_at: '2026-01-01T00:01:00Z',
+  };
+  const stale = { ...terminal, status: 'running', completed_at: undefined };
+
+  assert.equal(reconcilePage([terminal], [stale], 'head')[0].status, 'completed');
+  assert.equal(reconcilePage([stale], [terminal], 'head')[0].status, 'completed');
+});
+
+test('deduplicates synthetic final answers when a persisted reply crosses a page boundary', () => {
+  const synthetic = {
+    type: 'message', id: 'run-final-9-artifact', idea_id: 'idea-1', content: 'Synthetic',
+    metadata: { run_id: 9, synthetic_from_run_artifact: true },
+  };
+  const persisted = {
+    type: 'message', id: 'persisted-9', idea_id: 'idea-1', content: 'Persisted',
+    metadata: { run_id: 9 },
+  };
+  const run = { type: 'run', id: '9', run_id: 9, idea_id: 'idea-1', status: 'completed' };
+
+  const persistedInHead = reconcilePage([persisted], [run, synthetic], 'older');
+  const persistedInOlder = reconcilePage([synthetic], [run, persisted], 'older');
+  for (const result of [persistedInHead, persistedInOlder]) {
+    assert.deepEqual(
+      result.filter((item) => item.type === 'message').map((item) => item.id),
+      ['persisted-9'],
+    );
+  }
+});
+
+test('repeated overlapping older pages recover the full chronological sequence', () => {
+  const messages = (start, end) => Array.from(
+    { length: end - start + 1 },
+    (_, index) => message(String(start + index)),
+  );
+  let stream = reconcilePage([], messages(801, 1000), 'initial');
+  for (const page of [
+    messages(601, 801),
+    messages(401, 601),
+    messages(201, 401),
+    messages(1, 201),
+  ]) {
+    stream = reconcilePage(stream, page, 'older');
+  }
+
+  assert.equal(stream.length, 1000);
+  assert.equal(new Set(stream.map((item) => `${item.type}:${item.id}`)).size, 1000);
+  assert.deepEqual(stream.map((item) => item.id), messages(1, 1000).map((item) => item.id));
 });

--- a/frontend/src/lib/utils/cortexRunStream.ts
+++ b/frontend/src/lib/utils/cortexRunStream.ts
@@ -62,6 +62,13 @@ export function streamItemBelongsToIdea(
   return Boolean(ideaId && streamItemIdeaId(item) === ideaId);
 }
 
+function streamItemIdentity(
+  item: Partial<CortexRunStreamItem> | null | undefined,
+): string | null {
+  if (!item?.type || item.id === null || item.id === undefined || item.id === '') return null;
+  return `${item.type}:${item.id}`;
+}
+
 export function isLivePartialReply(item: Partial<CortexRunStreamItem> | null | undefined): boolean {
   return Boolean(item?.metadata?.live_agent_text);
 }
@@ -237,6 +244,49 @@ export function hasVisiblePersistedRunMessage(item: CortexRunStreamItem): boolea
   );
 }
 
+const STREAM_KIND_RANK: Record<string, number> = { message: 0, run: 1, visual_block: 2 };
+
+function compareStreamItems(left: CortexRunStreamItem, right: CortexRunStreamItem): number {
+  const byTime = (timestampMs(left.timestamp) ?? 0) - (timestampMs(right.timestamp) ?? 0);
+  if (byTime) return byTime;
+  const leftKind = STREAM_KIND_RANK[left.type] ?? 3;
+  const byKind = leftKind - (STREAM_KIND_RANK[right.type] ?? 3);
+  if (byKind) return byKind;
+  const leftId = String(left.id), rightId = String(right.id);
+  const persistedId = left.type === 'visual_block' ? /^vb-\d+$/ : /^\d+$/;
+  if (leftKind < 3 && persistedId.test(leftId) && persistedId.test(rightId)) {
+    const byRowId = Number(leftId.replace('vb-', '')) - Number(rightId.replace('vb-', ''));
+    if (byRowId) return byRowId;
+  }
+  return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+}
+
+export function mergeThreadStreamPageItems(
+  current: CortexRunStreamItem[],
+  pageItems: CortexRunStreamItem[],
+  mode: 'initial' | 'head' | 'older',
+): CortexRunStreamItem[] {
+  const byIdentity = new Map<string, CortexRunStreamItem>();
+  for (const item of mode === 'older' ? [...pageItems, ...current] : [...current, ...pageItems]) {
+    byIdentity.set(`${item.type}:${item.id}`, item);
+  }
+  const items = [...byIdentity.values()];
+  const persistedRunIds = new Set(
+    items
+      .filter((item) => hasVisiblePersistedRunMessage(item) && item.metadata?.synthetic_from_run_artifact !== true)
+      .map(streamItemRunId)
+      .filter((value): value is string => Boolean(value)),
+  );
+  const syntheticRunIds = new Set<string>();
+  return items.filter((item) => {
+    if (item.metadata?.synthetic_from_run_artifact !== true) return true;
+    const runId = streamItemRunId(item);
+    if (!runId || persistedRunIds.has(runId) || syntheticRunIds.has(runId)) return false;
+    syntheticRunIds.add(runId);
+    return true;
+  }).sort(compareStreamItems);
+}
+
 export function mergeLiveStreamState(
   items: CortexRunStreamItem[],
   liveStream: CortexRunStreamItem[],
@@ -271,10 +321,18 @@ export function mergeLiveStreamState(
       .map((item) => streamItemRunId(item))
       .filter((value): value is string => Boolean(value)),
   );
+  const withRunIdentities = new Set(
+    withRuns.map(streamItemIdentity).filter((value): value is string => Boolean(value)),
+  );
   const livePartials = liveStream.filter((item) => {
     if (!isLivePartialReply(item) || !streamItemBelongsToIdea(item, ideaId)) return false;
     const runId = streamItemRunId(item);
-    return Boolean(runId && !persistedRunIds.has(runId));
+    const identity = streamItemIdentity(item);
+    return Boolean(
+      runId &&
+      !persistedRunIds.has(runId) &&
+      (!identity || !withRunIdentities.has(identity)),
+    );
   });
   return livePartials.length ? [...withRuns, ...livePartials] : withRuns;
 }

--- a/frontend/src/lib/utils/threadHistoryOperation.test.js
+++ b/frontend/src/lib/utils/threadHistoryOperation.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  canShowEarlierThreadHistory,
+  ownsThreadHistoryOperation,
+} from '../features/threads/domain/threadTranscriptAdapter.ts';
+import { buildThreadStreamWindow } from './threadStreamOrdering.ts';
+
+const messages = (start, count) => Array.from(
+  { length: count }, (_, index) => ({ type: 'message', id: String(start + index) }),
+);
+
+const ids = (window) => window.items.map((item) => item.id);
+
+test('a deferred stale operation cannot clear the next thread owner', async () => {
+  let resolveThreadA;
+  const threadAResponse = new Promise((resolve) => { resolveThreadA = resolve; });
+  let currentToken = 0;
+  const threadA = { threadId: 'thread-a', token: ++currentToken };
+  const threadAOwnsOnSettle = threadAResponse.then(() =>
+    ownsThreadHistoryOperation(threadA, 'thread-b', currentToken));
+  currentToken += 1;
+  const threadB = { threadId: 'thread-b', token: ++currentToken };
+  resolveThreadA();
+
+  assert.equal(await threadAOwnsOnSettle, false);
+  assert.equal(ownsThreadHistoryOperation(threadB, 'thread-b', currentToken), true);
+});
+
+test('remote history remains reachable without local transcript items', () => {
+  assert.equal(canShowEarlierThreadHistory(null, true), true);
+  assert.equal(canShowEarlierThreadHistory(null, false), false);
+});
+
+test('pre-arming advances each prepended server page without changing the current window', () => {
+  let stream = messages(401, 200);
+  let window = buildThreadStreamWindow(stream);
+
+  for (const start of [201, 1]) {
+    const cursor = window.startCursor;
+    assert.deepEqual(ids(buildThreadStreamWindow(stream, cursor)), ids(window));
+    stream = [...messages(start, 200), ...stream];
+    window = buildThreadStreamWindow(stream, cursor);
+    assert.equal(window.items.length, 601 - start);
+  }
+});
+
+test('an empty window cursor reveals the first remote page', () => {
+  const empty = buildThreadStreamWindow([]);
+  const firstPage = messages(1, 200);
+  assert.deepEqual(empty.startCursor, { index: 0, key: '' });
+  assert.deepEqual(buildThreadStreamWindow(firstPage, empty.startCursor).items, firstPage);
+});
+
+test('pre-arming crosses a protected prefix when the remote page arrives', () => {
+  const protectedPrefix = [
+    { type: 'run', id: 'active', run_id: 'active', status: 'running' },
+    ...Array.from({ length: 50 }, (_, index) => ({
+      type: 'message', id: `live-${index}`, metadata: { run_id: 'active' },
+    })),
+  ];
+  const stream = [...protectedPrefix, ...messages(201, 200)];
+  const initial = buildThreadStreamWindow(stream);
+  assert.equal(initial.items.length, stream.length);
+  assert.deepEqual(ids(buildThreadStreamWindow(stream, initial.startCursor)), ids(initial));
+  assert.equal(
+    buildThreadStreamWindow([...messages(1, 200), ...stream], initial.startCursor).items.length,
+    stream.length + 200,
+  );
+});
+
+test('a failed pre-armed request leaves retry behavior unchanged', () => {
+  const stream = messages(201, 200);
+  const initial = buildThreadStreamWindow(stream);
+  const failed = buildThreadStreamWindow(stream, initial.startCursor);
+  assert.deepEqual(ids(failed), ids(initial));
+  assert.equal(
+    buildThreadStreamWindow([...messages(1, 200), ...stream], failed.startCursor).items.length,
+    400,
+  );
+});

--- a/frontend/src/lib/utils/threadRouteOpening.test.js
+++ b/frontend/src/lib/utils/threadRouteOpening.test.js
@@ -1,10 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import {
   buildSyncedThreadRouteHref,
   decideThreadRouteSelection,
 } from '../features/cortex/domain/threadRouteOpening.ts';
+
+test('a superseded same-thread load remains successful for URL synchronization', () => {
+  const source = readFileSync(new URL('../stores/cortex.svelte.ts', import.meta.url), 'utf8');
+  const loadDirectThread = source.match(/async loadDirectThread[\s\S]*?\n  async selectIdea/)?.[0] ?? '';
+  assert.match(loadDirectThread, /const applied = this\._applyThreadStreamPage/);
+  assert.match(loadDirectThread, /return applied \|\| this\.selectedIdeaId === id;/);
+});
 
 test('thread routes load through the direct thread path', () => {
   assert.deepEqual(

--- a/frontend/src/lib/utils/threadStreamOrdering.test.js
+++ b/frontend/src/lib/utils/threadStreamOrdering.test.js
@@ -19,7 +19,7 @@ test('windows newest 200 and repeated cursors reveal the complete stream', () =>
   let window = buildThreadStreamWindow(stream);
   const sizes = [window.items.length];
   assert.deepEqual(window.items, stream.slice(800));
-  while (window.hasEarlier) {
+  while (window.previousCursor) {
     assert.ok(window.previousCursor);
     window = buildThreadStreamWindow(stream, window.previousCursor);
     sizes.push(window.items.length);
@@ -88,7 +88,7 @@ test('one previous cursor crosses a retained protected span to reveal 200 hidden
   const newlyVisible = expanded.items.filter((item) => !initial.items.includes(item) && !item.metadata?.run_id);
   assert.equal(newlyVisible.length, 200);
   assert.equal(newlyVisible[0].id, 'message-50');
-  assert.equal(expanded.hasEarlier, true);
+  assert.ok(expanded.previousCursor);
 });
 
 test('places queued follow-up messages after the run reply they are waiting for', () => {

--- a/frontend/src/lib/utils/threadStreamOrdering.ts
+++ b/frontend/src/lib/utils/threadStreamOrdering.ts
@@ -68,7 +68,7 @@ function cursorIndex<T extends ThreadStreamOrderingItem>(items: readonly T[], cu
 export function buildThreadStreamWindow<T extends ThreadStreamOrderingItem>(
   items: readonly T[],
   before: ThreadStreamWindowCursor | null = null,
-): { items: T[]; previousCursor: ThreadStreamWindowCursor | null; hasEarlier: boolean } {
+): { items: T[]; startCursor: ThreadStreamWindowCursor; previousCursor: ThreadStreamWindowCursor | null } {
   const protectedItems = protectedIndices(items);
   let start = before ? cursorIndex(items, before) : Math.max(0, items.length - THREAD_STREAM_WINDOW_BATCH_SIZE);
   if (before) {
@@ -79,10 +79,11 @@ export function buildThreadStreamWindow<T extends ThreadStreamOrderingItem>(
     }
   }
   const hasEarlier = items.some((_, index) => index < start && !protectedItems.has(index));
+  const startCursor = { index: start, key: items.length ? itemKey(items[start]) : '' };
   return {
     items: items.filter((_, index) => index >= start || protectedItems.has(index)),
-    previousCursor: hasEarlier ? { index: start, key: itemKey(items[start]) } : null,
-    hasEarlier,
+    startCursor,
+    previousCursor: hasEarlier ? startCursor : null,
   };
 }
 

--- a/frontend/src/lib/utils/workspaceSceneLifecycle.test.js
+++ b/frontend/src/lib/utils/workspaceSceneLifecycle.test.js
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const workspaceSceneSource = readFileSync(
+  new URL('../features/workspace-scene/components/WorkspaceScene.svelte', import.meta.url),
+  'utf8',
+);
+
+function functionSource(name) {
+  const start = workspaceSceneSource.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} should exist`);
+
+  let parameterDepth = 0;
+  let bodyStart = -1;
+  for (let index = start; index < workspaceSceneSource.length; index += 1) {
+    const char = workspaceSceneSource[index];
+    if (char === '(') parameterDepth += 1;
+    else if (char === ')') parameterDepth -= 1;
+    else if (char === '{' && parameterDepth === 0) {
+      bodyStart = index;
+      break;
+    }
+  }
+  assert.notEqual(bodyStart, -1, `${name} body should exist`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < workspaceSceneSource.length; index += 1) {
+    const char = workspaceSceneSource[index];
+    if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return workspaceSceneSource.slice(start, index + 1);
+    }
+  }
+
+  throw new Error(`${name} source is incomplete`);
+}
+
+test('workspace orbit heat always cools to zero and only runs while visible', () => {
+  const heatOrbit = functionSource('heatOrbit');
+
+  assert.match(heatOrbit, /\.alphaTarget\(0\)/);
+  assert.match(heatOrbit, /Math\.max\(simulation\.alpha\(\), alpha\)/);
+  assert.match(heatOrbit, /document\.visibilityState !== 'visible'/);
+  assert.match(heatOrbit, /schedulePrimitiveOrbitVisuals/);
+  assert.match(heatOrbit, /simulation\.restart\(\)/);
+  assert.ok(heatOrbit.indexOf('.alphaTarget(0)') < heatOrbit.indexOf("visibilityState !== 'visible'"));
+  assert.ok(heatOrbit.indexOf("visibilityState !== 'visible'") < heatOrbit.indexOf('simulation.restart()'));
+});
+
+test('workspace orbit has no permanent heat, random force, or periodic wake machinery', () => {
+  assert.doesNotMatch(workspaceSceneSource, /\.force\('brownian'/);
+  const alphaTargets = Array.from(
+    workspaceSceneSource.matchAll(/\.alphaTarget\(([^)]*)\)/g),
+    (match) => match[1].trim(),
+  );
+  assert.deepEqual(alphaTargets, ['0', '0']);
+  assert.equal(workspaceSceneSource.match(/simulation\.restart\(\)/g)?.length, 1);
+  assert.doesNotMatch(workspaceSceneSource, /workspaceMotionSuspended|suspendWorkspaceMotion|resumeWorkspaceMotion/);
+  assert.doesNotMatch(workspaceSceneSource, /lastOrbitTickAt|ORBIT_WAKE_CHECK_INTERVAL_MS|ORBIT_STALE_AFTER_MS|orbitWakeCheckInterval|checkOrbitMotionHealth/);
+});
+
+test('workspace visibility stops hidden work and resumes only retained heat', () => {
+  const visibility = functionSource('handleVisibilityChange');
+  const mount = workspaceSceneSource.match(/onMount\(\(\) => \{[\s\S]*?\n  \}\);/)?.[0] ?? '';
+
+  assert.match(visibility, /visibilityState === 'hidden'/);
+  assert.match(visibility, /simulation\.stop\(\)/);
+  assert.match(visibility, /cancelPrimitiveOrbitVisualSync\(\)/);
+  assert.match(visibility, /simulation\.alpha\(\) < simulation\.alphaMin\(\)/);
+  assert.match(visibility, /heatOrbit\(0\)/);
+  assert.match(workspaceSceneSource, /simulation = createSim[\s\S]*?paused \|\| document\.visibilityState !== 'visible'\) simulation\.stop\(\)/);
+  assert.doesNotMatch(mount, /handleVisibilityChange\(\)/);
+});
+
+test('workspace pause survives rebuilds and restores an open thread anchor', () => {
+  const togglePause = functionSource('handleTogglePause');
+  const resetRuntime = functionSource('resetRenderRuntime');
+  const renderCanvas = functionSource('renderCanvas');
+  const restoreThreadAnchor = functionSource('restoreThreadAnchorState');
+  const syncThreadAnchor = functionSource('syncThreadAnchor');
+
+  assert.match(togglePause, /if \(paused\)[\s\S]*restoreThreadAnchorState\([\s\S]*stopActiveSimulation\(\)/);
+  assert.match(togglePause, /else \{\s*renderCanvas\(\{ preserveViewport: true \}\);\s*\}/);
+  assert.match(resetRuntime, /restoreThreadAnchorState\([\s\S]*stopActiveSimulation\(\)/);
+  assert.match(renderCanvas, /untrack\(syncThreadAnchor\)/);
+  assert.ok(restoreThreadAnchor.indexOf('previousNode.fx = previous.fx') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.ok(restoreThreadAnchor.indexOf('previousNode.fy = previous.fy') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.ok(restoreThreadAnchor.indexOf('delete previousNode._threadAnchorPinned') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.match(syncThreadAnchor, /if \(destroyed \|\| !simulation\) return;/);
+  assert.match(workspaceSceneSource, /if \(paused \|\| document\.visibilityState !== 'visible'\) simulation\.stop\(\)/);
+});
+
+test('workspace settle finalizes primitive motion and persists once', () => {
+  const endHandler = workspaceSceneSource.match(/simulation\.on\('end', \(\) => \{[\s\S]*?\n    \}\);/)?.[0] ?? '';
+
+  assert.match(endHandler, /cancelPrimitiveOrbitVisualSync\(\)/);
+  assert.match(endHandler, /syncPrimitiveMotionVisuals\(nodes\)/);
+  assert.match(endHandler, /persistSceneIdeaPositions\(positions\)/);
+  assert.equal(endHandler.match(/syncPrimitiveMotionVisuals\(nodes\)/g)?.length, 1);
+  assert.equal(endHandler.match(/persistSceneIdeaPositions\(positions\)/g)?.length, 1);
+});
+
+test('workspace focus flow is event-driven instead of polled', () => {
+  const updateFlow = functionSource('updateFlowState');
+
+  assert.match(updateFlow, /if \(destroyed\) return;/);
+  assert.match(workspaceSceneSource, /document\.addEventListener\('focusin', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.addEventListener\('focusout', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('focusin', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('focusout', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('visibilitychange', handleVisibilityChange\)/);
+  assert.match(workspaceSceneSource, /window\.removeEventListener\('cortex-fit-view', handleFitView\)/);
+  assert.match(workspaceSceneSource, /window\.removeEventListener\('cortex-toggle-pause', handleTogglePause\)/);
+  assert.doesNotMatch(workspaceSceneSource, /flowCheckInterval|setInterval\(checkFlowState/);
+});
+
+test('workspace topology and app wakes are signature-deduplicated', () => {
+  assert.match(workspaceSceneSource, /nextTopologyKey === connectionTopologyKey/);
+  assert.match(workspaceSceneSource, /linkForce\?\.links\(workspaceConnectionLinkData\(visible\)\)/);
+  assert.equal(workspaceSceneSource.match(/linkForce\?\.links\(workspaceConnectionLinkData\(visible\)\)/g)?.length, 1);
+  assert.match(workspaceSceneSource, /if \(layoutChanged\) heatOrbit\(0\.12\)/);
+  assert.doesNotMatch(workspaceSceneSource, /app\.updated_at/);
+});
+
+test('initial presence seeds without heat and later signature changes heat once', () => {
+  const presenceEffect = workspaceSceneSource.match(
+    /const typingEntries = Array\.from\(cortex\.typingUsers\.values\(\)\)[\s\S]*?heatOrbit\(0\.08\);/,
+  )?.[0] ?? '';
+
+  assert.match(workspaceSceneSource, /let presenceMotionKey: string \| null = null;/);
+  assert.match(presenceEffect, /`\$\{entry\.user_id\}:\$\{entry\.idea_id\}`/);
+  assert.match(presenceEffect, /new Set\(\s*presenceStore\.viewers\.map\(\(entry\) => entry\.user_id\)/);
+  assert.match(presenceEffect, /const initialPresence = presenceMotionKey === null;/);
+  assert.match(presenceEffect, /if \(!presenceChanged\) return;/);
+  assert.match(presenceEffect, /presenceMotionKey = nextPresenceMotionKey;\s*refreshOrbitVisualState\(\);\s*if \(!initialPresence\) heatOrbit\(0\.08\);/);
+});
+
+test('accepted archive mutations start before teardown-stoppable visual frames', () => {
+  assert.match(workspaceSceneSource, /let destroyed = false;/);
+  assert.match(workspaceSceneSource, /onDestroy\(\(\) => \{\s*destroyed = true;/);
+
+  const localFrameFunctions = [
+    ['popPrimitiveBlob', 'tick', 'cortex.deleteIdea(nodeId)'],
+    ['animatePinDeleteToBin', 'archiveTick', 'onpindelete({ pinId: pin.pinId })'],
+    ['animateAppArchiveToBin', 'archiveTick', 'onapparchive?.({ appId: app.id })'],
+    ['animateArchiveToBin', 'archiveTick', 'cortex.deleteIdea(d.id)'],
+  ];
+  for (const [owner, callback, mutation] of localFrameFunctions) {
+    const source = functionSource(owner);
+    assert.match(
+      source,
+      new RegExp(`function ${callback}\\([^)]*\\) \\{\\s*if \\(destroyed\\) return;`),
+      `${owner} should stop its local frame after teardown`,
+    );
+    assert.ok(
+      source.indexOf(mutation) < source.indexOf(`requestAnimationFrame(${callback})`),
+      `${owner} should start its accepted mutation before its first visual frame`,
+    );
+  }
+});

--- a/scripts/benchmark_frontend.mjs
+++ b/scripts/benchmark_frontend.mjs
@@ -84,6 +84,7 @@ const STRESS_READY_IMPROVEMENT_TARGET_PCT = 10;
 const STRESS_DOM_NODE_BUDGET = 4000;
 const STRESS_TASK_P50_BUDGET_MS = 450;
 const STRESS_LONG_TASK_P95_BUDGET_MS = 250;
+const WORKSPACE_IDLE_WAKE_BUDGET_MS = 34;
 const APP_ASSET_RESOURCE_TYPES = new Set(['Script', 'Stylesheet']);
 const VITE_CLIENT_MANIFEST_URL = new URL(
   '../frontend/.svelte-kit/output/client/.vite/manifest.json',
@@ -165,6 +166,9 @@ function parseArgs(argv) {
     json: false,
     keepChromeProfile: false,
     manifest: null,
+    workspaceIdle: false,
+    idleSettleMs: 10_000,
+    idleWindowMs: 10_000,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -196,6 +200,9 @@ function parseArgs(argv) {
     else if (arg === '--json') options.json = true;
     else if (arg === '--keep-chrome-profile') options.keepChromeProfile = true;
     else if (arg === '--manifest') options.manifest = next();
+    else if (arg === '--workspace-idle') options.workspaceIdle = true;
+    else if (arg === '--idle-settle-ms') options.idleSettleMs = Number(next());
+    else if (arg === '--idle-window-ms') options.idleWindowMs = Number(next());
     else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -214,6 +221,12 @@ function parseArgs(argv) {
   if (!Number.isFinite(options.ideas) || options.ideas < 1) throw new Error('--ideas must be >= 1');
   if (!Number.isFinite(options.connections) || options.connections < 0) throw new Error('--connections must be >= 0');
   if (!Number.isFinite(options.streamItems) || options.streamItems < 0) throw new Error('--stream-items must be >= 0');
+  if (![options.idleSettleMs, options.idleWindowMs].every((value) => Number.isFinite(value) && value >= 0)) {
+    throw new Error('workspace idle durations must be >= 0');
+  }
+  if (options.workspaceIdle && options.scenarios.some((scenario) => !['workspace', 'threadCanonical'].includes(scenario))) {
+    throw new Error('--workspace-idle supports only workspace and threadCanonical scenarios');
+  }
   if (!['legacy', 'paged'].includes(options.streamContract)) {
     throw new Error('--stream-contract must be legacy or paged');
   }
@@ -240,6 +253,9 @@ Options:
   --out PATH                  Write the full JSON report to PATH
   --compare BEFORE,AFTER      Print a before/after win chart from two JSON reports
   --manifest PATH             Vite client manifest for the target build
+  --workspace-idle            Measure settled workspace/browser idle behavior
+  --idle-settle-ms N          Settle delay before idle measurement (default: 10000)
+  --idle-window-ms N          Idle measurement window (default: 10000)
   --allow-unknown-api         Do not fail when the app calls an unmocked API route
   --json                      Print machine-readable JSON
 `);
@@ -892,6 +908,7 @@ function mockApiResponse(method, url, fixture) {
   if (pathName === '/api/cortex/ideas') {
     return jsonResponse(200, fixture.ideas, { label: 'GET /api/cortex/ideas' });
   }
+  if (pathName === '/api/cortex/ideas/positions' && methodUpper === 'PUT') return jsonResponse(200, { ok: true }, { label: 'PUT /api/cortex/ideas/positions', sidecar: true });
   if (pathName === '/api/cortex/bootstrap') {
     const include = new Set(
       (url.searchParams.get('include') || 'core')
@@ -1148,6 +1165,151 @@ function performanceDurationMs(before, after, name) {
   return (end - start) * 1000;
 }
 
+async function workspaceIdleSnapshot(client) {
+  return evaluate(client, `(() => {
+    const value = window.__illoBench?.workspaceIdle;
+    return value ? { available: value.available, rafExecuted: value.rafExecuted,
+      signalStyleWrites: value.signalStyleWrites } : { available: false };
+  })()`);
+}
+
+function workspaceIdleCounterDelta(before, after) {
+  return {
+    rafCallbacks: after.rafExecuted - before.rafExecuted,
+    signalStyleWrites: after.signalStyleWrites - before.signalStyleWrites,
+  };
+}
+
+async function measureWorkspaceIdleWindow(client, durationMs) {
+  const beforeSnapshot = await workspaceIdleSnapshot(client);
+  const beforePerformance = await performanceMetrics(client);
+  await sleep(durationMs);
+  const afterPerformance = await performanceMetrics(client);
+  const afterSnapshot = await workspaceIdleSnapshot(client);
+  const counters = workspaceIdleCounterDelta(beforeSnapshot, afterSnapshot);
+  const taskDurationMs = performanceDurationMs(beforePerformance, afterPerformance, 'TaskDuration');
+  const scriptDurationMs = performanceDurationMs(beforePerformance, afterPerformance, 'ScriptDuration');
+  return {
+    available: beforeSnapshot.available === true && afterSnapshot.available === true &&
+      [taskDurationMs, scriptDurationMs, counters.rafCallbacks, counters.signalStyleWrites].every(Number.isFinite),
+    taskDurationMs,
+    scriptDurationMs,
+    ...counters,
+  };
+}
+
+async function setWorkspaceIdleVisibility(client, state) {
+  return evaluate(client, `window.__illoBench?.workspaceIdle?.setVisibilityState?.(${JSON.stringify(state)}) ?? null`);
+}
+
+async function measureWorkspaceIdleHiddenControl(client, hiddenMs) {
+  let restored = false;
+  try {
+    const hiddenState = await setWorkspaceIdleVisibility(client, 'hidden');
+    if (hiddenState !== 'hidden') return { available: false, reason: 'visibility override did not enter hidden state' };
+    await sleep(100);
+    const hiddenBefore = await workspaceIdleSnapshot(client);
+    await sleep(hiddenMs);
+    const hiddenAfter = await workspaceIdleSnapshot(client);
+    const visibleState = await setWorkspaceIdleVisibility(client, 'visible');
+    restored = visibleState === 'visible';
+    const visibleBefore = await workspaceIdleSnapshot(client);
+    await sleep(500);
+    const visibleAfter = await workspaceIdleSnapshot(client);
+    return {
+      available: restored && hiddenBefore.available && hiddenAfter.available,
+      ...workspaceIdleCounterDelta(hiddenBefore, hiddenAfter),
+      resumeRafCallbacks: visibleAfter.rafExecuted - visibleBefore.rafExecuted,
+      resumeSignalStyleWrites: visibleAfter.signalStyleWrites - visibleBefore.signalStyleWrites,
+    };
+  } finally {
+    if (!restored) await setWorkspaceIdleVisibility(client, 'visible').catch(() => {});
+  }
+}
+
+async function waitForWorkspaceIdleProbe(client, timeoutMs) {
+  await waitForExpression(
+    client,
+    `(() => {
+      const probe = window.__illoBench?.workspaceIdle?.activeProbe;
+      return Number.isFinite(probe?.firstRafMs) && Number.isFinite(probe?.firstSignalStyleMs);
+    })()`,
+    timeoutMs,
+  ).catch(() => null);
+  return evaluate(client, 'window.__illoBench?.workspaceIdle?.activeProbe ?? null');
+}
+
+async function finishWorkspaceWakeProbe(client, matchedExpression = 'true') {
+  const probe = await waitForWorkspaceIdleProbe(client, 1_200);
+  const matched = await evaluate(client, matchedExpression);
+  const wakeTimestamps = [probe?.firstRafMs, probe?.firstSignalStyleMs];
+  const available = matched === true && wakeTimestamps.every(Number.isFinite);
+  return { available, resumeMs: available ? Math.max(...wakeTimestamps) : null };
+}
+
+async function measureWorkspaceMutationWake(client) {
+  const dispatched = await evaluate(client, `(() => {
+    const telemetry = window.__illoBench?.workspaceIdle;
+    const socket = telemetry?.sockets?.find((candidate) => candidate.readyState === 1);
+    const signal = document.querySelector('[data-constellation-signal-id="idea-2"]');
+    if (!telemetry || !socket || !(signal instanceof HTMLElement)) return null;
+    telemetry.beginProbe();
+    socket.__dispatch({
+      type: 'message',
+      data: JSON.stringify({ type: 'idea_updated', idea_id: 'idea-2', fields: { status: 'done' } }),
+    });
+    return true;
+  })()`);
+  if (!dispatched) return { available: false };
+  return finishWorkspaceWakeProbe(client,
+    `document.querySelector('[data-constellation-signal-id="idea-2"]')?.classList.contains('constellation-signal-blob-cue-attention') === true`,
+  );
+}
+
+async function measureWorkspaceDragWake(client) {
+  const target = await evaluate(client, `(() => {
+    const telemetry = window.__illoBench?.workspaceIdle;
+    const signal = document.querySelector('[data-constellation-signal-id="idea-3"]') ||
+      document.querySelector('[data-constellation-signal-id]');
+    if (!telemetry || !(signal instanceof HTMLElement)) return null;
+    const rect = signal.getBoundingClientRect();
+    telemetry.beginProbe();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  })()`);
+  if (!target) return { available: false };
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mousePressed', x: target.x, y: target.y, button: 'left', buttons: 1, clickCount: 1,
+  });
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved', x: target.x + 36, y: target.y + 18, button: 'left', buttons: 1,
+  });
+  const probe = await finishWorkspaceWakeProbe(client);
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased', x: target.x + 36, y: target.y + 18, button: 'left', buttons: 0, clickCount: 1,
+  });
+  return probe;
+}
+
+async function measureWorkspaceIdleContract(client, scenario, options) {
+  await sleep(options.idleSettleMs);
+  const idle = await measureWorkspaceIdleWindow(client, options.idleWindowMs);
+  const hidden = await measureWorkspaceIdleHiddenControl(client, 2_000);
+  if (scenario.directThread) return { available: idle.available && hidden.available, idle, hidden };
+  const mutation = await measureWorkspaceMutationWake(client);
+  await sleep(6_500);
+  const drag = await measureWorkspaceDragWake(client);
+  return {
+    available: idle.available && hidden.available && mutation.available && drag.available,
+    idle,
+    hidden,
+    mutation,
+    drag,
+  };
+}
+
 async function waitForExpression(client, expression, timeoutMs) {
   const started = performance.now();
   const deadline = started + timeoutMs;
@@ -1188,7 +1350,7 @@ async function waitForExpression(client, expression, timeoutMs) {
   );
 }
 
-function installPageInstrumentationSource() {
+function installPageInstrumentationSource(workspaceIdle = false) {
   return `(() => {
     window.__illoBench = {
       longTasks: [],
@@ -1198,6 +1360,59 @@ function installPageInstrumentationSource() {
       errors: [],
       wsMessages: [],
     };
+
+    ${workspaceIdle ? `
+    const idle = window.__illoBench.workspaceIdle = {
+      available: true,
+      rafExecuted: 0,
+      signalStyleWrites: 0,
+      activeProbe: null,
+      sockets: [],
+    };
+
+    idle.beginProbe = () => idle.activeProbe = { startedAt: performance.now(), firstRafMs: null, firstSignalStyleMs: null };
+
+    const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+    window.requestAnimationFrame = (callback) => nativeRequestAnimationFrame((timestamp) => {
+        idle.rafExecuted += 1;
+        const probe = idle.activeProbe;
+        if (probe && probe.firstRafMs === null) probe.firstRafMs = performance.now() - probe.startedAt;
+        return callback(timestamp);
+      });
+
+    try {
+      const mutationObserver = new MutationObserver((records) => {
+        for (const record of records) {
+          if (!(record.target instanceof Element) || !record.target.matches('[data-constellation-signal-id]')) continue;
+          idle.signalStyleWrites += 1;
+          const probe = idle.activeProbe;
+          if (probe && probe.firstSignalStyleMs === null) probe.firstSignalStyleMs = performance.now() - probe.startedAt;
+        }
+      });
+      mutationObserver.observe(document, { subtree: true, attributes: true, attributeFilter: ['style'] });
+    } catch (error) {
+      idle.available = false;
+      window.__illoBench.errors.push('workspace idle mutation observer: ' + String(error?.message || error));
+    }
+
+    try {
+      const nativeVisibilityState = document.visibilityState;
+      let visibilityOverride = null;
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => visibilityOverride ?? nativeVisibilityState,
+      });
+      idle.setVisibilityState = (state) => {
+        if (state !== 'visible' && state !== 'hidden') throw new Error('unsupported visibility state');
+        visibilityOverride = state;
+        document.dispatchEvent(new Event('visibilitychange'));
+        return document.visibilityState;
+      };
+    } catch (error) {
+      idle.available = false;
+      window.__illoBench.errors.push('workspace idle visibility override: ' + String(error?.message || error));
+    }
+    ` : ''}
 
     window.addEventListener('error', (event) => {
       window.__illoBench.errors.push(String(event.message || 'unknown error'));
@@ -1256,6 +1471,7 @@ function installPageInstrumentationSource() {
         this.onerror = null;
         this.onclose = null;
         this.__listeners = new Map();
+        window.__illoBench.workspaceIdle?.sockets.push(this);
         queueMicrotask(() => {
           if (this.readyState !== BenchWebSocket.CONNECTING) return;
           this.readyState = BenchWebSocket.OPEN;
@@ -1322,7 +1538,7 @@ async function configurePage(client, fixture, options, apiCalls) {
     patterns: [{ urlPattern: '*://*/api/*', requestStage: 'Request' }],
   });
   const instrumentation = await client.send('Page.addScriptToEvaluateOnNewDocument', {
-    source: installPageInstrumentationSource(),
+    source: installPageInstrumentationSource(options.workspaceIdle),
   });
 
   const pendingMocks = new Set();
@@ -2066,6 +2282,9 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
         decodedBodySize: navigation?.decodedBodySize ?? 0,
       };
     })()`);
+    const workspaceIdleContract = options.workspaceIdle
+      ? await measureWorkspaceIdleContract(client, scenario, options)
+      : null;
     const performanceMetricsAfter = await performanceMetrics(client);
     const taskDurationMs = performanceDurationMs(
       performanceMetricsBefore,
@@ -2171,6 +2390,7 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
       readyMs,
       postCloseReadyMs,
       requestContract,
+      workspaceIdleContract,
       lazyAssetContract,
       historyContract,
       apiCallCount: measuredApiCalls.length,
@@ -2307,6 +2527,37 @@ function summarizeScenario(samples) {
   const longTaskTotalValues = finiteValues('longTaskTotalMs');
   const maxLongTaskValues = finiteValues('maxLongTaskMs');
   const domNodeValues = finiteValues('domNodes');
+  const workspaceIdleSamples = measuredSamples
+    .map((sample) => sample.workspaceIdleContract)
+    .filter(Boolean);
+  const workspaceIdleValues = (path) => workspaceIdleSamples
+    .map((sample) => path.reduce((value, key) => value?.[key], sample))
+    .filter(Number.isFinite);
+  const summarizeWorkspaceIdle = (path) => summarizeNumbers(workspaceIdleValues(path));
+  const workspaceInteractionSamples = workspaceIdleSamples.filter((sample) => sample.mutation);
+  const workspaceIdleTelemetryAvailable = workspaceIdleSamples.length === measuredSamples.length &&
+    workspaceIdleSamples.every((sample) => sample.available === true);
+  const workspaceIdleNoPeriodicWake = workspaceIdleSamples.length === measuredSamples.length &&
+    workspaceIdleSamples.every((sample) => (
+    sample.idle?.available === true &&
+    sample.idle.rafCallbacks === 0 &&
+    sample.idle.signalStyleWrites === 0 &&
+    sample.hidden?.available === true &&
+    sample.hidden.rafCallbacks === 0 &&
+    sample.hidden.signalStyleWrites === 0 &&
+    sample.hidden.resumeRafCallbacks === 0 &&
+    sample.hidden.resumeSignalStyleWrites === 0
+  ));
+  const wakeSummary = (key) => summarizeNumbers(
+    workspaceInteractionSamples.map((sample) => sample[key]?.resumeMs).filter(Number.isFinite),
+  );
+  const mutationWake = wakeSummary('mutation');
+  const dragWake = wakeSummary('drag');
+  const workspaceIdleInteractionContractPassed = workspaceInteractionSamples.length === 0 || (
+    workspaceInteractionSamples.length === measuredSamples.length &&
+    workspaceInteractionSamples.every((sample) => sample.mutation?.available && sample.drag?.available) &&
+    mutationWake.p95 <= WORKSPACE_IDLE_WAKE_BUDGET_MS && dragWake.p95 <= WORKSPACE_IDLE_WAKE_BUDGET_MS
+  );
 
   return {
     runs: measuredSamples.length,
@@ -2477,6 +2728,15 @@ function summarizeScenario(samples) {
     long_task_count: summarizeNumbers(longTaskCountValues),
     long_task_total_ms: summarizeNumbers(longTaskTotalValues),
     max_long_task_ms: summarizeNumbers(maxLongTaskValues),
+    workspace_idle_telemetry_available: workspaceIdleTelemetryAvailable,
+    workspace_idle_no_periodic_wake: workspaceIdleNoPeriodicWake,
+    workspace_idle_interaction_contract_passed: workspaceIdleInteractionContractPassed,
+    workspace_idle_task_duration_ms: summarizeWorkspaceIdle(['idle', 'taskDurationMs']),
+    workspace_idle_script_duration_ms: summarizeWorkspaceIdle(['idle', 'scriptDurationMs']),
+    workspace_idle_raf_callbacks: summarizeWorkspaceIdle(['idle', 'rafCallbacks']),
+    workspace_idle_signal_style_writes: summarizeWorkspaceIdle(['idle', 'signalStyleWrites']),
+    workspace_idle_mutation_resume_ms: mutationWake,
+    workspace_idle_drag_resume_ms: dragWake,
     routes,
     post_close_routes: postCloseRoutes,
     all_routes: allRoutes,
@@ -2722,7 +2982,7 @@ function pctDelta(before, after) {
 
 const COMPARISON_CONFIG_KEYS = [
   'runs', 'warmups', 'ideas', 'connections', 'streamItems', 'apiLatencyMs', 'sidecarLatencyMs',
-  'timeoutMs', 'allowUnknownApi',
+  'timeoutMs', 'allowUnknownApi', 'workspaceIdle', 'idleSettleMs', 'idleWindowMs',
 ];
 
 function comparisonSignature(result, scenarioKeys) {
@@ -2841,11 +3101,12 @@ function paginationAbsoluteFailures(key, summary, config) {
 function comparisonFailures(before, after, scenarioKeys) {
   const failures = [];
   const paginationComparison = isPaginationComparison(before, after);
+  const workspaceIdleComparison = before.config.workspaceIdle === true && after.config.workspaceIdle === true;
   const hasStreamContract = Boolean(before.config.streamContract || after.config.streamContract);
   if (comparisonSignature(before, scenarioKeys) !== comparisonSignature(after, scenarioKeys)) {
     failures.push('before/after benchmark config signatures differ');
   }
-  if (hasStreamContract && !paginationComparison) {
+  if (hasStreamContract && !paginationComparison && !workspaceIdleComparison) {
     failures.push('pagination comparison requires legacy before and paged after contracts');
   }
 
@@ -2885,6 +3146,31 @@ function comparisonFailures(before, after, scenarioKeys) {
       failures.push(`${key}: comparable FCP unavailable`);
     } else if ((!stress || paginationComparison) && !withinRegressionBudget(beforeFcp, afterFcp)) {
       failures.push(`${key}: FCP p50 regression >${MAX_REGRESSION_PCT}%`);
+    }
+
+    if (workspaceIdleComparison) {
+      if (!beforeScenario.summary.workspace_idle_telemetry_available || !summary.workspace_idle_telemetry_available) {
+        failures.push(`${key}: workspace idle telemetry unavailable`);
+      }
+      if (!directThread) {
+        const reductions = [
+          ['rAF callbacks', 'workspace_idle_raf_callbacks', 95],
+          ['signal style writes', 'workspace_idle_signal_style_writes', 95],
+          ['ScriptDuration', 'workspace_idle_script_duration_ms', 80],
+          ['TaskDuration', 'workspace_idle_task_duration_ms', 40],
+        ];
+        for (const [label, metric, target] of reductions) {
+          const beforeValue = beforeScenario.summary[metric]?.p50;
+          const afterValue = summary[metric]?.p50;
+          if (!Number.isFinite(beforeValue) || !Number.isFinite(afterValue) || beforeValue <= 0) {
+            failures.push(`${key}: comparable idle ${label} unavailable`);
+          } else if (-pctDelta(beforeValue, afterValue) < target) {
+            failures.push(`${key}: idle ${label} reduction <${target}%`);
+          }
+        }
+        if (!summary.workspace_idle_no_periodic_wake) failures.push(`${key}: settled workspace JS woke periodically`);
+        if (!summary.workspace_idle_interaction_contract_passed) failures.push(`${key}: interaction wake p95 >${WORKSPACE_IDLE_WAKE_BUDGET_MS}ms`);
+      }
     }
 
     if (stress && !paginationComparison) {
@@ -3055,6 +3341,7 @@ async function main() {
         sidecarLatencyMs: options.sidecarLatencyMs,
         timeoutMs: options.timeoutMs,
         allowUnknownApi: options.allowUnknownApi,
+        workspaceIdle: options.workspaceIdle, idleSettleMs: options.idleSettleMs, idleWindowMs: options.idleWindowMs,
         lazyAssetManifest: {
           threadStageModuleId: lazyAssetClosures.threadStage.moduleId,
           threadStageAssetCount: lazyAssetClosures.threadStage.assets.length,
@@ -3082,6 +3369,11 @@ async function main() {
       scenario.summary.rare_pane_first_open_ms.p75 > 0 &&
       scenario.summary.rare_pane_first_open_budget_passed === false
     ));
+    const idleTelemetryFailures = options.workspaceIdle
+      ? result.scenarios
+          .filter((scenario) => scenario.summary.workspace_idle_telemetry_available !== true)
+          .map((scenario) => `${scenario.key}: telemetry unavailable`)
+      : [];
     const threadFailures = result.scenarios.flatMap((scenario) => {
       if (!SCENARIOS[scenario.key]?.directThread) return [];
       const failures = directThreadHistoryFailures(scenario.key, scenario.summary);
@@ -3121,6 +3413,9 @@ async function main() {
     }
     if (threadFailures.length) {
       throw new Error(`Thread benchmark contract failed:\n${threadFailures.map((failure) => `- ${failure}`).join('\n')}`);
+    }
+    if (idleTelemetryFailures.length) {
+      throw new Error(`Workspace idle telemetry failed:\n${idleTelemetryFailures.map((failure) => `- ${failure}`).join('\n')}`);
     }
   } finally {
     client.close();

--- a/scripts/benchmark_frontend.mjs
+++ b/scripts/benchmark_frontend.mjs
@@ -10,6 +10,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
+import { gzipSync } from 'node:zlib';
 
 const DEFAULT_BASE_URL = 'http://127.0.0.1:5178';
 const DEFAULT_CHROME_PATHS = [
@@ -74,6 +75,9 @@ const DIRECT_THREAD_STARTUP_PAYLOAD_BUDGET_KB = 35.5;
 const DIRECT_ROUTE_P50_GAP_BUDGET_PCT = 5;
 const MAX_REGRESSION_PCT = 5;
 const THREAD_HISTORY_WINDOW_SIZE = 200;
+const THREAD_PAGE_RAW_BUDGET_BYTES = 180 * 1024;
+const THREAD_PAGE_FETCH_BUDGET_MS = 250;
+const THREAD_STARTUP_PAYLOAD_REDUCTION_TARGET_PCT = 75;
 const THREAD_HISTORY_REVEAL_BUDGET_MS = 150;
 const THREAD_HISTORY_VIEWPORT_DRIFT_BUDGET_PX = 2;
 const STRESS_READY_IMPROVEMENT_TARGET_PCT = 10;
@@ -149,6 +153,7 @@ function parseArgs(argv) {
     ideas: 120,
     connections: 240,
     streamItems: 80,
+    streamContract: 'paged',
     apiLatencyMs: 0,
     sidecarLatencyMs: null,
     timeoutMs: 20000,
@@ -179,6 +184,7 @@ function parseArgs(argv) {
     } else if (arg === '--ideas') options.ideas = Number(next());
     else if (arg === '--connections') options.connections = Number(next());
     else if (arg === '--stream-items') options.streamItems = Number(next());
+    else if (arg === '--stream-contract') options.streamContract = next();
     else if (arg === '--api-latency-ms') options.apiLatencyMs = Number(next());
     else if (arg === '--sidecar-latency-ms') options.sidecarLatencyMs = Number(next());
     else if (arg === '--timeout-ms') options.timeoutMs = Number(next());
@@ -208,6 +214,9 @@ function parseArgs(argv) {
   if (!Number.isFinite(options.ideas) || options.ideas < 1) throw new Error('--ideas must be >= 1');
   if (!Number.isFinite(options.connections) || options.connections < 0) throw new Error('--connections must be >= 0');
   if (!Number.isFinite(options.streamItems) || options.streamItems < 0) throw new Error('--stream-items must be >= 0');
+  if (!['legacy', 'paged'].includes(options.streamContract)) {
+    throw new Error('--stream-contract must be legacy or paged');
+  }
   return options;
 }
 
@@ -222,6 +231,7 @@ Options:
   --ideas N                   Mock thread count (default: 120)
   --connections N             Mock connection count (default: 240)
   --stream-items N            Mock thread transcript item count (default: 80)
+  --stream-contract NAME      legacy full array or paged response (default: paged)
   --api-latency-ms N          Artificial latency for every mocked API call (default: 0)
   --sidecar-latency-ms N      Latency for non-critical sidecar calls (default: api latency)
   --timeout-ms N              Per-run ready timeout (default: 20000)
@@ -578,6 +588,7 @@ function buildFixture(options) {
     ideas,
     connections,
     streamItems: buildStreamItems(options.streamItems),
+    streamContract: options.streamContract,
     chat: buildChatFixture(members),
     runtimeSettings: buildRuntimeSettingsFixture(),
     teamTokenAnalytics: buildTeamTokenAnalyticsFixture(members),
@@ -788,7 +799,40 @@ function buildChatFixture(members) {
   };
 }
 
+function threadStreamPage(streamItems, ideaId, before = null, limit = THREAD_HISTORY_WINDOW_SIZE) {
+  const cursorMatch = before?.match(/^bench-before-(\d+)$/) ?? null;
+  if (before && !cursorMatch) return null;
+  const end = cursorMatch ? Number(cursorMatch[1]) : streamItems.length;
+  if (!Number.isInteger(end) || end < 0 || end > streamItems.length) return null;
+  const start = Math.max(0, end - limit);
+  return {
+    idea_id: ideaId,
+    items: streamItems.slice(start, end),
+    has_more: start > 0,
+    next_before: start > 0 ? `bench-before-${start}` : null,
+  };
+}
+
+function mockThreadStreamPayload(fixture, ideaId, url, direct = false) {
+  if (fixture.streamContract === 'legacy') {
+    return direct
+      ? { idea_id: ideaId, stream: fixture.streamItems }
+      : fixture.streamItems;
+  }
+  const requestedLimit = Number(url.searchParams.get('limit') || THREAD_HISTORY_WINDOW_SIZE);
+  if (!Number.isInteger(requestedLimit) || requestedLimit < 1 || requestedLimit > THREAD_HISTORY_WINDOW_SIZE) {
+    return null;
+  }
+  return threadStreamPage(
+    fixture.streamItems,
+    ideaId,
+    url.searchParams.get('before'),
+    requestedLimit,
+  );
+}
+
 function jsonResponse(status, body, extra = {}) {
+  const threadPayloadText = extra.threadPayload ? JSON.stringify(extra.threadPayload) : null;
   return {
     status,
     body,
@@ -800,6 +844,10 @@ function jsonResponse(status, body, extra = {}) {
     label: extra.label,
     sidecar: Boolean(extra.sidecar),
     unknown: Boolean(extra.unknown),
+    threadPageKind: extra.threadPageKind ?? null,
+    threadPageItems: extra.threadPageItems ?? null,
+    threadPayloadBytes: threadPayloadText ? Buffer.byteLength(threadPayloadText) : null,
+    threadPayloadGzipBytes: threadPayloadText ? gzipSync(threadPayloadText).byteLength : null,
   };
 }
 
@@ -870,13 +918,20 @@ function mockApiResponse(method, url, fixture) {
       auth_status: include.has('auth_status') ? { setup_required: false, configured: true, provider: 'openai' } : null,
       meta: { include: [...include].sort() },
     };
+    let directThreadPayload = null;
     if (include.has('direct_thread')) {
-      body.direct_thread = {
-        idea_id: url.searchParams.get('idea_id') || 'idea-1',
-        stream: fixture.streamItems,
-      };
+      const ideaId = url.searchParams.get('idea_id') || 'idea-1';
+      directThreadPayload = mockThreadStreamPayload(fixture, ideaId, url, true);
+      body.direct_thread = directThreadPayload;
     }
-    return jsonResponse(200, body, { label: 'GET /api/cortex/bootstrap' });
+    return jsonResponse(200, body, {
+      label: 'GET /api/cortex/bootstrap',
+      threadPayload: directThreadPayload,
+      threadPageKind: directThreadPayload ? 'initial' : null,
+      threadPageItems: directThreadPayload
+        ? (directThreadPayload.items?.length ?? directThreadPayload.stream?.length ?? null)
+        : null,
+    });
   }
   if (pathName === '/api/cortex/connections') {
     return jsonResponse(200, fixture.connections, { label: 'GET /api/cortex/connections' });
@@ -886,7 +941,19 @@ function mockApiResponse(method, url, fixture) {
   }
   const unifiedStreamMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/unified-stream$/);
   if (unifiedStreamMatch) {
-    return jsonResponse(200, fixture.streamItems, { label: 'GET /api/cortex/ideas/{idea_id}/unified-stream' });
+    const payload = mockThreadStreamPayload(fixture, unifiedStreamMatch[1], url);
+    if (!payload) {
+      return jsonResponse(422, { detail: 'Invalid benchmark thread page cursor or limit' }, {
+        label: 'GET /api/cortex/ideas/{idea_id}/unified-stream',
+      });
+    }
+    const before = url.searchParams.get('before');
+    return jsonResponse(200, payload, {
+      label: 'GET /api/cortex/ideas/{idea_id}/unified-stream',
+      threadPayload: payload,
+      threadPageKind: fixture.streamContract === 'paged' ? (before ? 'older' : 'head') : 'legacy',
+      threadPageItems: payload.items?.length ?? payload.length,
+    });
   }
   const threadMessageMatch = pathName.match(/^\/api\/cortex\/ideas\/([^/]+)\/thread$/);
   if (threadMessageMatch && methodUpper === 'POST') {
@@ -1271,6 +1338,11 @@ async function configurePage(client, fixture, options, apiCalls) {
       label: response.label,
       status: response.status,
       bytes: Buffer.byteLength(bodyText),
+      gzipBytes: gzipSync(bodyText).byteLength,
+      threadPageKind: response.threadPageKind,
+      threadPageItems: response.threadPageItems,
+      threadPayloadBytes: response.threadPayloadBytes,
+      threadPayloadGzipBytes: response.threadPayloadGzipBytes,
       startedAt,
       fulfilledAt: null,
       durationMs: null,
@@ -1354,7 +1426,7 @@ function assertRequestContract(condition, scenario, expectation, calls) {
   );
 }
 
-function directThreadRequestContract(callsAtReady, scenario, streamItems) {
+function directThreadRequestContract(callsAtReady, scenario, streamItems, streamContract) {
   const bootstrapCalls = workspaceBootstrapCalls(callsAtReady);
   const directBootstrapCalls = directThreadBootstrapCalls(callsAtReady, scenario.ideaId);
   const directBootstrap = directBootstrapCalls[0] ?? null;
@@ -1386,6 +1458,12 @@ function directThreadRequestContract(callsAtReady, scenario, streamItems) {
     startupCalls: callsAtReady.length,
     startupPayloadKb,
     payloadBudgetKb,
+    streamContract,
+    initialBootstrapBytes: directBootstrap?.bytes ?? null,
+    initialBootstrapGzipBytes: directBootstrap?.gzipBytes ?? null,
+    initialThreadPayloadBytes: directBootstrap?.threadPayloadBytes ?? null,
+    initialThreadPayloadGzipBytes: directBootstrap?.threadPayloadGzipBytes ?? null,
+    initialThreadItems: directBootstrap?.threadPageItems ?? null,
   };
 }
 
@@ -1573,6 +1651,7 @@ async function measureThreadHistoryContract(client, scenario, options) {
       };
     };
     const rootFor = (id) => roots().find((root) => idFor(root) === id) ?? null;
+    const bench = window.__illoBench || {};
     const waitForReveal = async (previous) => {
       const deadline = performance.now() + ${Math.min(options.timeoutMs, 5000)};
       while (performance.now() < deadline) {
@@ -1596,6 +1675,7 @@ async function measureThreadHistoryContract(client, scenario, options) {
       const anchorId = before.ids[0];
       const anchorBefore = rootFor(anchorId);
       const topBefore = anchorBefore?.getBoundingClientRect().top;
+      const longTaskStart = bench.longTasks?.length ?? 0;
       const startedAt = performance.now();
       button.click();
       const settled = await waitForReveal(before.unique);
@@ -1608,6 +1688,7 @@ async function measureThreadHistoryContract(client, scenario, options) {
       const topAfter = rootFor(anchorId)?.getBoundingClientRect().top;
       const drift = Number.isFinite(topBefore) && Number.isFinite(topAfter)
         ? Math.abs(topAfter - topBefore) : null;
+      const revealLongTasks = (bench.longTasks || []).slice(longTaskStart);
       const expectedAdded = Math.min(batch, total - before.unique);
       const behaviorPassed = settled && added === expectedAdded && removed === 0 &&
         after.duplicates === 0 && after.valid && controlVisible() === (after.unique < total) && drift !== null;
@@ -1618,6 +1699,9 @@ async function measureThreadHistoryContract(client, scenario, options) {
         afterItems: after.unique,
         addedItems: added,
         removedItems: removed,
+        longTaskCount: revealLongTasks.length,
+        longTaskTotalMs: revealLongTasks.reduce((sum, task) => sum + task.duration, 0),
+        maxLongTaskMs: Math.max(0, ...revealLongTasks.map((task) => task.duration)),
         behaviorPassed,
       });
       if (!settled || after.unique <= before.unique) break;
@@ -1643,6 +1727,7 @@ async function measureThreadHistoryContract(client, scenario, options) {
       controlVisibilityPassed,
       finalRenderedIdentityCount: final.unique,
       repeatedRevealPassed,
+      longTaskObserverAvailable: bench.longTaskObserverAvailable === true,
       reveals,
     };
   })()`);
@@ -1678,7 +1763,6 @@ async function measureLazyAssetContract(
       assetRequests,
       options.baseUrl,
     );
-
     await waitForExpression(client, THREAD_READY_EXPRESSION, options.timeoutMs);
     const firstOpenMs = performance.now() - selectionStartedAt;
     const manifestProof = verifyManifestDeferredAssets(
@@ -1934,7 +2018,7 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
     const bootstrapCallsAtReady = workspaceBootstrapCalls(apiCallsAtReady);
     const workspaceCallsAtReady = workspaceStartupCalls(apiCallsAtReady);
     const directStartupContract = scenario.directThread
-      ? directThreadRequestContract(apiCallsAtReady, scenario, options.streamItems)
+      ? directThreadRequestContract(apiCallsAtReady, scenario, options.streamItems, options.streamContract)
       : null;
 
     if (scenario.modalId) {
@@ -1988,7 +2072,29 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
       performanceMetricsAfter,
       'TaskDuration',
     );
+    const historyApiStartIndex = apiCalls.length;
+    const historyPerformanceBefore = await performanceMetrics(client);
+    const historyStartedAt = performance.now();
     const historyContract = await measureThreadHistoryContract(client, scenario, options);
+    const historyPerformanceAfter = await performanceMetrics(client);
+    historyContract.wallMs = performance.now() - historyStartedAt;
+    historyContract.taskDurationMs = performanceDurationMs(
+      historyPerformanceBefore,
+      historyPerformanceAfter,
+      'TaskDuration',
+    );
+    const olderPageCalls = apiCalls.slice(historyApiStartIndex).filter(
+      (call) => call.threadPageKind === 'older',
+    );
+    historyContract.remotePageRequestCount = olderPageCalls.length;
+    historyContract.remotePageBytes = olderPageCalls.map((call) => call.threadPayloadBytes);
+    historyContract.remotePageGzipBytes = olderPageCalls.map((call) => call.threadPayloadGzipBytes);
+    historyContract.remotePageFetchMs = olderPageCalls.map((call) => call.durationMs);
+    historyContract.remotePageItems = olderPageCalls.map((call) => call.threadPageItems);
+    historyContract.reveals.forEach((reveal, index) => {
+      reveal.fetchMs = olderPageCalls[index]?.durationMs ?? null;
+      reveal.postFetchMs = Number.isFinite(reveal.fetchMs) ? reveal.revealMs - reveal.fetchMs : null;
+    });
 
     const measuredApiCalls = [...apiCalls];
     const bootstrapCallsBeforeClose = workspaceBootstrapCalls(measuredApiCalls);
@@ -2180,6 +2286,9 @@ function summarizeScenario(samples) {
       : null;
   };
   const revealValues = (key) => historyValues(historyReveals, key);
+  const remotePageValues = (key) => historySamples.flatMap(
+    (sample) => sample.historyContract[key] ?? [],
+  ).filter(Number.isFinite);
   const defaultPaneKinds = ['activity-initial', 'discussion', 'handoff-summary', 'activity'];
   const defaultPaneReadyMs = Object.fromEntries(defaultPaneKinds.map((kind) => [
     kind,
@@ -2236,6 +2345,21 @@ function summarizeScenario(samples) {
     ),
     startup_api_calls: summarizeNumbers(directStartupSamples.map((sample) => sample.requestContract.startupCalls)),
     startup_api_kb: summarizeNumbers(directStartupSamples.map((sample) => sample.requestContract.startupPayloadKb)),
+    initial_direct_bootstrap_bytes: summarizeNumbers(
+      directStartupSamples.map((sample) => sample.requestContract.initialBootstrapBytes).filter(Number.isFinite),
+    ),
+    initial_direct_bootstrap_gzip_bytes: summarizeNumbers(
+      directStartupSamples.map((sample) => sample.requestContract.initialBootstrapGzipBytes).filter(Number.isFinite),
+    ),
+    initial_thread_payload_bytes: summarizeNumbers(
+      directStartupSamples.map((sample) => sample.requestContract.initialThreadPayloadBytes).filter(Number.isFinite),
+    ),
+    initial_thread_payload_gzip_bytes: summarizeNumbers(
+      directStartupSamples.map((sample) => sample.requestContract.initialThreadPayloadGzipBytes).filter(Number.isFinite),
+    ),
+    initial_thread_items: summarizeNumbers(
+      directStartupSamples.map((sample) => sample.requestContract.initialThreadItems).filter(Number.isFinite),
+    ),
     direct_bootstrap_before_me_fulfilled: directStartupSamples.every(
       (sample) => sample.requestContract.bootstrapBeforeMeFulfilled,
     ),
@@ -2317,6 +2441,24 @@ function summarizeScenario(samples) {
     thread_history_viewport_drift_available: historyRevealArraysAvailable &&
       revealValues('viewportDriftPx').length === historyReveals.length,
     thread_history_viewport_drift_px: summarizeNumbers(revealValues('viewportDriftPx')),
+    thread_history_task_duration_available: historySamples.every(
+      (sample) => Number.isFinite(sample.historyContract.taskDurationMs),
+    ),
+    thread_history_task_duration_ms: summarizeNumbers(
+      historySamples.map((sample) => sample.historyContract.taskDurationMs).filter(Number.isFinite),
+    ),
+    thread_history_long_task_observer_available: historySamples.every(
+      (sample) => sample.historyContract.longTaskObserverAvailable === true,
+    ),
+    thread_history_max_long_task_ms: summarizeNumbers(revealValues('maxLongTaskMs')),
+    thread_history_post_fetch_ms: summarizeNumbers(revealValues('postFetchMs')),
+    thread_history_remote_page_requests: summarizeNumbers(
+      historySamples.map((sample) => sample.historyContract.remotePageRequestCount).filter(Number.isFinite),
+    ),
+    thread_history_remote_page_bytes: summarizeNumbers(remotePageValues('remotePageBytes')),
+    thread_history_remote_page_gzip_bytes: summarizeNumbers(remotePageValues('remotePageGzipBytes')),
+    thread_history_remote_page_fetch_ms: summarizeNumbers(remotePageValues('remotePageFetchMs')),
+    thread_history_remote_page_items: summarizeNumbers(remotePageValues('remotePageItems')),
     dom_nodes_available: domNodeValues.length === measuredSamples.length,
     dom_nodes: summarizeNumbers(domNodeValues),
     deep_field_feature_nodes: summarizeNumbers(measuredSamples.map((sample) => sample.deepFieldFeatureNodes ?? 0)),
@@ -2417,12 +2559,33 @@ function printTextReport(result) {
         `bootstrap before /api/me ${scenario.summary.direct_bootstrap_before_me_fulfilled ? 'PASS' : 'FAIL'}`,
       );
       console.log(
+        `${scenario.name} initial thread payload: ` +
+        `${(scenario.summary.initial_thread_payload_bytes.p50 / 1024).toFixed(2)}KB raw/` +
+        `${(scenario.summary.initial_thread_payload_gzip_bytes.p50 / 1024).toFixed(2)}KB gzip; ` +
+        `${scenario.summary.initial_thread_items.p50.toFixed(0)} items; ` +
+        `contract ${result.config.streamContract}`,
+      );
+      console.log(
         `${scenario.name} history markers: ${scenario.summary.thread_history_contract_passed ? 'PASS' : 'FAIL'} ` +
         `(initial identities/rendered ${Number.isFinite(historyCounts.initialIdentities?.p50) ? historyCounts.initialIdentities.p50.toFixed(0) : '-'}/` +
         `${Number.isFinite(historyCounts.initialItems?.p50) ? historyCounts.initialItems.p50.toFixed(0) : '-'}; ` +
         `reveal p95 ${scenario.summary.thread_history_reveal_ms.p95.toFixed(1)}ms; ` +
         `drift max ${scenario.summary.thread_history_viewport_drift_px.max.toFixed(1)}px; ` +
         `final identities ${Number.isFinite(historyCounts.finalIdentities?.p50) ? historyCounts.finalIdentities.p50.toFixed(0) : '-'})`,
+      );
+      console.log(
+        `${scenario.name} remote history: ` +
+        `${scenario.summary.thread_history_remote_page_requests.p50.toFixed(0)} pages; ` +
+        `page max ${(scenario.summary.thread_history_remote_page_bytes.max / 1024).toFixed(2)}KB raw/` +
+        `${(scenario.summary.thread_history_remote_page_gzip_bytes.max / 1024).toFixed(2)}KB gzip; ` +
+        `fetch p95 ${scenario.summary.thread_history_remote_page_fetch_ms.p95.toFixed(1)}ms`,
+      );
+      console.log(
+        `${scenario.name} history work: ` +
+        `CDP task p50/p95 ${scenario.summary.thread_history_task_duration_ms.p50.toFixed(1)}/` +
+        `${scenario.summary.thread_history_task_duration_ms.p95.toFixed(1)}ms; ` +
+        `post-fetch p95 ${scenario.summary.thread_history_post_fetch_ms.p95.toFixed(1)}ms; ` +
+        `long task max ${scenario.summary.thread_history_max_long_task_ms.max.toFixed(1)}ms`,
       );
     }
     if (scenario.summary.lazy_asset_observation_ms > 0) {
@@ -2540,6 +2703,8 @@ function directThreadHistoryFailures(key, summary) {
   for (const [label, availabilityKey, metricKey] of [
     ['history reveal', 'thread_history_reveal_available', 'thread_history_reveal_ms'],
     ['history viewport drift', 'thread_history_viewport_drift_available', 'thread_history_viewport_drift_px'],
+    ['history CDP task duration', 'thread_history_task_duration_available', 'thread_history_task_duration_ms'],
+    ['history long task', 'thread_history_long_task_observer_available', 'thread_history_max_long_task_ms'],
   ]) {
     const metric = summary[metricKey];
     const metricAvailable = metric && [metric.p50, metric.p95, metric.max].every(Number.isFinite);
@@ -2581,13 +2746,13 @@ function isThreadHistoryStressConfig(config) {
     config.apiLatencyMs === 100;
 }
 
-function stressAbsoluteFailures(key, summary) {
+function stressAbsoluteFailures(key, summary, revealBudgetMs = THREAD_HISTORY_REVEAL_BUDGET_MS) {
   const failures = [];
   const metrics = [
     ['CDP TaskDuration', summaryMetricAvailable(summary, 'task_duration_available', 'task_duration_ms'), summary.task_duration_ms?.p50, STRESS_TASK_P50_BUDGET_MS, 'ms'],
     ['LongTask p95', summaryMetricAvailable(summary, 'long_task_observer_available', 'long_task_count'), summary.max_long_task_ms?.p95, STRESS_LONG_TASK_P95_BUDGET_MS, 'ms'],
     ['DOM nodes max', summaryMetricAvailable(summary, 'dom_nodes_available', 'dom_nodes'), summary.dom_nodes?.max, STRESS_DOM_NODE_BUDGET, ''],
-    ['history reveal p95', summaryMetricAvailable(summary, 'thread_history_reveal_available', 'thread_history_reveal_ms'), summary.thread_history_reveal_ms?.p95, THREAD_HISTORY_REVEAL_BUDGET_MS, 'ms'],
+    ['history reveal p95', summaryMetricAvailable(summary, 'thread_history_reveal_available', 'thread_history_reveal_ms'), summary.thread_history_reveal_ms?.p95, revealBudgetMs, 'ms'],
     ['history viewport drift max', summaryMetricAvailable(summary, 'thread_history_viewport_drift_available', 'thread_history_viewport_drift_px'), summary.thread_history_viewport_drift_px?.max, THREAD_HISTORY_VIEWPORT_DRIFT_BUDGET_PX, 'px'],
   ];
   for (const [metric, available, value, budget, unit] of metrics) {
@@ -2607,10 +2772,81 @@ function stressAbsoluteFailures(key, summary) {
   return failures;
 }
 
+function isPaginationComparison(before, after) {
+  return before.config.streamContract === 'legacy' && after.config.streamContract === 'paged';
+}
+
+function paginationAbsoluteFailures(key, summary, config) {
+  const failures = [];
+  const bootstrapBytes = summary.initial_direct_bootstrap_bytes;
+  const threadPayloadBytes = summary.initial_thread_payload_bytes;
+  const initialItems = summary.initial_thread_items;
+  for (const [label, metric] of [
+    ['initial direct bootstrap bytes', bootstrapBytes],
+    ['initial thread payload bytes', threadPayloadBytes],
+    ['initial thread items', initialItems],
+  ]) {
+    if (!metric || ![metric.p50, metric.p95, metric.max].every(Number.isFinite) || metric.max <= 0) {
+      failures.push(`${key}: ${label} unavailable`);
+    }
+  }
+  if (Number.isFinite(bootstrapBytes?.max) && bootstrapBytes.max > THREAD_PAGE_RAW_BUDGET_BYTES) {
+    failures.push(`${key}: initial direct bootstrap exceeds ${THREAD_PAGE_RAW_BUDGET_BYTES} bytes`);
+  }
+  const expectedInitialItems = Math.min(config.streamItems, THREAD_HISTORY_WINDOW_SIZE);
+  if (Number.isFinite(initialItems?.min) && (
+    initialItems.min !== expectedInitialItems || initialItems.max !== expectedInitialItems
+  )) {
+    failures.push(`${key}: initial page must contain exactly ${expectedInitialItems} items`);
+  }
+
+  const expectedOlderPages = Math.max(
+    0,
+    Math.ceil(config.streamItems / THREAD_HISTORY_WINDOW_SIZE) - 1,
+  );
+  const pageRequests = summary.thread_history_remote_page_requests;
+  if (!pageRequests || ![pageRequests.min, pageRequests.max].every(Number.isFinite)) {
+    failures.push(`${key}: remote page request count unavailable`);
+  } else if (pageRequests.min !== expectedOlderPages || pageRequests.max !== expectedOlderPages) {
+    failures.push(`${key}: expected ${expectedOlderPages} remote pages`);
+  }
+  if (expectedOlderPages > 0) {
+    const pageBytes = summary.thread_history_remote_page_bytes;
+    const fetchMs = summary.thread_history_remote_page_fetch_ms;
+    const postFetchMs = summary.thread_history_post_fetch_ms;
+    const pageItems = summary.thread_history_remote_page_items;
+    for (const [label, metric] of [
+      ['remote page bytes', pageBytes],
+      ['remote page fetch', fetchMs],
+      ['remote page post-fetch work', postFetchMs],
+      ['remote page items', pageItems],
+    ]) {
+      if (!metric || ![metric.p50, metric.p95, metric.max].every(Number.isFinite) || metric.max <= 0) {
+        failures.push(`${key}: ${label} unavailable`);
+      }
+    }
+    if (Number.isFinite(pageBytes?.max) && pageBytes.max > THREAD_PAGE_RAW_BUDGET_BYTES) {
+      failures.push(`${key}: remote page exceeds ${THREAD_PAGE_RAW_BUDGET_BYTES} bytes`);
+    }
+    if (Number.isFinite(fetchMs?.p95) && fetchMs.p95 > THREAD_PAGE_FETCH_BUDGET_MS) {
+      failures.push(`${key}: remote page fetch p95 exceeds ${THREAD_PAGE_FETCH_BUDGET_MS}ms`);
+    }
+    if (Number.isFinite(pageItems?.max) && pageItems.max > THREAD_HISTORY_WINDOW_SIZE) {
+      failures.push(`${key}: remote page exceeds ${THREAD_HISTORY_WINDOW_SIZE} items`);
+    }
+  }
+  return failures;
+}
+
 function comparisonFailures(before, after, scenarioKeys) {
   const failures = [];
+  const paginationComparison = isPaginationComparison(before, after);
+  const hasStreamContract = Boolean(before.config.streamContract || after.config.streamContract);
   if (comparisonSignature(before, scenarioKeys) !== comparisonSignature(after, scenarioKeys)) {
     failures.push('before/after benchmark config signatures differ');
+  }
+  if (hasStreamContract && !paginationComparison) {
+    failures.push('pagination comparison requires legacy before and paged after contracts');
   }
 
   for (const key of scenarioKeys) {
@@ -2632,21 +2868,26 @@ function comparisonFailures(before, after, scenarioKeys) {
     const directThread = Boolean(SCENARIOS[key]?.directThread);
     const stress = directThread && isThreadHistoryStressConfig(after.config);
     if (directThread) failures.push(...directThreadHistoryFailures(key, summary));
+    if (directThread && after.config.streamContract === 'paged') {
+      failures.push(...paginationAbsoluteFailures(key, summary, after.config));
+    }
 
     const beforeReady = beforeScenario.summary.ready_ms;
     const afterReady = summary.ready_ms;
     const readyMetrics = [['p50', beforeReady.p50, afterReady.p50], ['p95', beforeReady.p95, afterReady.p95]];
     const stableReady = readyMetrics.map(([, beforeValue, afterValue]) => withinRegressionBudget(beforeValue, afterValue));
-    if (!stress && !stableReady.every(Boolean)) failures.push(`${key}: ready regression >${MAX_REGRESSION_PCT}%`);
+    if ((!stress || paginationComparison) && !stableReady.every(Boolean)) {
+      failures.push(`${key}: ready regression >${MAX_REGRESSION_PCT}%`);
+    }
     const beforeFcp = summaryMetricValue(beforeScenario.summary, 'fcp_available', 'fcp_ms', 'p50');
     const afterFcp = summaryMetricValue(summary, 'fcp_available', 'fcp_ms', 'p50');
-    if (!stress && (beforeFcp === null || afterFcp === null)) {
+    if ((!stress || paginationComparison) && (beforeFcp === null || afterFcp === null)) {
       failures.push(`${key}: comparable FCP unavailable`);
-    } else if (!stress && !withinRegressionBudget(beforeFcp, afterFcp)) {
+    } else if ((!stress || paginationComparison) && !withinRegressionBudget(beforeFcp, afterFcp)) {
       failures.push(`${key}: FCP p50 regression >${MAX_REGRESSION_PCT}%`);
     }
 
-    if (stress) {
+    if (stress && !paginationComparison) {
       for (const [percentileName, beforeValue, afterValue] of readyMetrics) {
         const improvementPct = -pctDelta(beforeValue, afterValue);
         if (improvementPct < STRESS_READY_IMPROVEMENT_TARGET_PCT) {
@@ -2656,20 +2897,35 @@ function comparisonFailures(before, after, scenarioKeys) {
           );
         }
       }
-      failures.push(...stressAbsoluteFailures(key, summary));
     }
+    if (stress) failures.push(...stressAbsoluteFailures(
+      key,
+      summary,
+      paginationComparison ? THREAD_PAGE_FETCH_BUDGET_MS : THREAD_HISTORY_REVEAL_BUDGET_MS,
+    ));
 
-    const paneMetrics = [
-      ['Vault first-open', beforeScenario.summary.rare_pane_first_open_ms.p75, summary.rare_pane_first_open_ms.p75],
-      ['Vault data-ready', beforeScenario.summary.rare_pane_data_ready_ms.p75, summary.rare_pane_data_ready_ms.p75],
-      ['Discussion', beforeScenario.summary.default_pane_ready_ms.discussion.p75, summary.default_pane_ready_ms.discussion.p75],
-      ['Handoff', beforeScenario.summary.default_pane_ready_ms['handoff-summary'].p75, summary.default_pane_ready_ms['handoff-summary'].p75],
-      ['Activity', beforeScenario.summary.default_pane_ready_ms.activity.p75, summary.default_pane_ready_ms.activity.p75],
-      ['Composer', beforeScenario.summary.composer_send_ready_ms.p75, summary.composer_send_ready_ms.p75],
-    ];
-    for (const [metric, beforeValue, afterValue] of paneMetrics) {
-      if (beforeValue > 0 && afterValue > 0 && !withinRegressionBudget(beforeValue, afterValue)) {
-        failures.push(`${key}: ${metric} p75 regressed >${MAX_REGRESSION_PCT}%`);
+    if (directThread && paginationComparison) {
+      if (before.config.streamItems > THREAD_HISTORY_WINDOW_SIZE) {
+        const beforeBootstrap = beforeScenario.summary.initial_direct_bootstrap_bytes?.p50;
+        const afterBootstrap = summary.initial_direct_bootstrap_bytes?.p50;
+        if (!Number.isFinite(beforeBootstrap) || !Number.isFinite(afterBootstrap) || beforeBootstrap <= 0) {
+          failures.push(`${key}: comparable initial direct bootstrap bytes unavailable`);
+        } else if (-pctDelta(beforeBootstrap, afterBootstrap) < THREAD_STARTUP_PAYLOAD_REDUCTION_TARGET_PCT) {
+          failures.push(`${key}: initial direct bootstrap reduction <${THREAD_STARTUP_PAYLOAD_REDUCTION_TARGET_PCT}%`);
+        }
+      }
+
+      const regressionMetrics = [
+        ['DOM p50', beforeScenario.summary.dom_nodes?.p50, summary.dom_nodes?.p50],
+        ['CDP task p50', summaryMetricValue(beforeScenario.summary, 'task_duration_available', 'task_duration_ms', 'p50'), summaryMetricValue(summary, 'task_duration_available', 'task_duration_ms', 'p50')],
+        ['Long task p95', summaryMetricValue(beforeScenario.summary, 'long_task_observer_available', 'max_long_task_ms', 'p95'), summaryMetricValue(summary, 'long_task_observer_available', 'max_long_task_ms', 'p95')],
+      ];
+      for (const [metric, beforeValue, afterValue] of regressionMetrics) {
+        if (!Number.isFinite(beforeValue) || !Number.isFinite(afterValue)) {
+          failures.push(`${key}: comparable ${metric} unavailable`);
+        } else if (!withinRegressionBudget(beforeValue, afterValue)) {
+          failures.push(`${key}: ${metric} regression >${MAX_REGRESSION_PCT}%`);
+        }
       }
     }
   }
@@ -2692,6 +2948,8 @@ function printComparison(before, after, scenarioKeys) {
       ['FCP p50', summaryMetricValue(beforeSummary, 'fcp_available', 'fcp_ms', 'p50'), summaryMetricValue(afterSummary, 'fcp_available', 'fcp_ms', 'p50'), 'ms'],
       ['API calls p50', beforeSummary.api_calls.p50, afterSummary.api_calls.p50, ''],
       ['API KB p50', beforeSummary.api_kb.p50, afterSummary.api_kb.p50, 'KB'],
+      ['initial bootstrap KB p50', beforeSummary.initial_direct_bootstrap_bytes?.p50 / 1024, afterSummary.initial_direct_bootstrap_bytes?.p50 / 1024, 'KB'],
+      ['initial thread payload KB p50', beforeSummary.initial_thread_payload_bytes?.p50 / 1024, afterSummary.initial_thread_payload_bytes?.p50 / 1024, 'KB'],
       ['rare pane first-open p75', beforeSummary.rare_pane_first_open_ms?.p75 ?? 0, afterSummary.rare_pane_first_open_ms?.p75 ?? 0, 'ms'],
       ['DOM nodes p50', beforeSummary.dom_nodes.p50, afterSummary.dom_nodes.p50, ''],
       ['D3 shadow nodes p50', beforeSummary.d3_shadow_nodes?.p50 ?? 0, afterSummary.d3_shadow_nodes?.p50 ?? 0, ''],
@@ -2703,6 +2961,12 @@ function printComparison(before, after, scenarioKeys) {
       ['history initial rendered identities p50', threadHistoryCounts(beforeSummary).initialIdentities?.p50 ?? null, threadHistoryCounts(afterSummary).initialIdentities?.p50 ?? null, ''],
       ['history reveal p95', beforeSummary.thread_history_reveal_ms?.p95 ?? 0, afterSummary.thread_history_reveal_ms?.p95 ?? 0, 'ms'],
       ['history drift max', beforeSummary.thread_history_viewport_drift_px?.max ?? 0, afterSummary.thread_history_viewport_drift_px?.max ?? 0, 'px'],
+      ['history CDP task p95', beforeSummary.thread_history_task_duration_ms?.p95, afterSummary.thread_history_task_duration_ms?.p95, 'ms'],
+      ['history long task max', beforeSummary.thread_history_max_long_task_ms?.max, afterSummary.thread_history_max_long_task_ms?.max, 'ms'],
+      ['history post-fetch p95', beforeSummary.thread_history_post_fetch_ms?.p95, afterSummary.thread_history_post_fetch_ms?.p95, 'ms'],
+      ['remote pages p50', beforeSummary.thread_history_remote_page_requests?.p50, afterSummary.thread_history_remote_page_requests?.p50, ''],
+      ['remote page KB max', beforeSummary.thread_history_remote_page_bytes?.max / 1024, afterSummary.thread_history_remote_page_bytes?.max / 1024, 'KB'],
+      ['remote fetch p95', beforeSummary.thread_history_remote_page_fetch_ms?.p95, afterSummary.thread_history_remote_page_fetch_ms?.p95, 'ms'],
     ];
     for (const [metric, beforeValue, afterValue, unit] of metrics) {
       rows.push({
@@ -2786,6 +3050,7 @@ async function main() {
         ideas: options.ideas,
         connections: options.connections,
         streamItems: options.streamItems,
+        streamContract: options.streamContract,
         apiLatencyMs: options.apiLatencyMs,
         sidecarLatencyMs: options.sidecarLatencyMs,
         timeoutMs: options.timeoutMs,
@@ -2820,8 +3085,17 @@ async function main() {
     const threadFailures = result.scenarios.flatMap((scenario) => {
       if (!SCENARIOS[scenario.key]?.directThread) return [];
       const failures = directThreadHistoryFailures(scenario.key, scenario.summary);
+      if (result.config.streamContract === 'paged') {
+        failures.push(...paginationAbsoluteFailures(scenario.key, scenario.summary, result.config));
+      }
       if (isThreadHistoryStressConfig(result.config)) {
-        failures.push(...stressAbsoluteFailures(scenario.key, scenario.summary));
+        failures.push(...stressAbsoluteFailures(
+          scenario.key,
+          scenario.summary,
+          result.config.streamContract === 'paged'
+            ? THREAD_PAGE_FETCH_BUDGET_MS
+            : THREAD_HISTORY_REVEAL_BUDGET_MS,
+        ));
       }
       return failures;
     });

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -110,6 +110,21 @@ def _make_thread_msg(**overrides):
     return obj
 
 
+def _stream_page(idea_id="idea-1"):
+    return {
+        "idea_id": idea_id,
+        "items": [{
+            "type": "message",
+            "timestamp": "2026-05-01T12:00:00Z",
+            "id": "1",
+            "role": "user",
+            "content": "Hello",
+        }],
+        "has_more": False,
+        "next_before": None,
+    }
+
+
 def _assign_thread_defaults_on_add(session):
     next_thread_id = 1
 
@@ -1319,23 +1334,29 @@ async def test_cortex_bootstrap_can_skip_team_members_for_direct_threads(client)
 
 
 @pytest.mark.asyncio
+async def test_unified_stream_route_enforces_page_limits_and_cursor(client):
+    from brain.app.api.routers.cortex import _idea_ops as idea_ops
+
+    with patch.object(idea_ops, "unified_stream_payload", AsyncMock(return_value=_stream_page())) as payload:
+        response = await client.get("/api/cortex/ideas/idea-1/unified-stream")
+
+    assert response.status_code == 200
+    assert payload.call_args.kwargs["limit"] == 200
+    assert (await client.get("/api/cortex/ideas/idea-1/unified-stream?limit=0")).status_code == 422
+    assert (await client.get("/api/cortex/ideas/idea-1/unified-stream?limit=201")).status_code == 422
+    assert (await client.get("/api/cortex/ideas/idea-1/unified-stream?before=bad")).status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_cortex_bootstrap_direct_thread_reuses_stream_payload(client):
     from brain.app.api.routers.cortex import _bootstrap as bootstrap_mod
 
-    stream = [
-        {
-            "type": "message",
-            "timestamp": "2026-05-01T12:00:00Z",
-            "id": "1",
-            "role": "user",
-            "content": "Hello",
-        }
-    ]
+    stream_page = _stream_page()
 
     with (
         patch.object(bootstrap_mod, "list_ideas_payload", AsyncMock(return_value=[])),
         patch.object(bootstrap_mod, "list_connections_payload", AsyncMock(return_value=[])),
-        patch.object(bootstrap_mod, "unified_stream_payload", return_value=stream) as stream_payload,
+        patch.object(bootstrap_mod, "unified_stream_payload", return_value=stream_page) as stream_payload,
     ):
         resp = await client.get("/api/cortex/bootstrap?include=ideas,connections,direct_thread&idea_id=idea-1")
 
@@ -1343,10 +1364,10 @@ async def test_cortex_bootstrap_direct_thread_reuses_stream_payload(client):
     data = resp.json()
     assert data["ideas"] == []
     assert data["connections"] == []
-    assert data["direct_thread"] == {"idea_id": "idea-1", "stream": stream}
+    assert data["direct_thread"] == stream_page
     stream_payload.assert_called_once()
     assert stream_payload.call_args.kwargs["idea_id"] == "idea-1"
-    assert stream_payload.call_args.kwargs["include_debug"] is False
+    assert stream_payload.call_args.kwargs["user"]["id"] == "user-1"
 
 
 @pytest.mark.asyncio
@@ -1354,21 +1375,13 @@ async def test_cortex_bootstrap_direct_thread_can_return_selected_idea_without_g
     from brain.app.api.routers.cortex import _bootstrap as bootstrap_mod
 
     idea = _make_idea(id="idea-1", title="Selected Thread")
-    stream = [
-        {
-            "type": "message",
-            "timestamp": "2026-05-01T12:00:00Z",
-            "id": "1",
-            "role": "user",
-            "content": "Hello",
-        }
-    ]
+    stream_page = _stream_page()
 
     with (
         patch.object(bootstrap_mod, "_require_idea_for_user", AsyncMock(return_value=idea)) as require_idea,
         patch.object(bootstrap_mod, "list_ideas_payload") as list_ideas,
         patch.object(bootstrap_mod, "list_connections_payload") as list_connections,
-        patch.object(bootstrap_mod, "unified_stream_payload", return_value=stream),
+        patch.object(bootstrap_mod, "unified_stream_payload", return_value=stream_page),
     ):
         resp = await client.get("/api/cortex/bootstrap?include=selected_idea,direct_thread&idea_id=idea-1")
 
@@ -1378,7 +1391,7 @@ async def test_cortex_bootstrap_direct_thread_can_return_selected_idea_without_g
     assert data["connections"] is None
     assert data["selected_idea"]["id"] == "idea-1"
     assert data["selected_idea"]["title"] == "Selected Thread"
-    assert data["direct_thread"] == {"idea_id": "idea-1", "stream": stream}
+    assert data["direct_thread"] == stream_page
     require_idea.assert_awaited_once()
     list_ideas.assert_not_called()
     list_connections.assert_not_called()

--- a/tests/test_cortex_stream_pagination.py
+++ b/tests/test_cortex_stream_pagination.py
@@ -1,0 +1,286 @@
+"""Unified Cortex stream pagination contract tests."""
+
+from __future__ import annotations
+
+import base64
+from collections import namedtuple
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
+
+from brain.app.api.routers.cortex import _idea_ops as idea_ops
+
+
+_MessageRow = namedtuple("_MessageRow", "message user_name user_color")
+
+
+def _result(rows):
+    return SimpleNamespace(all=lambda: rows)
+
+
+def _message(row_id: int, created_at: datetime, **overrides):
+    message = idea_ops.IdeaThread(**{
+        "id": row_id,
+        "idea_id": "idea-1",
+        "created_at": created_at,
+        "role": "user",
+        "content": f"message-{row_id}",
+        "attachments": [],
+        "metadata_": {},
+        "message_type": "message",
+        **overrides,
+    })
+    return _MessageRow(message, None, None)
+
+
+def _run(row_id: int, created_at: datetime, **overrides):
+    return idea_ops.AgentRun(**{
+        "id": row_id,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "thread_id": "idea-1",
+        "profile": "fast",
+        "recipe": "default",
+        "status": "completed",
+        "input_message": f"run-{row_id}",
+        "metadata_": {},
+        "completed_at": created_at,
+        **overrides,
+    })
+
+
+def _visual(row_id: int, created_at: datetime):
+    return idea_ops.VisualBlock(
+        id=row_id,
+        created_at=created_at,
+        idea_id="idea-1",
+        content_type="markdown",
+        title=f"visual-{row_id}",
+        content=f"content-{row_id}",
+        display_mode="inline",
+        run_id=None,
+        position_after=None,
+    )
+
+
+class _ControlledSession:
+    """Small PostgreSQL-query simulator for the three physical stream reads."""
+
+    def __init__(self, messages, runs, visuals, artifacts):
+        self.messages = messages
+        self.runs = runs
+        self.visuals = visuals
+        self.artifacts = artifacts
+        self.before = None
+        self.limit = 0
+        self.physical_query_count = 0
+        self.hydrated_run_ids: set[int] = set()
+
+    def begin_page(self, before: str | None, limit: int):
+        self.before = idea_ops._decode_stream_cursor(before)
+        self.limit = limit
+
+    @staticmethod
+    def _sql(stmt) -> str:
+        return str(stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )).lower()
+
+    def _assert_physical_query(self, kind: str, sql: str):
+        table = {
+            "message": "idea_threads",
+            "run": "agent_runs",
+            "visual_block": "visual_blocks",
+        }[kind]
+        assert "count(" not in sql
+        assert f"order by {table}.created_at desc, {table}.id desc" in sql
+        assert f"limit {self.limit + 1}" in sql
+        if kind == "run":
+            assert "headless" in sql
+            assert ("active_stream_roots" in sql) is (self.before is None)
+            if self.before is None:
+                active_root_cte = sql.split("active_stream_roots as", 1)[1]
+                active_root_cte = active_root_cte.split(")\n select agent_runs.id", 1)[0]
+                assert f"limit {idea_ops._STREAM_ACTIVE_ROOT_LIMIT}" in active_root_cte
+
+        if self.before is not None:
+            rank = idea_ops._STREAM_KIND_RANK[kind]
+            column = f"{table}.created_at"
+            assert str(self.before.created_at) in sql
+            if rank < self.before.kind_rank:
+                assert f"{column} <=" in sql
+            elif rank > self.before.kind_rank:
+                assert f"{column} <" in sql
+                assert f"{table}.id <" not in sql
+            else:
+                assert f"{column} <" in sql
+                assert f"{table}.id < {self.before.row_id}" in sql
+
+        self.physical_query_count += 1
+
+    def _bounded(self, kind: str, rows: list):
+        rows = [
+            row
+            for row in rows
+            if self.before is None or idea_ops._stream_candidate(kind, row).key < self.before
+        ]
+        rows.sort(key=lambda row: idea_ops._stream_candidate(kind, row).key, reverse=True)
+        return rows[: self.limit + 1]
+
+    async def execute(self, stmt):
+        sql = self._sql(stmt)
+        assert "from idea_threads" in sql
+        self._assert_physical_query("message", sql)
+        return _result(self._bounded("message", self.messages))
+
+    async def scalars(self, stmt):
+        sql = self._sql(stmt)
+        if "recent_stream_runs" in sql:
+            self._assert_physical_query("run", sql)
+            visible = [run for run in self.runs if run.metadata_.get("headless") is not True]
+            recent = self._bounded("run", visible)
+            if self.before is None:
+                active = [
+                    run
+                    for run in visible
+                    if run.parent_run_id is None and run.status in idea_ops.OPEN_RUN_STATUS_VALUES
+                ][: idea_ops._STREAM_ACTIVE_ROOT_LIMIT]
+                recent = list({run.id: run for run in [*recent, *active]}.values())
+            return _result(sorted(recent, key=lambda run: (run.created_at, run.id), reverse=True))
+        if "from visual_blocks" in sql:
+            self._assert_physical_query("visual_block", sql)
+            return _result(self._bounded("visual_block", self.visuals))
+        if "from agent_run_artifacts" in sql:
+            compiled = stmt.compile(dialect=postgresql.dialect())
+            run_ids = {
+                int(run_id)
+                for value in compiled.params.values()
+                if isinstance(value, (list, tuple, set))
+                for run_id in value
+            }
+            self.hydrated_run_ids.update(run_ids)
+            return _result([artifact for artifact in self.artifacts if artifact.run_id in run_ids])
+        if "agent_run_events" in sql or "parent_run_id in" in sql:
+            return _result([])
+        raise AssertionError(f"Unexpected stream query: {sql}")
+
+
+@asynccontextmanager
+async def _unit_of_work(session):
+    yield SimpleNamespace(session=session)
+
+
+@pytest.mark.asyncio
+async def test_unified_stream_paginates_the_full_mixed_history(monkeypatch):
+    base = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+
+    def at(minutes, seconds=0):
+        return base + timedelta(minutes=minutes, seconds=seconds)
+
+    active = _run(99, base, status="running", completed_at=None)
+    persisted_answer = _message(
+        3,
+        at(3),
+        role="illo",
+        content="Persisted answer",
+        metadata_={"run_id": 10},
+    )
+    session = _ControlledSession(
+        messages=[_message(1, at(1)), _message(2, at(2)), persisted_answer],
+        runs=[
+            active,
+            _run(10, at(2)),
+            _run(98, at(4, 30), metadata_={"headless": True}),
+            _run(11, at(5)),
+        ],
+        visuals=[_visual(3, at(2)), _visual(4, at(4))],
+        artifacts=[idea_ops.AgentRunArtifactRow(
+            id=501,
+            run_id=10,
+            artifact_type="final_answer",
+            title=None,
+            payload={},
+            text="Synthetic answer",
+            uri=None,
+            visibility="default",
+            created_at=at(2, 30),
+        )],
+    )
+    monkeypatch.setattr(idea_ops, "UnitOfWork", lambda: _unit_of_work(session))
+    monkeypatch.setattr(idea_ops, "_require_idea_for_user", AsyncMock())
+
+    pages = []
+    before = None
+    while True:
+        session.begin_page(before, limit=1)
+        page = await idea_ops.unified_stream_payload(
+            "idea-1",
+            limit=1,
+            before=before,
+            user={"id": "user-1"},
+        )
+        assert set(page) == {"idea_id", "items", "has_more", "next_before"}
+        pages.append(page)
+        if not page["has_more"]:
+            assert page["next_before"] is None
+            break
+        before = page["next_before"]
+
+    assert len(pages) == 8
+    assert idea_ops._decode_stream_cursor(pages[0]["next_before"]).row_id == 11
+    assert len(pages[0]["items"]) == 2  # One physical item plus the out-of-band active root.
+    assert [item["id"] for item in pages[0]["items"] if item["type"] == "run"] == ["99", "11"]
+    assert [
+        index for index, page in enumerate(pages)
+        if any(item["id"] == "99" for item in page["items"])
+    ] == [0, 7]
+    assert all(item.get("id") != "98" for page in pages for item in page["items"])
+    assert any(
+        item.get("id") == "vb-3" and item.get("position_after") is None
+        for page in pages for item in page["items"]
+    )
+    assert any(
+        item.get("metadata", {}).get("synthetic_from_run_artifact") is True
+        for item in pages[4]["items"]
+    )
+    items = [item for page in reversed(pages) for item in page["items"]]
+    raw_physical_ids = [
+        f"{item['type']}:{item['id']}"
+        for item in items
+        if item.get("metadata", {}).get("synthetic_from_run_artifact") is not True
+    ]
+    assert raw_physical_ids.count("run:99") == 2
+    assert list(dict.fromkeys(raw_physical_ids)) == [
+        "run:99",
+        "message:1",
+        "message:2",
+        "run:10",
+        "visual_block:vb-3",
+        "message:3",
+        "visual_block:vb-4",
+        "run:11",
+    ]
+    assert session.hydrated_run_ids == {10, 11, 99}
+    assert session.physical_query_count == len(pages) * 3
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "not-a-cursor",
+        base64.urlsafe_b64encode(b"v2|2026-01-01T00:00:00+00:00|0|1").decode(),
+        base64.urlsafe_b64encode(b"v1|2026-01-01T00:00:00|0|1").decode(),
+        base64.urlsafe_b64encode(b"v1|2026-01-01T00:00:00+00:00|00|1").decode(),
+    ],
+)
+def test_stream_cursor_rejects_malformed_or_unsupported_values(cursor):
+    with pytest.raises(HTTPException) as exc_info:
+        idea_ops._decode_stream_cursor(cursor)
+
+    assert exc_info.value.status_code == 400

--- a/tests/test_cortex_visual_reply.py
+++ b/tests/test_cortex_visual_reply.py
@@ -181,18 +181,23 @@ async def test_cortex_stream_includes_persisted_visual_block(monkeypatch):
 
     monkeypatch.setattr(idea_ops, "_require_idea_for_user", fake_require_idea)
 
-    items = await idea_ops.idea_unified_stream("idea-1", user={"id": "user-1"})
+    page = await idea_ops.idea_unified_stream("idea-1", user={"id": "user-1"})
 
-    assert items == [
-        {
-            "type": "visual_block",
-            "timestamp": created.isoformat(),
-            "id": "vb-5",
-            "content_type": "markdown",
-            "title": "Summary",
-            "content": "**Done**",
-            "display_mode": "inline",
-            "run_id": "99",
-            "position_after": 12,
-        }
-    ]
+    assert page == {
+        "idea_id": "idea-1",
+        "items": [
+            {
+                "type": "visual_block",
+                "timestamp": created.isoformat(),
+                "id": "vb-5",
+                "content_type": "markdown",
+                "title": "Summary",
+                "content": "**Done**",
+                "display_mode": "inline",
+                "run_id": "99",
+                "position_after": 12,
+            }
+        ],
+        "has_more": False,
+        "next_before": None,
+    }

--- a/tests/test_thread_history_ui_contract.py
+++ b/tests/test_thread_history_ui_contract.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STAGE_PATH = REPO_ROOT / "frontend/src/lib/features/threads/components/ThreadStageScreen.svelte"
+
+
+def _show_earlier_history_source() -> str:
+    source = STAGE_PATH.read_text()
+    return source[source.index("  async function showEarlierHistory() {"):source.index("  async function send() {")]
+
+
+def test_remote_history_prearms_before_fetch_and_settles_once():
+    stage = STAGE_PATH.read_text()
+    source = _show_earlier_history_source()
+    prearm = source.index("cursor: cursor ?? threadStreamWindow.startCursor")
+    fetch = source.index("await cortex.loadOlderThreadHistory(threadId)")
+    frame = source.index("requestAnimationFrame(() => {")
+    ownership = source.index("operationToken !== threadHistoryOperationToken || selectedThreadId !== threadId")
+    correction = source.index("anchor.getBoundingClientRect().top - anchorTop")
+    settled = source.index("programmaticScroll = false")
+
+    assert prearm < fetch
+    assert frame < ownership < correction < settled
+    assert source.count("requestAnimationFrame(() => {") == 2
+    assert source.count("operationToken !== threadHistoryOperationToken || selectedThreadId !== threadId") == 2
+    assert source.count("anchor.getBoundingClientRect().top - anchorTop") == 2
+    assert source.count("element.scrollHeight - scrollBottom") == 1
+    assert "let programmaticScroll = $state(false)" in stage
+    assert stage.count("programmaticScroll && userScrolledUp") == 2
+    assert "operationToken !== threadHistoryOperationToken || selectedThreadId !== threadId" in source
+    assert source.count("await tick();") == 1
+    assert "threadStreamWindow.previousCursor" not in source[fetch:]
+
+
+def test_history_reveal_preserves_the_first_visible_row_before_height_fallback():
+    source = _show_earlier_history_source()
+    anchor_adjustment = source.index("anchor.getBoundingClientRect().top - anchorTop")
+    height_fallback = source.index("element.scrollHeight - scrollBottom")
+
+    assert ".thread-history-window-control + *" in source
+    assert "anchor?.isConnected" in source
+    assert anchor_adjustment < height_fallback


### PR DESCRIPTION
## Summary

- hard-cut direct-thread bootstrap and unified-stream responses to one canonical paged shape
- return the newest 200 physical stream items with an opaque mixed-kind cursor
- bound message, run, and visual-block reads without `COUNT(*)` or a migration
- preserve up to 20 active root runs outside the physical page so live work never disappears
- merge head, older, and websocket updates with typed identity and canonical chronology
- let the existing “Show earlier history” control fetch and reveal remote pages with stale-operation and viewport-anchor protection
- remove obsolete debug/replace paths and four unreferenced CortexStore convenience methods

This PR is stacked on #302, which is stacked on #300 and #294. Review and merge in that order.

## Measured result

Production build, 100 ms mocked API latency, 5 warmups + 20 measured runs.

### Stress thread: 1,000 stream items

| Metric | Full response | Paged | Change |
|---|---:|---:|---:|
| Initial bootstrap | 423,717 B | 85,303 B | -79.9% |
| Initial thread payload | 423,065 B | 84,651 B | -80.0% |
| Ready p50 | 996.5 ms | 970.6 ms | -2.6% |
| Ready p95 | 1,112.0 ms | 1,114.9 ms | +0.3% |
| Task p50 | 407.2 ms | 386.4 ms | -5.1% |
| Long-task p95 | 96.3 ms | 94.5 ms | -1.9% |

- four older pages of exactly 200 items recover all 1,000 identities
- maximum older page: 84,818 B raw / 3,460 B gzip
- page fetch p95: 105.3 ms
- end-to-end reveal p95: 204.1 ms
- viewport drift max: 0.519 px
- no gaps, duplicates, ordering errors, stale-thread application, or browser errors

### Normal thread: 80 stream items

- no pagination control and zero older-page requests
- ready p50: -6.8%
- ready p95: -6.9%
- FCP: -4.5%
- task p50: -9.6%
- long-task p95: -22.7%

## Backend contract

- physical page limit: 200, `limit + 1` reads, no count query
- cursor order: `(created_at, kind rank, numeric id)`
- active-root injection cap: 20, head request only
- active roots are out-of-band: a head page may exceed the physical limit and the root can recur when older chronology reaches it; the client’s typed upsert removes that repeat
- no schema migration

## Validation

- independent agent-loop judge: PASS
- full repository test target: 3,483 passed, 59 skipped, 27 deselected
- frontend tests: 227 passed
- focused backend pagination/Cortex suite: 133 passed
- Svelte check: 0 errors, 0 warnings
- production build and bundle gate: passed
- final workspace click/lazy smoke: passed
- final eight-scenario smoke: 8/8, no browser errors or unknown routes
- fail-closed benchmark probes reject missing telemetry/history and mismatched configuration
- `git diff --check` and benchmark syntax check passed

## Size

- production: `+590/-234`, net +356 lines
- bundle: 241,232 → 242,170 gzip bytes (`+938`, `+0.389%`), still 7,830 bytes under the 250 KB budget
- no dependency or migration added
