### PR TITLE
Deliver handoff-packet briefs post-commit via a transactional outbox

### DIFF
--- a/brain/platform/db/alembic/versions/0026_packet_brief_deliveries.py
+++ b/brain/platform/db/alembic/versions/0026_packet_brief_deliveries.py
@@ -1,0 +1,91 @@
+"""Add packet brief deliveries (handoff-packet Slack-post outbox).
+
+Revision ID: 0026_packet_brief_deliveries
+Revises: 0025_pr_tracker_owner_fields
+Create Date: 2026-07-16
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0026_packet_brief_deliveries"
+down_revision = "0025_pr_tracker_owner_fields"
+branch_labels = None
+depends_on = None
+
+_TABLE = "packet_brief_deliveries"
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema=_schema()))
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name, schema=_schema())}
+
+
+def _uuid_type():
+    return postgresql.UUID(as_uuid=False) if op.get_bind().dialect.name == "postgresql" else sa.String()
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("id", _uuid_type(), primary_key=True),
+            sa.Column("org_id", _uuid_type(), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+            sa.Column(
+                "handoff_id",
+                _uuid_type(),
+                sa.ForeignKey("launch_handoffs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("state", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("idempotency_key", sa.String(length=120), nullable=False),
+            sa.Column("channel", sa.String(length=40), nullable=False),
+            sa.Column("thread_ts", sa.String(length=40), nullable=False),
+            sa.Column("bot_user_id", sa.String(length=40), nullable=True),
+            sa.Column("brief", sa.Text(), nullable=False),
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("posted_message_ts", sa.String(length=40), nullable=True),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            # CURRENT_TIMESTAMP, not NOW(): identical on Postgres, and a
+            # migration-created sqlite table must accept inserts too (NOW()
+            # passes DDL there but fails at INSERT time).
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                      server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                      server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.CheckConstraint(
+                "state IN ('pending', 'posting', 'posted', 'superseded', 'failed')",
+                name="ck_packet_brief_deliveries_state",
+            ),
+            sa.UniqueConstraint("handoff_id", name="uq_packet_brief_deliveries_handoff"),
+        )
+
+    if _table_exists(_TABLE) and not _index_exists(_TABLE, "ix_packet_brief_deliveries_org_state"):
+        op.create_index("ix_packet_brief_deliveries_org_state", _TABLE, ["org_id", "state"])
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, "ix_packet_brief_deliveries_org_state"):
+        op.drop_index("ix_packet_brief_deliveries_org_state", table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/brain/platform/db/models/__init__.py
+++ b/brain/platform/db/models/__init__.py
@@ -30,4 +30,5 @@ from brain.platform.db.models.workspace_app import *  # noqa
 from brain.platform.db.models.workspace_pin import *  # noqa
 from brain.platform.db.models.object_reference import *  # noqa
 from brain.platform.db.models.launch_handoff import *  # noqa
+from brain.platform.db.models.packet_delivery import *  # noqa
 from brain.platform.db.models.workspace_tool import *  # noqa

--- a/brain/platform/db/models/packet_delivery.py
+++ b/brain/platform/db/models/packet_delivery.py
@@ -1,0 +1,85 @@
+"""Outbox rows for handoff-packet brief delivery to Slack origin threads.
+
+One row per handoff id (spec: illo-handoff-packets, post-slice-05 hardening).
+The row is written inside the mint's savepoint so it commits or rolls back
+atomically with the handoff row, the idea stamp, and the run's terminal
+status — the Slack post itself happens strictly AFTER that commit (see
+``brain.systems.briefing.deliver``). ``idempotency_key`` is deterministic
+(``packet-brief:<handoff_id>``); the brief text embeds the handoff id via
+its launch URL, which is the in-thread marker crash recovery checks before
+ever re-sending.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from brain.platform.db.base import Base, TimestampMixin
+from brain.platform.db.constraints import check_in_constraint
+
+UUIDString = UUID(as_uuid=False).with_variant(String, "sqlite")
+
+# pending  → recorded at mint time, not yet attempted (or returned after a
+#            definite Slack reject that is worth retrying)
+# posting  → claimed by a deliverer; an attempt may be in flight. A stale
+#            claim is ambiguous (crash before OR after the send) and must be
+#            disambiguated by reading the origin thread before any re-send.
+# posted   → the brief is in the thread (send confirmed, or found by the
+#            disambiguation read).
+# superseded → the handoff was superseded before the brief went out; the
+#            obligation moved to the superseding row's delivery.
+# failed   → permanent Slack reject or attempt cap reached; loud log, no retry.
+PACKET_BRIEF_DELIVERY_STATES = ("pending", "posting", "posted", "superseded", "failed")
+
+__all__ = ["PacketBriefDelivery", "PACKET_BRIEF_DELIVERY_STATES"]
+
+
+class PacketBriefDelivery(Base, TimestampMixin):
+    """Transactional-outbox record for one handoff packet's human brief."""
+
+    __tablename__ = "packet_brief_deliveries"
+    __table_args__ = (
+        CheckConstraint(
+            check_in_constraint("state", PACKET_BRIEF_DELIVERY_STATES),
+            name="ck_packet_brief_deliveries_state",
+        ),
+        UniqueConstraint("handoff_id", name="uq_packet_brief_deliveries_handoff"),
+        Index("ix_packet_brief_deliveries_org_state", "org_id", "state"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        UUIDString,
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    org_id: Mapped[str] = mapped_column(
+        UUIDString,
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    handoff_id: Mapped[str] = mapped_column(
+        UUIDString,
+        ForeignKey("launch_handoffs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    state: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="pending", default="pending"
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(120), nullable=False)
+    channel: Mapped[str] = mapped_column(String(40), nullable=False)
+    thread_ts: Mapped[str] = mapped_column(String(40), nullable=False)
+    # Illo's Slack identity from the origin provenance: crash disambiguation
+    # counts only bot-authored thread messages, so a human pasting the same
+    # launch URL can never satisfy the "already posted" check.
+    bot_user_id: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    brief: Mapped[str] = mapped_column(Text, nullable=False)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"), default=0)
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    posted_message_ts: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/brain/systems/briefing/deliver.py
+++ b/brain/systems/briefing/deliver.py
@@ -1,0 +1,761 @@
+"""Illo Brain — post-commit delivery of handoff-packet briefs (outbox).
+
+Why this exists (spec: illo-handoff-packets, post-slice-05 hardening; Codex
+review finding 1, 2026-07-16): the mint runs inside the run's terminal-status
+transaction. Posting the Slack brief from inside that transaction meant a
+later commit failure left a live Slack message pointing at a rolled-back
+handoff row — and the crash-retry re-minted a new row and posted a second
+brief. The fix is a transactional outbox:
+
+- **Record** (:func:`record_brief_delivery`): the mint's savepoint persists
+  one ``PacketBriefDelivery`` row per handoff id, atomically with the
+  handoff row, idea stamp, and run status. No commit → no record → no post.
+- **Deliver** (:func:`deliver_pending_briefs`): strictly after that commit,
+  a claim → verify → post → mark state machine sends the brief, each step in
+  its own short transaction on its own session. Two triggers share it: the
+  post-commit fast path (:func:`schedule_post_commit_delivery`) for
+  same-second UX, and the slice-06 notify cycle as the guaranteed sweep.
+
+Crash-safety contract (the reason ``posting`` exists): the claim commits
+BEFORE the send, so ``pending`` provably means "never sent" and is safe to
+send blind. A worker crash after claiming leaves ``posting``, which is
+ambiguous — the send may or may not have reached Slack — so a stale
+``posting`` row is re-sent ONLY after a disambiguation read of the origin
+thread. The deterministic idempotency identifier is
+``packet-brief:<handoff_id>``; the brief's launch URL embeds the handoff id,
+and only messages authored by the recorded bot identity count. When the read
+fails or is incomplete, the row stays ``posting`` for the next sweep:
+delivery may be late, but a crashed worker is never re-sent blind.
+
+Concurrency notes (cross-family review, 2026-07-16):
+
+- Claims go through a ``FOR UPDATE SKIP LOCKED`` subselect: a row a live
+  transaction (e.g. the notify tick's refresh-supersede) still holds is
+  SKIPPED, never awaited — the sweep runs inside that tick, so blocking on
+  its locks would self-deadlock the tick.
+- ``claimed_at`` doubles as the fencing token: every post-claim transition
+  requires the claim stamp it was made under, so a paused worker whose lease
+  expired cannot stomp the reclaimer's state. The fence is re-verified
+  immediately before every send (again after the disambiguation read, whose
+  network latency is unbounded). The truly unpreventable residue: a send
+  whose interval from that final fence check until the message becomes
+  visible in Slack outlives the lease (worker suspension or a glacial
+  in-flight request) can race a reclaimer's thread read into a duplicate —
+  closing it needs provider-side idempotency Slack does not offer.
+- After winning a claim the worker posts the row's CURRENT committed
+  payload (re-read under the fence), not its pre-claim snapshot, so a
+  drift-repair that landed in between is honored.
+- SQLite (unit tests, fakes) compiles the FOR UPDATE clauses away; like the
+  mint's advisory lock, the races and lock-waits these guard against are
+  cross-connection, which those environments don't exercise. Production is
+  PostgreSQL.
+
+Total containment: nothing here may break a mint, a tick, or run-status
+persistence. Every failure degrades to a log line plus a later retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import and_, or_, select, update
+
+from brain.platform.db.models.packet_delivery import PacketBriefDelivery
+
+logger = logging.getLogger(__name__)
+
+# One sweep processes at most this many rows — the notify tick must stay
+# bounded even after a long outage backlog. Deferrals surface next tick.
+# Fresh (in-flight) claims are filtered OUT before the limit applies, so
+# stuck rows can never starve deliverable ones.
+DELIVERY_SWEEP_LIMIT = 10
+
+# A ``posting`` claim older than this is treated as a crashed worker and
+# becomes reclaimable (with the disambiguation read). Generous vs. the
+# ~seconds a healthy post takes, tiny vs. the notify cadence.
+STALE_POSTING_GRACE = timedelta(minutes=10)
+
+# After this many claims the row goes ``failed`` (ERROR log, no silent
+# infinite churn) — after one last disambiguation read, so an ambiguous
+# send that actually landed is recorded as posted, not failed.
+MAX_DELIVERY_ATTEMPTS = 8
+
+# Slack rejects that cannot succeed on retry with the same inputs.
+PERMANENT_SLACK_ERRORS = frozenset({"channel_not_found", "is_archived", "msg_too_long", "no_text"})
+
+_DISAMBIGUATION_THREAD_LIMIT = 200
+_DISAMBIGUATION_MAX_PAGES = 10  # 2000 messages; deeper threads read as "incomplete"
+
+# The fast-path task polls for the outbox row to become visible (committed):
+# the after_commit event also fires on savepoint releases (verified on
+# SQLAlchemy 2.0.49), so the dispatch may run before the outer commit.
+_VISIBILITY_POLL_ATTEMPTS = 5
+_VISIBILITY_POLL_DELAY_SECONDS = 1.5
+
+_INFO_QUEUE_KEY = "illo_brief_delivery_queue"
+_INFO_ARMED_KEY = "illo_brief_delivery_listeners_armed"
+
+
+@dataclass(frozen=True)
+class DeliveryTarget:
+    """Where the brief goes: the public origin thread, snapshotted at mint
+    time (mint holds the inbound event; delivery must not need it again).
+    ``bot_user_id`` is Illo's Slack identity from the same provenance — the
+    disambiguation read trusts only messages it authored."""
+
+    channel: str
+    thread_ts: str
+    bot_user_id: str | None = None
+
+
+def delivery_idempotency_key(handoff_id: Any) -> str:
+    return f"packet-brief:{handoff_id}"
+
+
+# --- mint-savepoint writes (caller's session, caller's savepoint) ---------
+#
+# These run inside mint_packet_for_job's write-phase savepoint. The
+# transfer's read is a locking read (FOR UPDATE): a plain read could see
+# ``pending``, lose the CPU to a claimer that posts the old brief, then
+# flush ``superseded`` over the claimer's state and spawn a replacement —
+# two Slack replies. The locking read serializes against the claim CAS.
+
+
+async def record_brief_delivery(
+    session: Any, *, org_id: str, handoff_id: str, target: DeliveryTarget, brief: str
+) -> PacketBriefDelivery:
+    """Persist the delivery obligation for a freshly created handoff."""
+    row = PacketBriefDelivery(
+        org_id=str(org_id),
+        handoff_id=str(handoff_id),
+        state="pending",
+        idempotency_key=delivery_idempotency_key(handoff_id),
+        channel=target.channel,
+        thread_ts=target.thread_ts,
+        bot_user_id=target.bot_user_id,
+        brief=brief,
+    )
+    session.add(row)
+    return row
+
+
+async def _delivery_for_handoff(
+    session: Any, handoff_id: str, *, for_update: bool = False
+) -> PacketBriefDelivery | None:
+    # populate_existing: the lock is only as good as the attributes read
+    # under it — an identity-map copy cached before a concurrent claim
+    # committed would still say "pending" and re-open the transfer/claim
+    # double-post (verification finding, 2026-07-16).
+    stmt = (
+        select(PacketBriefDelivery)
+        .where(PacketBriefDelivery.handoff_id == str(handoff_id))
+        .execution_options(populate_existing=True)
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def transfer_pending_delivery(
+    session: Any,
+    *,
+    org_id: str,
+    prior_handoff_id: str,
+    new_handoff_id: str,
+    new_brief: str | None,
+) -> bool:
+    """Supersede carry-over: an obligation that never went out follows the
+    superseding row (new brief, new launch URL) so the origin thread still
+    gets its one triage-moment reply — with current truth, not a dead link.
+
+    Only ``pending`` moves. ``posted`` means the thread already has its brief
+    (the noise gate holds — a supersede posts nothing new on its own), and
+    ``posting`` means a send may be in flight, so the old claim keeps the
+    obligation and resolves it against the old content. The FOR UPDATE read
+    serializes this decision against a concurrent claim.
+    """
+    prior = await _delivery_for_handoff(session, prior_handoff_id, for_update=True)
+    if prior is None or prior.state != "pending":
+        return False
+    prior.state = "superseded"
+    prior.last_error = None
+    existing = await _delivery_for_handoff(session, new_handoff_id)
+    if existing is not None:
+        return True  # the new mint recorded its own delivery; just retire the old one
+    if not new_brief:
+        logger.warning(
+            "pending brief for handoff %s superseded by %s without a replacement brief; "
+            "obligation dropped", prior_handoff_id, new_handoff_id,
+        )
+        return True
+    session.add(
+        PacketBriefDelivery(
+            org_id=str(org_id),
+            handoff_id=str(new_handoff_id),
+            state="pending",
+            idempotency_key=delivery_idempotency_key(new_handoff_id),
+            channel=prior.channel,
+            thread_ts=prior.thread_ts,
+            bot_user_id=prior.bot_user_id,
+            brief=new_brief,
+        )
+    )
+    return True
+
+
+async def refresh_pending_delivery_brief(session: Any, *, handoff_id: str, brief: str) -> None:
+    """Drift repair rewrote the row's content in place (same idempotency
+    key); an undelivered brief must describe what the row now says."""
+    row = await _delivery_for_handoff(session, handoff_id, for_update=True)
+    if row is not None and row.state == "pending":
+        row.brief = brief
+
+
+# --- the post-commit engine (its own sessions, its own transactions) ------
+
+
+def _default_session_factory() -> Callable[[], Any] | None:
+    try:
+        from brain.platform.db import SessionFactory
+
+        return SessionFactory
+    except Exception as exc:  # noqa: BLE001 — no platform DB → sweep is a no-op
+        logger.debug("brief delivery has no session factory (%s)", exc)
+        return None
+
+
+async def _default_poster(*, channel: str, text: str, thread_ts: str) -> dict[str, Any]:
+    from brain.systems.slack.client import slack_web_client_from_env
+
+    client = slack_web_client_from_env()
+    return await client.post_message(channel=channel, text=text, thread_ts=thread_ts)
+
+
+async def _default_thread_reader(*, channel: str, thread_ts: str) -> dict[str, Any]:
+    """Raw thread read for crash disambiguation (distinct from gather's
+    excerpting reader): walk the WHOLE thread or say so. ``complete=False``
+    means an unread tail may hide the brief — the caller must then treat
+    "not found" as "cannot decide", never as "absent"."""
+    from brain.systems.slack.client import slack_web_client_from_env
+
+    client = slack_web_client_from_env()
+    messages: list[dict[str, Any]] = []
+    cursor: str | None = None
+    complete = False
+    for _page in range(_DISAMBIGUATION_MAX_PAGES):
+        payload = await client.conversation_replies(
+            channel=channel, thread_ts=thread_ts,
+            limit=_DISAMBIGUATION_THREAD_LIMIT, cursor=cursor,
+        )
+        messages.extend(dict(m) for m in payload.get("messages") or [])
+        cursor = str(((payload.get("response_metadata") or {}).get("next_cursor")) or "")
+        if not cursor:
+            complete = True
+            break
+    return {"messages": messages, "complete": complete}
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    if value is not None and value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _snapshot(row: PacketBriefDelivery) -> dict[str, Any]:
+    return {
+        "id": str(row.id),
+        "org_id": str(row.org_id),
+        "handoff_id": str(row.handoff_id),
+        "state": str(row.state),
+        "channel": str(row.channel),
+        "thread_ts": str(row.thread_ts),
+        "bot_user_id": str(row.bot_user_id or "") or None,
+        "brief": str(row.brief),
+        "attempts": int(row.attempts or 0),
+        "claimed_at": row.claimed_at,
+    }
+
+
+def _claimable_clause(cutoff: datetime):
+    """Rows a deliverer may touch NOW: never-claimed, or a lease that
+    expired. Fresh in-flight claims stay invisible so they can neither be
+    stomped nor consume the sweep limit (starvation finding)."""
+    return or_(
+        PacketBriefDelivery.state == "pending",
+        and_(
+            PacketBriefDelivery.state == "posting",
+            PacketBriefDelivery.claimed_at.is_not(None),
+            PacketBriefDelivery.claimed_at <= cutoff,
+        ),
+    )
+
+
+async def _cas(
+    factory: Callable[[], Any],
+    delivery_id: str,
+    *,
+    where: list[Any],
+    values: dict[str, Any],
+    skip_locked: bool = False,
+) -> bool:
+    """One compare-and-swap in its own committed transaction. The rowcount
+    is the winner test — a concurrent claimer, an expired fence, or a
+    supersede transfer makes it 0 and the caller walks away.
+
+    ``skip_locked`` (claims only): route through a ``FOR UPDATE SKIP
+    LOCKED`` subselect so a row a live transaction holds (the notify tick's
+    own refresh!) is skipped instead of awaited — the sweep runs inside
+    that tick, and blocking on its locks would deadlock the tick against
+    itself. SQLite ignores the FOR UPDATE clause, which is correct there
+    (single-writer, and the tests exercise no cross-connection locks).
+    """
+    async with factory() as session:
+        conditions = [PacketBriefDelivery.id == str(delivery_id), *where]
+        if skip_locked:
+            locked_id = (
+                select(PacketBriefDelivery.id)
+                .where(*conditions)
+                .with_for_update(skip_locked=True)
+                .scalar_subquery()
+            )
+            stmt = update(PacketBriefDelivery).where(
+                PacketBriefDelivery.id.in_(select(locked_id))
+            )
+        else:
+            stmt = update(PacketBriefDelivery).where(*conditions)
+        result = await session.execute(
+            stmt.values(**values).execution_options(synchronize_session=False)
+        )
+        await session.commit()
+        return int(result.rowcount or 0) == 1
+
+
+async def _verified_reread(
+    factory: Callable[[], Any], delivery_id: str, *, claim_stamp: datetime
+) -> dict[str, Any] | None:
+    """Post-claim re-read under the fence: returns the row's CURRENT
+    committed payload (a drift repair may have landed between snapshot and
+    claim), or None when the fence is gone (someone else owns the row)."""
+    async with factory() as session:
+        row = (
+            await session.execute(
+                select(PacketBriefDelivery)
+                .where(PacketBriefDelivery.id == str(delivery_id))
+                # DB truth even on a session whose identity map already holds
+                # this row with attributes from before the CAS committed.
+                .execution_options(populate_existing=True)
+            )
+        ).scalars().first()
+    if row is None or str(row.state) != "posting":
+        return None
+    if _utc(row.claimed_at) != _utc(claim_stamp):
+        return None
+    return _snapshot(row)
+
+
+def _found_in_thread(
+    messages: list[dict[str, Any]], handoff_id: str, *, bot_user_id: str | None
+) -> str | None:
+    """The brief carries the handoff id in its launch URL. Only messages
+    authored by the recorded bot identity count — a human pasting the same
+    launch URL must not satisfy the check (the brief itself never arrived).
+    Without a recorded identity, any author matches (fail-open is the
+    duplicate-safe direction here)."""
+    marker = str(handoff_id).lower()
+    for message in messages:
+        if bot_user_id and str(message.get("user") or "") != bot_user_id:
+            continue
+        if marker in str(message.get("text") or "").lower():
+            return str(message.get("ts") or "") or "found"
+    return None
+
+
+async def _disambiguate(
+    item: dict[str, Any],
+    *,
+    thread_reader: Callable[..., Awaitable[dict[str, Any]]],
+) -> tuple[str, str | None]:
+    """Read the origin thread: ('posted', ts) when the brief is provably
+    there, ('absent', None) when the COMPLETE thread provably lacks it,
+    ('unknown', None) when the read failed or was truncated."""
+    handoff_id = item["handoff_id"]
+    try:
+        read = await thread_reader(channel=item["channel"], thread_ts=item["thread_ts"])
+    except Exception as exc:  # noqa: BLE001 — can't decide → stay posting, retry later
+        logger.warning(
+            "brief delivery for handoff %s: disambiguation read failed (%s)", handoff_id, exc,
+        )
+        return "unknown", None
+    messages = list(read.get("messages") or [])
+    found_ts = _found_in_thread(messages, handoff_id, bot_user_id=item.get("bot_user_id"))
+    if found_ts:
+        return "posted", found_ts
+    if not read.get("complete", False):
+        logger.warning(
+            "brief delivery for handoff %s: thread read incomplete; cannot prove "
+            "the brief absent", handoff_id,
+        )
+        return "unknown", None
+    return "absent", None
+
+
+async def _deliver_one(
+    item: dict[str, Any],
+    *,
+    factory: Callable[[], Any],
+    poster: Callable[..., Awaitable[dict[str, Any]]],
+    thread_reader: Callable[..., Awaitable[dict[str, Any]]],
+    now: datetime,
+    summary: dict[str, int],
+) -> None:
+    delivery_id = item["id"]
+    handoff_id = item["handoff_id"]
+    must_disambiguate = item["state"] == "posting"
+    fence = [
+        PacketBriefDelivery.state == "posting",
+        PacketBriefDelivery.claimed_at == now,  # our claim stamp = the fencing token
+    ]
+
+    if item["attempts"] >= MAX_DELIVERY_ATTEMPTS:
+        # One last honest look before recording a permanent failure: the
+        # final ambiguous send may in fact have landed. Both cap CASes are
+        # skip-locked for the same reason claims are: the notify tick's
+        # refresh may hold this row's lock (its transfer takes a FOR UPDATE
+        # read even on non-pending rows), and the sweep it awaits must skip,
+        # never block.
+        outcome, found_ts = ("absent", None)
+        if must_disambiguate:
+            outcome, found_ts = await _disambiguate(item, thread_reader=thread_reader)
+        if outcome == "unknown":
+            # Can't read the thread → can't prove the final send didn't land.
+            # Stays posting (retried, loudly) rather than recording a failure
+            # that might be a success.
+            summary["undecided"] += 1
+            return
+        if outcome == "posted":
+            await _cas(
+                factory, delivery_id,
+                where=[PacketBriefDelivery.state.in_(("pending", "posting"))],
+                values={
+                    "state": "posted", "posted_at": now, "last_error": None,
+                    "posted_message_ts": found_ts if found_ts != "found" else None,
+                },
+                skip_locked=True,
+            )
+            summary["already_posted"] += 1
+            return
+        if await _cas(
+            factory, delivery_id,
+            where=[PacketBriefDelivery.state.in_(("pending", "posting"))],
+            values={"state": "failed", "last_error": f"gave up after {item['attempts']} attempts"},
+            skip_locked=True,
+        ):
+            logger.error(
+                "brief for handoff %s FAILED permanently after %s attempts (last error stands); "
+                "the packet row and launch link are unaffected", handoff_id, item["attempts"],
+            )
+            summary["failed"] += 1
+        return
+
+    if must_disambiguate:
+        claimed = await _cas(
+            factory, delivery_id,
+            where=[
+                PacketBriefDelivery.state == "posting",
+                PacketBriefDelivery.claimed_at == item["claimed_at"],
+            ],
+            values={"state": "posting", "claimed_at": now, "attempts": item["attempts"] + 1},
+            skip_locked=True,
+        )
+    else:
+        claimed = await _cas(
+            factory, delivery_id,
+            where=[PacketBriefDelivery.state == "pending"],
+            values={"state": "posting", "claimed_at": now, "attempts": item["attempts"] + 1},
+            skip_locked=True,
+        )
+    if not claimed:
+        summary["lost_claim"] += 1
+        return
+
+    # Fence-verified re-read: freshest committed payload, and the last
+    # possible moment a paused-then-resumed worker discovers it lost its
+    # lease BEFORE talking to Slack.
+    current = await _verified_reread(factory, delivery_id, claim_stamp=now)
+    if current is None:
+        summary["lost_claim"] += 1
+        return
+    item = {**item, **{k: current[k] for k in ("channel", "thread_ts", "brief", "bot_user_id")}}
+
+    if must_disambiguate:
+        # The prior claim died mid-flight: the send may have reached Slack.
+        outcome, found_ts = await _disambiguate(item, thread_reader=thread_reader)
+        if outcome == "unknown":
+            summary["undecided"] += 1
+            return  # stays posting under our stamp; next sweep retries
+        if outcome == "posted":
+            await _cas(
+                factory, delivery_id, where=fence,
+                values={
+                    "state": "posted", "posted_at": now, "last_error": None,
+                    "posted_message_ts": found_ts if found_ts != "found" else None,
+                },
+            )
+            logger.info(
+                "brief for handoff %s was already in the thread (crashed claim); marked posted "
+                "without re-sending", handoff_id,
+            )
+            summary["already_posted"] += 1
+            return
+        # The thread read is network I/O of unbounded real-world latency:
+        # re-verify the fence so a lease that expired DURING the read can't
+        # slip a late send past a newer claimant.
+        if await _verified_reread(factory, delivery_id, claim_stamp=now) is None:
+            summary["lost_claim"] += 1
+            return
+
+    from brain.systems.slack.client import SlackApiError
+
+    try:
+        response = await poster(channel=item["channel"], text=item["brief"], thread_ts=item["thread_ts"])
+    except SlackApiError as exc:
+        # A definite reject: Slack answered, nothing was posted.
+        if exc.error in PERMANENT_SLACK_ERRORS:
+            await _cas(
+                factory, delivery_id, where=fence,
+                values={"state": "failed", "last_error": str(exc)},
+            )
+            logger.error(
+                "brief for handoff %s FAILED permanently: %s (channel %s)",
+                handoff_id, exc, item["channel"],
+            )
+            summary["failed"] += 1
+        else:
+            await _cas(
+                factory, delivery_id, where=fence,
+                values={"state": "pending", "claimed_at": None, "last_error": str(exc)},
+            )
+            logger.warning(
+                "brief delivery for handoff %s rejected by Slack (%s); requeued (attempt %s/%s)",
+                handoff_id, exc, item["attempts"] + 1, MAX_DELIVERY_ATTEMPTS,
+            )
+            summary["requeued"] += 1
+        return
+    except Exception as exc:  # noqa: BLE001 — ambiguous (timeout, transport): may have landed
+        logger.warning(
+            "brief delivery for handoff %s ambiguous (%s: %s); left in posting for the "
+            "disambiguating retry", handoff_id, type(exc).__name__, exc,
+        )
+        summary["undecided"] += 1
+        return
+
+    marked = await _cas(
+        factory, delivery_id, where=fence,
+        values={
+            "state": "posted", "posted_at": now, "last_error": None,
+            "posted_message_ts": str(response.get("ts") or "") or None,
+        },
+    )
+    if not marked:
+        # The message IS in the thread; only the bookkeeping lost its fence
+        # (a reclaimer took over mid-send). Its disambiguation read finds
+        # the message and records posted — never a second send.
+        logger.warning("brief for handoff %s posted but the posted-mark lost its fence", handoff_id)
+    summary["posted"] += 1
+
+
+async def deliver_pending_briefs(
+    *,
+    org_id: str | None = None,
+    handoff_ids: list[str] | None = None,
+    session_factory: Callable[[], Any] | None = None,
+    poster: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    thread_reader: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    now: datetime | None = None,
+    limit: int = DELIVERY_SWEEP_LIMIT,
+) -> dict[str, int]:
+    """Deliver undelivered briefs: the fast path targets ``handoff_ids`` it
+    just minted; the notify-cycle sweep passes ``org_id`` only. Never raises;
+    the summary says what happened (all keys are counts)."""
+    summary = {
+        "selected": 0, "posted": 0, "already_posted": 0, "requeued": 0,
+        "failed": 0, "undecided": 0, "in_flight": 0, "lost_claim": 0,
+    }
+    try:
+        factory = session_factory or _default_session_factory()
+        if factory is None:
+            return summary
+        moment = now or datetime.now(timezone.utc)
+
+        stmt = (
+            select(PacketBriefDelivery)
+            .where(_claimable_clause(moment - STALE_POSTING_GRACE))
+            .order_by(PacketBriefDelivery.created_at.asc())
+            .limit(max(1, int(limit)))
+            .execution_options(populate_existing=True)  # DB truth over identity map
+        )
+        if org_id:
+            stmt = stmt.where(PacketBriefDelivery.org_id == str(org_id))
+        if handoff_ids:
+            stmt = stmt.where(
+                PacketBriefDelivery.handoff_id.in_([str(h) for h in handoff_ids])
+            )
+        async with factory() as session:
+            candidates = [_snapshot(row) for row in (await session.execute(stmt)).scalars().all()]
+
+        summary["selected"] = len(candidates)
+        for item in candidates:
+            try:
+                await _deliver_one(
+                    item,
+                    factory=factory,
+                    poster=poster or _default_poster,
+                    thread_reader=thread_reader or _default_thread_reader,
+                    now=moment,
+                    summary=summary,
+                )
+            except Exception as exc:  # noqa: BLE001 — one bad row must not starve the rest
+                logger.warning(
+                    "brief delivery for handoff %s failed unexpectedly: %s",
+                    item.get("handoff_id"), exc,
+                )
+        return summary
+    except Exception as exc:  # noqa: BLE001 — total containment
+        logger.warning("brief delivery pass failed safely: %s", exc)
+        return summary
+
+
+# --- the post-commit fast path ---------------------------------------------
+#
+# after_commit is NOT outer-commit-only: on the installed SQLAlchemy it also
+# fires when a savepoint is released (verified empirically, 2026-07-16), and
+# ``in_transaction()`` cannot tell the two apart from inside the callback.
+# So the dispatch is deliberately event-time agnostic: arming QUEUES the
+# handoff ids in ``session.info``; any commit-ish fire drains the queue into
+# a task; the task then polls (bounded) for the rows to become VISIBLE in a
+# fresh session — visibility, not event timing, is the truth about the
+# commit. A ROOT rollback clears the queue (nothing queued can ever commit);
+# a savepoint rollback keeps it, because entries from surviving savepoints
+# still commit and dead entries self-clean (their rows never become visible,
+# so the task expires quietly). An early drain whose outer commit outlasts
+# the poll budget loses only the fast path — the sweep delivers.
+
+_POST_COMMIT_TASKS: set[asyncio.Task] = set()
+
+
+def _reap_delivery_task(task: asyncio.Task) -> None:
+    _POST_COMMIT_TASKS.discard(task)
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        logger.warning("post-commit brief delivery task died: %s", exc)
+
+
+async def _deliver_when_visible(org_id: str, handoff_ids: list[str]) -> None:
+    """Poll until the just-minted outbox rows are committed-visible, then
+    deliver. Gives up quietly after the poll budget — the notify-cycle
+    sweep remains the guaranteed path."""
+    for attempt in range(_VISIBILITY_POLL_ATTEMPTS):
+        summary = await deliver_pending_briefs(org_id=org_id, handoff_ids=handoff_ids)
+        if summary["selected"]:
+            return
+        if attempt < _VISIBILITY_POLL_ATTEMPTS - 1:
+            await asyncio.sleep(_VISIBILITY_POLL_DELAY_SECONDS)
+    logger.debug(
+        "fast-path delivery for handoffs %s saw no committed rows; leaving them to the sweep",
+        handoff_ids,
+    )
+
+
+def _spawn_delivery_task(org_id: str, handoff_ids: list[str]) -> None:
+    try:
+        task = asyncio.ensure_future(_deliver_when_visible(org_id, handoff_ids))
+        _POST_COMMIT_TASKS.add(task)
+        task.add_done_callback(_reap_delivery_task)
+    except Exception:  # noqa: BLE001 — the sweep remains the guaranteed path
+        logger.warning("post-commit brief delivery task failed to start", exc_info=True)
+
+
+def schedule_post_commit_delivery(session: Any, *, org_id: str, handoff_ids: list[str]) -> bool:
+    """Queue a fast-path delivery dispatch for the session's next commit.
+
+    One pair of listeners per session, armed once (``session.info`` flag);
+    subsequent calls only extend the queue — no per-mint listener
+    accumulation. Rollback clears the queue. Failure to arm is logged and
+    the notify-cycle sweep delivers instead. Returns True when queued."""
+    try:
+        sync_session = getattr(session, "sync_session", None)
+        if sync_session is None:
+            logger.debug("session has no sync_session; brief delivery deferred to the sweep")
+            return False
+        loop = asyncio.get_running_loop()
+        queue: list[tuple[str, str]] = sync_session.info.setdefault(_INFO_QUEUE_KEY, [])
+        queue.extend((str(org_id), str(h)) for h in handoff_ids)
+
+        if sync_session.info.get(_INFO_ARMED_KEY):
+            return True
+
+        def _drain_into_tasks(target_session: Any) -> None:
+            drained = list(target_session.info.get(_INFO_QUEUE_KEY) or [])
+            target_session.info[_INFO_QUEUE_KEY] = []
+            by_org: dict[str, list[str]] = {}
+            for org, handoff_id in drained:
+                bucket = by_org.setdefault(org, [])
+                if handoff_id not in bucket:
+                    bucket.append(handoff_id)
+            for org, ids in by_org.items():
+                try:
+                    # threadsafe: also correct same-thread, and the commit may
+                    # run on a session driven by another loop/thread (the
+                    # inline-runner topology).
+                    loop.call_soon_threadsafe(_spawn_delivery_task, org, ids)
+                except Exception:  # noqa: BLE001 — loop gone → sweep delivers
+                    logger.warning(
+                        "post-commit brief dispatch could not be scheduled", exc_info=True
+                    )
+
+        def _on_rollback(target_session: Any, previous: Any) -> None:
+            # Root rollback: the whole transaction is dead, nothing queued
+            # will ever become visible — clear. A NESTED (savepoint) rollback
+            # must NOT clear: entries queued by other, surviving savepoints
+            # still commit, and any entry whose own savepoint died is
+            # self-cleaning (its row never becomes visible, so the task
+            # expires without posting).
+            if getattr(previous, "nested", False):
+                return
+            if target_session.info.get(_INFO_QUEUE_KEY):
+                target_session.info[_INFO_QUEUE_KEY] = []
+
+        from sqlalchemy import event
+
+        event.listen(sync_session, "after_commit", _drain_into_tasks)
+        event.listen(sync_session, "after_soft_rollback", _on_rollback)
+        sync_session.info[_INFO_ARMED_KEY] = True
+        return True
+    except Exception as exc:  # noqa: BLE001 — never break the mint
+        logger.warning(
+            "post-commit brief dispatch not armed (%s); the notify-cycle sweep delivers instead",
+            exc,
+        )
+        return False
+
+
+__all__ = [
+    "DeliveryTarget",
+    "DELIVERY_SWEEP_LIMIT",
+    "MAX_DELIVERY_ATTEMPTS",
+    "PERMANENT_SLACK_ERRORS",
+    "STALE_POSTING_GRACE",
+    "delivery_idempotency_key",
+    "deliver_pending_briefs",
+    "record_brief_delivery",
+    "refresh_pending_delivery_brief",
+    "schedule_post_commit_delivery",
+    "transfer_pending_delivery",
+]

--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -14,8 +14,15 @@ Load-bearing stances:
   before packets existed: :func:`mint_packet_after_triage` never raises —
   every failure returns a ``MintResult(ok=False)`` and a log line.
 - **Noise gate.** ``create_launch_handoff_with_status`` reuse
-  (``created=False``) means this content already went out — mint posts
-  NOTHING to Slack on reuse. Re-triage of unchanged truth is silent.
+  (``created=False``) means this content already went out — mint records
+  NO Slack delivery on reuse. Re-triage of unchanged truth is silent.
+- **Post-commit delivery.** Mint never posts to Slack itself: the write
+  phase records a pending ``PacketBriefDelivery`` (one per handoff id)
+  inside its savepoint, and ``brain.systems.briefing.deliver`` posts it
+  strictly after the enclosing transaction commits — a rolled-back mint
+  leaves no Slack message, a crash-retry cannot double-post (the
+  deterministic ``packet-brief:<handoff_id>`` identity plus the
+  thread-read disambiguation own that).
 - **Supersede, existing vocabulary only.** When the job's truth changes,
   the new revision is a NEW row (new idempotency key); the prior row —
   found via the idea's packet stamp — becomes ``archived`` +
@@ -44,6 +51,13 @@ from sqlalchemy.exc import IntegrityError
 
 from brain.systems.briefing.compose import PacketRender, compose_packet, fill_launch_url
 from brain.systems.briefing.core import Dossier, DossierBudget, assemble_dossier
+from brain.systems.briefing.deliver import (
+    DeliveryTarget,
+    record_brief_delivery,
+    refresh_pending_delivery_brief,
+    schedule_post_commit_delivery,
+    transfer_pending_delivery,
+)
 from brain.systems.briefing.gather import (
     PUBLIC_CHANNEL_TYPE,
     DefaultGithubReader,
@@ -78,7 +92,11 @@ class Readers:
 class MintResult:
     ok: bool
     created: bool = False
-    posted: bool = False
+    # Delivery of the human brief is post-commit (outbox): "recorded" means a
+    # pending PacketBriefDelivery was written in the mint's savepoint;
+    # "skipped:<why>" means a created mint owes no Slack reply; "none" means
+    # nothing new to deliver (reuse, failure, refresh).
+    delivery: str = "none"
     handoff: LaunchHandoff | None = None
     human_brief: str = ""
     launch_url: str = ""
@@ -214,7 +232,8 @@ def _stamp_idea(idea: Any, *, handoff: LaunchHandoff, revision: str, owner_user_
 
 
 async def _supersede_prior(
-    session: Any, *, org_id: str, prior_handoff_id: str, new_row: LaunchHandoff
+    session: Any, *, org_id: str, prior_handoff_id: str, new_row: LaunchHandoff,
+    new_brief: str | None = None,
 ) -> None:
     from brain.systems.launch_handoffs import get_launch_handoff
 
@@ -224,6 +243,17 @@ async def _supersede_prior(
     old.status = "archived"
     old.metadata_ = {**(old.metadata_ or {}), "superseded_by": str(new_row.id)}
     new_row.metadata_ = {**(new_row.metadata_ or {}), "supersedes": str(old.id)}
+    # A brief that never went out follows the superseding row (the refresh
+    # lane records no delivery of its own, so an unfulfilled triage-moment
+    # reply would otherwise die with the archived row — or worse, post its
+    # dead launch link).
+    await transfer_pending_delivery(
+        session,
+        org_id=org_id,
+        prior_handoff_id=str(old.id),
+        new_handoff_id=str(new_row.id),
+        new_brief=new_brief,
+    )
     await session.flush()
 
 
@@ -271,6 +301,7 @@ async def mint_packet_for_job(
     budget: DossierBudget | None = None,
     require_clean_gather: bool = False,
     reader_user_id: str | None = None,
+    deliver_to: DeliveryTarget | None = None,
 ) -> MintResult:
     """Mint one packet. Raises nothing upward except via the caller's choice —
     the triage-facing wrapper is :func:`mint_packet_after_triage`.
@@ -279,6 +310,13 @@ async def mint_packet_for_job(
     down, partial fetch) must not supersede a healthy stored packet — a
     transient blip would rotate the revision, archive the good row, and
     rotate back on recovery, burning refresh slots on churn.
+
+    ``deliver_to`` (the triage/actionable lanes): a created mint records ONE
+    pending brief delivery for that target inside the write-phase savepoint —
+    the Slack post itself happens strictly post-commit (see
+    ``brain.systems.briefing.deliver``); a mint must never leave a live Slack
+    message pointing at state its transaction later rolled back. Reuse
+    records nothing (the noise gate). The refresh lane passes None.
     """
     packet, dossier = await build_packet_for_job(
         session,
@@ -310,6 +348,7 @@ async def mint_packet_for_job(
     # The idea is re-selected WITH a row lock before the stamp is read, so a
     # triage-mint racing a notify-refresh (slice 06) cannot double-supersede
     # or clobber a concurrent agent_details write (spec-pinned serialization).
+    delivery = "none"
     try:
         async with session.begin_nested():
             locked_idea = await _lock_idea(session, org_id=org_id, idea=idea)
@@ -319,13 +358,33 @@ async def mint_packet_for_job(
                 else {}
             )
             row, created = await create_launch_handoff_with_status(session, packet.handoff_input)
+            filled_brief = fill_launch_url(
+                packet.human_brief, launch_handoff_url_for_id(row.id, target_tool=row.target_tool)
+            )
             if created:
+                if deliver_to is not None:
+                    # Recorded BEFORE the supersede so the transfer sees the
+                    # new row already owes its own delivery.
+                    await record_brief_delivery(
+                        session, org_id=org_id, handoff_id=str(row.id),
+                        target=deliver_to, brief=filled_brief,
+                    )
+                    delivery = "recorded"
                 if prior.get("handoff_id"):
                     await _supersede_prior(
-                        session, org_id=org_id, prior_handoff_id=str(prior["handoff_id"]), new_row=row
+                        session, org_id=org_id, prior_handoff_id=str(prior["handoff_id"]),
+                        new_row=row, new_brief=filled_brief,
                     )
             elif _reused_row_drifted(row, packet):
                 _repair_drifted_row(row, packet)
+                # Refilled AFTER the repair: it may have rotated target_tool,
+                # which changes the launch URL an undelivered brief carries.
+                await refresh_pending_delivery_brief(
+                    session, handoff_id=str(row.id), brief=fill_launch_url(
+                        packet.human_brief,
+                        launch_handoff_url_for_id(row.id, target_tool=row.target_tool),
+                    ),
+                )
             if locked_idea is not None:
                 _stamp_idea(locked_idea, handoff=row, revision=packet.revision, owner_user_id=owner_user_id)
             await session.flush()
@@ -354,6 +413,7 @@ async def mint_packet_for_job(
     return MintResult(
         ok=True,
         created=created,
+        delivery=delivery,
         handoff=row,
         human_brief=fill_launch_url(packet.human_brief, launch_url),
         launch_url=launch_url,
@@ -409,10 +469,14 @@ async def _find_idea_by_stamp(session: Any, *, org_id: str, handoff_id: str) -> 
 
 async def refresh_packet_for_job(session: Any, *, org_id: str, handoff_row: Any,
                                  readers: Readers | None = None) -> MintResult:
-    """Slice 06: re-render a packet against current truth. NEVER posts to
-    Slack (nudges and digest lines carry the link); unchanged truth reuses
-    the row silently, changed truth supersedes. Contained like the triage
-    hook — a refresh failure degrades to a log line, never a dead tick.
+    """Slice 06: re-render a packet against current truth. Never creates a
+    NEW Slack post (nudges and digest lines carry the link); unchanged truth
+    reuses the row silently, changed truth supersedes. The one delivery
+    nuance: superseding a row whose triage-moment brief is still PENDING
+    transfers that unfulfilled obligation to the new row (fresh brief, fresh
+    launch URL) — the thread still gets its single reply, never a dead link.
+    Contained like the triage hook — a refresh failure degrades to a log
+    line, never a dead tick.
 
     Only packet-minted rows (``source_surface == "inbound_triage"``) are
     refreshable: the ORIGINAL ask/owner/target/provenance are reused from
@@ -455,7 +519,8 @@ async def refresh_packet_for_job(session: Any, *, org_id: str, handoff_row: Any,
             # (review finding: this branch skipped the write-phase savepoint).
             async with session.begin_nested():
                 await _supersede_prior(
-                    session, org_id=org_id, prior_handoff_id=str(handoff_row.id), new_row=result.handoff
+                    session, org_id=org_id, prior_handoff_id=str(handoff_row.id),
+                    new_row=result.handoff, new_brief=result.human_brief,
                 )
         return result
     except Exception as exc:  # noqa: BLE001 — total containment
@@ -481,21 +546,23 @@ def _record_job_ref(attribution: dict[str, Any] | None, idea: Any) -> str:
     return f"idea:{getattr(idea, 'id', '')}"
 
 
-async def _post_brief_to_origin_thread(*, event: Any, brief: str) -> bool:
-    """Backend Slack reply into the origin thread — same provenance and
-    public-only allowlist as gather; silent skip (False) when not possible.
-    Both mint hooks already hold the event, so provenance reads it directly
-    (no idea → event reload)."""
+def _delivery_target_for_event(event: Any) -> tuple[DeliveryTarget | None, str]:
+    """Origin-thread delivery target — same provenance and public-only
+    allowlist the deleted in-transaction post used, but resolved at MINT
+    time so the outbox row snapshots channel/thread_ts and delivery never
+    needs the event again. Returns (target, "") or (None, why)."""
     provenance = slack_provenance(event) if event is not None else None
-    if not provenance or provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
-        return False
-    from brain.systems.slack.client import slack_web_client_from_env
-
-    client = slack_web_client_from_env()
-    await client.post_message(
-        channel=provenance["channel"], text=brief, thread_ts=provenance["thread_ts"]
-    )
-    return True
+    if not provenance:
+        return None, "no_slack_provenance"
+    if provenance["channel_type"] != PUBLIC_CHANNEL_TYPE:
+        return None, "non_public"
+    return DeliveryTarget(
+        channel=provenance["channel"],
+        thread_ts=provenance["thread_ts"],
+        # Crash disambiguation trusts only Illo-authored thread messages —
+        # the same identity gather's echo filter already keys on.
+        bot_user_id=str(provenance.get("bot_user_id") or "") or None,
+    ), ""
 
 
 async def _mint_for_idea_and_event(
@@ -508,13 +575,16 @@ async def _mint_for_idea_and_event(
     readers: Readers | None,
 ) -> MintResult:
     """Shared stage for every inbound-completion lane once the job-home idea
-    is resolved: owner → target → mint → post-once. Raises upward; the
-    lane-facing wrappers own containment."""
+    is resolved: owner → target → mint → record-delivery-once. Raises upward;
+    the lane-facing wrappers own containment. The Slack reply itself is
+    post-commit: the savepoint records the obligation, the after-commit fast
+    path (or the notify-cycle sweep) sends it."""
     details = dict(getattr(idea, "agent_details", None) or {})
     assignment = dict(details.get("assignment") or {})
     owner_user_id = str(assignment.get("owner_id") or "") or None
     owner_label = await _owner_label(session, owner_user_id)
     target_tool = agent_target_for_member(owner_user_id, _member_targets())
+    deliver_to, delivery_skip = _delivery_target_for_event(event)
 
     result = await mint_packet_for_job(
         session,
@@ -529,15 +599,19 @@ async def _mint_for_idea_and_event(
         source_ref={"inbound_event_id": str(event.id)},
         readers=readers,
         reader_user_id=str(getattr(event, "authority_user_id", "") or "") or None,
+        deliver_to=deliver_to,
     )
     if result.ok and result.created:
-        try:
-            result.posted = await _post_brief_to_origin_thread(
-                event=event, brief=result.human_brief
-            )
-        except Exception as exc:  # noqa: BLE001 — the packet exists; the reply degraded
-            logger.warning("packet %s minted but Slack reply failed: %s",
-                           getattr(result.handoff, "id", "?"), exc)
+        if deliver_to is None:
+            result.delivery = f"skipped:{delivery_skip}"
+        elif result.delivery == "recorded":
+            try:
+                schedule_post_commit_delivery(
+                    session, org_id=org_id, handoff_ids=[str(result.handoff.id)]
+                )
+            except Exception as exc:  # noqa: BLE001 — the sweep remains the guaranteed path
+                logger.warning("packet %s minted but fast-path dispatch failed to arm: %s",
+                               getattr(result.handoff, "id", "?"), exc)
     return result
 
 

--- a/brain/systems/change_notifications_cycle.py
+++ b/brain/systems/change_notifications_cycle.py
@@ -176,6 +176,24 @@ async def _attach_and_refresh_packets(session, org_id, events) -> None:
         log.exception("packet link attachment failed safely; lines go out without links")
 
 
+async def _deliver_pending_briefs_safely(org_id) -> dict | None:
+    """Post-slice-05 hardening: the sweep half of the packet-brief outbox.
+    The mint records deliveries inside its transaction and an after-commit
+    fast path usually posts them within a second; this sweep is the
+    guaranteed retry for anything a crash or Slack outage left behind
+    (pending or stale-posting rows). Own sessions, fully contained — a
+    delivery failure degrades to a log line, never a dead tick."""
+    import logging
+
+    try:
+        from brain.systems.briefing.deliver import deliver_pending_briefs
+
+        return await deliver_pending_briefs(org_id=org_id)
+    except Exception:  # noqa: BLE001
+        logging.getLogger("illo.notify").exception("packet brief delivery sweep failed safely")
+        return None
+
+
 async def _default_post(channel_id, text) -> None:
     from brain.systems.slack.client import slack_web_client_from_env
 
@@ -218,12 +236,23 @@ async def run_notify_cycle(
     since=None,
     urgent_terms=DEFAULT_URGENT_TERMS,
     post=None,
+    deliver_briefs=None,
 ) -> dict:
     """One notify-cycle tick. Returns a small summary of what was sent."""
     verification = await _maybe_run_deploy_verification(session, org_id)
     events = await _load_change_events(session, org_id, since)
     await _fill_owner_labels(session, events)
     await _attach_and_refresh_packets(session, org_id, events)
+    # After the refresh: a supersede may have just moved a pending brief to
+    # its new revision, and this sweep should send THAT one.
+    deliveries = None
+    if session is not None:
+        try:
+            deliveries = await (deliver_briefs or _deliver_pending_briefs_safely)(org_id)
+        except Exception:  # noqa: BLE001 — a delivery failure never kills the tick
+            import logging
+
+            logging.getLogger("illo.notify").exception("brief delivery sweep failed safely")
     unclaimed = await _count_unclaimed(session, org_id)
     outbound = render_outbound(events, unclaimed_count=unclaimed, urgent_terms=urgent_terms)
 
@@ -241,4 +270,6 @@ async def run_notify_cycle(
     }
     if verification is not None:
         summary["verification"] = verification
+    if deliveries and deliveries.get("selected"):
+        summary["brief_deliveries"] = deliveries
     return summary

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -164,13 +164,13 @@ def _log_mint_result(*, event_id: str, run_id: int, lane: str, result: Any) -> N
         level = logging.DEBUG
     logger.log(
         level,
-        "packet mint: event=%s run=%s lane=%s ok=%s created=%s posted=%s reason=%s",
+        "packet mint: event=%s run=%s lane=%s ok=%s created=%s delivery=%s reason=%s",
         event_id,
         run_id,
         lane,
         getattr(result, "ok", None),
         getattr(result, "created", None),
-        getattr(result, "posted", None),
+        getattr(result, "delivery", None),
         reason,
     )
 

--- a/specs/illo-handoff-packets/README.md
+++ b/specs/illo-handoff-packets/README.md
@@ -6,8 +6,10 @@
 reviewed and hardened (four review rounds folded: 14+9+9+10 findings);
 06+07 implemented and unit-green, their adversarial pass is the next
 pickup, then the illo-dev pre-merge probe (briefs into `assets/`) and the
-doc-1155 delta at merge+deploy. Earlier per-slice status follows for
-provenance. Slices 01+02 implemented, cross-family reviewed,
+doc-1155 delta at merge+deploy. 2026-07-16: mint connected to the live
+completion lanes, and the deferred Slack-reply-before-commit window closed
+by the brief-delivery outbox (post-commit delivery; sections below).
+Earlier per-slice status follows for provenance. Slices 01+02 implemented, cross-family reviewed,
 hardened, and green —
 `brain/systems/briefing/{core,compose}.py` (pure), CLI probe
 (`python -m brain.systems.briefing --fixture
@@ -197,13 +199,13 @@ after the Codex worker wedged again — 0.15s CPU in 25min):**
 - Gather's provenance helpers promoted to public names
   (`load_inbound_event`, `slack_provenance`, `PUBLIC_CHANNEL_TYPE`) — mint
   consumes the single owner, no underscore imports.
-- Known deferred (recorded, review findings 4/5): the Slack reply still
-  precedes the outer commit (tiny 404-launch-link window if the
-  transaction later fails — revisit with slice 06's refresh cycle, which
-  is the natural post-commit home), and hook-level integration tests need
-  a real session (covered instead by mint-level regressions: echo
-  starvation, IntegrityError re-select, lock assertion, label fallback —
-  plus the illo-dev probe before merge).
+- Known deferred (recorded, review findings 4/5): ~~the Slack reply still
+  precedes the outer commit~~ — **FIXED 2026-07-16** by the brief-delivery
+  outbox (see the dedicated section below; re-confirmed as finding 1 of the
+  2026-07-16 Codex review of 6e477a5 before landing). Hook-level
+  integration tests still lean on mint-level regressions (echo starvation,
+  IntegrityError re-select, lock assertion, label fallback) plus the
+  sqlite lane end-to-ends in `tests/test_inbound_reconciliation.py`.
 
 **Post-deploy fix (2026-07-16, Claude-implemented): mint connected to the
 live completion lanes.** Production showed ZERO packets since the 07-13
@@ -236,6 +238,80 @@ still-contained layers:
   Regression suites: `tests/test_inbound_reconciliation.py` (lane
   end-to-end on sqlite), `tests/test_inbound_attribution.py`, actionable
   cases in `tests/test_briefing_mint.py`.
+
+**Post-slice-05 hardening (2026-07-16, Claude-implemented): brief delivery
+moved post-commit (transactional outbox).** Closes deferred finding 4/5 and
+finding 1 of the 2026-07-16 Codex review: the mint runs inside the run's
+terminal-status transaction (`runs/store.py` → `reconcile_inbound_triage_run`),
+so the old in-transaction Slack reply could survive a failed commit — a live
+message pointing at a rolled-back handoff row, then a second brief from the
+crash-retry's re-mint. Now:
+- **Record, don't post.** `mint_packet_for_job(deliver_to=…)` persists ONE
+  pending `PacketBriefDelivery` row per handoff id (`packet_brief_deliveries`,
+  migration 0026; unique on handoff_id) inside the existing write-phase
+  savepoint — atomically with the handoff row, idea stamp, and run status.
+  Provenance (channel/thread_ts, public-only allowlist) resolves at mint
+  time; non-public/no-provenance mints record nothing
+  (`MintResult.delivery = "skipped:<why>"` replaces `posted`).
+- **Deliver strictly post-commit** (`briefing/deliver.py`): claim (CAS
+  `pending→posting`, committed BEFORE the send) → fence-verified re-read →
+  post → mark `posted`, each step its own short transaction on its own
+  session. Deterministic identity `packet-brief:<handoff_id>`; the brief's
+  launch URL embeds the handoff id, and a stale `posting` claim (crashed
+  worker) is re-sent only after a disambiguation read of the origin thread —
+  counting ONLY Illo-authored messages (`bot_user_id` snapshot; a human
+  pasting the launch URL never satisfies it) and treating a failed or
+  truncated read as "cannot decide", never "absent" — so worker crashes
+  cannot duplicate the message. Definite Slack rejects requeue
+  (attempt-capped; the cap takes one last disambiguation look before
+  recording `failed` + ERROR) or fail fast on permanent errors; ambiguous
+  transport errors stay claimed for the next disambiguating pass.
+- **Concurrency posture (two Codex adversarial passes on the outbox,
+  2026-07-16 — 10 findings + a 4-finding verification, all folded):** every
+  sweep-side CAS that can touch a row the notify tick's own transaction may
+  hold (claims AND the attempts-cap transitions) goes through a
+  `FOR UPDATE SKIP LOCKED` subselect — the sweep runs awaited inside that
+  tick, so blocking there would self-deadlock it. The supersede transfer's
+  read is a locking read WITH `populate_existing` (a lock over stale
+  identity-map attributes would re-open the double-post it exists to
+  close); `claimed_at` doubles as a fencing token on every post-claim
+  transition, re-verified immediately before every send (again after the
+  disambiguation read, whose network latency is unbounded); the post-claim
+  re-read also picks up a drift-repaired brief. A capped row whose final
+  thread look is unreadable stays `posting` (retried loudly) — never
+  recorded `failed` on guesswork. Documented residual: a send whose
+  interval from the final fence check until the message is visible in
+  Slack outlives the 10-minute lease (suspension, glacial request) can
+  race a reclaimer's read into a duplicate — irreducible without
+  provider-side idempotency Slack does not offer. SQLite compiles the
+  locking clauses away: like the mint's advisory lock, the races they
+  close are cross-connection, which unit-test environments don't exercise
+  (production is PostgreSQL).
+- **Two triggers, one engine.** Fast path: mint queues the handoff id in
+  `session.info`; one pair of session-level listeners (armed once per
+  session — `after_commit` also fires on savepoint releases on the installed
+  SQLAlchemy, verified empirically, so the spawned task polls for the rows
+  to become committed-VISIBLE rather than trusting event timing; only a
+  ROOT rollback clears the queue — savepoint-rollback survivors still
+  commit, and dead entries self-clean via the visibility check) —
+  same-second UX as the old inline post. Guaranteed path: the slice-06
+  notify tick sweeps claimable rows org-scoped (`run_notify_cycle` →
+  `deliver_pending_briefs`, capped 10/tick AFTER filtering out fresh
+  in-flight claims so stuck rows can't starve deliverable ones; injectable,
+  contained).
+- **Supersede carry-over.** Archiving a row whose brief is still `pending`
+  transfers the obligation to the new revision (fresh brief, fresh URL, old
+  row's delivery → `superseded`); a `posted` prior transfers nothing (noise
+  gate holds). Refresh still never CREATES a post — it only carries an
+  unfulfilled one forward, so the origin thread gets its single
+  triage-moment reply with a live link, never a dead one. Drift-repair also
+  rewrites a still-pending brief in place.
+- Regression suites: `tests/test_briefing_deliver.py` (state machine: both
+  crash windows, permanent/transient/ambiguous errors, attempt cap, org
+  scoping, per-row containment), updated `tests/test_briefing_mint.py`
+  (record-not-post, skip reasons, transfer on supersede/refresh) and
+  `tests/test_inbound_reconciliation.py` (lane end-to-end through delivery
+  + the after-commit fast path on a real session).
 
 **Implementation decisions that refine slice texts (06+07, Claude-implemented):**
 - Slice 06: `format_line` appends `→ launch: <url>` (one field, Slack-
@@ -380,7 +456,11 @@ everything.
   vocabulary — old row → `archived` + `metadata_["superseded_by"] = <new id>`
   (the DB CHECK constraint allows only `open/launched/claimed/expired/
   archived`, `brain/contracts/statuses.py` + migration 0017 — do NOT invent
-  a `superseded` status; no migration in this feature).
+  a `superseded` status; no handoff-status migration in this feature).
+  The one sanctioned addition (2026-07-16, migration 0026):
+  `packet_brief_deliveries` is DELIVERY bookkeeping — the transactional
+  outbox for the Slack brief — never a second packet/job store; it holds
+  transport state (target, rendered brief, send state) keyed one-per-handoff.
 - **Privacy boundary:** packets widen who can read gathered context —
   `handoff.get` and the API are org-scoped, so anything gathered becomes
   readable by every org member/agent token. V1 gathers only team-visible

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -42,6 +42,8 @@ REVIEWED_DESTRUCTIVE_MIGRATIONS = {
     "0020_reconstructive_memory.py",
     # Upgrade intentionally removes replaced model-routing tables after migrating the default model.
     "0021_remove_intelligence_tiers.py",
+    # Downgrade removes only the packet brief delivery outbox table introduced by this migration.
+    "0026_packet_brief_deliveries.py",
 }
 
 

--- a/tests/test_briefing_deliver.py
+++ b/tests/test_briefing_deliver.py
@@ -1,0 +1,561 @@
+"""Post-commit brief delivery (the packet-brief outbox state machine).
+
+Contract under test (spec: illo-handoff-packets, post-slice-05 hardening):
+``pending`` is claim-then-send (the claim commits BEFORE the send, so
+pending provably means "never sent"); a stale ``posting`` claim is a crashed
+worker and is re-sent ONLY after the origin thread is read and shown not to
+contain the handoff id (the deterministic ``packet-brief:<handoff_id>``
+identity rides in the brief's launch URL) — worker crashes can never
+duplicate the message. Definite Slack rejects requeue or fail loudly;
+ambiguous transport errors stay claimed for the next disambiguating pass.
+Everything is contained: a delivery failure is a log line plus a retry,
+never a raise.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brain.platform.db.models.launch_handoff import LaunchHandoff
+from brain.platform.db.models.packet_delivery import PacketBriefDelivery
+from brain.systems.briefing.deliver import (
+    DELIVERY_SWEEP_LIMIT,
+    MAX_DELIVERY_ATTEMPTS,
+    STALE_POSTING_GRACE,
+    deliver_pending_briefs,
+    delivery_idempotency_key,
+    transfer_pending_delivery,
+)
+from brain.systems.slack.client import SlackApiError
+
+_ORG = str(uuid.uuid4())
+_NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory([
+        LaunchHandoff.__table__,
+        PacketBriefDelivery.__table__,
+    ])
+
+
+class _SessionLease:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def _factory(session):
+    return lambda: _SessionLease(session)
+
+
+class FakePoster:
+    def __init__(self, fail_with: Exception | None = None):
+        self.sent: list[dict] = []
+        self.fail_with = fail_with
+
+    async def __call__(self, *, channel, text, thread_ts):
+        if self.fail_with is not None:
+            raise self.fail_with
+        self.sent.append({"channel": channel, "text": text, "thread_ts": thread_ts})
+        return {"ok": True, "ts": "1752600100.0"}
+
+
+class FakeThread:
+    def __init__(self, messages=(), fail: bool = False, complete: bool = True):
+        self.messages = list(messages)
+        self.fail = fail
+        self.complete = complete
+        self.reads = 0
+
+    async def __call__(self, *, channel, thread_ts):
+        self.reads += 1
+        if self.fail:
+            raise RuntimeError("replies API down")
+        return {"messages": list(self.messages), "complete": self.complete}
+
+
+async def _seed(session, *, state="pending", attempts=0, claimed_at=None,
+                handoff_id=None, brief=None, bot_user_id=None) -> PacketBriefDelivery:
+    handoff_id = handoff_id or str(uuid.uuid4())
+    row = PacketBriefDelivery(
+        org_id=_ORG,
+        handoff_id=handoff_id,
+        state=state,
+        idempotency_key=delivery_idempotency_key(handoff_id),
+        channel="C0PROD",
+        thread_ts="1752600000.0",
+        bot_user_id=bot_user_id,
+        brief=brief or f"New packet — Launch: https://illo/api/launch-handoffs/{handoff_id}/launch",
+        attempts=attempts,
+        claimed_at=claimed_at,
+    )
+    session.add(row)
+    await session.flush()
+    await session.commit()
+    return row
+
+
+async def _fresh(session, row) -> PacketBriefDelivery:
+    await session.refresh(row)  # CAS updates bypass the ORM identity map
+    return row
+
+
+async def test_pending_posts_once_and_marks_posted(session):
+    row = await _seed(session)
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster, now=_NOW
+    )
+    assert summary["posted"] == 1
+    assert len(poster.sent) == 1
+    assert poster.sent[0]["channel"] == "C0PROD"
+    assert poster.sent[0]["thread_ts"] == "1752600000.0"
+    row = await _fresh(session, row)
+    assert row.state == "posted"
+    assert row.attempts == 1
+    assert row.posted_message_ts == "1752600100.0"
+    assert row.posted_at is not None
+
+
+async def test_pending_never_reads_the_thread(session):
+    """pending means the claim was never taken, so the send happens blind —
+    the disambiguation read is reserved for crashed claims."""
+    await _seed(session)
+    thread = FakeThread(messages=[])
+    await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=FakePoster(),
+        thread_reader=thread, now=_NOW,
+    )
+    assert thread.reads == 0
+
+
+async def test_stale_posting_with_brief_already_in_thread_never_resends(session):
+    """THE crash window: the worker died between the send and the
+    posted-mark. The retry must find the brief in the thread and mark
+    posted without a second message."""
+    handoff_id = str(uuid.uuid4())
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+        handoff_id=handoff_id,
+    )
+    poster = FakePoster()
+    thread = FakeThread(messages=[
+        {"ts": "1752600050.0", "user": "B0ILLO",
+         "text": f"New packet — Launch: https://illo/api/launch-handoffs/{handoff_id}/launch"},
+    ])
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["already_posted"] == 1
+    assert poster.sent == []  # never re-sent
+    row = await _fresh(session, row)
+    assert row.state == "posted"
+    assert row.posted_message_ts == "1752600050.0"  # the found message
+
+
+async def test_stale_posting_not_in_thread_sends_once(session):
+    """The other side of the crash window: the worker died BEFORE the send
+    reached Slack. The thread shows nothing, so the retry sends."""
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+    )
+    poster = FakePoster()
+    thread = FakeThread(messages=[{"ts": "1", "user": "jb", "text": "unrelated chatter"}])
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["posted"] == 1
+    assert len(poster.sent) == 1
+    row = await _fresh(session, row)
+    assert row.state == "posted"
+    assert row.attempts == 2
+
+
+async def test_fresh_posting_claim_is_invisible_to_the_sweep(session):
+    """A recent claim belongs to a live worker — the selection itself skips
+    it (it must neither be stomped nor consume the sweep limit)."""
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - timedelta(seconds=30),
+    )
+    poster = FakePoster()
+    thread = FakeThread()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["selected"] == 0
+    assert poster.sent == [] and thread.reads == 0
+    row = await _fresh(session, row)
+    assert row.state == "posting" and row.attempts == 1
+
+
+async def test_stuck_rows_cannot_starve_pending_work(session):
+    """The sweep limit applies AFTER filtering to claimable rows: a pile of
+    fresh in-flight claims must not push deliverable pending rows out."""
+    for _ in range(DELIVERY_SWEEP_LIMIT):
+        await _seed(session, state="posting", attempts=1,
+                    claimed_at=_NOW - timedelta(seconds=5))
+    pending = await _seed(session)  # newest row, but the only claimable one
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster, now=_NOW,
+    )
+    assert summary["selected"] == 1 and summary["posted"] == 1
+    assert (await _fresh(session, pending)).state == "posted"
+
+
+async def test_disambiguation_trusts_only_bot_authored_messages(session):
+    """A human pasting the same launch URL into the thread must not satisfy
+    the already-posted check — the brief itself never arrived."""
+    handoff_id = str(uuid.uuid4())
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+        handoff_id=handoff_id, bot_user_id="B0ILLO",
+    )
+    poster = FakePoster()
+    thread = FakeThread(messages=[
+        {"ts": "1752600050.0", "user": "U0HUMAN",  # a human, not Illo
+         "text": f"see https://illo/api/launch-handoffs/{handoff_id}/launch"},
+    ])
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["posted"] == 1  # human paste ignored; the brief still goes out
+    assert len(poster.sent) == 1
+    assert (await _fresh(session, row)).state == "posted"
+
+
+async def test_attempt_cap_on_posting_row_checks_thread_before_failing(session):
+    """The final ambiguous send may have landed: a capped posting row gets
+    one last disambiguation and is recorded posted, not failed."""
+    handoff_id = str(uuid.uuid4())
+    row = await _seed(
+        session, state="posting", attempts=MAX_DELIVERY_ATTEMPTS,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+        handoff_id=handoff_id,
+    )
+    poster = FakePoster()
+    thread = FakeThread(messages=[
+        {"ts": "1752600070.0", "user": "B0ILLO",
+         "text": f"New packet — Launch: https://illo/api/launch-handoffs/{handoff_id}/launch"},
+    ])
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["already_posted"] == 1 and summary["failed"] == 0
+    assert poster.sent == []
+    row = await _fresh(session, row)
+    assert row.state == "posted"
+    assert row.posted_message_ts == "1752600070.0"
+
+
+async def test_claim_posts_the_current_committed_brief_not_the_snapshot(session):
+    """Drift repair may rewrite a pending brief between the sweep's snapshot
+    and its claim — the send must carry the row's CURRENT content (the
+    fence-verified re-read), never the pre-claim snapshot."""
+    row = await _seed(session, brief="stale V1 brief")
+
+    calls = {"n": 0}
+
+    class InterleavingFactory:
+        """First factory() call serves the selection snapshot; the rewrite
+        lands right after it, BEFORE the claim transaction."""
+
+        def __call__(self):
+            calls["n"] += 1
+            if calls["n"] == 2:  # selection done; claim about to start
+                row.brief = "fresh V2 brief"
+                # synchronous mutation on the shared sqlite session is
+                # committed by the claim's own commit below
+            return _SessionLease(session)
+
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=InterleavingFactory(), poster=poster, now=_NOW,
+    )
+    assert summary["posted"] == 1
+    assert poster.sent[0]["text"] == "fresh V2 brief"
+
+
+async def test_incomplete_thread_read_never_blind_posts(session):
+    """A truncated read can't prove the brief absent — an unread tail may
+    hide it. 'Not found' in an incomplete read must stay claimed, not send."""
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+    )
+    poster = FakePoster()
+    thread = FakeThread(messages=[{"ts": "1", "user": "jb", "text": "unrelated"}],
+                        complete=False)
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=thread, now=_NOW,
+    )
+    assert summary["undecided"] == 1
+    assert poster.sent == []
+    assert (await _fresh(session, row)).state == "posting"
+
+
+async def test_disambiguation_read_failure_stays_posting(session):
+    """Can't read the thread → can't prove the brief isn't there → never
+    send. The row stays claimed for the next sweep."""
+    row = await _seed(
+        session, state="posting", attempts=1,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+    )
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=FakeThread(fail=True), now=_NOW,
+    )
+    assert summary["undecided"] == 1
+    assert poster.sent == []
+    row = await _fresh(session, row)
+    assert row.state == "posting"
+
+
+async def test_definite_slack_reject_requeues_with_error(session):
+    row = await _seed(session)
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session),
+        poster=FakePoster(fail_with=SlackApiError("ratelimited")), now=_NOW,
+    )
+    assert summary["requeued"] == 1
+    row = await _fresh(session, row)
+    assert row.state == "pending"  # definite reject: provably not posted
+    assert row.attempts == 1
+    assert "ratelimited" in (row.last_error or "")
+
+
+async def test_permanent_slack_reject_fails_loudly(session, caplog):
+    row = await _seed(session)
+    with caplog.at_level(logging.ERROR, logger="brain.systems.briefing.deliver"):
+        summary = await deliver_pending_briefs(
+            org_id=_ORG, session_factory=_factory(session),
+            poster=FakePoster(fail_with=SlackApiError("channel_not_found")), now=_NOW,
+        )
+    assert summary["failed"] == 1
+    row = await _fresh(session, row)
+    assert row.state == "failed"
+    assert any("FAILED permanently" in r.getMessage() for r in caplog.records)
+
+
+async def test_ambiguous_transport_error_stays_posting(session):
+    """A timeout may have delivered: the row must NOT go back to pending
+    (pending is send-blind) — it stays posting for the disambiguating pass."""
+    row = await _seed(session)
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session),
+        poster=FakePoster(fail_with=TimeoutError("socket timeout")), now=_NOW,
+    )
+    assert summary["undecided"] == 1
+    row = await _fresh(session, row)
+    assert row.state == "posting"
+    assert row.attempts == 1
+
+
+async def test_attempt_cap_fails_loudly_instead_of_churning(session, caplog):
+    row = await _seed(session, attempts=MAX_DELIVERY_ATTEMPTS)
+    poster = FakePoster()
+    with caplog.at_level(logging.ERROR, logger="brain.systems.briefing.deliver"):
+        summary = await deliver_pending_briefs(
+            org_id=_ORG, session_factory=_factory(session), poster=poster, now=_NOW,
+        )
+    assert summary["failed"] == 1
+    assert poster.sent == []
+    row = await _fresh(session, row)
+    assert row.state == "failed"
+    assert any("FAILED permanently" in r.getMessage() for r in caplog.records)
+
+
+async def test_targeted_delivery_only_touches_named_handoffs(session):
+    target = await _seed(session)
+    other = await _seed(session)
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, handoff_ids=[str(target.handoff_id)],
+        session_factory=_factory(session), poster=poster, now=_NOW,
+    )
+    assert summary["selected"] == 1 and summary["posted"] == 1
+    assert (await _fresh(session, target)).state == "posted"
+    assert (await _fresh(session, other)).state == "pending"
+
+
+async def test_sweep_is_org_scoped(session):
+    mine = await _seed(session)
+    foreign = PacketBriefDelivery(
+        org_id=str(uuid.uuid4()), handoff_id=str(uuid.uuid4()), state="pending",
+        idempotency_key="packet-brief:x", channel="C9", thread_ts="9.0", brief="b",
+    )
+    session.add(foreign)
+    await session.commit()
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster, now=_NOW,
+    )
+    assert summary["selected"] == 1
+    assert (await _fresh(session, mine)).state == "posted"
+    assert (await _fresh(session, foreign)).state == "pending"
+
+
+async def test_delivery_pass_is_totally_contained(caplog):
+    def exploding_factory():
+        raise RuntimeError("no database today")
+
+    with caplog.at_level(logging.WARNING, logger="brain.systems.briefing.deliver"):
+        summary = await deliver_pending_briefs(
+            org_id=_ORG, session_factory=exploding_factory, now=_NOW,
+        )
+    assert summary["selected"] == 0  # and, critically, nothing raised
+    assert any("failed safely" in r.getMessage() for r in caplog.records)
+
+
+async def test_one_bad_row_does_not_starve_the_rest(session):
+    """Per-row containment: a poster blowing up on one row must not stop
+    the sweep from delivering the next one."""
+    bad = await _seed(session)
+    good = await _seed(session)
+
+    class SelectivePoster(FakePoster):
+        async def __call__(self, *, channel, text, thread_ts):
+            if str(bad.handoff_id) in text:
+                raise SlackApiError("ratelimited")
+            return await super().__call__(channel=channel, text=text, thread_ts=thread_ts)
+
+    poster = SelectivePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster, now=_NOW,
+    )
+    assert summary["posted"] == 1 and summary["requeued"] == 1
+    assert (await _fresh(session, good)).state == "posted"
+    assert (await _fresh(session, bad)).state == "pending"
+
+
+async def test_attempt_cap_with_unreadable_thread_stays_posting(session, caplog):
+    """A capped posting row whose final look can't read the thread must NOT
+    be recorded failed — the last ambiguous send may have landed. It stays
+    posting: retried loudly, never resolved by guesswork."""
+    row = await _seed(
+        session, state="posting", attempts=MAX_DELIVERY_ATTEMPTS,
+        claimed_at=_NOW - STALE_POSTING_GRACE - timedelta(minutes=1),
+    )
+    poster = FakePoster()
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_factory(session), poster=poster,
+        thread_reader=FakeThread(fail=True), now=_NOW,
+    )
+    assert summary["undecided"] == 1 and summary["failed"] == 0
+    assert poster.sent == []
+    assert (await _fresh(session, row)).state == "posting"
+
+
+async def test_savepoint_rollback_keeps_the_fast_path_queue(session):
+    """Only a ROOT rollback proves the queued deliveries dead. A later,
+    unrelated savepoint rolling back must not strip earlier mints of their
+    fast path (their rows still commit; visibility-polling covers the rest)."""
+    from brain.systems.briefing.deliver import _INFO_QUEUE_KEY, schedule_post_commit_delivery
+
+    armed = schedule_post_commit_delivery(session, org_id=_ORG, handoff_ids=["h1"])
+    assert armed is True
+    assert session.sync_session.info[_INFO_QUEUE_KEY] == [(_ORG, "h1")]
+
+    try:  # an unrelated savepoint fails and rolls back
+        async with session.begin_nested():
+            raise RuntimeError("unrelated savepoint failure")
+    except RuntimeError:
+        pass
+    assert session.sync_session.info[_INFO_QUEUE_KEY] == [(_ORG, "h1")]  # kept
+
+    await session.rollback()  # the ROOT transaction dies
+    assert session.sync_session.info[_INFO_QUEUE_KEY] == []  # cleared
+
+
+async def test_uncommitted_outbox_rows_are_invisible_to_the_deliverer(tmp_path, sqlite_postgres_ddl_patch):
+    """The whole point of the outbox, proven with REAL independent sessions
+    on a file-backed database: a delivery recorded inside a still-open
+    transaction is invisible to the deliverer; only the commit publishes it."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy.schema import CreateTable
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/outbox.db")
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(CreateTable(PacketBriefDelivery.__table__, if_not_exists=True))
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        writer = factory()
+        handoff_id = str(uuid.uuid4())
+        writer.add(PacketBriefDelivery(
+            org_id=_ORG, handoff_id=handoff_id, state="pending",
+            idempotency_key=delivery_idempotency_key(handoff_id),
+            channel="C0PROD", thread_ts="1752600000.0",
+            brief=f"Launch: https://illo/api/launch-handoffs/{handoff_id}/launch",
+        ))
+        await writer.flush()  # INSERT sent, transaction still open
+
+        poster = FakePoster()
+        summary = await deliver_pending_briefs(
+            org_id=_ORG, session_factory=factory, poster=poster, now=_NOW,
+        )
+        assert summary["selected"] == 0  # not committed → not deliverable
+        assert poster.sent == []
+
+        await writer.commit()
+        summary = await deliver_pending_briefs(
+            org_id=_ORG, session_factory=factory, poster=poster, now=_NOW,
+        )
+        assert summary["posted"] == 1
+        assert len(poster.sent) == 1
+        await writer.close()
+    finally:
+        await engine.dispose()
+
+
+async def test_transfer_moves_only_pending_obligations(session):
+    """Supersede carry-over (unit): pending moves to the new handoff with
+    the new brief; posted stays where it is and transfers nothing."""
+    pending = await _seed(session)
+    new_id = str(uuid.uuid4())
+    moved = await transfer_pending_delivery(
+        session, org_id=_ORG, prior_handoff_id=str(pending.handoff_id),
+        new_handoff_id=new_id, new_brief=f"fresh brief {new_id}",
+    )
+    await session.flush()
+    assert moved is True
+    assert pending.state == "superseded"
+    from sqlalchemy import select
+
+    rows = list((await session.scalars(
+        select(PacketBriefDelivery).where(PacketBriefDelivery.handoff_id == new_id)
+    )).all())
+    assert len(rows) == 1
+    assert rows[0].state == "pending"
+    assert rows[0].brief == f"fresh brief {new_id}"
+    assert rows[0].channel == pending.channel and rows[0].thread_ts == pending.thread_ts
+
+    posted = await _seed(session, state="posted")
+    moved = await transfer_pending_delivery(
+        session, org_id=_ORG, prior_handoff_id=str(posted.handoff_id),
+        new_handoff_id=str(uuid.uuid4()), new_brief="never used",
+    )
+    assert moved is False
+    assert posted.state == "posted"

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -1,10 +1,17 @@
 """Slice 05 (illo-handoff-packets): triage-moment minting.
 
-Contract under test: gather→compose→create→stamp→post orchestration with a
-hard noise gate (reuse posts nothing), supersede via the EXISTING status
-vocabulary (archived + superseded_by — never a new status), total failure
-containment (a packet bug can never break triage), stamps in Illo-owned
-idea state, and per-owner launch targets from config-with-default.
+Contract under test: gather→compose→create→stamp→record-delivery
+orchestration with a hard noise gate (reuse records nothing), supersede via
+the EXISTING status vocabulary (archived + superseded_by — never a new
+status), total failure containment (a packet bug can never break triage),
+stamps in Illo-owned idea state, and per-owner launch targets from
+config-with-default.
+
+Post-slice-05 hardening: mint NEVER posts to Slack in-transaction — it
+persists one pending ``PacketBriefDelivery`` per created handoff inside its
+savepoint (rolled back with everything else on failure), and the post-commit
+deliverer (tests/test_briefing_deliver.py) sends it. The ``posts`` fixture
+now guards that nothing here ever talks to Slack synchronously.
 """
 
 from __future__ import annotations
@@ -109,6 +116,7 @@ class FakeSession:
         self._events = {str(e.id): e for e in events}
         self._users = list(users)
         self.handoffs: list[SimpleNamespace] = []
+        self.deliveries: list = []  # PacketBriefDelivery rows the mint records
         self._next_id = 1
         self.flush_count = 0
 
@@ -149,6 +157,8 @@ class FakeSession:
                 h for h in self.handoffs
                 if str(h.org_id) in values and str(h.idempotency_key) in values
             ]
+        elif name == "PacketBriefDelivery":  # deliver's savepoint helpers select by handoff_id
+            rows = [d for d in self.deliveries if str(d.handoff_id) in values]
         elif name == "User":  # the label lookup selects User columns
             rows = [u for u in self._users if str(u.id) in values]
         else:  # pragma: no cover
@@ -165,6 +175,12 @@ class FakeSession:
                 row.id = f"idea-{self._next_id}"
                 self._next_id += 1
             self._ideas.append(row)
+            return
+        if type(row).__name__ == "PacketBriefDelivery":
+            if not getattr(row, "id", None):
+                row.id = f"del-{self._next_id}"
+                self._next_id += 1
+            self.deliveries.append(row)
             return
         if not getattr(row, "id", None):
             row.id = f"hf-{self._next_id}"
@@ -238,7 +254,7 @@ async def test_create_with_status_flags_created_vs_reused():
     assert str(again.id) == str(row.id)
 
 
-async def test_triage_mint_posts_once_and_stamps_idea(posts):
+async def test_triage_mint_records_one_delivery_and_stamps_idea(posts):
     idea = _idea()
     session = FakeSession(ideas=[idea], events=[_event()],
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
@@ -246,11 +262,17 @@ async def test_triage_mint_posts_once_and_stamps_idea(posts):
         session, event=_event(), run_row=SimpleNamespace(id=1), attribution=None,
         readers=_readers(),
     )
-    assert result.ok and result.created and result.posted
-    assert len(posts) == 1
-    assert posts[0]["channel"] == "C0PROD" and posts[0]["thread_ts"] == "1751964840.0"
-    assert "Launch: http" in posts[0]["text"]
-    assert "→ Axel" in posts[0]["text"]
+    assert result.ok and result.created and result.delivery == "recorded"
+    assert posts == []  # NOTHING goes to Slack inside the mint transaction
+    assert len(session.deliveries) == 1
+    delivery = session.deliveries[0]
+    assert delivery.state == "pending"
+    assert delivery.channel == "C0PROD" and delivery.thread_ts == "1751964840.0"
+    assert delivery.handoff_id == str(result.handoff.id)
+    assert delivery.idempotency_key == f"packet-brief:{result.handoff.id}"
+    assert "Launch: http" in delivery.brief
+    assert "→ Axel" in delivery.brief
+    assert str(result.handoff.id) in delivery.brief  # the crash-dedup marker
     stamp = idea.agent_details["packet"]
     assert stamp["handoff_id"] == str(result.handoff.id)
     assert stamp["owner_user_id"] == _OWNER
@@ -267,9 +289,10 @@ async def test_remint_of_unchanged_truth_is_silent(posts):
         session, event=_event(), run_row=SimpleNamespace(id=2), readers=_readers())
     assert first.created and second.ok and not second.created
     assert second.reason == "reused"
-    assert not second.posted
-    assert len(posts) == 1  # the noise gate: one thread reply, ever
+    assert second.delivery == "none"
+    assert len(session.deliveries) == 1  # the noise gate: one obligation, ever
     assert len(session.handoffs) == 1
+    assert posts == []
 
 
 async def test_changed_truth_supersedes_with_existing_vocabulary(posts):
@@ -282,13 +305,21 @@ async def test_changed_truth_supersedes_with_existing_vocabulary(posts):
     idea.title = "Maison L. melted hands — rerun requested"
     second = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=2), readers=_readers())
-    assert second.created and len(posts) == 2
+    assert second.created and second.delivery == "recorded"
     old = next(h for h in session.handoffs if str(h.id) == str(first.handoff.id))
     new = next(h for h in session.handoffs if str(h.id) == str(second.handoff.id))
     assert old.status == "archived"  # NEVER an invented status
     assert (old.metadata_ or {}).get("superseded_by") == str(new.id)
     assert (new.metadata_ or {}).get("supersedes") == str(old.id)
     assert idea.agent_details["packet"]["handoff_id"] == str(new.id)
+    # The undelivered first brief is retired by the transfer; the new mint's
+    # own obligation is the one that posts (a changed-truth re-mint owes a
+    # fresh reply — the old brief would have posted a dead launch link).
+    by_handoff = {str(d.handoff_id): d for d in session.deliveries}
+    assert by_handoff[str(old.id)].state == "superseded"
+    assert by_handoff[str(new.id)].state == "pending"
+    assert str(new.id) in by_handoff[str(new.id)].brief
+    assert posts == []
 
 
 async def test_mint_failure_is_contained(posts):
@@ -311,7 +342,7 @@ async def test_mint_failure_is_contained(posts):
     assert posts == []  # and, critically, nothing raised
 
 
-async def test_non_public_provenance_mints_but_never_posts(posts):
+async def test_non_public_provenance_mints_but_never_records_delivery(posts):
     idea = _idea()
     session = FakeSession(ideas=[idea], events=[_event(channel_type="group")],
                           users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
@@ -320,7 +351,8 @@ async def test_non_public_provenance_mints_but_never_posts(posts):
         readers=_readers(),
     )
     assert result.ok and result.created
-    assert result.posted is False
+    assert result.delivery == "skipped:non_public"
+    assert session.deliveries == []  # nothing owed, ever — not even later
     assert posts == []
     assert len(session.handoffs) == 1  # the packet still exists for the digest
 
@@ -394,13 +426,15 @@ async def test_own_brief_in_thread_does_not_rotate_revision(posts):
     readers = Readers(slack=slack, github=NoGithub())
     first = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=readers)
-    assert first.created and len(posts) == 1
-    # Illo's brief lands in the thread under the BOT user id from provenance.
-    slack.extra.append({"ts": "1751964900.0", "user": "B0ILLO", "text": posts[0]["text"]})
+    assert first.created and len(session.deliveries) == 1
+    # Illo's brief (delivered post-commit) lands in the thread under the BOT
+    # user id from provenance.
+    slack.extra.append({"ts": "1751964900.0", "user": "B0ILLO",
+                        "text": session.deliveries[0].brief})
     second = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=2), readers=readers)
     assert not second.created  # bot message filtered → same dossier → same key
-    assert len(posts) == 1  # no echo repost
+    assert len(session.deliveries) == 1  # no echo re-record
     assert len(session.handoffs) == 1
 
 
@@ -414,7 +448,7 @@ async def test_integrity_race_reselects_as_reused_and_stamps(posts):
                                  users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
     first = await mint_packet_after_triage(
         winner_session, event=_event(), run_row=SimpleNamespace(id=1), readers=_readers())
-    assert first.created and len(posts) == 1
+    assert first.created and len(winner_session.deliveries) == 1
 
     # The loser: same content, but its insert flush raises IntegrityError.
     idea.agent_details = {**idea.agent_details}
@@ -423,7 +457,7 @@ async def test_integrity_race_reselects_as_reused_and_stamps(posts):
     second = await mint_packet_after_triage(
         winner_session, event=_event(), run_row=SimpleNamespace(id=2), readers=_readers())
     assert second.ok and not second.created
-    assert len(posts) == 1  # loser posts nothing
+    assert second.delivery == "none"  # loser records nothing
     assert idea.agent_details["packet"]["handoff_id"] == str(first.handoff.id)
 
 
@@ -474,8 +508,11 @@ async def test_refresh_unchanged_truth_is_silent_reuse(posts):
     result = await refresh_packet_for_job(
         session, org_id=_ORG, handoff_row=first.handoff, readers=_clean_readers())
     assert result.ok and not result.created
-    assert len(posts) == 1  # refresh NEVER posts
+    assert result.delivery == "none"  # refresh never records a new post
+    assert len(session.deliveries) == 1  # the original obligation, untouched
+    assert session.deliveries[0].state == "pending"
     assert len(session.handoffs) == 1
+    assert posts == []
 
 
 async def test_refresh_skips_on_degraded_gather(posts):
@@ -498,7 +535,11 @@ async def test_refresh_skips_on_degraded_gather(posts):
     assert live.status != "archived"
 
 
-async def test_refresh_changed_truth_supersedes_without_posting(posts):
+async def test_refresh_changed_truth_supersedes_and_carries_pending_brief(posts):
+    """Refresh never creates a NEW post — but a triage-moment brief that
+    never went out must follow the superseding row (fresh brief, fresh
+    launch URL), or the thread would either stay silent forever or later
+    get a dead link."""
     from brain.systems.briefing.mint import refresh_packet_for_job
 
     idea = _idea()
@@ -510,11 +551,36 @@ async def test_refresh_changed_truth_supersedes_without_posting(posts):
     result = await refresh_packet_for_job(
         session, org_id=_ORG, handoff_row=first.handoff, readers=_clean_readers())
     assert result.ok and result.created
-    assert len(posts) == 1  # still only the original triage reply
     old = next(h for h in session.handoffs if str(h.id) == str(first.handoff.id))
     assert old.status == "archived"
     assert (old.metadata_ or {}).get("superseded_by") == str(result.handoff.id)
     assert idea.agent_details["packet"]["handoff_id"] == str(result.handoff.id)
+    by_handoff = {str(d.handoff_id): d for d in session.deliveries}
+    assert by_handoff[str(old.id)].state == "superseded"
+    carried = by_handoff[str(result.handoff.id)]
+    assert carried.state == "pending"
+    assert carried.channel == "C0PROD" and carried.thread_ts == "1751964840.0"
+    assert str(result.handoff.id) in carried.brief  # refreshed content, live link
+    assert posts == []
+
+
+async def test_refresh_supersede_of_posted_brief_carries_nothing(posts):
+    """Once the thread has its reply, supersede must not schedule another
+    one — digest/nudge lines carry the new link (the slice-06 stance)."""
+    from brain.systems.briefing.mint import refresh_packet_for_job
+
+    idea = _idea()
+    session = FakeSession(ideas=[idea], events=[_event()],
+                          users=[SimpleNamespace(id=_OWNER, name="Axel", email=None)])
+    first = await mint_packet_after_triage(
+        session, event=_event(), run_row=SimpleNamespace(id=1), readers=_clean_readers())
+    session.deliveries[0].state = "posted"  # the deliverer already sent it
+    idea.title = "Maison L. melted hands — rerun verified"
+    result = await refresh_packet_for_job(
+        session, org_id=_ORG, handoff_row=first.handoff, readers=_clean_readers())
+    assert result.ok and result.created
+    assert len(session.deliveries) == 1  # no new obligation
+    assert session.deliveries[0].state == "posted"
 
 
 async def test_refresh_rejects_non_packet_handoffs(posts):
@@ -538,6 +604,7 @@ async def test_probe_stage_creates_and_posts_nothing(posts):
     )
     assert "Launch: {launch_url}" in packet.human_brief  # placeholder intact
     assert session.handoffs == []  # no row
+    assert session.deliveries == []  # no obligation
     assert posts == []  # no reply
 
 
@@ -586,7 +653,7 @@ def _hermetic_assignment_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
-async def test_actionable_run_mints_job_home_and_posts(posts):
+async def test_actionable_run_mints_job_home_and_records_delivery(posts):
     from brain.systems.briefing.mint import mint_packet_after_actionable_run
 
     session = FakeSession(events=[_actionable_event()])
@@ -595,7 +662,7 @@ async def test_actionable_run_mints_job_home_and_posts(posts):
         attribution=_attribution(), readers=_readers(),
     )
 
-    assert result.ok and result.created and result.posted
+    assert result.ok and result.created and result.delivery == "recorded"
     assert len(session.handoffs) == 1
     row = session.handoffs[0]
     assert row.source_surface == "inbound_triage"
@@ -613,9 +680,11 @@ async def test_actionable_run_mints_job_home_and_posts(posts):
     assert "uwear-ai/uwear-backend#616" in (idea.description or "")
     assert details["packet"]["handoff_id"] == str(row.id)  # stamped
 
-    assert len(posts) == 1
-    assert posts[0]["channel"] == "C0PROD"
-    assert posts[0]["thread_ts"] == "1751964840.0"
+    assert posts == []  # post-commit delivery, never in-transaction
+    assert len(session.deliveries) == 1
+    assert session.deliveries[0].channel == "C0PROD"
+    assert session.deliveries[0].thread_ts == "1751964840.0"
+    assert session.deliveries[0].state == "pending"
 
 
 async def test_actionable_run_without_durable_work_skips(posts):
@@ -635,6 +704,7 @@ async def test_actionable_run_without_durable_work_skips(posts):
     assert result.reason == "no durable work created by run"
     assert session.handoffs == []
     assert session._ideas == []
+    assert session.deliveries == []
     assert posts == []
 
 
@@ -655,10 +725,10 @@ async def test_actionable_run_mint_is_one_shot_per_event(posts):
     assert second.reason == "packet already minted for event"
     assert len(session.handoffs) == 1
     assert len(session._ideas) == 1
-    assert len(posts) == 1
+    assert len(session.deliveries) == 1
 
 
-async def test_actionable_run_non_public_provenance_never_posts(posts):
+async def test_actionable_run_non_public_provenance_never_records_delivery(posts):
     from brain.systems.briefing.mint import mint_packet_after_actionable_run
 
     session = FakeSession(events=[_actionable_event("im")])
@@ -667,8 +737,9 @@ async def test_actionable_run_non_public_provenance_never_posts(posts):
         attribution=_attribution(), readers=_readers(),
     )
     assert result.ok and result.created
-    assert result.posted is False
+    assert result.delivery == "skipped:non_public"
     assert len(session.handoffs) == 1  # persistence is never suppressed
+    assert session.deliveries == []
     assert posts == []
 
 

--- a/tests/test_change_notifications.py
+++ b/tests/test_change_notifications.py
@@ -153,7 +153,8 @@ class TestNotifyCycleOrchestration:
         monkeypatch.setattr(cyc, "_count_unclaimed", lambda *a, **k: _async_value(0))
 
         result = await cyc.run_notify_cycle(
-            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None)
+            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None),
+            deliver_briefs=lambda org: _async_value(None),
         )
         assert result == {
             "events": 0,
@@ -175,9 +176,56 @@ class TestNotifyCycleOrchestration:
         )
 
         result = await cyc.run_notify_cycle(
-            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None)
+            object(), org_id="o", channel_id="C123", post=lambda *a: _async_value(None),
+            deliver_briefs=lambda org: _async_value(None),
         )
         assert result["verification"] == {"verified": 2}
+
+    async def test_brief_delivery_sweep_runs_and_reports(self, monkeypatch):
+        """Slice-06 sweep half of the packet-brief outbox: the tick invokes
+        the deliverer org-scoped, reports only when something was selected,
+        and a sweep failure never kills the tick."""
+        import brain.systems.change_notifications_cycle as cyc
+
+        monkeypatch.setattr(cyc, "_load_change_events", lambda *a, **k: _async_value([]))
+        monkeypatch.setattr(cyc, "_count_unclaimed", lambda *a, **k: _async_value(0))
+
+        swept: list[str] = []
+
+        async def fake_deliver(org_id):
+            swept.append(org_id)
+            return {"selected": 2, "posted": 2}
+
+        result = await cyc.run_notify_cycle(
+            object(), org_id="o", channel_id="C123",
+            post=lambda *a: _async_value(None), deliver_briefs=fake_deliver,
+        )
+        assert swept == ["o"]
+        assert result["brief_deliveries"] == {"selected": 2, "posted": 2}
+
+        # A quiet sweep stays out of the summary.
+        result = await cyc.run_notify_cycle(
+            object(), org_id="o", channel_id="C123",
+            post=lambda *a: _async_value(None),
+            deliver_briefs=lambda org: _async_value({"selected": 0}),
+        )
+        assert "brief_deliveries" not in result
+
+        # No session (unit contexts) → no sweep at all.
+        result = await cyc.run_notify_cycle(
+            None, org_id="o", channel_id="C123",
+            post=lambda *a: _async_value(None), deliver_briefs=fake_deliver,
+        )
+        assert swept == ["o"]
+
+        async def exploding_deliver(org_id):
+            raise RuntimeError("delivery infrastructure down")
+
+        result = await cyc.run_notify_cycle(
+            object(), org_id="o", channel_id="C123",
+            post=lambda *a: _async_value(None), deliver_briefs=exploding_deliver,
+        )
+        assert result["events"] == 0  # the tick survived
 
 
 async def _async_value(value):

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -7,8 +7,11 @@ shipped. The mint hook was gated on the dormant lane, so zero packets were
 ever minted. The regression contract:
 
 - a ``slack_teammate_run``-filed GitHub issue produces a ``launch_handoffs``
-  row with ``source_surface='inbound_triage'`` and a Slack thread post when
-  the provenance is a public channel;
+  row with ``source_surface='inbound_triage'`` and a PENDING brief-delivery
+  outbox row when the provenance is a public channel — the Slack post itself
+  happens strictly post-commit (``brain.systems.briefing.deliver``), so a
+  failed terminal-status commit can never leave a live Slack message
+  pointing at rolled-back state;
 - runs that only replied in Slack never mint;
 - the slack lane's already-terminal receipt and event are never rewritten;
 - every mint decision leaves a log line (a dormant gate can't be silent);
@@ -34,6 +37,8 @@ from brain.platform.db.models.idea import Idea
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.platform.db.models.launch_handoff import LaunchHandoff
 from brain.platform.db.models.org import User
+from brain.platform.db.models.packet_delivery import PacketBriefDelivery
+from brain.systems.briefing.deliver import deliver_pending_briefs
 from brain.systems.briefing.gather import SlackThreadRead
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
 
@@ -62,8 +67,35 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
         InboundDecisionReceiptRow.__table__,
         Idea.__table__,
         LaunchHandoff.__table__,
+        PacketBriefDelivery.__table__,
         User.__table__,
     ])
+
+
+class _SessionLease:
+    """A factory shim handing the deliverer the test's live sqlite session
+    (in-memory sqlite is per-connection, so a real second session would see
+    an empty database). Close is a no-op; commits are real."""
+
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def _lease_factory(session):
+    return lambda: _SessionLease(session)
+
+
+async def _deliveries(session) -> list[PacketBriefDelivery]:
+    rows = list((await session.scalars(select(PacketBriefDelivery))).all())
+    for row in rows:
+        await session.refresh(row)  # the deliverer's CAS bypasses the ORM
+    return rows
 
 
 @pytest.fixture(autouse=True)
@@ -194,7 +226,7 @@ async def _ideas(session) -> list[Idea]:
     return list((await session.scalars(select(Idea))).all())
 
 
-async def test_slack_filed_issue_mints_packet_and_posts(session, posts, caplog):
+async def test_slack_filed_issue_mints_packet_and_records_delivery(session, posts, caplog):
     event_id, run_id = await _seed_slack_lane(
         session, tool_results=[("create_github_issue", _ISSUE_RESULT),
                                ("post_slack_reply", _REPLY_RESULT)],
@@ -220,14 +252,22 @@ async def test_slack_filed_issue_mints_packet_and_posts(session, posts, caplog):
     assert "uwear-ai/uwear-backend#616" in (idea.description or "")
     assert (row.metadata_ or {}).get("job_ref") == f"idea:{idea.id}"
 
-    assert len(posts) == 1
-    assert posts[0]["channel"] == "C0ALERTS"
-    assert posts[0]["thread_ts"] == "1752600000.0"
+    # In-transaction: NO Slack post — the outbox row carries the obligation.
+    assert posts == []
+    deliveries = await _deliveries(session)
+    assert len(deliveries) == 1
+    delivery = deliveries[0]
+    assert delivery.state == "pending"
+    assert delivery.handoff_id == str(row.id)
+    assert delivery.idempotency_key == f"packet-brief:{row.id}"
+    assert delivery.channel == "C0ALERTS" and delivery.thread_ts == "1752600000.0"
+    assert str(row.id) in delivery.brief  # launch URL = the crash-dedup marker
 
     mint_lines = [r for r in caplog.records if "packet mint:" in r.getMessage()]
     assert len(mint_lines) == 1
     assert "lane=slack_teammate_run" in mint_lines[0].getMessage()
     assert "ok=True" in mint_lines[0].getMessage()
+    assert "delivery=recorded" in mint_lines[0].getMessage()
 
     # The admission receipt and event stay exactly as the slack lane wrote them.
     stored = (await session.scalars(select(InboundDecisionReceiptRow))).one()
@@ -236,6 +276,27 @@ async def test_slack_filed_issue_mints_packet_and_posts(session, posts, caplog):
     event = await session.get(InboundEventRow, event_id)
     assert event.status == "processed"
     assert "triage" not in dict(event.action_result or {})
+
+    # Post-commit: the deliverer sends exactly the recorded brief to the
+    # recorded target and marks the row posted.
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_lease_factory(session)
+    )
+    assert summary["posted"] == 1
+    assert len(posts) == 1
+    assert posts[0]["channel"] == "C0ALERTS"
+    assert posts[0]["thread_ts"] == "1752600000.0"
+    assert posts[0]["text"] == delivery.brief
+    deliveries = await _deliveries(session)
+    assert deliveries[0].state == "posted"
+    assert deliveries[0].posted_at is not None
+
+    # A second pass finds nothing to do — crash-retry safe at the sweep level.
+    summary = await deliver_pending_briefs(
+        org_id=_ORG, session_factory=_lease_factory(session)
+    )
+    assert summary["selected"] == 0
+    assert len(posts) == 1
 
 
 async def test_slack_reply_only_run_skips_with_log_line(session, posts, caplog):
@@ -247,6 +308,7 @@ async def test_slack_reply_only_run_skips_with_log_line(session, posts, caplog):
 
     assert await _handoffs(session) == []
     assert await _ideas(session) == []
+    assert await _deliveries(session) == []
     assert posts == []
     mint_lines = [r for r in caplog.records if "packet mint:" in r.getMessage()]
     assert len(mint_lines) == 1
@@ -259,10 +321,10 @@ async def test_slack_lane_mint_is_one_shot(session, posts, caplog):
     )
     await reconcile_inbound_triage_run(session, run_id)
     with caplog.at_level(logging.INFO, logger="brain.systems.inbound.reconciliation"):
-        await reconcile_inbound_triage_run(session, run_id)  # duplicate delivery
+        await reconcile_inbound_triage_run(session, run_id)  # duplicate reconcile
 
     assert len(await _handoffs(session)) == 1
-    assert len(posts) == 1
+    assert len(await _deliveries(session)) == 1  # one obligation, ever
     second = [r for r in caplog.records if "packet mint:" in r.getMessage()]
     assert len(second) == 1
     assert "reason=packet already minted for event" in second[0].getMessage()
@@ -322,7 +384,8 @@ async def test_submit_lane_mints_on_durable_work_without_post(session, posts):
     rows = await _handoffs(session)
     assert len(rows) == 1
     assert rows[0].source_surface == "inbound_triage"
-    assert posts == []  # no slack provenance → persistence without a post
+    assert posts == []
+    assert await _deliveries(session) == []  # no slack provenance → nothing owed
 
     # Re-reconcile (illo_get_result polls do this): terminal receipt, no re-mint.
     await reconcile_inbound_triage_run(session, run.id)
@@ -378,7 +441,9 @@ async def test_triage_lane_still_mints_unconditionally(session, posts):
     rows = await _handoffs(session)
     assert len(rows) == 1
     assert rows[0].source_surface == "inbound_triage"
-    assert len(posts) == 1
+    assert posts == []
+    deliveries = await _deliveries(session)
+    assert len(deliveries) == 1 and deliveries[0].state == "pending"
 
 
 async def test_submit_mint_failure_is_retried_by_next_poll(session, posts, monkeypatch):
@@ -434,3 +499,47 @@ async def test_submit_mint_failure_is_retried_by_next_poll(session, posts, monke
     ideas = await _ideas(session)
     assert len(ideas) == 1  # the failed attempt's job home was reused
     assert ideas[0].agent_details["packet"]["handoff_id"] == str(rows[0].id)
+
+
+async def test_mint_arms_fast_path_that_fires_only_after_commit(session, posts, monkeypatch):
+    """The post-commit fast path: the mint arms a one-shot after-commit
+    dispatch; nothing runs before the enclosing transaction commits (the
+    whole point — no Slack side effect can precede the terminal-status
+    write), and the commit triggers a delivery targeted at the minted
+    handoff."""
+    import asyncio
+
+    import brain.systems.briefing.deliver as deliver_module
+
+    dispatched: list[dict] = []
+
+    async def fake_deliver(**kwargs):
+        dispatched.append(kwargs)
+        return {"selected": 1, "posted": 1}
+
+    monkeypatch.setattr(deliver_module, "deliver_pending_briefs", fake_deliver)
+
+    _, run_id = await _seed_slack_lane(
+        session, tool_results=[("create_github_issue", _ISSUE_RESULT)],
+    )
+    await reconcile_inbound_triage_run(session, run_id)
+    rows = await _handoffs(session)
+    assert len(rows) == 1
+
+    await asyncio.sleep(0)
+    assert dispatched == []  # armed, not fired: the transaction is still open
+
+    await session.commit()
+    for _ in range(5):  # after_commit → call_soon → task; give the loop a few turns
+        await asyncio.sleep(0)
+        if dispatched:
+            break
+    assert len(dispatched) == 1
+    assert dispatched[0]["org_id"] == _ORG
+    assert dispatched[0]["handoff_ids"] == [str(rows[0].id)]
+
+    # once=True: a later commit must not re-dispatch
+    await session.commit()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert len(dispatched) == 1

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -50,6 +50,7 @@ EXPECTED_TABLES = {
     "inbound_events",
     "inbound_source_policies",
     "launch_handoffs",
+    "packet_brief_deliveries",
     "idea_connections",
     "idea_project_attachments",
     "idea_state_log",


### PR DESCRIPTION
## Why

The packet mint runs inside the run's terminal-status transaction (`runs/store.py` → `reconcile_inbound_triage_run`). Posting the human brief to the Slack origin thread from inside that transaction meant a failed outer commit left a **live Slack message pointing at a rolled-back handoff row** — and the crash-retry re-minted a new row and posted a second brief with the first pointing at a dead launch URL. Recorded as the slice-05 deferred item in `specs/illo-handoff-packets/README.md`; re-confirmed as finding 1 of the 2026-07-16 Codex review of 6e477a5.

## What

**Record, don't post.** `mint_packet_for_job(deliver_to=…)` persists one pending `PacketBriefDelivery` row per handoff id (migration `0026`, unique on `handoff_id`, deterministic `packet-brief:<handoff_id>` idempotency key, provenance + `bot_user_id` + URL-filled brief snapshot) inside the existing write-phase savepoint — atomic with the handoff row, idea stamp, and run status. Non-public / no-provenance mints record nothing (`MintResult.delivery = "skipped:<why>"` replaces `posted`).

**Deliver strictly post-commit** (`brain/systems/briefing/deliver.py`, new): claim (`FOR UPDATE SKIP LOCKED` CAS, committed before the send) → fence-verified re-read → post → fenced mark, each step its own short transaction. A stale `posting` claim (crashed worker) re-sends only after a **complete, bot-authored-only** read of the origin thread proves the handoff id absent; failed/truncated reads stay claimed. Permanent Slack rejects fail loudly; transient ones requeue with an attempt cap that takes a final disambiguation look before recording `failed`.

**Two triggers, one engine.** Fast path: mint queues ids in `session.info` and a visibility-polling task delivers within ~a second of the real commit (`after_commit` fires on savepoint releases on our SQLAlchemy — verified empirically — so event timing is never trusted; root rollbacks clear the queue, savepoint rollbacks keep it). Guaranteed path: the slice-06 notify tick sweeps claimable rows org-scoped, filtered before the per-tick cap so stuck rows can't starve deliverable ones.

**Supersede carry-over.** Archiving a row whose brief is still pending transfers the obligation to the new revision (fresh brief, fresh URL); posted priors transfer nothing. Refresh still never creates a new post.

## Review provenance

Two Codex xhigh adversarial passes drove the hardening: 10 findings (3 HIGH: tick self-deadlock via awaited-sweep lock waits; transfer/claim double-post race; unfenced lease takeover) plus a 4-finding verification pass — all folded. Documented residual: a send outliving the 10-minute lease between the final fence check and Slack visibility can still race a reclaimer's thread read — irreducible without provider-side idempotency Slack does not offer.

## Verification

- `tests/test_briefing_deliver.py` (new, 23 tests): both crash windows, fencing, bot-filtered disambiguation, incomplete-read honesty, attempt cap, starvation, org scoping, real-independent-sessions proof that uncommitted rows are invisible.
- Updated `tests/test_briefing_mint.py`, `tests/test_inbound_reconciliation.py` (lane end-to-end through delivery + the after-commit fast path), `tests/test_change_notifications.py`.
- Full fast suite: 3679 passed. Full Docker pg16 suite: 3749 passed with migration 0026 executed on real Postgres; remaining failures reproduce identically on clean origin/main (pre-existing env issues). Migration upgrade/downgrade + INSERT also proven on sqlite in isolation.
- Spec README deferred-items note rewritten; design + invariants recorded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)