### PR TITLE
Extract tool-result refs before the event preview truncates them

### DIFF
--- a/brain/systems/briefing/gather.py
+++ b/brain/systems/briefing/gather.py
@@ -111,15 +111,18 @@ class DefaultSlackReader:
     def __init__(self, client: Any | None = None) -> None:
         self._client = client
 
-    def _resolve_client(self) -> Any:
+    async def _resolve_client(self) -> Any:
         if self._client is None:
-            from brain.systems.slack.client import slack_web_client_from_env
+            from brain.systems.slack.client import slack_web_client_from_runtime
 
-            self._client = slack_web_client_from_env()
+            self._client = await slack_web_client_from_runtime(
+                requested_by="packet_gather",
+                reason="Read the origin Slack thread for a handoff dossier.",
+            )
         return self._client
 
     async def read_thread(self, *, channel: str, thread_ts: str, limit: int) -> SlackThreadRead:
-        client = self._resolve_client()
+        client = await self._resolve_client()
         collected: list[dict[str, Any]] = []
         total = 0
         cursor: str | None = None

--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -489,9 +489,11 @@ async def _post_brief_to_origin_thread(*, event: Any, brief: str) -> bool:
     provenance = slack_provenance(event) if event is not None else None
     if not provenance or provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
         return False
-    from brain.systems.slack.client import slack_web_client_from_env
+    from brain.systems.slack.client import slack_web_client_from_runtime
 
