### PR TITLE
Quiesce idle workspace motion

### DIFF
--- a/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
+++ b/frontend/src/lib/features/workspace-scene/components/WorkspaceScene.svelte
@@ -1761,8 +1761,10 @@
     const duration = 220;
     archivingIdeaId = nodeId;
     archivingIdeaProgress = 0;
+    void cortex.deleteIdea(nodeId);
 
     function tick(now: number) {
+      if (destroyed) return;
       const progress = Math.min((now - startedAt) / duration, 1);
       archivingIdeaProgress = d3.easeCubicOut(progress);
       syncPrimitiveDragVisuals();
@@ -1772,7 +1774,6 @@
       }
       archivingIdeaId = null;
       archivingIdeaProgress = 0;
-      cortex.deleteIdea(nodeId);
     }
 
     requestAnimationFrame(tick);
@@ -1870,7 +1871,7 @@
     state.node.y = point.y;
     dragging({ active: false, x: point.x, y: point.y, clientX: event.clientX, clientY: event.clientY }, state.node);
     syncPrimitiveDragVisuals();
-    if (simulation) simulation.alpha(0.18).restart();
+    heatOrbit(0.18);
     return true;
   }
 
@@ -1953,17 +1954,25 @@
     const startTime = performance.now();
     archivingPinId = pin.pinId;
     archivingPinProgress = 0;
+    const deletion = onpindelete
+      ? Promise.resolve().then(() => onpindelete({ pinId: pin.pinId })).then(
+          () => true,
+          () => false,
+        )
+      : null;
 
     function finish() {
+      if (destroyed) return;
       archivingPinId = null;
       archivingPinProgress = 0;
       resetArchiveDragInteraction();
       localPinPositions.delete(pin.pinId);
       syncPrimitiveOrbitVisuals();
-      if (simulation) simulation.alpha(0.16).restart();
+      heatOrbit(0.16);
     }
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -1979,17 +1988,19 @@
         return;
       }
 
-      if (!onpindelete) {
+      if (!deletion) {
         patchPrimitivePinPosition(pin.pinId, fallbackPosition.x, fallbackPosition.y);
         finish();
         return;
       }
 
-      Promise.resolve(onpindelete({ pinId: pin.pinId }))
-        .catch(() => {
+      void deletion.then((deleted) => {
+        if (destroyed) return;
+        if (!deleted) {
           patchPrimitivePinPosition(pin.pinId, fallbackPosition.x, fallbackPosition.y);
-        })
-        .finally(finish);
+        }
+        finish();
+      });
     }
 
     requestAnimationFrame(archiveTick);
@@ -2104,7 +2115,7 @@
     dragTargetAnchorId = null;
     archiveDropAppId = archiveTarget ? app.id : null;
     setArchiveDragState(true, Boolean(archiveTarget));
-    if (simulation) simulation.alpha(0.08).restart();
+    heatOrbit(0.08);
     return true;
   }
 
@@ -2120,8 +2131,13 @@
     const startTime = performance.now();
     archivingAppId = app.id;
     archivingAppProgress = 0;
+    const archive = Promise.resolve().then(() => onapparchive?.({ appId: app.id })).then(
+      () => true,
+      () => false,
+    );
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -2137,18 +2153,18 @@
         return;
       }
 
-      Promise.resolve(onapparchive?.({ appId: app.id }))
-        .catch(() => {
+      void archive.then((archived) => {
+        if (destroyed) return;
+        if (!archived) {
           patchPrimitiveAppPosition(app.id, fallbackPosition.x, fallbackPosition.y);
-        })
-        .finally(() => {
-          archivingAppId = null;
-          archivingAppProgress = 0;
-          resetArchiveDragInteraction();
-          localAppPositions.delete(app.id);
-          syncPrimitiveOrbitVisuals();
-          if (simulation) simulation.alpha(0.16).restart();
-        });
+        }
+        archivingAppId = null;
+        archivingAppProgress = 0;
+        resetArchiveDragInteraction();
+        localAppPositions.delete(app.id);
+        syncPrimitiveOrbitVisuals();
+        heatOrbit(0.16);
+      });
     }
 
     requestAnimationFrame(archiveTick);
@@ -2176,7 +2192,7 @@
           x: state.previousX,
           y: state.previousY,
         });
-        if (simulation) simulation.alpha(0.16).restart();
+        heatOrbit(0.16);
         return didMove;
       }
 
@@ -2189,7 +2205,7 @@
           localAppPositions.delete(app.id);
           syncPrimitiveOrbitVisuals();
         });
-      if (simulation) simulation.alpha(0.16).restart();
+      heatOrbit(0.16);
 
       return didMove;
     }
@@ -2259,6 +2275,9 @@
   let orbitAnchorLookup: AttractorLookup = { byId: new Map(), byName: new Map(), byAnchorKey: new Map() };
   let sunLayoutKey = '';
   let pinLayoutKey = '';
+  let appLayoutKey = '';
+  let connectionTopologyKey = '';
+  let presenceMotionKey: string | null = null;
   let sunPulseFrame: number | null = null;
   let breathingFrame: number | null = null;
   let particleFrame: number | null = null;
@@ -2268,20 +2287,16 @@
   let primitiveSyncLastAt = 0;
   let simulationPaintLastAt = 0;
   let renderOwnerWarningIssued = false;
-  let workspaceMotionSuspended = false;
+  let destroyed = false;
   let _isDragging = false;
-  let lastOrbitTickAt = 0;
   const PREVIEW_MEMBER_PREFIX = '__cortex-preview-user__';
   const PREVIEW_IDEA_PREFIX = '__cortex-preview-idea__';
   const PRIMITIVE_SYNC_INTERVAL_MS = 16;
   const SIMULATION_PAINT_INTERVAL_MS = 16;
-  const ORBIT_WAKE_CHECK_INTERVAL_MS = 4_000;
-  const ORBIT_STALE_AFTER_MS = 6_500;
 
   type SimulationPerformanceProfile = {
     alphaDecay: number;
     alphaMin: number;
-    idleAlphaTarget: number;
     collideIterations: number;
     velocityDecay: number;
   };
@@ -2296,10 +2311,6 @@
 
   function activeSimulationProfile() {
     return simulationPerformanceProfile(activeSimulationNodeCount());
-  }
-
-  function idleOrbitAlphaTarget() {
-    return activeSimulationProfile().idleAlphaTarget;
   }
 
   function primitiveSyncIntervalMs() {
@@ -2359,6 +2370,21 @@
     primitiveSyncNodes = null;
   }
 
+  function heatOrbit(alpha: number) {
+    if (!simulation || paused) return;
+
+    simulation
+      .alphaTarget(0)
+      .alpha(Math.max(simulation.alpha(), alpha));
+
+    if (document.visibilityState !== 'visible') return;
+
+    primitiveSyncLastAt = 0;
+    simulationPaintLastAt = 0;
+    schedulePrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
+    simulation.restart();
+  }
+
   function stopActiveSimulation() {
     if (!simulation) return;
     simulation.on('tick', null);
@@ -2383,42 +2409,13 @@
     cancelPrimitiveOrbitVisualSync();
   }
 
-  function suspendWorkspaceMotion() {
-    if (workspaceMotionSuspended) return;
-    workspaceMotionSuspended = true;
-    if (simulation) {
-      simulation.alphaTarget(0);
-      simulation.stop();
-      syncPrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
-    }
-    cancelRenderFrames();
-    g?.selectAll('*').interrupt();
-  }
-
-  function resumeWorkspaceMotion() {
-    if (!workspaceMotionSuspended) return;
-    workspaceMotionSuspended = false;
-    if (!simulation) {
-      renderCanvas({ preserveViewport: true });
-      return;
-    }
-    const nodes = simulation.nodes() as OrbitNode[];
-    clearAttractionCache(nodes);
-    simulation
-      .alphaTarget(idleOrbitAlphaTarget())
-      .alpha(Math.max(simulation.alpha(), 0.14))
-      .restart();
-    syncPrimitiveMotionVisuals(nodes);
-  }
-
   function resetRenderRuntime() {
     renderGeneration += 1;
-    workspaceMotionSuspended = false;
+    restoreThreadAnchorState(simulation?.nodes() as OrbitNode[] | undefined);
     stopActiveSimulation();
     cancelRenderFrames();
     primitiveSyncLastAt = 0;
     simulationPaintLastAt = 0;
-    lastOrbitTickAt = 0;
     coreGroup = undefined as any;
   }
 
@@ -2510,11 +2507,7 @@
     if (!simulation) return;
     const profile = activeSimulationProfile();
     simulation.force('collide', d3.forceCollide().radius((d: any) => bubbleCollisionRadius(d)).strength(0.84).iterations(profile.collideIterations));
