### PR TITLE
Pagination cursors on broad readers + bounded reflex watermark reader (#312)

### DIFF
--- a/brain/app/api/routers/agent_mcp_domains.py
+++ b/brain/app/api/routers/agent_mcp_domains.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.pagination import next_offset_token, page_offset
 from brain.systems.external_agents import service as external_agents
 from brain.systems.user_domains.service import AsyncDomainService, DomainNotFound
 
@@ -113,6 +114,10 @@ DOMAIN_MCP_TOOLS: dict[str, dict[str, Any]] = {
                     "type": "integer",
                     "description": "Maximum records, relations, or events to return, 1-100.",
                     "default": 25,
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by a previous inspection.",
                 },
             },
         ),
@@ -251,6 +256,9 @@ async def _tool_inspect_domains(
             ]
         }
 
+    page_kind = f"hosted_domain:{domain.id}"
+    offset = page_offset(_clean_optional_string(arguments.get("cursor")), kind=page_kind)
+    has_more = False
     payload: dict[str, Any] = {"domain": await service.serialize_domain_schema(domain)}
     record_id = _clean_optional_int(arguments.get("record_id"))
     if record_id is not None:
@@ -269,6 +277,7 @@ async def _tool_inspect_domains(
             include_archived=include_archived,
             limit=limit,
             order=record_order,
+            offset=offset,
         )
         if record_format == "compact":
             records = [
@@ -294,6 +303,7 @@ async def _tool_inspect_domains(
                 "format": record_format,
             }
         )
+        has_more = has_more or offset + len(records) < total
     if bool(arguments.get("include_relations", False)):
         payload["relations"] = [
             await service.serialize_relation(relation)
@@ -315,8 +325,27 @@ async def _tool_inspect_domains(
                 domain.id,
                 record_id=record_id,
                 limit=limit,
+                offset=offset,
             )
         ]
+        event_total = await service.count_events(
+            principal.org_id,
+            domain.id,
+            record_id=record_id,
+        )
+        payload["event_total_matching"] = event_total
+        has_more = has_more or offset + len(payload["events"]) < event_total
+    if bool(arguments.get("include_records", False)) or bool(arguments.get("include_events", False)):
+        payload["truncated"] = has_more
+        payload["next_page"] = (
+            next_offset_token(kind=page_kind, offset=offset, returned=limit)
+            if has_more
+            else None
+        )
+        payload["evidence_health"] = {
+            "status": "ok",
+            "completeness": "more_available" if has_more else "complete",
+        }
     return payload
 
 

--- a/brain/app/api/routers/domains.py
+++ b/brain/app/api/routers/domains.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.app.api.auth import get_current_user
@@ -29,6 +29,7 @@ from brain.app.api.schemas.domains import (
     DomainSchemaRead,
     DomainSummaryRead,
 )
