### PR TITLE
[Chantier] Embeddings + relevance ranking for reconstructive recall (#342)

### DIFF
--- a/.review/342-illo-dev-smoke.md
+++ b/.review/342-illo-dev-smoke.md
@@ -1,0 +1,46 @@
+# Issue #342 illo-dev smoke gate
+
+Do not run this in the sandboxed worktree. Run it on illo-dev after deployment,
+with the app environment loaded and a `psql`-compatible database URL available.
+
+```bash
+export ILLO_DB_URL="${DATABASE_URL/postgresql+asyncpg/postgresql}"
+export ILLO_DB_URL="${ILLO_DB_URL/postgresql+psycopg/postgresql}"
+export ILLO_USER_ID="<reda-user-uuid>"
+export ILLO_ORG_ID="<uwear-org-uuid>"
+
+python3 -m brain.app.cli.memory backfill-embeddings --batch-size 25
+
+for reconstruction_id in 70 71 72; do
+  query="$(psql "$ILLO_DB_URL" -Atc "SELECT query_text FROM reconstruction_runs WHERE id = ${reconstruction_id}")"
+  echo "reconstruction ${reconstruction_id}: ${query}"
+  python3 -m brain.app.cli.memory query "$query" --limit 5 --user-id "$ILLO_USER_ID" --org-id "$ILLO_ORG_ID" | jq -r '.results[] | [.id, .scores.confidence, .content] | @tsv'
+done
+
+python3 -m brain.app.cli.memory query "axel-havard" --limit 5 --user-id "$ILLO_USER_ID" --org-id "$ILLO_ORG_ID" | jq -r '.results[] | [.id, .scores.confidence, .content] | @tsv'
+
+psql "$ILLO_DB_URL" -Atc "
+SELECT count(*)
+FROM memory_nodes AS node
+WHERE node.node_kind IN ('content', 'summary', 'procedure', 'policy')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM memory_node_embeddings AS embedding
+    WHERE embedding.node_id = node.id
+      AND embedding.embedding_kind = 'content'
+      AND embedding.embedding IS NOT NULL
+  );"
+```
+
+Pass conditions:
+
+- Each run 70–72 query lists Aritzia evidence above the staging-deploy receipt.
+- The exact `axel-havard` lookup returns the node containing that handle.
+- The final count is `0`. Re-running the backfill reports only skipped vectors.
+
+If the backfill is interrupted, rerun the same command; committed vectors are
+skipped. For deliberately chunked runs, combine `--limit` with
+`--after-id <last_node_id>` from the prior JSON output. If `failed` is nonzero,
+rerun without `--after-id` so gaps are retried. Cue and tag nodes are intentionally
+excluded because recall ranks source-backed content-bearing nodes; embedding
+terse routing vocabulary would add cost and crowd semantic candidates.

--- a/brain/app/cli/memory.py
+++ b/brain/app/cli/memory.py
@@ -16,6 +16,10 @@ from types import SimpleNamespace
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.quality.gate import check_quality
 from brain.systems.reconstructive_memory.controller import reconstruct_memory
+from brain.systems.reconstructive_memory.embeddings import (
+    EMBEDDABLE_NODE_KINDS,
+    backfill_memory_node_embeddings,
+)
 
 
 # ============================================================
@@ -274,6 +278,22 @@ async def cmd_index(args):
     }, indent=2, default=str))
 
 
+async def cmd_backfill_embeddings(args):
+    async with UnitOfWork() as uow:
+        result = await backfill_memory_node_embeddings(
+            uow.session,
+            batch_size=args.batch_size,
+            after_id=args.after_id,
+            limit=args.limit,
+            commit_batches=True,
+        )
+    print(json.dumps({
+        **result.to_dict(),
+        "embedded_node_kinds": list(EMBEDDABLE_NODE_KINDS),
+        "excluded_node_kinds": ["cue", "tag"],
+    }, indent=2))
+
+
 def _write_context_from_args(args, *, source: str) -> SimpleNamespace | None:
     user_id = getattr(args, "user_id", None)
     if not user_id:
@@ -414,13 +434,31 @@ async def main():
 
     p = sub.add_parser("index"); p.add_argument("--limit", "-l", type=int, default=50)
 
+    p = sub.add_parser(
+        "backfill-embeddings",
+        description=(
+            "Backfill semantic vectors for content, summary, procedure, and policy nodes. "
+            "Cue/tag nodes are intentionally excluded: they route the graph but do not carry "
+            "the source-backed answer text ranked by recall."
+        ),
+        epilog=(
+            "Rows that already have the current model+content embedding are skipped. "
+            "Each batch commits independently. A plain rerun safely resumes by skipping completed rows; "
+            "for deliberately chunked runs, combine --limit with --after-id and the prior last_node_id."
+        ),
+    )
+    p.add_argument("--batch-size", type=int, default=25, help="Nodes per committed batch (default: 25)")
+    p.add_argument("--after-id", type=int, default=0, help="Resume strictly after this memory_nodes.id")
+    p.add_argument("--limit", type=int, help="Maximum nodes to scan in this invocation")
+
     p = sub.add_parser("import-md"); p.add_argument("file")
 
     args = parser.parse_args()
     cmd_map = {
         "add": cmd_add, "query": cmd_query, "get": cmd_get, "context": cmd_context,
         "connect": cmd_connect, "list": cmd_list, "stats": cmd_stats, "decay": cmd_decay,
-        "index": cmd_index, "import-md": cmd_import_md,
+        "index": cmd_index, "backfill-embeddings": cmd_backfill_embeddings,
+        "import-md": cmd_import_md,
     }
     await cmd_map[args.command](args)
 

--- a/brain/app/mcp/server.py
+++ b/brain/app/mcp/server.py
@@ -216,6 +216,7 @@ async def async_tool_brain_recall(
     attention_debug: bool = False,
     expand_lazy_load: bool | None = None,
     service_retrieval: bool = False,
+    run_id: int | str | None = None,
 ) -> dict:
     """Compatibility recall over source-backed reconstructive memory.
 
@@ -223,11 +224,13 @@ async def async_tool_brain_recall(
     Without viewer context, recall intentionally returns no memories.
     """
     reconstruct_user_id = user_id or ("system" if service_retrieval else None)
+    parsed_run_id = _coerce_int(run_id)
     evidence_pack = await async_tool_memory_reconstruct(
         query=query,
         limit=limit,
         user_id=reconstruct_user_id,
         org_id=org_id,
+        run_id=parsed_run_id,
     )
     memories = _recall_memories_from_evidence_pack(evidence_pack, limit=limit)
 
@@ -240,6 +243,7 @@ async def async_tool_brain_recall(
         attention_debug=attention_debug,
         expand_lazy_load=expand_lazy_load,
         service_retrieval=service_retrieval,
+        run_id=parsed_run_id,
     )
     response["memory_system"] = "reconstructive"
     response["compatibility_alias"] = "brain_recall"
@@ -356,6 +360,7 @@ async def _finalize_recall_response(
     attention_debug: bool,
     expand_lazy_load: bool | None,
     service_retrieval: bool = False,
+    run_id: int | None = None,
 ) -> dict:
 
     await _async_log_retrieval(query, memories)