-    if (workspaceMotionSuspended) {
-      syncPrimitiveOrbitVisuals(simulation.nodes() as OrbitNode[]);
-      return;
-    }
-    simulation.alpha(alpha).restart();
+    heatOrbit(alpha);
   }
 
   // ── SVG Defs (from cortex-physics.js createDefs) ───────────
@@ -2589,7 +2582,7 @@
     return d3.forceSimulation(nodes)
       .alphaDecay(profile.alphaDecay)
       .alphaMin(profile.alphaMin)
-      .alphaTarget(profile.idleAlphaTarget)
+      .alphaTarget(0)
       .velocityDecay(profile.velocityDecay)
       .force('center', orbitAnchors.length > 0 ? null : d3.forceCenter(w / 2, h / 2).strength(0.02))
       .force('collide', d3.forceCollide().radius((d: any) => bubbleCollisionRadius(d)).strength(0.84).iterations(profile.collideIterations))
@@ -2652,13 +2645,6 @@
         for (const n of nodes) {
           // Subtle upward float for high-salience nodes (reduced to avoid directional bias)
           n.vy -= ((n.salience_score || 5) / 10) * 0.03 * alpha;
-        }
-      })
-      .force('brownian', () => {
-        for (const n of nodes) {
-          // Gentle random perturbation keeps motion organic (not alpha-dependent)
-          n.vx += (Math.random() - 0.5) * 0.15;
-          n.vy += (Math.random() - 0.5) * 0.15;
         }
       });
   }
@@ -3073,8 +3059,7 @@
   }
 
   function restartOrbitSettle() {
-    if (!simulation) return;
-    simulation.alpha(Math.max(simulation.alpha(), 0.22)).restart();
+    heatOrbit(0.22);
   }
 
   function dragStart(e: any, d: any) {
@@ -3083,7 +3068,7 @@
     dragTargetAnchorId = null;
     archiveDropIdeaId = null;
     setArchiveDragState(canArchiveNode(d), false);
-    if (!e.active && simulation) simulation.alphaTarget(0.1).restart();
+    if (!e.active) heatOrbit(0.1);
     d.fx = d.x; d.fy = d.y;
     d._dragOrigX = d.x; d._dragOrigY = d.y;
   }
@@ -3132,8 +3117,10 @@
     const startTime = performance.now();
     archivingIdeaId = d.id;
     archivingIdeaProgress = 0;
+    void cortex.deleteIdea(d.id);
 
     function archiveTick(t: number) {
+      if (destroyed) return;
       const elapsed = t - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const eased = 1 - (1 - progress) ** 3;
@@ -3154,9 +3141,8 @@
       archivingIdeaId = null;
       archivingIdeaProgress = 0;
       resetArchiveDragInteraction();
-      cortex.deleteIdea(d.id);
       el.remove();
-      if (simulation) simulation.alpha(0.3).restart();
+      heatOrbit(0.3);
     }
 
     requestAnimationFrame(archiveTick);
@@ -3169,8 +3155,7 @@
       _isDragging = false;
       dragTargetAnchorId = null;
       resetArchiveDragInteraction();
-      if (!e.active && simulation) simulation.alphaTarget(idleOrbitAlphaTarget());
-      if (simulation) simulation.alpha(0.1).restart();
+      heatOrbit(0.1);
       return;
     }
 
@@ -3178,7 +3163,6 @@
     _isDragging = false;
     dragTargetAnchorId = null;
     resetArchiveDragInteraction();
-    if (!e.active && simulation) simulation.alphaTarget(idleOrbitAlphaTarget());
     if (coreGroup) coreGroup.select('.core-circle').attr('filter', 'url(#core-glow)');
 
     const dragDx = d.x - (d._dragOrigX || d.x);
@@ -3194,7 +3178,7 @@
       el.select('.bubble-cloud').transition().duration(200).attr('transform', 'scale(1)');
       el.transition().duration(200).attr('opacity', (dd: any) => bubbleOpacity(dd.status));
       syncPrimitiveDragVisuals();
-      if (simulation) simulation.alpha(0.22).restart();
+      heatOrbit(0.22);
       return;
     }
 
@@ -3229,7 +3213,7 @@
       if (dragDist > 20) {
         cortex.updateIdeaPosition(d.id, d.x, d.y);
       }
-      if (simulation) simulation.alpha(0.15).restart();
+      heatOrbit(0.15);
     }
   }
 
@@ -3309,7 +3293,7 @@
     setTimeout(() => {
       cortex.deleteIdea(d.id);
       el.remove();
-      if (simulation) { simulation.alpha(0.3).restart(); }
+      heatOrbit(0.3);
     }, 250);
   }
 
@@ -3547,6 +3531,41 @@
     });
   }
 
+  function workspaceConnectionLinkData(visible: any[]) {
+    const visibleIds = new Set(visible.map((idea: any) => idea.id));
+    const visibleById = new Map(visible.map((idea: any) => [idea.id, idea] as const));
+    return cortex.connections
+      .filter((connection: any) => visibleIds.has(connection.source_id) && visibleIds.has(connection.target_id))
+      .map((connection: any) => {
+        const sourceIdea = visibleById.get(connection.source_id);
+        const targetIdea = visibleById.get(connection.target_id);
+
+        return {
+          ...connection,
+          source: connection.source_id,
+          target: connection.target_id,
+          sourceUserId: sourceIdea?.user_id,
+          targetUserId: targetIdea?.user_id,
+          sourceAccent: sourceIdea ? ownerColor(sourceIdea) : undefined,
+          targetAccent: targetIdea ? ownerColor(targetIdea) : undefined,
+        };
+      });
+  }
+
+  function workspaceConnectionTopologyKey(visible: any[]) {
+    const visibleIds = new Set(visible.map((idea: any) => idea.id));
+    const ownership = visible
+      .map((idea: any) => `${idea.id}:${idea.user_id ?? ''}`)
+      .sort()
+      .join('|');
+    const connections = cortex.connections
+      .filter((connection: any) => visibleIds.has(connection.source_id) && visibleIds.has(connection.target_id))
+      .map((connection: any) => `${connection.id}:${connection.source_id}:${connection.target_id}`)
+      .sort()
+      .join('|');
+    return `${ownership}::${connections}`;
+  }
+
   function renderCanvas({ preserveViewport = false }: { preserveViewport?: boolean } = {}) {
     if (!containerEl) return;
     const preservedTransform = preserveViewport ? untrack(() => currentZoomTransform) : null;
@@ -3618,26 +3637,11 @@
     const visible = syncSceneNodes(cortex.filteredIdeas);
     clearAttractionCache(visible);
 
-    const visibleIds = new Set(visible.map((i: any) => i.id));
-    const visibleById = new Map(visible.map((idea: any) => [idea.id, idea] as const));
-    const linkData = cortex.connections
-      .filter((c: any) => visibleIds.has(c.source_id) && visibleIds.has(c.target_id))
-      .map((c: any) => {
-        const sourceIdea = visibleById.get(c.source_id);
-        const targetIdea = visibleById.get(c.target_id);
-
-        return {
-          ...c,
-          source: c.source_id,
-          target: c.target_id,
-          sourceUserId: sourceIdea?.user_id,
-          targetUserId: targetIdea?.user_id,
-          sourceAccent: sourceIdea ? ownerColor(sourceIdea) : undefined,
-          targetAccent: targetIdea ? ownerColor(targetIdea) : undefined,
-        };
-      });
+    const linkData = workspaceConnectionLinkData(visible);
+    connectionTopologyKey = workspaceConnectionTopologyKey(visible);
 
     simulation = createSim(visible, linkData, canvasW, canvasH);
+    if (paused || document.visibilityState !== 'visible') simulation.stop();
 
     const linkSel = USE_D3_SHADOW_SCENE
       ? g.selectAll('.connection-path').data(linkData, (d: any) => d.id)
@@ -3696,7 +3700,6 @@
     simulation.on('tick', () => {
       if (renderToken !== renderGeneration) return;
       const now = performance.now();
-      lastOrbitTickAt = now;
       if (simulationPaintLastAt && now - simulationPaintLastAt < simulationPaintIntervalMs()) return;
       simulationPaintLastAt = now;
       if (linkSel) linkSel.attr('d', curvedLinkPath);
@@ -3736,7 +3739,7 @@
           pair.target.vy -= (dy / dist) * strength;
         }
       });
-      simulation.alpha(0.18).restart();
+      heatOrbit(0.18);
     };
 
     // Semantic clustering is progressive enhancement: keep the initial orbit
@@ -3759,33 +3762,40 @@
     // Save positions when simulation settles
     simulation.on('end', () => {
       if (renderToken !== renderGeneration) return;
-      const positions = collectSceneIdeaPositions(
-        simulation?.nodes() as OrbitNode[] ?? [],
-        isPreviewIdeaId,
-      );
+      const nodes = simulation?.nodes() as OrbitNode[] ?? [];
+      cancelPrimitiveOrbitVisualSync();
+      syncPrimitiveMotionVisuals(nodes);
+      const positions = collectSceneIdeaPositions(nodes, isPreviewIdeaId);
       persistSceneIdeaPositions(positions).catch(() => {});
     });
