### PR TITLE
[Illo-QA] Doc 1155 scheduled memory contract — recall at start, ingest durable outcomes (#344)

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -13,61 +13,60 @@ staging, review, merge, deploy, and close/reopen workflow across
 
 ## Source Of Truth
 
-When available, read Enterprise Documentation Domain id `37`, object
-`doc_page`, record id `1155`, slug `uwear-engineering-triage` (use
-`manage_domain` `action=get_record` `domain_id=37` `record_id=1155`). Treat
-that document as the live operating model. If it conflicts with this bundled
-skill, surface the conflict and prefer the live document after verification.
-On-demand mode playbooks (see **On-demand Run Modes**) are separate Domain
-`37` records fetched the same way; the live records override the bundled
+Read Enterprise Documentation Domain `37` `doc_page` record `1155`, slug
+`uwear-engineering-triage`, with `manage_domain` `action=get_record`
+`domain_id=37` `record_id=1155`. It is the live operating model; surface any
+conflict and prefer the verified live document. On-demand playbooks are
+separate Domain `37` records; their live versions override bundled
 `references/` assets.
 
 ## On-demand Run Modes
 
-Some run modes are deliberately NOT in this core document: their full
-playbooks live as separate Enterprise Documentation Domain `37` `doc_page`
-records so the per-run core read stays small and untruncated. When a run
-enters one of these modes, fetch the playbook FIRST (`manage_domain`
-`action=get_record` `domain_id=37` with the `record_id` below) and follow
-it — never run the mode from this summary alone. If the record read fails,
-fall back to the bundled skill asset (`skill_asset`
-`name="uwear-engineering-triage"` with the `path` below); if both fail,
-degrade loudly: say the playbook was unreachable and defer the mode's
-writes.
+Full playbooks stay in separate Domain `37` `doc_page` records so this core
+read remains untruncated. On entering a listed mode, fetch its record FIRST
+with `manage_domain` `action=get_record` `domain_id=37`, then follow it. If
+that fails, use `skill_asset` `name="uwear-engineering-triage"` with the path
+below. If both fail, say so and defer the mode's writes.
 
 - **Direct customer support** — record `1271`, asset
-  `references/customer-support.md`. When a customer-support report arrives
-  (e.g. a Retool "New: Issue" with a `User` / `Profile ID` / `Message` about
-  a wrong generation): investigate the generation read-only and form a
-  hypothesis BEFORE filing or assigning anything. Always-on core rule:
-  customer-generation issues have NO owner until an investigation hypothesis
-  exists (see **Ownership**).
+  `references/customer-support.md`. Fetch on a customer-support report;
+  investigate the generation read-only and form a hypothesis before filing or
+  assigning. Always-on: customer-generation issues have NO owner until that
+  hypothesis exists (see **Ownership**).
 - **Creating work items** — record `1272`, asset
-  `references/creating-work-items.md`. The decision tree for real GitHub
-  issues vs internal tracker records, honest failure handling, and tracker
-  external-id formats. Fetch BEFORE calling `create_github_issue` or
-  creating a Domain `1` tracker record. Always-on core rules: one problem =
-  one issue — search open AND closed GitHub issues and Domain `1` records
-  for the same error signature or Rollbar id (prefer the structured
-  `rollbar_item` field; an exact match has no recency cutoff) before filing,
-  and a match — even closed or `Done` — routes through the **Deploy-State
-  Ladder**, never a refile; never describe an internal tracker record as a
-  GitHub issue.
+  `references/creating-work-items.md`. Fetch before `create_github_issue` or a
+  Domain `1` tracker write. Always-on: one problem = one issue; search open and
+  closed GitHub issues plus Domain `1` for the error signature or Rollbar id
+  (prefer `rollbar_item`; exact matches never expire). Any match, even closed
+  or `Done`, uses the **Deploy-State Ladder**, never a refile; never describe
+  an internal tracker record as a GitHub issue.
 - **Backlog maintenance** — record `1273`, asset
-  `references/backlog-maintenance.md`. One-time backlog seeding plus the
-  three backlog-hygiene modes (`process-design`, `no-write-audit`,
-  `live-hygiene-run`). Fetch when a human asks for a seed or hygiene pass —
-  never as part of a scheduled digest run. Always-on core rule: close
-  candidates are approval batches; never close GitHub issues or PRs without
+  `references/backlog-maintenance.md`. Covers seeding and `process-design`,
+  `no-write-audit`, `live-hygiene-run`; fetch only on a human request, never in
+  a scheduled digest. Always-on: never close GitHub issues or PRs without
   delegated authority.
 - **Chantier operations** — record `1274`, asset
   `references/chantier-operations.md`. Fetch before every scheduled digest and
-  before filing or recording a new work item. It defines chantier-primary
-  digests, attach-at-triage, induction, freshness, and close-out. Always-on core
-  rules: check active chantiers before filing; attach an exact match, but only
-  PROPOSE (never auto-create) a chantier for an ungrouped family; never let an
-  active chantier disappear silently or hide one that is stale, blocked, or
-  missing `next_step`.
+  before filing or recording a new work item. Always-on: check active
+  chantiers; attach an exact match, only PROPOSE (never auto-create) an
+  ungrouped family, and surface every stale, blocked, or incomplete chantier.
+
+## Memory
+
+At run START, before deciding, call `memory_reconstruct` with the concrete
+subjects at hand (repo, issue/PR, person, or incident). Recall is context, not
+proof: verify every load-bearing claim against live sources.
+
+At run END, if the run produced a durable outcome, make exactly one
+`memory_ingest_source` call for the most reusable decision, ownership change,
+standing guidance, or incident conclusion. Start content with the one-line
+framing `What future runs need: ...`. Never ingest ephemeral state such as open
+counts, run summaries, or “posted to Slack” receipts. Use `confidence=0.9` for
+human-stated facts or approvals; cap inferences at `0.7` and use the lower value
+when mixed.
+
+For selection, dedup wording, and examples, fetch Domain `37` record `1275`,
+asset `references/memory.md`, using the live-first fallback above.
 
 ## Coordination Pipeline
 

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md
@@ -1,0 +1,100 @@
+# Uwear Engineering Triage — Memory Playbook
+> On-demand mode playbook for Enterprise Documentation Domain `37` record
+> `1275`, slug `uwear-engineering-triage-memory`.
+> Core doc: Domain `37` record `1155` (bundled skill
+> `uwear-engineering-triage`); fetch per its **Memory** section.
+
+## Purpose
+
+Memory should let a later coordinator make a better decision without
+re-discovering a durable outcome. It supplements live GitHub, Domain, Slack,
+and incident evidence; it never replaces them.
+
+## Run Start — Recall on Subject
+
+Before deciding, call `memory_reconstruct` at least once with the concrete
+subjects of this run. Name stable identifiers where available: repo, issue or
+PR number, person, chantier slug, Rollbar item, or incident id. One compact
+query may include all closely related subjects; use a follow-up only when the
+first evidence pack exposes a relevant unresolved question.
+
+Example query: `uwear-ai/uwear-backend issue #905, Axel, incident
+Uwear-API#2206: prior decisions, ownership, and incident conclusions`.
+
+Treat the evidence pack as context. Before relying on a recalled fact to
+assign, close, escalate, suppress, or post, verify it against the current
+GitHub/Domain/Slack/incident source. A conflict or stale source is a reason to
+say what changed, not to force the old memory onto the present.
+
+## Run End — Select One Durable Outcome
+
+If the run produced a durable outcome, call `memory_ingest_source` exactly
+once for the single outcome most useful to future runs. If nothing crossed
+that bar, do not ingest. Durable outcomes include:
+
+- a decision or human approval that governs later action;
+- an ownership change, including its scope and effective condition;
+- standing guidance expected to survive the current run; or
+- an incident conclusion supported strongly enough to guide future triage.
+
+### What Makes a Good Memory
+
+A good memory is decision-relevant to a later run, atomic, concrete about its
+subject, grounded in named evidence or human authority, and expected to remain
+useful after the current queue state changes. It says what governs future
+action and under what condition it stops governing.
+
+Do not ingest open counts, queue snapshots, current CI state, routine run
+summaries, Slack-post receipts, poll results, or “no change” observations.
+Those are live/ephemeral evidence. If several durable outcomes occur, choose
+the most consequential one; their authoritative records remain the source of
+truth.
+
+Use `content_kind="decision"`, `"fact"`, or `"procedure"` as appropriate.
+Set `confidence=0.9` for facts or approvals stated by a human. An inferred
+conclusion is at most `0.7`; mixed human/inferred content uses the lower value.
+
+## Stable Phrasing and Dedup
+
+Ingestion derives `normalized_key` from the first sentence's normalized text.
+Make that sentence stable and atomic so a repeated outcome resolves to the
+same key:
+
+1. Start exactly `What future runs need: <subject> <durable outcome>.`
+2. Use the same canonical subject and identifiers every time (repo-qualified
+   issue/PR, chantier slug, person, incident id).
+3. State one outcome. Put evidence or qualifications in later sentences.
+4. Never lead with a timestamp, run id, “today”, message id, or delivery
+   receipt; those manufacture a new key for the same outcome.
+5. When the same outcome is reaffirmed, reuse its first sentence verbatim.
+   When it is superseded, name the old outcome and the replacement explicitly.
+
+## Examples
+
+Good — human-approved ownership change (`confidence=0.9`):
+
+> What future runs need: Uwear-API#2206 is owned by Axel until production
+> verification. Reda approved this ownership condition in the incident thread.
+
+Good — inferred incident conclusion (`confidence=0.7`):
+
+> What future runs need: Uwear-API#2206 most likely originates in the backend
+> render path. This is inferred from matching traces and must be rechecked
+> against live incident evidence before escalation.
+
+Good — standing guidance (`confidence=0.9`):
+
+> What future runs need: staging-to-main promotion PRs require a human merge.
+> Reda confirmed this standing approval boundary.
+
+Bad — ephemeral count:
+
+> There are 42 open issues right now.
+
+Bad — delivery receipt:
+
+> Run 1842 posted the 8:00 digest to Slack.
+
+Bad — unstable duplicate framing:
+
+> Today we again decided Axel should own Uwear-API#2206.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.5.0"
+version = "1.6.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"
@@ -39,3 +39,4 @@ asset_2 = "references/creating-work-items.md"
 asset_3 = "references/backlog-maintenance.md"
 asset_4 = "references/chantier-record-contract.md"
 asset_5 = "references/chantier-operations.md"
+asset_6 = "references/memory.md"

--- a/docs/344-live-delta.md
+++ b/docs/344-live-delta.md
@@ -1,0 +1,159 @@
+# Issue #344 deploy note — Domain 37 memory contract
+
+This branch performs no live, SSH, or migration write. After the commit lands,
+deployment must apply the exact Domain `37` changes below. The embeddings and
+recall-ranking slice from #342 has already merged; that sequencing is a soft
+dependency so the first coordinator recalls are relevant, not an activation
+blocker.
+
+## 1. Create the on-demand memory record
+
+Create a `doc_page` with:
+
+- intended record id: `1275` (the core pointer is pinned to this id; assert the
+  returned id before continuing);
+- slug: `uwear-engineering-triage-memory`;
+- title: `Uwear Engineering Triage — Memory Playbook`; and
+- content: the exact UTF-8 contents of
+  `brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md`.
+
+Expected content fingerprint:
+
+- characters: `4330`;
+- bytes: `4356`; and
+- SHA-256: `d1ad372fb34b3b7b3f24c26bf47c784ddd0ae594a3c5f7ccbedc4712908afe4b`.
+
+Read record `1275` back and require byte identity with the bundled reference.
+If id `1275` is occupied, the slug differs, or the content differs, stop: do
+not update core record `1155` to point at a missing or different playbook.
+
+## 2. Replace core record 1155 with doc v9
+
+Read Domain `37` `doc_page` record `1155` and verify slug
+`uwear-engineering-triage`. It is expected to be v8 immediately before this
+activation. Update by `record_id=1155` with the just-read `expected_version`,
+preserving all record fields except:
+
+- set `data.content` to the exact UTF-8 contents of
+  `brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md`.
+
+This is a whole-content replacement, not a hand-edited approximation. Expected
+v9 fingerprint:
+
+- characters: `33554` (must remain `< 34000`);
+- bytes: `33686`; and
+- SHA-256: `8321b96e0c1f8fe293e101a58e040c7b51a81cda9db37b5cbe564ef31d118866`.
+
+If record `1155` is no longer v8, re-read and reconcile the newer live edit
+into the bundle before writing. Never silently overwrite it.
+
+Record the activation time before waiting for acceptance runs:
+
+```bash
+ACTIVATED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\n' "$ACTIVATED_AT_UTC"
+```
+
+## 3. SSH byte-identity verification
+
+From the deployed checkout on the operator workstation, set the SSH target.
+The helper extracts `data->>'content'` as base64 so `psql` cannot add a row
+terminator that would make a byte comparison lie:
+
+```bash
+export ILLO_SSH='<ssh-user>@<server>'
+
+fetch_domain_content() {
+  local record_id="$1"
+  ssh "$ILLO_SSH" "bash -s -- '$record_id'" <<'REMOTE'
+set -euo pipefail
+record_id="$1"
+[[ "$record_id" =~ ^[0-9]+$ ]]
+cd ~/illospace
+docker compose --env-file deploy/compose/.env \
+  -f deploy/compose/docker-compose.yml \
+  exec -T postgres sh -lc \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At' <<SQL | tr -d '\r\n' | base64 -d
+SELECT encode(convert_to(data->>'content', 'UTF8'), 'base64')
+FROM domain_records
+WHERE domain_id = 37 AND id = ${record_id};
+SQL
+REMOTE
+}
+
+fetch_domain_content 1155 > /tmp/domain-37-1155.md
+fetch_domain_content 1275 > /tmp/domain-37-1275.md
+
+cmp -s \
+  brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md \
+  /tmp/domain-37-1155.md
+cmp -s \
+  brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md \
+  /tmp/domain-37-1275.md
+shasum -a 256 /tmp/domain-37-1155.md /tmp/domain-37-1275.md
+```
+
+Both `cmp` commands must exit `0`, and the hashes must equal the fingerprints
+above. Also read both records normally and confirm record `1155` is v9, record
+`1275` has the expected slug, and the core pointer names record `1275` plus
+`references/memory.md`.
+
+## 4. Cycle-2 acceptance
+
+Wait for the next three completed scheduled cycle-2 runs after
+`ACTIVATED_AT_UTC`, then run:
+
+```bash
+ssh "$ILLO_SSH" "bash -s -- '$ACTIVATED_AT_UTC'" <<'REMOTE'
+set -euo pipefail
+activated_at="$1"
+cd ~/illospace
+docker compose --env-file deploy/compose/.env \
+  -f deploy/compose/docker-compose.yml \
+  exec -T -e ACTIVATED_AT_UTC="$activated_at" postgres sh -lc \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v activated_at="$ACTIVATED_AT_UTC" -P pager=off' <<'SQL'
+WITH latest AS (
+  SELECT id, run_id, scheduled_for
+  FROM cycle_runs
+  WHERE cycle_id = 2
+    AND status = 'completed'
+    AND scheduled_for >= :'activated_at'::timestamptz
+  ORDER BY scheduled_for DESC
+  LIMIT 3
+)
+SELECT
+  latest.id AS cycle_run_id,
+  latest.run_id AS agent_run_id,
+  latest.scheduled_for,
+  count(events.id) FILTER (
+    WHERE events.event_type = 'run.tool_completed'
+      AND events.payload->>'tool_name' = 'memory_reconstruct'
+  ) AS reconstruct_calls,
+  coalesce(jsonb_agg(events.payload->'args' ORDER BY events.sequence_no) FILTER (
+    WHERE events.event_type = 'run.tool_completed'
+      AND events.payload->>'tool_name' = 'memory_reconstruct'
+  ), '[]'::jsonb) AS reconstruct_args,
+  count(events.id) FILTER (
+    WHERE events.event_type = 'run.tool_completed'
+      AND events.payload->>'tool_name' = 'memory_ingest_source'
+  ) AS ingest_calls,
+  coalesce(jsonb_agg(events.payload->'args' ORDER BY events.sequence_no) FILTER (
+    WHERE events.event_type = 'run.tool_completed'
+      AND events.payload->>'tool_name' = 'memory_ingest_source'
+  ), '[]'::jsonb) AS ingest_args
+FROM latest
+LEFT JOIN agent_run_events AS events ON events.run_id = latest.run_id
+GROUP BY latest.id, latest.run_id, latest.scheduled_for
+ORDER BY latest.scheduled_for DESC;
+SQL
+REMOTE
+```
+
+Acceptance requires exactly three rows. Every row must have
+`reconstruct_calls >= 1`, and `reconstruct_args` must name concrete subjects
+from that run (repo, issue/PR, person, chantier, or incident), not a generic
+“what do you remember?” query. For a digest run that made a real durable
+decision, `ingest_calls` must be exactly `1`; inspect `ingest_args` and require
+content beginning `What future runs need:`, a durable decision/ownership/
+guidance/conclusion, and the correct confidence (`0.9` human-stated,
+`<= 0.7` inferred). Runs without a durable outcome should have zero ingests.

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -53,7 +53,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.5.0"
+    assert bundle.manifest.version == "1.6.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -138,16 +138,51 @@ def test_uwear_triage_chantier_primary_digest_keeps_person_coverage():
     assert "outcome summary in the goal's language" in procedure
 
 
-def test_uwear_triage_live_delta_fingerprints_exact_bundle_mirrors():
+def test_uwear_triage_scheduled_memory_contract():
     from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
     from brain.systems.skills.bundles import load_skill_bundle
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
-    note = (Path(__file__).parents[1] / "docs" / "329-live-delta.md").read_text()
+    procedure = bundle.skill_markdown
+    memory = _uwear_triage_asset(bundle, "references/memory.md")
+
+    for expected in (
+        "## Memory",
+        "At run START",
+        "memory_reconstruct",
+        "load-bearing claim against live sources",
+        "At run END",
+        "memory_ingest_source",
+        "What future runs need:",
+        "confidence=0.9",
+        "cap inferences at `0.7`",
+        "record `1275`",
+        "`references/memory.md`",
+    ):
+        assert expected in procedure
+
+    for expected in (
+        "## Run Start — Recall on Subject",
+        "## Run End — Select One Durable Outcome",
+        "### What Makes a Good Memory",
+        "## Stable Phrasing and Dedup",
+        "`normalized_key`",
+        "Bad — ephemeral count",
+        "Bad — delivery receipt",
+    ):
+        assert expected in memory
+
+
+def test_uwear_triage_memory_delta_fingerprints_exact_bundle_mirrors():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    note = (Path(__file__).parents[1] / "docs" / "344-live-delta.md").read_text()
     mirrors = (
-        (bundle.skill_markdown, "v8"),
+        (bundle.skill_markdown, "v9"),
         (
-            _uwear_triage_asset(bundle, "references/chantier-operations.md"),
+            _uwear_triage_asset(bundle, "references/memory.md"),
             "content",
         ),
     )
@@ -261,6 +296,7 @@ def test_uwear_triage_on_demand_run_mode_split():
         "references/creating-work-items.md",
         "references/backlog-maintenance.md",
         "references/chantier-operations.md",
+        "references/memory.md",
     ):
         # The core names each playbook asset path, and every playbook carries
         # the provenance preamble pointing back at the core doc.


