### PR TITLE
[Illo-QA] Post-deploy behavior-verification gate for QA fixes (#318)

### DIFF
--- a/brain/platform/db/alembic/versions/0024_cycle_degradation_state.py
+++ b/brain/platform/db/alembic/versions/0024_cycle_degradation_state.py
@@ -1,0 +1,51 @@
+"""Add durable per-Cycle degradation state.
+
+Revision ID: 0024_cycle_degradation_state
+Revises: 0023_agent_run_parent_step_idempotency
+Create Date: 2026-07-15
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "0024_cycle_degradation_state"
+down_revision = "0023_agent_run_parent_step_idempotency"
+branch_labels = None
+depends_on = None
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _column_exists(column_name: str) -> bool:
+    return column_name in {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns("cycles", schema=_schema())
+    }
+
+
+def upgrade() -> None:
+    if _column_exists("degradation_state"):
+        return
+    json_type = sa.JSON() if op.get_bind().dialect.name == "sqlite" else JSONB()
+    op.add_column(
+        "cycles",
+        sa.Column(
+            "degradation_state",
+            json_type,
+            nullable=False,
+            server_default=sa.text(
+                "'{}'" if op.get_bind().dialect.name == "sqlite" else "'{}'::jsonb"
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    if _column_exists("degradation_state"):
+        op.drop_column("cycles", "degradation_state")

--- a/brain/platform/db/models/cycle.py
+++ b/brain/platform/db/models/cycle.py
@@ -69,6 +69,9 @@ class Cycle(Base, TimestampMixin):
     last_run_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     last_status: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    degradation_state: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )

--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -45,6 +45,12 @@ _EVIDENCE_HEALTH_VALUES = (
     "unavailable",
     "unknown",
 )
+_EVIDENCE_HEALTH_REPORT_RE = re.compile(
+    r"(?:evidence_health|evidence health)\s*(?::|=|is)\s*"
+    r"(?P<value>ok|healthy|degraded|partial|sparse|failed|unavailable|unknown)"
+    r"(?P<detail>[^\n.]{0,240})",
+    re.IGNORECASE,
+)
 
 _NON_PRESERVABLE_OUTPUTS = frozenset(
     {
@@ -118,6 +124,20 @@ def _contains_any(normalized_text: str, terms: tuple[str, ...]) -> bool:
     return any(term in normalized_text for term in terms)
 
 
+def _reported_evidence_health(candidate_answer: str | None) -> dict[str, Any] | None:
+    matches = list(_EVIDENCE_HEALTH_REPORT_RE.finditer(str(candidate_answer or "")))
+    if not matches:
+        return None
+    match = matches[-1]
+    value = str(match.group("value") or "").lower()
+    status = "ok" if value in {"ok", "healthy"} else "degraded"
+    report: dict[str, Any] = {"status": status, "reported_value": value}
+    if status == "degraded":
+        detail = re.sub(r"^[\s:;=—-]+", "", str(match.group("detail") or "")).strip()
+        report["cause"] = detail or "Evidence health reported degraded without a named cause."
+    return report
+
+
 def _mission_required_output_labels(mission: str) -> list[str]:
     normalized = _normalize_text(mission)
     labels = [
@@ -175,6 +195,26 @@ def _satisfies_required_output(
     return requirement.replace("_", " ") in normalized_candidate
 
 
+def _missing_mandatory_degradation_escalations(
+    result_contract: dict[str, Any],
+    *,
+    normalized_candidate: str,
+) -> list[str]:
+    missing: list[str] = []
+    for raw_escalation in _json_list(
+        result_contract.get("mandatory_degradation_escalations")
+    ):
+        escalation = _json_dict(raw_escalation)
+        key = str(escalation.get("key") or "").strip()
+        summary = _normalize_text(escalation.get("summary"))
+        if not key or not summary:
+            continue
+        if summary in normalized_candidate:
+            continue
+        missing.append(f"mandatory_degradation_escalation:{key}")
+    return missing
+
+
 def evaluate_cycle_result_contract(
     *,
     candidate_answer: str | None,
@@ -208,6 +248,13 @@ def evaluate_cycle_result_contract(
         ):
             missing.append(requirement_name)
 
+    missing.extend(
+        _missing_mandatory_degradation_escalations(
+            result_contract,
+            normalized_candidate=normalized_candidate,
+        )
+    )
+
     for label in _mission_required_output_labels(mission):
         if not _contains_any(normalized_candidate, _MISSION_OUTPUT_ALIASES[label]):
             missing.append(label)
@@ -230,6 +277,7 @@ def evaluate_cycle_result_contract(
             else _candidate_summary(candidate_answer)
         ),
         "provider_error": detected_provider_error,
+        "reported_evidence_health": _reported_evidence_health(candidate_answer),
     }
 
 
@@ -660,6 +708,7 @@ def _base_verdict(
         "side_effects_succeeded": bool(evidence_packet.get("side_effects_succeeded")),
         "domain_side_effects_succeeded": bool(evidence_packet.get("domain_side_effects_succeeded")),
         "provider_error": initial_review.get("provider_error"),
+        "reported_evidence_health": initial_review.get("reported_evidence_health"),
     }
 
 
@@ -802,6 +851,9 @@ async def async_prepare_cycle_run_visible_finalization(
                     "repaired_artifact_id": getattr(repaired_artifact, "id", None),
                     "repaired_summary": repair_review["candidate_summary"],
                     "final_missing_outputs": [],
+                    "reported_evidence_health": repair_review.get(
+                        "reported_evidence_health"
+                    ),
                 }
             )
             _persist_cycle_contract_verdict(cycle_run, verdict)

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from brain.systems.cycles.degradation import mandatory_escalations
+
 SCHEDULED_REVIEW_WINDOW_HOURS = 24
 
 
@@ -34,9 +36,11 @@ def cycle_scheduled_review_window(scheduled_for: datetime | None) -> dict[str, A
     }
 
 
-def cycle_result_contract() -> dict[str, Any]:
+def cycle_result_contract(
+    degradation_tracking: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """The minimum output contract for autonomous cycle runs."""
-    return {
+    contract = {
         "kind": "autonomous_cycle_run_result",
         "required_outputs": [
             "answer_the_cycle_mission",
@@ -55,6 +59,15 @@ def cycle_result_contract() -> dict[str, Any]:
             "follow_next_page_to_completion_and_report_ok_when_no_reader_warnings_or_failures_remain"
         ),
     }
+    escalations = mandatory_escalations(degradation_tracking)
+    if escalations:
+        contract["mandatory_degradation_escalations"] = escalations
+        contract["degradation_escalation_instruction"] = (
+            "This is the required digest at or after each escalation's "
+            "next_required_digest_at. The visible digest MUST name every cause exactly; "
+            "off-cadence silence is not allowed to consume the escalation."
+        )
+    return contract
 
 
 def pending_evidence_health_receipt(scheduled_for: datetime | None) -> dict[str, Any]:
@@ -79,13 +92,19 @@ def pending_evidence_health_receipt(scheduled_for: datetime | None) -> dict[str,
     }
 
 
-def cycle_launch_receipt(*, cycle_id: int | None, cycle_run_id: int | None, scheduled_for: datetime | None) -> dict[str, Any]:
+def cycle_launch_receipt(
+    *,
+    cycle_id: int | None,
+    cycle_run_id: int | None,
+    scheduled_for: datetime | None,
+    result_contract: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     return {
         "kind": "cycle_launch_receipt",
         "cycle_id": cycle_id,
         "cycle_run_id": cycle_run_id,
         "scheduled_for": _iso(_aware_utc(scheduled_for)),
         "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),
-        "result_contract": cycle_result_contract(),
+        "result_contract": result_contract or cycle_result_contract(),
         "evidence_health": pending_evidence_health_receipt(scheduled_for),
     }

--- a/brain/systems/cycles/degradation.py
+++ b/brain/systems/cycles/degradation.py
@@ -1,0 +1,273 @@
+"""Cross-run degradation tracking and required-digest escalation."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from hashlib import sha256
+import re
+from typing import Any, Iterable, Mapping
+from zoneinfo import ZoneInfo
+
+
+DEGRADATION_ESCALATION_THRESHOLD = 3
+DEGRADATION_TRACKING_SCHEMA_VERSION = 1
+REQUIRED_DIGEST_HOURS = (8, 13, 18)
+REQUIRED_DIGEST_TIMEZONE = "America/Toronto"
+
+
+def _aware_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    aware = _aware_utc(value)
+    return aware.isoformat() if aware is not None else None
+
+
+def _text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list | tuple) else []
+
+
+def _cause_key(parts: Iterable[Any]) -> str:
+    normalized = "|".join(_text(part).lower() for part in parts if _text(part))
+    return f"degradation:{sha256(normalized.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _failure_cause(value: Mapping[str, Any]) -> dict[str, str]:
+    failure = dict(value)
+    tool = _text(failure.get("tool"))
+    stage = _text(failure.get("stage"))
+    repo = _text(failure.get("repo"))
+    kind = _text(failure.get("kind"))
+    error = _text(
+        failure.get("error")
+        or failure.get("reason")
+        or failure.get("message")
+        or "evidence reader failed"
+    )
+    scope_parts = [part for part in (tool, stage, repo) if part]
+    summary = " / ".join(scope_parts)
+    summary = f"{summary}: {error}" if summary else error
+    return {
+        "key": _cause_key((kind, tool, stage, repo, error)),
+        "summary": summary,
+    }
+
+
+def degradation_causes(
+    *,
+    status: str,
+    error: str | None,
+    evidence_health: Mapping[str, Any] | None,
+    reported_evidence_health: Mapping[str, Any] | None = None,
+) -> list[dict[str, str]]:
+    """Return stable, human-readable causes recorded by one scheduled run."""
+
+    health = _dict(evidence_health)
+    health_degraded = _text(health.get("status")).lower() == "degraded"
+    reported_health = _dict(reported_evidence_health)
+    reported_degraded = _text(reported_health.get("status")).lower() == "degraded"
+    causes: list[dict[str, str]] = []
+    for failure in _list(health.get("failures")):
+        if isinstance(failure, Mapping):
+            causes.append(_failure_cause(failure))
+
+    for field in ("causes", "gaps"):
+        for raw_cause in _list(health.get(field)):
+            if isinstance(raw_cause, Mapping):
+                causes.append(_failure_cause(raw_cause))
+            elif _text(raw_cause):
+                summary = _text(raw_cause)
+                causes.append({"key": _cause_key((field, summary)), "summary": summary})
+
+    status_degraded = _text(status).lower() == "degraded"
+    if not causes and (health_degraded or reported_degraded or status_degraded):
+        summary = (
+            _text(reported_health.get("cause"))
+            or _text(error)
+            or _text(health.get("reason"))
+        )
+        if not summary:
+            summary = "Evidence health degraded without a named cause."
+        causes.append({"key": _cause_key(("run", summary)), "summary": summary})
+
+    deduped: dict[str, dict[str, str]] = {}
+    for cause in causes:
+        deduped.setdefault(cause["key"], cause)
+    return list(deduped.values())
+
+
+def next_required_digest_at(scheduled_for: datetime) -> datetime:
+    """Return the first required 08:00/13:00/18:00 ET digest after a run."""
+
+    scheduled_utc = _aware_utc(scheduled_for)
+    if scheduled_utc is None:
+        raise ValueError("scheduled_for is required")
+    zone = ZoneInfo(REQUIRED_DIGEST_TIMEZONE)
+    local = scheduled_utc.astimezone(zone)
+    for hour in REQUIRED_DIGEST_HOURS:
+        candidate = datetime.combine(local.date(), time(hour=hour), tzinfo=zone)
+        if candidate > local:
+            return candidate.astimezone(timezone.utc)
+    tomorrow = local.date() + timedelta(days=1)
+    return datetime.combine(
+        tomorrow,
+        time(hour=REQUIRED_DIGEST_HOURS[0]),
+        tzinfo=zone,
+    ).astimezone(timezone.utc)
+
+
+def empty_degradation_state() -> dict[str, Any]:
+    return {
+        "schema_version": DEGRADATION_TRACKING_SCHEMA_VERSION,
+        "threshold": DEGRADATION_ESCALATION_THRESHOLD,
+        "digest_cadence": {
+            "timezone": REQUIRED_DIGEST_TIMEZONE,
+            "local_hours": list(REQUIRED_DIGEST_HOURS),
+        },
+        "active_causes": [],
+        "pending_escalations": [],
+    }
+
+
+def _persistent_state(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    state = empty_degradation_state()
+    raw = _dict(value)
+    state["active_causes"] = [
+        dict(item) for item in _list(raw.get("active_causes")) if isinstance(item, Mapping)
+    ]
+    state["pending_escalations"] = [
+        dict(item)
+        for item in _list(raw.get("pending_escalations"))
+        if isinstance(item, Mapping)
+    ]
+    return state
+
+
+def degradation_tracking_for_run(
+    state: Mapping[str, Any] | None,
+    *,
+    scheduled_for: datetime | None,
+) -> dict[str, Any]:
+    """Snapshot durable degradation state and mark escalations due in this run."""
+
+    snapshot = _persistent_state(state)
+    scheduled_utc = _aware_utc(scheduled_for)
+    mandatory: list[dict[str, Any]] = []
+    for escalation in snapshot["pending_escalations"]:
+        target_text = _text(escalation.get("next_required_digest_at"))
+        try:
+            target = datetime.fromisoformat(target_text) if target_text else None
+        except ValueError:
+            target = None
+        if scheduled_utc is not None and target is not None and scheduled_utc >= _aware_utc(target):
+            mandatory.append(dict(escalation))
+    snapshot["mandatory_in_current_digest"] = bool(mandatory)
+    snapshot["mandatory_causes"] = mandatory
+    return snapshot
+
+
+def advance_degradation_state(
+    run_tracking: Mapping[str, Any] | None,
+    *,
+    causes: Iterable[Mapping[str, Any]],
+    scheduled_for: datetime,
+    mandatory_digest_satisfied: bool,
+) -> dict[str, Any]:
+    """Advance counters after a run and retain escalations until a valid digest names them."""
+
+    previous = _persistent_state(run_tracking)
+    previous_active = {
+        _text(item.get("key")): dict(item)
+        for item in previous["active_causes"]
+        if _text(item.get("key"))
+    }
+    pending = {
+        _text(item.get("key")): dict(item)
+        for item in previous["pending_escalations"]
+        if _text(item.get("key"))
+    }
+    run_snapshot = _dict(run_tracking)
+    if mandatory_digest_satisfied and run_snapshot.get("mandatory_in_current_digest"):
+        for item in _list(run_snapshot.get("mandatory_causes")):
+            if isinstance(item, Mapping):
+                pending.pop(_text(item.get("key")), None)
+
+    scheduled_iso = _iso(scheduled_for)
+    active: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_cause in causes:
+        cause = _dict(raw_cause)
+        key = _text(cause.get("key"))
+        summary = _text(cause.get("summary"))
+        if not key or not summary or key in seen:
+            continue
+        seen.add(key)
+        prior = previous_active.get(key, {})
+        count = int(prior.get("consecutive_degraded_runs") or 0) + 1
+        item = {
+            "key": key,
+            "summary": summary,
+            "consecutive_degraded_runs": count,
+            "first_seen_at": prior.get("first_seen_at") or scheduled_iso,
+            "last_seen_at": scheduled_iso,
+        }
+        active.append(item)
+        if count >= DEGRADATION_ESCALATION_THRESHOLD:
+            escalation = pending.get(key)
+            if escalation is None:
+                escalation = {
+                    **item,
+                    "escalated_at": scheduled_iso,
+                    "next_required_digest_at": _iso(next_required_digest_at(scheduled_for)),
+                }
+            else:
+                escalation.update(
+                    {
+                        "summary": summary,
+                        "consecutive_degraded_runs": count,
+                        "last_seen_at": scheduled_iso,
+                    }
+                )
+            pending[key] = escalation
+
+    state = empty_degradation_state()
+    state["active_causes"] = active
+    state["pending_escalations"] = list(pending.values())
+    return state
+
+
+def mandatory_escalations(run_tracking: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    tracking = _dict(run_tracking)
+    if not tracking.get("mandatory_in_current_digest"):
+        return []
+    return [
+        dict(item)
+        for item in _list(tracking.get("mandatory_causes"))
+        if isinstance(item, Mapping)
+    ]
+
+
+__all__ = [
+    "DEGRADATION_ESCALATION_THRESHOLD",
+    "REQUIRED_DIGEST_HOURS",
+    "REQUIRED_DIGEST_TIMEZONE",
+    "advance_degradation_state",
+    "degradation_causes",
+    "degradation_tracking_for_run",
+    "empty_degradation_state",
+    "mandatory_escalations",
+    "next_required_digest_at",
+]

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -28,6 +28,11 @@ from brain.systems.cycles.contracts import (
     cycle_scheduled_review_window,
     pending_evidence_health_receipt,
 )
+from brain.systems.cycles.degradation import (
+    advance_degradation_state,
+    degradation_causes,
+    degradation_tracking_for_run,
+)
 from brain.systems.cycles.serializers import (
     serialize_cycle_guidance,
     serialize_cycle_output_target,
@@ -156,12 +161,17 @@ async def async_prepare_cycle_run_memory_snapshot(session, cycle: Cycle, run: Cy
     revision = await _async_latest_cycle_revision(session, cycle.id)
     guidance_rows = await _async_active_cycle_guidance(session, cycle.id)
     target_rows = await _async_active_cycle_output_targets(session, cycle.id)
+    degradation_tracking = degradation_tracking_for_run(
+        getattr(cycle, "degradation_state", None),
+        scheduled_for=getattr(run, "scheduled_for", None),
+    )
     snapshot = _build_cycle_run_memory_snapshot(
         cycle,
         run=run,
         revision=revision,
         guidance_rows=guidance_rows,
         target_rows=target_rows,
+        degradation_tracking=degradation_tracking,
     )
 
     if snapshot["revision_id"] is not None:
@@ -179,11 +189,17 @@ def _build_cycle_run_memory_snapshot(
     revision: CycleRevision | None,
     guidance_rows: list[CycleGuidance],
     target_rows: list[CycleOutputTarget],
+    degradation_tracking: dict | None = None,
 ) -> dict:
     output_targets = [serialize_cycle_output_target(target) for target in target_rows]
     _ensure_default_output_targets(cycle, output_targets)
     scheduled_for = getattr(run, "scheduled_for", None)
     cycle_run_id = getattr(run, "id", None)
+    degradation_tracking = degradation_tracking or degradation_tracking_for_run(
+        getattr(cycle, "degradation_state", None),
+        scheduled_for=scheduled_for,
+    )
+    result_contract = cycle_result_contract(degradation_tracking)
 
     return {
         "revision_id": revision.id if revision is not None else None,
@@ -197,13 +213,15 @@ def _build_cycle_run_memory_snapshot(
                 "workspace_id": string_or_none(cycle.org_id),
                 "owner_user_id": string_or_none(cycle.user_id),
                 "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),
-                "result_contract": cycle_result_contract(),
+                "result_contract": result_contract,
                 "evidence_health": pending_evidence_health_receipt(scheduled_for),
+                "degradation_tracking": degradation_tracking,
                 "launch_receipts": [
                     cycle_launch_receipt(
                         cycle_id=cycle.id,
                         cycle_run_id=cycle_run_id,
                         scheduled_for=scheduled_for,
+                        result_contract=result_contract,
                     )
                 ],
                 **creator_payload(cycle),
@@ -329,8 +347,33 @@ async def record_cycle_run_evaluation(
         skip_reason=skip_reason,
     )
     score = 1 if status == "completed" else 0 if status in {"failed", "degraded", "auth_blocked"} else None
-    run.self_review_summary = summary
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
+    launch_tracking = json_dict(context_snapshot.get("degradation_tracking"))
+    verdict = json_dict(context_snapshot.get(MISSION_RESULT_CONTRACT_VERDICT_KEY))
+    observed_causes = degradation_causes(
+        status=status,
+        error=error,
+        evidence_health=json_dict(context_snapshot.get("evidence_health")),
+        reported_evidence_health=json_dict(verdict.get("reported_evidence_health")),
+    )
+    degradation_state = advance_degradation_state(
+        launch_tracking,
+        causes=observed_causes,
+        scheduled_for=run.scheduled_for,
+        mandatory_digest_satisfied=(
+            status == "completed"
+            and verdict.get("settlement_status")
+            in {"mission_success", "mission_success_after_repair"}
+        ),
+    )
+    cycle.degradation_state = jsonable(degradation_state)
+    context_snapshot["degradation_tracking"] = {
+        **launch_tracking,
+        "observed_causes": observed_causes,
+        "result_state": degradation_state,
+    }
+    run.context_snapshot = jsonable(context_snapshot)
+    run.self_review_summary = summary
     session.add(
         CycleRunEvaluation(
             cycle_id=cycle.id,
@@ -348,6 +391,7 @@ async def record_cycle_run_evaluation(
                 "scheduled_review_window": context_snapshot.get("scheduled_review_window"),
                 "result_contract": context_snapshot.get("result_contract"),
                 "evidence_health": context_snapshot.get("evidence_health"),
+                "degradation_tracking": context_snapshot.get("degradation_tracking"),
                 "launch_receipts": context_snapshot.get("launch_receipts", []),
                 MISSION_RESULT_CONTRACT_VERDICT_KEY: context_snapshot.get(
                     MISSION_RESULT_CONTRACT_VERDICT_KEY

--- a/brain/systems/cycles/prompts.py
+++ b/brain/systems/cycles/prompts.py
@@ -18,6 +18,11 @@ _MISSION_SEED_MAX_CHARS = 12_000
 
 
 def cycle_launch_envelope(cycle: Cycle, run: CycleRun) -> dict:
+    context_snapshot = json_dict(getattr(run, "context_snapshot", None))
+    degradation_tracking = json_dict(context_snapshot.get("degradation_tracking"))
+    result_contract = context_snapshot.get("result_contract")
+    if not isinstance(result_contract, dict):
+        result_contract = cycle_result_contract(degradation_tracking)
     return {
         "version": CYCLE_LAUNCH_ENVELOPE_VERSION,
         "origin": "scheduled_cycle",
@@ -33,13 +38,16 @@ def cycle_launch_envelope(cycle: Cycle, run: CycleRun) -> dict:
         "thread_visibility": "output_target",
         "cycle_memory_role": "source_of_truth",
         "scheduled_review_window": cycle_scheduled_review_window(run.scheduled_for),
-        "result_contract": cycle_result_contract(),
-        "evidence_health": pending_evidence_health_receipt(run.scheduled_for),
+        "result_contract": result_contract,
+        "evidence_health": context_snapshot.get("evidence_health")
+        or pending_evidence_health_receipt(run.scheduled_for),
+        "degradation_tracking": degradation_tracking,
     }
 
 
 def cycle_run_metadata(cycle: Cycle, run: CycleRun) -> dict:
     envelope = cycle_launch_envelope(cycle, run)
+    result_contract = envelope["result_contract"]
     return {
         "source": "cycle",
         "origin": "cycle",
@@ -53,13 +61,14 @@ def cycle_run_metadata(cycle: Cycle, run: CycleRun) -> dict:
             "kind": "autonomous_cycle_run",
             "active_instruction_source": "cycle.prompt",
             "lifecycle_owner": "cycle_run",
-            "result": cycle_result_contract(),
+            "result": result_contract,
         },
-        "evidence_health": pending_evidence_health_receipt(run.scheduled_for),
+        "evidence_health": envelope["evidence_health"],
         "launch_receipt": cycle_launch_receipt(
             cycle_id=cycle.id,
             cycle_run_id=run.id,
             scheduled_for=run.scheduled_for,
+            result_contract=result_contract,
         ),
         "context_policy": {
             "current_instruction_role": "scheduled_prompt",
@@ -80,6 +89,7 @@ def cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
     envelope = cycle_launch_envelope(cycle, run)
     review_window = envelope["scheduled_review_window"]
     result_contract = envelope["result_contract"]
+    degradation_instruction = _degradation_instruction(envelope["degradation_tracking"])
     return (
         f"[Idea: \"{idea.title}\" | {idea.id}]\n\n"
         "## Scheduled Prompt Launch\n"
@@ -96,6 +106,7 @@ def cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
         "- You may create, update, delete, or run Cycles when that is the right workspace action; include rationale.\n"
         "- If an output target is unavailable, repair or replace it when possible instead of treating it as a blocker.\n"
         "- Report evidence health explicitly. Follow next_page tokens to completion; routine pagination is not degradation and fully paginated reads are evidence_health=ok. If readers fail, warn, return unexpectedly sparse data, or cannot page to completion, mark the run degraded in your self-review and name the gap.\n"
+        f"{degradation_instruction}"
         "- End with a short self-review summary suitable for the Cycle ledger and visible outputs.\n\n"
         "## Result Contract\n"
         f"{_json_block(result_contract)}\n\n"
@@ -114,6 +125,36 @@ def _mission_block(prompt: str) -> str:
         f"{prompt[:_MISSION_SEED_MAX_CHARS]}\n\n"
         f"[Cycle mission truncated for launch: {omitted} chars omitted. The full mission remains "
         "authoritative - read it with manage_cycle before deviating from it.]"
+    )
+
+
+def _degradation_instruction(tracking: dict) -> str:
+    pending = [
+        item
+        for item in tracking.get("pending_escalations", [])
+        if isinstance(item, dict) and item.get("summary")
+    ]
+    if not pending:
+        return ""
+    causes = "; ".join(
+        f"{item.get('key')}: {item.get('summary')}"
+        for item in (
+            tracking.get("mandatory_causes", [])
+            if tracking.get("mandatory_in_current_digest")
+            else pending
+        )
+        if isinstance(item, dict)
+    )
+    if tracking.get("mandatory_in_current_digest"):
+        return (
+            "- MANDATORY DEGRADATION ESCALATION: this run is the next required digest. "
+            f"The visible digest MUST name these causes exactly: {causes}. Do not silently skip "
+            "the digest.\n"
+        )
+    return (
+        "- Pending cross-run degradation escalation: preserve these causes for the next required "
+        f"08:00/13:00/18:00 America/Toronto digest: {causes}. Off-cadence silence must not "
+        "consume them.\n"
     )
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Start here when you want to understand, run, or extend Illo Brain.
 - [Server Setup](server-setup.md) - canonical single-server team deployment runbook.
 - [Deployment](deployment.md) - deployment overview and advanced native notes.
 - [Cycles](cycles.md) - scheduler-owned recurring jobs.
+- [Illo-QA Close Criteria](qa-close-criteria.md) - required post-deploy run
+  evidence before an `[Illo-QA]` issue is completed.
 - [Project Workspaces](project-workspaces.md) - Project root, thread draft, base, conflict, and publish semantics.
 - [Workspace Tool Installer](workspace-tools.md) - opt-in persisted tool bundles for team-specific skill dependencies.
 - [Security Model](security-model.md) - secrets, tool execution, browser sessions, and data boundaries.

--- a/docs/qa-close-criteria.md
+++ b/docs/qa-close-criteria.md
@@ -1,0 +1,49 @@
+# Illo-QA Close Criteria
+
+An `[Illo-QA]` issue is complete only when its fix is deployed and the reported
+runtime symptom is gone. A merge, a green pre-merge test suite, or an issue
+automation transition is not post-deploy verification.
+
+## Completion rule
+
+Do not close an `[Illo-QA]` issue as `COMPLETED` until the issue records both:
+
+- the named post-deploy verifying run ID; and
+- a one-line quote from that run showing the original symptom is gone.
+
+The run must execute against the deployed coordinator image that is meant to
+contain the fix. If the probe cannot reach that runtime, the result is
+`REQUIRES LIVE RUNTIME`, never an inferred pass.
+
+## Symptom-gone rules
+
+- **#311 — child-reader credentials:** at least one `spawn_worker` child reader
+  has a readable summary through `run.get`, with no `GITHUB_TOKEN` or Project
+  Context materialization error.
+- **#306 — pull-request health:** `get_pull_request` or
+  `pull_request_checks` for an open PR returns mergeability and CI state without
+  a 403.
+- **#312 — broad evidence reads:** a broad Tracker/Event read follows pagination
+  to `evidence_health.completeness=complete` without hitting the visible-output
+  limit or replacing pagination with compensating time slices.
+- **#290 — tracker idempotency:** creating a tracker record twice for the same
+  `external_id`, including an assignee-spelling variation, reuses one canonical
+  record and leaves exactly one active row.
+
+## Verification probe
+
+[`scripts/post_deploy_qa_probe.py`](../scripts/post_deploy_qa_probe.py) is the
+machine-checkable source of truth for these assertions. It drives the deployed
+coordinator through Illo's hosted MCP bridge, then verifies the existing
+`spawn_worker`, GitHub, workspace-data, and Domain tool receipts with `run.get`.
+It does not call GitHub or the Domain database through a parallel client.
+
+Use `--self-test` for an offline assertion check and `--dry-run` for the exact
+manual checks. For a deployed run, pass `--target`, `--thread-id`, and the
+symptom-specific runtime identifiers shown by `--help`; the bridge token comes
+from `ILLO_BRIDGE_TOKEN` by default. A previously triggered verification can be
+checked with `--run-id` instead of creating another run.
+
+Record each emitted `PASS — evidence: ...` line on the issue with its AgentRun
+ID. A `FAIL` reopens or keeps open the issue; `REQUIRES LIVE RUNTIME` leaves the
+close gate pending.

--- a/scripts/post_deploy_qa_probe.py
+++ b/scripts/post_deploy_qa_probe.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Verify the runtime symptoms covered by Illo-QA #290/#306/#311/#312.
+
+The live path talks only to Illo's hosted MCP bridge. The coordinator under test
+must exercise its registered spawn_worker, GitHub, workspace-data, and Domain
+tools; this script reads the resulting run ledger and asserts their behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any, Iterable, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MCP_CLIENT_ROOT = REPO_ROOT / "tools" / "illo-personal-agent-mcp"
+if str(MCP_CLIENT_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_CLIENT_ROOT))
+
+from illo_personal_agent_mcp.server import (  # noqa: E402
+    IlloBridgeClient,
+    IlloBridgeConfig,
+    IlloBridgeError,
+)
+
+
+PASS = "PASS"
+FAIL = "FAIL"
+REQUIRES_LIVE_RUNTIME = "REQUIRES LIVE RUNTIME"
+SYMPTOMS = ("311", "306", "312", "290")
+TERMINAL_RUN_STATUSES = {"completed", "failed", "canceled", "degraded", "auth_blocked"}
+
+
+MANUAL_CHECKS = {
+    "311": (
+        "In a coordinator run, call spawn_worker for a child repo reader; use illo_read "
+        "run.get on the returned child_run_id and verify a readable final summary with no "
+        "GITHUB_TOKEN/project-context materialization error."
+    ),
+    "306": (
+        "In a coordinator run, call read_github_source(action='get_pull_request') for one "
+        "open PR and verify pull_request.mergeable/mergeable_state plus checks or "
+        "combined_status are returned without status_code=403."
+    ),
+    "312": (
+        "In a coordinator run, perform one broad query_workspace_data Tracker/Event read; "
+        "follow every next_page cursor and verify the final page reports "
+        "evidence_health.completeness='complete' without a visible-output-limit error or "
+        "compensating time slices."
+    ),
+    "290": (
+        "In a coordinator run, call manage_domain create_record twice for the same tracker "
+        "external_id while varying assignee spelling, then query active records for that "
+        "external_id and verify both creates return the same record id and exactly one active "
+        "row exists."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    symptom: str
+    status: str
+    evidence: str
+
+    def render(self) -> str:
+        return f"#{self.symptom} {self.status} — evidence: {self.evidence}"
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list | tuple) else []
+
+
+def _text(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _decode_json_values(value: Any) -> list[Any]:
+    """Walk one tool event, decoding JSON strings without losing outer evidence."""
+
+    values = [value]
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return values
+        values.extend(_decode_json_values(decoded))
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            values.extend(_decode_json_values(child))
+    elif isinstance(value, list | tuple):
+        for child in value:
+            values.extend(_decode_json_values(child))
+    return values
+
+
+def _run_payload(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    root = bundle.get("root")
+    return _dict(root) if isinstance(root, Mapping) else dict(bundle)
+
+
+def _run_id(run_payload: Mapping[str, Any]) -> int | None:
+    run = _dict(run_payload.get("run"))
+    value = run.get("run_id", run.get("id"))
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _tool_name(event: Mapping[str, Any]) -> str:
+    payload = _dict(event.get("payload"))
+    return _text(payload.get("tool_name") or payload.get("tool")).lower()
+
+
+def _tool_events(run_payload: Mapping[str, Any], tool_names: Iterable[str]) -> list[dict[str, Any]]:
+    expected = {name.lower() for name in tool_names}
+    return [
+        dict(event)
+        for event in _list(run_payload.get("tool_events"))
+        if isinstance(event, Mapping) and _tool_name(event) in expected
+    ]
+
+
+def _event_objects(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    objects: list[dict[str, Any]] = []
+    for event in events:
+        for value in _decode_json_values(_dict(event).get("payload")):
+            if isinstance(value, Mapping):
+                objects.append(dict(value))
+    return objects
+
+
+def _contains_error_blob(value: Any, terms: Iterable[str]) -> bool:
+    blob = json.dumps(value, ensure_ascii=False, default=str).lower()
+    return any(term.lower() in blob for term in terms)
+
+
+def _artifact_summary(run_payload: Mapping[str, Any]) -> str:
+    for artifact in reversed(_list(run_payload.get("artifacts"))):
+        if not isinstance(artifact, Mapping):
+            continue
+        if _text(artifact.get("artifact_type")).lower() != "final_answer":
+            continue
+        text = _text(artifact.get("text"))
+        if text:
+            return text
+    return ""
+
+
+def check_311(bundle: Mapping[str, Any]) -> ProbeResult:
+    root = _run_payload(bundle)
+    events = _tool_events(root, {"spawn_worker"})
+    objects = _event_objects(events)
+    child_id = next(
+        (
+            value.get("child_run_id") or value.get("run_id")
+            for value in objects
+            if value.get("child_run_id") or value.get("run_id")
+        ),
+        None,
+    )
+    if not events or child_id is None:
+        return ProbeResult("311", FAIL, "no spawn_worker event with a child_run_id")
+
+    children = _dict(bundle.get("child_runs"))
+    child = _dict(children.get(str(child_id), children.get(child_id)))
+    if not child:
+        return ProbeResult("311", FAIL, f"child run {child_id} was not available through run.get")
+    summary = _artifact_summary(child)
+    forbidden = (
+        "github_token materialization",
+        "github_token could not be materialized",
+        "project_context_materialization",
+    )
+    if _contains_error_blob(child, forbidden):
+        return ProbeResult("311", FAIL, f"child run {child_id} contains a credential materialization error")
+    status = _text(_dict(child.get("run")).get("status")).lower()
+    if status != "completed" or len(summary) < 20:
+        return ProbeResult(
+            "311",
+            FAIL,
+            f"child run {child_id} status={status or 'unknown'} readable_summary={bool(summary)}",
+        )
+    return ProbeResult("311", PASS, f"child run {child_id} completed; summary={summary[:180]}")
+
+
+def check_306(bundle: Mapping[str, Any]) -> ProbeResult:
+    root = _run_payload(bundle)
+    events = _tool_events(root, {"read_github_source"})
+    objects = _event_objects(events)
+    candidates = [
+        value
+        for value in objects
+        if isinstance(value.get("pull_request"), Mapping)
+        and (isinstance(value.get("checks"), Mapping) or "combined_status" in value)
+    ]
+    if not candidates:
+        denied = next((value for value in objects if value.get("status_code") == 403), None)
+        detail = f"GitHub returned 403: {_text(denied.get('error'))}" if denied else "no PR detail + CI payload"
+        return ProbeResult("306", FAIL, detail)
+    payload = candidates[-1]
+    if payload.get("status_code") == 403 or payload.get("error"):
+        return ProbeResult("306", FAIL, f"PR read failed: {_text(payload.get('error')) or 'HTTP 403'}")
+    pull_request = _dict(payload.get("pull_request"))
+    checks = _dict(payload.get("checks"))
+    if "mergeable" not in pull_request and "mergeable_state" not in pull_request:
+        return ProbeResult("306", FAIL, "PR payload omitted mergeability")
+    ci_status = payload.get("combined_status", checks.get("status"))
+    if ci_status is None:
+        return ProbeResult("306", FAIL, "PR payload omitted CI/combined status")
+    return ProbeResult(
+        "306",
+        PASS,
+        f"PR #{pull_request.get('number', '?')} mergeable={pull_request.get('mergeable')} "
+        f"mergeable_state={pull_request.get('mergeable_state')} CI={ci_status}",
+    )
+
+
+def _is_tracker_event_page(value: Mapping[str, Any]) -> bool:
+    sources = _dict(value.get("sources"))
+    return {"domain_records", "domain_events"}.issubset(sources)
+
+
+def check_312(bundle: Mapping[str, Any]) -> ProbeResult:
+    root = _run_payload(bundle)
+    events = _tool_events(root, {"query_workspace_data"})
+    objects = [value for value in _event_objects(events) if _is_tracker_event_page(value)]
+    if not objects:
+        return ProbeResult("312", FAIL, "no broad Tracker/Event reader page was recorded")
+    if _contains_error_blob(
+        objects,
+        ("visible-output limit", "visible output limit", "output too large", "compensating slice"),
+    ):
+        return ProbeResult("312", FAIL, "reader hit the visible-output limit or needed compensating slices")
+    completed = [
+        value
+        for value in objects
+        if value.get("next_page") in {None, ""}
+        and _dict(value.get("evidence_health")).get("status") == "ok"
+        and _dict(value.get("evidence_health")).get("completeness") == "complete"
+        and not value.get("error")
+    ]
+    if not completed:
+        return ProbeResult("312", FAIL, f"{len(objects)} page(s) recorded but no complete final page")
+    total = sum(
+        int(value.get("total_count") or value.get("returned") or 0)
+        for value in completed[-1:]
+    )
+    return ProbeResult(
+        "312",
+        PASS,
+        f"{len(objects)} Tracker/Event page(s) completed; final completeness=complete count={total}",
+    )
+
+
+def _record_from_object(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    record = value.get("record")
+    return dict(record) if isinstance(record, Mapping) else None
+
+
+def check_290(bundle: Mapping[str, Any]) -> ProbeResult:
+    root = _run_payload(bundle)
+    events = _tool_events(root, {"manage_domain"})
+    objects = _event_objects(events)
+    created = [record for value in objects if (record := _record_from_object(value))]
+    record_ids = [record.get("id") for record in created if record.get("id") is not None]
+    query_pages = [value for value in objects if isinstance(value.get("records"), list)]
+    if len(record_ids) < 2:
+        return ProbeResult("290", FAIL, "fewer than two create_record receipts were recorded")
+    first_data = _dict(created[0].get("data"))
+    second_data = _dict(created[1].get("data"))
+    external_ids = [_text(first_data.get("external_id")), _text(second_data.get("external_id"))]
+    assignees = [_text(first_data.get("assignee")), _text(second_data.get("assignee"))]
+    if not all(external_ids) or external_ids[0].casefold() != external_ids[1].casefold():
+        return ProbeResult("290", FAIL, f"create receipts did not share one external_id: {external_ids}")
+    if not all(assignees) or assignees[0] == assignees[1]:
+        return ProbeResult("290", FAIL, f"create receipts did not exercise spelling variance: {assignees}")
+    if len(set(record_ids[:2])) != 1:
+        return ProbeResult("290", FAIL, f"duplicate creates forked record ids {record_ids[:2]}")
+    if not query_pages:
+        return ProbeResult("290", FAIL, "no active-row query followed the duplicate creates")
+    active_records = [record for record in query_pages[-1]["records"] if isinstance(record, Mapping)]
+    if len(active_records) != 1 or active_records[0].get("id") != record_ids[0]:
+        return ProbeResult(
+            "290",
+            FAIL,
+            f"active-row query returned ids {[record.get('id') for record in active_records]}",
+        )
+    active_external_id = _text(_dict(active_records[0].get("data")).get("external_id"))
+    if active_external_id.casefold() != external_ids[0].casefold():
+        return ProbeResult(
+            "290",
+            FAIL,
+            f"active-row query returned external_id={active_external_id or 'missing'}",
+        )
+    assignee = _dict(active_records[0].get("data")).get("assignee")
+    return ProbeResult(
+        "290",
+        PASS,
+        f"both creates reused record {record_ids[0]}; active rows=1; assignee={assignee}",
+    )
+
+
+CHECKERS = {"311": check_311, "306": check_306, "312": check_312, "290": check_290}
+
+
+def evaluate_probe(symptom: str, bundle: Mapping[str, Any]) -> ProbeResult:
+    result = CHECKERS[symptom](bundle)
+    root_id = _run_id(_run_payload(bundle))
+    evidence = f"run {root_id}; {result.evidence}" if root_id is not None else result.evidence
+    return ProbeResult(result.symptom, result.status, evidence)
+
+
+def _event(tool: str, result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "event_type": "run.tool_completed",
+        "payload": {"tool_name": tool, "result": json.dumps(result)},
+    }
+
+
+def self_test_bundle() -> dict[str, Any]:
+    """Synthetic run.get receipts that exercise every assertion without network access."""
+
+    return {
+        "root": {
+            "run": {"run_id": 900, "status": "completed"},
+            "tool_events": [
+                _event("spawn_worker", {"ok": True, "child_run_id": 901}),
+                _event(
+                    "read_github_source",
+                    {
+                        "pull_request": {
+                            "number": 318,
+                            "mergeable": True,
+                            "mergeable_state": "clean",
+                        },
+                        "checks": {"status": "success", "total": 4},
+                        "combined_status": "success",
+                    },
+                ),
+                _event(
+                    "query_workspace_data",
+                    {
+                        "sources": {"domain_records": [{"id": 1}], "domain_events": [{"id": 2}]},
+                        "total_count": 2,
+                        "next_page": None,
+                        "evidence_health": {"status": "ok", "completeness": "complete"},
+                    },
+                ),
+                _event("manage_domain", {"record": {"id": 77, "data": {"external_id": "PR-318", "assignee": "Reda"}}}),
+                _event("manage_domain", {"record": {"id": 77, "data": {"external_id": "PR-318", "assignee": "reda"}}}),
+                _event(
+                    "manage_domain",
+                    {
+                        "records": [
+                            {"id": 77, "data": {"external_id": "PR-318", "assignee": "reda"}}
+                        ],
+                        "next_page": None,
+                        "evidence_health": {"status": "ok", "completeness": "complete"},
+                    },
+                ),
+            ],
+            "artifacts": [{"artifact_type": "final_answer", "text": "Root probe completed."}],
+        },
+        "child_runs": {
+            "901": {
+                "run": {"run_id": 901, "status": "completed"},
+                "tool_events": [],
+                "artifacts": [
+                    {
+                        "artifact_type": "final_answer",
+                        "text": "Readable child summary from the repository reader.",
+                    }
+                ],
+            }
+        },
+    }
+
+
+def _prompt_for(symptom: str, args: argparse.Namespace) -> str:
+    common = (
+        f"Run the [Illo-QA] #{symptom} post-deploy behavior probe. This is a runtime "
+        "verification, not a code review. Use the named coordinator tools and leave their "
+        "receipts in this AgentRun so run.get can verify them. Do not claim PASS without the "
+        "tool evidence. "
+    )
+    if symptom == "311":
+        return common + (
+            "Call spawn_worker once with a child repo-reader objective for "
+            f"{args.repo}. After it finishes, read the child run and summarize one repository fact."
+        )
+    if symptom == "306":
+        return common + (
+            "Call read_github_source(action='get_pull_request') for "
+            f"repo={args.repo}, pull_number={args.pull_number}. Report mergeability and CI status."
+        )
+    if symptom == "312":
+        return common + (
+            "Call query_workspace_data for a broad Tracker/Event read covering domain_records "
+            "and domain_events. Follow next_page until it is null. Do not replace pagination "
+            "with time slices; report the final evidence_health completeness."
+        )
+    return common + (
+        "Using manage_domain, call create_record twice in the existing tracker with "
+        f"domain_id={args.tracker_domain_id}, object_key={args.tracker_object_key}, "
+        f"external_id={args.external_id!r}. Use assignee={args.assignee_a!r} first and "
+        f"assignee={args.assignee_b!r} second, keeping all other required fields valid and "
+        "identical. Then query active records for that exact external_id and leave the two "
+        "create receipts plus the query receipt in this run."
+    )
+
+
+def _missing_live_arguments(symptom: str, args: argparse.Namespace) -> list[str]:
+    required: dict[str, tuple[str, ...]] = {
+        "311": ("repo",),
+        "306": ("repo", "pull_number"),
+        "312": (),
+        "290": (
+            "tracker_domain_id",
+            "tracker_object_key",
+            "external_id",
+            "assignee_a",
+            "assignee_b",
+        ),
+    }
+    return [name.replace("_", "-") for name in required[symptom] if not getattr(args, name)]
+
+
+def _trigger_run(client: IlloBridgeClient, symptom: str, args: argparse.Namespace) -> int:
+    response = client.act(
+        "thread.post_message",
+        arguments={
+            "thread_id": args.thread_id,
+            "body": _prompt_for(symptom, args),
+            "trigger_illo": True,
+        },
+        reason=f"Illo-QA #{symptom} post-deploy behavior verification",
+        idempotency_key=f"illo-qa-{symptom}-{int(time.time())}",
+        metadata={"source": "post_deploy_qa_probe", "symptom": symptom},
+    )
+    candidates = [response, _dict(response.get("trigger")), _dict(response.get("result"))]
+    for candidate in candidates:
+        value = candidate.get("run_id")
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    raise IlloBridgeError("thread trigger did not return a run_id")
+
+
+def _read_run(client: IlloBridgeClient, run_id: int) -> dict[str, Any]:
+    return client.read(
+        "run.get",
+        arguments={
+            "run_id": run_id,
+            "include_tool_events": True,
+            "include_artifacts": True,
+            "limit": 200,
+        },
+    )
+
+
+def _wait_for_run(
+    client: IlloBridgeClient,
+    run_id: int,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    latest: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        latest = _read_run(client, run_id)
+        status = _text(_dict(latest.get("run")).get("status")).lower()
+        if status in TERMINAL_RUN_STATUSES:
+            return latest
+        time.sleep(poll_seconds)
+    status = _text(_dict(latest.get("run")).get("status")) or "unknown"
+    raise IlloBridgeError(f"run {run_id} did not finish within {timeout_seconds}s (status={status})")
+
+
+def _hydrate_child_runs(
+    client: IlloBridgeClient,
+    bundle: dict[str, Any],
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> None:
+    events = _tool_events(_run_payload(bundle), {"spawn_worker"})
+    child_ids = {
+        int(value.get("child_run_id"))
+        for value in _event_objects(events)
+        if str(value.get("child_run_id") or "").isdigit()
+    }
+    children = bundle.setdefault("child_runs", {})
+    for child_id in child_ids:
+        children[str(child_id)] = _wait_for_run(
+            client,
+            child_id,
+            timeout_seconds=timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+
+
+def _live_bundle(
+    client: IlloBridgeClient,
+    symptom: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    run_id = args.run_id or _trigger_run(client, symptom, args)
+    root = _wait_for_run(
+        client,
+        run_id,
+        timeout_seconds=args.wait_timeout,
+        poll_seconds=args.poll_interval,
+    )
+    bundle: dict[str, Any] = {"root": root, "child_runs": {}}
+    if symptom == "311":
+        _hydrate_child_runs(
+            client,
+            bundle,
+            timeout_seconds=args.wait_timeout,
+            poll_seconds=args.poll_interval,
+        )
+    return bundle
+
+
+def _selected_symptoms(args: argparse.Namespace) -> list[str]:
+    return list(dict.fromkeys(args.symptom or SYMPTOMS))
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symptom", action="append", choices=SYMPTOMS, help="Run one symptom; repeat as needed.")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run all assertions against offline synthetic run receipts.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print exact live checks without network access.")
+    parser.add_argument(
+        "--evidence-file",
+        type=Path,
+        help="Assert an exported run.get bundle instead of using the network.",
+    )
+    parser.add_argument("--target", help="Deployed Illo base URL (or set ILLO_BASE_URL).")
+    parser.add_argument(
+        "--token-env",
+        default="ILLO_BRIDGE_TOKEN",
+        help="Environment variable containing the bridge token.",
+    )
+    parser.add_argument("--thread-id", help="Existing thread to receive the live probe prompt.")
+    parser.add_argument("--run-id", type=int, help="Inspect an existing verifying AgentRun instead of triggering one.")
+    parser.add_argument("--repo", help="GitHub owner/repo used by #311 and #306.")
+    parser.add_argument("--pull-number", type=int, help="Open PR number used by #306.")
+    parser.add_argument("--tracker-domain-id", type=int, help="Existing Tracker Domain id used by #290.")
+    parser.add_argument("--tracker-object-key", help="Tracker object key used by #290.")
+    parser.add_argument("--external-id", help="Disposable or existing external_id used by #290.")
+    parser.add_argument("--assignee-a", help="First assignee spelling used by #290.")
+    parser.add_argument("--assignee-b", help="Second assignee spelling variant used by #290.")
+    parser.add_argument("--wait-timeout", type=float, default=600.0, help="Seconds to wait for each live run.")
+    parser.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between run.get polls.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    symptoms = _selected_symptoms(args)
+    if args.self_test:
+        bundle = self_test_bundle()
+        results = [evaluate_probe(symptom, bundle) for symptom in symptoms]
+    elif args.evidence_file:
+        bundle = json.loads(args.evidence_file.read_text(encoding="utf-8"))
+        results = [evaluate_probe(symptom, _dict(bundle)) for symptom in symptoms]
+    elif args.dry_run or not (args.target or os.environ.get("ILLO_BASE_URL")):
+        results = [
+            ProbeResult(symptom, REQUIRES_LIVE_RUNTIME, MANUAL_CHECKS[symptom])
+            for symptom in symptoms
+        ]
+    else:
+        target = _text(args.target or os.environ.get("ILLO_BASE_URL"))
+        token = _text(os.environ.get(args.token_env))
+        if not token:
+            results = [
+                ProbeResult(
+                    symptom,
+                    REQUIRES_LIVE_RUNTIME,
+                    f"set {args.token_env}; {MANUAL_CHECKS[symptom]}",
+                )
+                for symptom in symptoms
+            ]
+        elif not args.run_id and not args.thread_id:
+            results = [
+                ProbeResult(
+                    symptom,
+                    REQUIRES_LIVE_RUNTIME,
+                    f"pass --thread-id or --run-id; {MANUAL_CHECKS[symptom]}",
+                )
+                for symptom in symptoms
+            ]
+        else:
+            client = IlloBridgeClient(
+                IlloBridgeConfig(target, token, timeout_seconds=max(10.0, args.poll_interval * 2))
+            )
+            results = []
+            for symptom in symptoms:
+                missing = _missing_live_arguments(symptom, args) if not args.run_id else []
+                if missing:
+                    results.append(
+                        ProbeResult(
+                            symptom,
+                            REQUIRES_LIVE_RUNTIME,
+                            f"missing {', '.join('--' + item for item in missing)}; "
+                            f"{MANUAL_CHECKS[symptom]}",
+                        )
+                    )
+                    continue
+                try:
+                    results.append(
+                        evaluate_probe(symptom, _live_bundle(client, symptom, args))
+                    )
+                except (IlloBridgeError, OSError, ValueError) as exc:
+                    results.append(ProbeResult(symptom, FAIL, _text(exc)))
+
+    for result in results:
+        print(result.render())
+    return 1 if any(result.status == FAIL for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cycle_degradation.py
+++ b/tests/test_cycle_degradation.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brain.platform.db.models.cycle import Cycle, CycleRun
+from brain.platform.db.models.idea import Idea
+from brain.systems.cycles import memory as cycle_memory
+from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
+from brain.systems.cycles.contracts import cycle_result_contract
+from brain.systems.cycles.degradation import (
+    advance_degradation_state,
+    degradation_causes,
+    degradation_tracking_for_run,
+    empty_degradation_state,
+)
+from brain.systems.cycles.prompts import cycle_run_message
+
+
+CAUSE_FAILURE = {
+    "kind": "worker_tool_failure",
+    "tool": "spawn_worker",
+    "stage": "project_context_materialization",
+    "repo": "Illospace/illospace",
+    "error": "GITHUB_TOKEN could not be materialized for the child reader",
+}
+
+
+def _record_degraded_run(state: dict, scheduled_for: datetime) -> dict:
+    causes = degradation_causes(
+        status="degraded",
+        error=None,
+        evidence_health={"status": "degraded", "failures": [CAUSE_FAILURE]},
+    )
+    tracking = degradation_tracking_for_run(state, scheduled_for=scheduled_for)
+    return advance_degradation_state(
+        tracking,
+        causes=causes,
+        scheduled_for=scheduled_for,
+        mandatory_digest_satisfied=False,
+    )
+
+
+def test_cross_run_degradation_escalates_only_after_three_consecutive_runs():
+    first_at = datetime(2026, 7, 14, 14, 19, tzinfo=timezone.utc)
+    state = empty_degradation_state()
+
+    state = _record_degraded_run(state, first_at)
+    assert state["active_causes"][0]["consecutive_degraded_runs"] == 1
+    assert state["pending_escalations"] == []
+
+    state = _record_degraded_run(state, first_at + timedelta(minutes=30))
+    assert state["active_causes"][0]["consecutive_degraded_runs"] == 2
+    assert state["pending_escalations"] == []
+
+    state = _record_degraded_run(state, first_at + timedelta(minutes=60))
+    assert state["active_causes"][0]["consecutive_degraded_runs"] == 3
+    escalation = state["pending_escalations"][0]
+    assert escalation["summary"].startswith(
+        "spawn_worker / project_context_materialization / Illospace/illospace"
+    )
+    assert escalation["next_required_digest_at"] == "2026-07-14T17:00:00+00:00"
+
+    before_digest = degradation_tracking_for_run(
+        state,
+        scheduled_for=datetime(2026, 7, 14, 16, 59, tzinfo=timezone.utc),
+    )
+    assert before_digest["mandatory_in_current_digest"] is False
+
+    required_digest = degradation_tracking_for_run(
+        state,
+        scheduled_for=datetime(2026, 7, 14, 17, 0, tzinfo=timezone.utc),
+    )
+    assert required_digest["mandatory_in_current_digest"] is True
+    assert required_digest["mandatory_causes"][0]["consecutive_degraded_runs"] == 3
+
+
+def test_non_degraded_run_resets_counter_but_does_not_consume_pending_digest():
+    first_at = datetime(2026, 7, 14, 14, 19, tzinfo=timezone.utc)
+    state = empty_degradation_state()
+    for offset in range(3):
+        state = _record_degraded_run(state, first_at + timedelta(minutes=30 * offset))
+
+    off_cadence = degradation_tracking_for_run(
+        state,
+        scheduled_for=datetime(2026, 7, 14, 16, 30, tzinfo=timezone.utc),
+    )
+    state = advance_degradation_state(
+        off_cadence,
+        causes=[],
+        scheduled_for=datetime(2026, 7, 14, 16, 30, tzinfo=timezone.utc),
+        mandatory_digest_satisfied=True,
+    )
+
+    assert state["active_causes"] == []
+    assert len(state["pending_escalations"]) == 1
+
+
+def test_self_reported_degraded_evidence_supplies_a_machine_tracked_cause():
+    review = evaluate_cycle_result_contract(
+        candidate_answer=(
+            "The workspace review found a source gap. Evidence health: degraded — "
+            "GitHub PR health returned HTTP 403. Next action: repair the project binding. "
+            "Self-review summary: the evidence gap was reported."
+        ),
+        result_contract={"kind": "autonomous_cycle_run_result", "required_outputs": []},
+        mission="Review workspace health.",
+    )
+
+    causes = degradation_causes(
+        status="completed",
+        error=None,
+        evidence_health={"status": "pending"},
+        reported_evidence_health=review["reported_evidence_health"],
+    )
+
+    assert review["reported_evidence_health"] == {
+        "status": "degraded",
+        "reported_value": "degraded",
+        "cause": "GitHub PR health returned HTTP 403",
+    }
+    assert causes[0]["summary"] == "GitHub PR health returned HTTP 403"
+
+
+def test_required_digest_contract_and_prompt_name_escalated_cause():
+    first_at = datetime(2026, 7, 14, 14, 19, tzinfo=timezone.utc)
+    state = empty_degradation_state()
+    for offset in range(3):
+        state = _record_degraded_run(state, first_at + timedelta(minutes=30 * offset))
+    scheduled_for = datetime(2026, 7, 14, 17, 0, tzinfo=timezone.utc)
+    tracking = degradation_tracking_for_run(state, scheduled_for=scheduled_for)
+    contract = cycle_result_contract(tracking)
+    cause = contract["mandatory_degradation_escalations"][0]
+
+    missing = evaluate_cycle_result_contract(
+        candidate_answer=(
+            "The required digest reviewed workspace evidence. Evidence health: ok. "
+            "Next action: monitor recovery. Self-review summary: digest complete."
+        ),
+        result_contract=contract,
+        mission="Publish the required digest.",
+    )
+    assert missing["approved"] is False
+    assert missing["missing_outputs"] == [
+        f"mandatory_degradation_escalation:{cause['key']}"
+    ]
+
+    named = evaluate_cycle_result_contract(
+        candidate_answer=(
+            "The required digest reviewed workspace evidence and names the persistent cause: "
+            f"{cause['summary']}. Evidence health: degraded. Next action: repair credentials. "
+            "Self-review summary: the escalated cause was surfaced."
+        ),
+        result_contract=contract,
+        mission="Publish the required digest.",
+    )
+    assert named["approved"] is True
+
+    cycle = Cycle()
+    cycle.id = 7
+    cycle.name = "Coordinator digest"
+    cycle.prompt = "Publish the required digest."
+    run = CycleRun()
+    run.id = 12
+    run.scheduled_for = scheduled_for
+    run.guidance_snapshot = []
+    run.output_targets_snapshot = []
+    run.context_snapshot = {
+        "scheduled_review_window": {},
+        "result_contract": contract,
+        "evidence_health": {"status": "pending"},
+        "degradation_tracking": tracking,
+    }
+    idea = Idea()
+    idea.id = "idea-1"
+    idea.title = "Coordinator digest"
+
+    prompt = cycle_run_message(idea, cycle, run)
+
+    assert "MANDATORY DEGRADATION ESCALATION" in prompt
+    assert cause["summary"] in prompt
+    assert "MUST name" in prompt
+
+
+def test_satisfied_required_digest_consumes_pending_escalation():
+    first_at = datetime(2026, 7, 14, 14, 19, tzinfo=timezone.utc)
+    state = empty_degradation_state()
+    for offset in range(3):
+        state = _record_degraded_run(state, first_at + timedelta(minutes=30 * offset))
+    scheduled_for = datetime(2026, 7, 14, 17, 0, tzinfo=timezone.utc)
+    tracking = degradation_tracking_for_run(state, scheduled_for=scheduled_for)
+
+    state = advance_degradation_state(
+        tracking,
+        causes=[],
+        scheduled_for=scheduled_for,
+        mandatory_digest_satisfied=True,
+    )
+
+    assert state["pending_escalations"] == []
+
+
+@pytest.mark.asyncio
+async def test_cycle_evaluations_persist_counter_and_seed_next_digest_machine_record():
+    class CaptureSession:
+        def __init__(self):
+            self.added = []
+
+        def add(self, value):
+            self.added.append(value)
+
+    session = CaptureSession()
+    cycle = Cycle()
+    cycle.id = 7
+    cycle.user_id = "user-1"
+    cycle.org_id = "org-1"
+    cycle.target_idea_id = None
+    cycle.degradation_state = {}
+    first_at = datetime(2026, 7, 14, 14, 19, tzinfo=timezone.utc)
+
+    for offset in range(3):
+        scheduled_for = first_at + timedelta(minutes=30 * offset)
+        run = CycleRun()
+        run.id = 100 + offset
+        run.run_id = 200 + offset
+        run.idea_id = None
+        run.scheduled_for = scheduled_for
+        run.context_snapshot = {
+            "evidence_health": {"status": "degraded", "failures": [CAUSE_FAILURE]},
+            "degradation_tracking": degradation_tracking_for_run(
+                cycle.degradation_state,
+                scheduled_for=scheduled_for,
+            ),
+        }
+
+        await cycle_memory.record_cycle_run_evaluation(
+            session,
+            run,
+            cycle,
+            status="completed",
+        )
+
+    final_evaluation = session.added[-1]
+    result_state = final_evaluation.details["degradation_tracking"]["result_state"]
+    assert result_state["active_causes"][0]["consecutive_degraded_runs"] == 3
+    assert len(result_state["pending_escalations"]) == 1
+
+    digest_run = CycleRun()
+    digest_run.id = 104
+    digest_run.scheduled_for = datetime(2026, 7, 14, 17, 0, tzinfo=timezone.utc)
+    snapshot = cycle_memory._build_cycle_run_memory_snapshot(
+        cycle,
+        run=digest_run,
+        revision=None,
+        guidance_rows=[],
+        target_rows=[],
+    )
+    context = snapshot["context_snapshot"]
+
+    assert context["degradation_tracking"]["mandatory_in_current_digest"] is True
+    assert context["result_contract"]["mandatory_degradation_escalations"][0][
+        "consecutive_degraded_runs"
+    ] == 3

--- a/tests/test_post_deploy_qa_probe.py
+++ b/tests/test_post_deploy_qa_probe.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def _load_probe_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "post_deploy_qa_probe.py"
+    spec = importlib.util.spec_from_file_location("post_deploy_qa_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_offline_self_test_exercises_all_four_symptoms(capsys):
+    probe = _load_probe_module()
+
+    exit_code = probe.main(["--self-test"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    for symptom in probe.SYMPTOMS:
+        assert f"#{symptom} PASS — evidence:" in output
+    assert "REQUIRES LIVE RUNTIME" not in output
+
+
+def test_dry_run_labels_every_check_as_requiring_live_runtime(capsys):
+    probe = _load_probe_module()
+
+    exit_code = probe.main(["--dry-run"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    for symptom in probe.SYMPTOMS:
+        assert f"#{symptom} REQUIRES LIVE RUNTIME — evidence:" in output
+    assert "run.get" in output
+    assert "status_code=403" in output
+    assert "next_page" in output
+    assert "assignee spelling" in output
+
+
+def test_pr_probe_fails_on_403_with_clear_evidence():
+    probe = _load_probe_module()
+    bundle = {
+        "root": {
+            "run": {"run_id": 1, "status": "completed"},
+            "tool_events": [
+                probe._event(
+                    "read_github_source",
+                    {"error": "Resource not accessible", "status_code": 403},
+                )
+            ],
+        }
+    }
+
+    result = probe.check_306(bundle)
+
+    assert result.status == probe.FAIL
+    assert "403" in result.evidence
+
+
+def test_worker_probe_fails_on_materialization_error():
+    probe = _load_probe_module()
+    bundle = probe.self_test_bundle()
+    bundle["child_runs"]["901"]["artifacts"][0]["text"] = (
+        "GITHUB_TOKEN could not be materialized for project context."
+    )
+
+    result = probe.check_311(bundle)
+
+    assert result.status == probe.FAIL
+    assert "materialization error" in result.evidence
+
+
+def test_tracker_probe_fails_when_duplicate_create_forks_active_row():
+    probe = _load_probe_module()
+    bundle = probe.self_test_bundle()
+    manage_events = [
+        event
+        for event in bundle["root"]["tool_events"]
+        if event["payload"]["tool_name"] == "manage_domain"
+    ]
+    manage_events[1] = probe._event(
+        "manage_domain",
+        {"record": {"id": 78, "data": {"external_id": "PR-318", "assignee": "reda"}}},
+    )
+    bundle["root"]["tool_events"] = [
+        event
+        for event in bundle["root"]["tool_events"]
+        if event["payload"]["tool_name"] != "manage_domain"
+    ] + manage_events
+
+    result = probe.check_290(bundle)
+
+    assert result.status == probe.FAIL
+    assert "forked record ids" in result.evidence


### PR DESCRIPTION
Closes #318

## What this does
Adds the post-deploy behavior-verification gate for `[Illo-QA]` fixes, plus the two mechanisms that make it enforceable, covering **issue acceptance items 1, 2, and 5**.

1. **Close-criteria convention** — `docs/qa-close-criteria.md` (linked from `docs/README.md`): no `[Illo-QA]` issue may be closed `COMPLETED` without a named post-deploy verifying run id + a one-line symptom-gone quote recorded on the issue. Enumerates the four per-symptom pass conditions.
2. **Machine-checkable per-symptom probe** — `scripts/post_deploy_qa_probe.py`: asserts the four runtime symptoms (#311 child-reader credential materialization, #306 PR mergeability/CI 403, #312 broad-read truncation, #290 idempotent tracker upsert). Parameterized for a live target (`--target/--token-env/--thread-id/--run-id/--repo/--pull-number/--external-id/--assignee-a/-b`); `--self-test` runs all four against offline synthetic run receipts (all PASS), `--dry-run` correctly reports REQUIRES-LIVE-RUNTIME instead of faking a pass.
3. **Cross-run degradation escalation** — `brain/systems/cycles/degradation.py` + durable per-Cycle `degradation_state` (migration `0024`): a degradation cause degraded on **≥3 consecutive scheduled runs** is escalated into the next required 8/13/18 ET digest and the coordinator's scheduled-run instruction is made to name it (`prompts.py::_degradation_instruction`), instead of silently skipping off-cadence. Single-run degrade behavior is unchanged; escalation is retained until a valid digest names it.

## Explicitly NOT done here — runtime/deploy-owned (issue items 3 & 4)
A repo worktree cannot verify a *deployed* image or trigger a live scheduled run. These two acceptance items are deferred to the runtime owner (Reda), and the probe above is the turnkey tool for both:
- **Item 3:** confirm whether the #290/#306/#311/#312 fixes are deployed & effective on the running illospace-worker (merged-commit vs. deployed-image), reopen/re-fix any merged-but-ineffective. → run `scripts/post_deploy_qa_probe.py` against the deployed coordinator.
- **Item 4:** demonstrate a subsequent scheduled coordinator run shows #311's symptom gone at runtime. → same probe, `--symptom 311`, against a real run.

## Verification (in the worker's worktree, repo venv)
- `tests/test_cycle_degradation.py` + `tests/test_post_deploy_qa_probe.py` + affected cycles/agent-run suites: **184 passed, 1 skipped**.
- Alembic: single head `0024_cycle_degradation_state` (chains off `0023`); migration is idempotent + dialect-aware (JSONB on Postgres, JSON on SQLite).
- Probe `--self-test`: all four symptoms PASS; `--dry-run`: all four REQUIRES-LIVE-RUNTIME.

## Acceptance checks
- [x] Close-criteria doc states the post-deploy verifying-run-id + symptom-quote requirement and lists the four per-symptom conditions.
- [x] Per-symptom probe exists, exercises all four conditions, emits PASS/FAIL/REQUIRES-LIVE-RUNTIME with evidence.
- [x] ≥3 consecutive degraded runs for one cause → next-digest data + scheduled instruction require it be named; 1–2 do not escalate (unit-tested).
- [x] Regression: existing cycles/contract-gate/evidence-health tests green; single-run degrade + non-degraded runs unchanged.
- [ ] **(Reda / runtime)** Item 3: deployment effectiveness of #290/#306/#311/#312 confirmed via the probe against the deployed coordinator.
- [ ] **(Reda / runtime)** Item 4: a scheduled run shows #311's symptom gone at runtime.

Draft — authored by a Codex worker, reviewed by the R3 orchestrator (Claude). Not for merge until Reda's review.