+    untrack(syncThreadAnchor);
   }
 
   // ── Lifecycle ──────────────────────────────────────────────
   let paused = false;
   let flowState = $state(false);
-  let flowCheckInterval: any = null;
-  let orbitWakeCheckInterval: ReturnType<typeof setInterval> | null = null;
 
-  function checkFlowState() {
+  function updateFlowState() {
+    if (destroyed) return;
     const panelOpen = cortex.panelOpen;
     const activeInput = document.activeElement?.tagName === 'TEXTAREA';
-    if (panelOpen && activeInput && !flowState) {
-      flowState = true;
+    const nextFlowState = panelOpen && activeInput;
+    if (nextFlowState === flowState) return;
+
+    flowState = nextFlowState;
+    if (nextFlowState) {
       g?.selectAll('.bubble-group')
         .filter((d: any) => d.id !== cortex.selectedIdeaId)
         .transition().duration(600).attr('opacity', 0.38);
-    } else if ((!panelOpen || !activeInput) && flowState) {
-      flowState = false;
+    } else {
       g?.selectAll('.bubble-group').transition().duration(600)
         .attr('opacity', (d: any) => bubbleOpacity(d.status));
     }
+  }
+
+  function handleFlowFocusChange() {
+    if (destroyed) return;
+    queueMicrotask(updateFlowState);
   }
 
   function handleFitView() {
@@ -3797,6 +3807,7 @@
   function handleTogglePause() {
     paused = !paused;
     if (paused) {
+      restoreThreadAnchorState(simulation?.nodes() as OrbitNode[] | undefined);
       renderGeneration += 1;
       cancelRenderFrames();
       stopActiveSimulation();
@@ -3805,28 +3816,15 @@
     }
   }
 
-  function ensureOrbitMotionActive() {
-    if (!simulation || paused || workspaceMotionSuspended) return;
-    const nodes = simulation.nodes() as OrbitNode[];
-    clearAttractionCache(nodes);
-    simulation
-      .alphaTarget(idleOrbitAlphaTarget())
-      .alpha(Math.max(simulation.alpha(), 0.14))
-      .restart();
-    schedulePrimitiveOrbitVisuals(nodes);
-  }
-
   function handleVisibilityChange() {
-    if (document.visibilityState !== 'visible') return;
-    ensureOrbitMotionActive();
-  }
-
-  function checkOrbitMotionHealth() {
-    if (!simulation || paused || workspaceMotionSuspended || document.visibilityState === 'hidden') return;
-    const now = performance.now();
-    if (!lastOrbitTickAt || now - lastOrbitTickAt > ORBIT_STALE_AFTER_MS) {
-      ensureOrbitMotionActive();
+    if (!simulation || paused) return;
+    if (document.visibilityState === 'hidden') {
+      simulation.stop();
+      cancelPrimitiveOrbitVisualSync();
+      return;
     }
+    if (simulation.alpha() < simulation.alphaMin()) return;
+    heatOrbit(0);
   }
 
   // Track rendered idea IDs to detect new ones
@@ -3857,14 +3855,9 @@
       nodes.push(sceneNode);
       simulation.nodes(nodes);
     }
-    if (!workspaceMotionSuspended) {
-      simulation.alpha(0.5).restart();
-    }
+    heatOrbit(0.5);
 
     if (!USE_D3_SHADOW_SCENE) {
-      if (workspaceMotionSuspended) {
-        collapseBirthAnimation(sceneNode);
-      }
       syncPrimitiveOrbitVisuals(Array.from(orbitSceneNodesById.values()));
       syncPrimitiveMotionVisuals(simulation.nodes() as OrbitNode[]);
       return;
@@ -3882,21 +3875,14 @@
     renderBubbleContent(bubble, qPosMap);
     syncPrimitiveOrbitVisuals(Array.from(orbitSceneNodesById.values()));
 
-    if (workspaceMotionSuspended) {
-      bubble.select('.bubble-cloud')
-        .attr('opacity', bubbleOpacity(sceneNode.status))
-        .attr('transform', 'scale(1)');
-      bubble.select('.bubble-label').attr('opacity', 1);
-    } else {
-      bubble.select('.bubble-cloud')
-        .attr('opacity', 0).attr('transform', 'scale(0)')
-        .transition('bubble-birth-cloud').duration(600).ease(d3.easeCubicOut)
-        .attr('opacity', bubbleOpacity(sceneNode.status))
-        .attr('transform', 'scale(1)');
-      bubble.select('.bubble-label')
-        .attr('opacity', 0)
-        .transition('bubble-birth-label').delay(300).duration(400).attr('opacity', 1);
-    }
+    bubble.select('.bubble-cloud')
+      .attr('opacity', 0).attr('transform', 'scale(0)')
+      .transition('bubble-birth-cloud').duration(600).ease(d3.easeCubicOut)
+      .attr('opacity', bubbleOpacity(sceneNode.status))
+      .attr('transform', 'scale(1)');
+    bubble.select('.bubble-label')
+      .attr('opacity', 0)
+      .transition('bubble-birth-label').delay(300).duration(400).attr('opacity', 1);
 
     bubble
       .on('click', (e: Event) => {
@@ -3936,8 +3922,9 @@
     window.addEventListener('cortex-fit-view', handleFitView);
     window.addEventListener('cortex-toggle-pause', handleTogglePause);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    flowCheckInterval = setInterval(checkFlowState, 2000);
-    orbitWakeCheckInterval = setInterval(checkOrbitMotionHealth, ORBIT_WAKE_CHECK_INTERVAL_MS);
+    document.addEventListener('focusin', handleFlowFocusChange);
+    document.addEventListener('focusout', handleFlowFocusChange);
+    handleFlowFocusChange();
   });
 
   // Re-initialize attractors when teamMembers loads or user-owned cluster loads change.
@@ -4005,7 +3992,7 @@
     const nodes = simulation?.nodes() as OrbitNode[] | undefined;
     if (nodes) clearAttractionCache(nodes);
     refreshOrbitVisualState();
-    if (simulation) simulation.alpha(0.24).restart();
+    heatOrbit(0.24);
   });
 
   $effect(() => {
@@ -4016,23 +4003,27 @@
   });
 
   $effect(() => {
-    const appLayoutKey = apps
-      .map((app) => [
-        app.id,
-        app.updated_at,
-        app.anchor_user_id ?? '',
-        app.visual_spec?.orbit_anchor_type ?? '',
-        app.visual_spec?.orbit_anchor_id ?? '',
-        app.visual_spec?.position_x ?? '',
-        app.visual_spec?.position_y ?? '',
-      ].join(':'))
+    const nextAppLayoutKey = apps
+      .filter((app) => !app.archived_at)
+      .map((app) => {
+        const position = workspaceAppStoredPosition(app);
+        return [
+          app.id,
+          app.created_at,
+          workspaceAppAnchorId(app),
+          workspaceAppOrbitOrder(app) ?? '',
+          position?.x ?? '',
+          position?.y ?? '',
+        ].join(':');
+      })
+      .sort()
       .join('|');
+    const layoutChanged = nextAppLayoutKey !== appLayoutKey;
+    appLayoutKey = nextAppLayoutKey;
     activeAppId;
     if (svg) {
       syncPrimitiveOrbitVisuals();
-      if (simulation && !workspaceMotionSuspended) {
-        simulation.alpha(Math.max(simulation.alpha(), 0.12)).restart();
-      }
+      if (layoutChanged) heatOrbit(0.12);
     }
   });
 
@@ -4066,11 +4057,26 @@
     }
   });
 
