### PR TITLE
Fix get_pull_request 403 by deriving CI status from check-runs

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -591,17 +591,15 @@ async def _async_get_pull_request_checks(
             page_runs = page_data.get("check_runs") if isinstance(page_data, dict) else None
             if isinstance(page_runs, list):
                 check_runs.extend(page_runs)
-    combined = await _async_request(
-        client,
-        "GET",
-        f"/repos/{owner}/{repo}/commits/{sha}/status",
-        token=token,
-    )
+    checks_payload = _check_runs_payload(checks)
+    # Modern CI (GitHub Actions, gitleaks, etc.) surfaces through check runs. The
+    # legacy statuses API needs statuses:read, which illo-bot deliberately omits
+    # to avoid a GitHub App re-approval.
     return {
         "repo": slug,
         "sha": sha,
-        "checks": _check_runs_payload(checks),
-        "combined_status": combined.get("state") if isinstance(combined, dict) else None,
+        "checks": checks_payload,
+        "combined_status": checks_payload["status"],
     }
 
 

--- a/tests/test_github_source_tool.py
+++ b/tests/test_github_source_tool.py
@@ -476,7 +476,6 @@ async def test_pull_request_reader_fetches_details_and_checks_with_same_token():
                         {"name": "lint", "status": "completed", "conclusion": "failure"},
                     ],
                 },
-                {"state": "failure", "statuses": []},
             ]
         ),
     ) as request:
@@ -498,10 +497,8 @@ async def test_pull_request_reader_fetches_details_and_checks_with_same_token():
     assert [call.args[2] for call in request.await_args_list] == [
         "/repos/uwear-ai/uwear-backend/pulls/42",
         "/repos/uwear-ai/uwear-backend/commits/abc123/check-runs",
-        "/repos/uwear-ai/uwear-backend/commits/abc123/status",
     ]
     assert [call.kwargs["token"] for call in request.await_args_list] == [
-        "primary-token",
         "primary-token",
         "primary-token",
     ]
@@ -533,7 +530,6 @@ async def test_get_pull_request_uses_project_bound_token_for_mergeability_and_ci
                         {"name": "lint", "status": "completed", "conclusion": "success"},
                     ],
                 },
-                {"state": "success", "statuses": []},
             ]
         ),
     ) as request:
@@ -577,7 +573,6 @@ async def test_get_pull_request_uses_project_bound_token_for_mergeability_and_ci
     assert [call.args[2] for call in request.await_args_list] == [
         "/repos/uwear-ai/uwear-backend/pulls/859",
         "/repos/uwear-ai/uwear-backend/commits/head859/check-runs",
-        "/repos/uwear-ai/uwear-backend/commits/head859/status",
     ]
     assert all(call.kwargs["token"] == "app-token" for call in request.await_args_list)
 
@@ -585,16 +580,16 @@ async def test_get_pull_request_uses_project_bound_token_for_mergeability_and_ci
 @pytest.mark.asyncio
 async def test_pull_request_checks_action_reads_checks_and_combined_status():
     with patch(
-        "brain.systems.runs.tool_catalog.handlers.github.async_get_pull_request_checks",
+        "brain.systems.cortex.project_context.github._async_request",
         new=AsyncMock(
             return_value={
-                "repo": "uwear-ai/uwear-backend",
-                "sha": "abc123",
-                "checks": {"total": 1, "success": 0, "failure": 0, "pending": 1},
-                "combined_status": "pending",
+                "total_count": 1,
+                "check_runs": [
+                    {"name": "unit", "status": "in_progress", "conclusion": None},
+                ],
             }
         ),
-    ) as get_checks:
+    ) as request:
         result = json.loads(
             await _handle_read_github_source(
                 action="pull_request_checks",
@@ -603,13 +598,13 @@ async def test_pull_request_checks_action_reads_checks_and_combined_status():
             )
         )
 
-    assert result["checks"] == {"total": 1, "success": 0, "failure": 0, "pending": 1}
+    assert result["checks"]["status"] == "pending"
     assert result["combined_status"] == "pending"
-    get_checks.assert_awaited_once_with(
-        "uwear-ai/uwear-backend",
-        "abc123",
-        token=None,
-    )
+    requested_urls = [call.args[2] for call in request.await_args_list]
+    assert requested_urls == [
+        "/repos/uwear-ai/uwear-backend/commits/abc123/check-runs",
+    ]
+    assert "/repos/uwear-ai/uwear-backend/commits/abc123/status" not in requested_urls
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Illo's Uwear coordinator gets GitHub **403 "Resource not accessible by integration"** on every `get_pull_request` / `pull_request_checks` call, degrading its PR-health evidence (and making digests self-suppress on "DEGRADED evidence").

Root cause: `_async_get_pull_request_checks` fetches the legacy combined commit status via `GET /repos/{o}/{r}/commits/{sha}/status`, which requires a **`statuses:read`** GitHub App scope. The illo-bot App installation token is minted without it (scope: `issues:write, contents:read, pull_requests:read, checks:read`), so that call 403s and fails the whole PR read. The sibling `/commits/{sha}/check-runs` call (needs only `checks:read`) succeeds — which is why PR *list/count* reads work but *detail* reads 403.

This is distinct from #311/#315 (spawned-worker credential propagation) and isn't fixed by it — in fact, once workers can read GitHub, they'd hit the same 403.

## Fix

Derive `combined_status` from the check-runs we already fetch instead of calling the `statuses`-gated endpoint. `_check_runs_payload()` already rolls check-runs up into `none/pending/failure/success/unknown` with the right semantics, so we compute it once and reuse it. Modern CI (GitHub Actions — `test`, `gitleaks`, etc.) surfaces through check-runs, not the legacy commit-statuses API, so no real signal is lost, and `combined_status` now matches `checks.status`. **No GitHub App re-approval required.**

`combined_status` is only consumed as informational data (verified: no code switches on its value). Tests updated, plus a regression guard asserting `/commits/{sha}/status` is never requested. **18 tests pass.**

Implemented via Codex (gpt-5.6-sol), reviewed by Claude (Opus 4.8).

## Alternative considered

Adding `statuses:read` to the App mint scope — rejected: it needs a GitHub-side permission grant + installation re-approval *first* (otherwise the mint 422s and breaks all GitHub reads), for a legacy endpoint modern CI doesn't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
