### PR TITLE
Resolve backend Slack bot token Vault-first (packet post/gather/notify)

### DIFF
--- a/brain/systems/briefing/gather.py
+++ b/brain/systems/briefing/gather.py
@@ -111,15 +111,18 @@ class DefaultSlackReader:
     def __init__(self, client: Any | None = None) -> None:
         self._client = client
 
-    def _resolve_client(self) -> Any:
+    async def _resolve_client(self) -> Any:
         if self._client is None:
-            from brain.systems.slack.client import slack_web_client_from_env
+            from brain.systems.slack.client import slack_web_client_from_runtime
 
-            self._client = slack_web_client_from_env()
+            self._client = await slack_web_client_from_runtime(
+                requested_by="packet_gather",
+                reason="Read the origin Slack thread for a handoff dossier.",
+            )
         return self._client
 
     async def read_thread(self, *, channel: str, thread_ts: str, limit: int) -> SlackThreadRead:
-        client = self._resolve_client()
+        client = await self._resolve_client()
         collected: list[dict[str, Any]] = []
         total = 0
         cursor: str | None = None

--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -489,9 +489,11 @@ async def _post_brief_to_origin_thread(*, event: Any, brief: str) -> bool:
     provenance = slack_provenance(event) if event is not None else None
     if not provenance or provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
         return False
-    from brain.systems.slack.client import slack_web_client_from_env
+    from brain.systems.slack.client import slack_web_client_from_runtime
 