-  $effect(() => {
+  function restoreThreadAnchorState(nodes: OrbitNode[] = []) {
+    const previous = threadAnchorState;
+    if (!previous) return false;
+
+    const previousNode = nodes.find((node) => node.id === previous.id)
+      ?? orbitSceneNodesById.get(previous.id);
+    if (previousNode) {
+      previousNode.fx = previous.fx;
+      previousNode.fy = previous.fy;
+      delete previousNode._threadAnchorPinned;
+    }
+    threadAnchorState = null;
+    return true;
+  }
+
+  function syncThreadAnchor() {
     const panelOpen = cortex.panelOpen;
     const selectedId = cortex.selectedIdeaId;
 
-    if (!simulation) return;
+    if (destroyed || !simulation) return;
     const nodes = simulation.nodes() as OrbitNode[];
 
     if (panelOpen && selectedId) {
@@ -4079,15 +4085,7 @@
       collapseBirthAnimation(anchorNode);
 
       if (!threadAnchorState || threadAnchorState.id !== selectedId) {
-        const prevAnchorState = threadAnchorState;
-        if (prevAnchorState) {
-          const prevNode = nodes.find((node) => node.id === prevAnchorState.id);
-          if (prevNode) {
-            prevNode.fx = prevAnchorState.fx;
-            prevNode.fy = prevAnchorState.fy;
-            delete prevNode._threadAnchorPinned;
-          }
-        }
+        restoreThreadAnchorState(nodes);
 
         threadAnchorState = {
           id: selectedId,
@@ -4103,27 +4101,15 @@
       return;
     }
 
-    if (threadAnchorState) {
-      const prevNode = nodes.find((node) => node.id === threadAnchorState?.id);
-      if (prevNode) {
-        prevNode.fx = threadAnchorState.fx;
-        prevNode.fy = threadAnchorState.fy;
-        delete prevNode._threadAnchorPinned;
-      }
-      threadAnchorState = null;
+    if (restoreThreadAnchorState(nodes)) {
       refreshCollisionForce(0.14);
       handleFocusMode(currentZoomTransform);
     }
 
     releaseThreadAnchors(nodes);
-  });
+  }
 
-  $effect(() => {
-    const panelOpen = cortex.panelOpen;
-    const selectedId = cortex.selectedIdeaId;
-    if (!svg || !simulation || !panelOpen || !selectedId) return;
-    ensureOrbitMotionActive();
-  });
+  $effect(syncThreadAnchor);
 
   // Track node properties for change detection
   let nodeSnapshotMap = new Map<string, WorkspaceSceneNodeSnapshot>();
@@ -4225,27 +4211,58 @@
           const nodes = (simulation.nodes() as OrbitNode[]).filter((n) => n.id !== id);
           simulation.nodes(nodes);
           clearAttractionCache(nodes);
-          simulation.alpha(0.2).restart();
+          heatOrbit(0.2);
         }
       }
     }
   });
 
   $effect(() => {
-    const typingEntries = Array.from(cortex.typingUsers.values()).map((entry) => `${entry.user_id}:${entry.idea_id}`).join('|');
-    typingEntries;
+    const visible = (cortex.filteredIdeas as WorkspaceSceneIdeaSnapshot[]).filter((idea) => !idea?.archived_at);
+    const nextTopologyKey = workspaceConnectionTopologyKey(visible);
+    if (!simulation || nextTopologyKey === connectionTopologyKey) return;
+
+    connectionTopologyKey = nextTopologyKey;
+    const linkForce = simulation.force('link') as d3.ForceLink<OrbitNode, any> | undefined;
+    linkForce?.links(workspaceConnectionLinkData(visible));
+    heatOrbit(0.18);
+  });
+
+  $effect(() => {
+    const typingEntries = Array.from(cortex.typingUsers.values())
+      .map((entry) => `${entry.user_id}:${entry.idea_id}`)
+      .sort()
+      .join('|');
+    const viewerEntries = Array.from(new Set(
+      presenceStore.viewers.map((entry) => entry.user_id),
+    ))
+      .sort()
+      .join('|');
+    const nextPresenceMotionKey = `${typingEntries}::${viewerEntries}`;
+    const initialPresence = presenceMotionKey === null;
+    const presenceChanged = nextPresenceMotionKey !== presenceMotionKey;
+    if (!presenceChanged) return;
+
+    presenceMotionKey = nextPresenceMotionKey;
     refreshOrbitVisualState();
+    if (!initialPresence) heatOrbit(0.08);
+  });
+
+  $effect(() => {
+    cortex.panelOpen;
+    handleFlowFocusChange();
   });
 
   onDestroy(() => {
+    destroyed = true;
     resetArchiveDragInteraction();
     resetRenderRuntime();
-    if (flowCheckInterval) clearInterval(flowCheckInterval);
-    if (orbitWakeCheckInterval) clearInterval(orbitWakeCheckInterval);
     cortex.setBirthContext(null);
     window.removeEventListener('cortex-fit-view', handleFitView);
     window.removeEventListener('cortex-toggle-pause', handleTogglePause);
     document.removeEventListener('visibilitychange', handleVisibilityChange);
+    document.removeEventListener('focusin', handleFlowFocusChange);
+    document.removeEventListener('focusout', handleFlowFocusChange);
   });
 </script>
 

--- a/frontend/src/lib/utils/cortexOrbitPhysics.test.js
+++ b/frontend/src/lib/utils/cortexOrbitPhysics.test.js
@@ -1,20 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { forceSimulation } from 'd3-force';
 
 import { cortexOrbitPerformanceProfile } from './cortexOrbitPhysics.ts';
 
-test('orbit performance profiles keep a nonzero idle alpha target above alphaMin', () => {
+test('orbit performance profiles cool naturally with a zero alpha target', () => {
   for (const nodeCount of [1, 60, 120, 220]) {
     const profile = cortexOrbitPerformanceProfile(nodeCount);
-    assert.ok(
-      profile.idleAlphaTarget > profile.alphaMin,
-      `nodeCount=${nodeCount} should not let the orbit simulation cool below alphaMin`,
-    );
-  }
-});
+    assert.equal('idleAlphaTarget' in profile, false, `nodeCount=${nodeCount} must not encode perpetual heat`);
 
-test('orbit idle heat tapers down for dense workspaces', () => {
-  assert.ok(cortexOrbitPerformanceProfile(1).idleAlphaTarget > cortexOrbitPerformanceProfile(60).idleAlphaTarget);
-  assert.ok(cortexOrbitPerformanceProfile(60).idleAlphaTarget > cortexOrbitPerformanceProfile(120).idleAlphaTarget);
-  assert.ok(cortexOrbitPerformanceProfile(120).idleAlphaTarget > cortexOrbitPerformanceProfile(220).idleAlphaTarget);
+    for (const initialAlpha of [1, 0.14]) {
+      const simulation = forceSimulation([])
+        .stop()
+        .alpha(initialAlpha)
+        .alphaDecay(profile.alphaDecay)
+        .alphaMin(profile.alphaMin)
+        .alphaTarget(0);
+      for (let ticks = 0; simulation.alpha() >= profile.alphaMin && ticks < 1600; ticks += 1) {
+        simulation.tick();
+      }
+      assert.ok(simulation.alpha() < profile.alphaMin, `nodeCount=${nodeCount} alpha=${initialAlpha} did not converge`);
+    }
+  }
 });

--- a/frontend/src/lib/utils/cortexOrbitPhysics.ts
+++ b/frontend/src/lib/utils/cortexOrbitPhysics.ts
@@ -1,7 +1,6 @@
 export type CortexOrbitPerformanceProfile = {
   alphaDecay: number;
   alphaMin: number;
-  idleAlphaTarget: number;
   collideIterations: number;
   velocityDecay: number;
 };
@@ -23,7 +22,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.018,
       alphaMin: 0.003,
-      idleAlphaTarget: 0.004,
       collideIterations: 1,
       velocityDecay: 0.38,
     };
@@ -32,7 +30,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.012,
       alphaMin: 0.002,
-      idleAlphaTarget: 0.006,
       collideIterations: 2,
       velocityDecay: 0.36,
     };
@@ -41,7 +38,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
     return {
       alphaDecay: 0.008,
       alphaMin: 0.0015,
-      idleAlphaTarget: 0.009,
       collideIterations: 2,
       velocityDecay: 0.35,
     };
@@ -49,7 +45,6 @@ export function cortexOrbitPerformanceProfile(nodeCount: number): CortexOrbitPer
   return {
     alphaDecay: 0.0045,
     alphaMin: 0.001,
-    idleAlphaTarget: 0.012,
     collideIterations: 3,
     velocityDecay: 0.34,
   };