+from brain.kernel.common.pagination import InvalidPageToken, next_offset_token, page_offset
 from brain.systems.user_domains.service import AsyncDomainService, DomainError, DomainNotFound
 
 router = APIRouter(
@@ -45,7 +46,7 @@ def _service(db: AsyncSession) -> AsyncDomainService:
 def _domain_error(exc: Exception) -> HTTPException:
     if isinstance(exc, DomainNotFound):
         return HTTPException(status_code=404, detail=str(exc))
-    if isinstance(exc, DomainError):
+    if isinstance(exc, (DomainError, InvalidPageToken)):
         return HTTPException(status_code=400, detail=str(exc))
     return HTTPException(status_code=500, detail=str(exc))
 
@@ -202,17 +203,22 @@ async def add_domain_relation_type(
 @router.get("/{domain_id}/records", response_model=list[DomainRecordRead])
 async def list_domain_records(
     domain_id: int,
+    response: Response,
     object_key: str | None = None,
     search: str | None = None,
     include_archived: bool = False,
     limit: int = 100,
+    cursor: str | None = None,
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = require_org_context(user)
     service = _service(db)
     try:
-        return [
+        page_limit = max(1, min(int(limit or 100), 500))
+        page_kind = f"domain_api:records:{domain_id}"
+        offset = page_offset(cursor, kind=page_kind)
+        records = [
             await service.serialize_record(record)
             for record in await service.list_records(
                 org_id,
@@ -220,10 +226,28 @@ async def list_domain_records(
                 object_key=object_key,
                 search=search,
                 include_archived=include_archived,
-                limit=limit,
+                limit=page_limit,
+                offset=offset,
             )
         ]
-    except (DomainError, DomainNotFound) as exc:
+        total = await service.count_records(
+            org_id,
+            domain_id,
+            object_key=object_key,
+            search=search,
+            include_archived=include_archived,
+        )
+        has_more = offset + len(records) < total
+        response.headers["X-Truncated"] = str(has_more).lower()
+        response.headers["X-Evidence-Health"] = "ok"
+        if has_more:
+            response.headers["X-Next-Page"] = next_offset_token(
+                kind=page_kind,
+                offset=offset,
+                returned=len(records),
+            )
+        return records
+    except (DomainError, DomainNotFound, InvalidPageToken) as exc:
         raise _domain_error(exc) from exc
 
 
@@ -404,17 +428,39 @@ async def remove_domain_relation(
 @router.get("/{domain_id}/events", response_model=list[DomainEventRead])
 async def list_domain_events(
     domain_id: int,
+    response: Response,
     record_id: int | None = None,
     limit: int = 50,
+    cursor: str | None = None,
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
     org_id = require_org_context(user)
     service = _service(db)
     try:
-        return [
+        page_limit = max(1, min(int(limit or 50), 200))
+        page_kind = f"domain_api:events:{domain_id}"
+        offset = page_offset(cursor, kind=page_kind)
+        events = [
             service.serialize_event(event)
-            for event in await service.list_events(org_id, domain_id, record_id=record_id, limit=limit)
+            for event in await service.list_events(
+                org_id,
+                domain_id,
+                record_id=record_id,
+                limit=page_limit,
+                offset=offset,
+            )
         ]
-    except (DomainError, DomainNotFound) as exc:
+        total = await service.count_events(org_id, domain_id, record_id=record_id)
+        has_more = offset + len(events) < total
+        response.headers["X-Truncated"] = str(has_more).lower()
+        response.headers["X-Evidence-Health"] = "ok"
+        if has_more:
+            response.headers["X-Next-Page"] = next_offset_token(
+                kind=page_kind,
+                offset=offset,
+                returned=len(events),
+            )
+        return events
+    except (DomainError, DomainNotFound, InvalidPageToken) as exc:
         raise _domain_error(exc) from exc

--- a/brain/kernel/common/pagination.py
+++ b/brain/kernel/common/pagination.py
@@ -1,0 +1,56 @@
+"""Opaque pagination tokens shared by bounded readers."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+class InvalidPageToken(ValueError):
+    """Raised when a pagination token is malformed or belongs to another reader."""
+
+
+def encode_page_token(kind: str, position: Mapping[str, Any]) -> str:
+    payload = {
+        "v": 1,
+        "kind": str(kind),
+        "position": dict(position),
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_page_token(token: str | None, *, kind: str) -> dict[str, Any]:
+    if not token:
+        return {}
+    try:
+        encoded = str(token).strip()
+        padding = "=" * (-len(encoded) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded + padding).decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise InvalidPageToken("Invalid pagination cursor") from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("v") != 1
+        or payload.get("kind") != kind
+        or not isinstance(payload.get("position"), dict)
+    ):
+        raise InvalidPageToken("Invalid pagination cursor")
+    return dict(payload["position"])
+
+
+def page_offset(token: str | None, *, kind: str) -> int:
+    position = decode_page_token(token, kind=kind)
+    try:
+        offset = int(position.get("offset", 0))
+    except (TypeError, ValueError) as exc:
+        raise InvalidPageToken("Invalid pagination cursor") from exc
+    if offset < 0:
+        raise InvalidPageToken("Invalid pagination cursor")
+    return offset
+
+
+def next_offset_token(*, kind: str, offset: int, returned: int) -> str:
+    return encode_page_token(kind, {"offset": max(0, int(offset)) + max(0, int(returned))})

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from brain.kernel.common.pagination import InvalidPageToken, decode_page_token, encode_page_token
 from brain.platform.async_io import async_http_client, sync_http_client
 
 
@@ -403,12 +404,23 @@ async def async_list_repo_issues(
     since: str | None = None,
     include_pull_requests: bool = False,
     limit: int = 30,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
     owner, repo = slug.split("/", 1)
     max_items = max(1, min(int(limit or 30), GITHUB_ITEM_LIMIT))
+    page_kind = f"github_issues:{slug}"
+    position = decode_page_token(cursor, kind=page_kind)
+    try:
+        page = int(position.get("page", 1))
+        page_index = int(position.get("index", 0))
+    except (TypeError, ValueError) as exc:
+        raise InvalidPageToken("Invalid pagination cursor") from exc
+    if page < 1 or page_index < 0:
+        raise InvalidPageToken("Invalid pagination cursor")
     params: dict[str, Any] = {
         "state": state or "open",
         "per_page": GITHUB_ITEM_LIMIT,
+        "page": page,
         "sort": "updated",
         "direction": "desc",
     }
@@ -430,14 +442,27 @@ async def async_list_repo_issues(
             token=token,
             params=params,
         )
-    items = data if isinstance(data, list) else []
+    raw_items = data if isinstance(data, list) else []
+    items = raw_items
     if not include_pull_requests:
         items = [item for item in items if not (isinstance(item, dict) and item.get("pull_request"))]
+    selected = items[page_index : page_index + max_items]
+    next_position = None
+    if page_index + max_items < len(items):
+        next_position = {"page": page, "index": page_index + max_items}
+    elif len(raw_items) == GITHUB_ITEM_LIMIT:
+        next_position = {"page": page + 1, "index": 0}
     return {
         "repo": slug,
         "state": params["state"],
-        "issues": [_issue_payload(item) for item in items[:max_items] if isinstance(item, dict)],
+        "issues": [_issue_payload(item) for item in selected if isinstance(item, dict)],
         "included_pull_requests": include_pull_requests,
+        "truncated": next_position is not None,
+        "next_page": encode_page_token(page_kind, next_position) if next_position else None,
+        "evidence_health": {
+            "status": "ok",
+            "completeness": "more_available" if next_position else "complete",
+        },
     }
 
 
@@ -449,12 +474,23 @@ async def async_list_repo_pull_requests(
     head: str | None = None,
     base: str | None = None,
     limit: int = 30,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
     owner, repo = slug.split("/", 1)
     max_items = max(1, min(int(limit or 30), GITHUB_ITEM_LIMIT))
+    page_kind = f"github_pull_requests:{slug}"
+    position = decode_page_token(cursor, kind=page_kind)
+    try:
+        page = int(position.get("page", 1))
+        page_index = int(position.get("index", 0))
+    except (TypeError, ValueError) as exc:
+        raise InvalidPageToken("Invalid pagination cursor") from exc
+    if page < 1 or page_index < 0:
+        raise InvalidPageToken("Invalid pagination cursor")
     params: dict[str, Any] = {
         "state": state or "open",
-        "per_page": max_items,
+        "per_page": GITHUB_ITEM_LIMIT,
+        "page": page,
         "sort": "updated",
         "direction": "desc",
     }
@@ -471,10 +507,22 @@ async def async_list_repo_pull_requests(
             params=params,
         )
     items = data if isinstance(data, list) else []
+    selected = items[page_index : page_index + max_items]
+    next_position = None
+    if page_index + max_items < len(items):
+        next_position = {"page": page, "index": page_index + max_items}
+    elif len(items) == GITHUB_ITEM_LIMIT:
+        next_position = {"page": page + 1, "index": 0}
     return {
         "repo": slug,
         "state": params["state"],
-        "pull_requests": [_pull_request_payload(item) for item in items[:max_items] if isinstance(item, dict)],
+        "pull_requests": [_pull_request_payload(item) for item in selected if isinstance(item, dict)],
+        "truncated": next_position is not None,
+        "next_page": encode_page_token(page_kind, next_position) if next_position else None,
+        "evidence_health": {
+            "status": "ok",
+            "completeness": "more_available" if next_position else "complete",
+        },
     }
 
 

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -50,6 +50,10 @@ def cycle_result_contract() -> dict[str, Any]:
             "the_run_cannot_access_required_context_or_output_targets",
             "the_final_response_does_not_state_evidence_health",
         ],
+        "pagination_health": (
+            "truncated_with_next_page_means_more_available_not_degraded; "
+            "follow_next_page_to_completion_and_report_ok_when_no_reader_warnings_or_failures_remain"
+        ),
     }
 
 
@@ -66,9 +70,11 @@ def pending_evidence_health_receipt(scheduled_for: datetime | None) -> dict[str,
             "output_target_available",
         ],
         "repair_instruction": (
-            "If evidence readers are empty, warning, or failing in a way that conflicts with "
-            "the mission, report evidence_health=degraded and name the repair before drawing "
-            "strong conclusions."
+            "Follow next_page tokens until pagination is complete. Routine truncation with a cursor "
+            "is more_available, not degraded; report evidence_health=ok after all pages complete. "
+            "If evidence readers are empty, warning, failing, or cannot be paged to completion in a "
+            "way that conflicts with the mission, report evidence_health=degraded and name the gap "
+            "before drawing strong conclusions."
         ),
     }
 

--- a/brain/systems/cycles/prompts.py
+++ b/brain/systems/cycles/prompts.py
@@ -95,7 +95,7 @@ def cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
         "- Use Cycle memory, revisions, guidance, output targets, and the workspace state as source of truth.\n"
         "- You may create, update, delete, or run Cycles when that is the right workspace action; include rationale.\n"
         "- If an output target is unavailable, repair or replace it when possible instead of treating it as a blocker.\n"
-        "- Report evidence health explicitly. If readers fail, warn, or return unexpectedly sparse data, mark the run degraded in your self-review and name the repair.\n"
+        "- Report evidence health explicitly. Follow next_page tokens to completion; routine pagination is not degradation and fully paginated reads are evidence_health=ok. If readers fail, warn, return unexpectedly sparse data, or cannot page to completion, mark the run degraded in your self-review and name the gap.\n"
         "- End with a short self-review summary suitable for the Cycle ledger and visible outputs.\n\n"
         "## Result Contract\n"
         f"{_json_block(result_contract)}\n\n"

--- a/brain/systems/runs/tool_catalog/definitions/brain.py
+++ b/brain/systems/runs/tool_catalog/definitions/brain.py
@@ -601,8 +601,13 @@ BRAIN_TOOLS = [
                 "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter."},
                 "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL or /threads/{id} route filter."},
                 "domain_id": {"type": "integer", "description": "Optional Domain id filter."},
+                "cycle_id": {"type": "integer", "description": "Optional Cycle id filter."},
                 "object_key": {"type": "string", "description": "Optional Domain object key filter."},
                 "include_archived": {"type": "boolean", "default": False},
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by a previous call.",
+                },
             },
         },
     },
@@ -651,6 +656,10 @@ BRAIN_TOOLS = [
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
                 "idea_id": {"type": "string", "description": "Optional Cortex idea/thread id filter."},
                 "thread_url": {"type": "string", "description": "Optional canonical Illo Thread URL or /threads/{id} route filter."},
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by a previous call.",
+                },
             },
         },
     },
@@ -718,6 +727,10 @@ BRAIN_TOOLS = [
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
                 "include_archived": {"type": "boolean", "default": False},
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by a previous call.",
+                },
             },
         },
     },
@@ -739,6 +752,21 @@ BRAIN_TOOLS = [
                 "end_at": {"type": "string", "description": "ISO timestamp for custom upper bound."},
                 "limit": {"type": "integer", "description": "Max records per source (default 20)", "default": 20},
                 "include_deleted": {"type": "boolean", "default": False},
+                "cycle_id": {
+                    "type": "integer",
+                    "description": "Optional Cycle id filter; required for last_completed_run.",
+                },
+                "last_completed_run": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Return only this Cycle's latest completed-run timestamp using one bounded query."
+                    ),
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by a previous call.",
+                },
             },
         },
     },

--- a/brain/systems/runs/tool_catalog/definitions/domain_inbound.py
+++ b/brain/systems/runs/tool_catalog/definitions/domain_inbound.py
@@ -110,6 +110,10 @@ DOMAIN_TOOLS = [
                     ),
                 },
                 "limit": {"type": "integer", "default": 50, "description": "Maximum records/events to return."},
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by query_records or events.",
+                },
                 "include_archived": {"type": "boolean", "default": False},
                 "record_id": {"type": "integer", "description": "Record id for get/update/remove/events."},
                 "data": {"type": "object", "description": "Record data for create_record."},

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -73,6 +73,10 @@ GITHUB_TOOLS = [
                     "description": "Head commit SHA required by pull_request_checks.",
                 },
                 "limit": {"type": "integer", "default": 30, "description": "Maximum items to return, 1-100."},
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_page token returned by an issue or pull-request listing.",
+                },
                 "token_secret_key": {
                     "type": "string",
                     "description": "Optional Vault secret key containing a GitHub token for private repos.",

--- a/brain/systems/runs/tool_catalog/handlers/domains.py
+++ b/brain/systems/runs/tool_catalog/handlers/domains.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from brain.kernel.common.pagination import next_offset_token, page_offset
 from brain.systems.runs.tool_catalog.handlers.common import *
 
 
@@ -43,6 +44,7 @@ async def _handle_manage_domain(
     source_record_id: int | None = None,
     target_record_id: int | None = None,
     properties: dict | None = None,
+    cursor: str | None = None,
 ) -> str:
     action = str(action or "").strip().lower()
     if action == "help":
@@ -141,6 +143,9 @@ async def _handle_manage_domain(
                 return json.dumps({"relation_type": await service.serialize_relation_type(added)}, default=str)
 
             if action == "query_records":
+                page_limit = max(1, min(int(limit or 50), 500))
+                page_kind = f"manage_domain:records:{domain.id}"
+                offset = page_offset(cursor, kind=page_kind)
                 record_format = str(format or "full").strip().lower()
                 if record_format not in {"full", "compact"}:
                     raise DomainError("format must be 'full' or 'compact'")
@@ -156,8 +161,9 @@ async def _handle_manage_domain(
                     object_key=object_key,
                     search=search,
                     include_archived=include_archived,
-                    limit=limit,
+                    limit=page_limit,
                     order=record_order,
+                    offset=offset,
                 )
                 if record_format == "compact":
                     records = [
@@ -173,6 +179,7 @@ async def _handle_manage_domain(
                     search=search,
                     include_archived=include_archived,
                 )
+                has_more = offset + len(records) < total
                 return json.dumps(
                     {
                         "records": records,
@@ -180,6 +187,20 @@ async def _handle_manage_domain(
                         "total_matching": total,
                         "order": record_order,
                         "format": record_format,
+                        "truncated": has_more,
+                        "next_page": (
+                            next_offset_token(
+                                kind=page_kind,
+                                offset=offset,
+                                returned=len(records),
+                            )
+                            if has_more
+                            else None
+                        ),
+                        "evidence_health": {
+                            "status": "ok",
+                            "completeness": "more_available" if has_more else "complete",
+                        },
                     },
                     default=str,
                 )
@@ -258,16 +279,47 @@ async def _handle_manage_domain(
                 return json.dumps({"relation": await service.serialize_relation(relation)}, default=str)
 
             if action == "events":
+                page_limit = max(1, min(int(limit or 50), 200))
+                page_kind = f"manage_domain:events:{domain.id}"
+                offset = page_offset(cursor, kind=page_kind)
                 events = [
                     service.serialize_event(event)
                     for event in await service.list_events(
                         org_id,
                         domain.id,
                         record_id=record_id,
-                        limit=limit,
+                        limit=page_limit,
+                        offset=offset,
                     )
                 ]
-                return json.dumps({"events": events}, default=str)
+                total = await service.count_events(
+                    org_id,
+                    domain.id,
+                    record_id=record_id,
+                )
+                has_more = offset + len(events) < total
+                return json.dumps(
+                    {
+                        "events": events,
+                        "returned": len(events),
+                        "total_matching": total,
+                        "truncated": has_more,
+                        "next_page": (
+                            next_offset_token(
+                                kind=page_kind,
+                                offset=offset,
+                                returned=len(events),
+                            )
+                            if has_more
+                            else None
+                        ),
+                        "evidence_health": {
+                            "status": "ok",
+                            "completeness": "more_available" if has_more else "complete",
+                        },
+                    },
+                    default=str,
+                )
 
             return json.dumps({"error": f"Unknown action: {action}"})
     except (DomainError, DomainNotFound) as exc:

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import json
 from typing import Any
 
+from brain.kernel.common.pagination import InvalidPageToken
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_create_repo_issue,
@@ -240,6 +241,7 @@ async def _read_with_token(
     token: str | None,
     pull_number: int | None,
     sha: str | None,
+    cursor: str | None,
 ) -> dict[str, Any]:
     if action in {"repo", "get_repo"}:
         repo = await async_get_repo_by_slug(repo_slug, token=token)
@@ -258,6 +260,7 @@ async def _read_with_token(
             since=_clean(since),
             include_pull_requests=bool(include_pull_requests),
             limit=_limit(limit),
+            cursor=cursor,
         )
     if action in {"list_pull_requests", "pull_requests", "prs"}:
         return await async_list_repo_pull_requests(
@@ -267,6 +270,7 @@ async def _read_with_token(
             head=_clean(head),
             base=_clean(base),
             limit=_limit(limit),
+            cursor=cursor,
         )
     if action in {"pull_request", "get_pull_request", "pr"}:
         return await async_get_pull_request(
@@ -309,6 +313,7 @@ async def _handle_read_github_source(
     sha: str | None = None,
     limit: int = 30,
     token_secret_key: str | None = None,
+    cursor: str | None = None,
 ) -> str:
     """Read GitHub repo metadata, issues, pull requests, counts, or CI checks."""
 
@@ -405,7 +410,10 @@ async def _handle_read_github_source(
                 token=candidate["token"],
                 pull_number=clean_pull_number,
                 sha=clean_sha,
+                cursor=_clean(cursor),
             )
+        except InvalidPageToken as exc:
+            return json.dumps({"error": str(exc)})
         except GitHubConnectorError as exc:
             last_error = exc
             if exc.status_code in negative_cache_statuses:

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 
 from sqlalchemy import String, and_, cast, func, or_, select
 
+from brain.kernel.common.pagination import next_offset_token, page_offset
 from brain.systems.cortex.thread_links import thread_id_from_reference, thread_link_payload
 from brain.systems.runs.tool_definitions import WORKSPACE_OVERVIEW_SPARSE_GUIDANCE
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, logger
@@ -29,11 +30,13 @@ class WorkspaceDataQueryContext:
     idea_id: str | None
     run_id: int | None
     domain_id: int | None
+    cycle_id: int | None
     object_key: str | None
     query: str | None
     search: str | None
     include_archived: bool
     limit: int
+    offset: int
 
 
 @dataclass(frozen=True)
@@ -202,6 +205,22 @@ def _optional_text(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _workspace_page_kind(source_names: list[str]) -> str:
+    return f"workspace_data:{','.join(source_names)}"
+
+
+def _page_rows(
+    payload: dict[str, Any],
+    source: str,
+    rows: list[Any],
+    *,
+    limit: int,
+) -> list[Any]:
+    if len(rows) > limit:
+        payload.setdefault("_more_sources", []).append(source)
+    return rows[:limit]
 
 
 def _thread_id_from_first_reference(*values: Any) -> str | None:
@@ -842,6 +861,7 @@ async def _query_domains(
     search: str | None,
     include_archived: bool,
     limit: int,
+    offset: int = 0,
 ) -> None:
     if not org_id:
         payload["warnings"].append({"source": "domains", "error": "org_id required"})
@@ -849,7 +869,13 @@ async def _query_domains(
         return
     from brain.platform.db.models.domain import Domain
 
-    stmt = select(Domain).where(Domain.org_id == org_id).order_by(Domain.updated_at.desc()).limit(limit)
+    stmt = (
+        select(Domain)
+        .where(Domain.org_id == org_id)
+        .order_by(Domain.updated_at.desc(), Domain.id.desc())
+        .offset(offset)
+        .limit(limit + 1)
+    )
     stmt = _apply_date_bounds(stmt, Domain.updated_at, start, end)
     if domain_id is not None:
         stmt = stmt.where(Domain.id == domain_id)
@@ -861,7 +887,12 @@ async def _query_domains(
     if text_match is not None:
         stmt = stmt.where(text_match)
 
-    rows = await _session_scalars_all(session, stmt)
+    rows = _page_rows(
+        payload,
+        "domains",
+        await _session_scalars_all(session, stmt),
+        limit=limit,
+    )
     payload["sources"]["domains"] = [
         {
             "id": int(domain.id),
@@ -893,6 +924,7 @@ async def _query_domain_records(
     search: str | None,
     include_archived: bool,
     limit: int,
+    offset: int = 0,
 ) -> None:
     if not org_id:
         payload["warnings"].append({"source": "domain_records", "error": "org_id required"})
@@ -906,7 +938,8 @@ async def _query_domain_records(
         .join(DomainObjectType, DomainObjectType.id == DomainRecord.object_type_id)
         .where(DomainRecord.org_id == org_id)
         .order_by(DomainRecord.updated_at.desc(), DomainRecord.id.desc())
-        .limit(limit)
+        .offset(offset)
+        .limit(limit + 1)
     )
     stmt = _apply_date_bounds(stmt, DomainRecord.updated_at, start, end)
     if domain_id is not None:
@@ -921,7 +954,12 @@ async def _query_domain_records(
     if text_match is not None:
         stmt = stmt.where(text_match)
 
-    rows = await _session_execute_all(session, stmt)
+    rows = _page_rows(
+        payload,
+        "domain_records",
+        await _session_execute_all(session, stmt),
+        limit=limit,
+    )
     payload["sources"]["domain_records"] = [
         {
             "id": int(record.id),
@@ -952,6 +990,7 @@ async def _query_domain_events(
     domain_id: int | None,
     search: str | None,
     limit: int,
+    offset: int = 0,
 ) -> None:
     if not org_id:
         payload["warnings"].append({"source": "domain_events", "error": "org_id required"})
@@ -964,7 +1003,8 @@ async def _query_domain_events(
         .join(Domain, Domain.id == DomainEvent.domain_id)
         .where(DomainEvent.org_id == org_id)
         .order_by(DomainEvent.created_at.desc(), DomainEvent.id.desc())
-        .limit(limit)
+        .offset(offset)
+        .limit(limit + 1)
     )
     stmt = _apply_date_bounds(stmt, DomainEvent.created_at, start, end)
     if domain_id is not None:
@@ -975,7 +1015,12 @@ async def _query_domain_events(
     if text_match is not None:
         stmt = stmt.where(text_match)
 
-    rows = await _session_execute_all(session, stmt)
+    rows = _page_rows(
+        payload,
+        "domain_events",
+        await _session_execute_all(session, stmt),
+        limit=limit,
+    )
     payload["sources"]["domain_events"] = [
         {
             "id": int(event.id),
@@ -1121,9 +1166,11 @@ async def _query_cycles(
     org_id: str | None,
     user_id: str | None,
     person_ids: list[str],
+    cycle_id: int | None,
     search: str | None,
     include_archived: bool,
     limit: int,
+    offset: int = 0,
 ) -> None:
     from brain.platform.db.models.cycle import Cycle
     from brain.platform.db.models.idea import Idea
@@ -1133,13 +1180,16 @@ async def _query_cycles(
         select(Cycle, User, Idea)
         .outerjoin(User, User.id == Cycle.user_id)
         .outerjoin(Idea, Idea.id == Cycle.target_idea_id)
-        .order_by(Cycle.updated_at.desc().nullslast(), Cycle.created_at.desc())
-        .limit(limit)
+        .order_by(Cycle.updated_at.desc().nullslast(), Cycle.created_at.desc(), Cycle.id.desc())
+        .offset(offset)
+        .limit(limit + 1)
     )
     stmt = _scope_cycle(stmt, Cycle, User, org_id=org_id, user_id=user_id)
     stmt = _apply_date_bounds(stmt, Cycle.updated_at, start, end)
     if person_ids:
         stmt = stmt.where(Cycle.user_id.in_(person_ids))
+    if cycle_id is not None:
+        stmt = stmt.where(Cycle.id == cycle_id)
     if not include_archived:
         stmt = stmt.where(Cycle.deleted_at.is_(None))
     text_match = _text_filter(
@@ -1155,7 +1205,12 @@ async def _query_cycles(
     if text_match is not None:
         stmt = stmt.where(text_match)
 
-    rows = await _session_execute_all(session, stmt)
+    rows = _page_rows(
+        payload,
+        "cycles",
+        await _session_execute_all(session, stmt),
+        limit=limit,
+    )
     payload["sources"]["cycles"] = [
         {
             "id": int(cycle.id),
@@ -1200,9 +1255,11 @@ async def _query_cycle_runs(
     user_id: str | None,
     person_ids: list[str],
     idea_id: str | None,
+    cycle_id: int | None,
     search: str | None,
     include_archived: bool,
     limit: int,
+    offset: int = 0,
 ) -> None:
     from brain.platform.db.models.cycle import Cycle, CycleRun
     from brain.platform.db.models.idea import Idea
@@ -1214,12 +1271,15 @@ async def _query_cycle_runs(
         .outerjoin(User, User.id == Cycle.user_id)
         .outerjoin(Idea, Idea.id == CycleRun.idea_id)
         .order_by(CycleRun.created_at.desc(), CycleRun.id.desc())
-        .limit(limit)
+        .offset(offset)
+        .limit(limit + 1)
     )
     stmt = _scope_cycle(stmt, Cycle, User, org_id=org_id, user_id=user_id)
     stmt = _apply_date_bounds(stmt, CycleRun.created_at, start, end)
     if idea_id:
         stmt = stmt.where(CycleRun.idea_id == idea_id)
+    if cycle_id is not None:
+        stmt = stmt.where(CycleRun.cycle_id == cycle_id)
     if person_ids:
         stmt = stmt.where(Cycle.user_id.in_(person_ids))
     if not include_archived:
@@ -1237,7 +1297,12 @@ async def _query_cycle_runs(
     if text_match is not None:
         stmt = stmt.where(text_match)
 
-    rows = await _session_execute_all(session, stmt)
+    rows = _page_rows(
+        payload,
+        "cycle_runs",
+        await _session_execute_all(session, stmt),
+        limit=limit,
+    )
     payload["sources"]["cycle_runs"] = [
         {
             "id": int(run.id),
@@ -1267,6 +1332,63 @@ async def _query_cycle_runs(
         }
         for run, cycle, user, idea in rows
     ]
+
+
+async def _query_last_completed_cycle_run(
+    *,
+    cycle_id: int,
+    org_id: str | None,
+    user_id: str | None,
+    include_deleted: bool,
+) -> dict[str, Any]:
+    """Read one cycle watermark without scanning the broad run-history surface."""
+    from brain.platform.db.models.cycle import Cycle, CycleRun
+    from brain.platform.db.models.org import User
+    from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+    if not org_id and not user_id:
+        return {
+            "view": "cycle_last_completed_run",
+            "cycle_id": cycle_id,
+            "last_completed_run": None,
+            "error": "read_cycles could not access this workspace or user context",
+            "evidence_health": {"status": "degraded", "completeness": "unavailable"},
+        }
+
+    async with UnitOfWork() as uow:
+        stmt = (
+            select(CycleRun, Cycle)
+            .join(Cycle, Cycle.id == CycleRun.cycle_id)
+            .where(
+                CycleRun.cycle_id == cycle_id,
+                CycleRun.completed_at.is_not(None),
+            )
+            .order_by(CycleRun.completed_at.desc(), CycleRun.id.desc())
+            .limit(1)
+        )
+        stmt = _scope_cycle(stmt, Cycle, User, org_id=org_id, user_id=user_id)
+        if not include_deleted:
+            stmt = stmt.where(Cycle.deleted_at.is_(None))
+        rows = await _session_execute_all(uow.session, stmt)
+
+    if not rows:
+        watermark = None
+    else:
+        run, cycle = rows[0]
+        watermark = {
+            "cycle_id": int(cycle.id),
+            "cycle_name": cycle.name,
+            "cycle_run_id": int(run.id),
+            "completed_at": _serialize_dt(run.completed_at),
+            "status": run.status,
+            "run_id": int(run.run_id) if run.run_id is not None else None,
+        }
+    return {
+        "view": "cycle_last_completed_run",
+        "cycle_id": cycle_id,
+        "last_completed_run": watermark,
+        "evidence_health": {"status": "ok", "completeness": "complete"},
+    }
 
 
 def _activity_timestamp(record: Mapping[str, Any]) -> str | None:
@@ -1516,6 +1638,7 @@ async def _run_domains(session: Any, payload: dict[str, Any], ctx: WorkspaceData
         search=ctx.search,
         include_archived=ctx.include_archived,
         limit=ctx.limit,
+        offset=ctx.offset,
     )
 
 
@@ -1532,6 +1655,7 @@ async def _run_domain_records(session: Any, payload: dict[str, Any], ctx: Worksp
         search=ctx.search,
         include_archived=ctx.include_archived,
         limit=ctx.limit,
+        offset=ctx.offset,
     )
 
 
@@ -1546,6 +1670,7 @@ async def _run_domain_events(session: Any, payload: dict[str, Any], ctx: Workspa
         domain_id=ctx.domain_id,
         search=ctx.search,
         limit=ctx.limit,
+        offset=ctx.offset,
     )
 
 
@@ -1585,9 +1710,11 @@ async def _run_cycles(session: Any, payload: dict[str, Any], ctx: WorkspaceDataQ
         org_id=ctx.org_id,
         user_id=ctx.user_id,
         person_ids=ctx.person_ids,
+        cycle_id=ctx.cycle_id,
         search=ctx.search,
         include_archived=ctx.include_archived,
         limit=ctx.limit,
+        offset=ctx.offset,
     )
 
 
@@ -1601,9 +1728,11 @@ async def _run_cycle_runs(session: Any, payload: dict[str, Any], ctx: WorkspaceD
         user_id=ctx.user_id,
         person_ids=ctx.person_ids,
         idea_id=ctx.idea_id,
+        cycle_id=ctx.cycle_id,
         search=ctx.search,
         include_archived=ctx.include_archived,
         limit=ctx.limit,
+        offset=ctx.offset,
     )
 
 
@@ -1724,8 +1853,10 @@ async def query_workspace_data(
     limit: int = 20,
     idea_id: str | None = None,
     domain_id: int | None = None,
+    cycle_id: int | None = None,
     object_key: str | None = None,
     include_archived: bool = False,
+    cursor: str | None = None,
     user_id: str | None = None,
     org_id: str | None = None,
     run_id: int | None = None,
@@ -1740,6 +1871,8 @@ async def query_workspace_data(
     source_names = _normalize_sources(sources)
     start, end, resolved_window = _time_bounds(time_window, start_at=start_at, end_at=end_at)
     per_source_limit = min(max(int(limit or 20), 1), 100)
+    page_kind = _workspace_page_kind(source_names)
+    offset = page_offset(cursor, kind=page_kind)
     payload: dict[str, Any] = {
         "query": query,
         "search": search,
@@ -1764,6 +1897,7 @@ async def query_workspace_data(
             "person": person,
             "idea_id": idea_id,
             "domain_id": domain_id,
+            "cycle_id": cycle_id,
             "object_key": object_key,
         },
         "people": [],
@@ -1827,11 +1961,13 @@ async def query_workspace_data(
             idea_id=idea_id,
             run_id=run_id,
             domain_id=domain_id,
+            cycle_id=cycle_id,
             object_key=object_key,
             query=query,
             search=search,
             include_archived=include_archived,
             limit=per_source_limit,
+            offset=offset,
         )
 
         for source in source_names:
@@ -1843,12 +1979,30 @@ async def query_workspace_data(
                 payload["sources"][source] = []
                 _add_error(payload, source, exc)
 
+    more_sources = list(dict.fromkeys(payload.pop("_more_sources", [])))
+    has_more = bool(more_sources)
     payload["counts"] = {
         source: len(rows) if isinstance(rows, list) else 0
         for source, rows in payload["sources"].items()
     }
     payload["total_count"] = sum(payload["counts"].values())
     payload["activity_items"] = _build_activity_items(payload, limit=per_source_limit)
+    payload["pagination"] = {
+        "offset": offset,
+        "limit": per_source_limit,
+        "has_more": has_more,
+        "more_sources": more_sources,
+    }
+    payload["truncated"] = has_more
+    payload["next_page"] = (
+        next_offset_token(kind=page_kind, offset=offset, returned=per_source_limit)
+        if has_more
+        else None
+    )
+    payload["evidence_health"] = {
+        "status": "degraded" if payload["warnings"] else "ok",
+        "completeness": "more_available" if has_more else "complete",
+    }
     return payload
 
 
@@ -1857,6 +2011,7 @@ def _workspace_query_scope(
     idea_id: str | None = None,
     thread_url: str | None = None,
     domain_id: int | None = None,
+    cycle_id: int | None = None,
     object_key: str | None = None,
     include_archived: bool = False,
     default_current_idea: bool = False,
@@ -1873,6 +2028,7 @@ def _workspace_query_scope(
     return {
         "idea_id": scoped_idea_id,
         "domain_id": domain_id,
+        "cycle_id": cycle_id,
         "object_key": _optional_text(object_key),
         "include_archived": include_archived,
         "user_id": _optional_text(getattr(_agent_context, "user_id", None) or execution_metadata.get("user_id")),
@@ -1886,6 +2042,7 @@ async def _query_workspace_data_for_agent(**kwargs: Any) -> dict[str, Any]:
         idea_id=kwargs.pop("idea_id", None),
         thread_url=kwargs.pop("thread_url", None),
         domain_id=kwargs.pop("domain_id", None),
+        cycle_id=kwargs.pop("cycle_id", None),
         object_key=kwargs.pop("object_key", None),
         include_archived=bool(kwargs.pop("include_archived", False)),
         default_current_idea=bool(kwargs.pop("_default_current_idea", False)),
@@ -1969,8 +2126,10 @@ async def _handle_query_workspace_data(
     idea_id: str | None = None,
     thread_url: str | None = None,
     domain_id: int | None = None,
+    cycle_id: int | None = None,
     object_key: str | None = None,
     include_archived: bool = False,
+    cursor: str | None = None,
 ) -> str:
     payload = await _query_workspace_data_for_agent(
         sources=sources,
@@ -1984,8 +2143,10 @@ async def _handle_query_workspace_data(
         idea_id=idea_id,
         thread_url=thread_url,
         domain_id=domain_id,
+        cycle_id=cycle_id,
         object_key=object_key,
         include_archived=include_archived,
+        cursor=cursor,
         _default_current_idea=True,
     )
     return json.dumps(payload, default=str)
@@ -2035,6 +2196,7 @@ async def _handle_read_team_activity(
     limit: int = 20,
     idea_id: str | None = None,
     thread_url: str | None = None,
+    cursor: str | None = None,
 ) -> str:
     payload = await _query_workspace_data_for_agent(
         sources=["activity"],
@@ -2047,10 +2209,12 @@ async def _handle_read_team_activity(
         limit=limit,
         idea_id=idea_id,
         thread_url=thread_url,
+        cursor=cursor,
     )
     payload = _workspace_view_payload("team_activity", payload)
     payload["answering_guidance"] = [
         "Base recaps on activity_items first, then use per-source rows for detail.",
+        "When next_page is present, follow it before treating the activity window as complete.",
         "When pointing someone to existing work in a Cortex Thread, include the returned thread_url with the Thread title.",
         "When results are empty, say what was checked instead of guessing from memory.",
     ]
@@ -2123,6 +2287,7 @@ async def _handle_read_workspace_records(
     end_at: str | None = None,
     limit: int = 20,
     include_archived: bool = False,
+    cursor: str | None = None,
 ) -> str:
     payload = await _query_workspace_data_for_agent(
         sources=["records"],
@@ -2135,10 +2300,12 @@ async def _handle_read_workspace_records(
         end_at=end_at,
         limit=limit,
         include_archived=include_archived,
+        cursor=cursor,
     )
     payload = _workspace_view_payload("workspace_records", payload)
     payload["answering_guidance"] = [
         "Domains are user-created structured databases, not the system's raw database tables.",
+        "When next_page is present, follow it before treating records or Domain events as complete.",
         "Use Domain schemas to explain what each record type is for before summarizing records.",
     ]
     return json.dumps(payload, default=str)
@@ -2153,7 +2320,24 @@ async def _handle_read_cycles(
     end_at: str | None = None,
     limit: int = 20,
     include_deleted: bool = False,
+    cycle_id: int | None = None,
+    last_completed_run: bool = False,
+    cursor: str | None = None,
 ) -> str:
+    if last_completed_run:
+        if cycle_id is None or cycle_id < 1:
+            return json.dumps({"error": "last_completed_run requires a positive cycle_id"})
+        scope = _workspace_query_scope(
+            cycle_id=cycle_id,
+            include_archived=include_deleted,
+        )
+        payload = await _query_last_completed_cycle_run(
+            cycle_id=cycle_id,
+            org_id=scope["org_id"],
+            user_id=scope["user_id"],
+            include_deleted=include_deleted,
+        )
+        return json.dumps(payload, default=str)
     payload = await _query_workspace_data_for_agent(
         sources=["cycles"],
         query=query or "workspace cycles",
@@ -2164,10 +2348,13 @@ async def _handle_read_cycles(
         end_at=end_at,
         limit=limit,
         include_archived=include_deleted,
+        cycle_id=cycle_id,
+        cursor=cursor,
     )
     payload = _workspace_view_payload("cycles", payload)
     payload["answering_guidance"] = [
         "Use cycles for recurring configuration and cycle_runs for actual execution history.",
+        "When next_page is present, follow it before treating Cycle run history as complete.",
         "Distinguish enabled/disabled/deleted Cycles when summarizing scheduled work.",
     ]
     return json.dumps(payload, default=str)

--- a/brain/systems/user_domains/service.py
+++ b/brain/systems/user_domains/service.py
@@ -459,6 +459,7 @@ class AsyncDomainService:
         include_archived: bool = False,
         limit: int = 100,
         order: str = "updated_desc",
+        offset: int = 0,
     ) -> Sequence[DomainRecord]:
         if order not in {"updated_desc", "updated_asc"}:
             raise DomainError("order must be 'updated_desc' or 'updated_asc'")
@@ -471,14 +472,19 @@ class AsyncDomainService:
         )
         stmt = select(DomainRecord).where(*where_clauses)
         max_results = max(1, min(int(limit), 500))
+        page_offset = max(0, int(offset or 0))
         if order == "updated_asc":
             stmt = stmt.order_by(DomainRecord.updated_at.asc(), DomainRecord.id.asc())
         else:
             stmt = stmt.order_by(DomainRecord.updated_at.desc(), DomainRecord.id.desc())
-        stmt = stmt.limit(500 if filters else max_results)
+        if filters:
+            stmt = stmt.limit(500)
+        else:
+            stmt = stmt.offset(page_offset).limit(max_results)
         records = (await self.session.scalars(stmt)).all()
         if filters:
-            return [record for record in records if _record_matches_filters(record, filters)][:max_results]
+            matches = [record for record in records if _record_matches_filters(record, filters)]
+            return matches[page_offset : page_offset + max_results]
         return records
 
     async def count_records(
@@ -943,6 +949,7 @@ class AsyncDomainService:
         *,
         record_id: int | None = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> Sequence[DomainEvent]:
         await self.get_domain(org_id, domain_id)
         stmt = select(DomainEvent).where(
@@ -951,8 +958,28 @@ class AsyncDomainService:
         )
         if record_id is not None:
             stmt = stmt.where(DomainEvent.record_id == record_id)
-        stmt = stmt.order_by(DomainEvent.created_at.desc(), DomainEvent.id.desc()).limit(max(1, min(limit, 200)))
+        stmt = (
+            stmt.order_by(DomainEvent.created_at.desc(), DomainEvent.id.desc())
+            .offset(max(0, int(offset or 0)))
+            .limit(max(1, min(limit, 200)))
+        )
         return (await self.session.scalars(stmt)).all()
+
+    async def count_events(
+        self,
+        org_id: str,
+        domain_id: int,
+        *,
+        record_id: int | None = None,
+    ) -> int:
+        await self.get_domain(org_id, domain_id)
+        stmt = select(func.count()).select_from(DomainEvent).where(
+            DomainEvent.org_id == org_id,
+            DomainEvent.domain_id == domain_id,
+        )
+        if record_id is not None:
+            stmt = stmt.where(DomainEvent.record_id == record_id)
+        return int(await self.session.scalar(stmt) or 0)
 
     async def get_object_type(
         self,

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -789,3 +789,43 @@ async def test_count_records_matches_list_scope_without_limit_or_order(session):
     ) == len(all_alpha_tickets) == 2
     assert len(await service.list_records(ORG_ID, domain.id, limit=1)) == 1
     assert await service.count_records(ORG_ID, domain.id) == 3
+
+
+async def test_record_and_event_list_offsets_fetch_following_pages(session):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="Paginated Tracker",
+        objects=[
+            {
+                "key": "ticket",
+                "title_field": "title",
+                "fields": [{"key": "title", "field_type": "text", "required": True}],
+            }
+        ],
+    )
+    created = [
+        await service.create_record(
+            ORG_ID,
+            domain.id,
+            "ticket",
+            data={"title": f"Ticket {index}"},
+        )
+        for index in range(5)
+    ]
+
+    first_records = await service.list_records(ORG_ID, domain.id, limit=2)
+    second_records = await service.list_records(ORG_ID, domain.id, limit=2, offset=2)
+    third_records = await service.list_records(ORG_ID, domain.id, limit=2, offset=4)
+    assert [record.id for record in first_records + second_records + third_records] == [
+        record.id for record in reversed(created)
+    ]
+
+    all_events = await service.list_events(ORG_ID, domain.id, limit=20)
+    paged_events = []
+    for offset in range(0, len(all_events), 2):
+        paged_events.extend(
+            await service.list_events(ORG_ID, domain.id, limit=2, offset=offset)
+        )
+    assert [event.id for event in paged_events] == [event.id for event in all_events]
+    assert await service.count_events(ORG_ID, domain.id) == len(all_events)

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from brain.systems.cortex.project_context.github import GitHubConnectorError, _issue_payload
+from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
+    _issue_payload,
+    async_list_repo_issues,
+    async_list_repo_pull_requests,
+)
 from brain.systems.runs.execution_context import bind_agent_context, snapshot_agent_context
 from brain.systems.runs.tool_catalog.handlers.github import (
     _github_token_candidates,
@@ -64,6 +69,51 @@ async def test_read_github_source_handler_lists_issues_with_canonical_repo_and_b
     assert list_issues.await_args.kwargs["labels"] == ["bug"]
     assert list_issues.await_args.kwargs["assignee"] == "redawear"
     assert list_issues.await_args.kwargs["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_github_issue_and_pull_request_lists_return_working_next_page_tokens():
+    issues = [
+        {"id": number, "number": number, "title": f"Issue {number}", "state": "open"}
+        for number in range(1, 5)
+    ]
+    pulls = [
+        {"id": number, "number": number, "title": f"PR {number}", "state": "open"}
+        for number in range(1, 4)
+    ]
+
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(return_value=issues),
+    ):
+        first_issues = await async_list_repo_issues("acme/widgets", limit=2)
+        second_issues = await async_list_repo_issues(
+            "acme/widgets",
+            limit=2,
+            cursor=first_issues["next_page"],
+        )
+
+    assert [item["number"] for item in first_issues["issues"]] == [1, 2]
+    assert first_issues["truncated"] is True
+    assert [item["number"] for item in second_issues["issues"]] == [3, 4]
+    assert second_issues["truncated"] is False
+    assert second_issues["evidence_health"] == {"status": "ok", "completeness": "complete"}
+
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(return_value=pulls),
+    ):
+        first_pulls = await async_list_repo_pull_requests("acme/widgets", limit=2)
+        second_pulls = await async_list_repo_pull_requests(
+            "acme/widgets",
+            limit=2,
+            cursor=first_pulls["next_page"],
+        )
+
+    assert [item["number"] for item in first_pulls["pull_requests"]] == [1, 2]
+    assert first_pulls["next_page"]
+    assert [item["number"] for item in second_pulls["pull_requests"]] == [3]
+    assert second_pulls["next_page"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_hosted_mcp_domains.py
+++ b/tests/test_hosted_mcp_domains.py
@@ -103,8 +103,9 @@ async def test_hosted_mcp_inspect_domains_reads_schema_and_optional_records():
             include_archived=False,
             limit=100,
             order="updated_desc",
+            offset=0,
         ):
-            assert (org_id, domain_id, object_key, search, filters, include_archived, limit, order) == (
+            assert (org_id, domain_id, object_key, search, filters, include_archived, limit, order, offset) == (
                 "org-1",
                 3,
                 "company",
@@ -113,6 +114,7 @@ async def test_hosted_mcp_inspect_domains_reads_schema_and_optional_records():
                 False,
                 2,
                 "updated_asc",
+                0,
             )
             return [record]
 
@@ -167,9 +169,13 @@ async def test_hosted_mcp_inspect_domains_reads_schema_and_optional_records():
         async def serialize_relation(self, item):
             return {"id": item.id}
 
-        async def list_events(self, org_id, domain_id, *, record_id=None, limit=50):
-            assert (org_id, domain_id, record_id, limit) == ("org-1", 3, None, 2)
+        async def list_events(self, org_id, domain_id, *, record_id=None, limit=50, offset=0):
+            assert (org_id, domain_id, record_id, limit, offset) == ("org-1", 3, None, 2, 0)
             return [event]
+
+        async def count_events(self, org_id, domain_id, *, record_id=None):
+            assert (org_id, domain_id, record_id) == ("org-1", 3, None)
+            return 1
 
         def serialize_event(self, item):
             return {"id": item.id, "event_type": item.event_type}
@@ -211,6 +217,8 @@ async def test_hosted_mcp_inspect_domains_reads_schema_and_optional_records():
 
     assert response.status_code == 200
     payload = json.loads(response.json()["result"]["content"][0]["text"])
+    next_page = payload.pop("next_page")
+    assert next_page
     assert payload == {
         "domain": {"id": 3, "slug": "crm", "objects": [{"key": "company"}]},
         "records": [{"id": 9, "title": "Acme", "data": {"status": "active"}}],
@@ -220,6 +228,9 @@ async def test_hosted_mcp_inspect_domains_reads_schema_and_optional_records():
         "format": "compact",
         "relations": [{"id": 4}],
         "events": [{"id": 7, "event_type": "record.created"}],
+        "event_total_matching": 1,
+        "truncated": True,
+        "evidence_health": {"status": "ok", "completeness": "more_available"},
     }
     assert session.order == []
 

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+import json
 from types import SimpleNamespace
 
 from sqlalchemy import select
@@ -357,3 +358,234 @@ def test_workspace_data_activity_items_sort_newest_signals_first():
     assert items[0]["summary"] == "Let's fix the current thread activity answer."
     assert items[0]["thread_url"] == "https://illo.example.com/threads/idea-2"
     assert items[0]["thread_reference"]["thread_id"] == "idea-2"
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def all(self):
+        return self._rows
+
+
+def _select_page(rows, stmt):
+    offset_clause = getattr(stmt, "_offset_clause", None)
+    limit_clause = getattr(stmt, "_limit_clause", None)
+    offset = int(getattr(offset_clause, "value", 0) or 0)
+    limit = int(getattr(limit_clause, "value", len(rows)) or len(rows))
+    return list(rows)[offset : offset + limit]
+
+
+async def test_read_cycles_pages_to_complete_history_and_watermark_is_one_bounded_query(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    now = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+    cycle = SimpleNamespace(
+        id=7,
+        name="GitHub Reflex",
+        user_id="user-1",
+        org_id="org-1",
+        deleted_at=None,
+    )
+    user = SimpleNamespace(name="Reflex owner")
+    runs = []
+    for run_id in range(5, 0, -1):
+        completed_at = now - timedelta(minutes=5 - run_id)
+        run = SimpleNamespace(
+            id=run_id,
+            cycle_id=cycle.id,
+            revision_id=None,
+            created_at=completed_at,
+            scheduled_for=completed_at,
+            started_at=completed_at,
+            completed_at=completed_at,
+            status="completed",
+            error=None,
+            skip_reason=None,
+            idea_id=None,
+            run_id=100 + run_id,
+            prompt_snapshot="Check GitHub events",
+            guidance_snapshot=[],
+            output_targets_snapshot=[],
+            context_snapshot={},
+            self_review_summary="Healthy evidence",
+        )
+        runs.append((run, cycle, user, None))
+
+    class CycleHistorySession(_FakeSession):
+        def __init__(self):
+            super().__init__()
+            self.statements = []
+
+        def execute(self, stmt):
+            self.statements.append(stmt)
+            return _RowsResult(_select_page(runs, stmt))
+
+    history_session = CycleHistorySession()
+    _patch_uow(monkeypatch, history_session)
+    monkeypatch.setattr(
+        workspace_data,
+        "_SOURCE_ADAPTERS",
+        {
+            "cycle_runs": workspace_data.WorkspaceDataSource(
+                name="cycle_runs",
+                description="Cycle history",
+                groups=("cycles",),
+                handler=workspace_data._run_cycle_runs,
+            )
+        },
+    )
+
+    seen_ids = []
+    cursor = None
+    pages = []
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}):
+        while True:
+            page = json.loads(
+                await workspace_data._handle_read_cycles(
+                    cycle_id=cycle.id,
+                    limit=2,
+                    cursor=cursor,
+                )
+            )
+            pages.append(page)
+            seen_ids.extend(item["id"] for item in page["sources"]["cycle_runs"])
+            cursor = page["next_page"]
+            if cursor is None:
+                break
+
+    assert seen_ids == [5, 4, 3, 2, 1]
+    assert pages[0]["truncated"] is True
+    assert pages[0]["next_page"]
+    assert pages[-1]["truncated"] is False
+    assert pages[-1]["evidence_health"] == {"status": "ok", "completeness": "complete"}
+
+    class WatermarkSession(_FakeSession):
+        def __init__(self):
+            super().__init__()
+            self.statements = []
+
+        def execute(self, stmt):
+            self.statements.append(stmt)
+            return _RowsResult([(runs[0][0], cycle)])
+
+    watermark_session = WatermarkSession()
+    _patch_uow(monkeypatch, watermark_session)
+    with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}):
+        watermark = json.loads(
+            await workspace_data._handle_read_cycles(
+                cycle_id=cycle.id,
+                last_completed_run=True,
+            )
+        )
+
+    assert len(watermark_session.statements) == 1
+    statement = watermark_session.statements[0]
+    assert int(statement._limit_clause.value) == 1
+    assert "cycle_runs.completed_at IS NOT NULL" in str(statement)
+    assert watermark["last_completed_run"]["completed_at"] == runs[0][0].completed_at.isoformat()
+    assert watermark["evidence_health"] == {"status": "ok", "completeness": "complete"}
+    assert "truncated" not in watermark
+
+
+async def test_domain_tracker_and_event_feed_page_to_evidence_health_ok(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    now = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+    domain = SimpleNamespace(id=1, name="Tracker", archived_at=None)
+    object_type = SimpleNamespace(key="ticket", name="Ticket")
+    record_rows = [
+        (
+            SimpleNamespace(
+                id=record_id,
+                domain_id=1,
+                created_at=now - timedelta(minutes=record_id),
+                updated_at=now - timedelta(minutes=record_id),
+                title=f"Ticket {record_id}",
+                data={"status": "open"},
+                version=1,
+            ),
+            domain,
+            object_type,
+        )
+        for record_id in range(5, 0, -1)
+    ]
+    event_domain = SimpleNamespace(id=38, name="Event feed")
+    event_rows = [
+        (
+            SimpleNamespace(
+                id=event_id,
+                created_at=now - timedelta(minutes=event_id),
+                event_type="github.issue.updated",
+                domain_id=38,
+                record_id=None,
+                relation_id=None,
+                actor_kind="agent",
+                actor_id="reflex",
+                run_id=200 + event_id,
+                idea_id=None,
+                reason="Observed GitHub update",
+            ),
+            event_domain,
+        )
+        for event_id in range(5, 0, -1)
+    ]
+
+    class DomainPagingSession(_FakeSession):
+        def __init__(self, rows):
+            super().__init__()
+            self.rows = rows
+
+        def execute(self, stmt):
+            return _RowsResult(_select_page(self.rows, stmt))
+
+    async def read_all(source, handler, rows, domain_id):
+        _patch_uow(monkeypatch, DomainPagingSession(rows))
+        monkeypatch.setattr(
+            workspace_data,
+            "_SOURCE_ADAPTERS",
+            {
+                source: workspace_data.WorkspaceDataSource(
+                    name=source,
+                    description=source,
+                    groups=("records",),
+                    handler=handler,
+                )
+            },
+        )
+        seen = []
+        cursor = None
+        final_page = None
+        with bind_agent_context({"user_id": "user-1", "org_id": "org-1"}):
+            while True:
+                final_page = json.loads(
+                    await workspace_data._handle_read_workspace_records(
+                        domain_id=domain_id,
+                        limit=2,
+                        cursor=cursor,
+                    )
+                )
+                seen.extend(item["id"] for item in final_page["sources"][source])
+                cursor = final_page["next_page"]
+                if cursor is None:
+                    return seen, final_page
+
+    record_ids, record_final = await read_all(
+        "domain_records",
+        workspace_data._run_domain_records,
+        record_rows,
+        1,
+    )
+    event_ids, event_final = await read_all(
+        "domain_events",
+        workspace_data._run_domain_events,
+        event_rows,
+        38,
+    )
+
+    assert record_ids == [5, 4, 3, 2, 1]
+    assert event_ids == [5, 4, 3, 2, 1]
+    assert record_final["evidence_health"] == {"status": "ok", "completeness": "complete"}
+    assert event_final["evidence_health"] == {"status": "ok", "completeness": "complete"}


### PR DESCRIPTION
Closes #312.

## Problem
Broad "list everything" reads — cycle-run history, the Domain 1 tracker listing, Domain 38 event feed, and broad GitHub issue/PR listings — truncated on essentially **every** run with no cursor, forcing both scheduled cycles to improvise narrow compensating slices each run. "Evidence health: degraded / OK after compensating reads" became the default state, diluting the degraded signal. Most acute: the **GitHub Reflex** couldn't read its own last-completed-run watermark cleanly (10/10 runs repaired via a narrow lookup).

Distinct from closed #282 (parent's own GitHub reads 404ing) — here reads succeed but truncate.

## Fix
- **Opaque `next_page` cursors** (new `brain/kernel/common/pagination.py`) — base64, versioned, **kind-namespaced** so a token from one reader can't be replayed against another. Wired into cycle-run history, Domain records & events, hosted MCP listings, and GitHub issue/PR listings. Additive: absent cursor ⇒ current default page behavior.
- **Bounded reflex watermark reader** — `read_cycles(cycle_id=…, last_completed_run=true)` resolves the last completed run for a cycle via a single `LIMIT 1` query instead of scanning a truncated broad history.
- **Evidence-health vocabulary** — routine truncation-with-cursor is *more available*, not *degraded*; a read paged to completion reports `ok`. `degraded` is reserved for real reader failure / missing evidence. Result contract + Cycle prompts updated to instruct following `next_page` to completion.

## Review surface
Local checkout — no deploy preview (backend readers / agent-runtime change):
```
cd <worktree> && /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_domains_service.py tests/test_github_source_tool.py \
  tests/test_hosted_mcp_domains.py tests/test_workspace_data_query.py -q
```
**49 passed** (2026-07-14). Codex's broader run: focused suite 125 passed, compatibility suite 207 passed.

## Acceptance checks
- [x] Cycle-run history reader returns a cursor; paging all pages yields the complete history, no truncation marker (multi-page cycle).
- [x] Reflex obtains its last-completed-run timestamp in one bounded call, no "truncated → repaired" note.
- [x] Domain 1 tracker + Domain 38 feed return complete data or a cursor; paginating to completion reports evidence-health `ok`.
- [x] Regression: uncursored default behavior unchanged; existing domain/cycle/github tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Draft — do not merge until Reda reviews.