### PR TITLE
[Illo-QA] Activate scheduler catalog on daemon startup (#343)

### DIFF
--- a/brain/app/cli/scheduler.py
+++ b/brain/app/cli/scheduler.py
@@ -14,7 +14,11 @@ from brain.app.scheduler.catalog import (
     async_sync_scheduler_catalog,
     normalize_owner_mode,
 )
-from brain.app.scheduler.daemon import async_scheduler_daemon_tick, async_scheduler_health_snapshot
+from brain.app.scheduler.daemon import (
+    async_scheduler_daemon_startup,
+    async_scheduler_daemon_tick,
+    async_scheduler_health_snapshot,
+)
 from brain.app.scheduler.executor import (
     async_drain_scheduler,
     async_retry_scheduler_run,
@@ -199,6 +203,13 @@ async def cmd_retry_run(args: argparse.Namespace) -> int:
 async def cmd_daemon(args: argparse.Namespace) -> int:
     tick = 0
     try:
+        async with UnitOfWork() as uow:
+            startup = await async_scheduler_daemon_startup(
+                uow.session,
+                owner_mode=args.owner_mode,
+                now=_now_from_args(args),
+            )
+        _emit({"event": "scheduler_startup", **startup})
         while True:
             async with UnitOfWork() as uow:
                 result = await async_scheduler_daemon_tick(

--- a/brain/app/scheduler/__init__.py
+++ b/brain/app/scheduler/__init__.py
@@ -7,7 +7,11 @@ from brain.app.scheduler.catalog import (
     async_upsert_scheduler_job,
     normalize_owner_mode,
 )
-from brain.app.scheduler.daemon import async_scheduler_daemon_tick, async_scheduler_health_snapshot
+from brain.app.scheduler.daemon import (
+    async_scheduler_daemon_startup,
+    async_scheduler_daemon_tick,
+    async_scheduler_health_snapshot,
+)
 from brain.app.scheduler.executor import (
     async_claim_scheduler_run,
     async_drain_scheduler,
@@ -54,6 +58,7 @@ __all__ = [
     "async_resume_scheduler_run",
     "async_run_scheduler_job",
     "async_run_scheduler_run",
+    "async_scheduler_daemon_startup",
     "async_scheduler_daemon_tick",
     "async_scheduler_health_snapshot",
     "async_set_scheduler_job_load_shed",

--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -20,13 +20,15 @@ from brain.app.scheduler.runtime import normalize_owner_mode as _normalize_owner
 from brain.app.scheduler.runtime import normalize_run_status
 
 DEFAULT_SCHEDULER_TIMEZONE = os.getenv("SCHEDULER_DEFAULT_TIMEZONE", "America/Toronto")
+CATALOG_HANDLER_KIND = "scheduler_builtin"
+CATALOG_RETIRE_REASON = "removed from scheduler catalog"
 
 SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
     {
         "job_key": "nightly_sleep",
         "family": "nightly_sleep",
         "program_key": "nightly_sleep",
-        "handler_kind": "scheduler_builtin",
+        "handler_kind": CATALOG_HANDLER_KIND,
         "handler_ref": "brain.app.scheduler.programs:nightly_sleep",
         "cron_expr": "0 3 * * *",
         "default_payload": {
@@ -60,7 +62,7 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "job_key": "curiosity_cron",
         "family": "curiosity_cron",
         "program_key": "curiosity",
-        "handler_kind": "scheduler_builtin",
+        "handler_kind": CATALOG_HANDLER_KIND,
         "handler_ref": "brain.app.scheduler.programs:curiosity",
         "cron_expr": "0 22 * * *",
         "default_payload": {
@@ -325,13 +327,16 @@ async def async_sync_scheduler_catalog(
     now: datetime | None = None,
     job_keys: tuple[str, ...] | None = None,
 ) -> dict[str, int]:
-    """Ensure built-in scheduler jobs exist without touching legacy cron tables."""
+    """Reconcile built-in jobs and soft-retire removed entries on a full sync."""
     now = now or datetime.now(timezone.utc)
     owner_mode = normalize_owner_mode(owner_mode)
     if owner_mode != OWNER_MODE_SCHEDULER:
         raise ValueError("Legacy cron/mirror owner modes are retired; use owner_mode='scheduler'.")
 
     selected_keys = {_slugify(key) for key in job_keys or ()}
+    catalog_job_keys = {
+        _slugify(str(definition["job_key"])) for definition in SCHEDULER_CATALOG
+    }
     upserted = 0
     for definition in SCHEDULER_CATALOG:
         aliases = {
@@ -363,8 +368,29 @@ async def async_sync_scheduler_catalog(
             now=now,
         )
         upserted += 1
+
+    retired = 0
+    if not selected_keys:
+        catalog_jobs = await session.scalars(
+            select(SchedulerJob).where(
+                SchedulerJob.owner_mode == owner_mode,
+                SchedulerJob.handler_kind == CATALOG_HANDLER_KIND,
+            )
+        )
+        for job in catalog_jobs.all():
+            if _slugify(job.job_key) in catalog_job_keys:
+                continue
+            if not job.enabled and job.pause_reason == CATALOG_RETIRE_REASON:
+                continue
+            retired_job = await async_retire_scheduler_job(
+                session,
+                job.job_key,
+                reason=CATALOG_RETIRE_REASON,
+            )
+            if retired_job is not None:
+                retired += 1
     await session.flush()
-    return {"upserted": upserted}
+    return {"upserted": upserted, "retired": retired}
 
 
 async def async_list_scheduler_jobs(session: AsyncSession) -> list[dict[str, Any]]:

--- a/brain/app/scheduler/daemon.py
+++ b/brain/app/scheduler/daemon.py
@@ -1,6 +1,7 @@
 """Scheduler daemon and operational health helpers."""
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from datetime import datetime, timezone
 from typing import Any
@@ -15,8 +16,10 @@ from brain.platform.db.models.scheduler import (
     SchedulerRun,
 )
 from brain.app.scheduler.catalog import (
+    DEFAULT_SCHEDULER_TIMEZONE,
     async_list_scheduler_jobs,
     async_list_scheduler_runs,
+    async_sync_scheduler_catalog,
     normalize_owner_mode,
 )
 from brain.app.scheduler.executor import async_drain_scheduler
@@ -25,6 +28,8 @@ from brain.app.scheduler.runtime import (
     async_reclaim_expired_leases,
     normalize_run_status,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -227,6 +232,47 @@ async def async_scheduler_health_snapshot(
         active_leases=active_leases,
         expired_leases=expired_leases,
     )
+
+
+async def async_scheduler_daemon_startup(
+    session: AsyncSession,
+    *,
+    owner_mode: str = OWNER_MODE_SCHEDULER,
+    timezone_name: str = DEFAULT_SCHEDULER_TIMEZONE,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Synchronize the built-in catalog before the daemon starts draining work."""
+    now = now or _utc_now()
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    owner_mode = normalize_owner_mode(owner_mode)
+    catalog = await async_sync_scheduler_catalog(
+        session,
+        owner_mode=owner_mode,
+        timezone_name=timezone_name,
+        now=now,
+    )
+    snapshot = await async_scheduler_health_snapshot(
+        session,
+        owner_mode=owner_mode,
+        now=now,
+    )
+    logger.info(
+        "Scheduler catalog synchronized at daemon startup: upserted=%s retired=%s "
+        "jobs_total=%s jobs_enabled=%s",
+        catalog["upserted"],
+        catalog["retired"],
+        snapshot["summary"]["jobs_total"],
+        snapshot["summary"]["jobs_enabled"],
+    )
+    await session.flush()
+    return {
+        "ok": True,
+        "owner_mode": owner_mode,
+        "catalog": catalog,
+        "snapshot": snapshot,
+    }
 
 
 async def async_scheduler_daemon_tick(

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import os
 import shlex
 import socket
@@ -58,6 +59,7 @@ from brain.app.scheduler.runtime import (
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 Runner = Callable[..., Any]
+logger = logging.getLogger(__name__)
 
 _FINAL_RUN_STATUSES = {
     RUN_STATUS_SETTLED_SUCCESS,
@@ -467,11 +469,56 @@ async def _async_run_step(
     env = _shell_env(job, run, step.step_key)
     results: list[dict[str, Any]] = []
     for command in commands:
-        proc = await _call_runner(runner, command, env=env, timeout_seconds=job.timeout_seconds)
+        try:
+            proc = await _call_runner(
+                runner,
+                command,
+                env=env,
+                timeout_seconds=job.timeout_seconds,
+            )
+        except Exception as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            results.append(
+                {
+                    "command": list(command),
+                    "exception_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+            )
+            logger.exception(
+                "Scheduler step crashed: run_id=%s job_key=%s step_key=%s command=%s",
+                run.id,
+                job.job_key,
+                step.step_key,
+                list(command),
+            )
+            await async_update_run_step(
+                session,
+                step,
+                status=RUN_STATUS_RETRYABLE,
+                finished_at=now,
+                result_summary={"results": results},
+                error_text=error_text,
+            )
+            return {
+                "ok": False,
+                "step_key": step.step_key,
+                "results": results,
+                "error": error_text,
+            }
         summary = {"command": list(command), **_command_summary(proc)}
         results.append(summary)
         if int(getattr(proc, "returncode", 1)) != 0:
             error_text = summary["stderr_tail"] or summary["stdout_tail"] or "step failed"
+            logger.error(
+                "Scheduler step failed: run_id=%s job_key=%s step_key=%s "
+                "returncode=%s error=%s",
+                run.id,
+                job.job_key,
+                step.step_key,
+                summary["returncode"],
+                error_text,
+            )
             await async_update_run_step(
                 session,
                 step,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -11,7 +11,7 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 
-from brain.platform.db.models.scheduler import SchedulerJob, SchedulerLease, SchedulerRun, SchedulerRunStep
+import brain.app.scheduler.catalog as scheduler_catalog
 from brain.app.scheduler.catalog import async_list_scheduler_jobs, async_sync_scheduler_catalog
 from brain.app.scheduler.contracts import (
     extract_declared_actions,
@@ -19,7 +19,11 @@ from brain.app.scheduler.contracts import (
     validate_declared_actions,
     validate_recurring_task_contract,
 )
-from brain.app.scheduler.daemon import async_scheduler_daemon_tick, async_scheduler_health_snapshot
+from brain.app.scheduler.daemon import (
+    async_scheduler_daemon_startup,
+    async_scheduler_daemon_tick,
+    async_scheduler_health_snapshot,
+)
 from brain.app.scheduler.executor import (
     async_execute_scheduler_run,
     async_run_scheduler_run,
@@ -38,6 +42,7 @@ from brain.app.scheduler.runtime import (
     async_reclaim_expired_leases,
     async_update_run_step,
 )
+from brain.platform.db.models.scheduler import SchedulerJob, SchedulerLease, SchedulerRun, SchedulerRunStep
 
 pytestmark = pytest.mark.asyncio
 
@@ -120,7 +125,7 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     await session.flush()
 
-    assert result == {"upserted": 2}
+    assert result == {"upserted": 2, "retired": 0}
     jobs = {job["job_key"]: job for job in await async_list_scheduler_jobs(session)}
     assert set(jobs) == {"curiosity_cron", "nightly_sleep"}
     assert jobs["nightly_sleep"]["owner_mode"] == "scheduler"
@@ -132,6 +137,70 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
         assert not job["handler_ref"].endswith(".sh")
         assert "script_path" not in job["default_payload"]
         assert "legacy_cron_retired" not in job["default_payload"]
+
+
+async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_restart(session):
+    first_boot = datetime(2026, 4, 20, 0, 0, tzinfo=timezone.utc)
+    await async_sync_scheduler_catalog(session, timezone_name="UTC", now=first_boot)
+    first_jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+    first_ids = {key: job.id for key, job in first_jobs.items()}
+
+    restart = datetime(2026, 4, 21, 23, 0, tzinfo=timezone.utc)
+    result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=restart)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+
+    assert result == {"upserted": 2, "retired": 0}
+    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 2
+    assert {key: job.id for key, job in jobs.items()} == first_ids
+    assert all(job.next_run_at > restart for job in jobs.values())
+    assert await async_materialize_due_runs(session, now=restart) == []
+
+
+async def test_sync_scheduler_catalog_first_registration_never_backfills_missed_runs(session):
+    now = datetime(2026, 4, 21, 3, 5, tzinfo=timezone.utc)
+
+    await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+
+    assert jobs["nightly_sleep"].next_run_at.isoformat().startswith("2026-04-22T03:00:00")
+    assert jobs["curiosity_cron"].next_run_at.isoformat().startswith("2026-04-21T22:00:00")
+
+
+async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(session, monkeypatch):
+    now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
+    await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
+    monkeypatch.setattr(
+        scheduler_catalog,
+        "SCHEDULER_CATALOG",
+        tuple(
+            definition
+            for definition in scheduler_catalog.SCHEDULER_CATALOG
+            if definition["job_key"] == "nightly_sleep"
+        ),
+    )
+
+    result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+
+    assert result == {"upserted": 1, "retired": 1}
+    assert jobs["nightly_sleep"].enabled is True
+    assert jobs["curiosity_cron"].enabled is False
+    assert jobs["curiosity_cron"].pause_reason == "removed from scheduler catalog"
+
+    repeated = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
+    assert repeated == {"upserted": 1, "retired": 0}
+
+
+async def test_scheduler_daemon_startup_syncs_catalog_before_snapshot(session):
+    now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
+
+    result = await async_scheduler_daemon_startup(session, now=now, timezone_name="UTC")
+
+    assert result["ok"] is True
+    assert result["catalog"] == {"upserted": 2, "retired": 0}
+    assert result["snapshot"]["summary"]["jobs_total"] == 2
+    assert result["snapshot"]["summary"]["jobs_enabled"] == 2
+    assert all(job["next_run_at"] > now.isoformat() for job in result["snapshot"]["jobs"])
 
 
 async def test_due_run_materialization_records_scheduler_jobs(session):
@@ -772,6 +841,57 @@ async def test_async_run_scheduler_run_persists_step_failures_and_resumes(sessio
     ).all()
     assert all(step.status == RUN_STATUS_SETTLED_SUCCESS for step in steps)
     assert all("brain.jobs.pipelines.consolidate" not in call for call in calls)
+
+
+async def test_scheduler_step_crash_is_persisted_in_snapshot_and_logs(session, caplog):
+    job = _make_scheduler_job(
+        default_payload={
+            "name": "Nightly Sleep",
+            "step_plan": [
+                {
+                    "step_key": "memory_consolidation",
+                    "sequence_no": 1,
+                    "command": "python3 -m brain.jobs.pipelines.consolidate --phase all",
+                }
+            ],
+        },
+    )
+    session.add(job)
+    await session.flush()
+    run = (
+        await async_materialize_due_runs(
+            session,
+            now=datetime(2026, 4, 21, 3, 1, tzinfo=timezone.utc),
+        )
+    )[0]
+
+    def crashing_runner(command, *, cwd=None):
+        raise RuntimeError("consolidation process crashed")
+
+    failed = await async_run_scheduler_run(
+        session,
+        run.id,
+        owner_id="tester",
+        runner=crashing_runner,
+        now=datetime(2026, 4, 21, 3, 2, tzinfo=timezone.utc),
+    )
+    snapshot = await async_scheduler_health_snapshot(
+        session,
+        now=datetime(2026, 4, 21, 3, 2, tzinfo=timezone.utc),
+    )
+    step = await session.scalar(
+        select(SchedulerRunStep).where(SchedulerRunStep.run_id == run.id)
+    )
+
+    assert failed.status == "retryable"
+    assert failed.error_text == "RuntimeError: consolidation process crashed"
+    assert step is not None
+    assert step.status == "retryable"
+    assert step.result_summary["results"][0]["exception_type"] == "RuntimeError"
+    assert snapshot["health"]["status"] == "degraded"
+    assert snapshot["runs"][0]["status"] == "retryable"
+    assert snapshot["runs"][0]["error_text"] == failed.error_text
+    assert "Scheduler step crashed" in caplog.text
 
 
 async def test_retry_policy_backoff_controls_automatic_reclaim(session):


### PR DESCRIPTION
Closes #343 — part of the mémoire umbrella #341 (recall-ranking keystone #342 already merged).

## What this does
Activates the scheduler catalog so the already-built nightly memory maintenance actually runs. The `illospace-scheduler-1` daemon was idling forever (`scheduler_jobs` had 0 rows → "no scheduler jobs registered") because nothing ever called `async_sync_scheduler_catalog`. This wires that sync into daemon boot.

- **Startup sync**: `cmd_daemon` now calls a new `async_scheduler_daemon_startup` before the tick loop and emits a `scheduler_startup` event with an operational snapshot.
- **Idempotent**: re-running the sync does not duplicate jobs.
- **Forward-only** `next_run_at` seeding — no catch-up backfill / no immediate fire on boot.
- **Soft-retire** of jobs dropped from the catalog via the existing `async_retire_scheduler_job` path (full sync only, guarded by `handler_kind == scheduler_builtin`).
- **Loud degradation**: a crashing scheduler step is caught, logged with context, and recorded as `RETRYABLE` with error text — never swallowed.

Scope fences respected: **no** change to what consolidation does, **no** cycle-thread scheduling change (that's `illospace-worker-1`), **no** recall-ranking change, **no migration**.

## Base-code note for the reviewer (surfaced, not fixed here)
On current `origin/main`, `brain/jobs/pipelines/consolidate.py` inserts `consolidation_runs` and counts active `MemoryNode` rows but does **not** inspect `memory_edges`, perform decay, or write `memory_health_log`. This ticket's scope fence is "don't change what consolidation does," so it was left untouched — but that means the issue's health/decay deploy gate (`≥1 memory_health_log` row, decayed count) is **not** guaranteed by main as-is. Flagging so it can be resolved before treating that gate as passed (likely a follow-up slice under #341).

## Tests
- Codex worker ran the suite in-sandbox: **84 passed** (scheduler, nightly pipeline, scheduler API, RBAC) + `git diff --check` clean. `tests/test_scheduler.py` gained coverage for catalog-sync idempotency, forward-only seeding (no catch-up), and the retire path.
- Local `py_compile` of all changed files: clean. Full suite runs in CI (needs the Docker test DB; not runnable in this worktree).

## illo-dev acceptance (human, at deploy)
```bash
docker restart illospace-scheduler-1
docker logs --since 2m illospace-scheduler-1 | grep scheduler_startup
docker exec illospace-scheduler-1 python -m brain.app.cli.scheduler status | tee /tmp/scheduler-snapshot.json
# gate: jobs_total>=2, both enabled, next_run_at in the future
jq -e '(.summary.jobs_total>=2) and all(.jobs[]|select(.job_key=="nightly_sleep" or .job_key=="curiosity_cron"); .enabled and (.next_run_at>.now))' /tmp/scheduler-snapshot.json
```
After the first night: `≥1` `consolidation_runs` row, curated memories intact, decay consistent with the ~75 low-confidence (0.45) candidates — **subject to the consolidation base-code note above.** Restarting the container must not duplicate jobs or fire immediate catch-up runs.

🤖 draft opened by R3 (Codex-implemented, director-reviewed). Do not merge until the illo-dev gate + the consolidation note are cleared.