--- a/frontend/src/lib/utils/workspaceSceneLifecycle.test.js
+++ b/frontend/src/lib/utils/workspaceSceneLifecycle.test.js
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const workspaceSceneSource = readFileSync(
+  new URL('../features/workspace-scene/components/WorkspaceScene.svelte', import.meta.url),
+  'utf8',
+);
+
+function functionSource(name) {
+  const start = workspaceSceneSource.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} should exist`);
+
+  let parameterDepth = 0;
+  let bodyStart = -1;
+  for (let index = start; index < workspaceSceneSource.length; index += 1) {
+    const char = workspaceSceneSource[index];
+    if (char === '(') parameterDepth += 1;
+    else if (char === ')') parameterDepth -= 1;
+    else if (char === '{' && parameterDepth === 0) {
+      bodyStart = index;
+      break;
+    }
+  }
+  assert.notEqual(bodyStart, -1, `${name} body should exist`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < workspaceSceneSource.length; index += 1) {
+    const char = workspaceSceneSource[index];
+    if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return workspaceSceneSource.slice(start, index + 1);
+    }
+  }
+
+  throw new Error(`${name} source is incomplete`);
+}
+
+test('workspace orbit heat always cools to zero and only runs while visible', () => {
+  const heatOrbit = functionSource('heatOrbit');
+
+  assert.match(heatOrbit, /\.alphaTarget\(0\)/);
+  assert.match(heatOrbit, /Math\.max\(simulation\.alpha\(\), alpha\)/);
+  assert.match(heatOrbit, /document\.visibilityState !== 'visible'/);
+  assert.match(heatOrbit, /schedulePrimitiveOrbitVisuals/);
+  assert.match(heatOrbit, /simulation\.restart\(\)/);
+  assert.ok(heatOrbit.indexOf('.alphaTarget(0)') < heatOrbit.indexOf("visibilityState !== 'visible'"));
+  assert.ok(heatOrbit.indexOf("visibilityState !== 'visible'") < heatOrbit.indexOf('simulation.restart()'));
+});
+
+test('workspace orbit has no permanent heat, random force, or periodic wake machinery', () => {
+  assert.doesNotMatch(workspaceSceneSource, /\.force\('brownian'/);
+  const alphaTargets = Array.from(
+    workspaceSceneSource.matchAll(/\.alphaTarget\(([^)]*)\)/g),
+    (match) => match[1].trim(),
+  );
+  assert.deepEqual(alphaTargets, ['0', '0']);
+  assert.equal(workspaceSceneSource.match(/simulation\.restart\(\)/g)?.length, 1);
+  assert.doesNotMatch(workspaceSceneSource, /workspaceMotionSuspended|suspendWorkspaceMotion|resumeWorkspaceMotion/);
+  assert.doesNotMatch(workspaceSceneSource, /lastOrbitTickAt|ORBIT_WAKE_CHECK_INTERVAL_MS|ORBIT_STALE_AFTER_MS|orbitWakeCheckInterval|checkOrbitMotionHealth/);
+});
+
+test('workspace visibility stops hidden work and resumes only retained heat', () => {
+  const visibility = functionSource('handleVisibilityChange');
+  const mount = workspaceSceneSource.match(/onMount\(\(\) => \{[\s\S]*?\n  \}\);/)?.[0] ?? '';
+
+  assert.match(visibility, /visibilityState === 'hidden'/);
+  assert.match(visibility, /simulation\.stop\(\)/);
+  assert.match(visibility, /cancelPrimitiveOrbitVisualSync\(\)/);
+  assert.match(visibility, /simulation\.alpha\(\) < simulation\.alphaMin\(\)/);
+  assert.match(visibility, /heatOrbit\(0\)/);
+  assert.match(workspaceSceneSource, /simulation = createSim[\s\S]*?paused \|\| document\.visibilityState !== 'visible'\) simulation\.stop\(\)/);
+  assert.doesNotMatch(mount, /handleVisibilityChange\(\)/);
+});
+
+test('workspace pause survives rebuilds and restores an open thread anchor', () => {
+  const togglePause = functionSource('handleTogglePause');
+  const resetRuntime = functionSource('resetRenderRuntime');
+  const renderCanvas = functionSource('renderCanvas');
+  const restoreThreadAnchor = functionSource('restoreThreadAnchorState');
+  const syncThreadAnchor = functionSource('syncThreadAnchor');
+
+  assert.match(togglePause, /if \(paused\)[\s\S]*restoreThreadAnchorState\([\s\S]*stopActiveSimulation\(\)/);
+  assert.match(togglePause, /else \{\s*renderCanvas\(\{ preserveViewport: true \}\);\s*\}/);
+  assert.match(resetRuntime, /restoreThreadAnchorState\([\s\S]*stopActiveSimulation\(\)/);
+  assert.match(renderCanvas, /untrack\(syncThreadAnchor\)/);
+  assert.ok(restoreThreadAnchor.indexOf('previousNode.fx = previous.fx') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.ok(restoreThreadAnchor.indexOf('previousNode.fy = previous.fy') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.ok(restoreThreadAnchor.indexOf('delete previousNode._threadAnchorPinned') < restoreThreadAnchor.indexOf('threadAnchorState = null'));
+  assert.match(syncThreadAnchor, /if \(destroyed \|\| !simulation\) return;/);
+  assert.match(workspaceSceneSource, /if \(paused \|\| document\.visibilityState !== 'visible'\) simulation\.stop\(\)/);
+});
+
+test('workspace settle finalizes primitive motion and persists once', () => {
+  const endHandler = workspaceSceneSource.match(/simulation\.on\('end', \(\) => \{[\s\S]*?\n    \}\);/)?.[0] ?? '';
+
+  assert.match(endHandler, /cancelPrimitiveOrbitVisualSync\(\)/);
+  assert.match(endHandler, /syncPrimitiveMotionVisuals\(nodes\)/);
+  assert.match(endHandler, /persistSceneIdeaPositions\(positions\)/);
+  assert.equal(endHandler.match(/syncPrimitiveMotionVisuals\(nodes\)/g)?.length, 1);
+  assert.equal(endHandler.match(/persistSceneIdeaPositions\(positions\)/g)?.length, 1);
+});
+
+test('workspace focus flow is event-driven instead of polled', () => {
+  const updateFlow = functionSource('updateFlowState');
+
+  assert.match(updateFlow, /if \(destroyed\) return;/);
+  assert.match(workspaceSceneSource, /document\.addEventListener\('focusin', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.addEventListener\('focusout', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('focusin', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('focusout', handleFlowFocusChange\)/);
+  assert.match(workspaceSceneSource, /document\.removeEventListener\('visibilitychange', handleVisibilityChange\)/);
+  assert.match(workspaceSceneSource, /window\.removeEventListener\('cortex-fit-view', handleFitView\)/);
+  assert.match(workspaceSceneSource, /window\.removeEventListener\('cortex-toggle-pause', handleTogglePause\)/);
+  assert.doesNotMatch(workspaceSceneSource, /flowCheckInterval|setInterval\(checkFlowState/);
+});
+
+test('workspace topology and app wakes are signature-deduplicated', () => {
+  assert.match(workspaceSceneSource, /nextTopologyKey === connectionTopologyKey/);
+  assert.match(workspaceSceneSource, /linkForce\?\.links\(workspaceConnectionLinkData\(visible\)\)/);
+  assert.equal(workspaceSceneSource.match(/linkForce\?\.links\(workspaceConnectionLinkData\(visible\)\)/g)?.length, 1);
+  assert.match(workspaceSceneSource, /if \(layoutChanged\) heatOrbit\(0\.12\)/);
+  assert.doesNotMatch(workspaceSceneSource, /app\.updated_at/);
+});
+
+test('initial presence seeds without heat and later signature changes heat once', () => {
+  const presenceEffect = workspaceSceneSource.match(
+    /const typingEntries = Array\.from\(cortex\.typingUsers\.values\(\)\)[\s\S]*?heatOrbit\(0\.08\);/,
+  )?.[0] ?? '';
+
+  assert.match(workspaceSceneSource, /let presenceMotionKey: string \| null = null;/);
+  assert.match(presenceEffect, /`\$\{entry\.user_id\}:\$\{entry\.idea_id\}`/);
+  assert.match(presenceEffect, /new Set\(\s*presenceStore\.viewers\.map\(\(entry\) => entry\.user_id\)/);
+  assert.match(presenceEffect, /const initialPresence = presenceMotionKey === null;/);
+  assert.match(presenceEffect, /if \(!presenceChanged\) return;/);
+  assert.match(presenceEffect, /presenceMotionKey = nextPresenceMotionKey;\s*refreshOrbitVisualState\(\);\s*if \(!initialPresence\) heatOrbit\(0\.08\);/);
+});
+
+test('accepted archive mutations start before teardown-stoppable visual frames', () => {
+  assert.match(workspaceSceneSource, /let destroyed = false;/);
+  assert.match(workspaceSceneSource, /onDestroy\(\(\) => \{\s*destroyed = true;/);
+
+  const localFrameFunctions = [
+    ['popPrimitiveBlob', 'tick', 'cortex.deleteIdea(nodeId)'],
+    ['animatePinDeleteToBin', 'archiveTick', 'onpindelete({ pinId: pin.pinId })'],
+    ['animateAppArchiveToBin', 'archiveTick', 'onapparchive?.({ appId: app.id })'],
+    ['animateArchiveToBin', 'archiveTick', 'cortex.deleteIdea(d.id)'],
+  ];
+  for (const [owner, callback, mutation] of localFrameFunctions) {
+    const source = functionSource(owner);
+    assert.match(
+      source,
+      new RegExp(`function ${callback}\\([^)]*\\) \\{\\s*if \\(destroyed\\) return;`),
+      `${owner} should stop its local frame after teardown`,
+    );
+    assert.ok(
+      source.indexOf(mutation) < source.indexOf(`requestAnimationFrame(${callback})`),
+      `${owner} should start its accepted mutation before its first visual frame`,
+    );
+  }
+});

--- a/scripts/benchmark_frontend.mjs
+++ b/scripts/benchmark_frontend.mjs
@@ -84,6 +84,7 @@ const STRESS_READY_IMPROVEMENT_TARGET_PCT = 10;
 const STRESS_DOM_NODE_BUDGET = 4000;
 const STRESS_TASK_P50_BUDGET_MS = 450;
 const STRESS_LONG_TASK_P95_BUDGET_MS = 250;
+const WORKSPACE_IDLE_WAKE_BUDGET_MS = 34;
 const APP_ASSET_RESOURCE_TYPES = new Set(['Script', 'Stylesheet']);
 const VITE_CLIENT_MANIFEST_URL = new URL(
   '../frontend/.svelte-kit/output/client/.vite/manifest.json',
@@ -165,6 +166,9 @@ function parseArgs(argv) {
     json: false,
     keepChromeProfile: false,
     manifest: null,
+    workspaceIdle: false,
+    idleSettleMs: 10_000,
+    idleWindowMs: 10_000,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -196,6 +200,9 @@ function parseArgs(argv) {
     else if (arg === '--json') options.json = true;
     else if (arg === '--keep-chrome-profile') options.keepChromeProfile = true;
     else if (arg === '--manifest') options.manifest = next();
+    else if (arg === '--workspace-idle') options.workspaceIdle = true;
+    else if (arg === '--idle-settle-ms') options.idleSettleMs = Number(next());
+    else if (arg === '--idle-window-ms') options.idleWindowMs = Number(next());
     else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -214,6 +221,12 @@ function parseArgs(argv) {
   if (!Number.isFinite(options.ideas) || options.ideas < 1) throw new Error('--ideas must be >= 1');
   if (!Number.isFinite(options.connections) || options.connections < 0) throw new Error('--connections must be >= 0');
   if (!Number.isFinite(options.streamItems) || options.streamItems < 0) throw new Error('--stream-items must be >= 0');
+  if (![options.idleSettleMs, options.idleWindowMs].every((value) => Number.isFinite(value) && value >= 0)) {
+    throw new Error('workspace idle durations must be >= 0');
+  }
+  if (options.workspaceIdle && options.scenarios.some((scenario) => !['workspace', 'threadCanonical'].includes(scenario))) {
+    throw new Error('--workspace-idle supports only workspace and threadCanonical scenarios');
+  }
   if (!['legacy', 'paged'].includes(options.streamContract)) {
     throw new Error('--stream-contract must be legacy or paged');
   }
@@ -240,6 +253,9 @@ Options:
   --out PATH                  Write the full JSON report to PATH
   --compare BEFORE,AFTER      Print a before/after win chart from two JSON reports
   --manifest PATH             Vite client manifest for the target build
+  --workspace-idle            Measure settled workspace/browser idle behavior
+  --idle-settle-ms N          Settle delay before idle measurement (default: 10000)
+  --idle-window-ms N          Idle measurement window (default: 10000)
   --allow-unknown-api         Do not fail when the app calls an unmocked API route
   --json                      Print machine-readable JSON
 `);
