### PR TITLE
Improve agent run performance and reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,5 +78,14 @@ EMBEDDING_WORKER_WARMUP_WAIT_SECONDS=180
 EMBEDDING_WORKER_RESTART_TIMEOUT_SECONDS=300
 LLM_MODEL=
 
+# Agent execution safeguards (optional)
+# Dedicated capacity for synchronous tools; excess calls wait in the bounded queue.
+# AGENT_SYNC_TOOL_MAX_WORKERS=16
+# AGENT_SYNC_TOOL_MAX_QUEUE=32
+# AGENT_SYNC_TOOL_ADMISSION_TIMEOUT_SECONDS=2
+# Durable recipe ownership is never stolen from a live owner; the heartbeat-
+# based stale-run reaper settles abandoned runs safely.
+# AGENT_RUN_LEASE_WAIT_SECONDS=900
+
 # Workspace root for project-context integrations (optional)
 WORKSPACE_ROOT=

--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -82,10 +82,12 @@ async def _cancel_run_with_event(store: AsyncAgentRunStore, run_id: int, *, reas
     row = await store.require_run(int(run_id))
     if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
         return
+    canceled = await store.set_status(int(run_id), RunStatus.CANCELED, reason=reason)
+    if canceled.status != RunStatus.CANCELED:
+        return
     await store.append_event(
         run_event(int(run_id), "run.canceled", {"reason": reason}, root_run_id=row.root_run_id)
     )
-    await store.set_status(int(run_id), RunStatus.CANCELED, reason=reason)
 
 
 async def _require_idea_for_run_history(session, idea_id: str, user: dict[str, Any]) -> None:

--- a/brain/platform/async_io.py
+++ b/brain/platform/async_io.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import contextvars
+from contextlib import contextmanager
+from functools import partial
+import inspect
+import os
 import shutil
 import subprocess
+import threading
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, TypeVar
@@ -13,8 +20,227 @@ import httpx
 T = TypeVar("T")
 
 
+def _env_int(name: str, default: int, *, minimum: int) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except ValueError:
+        return default
+
+
+_TOOL_EXECUTOR_MAX_WORKERS = _env_int("AGENT_SYNC_TOOL_MAX_WORKERS", 16, minimum=1)
+_TOOL_EXECUTOR_MAX_QUEUE = _env_int("AGENT_SYNC_TOOL_MAX_QUEUE", 32, minimum=0)
+_TOOL_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_TOOL_EXECUTOR_MAX_WORKERS,
+    thread_name_prefix="agent-tool",
+)
+_TOOL_ADMISSION = threading.BoundedSemaphore(
+    _TOOL_EXECUTOR_MAX_WORKERS + _TOOL_EXECUTOR_MAX_QUEUE
+)
+
+
+class BlockingInvocationCancelled(asyncio.CancelledError):
+    """Cancellation raised only after an unavoidable sync call has settled."""
+
+    def __init__(self, *, result: Any = None, error: Exception | None = None):
+        super().__init__("blocking invocation settled after cancellation")
+        self.result = result
+        self.error = error
+
+
+class ToolExecutorOverloaded(RuntimeError):
+    """The isolated synchronous-tool pool has no bounded admission capacity."""
+
+
+class InvocationProbe:
+    """Call-local state distinguishing a live sync phase from returned async work."""
+
+    def __init__(self):
+        self.side_effect_started = False
+        self._blocking_lock = threading.Lock()
+        self._active_blocking_states: set[_BlockingCallState] = set()
+
+    def enter_blocking_call(self, state: "_BlockingCallState") -> None:
+        with self._blocking_lock:
+            self._active_blocking_states.add(state)
+
+    def leave_blocking_call(self, state: "_BlockingCallState") -> None:
+        with self._blocking_lock:
+            self._active_blocking_states.discard(state)
+
+    def blocking_snapshot(self) -> tuple[bool, bool]:
+        """Return whether a sync call is active and whether one has started."""
+        with self._blocking_lock:
+            states = tuple(self._active_blocking_states)
+        return bool(states), any(state.started.is_set() for state in states)
+
+    @property
+    def active_blocking_calls(self) -> int:
+        with self._blocking_lock:
+            return len(self._active_blocking_states)
+
+
+class _BlockingCallState:
+    def __init__(self):
+        self.started = threading.Event()
+
+
+_CURRENT_INVOCATION_PROBE: contextvars.ContextVar[InvocationProbe | None] = contextvars.ContextVar(
+    "agent_tool_invocation_probe",
+    default=None,
+)
+
+
+@contextmanager
+def bind_invocation_probe(probe: InvocationProbe):
+    token = _CURRENT_INVOCATION_PROBE.set(probe)
+    try:
+        yield probe
+    finally:
+        _CURRENT_INVOCATION_PROBE.reset(token)
+
+
+def mark_side_effect_started() -> None:
+    """Mark the point after preflight where a mutating handler may take effect."""
+    probe = _CURRENT_INVOCATION_PROBE.get()
+    if probe is not None:
+        probe.side_effect_started = True
+
+
+async def _await_task_uninterruptibly(task):
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.done():
+                return task.result()
+
+
+async def run_tool_blocking(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run a sync tool in an isolated executor with bounded admission."""
+    probe = _CURRENT_INVOCATION_PROBE.get()
+    return await _run_tool_blocking(_BlockingCallState(), func, args, kwargs, probe=probe)
+
+
+async def _run_tool_blocking(
+    state: _BlockingCallState,
+    func: Callable[..., T],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    probe: InvocationProbe | None = None,
+) -> T:
+    loop = asyncio.get_running_loop()
+    admitted = False
+    if probe is not None:
+        probe.enter_blocking_call(state)
+    try:
+        try:
+            timeout = max(0.001, float(os.getenv("AGENT_SYNC_TOOL_ADMISSION_TIMEOUT_SECONDS", "2")))
+        except ValueError:
+            timeout = 2.0
+        deadline = loop.time() + timeout
+        while not _TOOL_ADMISSION.acquire(blocking=False):
+            if loop.time() >= deadline:
+                raise ToolExecutorOverloaded(
+                    "Synchronous tool capacity is saturated; retry after other tool calls finish"
+                )
+            await asyncio.sleep(min(0.01, max(0.001, deadline - loop.time())))
+        admitted = True
+        context = contextvars.copy_context()
+        call = partial(func, *args, **kwargs)
+
+        def run_call():
+            state.started.set()
+            return context.run(call)
+
+        concurrent_worker = _TOOL_EXECUTOR.submit(run_call)
+        worker = asyncio.wrap_future(concurrent_worker, loop=loop)
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError as cancellation:
+            # ``shield`` protects submitted work from the caller's cancellation.
+            # If the executor has not started it yet, cancel the underlying
+            # concurrent future directly so a canceled tool cannot run later.
+            if not state.started.is_set() and concurrent_worker.cancel():
+                raise
+            try:
+                result = await _await_task_uninterruptibly(worker)
+            except Exception as exc:
+                raise BlockingInvocationCancelled(error=exc) from cancellation
+            raise BlockingInvocationCancelled(result=result) from cancellation
+    finally:
+        if admitted:
+            _TOOL_ADMISSION.release()
+        if probe is not None:
+            probe.leave_blocking_call(state)
+
+
 async def run_blocking(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
     return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def callable_runs_on_event_loop(func: Callable[..., Any]) -> bool:
+    call = getattr(func, "__call__", None)
+    return (
+        inspect.iscoroutinefunction(func)
+        or inspect.iscoroutinefunction(call)
+        or bool(getattr(func, "_illo_run_on_event_loop", False))
+    )
+
+
+def callable_uses_blocking_thread(func: Callable[..., Any]) -> bool:
+    explicit = getattr(func, "_illo_uses_blocking_thread", None)
+    if explicit is not None:
+        return bool(explicit)
+    if getattr(func, "_illo_run_on_event_loop", False):
+        wrapped = getattr(func, "__wrapped__", None)
+        return callable_uses_blocking_thread(wrapped) if callable(wrapped) else False
+    return not callable_runs_on_event_loop(func)
+
+
+async def invoke_maybe_async(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Invoke async callables on-loop and offload synchronous work.
+
+    Context variables are copied into the isolated tool executor, so runtime-bound
+    AgentRun context remains visible to synchronous handlers without blocking
+    heartbeats, cancellation, or other runner slots.
+    """
+
+    if callable_runs_on_event_loop(func):
+        result = func(*args, **kwargs)
+    else:
+        probe = _CURRENT_INVOCATION_PROBE.get()
+        state = _BlockingCallState()
+        blocking_task = asyncio.create_task(
+            _run_tool_blocking(state, func, args, kwargs, probe=probe),
+            name=f"blocking-{getattr(func, '__name__', 'callable')}",
+        )
+        try:
+            result = await asyncio.shield(blocking_task)
+        except asyncio.CancelledError as cancellation:
+            if not state.started.is_set():
+                blocking_task.cancel()
+                try:
+                    await _await_task_uninterruptibly(blocking_task)
+                except BaseException:
+                    pass
+                raise
+            try:
+                result = await _await_task_uninterruptibly(blocking_task)
+            except Exception as exc:
+                raise BlockingInvocationCancelled(error=exc) from cancellation
+            if inspect.isawaitable(result):
+                if inspect.iscoroutine(result):
+                    result.close()
+                else:
+                    cancel = getattr(result, "cancel", None)
+                    if callable(cancel):
+                        cancel()
+                raise
+            raise BlockingInvocationCancelled(result=result) from cancellation
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 async def ensure_dir(path: str | Path, *, parents: bool = True, exist_ok: bool = True) -> Path:

--- a/brain/platform/db/alembic/versions/0023_agent_run_parent_step_idempotency.py
+++ b/brain/platform/db/alembic/versions/0023_agent_run_parent_step_idempotency.py
@@ -1,0 +1,176 @@
+"""Add durable parent-step idempotency for child AgentRuns.
+
+Revision ID: 0023_agent_run_parent_step_idempotency
+Revises: 0022_workspace_app_collaboration_events
+Create Date: 2026-07-10
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from hashlib import sha256
+import json
+import sqlalchemy as sa
+
+
+revision = "0023_agent_run_parent_step_idempotency"
+down_revision = "0022_workspace_app_collaboration_events"
+branch_labels = None
+depends_on = None
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _column_exists(column_name: str) -> bool:
+    return column_name in {
+        column["name"]
+        for column in _inspector().get_columns("agent_runs", schema=_schema())
+    }
+
+
+def _constraint_exists(constraint_name: str) -> bool:
+    return constraint_name in {
+        constraint["name"]
+        for constraint in _inspector().get_unique_constraints("agent_runs", schema=_schema())
+    }
+
+
+def _check_exists(constraint_name: str) -> bool:
+    return constraint_name in {
+        constraint["name"]
+        for constraint in _inspector().get_check_constraints("agent_runs", schema=_schema())
+    }
+
+
+def _legacy_step_hash(run_id: int, metadata) -> str:
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except json.JSONDecodeError:
+            metadata = {}
+    metadata = metadata if isinstance(metadata, dict) else {}
+    step_key = str(metadata.get("parent_step_key") or f"legacy-run:{run_id}").strip()
+    return sha256(step_key.encode()).hexdigest()
+
+
+def _backfill_parent_step_hashes() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("LOCK TABLE agent_runs IN ACCESS EXCLUSIVE MODE")
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, parent_run_id, metadata FROM agent_runs "
+            "WHERE parent_run_id IS NOT NULL"
+        )
+    ).mappings()
+    seen: dict[tuple[int, str], int] = {}
+    updates: list[tuple[int, str]] = []
+    for row in rows:
+        run_id = int(row["id"])
+        parent_run_id = int(row["parent_run_id"])
+        key_hash = _legacy_step_hash(run_id, row["metadata"])
+        collision_key = (parent_run_id, key_hash)
+        if collision_key in seen:
+            raise RuntimeError(
+                "Duplicate legacy AgentRun parent step detected for runs "
+                f"{seen[collision_key]} and {run_id}; reconcile before upgrading"
+            )
+        seen[collision_key] = run_id
+        updates.append((run_id, key_hash))
+    for run_id, key_hash in updates:
+        bind.execute(
+            sa.text(
+                "UPDATE agent_runs SET parent_step_key_hash = :key_hash "
+                "WHERE id = :run_id"
+            ),
+            {"run_id": run_id, "key_hash": key_hash},
+        )
+
+
+def upgrade() -> None:
+    columns = {
+        "parent_step_key_hash": sa.Column("parent_step_key_hash", sa.String(length=64), nullable=True),
+        "execution_token": sa.Column("execution_token", sa.String(length=64), nullable=True),
+        "execution_attempt": sa.Column(
+            "execution_attempt",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    }
+    missing_columns = [column for name, column in columns.items() if not _column_exists(name)]
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("agent_runs") as batch:
+            for column in missing_columns:
+                batch.add_column(column)
+        _backfill_parent_step_hashes()
+        with op.batch_alter_table("agent_runs") as batch:
+            if not _constraint_exists("uq_agent_runs_parent_step_key_hash"):
+                batch.create_unique_constraint(
+                    "uq_agent_runs_parent_step_key_hash",
+                    ["parent_run_id", "parent_step_key_hash"],
+                )
+            if not _check_exists("ck_agent_runs_child_parent_step_hash"):
+                batch.create_check_constraint(
+                    "ck_agent_runs_child_parent_step_hash",
+                    "parent_run_id IS NULL OR parent_step_key_hash IS NOT NULL",
+                )
+        return
+    for column in missing_columns:
+        op.add_column("agent_runs", column)
+    _backfill_parent_step_hashes()
+    if not _constraint_exists("uq_agent_runs_parent_step_key_hash"):
+        op.create_unique_constraint(
+            "uq_agent_runs_parent_step_key_hash",
+            "agent_runs",
+            ["parent_run_id", "parent_step_key_hash"],
+        )
+    if not _check_exists("ck_agent_runs_child_parent_step_hash"):
+        op.create_check_constraint(
+            "ck_agent_runs_child_parent_step_hash",
+            "agent_runs",
+            "parent_run_id IS NULL OR parent_step_key_hash IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    drop_constraint = _constraint_exists("uq_agent_runs_parent_step_key_hash")
+    drop_check = _check_exists("ck_agent_runs_child_parent_step_hash")
+    drop_columns = [
+        name
+        for name in (
+            "execution_attempt",
+            "execution_token",
+            "parent_step_key_hash",
+        )
+        if _column_exists(name)
+    ]
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("agent_runs") as batch:
+            if drop_constraint:
+                batch.drop_constraint("uq_agent_runs_parent_step_key_hash", type_="unique")
+            if drop_check:
+                batch.drop_constraint("ck_agent_runs_child_parent_step_hash", type_="check")
+            for column_name in drop_columns:
+                batch.drop_column(column_name)
+        return
+    if drop_constraint:
+        op.drop_constraint(
+            "uq_agent_runs_parent_step_key_hash",
+            "agent_runs",
+            type_="unique",
+        )
+    if drop_check:
+        op.drop_constraint(
+            "ck_agent_runs_child_parent_step_hash",
+            "agent_runs",
+            type_="check",
+        )
+    for column_name in drop_columns:
+        op.drop_column("agent_runs", column_name)

--- a/brain/platform/db/models/agent_run.py
+++ b/brain/platform/db/models/agent_run.py
@@ -40,6 +40,10 @@ class AgentRunRow(Base, TimestampMixin):
             check_in_constraint("status", AGENT_RUN_DB_STATUS_VALUES),
             name="ck_agent_runs_status",
         ),
+        CheckConstraint(
+            "parent_run_id IS NULL OR parent_step_key_hash IS NOT NULL",
+            name="ck_agent_runs_child_parent_step_hash",
+        ),
         Index("ix_agent_runs_org_created", "org_id", "created_at"),
         Index("ix_agent_runs_thread_created", "thread_id", "created_at"),
         Index("ix_agent_runs_status_created", "status", "created_at"),
@@ -52,6 +56,11 @@ class AgentRunRow(Base, TimestampMixin):
             "source_idempotency_scope",
             "source_idempotency_key",
             name="uq_agent_runs_org_source_idempotency",
+        ),
+        UniqueConstraint(
+            "parent_run_id",
+            "parent_step_key_hash",
+            name="uq_agent_runs_parent_step_key_hash",
         ),
     )
 
@@ -81,6 +90,9 @@ class AgentRunRow(Base, TimestampMixin):
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, nullable=False, server_default=sql_text("'{}'::jsonb"), default=dict)
     source_idempotency_scope: Mapped[str | None] = mapped_column(String(80), nullable=True)
     source_idempotency_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    parent_step_key_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    execution_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    execution_attempt: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0", default=0)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/brain/systems/runs/actions.py
+++ b/brain/systems/runs/actions.py
@@ -23,6 +23,12 @@ from pydantic import (
     model_validator,
 )
 
+from brain.platform.async_io import (
+    BlockingInvocationCancelled,
+    callable_uses_blocking_thread,
+    invoke_maybe_async,
+    mark_side_effect_started,
+)
 from brain.systems.runs.tool_catalog.metadata import ActionPolicyResult
 from brain.systems.runs.tool_catalog.registry import action_policy_for_tool
 
@@ -680,9 +686,29 @@ def wrap_action_manifest_audit(
             logger.debug("Failed to build action manifest", exc_info=True)
 
         try:
-            result = handler(*args, **kwargs)
-            if inspect.isawaitable(result):
-                result = await result
+            mark_side_effect_started()
+            result = await invoke_maybe_async(handler, *args, **kwargs)
+        except BlockingInvocationCancelled as exc:
+            failure = str(exc.error) if exc.error else result_failure_summary(exc.result)
+            if manifest_id:
+                completion = complete_action_manifest(
+                    manifest_id,
+                    outcome_status="failed" if failure else "succeeded",
+                    outcome_error=failure,
+                )
+                if inspect.isawaitable(completion):
+                    await completion
+            raise
+        except asyncio.CancelledError:
+            if manifest_id:
+                completion = complete_action_manifest(
+                    manifest_id,
+                    outcome_status="indeterminate",
+                    outcome_error="caller canceled before a definitive action outcome",
+                )
+                if inspect.isawaitable(completion):
+                    await completion
+            raise
         except Exception as exc:
             if manifest_id:
                 completion = complete_action_manifest(
@@ -715,4 +741,8 @@ def wrap_action_manifest_audit(
         return awaitable
 
     wrapper._action_manifest_audited = True
+    wrapper._illo_marks_side_effect_start = True
+    wrapper._illo_run_on_event_loop = True
+    wrapper._illo_uses_blocking_thread = callable_uses_blocking_thread(handler)
+    wrapper.__wrapped__ = handler
     return wrapper

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -881,11 +881,9 @@ def _normalize_datetime(value: Any) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-async def _latest_event_times_for_rows_async(session, rows: list[AgentRunRow]) -> tuple[dict[int, datetime], dict[int, datetime]]:
+async def _latest_event_times_for_rows_async(session, rows: list[AgentRunRow]) -> dict[int, datetime]:
     run_ids = {int(row.id) for row in rows}
-    root_ids = {int(row.root_run_id or row.id) for row in rows}
     latest_by_run: dict[int, datetime] = {}
-    latest_by_root: dict[int, datetime] = {}
     if run_ids:
         result = await session.execute(
             select(AgentRunEventRow.run_id, func.max(AgentRunEventRow.created_at))
@@ -896,17 +894,7 @@ async def _latest_event_times_for_rows_async(session, rows: list[AgentRunRow]) -
             parsed = _normalize_datetime(created_at)
             if parsed is not None:
                 latest_by_run[int(run_id)] = parsed
-    if root_ids:
-        result = await session.execute(
-            select(AgentRunEventRow.root_run_id, func.max(AgentRunEventRow.created_at))
-            .where(AgentRunEventRow.root_run_id.in_(root_ids))
-            .group_by(AgentRunEventRow.root_run_id)
-        )
-        for root_id, created_at in result:
-            parsed = _normalize_datetime(created_at)
-            if parsed is not None:
-                latest_by_root[int(root_id)] = parsed
-    return latest_by_run, latest_by_root
+    return latest_by_run
 
 
 async def _active_root_run_ids_for_children_async(session, rows: list[AgentRunRow]) -> set[int]:
@@ -930,7 +918,6 @@ def _run_liveness_at(
     row: AgentRunRow,
     *,
     latest_event_by_run: dict[int, datetime],
-    latest_event_by_root: dict[int, datetime],
 ) -> datetime | None:
     metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
     heartbeat = metadata.get("runner_heartbeat")
@@ -941,10 +928,83 @@ def _run_liveness_at(
         _normalize_datetime(row.created_at),
         _normalize_datetime(heartbeat.get("at")),
         latest_event_by_run.get(int(row.id)),
-        latest_event_by_root.get(int(row.root_run_id or row.id)),
     ]
     live = [candidate for candidate in candidates if candidate is not None]
     return max(live) if live else None
+
+
+async def _reap_stale_candidate(
+    session,
+    store: AsyncAgentRunStore,
+    row: AgentRunRow,
+    *,
+    root_run_id: int,
+    cutoff: datetime,
+    stale_after_seconds: float,
+) -> tuple[bool, dict[str, Any] | None]:
+    candidate_tx = await session.begin_nested()
+    try:
+        locked = await store.lock_run_liveness(int(row.id), root_run_id)
+        if locked is None:
+            await candidate_tx.rollback()
+            return False, None
+        row, locked_root = locked
+        if str(row.status or "") not in _PROCESS_ACTIVE_STATUS_VALUES:
+            await candidate_tx.rollback()
+            return False, None
+        if (
+            row.parent_run_id is not None
+            and locked_root is not None
+            and str(locked_root.status or "") in _PROCESS_ACTIVE_STATUS_VALUES
+        ):
+            await candidate_tx.rollback()
+            return False, None
+        locked_event_by_run = await _latest_event_times_for_rows_async(session, [row])
+        last_liveness_at = _run_liveness_at(
+            row,
+            latest_event_by_run=locked_event_by_run,
+        )
+        if last_liveness_at is not None and last_liveness_at > cutoff:
+            await candidate_tx.rollback()
+            return False, None
+        metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
+        heartbeat = metadata.get("runner_heartbeat")
+        heartbeat = dict(heartbeat) if isinstance(heartbeat, dict) else {}
+        payload = {
+            "error": "runner heartbeat stale",
+            "reason": "runner_heartbeat_stale",
+            "stale_after_seconds": int(stale_after_seconds),
+            "last_heartbeat_at": heartbeat.get("at"),
+            "last_heartbeat_reason": heartbeat.get("reason"),
+            "last_liveness_at": last_liveness_at.isoformat() if last_liveness_at else None,
+            "last_run_update_at": row.updated_at.isoformat() if row.updated_at else None,
+        }
+        _failed_run, changed = await store.set_status_with_result(
+            int(row.id),
+            RunStatus.FAILED,
+            reason="runner_heartbeat_stale",
+            expected_updated_at=row.updated_at,
+            expected_execution_token=row.execution_token,
+            expected_execution_attempt=int(row.execution_attempt or 0),
+            rollback_on_conflict=False,
+        )
+        if not changed:
+            await candidate_tx.rollback()
+            return False, None
+        event = run_event(int(row.id), "run.failed", payload, root_run_id=row.root_run_id)
+        event_row = await store.append_event(event)
+        await _project_live_event_async(
+            session,
+            event.event_type,
+            _event_stream_payload(event, event_row, row),
+        )
+        status_payload = await _settle_terminal_root_run_async(session, int(row.id))
+        await candidate_tx.commit()
+        return True, status_payload
+    except BaseException:
+        if candidate_tx.is_active:
+            await candidate_tx.rollback()
+        raise
 
 
 async def reap_stale_active_runs(
@@ -971,7 +1031,7 @@ async def reap_stale_active_runs(
         )
         rows = list(result.all())
         store = AsyncAgentRunStore(uow.session)
-        latest_event_by_run, latest_event_by_root = await _latest_event_times_for_rows_async(uow.session, rows)
+        latest_event_by_run = await _latest_event_times_for_rows_async(uow.session, rows)
         active_root_run_ids = await _active_root_run_ids_for_children_async(uow.session, rows)
         for row in rows:
             if str(row.status or "") not in _PROCESS_ACTIVE_STATUS_VALUES:
@@ -982,27 +1042,19 @@ async def reap_stale_active_runs(
             last_liveness_at = _run_liveness_at(
                 row,
                 latest_event_by_run=latest_event_by_run,
-                latest_event_by_root=latest_event_by_root,
             )
             if last_liveness_at is not None and last_liveness_at > cutoff:
                 continue
-            metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
-            heartbeat = metadata.get("runner_heartbeat")
-            heartbeat = dict(heartbeat) if isinstance(heartbeat, dict) else {}
-            payload = {
-                "error": "runner heartbeat stale",
-                "reason": "runner_heartbeat_stale",
-                "stale_after_seconds": int(stale_after_seconds),
-                "last_heartbeat_at": heartbeat.get("at"),
-                "last_heartbeat_reason": heartbeat.get("reason"),
-                "last_liveness_at": last_liveness_at.isoformat() if last_liveness_at else None,
-                "last_run_update_at": row.updated_at.isoformat() if row.updated_at else None,
-            }
-            event = run_event(int(row.id), "run.failed", payload, root_run_id=row.root_run_id)
-            event_row = await store.append_event(event)
-            await store.set_status(int(row.id), RunStatus.FAILED, reason="runner_heartbeat_stale")
-            await _project_live_event_async(uow.session, event.event_type, _event_stream_payload(event, event_row, row))
-            status_payload = await _settle_terminal_root_run_async(uow.session, int(row.id))
+            candidate_reaped, status_payload = await _reap_stale_candidate(
+                uow.session,
+                store,
+                row,
+                root_run_id=root_run_id,
+                cutoff=cutoff,
+                stale_after_seconds=stale_after_seconds,
+            )
+            if not candidate_reaped:
+                continue
             if status_payload:
                 status_payloads.append(status_payload)
             reaped += 1

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -10,10 +10,21 @@ import logging
 import os
 from typing import Any, Callable
 
+from brain.platform.async_io import (
+    InvocationProbe,
+    bind_invocation_probe,
+    invoke_maybe_async,
+    mark_side_effect_started,
+)
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
-from brain.systems.runs.tool_catalog.registry import output_budget_chars_for_tool
+from brain.systems.runs.tool_catalog.registry import (
+    action_policy_for_tool,
+    get_tool_registration,
+    output_budget_chars_for_tool,
+)
 
 logger = logging.getLogger("agent")
+_background_tool_tasks: set[asyncio.Task[ResolvedToolCall]] = set()
 
 _DEFAULT_TOOL_TIMEOUT_SECONDS = 180.0
 _DEFAULT_TOOL_TIMEOUT_GRACE_SECONDS = 5.0
@@ -111,6 +122,17 @@ def _timeout_result(request: PendingToolCall, timeout_seconds: float) -> Resolve
         ),
         is_error=True,
     )
+
+
+def _must_finish_before_reporting(request: PendingToolCall) -> bool:
+    """Return whether a still-running call could make a retry unsafe."""
+    registration = get_tool_registration(request.tool_name)
+    if registration is None:
+        return bool(getattr(request.handler, "_action_manifest_audited", False))
+    if action_policy_for_tool(request.tool_name, kwargs=request.tool_input) is None:
+        return False
+    side_effect = str(getattr(registration.side_effect_class, "value", registration.side_effect_class))
+    return side_effect not in {"read_only", "read_only_external"}
 
 
 def _truncate_middle_text(text: str, max_chars: int) -> str:
@@ -246,7 +268,7 @@ async def async_invoke_tool_handler(
 ):
     """Execute a tool handler with optional propagated AgentRun context."""
     with _BoundAgentContext(agent_context, threadlocal_context):
-        return await async_run_tool_awaitable(handler(**tool_input))
+        return await invoke_maybe_async(handler, **tool_input)
 
 
 def invoke_tool_handler(
@@ -268,6 +290,8 @@ async def _async_resolve_tool_call_once(
 ) -> ResolvedToolCall:
     """Execute one tool request and normalize success/error handling."""
     try:
+        if not getattr(request.handler, "_illo_marks_side_effect_start", False):
+            mark_side_effect_started()
         result = await async_invoke_tool_handler(
             request.handler,
             request.tool_input,
@@ -319,18 +343,78 @@ async def async_resolve_tool_call(
 ) -> ResolvedToolCall:
     """Execute one tool request with an async watchdog timeout."""
     timeout_seconds = _tool_timeout_seconds(request.tool_name, request.tool_input)
-    call = _async_resolve_tool_call_once(
-        request,
-        agent_context=agent_context,
-        threadlocal_context=threadlocal_context,
-    )
+    probe = InvocationProbe()
+
+    async def call_with_probe():
+        with bind_invocation_probe(probe):
+            return await _async_resolve_tool_call_once(
+                request,
+                agent_context=agent_context,
+                threadlocal_context=threadlocal_context,
+            )
+
+    call = call_with_probe()
     if timeout_seconds is None:
         return await call
+    must_finish = _must_finish_before_reporting(request)
+    task = asyncio.create_task(call, name=f"tool-{request.tool_name}-blocking-boundary")
     try:
-        return await asyncio.wait_for(call, timeout=timeout_seconds)
-    except TimeoutError:
-        logger.warning("Tool %s timed out after %.2fs", request.tool_name, timeout_seconds)
-        return _timeout_result(request, timeout_seconds)
+        done, _ = await asyncio.wait({task}, timeout=timeout_seconds)
+    except asyncio.CancelledError:
+        blocking_active, blocking_started = probe.blocking_snapshot()
+        blocking_unavoidable = blocking_active and blocking_started
+        action_started = probe.side_effect_started and (
+            not blocking_active or blocking_started
+        )
+        if must_finish and action_started:
+            _track_background_tool_task(task)
+        elif blocking_unavoidable:
+            task.cancel()
+            _track_background_tool_task(task)
+        else:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        raise
+    if task in done:
+        return task.result()
+    blocking_active, blocking_started = probe.blocking_snapshot()
+    blocking_unavoidable = blocking_active and blocking_started
+    action_started = probe.side_effect_started and (
+        not blocking_active or blocking_started
+    )
+    if must_finish and action_started:
+        logger.warning(
+            "Tool %s exceeded its %.2fs watchdog; waiting for a definitive action outcome",
+            request.tool_name,
+            timeout_seconds,
+        )
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _track_background_tool_task(task)
+            raise
+    task.cancel()
+    if blocking_unavoidable:
+        _track_background_tool_task(task)
+    else:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        if task.done() and not task.cancelled():
+            return task.result()
+    logger.warning("Tool %s timed out after %.2fs", request.tool_name, timeout_seconds)
+    return _timeout_result(request, timeout_seconds)
+
+
+def _track_background_tool_task(task: asyncio.Task[ResolvedToolCall]) -> None:
+    if task.done():
+        return
+    _background_tool_tasks.add(task)
+    task.add_done_callback(_background_tool_tasks.discard)
 
 
 def _resolve_tool_call_sync(

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import inspect
 import logging
@@ -15,7 +16,12 @@ from brain.systems.runs.context import RunContextLoader
 from brain.systems.runs.domain import AgentRun, AgentRunRequest, ArtifactType, RunProfile, RunRecipe
 from brain.systems.runs.events import activity_event, run_event, text_delta_event
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
-from brain.systems.runs.store import AsyncAgentRunStore, to_domain
+from brain.systems.runs.store import (
+    AsyncAgentRunStore,
+    ExecutionClaim,
+    ExecutionClaimLost,
+    to_domain,
+)
 from brain.systems.runs.stream import RunStream
 from brain.systems.runs.steering import SteeringInbox, SteeringMessage
 from brain.systems.runs.tools import AsyncRunToolExecutor
@@ -160,6 +166,7 @@ class RunRuntime:
     ) -> AgentRun:
         return await self.store.create_child_run(
             self.run,
+            initial_status=RunStatus.STARTING,
             recipe=recipe,
             message=message,
             profile=profile or self.request.profile,
@@ -234,7 +241,42 @@ class AsyncAgentRunEngine:
         return await self.store.set_status(run_id, RunStatus.PAUSED, reason=reason)
 
     async def run_existing(self, run_id: int) -> AgentRun:
-        row = await self.store.require_run(run_id)
+        execution_lease = getattr(self.store, "execution_lease", None)
+        if callable(execution_lease):
+            post_completion_tasks: list[Callable[[], Awaitable[Any]]] = []
+            try:
+                async with execution_lease(run_id) as execution_claim:
+                    if execution_claim is None:
+                        refresh_run = getattr(self.store, "refresh_run", None)
+                        row = await refresh_run(run_id) if callable(refresh_run) else await self.store.require_run(run_id)
+                        return to_domain(row)
+                    completed = await self._run_existing_owned(
+                        run_id,
+                        execution_claim=execution_claim,
+                        deferred_post_completion_tasks=post_completion_tasks,
+                    )
+            except ExecutionClaimLost:
+                await self.store.session.rollback()
+                refresh_run = getattr(self.store, "refresh_run", None)
+                row = await refresh_run(run_id) if callable(refresh_run) else await self.store.require_run(run_id)
+                return to_domain(row)
+            for task in post_completion_tasks:
+                _schedule_post_completion_task(run_id, task)
+            return completed
+        return await self._run_existing_owned(run_id)
+
+    async def _run_existing_owned(
+        self,
+        run_id: int,
+        *,
+        execution_claim: ExecutionClaim | None = None,
+        deferred_post_completion_tasks: list[Callable[[], Awaitable[Any]]] | None = None,
+    ) -> AgentRun:
+        row = (
+            await self.store.assert_execution_claim(execution_claim)
+            if execution_claim is not None
+            else await self.store.require_run(run_id)
+        )
         if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
             return to_domain(row)
         if not str(row.org_id or "").strip():
@@ -242,6 +284,7 @@ class AsyncAgentRunEngine:
                 row.id,
                 RunStatus.FAILED,
                 reason="AgentRun missing workspace org_id",
+                execution_claim=execution_claim,
             )
         request = AgentRunRequest(
             org_id=row.org_id,
@@ -257,7 +300,7 @@ class AsyncAgentRunEngine:
             model_policy=dict(row.model_policy or {}),
             metadata=dict(row.metadata_ or {}),
         )
-        run = await self._enter_running(row)
+        run = to_domain(row) if execution_claim is not None else await self._enter_running(row)
         cancel_event = self.cancel_event_factory(run.id) if self.cancel_event_factory else None
         runtime = RunRuntime(
             run=run,
@@ -273,43 +316,56 @@ class AsyncAgentRunEngine:
         )
         recipe = self.recipes.get(request.normalized_recipe.value)
         if recipe is None:
-            return await self.fail(run.id, f"No recipe registered for {request.normalized_recipe.value!r}")
+            return await self.fail(
+                run.id,
+                f"No recipe registered for {request.normalized_recipe.value!r}",
+                execution_claim=execution_claim,
+            )
         try:
             result = recipe.execute(runtime)
             if inspect.isawaitable(result):
                 result = await result
         except Exception as exc:
-            return await self.fail(run.id, str(exc))
+            return await self.fail(run.id, str(exc), execution_claim=execution_claim)
         for artifact in result.artifacts:
             await self.store.append_artifact(artifact)
         if await cancel_event_is_set(cancel_event):
-            return await self.cancel(run.id, reason="user_canceled")
+            return await self.cancel(
+                run.id,
+                reason="user_canceled",
+                execution_claim=execution_claim,
+            )
         result_status = RunStatus(result.status)
         if result_status == RunStatus.PAUSED:
-            return await self.store.set_status(run.id, result_status)
+            return await self.store.set_status(
+                run.id,
+                result_status,
+                execution_claim=execution_claim,
+            )
         if result_status == RunStatus.FAILED:
-            if result.output:
-                artifact = await self.store.append_final_answer_once(
-                    run.id,
-                    result.output,
-                    root_run_id=run.root_run_id,
-                )
-                safe_output = str(getattr(artifact, "text", None) or result.output)
-                if not await self.store.has_event_type(run.id, "run.text_delta"):
-                    await self.store.append_event(
-                        run_event(
-                            run.id,
-                            "run.text_completed",
-                            {"text": safe_output},
-                            root_run_id=run.root_run_id,
-                        )
-                    )
-            return await self.fail(run.id, result.output or "recipe_failed")
+            return await self.fail(
+                run.id,
+                result.output or "recipe_failed",
+                final_output=result.output or None,
+                execution_claim=execution_claim,
+            )
         if result_status == RunStatus.CANCELED:
-            return await self.cancel(run.id, reason=result.output or None)
-        completed = await self.complete(run.id, output=result.output, status=result_status)
-        for task in result.post_completion_tasks:
-            _schedule_post_completion_task(run.id, task)
+            return await self.cancel(
+                run.id,
+                reason=result.output or None,
+                execution_claim=execution_claim,
+            )
+        completed = await self.complete(
+            run.id,
+            output=result.output,
+            status=result_status,
+            execution_claim=execution_claim,
+        )
+        if deferred_post_completion_tasks is None:
+            for task in result.post_completion_tasks:
+                _schedule_post_completion_task(run.id, task)
+        else:
+            deferred_post_completion_tasks.extend(result.post_completion_tasks)
         return completed
 
     async def complete(
@@ -318,47 +374,121 @@ class AsyncAgentRunEngine:
         *,
         output: str = "",
         status: RunStatus = RunStatus.COMPLETED,
+        execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
-        row = await self.store.require_run(run_id)
-        if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
-            return to_domain(row)
-        if output:
-            artifact = await self.store.append_final_answer_once(
+        async with self._atomic_terminal_write():
+            row = await self.store.require_run(run_id)
+            if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
+                return to_domain(row)
+            completed = await self.store.set_status(
                 run_id,
-                output,
-                root_run_id=row.root_run_id,
+                status,
+                execution_claim=execution_claim,
             )
-            safe_output = str(getattr(artifact, "text", None) or output)
-            if not await self.store.has_event_type(run_id, "run.text_delta"):
-                await self.store.append_event(
-                    run_event(
-                        run_id,
-                        "run.text_completed",
-                        {"text": safe_output},
-                        root_run_id=row.root_run_id,
-                    )
+            if completed.status != status:
+                return completed
+            if output:
+                artifact = await self.store.append_final_answer_once(
+                    run_id,
+                    output,
+                    root_run_id=row.root_run_id,
                 )
-        await self.store.append_event(
-            run_event(run_id, "run.completed", {"status": status.value}, root_run_id=row.root_run_id)
-        )
-        return await self.store.set_status(run_id, status)
+                safe_output = str(getattr(artifact, "text", None) or output)
+                if not await self.store.has_event_type(run_id, "run.text_delta"):
+                    await self.store.append_event(
+                        run_event(
+                            run_id,
+                            "run.text_completed",
+                            {"text": safe_output},
+                            root_run_id=row.root_run_id,
+                        )
+                    )
+            await self.store.append_event(
+                run_event(run_id, "run.completed", {"status": status.value}, root_run_id=row.root_run_id)
+            )
+            return completed
 
-    async def fail(self, run_id: int, error: str) -> AgentRun:
-        row = await self.store.require_run(run_id)
-        if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
-            return to_domain(row)
-        safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
-        await self.store.append_event(
-            run_event(run_id, "run.failed", {"error": safe_error}, root_run_id=row.root_run_id)
-        )
-        return await self.store.set_status(run_id, RunStatus.FAILED, reason=safe_error)
+    async def fail(
+        self,
+        run_id: int,
+        error: str,
+        *,
+        final_output: str | None = None,
+        execution_claim: ExecutionClaim | None = None,
+    ) -> AgentRun:
+        async with self._atomic_terminal_write():
+            row = await self.store.require_run(run_id)
+            if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
+                return to_domain(row)
+            safe_error = await self.store.safe_cycle_provider_error_text(run_id, str(error or ""))
+            failed = await self.store.set_status(
+                run_id,
+                RunStatus.FAILED,
+                reason=safe_error,
+                execution_claim=execution_claim,
+            )
+            if failed.status != RunStatus.FAILED:
+                return failed
+            if final_output:
+                artifact = await self.store.append_final_answer_once(
+                    run_id,
+                    final_output,
+                    root_run_id=row.root_run_id,
+                )
+                safe_output = str(getattr(artifact, "text", None) or final_output)
+                if not await self.store.has_event_type(run_id, "run.text_delta"):
+                    await self.store.append_event(
+                        run_event(
+                            run_id,
+                            "run.text_completed",
+                            {"text": safe_output},
+                            root_run_id=row.root_run_id,
+                        )
+                    )
+            await self.store.append_event(
+                run_event(run_id, "run.failed", {"error": safe_error}, root_run_id=row.root_run_id)
+            )
+            return failed
 
-    async def cancel(self, run_id: int, *, reason: str | None = None) -> AgentRun:
-        row = await self.store.require_run(run_id)
-        if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
-            return to_domain(row)
-        await self.store.append_event(run_event(run_id, "run.canceled", {"reason": reason}, root_run_id=row.root_run_id))
-        return await self.store.set_status(run_id, RunStatus.CANCELED, reason=reason)
+    async def cancel(
+        self,
+        run_id: int,
+        *,
+        reason: str | None = None,
+        execution_claim: ExecutionClaim | None = None,
+    ) -> AgentRun:
+        async with self._atomic_terminal_write():
+            row = await self.store.require_run(run_id)
+            if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
+                return to_domain(row)
+            canceled = await self.store.set_status(
+                run_id,
+                RunStatus.CANCELED,
+                reason=reason,
+                execution_claim=execution_claim,
+            )
+            if canceled.status != RunStatus.CANCELED:
+                return canceled
+            await self.store.append_event(
+                run_event(run_id, "run.canceled", {"reason": reason}, root_run_id=row.root_run_id)
+            )
+            return canceled
+
+    @asynccontextmanager
+    async def _atomic_terminal_write(self):
+        """Keep terminal status, output, and semantic events in one transaction."""
+        auto_commit = self.store.auto_commit
+        self.store.auto_commit = False
+        try:
+            yield
+        except BaseException:
+            await self.store.session.rollback()
+            raise
+        else:
+            if auto_commit:
+                await self.store.session.commit()
+        finally:
+            self.store.auto_commit = auto_commit
 
     async def _enter_running(self, row) -> AgentRun:
         status = coerce_run_status(row.status, default=RunStatus.FAILED)

--- a/brain/systems/runs/recipes/phase_barrier.py
+++ b/brain/systems/runs/recipes/phase_barrier.py
@@ -136,6 +136,10 @@ async def review_completed_phase(
     if metadata.get("disable_phase_barrier_review") is True:
         return PhaseBarrierDecision.no_change("Phase barrier review disabled for this run.")
 
+    pending_worker_ids = _pending_worker_node_ids(plan)
+    if not pending_worker_ids:
+        return PhaseBarrierDecision.no_change("No pending worker nodes remain to revise.")
+
     payload = _review_payload(plan, node, node_results)
     model_policy = dict(getattr(runtime.request, "model_policy", {}) or {})
     model = model_policy.get("coordinator_model") or model_policy.get("model")
@@ -155,7 +159,7 @@ async def review_completed_phase(
         run_event(
             runtime.run.id,
             "run.phase_review_started",
-            {"node_id": node.id, "completed_node_id": node.id, "pending_nodes": _pending_node_ids(plan)},
+            {"node_id": node.id, "completed_node_id": node.id, "pending_nodes": pending_worker_ids},
             root_run_id=runtime.run.root_run_id,
             producer="deep",
         )
@@ -210,6 +214,7 @@ def apply_phase_barrier_decision(plan: DeepPlan, decision: PhaseBarrierDecision)
         return plan, ()
 
     nodes = list(plan.nodes)
+    blocked_node_ids = set(plan.blocked_node_ids())
     applied: list[dict[str, Any]] = []
     for revision in decision.revisions:
         index = next((idx for idx, node in enumerate(nodes) if node.id == revision.node_id), None)
@@ -219,6 +224,9 @@ def apply_phase_barrier_decision(plan: DeepPlan, decision: PhaseBarrierDecision)
         node = nodes[index]
         if not node.is_pending:
             applied.append({"node_id": node.id, "status": "ignored", "reason": "node_not_pending"})
+            continue
+        if node.id in blocked_node_ids:
+            applied.append({"node_id": node.id, "status": "ignored", "reason": "node_blocked"})
             continue
         if _node_kind(node) != "worker":
             applied.append({"node_id": node.id, "status": "ignored", "reason": "node_not_worker"})
@@ -300,6 +308,7 @@ def plan_revision_artifact(
 
 def _review_payload(plan: DeepPlan, node: RunNode, node_results: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
     completed_result = dict(node_results.get(node.id) or {})
+    blocked_node_ids = set(plan.blocked_node_ids())
     return {
         "objective": plan.objective,
         "completed_phase": {
@@ -314,8 +323,9 @@ def _review_payload(plan: DeepPlan, node: RunNode, node_results: Mapping[str, di
         "pending_nodes": [
             node.to_payload()
             for node in plan.pending_nodes()
-            if _node_kind(node) == "worker"
+            if _node_kind(node) == "worker" and node.id not in blocked_node_ids
         ],
+        "blocked_node_ids": sorted(blocked_node_ids),
         "plan": plan.to_payload(),
         "instructions": (
             "Revise only pending worker nodes. Do not alter completed nodes. "
@@ -398,8 +408,13 @@ def _node_revision_snapshot(node: RunNode) -> dict[str, Any]:
     }
 
 
-def _pending_node_ids(plan: DeepPlan) -> list[str]:
-    return [node.id for node in plan.pending_nodes()]
+def _pending_worker_node_ids(plan: DeepPlan) -> list[str]:
+    blocked_node_ids = set(plan.blocked_node_ids())
+    return [
+        node.id
+        for node in plan.pending_nodes()
+        if _node_kind(node) == "worker" and node.id not in blocked_node_ids
+    ]
 
 
 def _node_kind(node: RunNode) -> str:

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from hashlib import sha256
 import logging
+import os
 import threading
 from typing import Any
+import uuid
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -51,6 +57,23 @@ _DEFERRED_RUN_ACTIVE_STATUS_VALUES = frozenset({
     RunStatus.VERIFYING.value,
 })
 _SOURCE_IDEMPOTENCY_METADATA_KEYS = ("idempotency_key", "idempotencyKey")
+_CREATABLE_RUN_STATUSES = frozenset({RunStatus.QUEUED, RunStatus.STARTING})
+_CHILD_CREATION_TOKEN_METADATA_KEY = "parent_step_creation_token"
+_UNSET = object()
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionClaim:
+    """Durable ownership fence for one recipe execution attempt."""
+
+    run_id: int
+    token: str
+    attempt: int
+    lost: asyncio.Event = field(default_factory=asyncio.Event, compare=False, repr=False)
+
+
+class ExecutionClaimLost(RuntimeError):
+    """Raised when an execution owner loses its durable fencing claim."""
 
 
 _EVENT_LOCKS_GUARD = threading.Lock()
@@ -65,6 +88,32 @@ def _event_lock(run_id: int) -> threading.RLock:
             _EVENT_LOCKS[int(run_id)] = lock
         return lock
 
+
+def _creatable_run_status(value: RunStatus | str) -> RunStatus:
+    try:
+        status = value if isinstance(value, RunStatus) else RunStatus(str(value).strip().lower())
+    except ValueError as exc:
+        raise ValueError(f"Unsupported initial run status: {value!r}") from exc
+    if status not in _CREATABLE_RUN_STATUSES:
+        raise ValueError(
+            f"Initial run status must be queued or starting, got {status.value!r}"
+        )
+    return status
+
+
+def _parent_step_key_hash(step_key: str | None) -> str | None:
+    normalized = str(step_key or "").strip()
+    return sha256(normalized.encode()).hexdigest() if normalized else None
+
+
+async def _await_uninterruptibly(awaitable):
+    task = asyncio.create_task(awaitable)
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.done():
+                return task.result()
 
 
 def to_domain(row: AgentRunRow) -> AgentRun:
@@ -176,10 +225,47 @@ class AsyncAgentRunStore:
         )
         return (await self.session.scalars(stmt)).first()
 
-    async def create_run(self, request: AgentRunRequest) -> AgentRun:
+    async def _run_for_parent_step(
+        self,
+        *,
+        parent_run_id: int | None,
+        parent_step_key_hash: str | None,
+    ) -> AgentRunRow | None:
+        if parent_run_id is None or not parent_step_key_hash:
+            return None
+        stmt = (
+            select(AgentRunRow)
+            .where(
+                AgentRunRow.parent_run_id == int(parent_run_id),
+                AgentRunRow.parent_step_key_hash == str(parent_step_key_hash),
+            )
+            .order_by(AgentRunRow.id.asc())
+            .limit(1)
+        )
+        return (await self.session.scalars(stmt)).first()
+
+    async def create_run(
+        self,
+        request: AgentRunRequest,
+        *,
+        initial_status: RunStatus | str = RunStatus.QUEUED,
+        parent_step_key_hash: str | None = None,
+    ) -> AgentRun:
         profile = request.normalized_profile
         recipe = request.normalized_recipe
-        source_idempotency_scope, source_idempotency_key = _source_idempotency_parts(request)
+        status = _creatable_run_status(initial_status)
+        parent_step_key_hash = str(parent_step_key_hash or "").strip() or None
+        existing = await self._run_for_parent_step(
+            parent_run_id=request.parent_run_id,
+            parent_step_key_hash=parent_step_key_hash,
+        )
+        if existing is not None:
+            return to_domain(existing)
+        source_idempotency_scope, source_idempotency_key = (
+            _source_idempotency_parts(request)
+            if request.parent_run_id is None
+            else (None, None)
+        )
         existing = await self._run_for_source_idempotency(
             org_id=request.org_id,
             scope=source_idempotency_scope,
@@ -196,7 +282,7 @@ class AsyncAgentRunStore:
             root_run_id=request.root_run_id,
             profile=profile.value,
             recipe=recipe.value,
-            status=RunStatus.QUEUED.value,
+            status=status.value,
             input_message=request.message,
             target_ref=dict(request.target_ref or {}),
             workspace_ref=dict(request.workspace_ref or {}),
@@ -204,6 +290,8 @@ class AsyncAgentRunStore:
             metadata_=dict(request.metadata or {}),
             source_idempotency_scope=source_idempotency_scope,
             source_idempotency_key=source_idempotency_key,
+            parent_step_key_hash=parent_step_key_hash,
+            started_at=datetime.now(timezone.utc) if status == RunStatus.STARTING else None,
         )
         try:
             async with self.session.begin_nested():
@@ -214,6 +302,12 @@ class AsyncAgentRunStore:
                     row.root_run_id = row.id
                 await self.session.flush()
         except IntegrityError:
+            existing = await self._run_for_parent_step(
+                parent_run_id=request.parent_run_id,
+                parent_step_key_hash=parent_step_key_hash,
+            )
+            if existing is not None:
+                return to_domain(existing)
             existing = await self._run_for_source_idempotency(
                 org_id=request.org_id,
                 scope=source_idempotency_scope,
@@ -226,52 +320,130 @@ class AsyncAgentRunStore:
             run_event(
                 row.id,
                 "run.created",
-                {"profile": profile.value, "recipe": recipe.value},
+                {"profile": profile.value, "recipe": recipe.value, "status": status.value},
                 root_run_id=row.root_run_id,
             )
         )
         return to_domain(row)
 
-    async def create_child_run(self, parent: AgentRun | AgentRunRow, **kwargs: Any) -> AgentRun:
+    async def create_child_run(
+        self,
+        parent: AgentRun | AgentRunRow,
+        *,
+        initial_status: RunStatus | str = RunStatus.QUEUED,
+        **kwargs: Any,
+    ) -> AgentRun:
+        child, _created = await self.create_child_run_with_result(
+            parent,
+            initial_status=initial_status,
+            **kwargs,
+        )
+        return child
+
+    async def create_child_run_with_result(
+        self,
+        parent: AgentRun | AgentRunRow,
+        *,
+        initial_status: RunStatus | str = RunStatus.QUEUED,
+        **kwargs: Any,
+    ) -> tuple[AgentRun, bool]:
+        status = _creatable_run_status(initial_status)
         parent_run = parent if isinstance(parent, AgentRunRow) else await self.require_run(parent.id)
         recipe = kwargs["recipe"]
         recipe_value = recipe.value if isinstance(recipe, RunRecipe) else str(recipe)
         step_key = kwargs.get("step_key")
         thread_id = kwargs.get("thread_id") or parent_run.thread_id
         metadata_payload = dict(kwargs.get("metadata") or {})
-        if step_key:
-            metadata_payload["parent_step_key"] = step_key
-            existing = await self.child_run_for_step(parent_run.id, step_key)
-            if existing is not None:
-                return to_domain(existing)
-        child = await self.create_run(
-            AgentRunRequest(
-                org_id=parent_run.org_id,
-                user_id=parent_run.user_id,
-                thread_id=str(thread_id),
-                parent_run_id=parent_run.id,
-                root_run_id=parent_run.root_run_id or parent_run.id,
-                profile=kwargs.get("profile") or parent_run.profile,
-                recipe=recipe_value,
-                message=kwargs["message"],
-                target_ref=dict(
-                    kwargs["target_ref"]
-                    if kwargs.get("target_ref") is not None
-                    else parent_run.target_ref or {}
+        creation_token = uuid.uuid4().hex if step_key else None
+        auto_commit = self.auto_commit
+        commit_at_end = auto_commit or status == RunStatus.STARTING
+        self.auto_commit = False
+        try:
+            # Python's sqlite3 legacy transaction mode does not begin a real
+            # outer transaction for SELECT before SAVEPOINT. Force one so the
+            # nested idempotent insert cannot commit ahead of its parent event.
+            if self._dialect_name() == "sqlite":
+                await self.session.execute(
+                    update(AgentRunRow)
+                    .where(AgentRunRow.id == int(parent_run.id))
+                    .values(updated_at=AgentRunRow.updated_at)
+                )
+            else:
+                await self.session.execute(
+                    select(AgentRunRow.id)
+                    .where(AgentRunRow.id == int(parent_run.id))
+                    .with_for_update()
+                )
+            if step_key:
+                metadata_payload["parent_step_key"] = step_key
+                metadata_payload[_CHILD_CREATION_TOKEN_METADATA_KEY] = creation_token
+                existing = await self.child_run_for_step(parent_run.id, step_key)
+                if existing is not None:
+                    child = to_domain(existing)
+                    await self._append_child_created_once(parent_run, child, step_key)
+                    if commit_at_end:
+                        await self.session.commit()
+                    return child, False
+            child = await self.create_run(
+                AgentRunRequest(
+                    org_id=parent_run.org_id,
+                    user_id=parent_run.user_id,
+                    thread_id=str(thread_id),
+                    parent_run_id=parent_run.id,
+                    root_run_id=parent_run.root_run_id or parent_run.id,
+                    profile=kwargs.get("profile") or parent_run.profile,
+                    recipe=recipe_value,
+                    message=kwargs["message"],
+                    target_ref=dict(
+                        kwargs["target_ref"]
+                        if kwargs.get("target_ref") is not None
+                        else parent_run.target_ref or {}
+                    ),
+                    workspace_ref=dict(
+                        kwargs["workspace_ref"]
+                        if kwargs.get("workspace_ref") is not None
+                        else parent_run.workspace_ref or {}
+                    ),
+                    model_policy=dict(
+                        kwargs["model_policy"]
+                        if kwargs.get("model_policy") is not None
+                        else parent_run.model_policy or {}
+                    ),
+                    metadata=metadata_payload,
                 ),
-                workspace_ref=dict(
-                    kwargs["workspace_ref"]
-                    if kwargs.get("workspace_ref") is not None
-                    else parent_run.workspace_ref or {}
-                ),
-                model_policy=dict(
-                    kwargs["model_policy"]
-                    if kwargs.get("model_policy") is not None
-                    else parent_run.model_policy or {}
-                ),
-                metadata=metadata_payload,
+                initial_status=status,
+                parent_step_key_hash=_parent_step_key_hash(step_key),
             )
-        )
+            created_here = not step_key or child.metadata.get(_CHILD_CREATION_TOKEN_METADATA_KEY) == creation_token
+            await self._append_child_created_once(parent_run, child, step_key)
+            if commit_at_end:
+                await self.session.commit()
+            return child, created_here
+        except BaseException:
+            await self.session.rollback()
+            raise
+        finally:
+            self.auto_commit = auto_commit
+
+    async def _append_child_created_once(
+        self,
+        parent_run: AgentRunRow,
+        child: AgentRun,
+        step_key: str | None,
+    ) -> bool:
+        existing_events = (
+            await self.session.scalars(
+                select(AgentRunEventRow).where(
+                    AgentRunEventRow.run_id == int(parent_run.id),
+                    AgentRunEventRow.event_type == "run.child_created",
+                )
+            )
+        ).all()
+        if any(
+            int((event.payload or {}).get("child_run_id") or 0) == int(child.id)
+            for event in existing_events
+        ):
+            return False
         await self.append_event(
             run_event(
                 parent_run.id,
@@ -280,9 +452,15 @@ class AsyncAgentRunStore:
                 root_run_id=parent_run.root_run_id or parent_run.id,
             )
         )
-        return child
+        return True
 
     async def child_run_for_step(self, parent_run_id: int, step_key: str) -> AgentRunRow | None:
+        hashed = await self._run_for_parent_step(
+            parent_run_id=parent_run_id,
+            parent_step_key_hash=_parent_step_key_hash(step_key),
+        )
+        if hashed is not None:
+            return hashed
         rows = (
             await self.session.scalars(
                 select(AgentRunRow)
@@ -295,6 +473,209 @@ class AsyncAgentRunStore:
             if str(metadata.get("parent_step_key") or "") == str(step_key):
                 return row
         return None
+
+    @asynccontextmanager
+    async def execution_lease(self, run_id: int):
+        """Claim one fenced recipe attempt without pinning a DB connection."""
+        run_id = int(run_id)
+        token = uuid.uuid4().hex
+        await self.session.commit()
+        observed_owner = False
+        claim: ExecutionClaim | None = None
+        try:
+            while claim is None:
+                row = await self.refresh_run(run_id)
+                status = coerce_run_status(row.status, default=RunStatus.FAILED)
+                if status in TERMINAL_RUN_STATUSES:
+                    await self.session.rollback()
+                    yield None
+                    return
+                if observed_owner and status == RunStatus.PAUSED and not row.execution_token:
+                    await self.session.rollback()
+                    yield None
+                    return
+                claim = await self._try_acquire_execution_claim(
+                    row,
+                    token=token,
+                )
+                if claim is not None:
+                    break
+                observed_owner = True
+                if not await self._wait_for_execution_retry(run_id):
+                    yield None
+                    return
+        except BaseException:
+            await _await_uninterruptibly(self.session.rollback())
+            if claim is not None:
+                await _await_uninterruptibly(self._release_execution_claim(claim))
+            raise
+
+        try:
+            yield claim
+        except BaseException:
+            await _await_uninterruptibly(self.session.rollback())
+            raise
+        else:
+            await _await_uninterruptibly(self.session.commit())
+        finally:
+            await _await_uninterruptibly(self._release_execution_claim(claim))
+
+    async def _try_acquire_execution_claim(
+        self,
+        row: AgentRunRow,
+        *,
+        token: str,
+    ) -> ExecutionClaim | None:
+        auto_commit = self.auto_commit
+        self.auto_commit = False
+        try:
+            return await self._try_acquire_execution_claim_transaction(row, token=token)
+        except BaseException:
+            await _await_uninterruptibly(self.session.rollback())
+            raise
+        finally:
+            self.auto_commit = auto_commit
+
+    async def _try_acquire_execution_claim_transaction(
+        self,
+        row: AgentRunRow,
+        *,
+        token: str,
+    ) -> ExecutionClaim | None:
+        status = coerce_run_status(row.status, default=RunStatus.FAILED)
+        if status in TERMINAL_RUN_STATUSES:
+            return None
+        now = datetime.now(timezone.utc)
+        initial_attempt = int(row.execution_attempt or 0)
+        attempt = initial_attempt + 1
+        result = await self.session.execute(
+            update(AgentRunRow)
+            .where(
+                AgentRunRow.id == int(row.id),
+                AgentRunRow.status == status.value,
+                AgentRunRow.execution_attempt == initial_attempt,
+                AgentRunRow.status.in_(_DEFERRED_RUN_ACTIVE_STATUS_VALUES),
+                AgentRunRow.execution_token.is_(None),
+            )
+            .values(
+                status=RunStatus.RUNNING.value,
+                execution_token=str(token),
+                execution_attempt=attempt,
+                started_at=row.started_at or now,
+                updated_at=now,
+            )
+            .returning(AgentRunRow.id)
+            .execution_options(synchronize_session=False)
+        )
+        if result.scalar_one_or_none() is None:
+            await self.session.rollback()
+            return None
+
+        root_run_id = row.root_run_id or row.id
+        if status == RunStatus.QUEUED:
+            await self.append_event(
+                status_changed_event(
+                    row.id,
+                    from_status=RunStatus.QUEUED.value,
+                    to_status=RunStatus.STARTING.value,
+                    root_run_id=root_run_id,
+                    reason="claimed",
+                )
+            )
+            await self.append_event(
+                status_changed_event(
+                    row.id,
+                    from_status=RunStatus.STARTING.value,
+                    to_status=RunStatus.RUNNING.value,
+                    root_run_id=root_run_id,
+                )
+            )
+        elif status != RunStatus.RUNNING:
+            await self.append_event(
+                status_changed_event(
+                    row.id,
+                    from_status=status.value,
+                    to_status=RunStatus.RUNNING.value,
+                    root_run_id=root_run_id,
+                )
+            )
+        lifecycle_event = (
+            "run.resumed"
+            if status in {RunStatus.RUNNING, RunStatus.PAUSED, RunStatus.VERIFYING}
+            else "run.started"
+        )
+        await self.append_event(
+            run_event(
+                row.id,
+                lifecycle_event,
+                {"from_status": status.value, "execution_attempt": attempt},
+                root_run_id=root_run_id,
+            )
+        )
+        await self.session.commit()
+        return ExecutionClaim(run_id=int(row.id), token=str(token), attempt=attempt)
+
+    async def refresh_run(self, run_id: int) -> AgentRunRow:
+        row = (
+            await self.session.scalars(
+                select(AgentRunRow)
+                .where(AgentRunRow.id == int(run_id))
+                .execution_options(populate_existing=True)
+            )
+        ).one_or_none()
+        if row is None:
+            raise LookupError(f"Run {run_id} not found")
+        return row
+
+    async def _wait_for_execution_retry(self, run_id: int) -> bool:
+        try:
+            timeout_seconds = max(1.0, float(os.getenv("AGENT_RUN_LEASE_WAIT_SECONDS", "900")))
+        except ValueError:
+            timeout_seconds = 900.0
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        delay = 0.05
+        while True:
+            row = await self.refresh_run(run_id)
+            status = coerce_run_status(row.status, default=RunStatus.FAILED)
+            active_token = str(row.execution_token or "")
+            await self.session.rollback()
+            if status in TERMINAL_RUN_STATUSES or (
+                status == RunStatus.PAUSED and not active_token
+            ):
+                return False
+            if not active_token:
+                return True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError(f"Timed out waiting for AgentRun {run_id} execution owner")
+            await asyncio.sleep(min(delay, remaining))
+            delay = min(1.0, delay * 1.7)
+
+    async def assert_execution_claim(self, claim: ExecutionClaim) -> AgentRunRow:
+        row = await self.refresh_run(claim.run_id)
+        if (
+            claim.lost.is_set()
+            or str(row.execution_token or "") != claim.token
+            or int(row.execution_attempt or 0) != claim.attempt
+            or coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES
+        ):
+            raise ExecutionClaimLost(
+                f"AgentRun {claim.run_id} execution claim {claim.attempt} is no longer current"
+            )
+        return row
+
+    async def _release_execution_claim(self, claim: ExecutionClaim) -> None:
+        await self.session.execute(
+            update(AgentRunRow)
+            .where(
+                AgentRunRow.id == claim.run_id,
+                AgentRunRow.execution_token == claim.token,
+                AgentRunRow.execution_attempt == claim.attempt,
+            )
+            .values(execution_token=None)
+        )
+        await self.session.commit()
 
     async def child_runs(self, parent_run_id: int) -> list[AgentRunRow]:
         result = await self.session.scalars(
@@ -471,35 +852,121 @@ class AsyncAgentRunStore:
     async def step_completed(self, run_id: int, step_key: str) -> bool:
         return step_key in ((await self.cursor_for_run(run_id)).get("completed_steps") or {})
 
-    async def set_status(self, run_id: int, status: RunStatus | str, *, reason: str | None = None) -> AgentRun:
-        row = await self.require_run(run_id)
+    async def set_status(
+        self,
+        run_id: int,
+        status: RunStatus | str,
+        *,
+        reason: str | None = None,
+        execution_claim: ExecutionClaim | None = None,
+    ) -> AgentRun:
+        run, _changed = await self.set_status_with_result(
+            run_id,
+            status,
+            reason=reason,
+            execution_claim=execution_claim,
+        )
+        return run
+
+    async def set_status_with_result(
+        self,
+        run_id: int,
+        status: RunStatus | str,
+        *,
+        reason: str | None = None,
+        execution_claim: ExecutionClaim | None = None,
+        expected_updated_at: datetime | None | object = _UNSET,
+        expected_execution_token: str | None | object = _UNSET,
+        expected_execution_attempt: int | object = _UNSET,
+        rollback_on_conflict: bool = True,
+    ) -> tuple[AgentRun, bool]:
+        if execution_claim is not None and execution_claim.lost.is_set():
+            raise ExecutionClaimLost(
+                f"AgentRun {run_id} execution claim {execution_claim.attempt} is no longer current"
+            )
+        row = await self.refresh_run(run_id)
+        persisted_status = coerce_run_status(row.status, default=RunStatus.FAILED)
+        if execution_claim is not None and (
+            str(row.execution_token or "") != execution_claim.token
+            or int(row.execution_attempt or 0) != execution_claim.attempt
+            or persisted_status in TERMINAL_RUN_STATUSES
+        ):
+            execution_claim.lost.set()
+            raise ExecutionClaimLost(
+                f"AgentRun {run_id} execution claim {execution_claim.attempt} is no longer current"
+            )
+        if persisted_status in TERMINAL_RUN_STATUSES:
+            return to_domain(row), False
         current, target = ensure_run_transition(row.status, status)
         if current == target:
-            return to_domain(row)
+            if execution_claim is not None:
+                await self.assert_execution_claim(execution_claim)
+            return to_domain(row), False
         now = datetime.now(timezone.utc)
-        row.status = target.value
+        values: dict[str, Any] = {
+            "status": target.value,
+            "updated_at": now,
+        }
         if target == RunStatus.STARTING:
-            row.started_at = row.started_at or now
+            values["started_at"] = row.started_at or now
         elif target == RunStatus.PAUSED:
-            row.paused_at = now
+            values["paused_at"] = now
         elif target == RunStatus.COMPLETED:
-            row.completed_at = now
+            values["completed_at"] = now
         elif target == RunStatus.FAILED:
-            row.failed_at = now
+            values["failed_at"] = now
         elif target == RunStatus.CANCELED:
-            row.canceled_at = now
+            values["canceled_at"] = now
+        if target in TERMINAL_RUN_STATUSES or target == RunStatus.PAUSED:
+            values["execution_token"] = None
+
+        predicates = [
+            AgentRunRow.id == int(run_id),
+            AgentRunRow.status == current.value,
+        ]
+        if execution_claim is not None:
+            predicates.extend([
+                AgentRunRow.execution_token == execution_claim.token,
+                AgentRunRow.execution_attempt == execution_claim.attempt,
+            ])
+        if expected_updated_at is not _UNSET:
+            predicates.append(AgentRunRow.updated_at == expected_updated_at)
+        if expected_execution_token is not _UNSET:
+            predicates.append(AgentRunRow.execution_token == expected_execution_token)
+        if expected_execution_attempt is not _UNSET:
+            predicates.append(AgentRunRow.execution_attempt == int(expected_execution_attempt))
+        result = await self.session.execute(
+            update(AgentRunRow)
+            .where(*predicates)
+            .values(**values)
+            .returning(AgentRunRow.id)
+            .execution_options(synchronize_session=False)
+        )
+        if result.scalar_one_or_none() is None:
+            if rollback_on_conflict:
+                await self.session.rollback()
+            if execution_claim is not None:
+                execution_claim.lost.set()
+                raise ExecutionClaimLost(
+                    f"AgentRun {run_id} execution claim {execution_claim.attempt} lost a status race"
+                )
+            return to_domain(await self.refresh_run(run_id)), False
+
         await self.append_event(
             status_changed_event(
-                row.id,
+                int(run_id),
                 from_status=current.value,
                 to_status=target.value,
                 root_run_id=row.root_run_id,
                 reason=reason,
             )
         )
+        row = await self.refresh_run(run_id)
         if target in TERMINAL_RUN_STATUSES:
             await _reconcile_inbound_triage_run_if_needed(self.session, row)
-        return to_domain(row)
+        if self.auto_commit:
+            await self.session.commit()
+        return to_domain(row), True
 
     async def append_steering(
         self,
@@ -576,11 +1043,9 @@ class AsyncAgentRunStore:
 
     async def append_event(self, event: AgentRunEvent) -> AgentRunEventRow:
         with _event_lock(int(event.run_id)):
-            if self._dialect_name() == "postgresql":
-                await self.session.execute(
-                    text("SELECT pg_advisory_xact_lock(:run_id)"),
-                    {"run_id": int(event.run_id)},
-                )
+            await self.lock_event_stream(
+                int(event.run_id),
+            )
             sequence_no = event.sequence_no
             if sequence_no is None:
                 sequence_no = int(
@@ -607,6 +1072,56 @@ class AsyncAgentRunStore:
             if self.auto_commit:
                 await self.session.commit()
             return row
+
+    async def lock_event_stream(self, run_id: int) -> None:
+        """Serialize event writers for one run."""
+        if self._dialect_name() != "postgresql":
+            return
+        await self.session.execute(
+            text("SELECT pg_advisory_xact_lock(:run_id)"),
+            {"run_id": int(run_id)},
+        )
+
+    async def try_lock_event_stream(self, run_id: int) -> bool:
+        """Try to fence one event stream without waiting into a lock cycle."""
+        if self._dialect_name() != "postgresql":
+            return True
+        return bool(
+            await self.session.scalar(
+                text("SELECT pg_try_advisory_xact_lock(:run_id)"),
+                {"run_id": int(run_id)},
+            )
+        )
+
+    async def lock_run_liveness(
+        self,
+        run_id: int,
+        root_run_id: int | None = None,
+    ) -> tuple[AgentRunRow, AgentRunRow | None] | None:
+        """Fence heartbeat and event writes while stale evidence is revalidated."""
+        run_id = int(run_id)
+        root_run_id = int(root_run_id or run_id)
+        lock_ids = sorted({run_id, root_run_id})
+        if self._dialect_name() == "sqlite":
+            await self.session.execute(
+                update(AgentRunRow)
+                .where(AgentRunRow.id.in_(lock_ids))
+                .values(updated_at=AgentRunRow.updated_at)
+            )
+        else:
+            locked_rows = await self.session.scalars(
+                select(AgentRunRow)
+                .where(AgentRunRow.id.in_(lock_ids))
+                .order_by(AgentRunRow.id.asc())
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            )
+            locked_rows.all()
+        if not await self.try_lock_event_stream(run_id):
+            return None
+        row = await self.refresh_run(run_id)
+        root_row = row if root_run_id == run_id else await self.get_run(root_run_id)
+        return row, root_row
 
     async def safe_cycle_provider_error_text(self, run_id: int, text_value: str) -> str:
         if text_value.startswith(PROVIDER_ERROR_SENTINEL_PREFIX):
@@ -758,7 +1273,12 @@ class AsyncAgentRunStore:
         return older_active is not None
 
     async def _locked_run(self, run_id: int) -> AgentRunRow:
-        stmt = select(AgentRunRow).where(AgentRunRow.id == int(run_id)).limit(1)
+        stmt = (
+            select(AgentRunRow)
+            .where(AgentRunRow.id == int(run_id))
+            .limit(1)
+            .execution_options(populate_existing=True)
+        )
         if self._dialect_name() == "postgresql":
             stmt = stmt.with_for_update()
         row = (await self.session.scalars(stmt)).first()
@@ -771,7 +1291,12 @@ class AsyncAgentRunStore:
         return str(getattr(getattr(bind, "dialect", None), "name", "") or "")
 
 
-__all__ = ["AsyncAgentRunStore", "to_domain"]
+__all__ = [
+    "AsyncAgentRunStore",
+    "ExecutionClaim",
+    "ExecutionClaimLost",
+    "to_domain",
+]
 
 
 def _jsonable(value: Any) -> Any:

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -19,6 +19,7 @@ import uuid
 import inspect
 
 from brain.kernel import config as brain_config
+from brain.platform.async_io import invoke_maybe_async
 from brain.systems.runs import actions as action_audit
 from brain.systems.runs.evidence import normalize_tool_call_evidence
 from brain.systems.runs.execution_artifacts import (
@@ -946,9 +947,7 @@ def _record_tool_evidence(tool_name: str, args: dict | None, result: object) -> 
 def _wrap_tool_evidence(tool_name: str, handler):
     """Wrap a handler so successful backend tool output becomes evidence."""
     async def wrapper(*args, **kwargs):
-        result = handler(*args, **kwargs)
-        if inspect.isawaitable(result):
-            result = await result
+        result = await invoke_maybe_async(handler, *args, **kwargs)
         evidence_args = dict(kwargs)
         if args:
             evidence_args["_args"] = list(args)

--- a/brain/systems/runs/tool_catalog/handlers/composition.py
+++ b/brain/systems/runs/tool_catalog/handlers/composition.py
@@ -152,6 +152,18 @@ def _resolved_workspace_tool_runtime_args(
     return _resolved_workspace_tool_env, _resolved_workspace_tool_sensitive_values
 
 
+def _run_on_event_loop_adapter(handler):
+    """Mark a sync compatibility adapter whose returned awaitable does the work."""
+    handler._illo_run_on_event_loop = True
+    return handler
+
+
+def _private_async_adapter(name: str, default):
+    return _run_on_event_loop_adapter(
+        lambda **kwargs: _patched_private(name, default)(**kwargs)
+    )
+
+
 def _get_tool_handlers(
     workspace_root: str | None = None,
     allowed_workspaces: list[str | dict] | None = None,
@@ -200,6 +212,9 @@ def _get_tool_handlers(
             org_id=getattr(_agent_context, "org_id", None),
         )
 
+    _manage_deployment._illo_run_on_event_loop = True
+    _manage_runtime_services._illo_run_on_event_loop = True
+
     handlers = {
         # Brain tools (workspace-independent — always hit shared DB)
         "brain_recall": _wrap_brain_recall(async_tool_brain_recall),
@@ -210,23 +225,27 @@ def _get_tool_handlers(
         "skill_view": _wrap_tool_evidence("skill_view", async_tool_skill_view),
         "skill_asset": async_tool_skill_asset,
         "brain_encode": _wrap_brain_encode(async_tool_brain_encode),
-        "brain_vault": lambda key, reason=None: tool_brain_vault(
-            key,
-            reason=reason,
-            user_id=_current_agent_value("user_id"),
-            org_id=_current_agent_value("org_id"),
-            run_id=_current_run_id(),
-            idea_id=_current_idea_id(),
-            requested_by=_current_requested_by(),
-            **_current_project_token_context(),
+        "brain_vault": _run_on_event_loop_adapter(
+            lambda key, reason=None: tool_brain_vault(
+                key,
+                reason=reason,
+                user_id=_current_agent_value("user_id"),
+                org_id=_current_agent_value("org_id"),
+                run_id=_current_run_id(),
+                idea_id=_current_idea_id(),
+                requested_by=_current_requested_by(),
+                **_current_project_token_context(),
+            )
         ),
-        "vault_inventory": lambda category=None, access_level=None: tool_vault_inventory(
-            category=category,
-            access_level=access_level,
-            user_id=_current_agent_value("user_id"),
-            org_id=_current_agent_value("org_id"),
+        "vault_inventory": _run_on_event_loop_adapter(
+            lambda category=None, access_level=None: tool_vault_inventory(
+                category=category,
+                access_level=access_level,
+                user_id=_current_agent_value("user_id"),
+                org_id=_current_agent_value("org_id"),
+            )
         ),
-        "vault_secret_prompt": (
+        "vault_secret_prompt": _run_on_event_loop_adapter(
             lambda key_name, description=None, category="api", reason=None: tool_vault_secret_prompt(
                 key_name,
                 description=description,
@@ -239,19 +258,21 @@ def _get_tool_handlers(
                 requested_by=_current_requested_by(),
             )
         ),
-        "runtime_settings": lambda provider=None: tool_runtime_settings(
-            provider=provider,
-            user_id=getattr(_agent_context, "user_id", None),
-            org_id=getattr(_agent_context, "org_id", None),
+        "runtime_settings": _run_on_event_loop_adapter(
+            lambda provider=None: tool_runtime_settings(
+                provider=provider,
+                user_id=getattr(_agent_context, "user_id", None),
+                org_id=getattr(_agent_context, "org_id", None),
+            )
         ),
         "read_self_context": _handle_read_self_context,
         "read_capabilities": _handle_read_capabilities,
         "manage_deployment": _manage_deployment,
         "manage_runtime_services": _manage_runtime_services,
-        "transcribe_audio_attachment": lambda **kw: _patched_private(
+        "transcribe_audio_attachment": _private_async_adapter(
             "_handle_transcribe_audio_attachment",
             _handle_transcribe_audio_attachment,
-        )(**kw),
+        ),
         "manage_soul": lambda action, content=None, reason=None: manage_agent_soul(
             action,
             content=content,
@@ -266,73 +287,73 @@ def _get_tool_handlers(
         "read_workspace_records": _handle_read_workspace_records,
         "read_cycles": _handle_read_cycles,
         "read_workspace_apps": _handle_read_workspace_apps,
-        "read_github_source": lambda **kw: _patched_private(
+        "read_github_source": _private_async_adapter(
             "_handle_read_github_source",
             _handle_read_github_source,
-        )(**kw),
-        "create_github_issue": lambda **kw: _patched_private(
+        ),
+        "create_github_issue": _private_async_adapter(
             "_handle_create_github_issue",
             _handle_create_github_issue,
-        )(**kw),
-        "check_fix_deploy_state": lambda **kw: _patched_private(
+        ),
+        "check_fix_deploy_state": _private_async_adapter(
             "_handle_check_fix_deploy_state",
             _handle_check_fix_deploy_state,
-        )(**kw),
+        ),
         "read_thread_messages": _handle_read_thread_messages,
-        "post_chat_message": lambda **kw: _patched_private(
+        "post_chat_message": _private_async_adapter(
             "_handle_post_chat_message",
             _handle_post_chat_message,
-        )(**kw),
-        "post_slack_reply": lambda **kw: _patched_private(
+        ),
+        "post_slack_reply": _private_async_adapter(
             "_handle_post_slack_reply",
             _handle_post_slack_reply,
-        )(**kw),
-        "post_thread_discussion_reply": lambda **kw: _patched_private(
+        ),
+        "post_thread_discussion_reply": _private_async_adapter(
             "_handle_post_thread_discussion_reply",
             _handle_post_thread_discussion_reply,
-        )(**kw),
-        "publish_thread_asset": lambda **kw: _patched_private(
+        ),
+        "publish_thread_asset": _private_async_adapter(
             "_handle_publish_thread_asset",
             _handle_publish_thread_asset,
-        )(**kw),
-        "publish_thread_artifact": lambda **kw: _patched_private(
+        ),
+        "publish_thread_artifact": _private_async_adapter(
             "_handle_publish_thread_artifact",
             _handle_publish_thread_artifact,
-        )(**kw),
-        "post_ai_timeline_message": lambda **kw: _patched_private(
+        ),
+        "post_ai_timeline_message": _private_async_adapter(
             "_handle_post_ai_timeline_message",
             _handle_post_ai_timeline_message,
-        )(**kw),
-        "create_launch_handoff": lambda **kw: _patched_private(
+        ),
+        "create_launch_handoff": _private_async_adapter(
             "_handle_create_launch_handoff",
             _handle_create_launch_handoff,
-        )(**kw),
-        "read_thread_discussion": lambda **kw: _patched_private(
+        ),
+        "read_thread_discussion": _private_async_adapter(
             "_handle_read_thread_discussion",
             _handle_read_thread_discussion,
-        )(**kw),
-        "read_slack_conversation": lambda **kw: _patched_private(
+        ),
+        "read_slack_conversation": _private_async_adapter(
             "_handle_read_slack_conversation",
             _handle_read_slack_conversation,
-        )(**kw),
-        "manage_slack": lambda **kw: _patched_private(
+        ),
+        "manage_slack": _private_async_adapter(
             "_handle_manage_slack",
             _handle_manage_slack,
-        )(**kw),
-        "manage_cycle": lambda **kw: _patched_private("_handle_manage_cycle", _handle_manage_cycle)(**kw),
-        "manage_domain": lambda **kw: _patched_private("_handle_manage_domain", _handle_manage_domain)(**kw),
-        "manage_inbound": lambda **kw: _patched_private("_handle_manage_inbound", _handle_manage_inbound)(**kw),
-        "manage_idea": lambda **kw: _patched_private("_handle_manage_idea", _handle_manage_idea)(**kw),
-        "manage_project": lambda **kw: _patched_private("_handle_manage_project", _handle_manage_project)(**kw),
-        "manage_skill": lambda **kw: _patched_private("_handle_manage_skill", _handle_manage_skill)(**kw),
-        "manage_workspace_app": lambda **kw: _patched_private(
+        ),
+        "manage_cycle": _private_async_adapter("_handle_manage_cycle", _handle_manage_cycle),
+        "manage_domain": _private_async_adapter("_handle_manage_domain", _handle_manage_domain),
+        "manage_inbound": _private_async_adapter("_handle_manage_inbound", _handle_manage_inbound),
+        "manage_idea": _private_async_adapter("_handle_manage_idea", _handle_manage_idea),
+        "manage_project": _private_async_adapter("_handle_manage_project", _handle_manage_project),
+        "manage_skill": _private_async_adapter("_handle_manage_skill", _handle_manage_skill),
+        "manage_workspace_app": _private_async_adapter(
             "_handle_manage_workspace_app",
             _handle_manage_workspace_app,
-        )(**kw),
-        "manage_workspace_tools": lambda **kw: _patched_private(
+        ),
+        "manage_workspace_tools": _private_async_adapter(
             "_handle_manage_workspace_tools",
             _handle_manage_workspace_tools,
-        )(**kw),
+        ),
         # Session scratchpad tools
         "session_write": _handle_session_write,
         "session_read": _handle_session_read,
@@ -342,10 +363,12 @@ def _get_tool_handlers(
         "session_promote": _handle_session_promote,
         "session_close": _handle_session_close,
         "cortex_reply": _handle_cortex_reply,
-        "cortex_visual_reply": lambda **kwargs: _handle_cortex_visual_reply(**kwargs),
+        "cortex_visual_reply": _run_on_event_loop_adapter(
+            lambda **kwargs: _handle_cortex_visual_reply(**kwargs)
+        ),
         "my_activity": _handle_my_activity,
-        "spawn_worker": lambda **kw: _patched_private("_handle_spawn_worker", _handle_spawn_worker)(**kw),
-        "browser": lambda **kw: _patched_private("_handle_browser", _handle_browser)(**kw),
+        "spawn_worker": _private_async_adapter("_handle_spawn_worker", _handle_spawn_worker),
+        "browser": _private_async_adapter("_handle_browser", _handle_browser),
         "web_search": _handle_web_search,
         "web_fetch": _handle_web_fetch,
     }
@@ -599,6 +622,7 @@ def _get_tool_handlers(
                     org_id = execution_metadata.get("org_id")
             return user_id, org_id
 
+        @_run_on_event_loop_adapter
         def _summarize_file_for_task_with_context(
             path,
             question,
@@ -618,6 +642,7 @@ def _get_tool_handlers(
                 workspace_root=_workspace_hint(),
             )
 
+        @_run_on_event_loop_adapter
         def _summarize_files_for_task_with_context(
             paths,
             question,

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -263,9 +263,7 @@ async def _handle_spawn_worker(
     async with UnitOfWork() as uow:
         store = AsyncAgentRunStore(uow.session)
         parent = await store.require_run(parent_run_id)
-        existing = await store.child_run_for_step(parent.id, step_key)
-        deduplicated = existing is not None
-        child = await store.create_child_run(
+        child, created = await store.create_child_run_with_result(
             parent,
             recipe=RunRecipe.WORKER,
             message=child_message,
@@ -277,21 +275,23 @@ async def _handle_spawn_worker(
             model_policy=dict(parent.model_policy or {}),
             metadata=worker_metadata,
         )
-        await store.append_event(
-            run_event(
-                int(parent.id),
-                "run.worker_spawned",
-                {
-                    "child_run_id": child.id,
-                    "step_key": step_key,
-                    "headless": bool(headless),
-                    "role": assignment.role,
-                    "objective": assignment.objective,
-                },
-                root_run_id=parent.root_run_id or parent.id,
-                producer="spawn_worker",
+        deduplicated = not created
+        if created:
+            await store.append_event(
+                run_event(
+                    int(parent.id),
+                    "run.worker_spawned",
+                    {
+                        "child_run_id": child.id,
+                        "step_key": step_key,
+                        "headless": bool(headless),
+                        "role": assignment.role,
+                        "objective": assignment.objective,
+                    },
+                    root_run_id=parent.root_run_id or parent.id,
+                    producer="spawn_worker",
+                )
             )
-        )
 
     return json.dumps(
         {

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 import fnmatch
@@ -10,6 +11,12 @@ import json
 import os
 from typing import Any
 
+from brain.platform.async_io import (
+    BlockingInvocationCancelled,
+    callable_uses_blocking_thread,
+    invoke_maybe_async,
+    mark_side_effect_started,
+)
 from brain.systems.runs.actions import (
     blocked_action_result,
     build_action_manifest,
@@ -197,11 +204,84 @@ class AsyncRunToolExecutor:
             )
             try:
                 with bind_agent_context(_handler_context_from_action_context(action_context)):
-                    result = handler(**handler_args)
-                    if inspect.isawaitable(result):
-                        result = await result
+                    mark_side_effect_started()
+                    result = await invoke_maybe_async(handler, **handler_args)
             finally:
                 workspace_tool_runtime.cleanup()
+        except BlockingInvocationCancelled as exc:
+            failure = str(exc.error) if exc.error else result_failure_summary(exc.result)
+            if manifest_id:
+                await _maybe_await(
+                    complete_action_manifest(
+                        manifest_id,
+                        outcome_status="failed" if failure else "succeeded",
+                        outcome_error=failure,
+                    )
+                )
+            if failure:
+                await self._append_event(
+                    run_event(
+                        run_id,
+                        "run.tool_failed",
+                        _event_payload(tool.name, safe_args, error=failure),
+                        root_run_id=root_run_id,
+                    )
+                )
+                record = ToolRecord(
+                    tool_name=tool.name,
+                    args=safe_args,
+                    status="failed",
+                    artifact_type=artifact_type,
+                    side_effect=side_effect,
+                    error=failure[:1000],
+                )
+                await self._append_artifact(
+                    run_id,
+                    root_run_id=root_run_id,
+                    artifact_type=artifact_type,
+                    title=f"{tool.name} failed",
+                    payload=record.to_payload(),
+                    text=failure[:4000],
+                )
+            else:
+                safe_result = redact_tool_result(tool.name, exc.result)
+                await self._append_event(
+                    run_event(
+                        run_id,
+                        "run.tool_completed",
+                        _event_payload(tool.name, safe_args, result=safe_result[:1000]),
+                        root_run_id=root_run_id,
+                    )
+                )
+                record = ToolRecord(
+                    tool_name=tool.name,
+                    args=safe_args,
+                    status="completed",
+                    artifact_type=artifact_type,
+                    side_effect=side_effect,
+                    result_preview=safe_result[:1000],
+                )
+                await self._append_artifact(
+                    run_id,
+                    root_run_id=root_run_id,
+                    artifact_type=artifact_type,
+                    title=tool.name,
+                    payload=record.to_payload(),
+                    text=safe_result[:4000],
+                )
+            if collector is not None:
+                collector.append(record)
+            raise
+        except asyncio.CancelledError:
+            if manifest_id:
+                await _maybe_await(
+                    complete_action_manifest(
+                        manifest_id,
+                        outcome_status="indeterminate",
+                        outcome_error="caller canceled before a definitive action outcome",
+                    )
+                )
+            raise
         except Exception as exc:
             error_text = str(exc)
             if manifest_id:
@@ -488,6 +568,8 @@ def wrap_tool_handlers(
             )
 
         _handler.__name__ = getattr(handler, "__name__", f"runtime_{tool_name}")
+        _handler._illo_marks_side_effect_start = True
+        _handler._illo_uses_blocking_thread = callable_uses_blocking_thread(handler)
         wrapped[tool_name] = _handler
     return wrapped
 

--- a/brain/systems/tools/handlers.py
+++ b/brain/systems/tools/handlers.py
@@ -33,7 +33,7 @@ from brain.systems.runs.project_execution_env import (
     redact_sensitive_output,
 )
 from brain.systems.runs.secret_mounts import SECRET_ENV_SCHEMA
-from brain.platform.async_io import run_blocking, run_subprocess_sync
+from brain.platform.async_io import run_blocking, run_subprocess_sync, run_tool_blocking
 
 logger = logging.getLogger("agent.tools")
 
@@ -270,7 +270,8 @@ async def handle_semantic_search(query: str, scope: str = "both", limit: int = 5
 
             async with UnitOfWork() as uow:
                 runtime_config = await async_get_embedding_runtime_config(uow.session, include_secret=True)
-            code_results = _semantic_code_search(
+            code_results = await run_tool_blocking(
+                _semantic_code_search,
                 query,
                 limit=limit,
                 workspace_root=workspace_root,
@@ -1055,11 +1056,11 @@ async def handle_summarize_file_for_task(
     workspace_root: str | None = None,
 ) -> dict:
     """Answer a narrow question about one file with bounded context."""
-    summary = handle_file_summary(path, workspace_root=workspace_root)
+    summary = await run_tool_blocking(handle_file_summary, path, workspace_root=workspace_root)
     if "error" in summary:
         return {"error": summary["error"]}
 
-    lines, error = _read_file_lines(path, workspace_root=workspace_root)
+    lines, error = await run_tool_blocking(_read_file_lines, path, workspace_root=workspace_root)
     if error:
         return {"error": error}
     total_lines = len(lines or [])
@@ -1121,7 +1122,8 @@ async def handle_summarize_files_for_task(
     workspace_root: str | None = None,
 ) -> dict:
     """Answer a narrow question across multiple files with bounded synthesis."""
-    implementation_map = handle_build_implementation_map(
+    implementation_map = await run_tool_blocking(
+        handle_build_implementation_map,
         question,
         paths=paths,
         max_files=max_files,
@@ -1133,10 +1135,10 @@ async def handle_summarize_files_for_task(
     selected = []
     ranked_paths = [item["path"] for item in implementation_map.get("files_ranked", [])]
     for raw_path in ranked_paths[: max(1, min(max_files, 12))]:
-        summary = handle_file_summary(raw_path, workspace_root=workspace_root)
+        summary = await run_tool_blocking(handle_file_summary, raw_path, workspace_root=workspace_root)
         if "error" in summary:
             continue
-        lines, error = _read_file_lines(raw_path, workspace_root=workspace_root)
+        lines, error = await run_tool_blocking(_read_file_lines, raw_path, workspace_root=workspace_root)
         if error:
             continue
         chunks = _select_relevant_chunks(lines or [], question, summary, max_chunks=2)

--- a/scripts/bench_agent_run_deep_child_runs.py
+++ b/scripts/bench_agent_run_deep_child_runs.py
@@ -58,9 +58,11 @@ async def _main_async() -> int:
                 recipes={"deep": DeepRecipe(), "scout": ScoutRecipe(), "worker": SmokeWorkerRecipe()},
             ).run(
                 AgentRunRequest(
+                    org_id="bench",
                     thread_id="bench-deep-child-runs",
                     message="Implement a tiny smoke task and verify evidence.",
                     profile="deep",
+                    model_policy={"model": "openai/benchmark", "thinking": "low"},
                     metadata={"deep_workers": [{"role": "smoke", "objective": "Produce deterministic worker evidence."}]},
                 )
             )
@@ -97,7 +99,7 @@ def _patch_offline_invocations() -> None:
     import brain.systems.runs.recipes.deep as deep_module
     import brain.systems.runs.recipes.phase_barrier as phase_barrier_module
 
-    def _invoke(spec):
+    async def _invoke(spec):
         session_id = str(getattr(spec, "session_id", "") or "")
         if "phase-review" in session_id:
             return SimpleNamespace(
@@ -106,8 +108,8 @@ def _patch_offline_invocations() -> None:
             )
         return SimpleNamespace(output="Deep completed using native AgentRun workers.", success=True)
 
-    deep_module.invoke_direct_agent = _invoke
-    phase_barrier_module.invoke_direct_agent = _invoke
+    deep_module.invoke_direct_agent_async = _invoke
+    phase_barrier_module.invoke_direct_agent_async = _invoke
 
 
 async def _session_factory():

--- a/scripts/bench_agent_run_fast_readme.py
+++ b/scripts/bench_agent_run_fast_readme.py
@@ -61,6 +61,7 @@ async def _main_async() -> int:
             async with session_factory() as session:
                 run = await AsyncAgentRunEngine(session, recipes={"fast": ReadmeRecipe()}, stream=stream).run(
                     AgentRunRequest(
+                        org_id="bench",
                         thread_id="bench-fast-readme",
                         message="What is in the README?",
                         profile="fast",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -861,6 +861,68 @@ class TestAgentLoop:
             "payload": {"query": "beta"},
         }
 
+    @pytest.mark.asyncio
+    async def test_parallel_safe_sync_tool_batch_runs_off_loop(self):
+        from brain.systems.runs.direct_agent import _GateState
+        from brain.systems.runs.direct_loop.gates import check_gate_violations
+        from brain.systems.runs.direct_loop.tool_execution import async_execute_tool_calls
+
+        blocks = []
+        for index, name in enumerate(("read_file", "search_files"), start=1):
+            block = MagicMock()
+            block.type = "tool_use"
+            block.name = name
+            block.input = {"value": name}
+            block.id = f"sync-tool-{index}"
+            blocks.append(block)
+
+        response = MagicMock()
+        response.content = blocks
+        stop_ticker = asyncio.Event()
+        ticker_count = 0
+        rendezvous = threading.Barrier(2)
+
+        async def ticker():
+            nonlocal ticker_count
+            while not stop_ticker.is_set():
+                ticker_count += 1
+                await asyncio.sleep(0.01)
+
+        def blocking_handler(**kwargs):
+            rendezvous.wait(timeout=1)
+            time.sleep(0.05)
+            return kwargs
+
+        ticker_task = asyncio.create_task(ticker())
+        started_at = time.perf_counter()
+        try:
+            results = await async_execute_tool_calls(
+                response,
+                {"read_file": blocking_handler, "search_files": blocking_handler},
+                [],
+                _GateState(),
+                None,
+                None,
+                None,
+                "runner",
+                agent_context=SimpleNamespace(),
+                brain_tool_names=frozenset(),
+                gated_tool_names=frozenset(),
+                research_tool_names=frozenset(),
+                research_budget=0,
+                parallel_safe_tool_names=frozenset({"read_file", "search_files"}),
+                max_parallel_tool_calls=2,
+                check_gate_violations=check_gate_violations,
+            )
+        finally:
+            elapsed = time.perf_counter() - started_at
+            stop_ticker.set()
+            await ticker_task
+
+        assert elapsed < 0.5
+        assert ticker_count >= 3
+        assert [result["tool_use_id"] for result in results] == ["sync-tool-1", "sync-tool-2"]
+
     async def test_parallel_safe_tool_batch_propagates_agent_context(self):
         from brain.systems.runs.direct_agent import _execute_tool_calls_async, _GateState, _agent_context
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -43,6 +43,7 @@ class _Store:
         self.events = []
         self.artifacts = []
         self.created_requests = []
+        self.child_initial_statuses = []
         self.runs = {}
         self.children_by_step = {}
         self.completed_steps = {}
@@ -57,11 +58,12 @@ class _Store:
         self.artifacts.append(artifact)
         return _AwaitableValue(artifact)
 
-    def create_run(self, request):
+    def create_run(self, request, *, initial_status=None):
         from brain.systems.runs.domain import AgentRun
         from brain.systems.runs.ids import trace_id_for_run_id
         from brain.systems.runs.status import RunStatus
 
+        status = initial_status or RunStatus.QUEUED
         run_id = 100 + len(self.created_requests)
         run = AgentRun(
             id=run_id,
@@ -70,7 +72,7 @@ class _Store:
             input_message=request.message,
             profile=request.normalized_profile,
             recipe=request.normalized_recipe,
-            status=RunStatus.QUEUED,
+            status=status,
             org_id=request.org_id,
             user_id=request.user_id,
             parent_run_id=request.parent_run_id,
@@ -97,6 +99,7 @@ class _Store:
         model_policy=None,
         metadata=None,
         thread_id=None,
+        initial_status=None,
     ):
         from brain.systems.runs.domain import AgentRunRequest
         from brain.systems.runs.events import run_event
@@ -106,6 +109,7 @@ class _Store:
         metadata_payload = dict(metadata or {})
         if step_key:
             metadata_payload["parent_step_key"] = step_key
+        self.child_initial_statuses.append(initial_status)
         child = self.create_run(
             AgentRunRequest(
                 org_id=parent.org_id,
@@ -120,7 +124,8 @@ class _Store:
                 workspace_ref=dict(workspace_ref if workspace_ref is not None else parent.workspace_ref or {}),
                 model_policy=dict(model_policy if model_policy is not None else parent.model_policy or {}),
                 metadata=metadata_payload,
-            )
+            ),
+            initial_status=initial_status,
         ).value
         if step_key:
             self.children_by_step[step_key] = child
@@ -1325,7 +1330,8 @@ def test_headless_worker_policy_uses_canonical_disabled_tools():
     }
 
 
-async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monkeypatch):
+@pytest.mark.parametrize("created_here", [True, False])
+async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monkeypatch, created_here):
     from brain.systems.runs.domain import RunProfile, RunRecipe
     from brain.systems.runs.execution_context import bind_agent_context
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
@@ -1366,10 +1372,10 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
             assert step_key == "spawn_worker:bug-report"
             return None
 
-        async def create_child_run(self, parent_arg, **kwargs):
+        async def create_child_run_with_result(self, parent_arg, **kwargs):
             assert parent_arg is parent
             create_kwargs.update(kwargs)
-            return child
+            return child, created_here
 
         async def append_event(self, event):
             events.append(event)
@@ -1390,6 +1396,7 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
 
     assert payload["ok"] is True
     assert payload["child_run_id"] == child.id
+    assert payload["deduplicated"] is (not created_here)
     assert payload["next_action"]["repeat_guard"] == {
         "tool": "spawn_worker",
         "same_objective": "do_not_repeat",
@@ -1403,7 +1410,9 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
         "cortex_reply",
         "post_ai_timeline_message",
     }
-    assert [event.event_type for event in events] == ["run.worker_spawned"]
+    assert [event.event_type for event in events] == (
+        ["run.worker_spawned"] if created_here else []
+    )
 
 
 async def test_spawn_worker_handler_prefers_runtime_run_id_over_stale_context(monkeypatch):
@@ -1446,10 +1455,10 @@ async def test_spawn_worker_handler_prefers_runtime_run_id_over_stale_context(mo
             assert parent_id == current_parent.id
             return None
 
-        async def create_child_run(self, parent_arg, **kwargs):
+        async def create_child_run_with_result(self, parent_arg, **kwargs):
             assert parent_arg is current_parent
             created.update(kwargs)
-            return child
+            return child, True
 
         async def append_event(self, event):
             assert event.run_id == current_parent.id
@@ -1588,6 +1597,7 @@ async def test_deep_recipe_uses_native_child_runs(monkeypatch):
     ]
     assert len(worker_requests) == 2
     assert [request.parent_run_id for request in worker_requests] == [42, 42]
+    assert store.child_initial_statuses == [RunStatus.STARTING] * 3
     assert executed == [100, 101, 102]
     assert result.status.value == "completed"
     assert "Deep completed using native AgentRun workers." in result.output
@@ -1615,8 +1625,7 @@ async def test_deep_recipe_uses_native_child_runs(monkeypatch):
         for event in store.events
         if event.event_type == "run.phase_review_started"
     ]
-    assert "investigate" in reviewed_nodes
-    assert "execute" in reviewed_nodes
+    assert reviewed_nodes == ["scout"]
     worker_completion_positions = [
         index
         for index, event in enumerate(store.events)
@@ -1629,7 +1638,93 @@ async def test_deep_recipe_uses_native_child_runs(monkeypatch):
         if event.event_type == "run.phase_review_started"
         and event.payload.get("completed_node_id") in {"investigate", "execute"}
     ]
-    assert max(worker_completion_positions) < min(worker_review_positions)
+    assert worker_completion_positions
+    assert worker_review_positions == []
+
+
+@pytest.mark.asyncio
+async def test_phase_review_skips_failed_topologies_with_only_blocked_workers(monkeypatch):
+    from brain.systems.runs.graph import DeepPlan, RunNode
+    from brain.systems.runs.recipes.phase_barrier import review_completed_phase
+
+    async def unexpected_review(_spec):
+        raise AssertionError("blocked worker topology must not invoke the coordinator model")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.phase_barrier.invoke_direct_agent_async",
+        unexpected_review,
+    )
+    runtime = _runtime("deep")
+    plans = (
+        (
+            DeepPlan(
+                nodes=(
+                    RunNode(id="scout", kind="scout", recipe="scout", status="failed"),
+                    RunNode(id="investigate", depends_on=("scout",)),
+                    RunNode(id="execute", depends_on=("investigate",)),
+                )
+            ),
+            "scout",
+        ),
+        (
+            DeepPlan(
+                nodes=(
+                    RunNode(id="scout", kind="scout", recipe="scout", status="completed"),
+                    RunNode(id="investigate", status="failed", depends_on=("scout",)),
+                    RunNode(id="execute", depends_on=("investigate",)),
+                )
+            ),
+            "investigate",
+        ),
+    )
+
+    for plan, completed_node_id in plans:
+        decision = await review_completed_phase(
+            runtime,
+            plan,
+            plan.require_node(completed_node_id),
+            {completed_node_id: {"status": "failed"}},
+        )
+        assert decision.revisions == ()
+        assert decision.summary == "No pending worker nodes remain to revise."
+
+    assert not any(event.event_type == "run.phase_review_started" for event in runtime.store.events)
+
+
+@pytest.mark.asyncio
+async def test_phase_review_payload_excludes_blocked_workers(monkeypatch):
+    from brain.systems.runs.graph import DeepPlan, RunNode
+    from brain.systems.runs.recipes.phase_barrier import review_completed_phase
+
+    captured = {}
+
+    async def capture_review(spec):
+        captured.update(json.loads(spec.message))
+        return SimpleNamespace(output='{"summary":"keep going","revisions":[]}', success=True)
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.phase_barrier.invoke_direct_agent_async",
+        capture_review,
+    )
+    plan = DeepPlan(
+        nodes=(
+            RunNode(id="scout", kind="scout", recipe="scout", status="completed"),
+            RunNode(id="failed", status="failed", depends_on=("scout",)),
+            RunNode(id="blocked", depends_on=("failed",)),
+            RunNode(id="independent", depends_on=("scout",)),
+        )
+    )
+    runtime = _runtime("deep")
+
+    await review_completed_phase(
+        runtime,
+        plan,
+        plan.require_node("failed"),
+        {"failed": {"status": "failed"}},
+    )
+
+    assert [node["id"] for node in captured["pending_nodes"]] == ["independent"]
+    assert captured["blocked_node_ids"] == ["blocked"]
 
 
 async def test_deep_coordinator_synthesis_uses_soul_and_owns_final_answer(monkeypatch):
@@ -2645,6 +2740,41 @@ async def test_runtime_tool_executor_audits_high_risk_actions_autonomously(monke
     assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
 
 
+async def test_runtime_tool_executor_offloads_sync_handlers():
+    import time
+
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    runtime = _runtime("worker")
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+    stop_ticker = asyncio.Event()
+    ticker_count = 0
+
+    async def ticker():
+        nonlocal ticker_count
+        while not stop_ticker.is_set():
+            ticker_count += 1
+            await asyncio.sleep(0.01)
+
+    def blocking_handler(**kwargs):
+        time.sleep(0.1)
+        return {"ok": True, **kwargs}
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await executor.execute(
+            42,
+            ToolExecution(name="read_file", args={"path": "README.md"}, handler=blocking_handler),
+            root_run_id=42,
+        )
+    finally:
+        stop_ticker.set()
+        await ticker_task
+
+    assert result == {"ok": True, "path": "README.md"}
+    assert ticker_count >= 3
+
+
 @pytest.mark.asyncio
 async def test_direct_loop_returns_timeout_as_tool_error(monkeypatch):
     from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
@@ -2660,6 +2790,624 @@ async def test_direct_loop_returns_timeout_as_tool_error(monkeypatch):
     assert resolved.is_error is True
     assert "slow_tool" in resolved.result_text
     assert "timed out" in resolved.result_text
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_cancels_production_async_adapter_at_timeout(monkeypatch):
+    import brain.systems.runs.tool_handlers as tool_handlers
+    from brain.platform.async_io import callable_uses_blocking_thread
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+    from brain.systems.runs.tool_catalog.handlers.composition import _get_tool_handlers
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    canceled = asyncio.Event()
+
+    async def slow_manage_cycle(**_kwargs):
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            canceled.set()
+            raise
+
+    monkeypatch.setattr(tool_handlers, "_handle_manage_cycle", slow_manage_cycle)
+    handler = _get_tool_handlers()["manage_cycle"]
+
+    assert callable_uses_blocking_thread(handler) is False
+    resolved = await async_resolve_tool_call(
+        PendingToolCall("tool-1", "manage_cycle", {"action": "list"}, handler)
+    )
+
+    assert resolved.is_error is True
+    assert "timed out" in resolved.result_text
+    assert canceled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_detects_unmarked_sync_adapter_returning_coroutine(monkeypatch):
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    canceled = asyncio.Event()
+
+    def unmarked_adapter():
+        async def inner():
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                canceled.set()
+                raise
+
+        return inner()
+
+    resolved = await async_resolve_tool_call(
+        PendingToolCall("tool-1", "unregistered_read", {}, unmarked_adapter)
+    )
+
+    assert resolved.is_error is True
+    assert "timed out" in resolved.result_text
+    assert canceled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_caller_cancellation_cancels_pure_async_read(monkeypatch):
+    import brain.systems.runs.direct_loop.tool_execution as tool_execution
+
+    started = asyncio.Event()
+    canceled = asyncio.Event()
+
+    async def never_finishes():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            canceled.set()
+            raise
+
+    task = asyncio.create_task(
+        tool_execution.async_resolve_tool_call(
+            tool_execution.PendingToolCall("tool-1", "unregistered_read", {}, never_finishes)
+        )
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+
+    assert canceled.is_set()
+    assert not tool_execution._background_tool_tasks
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_still_drains_submitted_sync_handler():
+    import threading
+    import time
+
+    from brain.platform.async_io import invoke_maybe_async
+
+    started = threading.Event()
+    finished = threading.Event()
+
+    def slow_handler():
+        started.set()
+        time.sleep(0.08)
+        finished.set()
+        return {"ok": True}
+
+    task = asyncio.create_task(invoke_maybe_async(slow_handler))
+    while not started.is_set():
+        await asyncio.sleep(0.001)
+    task.cancel()
+    await asyncio.sleep(0.005)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_sync_tool_admission_never_runs_handler(monkeypatch):
+    from brain.platform.async_io import invoke_maybe_async
+
+    class SaturatedAdmission:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return False
+
+    called = False
+
+    def handler():
+        nonlocal called
+        called = True
+
+    monkeypatch.setenv("AGENT_SYNC_TOOL_ADMISSION_TIMEOUT_SECONDS", "1")
+    monkeypatch.setattr(
+        "brain.platform.async_io._TOOL_ADMISSION",
+        SaturatedAdmission(),
+    )
+    task = asyncio.create_task(invoke_maybe_async(handler))
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_queued_sync_handler_never_starts(monkeypatch):
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    import brain.platform.async_io as async_io
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    admission = threading.BoundedSemaphore(2)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_called = threading.Event()
+
+    def occupy_worker():
+        first_started.set()
+        assert release_first.wait(timeout=1)
+
+    def queued_handler():
+        second_called.set()
+
+    monkeypatch.setattr(async_io, "_TOOL_EXECUTOR", executor)
+    monkeypatch.setattr(async_io, "_TOOL_ADMISSION", admission)
+    first = asyncio.create_task(async_io.invoke_maybe_async(occupy_worker))
+    second = None
+    try:
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+        second = asyncio.create_task(async_io.invoke_maybe_async(queued_handler))
+        await asyncio.sleep(0.02)
+        second.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second
+        release_first.set()
+        await first
+        await asyncio.sleep(0.02)
+    finally:
+        release_first.set()
+        if not first.done():
+            await first
+        executor.shutdown(wait=True)
+
+    assert not second_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_cancels_mutation_before_sync_admission(monkeypatch):
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    class SaturatedAdmission:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return False
+
+    called = False
+
+    def handler(action):
+        nonlocal called
+        assert action == "create"
+        called = True
+        return {"ok": True}
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("AGENT_SYNC_TOOL_ADMISSION_TIMEOUT_SECONDS", "1")
+    monkeypatch.setattr("brain.platform.async_io._TOOL_ADMISSION", SaturatedAdmission())
+    task = asyncio.create_task(
+        async_resolve_tool_call(
+            PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, handler)
+        )
+    )
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0.02)
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_cancels_later_queued_mutation_after_completed_blocking_phase(monkeypatch):
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    import brain.platform.async_io as async_io
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    admission = threading.BoundedSemaphore(2)
+    preflight_done = asyncio.Event()
+    allow_mutation = asyncio.Event()
+    occupier_started = threading.Event()
+    release_occupier = threading.Event()
+    mutation_called = threading.Event()
+
+    def occupy_worker():
+        occupier_started.set()
+        assert release_occupier.wait(timeout=1)
+
+    def mutate():
+        mutation_called.set()
+        return {"ok": True}
+
+    async def handler(action):
+        assert action == "create"
+        await async_io.run_tool_blocking(lambda: "preflight")
+        preflight_done.set()
+        await allow_mutation.wait()
+        return await async_io.run_tool_blocking(mutate)
+
+    monkeypatch.setattr(async_io, "_TOOL_EXECUTOR", executor)
+    monkeypatch.setattr(async_io, "_TOOL_ADMISSION", admission)
+    resolver = asyncio.create_task(
+        async_resolve_tool_call(
+            PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, handler)
+        )
+    )
+    occupier = None
+    try:
+        await preflight_done.wait()
+        occupier = asyncio.create_task(async_io.invoke_maybe_async(occupy_worker))
+        while not occupier_started.is_set():
+            await asyncio.sleep(0.001)
+        allow_mutation.set()
+        await asyncio.sleep(0.02)
+        resolver.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resolver
+        release_occupier.set()
+        await occupier
+        await asyncio.sleep(0.02)
+    finally:
+        release_occupier.set()
+        if occupier is not None and not occupier.done():
+            await occupier
+        executor.shutdown(wait=True)
+
+    assert not mutation_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_cancels_mutation_during_async_audit_preflight(monkeypatch):
+    from brain.systems.runs.actions import wrap_action_manifest_audit
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    preflight_started = asyncio.Event()
+    preflight_canceled = asyncio.Event()
+    mutation_called = False
+
+    async def record_manifest(_manifest):
+        preflight_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            preflight_canceled.set()
+            raise
+
+    async def mutation(path, content):
+        nonlocal mutation_called
+        mutation_called = True
+        return {"path": path, "bytes": len(content)}
+
+    wrapped = wrap_action_manifest_audit(
+        "write_file",
+        mutation,
+        context_factory=lambda: {"run_id": 42, "org_id": "org-1"},
+    )
+    monkeypatch.setattr("brain.systems.runs.actions.record_action_manifest", record_manifest)
+    task = asyncio.create_task(
+        async_resolve_tool_call(
+            PendingToolCall(
+                "tool-1",
+                "write_file",
+                {"path": "note.txt", "content": "hello"},
+                wrapped,
+            )
+        )
+    )
+    await preflight_started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+
+    assert preflight_canceled.is_set()
+    assert mutation_called is False
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_watchdog_tracks_public_blocking_helper(monkeypatch):
+    import threading
+    import time
+
+    from brain.platform.async_io import run_tool_blocking
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    finished = threading.Event()
+
+    def slow_read():
+        time.sleep(0.12)
+        finished.set()
+        return {"ok": True}
+
+    async def handler():
+        return await run_tool_blocking(slow_read)
+
+    started_at = time.monotonic()
+    resolved = await async_resolve_tool_call(
+        PendingToolCall("tool-1", "unregistered_read", {}, handler)
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert resolved.is_error is True
+    assert "timed out" in resolved.result_text
+    assert elapsed < 0.08
+    assert not finished.is_set()
+    assert finished.wait(timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_waits_for_sync_action_before_reporting_outcome(monkeypatch):
+    import time
+
+    from brain.systems.runs.actions import wrap_action_manifest_audit
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    records = []
+    completions = []
+    completed = asyncio.Event()
+
+    def record(manifest):
+        records.append(manifest.to_db_values())
+        return 1
+
+    def complete(manifest_id, **kwargs):
+        completions.append({"manifest_id": manifest_id, **kwargs})
+        completed.set()
+
+    def slow_handler(action):
+        assert action == "create"
+        time.sleep(0.1)
+        return {"ok": True}
+
+    wrapped = wrap_action_manifest_audit(
+        "manage_cycle",
+        slow_handler,
+        context_factory=lambda: {"run_id": 42, "org_id": "org-1"},
+    )
+    monkeypatch.setattr("brain.systems.runs.actions.record_action_manifest", record)
+    monkeypatch.setattr("brain.systems.runs.actions.complete_action_manifest", complete)
+
+    resolved = await async_resolve_tool_call(
+        PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, wrapped)
+    )
+
+    assert resolved.is_error is False
+    assert json.loads(resolved.result_text) == {"ok": True}
+    assert completed.is_set()
+    assert len(records) == 1
+    assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
+
+
+@pytest.mark.asyncio
+async def test_direct_loop_waits_for_async_mutation_before_reporting_outcome(monkeypatch):
+    from brain.systems.runs.actions import wrap_action_manifest_audit
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    completions = []
+
+    async def slow_mutation(action):
+        assert action == "create"
+        await asyncio.sleep(0.05)
+        return {"ok": True}
+
+    wrapped = wrap_action_manifest_audit(
+        "manage_cycle",
+        slow_mutation,
+        context_factory=lambda: {"run_id": 42, "org_id": "org-1"},
+    )
+    monkeypatch.setattr("brain.systems.runs.actions.record_action_manifest", lambda _manifest: 1)
+    monkeypatch.setattr(
+        "brain.systems.runs.actions.complete_action_manifest",
+        lambda manifest_id, **kwargs: completions.append({"manifest_id": manifest_id, **kwargs}),
+    )
+
+    resolved = await async_resolve_tool_call(
+        PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, wrapped)
+    )
+
+    assert resolved.is_error is False
+    assert json.loads(resolved.result_text) == {"ok": True}
+    assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_after_watchdog_does_not_abort_async_mutation(monkeypatch):
+    from brain.systems.runs.direct_loop.tool_execution import PendingToolCall, async_resolve_tool_call
+
+    monkeypatch.setenv("AGENT_TOOL_TIMEOUT_SECONDS", "0.02")
+    started = asyncio.Event()
+    completed = asyncio.Event()
+    canceled = asyncio.Event()
+
+    async def mutation(action):
+        assert action == "create"
+        started.set()
+        try:
+            await asyncio.sleep(0.1)
+            completed.set()
+            return {"ok": True}
+        except asyncio.CancelledError:
+            canceled.set()
+            raise
+
+    task = asyncio.create_task(
+        async_resolve_tool_call(
+            PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, mutation)
+        )
+    )
+    await started.wait()
+    await asyncio.sleep(0.04)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(completed.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert not canceled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_sync_action_cancellation_drains_handler_and_audit(monkeypatch):
+    import threading
+    import time
+
+    from brain.systems.runs.actions import wrap_action_manifest_audit
+
+    started = threading.Event()
+    finished = threading.Event()
+    completions = []
+
+    def slow_mutation(action):
+        assert action == "create"
+        started.set()
+        time.sleep(0.08)
+        finished.set()
+        return {"ok": True}
+
+    wrapped = wrap_action_manifest_audit(
+        "manage_cycle",
+        slow_mutation,
+        context_factory=lambda: {"run_id": 42, "org_id": "org-1"},
+    )
+    monkeypatch.setattr("brain.systems.runs.actions.record_action_manifest", lambda _manifest: 1)
+    monkeypatch.setattr(
+        "brain.systems.runs.actions.complete_action_manifest",
+        lambda manifest_id, **kwargs: completions.append({"manifest_id": manifest_id, **kwargs}),
+    )
+
+    task = asyncio.create_task(wrapped(action="create"))
+    while not started.is_set():
+        await asyncio.sleep(0.001)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert finished.is_set()
+    assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
+
+
+@pytest.mark.asyncio
+async def test_runtime_tool_cleanup_waits_for_canceled_sync_handler(monkeypatch):
+    import threading
+    import time
+
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+    from brain.systems.runs.workspace_tool_runtime import WorkspaceToolRuntimeMaterialization
+
+    started = threading.Event()
+    finished = threading.Event()
+    cleaned = []
+    materialization = WorkspaceToolRuntimeMaterialization()
+    materialization.cleanup = lambda: cleaned.append(finished.is_set())
+
+    async def fake_materialization(*_args, **_kwargs):
+        return materialization
+
+    def slow_handler(**_kwargs):
+        started.set()
+        time.sleep(0.08)
+        finished.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tools.resolve_workspace_tool_runtime",
+        fake_materialization,
+    )
+    monkeypatch.setattr("brain.systems.runs.tools.record_action_manifest", lambda _manifest: None)
+    runtime = _runtime("worker")
+    task = asyncio.create_task(
+        AsyncRunToolExecutor(runtime.store).execute(
+            42,
+            ToolExecution(name="exec_command", args={"command": "echo ok"}, handler=slow_handler),
+            root_run_id=42,
+        )
+    )
+    while not started.is_set():
+        await asyncio.sleep(0.001)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert finished.is_set()
+    assert cleaned == [True]
+    assert [
+        event.event_type
+        for event in runtime.store.events
+        if event.event_type in {"run.tool_completed", "run.tool_failed"}
+    ] == ["run.tool_completed"]
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_executor_rejects_overload_without_using_default_pool(monkeypatch):
+    from brain.platform.async_io import ToolExecutorOverloaded, invoke_maybe_async
+
+    class SaturatedAdmission:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return False
+
+    monkeypatch.setenv("AGENT_SYNC_TOOL_ADMISSION_TIMEOUT_SECONDS", "0.01")
+    monkeypatch.setattr(
+        "brain.platform.async_io._TOOL_ADMISSION",
+        SaturatedAdmission(),
+    )
+
+    with pytest.raises(ToolExecutorOverloaded, match="capacity is saturated"):
+        await invoke_maybe_async(lambda: {"ok": True})
+
+
+@pytest.mark.asyncio
+async def test_production_file_summary_handler_keeps_event_loop_responsive(monkeypatch):
+    import time
+
+    import brain.systems.tools.handlers as extended_handlers
+    from brain.systems.runs.tool_catalog.handlers.composition import _get_tool_handlers
+
+    def slow_file_summary(path, workspace_root=None):
+        time.sleep(0.08)
+        return {"path": path, "workspace_root": workspace_root}
+
+    monkeypatch.setattr(extended_handlers, "handle_file_summary", slow_file_summary)
+    handler = _get_tool_handlers(workspace_root="/tmp/work")["file_summary"]
+    ticker_count = 0
+    stop_ticker = asyncio.Event()
+
+    async def ticker():
+        nonlocal ticker_count
+        while not stop_ticker.is_set():
+            ticker_count += 1
+            await asyncio.sleep(0.005)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        result = await handler(path="README.md")
+    finally:
+        stop_ticker.set()
+        await ticker_task
+
+    assert result == {"path": "README.md", "workspace_root": "/tmp/work"}
+    assert ticker_count >= 5
 
 
 async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_result_artifact(monkeypatch):

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -44,6 +44,22 @@ async def session_factory() -> AsyncIterator[Callable[[], AsyncSession]]:
     await engine.dispose()
 
 
+async def _file_session_factory(database):
+    _patch_sqlite_for_agent_run_tables()
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{database}",
+        connect_args={"timeout": 5},
+    )
+    async with engine.begin() as connection:
+        for table in [
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+        ]:
+            await connection.execute(CreateTable(table, if_not_exists=True))
+    return engine, async_sessionmaker(bind=engine, expire_on_commit=False)
+
+
 class _SessionUoW:
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -87,6 +103,699 @@ async def test_restart_resume_skips_completed_steps_from_persisted_cursor(sessio
     assert row.metadata_["cursor"]["completed_steps"]["first"]["result"] == "first-result"
     assert row.metadata_["cursor"]["completed_steps"]["second"]["result"] == "second-result"
     assert (await _event_types(restarted, run.id)).count("run.step_skipped") == 1
+
+
+async def test_inline_child_is_atomically_owned_before_parent_executes_it(session_factory):
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    root = await store.create_run(_run_request(thread_id="thread-1", message="root"))
+    await store.set_status(root.id, RunStatus.STARTING)
+    await store.set_status(root.id, RunStatus.RUNNING)
+
+    inline = await store.create_child_run(
+        root,
+        recipe=RunRecipe.WORKER,
+        message="inline child",
+        step_key="node:inline",
+        initial_status=RunStatus.STARTING,
+    )
+    repeated = await store.create_child_run(
+        root,
+        recipe=RunRecipe.WORKER,
+        message="inline child",
+        step_key="node:inline",
+        initial_status=RunStatus.STARTING,
+    )
+    queued = await store.create_child_run(
+        root,
+        recipe=RunRecipe.WORKER,
+        message="queued child",
+        step_key="spawn_worker:queued",
+    )
+    await session.commit()
+
+    competing_session = session_factory()
+    competing_store = AsyncAgentRunStore(competing_session)
+    assert repeated.id == inline.id
+    assert inline.status == RunStatus.STARTING
+    assert inline.started_at is not None
+    assert await competing_store.claim_run(inline.id) is None
+    claimed = await competing_store.claim_next()
+    assert claimed is not None
+    assert claimed.id == queued.id
+
+    completed = await AsyncAgentRunEngine(
+        competing_session,
+        recipes={RunRecipe.WORKER.value: StaticAnswerRecipe("done")},
+    ).run_existing(inline.id)
+    assert completed.status == RunStatus.COMPLETED
+
+
+async def test_child_does_not_inherit_root_source_idempotency(session_factory):
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    source_metadata = {
+        "idempotency_key": "slack:C123:1712345678.000100",
+        "work_intake": {"source": "slack"},
+    }
+    root = await store.create_run(
+        _run_request(
+            thread_id="thread-slack",
+            message="root",
+            metadata=source_metadata,
+        )
+    )
+    child = await store.create_child_run(
+        root,
+        recipe=RunRecipe.WORKER,
+        message="child",
+        step_key="node:slack-child",
+        metadata=source_metadata,
+        initial_status=RunStatus.STARTING,
+    )
+
+    assert child.id != root.id
+    assert child.parent_run_id == root.id
+
+
+async def test_child_creation_and_parent_event_are_atomic_and_repairable(tmp_path, monkeypatch):
+    database_engine, factory = await _file_session_factory(tmp_path / "child-event-atomicity.sqlite3")
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session, auto_commit=True)
+            root = await store.create_run(
+                _run_request(thread_id="thread-child-event", message="root")
+            )
+            root_id = root.id
+
+            original_append = store._append_child_created_once
+
+            async def fail_parent_event(*_args, **_kwargs):
+                raise RuntimeError("parent event failed")
+
+            monkeypatch.setattr(store, "_append_child_created_once", fail_parent_event)
+            with pytest.raises(RuntimeError, match="parent event failed"):
+                await store.create_child_run(
+                    root,
+                    recipe=RunRecipe.WORKER,
+                    message="child",
+                    step_key="node:atomic-child",
+                    initial_status=RunStatus.STARTING,
+                )
+
+            monkeypatch.setattr(store, "_append_child_created_once", original_append)
+
+        async with factory() as creation_session:
+            creation_store = AsyncAgentRunStore(creation_session, auto_commit=True)
+            root_row = await creation_store.require_run(root_id)
+            child, created = await creation_store.create_child_run_with_result(
+                root_row,
+                recipe=RunRecipe.WORKER,
+                message="child",
+                step_key="node:atomic-child",
+                initial_status=RunStatus.STARTING,
+            )
+            assert created is True
+            child_id = child.id
+
+        async with factory() as repair_session:
+            await repair_session.execute(
+                AgentRunEventRow.__table__.delete().where(
+                    AgentRunEventRow.run_id == root_id,
+                    AgentRunEventRow.event_type == "run.child_created",
+                )
+            )
+            await repair_session.commit()
+            repair_store = AsyncAgentRunStore(repair_session, auto_commit=True)
+            root_row = await repair_store.require_run(root_id)
+            replayed, created = await repair_store.create_child_run_with_result(
+                root_row,
+                recipe=RunRecipe.WORKER,
+                message="child",
+                step_key="node:atomic-child",
+                initial_status=RunStatus.STARTING,
+            )
+            assert replayed.id == child_id
+            assert created is False
+
+        async with factory() as inspection_session:
+            children = (
+                await inspection_session.scalars(
+                    select(AgentRunRow).where(AgentRunRow.parent_run_id == root_id)
+                )
+            ).all()
+            assert [row.id for row in children] == [child_id]
+            child_events = (
+                await inspection_session.scalars(
+                    select(AgentRunEventRow).where(
+                        AgentRunEventRow.run_id == root_id,
+                        AgentRunEventRow.event_type == "run.child_created",
+                    )
+                )
+            ).all()
+            assert len(child_events) == 1
+            assert child_events[0].payload["child_run_id"] == child_id
+    finally:
+        await database_engine.dispose()
+
+
+async def test_concurrent_inline_child_creation_and_execution_is_exactly_once(tmp_path):
+    _patch_sqlite_for_agent_run_tables()
+    database = tmp_path / "concurrent-agent-runs.sqlite3"
+    database_engine = create_async_engine(
+        f"sqlite+aiosqlite:///{database}",
+        connect_args={"timeout": 5},
+    )
+    async with database_engine.begin() as connection:
+        for table in [
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+        ]:
+            await connection.execute(CreateTable(table, if_not_exists=True))
+    factory = async_sessionmaker(bind=database_engine, expire_on_commit=False)
+    try:
+        async with factory() as setup_session:
+            setup_store = AsyncAgentRunStore(setup_session)
+            root = await setup_store.create_run(
+                _run_request(thread_id="thread-concurrent", message="root")
+            )
+            await setup_store.set_status(root.id, RunStatus.STARTING)
+            await setup_store.set_status(root.id, RunStatus.RUNNING)
+            await setup_session.commit()
+
+        async def create_inline_child() -> int:
+            async with factory() as session:
+                child = await AsyncAgentRunStore(session).create_child_run(
+                    root,
+                    recipe=RunRecipe.WORKER,
+                    message="same logical child",
+                    step_key="node:concurrent",
+                    initial_status=RunStatus.STARTING,
+                )
+                return child.id
+
+        child_ids = await asyncio.gather(create_inline_child(), create_inline_child())
+        assert child_ids[0] == child_ids[1]
+
+        async with factory() as inspection_session:
+            children = (
+                await inspection_session.scalars(
+                    select(AgentRunRow).where(AgentRunRow.parent_run_id == root.id)
+                )
+            ).all()
+            assert [child.id for child in children] == [child_ids[0]]
+            assert children[0].parent_step_key_hash is not None
+
+        recipe_calls = 0
+
+        class SideEffectRecipe:
+            async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+                nonlocal recipe_calls
+                recipe_calls += 1
+                await asyncio.sleep(0.05)
+                return RunRecipeResult(output="done")
+
+        first_session = factory()
+        second_session = factory()
+        await first_session.get(AgentRunRow, child_ids[0])
+        await second_session.get(AgentRunRow, child_ids[0])
+        first, second = await asyncio.gather(
+            AsyncAgentRunEngine(
+                first_session,
+                recipes={RunRecipe.WORKER.value: SideEffectRecipe()},
+            ).run_existing(child_ids[0]),
+            AsyncAgentRunEngine(
+                second_session,
+                recipes={RunRecipe.WORKER.value: SideEffectRecipe()},
+            ).run_existing(child_ids[0]),
+        )
+        await first_session.close()
+        await second_session.close()
+        assert first.status == RunStatus.COMPLETED
+        assert second.status == RunStatus.COMPLETED
+        assert recipe_calls == 1
+
+        async with factory() as setup_session:
+            paused_child = await AsyncAgentRunStore(setup_session).create_child_run(
+                root,
+                recipe=RunRecipe.WORKER,
+                message="pause once",
+                step_key="node:paused",
+                initial_status=RunStatus.STARTING,
+            )
+
+        pause_calls = 0
+
+        class PauseRecipe:
+            async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+                nonlocal pause_calls
+                pause_calls += 1
+                await asyncio.sleep(0.05)
+                return RunRecipeResult(output="needs input", status=RunStatus.PAUSED)
+
+        first_pause_session = factory()
+        second_pause_session = factory()
+        await first_pause_session.get(AgentRunRow, paused_child.id)
+        await second_pause_session.get(AgentRunRow, paused_child.id)
+        paused_first, paused_second = await asyncio.gather(
+            AsyncAgentRunEngine(
+                first_pause_session,
+                recipes={RunRecipe.WORKER.value: PauseRecipe()},
+            ).run_existing(paused_child.id),
+            AsyncAgentRunEngine(
+                second_pause_session,
+                recipes={RunRecipe.WORKER.value: PauseRecipe()},
+            ).run_existing(paused_child.id),
+        )
+        await first_pause_session.close()
+        await second_pause_session.close()
+        assert paused_first.status == RunStatus.PAUSED
+        assert paused_second.status == RunStatus.PAUSED
+        assert pause_calls == 1
+    finally:
+        await database_engine.dispose()
+
+
+async def test_execution_claim_prevents_canceled_run_from_owner_completion(tmp_path):
+    database_engine, factory = await _file_session_factory(tmp_path / "cancel-fence.sqlite3")
+    recipe_started = asyncio.Event()
+    finish_recipe = asyncio.Event()
+    calls = 0
+
+    class BlockedRecipe:
+        async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+            nonlocal calls
+            calls += 1
+            recipe_started.set()
+            await finish_recipe.wait()
+            return RunRecipeResult(output="must not publish")
+
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            run = await store.create_run(
+                _run_request(thread_id="thread-cancel-fence", message="race")
+            )
+            await store.set_status(run.id, RunStatus.STARTING)
+            await setup_session.commit()
+            run_id = run.id
+
+        owner_session = factory()
+        owner_task = asyncio.create_task(
+            AsyncAgentRunEngine(
+                owner_session,
+                recipes={RunRecipe.FAST.value: BlockedRecipe()},
+            ).run_existing(run_id)
+        )
+        await asyncio.wait_for(recipe_started.wait(), timeout=1)
+
+        async with factory() as cancel_session:
+            canceled = await AsyncAgentRunStore(cancel_session).set_status(
+                run_id,
+                RunStatus.CANCELED,
+                reason="user_canceled",
+            )
+            await cancel_session.commit()
+            assert canceled.status == RunStatus.CANCELED
+
+        finish_recipe.set()
+        result = await asyncio.wait_for(owner_task, timeout=2)
+        await owner_session.close()
+
+        assert result.status == RunStatus.CANCELED
+        assert calls == 1
+        async with factory() as inspection_session:
+            row = await inspection_session.get(AgentRunRow, run_id)
+            assert row is not None
+            assert row.status == RunStatus.CANCELED.value
+            assert row.execution_token is None
+            artifacts = (
+                await inspection_session.scalars(
+                    select(AgentRunArtifactRow).where(AgentRunArtifactRow.run_id == run_id)
+                )
+            ).all()
+            assert not [artifact for artifact in artifacts if artifact.text == "must not publish"]
+            assert "run.completed" not in await _event_types(inspection_session, run_id)
+    finally:
+        await database_engine.dispose()
+
+
+async def test_stale_cancel_cannot_overwrite_or_emit_after_completed_execution(tmp_path):
+    from brain.app.api.routers.cortex._run import _cancel_run_with_event
+
+    database_engine, factory = await _file_session_factory(tmp_path / "stale-cancel.sqlite3")
+    recipe_started = asyncio.Event()
+    finish_recipe = asyncio.Event()
+
+    class BlockedRecipe:
+        async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+            recipe_started.set()
+            await finish_recipe.wait()
+            return RunRecipeResult(output="done")
+
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            run = await store.create_run(
+                _run_request(thread_id="thread-stale-cancel", message="race")
+            )
+            await store.set_status(run.id, RunStatus.STARTING)
+            await setup_session.commit()
+            run_id = run.id
+
+        owner_session = factory()
+        owner_task = asyncio.create_task(
+            AsyncAgentRunEngine(
+                owner_session,
+                recipes={RunRecipe.FAST.value: BlockedRecipe()},
+            ).run_existing(run_id)
+        )
+        await asyncio.wait_for(recipe_started.wait(), timeout=1)
+
+        stale_cancel_session = factory()
+        stale_row = await stale_cancel_session.get(AgentRunRow, run_id)
+        assert stale_row is not None and stale_row.status == RunStatus.RUNNING.value
+
+        finish_recipe.set()
+        completed = await asyncio.wait_for(owner_task, timeout=2)
+        await owner_session.close()
+        assert completed.status == RunStatus.COMPLETED
+
+        await _cancel_run_with_event(
+            AsyncAgentRunStore(stale_cancel_session),
+            run_id,
+            reason="late_cancel",
+        )
+        await stale_cancel_session.commit()
+        await stale_cancel_session.close()
+
+        async with factory() as inspection_session:
+            row = await inspection_session.get(AgentRunRow, run_id)
+            assert row is not None and row.status == RunStatus.COMPLETED.value
+            assert "run.canceled" not in await _event_types(inspection_session, run_id)
+    finally:
+        await database_engine.dispose()
+
+
+async def test_auto_commit_terminal_output_failure_rolls_back_terminal_status(tmp_path, monkeypatch):
+    database_engine, factory = await _file_session_factory(tmp_path / "terminal-atomicity.sqlite3")
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            run = await store.create_run(
+                _run_request(thread_id="thread-terminal-atomicity", message="finish atomically")
+            )
+            await store.set_status(run.id, RunStatus.STARTING)
+            await setup_session.commit()
+            run_id = run.id
+
+        owner_session = factory()
+        engine = AsyncAgentRunEngine(
+            owner_session,
+            recipes={RunRecipe.FAST.value: StaticAnswerRecipe("final output")},
+            auto_commit_events=True,
+        )
+
+        async def fail_final_answer(*_args, **_kwargs):
+            raise RuntimeError("artifact write failed")
+
+        monkeypatch.setattr(engine.store, "append_final_answer_once", fail_final_answer)
+        with pytest.raises(RuntimeError, match="artifact write failed"):
+            await engine.run_existing(run_id)
+        await owner_session.close()
+
+        async with factory() as inspection_session:
+            row = await inspection_session.get(AgentRunRow, run_id)
+            assert row is not None
+            assert row.status == RunStatus.RUNNING.value
+            assert row.execution_token is None
+            assert "run.completed" not in await _event_types(inspection_session, run_id)
+            artifacts = (
+                await inspection_session.scalars(
+                    select(AgentRunArtifactRow).where(AgentRunArtifactRow.run_id == run_id)
+                )
+            ).all()
+            assert not [artifact for artifact in artifacts if artifact.artifact_type == "final_answer"]
+    finally:
+        await database_engine.dispose()
+
+
+async def test_auto_commit_claim_event_failure_rolls_back_claim(tmp_path, monkeypatch):
+    database_engine, factory = await _file_session_factory(tmp_path / "claim-atomicity.sqlite3")
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            run = await store.create_run(
+                _run_request(thread_id="thread-claim-atomicity", message="start atomically")
+            )
+            await store.set_status(run.id, RunStatus.STARTING)
+            await setup_session.commit()
+            run_id = run.id
+
+        owner_session = factory()
+        engine = AsyncAgentRunEngine(
+            owner_session,
+            recipes={RunRecipe.FAST.value: StaticAnswerRecipe("must not run")},
+            auto_commit_events=True,
+        )
+        original_append = engine.store.append_event
+
+        async def fail_started_event(event):
+            if event.event_type == "run.started":
+                raise RuntimeError("started event failed")
+            return await original_append(event)
+
+        monkeypatch.setattr(engine.store, "append_event", fail_started_event)
+        with pytest.raises(RuntimeError, match="started event failed"):
+            await engine.run_existing(run_id)
+        await owner_session.close()
+
+        async with factory() as inspection_session:
+            row = await inspection_session.get(AgentRunRow, run_id)
+            assert row is not None
+            assert row.status == RunStatus.STARTING.value
+            assert row.execution_token is None
+            assert row.execution_attempt == 0
+            assert "run.started" not in await _event_types(inspection_session, run_id)
+    finally:
+        await database_engine.dispose()
+
+
+async def test_active_execution_claim_is_not_stolen_from_live_owner(tmp_path):
+    database_engine, factory = await _file_session_factory(tmp_path / "active-claim.sqlite3")
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            run = await store.create_run(
+                _run_request(thread_id="thread-expired-claim", message="recover")
+            )
+            await store.set_status(run.id, RunStatus.STARTING)
+            await store.set_status(run.id, RunStatus.RUNNING)
+            row = await store.require_run(run.id)
+            row.execution_token = "live-owner"
+            row.execution_attempt = 7
+            await setup_session.commit()
+            run_id = run.id
+
+        async with factory() as contender_session:
+            contender_store = AsyncAgentRunStore(contender_session)
+            row = await contender_store.refresh_run(run_id)
+            claim = await contender_store._try_acquire_execution_claim(
+                row,
+                token="contender",
+            )
+            assert claim is None
+
+        async with factory() as inspection_session:
+            row = await inspection_session.get(AgentRunRow, run_id)
+            assert row is not None
+            assert row.status == RunStatus.RUNNING.value
+            assert row.execution_attempt == 7
+            assert row.execution_token == "live-owner"
+    finally:
+        await database_engine.dispose()
+
+
+async def test_stale_status_cas_preserves_live_owner_and_prior_batch_changes(tmp_path):
+    database_engine, factory = await _file_session_factory(tmp_path / "stale-status-cas.sqlite3")
+    old = datetime.now(timezone.utc) - timedelta(seconds=300)
+    now = datetime.now(timezone.utc)
+    try:
+        async with factory() as setup_session:
+            store = AsyncAgentRunStore(setup_session)
+            runs = []
+            for index in range(2):
+                run = await store.create_run(
+                    _run_request(thread_id=f"thread-stale-cas-{index}", message="stale")
+                )
+                await store.set_status(run.id, RunStatus.STARTING)
+                await store.set_status(run.id, RunStatus.RUNNING)
+                row = await store.require_run(run.id)
+                row.execution_token = f"owner-{index}"
+                row.execution_attempt = index + 1
+                row.updated_at = old
+                runs.append(run.id)
+            await setup_session.commit()
+
+        stale_session = factory()
+        stale_store = AsyncAgentRunStore(stale_session)
+        stale_rows = [await stale_store.refresh_run(run_id) for run_id in runs]
+        expected = [
+            (row.updated_at, row.execution_token, int(row.execution_attempt or 0))
+            for row in stale_rows
+        ]
+
+        async with factory() as live_session:
+            live_store = AsyncAgentRunStore(live_session)
+            assert await live_store.heartbeat_run(runs[1], now=now, reason="owner_is_alive")
+            await live_session.commit()
+
+        _first, first_changed = await stale_store.set_status_with_result(
+            runs[0],
+            RunStatus.FAILED,
+            reason="runner_heartbeat_stale",
+            expected_updated_at=expected[0][0],
+            expected_execution_token=expected[0][1],
+            expected_execution_attempt=expected[0][2],
+            rollback_on_conflict=False,
+        )
+        second, second_changed = await stale_store.set_status_with_result(
+            runs[1],
+            RunStatus.FAILED,
+            reason="runner_heartbeat_stale",
+            expected_updated_at=expected[1][0],
+            expected_execution_token=expected[1][1],
+            expected_execution_attempt=expected[1][2],
+            rollback_on_conflict=False,
+        )
+        assert first_changed is True
+        assert second_changed is False
+        assert second.status == RunStatus.RUNNING
+        await stale_session.commit()
+        await stale_session.close()
+
+        async with factory() as inspection_session:
+            first_row = await inspection_session.get(AgentRunRow, runs[0])
+            second_row = await inspection_session.get(AgentRunRow, runs[1])
+            assert first_row is not None and first_row.status == RunStatus.FAILED.value
+            assert first_row.execution_token is None
+            assert second_row is not None and second_row.status == RunStatus.RUNNING.value
+            assert second_row.execution_token == "owner-1"
+            assert second_row.metadata_["runner_heartbeat"]["reason"] == "owner_is_alive"
+    finally:
+        await database_engine.dispose()
+
+
+async def test_canceled_run_is_not_entered_by_recipe(session_factory):
+    calls = 0
+
+    class UnexpectedRecipe:
+        async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+            nonlocal calls
+            calls += 1
+            return RunRecipeResult(output="unexpected")
+
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(
+        _run_request(thread_id="thread-canceled-before-entry", message="do not run")
+    )
+    await store.set_status(run.id, RunStatus.CANCELED)
+    await session.commit()
+
+    result = await AsyncAgentRunEngine(
+        session,
+        recipes={RunRecipe.FAST.value: UnexpectedRecipe()},
+    ).run_existing(run.id)
+
+    assert result.status == RunStatus.CANCELED
+    assert calls == 0
+
+
+@pytest.mark.requires_db
+async def test_postgres_execution_token_allows_one_recipe_attempt(db_engine):
+    import uuid
+
+    from brain.platform.db.models.org import Org
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    slug = f"lease-{uuid.uuid4().hex[:12]}"
+    root_id = None
+    child_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(Org(id=org_id, name="Lease Test", slug=slug))
+            await setup_session.flush()
+            setup_store = AsyncAgentRunStore(setup_session)
+            root = await setup_store.create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="root",
+                )
+            )
+            root_id = root.id
+            await setup_store.set_status(root.id, RunStatus.STARTING)
+            await setup_store.set_status(root.id, RunStatus.RUNNING)
+            child = await setup_store.create_child_run(
+                root,
+                recipe=RunRecipe.WORKER,
+                message="child",
+                step_key="node:postgres-exactly-once",
+                initial_status=RunStatus.STARTING,
+            )
+            child_id = child.id
+
+        calls = 0
+
+        class Recipe:
+            async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+                nonlocal calls
+                calls += 1
+                await asyncio.sleep(0.05)
+                return RunRecipeResult(output="done")
+
+        first_session = factory()
+        second_session = factory()
+        await first_session.get(AgentRunRow, child_id)
+        await second_session.get(AgentRunRow, child_id)
+        first, second = await asyncio.gather(
+            AsyncAgentRunEngine(
+                first_session,
+                recipes={RunRecipe.WORKER.value: Recipe()},
+            ).run_existing(child_id),
+            AsyncAgentRunEngine(
+                second_session,
+                recipes={RunRecipe.WORKER.value: Recipe()},
+            ).run_existing(child_id),
+        )
+        await first_session.close()
+        await second_session.close()
+
+        assert first.status == RunStatus.COMPLETED
+        assert second.status == RunStatus.COMPLETED
+        assert calls == 1
+    finally:
+        async with factory() as cleanup_session:
+            if root_id is not None:
+                run_ids = [value for value in (root_id, child_id) if value is not None]
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id.in_(run_ids))
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
 
 
 async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory):
@@ -531,6 +1240,8 @@ async def test_stale_active_run_reaper_fails_abandoned_runs(session_factory):
     row.created_at = old
     row.started_at = old
     row.updated_at = old
+    row.execution_token = "abandoned-owner"
+    row.execution_attempt = 3
     row.metadata_ = {"runner_heartbeat": {"at": old.isoformat(), "reason": "runner_running"}}
     for event in (await session.scalars(select(AgentRunEventRow).where(AgentRunEventRow.run_id == run.id))).all():
         event.created_at = old
@@ -552,6 +1263,7 @@ async def test_stale_active_run_reaper_fails_abandoned_runs(session_factory):
     assert count == 1
     assert row is not None
     assert row.status == RunStatus.FAILED.value
+    assert row.execution_token is None
     failed_events = [
         event
         for event in (await session.scalars(

--- a/tests/test_tool_policy.py
+++ b/tests/test_tool_policy.py
@@ -215,6 +215,44 @@ def test_low_risk_action_executes_under_enforced_policy(monkeypatch):
     assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
 
 
+@pytest.mark.asyncio
+async def test_action_manifest_wrapper_offloads_sync_handler(monkeypatch):
+    import asyncio
+    import time
+
+    from brain.systems.runs.actions import wrap_action_manifest_audit
+
+    monkeypatch.setenv("AGENT_ACTION_POLICY_MODE", "enforce")
+    records, completions, record, complete = _capture_manifests()
+    stop_ticker = asyncio.Event()
+    ticker_count = 0
+
+    async def ticker():
+        nonlocal ticker_count
+        while not stop_ticker.is_set():
+            ticker_count += 1
+            await asyncio.sleep(0.01)
+
+    def handler(**kwargs):
+        time.sleep(0.1)
+        return {"ok": True, **kwargs}
+
+    wrapped = wrap_action_manifest_audit("web_fetch", handler, context_factory=_manifest_context)
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        with patch("brain.systems.runs.actions.record_action_manifest", side_effect=record), \
+             patch("brain.systems.runs.actions.complete_action_manifest", side_effect=complete):
+            result = await wrapped(url="https://example.com")
+    finally:
+        stop_ticker.set()
+        await ticker_task
+
+    assert result == {"ok": True, "url": "https://example.com"}
+    assert ticker_count >= 3
+    assert len(records) == 1
+    assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
+
+
 def test_denied_action_does_not_invoke_handler(monkeypatch):
     from brain.systems.runs.actions import wrap_action_manifest_audit
 


### PR DESCRIPTION
## Summary

- run synchronous production tools on a bounded shared executor so independent agent tool calls no longer serialize the event loop
- skip redundant Deep-planner review calls when no runnable worker assignments remain
- add atomic child-run idempotency, durable execution claims, and fenced stale-run recovery
- make terminal state, output, and lifecycle events transactional
- add migration `0023` plus adversarial concurrency, cancellation, and state-machine coverage
- repair the Fast and Deep benchmark scripts

## Why

Fast agent runs were paying avoidable event-loop blocking costs, Deep runs could spend coordinator calls reviewing work that could not progress, and concurrent retries or recovery could race around child creation and terminal state. Together these made the system slower and less predictable under load and failure.

## Impact

- two parallel 150 ms synchronous handlers improved from about 307 ms to 155 ms (about 49.5% faster)
- the representative Deep topology reduces coordinator review calls from 4 to 1
- child creation and spawn events are now exactly-once under concurrent repair
- live execution claims cannot be stolen; crashed claims are settled through fenced, idempotent recovery
- caller cancellation is prompt for read-only work while already-started mutations complete definitively

## Validation

- full non-database suite: passed
- full PostgreSQL suite: 3,551 passed, 10 skipped, 3 failed; all three failures reproduce unchanged on a clean `196c644` worktree and touch byte-identical production/test files
- focused runtime/state/runner/cortex suite: 159 passed, 1 skipped
- fresh PostgreSQL migration through `0023`: passed
- PostgreSQL exactly-once, heartbeat/completion race, deadlock, and batch-reaper checks: passed
- Fast and Deep smoke benchmarks: passed
- `git diff --check` and Python compilation: passed

The three baseline failures are in cross-channel memory filtering and a quality test that patches a nonexistent symbol; this change does not modify those paths.
