### PR TITLE
[Illo-QA] Classifier: ask one question instead of going silent (#358)

### DIFF
--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -239,8 +239,9 @@ def slack_channel_monitor_message(
     """Frame a monitored-channel message as a passive triage decision.
 
     The message has already been acknowledged with a 👀 reaction at ingest, so
-    the run's job is only to decide whether the content is ticket-worthy — and to
-    stay silent otherwise.
+    the run's job is to decide whether the content is ticket-worthy, needs one
+    clarifying question, or warrants silence. Silence is correct for chatter and
+    alert commentary — never for a human request or a direct @-mention.
     """
 
     text = _clean(payload.get("text"))[:2000]
@@ -253,7 +254,10 @@ def slack_channel_monitor_message(
         "and has already been acknowledged with a 👀 reaction — do not acknowledge it again.",
         "",
         "Classify this message and act accordingly:",
-        "- Casual chatter, or discussion about an existing alert: take NO visible action. Do not reply.",
+        "- Casual chatter, or discussion about an existing alert that does not itself ask for "
+        "work: take NO visible action. Do not reply. A message is NOT alert commentary merely "
+        "because it arrived near an alert — if a human is asking for something, it belongs in "
+        "the underspecified-request branch below, not here.",
         "- A genuine automated alert (Sentry, Rollbar, CI) or a user-reported problem that is "
         "ticket-worthy AND the target repo and incident are both clear: open a REAL GitHub issue "
         "with create_github_issue in the correct uwear-ai repo. Load the 'uwear-engineering-triage' "
@@ -262,6 +266,19 @@ def slack_channel_monitor_message(
         "section (a Domain 37 doc_page record; skill_asset references/creating-work-items.md as "
         "fallback), then optionally "
         "post a brief Slack note with post_slack_reply citing the issue number and URL.",
+        "- If your investigation reaches a root-cause hypothesis naming the target repo, that IS "
+        "'repo and incident clear': file the issue in that repo in the same run. Include the "
+        "investigation findings in the issue body — not just a link to Slack — so the analysis is "
+        "captured in the work item instead of being left only in Slack.",
+        "- A human request/report or apparent request for work that is actionable but "
+        "underspecified because the target repo or incident is unclear: do NOT stay silent and do "
+        "NOT return 'No visible action taken.' Ask exactly ONE focused clarifying question "
+        "in-thread with post_slack_reply, then act on the answer. Proximity to an existing alert "
+        "alone does not turn an apparent human request into alert commentary. This branch does "
+        "not apply to casual chatter or genuine commentary that does not ask for work.",
+        "- A message that @-mentions Illo must NEVER end in silence or 'No visible action taken.' "
+        "Either file the issue or post a visible reply; if the details are insufficient to file, "
+        "ask exactly ONE focused clarifying question in-thread.",
         "- A user-submitted feature request or product idea (feedback relayed by a bot such as "
         "Retool — e.g. '*New:* Idea' or '*New:* Feedback' with a user email and profile id — is "
         "a real customer ask, NOT chatter and NOT low-signal): if the ask is concrete and "
@@ -278,14 +295,15 @@ def slack_channel_monitor_message(
         "to prod that still fires PAST the settle window (~30 min after deploy) means the fix "
         "did not work — reopen the ticket and escalate to the fix author (re-fires inside the "
         "settle window are expected drain noise).",
-        "- Ticket-worthy but the repo/incident is unclear, or create_github_issue reports "
-        "no write-capable token can reach the repo (no_write_token / 403 / 404): do NOT claim a "
-        "GitHub issue was filed. Ask for clarification with post_slack_reply, or record an internal "
-        "tracker record + handoff so it is not lost.",
-        "- Ambiguous or low-signal: prefer no visible action; the 👀 already confirms you saw it.",
+        "- If create_github_issue reports no write-capable token can reach the repo "
+        "(no_write_token / 403 / 404): do NOT claim a GitHub issue was filed. Surface the failure "
+        "with post_slack_reply, or record an internal tracker record + handoff so it is not lost.",
+        "- Ambiguous or low-signal content that is neither a human request/report nor a direct "
+        "@-mention: prefer no visible action; the 👀 already confirms you saw it.",
         "",
-        "Silence is the correct default. Only use post_slack_reply when you have opened/flagged a "
-        "ticket or must surface something important. Use read_slack_conversation "
+        "Silence is the correct default for casual chatter and genuine alert commentary. Use "
+        "post_slack_reply when you have opened/flagged a ticket, must ask the one clarifying "
+        "question required above, or must surface something important. Use read_slack_conversation "
         "(scope=recent_channel or thread) for more context before deciding. An internal Domain/"
         "tracker record is NOT a GitHub issue — only a successful create_github_issue opens a real "
         "issue; never describe a tracker record as a filed GitHub issue.",

--- a/tests/test_slack_channel_monitor.py
+++ b/tests/test_slack_channel_monitor.py
@@ -639,3 +639,88 @@ async def test_monitor_channel_preserves_identity_map_metadata():
     # Adding a monitor must not clobber the existing identity map.
     assert connection.metadata_["slack"]["identity_map"] == {"U1": "user-1"}
     assert connection.metadata_["slack"]["monitored_channels"][0]["channel_id"] == "C_ALERTS"
+
+
+def test_channel_monitor_replays_2026_07_16_requests_without_silence():
+    """Both #358 anchor messages reach a visible-action classifier branch."""
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    messages = [
+        "demande assez facile a faire je pense",
+        (
+            "@Illo bug in staging, downloading in bulk make ZIPs that cant be opened "
+            "(also abnormaly just 6kb zips vs excpected 3MB and more for multiples photos)"
+        ),
+    ]
+
+    run_messages = []
+    for message in messages:
+        monitored_payload = _channel_monitor_payload()
+        monitored_payload["text"] = message
+        work = build_slack_work_intake_payload(
+            org_id="org1",
+            authority_user_id="user1",
+            payload=monitored_payload,
+        )
+        run_message = work["payload"]["run_message"]
+        assert f"Message text: {message}" in run_message
+        assert "ask exactly ONE focused clarifying question in-thread" in run_message
+        run_messages.append(run_message)
+
+    bulk_download_run_message = run_messages[1]
+    assert "root-cause hypothesis naming the target repo" in bulk_download_run_message
+    assert "repo and incident clear" in bulk_download_run_message
+    assert (
+        "include the investigation findings in the issue body"
+        in bulk_download_run_message.lower()
+    )
+    assert "same run" in bulk_download_run_message
+
+
+def test_channel_monitor_third_branch_preserves_casual_commentary_silence():
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    work = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=_channel_monitor_payload(),
+    )
+
+    run_message = work["payload"]["run_message"]
+    # The silence branch must survive the #358 third branch: chatter and pure alert
+    # commentary still get no visible action.
+    assert (
+        "Casual chatter, or discussion about an existing alert that does not itself ask for "
+        "work: take NO visible action. Do not reply."
+    ) in run_message
+    # ...but proximity to an alert must not by itself route a human request into
+    # silence — that misread is what produced run 1562 (#358 instance 1).
+    assert "NOT alert commentary merely because it arrived near an alert" in run_message
+    assert "does not apply to casual chatter or genuine commentary" in run_message
+
+
+@pytest.mark.parametrize("event_type", ["app_mention", "message"])
+def test_every_app_mention_inbound_event_requires_a_visible_response(event_type):
+    from brain.systems.slack.ingress import normalize_slack_socket_event
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    envelope = normalize_slack_socket_event(
+        _socket_mode_channel_message(
+            type=event_type,
+            text="<@BILLO> not enough detail yet",
+        ),
+        bot_user_id="BILLO",
+        monitored_channels={"C_ALERTS"},
+    )
+
+    assert envelope is not None
+    assert envelope["origin"] == "slack.app_mention"
+    work = build_slack_work_intake_payload(
+        org_id="org1",
+        authority_user_id="user1",
+        payload=envelope["payload"],
+    )
+    metadata = work["payload"]["metadata"]
+    assert metadata["required_response_tool"] == "post_slack_reply"
+    assert metadata["final_answer_target_surface"] == "slack"
+    assert "No visible action taken." not in work["payload"]["run_message"]


### PR DESCRIPTION
Closes #358.

## What this changes

The monitored-channel classifier offered exactly two outcomes — **file a real GitHub issue**, or **total silence**. Genuine-but-underspecified requests fell into the silence branch, so the human had to come back and ask. Twice in five hours on 2026-07-16:

- `12:37` "demande assez facile a faire je pense" → run `1562` answered `No visible action taken.` → an hour later: *"@Illo did you make a ticket for this?"*
- `17:22` the bulk-download ZIP report → run `1600` produced a correct root-cause hypothesis, posted it to Slack, filed nothing → 23 min later: *"@Illo make a ticket please"*

Run 1562 followed its instructions **correctly** — the message landed near a Rollbar alert, so "discussion about an existing alert" was a defensible read. The instructions, not the judgment, produced the wrong outcome. So this PR changes the instructions.

Three additions to `brain/systems/slack/triggers.py`:

1. **Actionable-but-underspecified → one question, not silence.** A human request/report that fails the "repo and incident both clear" bar now gets exactly ONE focused clarifying question in-thread, then acts on the answer.
2. **A named root cause IS "repo and incident clear."** When Illo's own investigation reaches a hypothesis naming the repo, it files in the same run — and carries the findings into the issue body rather than leaving the analysis in a Slack scrollback.
3. **A direct @-mention may never end in silence.** File, or reply — even if the reply is "not enough to file — which repo?".

Plus a fix beyond the ticket's ask: the **silence branch was qualified**. It previously read "discussion about an existing alert: take NO visible action" with no caveat, and it is read *first* — exactly the branch run 1562 matched. It now states that a message is not alert commentary merely because it arrived near an alert. Silence remains correct for casual chatter and genuine commentary; that branch is otherwise intact and still tested.

## How to judge this

Nothing to click — this is a prompt-contract change. The reviewable surface is the classifier text itself: **`brain/systems/slack/triggers.py`, the `Classify this message and act accordingly:` block.** Read it as if you were Illo receiving a vague message near an alert, and ask whether the right branch is now obvious.

Acceptance checks:

1. ✅ Underspecified genuine request → one clarifying question or a filed issue; never `No visible action taken.`
2. ✅ `app_mention` never terminates silently (`required_response_tool=post_slack_reply`, and the silent-no-op string is absent from the run message).
3. ✅ Investigation with a named repo → filed in the same run, findings in the issue body.
4. ⚠️ **Partially met — please read.** The replay test asserts both 2026-07-16 messages compose a run message carrying the new branch. It does **not** prove an LLM then chooses that branch: the classifier is a prompt, and there is no model in the test loop. A true replay needs a live/eval run against the two messages. Ticket check 4 is therefore covered structurally, not behaviorally.

## Tests

`tests/test_slack_channel_monitor.py` — 30 passed (72 with `tests/test_slack_teammate.py`), including the 2026-07-16 replay, the app_mention parametrization, and the casual-commentary silence guard.

```
venv/bin/python -m pytest tests/test_slack_channel_monitor.py tests/test_slack_teammate.py -q
```

## Assumptions

- The fix belongs in the instruction text, not in the classifier's judgment (the ticket's own framing — run 1562 obeyed its instructions).
- The pendulum must not swing into noise: Illo must still stay quiet for chatter and alert commentary. This is why the silence branch was qualified rather than removed.

---
🤖 Drafted by Routine R3 (Codex worker, xhigh review by the orchestrator). Branch conditions written by Codex; silence-branch qualification and the docstring fix added during orchestrator review.