@@ -892,6 +908,7 @@ function mockApiResponse(method, url, fixture) {
   if (pathName === '/api/cortex/ideas') {
     return jsonResponse(200, fixture.ideas, { label: 'GET /api/cortex/ideas' });
   }
+  if (pathName === '/api/cortex/ideas/positions' && methodUpper === 'PUT') return jsonResponse(200, { ok: true }, { label: 'PUT /api/cortex/ideas/positions', sidecar: true });
   if (pathName === '/api/cortex/bootstrap') {
     const include = new Set(
       (url.searchParams.get('include') || 'core')
@@ -1148,6 +1165,151 @@ function performanceDurationMs(before, after, name) {
   return (end - start) * 1000;
 }
 
+async function workspaceIdleSnapshot(client) {
+  return evaluate(client, `(() => {
+    const value = window.__illoBench?.workspaceIdle;
+    return value ? { available: value.available, rafExecuted: value.rafExecuted,
+      signalStyleWrites: value.signalStyleWrites } : { available: false };
+  })()`);
+}
+
+function workspaceIdleCounterDelta(before, after) {
+  return {
+    rafCallbacks: after.rafExecuted - before.rafExecuted,
+    signalStyleWrites: after.signalStyleWrites - before.signalStyleWrites,
+  };
+}
+
+async function measureWorkspaceIdleWindow(client, durationMs) {
+  const beforeSnapshot = await workspaceIdleSnapshot(client);
+  const beforePerformance = await performanceMetrics(client);
+  await sleep(durationMs);
+  const afterPerformance = await performanceMetrics(client);
+  const afterSnapshot = await workspaceIdleSnapshot(client);
+  const counters = workspaceIdleCounterDelta(beforeSnapshot, afterSnapshot);
+  const taskDurationMs = performanceDurationMs(beforePerformance, afterPerformance, 'TaskDuration');
+  const scriptDurationMs = performanceDurationMs(beforePerformance, afterPerformance, 'ScriptDuration');
+  return {
+    available: beforeSnapshot.available === true && afterSnapshot.available === true &&
+      [taskDurationMs, scriptDurationMs, counters.rafCallbacks, counters.signalStyleWrites].every(Number.isFinite),
+    taskDurationMs,
+    scriptDurationMs,
+    ...counters,
+  };
+}
+
+async function setWorkspaceIdleVisibility(client, state) {
+  return evaluate(client, `window.__illoBench?.workspaceIdle?.setVisibilityState?.(${JSON.stringify(state)}) ?? null`);
+}
+
+async function measureWorkspaceIdleHiddenControl(client, hiddenMs) {
+  let restored = false;
+  try {
+    const hiddenState = await setWorkspaceIdleVisibility(client, 'hidden');
+    if (hiddenState !== 'hidden') return { available: false, reason: 'visibility override did not enter hidden state' };
+    await sleep(100);
+    const hiddenBefore = await workspaceIdleSnapshot(client);
+    await sleep(hiddenMs);
+    const hiddenAfter = await workspaceIdleSnapshot(client);
+    const visibleState = await setWorkspaceIdleVisibility(client, 'visible');
+    restored = visibleState === 'visible';
+    const visibleBefore = await workspaceIdleSnapshot(client);
+    await sleep(500);
+    const visibleAfter = await workspaceIdleSnapshot(client);
+    return {
+      available: restored && hiddenBefore.available && hiddenAfter.available,
+      ...workspaceIdleCounterDelta(hiddenBefore, hiddenAfter),
+      resumeRafCallbacks: visibleAfter.rafExecuted - visibleBefore.rafExecuted,
+      resumeSignalStyleWrites: visibleAfter.signalStyleWrites - visibleBefore.signalStyleWrites,
+    };
+  } finally {
+    if (!restored) await setWorkspaceIdleVisibility(client, 'visible').catch(() => {});
+  }
+}
+
+async function waitForWorkspaceIdleProbe(client, timeoutMs) {
+  await waitForExpression(
+    client,
+    `(() => {
+      const probe = window.__illoBench?.workspaceIdle?.activeProbe;
+      return Number.isFinite(probe?.firstRafMs) && Number.isFinite(probe?.firstSignalStyleMs);
+    })()`,
+    timeoutMs,
+  ).catch(() => null);
+  return evaluate(client, 'window.__illoBench?.workspaceIdle?.activeProbe ?? null');
+}
+
+async function finishWorkspaceWakeProbe(client, matchedExpression = 'true') {
+  const probe = await waitForWorkspaceIdleProbe(client, 1_200);
+  const matched = await evaluate(client, matchedExpression);
+  const wakeTimestamps = [probe?.firstRafMs, probe?.firstSignalStyleMs];
+  const available = matched === true && wakeTimestamps.every(Number.isFinite);
+  return { available, resumeMs: available ? Math.max(...wakeTimestamps) : null };
+}
+
+async function measureWorkspaceMutationWake(client) {
+  const dispatched = await evaluate(client, `(() => {
+    const telemetry = window.__illoBench?.workspaceIdle;
+    const socket = telemetry?.sockets?.find((candidate) => candidate.readyState === 1);
+    const signal = document.querySelector('[data-constellation-signal-id="idea-2"]');
+    if (!telemetry || !socket || !(signal instanceof HTMLElement)) return null;
+    telemetry.beginProbe();
+    socket.__dispatch({
+      type: 'message',
+      data: JSON.stringify({ type: 'idea_updated', idea_id: 'idea-2', fields: { status: 'done' } }),
+    });
+    return true;
+  })()`);
+  if (!dispatched) return { available: false };
+  return finishWorkspaceWakeProbe(client,
+    `document.querySelector('[data-constellation-signal-id="idea-2"]')?.classList.contains('constellation-signal-blob-cue-attention') === true`,
+  );
+}
+
+async function measureWorkspaceDragWake(client) {
+  const target = await evaluate(client, `(() => {
+    const telemetry = window.__illoBench?.workspaceIdle;
+    const signal = document.querySelector('[data-constellation-signal-id="idea-3"]') ||
+      document.querySelector('[data-constellation-signal-id]');
+    if (!telemetry || !(signal instanceof HTMLElement)) return null;
+    const rect = signal.getBoundingClientRect();
+    telemetry.beginProbe();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  })()`);
+  if (!target) return { available: false };
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mousePressed', x: target.x, y: target.y, button: 'left', buttons: 1, clickCount: 1,
+  });
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved', x: target.x + 36, y: target.y + 18, button: 'left', buttons: 1,
+  });
+  const probe = await finishWorkspaceWakeProbe(client);
+  await client.send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased', x: target.x + 36, y: target.y + 18, button: 'left', buttons: 0, clickCount: 1,
+  });
+  return probe;
+}
+
+async function measureWorkspaceIdleContract(client, scenario, options) {
+  await sleep(options.idleSettleMs);
+  const idle = await measureWorkspaceIdleWindow(client, options.idleWindowMs);
+  const hidden = await measureWorkspaceIdleHiddenControl(client, 2_000);
+  if (scenario.directThread) return { available: idle.available && hidden.available, idle, hidden };
+  const mutation = await measureWorkspaceMutationWake(client);
+  await sleep(6_500);
+  const drag = await measureWorkspaceDragWake(client);
+  return {
+    available: idle.available && hidden.available && mutation.available && drag.available,
+    idle,
+    hidden,
+    mutation,
+    drag,
+  };
+}
+
 async function waitForExpression(client, expression, timeoutMs) {
   const started = performance.now();
   const deadline = started + timeoutMs;
@@ -1188,7 +1350,7 @@ async function waitForExpression(client, expression, timeoutMs) {
   );
 }
 
