### PR TITLE
coordinator: close residual gaps in read_github_source PR reader — combined status, CI counts, attempted-token-source errors (#306)

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -266,9 +266,23 @@ def _check_runs_payload(data: Any) -> dict[str, Any]:
     else:
         status = "unknown"
     total_count = data.get("total_count") if isinstance(data, dict) else None
+    success_conclusions = {"success", "neutral", "skipped"}
+    success = sum(
+        run.get("status") == "completed" and run.get("conclusion") in success_conclusions
+        for run in check_runs
+    )
+    failure = sum(
+        run.get("status") == "completed" and run.get("conclusion") in failure_conclusions
+        for run in check_runs
+    )
+    pending = len(check_runs) - success - failure
     return {
         "status": status,
         "total_count": int(total_count) if isinstance(total_count, int) else len(check_runs),
+        "total": len(check_runs),
+        "success": success,
+        "failure": failure,
+        "pending": pending,
         "check_runs": check_runs,
     }
 
@@ -470,7 +484,7 @@ async def async_get_pull_request(
     *,
     token: str | None = None,
 ) -> dict[str, Any]:
-    """Read one pull request and its head commit's check runs with one identity."""
+    """Read one pull request and its head commit's CI state with one identity."""
 
     owner, repo = slug.split("/", 1)
     async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
@@ -484,33 +498,69 @@ async def async_get_pull_request(
         head_sha = head.get("sha") if isinstance(head, dict) else None
         if not head_sha:
             raise GitHubConnectorError(status_code=502, message="GitHub pull request response omitted the head SHA.")
-        checks = await _async_request(
-            client,
-            "GET",
-            f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
-            token=token,
-            params={"per_page": GITHUB_ITEM_LIMIT, "page": 1},
-        )
-        total_checks = checks.get("total_count") if isinstance(checks, dict) else None
-        check_runs = checks.get("check_runs") if isinstance(checks, dict) else None
-        if isinstance(total_checks, int) and isinstance(check_runs, list):
-            page_count = (total_checks + GITHUB_ITEM_LIMIT - 1) // GITHUB_ITEM_LIMIT
-            for page in range(2, page_count + 1):
-                page_data = await _async_request(
-                    client,
-                    "GET",
-                    f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
-                    token=token,
-                    params={"per_page": GITHUB_ITEM_LIMIT, "page": page},
-                )
-                page_runs = page_data.get("check_runs") if isinstance(page_data, dict) else None
-                if isinstance(page_runs, list):
-                    check_runs.extend(page_runs)
+        ci = await _async_get_pull_request_checks(client, slug, head_sha, token=token)
     return {
         "repo": slug,
         "pull_request": _pull_request_detail_payload(pr if isinstance(pr, dict) else {}),
-        "checks": _check_runs_payload(checks),
+        "checks": ci["checks"],
+        "combined_status": ci["combined_status"],
     }
+
+
+async def _async_get_pull_request_checks(
+    client: httpx.AsyncClient,
+    slug: str,
+    sha: str,
+    *,
+    token: str | None,
+) -> dict[str, Any]:
+    owner, repo = slug.split("/", 1)
+    checks = await _async_request(
+        client,
+        "GET",
+        f"/repos/{owner}/{repo}/commits/{sha}/check-runs",
+        token=token,
+        params={"per_page": GITHUB_ITEM_LIMIT, "page": 1},
+    )
+    total_checks = checks.get("total_count") if isinstance(checks, dict) else None
+    check_runs = checks.get("check_runs") if isinstance(checks, dict) else None
+    if isinstance(total_checks, int) and isinstance(check_runs, list):
+        page_count = (total_checks + GITHUB_ITEM_LIMIT - 1) // GITHUB_ITEM_LIMIT
+        for page in range(2, page_count + 1):
+            page_data = await _async_request(
+                client,
+                "GET",
+                f"/repos/{owner}/{repo}/commits/{sha}/check-runs",
+                token=token,
+                params={"per_page": GITHUB_ITEM_LIMIT, "page": page},
+            )
+            page_runs = page_data.get("check_runs") if isinstance(page_data, dict) else None
+            if isinstance(page_runs, list):
+                check_runs.extend(page_runs)
+    combined = await _async_request(
+        client,
+        "GET",
+        f"/repos/{owner}/{repo}/commits/{sha}/status",
+        token=token,
+    )
+    return {
+        "repo": slug,
+        "sha": sha,
+        "checks": _check_runs_payload(checks),
+        "combined_status": combined.get("state") if isinstance(combined, dict) else None,
+    }
+
+
+async def async_get_pull_request_checks(
+    slug: str,
+    sha: str,
+    *,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Read check runs and the combined commit status for a PR head SHA."""
+
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        return await _async_get_pull_request_checks(client, slug, sha, token=token)
 
 
 async def async_get_pull_request_deploy_info(

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -22,12 +22,14 @@ GITHUB_TOOLS = [
                         "list_issues",
                         "list_pull_requests",
                         "get_pull_request",
+                        "pull_request_checks",
                         "get_counts",
                     ],
                     "default": "list_issues",
                     "description": (
-                        "Which GitHub source data to read. get_pull_request includes mergeability and CI "
-                        "check runs; get_counts returns exact issue and PR counts for the requested state."
+                        "Which GitHub source data to read. get_pull_request includes mergeability, CI "
+                        "check runs, and combined status; pull_request_checks reads CI for a head SHA; "
+                        "get_counts returns exact issue and PR counts for the requested state."
                     ),
                 },
                 "repo": {
@@ -60,6 +62,15 @@ GITHUB_TOOLS = [
                     "type": "integer",
                     "minimum": 1,
                     "description": "Pull request number required by get_pull_request.",
+                },
+                "number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Alias for pull_number when using get_pull_request.",
+                },
+                "sha": {
+                    "type": "string",
+                    "description": "Head commit SHA required by pull_request_checks.",
                 },
                 "limit": {"type": "integer", "default": 30, "description": "Maximum items to return, 1-100."},
                 "token_secret_key": {

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -12,6 +12,7 @@ from brain.systems.cortex.project_context.github import (
     async_create_repo_issue,
     async_get_pull_request_deploy_info,
     async_get_pull_request,
+    async_get_pull_request_checks,
     async_get_repo_counts,
     async_get_repo_by_slug,
     async_list_repo_issues,
@@ -232,6 +233,7 @@ async def _read_with_token(
     limit: int,
     token: str | None,
     pull_number: int | None,
+    sha: str | None,
 ) -> dict[str, Any]:
     if action in {"repo", "get_repo"}:
         repo = await async_get_repo_by_slug(repo_slug, token=token)
@@ -266,6 +268,12 @@ async def _read_with_token(
             int(pull_number or 0),
             token=token,
         )
+    if action in {"pull_request_checks", "pr_checks", "checks"}:
+        return await async_get_pull_request_checks(
+            repo_slug,
+            str(sha or ""),
+            token=token,
+        )
     if action in {"counts", "get_counts", "exact_counts"}:
         return await async_get_repo_counts(
             repo_slug,
@@ -274,7 +282,7 @@ async def _read_with_token(
         )
     raise ValueError(
         "read_github_source action must be get_repo, list_issues, list_pull_requests, "
-        "get_pull_request, or get_counts"
+        "get_pull_request, pull_request_checks, or get_counts"
     )
 
 
@@ -291,6 +299,8 @@ async def _handle_read_github_source(
     head: str | None = None,
     base: str | None = None,
     pull_number: int | None = None,
+    number: int | None = None,
+    sha: str | None = None,
     limit: int = 30,
     token_secret_key: str | None = None,
 ) -> str:
@@ -311,6 +321,9 @@ async def _handle_read_github_source(
         "pull_request",
         "get_pull_request",
         "pr",
+        "pull_request_checks",
+        "pr_checks",
+        "checks",
         "counts",
         "get_counts",
         "exact_counts",
@@ -319,18 +332,21 @@ async def _handle_read_github_source(
         return json.dumps({
             "error": (
                 "read_github_source action must be get_repo, list_issues, list_pull_requests, "
-                "get_pull_request, or get_counts"
+                "get_pull_request, pull_request_checks, or get_counts"
             )
         })
     if clean_action in {"pull_request", "get_pull_request", "pr"}:
         try:
-            clean_pull_number = int(pull_number or 0)
+            clean_pull_number = int(number or pull_number or 0)
         except (TypeError, ValueError):
             clean_pull_number = 0
         if clean_pull_number < 1:
             return json.dumps({"error": "get_pull_request requires a positive pull_number"})
     else:
         clean_pull_number = None
+    clean_sha = _clean(sha)
+    if clean_action in {"pull_request_checks", "pr_checks", "checks"} and not clean_sha:
+        return json.dumps({"error": "pull_request_checks requires sha"})
 
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,
@@ -350,7 +366,11 @@ async def _handle_read_github_source(
         ]
         if cached_errors:
             cached_error = cached_errors[-1]
-            return json.dumps({"error": cached_error.message, "status_code": cached_error.status_code})
+            return json.dumps({
+                "error": cached_error.message,
+                "status_code": cached_error.status_code,
+                "attempted_token_sources": [candidate["source"] for candidate in candidates],
+            })
         return json.dumps({"error": "No GitHub token candidates were available"})
     last_error: GitHubConnectorError | None = None
     retry_statuses = {401, 403, 404}
@@ -359,7 +379,9 @@ async def _handle_read_github_source(
         # this candidate cannot search the private repository.
         retry_statuses.add(422)
     negative_cache_statuses = {401, 404}
+    attempted_token_sources: list[str] = []
     for index, candidate in enumerate(read_candidates):
+        attempted_token_sources.append(candidate["source"])
         try:
             payload = await _read_with_token(
                 action=clean_action,
@@ -376,6 +398,7 @@ async def _handle_read_github_source(
                 limit=limit,
                 token=candidate["token"],
                 pull_number=clean_pull_number,
+                sha=clean_sha,
             )
         except GitHubConnectorError as exc:
             last_error = exc
@@ -383,7 +406,11 @@ async def _handle_read_github_source(
                 read_state.rejected[(candidate.get("token"), repo_slug)] = exc
             if exc.status_code in retry_statuses and index < len(read_candidates) - 1:
                 continue
-            return json.dumps({"error": exc.message, "status_code": exc.status_code})
+            return json.dumps({
+                "error": exc.message,
+                "status_code": exc.status_code,
+                "attempted_token_sources": attempted_token_sources,
+            })
         read_state.preferred[repo_slug] = candidate.get("token")
         payload["token_secret_key_used"] = bool(candidate.get("key_name"))
         payload["token_source"] = candidate["source"]
@@ -392,7 +419,11 @@ async def _handle_read_github_source(
         return json.dumps(payload, default=str)
 
     if last_error is not None:
-        return json.dumps({"error": last_error.message, "status_code": last_error.status_code})
+        return json.dumps({
+            "error": last_error.message,
+            "status_code": last_error.status_code,
+            "attempted_token_sources": attempted_token_sources,
+        })
     return json.dumps({"error": "No GitHub token candidates were available"})
 
 

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -426,6 +426,7 @@ async def test_pull_request_reader_fetches_details_and_checks_with_same_token():
                         {"name": "lint", "status": "completed", "conclusion": "failure"},
                     ],
                 },
+                {"state": "failure", "statuses": []},
             ]
         ),
     ) as request:
@@ -439,14 +440,166 @@ async def test_pull_request_reader_fetches_details_and_checks_with_same_token():
     assert result["pull_request"]["mergeable_state"] == "clean"
     assert result["checks"]["status"] == "failure"
     assert result["checks"]["total_count"] == 2
+    assert {
+        key: result["checks"][key]
+        for key in ("total", "success", "failure", "pending")
+    } == {"total": 2, "success": 1, "failure": 1, "pending": 0}
+    assert result["combined_status"] == "failure"
     assert [call.args[2] for call in request.await_args_list] == [
         "/repos/uwear-ai/uwear-backend/pulls/42",
         "/repos/uwear-ai/uwear-backend/commits/abc123/check-runs",
+        "/repos/uwear-ai/uwear-backend/commits/abc123/status",
     ]
     assert [call.kwargs["token"] for call in request.await_args_list] == [
         "primary-token",
         "primary-token",
+        "primary-token",
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_pull_request_uses_project_bound_token_for_mergeability_and_ci():
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(return_value={"GITHUB_TOKEN": "app-token"}),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(
+            side_effect=[
+                {
+                    "number": 859,
+                    "state": "open",
+                    "mergeable": True,
+                    "mergeable_state": "clean",
+                    "head": {"sha": "head859"},
+                },
+                {
+                    "total_count": 2,
+                    "check_runs": [
+                        {"name": "unit", "status": "completed", "conclusion": "success"},
+                        {"name": "lint", "status": "completed", "conclusion": "success"},
+                    ],
+                },
+                {"state": "success", "statuses": []},
+            ]
+        ),
+    ) as request:
+        result = json.loads(
+            await _handle_read_github_source(
+                action="get_pull_request",
+                repo="uwear-ai/uwear-backend",
+                number=859,
+            )
+        )
+
+    assert result["pull_request"]["mergeable_state"] == "clean"
+    assert result["checks"] == {
+        "status": "success",
+        "total_count": 2,
+        "total": 2,
+        "success": 2,
+        "failure": 0,
+        "pending": 0,
+        "check_runs": [
+            {
+                "name": "unit",
+                "status": "completed",
+                "conclusion": "success",
+                "details_url": None,
+                "started_at": None,
+                "completed_at": None,
+            },
+            {
+                "name": "lint",
+                "status": "completed",
+                "conclusion": "success",
+                "details_url": None,
+                "started_at": None,
+                "completed_at": None,
+            },
+        ],
+    }
+    assert result["combined_status"] == "success"
+    assert result["token_source"] == "project_binding:GITHUB_TOKEN"
+    assert [call.args[2] for call in request.await_args_list] == [
+        "/repos/uwear-ai/uwear-backend/pulls/859",
+        "/repos/uwear-ai/uwear-backend/commits/head859/check-runs",
+        "/repos/uwear-ai/uwear-backend/commits/head859/status",
+    ]
+    assert all(call.kwargs["token"] == "app-token" for call in request.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_pull_request_checks_action_reads_checks_and_combined_status():
+    with patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_pull_request_checks",
+        new=AsyncMock(
+            return_value={
+                "repo": "uwear-ai/uwear-backend",
+                "sha": "abc123",
+                "checks": {"total": 1, "success": 0, "failure": 0, "pending": 1},
+                "combined_status": "pending",
+            }
+        ),
+    ) as get_checks:
+        result = json.loads(
+            await _handle_read_github_source(
+                action="pull_request_checks",
+                repo="uwear-ai/uwear-backend",
+                sha="abc123",
+            )
+        )
+
+    assert result["checks"] == {"total": 1, "success": 0, "failure": 0, "pending": 1}
+    assert result["combined_status"] == "pending"
+    get_checks.assert_awaited_once_with(
+        "uwear-ai/uwear-backend",
+        "abc123",
+        token=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_request_detail_reports_all_denied_token_sources():
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_resolve_project_bound_env_tokens",
+        new=AsyncMock(
+            return_value={
+                "GITHUB_TOKEN": "primary-token",
+                "GITHUB_TOKEN__AXEL": "secondary-token",
+            }
+        ),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_list_secrets",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "brain.systems.runs.tool_catalog.handlers.github.async_get_pull_request",
+        new=AsyncMock(
+            side_effect=[
+                GitHubConnectorError(status_code=403, message="Forbidden"),
+                GitHubConnectorError(status_code=404, message="Not visible"),
+            ]
+        ),
+    ):
+        result = json.loads(
+            await _handle_read_github_source(
+                action="get_pull_request",
+                repo="uwear-ai/uwear-backend",
+                number=859,
+            )
+        )
+
+    assert result == {
+        "error": "Not visible",
+        "status_code": 404,
+        "attempted_token_sources": [
+            "project_binding:GITHUB_TOKEN",
+            "project_binding:GITHUB_TOKEN__AXEL",
+        ],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #306.

## Honest scope note (important for review)
#306 was filed 2026-07-11 with the premise that **no** single-PR mergeability / CI reader exists and that the coordinator 403s because its probe isn't routed through the App token. That premise was **already stale on main**: `async_get_pull_request` exists and the `get_pull_request` action is wired through the same `_github_token_candidates()` / project-bound App-token path as `list_pull_requests`. R2's evidence (msg-1401/1407/1413) is from 2026-07-10 runs, before the reader + the `checks:read` App scope (PR #299, merged 2026-07-10 18:26Z) landed.

This PR therefore does **not** "add the missing reader" — it closes the **residual gaps** the pre-existing reader still had, which are exactly what #306's acceptance checks call for.

## What this changes
- **`combined_status`** — `get_pull_request` now also reads `GET /repos/{o}/{r}/commits/{sha}/status` and surfaces the combined state. Main read only check-runs, never the combined status endpoint.
- **Decision-ready check counts** — `_check_runs_payload` now returns `{total, success, failure, pending}` (main had only `status` + `total_count` + raw `check_runs`).
- **`pull_request_checks` action** — standalone reader for check-runs + combined status by head SHA (`async_get_pull_request_checks`), reusable without a full PR fetch.
- **`attempted_token_sources`** — every 403/404 error path (per-candidate exhaustion, negative-cache short-circuit, final failure) now lists the token sources tried, mirroring how the list path degrades (acceptance check #3). Main returned only `{error, status_code}`.
- **`number`** accepted as an alias for `pull_number`.

## Review surface (no diff-reading required)
- **Run the tests:** `cd <worktree-or-checkout> && venv/bin/python -m pytest tests/test_github_source_tool.py -q` → **17 passed** (14 pre-existing regressions + 3 new).
- New tests assert the intended behavior:
  - `test_get_pull_request_uses_project_bound_token_for_mergeability_and_ci` — App token used (`token_source == project_binding:GITHUB_TOKEN`), `mergeable_state == clean`, single-PR GET + check-runs + combined-status endpoints all hit, `combined_status == success`.
  - `test_pull_request_checks_action_reads_checks_and_combined_status` — the new action.
  - `test_pull_request_detail_reports_all_denied_token_sources` — all candidates 403/404 → structured `error` + `attempted_token_sources`, no unhandled exception.

## Acceptance checks
1. `get_pull_request(repo=uwear-ai/uwear-backend, number=859)` returns `mergeable_state` + a check summary via the App token, no 403 — ✔ (covered by test 1; real-repo call still needs the App install token at runtime).
2. Coordinator can report CI/mergeability inline (green/blocked + combined_status) — ✔ payload shape now decision-ready.
3. All-denied tokens → structured `error` listing attempted sources — ✔ (test 3).
4. Regression: `get_repo` / `list_issues` / `list_pull_requests` unchanged — ✔ (14 pre-existing tests green).

Backend-only; no migration, no frontend. Left as **draft** for Reda's review — do not merge until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)