### PR TITLE
Harden cycle scheduler against silent wedges

### DIFF
--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -15,7 +15,11 @@ from brain.systems.runs.cortex.runner import (
     start_runner,
     stop_runner,
 )
-from brain.systems.cycles import start_cycle_scheduler, stop_cycle_scheduler
+from brain.systems.cycles import (
+    seconds_since_last_cycle_tick,
+    start_cycle_scheduler,
+    stop_cycle_scheduler,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -79,6 +83,16 @@ def _queue_stall_grace_seconds() -> float:
         return 45.0
 
 
+def _cycle_scheduler_stall_grace_seconds() -> float:
+    try:
+        return max(
+            1.0,
+            float(os.getenv("ILLO_CYCLE_SCHEDULER_STALL_GRACE_SECONDS", "300")),
+        )
+    except Exception:
+        return 300.0
+
+
 def _require_embedding_backend_ready() -> None:
     """Block worker startup until the configured GPU embedding worker is ready."""
     import brain.kernel.config as cfg
@@ -120,6 +134,7 @@ def main() -> None:
         check_interval_seconds=_queue_health_check_interval_seconds(),
         stall_grace_seconds=_queue_stall_grace_seconds(),
     )
+    cycle_scheduler_stall_grace_seconds = _cycle_scheduler_stall_grace_seconds()
     try:
         while _running:
             now = time.monotonic()
@@ -149,6 +164,18 @@ def main() -> None:
                             },
                         )
                         raise SystemExit(1)
+
+            if cycle_scheduler_enabled:
+                seconds_since_last_tick = seconds_since_last_cycle_tick()
+                if (
+                    seconds_since_last_tick is not None
+                    and seconds_since_last_tick > cycle_scheduler_stall_grace_seconds
+                ):
+                    logger.error(
+                        "cycle scheduler wedged; exiting for restart",
+                        extra={"seconds_since_last_tick": seconds_since_last_tick},
+                    )
+                    raise SystemExit(1)
             time.sleep(_poll_interval())
     finally:
         stop_runner(drain_timeout_seconds=_shutdown_drain_timeout_seconds())

--- a/brain/systems/cycles/__init__.py
+++ b/brain/systems/cycles/__init__.py
@@ -1,6 +1,11 @@
 """Cycle scheduling package."""
 