-function installPageInstrumentationSource() {
+function installPageInstrumentationSource(workspaceIdle = false) {
   return `(() => {
     window.__illoBench = {
       longTasks: [],
@@ -1198,6 +1360,59 @@ function installPageInstrumentationSource() {
       errors: [],
       wsMessages: [],
     };
+
+    ${workspaceIdle ? `
+    const idle = window.__illoBench.workspaceIdle = {
+      available: true,
+      rafExecuted: 0,
+      signalStyleWrites: 0,
+      activeProbe: null,
+      sockets: [],
+    };
+
+    idle.beginProbe = () => idle.activeProbe = { startedAt: performance.now(), firstRafMs: null, firstSignalStyleMs: null };
+
+    const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+    window.requestAnimationFrame = (callback) => nativeRequestAnimationFrame((timestamp) => {
+        idle.rafExecuted += 1;
+        const probe = idle.activeProbe;
+        if (probe && probe.firstRafMs === null) probe.firstRafMs = performance.now() - probe.startedAt;
+        return callback(timestamp);
+      });
+
+    try {
+      const mutationObserver = new MutationObserver((records) => {
+        for (const record of records) {
+          if (!(record.target instanceof Element) || !record.target.matches('[data-constellation-signal-id]')) continue;
+          idle.signalStyleWrites += 1;
+          const probe = idle.activeProbe;
+          if (probe && probe.firstSignalStyleMs === null) probe.firstSignalStyleMs = performance.now() - probe.startedAt;
+        }
+      });
+      mutationObserver.observe(document, { subtree: true, attributes: true, attributeFilter: ['style'] });
+    } catch (error) {
+      idle.available = false;
+      window.__illoBench.errors.push('workspace idle mutation observer: ' + String(error?.message || error));
+    }
+
+    try {
+      const nativeVisibilityState = document.visibilityState;
+      let visibilityOverride = null;
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => visibilityOverride ?? nativeVisibilityState,
+      });
+      idle.setVisibilityState = (state) => {
+        if (state !== 'visible' && state !== 'hidden') throw new Error('unsupported visibility state');
+        visibilityOverride = state;
+        document.dispatchEvent(new Event('visibilitychange'));
+        return document.visibilityState;
+      };
+    } catch (error) {
+      idle.available = false;
+      window.__illoBench.errors.push('workspace idle visibility override: ' + String(error?.message || error));
+    }
+    ` : ''}
 
     window.addEventListener('error', (event) => {
       window.__illoBench.errors.push(String(event.message || 'unknown error'));
@@ -1256,6 +1471,7 @@ function installPageInstrumentationSource() {
         this.onerror = null;
         this.onclose = null;
         this.__listeners = new Map();
+        window.__illoBench.workspaceIdle?.sockets.push(this);
         queueMicrotask(() => {
           if (this.readyState !== BenchWebSocket.CONNECTING) return;
           this.readyState = BenchWebSocket.OPEN;
@@ -1322,7 +1538,7 @@ async function configurePage(client, fixture, options, apiCalls) {
     patterns: [{ urlPattern: '*://*/api/*', requestStage: 'Request' }],
   });
   const instrumentation = await client.send('Page.addScriptToEvaluateOnNewDocument', {
-    source: installPageInstrumentationSource(),
+    source: installPageInstrumentationSource(options.workspaceIdle),
   });
 
   const pendingMocks = new Set();
@@ -2066,6 +2282,9 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
         decodedBodySize: navigation?.decodedBodySize ?? 0,
       };
     })()`);
