### PR TITLE
Connect handoff-packet minting to the live completion lanes

### DIFF
--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -2,8 +2,11 @@
 
 The single owner of gather → assemble → compose → create → stamp → post for
 handoff packets (spec: illo-handoff-packets slice 05). Triage completion
-calls :func:`mint_packet_after_triage`; the notify refresh (slice 06) and
-the pre-merge probe reuse the same stages.
+calls :func:`mint_packet_after_triage`; the live actionable lanes
+(slack_teammate_run, illo_submit) call
+:func:`mint_packet_after_actionable_run` when attribution shows the run
+created durable work; the notify refresh (slice 06) and the pre-merge probe
+reuse the same stages.
 
 Load-bearing stances:
 
@@ -51,6 +54,7 @@ from brain.systems.briefing.gather import (
     load_inbound_event,
     slack_provenance,
 )
+from brain.systems.inbound.attribution import durable_work_refs
 from brain.systems.launch_handoffs import (
     LaunchHandoff,
     agent_target_for_member,
@@ -477,10 +481,11 @@ def _record_job_ref(attribution: dict[str, Any] | None, idea: Any) -> str:
     return f"idea:{getattr(idea, 'id', '')}"
 
 
-async def _post_brief_to_origin_thread(session: Any, *, org_id: str, idea: Any, brief: str) -> bool:
+async def _post_brief_to_origin_thread(*, event: Any, brief: str) -> bool:
     """Backend Slack reply into the origin thread — same provenance and
-    public-only allowlist as gather; silent skip (False) when not possible."""
-    event = await load_inbound_event(session, org_id=org_id, idea=idea)
+    public-only allowlist as gather; silent skip (False) when not possible.
+    Both mint hooks already hold the event, so provenance reads it directly
+    (no idea → event reload)."""
     provenance = slack_provenance(event) if event is not None else None
     if not provenance or provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
         return False
@@ -491,6 +496,49 @@ async def _post_brief_to_origin_thread(session: Any, *, org_id: str, idea: Any, 
         channel=provenance["channel"], text=brief, thread_ts=provenance["thread_ts"]
     )
     return True
+
+
+async def _mint_for_idea_and_event(
+    session: Any,
+    *,
+    org_id: str,
+    idea: Any,
+    event: Any,
+    attribution: dict[str, Any] | None,
+    readers: Readers | None,
+) -> MintResult:
+    """Shared stage for every inbound-completion lane once the job-home idea
+    is resolved: owner → target → mint → post-once. Raises upward; the
+    lane-facing wrappers own containment."""
+    details = dict(getattr(idea, "agent_details", None) or {})
+    assignment = dict(details.get("assignment") or {})
+    owner_user_id = str(assignment.get("owner_id") or "") or None
+    owner_label = await _owner_label(session, owner_user_id)
+    target_tool = agent_target_for_member(owner_user_id, _member_targets())
+
+    result = await mint_packet_for_job(
+        session,
+        org_id=org_id,
+        idea=idea,
+        job_ref=_record_job_ref(attribution, idea),
+        ask=_ask_from_event(idea, event),
+        owner_user_id=owner_user_id,
+        owner_label=owner_label,
+        target_tool=target_tool,
+        source_surface="inbound_triage",
+        source_ref={"inbound_event_id": str(event.id)},
+        readers=readers,
+        reader_user_id=str(getattr(event, "authority_user_id", "") or "") or None,
+    )
+    if result.ok and result.created:
+        try:
+            result.posted = await _post_brief_to_origin_thread(
+                event=event, brief=result.human_brief
+            )
+        except Exception as exc:  # noqa: BLE001 — the packet exists; the reply degraded
+            logger.warning("packet %s minted but Slack reply failed: %s",
+                           getattr(result.handoff, "id", "?"), exc)
+    return result
 
 
 async def mint_packet_after_triage(
@@ -521,35 +569,197 @@ async def mint_packet_after_triage(
         if idea is None:
             return MintResult(ok=False, reason="no triage idea for event")
 
-        details = dict(getattr(idea, "agent_details", None) or {})
-        assignment = dict(details.get("assignment") or {})
-        owner_user_id = str(assignment.get("owner_id") or "") or None
-        owner_label = await _owner_label(session, owner_user_id)
-        target_tool = agent_target_for_member(owner_user_id, _member_targets())
-
-        result = await mint_packet_for_job(
-            session,
-            org_id=org_id,
-            idea=idea,
-            job_ref=_record_job_ref(attribution, idea),
-            ask=_ask_from_event(idea, event),
-            owner_user_id=owner_user_id,
-            owner_label=owner_label,
-            target_tool=target_tool,
-            source_surface="inbound_triage",
-            source_ref={"inbound_event_id": str(event.id)},
-            readers=readers,
-            reader_user_id=str(getattr(event, "authority_user_id", "") or "") or None,
+        return await _mint_for_idea_and_event(
+            session, org_id=org_id, idea=idea, event=event,
+            attribution=attribution, readers=readers,
         )
-        if result.ok and result.created:
-            try:
-                result.posted = await _post_brief_to_origin_thread(
-                    session, org_id=org_id, idea=idea, brief=result.human_brief
+    except Exception as exc:  # noqa: BLE001 — total containment
+        logger.warning("packet mint failed for event %s: %s", getattr(event, "id", "?"), exc)
+        return MintResult(ok=False, reason=f"{type(exc).__name__}: {exc}")
+
+
+def _github_repo_from_refs(work_refs: list[dict[str, str]]) -> str | None:
+    for ref in work_refs:
+        if str(ref.get("kind") or "") in ("github_issue", "github_pull_request"):
+            slug = str(ref.get("id") or "").split("#", 1)[0]
+            if slug.count("/") == 1:
+                return slug
+    return None
+
+
+async def _create_job_home_idea(
+    session: Any,
+    *,
+    org_id: str,
+    event: Any,
+    run_row: Any,
+    attribution: dict[str, Any] | None,
+    work_refs: list[dict[str, str]],
+) -> Any | None:
+    """Create the job-home idea the actionable lanes lack.
+
+    Slack-teammate and submission runs are admitted without a triage idea
+    (only ``_queue_illo_triage`` creates one), so when such a run completes
+    with durable work there is no stamp target, no gather anchor, and no
+    provenance bridge. This mirrors the triage idea's exact shape —
+    ``agent_details.inbound_triage.event_id`` is what ``load_inbound_event``
+    and gather's provenance walk — but deliberately admits NO new run: the
+    work already happened; the idea documents where it was routed.
+
+    The description embeds each work ref (``owner/repo#N`` included) so
+    gather's same-job reference discovery reaches the created artifacts.
+    Returns None (mint skips, logged by the hook) when no owner resolves
+    and no unclaimed pool is configured — the same parking rule as triage.
+    """
+    from brain.platform.db.models.idea import Idea
+    from brain.systems.inbound.assignment import default_rules, resolve_owner
+    from brain.systems.inbound.service import _unclaimed_pool_user_id
+    from brain.systems.task_domain import classify_task_domain
+
+    envelope = dict(getattr(event, "envelope", None) or {})
+    summary = str(envelope.get("summary") or "").strip()
+    origin = str(getattr(event, "origin", "") or "")
+    ref_ids = [str(ref.get("id") or "") for ref in work_refs if ref.get("id")]
+    repo = _github_repo_from_refs(work_refs)
+    task_domain = classify_task_domain(summary)
+    run_user_id = str(getattr(run_row, "user_id", "") or "") or None
+    authority_user_id = str(getattr(event, "authority_user_id", "") or "") or None
+    # Same rule order as _queue_illo_triage: domain rules only when a repo
+    # anchors the signal (here: the repo the run actually filed into), so a
+    # stray keyword in a Slack message can't yank ownership on its own.
+    decision = resolve_owner(
+        task_domain=task_domain if repo else None,
+        repo=repo,
+        connection_owner_id=run_user_id or authority_user_id,
+        rules=default_rules(),
+    )
+    owner_user_id = decision.user_id
+    unclaimed = False
+    if not owner_user_id:
+        pool_user_id = _unclaimed_pool_user_id()
+        if not pool_user_id:
+            return None
+        owner_user_id = pool_user_id
+        unclaimed = True
+
+    title = summary[:180] or f"Inbound {origin} signal routed by Illo"[:180]
+    description_lines = [
+        f"Illo run {getattr(run_row, 'id', '?')} handled this {origin or 'inbound'} "
+        "signal and created durable work.",
+        f"Work refs: {', '.join(ref_ids) or 'unknown'}",
+    ]
+    idea = Idea(
+        title=title,
+        description="\n".join(description_lines)[:500],
+        status="emerged",
+        origin="inbound_signal",
+        origin_ref=f"inbound_event:{event.id}",
+        user_id=owner_user_id,
+        org_id=org_id,
+        agent_details={
+            "inbound_triage": {
+                "event_id": str(event.id),
+                "origin": origin,
+                "reason": "actionable_run_completion",
+                "connection_id": str(getattr(event, "connection_id", "") or "") or None,
+                "policy_id": None,
+            },
+            "task_domain": task_domain.value,
+            "assignment": {
+                "owner_id": owner_user_id,
+                "basis": decision.basis.value,
+                "authority_user_id": authority_user_id,
+                "unclaimed": unclaimed,
+            },
+            # Gather's evidence piece renders scalar values from this trail.
+            "attribution": {
+                "summary": str((attribution or {}).get("summary") or ""),
+                "tools": ", ".join(
+                    str(tool) for tool in (attribution or {}).get("tool_names") or []
+                ),
+                "run_id": str(getattr(run_row, "id", "") or ""),
+            },
+        },
+    )
+    # Own savepoint: an INSERT failure must roll back cleanly instead of
+    # poisoning the caller's transaction (which holds the run's terminal
+    # status write) — the same commit-time containment mint_packet_for_job
+    # keeps for its write phase.
+    async with session.begin_nested():
+        session.add(idea)
+        await session.flush()
+    return idea
+
+
+async def mint_packet_after_actionable_run(
+    session: Any,
+    *,
+    event: Any,
+    run_row: Any,
+    attribution: dict[str, Any] | None,
+    readers: Readers | None = None,
+) -> MintResult:
+    """Completion hook for the live actionable lanes (``slack_teammate_run``,
+    ``illo_submit``): mint iff attribution proves the run created or routed
+    durable work. NEVER raises — these runs worked before packets existed.
+
+    Differences from the triage hook, both deliberate:
+
+    - **Durable-work predicate.** Triage completion IS the routing moment,
+      so it mints unconditionally. These runs answer questions and stay
+      silent far more often than they route work — only
+      :func:`durable_work_refs` evidence mints, so a Slack reply can never
+      spawn a packet.
+    - **One-shot stamp guard.** The slack lane's receipt is terminal at
+      admission time, so the reconcile transition can't serve as the
+      once-per-lifecycle gate the triage lane uses. The idea's packet stamp
+      is the gate instead: stamped → skip (refresh, slice 06, owns truth
+      drift after that). A failed mint leaves no stamp, so a crash-retry
+      of the same terminal transition retries the mint.
+    """
+    try:
+        org_id = str(getattr(event, "org_id", "") or "")
+        if not org_id:
+            return MintResult(ok=False, reason="event has no org")
+        work_refs = durable_work_refs(attribution)
+        if not work_refs:
+            return MintResult(ok=False, reason="no durable work created by run")
+
+        from brain.platform.db.models.idea import Idea
+
+        idea = (
+            (
+                await session.execute(
+                    select(Idea)
+                    .where(
+                        Idea.origin_ref == f"inbound_event:{event.id}",
+                        Idea.org_id == org_id,
+                    )
+                    .order_by(Idea.created_at.asc())
+                    .limit(1)
                 )
-            except Exception as exc:  # noqa: BLE001 — the packet exists; the reply degraded
-                logger.warning("packet %s minted but Slack reply failed: %s",
-                               getattr(result.handoff, "id", "?"), exc)
-        return result
+            )
+            .scalars()
+            .first()
+        )
+        if idea is not None and dict(dict(getattr(idea, "agent_details", None) or {}).get("packet") or {}):
+            return MintResult(ok=False, reason="packet already minted for event")
+        if idea is None:
+            idea = await _create_job_home_idea(
+                session,
+                org_id=org_id,
+                event=event,
+                run_row=run_row,
+                attribution=attribution,
+                work_refs=work_refs,
+            )
+        if idea is None:
+            return MintResult(ok=False, reason="no owner and no unclaimed pool for job home")
+
+        return await _mint_for_idea_and_event(
+            session, org_id=org_id, idea=idea, event=event,
+            attribution=attribution, readers=readers,
+        )
     except Exception as exc:  # noqa: BLE001 — total containment
         logger.warning("packet mint failed for event %s: %s", getattr(event, "id", "?"), exc)
         return MintResult(ok=False, reason=f"{type(exc).__name__}: {exc}")

--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -578,6 +578,25 @@ async def mint_packet_after_triage(
         return MintResult(ok=False, reason=f"{type(exc).__name__}: {exc}")
 
 
+async def _acquire_event_mint_lock(session: Any, *, org_id: str, event_id: str) -> None:
+    """Postgres advisory xact lock keyed on (org, event) — released at the
+    caller's commit/rollback. Non-postgres sessions (unit tests on sqlite,
+    fakes) skip it: the races it closes are cross-connection, which those
+    environments don't exercise."""
+    try:
+        dialect = getattr(getattr(session, "bind", None), "dialect", None)
+        if getattr(dialect, "name", "") != "postgresql":
+            return
+    except Exception:  # noqa: BLE001 — no bind info → assume no lock support
+        return
+    from sqlalchemy import text as sql_text
+
+    await session.execute(
+        sql_text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+        {"key": f"packet-mint:{org_id}:{event_id}"},
+    )
+
+
 def _github_repo_from_refs(work_refs: list[dict[str, str]]) -> str | None:
     for ref in work_refs:
         if str(ref.get("kind") or "") in ("github_issue", "github_pull_request"):
@@ -724,6 +743,15 @@ async def mint_packet_after_actionable_run(
         work_refs = durable_work_refs(attribution)
         if not work_refs:
             return MintResult(ok=False, reason="no durable work created by run")
+
+        # Serialize per event BEFORE the idea lookup: ideas have no unique
+        # constraint on origin_ref, so an unlocked check-then-insert lets two
+        # concurrent reconciles (illo_get_result polls racing on a still-open
+        # submit receipt) create two job homes → two packets (cross-family
+        # review finding, 2026-07-16). The xact-scoped advisory lock makes
+        # lookup → stamp check → create → mint one critical section per
+        # event; the loser blocks, then sees the winner's committed stamp.
+        await _acquire_event_mint_lock(session, org_id=org_id, event_id=str(event.id))
 
         from brain.platform.db.models.idea import Idea
 

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -83,6 +83,31 @@ _OBJECT_REF_KINDS = {
     "run": "agent_run",
 }
 
+# GitHub artifacts come back as {"repo": "owner/name", "issue": {"type",
+# "number", ...}} (the connector's payload contract), not as *_id keys, so
+# the maps above cannot see them. Without this extraction a run whose whole
+# outcome is a filed issue reports no durable refs at all.
+_GITHUB_ARTIFACT_KINDS = {
+    "issue": "github_issue",
+    "pull_request": "github_pull_request",
+}
+
+# Ref kinds that represent routed/created WORK (something a teammate or
+# their agent picks up), as opposed to conversation, memory, or plumbing
+# state. This is the packet-mint predicate's vocabulary (mirrors how
+# preservation.py filters mutated refs by kind).
+WORK_ITEM_REF_KINDS = frozenset(
+    {
+        "github_issue",
+        "github_pull_request",
+        "idea",
+        "domain_record",
+        "agent_run",
+        "launch_handoff",
+        "thread",
+    }
+)
+
 
 def _json_dict(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
@@ -207,10 +232,34 @@ def _add_explicit_ref_values(
     _add_explicit_ref(refs, seen, value=value, source=source)
 
 
+def _add_github_artifact_ref(
+    refs: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    value: Mapping[str, Any],
+    source: str,
+) -> None:
+    repo = str(value.get("repo") or "").strip()
+    issue = value.get("issue")
+    if repo.count("/") != 1 or not isinstance(issue, Mapping):
+        return
+    try:
+        number = int(str(issue.get("number") or "").strip())
+    except (TypeError, ValueError):
+        return
+    if number < 1:
+        return
+    kind = _GITHUB_ARTIFACT_KINDS.get(str(issue.get("type") or "issue").strip() or "issue")
+    if kind is None:
+        return
+    _add_ref(refs, seen, kind=kind, value=f"{repo}#{number}", source=source)
+
+
 def _collect_refs(value: Any, refs: list[dict[str, str]], seen: set[tuple[str, str]], *, source: str) -> None:
     if len(refs) >= _MAX_TARGET_REFS:
         return
     if isinstance(value, Mapping):
+        _add_github_artifact_ref(refs, seen, value=value, source=source)
         for key, child in value.items():
             key_text = str(key)
             if key_text in _EXPLICIT_REF_KEYS:
@@ -383,4 +432,30 @@ async def summarize_inbound_run_attribution(
     }
 
 
-__all__ = ["summarize_inbound_run_attribution"]
+def durable_work_refs(attribution: Mapping[str, Any] | None) -> list[dict[str, str]]:
+    """Mutated refs proving the run created or routed durable WORK.
+
+    The packet-mint predicate for actionable-run lanes: only refs of
+    work-item kinds count, and refs produced by conversational tools
+    (``side_effect_class == "chat_message"``) never do — a Slack reply is
+    an answer, not routed work, and must not mint a packet.
+    """
+    out: list[dict[str, str]] = []
+    for ref in (attribution or {}).get("mutated_target_refs") or []:
+        if not isinstance(ref, Mapping):
+            continue
+        if str(ref.get("kind") or "") not in WORK_ITEM_REF_KINDS:
+            continue
+        source = str(ref.get("source") or "")
+        registration = get_tool_registration(source) if source else None
+        if _enum_value(getattr(registration, "side_effect_class", "")) == "chat_message":
+            continue
+        out.append({str(key): str(value) for key, value in ref.items()})
+    return out
+
+
+__all__ = [
+    "WORK_ITEM_REF_KINDS",
+    "durable_work_refs",
+    "summarize_inbound_run_attribution",
+]

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -1,7 +1,8 @@
-"""Reconcile inbound decision receipts after Illo triage runs finish."""
+"""Reconcile inbound decision receipts after inbound-admitted runs finish."""
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -19,6 +20,15 @@ from brain.systems.inbound.preservation import (
 from brain.systems.inbound.status import STATUS_REVIEW_REQUIRED
 from brain.systems.runs.domain import AgentRun, ArtifactType
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
+
+logger = logging.getLogger(__name__)
+
+# Receipt lanes. Triage/submit receipts are written NON-terminal at admission
+# and this module transitions them when the run finishes; the slack-teammate
+# lane writes its receipt already-terminal ("run admitted" IS its decision),
+# so it gets a mint check here but never a receipt/event rewrite.
+_TRIAGE_RECEIPT_TYPES = frozenset({"illo_triage", "illo_submit"})
+_ACTIONABLE_RECEIPT_TYPES = frozenset({"slack_teammate_run"})
 
 
 def _json_dict(value: Any) -> dict[str, Any]:
@@ -115,6 +125,7 @@ async def _inbound_receipt_for_run(
     *,
     event_id: str,
     run_id: int,
+    receipt_types: frozenset[str],
 ) -> InboundDecisionReceiptRow | None:
     rows = (
         await session.scalars(
@@ -126,22 +137,81 @@ async def _inbound_receipt_for_run(
     for row in rows:
         tool_use = _json_dict(row.tool_use)
         target = _json_dict(row.target)
-        if tool_use.get("type") not in {"illo_triage", "illo_submit"}:
+        if tool_use.get("type") not in receipt_types:
             continue
         if str(tool_use.get("run_id") or target.get("run_id") or "") == str(run_id):
             return row
     return None
 
 
+def _log_mint_result(*, event_id: str, run_id: int, lane: str, result: Any) -> None:
+    """One line per mint decision (worker logs at INFO). This is what makes a
+    dormant lane visible: silence around packets is itself the bug this line
+    guards against — skips say WHY, mints say what happened."""
+    logger.info(
+        "packet mint: event=%s run=%s lane=%s ok=%s created=%s posted=%s reason=%s",
+        event_id,
+        run_id,
+        lane,
+        getattr(result, "ok", None),
+        getattr(result, "created", None),
+        getattr(result, "posted", None),
+        getattr(result, "reason", "") or "minted",
+    )
+
+
+async def _mint_for_actionable_run(
+    session: AsyncSession,
+    *,
+    event: InboundEventRow,
+    run_row: AgentRunRow | AgentRun,
+    status: RunStatus,
+    event_id: str,
+    run_id: int,
+) -> None:
+    """Mint check for runs admitted by the slack-teammate lane.
+
+    Their receipts are terminal at admission, so the triage path's
+    transition guard can never fire — the mint's own stamp guard (see
+    :func:`mint_packet_after_actionable_run`) provides once-per-event.
+    Fully contained: this hook may never break run-status persistence."""
+    try:
+        receipt = await _inbound_receipt_for_run(
+            session, event_id=event_id, run_id=run_id, receipt_types=_ACTIONABLE_RECEIPT_TYPES
+        )
+        if receipt is None:
+            return
+        lane = str(_json_dict(receipt.tool_use).get("type") or "actionable")
+        if status != RunStatus.COMPLETED:
+            logger.info(
+                "packet mint skipped: event=%s run=%s lane=%s run_status=%s",
+                event_id, run_id, lane, status.value,
+            )
+            return
+        attribution = await summarize_inbound_run_attribution(session, run_id=run_id, status=status)
+        from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+        result = await mint_packet_after_actionable_run(
+            session, event=event, run_row=run_row, attribution=attribution
+        )
+        _log_mint_result(event_id=event_id, run_id=run_id, lane=lane, result=result)
+    except Exception:  # noqa: BLE001 — belt to mint's own containment
+        logger.warning("packet mint hook failed for event %s", event_id, exc_info=True)
+
+
 async def reconcile_inbound_triage_run(
     session: AsyncSession,
     run: AgentRunRow | AgentRun | int,
 ) -> InboundDecisionReceiptRow | None:
-    """Close the decision receipt loop for an inbound triage run.
+    """Close the decision receipt loop for an inbound-admitted run.
 
     Triage admission starts with an inbound event in ``review_required``. Once the
     admitted Illo run reaches a terminal state, the event and receipt should show
     the final run outcome instead of only the queued handoff.
+
+    Slack-teammate admissions close their receipt at admission time instead;
+    for those this function leaves receipt and event untouched and only runs
+    the packet-mint check (durable work → handoff packet).
     """
 
     row = await session.get(AgentRunRow, int(run)) if isinstance(run, int) else run
@@ -162,8 +232,18 @@ async def reconcile_inbound_triage_run(
         return None
 
     run_id = int(getattr(row, "id"))
-    receipt = await _inbound_receipt_for_run(session, event_id=event_id, run_id=run_id)
+    receipt = await _inbound_receipt_for_run(
+        session, event_id=event_id, run_id=run_id, receipt_types=_TRIAGE_RECEIPT_TYPES
+    )
     if receipt is None:
+        # Not the triage/submit lane. The slack-teammate lane lands here —
+        # its receipt closed at admission, but a COMPLETED run that created
+        # durable work still owes a handoff packet (the gate that silently
+        # never fired in prod: this lane is where actionable runs actually
+        # complete).
+        await _mint_for_actionable_run(
+            session, event=event, run_row=row, status=status, event_id=event_id, run_id=run_id
+        )
         return None
     # Captured BEFORE mutation: the packet hook fires only on the transition
     # INTO a terminal receipt state. Re-reconciles of an already-terminal
@@ -243,27 +323,35 @@ async def reconcile_inbound_triage_run(
 
     await session.flush()
 
-    # Handoff packet (spec: illo-handoff-packets slice 05): a COMPLETED
-    # triage routes work — mint the packet that makes it arrive warm.
-    # Once per receipt lifecycle (see receipt_was_terminal above). Double
+    # Handoff packet (spec: illo-handoff-packets slice 05): a COMPLETED run
+    # that routes work mints the packet that makes it arrive warm. Once per
+    # receipt lifecycle (see receipt_was_terminal above). Lanes differ:
+    # triage completion IS the routing moment, so illo_triage mints
+    # unconditionally; illo_submit runs often just answer, so they mint only
+    # when attribution shows durable work (the actionable-run path, which
+    # also carries a stamp guard against evidence-missing receipts that
+    # never reach a terminal state and re-enter here on every poll). Double
     # containment: mint never raises by contract, and the import + call sit
     # under their own guard so even an import-chain break cannot take down
     # the receipt loop that worked before packets existed.
-    if (
-        status == RunStatus.COMPLETED
-        and tool_use.get("type") == "illo_triage"
-        and not receipt_was_terminal
-    ):
+    receipt_type = str(tool_use.get("type") or "")
+    if status == RunStatus.COMPLETED and not receipt_was_terminal:
         try:
-            from brain.systems.briefing.mint import mint_packet_after_triage
+            if receipt_type == "illo_triage":
+                from brain.systems.briefing.mint import mint_packet_after_triage
 
-            await mint_packet_after_triage(
-                session, event=event, run_row=row, attribution=attribution
-            )
+                result = await mint_packet_after_triage(
+                    session, event=event, run_row=row, attribution=attribution
+                )
+            else:  # illo_submit — the only other admitted triage-lane type
+                from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+                result = await mint_packet_after_actionable_run(
+                    session, event=event, run_row=row, attribution=attribution
+                )
+            _log_mint_result(event_id=event_id, run_id=run_id, lane=receipt_type, result=result)
         except Exception:  # noqa: BLE001 — belt to mint's own containment
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "packet mint hook failed for event %s", event_id, exc_info=True
             )
 

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -144,11 +144,26 @@ async def _inbound_receipt_for_run(
     return None
 
 
+# Benign repeat outcomes on the poll-driven submit lane: the FIRST decision
+# already logged at INFO; every later illo_get_result poll re-derives the
+# same skip, which is churn, not signal.
+_REPEAT_SKIP_REASONS = frozenset(
+    {"packet already minted for event", "no durable work created by run"}
+)
+
+
 def _log_mint_result(*, event_id: str, run_id: int, lane: str, result: Any) -> None:
     """One line per mint decision (worker logs at INFO). This is what makes a
     dormant lane visible: silence around packets is itself the bug this line
-    guards against — skips say WHY, mints say what happened."""
-    logger.info(
+    guards against — skips say WHY, mints say what happened. The submit lane
+    re-dispatches on every result poll, so its benign repeat skips drop to
+    DEBUG; single-shot lanes always speak at INFO."""
+    reason = getattr(result, "reason", "") or "minted"
+    level = logging.INFO
+    if lane == "illo_submit" and reason in _REPEAT_SKIP_REASONS:
+        level = logging.DEBUG
+    logger.log(
+        level,
         "packet mint: event=%s run=%s lane=%s ok=%s created=%s posted=%s reason=%s",
         event_id,
         run_id,
@@ -156,7 +171,7 @@ def _log_mint_result(*, event_id: str, run_id: int, lane: str, result: Any) -> N
         getattr(result, "ok", None),
         getattr(result, "created", None),
         getattr(result, "posted", None),
-        getattr(result, "reason", "") or "minted",
+        reason,
     )
 
 
@@ -324,32 +339,39 @@ async def reconcile_inbound_triage_run(
     await session.flush()
 
     # Handoff packet (spec: illo-handoff-packets slice 05): a COMPLETED run
-    # that routes work mints the packet that makes it arrive warm. Once per
-    # receipt lifecycle (see receipt_was_terminal above). Lanes differ:
-    # triage completion IS the routing moment, so illo_triage mints
-    # unconditionally; illo_submit runs often just answer, so they mint only
-    # when attribution shows durable work (the actionable-run path, which
-    # also carries a stamp guard against evidence-missing receipts that
-    # never reach a terminal state and re-enter here on every poll). Double
-    # containment: mint never raises by contract, and the import + call sit
-    # under their own guard so even an import-chain break cannot take down
-    # the receipt loop that worked before packets existed.
+    # that routes work mints the packet that makes it arrive warm. Lanes
+    # differ. illo_triage: triage completion IS the routing moment — mint
+    # unconditionally, once per receipt lifecycle (receipt_was_terminal
+    # above). illo_submit: runs often just answer, so the actionable path
+    # mints only on durable-work evidence — and it dispatches on EVERY
+    # reconcile of a completed run, not just the receipt transition, so a
+    # contained mint failure is retried by the next illo_get_result poll
+    # instead of becoming permanent (cross-family review finding,
+    # 2026-07-16); its stamp guard makes minted events a cheap DB-only
+    # skip. Double containment: mint never raises by contract, and the
+    # import + call sit under their own guard so even an import-chain break
+    # cannot take down the receipt loop that worked before packets existed.
     receipt_type = str(tool_use.get("type") or "")
-    if status == RunStatus.COMPLETED and not receipt_was_terminal:
+    if status == RunStatus.COMPLETED:
         try:
+            result = None
             if receipt_type == "illo_triage":
-                from brain.systems.briefing.mint import mint_packet_after_triage
+                if not receipt_was_terminal:
+                    from brain.systems.briefing.mint import mint_packet_after_triage
 
-                result = await mint_packet_after_triage(
-                    session, event=event, run_row=row, attribution=attribution
-                )
+                    result = await mint_packet_after_triage(
+                        session, event=event, run_row=row, attribution=attribution
+                    )
             else:  # illo_submit — the only other admitted triage-lane type
                 from brain.systems.briefing.mint import mint_packet_after_actionable_run
 
                 result = await mint_packet_after_actionable_run(
                     session, event=event, run_row=row, attribution=attribution
                 )
-            _log_mint_result(event_id=event_id, run_id=run_id, lane=receipt_type, result=result)
+            if result is not None:
+                _log_mint_result(
+                    event_id=event_id, run_id=run_id, lane=receipt_type, result=result
+                )
         except Exception:  # noqa: BLE001 — belt to mint's own containment
             logger.warning(
                 "packet mint hook failed for event %s", event_id, exc_info=True

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -48,6 +48,9 @@ x-illo-env: &illo-env
   ILLO_PRODUCT_OWNER_USER_ID: ${ILLO_PRODUCT_OWNER_USER_ID:-}
   ILLO_REPO_OWNERS: ${ILLO_REPO_OWNERS:-}
   ILLO_UNCLAIMED_POOL_USER_ID: ${ILLO_UNCLAIMED_POOL_USER_ID:-}
+  # Handoff packets (specs/illo-handoff-packets): per-member launch targets.
+  # Empty default = codex for everyone (mint.py's config-with-default).
+  ILLO_MEMBER_AGENT_TARGETS: ${ILLO_MEMBER_AGENT_TARGETS:-}
   ILLO_GITHUB_WEBHOOK_SECRET: ${ILLO_GITHUB_WEBHOOK_SECRET:-}
   ILLO_GITHUB_CONNECTION_ID: ${ILLO_GITHUB_CONNECTION_ID:-}
   # Slice 5 deploy-state: watched repos arm the promotion sweep, ladder

--- a/specs/illo-handoff-packets/README.md
+++ b/specs/illo-handoff-packets/README.md
@@ -205,6 +205,38 @@ after the Codex worker wedged again — 0.15s CPU in 25min):**
   starvation, IntegrityError re-select, lock assertion, label fallback —
   plus the illo-dev probe before merge).
 
+**Post-deploy fix (2026-07-16, Claude-implemented): mint connected to the
+live completion lanes.** Production showed ZERO packets since the 07-13
+deploy: slice 05's hook fired only on `illo_triage` receipt transitions, but
+that lane went dormant on 07-09 — actionable runs actually complete as
+`slack_teammate_run` (receipt terminal at admission, so the transition
+guard can never fire) and `illo_submit`; neither lane creates the triage
+idea mint required, and every skip was silent. The fix, in three
+still-contained layers:
+- **Attribution sees filed GitHub artifacts**: `{"repo", "issue": {...}}`
+  connector payloads now yield `github_issue`/`github_pull_request`
+  mutated refs (`owner/repo#N`), and `durable_work_refs()` (attribution.py)
+  is the shared work predicate — work-item ref kinds only, refs from
+  `chat_message`-class tools never count (a Slack reply is not routed work).
+- **Lane-aware reconcile hook**: `illo_triage` keeps the unconditional
+  transition-gated mint; `illo_submit` mints on its receipt transition via
+  the new `mint_packet_after_actionable_run` (durable-work predicate);
+  `slack_teammate_run` receipts (never rewritten — they closed at
+  admission) get the same actionable mint with the idea's packet stamp as
+  the once-per-event gate. EVERY mint decision logs one INFO
+  `packet mint: event=… lane=… ok=… reason=…` line — a dormant gate can
+  never be silent again.
+- **Job-home idea for idea-less lanes**: `_create_job_home_idea` (mint.py)
+  mirrors `_queue_illo_triage`'s exact shape (same `inbound_triage`/
+  `assignment` keys, owner via `resolve_owner` with the FILED repo driving
+  repo rules, unclaimed-pool parking) so gather/provenance/refresh work
+  unchanged; the description embeds `owner/repo#N` work refs so gather
+  reaches the created artifacts; admits NO new run. Backfill of pre-fix
+  events is explicitly out of scope (the hook is transition-driven).
+  Regression suites: `tests/test_inbound_reconciliation.py` (lane
+  end-to-end on sqlite), `tests/test_inbound_attribution.py`, actionable
+  cases in `tests/test_briefing_mint.py`.
+
 **Implementation decisions that refine slice texts (06+07, Claude-implemented):**
 - Slice 06: `format_line` appends `→ launch: <url>` (one field, Slack-
   escaped, no new section). The cycle's `_attach_and_refresh_packets` maps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,34 @@ def allow_asgi_test_host_for_dev_auth_fallback(monkeypatch):
     )
 
 
+@pytest.fixture
+def sqlite_postgres_ddl_patch():
+    """Make postgres-typed tables (JSONB, BIGINT, ::jsonb defaults) render on
+    SQLite so repository tests can create them. Same guarded, idempotent
+    patch as test_agent_run_state_machine._patch_sqlite_for_agent_run_tables
+    (shared here for tests outside that module)."""
+    import re
+
+    from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+    if not hasattr(SQLiteTypeCompiler, "visit_JSONB"):
+        SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_BIGINT = lambda self, type_, **kw: "INTEGER"
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_agent_run_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+        return result
+
+    patched._agent_run_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
 # --- Docker test DB fixtures ---
 
 TEST_DB_URL = os.environ.get("TEST_DB_URL")

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -158,6 +158,14 @@ class FakeSession:
     def add(self, row):
         # Store the LIVE object (SQLAlchemy identity-map semantics): later
         # mutations through the returned row must be visible in the store.
+        if type(row).__name__ == "Idea":
+            # The actionable-lane hook creates the job-home idea itself; the
+            # ORM id default fires at INSERT, which this fake must emulate.
+            if not getattr(row, "id", None):
+                row.id = f"idea-{self._next_id}"
+                self._next_id += 1
+            self._ideas.append(row)
+            return
         if not getattr(row, "id", None):
             row.id = f"hf-{self._next_id}"
             self._next_id += 1
@@ -531,3 +539,184 @@ async def test_probe_stage_creates_and_posts_nothing(posts):
     assert "Launch: {launch_url}" in packet.human_brief  # placeholder intact
     assert session.handoffs == []  # no row
     assert posts == []  # no reply
+
+
+# --- Actionable-run minting (slack_teammate_run / illo_submit lanes) ---
+#
+# These lanes have NO pre-run triage idea and their receipts are terminal at
+# admission, so the hook must (a) only mint on durable-work evidence, (b)
+# create the job-home idea itself, and (c) one-shot via the packet stamp.
+
+_RUN_USER = "8b6f3f7e-0000-0000-0000-000000000002"
+_AUTHORITY = "8b6f3f7e-0000-0000-0000-000000000003"
+_ISSUE_REF = {
+    "kind": "github_issue",
+    "id": "uwear-ai/uwear-backend#616",
+    "source": "create_github_issue",
+}
+
+
+def _actionable_event(channel_type: str = "channel"):
+    event = _event(channel_type)
+    event.origin = "slack.channel_message"
+    event.connection_id = "conn-1"
+    event.authority_user_id = _AUTHORITY
+    return event
+
+
+def _run_row():
+    return SimpleNamespace(id=1602, user_id=_RUN_USER)
+
+
+def _attribution(refs=(_ISSUE_REF,)):
+    return {
+        "summary": "Illo created github_issue using create_github_issue.",
+        "tags": ["created"],
+        "tool_names": ["create_github_issue"],
+        "target_refs": list(refs),
+        "mutated_target_refs": list(refs),
+        "run_event_ids": [1],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_assignment_env(monkeypatch):
+    for key in ("ILLO_BUSINESS_OWNER_USER_ID", "ILLO_PRODUCT_OWNER_USER_ID",
+                "ILLO_REPO_OWNERS", "ILLO_UNCLAIMED_POOL_USER_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
+async def test_actionable_run_mints_job_home_and_posts(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    session = FakeSession(events=[_actionable_event()])
+    result = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=_attribution(), readers=_readers(),
+    )
+
+    assert result.ok and result.created and result.posted
+    assert len(session.handoffs) == 1
+    row = session.handoffs[0]
+    assert row.source_surface == "inbound_triage"
+    assert (row.metadata_ or {}).get("job_ref", "").startswith("idea:")
+
+    assert len(session._ideas) == 1
+    idea = session._ideas[0]
+    assert idea.origin_ref == f"inbound_event:{_EVENT_ID}"
+    assert idea.origin == "inbound_signal"
+    details = idea.agent_details
+    assert details["inbound_triage"]["event_id"] == _EVENT_ID
+    assert details["inbound_triage"]["reason"] == "actionable_run_completion"
+    assert details["assignment"]["owner_id"] == _RUN_USER  # connection basis
+    assert details["task_domain"]
+    assert "uwear-ai/uwear-backend#616" in (idea.description or "")
+    assert details["packet"]["handoff_id"] == str(row.id)  # stamped
+
+    assert len(posts) == 1
+    assert posts[0]["channel"] == "C0PROD"
+    assert posts[0]["thread_ts"] == "1751964840.0"
+
+
+async def test_actionable_run_without_durable_work_skips(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    chat_only = {
+        "mutated_target_refs": [
+            {"kind": "message", "id": "m1", "source": "post_slack_reply"},
+        ],
+    }
+    session = FakeSession(events=[_actionable_event()])
+    result = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=chat_only, readers=_readers(),
+    )
+    assert result.ok is False
+    assert result.reason == "no durable work created by run"
+    assert session.handoffs == []
+    assert session._ideas == []
+    assert posts == []
+
+
+async def test_actionable_run_mint_is_one_shot_per_event(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    session = FakeSession(events=[_actionable_event()])
+    first = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert first.ok and first.created
+    second = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert second.ok is False
+    assert second.reason == "packet already minted for event"
+    assert len(session.handoffs) == 1
+    assert len(session._ideas) == 1
+    assert len(posts) == 1
+
+
+async def test_actionable_run_non_public_provenance_never_posts(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    session = FakeSession(events=[_actionable_event("im")])
+    result = await mint_packet_after_actionable_run(
+        session, event=_actionable_event("im"), run_row=_run_row(),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert result.ok and result.created
+    assert result.posted is False
+    assert len(session.handoffs) == 1  # persistence is never suppressed
+    assert posts == []
+
+
+async def test_actionable_run_repo_rule_owns_the_packet(monkeypatch, posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    ruled_owner = "8b6f3f7e-0000-0000-0000-00000000000e"
+    monkeypatch.setenv("ILLO_REPO_OWNERS", f"uwear-backend={ruled_owner}")
+    session = FakeSession(events=[_actionable_event()])
+    result = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert result.ok and result.created
+    idea = session._ideas[0]
+    assert idea.agent_details["assignment"]["owner_id"] == ruled_owner
+    assert idea.agent_details["assignment"]["basis"] == "rule"
+
+
+async def test_actionable_run_unowned_without_pool_skips(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    event = _actionable_event()
+    event.authority_user_id = None
+    session = FakeSession(events=[event])
+    result = await mint_packet_after_actionable_run(
+        session, event=event, run_row=SimpleNamespace(id=1, user_id=None),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert result.ok is False
+    assert result.reason == "no owner and no unclaimed pool for job home"
+    assert session.handoffs == []
+    assert session._ideas == []
+
+
+async def test_actionable_run_unowned_parks_on_unclaimed_pool(monkeypatch, posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    pool = "8b6f3f7e-0000-0000-0000-00000000000f"
+    monkeypatch.setenv("ILLO_UNCLAIMED_POOL_USER_ID", pool)
+    event = _actionable_event()
+    event.authority_user_id = None
+    session = FakeSession(events=[event])
+    result = await mint_packet_after_actionable_run(
+        session, event=event, run_row=SimpleNamespace(id=1, user_id=None),
+        attribution=_attribution(), readers=_readers(),
+    )
+    assert result.ok and result.created
+    idea = session._ideas[0]
+    assert idea.agent_details["assignment"]["owner_id"] == pool
+    assert idea.agent_details["assignment"]["unclaimed"] is True

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -720,3 +720,29 @@ async def test_actionable_run_unowned_parks_on_unclaimed_pool(monkeypatch, posts
     idea = session._ideas[0]
     assert idea.agent_details["assignment"]["owner_id"] == pool
     assert idea.agent_details["assignment"]["unclaimed"] is True
+
+
+async def test_event_mint_lock_taken_on_postgres_only():
+    """The per-event advisory lock serializes concurrent actionable mints on
+    Postgres (ideas have no origin_ref uniqueness); other dialects skip it."""
+    from brain.systems.briefing.mint import _acquire_event_mint_lock
+
+    executed: list[str] = []
+
+    class LockSession:
+        def __init__(self, dialect_name):
+            self.bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+
+        async def execute(self, stmt, params=None):
+            executed.append((str(stmt), dict(params or {})))
+            return _Result([])
+
+    await _acquire_event_mint_lock(LockSession("postgresql"), org_id=_ORG, event_id=_EVENT_ID)
+    assert len(executed) == 1
+    assert "pg_advisory_xact_lock" in executed[0][0]
+    assert executed[0][1]["key"] == f"packet-mint:{_ORG}:{_EVENT_ID}"
+
+    executed.clear()
+    await _acquire_event_mint_lock(LockSession("sqlite"), org_id=_ORG, event_id=_EVENT_ID)
+    assert executed == []
+    await _acquire_event_mint_lock(FakeSession(), org_id=_ORG, event_id=_EVENT_ID)  # no bind at all

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -1,0 +1,145 @@
+"""Attribution: durable-ref extraction + the packet-mint work predicate.
+
+The gap under test (2026-07-16 fix): a run whose entire outcome is a filed
+GitHub issue reported NO mutated refs — the connector payload carries
+``{"repo", "issue": {"number"}}``, not ``*_id`` keys — which left the
+packet-mint predicate blind to the most common actionable outcome.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.systems.inbound.attribution import (
+    WORK_ITEM_REF_KINDS,
+    durable_work_refs,
+    summarize_inbound_run_attribution,
+)
+from brain.systems.runs.status import RunStatus
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory([
+        AgentRunRow.__table__,
+        AgentRunEventRow.__table__,
+    ])
+
+
+def _tool_event(run_id: int, seq: int, tool: str, result: dict) -> AgentRunEventRow:
+    return AgentRunEventRow(
+        run_id=run_id,
+        sequence_no=seq,
+        event_type="run.tool_completed",
+        payload={"tool_name": tool, "args": {}, "result": json.dumps(result)},
+    )
+
+
+async def _seed_run(session) -> int:
+    run = AgentRunRow(
+        org_id=None,
+        thread_id="t-1",
+        profile="fast",
+        recipe="illo",
+        status="completed",
+        input_message="x",
+    )
+    session.add(run)
+    await session.flush()
+    return int(run.id)
+
+
+async def test_created_github_issue_becomes_a_mutated_ref(session):
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "create_github_issue", {
+        "repo": "uwear-ai/uwear-backend",
+        "issue": {"type": "issue", "number": 616, "title": "Rollbar: boom",
+                  "html_url": "https://github.com/uwear-ai/uwear-backend/issues/616"},
+        "token_source": "github_app",
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+    refs = attribution["mutated_target_refs"]
+    assert {"kind": "github_issue", "id": "uwear-ai/uwear-backend#616",
+            "source": "create_github_issue"} in refs
+    assert durable_work_refs(attribution) == [
+        {"kind": "github_issue", "id": "uwear-ai/uwear-backend#616",
+         "source": "create_github_issue"}
+    ]
+
+
+async def test_created_pull_request_ref_kind(session):
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "create_github_issue", {
+        "repo": "uwear-ai/uwear-website",
+        "issue": {"type": "pull_request", "number": 88},
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+    kinds = {ref["kind"] for ref in attribution["mutated_target_refs"]}
+    assert "github_pull_request" in kinds
+
+
+async def test_error_payload_with_repo_yields_no_artifact_ref(session):
+    """The handler's failure shape carries ``repo`` but no ``issue`` — it must
+    never read as created work."""
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "create_github_issue", {
+        "error": "No GitHub App identity is connected",
+        "no_write_token": True,
+        "repo": "uwear-ai/uwear-backend",
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+    assert durable_work_refs(attribution) == []
+
+
+async def test_slack_reply_never_counts_as_durable_work(session):
+    run_id = await _seed_run(session)
+    session.add(_tool_event(run_id, 1, "post_slack_reply", {
+        "operation": "posted",
+        "channel_id": "C123",
+        "message_ts": "1752600000.0",
+    }))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+    assert durable_work_refs(attribution) == []
+
+
+def test_predicate_filters_kinds_and_chat_sources():
+    attribution = {
+        "mutated_target_refs": [
+            {"kind": "github_issue", "id": "a/b#1", "source": "create_github_issue"},
+            {"kind": "idea", "id": "i-1", "source": "manage_idea"},
+            {"kind": "message", "id": "m-1", "source": "post_chat_message"},
+            # work-item kind, but produced by a conversational tool:
+            {"kind": "thread", "id": "t-1", "source": "post_slack_reply"},
+            {"kind": "memory_source", "id": "s-1", "source": "brain_encode"},
+        ]
+    }
+    refs = durable_work_refs(attribution)
+    assert [ref["kind"] for ref in refs] == ["github_issue", "idea"]
+    assert durable_work_refs(None) == []
+    assert durable_work_refs({}) == []
+
+
+def test_work_item_vocabulary_is_the_expected_set():
+    assert WORK_ITEM_REF_KINDS == {
+        "github_issue", "github_pull_request", "idea", "domain_record",
+        "agent_run", "launch_handoff", "thread",
+    }

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -1,0 +1,381 @@
+"""Reconciliation → packet-mint lanes (the gate that never fired in prod).
+
+Production reality this file pins down (diagnosed 2026-07-16): actionable
+inbound runs complete as ``slack_teammate_run`` (and ``illo_submit``) —
+``illo_triage`` receipts stopped occurring on 2026-07-09, before packets
+shipped. The mint hook was gated on the dormant lane, so zero packets were
+ever minted. The regression contract:
+
+- a ``slack_teammate_run``-filed GitHub issue produces a ``launch_handoffs``
+  row with ``source_surface='inbound_triage'`` and a Slack thread post when
+  the provenance is a public channel;
+- runs that only replied in Slack never mint;
+- the slack lane's already-terminal receipt and event are never rewritten;
+- every mint decision leaves a log line (a dormant gate can't be silent);
+- the triage lane's unconditional mint and receipt transition are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from brain.platform.db.models.agent_run import (
+    AgentRunArtifactRow,
+    AgentRunEventRow,
+    AgentRunRow,
+)
+from brain.platform.db.models.idea import Idea
+from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.db.models.launch_handoff import LaunchHandoff
+from brain.platform.db.models.org import User
+from brain.systems.briefing.gather import SlackThreadRead
+from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+
+_ORG = str(uuid.uuid4())
+_CONN = str(uuid.uuid4())
+_RUN_USER = str(uuid.uuid4())
+_NOW = datetime(2026, 7, 16, 9, 0, tzinfo=timezone.utc)
+
+_ISSUE_RESULT = json.dumps({
+    "repo": "uwear-ai/uwear-backend",
+    "issue": {"type": "issue", "number": 616, "title": "Rollbar: boom",
+              "html_url": "https://github.com/uwear-ai/uwear-backend/issues/616"},
+    "token_source": "github_app",
+})
+_REPLY_RESULT = json.dumps({"operation": "posted", "channel_id": "C0PROD",
+                            "message_ts": "1752600001.0"})
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory([
+        AgentRunRow.__table__,
+        AgentRunEventRow.__table__,
+        AgentRunArtifactRow.__table__,
+        InboundEventRow.__table__,
+        InboundDecisionReceiptRow.__table__,
+        Idea.__table__,
+        LaunchHandoff.__table__,
+        User.__table__,
+    ])
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_assignment_env(monkeypatch):
+    for key in ("ILLO_BUSINESS_OWNER_USER_ID", "ILLO_PRODUCT_OWNER_USER_ID",
+                "ILLO_REPO_OWNERS", "ILLO_UNCLAIMED_POOL_USER_ID",
+                "ILLO_MEMBER_AGENT_TARGETS"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fake_readers(monkeypatch):
+    """Gather must do no live I/O in tests: swap the default readers the mint
+    constructs (mint builds them by the names it imported)."""
+
+    class FakeSlackReader:
+        def __init__(self, client=None):
+            pass
+
+        async def read_thread(self, *, channel, thread_ts, limit):
+            return SlackThreadRead(
+                messages=({"ts": thread_ts, "user": "U0AXEL", "text": "alert body"},),
+                total=1,
+                channel=channel,
+            )
+
+    class FakeGithubReader:
+        def __init__(self, org_id=None, user_id=None):
+            pass
+
+        async def read_ref(self, *, repo_slug, number):
+            return {"kind": "issue", "title": f"{repo_slug}#{number}", "body": "…",
+                    "state": "open", "body_total_chars": 1}
+
+    import brain.systems.briefing.mint as mint_module
+
+    monkeypatch.setattr(mint_module, "DefaultSlackReader", FakeSlackReader)
+    monkeypatch.setattr(mint_module, "DefaultGithubReader", FakeGithubReader)
+
+
+@pytest.fixture(autouse=True)
+def posts(monkeypatch):
+    recorded: list[dict] = []
+
+    class FakeClient:
+        async def post_message(self, *, channel, text, thread_ts=None):
+            recorded.append({"channel": channel, "text": text, "thread_ts": thread_ts})
+            return {"ok": True}
+
+    import brain.systems.slack.client as slack_client
+
+    monkeypatch.setattr(slack_client, "slack_web_client_from_env", lambda: FakeClient())
+    return recorded
+
+
+def _slack_envelope() -> dict:
+    return {
+        "kind": "slack_message",
+        "summary": "Rollbar: generation pipeline exploding",
+        "payload": {
+            "channel_id": "C0ALERTS",
+            "channel_type": "channel",
+            "thread_ts": "1752600000.0",
+            "message_ts": "1752600000.0",
+            "bot_user_id": "B0ILLO",
+        },
+        "hints": {},
+    }
+
+
+async def _seed_slack_lane(session, *, tool_results, run_status="completed") -> tuple[str, int]:
+    """One slack_teammate_run admission, receipt terminal at admission (the
+    production shape written by brain/systems/slack/inbound.py)."""
+    event = InboundEventRow(
+        org_id=_ORG,
+        connection_id=_CONN,
+        origin="slack.channel_message",
+        envelope=_slack_envelope(),
+        status="processed",
+        action_type="slack.run_admitted",
+    )
+    session.add(event)
+    await session.flush()
+
+    run = AgentRunRow(
+        org_id=_ORG,
+        user_id=_RUN_USER,
+        thread_id=f"slack:T1:C0ALERTS:1752600000.0",
+        profile="fast",
+        recipe="illo",
+        status=run_status,
+        input_message="monitor triage",
+        metadata_={"inbound_event": {"event_id": str(event.id)}},
+        completed_at=_NOW if run_status == "completed" else None,
+        failed_at=_NOW if run_status == "failed" else None,
+    )
+    session.add(run)
+    await session.flush()
+
+    event.action_result = {"operation": "slack_run_admitted", "run_id": run.id,
+                           "event_id": str(event.id)}
+    session.add(InboundDecisionReceiptRow(
+        event_id=str(event.id),
+        org_id=_ORG,
+        connection_id=_CONN,
+        status="processed",
+        tool_use={"type": "slack_teammate_run", "run_id": run.id,
+                  "slack_thread_id": "slack:T1:C0ALERTS:1752600000.0"},
+        target={"kind": "slack_message", "run_id": run.id},
+        outcome=dict(event.action_result),
+    ))
+    for seq, (tool, result) in enumerate(tool_results, start=1):
+        session.add(AgentRunEventRow(
+            run_id=run.id,
+            sequence_no=seq,
+            event_type="run.tool_completed",
+            payload={"tool_name": tool, "args": {}, "result": result},
+        ))
+    await session.flush()
+    return str(event.id), int(run.id)
+
+
+async def _handoffs(session) -> list[LaunchHandoff]:
+    return list((await session.scalars(select(LaunchHandoff))).all())
+
+
+async def _ideas(session) -> list[Idea]:
+    return list((await session.scalars(select(Idea))).all())
+
+
+async def test_slack_filed_issue_mints_packet_and_posts(session, posts, caplog):
+    event_id, run_id = await _seed_slack_lane(
+        session, tool_results=[("create_github_issue", _ISSUE_RESULT),
+                               ("post_slack_reply", _REPLY_RESULT)],
+    )
+    with caplog.at_level(logging.INFO, logger="brain.systems.inbound.reconciliation"):
+        receipt = await reconcile_inbound_triage_run(session, run_id)
+
+    assert receipt is None  # slack receipts are never rewritten
+
+    rows = await _handoffs(session)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source_surface == "inbound_triage"
+    assert row.source_ref.get("inbound_event_id") == event_id
+    assert row.status == "open"
+
+    ideas = await _ideas(session)
+    assert len(ideas) == 1
+    idea = ideas[0]
+    assert idea.origin_ref == f"inbound_event:{event_id}"
+    assert idea.agent_details["packet"]["handoff_id"] == str(row.id)
+    assert idea.agent_details["assignment"]["owner_id"] == _RUN_USER
+    assert "uwear-ai/uwear-backend#616" in (idea.description or "")
+    assert (row.metadata_ or {}).get("job_ref") == f"idea:{idea.id}"
+
+    assert len(posts) == 1
+    assert posts[0]["channel"] == "C0ALERTS"
+    assert posts[0]["thread_ts"] == "1752600000.0"
+
+    mint_lines = [r for r in caplog.records if "packet mint:" in r.getMessage()]
+    assert len(mint_lines) == 1
+    assert "lane=slack_teammate_run" in mint_lines[0].getMessage()
+    assert "ok=True" in mint_lines[0].getMessage()
+
+    # The admission receipt and event stay exactly as the slack lane wrote them.
+    stored = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    assert stored.status == "processed"
+    assert "reconciled_at" not in dict(stored.tool_use)
+    event = await session.get(InboundEventRow, event_id)
+    assert event.status == "processed"
+    assert "triage" not in dict(event.action_result or {})
+
+
+async def test_slack_reply_only_run_skips_with_log_line(session, posts, caplog):
+    _, run_id = await _seed_slack_lane(
+        session, tool_results=[("post_slack_reply", _REPLY_RESULT)],
+    )
+    with caplog.at_level(logging.INFO, logger="brain.systems.inbound.reconciliation"):
+        await reconcile_inbound_triage_run(session, run_id)
+
+    assert await _handoffs(session) == []
+    assert await _ideas(session) == []
+    assert posts == []
+    mint_lines = [r for r in caplog.records if "packet mint:" in r.getMessage()]
+    assert len(mint_lines) == 1
+    assert "reason=no durable work created by run" in mint_lines[0].getMessage()
+
+
+async def test_slack_lane_mint_is_one_shot(session, posts, caplog):
+    _, run_id = await _seed_slack_lane(
+        session, tool_results=[("create_github_issue", _ISSUE_RESULT)],
+    )
+    await reconcile_inbound_triage_run(session, run_id)
+    with caplog.at_level(logging.INFO, logger="brain.systems.inbound.reconciliation"):
+        await reconcile_inbound_triage_run(session, run_id)  # duplicate delivery
+
+    assert len(await _handoffs(session)) == 1
+    assert len(posts) == 1
+    second = [r for r in caplog.records if "packet mint:" in r.getMessage()]
+    assert len(second) == 1
+    assert "reason=packet already minted for event" in second[0].getMessage()
+
+
+async def test_failed_slack_run_never_mints(session, posts, caplog):
+    _, run_id = await _seed_slack_lane(
+        session, tool_results=[("create_github_issue", _ISSUE_RESULT)],
+        run_status="failed",
+    )
+    with caplog.at_level(logging.INFO, logger="brain.systems.inbound.reconciliation"):
+        await reconcile_inbound_triage_run(session, run_id)
+
+    assert await _handoffs(session) == []
+    assert posts == []
+    skipped = [r for r in caplog.records if "packet mint skipped" in r.getMessage()]
+    assert len(skipped) == 1
+    assert "run_status=failed" in skipped[0].getMessage()
+
+
+async def test_submit_lane_mints_on_durable_work_without_post(session, posts):
+    event = InboundEventRow(
+        org_id=_ORG,
+        connection_id=_CONN,
+        origin="mcp.submission",
+        envelope={"kind": "submission", "summary": "please file the melting bug"},
+        status="review_required",
+    )
+    session.add(event)
+    await session.flush()
+    run = AgentRunRow(
+        org_id=_ORG, user_id=_RUN_USER, thread_id=f"inbound:{_CONN}:{event.id}",
+        profile="fast", recipe="illo", status="completed",
+        input_message="submission",
+        metadata_={"inbound_event": {"event_id": str(event.id)}},
+        completed_at=_NOW,
+    )
+    session.add(run)
+    await session.flush()
+    event.action_result = {"handling": {"status": "queued", "run_id": run.id}}
+    session.add(InboundDecisionReceiptRow(
+        event_id=str(event.id), org_id=_ORG, connection_id=_CONN,
+        status="review_required",
+        tool_use={"type": "illo_submit", "status": "queued", "run_id": run.id},
+        target={"kind": "inbound_submission", "event_id": str(event.id)},
+        outcome=dict(event.action_result),
+    ))
+    session.add(AgentRunEventRow(
+        run_id=run.id, sequence_no=1, event_type="run.tool_completed",
+        payload={"tool_name": "create_github_issue", "args": {}, "result": _ISSUE_RESULT},
+    ))
+    await session.flush()
+
+    receipt = await reconcile_inbound_triage_run(session, run.id)
+
+    assert receipt is not None and receipt.status == "processed"  # loop still closes
+    rows = await _handoffs(session)
+    assert len(rows) == 1
+    assert rows[0].source_surface == "inbound_triage"
+    assert posts == []  # no slack provenance → persistence without a post
+
+    # Re-reconcile (illo_get_result polls do this): terminal receipt, no re-mint.
+    await reconcile_inbound_triage_run(session, run.id)
+    assert len(await _handoffs(session)) == 1
+
+
+async def test_triage_lane_still_mints_unconditionally(session, posts):
+    event = InboundEventRow(
+        org_id=_ORG,
+        connection_id=_CONN,
+        origin="webhook.sentry",
+        envelope=_slack_envelope(),  # public provenance so the post fires too
+        status="review_required",
+    )
+    session.add(event)
+    await session.flush()
+    run = AgentRunRow(
+        org_id=_ORG, user_id=_RUN_USER, thread_id="idea:t", profile="fast",
+        recipe="illo", status="completed", input_message="triage",
+        metadata_={"inbound_event": {"event_id": str(event.id)}},
+        completed_at=_NOW,
+    )
+    session.add(run)
+    await session.flush()
+    # The idea _queue_illo_triage would have created before the run.
+    session.add(Idea(
+        title="Inbound signal needs Illo triage: webhook.sentry",
+        description="triage home",
+        status="emerged",
+        origin="inbound_signal",
+        origin_ref=f"inbound_event:{event.id}",
+        user_id=_RUN_USER,
+        org_id=_ORG,
+        agent_details={
+            "inbound_triage": {"event_id": str(event.id)},
+            "task_domain": "engineering",
+            "assignment": {"owner_id": _RUN_USER, "basis": "connection", "unclaimed": False},
+        },
+    ))
+    session.add(InboundDecisionReceiptRow(
+        event_id=str(event.id), org_id=_ORG, connection_id=_CONN,
+        status="review_required",
+        tool_use={"type": "illo_triage", "run_id": run.id},
+        target={"kind": "cortex_idea"},
+        outcome={},
+    ))
+    # NO tool events at all: triage completion must mint regardless.
+    await session.flush()
+
+    receipt = await reconcile_inbound_triage_run(session, run.id)
+
+    assert receipt is not None and receipt.status == "processed"
+    rows = await _handoffs(session)
+    assert len(rows) == 1
+    assert rows[0].source_surface == "inbound_triage"
+    assert len(posts) == 1

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -379,3 +379,58 @@ async def test_triage_lane_still_mints_unconditionally(session, posts):
     assert len(rows) == 1
     assert rows[0].source_surface == "inbound_triage"
     assert len(posts) == 1
+
+
+async def test_submit_mint_failure_is_retried_by_next_poll(session, posts, monkeypatch):
+    """Cross-family review finding (2026-07-16): the receipt transitions to
+    processed even when the contained mint fails — a later illo_get_result
+    poll must retry the mint instead of the packet being lost forever."""
+    import brain.systems.briefing.mint as mint_module
+
+    event = InboundEventRow(
+        org_id=_ORG, connection_id=_CONN, origin="mcp.submission",
+        envelope={"kind": "submission", "summary": "file the melting bug"},
+        status="review_required",
+    )
+    session.add(event)
+    await session.flush()
+    run = AgentRunRow(
+        org_id=_ORG, user_id=_RUN_USER, thread_id=f"inbound:{_CONN}:{event.id}",
+        profile="fast", recipe="illo", status="completed", input_message="s",
+        metadata_={"inbound_event": {"event_id": str(event.id)}}, completed_at=_NOW,
+    )
+    session.add(run)
+    await session.flush()
+    session.add(InboundDecisionReceiptRow(
+        event_id=str(event.id), org_id=_ORG, connection_id=_CONN,
+        status="review_required",
+        tool_use={"type": "illo_submit", "status": "queued", "run_id": run.id},
+        target={"kind": "inbound_submission"}, outcome={},
+    ))
+    session.add(AgentRunEventRow(
+        run_id=run.id, sequence_no=1, event_type="run.tool_completed",
+        payload={"tool_name": "create_github_issue", "args": {}, "result": _ISSUE_RESULT},
+    ))
+    await session.flush()
+
+    real_build = mint_module.build_packet_for_job
+    calls = {"n": 0}
+
+    async def flaky_build(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("gather source down")
+        return await real_build(*args, **kwargs)
+
+    monkeypatch.setattr(mint_module, "build_packet_for_job", flaky_build)
+
+    receipt = await reconcile_inbound_triage_run(session, run.id)
+    assert receipt is not None and receipt.status == "processed"  # loop closed anyway
+    assert await _handoffs(session) == []  # mint failed, contained
+
+    await reconcile_inbound_triage_run(session, run.id)  # the retrying poll
+    rows = await _handoffs(session)
+    assert len(rows) == 1
+    ideas = await _ideas(session)
+    assert len(ideas) == 1  # the failed attempt's job home was reused
+    assert ideas[0].agent_details["packet"]["handoff_id"] == str(rows[0].id)


### PR DESCRIPTION
## Problem

Handoff-packet minting (specs/illo-handoff-packets, shipped 2026-07-13 in #308 + activated in #296/#297) **never fired in production** — zero `launch_handoffs` rows, zero packet stamps, zero packet log lines since deploy.

Root cause (read-only diagnostic against illo-dev, 2026-07-16): the slice-05 hook fired only on `illo_triage` receipt transitions, but that lane went dormant on 2026-07-09 — before packets shipped. Since Jul 13 actionable runs complete as:
- `slack_teammate_run` (81 receipts) — written **terminal at admission** by `brain/systems/slack/inbound.py`, so the reconcile hook's transition-into-terminal guard could never fire for them, and
- `illo_submit` (35 receipts) — admitted by the type filter but excluded by the hook's `type == "illo_triage"` gate.

Neither lane creates the triage Idea `mint_packet_after_triage` hard-requires (`origin_ref == "inbound_event:<id>"`, only `_queue_illo_triage` writes it), so even a widened type check would have skipped with `reason="no triage idea for event"`. Every skip was silent. 13 post-deploy runs completed a `create_github_issue` (e.g. runs 1602/#616, 1566/#614) — none produced a packet.

## Fix (three contained layers)

**1. Attribution sees filed GitHub artifacts** (`brain/systems/inbound/attribution.py`)
`{"repo": "owner/name", "issue": {"number": N}}` connector payloads now yield `github_issue` / `github_pull_request` mutated refs (`owner/repo#N`) — previously the ref maps only knew `*_id` keys, so a run whose whole outcome was a filed issue reported no durable refs at all. New `durable_work_refs()` is the shared mint predicate: work-item ref kinds only (`github_issue`, `github_pull_request`, `idea`, `domain_record`, `agent_run`, `launch_handoff`, `thread`), and refs produced by `chat_message`-class tools never count — a Slack reply is an answer, not routed work.

**2. Lane-aware reconcile hook** (`brain/systems/inbound/reconciliation.py`)
- `illo_triage`: unchanged — unconditional mint on its receipt transition.
- `illo_submit`: mints on its existing receipt transition via the new `mint_packet_after_actionable_run` (durable-work predicate; no Slack provenance → persists without posting).
- `slack_teammate_run`: receipts/events are **never rewritten** (they closed at admission); a COMPLETED run gets the actionable mint with the idea's **packet stamp** as the once-per-event gate (a failed mint leaves no stamp, so a crash-retry of the same transition retries).
- **Every mint decision logs one INFO line** — `packet mint: event=… run=… lane=… ok=… created=… posted=… reason=…` — so a dormant gate can never be silent again (fix for the 96-hour silence).

**3. Job-home idea for idea-less lanes** (`brain/systems/briefing/mint.py`)
`_create_job_home_idea` mirrors `_queue_illo_triage`'s exact shape (same `inbound_triage`/`assignment`/`task_domain` keys) so `load_inbound_event`, gather provenance, refresh (slice 06), and outcomes (slice 07) work unchanged. Owner via the same `resolve_owner` rules — with the **filed repo** driving repo rules (the wrong-owner-is-structural lesson), run-user/connection-authority fallback, unclaimed-pool parking. The description embeds `owner/repo#N` work refs so gather's same-job discovery reaches the created artifacts. Admits **no** new run. Savepoint-wrapped INSERT (commit-time containment parity with the mint write phase).

Also: `ILLO_MEMBER_AGENT_TARGETS` added to the compose `x-illo-env` anchor (the one env var mint.py reads was not passed through; empty default = codex, behavior unchanged).

Out of scope by decision: backfilling packets for pre-fix events (the hook is transition-driven; the 8 pre-Jul-13 rows are the older opt-in mechanism).

## Invariants preserved

- Containment: neither hook can raise into run-status persistence; all writes savepoint-wrapped.
- Noise gate: reuse posts nothing; only public-channel provenance posts; polls never re-gather after a successful mint (stamp guard also covers the evidence-missing submit receipts that re-enter reconcile on every poll).
- Supersede vocabulary, idempotency, no feature gates (merge = live), `source_surface="inbound_triage"` for refresh/outcomes compatibility.

## Verification

- `tests/test_inbound_reconciliation.py` (new): sqlite end-to-end through the real `reconcile_inbound_triage_run` — slack-filed issue → `launch_handoffs` row (`source_surface='inbound_triage'`) + thread post + untouched receipt/event + log line; reply-only run skips with logged reason; one-shot on duplicate delivery; failed runs skip; submit lane mints without posting and still closes its receipt; triage lane byte-for-byte behavior.
- `tests/test_inbound_attribution.py` (new): artifact-ref extraction (incl. the handler's error shape never reading as created work), predicate filtering.
- `tests/test_briefing_mint.py` (+7): job-home creation, assignment bases (connection / repo rule / unclaimed pool / no-owner skip), one-shot stamp, im-provenance persists-without-post.
- Full fast suite: 3656 passed. Full DB suite (docker pg16): 3729 passed — the 3 failures (`test_cross_channel`, `test_quality`) reproduce on clean `ed39c87` with the same DB, pre-existing and unrelated.
- Codex cross-family review (xhigh, adversarial): 4 findings, 3 folded in `1ddedaf` — (HIGH) per-event `pg_advisory_xact_lock` closes the unlocked check-then-insert race on the job-home idea (ideas have no `origin_ref` uniqueness; concurrent `illo_get_result` polls could double-mint); (MED) `illo_submit` completions now re-dispatch the stamp-guarded mint on every reconcile so a contained mint failure is retried by the next poll instead of becoming permanent; (LOW) benign repeat skips on the poll-driven submit lane log at DEBUG. Finding 1 (Slack post precedes the outer commit → rare crash-retry can duplicate the brief with a dead link) is the slice-05 spec's **recorded deferred item** ("revisit with slice 06's refresh cycle, the natural post-commit home") — tracked as a follow-up task, not blocking the fix that makes the feature exist.

Post-merge deploy plan: illo-dev `upgrade.sh --build --no-pull`, worker swap via `runtime-services.sh restart worker`, slack-connector recreate; then a live monitored-channel test alert → confirm `launch_handoffs` row + thread post + `packet mint:` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