-    client = slack_web_client_from_env()
+    client = await slack_web_client_from_runtime(
+        requested_by="packet_mint", reason="Post the handoff-packet brief to the origin thread."
+    )
     await client.post_message(
         channel=provenance["channel"], text=brief, thread_ts=provenance["thread_ts"]
     )

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -229,18 +229,38 @@ async def run_notify_cycle(
     unclaimed = await _count_unclaimed(session, org_id)
     outbound = render_outbound(events, unclaimed_count=unclaimed, urgent_terms=urgent_terms)
 
+    import logging
+
     sender = post or _default_post
+    log = logging.getLogger("illo.notify")
+    post_failures = 0
+    digest_posted = False
+    # A failed send (token unavailable, Slack rejection) must not kill the
+    # tick or the messages behind it — count it, log it, keep going
+    # (cross-family review finding, 2026-07-16: this path went live with the
+    # runtime-token resolver and previously had no containment).
     for message in outbound["immediate"]:
-        await sender(channel_id, message)
+        try:
+            await sender(channel_id, message)
+        except Exception:  # noqa: BLE001
+            post_failures += 1
+            log.warning("notify post failed; continuing with remaining messages", exc_info=True)
     if outbound["digest"]:
-        await sender(channel_id, outbound["digest"])
+        try:
+            await sender(channel_id, outbound["digest"])
+            digest_posted = True
+        except Exception:  # noqa: BLE001
+            post_failures += 1
+            log.warning("notify digest post failed", exc_info=True)
 
     summary = {
         "events": len(events),
         "immediate": len(outbound["immediate"]),
-        "digest_posted": bool(outbound["digest"]),
+        "digest_posted": digest_posted,
         "unclaimed": unclaimed,
     }
+    if post_failures:
+        summary["post_failures"] = post_failures
     if verification is not None:
         summary["verification"] = verification
     return summary

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -177,9 +177,11 @@ async def _attach_and_refresh_packets(session, org_id, events) -> None:
 
 
 async def _default_post(channel_id, text) -> None:
-    from brain.systems.slack.client import slack_web_client_from_env
+    from brain.systems.slack.client import slack_web_client_from_runtime
 
-    client = slack_web_client_from_env()
+    client = await slack_web_client_from_runtime(
+        requested_by="change_notifications", reason="Post a change-notification digest line."
+    )
     await client.post_message(channel=channel_id, text=text)
 
 

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -267,3 +267,51 @@ def slack_app_token_from_env() -> str:
 
 def slack_web_client_from_env() -> SlackWebClient:
     return SlackWebClient(slack_bot_token_from_env())
+
+
+async def slack_web_client_from_runtime(
+    *,
+    requested_by: str,
+    reason: str,
+) -> SlackWebClient:
+    """Backend Slack client with Vault-first bot-token resolution.
+
+    Deployments store SLACK_BOT_TOKEN in DB-backed runtime secrets, not in
+    every service's env (the compose anchor passes it to the connector
+    only), so env-only resolution silently strands backend posting/reading
+    in the worker and API — the packet-mint E2E on illo-dev caught exactly
+    that (2026-07-16). Resolution order mirrors the connector's
+    ``SlackConnectorConfig.from_runtime``: env when set, else the runtime
+    secret under the connector authority. One owner for the secret.
+    """
+    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        from brain.systems.slack.connector import resolve_slack_connector_authority
+        from brain.systems.vault.runtime_secrets import (
+            RuntimeSecretContext,
+            read_runtime_secret,
+        )
+
+        org_id = os.environ.get("ILLO_SLACK_ORG_ID") or os.environ.get("ILLO_ORG_ID")
+        owner_user_id = (
+            os.environ.get("ILLO_SLACK_OWNER_USER_ID")
+            or os.environ.get("ILLO_OWNER_USER_ID")
+        )
+        if not org_id or not owner_user_id:
+            org_id, owner_user_id = await resolve_slack_connector_authority(
+                org_id=org_id, owner_user_id=owner_user_id
+            )
+        token = str(
+            await read_runtime_secret(
+                "SLACK_BOT_TOKEN",
+                context=RuntimeSecretContext(actor_user_id=owner_user_id, org_id=org_id),
+                reason=reason,
+                requested_by=requested_by,
+                access="service",
+                allow_env_fallback=True,
+            )
+            or ""
+        ).strip()
+    if not token:
+        raise SlackConfigurationError("SLACK_BOT_TOKEN is required (env or runtime secret)")
+    return SlackWebClient(token)

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -206,7 +206,7 @@ def _readers():
 
 @pytest.fixture(autouse=True)
 def _no_real_slack_post(monkeypatch):
-    """mint's Slack reply goes through slack_web_client_from_env — stub it."""
+    """mint's Slack reply goes through slack_web_client_from_runtime — stub it."""
     posts: list[dict] = []
 
     class FakeClient:
@@ -216,7 +216,10 @@ def _no_real_slack_post(monkeypatch):
 
     import brain.systems.slack.client as slack_client
 
-    monkeypatch.setattr(slack_client, "slack_web_client_from_env", lambda: FakeClient())
+    async def fake_from_runtime(**_kwargs):
+        return FakeClient()
+
+    monkeypatch.setattr(slack_client, "slack_web_client_from_runtime", fake_from_runtime)
     return posts
 
 

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -357,3 +357,46 @@ class TestPacketLinkAttachment:
         events = [{"title": "t", "record_id": 1}]
         await cyc._attach_and_refresh_packets(None, "org-1", events)
         assert "launch_url" not in events[0]
+
+
+async def test_failed_sends_are_contained_and_counted(db_less_session=None):
+    """A raising sender (token unavailable, Slack rejection) must not kill the
+    tick; remaining messages still go out and the summary says how many
+    failed (cross-family review finding, 2026-07-16)."""
+    from unittest.mock import AsyncMock, patch
+
+    from brain.systems.change_notifications_cycle import run_notify_cycle
+
+    sent: list[str] = []
+
+    async def flaky_sender(channel_id, text):
+        if not sent:  # first send fails, later sends succeed
+            sent.append("FAILED")
+            raise RuntimeError("slack rejected the message")
+        sent.append(text)
+
+    events = [
+        {"kind": "assigned", "title": f"item {i}", "urgent": True, "owner_id": None}
+        for i in range(2)
+    ]
+    with (
+        patch("brain.systems.change_notifications_cycle._maybe_run_deploy_verification",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._load_change_events",
+              new=AsyncMock(return_value=events)),
+        patch("brain.systems.change_notifications_cycle._fill_owner_labels",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._attach_and_refresh_packets",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._count_unclaimed",
+              new=AsyncMock(return_value=0)),
+        patch("brain.systems.change_notifications_cycle.render_outbound",
+              return_value={"immediate": ["m1", "m2"], "digest": "d1"}),
+    ):
+        summary = await run_notify_cycle(
+            None, org_id="o", channel_id="C1", post=flaky_sender,
+        )
+
+    assert summary["post_failures"] == 1
+    assert summary["digest_posted"] is True  # later sends still attempted
+    assert sent == ["FAILED", "m2", "d1"]

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -115,7 +115,10 @@ def posts(monkeypatch):
 
     import brain.systems.slack.client as slack_client
 
-    monkeypatch.setattr(slack_client, "slack_web_client_from_env", lambda: FakeClient())
+    async def fake_from_runtime(**_kwargs):
+        return FakeClient()
+
+    monkeypatch.setattr(slack_client, "slack_web_client_from_runtime", fake_from_runtime)
     return recorded
 
 

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -177,3 +177,46 @@ async def test_slack_client_uploads_file_with_external_upload_flow(monkeypatch):
             },
         ),
     ]