+    const workspaceIdleContract = options.workspaceIdle
+      ? await measureWorkspaceIdleContract(client, scenario, options)
+      : null;
     const performanceMetricsAfter = await performanceMetrics(client);
     const taskDurationMs = performanceDurationMs(
       performanceMetricsBefore,
@@ -2171,6 +2390,7 @@ async function runScenario(client, scenarioKey, fixture, options, measured, lazy
       readyMs,
       postCloseReadyMs,
       requestContract,
+      workspaceIdleContract,
       lazyAssetContract,
       historyContract,
       apiCallCount: measuredApiCalls.length,
@@ -2307,6 +2527,37 @@ function summarizeScenario(samples) {
   const longTaskTotalValues = finiteValues('longTaskTotalMs');
   const maxLongTaskValues = finiteValues('maxLongTaskMs');
   const domNodeValues = finiteValues('domNodes');
+  const workspaceIdleSamples = measuredSamples
+    .map((sample) => sample.workspaceIdleContract)
+    .filter(Boolean);
+  const workspaceIdleValues = (path) => workspaceIdleSamples
+    .map((sample) => path.reduce((value, key) => value?.[key], sample))
+    .filter(Number.isFinite);
+  const summarizeWorkspaceIdle = (path) => summarizeNumbers(workspaceIdleValues(path));
+  const workspaceInteractionSamples = workspaceIdleSamples.filter((sample) => sample.mutation);
+  const workspaceIdleTelemetryAvailable = workspaceIdleSamples.length === measuredSamples.length &&
+    workspaceIdleSamples.every((sample) => sample.available === true);
+  const workspaceIdleNoPeriodicWake = workspaceIdleSamples.length === measuredSamples.length &&
+    workspaceIdleSamples.every((sample) => (
+    sample.idle?.available === true &&
+    sample.idle.rafCallbacks === 0 &&
+    sample.idle.signalStyleWrites === 0 &&
+    sample.hidden?.available === true &&
+    sample.hidden.rafCallbacks === 0 &&
+    sample.hidden.signalStyleWrites === 0 &&
+    sample.hidden.resumeRafCallbacks === 0 &&
+    sample.hidden.resumeSignalStyleWrites === 0
+  ));
+  const wakeSummary = (key) => summarizeNumbers(
+    workspaceInteractionSamples.map((sample) => sample[key]?.resumeMs).filter(Number.isFinite),
+  );
+  const mutationWake = wakeSummary('mutation');
+  const dragWake = wakeSummary('drag');
+  const workspaceIdleInteractionContractPassed = workspaceInteractionSamples.length === 0 || (
+    workspaceInteractionSamples.length === measuredSamples.length &&
+    workspaceInteractionSamples.every((sample) => sample.mutation?.available && sample.drag?.available) &&
+    mutationWake.p95 <= WORKSPACE_IDLE_WAKE_BUDGET_MS && dragWake.p95 <= WORKSPACE_IDLE_WAKE_BUDGET_MS
+  );
 
   return {
     runs: measuredSamples.length,
@@ -2477,6 +2728,15 @@ function summarizeScenario(samples) {
     long_task_count: summarizeNumbers(longTaskCountValues),
     long_task_total_ms: summarizeNumbers(longTaskTotalValues),
     max_long_task_ms: summarizeNumbers(maxLongTaskValues),
+    workspace_idle_telemetry_available: workspaceIdleTelemetryAvailable,
+    workspace_idle_no_periodic_wake: workspaceIdleNoPeriodicWake,
+    workspace_idle_interaction_contract_passed: workspaceIdleInteractionContractPassed,
+    workspace_idle_task_duration_ms: summarizeWorkspaceIdle(['idle', 'taskDurationMs']),
+    workspace_idle_script_duration_ms: summarizeWorkspaceIdle(['idle', 'scriptDurationMs']),
+    workspace_idle_raf_callbacks: summarizeWorkspaceIdle(['idle', 'rafCallbacks']),
+    workspace_idle_signal_style_writes: summarizeWorkspaceIdle(['idle', 'signalStyleWrites']),
+    workspace_idle_mutation_resume_ms: mutationWake,
+    workspace_idle_drag_resume_ms: dragWake,
     routes,
     post_close_routes: postCloseRoutes,
     all_routes: allRoutes,
@@ -2722,7 +2982,7 @@ function pctDelta(before, after) {
 
 const COMPARISON_CONFIG_KEYS = [
   'runs', 'warmups', 'ideas', 'connections', 'streamItems', 'apiLatencyMs', 'sidecarLatencyMs',
-  'timeoutMs', 'allowUnknownApi',
+  'timeoutMs', 'allowUnknownApi', 'workspaceIdle', 'idleSettleMs', 'idleWindowMs',
 ];
 
 function comparisonSignature(result, scenarioKeys) {
@@ -2841,11 +3101,12 @@ function paginationAbsoluteFailures(key, summary, config) {
 function comparisonFailures(before, after, scenarioKeys) {
   const failures = [];
   const paginationComparison = isPaginationComparison(before, after);
+  const workspaceIdleComparison = before.config.workspaceIdle === true && after.config.workspaceIdle === true;
   const hasStreamContract = Boolean(before.config.streamContract || after.config.streamContract);
   if (comparisonSignature(before, scenarioKeys) !== comparisonSignature(after, scenarioKeys)) {
     failures.push('before/after benchmark config signatures differ');
   }
-  if (hasStreamContract && !paginationComparison) {
+  if (hasStreamContract && !paginationComparison && !workspaceIdleComparison) {
     failures.push('pagination comparison requires legacy before and paged after contracts');
   }
 
@@ -2885,6 +3146,31 @@ function comparisonFailures(before, after, scenarioKeys) {
       failures.push(`${key}: comparable FCP unavailable`);
     } else if ((!stress || paginationComparison) && !withinRegressionBudget(beforeFcp, afterFcp)) {
       failures.push(`${key}: FCP p50 regression >${MAX_REGRESSION_PCT}%`);
+    }
+
+    if (workspaceIdleComparison) {
+      if (!beforeScenario.summary.workspace_idle_telemetry_available || !summary.workspace_idle_telemetry_available) {
+        failures.push(`${key}: workspace idle telemetry unavailable`);
+      }
+      if (!directThread) {
+        const reductions = [
+          ['rAF callbacks', 'workspace_idle_raf_callbacks', 95],
+          ['signal style writes', 'workspace_idle_signal_style_writes', 95],
+          ['ScriptDuration', 'workspace_idle_script_duration_ms', 80],
+          ['TaskDuration', 'workspace_idle_task_duration_ms', 40],
+        ];
+        for (const [label, metric, target] of reductions) {
+          const beforeValue = beforeScenario.summary[metric]?.p50;
+          const afterValue = summary[metric]?.p50;
+          if (!Number.isFinite(beforeValue) || !Number.isFinite(afterValue) || beforeValue <= 0) {
+            failures.push(`${key}: comparable idle ${label} unavailable`);
+          } else if (-pctDelta(beforeValue, afterValue) < target) {
+            failures.push(`${key}: idle ${label} reduction <${target}%`);
+          }
+        }
+        if (!summary.workspace_idle_no_periodic_wake) failures.push(`${key}: settled workspace JS woke periodically`);
+        if (!summary.workspace_idle_interaction_contract_passed) failures.push(`${key}: interaction wake p95 >${WORKSPACE_IDLE_WAKE_BUDGET_MS}ms`);
+      }
     }
 
     if (stress && !paginationComparison) {
@@ -3055,6 +3341,7 @@ async function main() {
         sidecarLatencyMs: options.sidecarLatencyMs,
         timeoutMs: options.timeoutMs,
         allowUnknownApi: options.allowUnknownApi,
+        workspaceIdle: options.workspaceIdle, idleSettleMs: options.idleSettleMs, idleWindowMs: options.idleWindowMs,
         lazyAssetManifest: {
           threadStageModuleId: lazyAssetClosures.threadStage.moduleId,
           threadStageAssetCount: lazyAssetClosures.threadStage.assets.length,
@@ -3082,6 +3369,11 @@ async function main() {
       scenario.summary.rare_pane_first_open_ms.p75 > 0 &&
       scenario.summary.rare_pane_first_open_budget_passed === false
     ));
+    const idleTelemetryFailures = options.workspaceIdle
+      ? result.scenarios
+          .filter((scenario) => scenario.summary.workspace_idle_telemetry_available !== true)
+          .map((scenario) => `${scenario.key}: telemetry unavailable`)
+      : [];
     const threadFailures = result.scenarios.flatMap((scenario) => {
       if (!SCENARIOS[scenario.key]?.directThread) return [];
       const failures = directThreadHistoryFailures(scenario.key, scenario.summary);
@@ -3121,6 +3413,9 @@ async function main() {
     }
     if (threadFailures.length) {
       throw new Error(`Thread benchmark contract failed:\n${threadFailures.map((failure) => `- ${failure}`).join('\n')}`);
+    }
+    if (idleTelemetryFailures.length) {
+      throw new Error(`Workspace idle telemetry failed:\n${idleTelemetryFailures.map((failure) => `- ${failure}`).join('\n')}`);
     }
   } finally {
     client.close();


### PR DESCRIPTION
## Summary

Stacked on #303.

The workspace orbit previously never became idle: a nonzero alpha target, alpha-independent Brownian force, periodic wake checks, and whole-scene primitive writes kept Chrome busy indefinitely. This change lets D3 cool naturally and routes real interaction/state changes through one bounded wake path.

Runtime code is net +12 lines; the larger diff is benchmark instrumentation and regression coverage.

## Measurable hypothesis

For a deterministic 120-idea / 240-connection workspace:

- settled 10s TaskDuration falls by at least 40%
- ScriptDuration falls by at least 80%
- rAF callbacks and signal style writes fall by at least 95%
- mutation and drag wake p95 stay at or below 34ms
- readiness and FCP regress no more than 5%

## What changed

- removed permanent orbit heat and the alpha-independent Brownian force
- centralized all explicit simulation wakes in `heatOrbit`, always cooling toward zero
- stopped hidden/paused work and resumed only retained heat
- replaced focus polling and periodic health wakes with events
- deduplicated app, connection-topology, and presence wakes
- final-painted and persisted positions exactly once on settle
- kept accepted archive commands durable across teardown and restored thread anchors correctly across pause/rebuild
- added real D3 convergence, lifecycle, teardown, visibility, and fail-closed browser benchmark coverage

## Results

Matched browser runs use 5 warmups + 20 measured samples on the same fixture and runner.

| Metric | `bf05bb3` | `6f1c22c` | Delta |
|---|---:|---:|---:|
| Idle TaskDuration p50 / p95 (10s) | 3354.17 / 3571.47 ms | 1745.33 / 1820.65 ms | -48.0% / -49.0% |
| Idle ScriptDuration p50 | 518.37 ms | 0 ms | -100% |
| Idle rAF callbacks p50 | 1200 | 0 | -100% |
| Idle signal style writes p50 | 36000 | 0 | -100% |
| Mutation wake p95 / max | 22.74 / 23.40 ms | 25.51 / 25.70 ms | under 34ms |
| Drag wake p95 / max | 15.15 / 16.00 ms | 19.42 / 23.50 ms | under 34ms |

All 20 candidate windows had exact-zero visible and hidden-return rAF/style activity and no browser errors.

A separately powered exact-build readiness bracket was stable: p50/p95 789.43/813.22ms versus the readiness-only base 778.65/804.06ms (+1.4%/+1.1%); FCP p50 improved 206→204ms. The long idle artifact itself contained two clustered, non-reproducible startup outliers (1030.9/905.4ms), so its combined compare exits on readiness p95; the immediate 20-run readiness bracket had max 820.1ms with unchanged thresholds.

## Validation

- frontend tests: 235/235
- `svelte-check`: 0 errors, 0 warnings
- production build: pass
- thread-stage bundle: 242,174 gzip bytes (7,826 under budget)
- WorkspaceScene entry: +46 gzip bytes versus base
- focused lifecycle/physics tests: 10/10
- independent production-semantics and benchmark judges: PASS
- all-eight browser command: exit 0; workspace/modal/lazy contracts pass (existing nonfatal direct-route timing diagnostics remain outside this diff)
