### PR TITLE
[Illo-QA] Remove blind post-run auto-encoding + archive backlog (#345)

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1898,7 +1898,7 @@ async def run_agent_async(
                 logger.warning("Unknown stop_reason: %s", response.stop_reason)
                 break
 
-        # Post-loop: harvest, auto-encode, save, return
+        # Post-loop: harvest, save, return
         output = _extract_text(state.messages)
         staged_reply_contents = [
             str(content or "").strip()

--- a/brain/systems/runs/direct_loop/session_effects.py
+++ b/brain/systems/runs/direct_loop/session_effects.py
@@ -37,75 +37,6 @@ async def async_memory_org_for_user(user_id: str | None, org_id: str | None = No
         return None
 
 
-def _auto_encode_if_needed(
-    tool_calls_made: list[str],
-    output: str,
-    session_id: str,
-    *,
-    user_id: str | None = None,
-    org_id: str | None = None,
-    idea_id: str | None = None,
-    run_id: int | None = None,
-) -> None:
-    """Auto-encode an episode if the agent acted but never called brain_encode."""
-    del user_id, org_id, idea_id, run_id
-
-    if "brain_encode" in tool_calls_made:
-        return
-    if not any(t in tool_calls_made for t in ("write_file", "edit_file", "exec_command")):
-        return
-    if not output or len(output) <= 50:
-        return
-    logger.debug("Auto-encode skipped in sync runtime; await async_auto_encode_if_needed for persistence")
-
-
-async def async_auto_encode_if_needed(
-    tool_calls_made: list[str],
-    output: str,
-    session_id: str,
-    *,
-    user_id: str | None = None,
-    org_id: str | None = None,
-    idea_id: str | None = None,
-    run_id: int | None = None,
-) -> None:
-    """Auto-encode an episode using native async memory writes."""
-
-    if "brain_encode" in tool_calls_made:
-        return
-    if not any(t in tool_calls_made for t in ("write_file", "edit_file", "exec_command")):
-        return
-    if not output or len(output) <= 50:
-        return
-    if not user_id:
-        logger.debug("Auto-encode skipped: missing user context")
-        return
-    try:
-        from brain.app.cli.memory import add_memory
-        from brain.platform.db.repositories.memory_write_context import MemoryWriteContext
-
-        resolved_org_id = await async_memory_org_for_user(user_id, org_id)
-        write_context = MemoryWriteContext(
-            user_id=user_id,
-            org_id=resolved_org_id,
-            visibility="org" if resolved_org_id else "private",
-            source="agent_auto_encode",
-            session_id=session_id,
-            idea_id=idea_id,
-            run_id=run_id,
-            confidence=0.45,
-            evidence={"auto_encode": True, "tool_calls": tool_calls_made[-8:]},
-        )
-        await add_memory(
-            content=f"[auto-encoded] {output[:300]}",
-            memory_type="episode", salience=4.0,
-            source="agent_auto_encode", tags=["auto_encoded", session_id[:20]],
-            write_context=write_context,
-        )
-    except Exception as exc:
-        logger.debug("Auto-encode failed: %s", exc)
-
-
 def apply_agent_session_side_effects(
     *,
     session_id: str,
@@ -122,31 +53,19 @@ def apply_agent_session_side_effects(
     skip_harvest: bool = False,
     persist_session: bool = True,
     memory_org_for_user: Callable[..., str | None] | None = None,
-    auto_encode_if_needed: Callable[..., None] | None = None,
     harvest_session: Callable[..., None] | None = None,
     save_session: Callable[..., None] | None = None,
 ) -> str | None:
-    """Run post-loop auto-encode, harvest, and session persistence effects."""
+    """Run post-loop harvest and session persistence effects."""
 
     metadata = metadata or {}
     memory_org_for_user = memory_org_for_user or _memory_org_for_user
-    auto_encode_if_needed = auto_encode_if_needed or _auto_encode_if_needed
     save_session = save_session or _save_session
 
     effective_org_id = (
         getattr(agent_context, "org_id", None)
         or metadata.get("org_id")
         or memory_org_for_user(user_id)
-    )
-
-    auto_encode_if_needed(
-        tool_calls_made,
-        output,
-        session_id,
-        user_id=user_id,
-        org_id=effective_org_id,
-        idea_id=idea_id,
-        run_id=run_id,
     )
 
     if not skip_harvest and harvest_session is not None:
@@ -186,15 +105,13 @@ async def async_apply_agent_session_side_effects(
     skip_harvest: bool = False,
     persist_session: bool = True,
     memory_org_for_user: Callable[..., Any] | None = None,
-    auto_encode_if_needed: Callable[..., Any] | None = None,
     harvest_session: Callable[..., Any] | None = None,
     save_session: Callable[..., Any] | None = None,
 ) -> str | None:
-    """Run post-loop auto-encode, harvest, and session persistence effects asynchronously."""
+    """Run post-loop harvest and session persistence effects asynchronously."""
 
     metadata = metadata or {}
     memory_org_for_user = memory_org_for_user or async_memory_org_for_user
-    auto_encode_if_needed = auto_encode_if_needed or async_auto_encode_if_needed
     harvest_session = harvest_session or _harvest_session
     save_session = save_session or async_save_session
 
@@ -203,16 +120,6 @@ async def async_apply_agent_session_side_effects(
         or metadata.get("org_id")
         or await _maybe_await(memory_org_for_user(user_id))
     )
-
-    await _maybe_await(auto_encode_if_needed(
-        tool_calls_made,
-        output,
-        session_id,
-        user_id=user_id,
-        org_id=effective_org_id,
-        idea_id=idea_id,
-        run_id=run_id,
-    ))
 
     if not skip_harvest:
         await _maybe_await(harvest_session(

--- a/brain/systems/sessions/harvest.py
+++ b/brain/systems/sessions/harvest.py
@@ -25,8 +25,7 @@ async def _harvest_session(
     Runs the active LLM-based harvest extraction, stores each item as an
     episodic memory, and links extracted topics to project narratives.
 
-    This is an additive step alongside auto-encode — harvest failure never
-    breaks the session close path.
+    Harvest failure never breaks the session close path.
     """
     try:
         from brain.systems.memory.harvest import extract_harvest_items

--- a/scripts/archive_auto_encoded_memories.py
+++ b/scripts/archive_auto_encoded_memories.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Archive legacy post-run auto-encoded memory exhaust.
+
+The default mode is a dry run. Pass ``--apply`` to soft-archive matching
+content nodes and cue/tag nodes that are not shared with active durable
+content. Sources, spans, assertions, embeddings, and graph edges are retained
+for provenance. Apply mode locks the selected nodes for the transaction and
+must run while memory writers are paused.
+
+Usage:
+    venv/bin/python scripts/archive_auto_encoded_memories.py
+    venv/bin/python scripts/archive_auto_encoded_memories.py \
+        --apply --confirm-writers-paused
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.platform.db.repositories.reconstructive_memory import (
+    ReconstructiveMemoryCompatibilityRepository,
+)
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+AUTO_ENCODED_PREFIX = "[auto-encoded]"
+CONTENT_BEARING_NODE_KINDS = ("content", "summary", "procedure", "policy")
+
+
+@dataclass(frozen=True)
+class ArchivePlan:
+    """Active memory nodes selected for one atomic archive operation."""
+
+    content_node_ids: tuple[int, ...] = ()
+    orphaned_cue_node_ids: tuple[int, ...] = ()
+    orphaned_tag_node_ids: tuple[int, ...] = ()
+
+    @property
+    def node_ids(self) -> tuple[int, ...]:
+        return (
+            *self.content_node_ids,
+            *self.orphaned_cue_node_ids,
+            *self.orphaned_tag_node_ids,
+        )
+
+    def report(self, *, applied: bool) -> dict[str, int | bool]:
+        total = len(self.node_ids)
+        return {
+            "applied": applied,
+            "archived": total if applied else 0,
+            "would_archive": 0 if applied else total,
+            "content_nodes": len(self.content_node_ids),
+            "orphaned_cue_nodes": len(self.orphaned_cue_node_ids),
+            "orphaned_tag_nodes": len(self.orphaned_tag_node_ids),
+        }
+
+
+async def _active_auto_encoded_content_ids(
+    session: AsyncSession,
+    *,
+    lock: bool,
+) -> tuple[int, ...]:
+    statement = (
+        select(MemoryNode.id)
+        .where(MemoryNode.node_kind == "content")
+        .where(MemoryNode.archived_at.is_(None))
+        .where(MemoryNode.text.startswith(AUTO_ENCODED_PREFIX, autoescape=True))
+        .order_by(MemoryNode.id)
+    )
+    if lock:
+        statement = statement.with_for_update(of=MemoryNode)
+    ids = await session.scalars(statement)
+    return tuple(int(node_id) for node_id in ids)
+
+
+async def _active_route_node_ids(
+    session: AsyncSession,
+    *,
+    content_node_ids: tuple[int, ...],
+    node_kind: str,
+    lock: bool,
+) -> tuple[int, ...]:
+    if node_kind == "tag":
+        route_join = MemoryEdgeNode.source_node_id == MemoryNode.id
+        content_edge = MemoryEdgeNode.target_node_id.in_(content_node_ids)
+        edge_kind = "tag_to_content"
+    elif node_kind == "cue":
+        route_join = MemoryEdgeNode.target_node_id == MemoryNode.id
+        content_edge = MemoryEdgeNode.source_node_id.in_(content_node_ids)
+        edge_kind = "content_to_cue"
+    else:  # pragma: no cover - private caller controls the supported kinds
+        raise ValueError(f"Unsupported route node kind: {node_kind}")
+
+    statement = (
+        select(MemoryNode.id)
+        .join(MemoryEdgeNode, route_join)
+        .where(MemoryNode.node_kind == node_kind)
+        .where(MemoryNode.archived_at.is_(None))
+        .where(MemoryEdgeNode.edge_kind == edge_kind)
+        .where(content_edge)
+        .order_by(MemoryNode.id)
+    )
+    if lock:
+        statement = statement.with_for_update(of=MemoryNode)
+    ids = await session.scalars(statement)
+    return tuple(sorted({int(node_id) for node_id in ids}))
+
+
+async def _route_nodes_shared_with_active_content(
+    session: AsyncSession,
+    *,
+    route_node_ids: tuple[int, ...],
+    archived_content_ids: tuple[int, ...],
+    node_kind: str,
+) -> set[int]:
+    if not route_node_ids:
+        return set()
+
+    if node_kind == "tag":
+        route_id = MemoryEdgeNode.source_node_id
+        content_join = MemoryEdgeNode.target_node_id == MemoryNode.id
+        edge_kind = "tag_to_content"
+    elif node_kind == "cue":
+        route_id = MemoryEdgeNode.target_node_id
+        content_join = MemoryEdgeNode.source_node_id == MemoryNode.id
+        edge_kind = "content_to_cue"
+    else:  # pragma: no cover - private caller controls the supported kinds
+        raise ValueError(f"Unsupported route node kind: {node_kind}")
+
+    ids = await session.scalars(
+        select(route_id)
+        .join(MemoryNode, content_join)
+        .where(route_id.in_(route_node_ids))
+        .where(MemoryEdgeNode.edge_kind == edge_kind)
+        .where(MemoryNode.node_kind.in_(CONTENT_BEARING_NODE_KINDS))
+        .where(MemoryNode.archived_at.is_(None))
+        .where(~MemoryNode.id.in_(archived_content_ids))
+        .distinct()
+    )
+    return {int(node_id) for node_id in ids}
+
+
+async def build_archive_plan(session: AsyncSession, *, lock: bool = False) -> ArchivePlan:
+    """Select active exhaust and route nodes made orphaned by its archive."""
+
+    content_node_ids = await _active_auto_encoded_content_ids(session, lock=lock)
+    if not content_node_ids:
+        return ArchivePlan()
+
+    cue_node_ids = await _active_route_node_ids(
+        session,
+        content_node_ids=content_node_ids,
+        node_kind="cue",
+        lock=lock,
+    )
+    tag_node_ids = await _active_route_node_ids(
+        session,
+        content_node_ids=content_node_ids,
+        node_kind="tag",
+        lock=lock,
+    )
+    shared_cue_ids = await _route_nodes_shared_with_active_content(
+        session,
+        route_node_ids=cue_node_ids,
+        archived_content_ids=content_node_ids,
+        node_kind="cue",
+    )
+    shared_tag_ids = await _route_nodes_shared_with_active_content(
+        session,
+        route_node_ids=tag_node_ids,
+        archived_content_ids=content_node_ids,
+        node_kind="tag",
+    )
+
+    return ArchivePlan(
+        content_node_ids=content_node_ids,
+        orphaned_cue_node_ids=tuple(
+            node_id for node_id in cue_node_ids if node_id not in shared_cue_ids
+        ),
+        orphaned_tag_node_ids=tuple(
+            node_id for node_id in tag_node_ids if node_id not in shared_tag_ids
+        ),
+    )
+
+
+async def archive_auto_encoded_memories(
+    session: AsyncSession,
+    *,
+    apply: bool = False,
+) -> ArchivePlan:
+    """Build the cleanup plan and optionally archive it through ``archive_many``."""
+
+    plan = await build_archive_plan(session, lock=apply)
+    if apply:
+        await ReconstructiveMemoryCompatibilityRepository(session).archive_many(plan.node_ids)
+    return plan
+
+
+async def _run(*, apply: bool) -> ArchivePlan:
+    async with UnitOfWork() as uow:
+        return await archive_auto_encoded_memories(uow.session, apply=apply)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Archive the selected nodes (default: dry run; requires paused writers)",
+    )
+    parser.add_argument(
+        "--confirm-writers-paused",
+        action="store_true",
+        help="Confirm memory-writing workers are paused for the apply transaction",
+    )
+    args = parser.parse_args()
+    if args.apply and not args.confirm_writers_paused:
+        parser.error("--apply requires --confirm-writers-paused")
+    plan = asyncio.run(_run(apply=args.apply))
+    print(json.dumps(plan.report(applied=args.apply), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/architecture-boundary-allowlist.json
+++ b/tests/fixtures/architecture-boundary-allowlist.json
@@ -253,16 +253,6 @@
       "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
     },
     {
-      "source": "brain/systems/runs/direct_loop/session_effects.py",
-      "import": "brain.app.cli.memory",
-      "source_layer": "brain.systems",
-      "target_layer": "brain.app",
-      "allowed_occurrences": 1,
-      "owner": "architecture-boundaries",
-      "planned_removal": "Extract the shared behavior behind the intended lower-layer contract, then remove or lower this allowance.",
-      "reason": "System code reuses app or CLI behavior; move reusable domain behavior into systems."
-    },
-    {
       "source": "brain/systems/runs/event_log.py",
       "import": "brain.app.api.ws.run_events",
       "source_layer": "brain.systems",

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -367,15 +367,12 @@ class TestRuntimeExtractionContracts:
         # Non-repeating calls: no reminder.
         assert _inject_nudges(["read_file:{}", "write_file:{}", "list_files:{}"]) is None
 
-    def test_session_effects_apply_auto_harvest_and_save(self):
+    def test_session_effects_apply_harvest_and_save(self):
         from brain.systems.runs.direct_loop.session_effects import apply_agent_session_side_effects
 
         calls = []
         tokens = SimpleNamespace(input=10, output=5, cache_read=2, cache_creation=1)
         messages = [{"role": "user", "content": "hello"}]
-
-        def auto_encode(tool_calls_made, output, session_id, **kwargs):
-            calls.append(("auto", tool_calls_made, output, session_id, kwargs))
 
         def harvest(session_id, harvested_messages, **kwargs):
             calls.append(("harvest", session_id, harvested_messages, kwargs))
@@ -390,7 +387,7 @@ class TestRuntimeExtractionContracts:
         effective_org_id = apply_agent_session_side_effects(
             session_id="session-1",
             messages=messages,
-            output="A long enough output to be eligible for auto encode if the tools acted.",
+            output="A routine file-change result long enough to exercise session side effects.",
             system_prompt="system",
             tokens=tokens,
             tool_calls_made=["write_file"],
@@ -400,13 +397,11 @@ class TestRuntimeExtractionContracts:
             idea_id="idea-1",
             run_id=42,
             memory_org_for_user=memory_org,
-            auto_encode_if_needed=auto_encode,
             harvest_session=harvest,
             save_session=save,
         )
 
         assert effective_org_id == "org-from-agent-run"
-        assert [call[0] for call in calls] == ["auto", "harvest", "save"]
-        assert calls[0][4]["org_id"] == "org-from-agent-run"
-        assert calls[1][3]["org_id"] == "org-from-agent-run"
-        assert calls[2][4] == (10, 5, 2, 1)
+        assert [call[0] for call in calls] == ["harvest", "save"]
+        assert calls[0][3]["org_id"] == "org-from-agent-run"
+        assert calls[1][4] == (10, 5, 2, 1)

--- a/tests/test_archive_auto_encoded_memories.py
+++ b/tests/test_archive_auto_encoded_memories.py
@@ -1,0 +1,186 @@
+"""Tests for the one-off auto-encoded memory cleanup script."""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+)
+from scripts.archive_auto_encoded_memories import archive_auto_encoded_memories
+
+SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "JSON"
+SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "VARCHAR(36)"
+
+
+def _node(node_kind: str, label: str, *, text: str | None = None) -> MemoryNode:
+    return MemoryNode(
+        node_kind=node_kind,
+        content_kind=(
+            node_kind
+            if node_kind in {"content", "summary", "procedure", "policy"}
+            else None
+        ),
+        canonical_label=label,
+        text=text,
+        normalized_key=label.lower(),
+        scope_key="default",
+        visibility="private",
+    )
+
+
+def _edge(source: MemoryNode, target: MemoryNode, edge_kind: str, span_id: int) -> MemoryEdgeNode:
+    return MemoryEdgeNode(
+        source_node_id=source.id,
+        target_node_id=target.id,
+        edge_kind=edge_kind,
+        visibility="private",
+        evidence_span_ids=[span_id],
+    )
+
+
+async def test_archive_is_safe_idempotent_and_retains_provenance(
+    async_sqlite_session_factory,
+):
+    session = await async_sqlite_session_factory(
+        [
+            MemorySource.__table__,
+            MemorySpan.__table__,
+            MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
+            MemoryEdgeNode.__table__,
+        ]
+    )
+    source = MemorySource(
+        visibility="private",
+        source_kind="agent_auto_encode",
+        source_ref="session-1",
+        content_digest="source-digest",
+        raw_content="[auto-encoded] Routine completion snapshot",
+    )
+    session.add(source)
+    await session.flush()
+    span = MemorySpan(
+        source_id=source.id,
+        text="[auto-encoded] Routine completion snapshot",
+        content_digest="span-digest",
+    )
+    session.add(span)
+    await session.flush()
+
+    exhaust_one = _node(
+        "content",
+        "auto snapshot one",
+        text="[auto-encoded] Routine completion snapshot",
+    )
+    exhaust_two = _node(
+        "content",
+        "auto snapshot two",
+        text="[auto-encoded] Another stale completion snapshot",
+    )
+    durable_content = _node(
+        "content",
+        "durable lesson",
+        text="Learned: validate the source contract before changing it.",
+    )
+    durable_summary = _node(
+        "summary",
+        "durable project summary",
+        text="The current project summary still uses the shared routing nodes.",
+    )
+    orphaned_cue = _node("cue", "routine completion")
+    shared_cue = _node("cue", "source contract")
+    orphaned_tag = _node("tag", "episode")
+    shared_tag = _node("tag", "lesson")
+    session.add_all(
+        [
+            exhaust_one,
+            exhaust_two,
+            durable_content,
+            durable_summary,
+            orphaned_cue,
+            shared_cue,
+            orphaned_tag,
+            shared_tag,
+        ]
+    )
+    await session.flush()
+    assertion = MemoryAssertionNode(
+        node_id=exhaust_one.id,
+        claim_text=exhaust_one.text,
+        source_span_ids=[span.id],
+    )
+    session.add(assertion)
+    session.add_all(
+        [
+            _edge(orphaned_tag, exhaust_one, "tag_to_content", span.id),
+            _edge(shared_tag, exhaust_one, "tag_to_content", span.id),
+            _edge(shared_tag, durable_summary, "tag_to_content", span.id),
+            _edge(exhaust_one, orphaned_cue, "content_to_cue", span.id),
+            _edge(exhaust_one, shared_cue, "content_to_cue", span.id),
+            _edge(durable_summary, shared_cue, "content_to_cue", span.id),
+            _edge(orphaned_cue, orphaned_tag, "cue_to_tag", span.id),
+        ]
+    )
+    await session.flush()
+
+    provenance_counts = {
+        model: await session.scalar(select(func.count()).select_from(model))
+        for model in (MemorySource, MemorySpan, MemoryAssertionNode, MemoryEdgeNode)
+    }
+
+    dry_run = await archive_auto_encoded_memories(session)
+    assert dry_run.report(applied=False) == {
+        "applied": False,
+        "archived": 0,
+        "would_archive": 4,
+        "content_nodes": 2,
+        "orphaned_cue_nodes": 1,
+        "orphaned_tag_nodes": 1,
+    }
+    assert not any(
+        node.archived_at
+        for node in (
+            exhaust_one,
+            exhaust_two,
+            durable_content,
+            durable_summary,
+            orphaned_cue,
+            shared_cue,
+            orphaned_tag,
+            shared_tag,
+        )
+    )
+
+    applied = await archive_auto_encoded_memories(session, apply=True)
+    await session.refresh(exhaust_one)
+    await session.refresh(exhaust_two)
+    await session.refresh(durable_content)
+    await session.refresh(durable_summary)
+    await session.refresh(orphaned_cue)
+    await session.refresh(shared_cue)
+    await session.refresh(orphaned_tag)
+    await session.refresh(shared_tag)
+
+    assert applied.report(applied=True)["archived"] == 4
+    assert exhaust_one.archived_at is not None
+    assert exhaust_two.archived_at is not None
+    assert orphaned_cue.archived_at is not None
+    assert orphaned_tag.archived_at is not None
+    assert durable_content.archived_at is None
+    assert durable_summary.archived_at is None
+    assert shared_cue.archived_at is None
+    assert shared_tag.archived_at is None
+    assert {
+        model: await session.scalar(select(func.count()).select_from(model))
+        for model in (MemorySource, MemorySpan, MemoryAssertionNode, MemoryEdgeNode)
+    } == provenance_counts
+
+    rerun = await archive_auto_encoded_memories(session, apply=True)
+    assert rerun.report(applied=True)["archived"] == 0

--- a/tests/test_async_unit_of_work.py
+++ b/tests/test_async_unit_of_work.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import inspect
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import func, select
 
+from brain.platform.db.models.reconstructive_memory import MemoryNode
 from brain.platform.db.repositories import unit_of_work as uow_module
 from brain.platform.db.repositories.unit_of_work import (
     AsyncRepositoryProxy,
@@ -217,7 +220,6 @@ def test_run_runtime_async_entrypoints_do_not_use_sync_bridges():
         inspect.getsource(event_log_module.async_record_run_degraded_event),
         inspect.getsource(telemetry_module.async_record_api_call),
         inspect.getsource(session_effects_module.async_memory_org_for_user),
-        inspect.getsource(session_effects_module.async_auto_encode_if_needed),
         inspect.getsource(session_effects_module.async_apply_agent_session_side_effects),
         inspect.getsource(project_execution_env_module._async_current_run_target_context),
         inspect.getsource(project_execution_env_module.async_current_project_bound_env),
@@ -337,9 +339,6 @@ async def test_async_session_effects_awaits_async_callbacks():
         calls.append(("memory_org", user_id))
         return "org-from-memory"
 
-    async def auto_encode(tool_calls_made, output, session_id, **kwargs):
-        calls.append(("auto", tool_calls_made, output, session_id, kwargs))
-
     async def harvest(session_id, harvested_messages, **kwargs):
         calls.append(("harvest", session_id, harvested_messages, kwargs))
 
@@ -349,7 +348,7 @@ async def test_async_session_effects_awaits_async_callbacks():
     effective_org_id = await session_effects_module.async_apply_agent_session_side_effects(
         session_id="session-1",
         messages=messages,
-        output="A long enough output to be eligible for auto encode if the tools acted.",
+        output="A routine file-change result long enough to exercise session side effects.",
         system_prompt="system",
         tokens=tokens,
         tool_calls_made=["write_file"],
@@ -359,13 +358,56 @@ async def test_async_session_effects_awaits_async_callbacks():
         idea_id="idea-1",
         run_id=42,
         memory_org_for_user=memory_org,
-        auto_encode_if_needed=auto_encode,
         harvest_session=harvest,
         save_session=save,
     )
 
     assert effective_org_id == "org-from-memory"
-    assert [call[0] for call in calls] == ["memory_org", "auto", "harvest", "save"]
-    assert calls[1][4]["org_id"] == "org-from-memory"
-    assert calls[2][3]["org_id"] == "org-from-memory"
-    assert calls[3][4] == (10, 5, 2, 1)
+    assert [call[0] for call in calls] == ["memory_org", "harvest", "save"]
+    assert calls[1][3]["org_id"] == "org-from-memory"
+    assert calls[2][4] == (10, 5, 2, 1)
+
+
+@pytest.mark.asyncio
+async def test_file_touching_routine_answer_creates_no_memory_nodes(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    session = await async_sqlite_session_factory([MemoryNode.__table__])
+
+    async def add_memory(*, content, memory_type, **kwargs):
+        del kwargs
+        session.add(
+            MemoryNode(
+                node_kind="content",
+                content_kind=memory_type,
+                canonical_label="unexpected automatic memory",
+                text=content,
+                normalized_key="unexpected automatic memory",
+                scope_key="default",
+                visibility="private",
+            )
+        )
+        await session.flush()
+
+    monkeypatch.setattr("brain.app.cli.memory.add_memory", add_memory)
+    harvest = AsyncMock()
+
+    await session_effects_module.async_apply_agent_session_side_effects(
+        session_id="session-routine-file-change",
+        messages=[{"role": "user", "content": "Update the file."}],
+        output=(
+            "Updated the requested configuration file and verified the routine change "
+            "without discovering any durable lesson."
+        ),
+        system_prompt="system",
+        tokens=SimpleNamespace(input=10, output=5, cache_read=0, cache_creation=0),
+        tool_calls_made=["write_file"],
+        user_id="user-1",
+        metadata={"org_id": "org-1"},
+        persist_session=False,
+        harvest_session=harvest,
+    )
+
+    harvest.assert_awaited_once()
+    assert await session.scalar(select(func.count()).select_from(MemoryNode)) == 0


### PR DESCRIPTION
Closes #345 — one slice of the mémoire chantier (#341).

## What
- Removes the post-run auto-encoder entirely (helpers, invocation hook, raw `[:300]` snapshot, and its architecture-boundary exception). Deliberate `memory_ingest_source` is the durable replacement.
- Adds `scripts/archive_auto_encoded_memories.py` to archive the legacy auto-encoded backlog: **dry-run by default**; applying requires `--apply --confirm-writers-paused`. Uses `archive_many`, preserves sources/spans/assertions/edges/embeddings, protects shared cue/tag nodes, is idempotent. Not executed here.
- No new Alembic migration — `alembic heads` remains single (`0027_chantier_digest_v2`).

## Verify (no web preview — Python backend)
- `venv/bin/python -m pytest tests/test_agent_split.py tests/test_async_unit_of_work.py tests/test_archive_auto_encoded_memories.py -m "not requires_db" -q` → **59 passed** (reproduced by R3).
- Confirm the auto-encode hook is gone and no memory node is written after a plain run.
- Archive script `--help` shows dry-run default; running without `--apply` writes nothing.

🤖 Draft opened by Routine R3. Overlaps #346/#347 (same mémoire family, shared files harvest.py / architecture-boundary-allowlist.json) — merge order matters; see PR list.