+
+
+async def test_runtime_client_prefers_env_token(monkeypatch):
+    from brain.systems.slack.client import slack_web_client_from_runtime
+
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env-token")
+    client = await slack_web_client_from_runtime(requested_by="t", reason="t")
+    assert client.bot_token == "xoxb-env-token"
+
+
+async def test_runtime_client_falls_back_to_runtime_secret(monkeypatch):
+    """Deployments keep SLACK_BOT_TOKEN in DB-backed runtime secrets, not in
+    every service env (illo-dev packet-mint E2E finding, 2026-07-16)."""
+    import brain.systems.slack.client as slack_client
+    import brain.systems.slack.connector as connector
+    import brain.systems.vault.runtime_secrets as runtime_secrets
+
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_ORG_ID", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_OWNER_USER_ID", raising=False)
+    monkeypatch.delenv("ILLO_ORG_ID", raising=False)
+    monkeypatch.delenv("ILLO_OWNER_USER_ID", raising=False)
+
+    async def fake_authority(*, org_id, owner_user_id):
+        assert org_id is None and owner_user_id is None
+        return "org-1", "user-1"
+
+    calls = {}
+
+    async def fake_read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback=False, env_names=None):
+        calls["key"] = key_name
+        calls["context"] = (context.actor_user_id, context.org_id)
+        calls["access"] = access
+        return "xoxb-vault-token"
+
+    monkeypatch.setattr(connector, "resolve_slack_connector_authority", fake_authority)
+    monkeypatch.setattr(runtime_secrets, "read_runtime_secret", fake_read_runtime_secret)
+
+    client = await slack_client.slack_web_client_from_runtime(requested_by="t", reason="t")
+    assert client.bot_token == "xoxb-vault-token"
+    assert calls["key"] == "SLACK_BOT_TOKEN"
+    assert calls["context"] == ("user-1", "org-1")
+    assert calls["access"] == "service"


### PR DESCRIPTION
## Problem

The illo-dev packet-mint E2E (follow-up to #332) caught a second dormant assumption: `slack_web_client_from_env` needs env `SLACK_BOT_TOKEN`, but this deployment stores the token **only in DB-backed runtime secrets** — the compose anchor passes the env var to the slack-connector service alone, and even there it renders empty (the connector actually resolves via `SlackConnectorConfig.from_runtime` → `read_runtime_secret`). Every backend Slack post/read outside the connector — mint's origin-thread brief, gather's Slack excerpts, the notify cycle's default post — raised `SlackConfigurationError`, contained into `posted=False` and degraded gather notes. Packets would persist but never post, and dossiers would silently lose their Slack context.

## Fix

- `slack_web_client_from_runtime(requested_by, reason)` in `brain/systems/slack/client.py`: env token when set, else the `SLACK_BOT_TOKEN` runtime secret under the connector authority (Vault-first, `access="service"`, env fallback) — mirrors the connector's own resolution; one owner for the secret.
- Switched the three backend consumers: `mint._post_brief_to_origin_thread`, `gather.DefaultSlackReader` (resolver now async, still cached), `change_notifications_cycle._default_post`.
- Codex review finding folded: `run_notify_cycle` sends are now individually contained — a raising sender no longer kills the tick mid-loop; failures log and surface as `summary.post_failures`.

## Verification

- New tests: env-first + vault-fallback resolution (context/access asserted), notify-send containment (later messages still attempted, failures counted). Full fast suite: 3663 passed.
- Codex cross-family review (high): 1 HIGH finding (notify containment) — folded with regression test; import-cycle, `read_runtime_secret` semantics, audit volume, and UnitOfWork isolation all verified clean.
- Live verification on illo-dev follows this merge (monitored-channel test alert → `launch_handoffs` row + thread post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)