### PR TITLE
Fix Cycle missing-output contract false-fail (auto-repair + preserve answer) (#310)

### DIFF
--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -46,6 +46,13 @@ _EVIDENCE_HEALTH_VALUES = (
     "unknown",
 )
 
+_NON_PRESERVABLE_OUTPUTS = frozenset(
+    {
+        "visible_final_answer",
+        "candidate_is_runtime_introspection",
+    }
+)
+
 _MISSION_OUTPUT_ALIASES: dict[str, tuple[str, ...]] = {
     "24h readout": (
         "24h readout",
@@ -96,6 +103,10 @@ def _dedupe(values: list[str]) -> list[str]:
         seen.add(key)
         deduped.append(key)
     return deduped
+
+
+def _missing_outputs_allow_append(missing_outputs: list[str]) -> bool:
+    return not _NON_PRESERVABLE_OUTPUTS.intersection(missing_outputs)
 
 
 def _looks_like_introspection_boilerplate(text: str) -> bool:
@@ -440,14 +451,27 @@ def _repair_prompt(
     evidence_packet: dict[str, Any],
     missing_outputs: list[str],
     candidate_answer: str,
+    append_only: bool = False,
 ) -> list[dict[str, str]]:
+    repair_instruction = (
+        "The candidate is a substantive draft that must remain unchanged. Produce only one or "
+        "more appendable sections for the named missing outputs. Append only the missing sections; "
+        "do not repeat or rewrite the candidate. Return the new section text only."
+        if append_only
+        else "Produce the corrected visible final answer only."
+    )
+    candidate_label = (
+        "Candidate visible answer to preserve unchanged"
+        if append_only
+        else "Candidate visible answer"
+    )
     return [
         {
             "role": "system",
             "content": (
                 "You are repairing one scheduled Cycle final answer before it becomes visible. "
                 "Use only the supplied mission, result contract, evidence packet, and candidate. "
-                "Do not claim fresh tool access. Produce the corrected visible final answer only. "
+                f"Do not claim fresh tool access. {repair_instruction} "
                 "If evidence is insufficient, say evidence_health=degraded and name the gap."
             ),
         },
@@ -462,7 +486,7 @@ def _repair_prompt(
                 f"{json.dumps(evidence_packet, ensure_ascii=True, sort_keys=True, default=str)[:5000]}\n\n"
                 "Missing required outputs:\n"
                 f"{json.dumps(missing_outputs, ensure_ascii=True)}\n\n"
-                "Candidate visible answer:\n"
+                f"{candidate_label}:\n"
                 f"{candidate_answer[:4000]}"
             ),
         },
@@ -525,6 +549,7 @@ async def _async_repair_cycle_contract_answer(
                 evidence_packet=evidence_packet,
                 missing_outputs=missing_outputs,
                 candidate_answer=candidate_answer,
+                append_only=_missing_outputs_allow_append(missing_outputs),
             ),
             max_tokens=1200,
             system=None,
@@ -557,11 +582,36 @@ def _completed_side_effect_names(evidence_packet: dict[str, Any]) -> list[str]:
     return _dedupe(names)
 
 
+def _candidate_can_be_preserved(
+    candidate_answer: str,
+    review: dict[str, Any],
+) -> bool:
+    missing_outputs = set(_json_list(review.get("missing_outputs")))
+    return (
+        bool(str(candidate_answer or "").strip())
+        and not review.get("provider_error")
+        and _missing_outputs_allow_append(list(missing_outputs))
+    )
+
+
+def _append_targeted_repair(candidate_answer: str, repair_answer: str) -> str:
+    candidate = str(candidate_answer or "").strip()
+    repair = str(repair_answer or "").strip()
+    if not candidate:
+        return repair
+    if not repair or repair in candidate:
+        return candidate
+    if candidate in repair:
+        return repair
+    return f"{candidate}\n\n{repair}"
+
+
 def _degraded_visible_answer(
     missing_outputs: list[str],
     *,
     provider_error: str | None = None,
     evidence_packet: dict[str, Any] | None = None,
+    candidate_answer: str | None = None,
 ) -> str:
     if provider_error:
         side_effect_names = _completed_side_effect_names(_json_dict(evidence_packet))
@@ -577,10 +627,14 @@ def _degraded_visible_answer(
             f"was produced. {side_effect_sentence}"
         )
     missing = ", ".join(missing_outputs[:8]) if missing_outputs else "required Cycle outputs"
-    return (
+    explanation = (
         "Cycle run degraded: mission_contract_failed. The run completed side effects, "
         f"but its visible final answer did not satisfy the Cycle result contract. Missing: {missing}."
     )
+    candidate = str(candidate_answer or "").strip()
+    if not candidate:
+        return explanation
+    return f"{candidate}\n\n---\n{explanation}"
 
 
 def _base_verdict(
@@ -691,7 +745,11 @@ async def async_prepare_cycle_run_visible_finalization(
         _persist_cycle_contract_verdict(cycle_run, verdict)
         return verdict
 
+    append_only = _candidate_can_be_preserved(candidate_answer, initial_review)
+    preserved_answer = candidate_answer if append_only else None
+    preserved_answer_source = "candidate" if append_only else None
     verdict["repair_attempted"] = True
+    verdict["repair_mode"] = "append_missing_outputs" if append_only else "replace_invalid_answer"
     try:
         repair_answer = await _async_repair_cycle_contract_answer(
             agent_run=agent_run,
@@ -705,8 +763,13 @@ async def async_prepare_cycle_run_visible_finalization(
         logger.exception("cycle_contract_repair_call_failed", extra={"run_id": int(agent_run.id)})
         repair_answer = None
     if repair_answer:
+        combined_answer = (
+            _append_targeted_repair(candidate_answer, repair_answer)
+            if append_only and not provider_error_kind(repair_answer)
+            else repair_answer
+        )
         repair_review = evaluate_cycle_result_contract(
-            candidate_answer=repair_answer,
+            candidate_answer=combined_answer,
             result_contract=result_contract,
             mission=mission,
             evidence_packet=evidence_packet,
@@ -721,18 +784,21 @@ async def async_prepare_cycle_run_visible_finalization(
             repaired_artifact = await _append_final_answer_artifact_once(
                 session,
                 agent_run,
-                repair_answer,
+                combined_answer,
                 payload={
                     "source": "cycle_result_contract_gate",
                     "repair_for_artifact_id": getattr(artifact, "id", None),
                     "initial_missing_outputs": list(initial_review["missing_outputs"]),
+                    "repair_mode": verdict["repair_mode"],
                 },
             )
             verdict.update(
                 {
                     "repair_succeeded": True,
                     "settlement_status": "mission_success_after_repair",
-                    "visible_answer_source": "repair",
+                    "visible_answer_source": (
+                        "candidate_with_repair" if append_only else "repair"
+                    ),
                     "repaired_artifact_id": getattr(repaired_artifact, "id", None),
                     "repaired_summary": repair_review["candidate_summary"],
                     "final_missing_outputs": [],
@@ -742,12 +808,16 @@ async def async_prepare_cycle_run_visible_finalization(
             return verdict
         verdict["repair_missing_outputs"] = list(repair_review["missing_outputs"])
         verdict["final_missing_outputs"] = list(repair_review["missing_outputs"])
+        if not append_only and _candidate_can_be_preserved(combined_answer, repair_review):
+            preserved_answer = combined_answer
+            preserved_answer_source = "repair"
 
     missing_outputs = list(verdict.get("final_missing_outputs") or verdict["missing_outputs"])
     degraded_answer = _degraded_visible_answer(
         missing_outputs,
         provider_error=verdict.get("provider_error"),
         evidence_packet=evidence_packet,
+        candidate_answer=preserved_answer,
     )
     degraded_artifact = await _append_final_answer_artifact_once(
         session,
@@ -757,12 +827,26 @@ async def async_prepare_cycle_run_visible_finalization(
             "source": "cycle_result_contract_gate",
             "settlement_status": "mission_contract_failed",
             "missing_outputs": missing_outputs,
+            "preserved_candidate_artifact_id": (
+                getattr(artifact, "id", None)
+                if preserved_answer_source == "candidate"
+                else None
+            ),
+            "preserved_answer_source": preserved_answer_source,
         },
     )
     verdict.update(
         {
             "settlement_status": "mission_contract_failed",
-            "visible_answer_source": "degraded_explanation",
+            "visible_answer_source": (
+                "candidate_with_degraded_explanation"
+                if preserved_answer_source == "candidate"
+                else (
+                    "repair_with_degraded_explanation"
+                    if preserved_answer_source == "repair"
+                    else "degraded_explanation"
+                )
+            ),
             "degraded_artifact_id": getattr(degraded_artifact, "id", None),
             "degraded_summary": _candidate_summary(degraded_answer),
             "final_missing_outputs": missing_outputs,

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1254,11 +1254,23 @@ def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
         ),
         created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
     )
+    completed_side_effect = AgentRunEventRow(
+        id=4,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=4,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "update_cycle_tracker",
+            "result": {"status": "ok", "record_id": 26},
+        },
+    )
     fake_session = _AsyncFakeSession(
         agent_run=agent_run,
         run=cycle_run,
         cycle=cycle,
         artifacts=[final_answer],
+        events=[completed_side_effect],
     )
     monkeypatch.setattr(
         service,
@@ -1284,6 +1296,8 @@ def test_finalize_cycle_run_from_run_updates_cycle_and_run(monkeypatch):
     verdict = evaluation.details["mission_result_contract_verdict"]
     assert verdict["settlement_status"] == "mission_success"
     assert verdict["candidate_artifact_id"] == 8
+    assert verdict["side_effects_succeeded"] is True
+    assert fake_session._artifacts[-1].text == final_answer.text
 
 
 def test_cycle_contract_rejects_raw_provider_error_as_visible_answer():
@@ -1423,6 +1437,113 @@ async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
     assert cycle_run.context_snapshot["mission_result_contract_verdict"] == verdict
 
 
+@pytest.mark.asyncio
+async def test_cycle_contract_gate_appends_one_missing_required_output_to_draft(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = "Review the scheduled Cycle smoke test."
+    agent_run.model_policy = {}
+    agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = 5
+    cycle_run.status = "running"
+    cycle_run.prompt_snapshot = agent_run.input_message
+    cycle_run.context_snapshot = {
+        "result_contract": {
+            "kind": "autonomous_cycle_run_result",
+            "required_outputs": [
+                "answer_the_cycle_mission",
+                "summarize_workspace_evidence_or_explicit_gaps",
+                "report_evidence_health",
+                "record_next_action_or_blocker",
+                "short_self_review_summary",
+            ],
+        }
+    }
+
+    cycle = Cycle()
+    cycle.id = 5
+    cycle.prompt = cycle_run.prompt_snapshot
+
+    substantive_draft = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text=(
+            "The scheduled Cycle smoke test completed successfully and its tracker was updated. "
+            "Workspace evidence showed the expected output with no explicit gaps. "
+            "Evidence health: ok. Next action: monitor the next scheduled run."
+        ),
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    completed_side_effect = AgentRunEventRow(
+        id=4,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=4,
+        event_type="run.tool_completed",
+        payload={"tool_name": "update_cycle_tracker", "result": {"status": "ok"}},
+    )
+    session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[substantive_draft],
+        events=[completed_side_effect],
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return "Self-review summary: the mission result is supported by the recorded evidence."
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+
+    verdict = await contract_gate.async_prepare_cycle_run_visible_finalization(session, 44)
+
+    assert len(repair_calls) == 1
+    assert repair_calls[0]["candidate_answer"] == substantive_draft.text
+    assert repair_calls[0]["missing_outputs"] == ["short_self_review_summary"]
+    assert verdict["settlement_status"] == "mission_success_after_repair"
+    assert verdict["repair_succeeded"] is True
+    assert verdict["final_missing_outputs"] == []
+    repaired_answer = session._artifacts[-1].text
+    assert substantive_draft.text in repaired_answer
+    assert "Self-review summary:" in repaired_answer
+    assert repaired_answer.count("Workspace evidence showed") == 1
+
+
+def test_cycle_contract_repair_prompt_requests_only_missing_sections():
+    from brain.systems.cycles.contract_gate import _repair_prompt
+
+    candidate = (
+        "Mission complete. Workspace evidence showed success. Evidence health: ok. "
+        "Next action: monitor."
+    )
+
+    messages = _repair_prompt(
+        mission="Review the scheduled Cycle smoke test.",
+        result_contract={"required_outputs": ["short_self_review_summary"]},
+        evidence_packet={"side_effects_succeeded": True},
+        missing_outputs=["short_self_review_summary"],
+        candidate_answer=candidate,
+        append_only=True,
+    )
+
+    prompt = "\n".join(message["content"] for message in messages)
+    assert "append only the missing section" in prompt.lower()
+    assert "do not repeat or rewrite" in prompt.lower()
+    assert candidate in prompt
+
+
 def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
     from brain.systems.cycles import contract_gate
 
@@ -1467,12 +1588,18 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
     cycle.last_error = None
     cycle.last_run_at = None
 
-    bad_answer = AgentRunArtifactRow(
+    substantive_draft = AgentRunArtifactRow(
         id=8,
         run_id=44,
         root_run_id=44,
         artifact_type="final_answer",
-        text="Verified current runtime facts:\n- Runtime scope: workspace-bound.",
+        text=(
+            "24h readout: workspace evidence showed the scheduled review completed. "
+            "Failure map: no execution failures were observed. Codebase implications: none. "
+            "Proposals: continue monitoring. Tracking summary: the tracker update succeeded. "
+            "Impact loop: compare the next run. Next action: monitor the next scheduled run. "
+            "Evidence health: ok. Domain record 26 contains the tracking result."
+        ),
         created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
     )
     domain_event = AgentRunEventRow(
@@ -1490,7 +1617,7 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
         agent_run=agent_run,
         run=cycle_run,
         cycle=cycle,
-        artifacts=[bad_answer],
+        artifacts=[substantive_draft],
         events=[domain_event],
     )
 
@@ -1498,7 +1625,7 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
 
     async def fake_repair(**kwargs):
         repair_calls.append(kwargs)
-        return "Verified current runtime facts: Git metadata is unavailable right now."
+        return "The repair attempt did not include the requested section."
 
     monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([fake_session]))
@@ -1510,8 +1637,9 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
     assert cycle.last_status == "degraded"
     assert cycle_run.error.startswith("mission_contract_failed: missing")
     latest_answer = fake_session._artifacts[-1].text
-    assert latest_answer.startswith("Cycle run degraded: mission_contract_failed")
-    assert "Verified current runtime facts" not in latest_answer
+    assert substantive_draft.text in latest_answer
+    assert "Cycle run degraded: mission_contract_failed" in latest_answer
+    assert latest_answer != "Cycle run degraded: mission_contract_failed"
     evaluation = next(
         item for item in fake_session.added if item.__class__.__name__ == "CycleRunEvaluation"
     )
@@ -1519,7 +1647,7 @@ def test_finalize_cycle_run_degrades_when_contract_repair_fails(monkeypatch):
     assert verdict["settlement_status"] == "mission_contract_failed"
     assert verdict["repair_attempted"] is True
     assert verdict["side_effects_succeeded"] is True
-    assert "24h readout" in verdict["missing_outputs"]
+    assert verdict["missing_outputs"] == ["short_self_review_summary"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #310.

## Problem
A scheduled Cycle run could complete **all** its side effects and still have its entire visible answer replaced by a `mission_contract_failed` stub because the answer omitted **one** required contract field. The omission was nondeterministic — a blind retry failed on a *different* field (runs 1186 / 1222 / 1236). 3 of 6 coordinator runs lost their real output this way.

Distinct from closed #272 (introspection self-context overwriting the answer) and #289 (raw provider `server_error` leaking as the answer): here the answer is genuine and correct, it simply omits one mandatory section.

## Fix (`brain/systems/cycles/contract_gate.py`)
- **Append-only repair.** A substantive draft missing required output section(s) is repaired by re-prompting the model to produce **only** the missing sections, appended to the untouched candidate — not a full blind re-run. Gated to *preservable* misses (excludes `visible_final_answer` / introspection).
- **Re-validation after append** so a section newly-omitted by the repair can't slip through.
- **Preserve real content on degrade.** When degradation is unavoidable, the stored/visible message keeps the model's substantive content above the `mission_contract_failed` explanation, instead of a bare stub.
- **Unchanged full-replacement** path for empty / provider-error / introspection answers (keeps #272/#289 behavior).
- `verdict` now records `repair_mode` (`append_missing_outputs` vs `replace_invalid_answer`).

Main already had the #272/#289 bounded single-repair machinery; this extends it to the missing-section case rather than adding a parallel path.

## Review surface
Local checkout — no deploy preview (backend agent-runtime change):
```
cd <worktree> && /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_cycles_service.py tests/test_agent_run_runtime.py \
  tests/test_agent_run_state_machine.py tests/test_direct_agent_async_contract.py -q
```
**177 passed, 1 skipped** (2026-07-14).

## Acceptance checks
- [x] Draft missing exactly one `required_output` → auto-repaired, completes **non-degraded**, substantive answer preserved (run-1186 shape).
- [x] Genuinely degraded run → stored/visible message contains the model's real content, not only the stub.
- [x] Append-repaired draft is re-validated → cannot fail on a *newly* omitted field that was present in the prior draft.
- [x] Regression: side-effects-done + good answer ⇒ answer surfaced; #272/#289 tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Draft — do not merge until Reda reviews.