-from brain.systems.cycles.scheduler import start_cycle_scheduler, stop_cycle_scheduler
+from brain.systems.cycles.scheduler import (
+    is_cycle_scheduler_running,
+    seconds_since_last_cycle_tick,
+    start_cycle_scheduler,
+    stop_cycle_scheduler,
+)
 from brain.systems.cycles.service import (
     async_run_cycle_now,
     async_schedule_due_cycles_once,
@@ -15,6 +20,8 @@ __all__ = [
     "compute_next_run_at",
     "finalize_cycle_run_from_run",
     "humanize_schedule",
+    "is_cycle_scheduler_running",
+    "seconds_since_last_cycle_tick",
     "start_cycle_scheduler",
     "stop_cycle_scheduler",
 ]

--- a/brain/systems/cycles/scheduler.py
+++ b/brain/systems/cycles/scheduler.py
@@ -5,6 +5,7 @@ import logging
 import os
 import asyncio
 import threading
+import time
 
 from brain.systems.cycles.service import async_schedule_due_cycles_once
 
@@ -14,15 +15,44 @@ _scheduler_running = False
 _scheduler_thread: threading.Thread | None = None
 _scheduler_task: asyncio.Task | None = None
 _poll_interval_sec = int(os.environ.get("CYCLE_SCHEDULER_POLL_SEC", "30"))
+_last_tick_ok: float | None = None
+_scheduler_state_lock = threading.Lock()
+
+
+def _tick_timeout_sec() -> float:
+    try:
+        return max(1.0, float(os.environ.get("CYCLE_SCHEDULER_TICK_TIMEOUT_SEC", "120")))
+    except Exception:
+        return 120.0
+
+
+def is_cycle_scheduler_running() -> bool:
+    with _scheduler_state_lock:
+        return _scheduler_running
+
+
+def seconds_since_last_cycle_tick() -> float | None:
+    with _scheduler_state_lock:
+        if not _scheduler_running or _last_tick_ok is None:
+            return None
+        last_tick_ok = _last_tick_ok
+    return max(0.0, time.monotonic() - last_tick_ok)
 
 
 async def _scheduler_loop() -> None:
-    global _scheduler_running
-    while _scheduler_running:
+    global _last_tick_ok
+    while is_cycle_scheduler_running():
+        timeout_sec = _tick_timeout_sec()
         try:
-            await async_schedule_due_cycles_once()
+            await asyncio.wait_for(async_schedule_due_cycles_once(), timeout=timeout_sec)
+        except asyncio.TimeoutError:
+            logger.error("Cycle scheduler tick timed out after %ss", timeout_sec)
         except Exception:
             logger.exception("Cycle scheduler tick failed")
+        else:
+            with _scheduler_state_lock:
+                if _scheduler_running:
+                    _last_tick_ok = time.monotonic()
         await asyncio.sleep(_poll_interval_sec)
 
 
@@ -31,26 +61,31 @@ def _scheduler_thread_main() -> None:
 
 
 def start_cycle_scheduler() -> None:
-    global _scheduler_running, _scheduler_task, _scheduler_thread
-    if _scheduler_running:
-        return
-    _scheduler_running = True
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        _scheduler_thread = threading.Thread(
-            target=_scheduler_thread_main,
-            daemon=True,
-            name="cycle-scheduler",
-        )
-        _scheduler_thread.start()
-    else:
-        _scheduler_task = loop.create_task(_scheduler_loop(), name="cycle-scheduler")
+    global _last_tick_ok, _scheduler_running, _scheduler_task, _scheduler_thread
+    with _scheduler_state_lock:
+        if _scheduler_running:
+            return
+        _scheduler_running = True
+        _last_tick_ok = time.monotonic()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            _scheduler_thread = threading.Thread(
+                target=_scheduler_thread_main,
+                daemon=True,
+                name="cycle-scheduler",
+            )
+            _scheduler_thread.start()
+        else:
+            _scheduler_task = loop.create_task(_scheduler_loop(), name="cycle-scheduler")
 
 
 def stop_cycle_scheduler() -> None:
-    global _scheduler_running, _scheduler_task
-    _scheduler_running = False
-    if _scheduler_task is not None and not _scheduler_task.done():
-        _scheduler_task.cancel()
-    _scheduler_task = None
+    global _last_tick_ok, _scheduler_running, _scheduler_task
+    with _scheduler_state_lock:
+        _scheduler_running = False
+        _last_tick_ok = None
+        scheduler_task = _scheduler_task
+        _scheduler_task = None
+    if scheduler_task is not None and not scheduler_task.done():
+        scheduler_task.cancel()

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -125,3 +125,36 @@ def test_cycle_scheduler_can_be_explicitly_enabled(monkeypatch):
     monkeypatch.setenv("ILLO_WORKER_ENABLE_CYCLE_SCHEDULER", "1")
 
     assert _cycle_scheduler_enabled() is True
+
+
+def test_cycle_scheduler_stall_grace_defaults_to_five_minutes(monkeypatch):
+    from brain.systems.cortex.worker import _cycle_scheduler_stall_grace_seconds
+
+    monkeypatch.delenv("ILLO_CYCLE_SCHEDULER_STALL_GRACE_SECONDS", raising=False)
+
+    assert _cycle_scheduler_stall_grace_seconds() == 300.0
+
+
+def test_worker_exits_when_cycle_scheduler_heartbeat_is_stale(monkeypatch, caplog):
+    from brain.systems.cortex import worker
+
+    class QueueStallMonitorStub:
+        def should_check(self, *, now):
+            return False
+
+    monkeypatch.setattr(worker, "_running", True)
+    monkeypatch.setattr(worker, "_require_embedding_backend_ready", lambda: None)
+    monkeypatch.setattr(worker, "_cycle_scheduler_enabled", lambda: True)
+    monkeypatch.setattr(worker, "start_cycle_scheduler", lambda: None)
+    monkeypatch.setattr(worker, "start_runner", lambda: None)
+    monkeypatch.setattr(worker, "runner_health_snapshot", lambda: {"runner_running": True})
+    monkeypatch.setattr(worker, "QueueStallMonitor", lambda **_kwargs: QueueStallMonitorStub())
+    monkeypatch.setattr(worker, "seconds_since_last_cycle_tick", lambda: 301.0)
+    monkeypatch.setattr(worker, "stop_runner", lambda **_kwargs: None)
+    monkeypatch.setattr(worker, "stop_cycle_scheduler", lambda: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        worker.main()
+
+    assert exc_info.value.code == 1
+    assert "cycle scheduler wedged; exiting for restart" in caplog.text

--- a/tests/test_cycle_scheduler.py
+++ b/tests/test_cycle_scheduler.py
@@ -1,0 +1,83 @@
+"""Cycle scheduler liveness tests."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from brain.systems.cycles import scheduler
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler_state():
+    scheduler.stop_cycle_scheduler()
+    yield
+    scheduler.stop_cycle_scheduler()
+
+
+async def test_timed_out_tick_is_cancelled_and_loop_continues(monkeypatch, caplog):
+    calls = 0
+    timed_out_tick_cancelled = asyncio.Event()
+
+    async def schedule_due_cycles_once():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                timed_out_tick_cancelled.set()
+                raise
+        with scheduler._scheduler_state_lock:
+            scheduler._scheduler_running = False
+
+    monkeypatch.setattr(scheduler, "async_schedule_due_cycles_once", schedule_due_cycles_once)
+    monkeypatch.setattr(scheduler, "_tick_timeout_sec", lambda: 0.01)
+    monkeypatch.setattr(scheduler, "_poll_interval_sec", 0)
+    with scheduler._scheduler_state_lock:
+        scheduler._scheduler_running = True
+        scheduler._last_tick_ok = 10.0
+
+    await asyncio.wait_for(scheduler._scheduler_loop(), timeout=0.2)
+
+    assert calls == 2
+    assert timed_out_tick_cancelled.is_set()
+    assert scheduler._last_tick_ok == 10.0
+    assert "Cycle scheduler tick timed out after 0.01s" in caplog.text
+
+
+async def test_successful_tick_advances_heartbeat(monkeypatch):
+    async def schedule_due_cycles_once():
+        return []
+
+    async def stop_after_tick(_delay):
+        with scheduler._scheduler_state_lock:
+            scheduler._scheduler_running = False
+
+    monkeypatch.setattr(scheduler, "async_schedule_due_cycles_once", schedule_due_cycles_once)
+    monkeypatch.setattr(scheduler.asyncio, "sleep", stop_after_tick)
+    monkeypatch.setattr(scheduler.time, "monotonic", lambda: 42.0)
+    with scheduler._scheduler_state_lock:
+        scheduler._scheduler_running = True
+        scheduler._last_tick_ok = 10.0
+
+    await scheduler._scheduler_loop()
+
+    assert scheduler._last_tick_ok == 42.0
+
+
+async def test_tick_age_is_none_before_start_and_after_stop(monkeypatch):
+    assert scheduler.seconds_since_last_cycle_tick() is None
+
+    monkeypatch.setattr(scheduler.time, "monotonic", lambda: 20.0)
+    with scheduler._scheduler_state_lock:
+        scheduler._scheduler_running = True
+        scheduler._last_tick_ok = 15.0
+
+    assert scheduler.seconds_since_last_cycle_tick() == 5.0
+
+    scheduler.stop_cycle_scheduler()
+
+    assert scheduler.seconds_since_last_cycle_tick() is None


### PR DESCRIPTION
## Problem

The cycle-scheduler thread — the background loop that fires Illo's coordinator digests and GitHub-reflex cycles — has silently wedged in production **twice**:
- a ~66-hour outage (only caught by a human), and
- again on 2026-07-13 after a worker recreate at 19:15 UTC, which is what caused the 8:00 AM ET coordinator digest to never fire the next morning.

**Root cause:** `_scheduler_loop` runs `await async_schedule_due_cycles_once()` with **no timeout**. If that await hangs (never returns, never raises), the loop's only log statement — inside `except` — never fires, so the wedge is completely silent. `next_run_at` freezes and no cycle ever runs again. It also can't self-heal: `start_cycle_scheduler()` early-returns while `_scheduler_running` is `True`, and `stop_cycle_scheduler()` can't interrupt a daemon thread stuck inside the await. Only a full process restart clears it — and a restart/recreate is itself the trigger, so the standard "just restart" fix re-arms the trap.

## Fix

1. **Prevent** (`scheduler.py`): wrap each tick in `asyncio.wait_for(tick, timeout=120s)` (env `CYCLE_SCHEDULER_TICK_TIMEOUT_SEC`). A hung/slow tick now raises, is logged distinctly, and the loop continues — self-recovering. 120s is safely above the tick's real work: verified that `async_schedule_due_cycles_once()` claims ≤10 due cycles, enqueues their `AgentRun`s, and returns — it does **not** inline-await run execution.
2. **Detect + recover** (`worker.py`): a monotonic successful-tick heartbeat, plus a worker-loop backstop that `raise SystemExit(1)` (→ container restart) if the heartbeat goes stale >300s (env `ILLO_CYCLE_SCHEDULER_STALL_GRACE_SECONDS`). This covers the terminal case where `wait_for`'s cancellation can't unstick the thread. Reuses the existing runner-supervisor / queue-stall self-heal idiom already in the worker.
3. **Tests**: timeout recovery (loop continues, heartbeat not advanced), heartbeat advance on success, accessor `None` before start / after stop, stall-grace default, worker exit-on-stale-heartbeat. **19 passing.**

Healthy-path behavior is unchanged (default 30s poll preserved).

Implemented via Codex (gpt-5.6-sol), reviewed by Claude (Opus 4.8).

## Follow-ups (not in this PR)

- `brain/systems/cycles/health.py::async_legacy_cycle_backlog_snapshot` already detects this exact wedge (stale-due cycles) but isn't wired to any alarm — worth surfacing to Slack/monitoring.
- Coordinator runs are separately hitting GitHub 403s on PR-health reads; #311/#315 (parent→reader credential propagation) may address the spawned-worker half once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