### PR DESCRIPTION
Closes #344 — part of the mémoire umbrella #341 (recall-ranking keystone #342 already merged, so first recalls will be relevant).

## What this does
Puts memory into the scheduled coordinator's loop. Scheduled runs (cycle 2 / cycle 8) currently make **zero** `memory_reconstruct` / `memory_ingest_source` calls — not a capability gap (the tools are in the default toolset) but a **prompt gap**: doc 1155 never mentioned them. This is a **doc/prompt change only — no code, no toolset, no migration.**

- **Core 1155** (`uwear-engineering-triage/SKILL.md`) gains a compact `## Memory` section (~1K chars): `memory_reconstruct` on concrete subjects at run start (context, not proof — verify load-bearing claims live); exactly one `memory_ingest_source` for durable outcomes at run end with a `What future runs need: …` framing; never ingest ephemeral state; confidence discipline (0.9 human-stated, ≤0.7 inferences).
- **On-demand record 1275** (`references/memory.md`): the fuller playbook — what makes a good memory, dedup phrasing rules for `normalized_key`, good/bad examples — pointed to from core.
- Bundle **version 1.5.0 → 1.6.0**, `asset_6` registered; contract/fingerprint/anti-regrowth tests updated.

## Budget + tests
- Core doc **~33.6K chars < 34K** (anti-regrowth test `test_builtin_skill_suite` green; ~446 chars headroom by the test's counter).
- Codex ran `tests/test_builtin_skill_suite.py`: **21 passed** (anti-regrowth, memory-contract, bundle fingerprint, `git diff --check`). Full suite runs in CI.

## Deploy-time acceptance (human — the live record does not exist yet)
This bundle change is the source of truth; the **live** Domain-37 record `1275` and the `1155` core update are applied at deploy. `docs/344-live-delta.md` carries the exact runbook:
1. Create live record `1275` + update core `1155` from the recorded fingerprints.
2. SSH `data->>'content'` extraction + byte-for-byte `cmp` (bundle ↔ live) must match.
3. Over the next 3 scheduled cycle-2 runs: each shows `memory_reconstruct ≥ 1` with on-subject args; a decision-making digest shows exactly one durable `memory_ingest_source` call (spot-check node quality, no exhaust).

Eyeball target for Reda: the `## Memory` section copy in `SKILL.md` and the good/bad examples in `references/memory.md` — is the recall/ingest contract the behavior you want scheduled runs to follow?

🤖 draft opened by R3 (Codex-implemented, director-reviewed). Do not merge until the byte-identity + cycle-2 recall gates pass at deploy.