@@ -386,6 +391,7 @@ async def _finalize_recall_response(
         user_id=user_id,
         org_id=org_id,
         service_retrieval=service_retrieval,
+        run_id=run_id,
         preload_budget_tokens=limit * 120,
         lazy_budget_tokens=max(0, limit * 40),
     )

--- a/brain/platform/db/alembic/versions/0026_chantier_object_type.py
+++ b/brain/platform/db/alembic/versions/0026_chantier_object_type.py
@@ -1,7 +1,7 @@
 """Provision the Domain-1 chantier record contract.
 
 Revision ID: 0026_chantier_object_type
-Revises: 0025_pr_tracker_owner_fields
+Revises: 0026_packet_brief_deliveries
 Create Date: 2026-07-16
 """
 
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 
 revision = "0026_chantier_object_type"
-down_revision = "0025_pr_tracker_owner_fields"
+down_revision = "0026_packet_brief_deliveries"
 branch_labels = None
 depends_on = None
 

--- a/brain/platform/db/repositories/reconstructive_memory.py
+++ b/brain/platform/db/repositories/reconstructive_memory.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 from sqlalchemy import and_, func, or_, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +18,7 @@ from brain.platform.db.models.reconstructive_memory import (
     MemoryAssertionNode,
     MemoryEdgeNode,
     MemoryNode,
+    MemoryNodeEmbedding,
     MemorySource,
     MemorySpan,
     ReconstructionEvidence,
@@ -24,6 +26,35 @@ from brain.platform.db.models.reconstructive_memory import (
     ReconstructionStep,
 )
 from brain.platform.db.repositories.base import BaseRepository
+
+_CONTENT_NODE_KINDS = ("content", "summary", "procedure", "policy")
+_QUERY_TERM_RE = re.compile(r"[a-zA-Z0-9_/-]{3,}")
+_QUERY_STOP_WORDS = {
+    "about",
+    "and",
+    "are",
+    "did",
+    "does",
+    "for",
+    "from",
+    "has",
+    "have",
+    "how",
+    "into",
+    "that",
+    "the",
+    "this",
+    "was",
+    "were",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "with",
+}
+_MIN_SEMANTIC_CANDIDATE_SCORE = 0.35
 
 
 def stable_digest(value: str) -> str:
@@ -137,6 +168,49 @@ class MemorySourceRepository(BaseRepository[MemorySource]):
         return source, rows
 
 
+class MemoryNodeEmbeddingRepository(BaseRepository[MemoryNodeEmbedding]):
+    model = MemoryNodeEmbedding
+    content_digest = staticmethod(stable_digest)
+
+    async def exists(
+        self,
+        *,
+        node_id: int,
+        embedding_kind: str,
+        model: str,
+        content_digest: str,
+    ) -> bool:
+        stmt = select(MemoryNodeEmbedding.id).where(
+            MemoryNodeEmbedding.node_id == node_id,
+            MemoryNodeEmbedding.embedding_kind == embedding_kind,
+            MemoryNodeEmbedding.model == model,
+            MemoryNodeEmbedding.content_digest == content_digest,
+        )
+        return (await self._session.scalars(stmt)).first() is not None
+
+    async def create(
+        self,
+        *,
+        node_id: int,
+        embedding_kind: str,
+        model: str,
+        dimension: int,
+        embedding: list[float],
+        content_digest: str,
+    ) -> MemoryNodeEmbedding:
+        row = MemoryNodeEmbedding(
+            node_id=node_id,
+            embedding_kind=embedding_kind,
+            model=model,
+            dimension=dimension,
+            embedding=embedding,
+            content_digest=content_digest,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return row
+
+
 class MemoryNodeRepository(BaseRepository[MemoryNode]):
     model = MemoryNode
 
@@ -189,18 +263,12 @@ class MemoryNodeRepository(BaseRepository[MemoryNode]):
         user_id: str | None = None,
         limit: int = 5,
         allow_global: bool = False,
+        query_embedding: Sequence[float] | np.ndarray | None = None,
+        embedding_model: str | None = None,
     ) -> list[MemoryNode]:
-        terms = [term for term in re.findall(r"[a-zA-Z0-9_/-]{3,}", query.lower()) if term]
-        if not terms:
+        query = query.strip()
+        if not query:
             return []
-        predicates = [
-            or_(
-                func.lower(MemoryNode.canonical_label).contains(term),
-                func.lower(MemoryNode.text).contains(term),
-                func.lower(MemoryNode.normalized_key).contains(term),
-            )
-            for term in terms[:8]
-        ]
         if allow_global:
             visibility_predicate = true()
         elif not user_id and not org_id:
@@ -211,18 +279,185 @@ class MemoryNodeRepository(BaseRepository[MemoryNode]):
                 and_(MemoryNode.visibility == "team", MemoryNode.org_id == org_id),
                 and_(MemoryNode.visibility == "private", MemoryNode.user_id == user_id),
             )