-    client = slack_web_client_from_env()
+    client = await slack_web_client_from_runtime(
+        requested_by="packet_mint", reason="Post the handoff-packet brief to the origin thread."
+    )
     await client.post_message(
         channel=provenance["channel"], text=brief, thread_ts=provenance["thread_ts"]
     )

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -229,18 +229,38 @@ async def run_notify_cycle(
     unclaimed = await _count_unclaimed(session, org_id)
     outbound = render_outbound(events, unclaimed_count=unclaimed, urgent_terms=urgent_terms)
 
+    import logging
+
     sender = post or _default_post
+    log = logging.getLogger("illo.notify")
+    post_failures = 0
+    digest_posted = False
+    # A failed send (token unavailable, Slack rejection) must not kill the
+    # tick or the messages behind it — count it, log it, keep going
+    # (cross-family review finding, 2026-07-16: this path went live with the
+    # runtime-token resolver and previously had no containment).
     for message in outbound["immediate"]:
-        await sender(channel_id, message)
+        try:
+            await sender(channel_id, message)
+        except Exception:  # noqa: BLE001
+            post_failures += 1
+            log.warning("notify post failed; continuing with remaining messages", exc_info=True)
     if outbound["digest"]:
-        await sender(channel_id, outbound["digest"])
+        try:
+            await sender(channel_id, outbound["digest"])
+            digest_posted = True
+        except Exception:  # noqa: BLE001
+            post_failures += 1
+            log.warning("notify digest post failed", exc_info=True)
 
     summary = {
         "events": len(events),
         "immediate": len(outbound["immediate"]),
-        "digest_posted": bool(outbound["digest"]),
+        "digest_posted": digest_posted,
         "unclaimed": unclaimed,
     }
+    if post_failures:
+        summary["post_failures"] = post_failures
     if verification is not None:
         summary["verification"] = verification
     return summary

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -177,9 +177,11 @@ async def _attach_and_refresh_packets(session, org_id, events) -> None:
 
 
 async def _default_post(channel_id, text) -> None:
-    from brain.systems.slack.client import slack_web_client_from_env
+    from brain.systems.slack.client import slack_web_client_from_runtime
 
-    client = slack_web_client_from_env()
+    client = await slack_web_client_from_runtime(
+        requested_by="change_notifications", reason="Post a change-notification digest line."
+    )
     await client.post_message(channel=channel_id, text=text)
 
 

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -276,6 +276,21 @@ def _collect_refs(value: Any, refs: list[dict[str, str]], seen: set[tuple[str, s
             _collect_refs(child, refs, seen, source=source)
 
 
+def collect_result_refs(result: Any, *, source: str) -> list[dict[str, str]]:
+    """Extract entity refs from a FULL tool result (pre-truncation).
+
+    Run events persist only a 1000-char result preview; a bigger mutating
+    result truncates into invalid JSON and the ref walk goes blind (found
+    live on illo-dev, 2026-07-16: a created tracker record was invisible to
+    the packet-mint predicate). The tool executor calls this on the full
+    text and stores the refs beside the preview as ``result_refs``.
+    """
+    refs: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    _collect_refs(_parse_result(result), refs, seen, source=source)
+    return refs
+
+
 def _target_refs(tool_events: list[AgentRunEventRow]) -> list[dict[str, str]]:
     refs: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
@@ -283,6 +298,9 @@ def _target_refs(tool_events: list[AgentRunEventRow]) -> list[dict[str, str]]:
         payload = _json_dict(row.payload)
         source = _tool_name(payload) or "tool_result"
         _collect_refs(_tool_result(payload), refs, seen, source=source)
+        # Full-fidelity channel: refs the executor extracted from the
+        # complete result before the stored preview truncated it.
+        _add_explicit_ref_values(refs, seen, value=payload.get("result_refs"), source=source)
     return refs
 
 
@@ -456,6 +474,7 @@ def durable_work_refs(attribution: Mapping[str, Any] | None) -> list[dict[str, s
 
 __all__ = [
     "WORK_ITEM_REF_KINDS",
+    "collect_result_refs",
     "durable_work_refs",
     "summarize_inbound_run_attribution",
 ]

--- a/brain/systems/inbound/attribution.py
+++ b/brain/systems/inbound/attribution.py
@@ -16,6 +16,13 @@ from brain.systems.runs.tool_catalog.registry import action_policy_for_tool, get
 
 _TOOL_COMPLETED_EVENT = "run.tool_completed"
 _MAX_TARGET_REFS = 20
+# Entity identities are short (uuids, integer ids, owner/repo#N). Anything
+# longer is result CONTENT that leaked into a ref-shaped position — drop it
+# (never truncate: a clipped id is a wrong ref), which also bounds the
+# persisted result_refs payload (cross-family review finding, 2026-07-16).
+_MAX_REF_ID_CHARS = 200
+_MAX_REF_KIND_CHARS = 64
+_MAX_REF_SOURCE_CHARS = 80
 _SUMMARY_OPERATION_TAGS = {
     "created",
     "updated",
@@ -170,13 +177,16 @@ def _add_ref(refs: list[dict[str, str]], seen: set[tuple[str, str]], *, kind: st
     if len(refs) >= _MAX_TARGET_REFS:
         return
     text = str(value or "").strip()
-    if not text:
+    kind_text = str(kind or "").strip()
+    if not text or not kind_text:
         return
-    key = (kind, text)
+    if len(text) > _MAX_REF_ID_CHARS or len(kind_text) > _MAX_REF_KIND_CHARS:
+        return
+    key = (kind_text, text)
     if key in seen:
         return
     seen.add(key)
-    refs.append({"kind": kind, "id": text, "source": source})
+    refs.append({"kind": kind_text, "id": text, "source": str(source or "")[:_MAX_REF_SOURCE_CHARS]})
 
 
 def _add_ref_values(

--- a/brain/systems/runs/presentation.py
+++ b/brain/systems/runs/presentation.py
@@ -74,7 +74,11 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
     public = {
         key: value
         for key, value in raw.items()
-        if key not in {"args", "result", "result_preview"} and not _is_sensitive_key(str(key).lower())
+        # result_refs is the backend attribution channel (full-fidelity refs
+        # extracted pre-truncation); it never goes to the browser — ref ids
+        # are raw result content and receive no _redact_text pass.
+        if key not in {"args", "result", "result_preview", "result_refs"}
+        and not _is_sensitive_key(str(key).lower())
     }
     public["tool_name"] = tool_name
     public["tool"] = tool_name

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -249,7 +249,7 @@ class AsyncRunToolExecutor:
                     run_event(
                         run_id,
                         "run.tool_completed",
-                        _event_payload(tool.name, safe_args, result=safe_result[:1000]),
+                        _event_payload(tool.name, safe_args, result=safe_result),
                         root_run_id=root_run_id,
                     )
                 )
@@ -345,7 +345,7 @@ class AsyncRunToolExecutor:
             run_event(
                 run_id,
                 "run.tool_completed",
-                _event_payload(tool.name, safe_args, result=safe_result[:1000]),
+                _event_payload(tool.name, safe_args, result=safe_result),
                 root_run_id=root_run_id,
             )
         )
@@ -634,7 +634,20 @@ def _event_payload(
         "side_effect": classify_side_effect(tool_name),
     }
     if result is not None:
-        payload["result"] = result
+        # The stored result is a bounded PREVIEW; entity refs are extracted
+        # from the FULL result first, or a big JSON result truncates into an
+        # unparseable string and downstream attribution (inbound packet
+        # minting, preservation evidence) goes blind to what the tool
+        # actually created (illo-dev E2E finding, 2026-07-16).
+        payload["result"] = result[:1000]
+        try:
+            from brain.systems.inbound.attribution import collect_result_refs
+
+            refs = collect_result_refs(result, source=tool_name)
+            if refs:
+                payload["result_refs"] = refs
+        except Exception:  # noqa: BLE001 — ref extraction may never break tool recording
+            pass
     if error is not None:
         payload["error"] = error[:1000]
     return payload

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -60,6 +60,9 @@ async def _maybe_await(value):
 
 def _event_stream_payload(event, row) -> dict[str, Any]:
     payload = dict(event.payload or {})
+    # Backend-only attribution channel; live stream consumers never see it
+    # (ref ids are raw result content with no redaction pass).
+    payload.pop("result_refs", None)
     event_id = int(getattr(row, "id", 0) or 0)
     payload.update({
         "run_id": int(event.run_id),

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -267,3 +267,51 @@ def slack_app_token_from_env() -> str:
 
 def slack_web_client_from_env() -> SlackWebClient:
     return SlackWebClient(slack_bot_token_from_env())
+
+
+async def slack_web_client_from_runtime(
+    *,
+    requested_by: str,
+    reason: str,
+) -> SlackWebClient:
+    """Backend Slack client with Vault-first bot-token resolution.
+
+    Deployments store SLACK_BOT_TOKEN in DB-backed runtime secrets, not in
+    every service's env (the compose anchor passes it to the connector
+    only), so env-only resolution silently strands backend posting/reading
+    in the worker and API — the packet-mint E2E on illo-dev caught exactly
+    that (2026-07-16). Resolution order mirrors the connector's
+    ``SlackConnectorConfig.from_runtime``: env when set, else the runtime
+    secret under the connector authority. One owner for the secret.
+    """
+    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        from brain.systems.slack.connector import resolve_slack_connector_authority
+        from brain.systems.vault.runtime_secrets import (
+            RuntimeSecretContext,
+            read_runtime_secret,
+        )
+
+        org_id = os.environ.get("ILLO_SLACK_ORG_ID") or os.environ.get("ILLO_ORG_ID")
+        owner_user_id = (
+            os.environ.get("ILLO_SLACK_OWNER_USER_ID")
+            or os.environ.get("ILLO_OWNER_USER_ID")
+        )
+        if not org_id or not owner_user_id:
+            org_id, owner_user_id = await resolve_slack_connector_authority(
+                org_id=org_id, owner_user_id=owner_user_id
+            )
+        token = str(
+            await read_runtime_secret(
+                "SLACK_BOT_TOKEN",
+                context=RuntimeSecretContext(actor_user_id=owner_user_id, org_id=org_id),
+                reason=reason,
+                requested_by=requested_by,
+                access="service",
+                allow_env_fallback=True,
+            )
+            or ""
+        ).strip()
+    if not token:
+        raise SlackConfigurationError("SLACK_BOT_TOKEN is required (env or runtime secret)")
+    return SlackWebClient(token)

--- a/specs/illo-handoff-packets/README.md
+++ b/specs/illo-handoff-packets/README.md
@@ -236,6 +236,21 @@ still-contained layers:
   Regression suites: `tests/test_inbound_reconciliation.py` (lane
   end-to-end on sqlite), `tests/test_inbound_attribution.py`, actionable
   cases in `tests/test_briefing_mint.py`.
+  The illo-dev E2E then exposed two more dormant assumptions, fixed the
+  same day: (#333) backend Slack posting/reading used env-only
+  `slack_web_client_from_env`, but deployments keep `SLACK_BOT_TOKEN` in
+  DB-backed runtime secrets — `slack_web_client_from_runtime` (Vault-first,
+  connector-authority, env fallback) now serves mint's post, gather's
+  reader, and the notify default post, with notify sends individually
+  contained; (#334) `run.tool_completed` events persist a 1000-char result
+  PREVIEW, so big mutating results truncated into unparseable JSON and
+  attribution reported "no durable work" for runs that created it (live
+  repro: record 1823 invisible) — the executor now extracts
+  `result_refs` from the FULL result beside the preview (backend-only
+  channel: stripped from public projections and the live stream; ref
+  fields bounded, oversized ids dropped). Deferred follow-up (recorded,
+  Codex finding on #332): the Slack brief still posts before the outer
+  commit — the post-commit outbox belongs with slice 06's refresh home.
 
 **Implementation decisions that refine slice texts (06+07, Claude-implemented):**
 - Slice 06: `format_line` appends `→ launch: <url>` (one field, Slack-

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -4604,3 +4604,50 @@ def test_truncate_tool_result_text_tiny_budget_skips_note(monkeypatch):
     assert len(result) <= 250
     assert "[System:" not in result
     assert "chars truncated by tool output budget" in result
+
+
+async def test_runtime_tool_executor_persists_full_result_refs_beside_preview():
+    """Big mutating results: the durable event keeps a 1000-char preview but
+    result_refs is extracted from the FULL result (illo-dev finding,
+    2026-07-16 — a created tracker record was invisible to attribution);
+    the live stream never carries the backend-only refs channel."""
+    import json as _json
+
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    runtime = _runtime("worker")
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+
+    big_result = _json.dumps({"record": {"id": 1823, "domain_id": 30, "pad": "x" * 5000}})
+    await executor.execute(
+        42,
+        ToolExecution(
+            name="manage_domain",
+            args={"action": "create_record"},
+            handler=lambda **kwargs: big_result,
+        ),
+        root_run_id=42,
+    )
+
+    completed = next(e for e in runtime.store.events if e.event_type == "run.tool_completed")
+    assert len(completed.payload["result"]) == 1000  # preview stays bounded
+    assert {"kind": "domain_record", "id": "1823", "source": "manage_domain"} in (
+        completed.payload["result_refs"]
+    )
+    streamed = [p for t, p in runtime.stream.messages if t == "run.tool_completed"]
+    assert streamed and all("result_refs" not in p for p in streamed)
+
+
+async def test_public_projection_never_carries_result_refs():
+    from brain.systems.runs.presentation import public_tool_event_payload
+
+    public = public_tool_event_payload(
+        {
+            "tool_name": "manage_domain",
+            "args": {"action": "create_record"},
+            "result": "{\"truncated",
+            "result_refs": [{"kind": "domain_record", "id": "sk-live-oops", "source": "x"}],
+        },
+        "run.tool_completed",
+    )
+    assert "result_refs" not in public

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -206,7 +206,7 @@ def _readers():
 
 @pytest.fixture(autouse=True)
 def _no_real_slack_post(monkeypatch):
-    """mint's Slack reply goes through slack_web_client_from_env — stub it."""
+    """mint's Slack reply goes through slack_web_client_from_runtime — stub it."""
     posts: list[dict] = []
 
     class FakeClient:
@@ -216,7 +216,10 @@ def _no_real_slack_post(monkeypatch):
 
     import brain.systems.slack.client as slack_client
 
-    monkeypatch.setattr(slack_client, "slack_web_client_from_env", lambda: FakeClient())
+    async def fake_from_runtime(**_kwargs):
+        return FakeClient()
+
+    monkeypatch.setattr(slack_client, "slack_web_client_from_runtime", fake_from_runtime)
     return posts
 
 

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -357,3 +357,46 @@ class TestPacketLinkAttachment:
         events = [{"title": "t", "record_id": 1}]
         await cyc._attach_and_refresh_packets(None, "org-1", events)
         assert "launch_url" not in events[0]
+
+
+async def test_failed_sends_are_contained_and_counted(db_less_session=None):
+    """A raising sender (token unavailable, Slack rejection) must not kill the
+    tick; remaining messages still go out and the summary says how many
+    failed (cross-family review finding, 2026-07-16)."""
+    from unittest.mock import AsyncMock, patch
+
+    from brain.systems.change_notifications_cycle import run_notify_cycle
+
+    sent: list[str] = []
+
+    async def flaky_sender(channel_id, text):
+        if not sent:  # first send fails, later sends succeed
+            sent.append("FAILED")
+            raise RuntimeError("slack rejected the message")
+        sent.append(text)
+
+    events = [
+        {"kind": "assigned", "title": f"item {i}", "urgent": True, "owner_id": None}
+        for i in range(2)
+    ]
+    with (
+        patch("brain.systems.change_notifications_cycle._maybe_run_deploy_verification",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._load_change_events",
+              new=AsyncMock(return_value=events)),
+        patch("brain.systems.change_notifications_cycle._fill_owner_labels",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._attach_and_refresh_packets",
+              new=AsyncMock(return_value=None)),
+        patch("brain.systems.change_notifications_cycle._count_unclaimed",
+              new=AsyncMock(return_value=0)),
+        patch("brain.systems.change_notifications_cycle.render_outbound",
+              return_value={"immediate": ["m1", "m2"], "digest": "d1"}),
+    ):
+        summary = await run_notify_cycle(
+            None, org_id="o", channel_id="C1", post=flaky_sender,
+        )
+
+    assert summary["post_failures"] == 1
+    assert summary["digest_posted"] is True  # later sends still attempted
+    assert sent == ["FAILED", "m2", "d1"]

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -143,3 +143,49 @@ def test_work_item_vocabulary_is_the_expected_set():
         "github_issue", "github_pull_request", "idea", "domain_record",
         "agent_run", "launch_handoff", "thread",
     }
+
+
+async def test_truncated_result_preview_recovers_refs_from_result_refs(session):
+    """Run events store a 1000-char result PREVIEW; the executor extracts
+    refs from the FULL result into payload.result_refs first. A truncated
+    (unparseable) preview must not blind attribution to what the tool
+    created (live illo-dev finding, 2026-07-16: tracker record invisible
+    to the packet-mint predicate)."""
+    run_id = await _seed_run(session)
+    big_result = json.dumps({"record": {"id": 1823, "domain_id": 30, "pad": "x" * 5000}})
+    session.add(AgentRunEventRow(
+        run_id=run_id,
+        sequence_no=1,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "manage_domain",
+            "args": {"action": "create_record"},
+            "result": big_result[:1000],  # what tools.py persists
+            "result_refs": [
+                {"kind": "domain_record", "id": "1823", "source": "manage_domain"},
+                {"kind": "domain", "id": "30", "source": "manage_domain"},
+            ],
+        },
+    ))
+    await session.flush()
+
+    attribution = await summarize_inbound_run_attribution(
+        session, run_id=run_id, status=RunStatus.COMPLETED
+    )
+    assert {"kind": "domain_record", "id": "1823", "source": "manage_domain"} in (
+        attribution["mutated_target_refs"]
+    )
+    durable = durable_work_refs(attribution)
+    assert any(ref["kind"] == "domain_record" and ref["id"] == "1823" for ref in durable)
+
+
+def test_event_payload_carries_full_result_refs_beside_preview():
+    from brain.systems.runs.tools import _event_payload
+
+    big_result = json.dumps({"record": {"id": 99, "pad": "y" * 3000}})
+    payload = _event_payload("manage_domain", {"action": "create_record"}, result=big_result)
+    assert len(payload["result"]) == 1000  # bounded preview
+    assert {"kind": "domain_record", "id": "99", "source": "manage_domain"} in payload["result_refs"]
+
+    small = _event_payload("post_slack_reply", {}, result=json.dumps({"ok": True, "channel_id": "C1"}))
+    assert "result_refs" not in small  # no refs → no key

--- a/tests/test_inbound_attribution.py
+++ b/tests/test_inbound_attribution.py
@@ -189,3 +189,16 @@ def test_event_payload_carries_full_result_refs_beside_preview():
 
     small = _event_payload("post_slack_reply", {}, result=json.dumps({"ok": True, "channel_id": "C1"}))
     assert "result_refs" not in small  # no refs → no key
+
+
+def test_oversized_ref_ids_are_dropped_never_truncated():
+    """A clipped id is a wrong ref, and unbounded ids would balloon the
+    persisted result_refs payload — drop anything id-shaped that is really
+    content (cross-family review finding, 2026-07-16)."""
+    from brain.systems.inbound.attribution import collect_result_refs
+
+    refs = collect_result_refs(
+        json.dumps({"record_id": "z" * 1_000_000, "idea_id": "idea-ok"}),
+        source="s" * 500,
+    )
+    assert refs == [{"kind": "idea", "id": "idea-ok", "source": "s" * 80}]

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -115,7 +115,10 @@ def posts(monkeypatch):
 
     import brain.systems.slack.client as slack_client
 
-    monkeypatch.setattr(slack_client, "slack_web_client_from_env", lambda: FakeClient())
+    async def fake_from_runtime(**_kwargs):
+        return FakeClient()
+
+    monkeypatch.setattr(slack_client, "slack_web_client_from_runtime", fake_from_runtime)
     return recorded
 
 

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -177,3 +177,46 @@ async def test_slack_client_uploads_file_with_external_upload_flow(monkeypatch):
             },
         ),
     ]
+
+
+async def test_runtime_client_prefers_env_token(monkeypatch):
+    from brain.systems.slack.client import slack_web_client_from_runtime
+
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env-token")
+    client = await slack_web_client_from_runtime(requested_by="t", reason="t")
+    assert client.bot_token == "xoxb-env-token"
+
+
+async def test_runtime_client_falls_back_to_runtime_secret(monkeypatch):
+    """Deployments keep SLACK_BOT_TOKEN in DB-backed runtime secrets, not in
+    every service env (illo-dev packet-mint E2E finding, 2026-07-16)."""
+    import brain.systems.slack.client as slack_client
+    import brain.systems.slack.connector as connector
+    import brain.systems.vault.runtime_secrets as runtime_secrets
+
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_ORG_ID", raising=False)
+    monkeypatch.delenv("ILLO_SLACK_OWNER_USER_ID", raising=False)
+    monkeypatch.delenv("ILLO_ORG_ID", raising=False)
+    monkeypatch.delenv("ILLO_OWNER_USER_ID", raising=False)
+
+    async def fake_authority(*, org_id, owner_user_id):
+        assert org_id is None and owner_user_id is None
+        return "org-1", "user-1"
+
+    calls = {}
+
+    async def fake_read_runtime_secret(key_name, *, context, reason, requested_by, access, allow_env_fallback=False, env_names=None):
+        calls["key"] = key_name
+        calls["context"] = (context.actor_user_id, context.org_id)
+        calls["access"] = access
+        return "xoxb-vault-token"
+
+    monkeypatch.setattr(connector, "resolve_slack_connector_authority", fake_authority)
+    monkeypatch.setattr(runtime_secrets, "read_runtime_secret", fake_read_runtime_secret)
+
+    client = await slack_client.slack_web_client_from_runtime(requested_by="t", reason="t")
+    assert client.bot_token == "xoxb-vault-token"
+    assert calls["key"] == "SLACK_BOT_TOKEN"
+    assert calls["context"] == ("user-1", "org-1")
+    assert calls["access"] == "service"


### PR DESCRIPTION
## Problem

The illo-dev packet-mint E2E (post #332/#333) hit the third dormant gap: `run.tool_completed` events persist `result=safe_result[:1000]` — a preview. Attribution parses that preview to extract entity refs for the packet-mint durable-work predicate; any result over 1000 chars truncates into unparseable JSON and the ref walk goes blind. Live repro: run 1625 created tracker record 1823 (the correct no-write-token fallback for a filed alert) and the mint hook logged `reason=no durable work created by run` — attribution literally could not see the record. Real `create_github_issue` payloads exceed 1000 chars too, so the headline case was equally starved. This is the run-1057 silent-truncation lesson one layer down.

## Fix

- `attribution.collect_result_refs(result, source)` — the same ref walk, run over the FULL redacted result at event-append time; `tools._event_payload` stores the bounded preview plus `payload.result_refs` (extraction contained: can never break tool recording). Both completion call sites pass the full result.
- `_target_refs` merges the full-fidelity channel beside the preview parse (deduped on kind+id).
- Codex review findings folded: `result_refs` is backend-only — stripped from `public_tool_event_payload` and the executor's live-stream payloads (ref ids are raw result content with no redaction pass); ref fields are bounded (id ≤ 200 / kind ≤ 64 / source ≤ 80 chars, oversized ids dropped never truncated) so the persisted channel cannot balloon.

## Verification

- Executor-level test: big mutating result → 1000-char preview + full refs on the durable event, refs absent from the stream; public-projection exclusion test; oversized-id drop test; truncated-preview recovery test through `summarize_inbound_run_attribution`.
- Full fast suite: 3668 passed.
- Codex cross-family review (high): 3 findings (public disclosure, payload bound, call-site test pin) — all folded.
- Live re-verification on illo-dev follows the merge (fresh monitored-channel alert → packet row + thread post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)