### PR TITLE
Route user feature requests to tickets in channel-monitor framing

### DIFF
--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -262,6 +262,15 @@ def slack_channel_monitor_message(
         "section (a Domain 37 doc_page record; skill_asset references/creating-work-items.md as "
         "fallback), then optionally "
         "post a brief Slack note with post_slack_reply citing the issue number and URL.",
+        "- A user-submitted feature request or product idea (feedback relayed by a bot such as "
+        "Retool — e.g. '*New:* Idea' or '*New:* Feedback' with a user email and profile id — is "
+        "a real customer ask, NOT chatter and NOT low-signal): if the ask is concrete and "
+        "actionable, it IS ticket-worthy — follow the same flow as above to open a REAL GitHub "
+        "issue in the correct uwear-ai repo, quoting the user's ask and including their "
+        "email/profile id in the issue body, then post a brief thread note with post_slack_reply "
+        "citing the issue number and URL so the team knows it was captured. Only if the ask is "
+        "too vague to act on, or it duplicates an existing open issue, comment on the existing "
+        "issue or stay silent instead.",
         "- An alert that matches an EXISTING ticket or issue (same Rollbar id/error signature): "
         "do NOT refile and do NOT blindly skip — follow the triage skill's Deploy-State Ladder: "
         "note occurrences while unfixed; a fix merged to staging but not promoted is expected "

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -319,6 +319,24 @@ def test_build_payload_for_channel_message_is_headless_and_not_forced_reply():
     assert "👀" in run_message
 
 
+def test_channel_monitor_framing_routes_feature_requests_to_tickets():
+    # Regression: a Retool-relayed customer feature request ("*New:* Idea") was
+    # classified "low-signal" and dropped because the framing only made
+    # user-reported *problems* ticket-worthy (run 1550, 2026-07-16).
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    payload = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+    )
+
+    run_message = payload["payload"]["run_message"]
+    assert "feature request or product idea" in run_message
+    assert "NOT chatter and NOT low-signal" in run_message
+    assert "email/profile id" in run_message
+
+
 def test_build_payload_for_mention_still_forces_reply():
     from brain.systems.slack.triggers import build_slack_work_intake_payload
 


### PR DESCRIPTION
## Why

This morning (2026-07-16) the Retool feedback bot posted a customer feature request in the monitored alerts channel ("**New:** Idea — ... — 'Please would it be possible to be able to name the outfits?'").

Illo 👀-acked it and spawned triage run **1550**, which completed in 17s with **zero tool calls** and the final answer:

> "No visible action taken. Classified as a low-signal feature idea, not an automated alert or clear user-reported problem requiring a GitHub issue."

The agent followed its framing exactly — the bug is in the framing. `slack_channel_monitor_message` (brain/systems/slack/triggers.py) only made two things ticket-worthy: automated alerts and user-reported **problems**. A feature request/idea matched neither, so it fell through to the "ambiguous or low-signal → silence" branch. The runtime triage doc never loads for that branch, and it has no feature-request intake path either.

## Fix

Add an explicit classification branch: customer feedback relayed by a bot (Retool "*New:* Idea" / "*New:* Feedback" with a user email + profile id) is a real customer ask, NOT chatter and NOT low-signal. If concrete and actionable → file a real GitHub issue in the correct uwear-ai repo (quoting the ask, including the requester's email/profile id in the private issue body), then post a brief thread note citing the issue. Vague or duplicate asks → comment on the existing issue or stay silent.

## Tests

- New regression test `test_channel_monitor_framing_routes_feature_requests_to_tickets`.
- `tests/test_slack_channel_monitor.py`: 26 passed.
- `test_slack_teammate.py` has 2 pre-existing failures on clean origin/main (env-related, unaffected by this change).

## Not covered here

- Backfill: the original ask still has no ticket.
- The runtime triage doc has no feature-request routing guidance; the creating-work-items playbook covers filing mechanics, so this may be fine as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)