### PR TITLE
Propagate parent GitHub/Project-Context creds to spawned reader workers (#311)

### DIFF
--- a/brain/systems/cortex/project_context/materializer.py
+++ b/brain/systems/cortex/project_context/materializer.py
@@ -35,7 +35,7 @@ from brain.systems.cortex.project_context.workspace_manifest import (
     ThreadDraftIdentity,
     normalize_project_workspace_manifest,
 )
-from brain.systems.vault import async_get_secret, list_secrets
+from brain.systems.vault import async_get_secret, async_resolve_project_bound_env_tokens, list_secrets
 
 
 _REPO_RESOURCE_KINDS = {
@@ -57,6 +57,7 @@ class ProjectContextMaterializationResult:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     degraded_resources: list[dict[str, str]] = field(default_factory=list)
+    failed_resources: list[dict[str, str]] = field(default_factory=list)
     resources_checked: int = 0
     empty_project: bool = False
 
@@ -85,11 +86,22 @@ class ProjectContextMaterializationResult:
                 "degraded_resources": self.degraded_resources[:10],
             }
         if self.status == "failed":
-            return {"status": "unavailable", "errors": self.errors[:10]}
+            return {
+                "status": "unavailable",
+                "errors": self.errors[:10],
+                "failed_resources": self.failed_resources[:10],
+            }
         return {"status": "ok"}
 
-    def fail(self, message: str) -> "ProjectContextMaterializationResult":
+    def fail(
+        self,
+        message: str,
+        *,
+        resource: dict[str, str] | None = None,
+    ) -> "ProjectContextMaterializationResult":
         self.errors.append(message)
+        if resource:
+            self.failed_resources.append(resource)
         return self
 
     def degrade(
@@ -106,6 +118,7 @@ class ProjectContextMaterializationResult:
         if usable_workspace_count or not self.warnings:
             return
         self.errors.extend(self.warnings)
+        self.failed_resources.extend(self.degraded_resources)
         self.warnings.clear()
         self.degraded_resources.clear()
 
@@ -281,41 +294,81 @@ async def _token_candidates(
     resource: dict[str, Any],
     user_id: str | None,
     org_id: str | None,
-) -> list[tuple[str | None, str | None, str | None]]:
+) -> list[tuple[str | None, str | None, str | None, str]]:
     explicit_key = _vault_key_from_resource(resource)
-    candidates: list[tuple[str | None, str | None, str | None]] = []
+    candidates: list[tuple[str | None, str | None, str | None, str]] = []
     if not user_id:
         if explicit_key:
-            return [(explicit_key, None, "Vault credential requires a run user_id context.")]
-        return [(None, None, None)]
+            return [(explicit_key, None, "Vault credential requires a run user_id context.", "vault")]
+        return [(None, None, None, "public")]
 
-    key_names = []
+    key_names: list[str] = []
     if explicit_key:
         key_names.append(explicit_key)
-    else:
-        key_names.extend(await _github_secret_names(user_id, org_id))
 
-    seen: set[str] = set()
-    for key_name in key_names:
-        if key_name in seen:
-            continue
-        seen.add(key_name)
+    seen_keys: set[str] = set()
+    seen_tokens: set[str] = set()
+
+    async def add_vault_keys() -> None:
+        for key_name in key_names:
+            if key_name in seen_keys:
+                continue
+            seen_keys.add(key_name)
+            try:
+                token = await async_get_secret(
+                    key_name,
+                    actor_user_id=user_id,
+                    org_id=org_id,
+                    accessed_by="github_runtime_tool",
+                )
+            except Exception as exc:
+                candidates.append((key_name, None, _vault_read_error_message(exc), "vault"))
+                continue
+            if token:
+                value = token.strip()
+                if value and value not in seen_tokens:
+                    seen_tokens.add(value)
+                    candidates.append((key_name, value, None, "vault"))
+            else:
+                candidates.append((key_name, None, "Vault secret was not found or is empty.", "vault"))
+
+    await add_vault_keys()
+
+    slug = _github_slug_from_resource(resource)
+    if slug and org_id:
         try:
-            token = await async_get_secret(
-                key_name,
+            bound_env = await async_resolve_project_bound_env_tokens(
                 actor_user_id=user_id,
                 org_id=org_id,
-                accessed_by="github_runtime_tool",
+                project_slug=slug,
             )
-        except Exception as exc:
-            candidates.append((key_name, None, _vault_read_error_message(exc)))
-            continue
-        if token:
-            candidates.append((key_name, token.strip(), None))
-        else:
-            candidates.append((key_name, None, "Vault secret was not found or is empty."))
+        except Exception:
+            bound_env = {}
+        if not isinstance(bound_env, dict):
+            bound_env = {}
+        preferred_names = ("GITHUB_TOKEN", "GH_TOKEN")
+        ordered_names = [
+            *[name for name in preferred_names if name in bound_env],
+            *sorted(
+                name
+                for name in bound_env
+                if name not in preferred_names
+                and not ("__" in name.upper() and name.upper().endswith("_LEGACY"))
+            ),
+        ]
+        for env_name in ordered_names:
+            token = _clean_text(bound_env.get(env_name))
+            if not token or token in seen_tokens:
+                continue
+            seen_tokens.add(token)
+            candidates.append((None, token, None, "project_binding"))
+
     if not explicit_key:
-        candidates.append((None, None, None))
+        key_names.extend(await _github_secret_names(user_id, org_id))
+        await add_vault_keys()
+
+    if not explicit_key:
+        candidates.append((None, None, None, "public"))
     return candidates
 
 
@@ -788,6 +841,7 @@ async def _materialize_resource(
     for candidate in await _token_candidates(resource, user_id, org_id):
         key_name, token = candidate[:2]
         token_error = candidate[2] if len(candidate) > 2 else None
+        credential = candidate[3] if len(candidate) > 3 else ("vault" if key_name else "public")
         if token_error:
             prefix = f"Vault key {key_name}: " if key_name else "GitHub credential: "
             errors.append(prefix + token_error)
@@ -816,7 +870,7 @@ async def _materialize_resource(
             workspace_path=workspace_path,
             branch=clone.get("branch") or branch,
             commit=clone.get("commit") or None,
-            credential="vault" if key_name else "public",
+            credential=credential,
             subpath=subpath,
         ), None
 
@@ -984,7 +1038,7 @@ async def materialize_project_context_workspaces(
             if _resource_failure_is_soft(resource):
                 result.degrade(error, resource=_degraded_resource_payload(resource, error))
             else:
-                result.fail(error)
+                result.fail(error, resource=_degraded_resource_payload(resource, error))
 
     result.fail_if_no_usable_workspace(usable_workspace_count)
 
@@ -1013,6 +1067,7 @@ async def materialize_project_context_workspaces(
         "errors": result.errors[:10],
         "warnings": result.warnings[:10],
         "degraded_resources": result.degraded_resources[:10],
+        "failed_resources": result.failed_resources[:10],
         "evidence_health": result.evidence_health,
         "empty_project": result.empty_project,
         "seed_resource_count": len(resources),

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -766,6 +766,158 @@ def _run_has_project_context(run: AgentRunRow | None) -> bool:
     return False
 
 
+def _evidence_health_with_failure(
+    evidence_health: Any,
+    failure: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
+    failures = [dict(item) for item in health.get("failures") or [] if isinstance(item, dict)]
+    identity = (
+        failure.get("worker_run_id"),
+        failure.get("repo"),
+        failure.get("stage"),
+    )
+    added = not any(
+        (item.get("worker_run_id"), item.get("repo"), item.get("stage")) == identity
+        for item in failures
+    )
+    if added:
+        failures.append(dict(failure))
+    health["status"] = "degraded"
+    health["failures"] = failures[:20]
+    health["failure_count"] = len(failures)
+    return health, added
+
+
+def _spawned_worker_materialization_failures(
+    run: AgentRunRow,
+    result: Any,
+) -> list[dict[str, Any]]:
+    raw_metadata = getattr(run, "metadata_", None)
+    metadata = dict(raw_metadata or {}) if isinstance(raw_metadata, dict) else {}
+    parent_run_id = getattr(run, "parent_run_id", None)
+    if parent_run_id is None or not (
+        metadata.get("spawned_by_tool") is True or metadata.get("origin") == "spawn_worker"
+    ):
+        return []
+
+    errors = [
+        str(item)
+        for item in [
+            *(getattr(result, "errors", []) or []),
+            *(getattr(result, "warnings", []) or []),
+        ]
+        if str(item).strip()
+    ]
+    failed_resources = [
+        dict(item)
+        for item in [
+            *(getattr(result, "failed_resources", []) or []),
+            *(getattr(result, "degraded_resources", []) or []),
+        ]
+        if isinstance(item, dict)
+    ]
+    if not failed_resources:
+        raw_target_ref = getattr(run, "target_ref", None)
+        target_ref = raw_target_ref if isinstance(raw_target_ref, dict) else {}
+        snapshot = target_ref.get("project_context_snapshot")
+        resources = snapshot.get("resources") if isinstance(snapshot, dict) else []
+        failed_resources = [dict(item) for item in resources or [] if isinstance(item, dict)][:1]
+    if not failed_resources:
+        failed_resources = [{}]
+
+    failures: list[dict[str, Any]] = []
+    for index, resource in enumerate(failed_resources):
+        repo = (
+            str(resource.get("repo") or resource.get("name") or "unknown").strip()
+            or "unknown"
+        )
+        if index < len(errors):
+            fallback_error = errors[index]
+        elif errors:
+            fallback_error = errors[0]
+        else:
+            fallback_error = "Project Context materialization failed."
+        error = str(resource.get("error") or fallback_error)
+        failures.append(
+            {
+                "kind": "worker_tool_failure",
+                "tool": "spawn_worker",
+                "child_run_id": int(run.id),
+                "worker_run_id": int(run.id),
+                "worker_role": str(metadata.get("worker_role") or "worker"),
+                "repo": repo,
+                "stage": "project_context_materialization",
+                "error": error,
+            }
+        )
+    return failures
+
+
+async def _record_spawned_worker_materialization_failure(
+    session: Any,
+    run: AgentRunRow,
+    result: Any,
+) -> None:
+    failures = _spawned_worker_materialization_failures(run, result)
+    if not failures or run.parent_run_id is None:
+        return
+
+    parent = await session.get(
+        AgentRunRow,
+        int(run.parent_run_id),
+        with_for_update=True,
+    )
+    if parent is None:
+        return
+    parent_metadata = (
+        dict(parent.metadata_ or {}) if isinstance(parent.metadata_, dict) else {}
+    )
+    added_failures: list[dict[str, Any]] = []
+    for failure in failures:
+        health, added = _evidence_health_with_failure(parent_metadata.get("evidence_health"), failure)
+        parent_metadata["evidence_health"] = health
+        if added:
+            added_failures.append(failure)
+    parent.metadata_ = parent_metadata
+
+    cycle_run_id = (
+        parent_metadata.get("cycle_run_id")
+        if parent_metadata.get("source") == "cycle"
+        else None
+    )
+    if cycle_run_id:
+        try:
+            from brain.platform.db.models.cycle import CycleRun
+
+            cycle_run = await session.get(
+                CycleRun,
+                int(cycle_run_id),
+                with_for_update=True,
+            )
+        except (TypeError, ValueError):
+            cycle_run = None
+        if cycle_run is not None:
+            context_snapshot = dict(cycle_run.context_snapshot or {})
+            cycle_health = context_snapshot.get("evidence_health")
+            for failure in failures:
+                cycle_health, _ = _evidence_health_with_failure(cycle_health, failure)
+            context_snapshot["evidence_health"] = cycle_health
+            cycle_run.context_snapshot = context_snapshot
+
+    store = AsyncAgentRunStore(session, auto_commit=True)
+    for failure in added_failures:
+        await store.append_event(
+            run_event(
+                int(parent.id),
+                "run.worker_failed",
+                failure,
+                root_run_id=parent.root_run_id or parent.id,
+                producer="spawn_worker",
+            )
+        )
+
+
 def _project_context_root(run_id: int, *, thread_id: str | None = None) -> str:
     base = brain_config.resolve_workspace_root(default=Path(tempfile.gettempdir()) / "illo-agent-runs").expanduser()
     if thread_id:
@@ -1158,6 +1310,20 @@ async def _async_materialize_project_context(run_id: int) -> tuple[bool, dict[st
         org_id=org_id,
     )
     async with _unit_of_work_factory()() as uow:
+        run = await uow.session.get(AgentRunRow, int(run_id))
+        has_materialization_failures = bool(
+            not result.ok
+            or getattr(result, "failed_resources", None)
+            or getattr(result, "degraded_resources", None)
+        )
+        if run is not None and has_materialization_failures:
+            try:
+                await _record_spawned_worker_materialization_failure(uow.session, run, result)
+            except Exception:
+                logger.exception(
+                    "spawned_worker_materialization_failure_recording_failed",
+                    extra={"run_id": int(run_id)},
+                )
         await _async_record_project_activity(
             uow.session,
             int(run_id),

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -28,6 +28,17 @@ _HEADLESS_BLOCKED_TOOLS = frozenset({
     "post_thread_discussion_reply",
 })
 
+_MATERIALIZED_PROJECT_CONTEXT_KEYS = frozenset({
+    "project_context_materialization",
+    "project_context_permission_scope",
+    "project_context_snapshot",
+    "project_runtime_context",
+    "project_workspace_manifest",
+    "resolved_workspace_root",
+    "workspace_root",
+    "workspaces",
+})
+
 
 def _current_agent_value(name: str) -> Any:
     value = getattr(_agent_context, name, None)
@@ -87,6 +98,21 @@ def _current_mapping(name: str) -> dict[str, Any]:
         if isinstance(value, Mapping):
             return dict(value)
     return {}
+
+
+def _inherited_run_mapping(
+    parent_value: Any,
+    current_value: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge live tool context without discarding durable Project materialization."""
+
+    parent = dict(parent_value or {}) if isinstance(parent_value, Mapping) else {}
+    current = dict(current_value or {}) if isinstance(current_value, Mapping) else {}
+    merged = {**parent, **current}
+    for key in _MATERIALIZED_PROJECT_CONTEXT_KEYS:
+        if key in parent:
+            merged[key] = parent[key]
+    return merged
 
 
 def _string_list(value: Any) -> list[str]:
@@ -270,8 +296,14 @@ async def _handle_spawn_worker(
             step_key=step_key,
             thread_id=_headless_thread_id(parent.id, step_key) if headless else None,
             profile=parent.profile,
-            target_ref=_current_mapping("target_ref") or dict(parent.target_ref or {}),
-            workspace_ref=_current_mapping("workspace_ref") or dict(parent.workspace_ref or {}),
+            target_ref=_inherited_run_mapping(
+                parent.target_ref,
+                _current_mapping("target_ref"),
+            ),
+            workspace_ref=_inherited_run_mapping(
+                parent.workspace_ref,
+                _current_mapping("workspace_ref"),
+            ),
             model_policy=dict(parent.model_policy or {}),
             metadata=worker_metadata,
         )

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -452,7 +452,11 @@ async def _query_runs(
     stmt = _apply_date_bounds(stmt, AgentRun.created_at, start, end)
     if run_id is not None:
         stmt = stmt.where(AgentRun.id != run_id)
-    if idea_id:
+    if idea_id and run_id is not None:
+        stmt = stmt.where(
+            or_(AgentRun.thread_id == idea_id, AgentRun.parent_run_id == run_id)
+        )
+    elif idea_id:
         stmt = stmt.where(AgentRun.thread_id == idea_id)
     if person_ids:
         stmt = stmt.where(AgentRun.user_id.in_(person_ids))

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1336,14 +1336,28 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
     from brain.systems.runs.execution_context import bind_agent_context
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
+    project_context_snapshot = {
+        "status": "validated",
+        "resources": [{"kind": "repo", "repo": "uwear-ai/uwear-backend"}],
+    }
     parent = SimpleNamespace(
         id=42,
         org_id="org-1",
         user_id="user-1",
         root_run_id=42,
         profile=RunProfile.FAST,
-        target_ref={"kind": "cortex_idea"},
-        workspace_ref={"workspace_root": "/tmp/work"},
+        target_ref={
+            "kind": "cortex_idea",
+            "project_context_snapshot": project_context_snapshot,
+        },
+        workspace_ref={
+            "workspace_root": "/tmp/work",
+            "project_context_snapshot": project_context_snapshot,
+            "project_runtime_context": {
+                "schema_version": 1,
+                "project_context_snapshot": project_context_snapshot,
+            },
+        },
         model_policy={"model": "openai/gpt-5.5"},
     )
     child = SimpleNamespace(id=99, root_run_id=42, recipe=RunRecipe.WORKER)
@@ -1383,7 +1397,11 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
     monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
     monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
 
-    with bind_agent_context(run=SimpleNamespace(id=parent.id)):
+    with bind_agent_context(
+        run=SimpleNamespace(id=parent.id),
+        target_ref={"kind": "cortex_idea", "idea_id": "idea-1"},
+        workspace_ref={"allowed_workspaces": ["/tmp/work"]},
+    ):
         payload = json.loads(
             await worker_handlers._handle_spawn_worker(
                 objective="File the reproducible blocker.",
@@ -1404,6 +1422,15 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
     assert "Do not call spawn_worker again" in payload["next_action"]["instruction"]
     assert "headless" in payload["next_action"]["instruction"]
     assert create_kwargs["thread_id"].startswith("headless-worker:42:")
+    assert create_kwargs["target_ref"] == {
+        "kind": "cortex_idea",
+        "idea_id": "idea-1",
+        "project_context_snapshot": project_context_snapshot,
+    }
+    assert create_kwargs["workspace_ref"]["workspace_root"] == "/tmp/work"
+    assert create_kwargs["workspace_ref"]["allowed_workspaces"] == ["/tmp/work"]
+    assert create_kwargs["workspace_ref"]["project_context_snapshot"] == project_context_snapshot
+    assert create_kwargs["workspace_ref"]["project_runtime_context"]["schema_version"] == 1
     assert create_kwargs["metadata"]["headless"] is True
     assert set(create_kwargs["metadata"]["tool_policy"]["disabled_tools"]) >= {
         "manage_cycle",

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 
 def test_project_context_materialization_result_is_ready_when_evidence_is_degraded():
     from brain.systems.cortex.project_context.materializer import ProjectContextMaterializationResult
@@ -558,6 +560,91 @@ async def test_materialize_github_project_context_reports_explicit_vault_failure
     resource = run.target_metadata["project_context_snapshot"]["resources"][1]
     assert resource["materialization"]["error"] == "Vault key GITHUB_EXAMPLE_TOKEN: Vault secret was not found or is empty."
     assert run.target_status == "invalid"
+
+
+async def test_spawned_reader_materializes_with_parent_project_bound_github_credential(tmp_path, monkeypatch):
+    from brain.systems.cortex.project_context import materializer
+    from brain.systems.cortex.project_context.materializer import materialize_project_context_workspaces
+
+    run = SimpleNamespace(
+        id=311,
+        parent_run_id=42,
+        user_id="user-1",
+        org_id="org-1",
+        metadata_={
+            "origin": "spawn_worker",
+            "spawned_by_tool": True,
+            "worker_role": "repo_reader",
+        },
+        target_ref={
+            "project_context_snapshot": {
+                "status": "validated",
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "repo": "uwear-ai/uwear-backend",
+                        "uri": "https://github.com/uwear-ai/uwear-backend",
+                    }
+                ],
+            }
+        },
+        workspace_ref={},
+        target_status="resolved",
+        target_validation_error=None,
+    )
+
+    class FakeSession:
+        async def get(self, _model, _id):
+            return run
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    clone_calls = []
+
+    def fake_clone(slug, destination, *, token, branch):
+        clone_calls.append({"slug": slug, "token": token})
+        destination.mkdir(parents=True)
+        (destination / "README.md").write_text("reader evidence", encoding="utf-8")
+        return {"path": str(destination), "branch": branch or "main", "commit": "reader123"}
+
+    resolve_project_bound = AsyncMock(
+        return_value={"GITHUB_TOKEN__COORDINATOR": "parent-working-token"}
+    )
+    monkeypatch.setattr(materializer, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(materializer, "list_secrets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        materializer,
+        "async_resolve_project_bound_env_tokens",
+        resolve_project_bound,
+        raising=False,
+    )
+    monkeypatch.setattr(materializer, "_clone_github_repo", fake_clone)
+
+    result = await materialize_project_context_workspaces(
+        run.id,
+        workspace_root=str(tmp_path / "headless-worker"),
+        user_id=run.user_id,
+        org_id=run.org_id,
+    )
+
+    assert result.ok
+    assert clone_calls == [{"slug": "uwear-ai/uwear-backend", "token": "parent-working-token"}]
+    resolve_project_bound.assert_awaited_once_with(
+        actor_user_id="user-1",
+        org_id="org-1",
+        project_slug="uwear-ai/uwear-backend",
+    )
+    assert (Path(result.workspaces[1]["path"]) / "README.md").read_text(encoding="utf-8") == "reader evidence"
+    assert "parent-working-token" not in str(run.target_ref)
+    assert "parent-working-token" not in str(run.workspace_ref)
+    assert "parent-working-token" not in str(run.metadata_)
 
 
 async def test_materialize_github_folder_uri_mounts_repo_subpath(tmp_path, monkeypatch):
@@ -1344,3 +1431,121 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
     assert captured["run_id"] == 49
     assert "Project Context unavailable" in captured["error"]
     assert "did not provide a usable workspace" in captured["final_answer"]
+
+
+@pytest.mark.parametrize("materialization_ok", [False, True])
+async def test_spawned_reader_materialization_issue_degrades_parent_cycle_evidence_health(
+    monkeypatch,
+    materialization_ok,
+):
+    from brain.systems.runs.cortex import runner
+
+    child = SimpleNamespace(
+        id=49,
+        parent_run_id=42,
+        root_run_id=42,
+        user_id="user-1",
+        org_id="org-1",
+        thread_id="headless-worker:42:reader",
+        metadata_={
+            "origin": "spawn_worker",
+            "spawned_by_tool": True,
+            "worker_role": "repo_reader",
+        },
+        target_ref={
+            "project_context_snapshot": {
+                "resources": [
+                    {
+                        "kind": "repo",
+                        "repo": "example-org/missing-repo",
+                        "uri": "https://github.com/example-org/missing-repo",
+                    }
+                ]
+            }
+        },
+        workspace_ref={},
+    )
+    parent = SimpleNamespace(
+        id=42,
+        root_run_id=42,
+        metadata_={
+            "source": "cycle",
+            "cycle_run_id": 12,
+            "evidence_health": {"status": "pending"},
+        },
+    )
+    cycle_run = SimpleNamespace(
+        id=12,
+        context_snapshot={"evidence_health": {"status": "pending", "expected_checks": ["github"]}},
+    )
+
+    class FakeSession:
+        async def get(self, _model, object_id, **_kwargs):
+            return {49: child, 42: parent, 12: cycle_run}.get(object_id)
+
+    class FakeUow:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    events = []
+
+    class FakeStore:
+        def __init__(self, _session, **_kwargs):
+            pass
+
+        async def append_event(self, event):
+            events.append(event)
+            return SimpleNamespace(id=len(events), sequence_no=len(events), root_run_id=42)
+
+    error = "Could not materialize GitHub repository example-org/missing-repo: credential denied."
+    resource_failure = {
+        "kind": "repo",
+        "repo": "example-org/missing-repo",
+        "error": error,
+    }
+    result = SimpleNamespace(
+        ok=materialization_ok,
+        workspaces=[{"path": "/tmp/project-root"}] if materialization_ok else [],
+        errors=[] if materialization_ok else [error],
+        warnings=[error] if materialization_ok else [],
+        failed_resources=[] if materialization_ok else [resource_failure],
+        degraded_resources=[resource_failure] if materialization_ok else [],
+    )
+    mark_failed = AsyncMock(return_value=None)
+    monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
+    monkeypatch.setattr(runner, "AsyncAgentRunStore", FakeStore)
+    monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
+    monkeypatch.setattr(runner, "materialize_project_context_workspaces", AsyncMock(return_value=result))
+    monkeypatch.setattr(runner, "_mark_run_failed_after_runner_error_async", mark_failed)
+
+    context_ready, status_payload = await runner._async_materialize_project_context(child.id)
+
+    assert context_ready is materialization_ok
+    assert status_payload is None
+    failure = parent.metadata_["evidence_health"]["failures"][0]
+    assert parent.metadata_["evidence_health"]["status"] == "degraded"
+    assert cycle_run.context_snapshot["evidence_health"]["status"] == "degraded"
+    assert cycle_run.context_snapshot["evidence_health"]["expected_checks"] == ["github"]
+    assert cycle_run.context_snapshot["evidence_health"]["failures"] == [failure]
+    assert failure == {
+        "kind": "worker_tool_failure",
+        "tool": "spawn_worker",
+        "child_run_id": 49,
+        "worker_run_id": 49,
+        "worker_role": "repo_reader",
+        "repo": "example-org/missing-repo",
+        "stage": "project_context_materialization",
+        "error": error,
+    }
+    assert [(event.run_id, event.event_type, event.payload) for event in events] == [
+        (42, "run.worker_failed", failure)
+    ]
+    if materialization_ok:
+        mark_failed.assert_not_awaited()
+    else:
+        mark_failed.assert_awaited_once()

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -309,6 +309,72 @@ async def test_workspace_data_runs_include_latest_final_answer_artifact():
     assert payload["sources"]["runs"][0]["thread_reference"]["title"] == "Current planning"
 
 
+async def test_workspace_data_runs_include_headless_child_summary_for_current_parent():
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    now = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+    child = SimpleNamespace(
+        id=49,
+        parent_run_id=42,
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+        status="completed",
+        thread_id="headless-worker:42:repo-reader",
+        user_id="user-1",
+        metadata_={"origin": "spawn_worker", "worker_role": "repo_reader"},
+        model_policy={},
+        input_message="Read uwear-backend",
+        context_summary="Read GitHub counts and Project Context.",
+    )
+    user = SimpleNamespace(name="Coordinator")
+    captured = {}
+
+    class _Result:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _Session:
+        def __init__(self):
+            self.calls = 0
+
+        def execute(self, stmt):
+            self.calls += 1
+            if self.calls == 1:
+                captured["sql"] = str(stmt.compile(dialect=postgresql.dialect()))
+                return _Result([(child, None, user)])
+            return _Result([(49, '{"repo":"uwear-backend","issues":17,"prs":4,"project_context":"ready"}')])
+
+    payload = {"sources": {}}
+    await workspace_data._query_runs(
+        _Session(),
+        payload,
+        start=None,
+        end=None,
+        org_id="org-1",
+        user_id=None,
+        person_ids=[],
+        idea_id="idea-1",
+        run_id=42,
+        search=None,
+        limit=20,
+    )
+
+    assert "agent_runs.thread_id =" in captured["sql"]
+    assert "agent_runs.parent_run_id =" in captured["sql"]
+    assert " OR " in captured["sql"]
+    assert len(payload["sources"]["runs"]) == 1
+    record = payload["sources"]["runs"][0]
+    assert record["id"] == 49
+    assert record["status"] == "completed"
+    assert record["output"] == (
+        '{"repo":"uwear-backend","issues":17,"prs":4,"project_context":"ready"}'
+    )
+
+
 def test_workspace_data_activity_items_sort_newest_signals_first():
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 


### PR DESCRIPTION
Closes #311.

## Problem
The Uwear Ticket Coordinator is instructed to fan out `spawn_worker` readers per repo. In practice those child readers **consistently failed credential/Project-Context materialization**, their summaries were never readable in time, and on **every** run the parent silently fell back to reading everything serially itself — paying to spawn workers whose output is discarded, while a standing "degraded" flag hid a dead subsystem.

Distinct from closed #281 (a repo *clone* failure hard-aborting the run — here the run doesn't abort) and #282 (parent's own legacy-Vault reads 404ing — here the parent's direct reads succeed).

## Fix
- **Preserve parent bindings into the child** (`workers.py`). Composing a spawned worker now merges the parent's durable Project-Context materialization + runtime bindings (`workspaces`, `project_context_materialization`, permission scope, resolved workspace root, …) instead of dropping them to whatever live tool context happened to be set — so the child inherits the same context the parent reads GitHub + Project Context with.
- **Re-resolve parent project-bound GitHub creds for child materialization** (`materializer.py`) via `async_resolve_project_bound_env_tokens`, with token-source labels on every candidate.
- **Name the failure loudly** (`runner.py` + `materializer.py`). A child materialization failure is recorded as a discrete per-repo worker/tool failure (repo + error) in parent/cycle evidence health — not a generic "compensating reads" note. New `failed_resources` on the materialization result distinguishes this.
- **Expose completed child summaries** to the parent's runs query without introducing a blocking join/wait (`workspace_data.py`).

## Review surface
Local checkout — no deploy preview (backend agent-runtime change):
```
cd <worktree> && /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_agent_run_runtime.py tests/test_project_context_materializer.py \
  tests/test_workspace_data_query.py -q
```
**145 passed** (2026-07-14). Codex's broader run: 235 passed, 1 skipped.

## Acceptance checks
- [x] A spawned repo reader reads its target repo's GitHub counts + Project Context resources **without** a credential/materialization failure; a non-empty compact summary reaches the parent.
- [x] A spawned reader that *does* fail materialization is named as a discrete worker/tool failure (repo + error) in evidence health, not a generic compensating-reads note.
- [x] Regression: spawn_worker / runs tool-catalog + materializer tests green; non-reader worker composition unchanged.

Note: the propagation plumbing + loud-failure surfacing are implemented in-repo; if a deployment's child runtime still lacks a secret the parent had, item 2 now surfaces exactly which repo/token failed instead of hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Draft — do not merge until Reda reviews.