### PR TITLE
[Chantier] Domain-1 chantier object type + record contract (#327)

### DIFF
--- a/brain/platform/db/alembic/versions/0026_chantier_object_type.py
+++ b/brain/platform/db/alembic/versions/0026_chantier_object_type.py
@@ -1,0 +1,360 @@
+"""Provision the Domain-1 chantier record contract.
+
+Revision ID: 0026_chantier_object_type
+Revises: 0025_pr_tracker_owner_fields
+Create Date: 2026-07-16
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0026_chantier_object_type"
+down_revision = "0025_pr_tracker_owner_fields"
+branch_labels = None
+depends_on = None
+
+
+_TRACKER_SLUG = "github-ticket-tracker"
+_OBJECT_KEY = "chantier"
+_CONTRACT_MARKER = "chantier-record-contract-v1"
+_OBJECT_VALUES = {
+    "name": "Chantier",
+    "description": (
+        "Cross-repository outcome container for coordinated work. "
+        f"Schema marker: {_CONTRACT_MARKER}."
+    ),
+    "title_field": "title",
+}
+_GITHUB_ISSUE_REF_PATTERN = (
+    r"github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:issue:[1-9][0-9]*"
+)
+_REFERENCE_SOURCES = ["github", "doc", "slack", "posthog", "url"]
+_FIELD_DEFINITION_COLUMNS = (
+    "name",
+    "field_type",
+    "required",
+    "options",
+    "default_value",
+    "validation",
+    "searchable",
+    "sortable",
+)
+_FIELD_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "key": "slug",
+        "name": "Stable slug",
+        "field_type": "text",
+        "required": True,
+        "options": [],
+        "default_value": None,
+        "validation": {
+            "immutable": True,
+            "max_length": 80,
+            "pattern": r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        },
+        "searchable": True,
+        "sortable": True,
+    },
+    {
+        "key": "title",
+        "name": "Title",
+        "field_type": "text",
+        "required": True,
+        "options": [],
+        "default_value": None,
+        "validation": {"max_length": 500},
+        "searchable": True,
+        "sortable": True,
+    },
+    {
+        "key": "goal",
+        "name": "Done-means goal",
+        "field_type": "long_text",
+        "required": True,
+        "options": [],
+        "default_value": None,
+        "validation": {
+            "max_length": 4000,
+            "pattern": r"(?is)^done means\s+\S.*$",
+        },
+        "searchable": True,
+        "sortable": False,
+    },
+    {
+        "key": "kind",
+        "name": "Kind",
+        "field_type": "enum",
+        "required": True,
+        "options": ["feature", "incident", "quality", "gtm"],
+        "default_value": None,
+        "validation": {},
+        "searchable": True,
+        "sortable": True,
+    },
+    {
+        "key": "state",
+        "name": "State",
+        "field_type": "enum",
+        "required": True,
+        "options": ["exploring", "building", "shipping", "verifying", "done", "paused"],
+        "default_value": None,
+        "validation": {},
+        "searchable": True,
+        "sortable": True,
+    },
+    {
+        "key": "owner",
+        "name": "Next-action owner",
+        "field_type": "text",
+        "required": False,
+        "options": [],
+        "default_value": None,
+        "validation": {"max_length": 120},
+        "searchable": True,
+        "sortable": True,
+    },
+    {
+        "key": "refs",
+        "name": "Typed references",
+        "field_type": "json",
+        "required": True,
+        "options": [],
+        "default_value": None,
+        "validation": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["source", "ref"],
+                "additional_properties": False,
+                "properties": {
+                    "source": {"type": "string", "enum": _REFERENCE_SOURCES},
+                    "ref": {"type": "string", "min_length": 1},
+                    "title": {"type": "string", "min_length": 1},
+                },
+                "source_ref_patterns": {"github": _GITHUB_ISSUE_REF_PATTERN},
+            },
+        },
+        "searchable": False,
+        "sortable": False,
+    },
+    {
+        "key": "parent_issue",
+        "name": "GitHub mirror parent issue",
+        "field_type": "text",
+        "required": False,
+        "options": [],
+        "default_value": None,
+        "validation": {"pattern": f"^{_GITHUB_ISSUE_REF_PATTERN}$"},
+        "searchable": True,
+        "sortable": False,
+    },
+    {
+        "key": "next_step",
+        "name": "Next most valuable step",
+        "field_type": "text",
+        "required": True,
+        "options": [],
+        "default_value": None,
+        "validation": {"max_length": 500, "pattern": r"^[^\r\n]+$"},
+        "searchable": True,
+        "sortable": False,
+    },
+    {
+        "key": "progress_note",
+        "name": "Progress note",
+        "field_type": "long_text",
+        "required": False,
+        "options": [],
+        "default_value": None,
+        "validation": {"max_length": 2000},
+        "searchable": True,
+        "sortable": False,
+    },
+    {
+        "key": "created_at",
+        "name": "Source created at",
+        "field_type": "datetime",
+        "required": False,
+        "options": [],
+        "default_value": None,
+        "validation": {},
+        "searchable": False,
+        "sortable": True,
+    },
+    {
+        "key": "updated_at",
+        "name": "Source updated at",
+        "field_type": "datetime",
+        "required": False,
+        "options": [],
+        "default_value": None,
+        "validation": {},
+        "searchable": False,
+        "sortable": True,
+    },
+)
+
+
+def _schema(bind: sa.Connection) -> str | None:
+    return "public" if bind.dialect.name == "postgresql" else None
+
+
+def _table_exists(bind: sa.Connection, table_name: str) -> bool:
+    return table_name in set(sa.inspect(bind).get_table_names(schema=_schema(bind)))
+
+
+def _table(bind: sa.Connection, metadata: sa.MetaData, table_name: str) -> sa.Table:
+    return sa.Table(
+        table_name,
+        metadata,
+        schema=_schema(bind),
+        autoload_with=bind,
+    )
+
+
+def _active_condition(table: sa.Table) -> sa.ColumnElement[bool]:
+    if "archived_at" not in table.c:
+        return sa.true()
+    return table.c.archived_at.is_(None)
+
+
+def _changed_values(
+    row: Mapping[str, Any],
+    desired: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {key: value for key, value in desired.items() if row.get(key) != value}
+
+
+def _next_sort_order(bind: sa.Connection, object_types: sa.Table, domain_id: int) -> int:
+    if "sort_order" not in object_types.c:
+        return 0
+    current = bind.scalar(
+        sa.select(sa.func.max(object_types.c.sort_order)).where(
+            object_types.c.domain_id == domain_id,
+            _active_condition(object_types),
+        )
+    )
+    return int(current or 0) + 1
+
+
+def _ensure_object_type(
+    bind: sa.Connection,
+    object_types: sa.Table,
+    domain_id: int,
+) -> int:
+    existing = bind.execute(
+        sa.select(object_types).where(
+            object_types.c.domain_id == domain_id,
+            object_types.c.key == _OBJECT_KEY,
+        )
+    ).mappings().first()
+    desired = dict(_OBJECT_VALUES)
+    if "archived_at" in object_types.c:
+        desired["archived_at"] = None
+
+    if existing is None:
+        insert_values: dict[str, Any] = {
+            "domain_id": domain_id,
+            "key": _OBJECT_KEY,
+            **desired,
+        }
+        if "sort_order" in object_types.c:
+            insert_values["sort_order"] = _next_sort_order(bind, object_types, domain_id)
+        result = bind.execute(object_types.insert().values(**insert_values))
+        return int(result.inserted_primary_key[0])
+
+    changed = _changed_values(existing, desired)
+    if _CONTRACT_MARKER not in str(existing.get("description") or ""):
+        changed["description"] = _OBJECT_VALUES["description"]
+    if changed:
+        if "updated_at" in object_types.c:
+            changed["updated_at"] = sa.func.now()
+        bind.execute(
+            object_types.update()
+            .where(object_types.c.id == existing["id"])
+            .values(**changed)
+        )
+    return int(existing["id"])
+
+
+def _ensure_fields(
+    bind: sa.Connection,
+    fields: sa.Table,
+    *,
+    domain_id: int,
+    object_type_id: int,
+) -> None:
+    for spec in _FIELD_SPECS:
+        desired = {column: spec[column] for column in _FIELD_DEFINITION_COLUMNS}
+        if "archived_at" in fields.c:
+            desired["archived_at"] = None
+        existing = bind.execute(
+            sa.select(fields).where(
+                fields.c.object_type_id == object_type_id,
+                fields.c.key == spec["key"],
+            )
+        ).mappings().first()
+        if existing is None:
+            bind.execute(
+                fields.insert().values(
+                    domain_id=domain_id,
+                    object_type_id=object_type_id,
+                    key=spec["key"],
+                    **desired,
+                )
+            )
+            continue
+
+        changed = _changed_values(existing, desired)
+        if not changed:
+            continue
+        if "updated_at" in fields.c:
+            changed["updated_at"] = sa.func.now()
+        bind.execute(
+            fields.update().where(fields.c.id == existing["id"]).values(**changed)
+        )
+
+
+def _upgrade(bind: sa.Connection) -> None:
+    required_tables = {
+        "domains",
+        "domain_object_types",
+        "domain_field_definitions",
+    }
+    if not all(_table_exists(bind, table_name) for table_name in required_tables):
+        return
+
+    metadata = sa.MetaData()
+    domains = _table(bind, metadata, "domains")
+    object_types = _table(bind, metadata, "domain_object_types")
+    fields = _table(bind, metadata, "domain_field_definitions")
+    domain_ids = bind.scalars(
+        sa.select(domains.c.id).where(
+            domains.c.slug == _TRACKER_SLUG,
+            _active_condition(domains),
+        )
+    ).all()
+    for domain_id in domain_ids:
+        object_type_id = _ensure_object_type(bind, object_types, int(domain_id))
+        _ensure_fields(
+            bind,
+            fields,
+            domain_id=int(domain_id),
+            object_type_id=object_type_id,
+        )
+
+
+def upgrade() -> None:
+    _upgrade(op.get_bind())
+
+
+def downgrade() -> None:
+    # Deliberate no-op: removing the schema would strand existing chantier
+    # records and typed cross-repository references.
+    return None

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-record-contract.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-record-contract.md
@@ -1,0 +1,82 @@
+# Domain 1 Chantier Record Contract
+
+This document defines only the persisted schema for `chantier` records in the
+`github-ticket-tracker` Domain. Chantier operating behavior belongs in its
+separate behavior document.
+
+## Object type
+
+- Domain slug: `github-ticket-tracker` (production Domain id `1`)
+- Object key: `chantier`
+- Display name: `Chantier`
+- Record title field: `title`
+- Contract version marker: `chantier-record-contract-v1`
+
+The dormant `milestone` object is unrelated and is not an alias or predecessor
+for this type.
+
+All fields below live in the record's `data` object for `manage_domain`
+creates, updates, and query results.
+
+## Fields
+
+| Field | Type | Required | Contract |
+| --- | --- | --- | --- |
+| `slug` | text | yes | Stable after creation; lowercase kebab-case, maximum 80 characters. |
+| `title` | text | yes | Human-readable chantier title, maximum 500 characters. |
+| `goal` | long text | yes | Outcome hook beginning with `Done means …`, maximum 4,000 characters. |
+| `kind` | enum | yes | `feature`, `incident`, `quality`, or `gtm`. |
+| `state` | enum | yes | `exploring`, `building`, `shipping`, `verifying`, `done`, or `paused`. This chantier state composes with, and does not replace, member tickets' Deploy-State Ladder. |
+| `owner` | text | no | Next-action owner, using the ticket record's builder-first ownership semantics; maximum 120 characters. |
+| `refs` | JSON array | yes | Typed references with the item shape below. An empty array is valid. |
+| `parent_issue` | text or null | no | GitHub mirror parent issue in external-id format. |
+| `next_step` | text | yes | One non-empty line naming the next most valuable step; maximum 500 characters. |
+| `progress_note` | long text | no | Progress context using the ticket record convention; maximum 2,000 characters. |
+| `created_at` | datetime or null | no | ISO 8601 source timestamp, following existing Domain-1 timestamp conventions. |
+| `updated_at` | datetime or null | no | ISO 8601 source timestamp, following existing Domain-1 timestamp conventions. |
+
+Each `refs` item is an object with exactly these keys:
+
+- `source` (required): `github`, `doc`, `slack`, `posthog`, or `url`
+- `ref` (required): a non-empty string
+- `title` (optional): a non-empty display string
+
+When `source` is `github`, `ref` must use
+`github:<owner>/<repo>:issue:<n>`. `parent_issue` uses that same format. The
+repository segment is part of the reference, so chantier membership is
+cross-repository by construction.
+
+## Full example record
+
+```json
+{
+  "slug": "agent-runtime-chantier-layer",
+  "title": "Agent runtime chantier layer",
+  "goal": "Done means related work is coordinated as one outcome across every affected repository.",
+  "kind": "feature",
+  "state": "building",
+  "owner": "Reda",
+  "refs": [
+    {
+      "source": "github",
+      "ref": "github:Illospace/illospace:issue:326",
+      "title": "Chantier layer umbrella"
+    },
+    {
+      "source": "github",
+      "ref": "github:Illospace/illospace:issue:327",
+      "title": "Domain-1 chantier object type and record contract"
+    },
+    {
+      "source": "doc",
+      "ref": "brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-record-contract.md",
+      "title": "Chantier record contract"
+    }
+  ],
+  "parent_issue": "github:Illospace/illospace:issue:326",
+  "next_step": "Merge the object-schema migration after its Domain and Alembic checks pass.",
+  "progress_note": "The keystone schema is implemented and awaiting verification.",
+  "created_at": "2026-07-16T14:00:00Z",
+  "updated_at": "2026-07-16T16:00:00Z"
+}
+```

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.3.0"
+version = "1.4.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"
@@ -37,3 +37,4 @@ references = "references/"
 asset_1 = "references/customer-support.md"
 asset_2 = "references/creating-work-items.md"
 asset_3 = "references/backlog-maintenance.md"
+asset_4 = "references/chantier-record-contract.md"

--- a/brain/systems/user_domains/service.py
+++ b/brain/systems/user_domains/service.py
@@ -74,7 +74,9 @@ def _validate_record_data(
                 raise DomainError(f"Field '{key}' is required")
             normalized[key] = None
             continue
-        normalized[key] = _coerce_field_value(field, value)
+        normalized_value = _coerce_field_value(field, value)
+        _validate_field_constraints(field, normalized_value)
+        normalized[key] = normalized_value
     return normalized
 
 
@@ -377,6 +379,9 @@ class AsyncDomainService:
             raise DomainError(f"Field '{key}' requires non-empty options")
         if not isinstance(options, list):
             raise DomainError(f"Field '{key}' options must be a list")
+        validation = payload.get("validation") or {}
+        if not isinstance(validation, Mapping):
+            raise DomainError(f"Field '{key}' validation must be an object")
         field = DomainFieldDefinition(
             domain_id=object_type.domain_id,
             object_type_id=object_type.id,
@@ -386,7 +391,7 @@ class AsyncDomainService:
             required=bool(payload.get("required", False)),
             options=[str(option) for option in options],
             default_value=payload.get("default_value"),
-            validation=payload.get("validation") or {},
+            validation=dict(validation),
             searchable=bool(payload.get("searchable", True)),
             sortable=bool(payload.get("sortable", True)),
         )
@@ -723,6 +728,7 @@ class AsyncDomainService:
         obj = await self.get_object_type_by_id(record.object_type_id)
         fields = await self.list_fields(obj.id)
         before = await self.serialize_record(record)
+        _validate_immutable_field_updates(fields, record.data or {}, data_patch or {})
         merged = dict(record.data or {})
         merged.update(data_patch or {})
         normalized = self.validate_record_data(fields, merged)
@@ -1458,6 +1464,148 @@ def _coerce_field_value(field: DomainFieldDefinition, value: Any) -> Any:
     if kind == "json":
         return value
     raise DomainError(f"Unsupported field type: {kind}")
+
+
+def _validate_field_constraints(field: DomainFieldDefinition, value: Any) -> None:
+    validation = field.validation or {}
+    if not isinstance(validation, Mapping):
+        raise DomainError(f"Field '{field.key}' has an invalid validation contract")
+    _validate_constraint_value(field.key, value, validation, path=field.key)
+
+
+def _validate_constraint_value(
+    field_key: str,
+    value: Any,
+    constraints: Mapping[str, Any],
+    *,
+    path: str,
+) -> None:
+    expected_type = constraints.get("type")
+    if expected_type is not None and not _matches_validation_type(value, expected_type):
+        raise DomainError(
+            f"Field '{field_key}' value at '{path}' must be {_validation_type_label(expected_type)}"
+        )
+
+    allowed_values = constraints.get("enum")
+    if isinstance(allowed_values, list) and value not in allowed_values:
+        raise DomainError(
+            f"Field '{field_key}' value at '{path}' must be one of: "
+            f"{', '.join(str(item) for item in allowed_values)}"
+        )
+
+    if isinstance(value, str | list | dict):
+        min_length = constraints.get("min_length", constraints.get("minLength"))
+        max_length = constraints.get("max_length", constraints.get("maxLength"))
+        if min_length is not None and len(value) < int(min_length):
+            raise DomainError(
+                f"Field '{field_key}' value at '{path}' must contain at least {int(min_length)} item(s)"
+            )
+        if max_length is not None and len(value) > int(max_length):
+            raise DomainError(
+                f"Field '{field_key}' value at '{path}' must contain at most {int(max_length)} item(s)"
+            )
+
+    pattern = constraints.get("pattern")
+    if pattern is not None and isinstance(value, str):
+        try:
+            matches = re.search(str(pattern), value) is not None
+        except re.error as exc:
+            raise DomainError(f"Field '{field_key}' has an invalid validation pattern") from exc
+        if not matches:
+            raise DomainError(f"Field '{field_key}' value at '{path}' has an invalid format")
+
+    if isinstance(value, list):
+        item_constraints = constraints.get("items")
+        if isinstance(item_constraints, Mapping):
+            for index, item in enumerate(value):
+                _validate_constraint_value(
+                    field_key,
+                    item,
+                    item_constraints,
+                    path=f"{path}[{index}]",
+                )
+
+    if not isinstance(value, Mapping):
+        return
+
+    required_keys = constraints.get("required")
+    if isinstance(required_keys, list):
+        missing = [key for key in required_keys if _is_empty(value.get(str(key)))]
+        if missing:
+            raise DomainError(
+                f"Field '{field_key}' value at '{path}' requires: "
+                f"{', '.join(str(key) for key in missing)}"
+            )
+
+    properties = constraints.get("properties")
+    if isinstance(properties, Mapping):
+        if constraints.get("additional_properties") is False:
+            unknown = sorted(set(value) - set(properties))
+            if unknown:
+                raise DomainError(
+                    f"Field '{field_key}' value at '{path}' has unknown key(s): "
+                    f"{', '.join(str(key) for key in unknown)}"
+                )
+        for key, property_constraints in properties.items():
+            if key not in value or not isinstance(property_constraints, Mapping):
+                continue
+            _validate_constraint_value(
+                field_key,
+                value[key],
+                property_constraints,
+                path=f"{path}.{key}",
+            )
+
+    source_ref_patterns = constraints.get("source_ref_patterns")
+    if isinstance(source_ref_patterns, Mapping):
+        source = value.get("source")
+        ref_pattern = source_ref_patterns.get(source)
+        ref = value.get("ref")
+        if ref_pattern is not None and (
+            not isinstance(ref, str) or re.fullmatch(str(ref_pattern), ref) is None
+        ):
+            raise DomainError(
+                f"Field '{field_key}' value at '{path}.ref' has an invalid format for source '{source}'"
+            )
+
+
+def _matches_validation_type(value: Any, expected_type: Any) -> bool:
+    return {
+        "array": isinstance(value, list),
+        "object": isinstance(value, Mapping),
+        "string": isinstance(value, str),
+        "number": isinstance(value, int | float) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+    }.get(str(expected_type), False)
+
+
+def _validation_type_label(expected_type: Any) -> str:
+    return {
+        "array": "an array",
+        "object": "an object",
+        "string": "a string",
+        "number": "a number",
+        "boolean": "a boolean",
+    }.get(str(expected_type), f"a value of type '{expected_type}'")
+
+
+def _validate_immutable_field_updates(
+    fields: Iterable[DomainFieldDefinition],
+    current_data: Mapping[str, Any],
+    data_patch: Mapping[str, Any],
+) -> None:
+    for field in fields:
+        validation = field.validation or {}
+        if (
+            not isinstance(validation, Mapping)
+            or not validation.get("immutable")
+            or field.key not in data_patch
+        ):
+            continue
+        requested = _coerce_field_value(field, data_patch[field.key])
+        _validate_field_constraints(field, requested)
+        if requested != current_data.get(field.key):
+            raise DomainError(f"Field '{field.key}' is immutable once set")
 
 
 def _record_title(

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -51,7 +51,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.3.0"
+    assert bundle.manifest.version == "1.4.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -62,6 +62,20 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
         "dependency check",
     ):
         assert expected in procedure
+
+
+def test_uwear_triage_bundle_packages_chantier_record_contract():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    contract = _uwear_triage_asset(bundle, "references/chantier-record-contract.md")
+
+    assert "# Domain 1 Chantier Record Contract" in contract
+    assert "`feature`, `incident`, `quality`, or `gtm`" in contract
+    assert "`exploring`, `building`, `shipping`, `verifying`, `done`, or `paused`" in contract
+    assert contract.count("```json") == 1
+    assert '"parent_issue": "github:Illospace/illospace:issue:326"' in contract
 
 
 def test_uwear_triage_skill_distinguishes_internal_tracker_from_real_github_issue():

--- a/tests/test_chantier_schema_migration.py
+++ b/tests/test_chantier_schema_migration.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib
+
+import sqlalchemy as sa
+
+
+MIGRATION_MODULE = "brain.platform.db.alembic.versions.0026_chantier_object_type"
+
+
+def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
+    metadata = sa.MetaData()
+    tables = {
+        "domains": sa.Table(
+            "domains",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("slug", sa.Text, nullable=False),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+        ),
+        "domain_object_types": sa.Table(
+            "domain_object_types",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("key", sa.Text, nullable=False),
+            sa.Column("name", sa.Text, nullable=False),
+            sa.Column("description", sa.Text),
+            sa.Column("title_field", sa.Text),
+            sa.Column("sort_order", sa.Integer, nullable=False, server_default="0"),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.UniqueConstraint("domain_id", "key"),
+        ),
+        "domain_field_definitions": sa.Table(
+            "domain_field_definitions",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("object_type_id", sa.Integer, nullable=False),
+            sa.Column("key", sa.Text, nullable=False),
+            sa.Column("name", sa.Text, nullable=False),
+            sa.Column("field_type", sa.Text, nullable=False),
+            sa.Column("required", sa.Boolean, nullable=False),
+            sa.Column("options", sa.JSON, nullable=False),
+            sa.Column("default_value", sa.JSON),
+            sa.Column("validation", sa.JSON, nullable=False),
+            sa.Column("searchable", sa.Boolean, nullable=False),
+            sa.Column("sortable", sa.Boolean, nullable=False),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.UniqueConstraint("object_type_id", "key"),
+        ),
+    }
+    return metadata, tables
+
+
+def _seed(connection: sa.Connection, tables: dict[str, sa.Table]) -> None:
+    connection.execute(
+        tables["domains"].insert(),
+        [
+            {"id": 1, "slug": "github-ticket-tracker", "archived_at": None},
+            {"id": 2, "slug": "other-domain", "archived_at": None},
+            {
+                "id": 3,
+                "slug": "github-ticket-tracker",
+                "archived_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+            },
+        ],
+    )
+    connection.execute(
+        tables["domain_object_types"].insert(),
+        [
+            {
+                "id": 1,
+                "domain_id": 1,
+                "key": "ticket",
+                "name": "Ticket",
+                "description": None,
+                "title_field": None,
+                "sort_order": 1,
+                "archived_at": None,
+            },
+            {
+                "id": 2,
+                "domain_id": 1,
+                "key": "milestone",
+                "name": "Milestone",
+                "description": "Dormant legacy object",
+                "title_field": None,
+                "sort_order": 4,
+                "archived_at": None,
+            },
+            {
+                "id": 3,
+                "domain_id": 2,
+                "key": "ticket",
+                "name": "Ticket",
+                "description": None,
+                "title_field": None,
+                "sort_order": 1,
+                "archived_at": None,
+            },
+        ],
+    )
+
+
+def test_migration_provisions_new_chantier_contract_idempotently_without_reusing_milestone():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        migration._upgrade(connection)
+        migration._upgrade(connection)
+
+        objects = connection.execute(
+            sa.select(tables["domain_object_types"]).order_by(
+                tables["domain_object_types"].c.domain_id,
+                tables["domain_object_types"].c.id,
+            )
+        ).mappings().all()
+        chantier_objects = [row for row in objects if row["key"] == "chantier"]
+        assert len(chantier_objects) == 1
+        chantier = chantier_objects[0]
+        assert chantier["domain_id"] == 1
+        assert chantier["name"] == "Chantier"
+        assert chantier["title_field"] == "title"
+        assert "chantier-record-contract-v1" in chantier["description"]
+        assert chantier["sort_order"] == 5
+
+        milestone = next(row for row in objects if row["key"] == "milestone")
+        assert milestone["id"] == 2
+        assert milestone["description"] == "Dormant legacy object"
+
+        fields = connection.execute(
+            sa.select(tables["domain_field_definitions"])
+            .where(
+                tables["domain_field_definitions"].c.object_type_id == chantier["id"]
+            )
+            .order_by(tables["domain_field_definitions"].c.id)
+        ).mappings().all()
+        assert [field["key"] for field in fields] == [
+            "slug",
+            "title",
+            "goal",
+            "kind",
+            "state",
+            "owner",
+            "refs",
+            "parent_issue",
+            "next_step",
+            "progress_note",
+            "created_at",
+            "updated_at",
+        ]
+        by_key = {field["key"]: field for field in fields}
+        assert {field["key"] for field in fields if field["required"]} == {
+            "slug",
+            "title",
+            "goal",
+            "kind",
+            "state",
+            "refs",
+            "next_step",
+        }
+        assert by_key["slug"]["required"] is True
+        assert by_key["slug"]["validation"]["immutable"] is True
+        assert by_key["kind"]["options"] == ["feature", "incident", "quality", "gtm"]
+        assert by_key["state"]["options"] == [
+            "exploring",
+            "building",
+            "shipping",
+            "verifying",
+            "done",
+            "paused",
+        ]
+        assert by_key["owner"]["name"] == "Next-action owner"
+        assert by_key["owner"]["required"] is False
+        assert by_key["refs"]["validation"]["type"] == "array"
+        assert by_key["refs"]["validation"]["items"]["properties"]["source"]["enum"] == [
+            "github",
+            "doc",
+            "slack",
+            "posthog",
+            "url",
+        ]
+        assert by_key["parent_issue"]["required"] is False
+        assert by_key["created_at"]["field_type"] == "datetime"
+        assert by_key["updated_at"]["field_type"] == "datetime"
+
+
+def test_migration_reconciles_drifted_object_and_field_definitions():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        migration._upgrade(connection)
+        chantier = connection.execute(
+            sa.select(tables["domain_object_types"]).where(
+                tables["domain_object_types"].c.domain_id == 1,
+                tables["domain_object_types"].c.key == "chantier",
+            )
+        ).mappings().one()
+        state = connection.execute(
+            sa.select(tables["domain_field_definitions"]).where(
+                tables["domain_field_definitions"].c.object_type_id == chantier["id"],
+                tables["domain_field_definitions"].c.key == "state",
+            )
+        ).mappings().one()
+        connection.execute(
+            tables["domain_object_types"]
+            .update()
+            .where(tables["domain_object_types"].c.id == chantier["id"])
+            .values(name="Project", description="old schema", archived_at=sa.func.now())
+        )
+        connection.execute(
+            tables["domain_field_definitions"]
+            .update()
+            .where(tables["domain_field_definitions"].c.id == state["id"])
+            .values(options=["todo", "done"], required=False, archived_at=sa.func.now())
+        )
+
+        migration._upgrade(connection)
+
+        repaired_object = connection.execute(
+            sa.select(tables["domain_object_types"]).where(
+                tables["domain_object_types"].c.id == chantier["id"]
+            )
+        ).mappings().one()
+        repaired_state = connection.execute(
+            sa.select(tables["domain_field_definitions"]).where(
+                tables["domain_field_definitions"].c.id == state["id"]
+            )
+        ).mappings().one()
+        assert repaired_object["name"] == "Chantier"
+        assert "chantier-record-contract-v1" in repaired_object["description"]
+        assert repaired_object["archived_at"] is None
+        assert repaired_state["required"] is True
+        assert repaired_state["options"] == [
+            "exploring",
+            "building",
+            "shipping",
+            "verifying",
+            "done",
+            "paused",
+        ]
+        assert repaired_state["archived_at"] is None
+
+
+def test_migration_is_a_noop_when_domain_schema_tables_are_absent():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        migration._upgrade(connection)

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -194,6 +194,123 @@ async def _create_pr_tracker(service: AsyncDomainService) -> Domain:
     )
 
 
+def _chantier_object_definition() -> dict:
+    github_issue_pattern = (
+        r"github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:issue:[1-9][0-9]*"
+    )
+    return {
+        "key": "chantier",
+        "name": "Chantier",
+        "title_field": "title",
+        "fields": [
+            {
+                "key": "slug",
+                "field_type": "text",
+                "required": True,
+                "validation": {
+                    "immutable": True,
+                    "max_length": 80,
+                    "pattern": r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                },
+            },
+            {"key": "title", "field_type": "text", "required": True},
+            {
+                "key": "goal",
+                "field_type": "long_text",
+                "required": True,
+                "validation": {"pattern": r"(?is)^done means\s+\S.*$"},
+            },
+            {
+                "key": "kind",
+                "field_type": "enum",
+                "required": True,
+                "options": ["feature", "incident", "quality", "gtm"],
+            },
+            {
+                "key": "state",
+                "field_type": "enum",
+                "required": True,
+                "options": [
+                    "exploring",
+                    "building",
+                    "shipping",
+                    "verifying",
+                    "done",
+                    "paused",
+                ],
+            },
+            {
+                "key": "owner",
+                "field_type": "text",
+                "validation": {"max_length": 120},
+            },
+            {
+                "key": "refs",
+                "field_type": "json",
+                "required": True,
+                "validation": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["source", "ref"],
+                        "additional_properties": False,
+                        "properties": {
+                            "source": {
+                                "type": "string",
+                                "enum": ["github", "doc", "slack", "posthog", "url"],
+                            },
+                            "ref": {"type": "string", "min_length": 1},
+                            "title": {"type": "string", "min_length": 1},
+                        },
+                        "source_ref_patterns": {"github": github_issue_pattern},
+                    },
+                },
+            },
+            {
+                "key": "parent_issue",
+                "field_type": "text",
+                "validation": {"pattern": f"^{github_issue_pattern}$"},
+            },
+            {
+                "key": "next_step",
+                "field_type": "text",
+                "required": True,
+                "validation": {"pattern": r"^[^\r\n]+$"},
+            },
+            {"key": "progress_note", "field_type": "long_text"},
+            {"key": "created_at", "field_type": "datetime"},
+            {"key": "updated_at", "field_type": "datetime"},
+        ],
+    }
+
+
+def _chantier_record_data() -> dict:
+    return {
+        "slug": "agent-runtime-keystone",
+        "title": "Agent runtime chantier layer",
+        "goal": "Done means chantier members can be coordinated across repositories.",
+        "kind": "feature",
+        "state": "building",
+        "owner": "Reda",
+        "refs": [
+            {
+                "source": "github",
+                "ref": "github:Illospace/illospace:issue:326",
+                "title": "Chantier layer umbrella",
+            },
+            {
+                "source": "doc",
+                "ref": "brain/references/chantier-record-contract.md",
+            },
+        ],
+        "parent_issue": "github:Illospace/illospace:issue:326",
+        "next_step": "Land the record contract and unblock member-ticket work.",
+        "progress_note": "Schema implementation is in review.",
+        "created_at": "2026-07-16T14:00:00Z",
+        "updated_at": "2026-07-16T15:00:00Z",
+    }
+
+
 async def _insert_legacy_pr_record(
     session,
     service: AsyncDomainService,
@@ -511,6 +628,213 @@ async def test_domain_one_pr_contract_handles_open_draft_and_merged_first_attemp
     assert merged.data["review_status"] == "merged"
     assert merged.data["assignee"] == "Axel"
     assert merged.data["progress_note"] == "Verify staging and close the linked ticket."
+
+
+async def test_chantier_contract_creates_updates_and_queries_full_records(session):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    data = _chantier_record_data()
+
+    created = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=data,
+    )
+    updated = await service.update_record(
+        ORG_ID,
+        domain.id,
+        created.id,
+        data_patch={
+            "state": "verifying",
+            "next_step": "Verify the migration against the complete Domain test suite.",
+            "updated_at": "2026-07-16T16:00:00Z",
+        },
+        expected_version=1,
+    )
+    queried = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="chantier",
+        search="agent runtime",
+    )
+
+    assert created.title == data["title"]
+    assert updated.version == 2
+    assert updated.data == {
+        **data,
+        "state": "verifying",
+        "next_step": "Verify the migration against the complete Domain test suite.",
+        "updated_at": "2026-07-16T16:00:00Z",
+    }
+    assert [record.id for record in queried] == [created.id]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda data: data.pop("title"), "title.*required"),
+        (lambda data: data.update(kind="project"), "kind.*one of"),
+        (lambda data: data.update(state="todo"), "state.*one of"),
+        (lambda data: data.update(slug="Not Kebab"), "slug.*invalid format"),
+        (lambda data: data.update(goal="Coordinate all member tickets."), "goal.*invalid format"),
+        (lambda data: data.update(refs={"source": "doc", "ref": "x"}), "refs.*array"),
+        (lambda data: data.update(refs=["doc:x"]), "refs.*object"),
+        (
+            lambda data: data.update(refs=[{"source": "jira", "ref": "PROJ-1"}]),
+            "refs.*one of",
+        ),
+        (lambda data: data.update(refs=[{"source": "doc"}]), "refs.*requires.*ref"),
+        (
+            lambda data: data.update(refs=[{"source": "doc", "ref": "x", "extra": True}]),
+            "refs.*unknown key.*extra",
+        ),
+        (
+            lambda data: data.update(refs=[{"source": "doc", "ref": "x", "title": ""}]),
+            "refs.*at least 1",
+        ),
+        (
+            lambda data: data.update(refs=[{"source": "github", "ref": "#326"}]),
+            "refs.*invalid format.*github",
+        ),
+        (
+            lambda data: data.update(parent_issue="https://github.com/Illospace/illospace/issues/326"),
+            "parent_issue.*invalid format",
+        ),
+        (lambda data: data.update(next_step="First sentence.\nSecond sentence."), "next_step.*invalid format"),
+        (lambda data: data.update(owner="x" * 121), "owner.*at most 120"),
+        (lambda data: data.update(created_at="yesterday"), "created_at.*ISO datetime"),
+    ],
+)
+async def test_chantier_contract_rejects_invalid_records(session, mutate, match):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    data = _chantier_record_data()
+    mutate(data)
+
+    with pytest.raises(DomainError, match=match):
+        await service.create_record(ORG_ID, domain.id, "chantier", data=data)
+
+
+async def test_chantier_slug_is_stable_after_creation(session):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    created = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=_chantier_record_data(),
+    )
+
+    with pytest.raises(DomainError, match="slug.*immutable"):
+        await service.update_record(
+            ORG_ID,
+            domain.id,
+            created.id,
+            data_patch={"slug": "renamed-keystone"},
+        )
+
+
+async def test_domain_field_validation_contract_must_be_an_object(session):
+    service = AsyncDomainService(session)
+
+    with pytest.raises(DomainError, match="validation must be an object"):
+        await service.create_domain(
+            ORG_ID,
+            name="Invalid field contract",
+            objects=[
+                {
+                    "key": "item",
+                    "fields": [
+                        {
+                            "key": "title",
+                            "field_type": "text",
+                            "validation": ["not", "an", "object"],
+                        }
+                    ],
+                }
+            ],
+        )
+
+
+async def test_manage_domain_round_trips_a_chantier_record(session, monkeypatch):
+    from brain.platform.db.repositories import unit_of_work
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.domains import _handle_manage_domain
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+
+    class SessionUnitOfWork:
+        def __init__(self, *args, **kwargs):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            if exc_type is None:
+                await session.flush()
+            return False
+
+    monkeypatch.setattr(unit_of_work, "UnitOfWork", SessionUnitOfWork)
+    data = _chantier_record_data()
+    with bind_agent_context({"org_id": ORG_ID, "user_id": USER_ID}):
+        created = json.loads(
+            await _handle_manage_domain(
+                action="create_record",
+                domain_id=domain.id,
+                object_key="chantier",
+                data=data,
+            )
+        )["record"]
+        updated = json.loads(
+            await _handle_manage_domain(
+                action="update_record",
+                domain_id=domain.id,
+                record_id=created["id"],
+                data_patch={
+                    "state": "shipping",
+                    "next_step": "Merge the schema migration after checks pass.",
+                },
+                expected_version=1,
+            )
+        )["record"]
+        queried = json.loads(
+            await _handle_manage_domain(
+                action="query_records",
+                domain_id=domain.id,
+                object_key="chantier",
+                search="keystone",
+            )
+        )
+
+    assert created["object_key"] == "chantier"
+    assert created["data"] == data
+    assert updated["version"] == 2
+    assert updated["data"]["state"] == "shipping"
+    assert queried["returned"] == queried["total_matching"] == 1
+    assert queried["records"][0]["id"] == created["id"]
 
 
 async def test_domain_events_drop_non_uuid_idea_ids(session):


### PR DESCRIPTION
Closes #327 — keystone of the #326 Chantier family.

## What
Creates a new **`chantier` object type in Domain 1 (`github-ticket-tracker`)** plus a documented, validated record contract, so chantier records can be created/updated/queried via `manage_domain`. This is the foundation the rest of the family (#328/#330/#331) builds on; dispatched solo so it lands before its dependents.

## How
- **Migration `0026_chantier_object_type.py`** — single alembic head off `0025` (the #325 PR-tracker migration). Idempotent (existence + changed-value diffing, contract marker `chantier-record-contract-v1`), dialect-aware (public schema on Postgres, guarded on SQLite), table-existence guarded, no-op documented downgrade (removing the type would strand records + cross-repo refs). Mirrors the 0025 precedent exactly.
- **Fields = the ticket contract, verbatim:** `slug` (immutable, kebab pattern), `title`, `goal` ("done means …" pattern), `kind` enum `feature|incident|quality|gtm`, `state` enum `exploring|building|shipping|verifying|done|paused`, `owner`, `refs` (typed-reference array w/ `github|doc|slack|posthog|url` sources + GitHub `external_id` pattern), `parent_issue`, `next_step`, `progress_note`, `created_at`, `updated_at`.
- **Runtime validation** for structured refs, patterns, lengths, immutable slug in `service.py`.
- **Schema doc only** (`chantier-record-contract.md`) with the full example record JSON. Behavior doc is deliberately left to the doc-v8 ticket #329 — no doc-conflict.
- Did **not** reuse the dormant `milestone` type (per the ticket constraint); test asserts non-reuse.

## Review surface (judge without reading the diff)
Run the affected suite in the worktree venv:
```
cd <worktree> && venv/bin/python -m pytest tests/test_chantier_schema_migration.py tests/test_domains_service.py tests/test_hosted_mcp_domains.py tests/test_alembic_config.py tests/test_builtin_skill_suite.py tests/test_pr_tracker_schema_migration.py -q
```
**74 passed** (independently re-run by the orchestrator, not just the worker). `alembic heads` → single head `0026_chantier_object_type`.

## Acceptance
- `chantier` object type provisioned idempotently on Domain 1; a record with all contract fields can be created/updated/queried via `manage_domain`, with enum/pattern/required validation enforced.
- Contract doc merged with the full example record JSON.
- Migration idempotent + guarded; single alembic head; existing `ticket`/`pull_request`/`repository` objects and tests unchanged and green.

## ⚠️ Heads-up for review
Migration 0026 mutates **persisted Domain 1 config** on deploy (adds the object type + fields). Idempotent + guarded, but flagged since it touches live tracker schema — same class of change as #323's 0025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