-        stmt = (
+
+        base_stmt = (
             select(MemoryNode)
             .where(MemoryNode.archived_at.is_(None))
-            .where(MemoryNode.node_kind.in_(["content", "summary", "procedure", "policy"]))
+            .where(MemoryNode.node_kind.in_(_CONTENT_NODE_KINDS))
             .where(visibility_predicate)
-            .where(or_(*predicates))
-            .order_by(MemoryNode.confidence.desc(), MemoryNode.updated_at.desc())
-            .limit(limit)
         )
         if org_id is not None:
-            stmt = stmt.where(or_(MemoryNode.org_id == org_id, MemoryNode.org_id.is_(None)))
-        return list((await self._session.scalars(stmt)).all())
+            base_stmt = base_stmt.where(or_(MemoryNode.org_id == org_id, MemoryNode.org_id.is_(None)))
+
+        query_vector = (
+            np.asarray(query_embedding, dtype=np.float32).reshape(-1)
+            if query_embedding is not None
+            else None
+        )
+
+        rows: list[tuple[MemoryNode, float | None]]
+        if query_vector is None or not embedding_model:
+            rows = [(node, None) for node in (await self._session.scalars(base_stmt)).all()]
+        elif self._session.get_bind().dialect.name == "postgresql":
+            similarity = 1.0 - MemoryNodeEmbedding.embedding.cosine_distance(query_vector.tolist())
+            semantic_scores = (
+                select(
+                    MemoryNodeEmbedding.node_id.label("node_id"),
+                    func.max(similarity).label("semantic_score"),
+                )
+                .where(MemoryNodeEmbedding.embedding.isnot(None))
+                .where(MemoryNodeEmbedding.model == embedding_model)
+                .where(MemoryNodeEmbedding.dimension == int(query_vector.shape[0]))
+                .group_by(MemoryNodeEmbedding.node_id)
+                .subquery()
+            )
+            ranked_stmt = (
+                base_stmt.add_columns(semantic_scores.c.semantic_score)
+                .outerjoin(semantic_scores, semantic_scores.c.node_id == MemoryNode.id)
+            )
+            rows = [
+                (node, float(semantic_score) if semantic_score is not None else None)
+                for node, semantic_score in (await self._session.execute(ranked_stmt)).all()
+            ]
+        else:
+            nodes = list((await self._session.scalars(base_stmt)).all())
+            semantic_by_node = await self._python_semantic_scores(
+                nodes=nodes,
+                query_vector=query_vector,
+                model=embedding_model,
+            )
+            rows = [(node, semantic_by_node.get(node.id)) for node in nodes]
+
+        return _rank_memory_nodes(query=query, rows=rows, limit=limit)
+
+    async def _python_semantic_scores(
+        self,
+        *,
+        nodes: Sequence[MemoryNode],
+        query_vector: np.ndarray,
+        model: str,
+    ) -> dict[int, float]:
+        """Portable cosine fallback used by SQLite unit tests."""
+
+        if not nodes:
+            return {}
+        stmt = select(MemoryNodeEmbedding).where(
+            MemoryNodeEmbedding.node_id.in_([node.id for node in nodes]),
+            MemoryNodeEmbedding.embedding.isnot(None),
+            MemoryNodeEmbedding.model == model,
+            MemoryNodeEmbedding.dimension == int(query_vector.shape[0]),
+        )
+        scores: dict[int, float] = {}
+        for row in (await self._session.scalars(stmt)).all():
+            vector = _coerce_embedding_vector(row.embedding)
+            similarity = _cosine_similarity(query_vector, vector)
+            if similarity is not None:
+                scores[row.node_id] = max(scores.get(row.node_id, -1.0), similarity)
+        return scores
+
+
+def _query_terms(query: str) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for match in _QUERY_TERM_RE.finditer(query.casefold()):
+        term = match.group(0)
+        if term in _QUERY_STOP_WORDS or term in seen:
+            continue
+        seen.add(term)
+        terms.append(term)
+        if len(terms) >= 8:
+            break
+    return tuple(terms)
+
+
+def _lexical_relevance(node: MemoryNode, *, query: str, terms: Sequence[str]) -> float:
+    fields = (
+        (node.canonical_label or "").casefold(),
+        (node.text or "").casefold(),
+        (node.normalized_key or "").casefold(),
+    )
+    normalized_query = " ".join(query.casefold().split())
+    exact = any(field == normalized_query for field in fields if field)
+    if not terms:
+        return 1.0 if exact else 0.0
+    hits = sum(1 for term in terms if any(term in field for field in fields))
+    return max(1.0 if exact else 0.0, hits / len(terms))
+
+
+def _blended_relevance_score(
+    *,
+    semantic_score: float | None,
+    lexical_score: float,
+    storage_confidence: float,
+) -> float:
+    storage_confidence = min(1.0, max(0.0, storage_confidence))
+    lexical_score = min(1.0, max(0.0, lexical_score))
+    if semantic_score is None:
+        # Missing vectors remain fully retrievable by text while backfill runs.
+        return 0.95 * lexical_score + 0.05 * storage_confidence
+    semantic_score = min(1.0, max(0.0, semantic_score))
+    # Similarity and query-term coverage own 97% of ranking. Storage confidence
+    # is only a stable tie-break signal and cannot swamp relevance.
+    return 0.72 * semantic_score + 0.25 * lexical_score + 0.03 * storage_confidence
+
+
+def _rank_memory_nodes(
+    *,
+    query: str,
+    rows: Sequence[tuple[MemoryNode, float | None]],
+    limit: int,
+) -> list[MemoryNode]:
+    terms = _query_terms(query)
+    ranked: list[MemoryNode] = []
+    for node, raw_semantic_score in rows:
+        semantic_score = (
+            min(1.0, max(0.0, float(raw_semantic_score)))
+            if raw_semantic_score is not None
+            else None
+        )
+        lexical_score = _lexical_relevance(node, query=query, terms=terms)
+        if lexical_score <= 0.0 and (
+            semantic_score is None or semantic_score < _MIN_SEMANTIC_CANDIDATE_SCORE
+        ):
+            continue
+        match_score = _blended_relevance_score(
+            semantic_score=semantic_score,
+            lexical_score=lexical_score,
+            storage_confidence=float(node.confidence or 0.0),
+        )
+        # These are query-local, non-persisted annotations consumed by the
+        # reconstruction controller and compatibility adapters.
+        node.retrieval_score = round(match_score, 4)
+        node.semantic_score = round(semantic_score, 4) if semantic_score is not None else None
+        node.lexical_score = round(lexical_score, 4)
+        ranked.append(node)
+
+    ranked.sort(
+        key=lambda node: (
+            -float(node.retrieval_score),
+            -float(node.semantic_score if node.semantic_score is not None else -1.0),
+            -float(node.lexical_score),
+            -(node.updated_at.timestamp() if node.updated_at is not None else 0.0),
+            node.id,
+        )
+    )
+    return ranked[: max(0, limit)]
+
+
+def _coerce_embedding_vector(value: Any) -> np.ndarray:
+    if isinstance(value, str):
+        cleaned = value.strip().removeprefix("[").removesuffix("]")
+        return np.fromstring(cleaned, sep=",", dtype=np.float32)
+    return np.asarray(value, dtype=np.float32).reshape(-1)
+
+
+def _cosine_similarity(left: np.ndarray, right: np.ndarray) -> float | None:
+    if left.shape != right.shape or not left.size:
+        return None
+    denominator = float(np.linalg.norm(left) * np.linalg.norm(right))
+    if denominator <= 0.0:
+        return None
+    return float(np.dot(left, right) / denominator)
 
 
 class MemoryEdgeRepository(BaseRepository[MemoryEdgeNode]):
@@ -689,8 +924,9 @@ class ReconstructiveMemoryCompatibilityRepository(BaseRepository[MemoryNode]):
             {
                 **_node_memory_payload(node),
                 "memory_type": _node_type(node),
-                "combined_score": float(node.confidence or 0.0),
-                "semantic_score": float(node.confidence or 0.0),
+                "combined_score": float(getattr(node, "retrieval_score", 0.0)),
+                "semantic_score": getattr(node, "semantic_score", None),
+                "lexical_score": float(getattr(node, "lexical_score", 0.0)),
                 "recency_score": 0.5,
             }
             for node in nodes

--- a/brain/systems/reconstructive_memory/contracts.py
+++ b/brain/systems/reconstructive_memory/contracts.py
@@ -15,6 +15,9 @@ class EvidenceItem:
     text: str
     source_text: str | None
     confidence: float
+    semantic_score: float | None = None
+    lexical_score: float = 0.0
+    storage_confidence: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -25,6 +28,9 @@ class EvidenceItem:
             "text": self.text,
             "source_text": self.source_text,
             "confidence": self.confidence,
+            "semantic_score": self.semantic_score,
+            "lexical_score": self.lexical_score,
+            "storage_confidence": self.storage_confidence,
         }
 
 

--- a/brain/systems/reconstructive_memory/controller.py
+++ b/brain/systems/reconstructive_memory/controller.py
@@ -1,8 +1,8 @@
-"""Deterministic reconstructive-memory controller.
+"""Source-backed reconstructive-memory controller.
 
