### PR TITLE
[Illo-QA] Chantier declare flow from Slack app mentions (#331)

### DIFF
--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md
@@ -177,5 +177,54 @@ unless the human explicitly delegated it.
 
 ## Declare Flow
 
-Reserved for ticket #331. Do not declare or auto-create a chantier from this
-playbook.
+The declaration door is an explicit Illo app mention containing the keyword
+`chantier`, preferably in this compact shape:
+
+`@Illo chantier: <title or slug> — done means <outcome> [kind: <kind>] [owner: <name>] [next_step: <step>] [links]`
+
+Do not infer a declaration from related vocabulary, a proposal, passive channel
+monitoring, or an ordinary mention without the `chantier` keyword. A direct
+message that was not normalized as an Illo app mention is not this flow. Questions
+such as "what chantiers are active?" remain reads, not declarations.
+
+The Slack mention lane persists the record before the conversational reply:
+
+1. Parse the title and `Done means ...` goal. Best-effort extras are `kind:`,
+   `owner:`, `next_step:`, and pasted links. Convert GitHub issue URLs to the
+   record contract's `github:<owner>/<repo>:issue:<n>` ref; retain other links
+   as typed `slack` or `url` refs.
+2. Derive a lowercase kebab slug. Before creating, lock the chantier object and
+   match all active records by exact slug, normalized title, or a title whose
+   kebab form is the same slug. A match is an update of that record; never create
+   a second record. The persisted slug remains immutable.
+3. New records start in `exploring`. Guess `incident`, `quality`, `feature`, or
+   `gtm` conservatively unless `kind:` is explicit. Preserve an existing kind,
+   owner, goal, and next step when a re-declaration omits those explicit values;
+   merge new refs without duplicating them.
+4. If no goal is supplied, persist a clearly inferred `Done means ...` goal and
+   label it as inferred in the reply. If no `next_step` can be inferred, persist
+   the contract placeholder and ask directly for `next_step` in the reply.
+
+Reply in the declaration's Slack thread, even when the mention was top-level.
+Say `created` or `updated`, then echo the slug, goal, explicit/guessed kind,
+builder-first owner suggestion, next step (or the request for one), and mirror
+outcome. An explicit `owner:` wins. Otherwise prefer the likely implementation
+builder from current ownership evidence; use `builder TBD` when the evidence is
+insufficient rather than assigning the declarer or coordinator by reflex.
+
+For engineering chantiers (`feature`, `incident`, or `quality`), open the GitHub
+parent mirror only when `parent_issue` is blank. Use `create_github_issue` with
+title `[Chantier] <title>` and a body containing the slug, `Done means ...` goal,
+and key refs. Before creating, search open and closed issues in the target repo
+for the exact slug or `[Chantier] <title>`; link an existing exact match rather
+than creating a duplicate. On success, update the same record's `parent_issue`
+with `expected_version`, then attach pasted GitHub issue refs through the native
+`add_github_sub_issue` tool. An existing `parent_issue` is proof the mirror was
+already opened; never open it again.
+
+The Domain record is the durable primary write. Repo ambiguity, missing GitHub
+credentials/scopes, or unavailable mirror/sub-issue tooling never rolls it back
+and never makes the declare fail. Degrade loudly in-thread as
+`mirror pending: <specific reason>`; when the interface itself is unavailable,
+the required wording is `mirror pending tooling`. Never claim a mirror exists
+without the returned GitHub issue number and URL.

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.5.0"
+version = "1.6.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"

--- a/brain/systems/slack/chantier_declare.py
+++ b/brain/systems/slack/chantier_declare.py
@@ -1,0 +1,595 @@
+"""Deterministic Slack declaration flow for Domain-1 chantiers.
+
+Language understanding remains deliberately small: a declaration must arrive
+as an explicit Slack app mention containing the word ``chantier``.  The parser
+extracts the mechanical record contract and leaves the normal Illo run to make
+the visible threaded reply and, for engineering work, attempt the GitHub parent
+mirror with the existing GitHub tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.domain import DomainRecord
+from brain.systems.user_domains.service import AsyncDomainService, DomainNotFound
+
+
+TRACKER_DOMAIN_SLUG = "github-ticket-tracker"
+CHANTIER_OBJECT_KEY = "chantier"
+SLACK_APP_MENTION_ORIGIN = "slack.app_mention"
+MISSING_NEXT_STEP = "Clarify the next most valuable step."
+GITHUB_PARENT_MIRROR_TOOL = "create_github_issue"
+GITHUB_SUB_ISSUE_TOOL = "add_github_sub_issue"
+
+_CHANTIER_KEYWORD_RE = re.compile(r"\bchantier\b", re.IGNORECASE)
+_SLACK_MENTION_RE = re.compile(r"<@[A-Z0-9]+>", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
+_KIND_RE = re.compile(r"\bkind\s*:\s*(feature|incident|quality|gtm)\b", re.IGNORECASE)
+_LABELED_VALUE_BOUNDARY = (
+    r"(?=\s+(?:kind|owner|goal|next[_ ]step)\s*:|\s+https?://|$)"
+)
+_OWNER_RE = re.compile(
+    r"\bowner\s*:\s*(?P<value>.+?)" + _LABELED_VALUE_BOUNDARY,
+    re.IGNORECASE,
+)
+_NEXT_STEP_RE = re.compile(
+    r"\bnext[_ ]step\s*:\s*(?P<value>.+?)" + _LABELED_VALUE_BOUNDARY,
+    re.IGNORECASE,
+)
+_GOAL_LABEL_RE = re.compile(
+    r"\bgoal\s*:\s*(?P<value>.+?)" + _LABELED_VALUE_BOUNDARY,
+    re.IGNORECASE,
+)
+_DONE_MEANS_RE = re.compile(r"\bdone\s+means\b", re.IGNORECASE)
+_GITHUB_ISSUE_URL_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/"
+    r"(?P<repo>[A-Za-z0-9_.-]+)/issues/(?P<number>[1-9][0-9]*)(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
+_QUESTION_PREFIXES = (
+    "are there",
+    "list",
+    "show",
+    "status",
+    "what",
+    "which",
+)
+
+
+@dataclass(frozen=True)
+class ChantierDeclaration:
+    """Best-effort structured interpretation of one Slack sentence."""
+
+    title: str
+    slug: str
+    goal: str
+    goal_is_explicit: bool
+    kind: str
+    kind_is_explicit: bool
+    owner: str | None
+    next_step: str | None
+    refs: tuple[dict[str, str], ...]
+    mirror_repo_suggestion: str | None
+
+
+@dataclass(frozen=True)
+class ChantierDeclareResult:
+    """Persisted result passed to the Slack run for echo/mirror completion."""
+
+    operation: str
+    domain_id: int
+    record_id: int
+    version: int
+    data: dict[str, Any]
+    goal_was_inferred: bool
+    kind_was_guessed: bool
+    needs_next_step: bool
+    owner_suggestion: str
+    mirror_status: str
+    mirror_repo_suggestion: str | None
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "domain_id": self.domain_id,
+            "record_id": self.record_id,
+            "version": self.version,
+            "data": self.data,
+            "goal_was_inferred": self.goal_was_inferred,
+            "kind_was_guessed": self.kind_was_guessed,
+            "needs_next_step": self.needs_next_step,
+            "owner_suggestion": self.owner_suggestion,
+            "mirror_status": self.mirror_status,
+            "mirror_repo_suggestion": self.mirror_repo_suggestion,
+        }
+
+
+def parse_chantier_declaration(text: str) -> ChantierDeclaration | None:
+    """Parse the narrow ``chantier: ...`` declaration contract.
+
+    Merely discussing or querying chantiers is not a declaration.  A colon is
+    the clearest door, while imperative/plain forms such as ``declare chantier
+    reliability`` are also accepted when they leave a non-question title.
+    """
+
+    raw = _SLACK_MENTION_RE.sub(" ", str(text or ""))
+    keyword = _CHANTIER_KEYWORD_RE.search(raw)
+    if keyword is None:
+        return None
+    prefix = raw[: keyword.start()].strip().casefold()
+    tail = raw[keyword.end() :].strip()
+    used_colon = tail.startswith(":")
+    tail = tail.lstrip(" \t:-–—")
+    if not tail or (
+        not used_colon
+        and (
+            prefix.startswith(_QUESTION_PREFIXES)
+            or tail.casefold().startswith(_QUESTION_PREFIXES)
+        )
+    ):
+        return None
+
+    urls = [_trim_url(url) for url in _URL_RE.findall(tail)]
+    working = _URL_RE.sub(" ", tail)
+
+    kind_match = _KIND_RE.search(working)
+    explicit_kind = kind_match.group(1).lower() if kind_match else None
+    if kind_match:
+        working = _remove_match(working, kind_match)
+
+    owner, working = _extract_labeled_value(_OWNER_RE, working)
+    next_step, working = _extract_labeled_value(_NEXT_STEP_RE, working)
+    labeled_goal, working = _extract_labeled_value(_GOAL_LABEL_RE, working)
+
+    working = _compact_spaces(working)
+    done_match = _DONE_MEANS_RE.search(working)
+    if labeled_goal:
+        title = _clean_title(working)
+        goal = _done_means_goal(labeled_goal)
+        goal_is_explicit = True
+    elif done_match:
+        title = _clean_title(working[: done_match.start()])
+        goal = _done_means_goal(working[done_match.start() :])
+        goal_is_explicit = True
+    else:
+        title = _clean_title(working)
+        goal = ""
+        goal_is_explicit = False
+
+    if not title:
+        return None
+    title = title[:500].rstrip()
+    slug = _slugify(title)
+    if not slug:
+        return None
+    if not goal:
+        goal = f"Done means {title} reaches its stated outcome."
+    goal = goal[:4000].rstrip()
+
+    guessed_kind = explicit_kind or _guess_kind(f"{title} {goal}")
+    refs = tuple(_refs_from_urls(urls))
+    mirror_repo = _first_github_repo(urls)
+    return ChantierDeclaration(
+        title=title,
+        slug=slug,
+        goal=goal,
+        goal_is_explicit=goal_is_explicit,
+        kind=guessed_kind,
+        kind_is_explicit=explicit_kind is not None,
+        owner=_clean_optional(owner, limit=120),
+        next_step=_clean_optional(next_step, limit=500, one_line=True),
+        refs=refs,
+        mirror_repo_suggestion=mirror_repo,
+    )
+
+
+async def maybe_declare_chantier_from_slack(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    actor_user_id: str | None,
+    origin: str,
+    text: str,
+) -> ChantierDeclareResult | None:
+    """Create/update a chantier only through the explicit app-mention door."""
+
+    if str(origin or "").strip() != SLACK_APP_MENTION_ORIGIN:
+        return None
+    declaration = parse_chantier_declaration(text)
+    if declaration is None:
+        return None
+    return await upsert_chantier_declaration(
+        session,
+        org_id=org_id,
+        actor_user_id=actor_user_id,
+        declaration=declaration,
+    )
+
+
+async def upsert_chantier_declaration(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    actor_user_id: str | None,
+    declaration: ChantierDeclaration,
+) -> ChantierDeclareResult:
+    """Idempotently persist a declaration by stable slug or obvious title."""
+
+    service = AsyncDomainService(session)
+    domain = next(
+        (item for item in await service.list_domains(org_id) if item.slug == TRACKER_DOMAIN_SLUG),
+        None,
+    )
+    if domain is None:
+        raise DomainNotFound(f"Domain '{TRACKER_DOMAIN_SLUG}' not found")
+
+    # Serialize the application-level slug/title upsert.  The chantier schema
+    # predates this flow and intentionally has no new database constraint, so a
+    # lock on its object type is the migration-free concurrency boundary.
+    await service.get_object_type(domain.id, CHANTIER_OBJECT_KEY, for_update=True)
+    records = await service.list_records(
+        org_id,
+        domain.id,
+        object_key=CHANTIER_OBJECT_KEY,
+        limit=500,
+        order="updated_asc",
+    )
+    existing = _matching_record(records, declaration)
+    reason = "Slack chantier declaration"
+
+    if existing is None:
+        data: dict[str, Any] = {
+            "slug": declaration.slug,
+            "title": declaration.title,
+            "goal": declaration.goal,
+            "kind": declaration.kind,
+            "state": "exploring",
+            "refs": [dict(item) for item in declaration.refs],
+            "next_step": declaration.next_step or MISSING_NEXT_STEP,
+        }
+        if declaration.owner:
+            data["owner"] = declaration.owner
+        record = await service.create_record(
+            org_id,
+            domain.id,
+            CHANTIER_OBJECT_KEY,
+            data=data,
+            actor_id=actor_user_id,
+            actor_kind="human",
+            reason=reason,
+        )
+        operation = "created"
+    else:
+        current = dict(existing.data or {})
+        patch: dict[str, Any] = {
+            "title": declaration.title,
+            "refs": _merge_refs(current.get("refs"), declaration.refs),
+        }
+        if declaration.goal_is_explicit or not current.get("goal"):
+            patch["goal"] = declaration.goal
+        if declaration.kind_is_explicit or not current.get("kind"):
+            patch["kind"] = declaration.kind
+        if declaration.owner:
+            patch["owner"] = declaration.owner
+        if declaration.next_step:
+            patch["next_step"] = declaration.next_step
+        record = await service.update_record(
+            org_id,
+            domain.id,
+            existing.id,
+            data_patch=patch,
+            expected_version=existing.version,
+            actor_id=actor_user_id,
+            actor_kind="human",
+            reason=reason,
+        )
+        operation = "updated"
+
+    persisted = dict(record.data or {})
+    next_step = str(persisted.get("next_step") or "").strip()
+    owner = str(persisted.get("owner") or "").strip()
+    parent_issue = str(persisted.get("parent_issue") or "").strip()
+    engineering = str(persisted.get("kind") or declaration.kind) != "gtm"
+    if parent_issue:
+        mirror_status = "linked"
+    elif engineering:
+        # The #328 native sub-issue interface is registered in the same run
+        # tool surface as create_github_issue.  The run completes this external
+        # write so token/repo selection stays in the audited GitHub tool lane.
+        mirror_status = "ready"
+    else:
+        mirror_status = "not_required"
+    return ChantierDeclareResult(
+        operation=operation,
+        domain_id=domain.id,
+        record_id=record.id,
+        version=record.version,
+        data=persisted,
+        goal_was_inferred=not declaration.goal_is_explicit,
+        kind_was_guessed=not declaration.kind_is_explicit,
+        needs_next_step=not next_step or next_step == MISSING_NEXT_STEP,
+        owner_suggestion=owner or "builder TBD",
+        mirror_status=mirror_status,
+        mirror_repo_suggestion=declaration.mirror_repo_suggestion,
+    )
+
+
+def apply_chantier_declare_run_contract(
+    trigger_payload: dict[str, Any],
+    *,
+    result: ChantierDeclareResult | None = None,
+    error: str | None = None,
+) -> None:
+    """Make the normal Slack run finish the declaration in the same thread."""
+
+    payload = dict(trigger_payload.get("payload") or {})
+    metadata = dict(payload.get("metadata") or {})
+    slack_trigger = dict(metadata.get("slack_trigger") or {})
+    response_target = dict(slack_trigger.get("response_target") or {})
+    response_target["thread_ts"] = str(
+        slack_trigger.get("thread_ts") or slack_trigger.get("message_ts") or ""
+    ).strip() or None
+    slack_trigger["response_target"] = response_target
+    metadata["slack_trigger"] = slack_trigger
+
+    base_message = str(payload.get("run_message") or "").strip()
+    if result is not None:
+        metadata["chantier_declare"] = result.as_metadata()
+        run_message = _successful_declare_run_message(base_message, result)
+    else:
+        clean_error = str(error or "unknown persistence error").strip()
+        metadata["chantier_declare"] = {"operation": "failed", "error": clean_error}
+        run_message = _failed_declare_run_message(base_message, clean_error)
+    trigger_payload["payload"] = {
+        **payload,
+        "metadata": metadata,
+        "run_message": run_message,
+    }
+
+
+def _successful_declare_run_message(
+    base_message: str,
+    result: ChantierDeclareResult,
+) -> str:
+    data = result.data
+    mirror_lines: list[str]
+    if result.mirror_status == "ready":
+        repo_hint = result.mirror_repo_suggestion or "none; infer from explicit team/repo context"
+        mirror_lines = [
+            "This is an engineering chantier with no parent_issue yet.",
+            f"Attempt the parent mirror with {GITHUB_PARENT_MIRROR_TOOL}; repo hint: {repo_hint}.",
+            (
+                "First search open and closed issues in the target repo for the exact chantier slug "
+                "or '[Chantier] <title>'; link an existing match instead of creating a duplicate."
+            ),
+            "Use title '[Chantier] <title>' and include the slug, Done-means goal, and key refs.",
+            (
+                "On success, update this same Domain record's parent_issue with expected_version, "
+                f"then attach pasted GitHub issue refs with {GITHUB_SUB_ISSUE_TOOL}."
+            ),
+            (
+                "If repo/token/tooling is unavailable, do not undo or fail the declaration; say "
+                "'mirror pending: <specific reason>' in the Slack confirmation."
+            ),
+        ]
+    elif result.mirror_status == "linked":
+        mirror_lines = [
+            f"The parent mirror already exists as {data.get('parent_issue')}; never create it again."
+        ]
+    else:
+        mirror_lines = ["This non-engineering chantier does not require a GitHub parent mirror."]
+
+    follow_up = (
+        "Ask the teammate for `next_step` because none could be inferred."
+        if result.needs_next_step
+        else f"Echo next_step: {data.get('next_step')}"
+    )
+    instructions = [
+        "A Slack chantier declaration has already been persisted deterministically.",
+        "Do not create another chantier record and do not change its stable slug.",
+        (
+            f"Persistence result: {result.operation} Domain {result.domain_id} "
+            f"record {result.record_id} v{result.version}."
+        ),
+        f"Slug: {data.get('slug')}",
+        f"Title: {data.get('title')}",
+        f"Goal: {data.get('goal')}",
+        f"Kind {'guess' if result.kind_was_guessed else 'explicit'}: {data.get('kind')}",
+        f"Owner suggestion (builder-first): {result.owner_suggestion}",
+        (
+            "If the owner suggestion is builder TBD, use current explicit issue/PR ownership evidence "
+            "to suggest the likely implementation builder; never delay or undo the declare for this."
+        ),
+        *mirror_lines,
+        (
+            "Reply with post_slack_reply in the declaration thread. State created/updated, slug, "
+            "goal, kind guess/explicit kind, builder-first owner suggestion, mirror outcome, and next_step."
+        ),
+        follow_up,
+        "Never claim a GitHub mirror was opened unless create_github_issue returned its issue number and URL.",
+        "",
+        "Persisted declaration JSON:",
+        json.dumps(result.as_metadata(), default=str, sort_keys=True),
+        "",
+        base_message,
+    ]
+    return "\n".join(instructions).strip()
+
+
+def _failed_declare_run_message(base_message: str, error: str) -> str:
+    return "\n".join(
+        [
+            "A Slack message used the explicit chantier declaration door, but persistence failed.",
+            "Do not claim that a chantier or GitHub mirror was created.",
+            f"Failure: {error}",
+            (
+                "Reply with post_slack_reply in the declaration thread and say "
+                f"'chantier declare failed: {error}'."
+            ),
+            "",
+            base_message,
+        ]
+    ).strip()
+
+
+def _matching_record(
+    records: Sequence[DomainRecord],
+    declaration: ChantierDeclaration,
+) -> DomainRecord | None:
+    incoming_title = _title_key(declaration.title)
+    for record in sorted(records, key=lambda item: item.id):
+        data = dict(record.data or {})
+        if str(data.get("slug") or "").casefold() == declaration.slug.casefold():
+            return record
+        stored_title = str(data.get("title") or record.title or "")
+        if _title_key(stored_title) == incoming_title:
+            return record
+        if _slugify(stored_title) == declaration.slug:
+            return record
+    return None
+
+
+def _merge_refs(existing: Any, incoming: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
+    merged: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    candidates = list(existing) if isinstance(existing, list) else []
+    candidates.extend(incoming)
+    for item in candidates:
+        if not isinstance(item, Mapping):
+            continue
+        source = str(item.get("source") or "").strip()
+        ref = str(item.get("ref") or "").strip()
+        key = (source, ref)
+        if not source or not ref or key in seen:
+            continue
+        clean = {"source": source, "ref": ref}
+        title = str(item.get("title") or "").strip()
+        if title:
+            clean["title"] = title
+        merged.append(clean)
+        seen.add(key)
+    return merged
+
+
+def _refs_from_urls(urls: Sequence[str]) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for url in urls:
+        github = _GITHUB_ISSUE_URL_RE.match(url)
+        if github:
+            repo = f"{github.group('owner')}/{github.group('repo')}"
+            number = github.group("number")
+            item = {
+                "source": "github",
+                "ref": f"github:{repo}:issue:{number}",
+                "title": f"GitHub issue {repo}#{number}",
+            }
+        elif ".slack.com/archives/" in url.casefold():
+            item = {"source": "slack", "ref": url}
+        else:
+            item = {"source": "url", "ref": url}
+        key = (item["source"], item["ref"])
+        if key not in seen:
+            refs.append(item)
+            seen.add(key)
+    return refs
+
+
+def _first_github_repo(urls: Sequence[str]) -> str | None:
+    for url in urls:
+        match = _GITHUB_ISSUE_URL_RE.match(url)
+        if match:
+            return f"{match.group('owner')}/{match.group('repo')}"
+    return None
+
+
+def _extract_labeled_value(pattern: re.Pattern[str], text: str) -> tuple[str | None, str]:
+    match = pattern.search(text)
+    if match is None:
+        return None, text
+    value = str(match.group("value") or "").strip(" \t,;–—-")
+    return value or None, _remove_match(text, match)
+
+
+def _remove_match(text: str, match: re.Match[str]) -> str:
+    return f"{text[:match.start()]} {text[match.end():]}"
+
+
+def _done_means_goal(value: str) -> str:
+    clean = _compact_spaces(value).strip(" \t,;–—-")
+    match = _DONE_MEANS_RE.match(clean)
+    if match:
+        clean = clean[match.end() :].strip()
+    return f"Done means {clean}" if clean else ""
+
+
+def _clean_title(value: str) -> str:
+    return _compact_spaces(value).strip(" \t,;:–—-")
+
+
+def _compact_spaces(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _clean_optional(value: str | None, *, limit: int, one_line: bool = False) -> str | None:
+    if value is None:
+        return None
+    clean = _compact_spaces(value) if one_line else str(value).strip()
+    return clean[:limit].rstrip() or None
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value or "").casefold()).strip("-")
+    return re.sub(r"-+", "-", slug)[:80].rstrip("-")
+
+
+def _title_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold()).strip()
+
+
+def _guess_kind(value: str) -> str:
+    words = _title_key(value)
+    if any(token in words for token in ("incident", "outage", "rollback", "hotfix", "sev ")):
+        return "incident"
+    if any(
+        token in words
+        for token in (
+            "hardening",
+            "quality",
+            "reliability",
+            "security",
+            "test ",
+            "testing",
+            "performance",
+            "alert",
+        )
+    ):
+        return "quality"
+    if any(token in words for token in ("marketing", "campaign", "sales", "seo", "growth")):
+        return "gtm"
+    return "feature"
+
+
+def _trim_url(value: str) -> str:
+    return str(value or "").rstrip(".,;:!?]}")
+
+
+__all__ = [
+    "CHANTIER_OBJECT_KEY",
+    "GITHUB_PARENT_MIRROR_TOOL",
+    "GITHUB_SUB_ISSUE_TOOL",
+    "MISSING_NEXT_STEP",
+    "TRACKER_DOMAIN_SLUG",
+    "ChantierDeclaration",
+    "ChantierDeclareResult",
+    "apply_chantier_declare_run_contract",
+    "maybe_declare_chantier_from_slack",
+    "parse_chantier_declaration",
+    "upsert_chantier_declaration",
+]

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -12,10 +12,16 @@ from brain.platform.db.models.org import User
 from brain.systems.inbound.service import _clean_optional, _complete_event
 from brain.systems.inbound.status import STATUS_FAILED, STATUS_PROCESSED
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.slack.chantier_declare import (
+    ChantierDeclareResult,
+    apply_chantier_declare_run_contract,
+    maybe_declare_chantier_from_slack,
+)
 from brain.systems.slack.triggers import (
     SLACK_MESSAGE_ENVELOPE_KIND,
     build_slack_work_intake_payload,
 )
+from brain.systems.user_domains.service import DomainError, DomainNotFound
 
 ACTION_SLACK_RUN_ADMITTED = "slack.run_admitted"
 
@@ -50,6 +56,21 @@ async def process_slack_message_envelope(
         )
 
     slack_payload = dict(normalized.get("payload") or {})
+    chantier_declare: ChantierDeclareResult | None = None
+    chantier_declare_error: str | None = None
+    try:
+        chantier_declare = await maybe_declare_chantier_from_slack(
+            session,
+            org_id=str(context.org_id),
+            actor_user_id=authority_user_id,
+            origin=str(normalized.get("origin") or ""),
+            text=str(slack_payload.get("text") or ""),
+        )
+    except (DomainError, DomainNotFound) as exc:
+        # Missing/mismatched Domain-1 configuration must be visible in the
+        # declaration thread, but it must not take down the normal Slack lane.
+        chantier_declare_error = str(exc)
+
     slack_thread_id = _slack_conversation_thread_id(slack_payload)
     trigger_payload = build_slack_work_intake_payload(
         org_id=context.org_id,
@@ -59,6 +80,12 @@ async def process_slack_message_envelope(
         connection_id=context.connection_id,
         idempotency_key=_clean_optional(normalized.get("idempotency_key")),
     )
+    if chantier_declare is not None or chantier_declare_error is not None:
+        apply_chantier_declare_run_contract(
+            trigger_payload,
+            result=chantier_declare,
+            error=chantier_declare_error,
+        )
     trigger_metadata = dict((trigger_payload.get("payload") or {}).get("metadata") or {})
     trigger_metadata["slack_thread_id"] = slack_thread_id
     trigger_payload["payload"] = {

--- a/docs/331-live-delta.md
+++ b/docs/331-live-delta.md
@@ -1,0 +1,53 @@
+# Issue #331 deploy note — chantier declare activation
+
+This branch intentionally performs no live Slack, GitHub, or Domain write.
+Deployment activates the code first, then updates the already-created on-demand
+playbook mirror and runs the disposable Slack acceptance below.
+
+## 1. Update the live on-demand playbook
+
+Read Enterprise Documentation Domain `37`, `doc_page` record `1274`, and verify
+its slug is `uwear-engineering-triage-chantier-operations`. Update only its
+`content` field, using the just-read `expected_version`, to the exact UTF-8
+contents of:
+
+`brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md`
+
+Expected content fingerprint:
+
+- characters: `11557`;
+- bytes: `11565`; and
+- SHA-256: `61e78f92198db86916c5ebe753244fb862cb529a7295ec5a89df4d962efa9751`.
+
+Read record `1274` back and require byte identity. Do not overwrite a newer
+unreconciled live edit. Domain `1` already has the chantier schema from #327;
+this issue has no Alembic migration or other schema activation.
+
+## 2. illo-dev Slack acceptance
+
+Use a unique disposable slug, for example
+`qa-declare-<UTC-YYYYMMDD-HHMM>`, in a channel where the illo-dev Slack app is
+present.
+
+1. Mention Illo with
+   `@Illo chantier: <unique-slug> — done means declare QA has one record and one threaded confirmation kind: quality owner: <reviewer>`.
+2. Require one reply in that message's thread. It must say `created` and echo
+   the exact slug, Done-means goal, kind, builder-first owner suggestion, ask
+   for `next_step`, and either cite the created GitHub parent issue or say
+   `mirror pending: <specific reason>`.
+3. Query Domain `1` `chantier` records for the exact slug. Require exactly one
+   active record with state `exploring`, the echoed fields, and the placeholder
+   `Clarify the next most valuable step.`
+4. Re-mention Illo with the same slug/title but a changed goal and
+   `next_step: archive the disposable QA record after verification`. Require an
+   `updated` threaded reply. Query again: still exactly one record, the same
+   record id, a higher version, and the changed goal/next step.
+5. Send an ordinary Illo mention without the keyword, for example
+   `@Illo please summarize declare QA; do not create work`. Require no new
+   chantier record; the unique-slug query still returns exactly one.
+6. If a parent mirror was created, require `parent_issue` to contain its exact
+   external id and verify re-declaration did not create a second parent. If the
+   declaration included pasted GitHub issue links, verify they are native
+   sub-issues of that parent.
+7. Archive the disposable Domain record and close the disposable GitHub mirror,
+   if one was created, after recording the evidence.

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -53,7 +53,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.5.0"
+    assert bundle.manifest.version == "1.6.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -103,7 +103,11 @@ def test_uwear_triage_bundle_packages_chantier_operations_v2():
         "stated goal or PRD",
         "incident family",
         "Never auto-create a chantier",
-        "Reserved for ticket #331",
+        "ordinary mention without the `chantier` keyword",
+        "second record",
+        "builder-first owner suggestion",
+        "`mirror pending tooling`",
+        "add_github_sub_issue",
     ):
         assert expected in playbook
 
@@ -143,16 +147,18 @@ def test_uwear_triage_live_delta_fingerprints_exact_bundle_mirrors():
     from brain.systems.skills.bundles import load_skill_bundle
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
-    note = (Path(__file__).parents[1] / "docs" / "329-live-delta.md").read_text()
+    core_note = (Path(__file__).parents[1] / "docs" / "329-live-delta.md").read_text()
+    declare_note = (Path(__file__).parents[1] / "docs" / "331-live-delta.md").read_text()
     mirrors = (
-        (bundle.skill_markdown, "v8"),
+        (bundle.skill_markdown, "v8", core_note),
         (
             _uwear_triage_asset(bundle, "references/chantier-operations.md"),
-            "content",
+            "declare content",
+            declare_note,
         ),
     )
 
-    for content, label in mirrors:
+    for content, label, note in mirrors:
         encoded = content.encode("utf-8")
         fingerprint = hashlib.sha256(encoded).hexdigest()
         assert f"characters: `{len(content)}`" in note, label

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -311,6 +311,230 @@ def _chantier_record_data() -> dict:
     }
 
 
+def test_slack_chantier_declaration_parses_mechanical_contract():
+    from brain.systems.slack.chantier_declare import parse_chantier_declaration
+
+    declaration = parse_chantier_declaration(
+        "<@BILLO> chantier: clothing-intake hardening — "
+        "done means zero pool alerts for a week kind: quality owner: Axel "
+        "next_step: verify prod for seven days "
+        "https://github.com/Illospace/illospace/issues/331 https://example.com/spec"
+    )
+
+    assert declaration is not None
+    assert declaration.slug == "clothing-intake-hardening"
+    assert declaration.title == "clothing-intake hardening"
+    assert declaration.goal == "Done means zero pool alerts for a week"
+    assert declaration.kind == "quality"
+    assert declaration.kind_is_explicit is True
+    assert declaration.owner == "Axel"
+    assert declaration.next_step == "verify prod for seven days"
+    assert declaration.mirror_repo_suggestion == "Illospace/illospace"
+    assert declaration.refs == (
+        {
+            "source": "github",
+            "ref": "github:Illospace/illospace:issue:331",
+            "title": "GitHub issue Illospace/illospace#331",
+        },
+        {"source": "url", "ref": "https://example.com/spec"},
+    )
+    assert parse_chantier_declaration("<@BILLO> what chantier are active?") is None
+
+
+async def test_slack_chantier_duplicate_declare_updates_one_record(session):
+    from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+
+    created = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text=(
+            "<@BILLO> chantier: clothing-intake hardening — "
+            "done means zero pool alerts for a week "
+            "https://github.com/Illospace/illospace/issues/331"
+        ),
+    )
+    updated = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text=(
+            "<@BILLO> chantier: Clothing intake hardening — "
+            "done means no pool alerts for fourteen days kind: incident owner: Axel "
+            "next_step: watch the production pool through Friday "
+            "https://example.com/runbook"
+        ),
+    )
+
+    records = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="chantier",
+    )
+    assert created is not None and created.operation == "created"
+    assert created.needs_next_step is True
+    assert updated is not None and updated.operation == "updated"
+    assert updated.record_id == created.record_id
+    assert updated.version == 2
+    assert updated.needs_next_step is False
+    assert len(records) == 1
+    assert records[0].data["slug"] == "clothing-intake-hardening"
+    assert records[0].data["goal"] == "Done means no pool alerts for fourteen days"
+    assert records[0].data["kind"] == "incident"
+    assert records[0].data["owner"] == "Axel"
+    assert records[0].data["next_step"] == "watch the production pool through Friday"
+    assert records[0].data["refs"] == [
+        {
+            "source": "github",
+            "ref": "github:Illospace/illospace:issue:331",
+            "title": "GitHub issue Illospace/illospace#331",
+        },
+        {"source": "url", "ref": "https://example.com/runbook"},
+    ]
+
+
+async def test_slack_chantier_declare_matches_obvious_title_and_reuses_parent_mirror(session):
+    from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    existing = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=_chantier_record_data(),
+    )
+
+    result = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text=(
+            "<@BILLO> chantier: Agent runtime chantier layer — "
+            "done means every member arrives with the same outcome context"
+        ),
+    )
+
+    records = await service.list_records(ORG_ID, domain.id, object_key="chantier")
+    assert result is not None and result.operation == "updated"
+    assert result.record_id == existing.id
+    assert result.data["slug"] == "agent-runtime-keystone"
+    assert result.mirror_status == "linked"
+    assert result.data["parent_issue"] == "github:Illospace/illospace:issue:326"
+    assert [record.id for record in records] == [existing.id]
+
+
+async def test_slack_chantier_router_does_not_create_without_keyword(session):
+    from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+
+    ordinary_mention = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text="<@BILLO> please harden clothing intake until pool alerts stay at zero",
+    )
+    dm_with_keyword = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.direct_message",
+        text="chantier: clothing intake hardening — done means no pool alerts",
+    )
+
+    records = await service.list_records(
+        ORG_ID,
+        domain.id,
+        object_key="chantier",
+    )
+    assert ordinary_mention is None
+    assert dm_with_keyword is None
+    assert records == []
+
+
+async def test_slack_chantier_declare_run_contract_requires_threaded_echo_and_mirror(session):
+    from brain.systems.slack.chantier_declare import (
+        apply_chantier_declare_run_contract,
+        maybe_declare_chantier_from_slack,
+    )
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    service = AsyncDomainService(session)
+    await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    result = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text=(
+            "<@BILLO> chantier: clothing-intake hardening — "
+            "done means zero pool alerts for a week"
+        ),
+    )
+    assert result is not None
+    trigger = build_slack_work_intake_payload(
+        org_id=ORG_ID,
+        authority_user_id=USER_ID,
+        payload={
+            "origin": "slack.app_mention",
+            "team_id": "T789",
+            "channel_id": "C456",
+            "channel_type": "channel",
+            "message_ts": "1716900000.000100",
+            "thread_ts": "1716900000.000100",
+            "slack_user_id": "U123",
+            "text": "<@BILLO> chantier: clothing-intake hardening",
+        },
+    )
+
+    apply_chantier_declare_run_contract(trigger, result=result)
+    request = await build_agent_run_request(
+        object(),
+        WorkIntakeEvent.from_trigger_payload(trigger),
+    )
+
+    metadata = trigger["payload"]["metadata"]
+    run_message = trigger["payload"]["run_message"]
+    assert metadata["slack_trigger"]["response_target"]["thread_ts"] == "1716900000.000100"
+    assert request.target_ref["slack_trigger"]["response_target"]["thread_ts"] == "1716900000.000100"
+    assert metadata["chantier_declare"]["record_id"] == result.record_id
+    assert "Reply with post_slack_reply in the declaration thread" in run_message
+    assert "create_github_issue" in run_message
+    assert "add_github_sub_issue" in run_message
+    assert "mirror pending: <specific reason>" in run_message
+    assert "Ask the teammate for `next_step`" in run_message
+
+
 async def _insert_legacy_pr_record(
     session,
     service: AsyncDomainService,


### PR DESCRIPTION
Closes #331 — part of the chantier-layer umbrella #326. Its blockers merged since it was filed: the playbook file (#329) and the sub-issue tooling (#328) are both on `main` now.

## What this does
The **declare door**: an `@Illo` app-mention containing `chantier:` creates or updates a Domain-1 chantier and echoes a threaded confirmation.

- **Gated**: requires the explicit `chantier` keyword + colon door **and** `slack.app_mention` origin. Plain mentions and DMs never create a record (no inference-based auto-create). New declare code lives in `brain/systems/slack/chantier_declare.py`, wired minimally into the existing mention lane in `inbound.py`.
- **Idempotent**: re-declaring an existing slug (or an obvious title match) **updates** the record via `expected_version` and says `updated` — never a duplicate.
- **Confirmation echo**: slug, goal, kind guess, builder-first owner suggestion, and a `next_step` request when none can be inferred. New chantiers start `exploring`.
- **Loud degradation**: engineering chantiers (`feature`/`incident`/`quality`) get GitHub parent/sub-issue mirror instructions; if the mirror can't run it degrades loudly (`mirror pending: <reason>`) without failing the declare. Domain-config errors surface in-thread but never take down the normal Slack lane.
- Declare section added to the `chantier-operations.md` playbook.

## ⚠️ Merge-order note (skill.toml collision with PR #351 / #344)
This PR and [#351](https://github.com/Illospace/illospace/pull/351) both bump `skill.toml` 1.5.0 → 1.6.0 and both touch `test_builtin_skill_suite.py` + the same bundle. **Whichever merges second will conflict** — rebase it on `main` and re-bump to 1.7.0 (+ its asset entry). Not a code problem, just ordering.

## Tests
- Targeted + architecture suite: **122 passed** — parsing, duplicate-update, obvious-title match, mirror reuse, threaded echo, and the **no-keyword / no-DM** regression (`test_domains_service.py` +224 lines, `test_builtin_skill_suite.py`). `py_compile` + `git diff --check` clean. No migration.
- Full fast suite in-sandbox: 3,744 passed / 9 failed / 5 errored — the failures are **environmental** (sandbox forbids local socket binding; broken external PyTorch install), unrelated to Slack-declare logic. CI is the authoritative gate.

## illo-dev acceptance (human, at deploy — runbook `docs/331-live-delta.md`)
1. Deploy + update Domain-37 record 1274 from the bundled playbook (verify fingerprint in the runbook).
2. `@Illo chantier: qa-declare-<ts> — done means … kind: quality owner: <reviewer>` → one threaded reply `created` with slug/goal/kind/owner/`next_step` request + mirror status. Domain-1 has exactly one `exploring` record for the slug.
3. Re-declare same slug, changed goal → `updated`, **same record ID**, higher version (no duplicate).
4. Ordinary mention **without** `chantier` → no new record.

Eyeball target for Reda: the threaded confirmation wording + owner-suggestion behavior — is this the declare UX you want? (Full kick-off protocol is the 2026-07-17 roadmap-meeting decision; this is the minimal mechanical contract, refinement follow-up expected.)

🤖 draft opened by R3 (Codex-implemented, director-reviewed). Do not merge until the illo-dev declare/dup/no-keyword gates pass + the skill.toml merge-order is resolved.
