### PR TITLE
Fix cycle result-contract validator desync — phantom "failure map" false-degrades 100% of Reflex runs (#322)

### DIFF
--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 MISSION_RESULT_CONTRACT_VERDICT_KEY = "mission_result_contract_verdict"
 _CONTRACT_KIND = "autonomous_cycle_run_result"
 _FINAL_ANSWER_TYPE = "final_answer"
+_MANDATORY_DEGRADATION_ESCALATION_PREFIX = "mandatory_degradation_escalation:"
 
 _INTROSPECTION_MARKERS = (
     "verified current runtime facts",
@@ -58,26 +59,6 @@ _NON_PRESERVABLE_OUTPUTS = frozenset(
         "candidate_is_runtime_introspection",
     }
 )
-
-_MISSION_OUTPUT_ALIASES: dict[str, tuple[str, ...]] = {
-    "24h readout": (
-        "24h readout",
-        "24-hour readout",
-        "24 hour readout",
-        "last 24h",
-        "last 24 hours",
-    ),
-    "failure map": ("failure map", "failure-map", "failure modes", "failures"),
-    "codebase implications": (
-        "codebase implications",
-        "code implications",
-        "implementation implications",
-    ),
-    "proposals": ("proposals", "proposal"),
-    "tracking summary": ("tracking summary", "tracking", "domain tracking"),
-    "impact loop": ("impact loop", "impact-loop"),
-    "next action": ("next action", "next step", "blocker"),
-}
 
 
 def _normalize_text(value: Any) -> str:
@@ -138,28 +119,25 @@ def _reported_evidence_health(candidate_answer: str | None) -> dict[str, Any] | 
     return report
 
 
-def _mission_required_output_labels(mission: str) -> list[str]:
-    normalized = _normalize_text(mission)
-    labels = [
-        label
-        for label, aliases in _MISSION_OUTPUT_ALIASES.items()
-        if _contains_any(normalized, aliases)
-    ]
-    return _dedupe(labels)
-
-
-def _domain_tracking_required(mission: str, evidence_packet: dict[str, Any]) -> bool:
-    if bool(evidence_packet.get("domain_side_effects_succeeded")):
-        return True
-    normalized = _normalize_text(mission)
-    return "domain" in normalized and ("record" in normalized or "tracking" in normalized)
-
-
 def _satisfies_required_output(
     requirement: str,
     *,
     normalized_candidate: str,
+    result_contract: dict[str, Any],
 ) -> bool:
+    if requirement.startswith(_MANDATORY_DEGRADATION_ESCALATION_PREFIX):
+        required_key = requirement.removeprefix(
+            _MANDATORY_DEGRADATION_ESCALATION_PREFIX
+        )
+        for raw_escalation in _json_list(
+            result_contract.get("mandatory_degradation_escalations")
+        ):
+            escalation = _json_dict(raw_escalation)
+            if str(escalation.get("key") or "").strip() != required_key:
+                continue
+            summary = _normalize_text(escalation.get("summary"))
+            return bool(summary and summary in normalized_candidate)
+        return False
     if requirement == "answer_the_cycle_mission":
         return (
             len(normalized_candidate) >= 80
@@ -192,27 +170,12 @@ def _satisfies_required_output(
             normalized_candidate,
             ("self-review", "self review", "review summary", "self review summary"),
         )
+    if requirement in {"domain_tracking", "domain_tracking_summary"}:
+        return _contains_any(
+            normalized_candidate,
+            ("domain tracking", "tracking summary", "domain record", "domain ledger"),
+        )
     return requirement.replace("_", " ") in normalized_candidate
-
-
-def _missing_mandatory_degradation_escalations(
-    result_contract: dict[str, Any],
-    *,
-    normalized_candidate: str,
-) -> list[str]:
-    missing: list[str] = []
-    for raw_escalation in _json_list(
-        result_contract.get("mandatory_degradation_escalations")
-    ):
-        escalation = _json_dict(raw_escalation)
-        key = str(escalation.get("key") or "").strip()
-        summary = _normalize_text(escalation.get("summary"))
-        if not key or not summary:
-            continue
-        if summary in normalized_candidate:
-            continue
-        missing.append(f"mandatory_degradation_escalation:{key}")
-    return missing
 
 
 def evaluate_cycle_result_contract(
@@ -223,9 +186,8 @@ def evaluate_cycle_result_contract(
     evidence_packet: dict[str, Any] | None = None,
     provider_exception: BaseException | str | None = None,
 ) -> dict[str, Any]:
-    """Return a deterministic verdict for a candidate scheduled-Cycle visible answer."""
+    """Validate a visible answer against only its advertised required outputs."""
 
-    evidence_packet = _json_dict(evidence_packet)
     normalized_candidate = _normalize_text(candidate_answer)
     detected_provider_error = provider_error_kind(
         candidate_answer,
@@ -238,39 +200,25 @@ def evaluate_cycle_result_contract(
     if _looks_like_introspection_boilerplate(candidate_answer):
         missing.append("candidate_is_runtime_introspection")
 
-    for requirement in _json_list(result_contract.get("required_outputs")):
-        requirement_name = str(requirement or "").strip()
-        if not requirement_name:
-            continue
+    enforced_required_outputs = _dedupe(
+        [
+            str(requirement or "").strip()
+            for requirement in _json_list(result_contract.get("required_outputs"))
+        ]
+    )
+    for requirement_name in enforced_required_outputs:
         if not _satisfies_required_output(
             requirement_name,
             normalized_candidate=normalized_candidate,
+            result_contract=result_contract,
         ):
             missing.append(requirement_name)
-
-    missing.extend(
-        _missing_mandatory_degradation_escalations(
-            result_contract,
-            normalized_candidate=normalized_candidate,
-        )
-    )
-
-    for label in _mission_required_output_labels(mission):
-        if not _contains_any(normalized_candidate, _MISSION_OUTPUT_ALIASES[label]):
-            missing.append(label)
-
-    if _domain_tracking_required(mission, evidence_packet):
-        has_domain_tracking = "domain" in normalized_candidate and _contains_any(
-            normalized_candidate,
-            ("record", "records", "tracking", "ledger"),
-        )
-        if not has_domain_tracking:
-            missing.append("domain_tracking_summary")
 
     missing = _dedupe(missing)
     return {
         "approved": not missing,
         "missing_outputs": missing,
+        "enforced_required_outputs": enforced_required_outputs,
         "candidate_summary": (
             safe_provider_error_sentinel(detected_provider_error)
             if detected_provider_error
@@ -283,11 +231,11 @@ def evaluate_cycle_result_contract(
 
 def _metadata_result_contract(agent_run: AgentRunRow | None) -> dict[str, Any]:
     metadata = _json_dict(getattr(agent_run, "metadata_", None))
-    contract = _json_dict(metadata.get("contract")).get("result")
-    if isinstance(contract, dict):
-        return dict(contract)
     launch_envelope = _json_dict(metadata.get("launch_envelope"))
     contract = launch_envelope.get("result_contract")
+    if isinstance(contract, dict):
+        return dict(contract)
+    contract = _json_dict(metadata.get("contract")).get("result")
     if isinstance(contract, dict):
         return dict(contract)
     launch_receipt = _json_dict(metadata.get("launch_receipt"))
@@ -301,11 +249,14 @@ def cycle_result_contract_for_run(
     agent_run: AgentRunRow | None,
     cycle_run: CycleRun | None,
 ) -> dict[str, Any]:
+    contract = _metadata_result_contract(agent_run)
+    if contract:
+        return contract
     context_snapshot = _json_dict(getattr(cycle_run, "context_snapshot", None))
     contract = context_snapshot.get("result_contract")
     if isinstance(contract, dict):
         return dict(contract)
-    return _metadata_result_contract(agent_run)
+    return {}
 
 
 def _is_result_contract(contract: dict[str, Any]) -> bool:
@@ -699,6 +650,9 @@ def _base_verdict(
         "candidate_summary": initial_review.get("candidate_summary") or _candidate_summary(candidate_answer),
         "missing_outputs": list(initial_review.get("missing_outputs") or []),
         "final_missing_outputs": list(initial_review.get("missing_outputs") or []),
+        "enforced_required_outputs": list(
+            initial_review.get("enforced_required_outputs") or []
+        ),
         "repair_attempted": False,
         "repair_succeeded": False,
         "settlement_status": (

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -64,6 +64,11 @@ def cycle_result_contract(
     }
     escalations = mandatory_escalations(degradation_tracking)
     if escalations:
+        contract["required_outputs"].extend(
+            f"mandatory_degradation_escalation:{escalation['key']}"
+            for escalation in escalations
+            if str(escalation.get("key") or "").strip()
+        )
         contract["mandatory_degradation_escalations"] = escalations
         contract["degradation_escalation_instruction"] = (
             "This is the required digest at or after each escalation's "

--- a/tests/test_cycle_degradation.py
+++ b/tests/test_cycle_degradation.py
@@ -145,6 +145,9 @@ def test_required_digest_contract_and_prompt_name_escalated_cause():
     assert missing["missing_outputs"] == [
         f"mandatory_degradation_escalation:{cause['key']}"
     ]
+    assert set(missing["enforced_required_outputs"]) <= set(
+        contract["required_outputs"]
+    )
 
     named = evaluate_cycle_result_contract(
         candidate_answer=(

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -27,6 +27,101 @@ RAW_PROVIDER_ERROR = (
     "ID `a7dd7556-test` in your message. | server_error | server_error"
 )
 
+RESULT_CONTRACT_REQUIRED_OUTPUTS = [
+    "answer_the_cycle_mission",
+    "summarize_workspace_evidence_or_explicit_gaps",
+    "report_evidence_health",
+    "record_next_action_or_blocker",
+    "short_self_review_summary",
+]
+REFLEX_MISSION = (
+    "Review GitHub events. If reader failures occur, report them under Evidence health. "
+    "End with exactly six lines: Reflex result / Evidence reviewed / Evidence health / "
+    "Domain tracking / Next action / Self-review."
+)
+REFLEX_ANSWER = (
+    "Reflex result: the scheduled GitHub review completed with no unresolved work.\n"
+    "Evidence reviewed: workspace GitHub events and current cycle state were inspected.\n"
+    "Evidence health: ok; the available readers returned complete results.\n"
+    "Domain tracking: no durable record update was needed for this run.\n"
+    "Next action: inspect new GitHub events at the next scheduled run.\n"
+    "Self-review: the mission and advertised result contract are satisfied."
+)
+
+
+def _result_contract(required_outputs=None):
+    return {
+        "kind": "autonomous_cycle_run_result",
+        "required_outputs": list(
+            RESULT_CONTRACT_REQUIRED_OUTPUTS
+            if required_outputs is None
+            else required_outputs
+        ),
+    }
+
+
+def _contract_finalization_scenario(
+    *,
+    cycle_id,
+    mission,
+    answer,
+    events=None,
+    launch_contract=None,
+    snapshot_contract=None,
+):
+    launch_contract = launch_contract or _result_contract()
+    snapshot_contract = snapshot_contract or launch_contract
+
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.root_run_id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.input_message = mission
+    agent_run.model_policy = {}
+    agent_run.metadata_ = {
+        "source": "cycle",
+        "cycle_run_id": 12,
+        "launch_envelope": {"result_contract": launch_contract},
+    }
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = cycle_id
+    cycle_run.status = "running"
+    cycle_run.completed_at = None
+    cycle_run.error = None
+    cycle_run.skip_reason = None
+    cycle_run.prompt_snapshot = mission
+    cycle_run.context_snapshot = {
+        "result_contract": snapshot_contract,
+        "evidence_health": {"status": "pending"},
+    }
+
+    cycle = Cycle()
+    cycle.id = cycle_id
+    cycle.prompt = mission
+    cycle.last_status = None
+    cycle.last_error = None
+    cycle.last_run_at = None
+
+    final_answer = AgentRunArtifactRow(
+        id=8,
+        run_id=44,
+        root_run_id=44,
+        artifact_type="final_answer",
+        text=answer,
+        created_at=datetime(2026, 4, 28, 20, 25, tzinfo=timezone.utc),
+    )
+    session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        artifacts=[final_answer],
+        events=events,
+    )
+    return session, cycle_run, cycle, final_answer
+
 
 class _FakeSession:
     def __init__(self, agent_run=None, run=None, cycle=None, artifacts=None, events=None):
@@ -1430,6 +1525,167 @@ def test_cycle_contract_rejects_empty_answer_with_captured_provider_exception():
     assert review["provider_error"] == "overloaded_error"
 
 
+@pytest.mark.parametrize("completed_event_count", [0, 2], ids=["no-op", "acted-on-events"])
+def test_reflex_cycle_satisfied_launch_contract_completes(
+    monkeypatch,
+    completed_event_count,
+):
+    from brain.systems.cycles import contract_gate
+
+    events = [
+        AgentRunEventRow(
+            id=index + 1,
+            run_id=44,
+            root_run_id=44,
+            sequence_no=index + 1,
+            event_type="run.tool_completed",
+            payload={
+                "tool_name": "update_github_event",
+                "result": {"status": "ok", "event_id": index + 100},
+            },
+        )
+        for index in range(completed_event_count)
+    ]
+    session, cycle_run, cycle, final_answer = _contract_finalization_scenario(
+        cycle_id=8,
+        mission=REFLEX_MISSION,
+        answer=REFLEX_ANSWER,
+        events=events,
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert repair_calls == []
+    assert cycle_run.status == "completed"
+    assert cycle_run.error is None
+    assert cycle.last_status == "completed"
+    assert cycle.last_error is None
+    verdict = cycle_run.context_snapshot["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_success"
+    assert verdict["missing_outputs"] == []
+    assert verdict["side_effects_succeeded"] is bool(completed_event_count)
+    assert session._artifacts[-1] is final_answer
+
+
+def test_coordinator_tracking_summary_does_not_add_undeclared_requirement(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    mission = (
+        "Publish the coordinator digest and include its domain-tracking summary line, "
+        "evidence health, next action, and self-review."
+    )
+    answer = (
+        "Coordinator result: the workspace digest completed and all scheduled work is current.\n"
+        "Evidence reviewed: current assignments and workspace activity were inspected.\n"
+        "Evidence health: ok; the available sources were complete.\n"
+        "Tracking summary: the coordination ledger is current.\n"
+        "Next action: review new assignments at the next scheduled run.\n"
+        "Self-review: the advertised result contract is satisfied."
+    )
+    session, cycle_run, cycle, _ = _contract_finalization_scenario(
+        cycle_id=2,
+        mission=mission,
+        answer=answer,
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert repair_calls == []
+    assert cycle_run.status == "completed"
+    assert cycle_run.error is None
+    assert cycle.last_status == "completed"
+    assert cycle.last_error is None
+
+
+@pytest.mark.parametrize(
+    ("mission", "evidence_packet"),
+    [
+        (REFLEX_MISSION, {}),
+        (
+            "Publish a coordinator digest with domain tracking.",
+            {"domain_side_effects_succeeded": True},
+        ),
+    ],
+    ids=["reflex", "coordinator"],
+)
+def test_cycle_contract_enforces_only_advertised_required_outputs(mission, evidence_packet):
+    from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
+
+    result_contract = _result_contract(["report_evidence_health"])
+    review = evaluate_cycle_result_contract(
+        candidate_answer="Evidence health: ok.",
+        result_contract=result_contract,
+        mission=mission,
+        evidence_packet=evidence_packet,
+    )
+
+    assert set(review["missing_outputs"]) <= set(result_contract["required_outputs"])
+    assert set(review["enforced_required_outputs"]) <= set(
+        result_contract["required_outputs"]
+    )
+    assert review["approved"] is True
+
+
+def test_cycle_contract_for_run_prefers_advertised_launch_envelope():
+    from brain.systems.cycles.contract_gate import cycle_result_contract_for_run
+
+    launch_contract = _result_contract(["report_evidence_health"])
+    stale_snapshot_contract = _result_contract(["failure_map"])
+    session, cycle_run, _, _ = _contract_finalization_scenario(
+        cycle_id=8,
+        mission=REFLEX_MISSION,
+        answer="Evidence health: ok.",
+        launch_contract=launch_contract,
+        snapshot_contract=stale_snapshot_contract,
+    )
+
+    assert cycle_result_contract_for_run(session._agent_run, cycle_run) == launch_contract
+
+
+def test_reflex_cycle_missing_declared_evidence_health_still_degrades(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    answer_without_evidence_health = "\n".join(
+        line for line in REFLEX_ANSWER.splitlines() if not line.startswith("Evidence health:")
+    )
+    session, cycle_run, cycle, _ = _contract_finalization_scenario(
+        cycle_id=8,
+        mission=REFLEX_MISSION,
+        answer=answer_without_evidence_health,
+    )
+
+    async def fake_repair(**kwargs):
+        return None
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert cycle_run.status == "degraded"
+    assert cycle_run.error == "mission_contract_failed: missing report_evidence_health"
+    assert cycle.last_status == "degraded"
+    assert cycle.last_error == cycle_run.error
+    verdict = cycle_run.context_snapshot["mission_result_contract_verdict"]
+    assert verdict["final_missing_outputs"] == ["report_evidence_health"]
+
+
 @pytest.mark.asyncio
 async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
     from brain.systems.cycles import contract_gate
@@ -1522,7 +1778,8 @@ async def test_cycle_contract_gate_repairs_bad_visible_answer_once(monkeypatch):
 
     assert len(repair_calls) == 1
     assert repair_calls[0]["candidate_answer"] == bad_answer.text
-    assert "24h readout" in repair_calls[0]["missing_outputs"]
+    assert "answer_the_cycle_mission" in repair_calls[0]["missing_outputs"]
+    assert "failure map" not in repair_calls[0]["missing_outputs"]
     assert verdict["repair_attempted"] is True
     assert verdict["repair_succeeded"] is True
     assert verdict["settlement_status"] == "mission_success_after_repair"


### PR DESCRIPTION
Closes #322.

## What this fixes
The GitHub Reflex cycle (cycle 8) was stamped `degraded: mission_contract_failed` on **100% of runs** with `Missing: failure map`, even though every run was correct. `failure map` is a **phantom** required-output — it's in neither the mission's mandated six-line closing block nor the launch envelope's `result_contract.required_outputs`. Same false-degrade class as #310, and the exact recurrence #318 warned about. Cycle 2 (Coordinator) hit the twin phantom `missing domain_tracking_summary`.

## Root cause
The validator derived its enforced required-field set from **three** sources, two of which are not the run's advertised contract:
1. `result_contract.required_outputs` — legitimate (advertised).
2. `_MISSION_OUTPUT_ALIASES` matched against **mission substrings** — this table literally contained `"failure map"`, so any mission mentioning it enforced it. ← phantom.
3. `_domain_tracking_required(mission, evidence_packet)` — inferred `domain_tracking_summary` from mission text + side effects. ← cycle-2 phantom.

The enforced set ≠ the set the run is told to satisfy → unsatisfiable by construction.

## The fix
- Delete the mission-substring alias table and the side-effect inference; the validator now enforces **only** the run's advertised `required_outputs`.
- Fold mandatory degradation escalations **into** `required_outputs` (as `mandatory_degradation_escalation:<key>`) so anything enforced is also declared — **enforced set ⊆ declared, by construction** (acceptance check 2, structurally guaranteed).
- Make `launch_envelope.result_contract` authoritative for the run (with snapshot fallback for legacy runs).
- **Retain** provider-error and introspection-boilerplate guards (#272 / #289) — no regression to those.
- A run that genuinely omits a **declared** required_output still degrades (check 5).

## Reviewer surface
- **Tests (director-verified green):** `cd <worktree> && venv/bin/python -m pytest tests/test_cycles_service.py tests/test_cycle_degradation.py tests/test_agent_run_runtime.py tests/test_agent_run_state_machine.py tests/test_direct_agent_async_contract.py -q` → **192 passed, 1 skipped**.
- Acceptance checks 1–5 from the issue are covered by the new tests in `test_cycles_service.py` (Reflex six-line block completes `completed` for both no-op and acted-on-N runs; enforced⊆declared assertion; genuine declared-omission still degrades).

## Files
- `brain/systems/cycles/contract_gate.py` — remove phantom sources, enforce advertised-only, contract-precedence fix.
- `brain/systems/cycles/contracts.py` — advertise mandatory escalations in `required_outputs`.
- `tests/test_cycles_service.py`, `tests/test_cycle_degradation.py` — regression coverage.

Draft — for Reda's review/merge. Implemented by Codex (gpt-5.6-sol), reviewed + verified by the R3 orchestrator.