### PR TITLE
Anchor actionable packets on the run's created work, not read refs

### DIFF
--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -508,6 +508,7 @@ async def _mint_for_idea_and_event(
     event: Any,
     attribution: dict[str, Any] | None,
     readers: Readers | None,
+    job_ref: str | None = None,
 ) -> MintResult:
     """Shared stage for every inbound-completion lane once the job-home idea
     is resolved: owner → target → mint → post-once. Raises upward; the
@@ -522,7 +523,7 @@ async def _mint_for_idea_and_event(
         session,
         org_id=org_id,
         idea=idea,
-        job_ref=_record_job_ref(attribution, idea),
+        job_ref=job_ref or _record_job_ref(attribution, idea),
         ask=_ask_from_event(idea, event),
         owner_user_id=owner_user_id,
         owner_label=owner_label,
@@ -786,9 +787,22 @@ async def mint_packet_after_actionable_run(
         if idea is None:
             return MintResult(ok=False, reason="no owner and no unclaimed pool for job home")
 
+        # Anchor the job on the run's OWN durable work, never on attribution
+        # target_refs at large — those include read-only tool results, and
+        # the first live packet anchored its dossier on the triage playbook
+        # doc the run had READ instead of the tracker item it CREATED
+        # (illo-dev E2E, handoff e827d633).
+        job_ref = next(
+            (
+                f"domain_record:{ref['id']}"
+                for ref in work_refs
+                if str(ref.get("kind") or "") == "domain_record" and ref.get("id")
+            ),
+            f"idea:{getattr(idea, 'id', '')}",
+        )
         return await _mint_for_idea_and_event(
             session, org_id=org_id, idea=idea, event=event,
-            attribution=attribution, readers=readers,
+            attribution=attribution, readers=readers, job_ref=job_ref,
         )
     except Exception as exc:  # noqa: BLE001 — total containment
         logger.warning("packet mint failed for event %s: %s", getattr(event, "id", "?"), exc)

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -749,3 +749,37 @@ async def test_event_mint_lock_taken_on_postgres_only():
     await _acquire_event_mint_lock(LockSession("sqlite"), org_id=_ORG, event_id=_EVENT_ID)
     assert executed == []
     await _acquire_event_mint_lock(FakeSession(), org_id=_ORG, event_id=_EVENT_ID)  # no bind at all
+
+
+async def test_actionable_job_ref_anchors_on_created_work_not_reads(posts):
+    """The first live packet (handoff e827d633) anchored its dossier on the
+    playbook doc the run READ because _record_job_ref walks target_refs at
+    large. The actionable lane must anchor on the run's own durable refs:
+    created record wins; issue-only runs anchor on the job-home idea."""
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    created_record = {"kind": "domain_record", "id": "1826", "source": "manage_domain"}
+    read_doc = {"kind": "domain_record", "id": "1272", "source": "manage_domain"}
+    attribution = {
+        "target_refs": [read_doc, created_record],  # read-first, like run 1627
+        "mutated_target_refs": [created_record],
+    }
+    session = FakeSession(events=[_actionable_event()])
+    result = await mint_packet_after_actionable_run(
+        session, event=_actionable_event(), run_row=_run_row(),
+        attribution=attribution, readers=_readers(),
+    )
+    assert result.ok and result.created
+    assert (session.handoffs[0].metadata_ or {}).get("job_ref") == "domain_record:1826"
+
+    # Issue-only durable work → the idea is the anchor (its description
+    # carries owner/repo#N for gather), never a read doc from target_refs.
+    session2 = FakeSession(events=[_actionable_event()])
+    result2 = await mint_packet_after_actionable_run(
+        session2, event=_actionable_event(), run_row=_run_row(),
+        attribution={"target_refs": [read_doc, _ISSUE_REF], "mutated_target_refs": [_ISSUE_REF]},
+        readers=_readers(),
+    )
+    assert result2.ok and result2.created
+    idea2 = session2._ideas[0]
+    assert (session2.handoffs[0].metadata_ or {}).get("job_ref") == f"idea:{idea2.id}"


### PR DESCRIPTION
The first live handoff packet (e827d633, run 1627 on illo-dev) anchored its dossier on the triage playbook doc the run had **read** — `_record_job_ref` walks attribution `target_refs` at large, and the doc's `get_record` ref precedes the created tracker record.

The actionable lane now derives `job_ref` from its own durable work refs: first created `domain_record` wins; issue-only runs anchor on the job-home idea (whose description carries `owner/repo#N` for gather's discovery). Passed as an explicit override into the shared mint stage — the triage lane's `_record_job_ref` behavior is byte-identical, refresh keeps reusing each row's stored anchor, and existing stamped events are untouched (no supersede churn; Codex review confirmed all three, verdict SHIP).

Regression test: read-doc-first attribution → `job_ref=domain_record:<created>`; issue-only durable work → `job_ref=idea:<id>`. Full fast suite: 3669 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)