-This is the first working replacement primitive for legacy top-k memory recall.
-It records a reconstruction run, searches source-backed content nodes, attaches
-assertions/source spans as evidence, and returns an evidence pack.
+It records a reconstruction run, ranks source-backed content nodes with blended
+semantic and lexical relevance, attaches assertions/source spans as evidence,
+and returns an evidence pack.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from brain.platform.db.repositories.reconstructive_memory import (
     ReconstructionRepository,
 )
 from brain.systems.reconstructive_memory.contracts import EvidenceItem, EvidencePack, ReconstructionTraceStep
+from brain.systems.reconstructive_memory.embeddings import embed_recall_query
 
 
 async def reconstruct_memory(
@@ -43,14 +44,17 @@ async def reconstruct_memory(
         run_id=run_id,
         thread_id=thread_id,
         budget_steps=3,
-        policy_version="deterministic-v1",
+        policy_version="blended-relevance-v1",
     )
 
+    query_embedding = await embed_recall_query(session, query)
     candidates = await node_repo.search_content_nodes(
         query=query,
         org_id=org_id,
         user_id=user_id,
         limit=limit,
+        query_embedding=query_embedding.vector if query_embedding else None,
+        embedding_model=query_embedding.model if query_embedding else None,
     )
     await reconstruction_repo.add_step(
         reconstruction_run_id=run.id,
@@ -59,7 +63,7 @@ async def reconstruct_memory(
         action_input={"query": query},
         action_output={"candidate_count": len(candidates)},
         selected_node_ids=[node.id for node in candidates],
-        reason="lexical cue seed over source-backed content nodes",
+        reason="blended semantic and lexical ranking over source-backed content nodes",
     )
 
     assertions = await assertion_repo.list_for_nodes([node.id for node in candidates])
@@ -88,7 +92,10 @@ async def reconstruct_memory(
             role="supports_answer",
             text=(assertion.claim_text if assertion else node.text or node.canonical_label),
             source_text=source_text,
-            confidence=float(assertion.confidence if assertion else node.confidence),
+            confidence=float(getattr(node, "retrieval_score", 0.0)),
+            semantic_score=getattr(node, "semantic_score", None),
+            lexical_score=float(getattr(node, "lexical_score", 0.0)),
+            storage_confidence=float(assertion.confidence if assertion else node.confidence),
         )
         supporting.append(item)
         await reconstruction_repo.add_evidence(
@@ -116,7 +123,7 @@ async def reconstruct_memory(
     trajectory = (
         ReconstructionTraceStep(
             action_kind="seed_cues",
-            reason="lexical cue seed over source-backed content nodes",
+            reason="blended semantic and lexical ranking over source-backed content nodes",
             selected_node_ids=tuple(node.id for node in candidates),
             output={"candidate_count": len(candidates)},
         ),

--- a/brain/systems/reconstructive_memory/embeddings.py
+++ b/brain/systems/reconstructive_memory/embeddings.py
@@ -1,0 +1,290 @@
+"""Embedding writes and backfill support for reconstructive memory nodes."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel.config import MEMORY_SEMANTIC_EMBEDDING_DIM
+from brain.platform.db.models.reconstructive_memory import MemoryAssertionNode, MemoryNode
+from brain.platform.db.repositories.reconstructive_memory import MemoryNodeEmbeddingRepository
+from brain.systems.memory import embeddings as embedding_client
+from brain.systems.runtime_settings import memory as runtime_settings
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+logger = logging.getLogger(__name__)
+
+EMBEDDABLE_NODE_KINDS = ("content", "summary", "procedure", "policy")
+
+
+@dataclass(frozen=True)
+class EmbeddingWriteResult:
+    created: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+    def __add__(self, other: EmbeddingWriteResult) -> EmbeddingWriteResult:
+        return EmbeddingWriteResult(
+            created=self.created + other.created,
+            skipped=self.skipped + other.skipped,
+            failed=self.failed + other.failed,
+        )
+
+
+@dataclass(frozen=True)
+class EmbeddingBackfillResult:
+    scanned: int
+    created: int
+    skipped: int
+    failed: int
+    last_node_id: int | None
+
+    def to_dict(self) -> dict[str, int | None]:
+        return {
+            "scanned": self.scanned,
+            "created": self.created,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "last_node_id": self.last_node_id,
+        }
+
+
+@dataclass(frozen=True)
+class RecallQueryEmbedding:
+    vector: np.ndarray
+    model: str
+
+
+def embedding_model_identity(runtime: EmbeddingRuntimeConfig) -> str:
+    """Return stable model metadata shared by writers and retrieval."""
+
+    backend = runtime.backend.strip().lower()
+    if backend == "api":
+        model = f"{backend}:{runtime.provider.strip().lower()}:{runtime.api_model}"
+    elif backend == "cpu":
+        model = f"{backend}:{runtime.cpu_model}"
+    else:
+        model = f"{backend}:default"
+    return model[:120]
+
+
+def node_embedding_text(node: MemoryNode) -> str:
+    return (node.text or node.canonical_label or "").strip()
+
+
+async def embed_recall_query(
+    session: AsyncSession,
+    query: str,
+) -> RecallQueryEmbedding | None:
+    """Embed a recall query, returning ``None`` for loud lexical degradation."""
+
+    try:
+        runtime = await runtime_settings.async_get_embedding_runtime_config(
+            session,
+            include_secret=True,
+        )
+        vector = np.asarray(
+            embedding_client.embed_query(query, runtime_config=runtime),
+            dtype=np.float32,
+        ).reshape(-1)
+        dimension = int(vector.shape[0])
+        if dimension != int(runtime.dimensions) or dimension != MEMORY_SEMANTIC_EMBEDDING_DIM:
+            raise ValueError(
+                "query embedding dimension mismatch "
+                f"(returned={dimension}, runtime={runtime.dimensions}, "
+                f"database={MEMORY_SEMANTIC_EMBEDDING_DIM})"
+            )
+        return RecallQueryEmbedding(vector=vector, model=embedding_model_identity(runtime))
+    except Exception as exc:
+        logger.warning(
+            "Semantic reconstructive recall unavailable; using lexical ranking for query %r: %s",
+            query[:120],
+            exc,
+        )
+        return None
+
+
+async def embed_node_texts(
+    session: AsyncSession,
+    *,
+    node: MemoryNode,
+    assertion_texts: Iterable[str] = (),
+    runtime_config: EmbeddingRuntimeConfig | None = None,
+) -> EmbeddingWriteResult:
+    """Write missing content/assertion embeddings without failing the caller.
+
+    Assertions get their own embedding only when their claim differs from the
+    node text. Each failed vector remains an explicit, backfillable gap.
+    """
+
+    try:
+        runtime = runtime_config or await runtime_settings.async_get_embedding_runtime_config(
+            session,
+            include_secret=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Could not load embedding configuration for memory node %s; leaving a backfillable gap: %s",
+            node.id,
+            exc,
+        )
+        return EmbeddingWriteResult(failed=1)
+
+    content_text = node_embedding_text(node)
+    payloads: list[tuple[str, str]] = []
+    if content_text:
+        payloads.append(("content", content_text))
+
+    normalized_content = " ".join(content_text.split()).casefold()
+    seen_assertions: set[str] = set()
+    for assertion_text in assertion_texts:
+        cleaned = " ".join((assertion_text or "").split()).strip()
+        normalized = cleaned.casefold()
+        if not cleaned or normalized == normalized_content or normalized in seen_assertions:
+            continue
+        seen_assertions.add(normalized)
+        payloads.append(("assertion", cleaned))
+
+    result = EmbeddingWriteResult()
+    for embedding_kind, text_value in payloads:
+        result += await _embed_one(
+            session,
+            node=node,
+            embedding_kind=embedding_kind,
+            text_value=text_value,
+            runtime_config=runtime,
+        )
+    return result
+
+
+async def _embed_one(
+    session: AsyncSession,
+    *,
+    node: MemoryNode,
+    embedding_kind: str,
+    text_value: str,
+    runtime_config: EmbeddingRuntimeConfig,
+) -> EmbeddingWriteResult:
+    repository = MemoryNodeEmbeddingRepository(session)
+    model = embedding_model_identity(runtime_config)
+    digest = repository.content_digest(text_value)
+    try:
+        async with session.begin_nested():
+            exists = await repository.exists(
+                node_id=node.id,
+                embedding_kind=embedding_kind,
+                model=model,
+                content_digest=digest,
+            )
+        if exists:
+            return EmbeddingWriteResult(skipped=1)
+        vector = np.asarray(
+            embedding_client.embed_document(text_value, runtime_config=runtime_config),
+            dtype=np.float32,
+        ).reshape(-1)
+        dimension = int(vector.shape[0])
+        if dimension != int(runtime_config.dimensions) or dimension != MEMORY_SEMANTIC_EMBEDDING_DIM:
+            raise ValueError(
+                "embedding dimension mismatch "
+                f"(returned={dimension}, runtime={runtime_config.dimensions}, "
+                f"database={MEMORY_SEMANTIC_EMBEDDING_DIM})"
+            )
+        async with session.begin_nested():
+            await repository.create(
+                node_id=node.id,
+                embedding_kind=embedding_kind,
+                model=model,
+                dimension=dimension,
+                embedding=vector.tolist(),
+                content_digest=digest,
+            )
+    except Exception as exc:
+        logger.warning(
+            "Embedding write failed for memory node %s (%s); leaving a backfillable gap: %s",
+            node.id,
+            embedding_kind,
+            exc,
+        )
+        return EmbeddingWriteResult(failed=1)
+    return EmbeddingWriteResult(created=1)
+
+
+async def backfill_memory_node_embeddings(
+    session: AsyncSession,
+    *,
+    batch_size: int = 25,
+    after_id: int = 0,
+    limit: int | None = None,
+    commit_batches: bool = True,
+) -> EmbeddingBackfillResult:
+    """Embed retrievable memory nodes in resumable, id-ordered batches.
+
+    Cue and tag nodes are deliberately excluded: they are routing/index graph
+    primitives, while recall ranks content-bearing nodes directly. Embedding
+    them would increase cost and let terse workspace vocabulary crowd the
+    evidence candidates without adding source-backed answer text.
+    """
+
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be at least 1")
+
+    runtime = await runtime_settings.async_get_embedding_runtime_config(session, include_secret=True)
+    cursor = max(0, int(after_id))
+    scanned = 0
+    total = EmbeddingWriteResult()
+    last_node_id: int | None = None
+
+    while limit is None or scanned < limit:
+        current_batch_size = batch_size if limit is None else min(batch_size, limit - scanned)
+        stmt = (
+            select(MemoryNode)
+            .where(MemoryNode.node_kind.in_(EMBEDDABLE_NODE_KINDS))
+            .where(MemoryNode.id > cursor)
+            .order_by(MemoryNode.id.asc())
+            .limit(current_batch_size)
+        )
+        nodes = list((await session.scalars(stmt)).all())
+        if not nodes:
+            break
+
+        assertions = list(
+            (
+                await session.scalars(
+                    select(MemoryAssertionNode).where(
+                        MemoryAssertionNode.node_id.in_([node.id for node in nodes])
+                    )
+                )
+            ).all()
+        )
+        assertions_by_node: dict[int, list[str]] = {}
+        for assertion in assertions:
+            assertions_by_node.setdefault(assertion.node_id, []).append(assertion.claim_text)
+
+        for node in nodes:
+            total += await embed_node_texts(
+                session,
+                node=node,
+                assertion_texts=assertions_by_node.get(node.id, ()),
+                runtime_config=runtime,
+            )
+
+        scanned += len(nodes)
+        cursor = nodes[-1].id
+        last_node_id = cursor
+        if commit_batches:
+            await session.commit()
+
+    return EmbeddingBackfillResult(
+        scanned=scanned,
+        created=total.created,
+        skipped=total.skipped,
+        failed=total.failed,
+        last_node_id=last_node_id,
+    )

--- a/brain/systems/reconstructive_memory/ingestion.py
+++ b/brain/systems/reconstructive_memory/ingestion.py
@@ -7,6 +7,7 @@ nodes, and graph edges in one transaction.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -23,6 +24,8 @@ from brain.platform.db.repositories.reconstructive_memory import (
     NodeDraft,
     SourceSpanDraft,
 )
+
+logger = logging.getLogger(__name__)
 
 _WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
 _STOP_WORDS = {
@@ -229,6 +232,24 @@ async def ingest_memory_source(
                 org_id=org_id,
                 visibility=visibility,
             )
+        )
+
+    try:
+        from brain.systems.reconstructive_memory.embeddings import embed_node_texts
+
+        await embed_node_texts(
+            session,
+            node=content_node,
+            assertion_texts=(assertion.claim_text,),
+        )
+    except Exception as exc:
+        # Embeddings are a recoverable derivative. The complete source-backed
+        # graph remains valid and the backfill CLI can fill this explicit gap.
+        logger.warning(
+            "Memory graph ingest completed but embedding failed for node %s; "
+            "leaving a backfillable gap: %s",
+            content_node.id,
+            exc,
         )
 
     return IngestedMemorySource(

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -727,11 +727,16 @@ def _wrap_brain_recall(original_fn):
             kwargs["user_id"] = getattr(_agent_context, "user_id", None)
         if kwargs.get("org_id") is None:
             kwargs["org_id"] = getattr(_agent_context, "org_id", None)
+        run = getattr(_agent_context, "run", None)
+        if kwargs.get("run_id") is None and run is not None:
+            kwargs["run_id"] = getattr(run, "run_id", None)
         if isinstance(execution_metadata, dict):
             if kwargs.get("user_id") is None:
                 kwargs["user_id"] = execution_metadata.get("user_id")
             if kwargs.get("org_id") is None:
                 kwargs["org_id"] = execution_metadata.get("org_id")
+            if kwargs.get("run_id") is None:
+                kwargs["run_id"] = execution_metadata.get("run_id")
         result = original_fn(**kwargs)
         if inspect.isawaitable(result):
             result = await result

--- a/scripts/async_db_debt_metrics.py
+++ b/scripts/async_db_debt_metrics.py
@@ -80,6 +80,10 @@ LEGACY_SYNC_TEST_HARNESSES = {
         "sqlalchemy_create_engine",
         "sqlalchemy_sessionmaker",
     },
+    "tests/test_chantier_schema_migration.py": {
+        "sqlalchemy_create_engine",
+        "sync_session_method_call",
+    },
     "tests/test_pr_tracker_schema_migration.py": {
         "sqlalchemy_create_engine",
         "sync_session_method_call",

--- a/tests/test_reconstructive_memory.py
+++ b/tests/test_reconstructive_memory.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from sqlalchemy import inspect, text
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+from sqlalchemy import inspect, select, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
@@ -24,13 +30,21 @@ from brain.platform.db.repositories.reconstructive_memory import (
     EdgeDraft,
     MemoryAssertionRepository,
     MemoryEdgeRepository,
+    MemoryNodeEmbeddingRepository,
     MemoryNodeRepository,
     MemorySourceRepository,
     NodeDraft,
     SourceSpanDraft,
 )
 from brain.systems.reconstructive_memory.controller import reconstruct_memory
+from brain.systems.reconstructive_memory.embeddings import (
+    backfill_memory_node_embeddings,
+    embed_recall_query,
+    embedding_model_identity,
+)
 from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+from brain.kernel.config import MEMORY_SEMANTIC_EMBEDDING_DIM
 
 
 SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "JSON"
@@ -51,6 +65,7 @@ async def _session(async_sqlite_session_factory):
             MemorySource.__table__,
             MemorySpan.__table__,
             MemoryNode.__table__,
+            MemoryNodeEmbedding.__table__,
             MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
             ReconstructionRun.__table__,
@@ -85,6 +100,77 @@ async def _session(async_sqlite_session_factory):
     )
     await session.commit()
     return session
+
+
+def _runtime_config() -> EmbeddingRuntimeConfig:
+    return EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="test-reconstructive-embedding",
+        cpu_model="unused",
+        dimensions=MEMORY_SEMANTIC_EMBEDDING_DIM,
+        api_key="test-key",
+    )
+
+
+def _unit_vector(axis: int) -> np.ndarray:
+    vector = np.zeros(MEMORY_SEMANTIC_EMBEDDING_DIM, dtype=np.float32)
+    vector[axis] = 1.0
+    return vector
+
+
+def _mock_embedding_runtime(monkeypatch, *, query_axis: int = 0, document_axis: int = 0) -> EmbeddingRuntimeConfig:
+    from brain.systems.memory import embeddings as embedding_client
+    from brain.systems.runtime_settings import memory as runtime_settings
+
+    runtime = _runtime_config()
+
+    async def fake_runtime_config(session, *, include_secret=True):
+        del session, include_secret
+        return runtime
+
+    monkeypatch.setattr(runtime_settings, "async_get_embedding_runtime_config", fake_runtime_config)
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_query",
+        lambda text, runtime_config=None: _unit_vector(query_axis),
+    )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_document",
+        lambda text, runtime_config=None: _unit_vector(document_axis),
+    )
+    return runtime
+
+
+async def _search_content_nodes(session, node_repo, *, query: str):
+    query_embedding = await embed_recall_query(session, query)
+    assert query_embedding is not None
+    return await node_repo.search_content_nodes(
+        query=query,
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        query_embedding=query_embedding.vector,
+        embedding_model=query_embedding.model,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _prevent_live_embeddings(monkeypatch):
+    from brain.systems.memory import embeddings as embedding_client
+    from brain.systems.runtime_settings import memory as runtime_settings
+
+    async def fake_runtime_config(session, *, include_secret=True):
+        del session, include_secret
+        return _runtime_config()
+
+    def unavailable(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("embedding backend intentionally unavailable in unit test")
+
+    monkeypatch.setattr(runtime_settings, "async_get_embedding_runtime_config", fake_runtime_config)
+    monkeypatch.setattr(embedding_client, "embed_query", unavailable)
+    monkeypatch.setattr(embedding_client, "embed_document", unavailable)
 
 
 def test_reconstructive_memory_models_expose_clean_slate_tables():
@@ -192,7 +278,8 @@ async def test_source_backed_graph_can_be_written_and_reconstructed(async_sqlite
     )
 
     assert source.id is not None
-    assert pack.confidence == 0.9
+    assert pack.confidence == pack.supporting_evidence[0].confidence
+    assert pack.confidence != assertion.confidence
     assert pack.supporting_evidence[0].node_id == content.id
     assert pack.supporting_evidence[0].assertion_id == assertion.id
     assert pack.supporting_evidence[0].source_span_id == spans[0].id
@@ -200,7 +287,7 @@ async def test_source_backed_graph_can_be_written_and_reconstructed(async_sqlite
     assert [step.action_kind for step in pack.trajectory] == ["seed_cues", "summarize_evidence"]
 
     runs = (await session.execute(text("SELECT status, final_confidence FROM reconstruction_runs"))).all()
-    assert runs == [("completed", 0.9)]
+    assert runs == [("completed", pack.confidence)]
     evidence_rows = (await session.execute(text("SELECT node_id, assertion_id, source_span_id FROM reconstruction_evidence"))).all()
     assert evidence_rows == [(content.id, assertion.id, spans[0].id)]
 
@@ -232,6 +319,133 @@ async def test_private_nodes_do_not_cross_user_visibility(async_sqlite_session_f
     assert pack.supporting_evidence == ()
     assert pack.confidence == 0.0
     assert pack.unresolved_questions == ("No source-backed evidence found for: Private migration fact",)
+
+
+async def test_semantic_match_outranks_newer_high_confidence_off_topic_node(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory)
+    runtime = _mock_embedding_runtime(monkeypatch, query_axis=0)
+    node_repo = MemoryNodeRepository(session)
+    embedding_repo = MemoryNodeEmbeddingRepository(session)
+
+    relevant = await node_repo.upsert_node(
+        draft=NodeDraft(
+            node_kind="content",
+            content_kind="project_fact",
+            canonical_label="Luxury retail client pilot",
+            text="The client pilot covered a sensor-assisted fitting experience.",
+            confidence=0.2,
+        ),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+    off_topic = await node_repo.upsert_node(
+        draft=NodeDraft(
+            node_kind="content",
+            content_kind="receipt",
+            canonical_label="Uwear staging deploy receipt",
+            text="The staging deployment completed successfully.",
+            confidence=0.99,
+        ),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+    off_topic.updated_at = datetime.now(timezone.utc)
+    relevant.updated_at = off_topic.updated_at - timedelta(days=30)
+    for node, vector in ((relevant, _unit_vector(0)), (off_topic, _unit_vector(1))):
+        await embedding_repo.create(
+            node_id=node.id,
+            embedding_kind="content",
+            model=embedding_model_identity(runtime),
+            dimension=MEMORY_SEMANTIC_EMBEDDING_DIM,
+            embedding=vector.tolist(),
+            content_digest=embedding_repo.content_digest(node.text or node.canonical_label),
+        )
+
+    results = await _search_content_nodes(
+        session,
+        node_repo,
+        query="What happened with the Aritzia account?",
+    )
+
+    assert [node.id for node in results] == [relevant.id]
+    assert results[0].retrieval_score > 0.7
+    assert results[0].semantic_score == 1.0
+
+
+async def test_exact_term_node_without_embedding_remains_findable(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory)
+    _mock_embedding_runtime(monkeypatch, query_axis=2)
+    node_repo = MemoryNodeRepository(session)
+    exact = await node_repo.upsert_node(
+        draft=NodeDraft(
+            node_kind="content",
+            content_kind="fact",
+            canonical_label="axel-havard",
+            text="Axel's GitHub handle is axel-havard.",
+            confidence=0.4,
+        ),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+
+    results = await _search_content_nodes(
+        session,
+        node_repo,
+        query="axel-havard",
+    )
+
+    assert [node.id for node in results] == [exact.id]
+    assert results[0].semantic_score is None
+    assert results[0].lexical_score == 1.0
+    assert results[0].retrieval_score == 0.97
+
+
+async def test_nonsense_query_does_not_fall_back_to_newest_confident_nodes(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory)
+    runtime = _mock_embedding_runtime(monkeypatch, query_axis=2)
+    node_repo = MemoryNodeRepository(session)
+    embedding_repo = MemoryNodeEmbeddingRepository(session)
+    for index, label in enumerate(("Newest staging receipt", "Old project decision")):
+        node = await node_repo.upsert_node(
+            draft=NodeDraft(
+                node_kind="content",
+                content_kind="fact",
+                canonical_label=label,
+                text=label,
+                confidence=0.99 - index * 0.1,
+            ),
+            org_id=_TEST_ORG_ID,
+            user_id=_TEST_USER_ID,
+            visibility="org",
+        )
+        await embedding_repo.create(
+            node_id=node.id,
+            embedding_kind="content",
+            model=embedding_model_identity(runtime),
+            dimension=MEMORY_SEMANTIC_EMBEDDING_DIM,
+            embedding=_unit_vector(index).tolist(),
+            content_digest=embedding_repo.content_digest(node.text or node.canonical_label),
+        )
+
+    results = await _search_content_nodes(
+        session,
+        node_repo,
+        query="zqxjkv blorptastic",
+    )
+
+    assert results == []
 
 
 async def test_mcp_memory_reconstruct_returns_evidence_pack(async_sqlite_session_factory, monkeypatch):
@@ -290,7 +504,8 @@ async def test_mcp_memory_reconstruct_returns_evidence_pack(async_sqlite_session
         user_id=_TEST_USER_ID,
     )
 
-    assert payload["confidence"] == 0.82
+    assert payload["confidence"] == payload["supporting_evidence"][0]["confidence"]
+    assert payload["confidence"] != 0.82
     assert payload["supporting_evidence"][0]["source_span_id"] == spans[0].id
     assert payload["trajectory"][0]["action_kind"] == "seed_cues"
 
@@ -333,7 +548,8 @@ async def test_brain_recall_compatibility_alias_reads_reconstructive_memory_with
 
     assert payload["compatibility_alias"] == "brain_recall"
     assert payload["memory_system"] == "reconstructive"
-    assert payload["evidence_pack"]["confidence"] == 0.81
+    assert payload["evidence_pack"]["confidence"] == payload["memories"][0]["similarity"]
+    assert payload["evidence_pack"]["confidence"] != 0.81
     assert payload["memories"][0]["memory_system"] == "reconstructive"
     assert payload["memories"][0]["source_span_id"] is not None
 
@@ -343,8 +559,9 @@ async def test_brain_recall_compatibility_alias_reads_reconstructive_memory_with
     assert memory_table_exists.first() is None
 
 
-async def test_ingest_memory_source_creates_reconstructable_graph(async_sqlite_session_factory):
+async def test_ingest_memory_source_creates_reconstructable_graph(async_sqlite_session_factory, monkeypatch):
     session = await _session(async_sqlite_session_factory)
+    _mock_embedding_runtime(monkeypatch)
 
     ingested = await ingest_memory_source(
         session,
@@ -364,14 +581,199 @@ async def test_ingest_memory_source_creates_reconstructable_graph(async_sqlite_s
     assert ingested.tag_node_ids
     assert ingested.edge_ids
 
+    embedding = (
+        await session.scalars(
+            select(MemoryNodeEmbedding).where(MemoryNodeEmbedding.node_id == ingested.content_node_id)
+        )
+    ).one()
+    assert embedding.embedding_kind == "content"
+
     pack = await reconstruct_memory(
         session,
         query="cite source spans",
         org_id=_TEST_ORG_ID,
         user_id=_TEST_USER_ID,
     )
-    assert pack.confidence == 0.88
+    assert pack.confidence == pytest.approx(0.9964)
+    assert pack.supporting_evidence[0].storage_confidence == 0.88
     assert "cite source spans" in pack.supporting_evidence[0].text.lower()
+
+
+async def test_embedding_failure_leaves_complete_backfillable_ingest(async_sqlite_session_factory):
+    session = await _session(async_sqlite_session_factory)
+
+    ingested = await ingest_memory_source(
+        session,
+        content="Embedding outages must not leave half-written memory graphs.",
+        content_kind="policy",
+        source_kind="manual_note",
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+        confidence=0.9,
+    )
+    await session.flush()
+
+    assert await session.get(MemoryNode, ingested.content_node_id) is not None
+    assert await session.get(MemoryAssertionNode, ingested.assertion_id) is not None
+    assert ingested.edge_ids
+    embeddings = list(
+        (
+            await session.scalars(
+                select(MemoryNodeEmbedding).where(
+                    MemoryNodeEmbedding.node_id == ingested.content_node_id
+                )
+            )
+        ).all()
+    )
+    assert embeddings == []
+
+
+async def test_embedding_backfill_is_batched_idempotent_and_excludes_cues_and_tags(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory)
+    _mock_embedding_runtime(monkeypatch)
+    node_repo = MemoryNodeRepository(session)
+    assertion_repo = MemoryAssertionRepository(session)
+
+    content = await node_repo.upsert_node(
+        draft=NodeDraft(
+            node_kind="content",
+            content_kind="fact",
+            canonical_label="Backfill target",
+            text="The content-node wording.",
+            confidence=0.7,
+        ),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+    cue = await node_repo.upsert_node(
+        draft=NodeDraft(node_kind="cue", canonical_label="backfill", confidence=0.7),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+    second_content = await node_repo.upsert_node(
+        draft=NodeDraft(
+            node_kind="summary",
+            content_kind="summary",
+            canonical_label="Second backfill target",
+            text="A second batch proves cursor-based resume.",
+            confidence=0.6,
+        ),
+        org_id=_TEST_ORG_ID,
+        user_id=_TEST_USER_ID,
+        visibility="org",
+    )
+    await assertion_repo.create_assertion(
+        draft=AssertionDraft(
+            node_id=content.id,
+            claim_text="A divergent assertion wording that also needs recall coverage.",
+            confidence=0.7,
+        )
+    )
+
+    first = await backfill_memory_node_embeddings(
+        session,
+        batch_size=1,
+        limit=1,
+        commit_batches=True,
+    )
+    resumed = await backfill_memory_node_embeddings(
+        session,
+        batch_size=1,
+        after_id=first.last_node_id or 0,
+        commit_batches=True,
+    )
+    repeated = await backfill_memory_node_embeddings(
+        session,
+        batch_size=1,
+        commit_batches=False,
+    )
+
+    assert first.scanned == 1
+    assert first.created == 2
+    assert resumed.scanned == 1
+    assert resumed.created == 1
+    assert repeated.created == 0
+    assert repeated.skipped == 3
+    rows = list((await session.scalars(select(MemoryNodeEmbedding))).all())
+    assert {(row.node_id, row.embedding_kind) for row in rows} == {
+        (content.id, "content"),
+        (content.id, "assertion"),
+        (second_content.id, "content"),
+    }
+    assert all(row.node_id != cue.id for row in rows)
+
+
+async def test_recall_observation_receives_agent_run_id(monkeypatch):
+    from brain.app.mcp import server as mcp_server
+
+    observe = AsyncMock(return_value={"retrieval_decision_id": None})
+    monkeypatch.setattr(mcp_server, "observe_retrieval", observe)
+    monkeypatch.setattr(mcp_server, "_async_log_retrieval", AsyncMock())
+
+    class _AttentionController:
+        def materialize_selection(self, memories, decision):
+            del decision
+            return SimpleNamespace(
+                selected=list(memories),
+                suppressed=[],
+                lazy_load_eligible=[],
+            )
+
+    monkeypatch.setattr(mcp_server, "AttentionController", _AttentionController)
+    result = await mcp_server._finalize_recall_response(
+        query="Aritzia account",
+        memories=[{"id": 1, "similarity": 0.83}],
+        limit=3,
+        user_id=_TEST_USER_ID,
+        org_id=_TEST_ORG_ID,
+        attention_debug=False,
+        expand_lazy_load=False,
+        run_id=72,
+    )
+
+    assert result["memories"] == [{"id": 1, "similarity": 0.83}]
+    assert observe.await_args.kwargs["run_id"] == 72
+
+
+async def test_retrieval_log_records_actual_match_score(monkeypatch):
+    from brain.app.mcp import server as mcp_server
+
+    captured = {}
+
+    class _RetrievalLogs:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+
+    class _Session:
+        async def flush(self):
+            return None
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.retrieval_logs = _RetrievalLogs()
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            del exc_type, exc, tb
+
+    monkeypatch.setattr(mcp_server, "UnitOfWork", _UnitOfWork)
+    await mcp_server._async_log_retrieval(
+        "Aritzia account",
+        [
+            {"id": 1, "similarity": 0.83, "confidence": 0.83},
+            {"id": 2, "similarity": 0.41, "confidence": 0.41},
+        ],
+    )
+
+    assert captured["top_score"] == 0.83
+    assert captured["results_returned"] == 2
 
 
 async def test_brain_encode_compatibility_alias_writes_reconstructive_memory(async_sqlite_session_factory, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -213,13 +213,20 @@ class TestIntegration:
 
         with patch("brain.app.mcp.server.async_tool_brain_recall", side_effect=fake_recall):
             handlers = _get_tool_handlers()
-            with bind_agent_context(AgentExecutionContext(user_id="user-1", org_id="org-1")):
+            with bind_agent_context(
+                AgentExecutionContext(
+                    user_id="user-1",
+                    org_id="org-1",
+                    run=SimpleNamespace(run_id=42),
+                )
+            ):
                 result = await handlers["brain_recall"](query="deployment notes")
 
         assert result == {"memories": []}
         assert captured["query"] == "deployment notes"
         assert captured["user_id"] == "user-1"
         assert captured["org_id"] == "org-1"
+        assert captured["run_id"] == 42
 
     def test_extended_tools_default_to_current_workspace_root(self, tmp_path):
         from brain.systems.runs.tool_handlers import _get_tool_handlers, _agent_context


### PR DESCRIPTION
Closes #342. Keystone slice of the mémoire chantier (#341).

## What this does
Gives reconstructive-memory recall a real relevance ranking instead of `ORDER BY confidence DESC, updated_at DESC` (which collapsed every query to "newest high-confidence nodes"):

1. **Embed at ingest** — `ingest_memory_source` now embeds content (and divergent assertion) text, **reusing the existing skills embedding backend** (`brain.systems.memory.embeddings` + `MEMORY_SEMANTIC_EMBEDDING_DIM` runtime config). Embedding failure never fails the ingest — it warns loudly and leaves a backfillable gap.
2. **Backfill CLI** — `python -m brain.app.cli.memory backfill-embeddings` — resumable (`--after-id`), batched (`--batch-size`/`--limit`), idempotent (skips already-embedded via content digest). Cues/tags deliberately excluded (routing primitives, not source-backed evidence) — documented in the CLI help + code.
3. **Blended ranking** in `search_content_nodes` — pgvector cosine over `memory_node_embeddings` + lexical signal, keeping visibility/archived filters. Un-embedded nodes stay lexically findable until backfilled. Includes a portable Python cosine fallback so unit tests exercise ranking without pgvector.
4. **Real scores** — `retrieval_log.top_score` and evidence confidence reflect the actual match score, not the flat 0.95 storage confidence.
5. **run_id threading** — `observe_retrieval` now receives `run_id` (was always NULL in `retrieval_decisions`).

No DB migration (existing table + pgvector scan sufficient at current corpus size).

## Verification
Unit tests (run in the worktree venv): **85 passed, 3 skipped, 0 failed** —
`pytest tests/test_reconstructive_memory.py tests/test_tools.py tests/test_attention_controller.py tests/test_brain_context.py tests/test_memory.py tests/test_embedding_dimensions.py tests/test_architecture_boundaries.py`
Tests prove: a semantically-matching node outranks a newer/higher-confidence off-topic node; exact-term lookup still returns its node; nonsense query yields low/empty; un-embedded node still lexically findable; `run_id` propagates.

## Live gate (illo-dev, post-merge — can't run in a sandbox worktree)
Copy-paste recipe committed at `.review/342-illo-dev-smoke.md`: runs the backfill, then the three Aritzia phrasings from reconstruction runs 70–72 (must rank Aritzia nodes above the staging-deploy receipt), the `axel-havard` exact lookup, and a `0 unembedded content nodes` count check.

## Reviewer acceptance checks
- [ ] Un-embedded nodes are never silently dropped from recall (lexical fallback holds)
- [ ] Embedding backend/config matches the skills path (no new backend introduced)
- [ ] Backfill is idempotent + resumable on re-run
- [ ] Reported scores are real match scores, not echoed storage confidence

🤖 Draft opened by Routine R3 (Codex-implemented, Claude-reviewed). Do not merge until the illo-dev smoke gate passes.