### PR TITLE
[Illo-QA] Never post a Slack fragment behind ok:true (#357)

### DIFF
--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
+from brain.systems.slack.client import SlackDeliveryError
 from brain.systems.slack.uploads import slack_image_upload_from_data_url
 
 
@@ -243,7 +244,7 @@ async def _handle_post_slack_reply(
 ) -> str:
     """Post an Illo-authored reply to the originating Slack surface."""
 
-    text = str(body or "").strip()
+    text = str(body or "")
     try:
         image_upload = slack_image_upload_from_data_url(
             image_data,
@@ -253,7 +254,7 @@ async def _handle_post_slack_reply(
         )
     except ValueError as exc:
         return json.dumps({"error": str(exc)})
-    if not text and image_upload is None:
+    if not text.strip() and image_upload is None:
         return json.dumps({"error": "post_slack_reply requires body or image_data"})
 
     trigger = _current_slack_trigger()
@@ -288,7 +289,7 @@ async def _handle_post_slack_reply(
                 file_bytes=image_upload.file_bytes,
                 filename=image_upload.filename,
                 title=image_upload.title,
-                initial_comment=text or None,
+                initial_comment=text if text.strip() else None,
                 thread_ts=target_thread_ts,
                 alt_txt=image_upload.alt_txt,
                 content_type=image_upload.content_type,
@@ -310,9 +311,24 @@ async def _handle_post_slack_reply(
                 thread_ts=target_thread_ts,
             )
         await _clear_processing_status(client, trigger)
+    except SlackDeliveryError as exc:
+        return json.dumps(exc.to_result())
     except Exception as exc:
-        return json.dumps({"error": str(exc)})
+        return json.dumps(
+            {
+                "ok": False,
+                "error": str(exc),
+                "submitted_chars": len(text),
+                "posted_chars": None,
+                "submitted_bytes": len(text.encode("utf-8")),
+                "posted_bytes": None,
+                "chunk_count": 0,
+                "truncated": None,
+            }
+        )
 
+    submitted_chars = int(response.get("submitted_chars", len(text)))
+    posted_chars = int(response.get("posted_chars", submitted_chars))
     return json.dumps(
         {
             "ok": True,
@@ -320,6 +336,12 @@ async def _handle_post_slack_reply(
             "thread_ts": target_thread_ts,
             "visibility": target_visibility,
             "uploaded_image": image_upload is not None,
+            "submitted_chars": submitted_chars,
+            "posted_chars": posted_chars,
+            "submitted_bytes": int(response.get("submitted_bytes", len(text.encode("utf-8")))),
+            "posted_bytes": int(response.get("posted_bytes", len(text.encode("utf-8")))),
+            "chunk_count": int(response.get("chunk_count", 1)),
+            "truncated": bool(response.get("truncated", posted_chars != submitted_chars)),
             "slack": response,
         },
         default=str,

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -341,7 +341,7 @@ async def _handle_post_slack_reply(
             "submitted_bytes": int(response.get("submitted_bytes", len(text.encode("utf-8")))),
             "posted_bytes": int(response.get("posted_bytes", len(text.encode("utf-8")))),
             "chunk_count": int(response.get("chunk_count", 1)),
-            "truncated": bool(response.get("truncated", posted_chars != submitted_chars)),
+            "truncated": bool(response.get("truncated", False)),
             "slack": response,
         },
         default=str,

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 from brain.platform.async_io import async_http_client
@@ -33,7 +34,7 @@ class SlackApiError(RuntimeError):
 
 
 class SlackDeliveryError(SlackApiError):
-    """Raised when Slack cannot prove that submitted text was stored intact."""
+    """Raised when Slack cannot prove that submitted text avoided truncation."""
 
     def __init__(
         self,
@@ -42,6 +43,7 @@ class SlackDeliveryError(SlackApiError):
         submitted_text: str,
         posted_text: str | None,
         chunk_count: int,
+        truncated: bool | None,
         detail: str,
     ) -> None:
         self.submitted_chars = len(submitted_text)
@@ -49,7 +51,7 @@ class SlackDeliveryError(SlackApiError):
         self.submitted_bytes = len(submitted_text.encode("utf-8"))
         self.posted_bytes = len(posted_text.encode("utf-8")) if posted_text is not None else None
         self.chunk_count = chunk_count
-        self.truncated = None if posted_text is None else posted_text != submitted_text
+        self.truncated = truncated
         self.detail = detail
         super().__init__(error)
 
@@ -93,6 +95,34 @@ def _response_warns_of_truncation(response: dict[str, Any]) -> bool:
     warnings = metadata.get("warnings") if isinstance(metadata, dict) else []
     values = [response.get("warning"), *(warnings if isinstance(warnings, list) else [])]
     return any(str(value or "").strip() == "message_truncated" for value in values)
+
+
+def _semantic_text_tokens(value: str) -> list[str]:
+    return re.findall(r"[^\W_]+", value.casefold())
+
+
+def _message_lede_survived(submitted_text: str, stored_text: str) -> bool:
+    submitted_lede = _semantic_text_tokens(submitted_text[:256])[:12]
+    if not submitted_lede:
+        return True
+    stored_lede = iter(_semantic_text_tokens(stored_text[:2048]))
+    return all(any(candidate == token for candidate in stored_lede) for token in submitted_lede)
+
+
+def _stored_text_indicates_truncation(submitted_text: str, stored_text: str) -> tuple[bool, str]:
+    # Slack may add link/mention markup and entity escapes, so equality is not
+    # an integrity signal. Be conservative both ways: flag only a material
+    # shortfall (> max(8 chars, 1%)) or loss of the semantic lede. Token order
+    # tolerates markup inserted by Slack without trying to reproduce its rules.
+    allowed_shortfall = max(8, (len(submitted_text) + 99) // 100)
+    materially_shorter = len(stored_text) < len(submitted_text) - allowed_shortfall
+    lede_survived = _message_lede_survived(submitted_text, stored_text)
+    reasons = []
+    if materially_shorter:
+        reasons.append(f"shortfall exceeded {allowed_shortfall} characters")
+    if not lede_survived:
+        reasons.append("semantic lede was not present at the start of Slack's stored text")
+    return bool(reasons), "; ".join(reasons)
 
 
 class SlackWebClient:
@@ -180,6 +210,7 @@ class SlackWebClient:
                     submitted_text=submitted_text,
                     posted_text="".join(stored_chunks),
                     chunk_count=len(responses),
+                    truncated=None,
                     detail=f"Slack failed while posting continuation {index + 1} of {len(chunks)}: {exc}",
                 ) from exc
 
@@ -191,18 +222,24 @@ class SlackWebClient:
                     submitted_text=submitted_text,
                     posted_text=None,
                     chunk_count=len(responses),
+                    truncated=None,
                     detail="Slack returned ok without message.text, so delivery integrity cannot be verified.",
                 )
             stored_chunks.append(stored_text)
-            if stored_text != chunk or _response_warns_of_truncation(response):
+            response_warned = _response_warns_of_truncation(response)
+            looks_truncated, mismatch_reason = _stored_text_indicates_truncation(chunk, stored_text)
+            if response_warned or looks_truncated:
+                reason = "Slack returned message_truncated" if response_warned else mismatch_reason
                 raise SlackDeliveryError(
                     "slack_message_delivery_mismatch",
                     submitted_text=submitted_text,
                     posted_text="".join(stored_chunks),
                     chunk_count=len(responses),
+                    truncated=True,
                     detail=(
-                        f"Slack stored {len(stored_text)} of {len(chunk)} characters "
-                        f"for chunk {index + 1} of {len(chunks)}."
+                        f"Slack stored {len(stored_text)} chars/{len(stored_text.encode('utf-8'))} bytes "
+                        f"for submitted chunk {index + 1} of {len(chunks)} "
+                        f"({len(chunk)} chars/{len(chunk.encode('utf-8'))} bytes): {reason}."
                     ),
                 )
 
@@ -214,6 +251,7 @@ class SlackWebClient:
                         submitted_text=submitted_text,
                         posted_text="".join(stored_chunks),
                         chunk_count=len(responses),
+                        truncated=None,
                         detail="Slack returned ok without a message timestamp for threaded continuations.",
                     )
 
@@ -226,7 +264,7 @@ class SlackWebClient:
                 "submitted_bytes": len(submitted_text.encode("utf-8")),
                 "posted_bytes": len(posted_text.encode("utf-8")),
                 "chunk_count": len(responses),
-                "truncated": posted_text != submitted_text,
+                "truncated": False,
             }
         )
         if len(responses) > 1:
@@ -255,6 +293,7 @@ class SlackWebClient:
                 submitted_text=submitted_text,
                 posted_text="",
                 chunk_count=0,
+                truncated=False,
                 detail=(
                     "Ephemeral Slack messages cannot be verified or continued safely; "
                     f"the {len(submitted_text)}-character message was not posted."
@@ -274,6 +313,7 @@ class SlackWebClient:
                 submitted_text=submitted_text,
                 posted_text=None,
                 chunk_count=1,
+                truncated=True,
                 detail="Slack warned that the ephemeral message was truncated.",
             )
         return {
@@ -306,6 +346,7 @@ class SlackWebClient:
                 submitted_text=initial_comment,
                 posted_text="",
                 chunk_count=0,
+                truncated=False,
                 detail=(
                     "Slack file initial comments cannot be continued safely; "
                     f"the {len(initial_comment)}-character comment and file were not posted."
@@ -334,7 +375,17 @@ class SlackWebClient:
             complete_request["initial_comment"] = initial_comment
         if thread_ts:
             complete_request["thread_ts"] = thread_ts
-        return await self._post("files.completeUploadExternal", complete_request)
+        result = await self._post("files.completeUploadExternal", complete_request)
+        if initial_comment and _response_warns_of_truncation(result):
+            raise SlackDeliveryError(
+                "slack_message_delivery_mismatch",
+                submitted_text=initial_comment,
+                posted_text=None,
+                chunk_count=1,
+                truncated=True,
+                detail="Slack warned that the file's initial comment was truncated.",
+            )
+        return result
 
     async def set_assistant_status(
         self,

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -8,6 +8,11 @@ from typing import Any
 from brain.platform.async_io import async_http_client
 
 
+# Slack recommends at most 4,000 characters for a top-level ``text`` field.
+# Split before the API boundary so a receiver-side limit cannot discard the lede.
+SLACK_MESSAGE_TEXT_CHARS = 4000
+
+
 class SlackConfigurationError(RuntimeError):
     """Raised when the self-hosted Slack connector is not configured."""
 
@@ -25,6 +30,69 @@ class SlackApiError(RuntimeError):
             else ""
         )
         super().__init__(f"{error}: {details}" if details else error)
+
+
+class SlackDeliveryError(SlackApiError):
+    """Raised when Slack cannot prove that submitted text was stored intact."""
+
+    def __init__(
+        self,
+        error: str,
+        *,
+        submitted_text: str,
+        posted_text: str | None,
+        chunk_count: int,
+        detail: str,
+    ) -> None:
+        self.submitted_chars = len(submitted_text)
+        self.posted_chars = len(posted_text) if posted_text is not None else None
+        self.submitted_bytes = len(submitted_text.encode("utf-8"))
+        self.posted_bytes = len(posted_text.encode("utf-8")) if posted_text is not None else None
+        self.chunk_count = chunk_count
+        self.truncated = None if posted_text is None else posted_text != submitted_text
+        self.detail = detail
+        super().__init__(error)
+
+    def to_result(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "error": self.error,
+            "detail": self.detail,
+            "submitted_chars": self.submitted_chars,
+            "posted_chars": self.posted_chars,
+            "submitted_bytes": self.submitted_bytes,
+            "posted_bytes": self.posted_bytes,
+            "chunk_count": self.chunk_count,
+            "truncated": self.truncated,
+        }
+
+
+def _message_text_chunks(text: str) -> list[str]:
+    if not text:
+        return [text]
+    return [
+        text[start : start + SLACK_MESSAGE_TEXT_CHARS]
+        for start in range(0, len(text), SLACK_MESSAGE_TEXT_CHARS)
+    ]
+
+
+def _stored_message_text(response: dict[str, Any]) -> str | None:
+    message = response.get("message")
+    if not isinstance(message, dict) or not isinstance(message.get("text"), str):
+        return None
+    return message["text"]
+
+
+def _posted_message_ts(response: dict[str, Any]) -> str | None:
+    message = response.get("message") if isinstance(response.get("message"), dict) else {}
+    return str(response.get("ts") or message.get("ts") or "").strip() or None
+
+
+def _response_warns_of_truncation(response: dict[str, Any]) -> bool:
+    metadata = response.get("response_metadata")
+    warnings = metadata.get("warnings") if isinstance(metadata, dict) else []
+    values = [response.get("warning"), *(warnings if isinstance(warnings, list) else [])]
+    return any(str(value or "").strip() == "message_truncated" for value in values)
 
 
 class SlackWebClient:
@@ -92,13 +160,85 @@ class SlackWebClient:
         text: str,
         thread_ts: str | None = None,
     ) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "channel": channel,
-            "text": text,
-        }
-        if thread_ts:
-            payload["thread_ts"] = thread_ts
-        return await self._post("chat.postMessage", payload)
+        submitted_text = str(text)
+        chunks = _message_text_chunks(submitted_text)
+        responses: list[dict[str, Any]] = []
+        stored_chunks: list[str] = []
+        continuation_thread_ts = thread_ts
+
+        for index, chunk in enumerate(chunks):
+            payload: dict[str, Any] = {"channel": channel, "text": chunk}
+            if continuation_thread_ts:
+                payload["thread_ts"] = continuation_thread_ts
+            try:
+                response = await self._post("chat.postMessage", payload)
+            except Exception as exc:
+                if not responses:
+                    raise
+                raise SlackDeliveryError(
+                    "slack_message_delivery_incomplete",
+                    submitted_text=submitted_text,
+                    posted_text="".join(stored_chunks),
+                    chunk_count=len(responses),
+                    detail=f"Slack failed while posting continuation {index + 1} of {len(chunks)}: {exc}",
+                ) from exc
+
+            responses.append(response)
+            stored_text = _stored_message_text(response)
+            if stored_text is None:
+                raise SlackDeliveryError(
+                    "slack_message_delivery_unverified",
+                    submitted_text=submitted_text,
+                    posted_text=None,
+                    chunk_count=len(responses),
+                    detail="Slack returned ok without message.text, so delivery integrity cannot be verified.",
+                )
+            stored_chunks.append(stored_text)
+            if stored_text != chunk or _response_warns_of_truncation(response):
+                raise SlackDeliveryError(
+                    "slack_message_delivery_mismatch",
+                    submitted_text=submitted_text,
+                    posted_text="".join(stored_chunks),
+                    chunk_count=len(responses),
+                    detail=(
+                        f"Slack stored {len(stored_text)} of {len(chunk)} characters "
+                        f"for chunk {index + 1} of {len(chunks)}."
+                    ),
+                )
+
+            if index == 0 and len(chunks) > 1 and not continuation_thread_ts:
+                continuation_thread_ts = _posted_message_ts(response)
+                if not continuation_thread_ts:
+                    raise SlackDeliveryError(
+                        "slack_message_delivery_unverified",
+                        submitted_text=submitted_text,
+                        posted_text="".join(stored_chunks),
+                        chunk_count=len(responses),
+                        detail="Slack returned ok without a message timestamp for threaded continuations.",
+                    )
+
+        posted_text = "".join(stored_chunks)
+        result = dict(responses[0])
+        result.update(
+            {
+                "submitted_chars": len(submitted_text),
+                "posted_chars": len(posted_text),
+                "submitted_bytes": len(submitted_text.encode("utf-8")),
+                "posted_bytes": len(posted_text.encode("utf-8")),
+                "chunk_count": len(responses),
+                "truncated": posted_text != submitted_text,
+            }
+        )
+        if len(responses) > 1:
+            result["continuations"] = [
+                {
+                    "channel": response.get("channel"),
+                    "ts": _posted_message_ts(response),
+                    "posted_chars": len(stored_chunk),
+                }
+                for response, stored_chunk in zip(responses[1:], stored_chunks[1:])
+            ]
+        return result
 
     async def post_ephemeral(
         self,
@@ -108,14 +248,43 @@ class SlackWebClient:
         text: str,
         thread_ts: str | None = None,
     ) -> dict[str, Any]:
+        submitted_text = str(text)
+        if len(submitted_text) > SLACK_MESSAGE_TEXT_CHARS:
+            raise SlackDeliveryError(
+                "slack_ephemeral_message_too_long",
+                submitted_text=submitted_text,
+                posted_text="",
+                chunk_count=0,
+                detail=(
+                    "Ephemeral Slack messages cannot be verified or continued safely; "
+                    f"the {len(submitted_text)}-character message was not posted."
+                ),
+            )
         payload: dict[str, Any] = {
             "channel": channel,
             "user": user,
-            "text": text,
+            "text": submitted_text,
         }
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return await self._post("chat.postEphemeral", payload)
+        result = await self._post("chat.postEphemeral", payload)
+        if _response_warns_of_truncation(result):
+            raise SlackDeliveryError(
+                "slack_message_delivery_mismatch",
+                submitted_text=submitted_text,
+                posted_text=None,
+                chunk_count=1,
+                detail="Slack warned that the ephemeral message was truncated.",
+            )
+        return {
+            **result,
+            "submitted_chars": len(submitted_text),
+            "posted_chars": len(submitted_text),
+            "submitted_bytes": len(submitted_text.encode("utf-8")),
+            "posted_bytes": len(submitted_text.encode("utf-8")),
+            "chunk_count": 1,
+            "truncated": False,
+        }
 
     async def upload_file(
         self,
@@ -130,6 +299,18 @@ class SlackWebClient:
         content_type: str = "application/octet-stream",
     ) -> dict[str, Any]:
         """Upload bytes through Slack's external upload flow and share the file."""
+
+        if initial_comment and len(initial_comment) > SLACK_MESSAGE_TEXT_CHARS:
+            raise SlackDeliveryError(
+                "slack_file_comment_too_long",
+                submitted_text=initial_comment,
+                posted_text="",
+                chunk_count=0,
+                detail=(
+                    "Slack file initial comments cannot be continued safely; "
+                    f"the {len(initial_comment)}-character comment and file were not posted."
+                ),
+            )
 
         upload_request: dict[str, Any] = {
             "filename": filename,

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1808,3 +1808,116 @@ async def test_slack_identity_mapping_service_links_user(session):
     assert mappings == [{"slack_user_id": "U123", "user_id": MAPPED_USER_ID, "user_name": "Alex"}]
     refreshed = await session.get(ExternalAgentConnectionRow, connection.id)
     assert refreshed.metadata_["slack"]["identity_map"] == {"U123": MAPPED_USER_ID}
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_preserves_oversized_body_across_thread(monkeypatch):
+    """Slack may return ok after storing only an oversized message's tail."""
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+    from brain.systems.slack.client import SlackWebClient
+
+    headline = "*Uwear 08:00 ET daily engineering brief*\n"
+    footer = "\nReda recap | Axel recap | JB recap"
+    body = headline + ("delivery evidence\n" * 260) + footer
+    submitted_chunks: list[dict[str, Any]] = []
+    stored_texts: list[str] = []
+
+    class _TailTruncatingSlackClient(SlackWebClient):
+        async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert method == "chat.postMessage"
+            submitted_chunks.append(dict(payload))
+            stored_text = str(payload["text"])[-4000:]
+            stored_texts.append(stored_text)
+            ts = f"1716900200.{len(submitted_chunks):06d}"
+            return {
+                "ok": True,
+                "channel": payload["channel"],
+                "ts": ts,
+                "message": {"text": stored_text, "ts": ts},
+            }
+
+    async def slack_client():
+        return _TailTruncatingSlackClient("xoxb-test")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                }
+            },
+        }
+    ):
+        result = json.loads(await _handle_post_slack_reply(body=body))
+
+    assert len(body) > 4000
+    assert result["ok"] is True
+    assert result["submitted_chars"] == len(body)
+    assert result["posted_chars"] == len(body)
+    assert result["truncated"] is False
+    assert result["chunk_count"] == len(submitted_chunks) == 2
+    assert "thread_ts" not in submitted_chunks[0]
+    assert submitted_chunks[1]["thread_ts"] == "1716900200.000001"
+    assert stored_texts[0].startswith(headline)
+    assert stored_texts[-1].endswith(footer)
+    assert "".join(stored_texts) == body
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_surfaces_receiver_side_tail_truncation(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+    from brain.systems.slack.client import SlackWebClient
+
+    body = "digest headline\n" + ("evidence\n" * 520) + "Reda | Axel | JB"
+
+    class _TailTruncatingSlackClient(SlackWebClient):
+        async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert method == "chat.postMessage"
+            stored_text = str(payload["text"])[-1000:]
+            return {
+                "ok": True,
+                "channel": payload["channel"],
+                "ts": "1716900200.000001",
+                "message": {"text": stored_text, "ts": "1716900200.000001"},
+            }
+
+    async def slack_client():
+        return _TailTruncatingSlackClient("xoxb-test")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                }
+            },
+        }
+    ):
+        result = json.loads(await _handle_post_slack_reply(body=body))
+
+    assert len(body) > 4000
+    assert result["ok"] is False
+    assert result["error"] == "slack_message_delivery_mismatch"
+    assert result["submitted_chars"] == len(body)
+    assert result["posted_chars"] == 1000
+    assert result["truncated"] is True

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1811,23 +1811,36 @@ async def test_slack_identity_mapping_service_links_user(session):
 
 
 @pytest.mark.asyncio
-async def test_post_slack_reply_preserves_oversized_body_across_thread(monkeypatch):
-    """Slack may return ok after storing only an oversized message's tail."""
+async def test_post_slack_reply_accepts_slack_rewrites_without_false_truncation(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
     from brain.systems.slack.client import SlackWebClient
 
     headline = "*Uwear 08:00 ET daily engineering brief*\n"
+    pull_url = "https://github.com/uwear-ai/illospace/pull/357"
     footer = "\nReda recap | Axel recap | JB recap"
-    body = headline + ("delivery evidence\n" * 260) + footer
+    body = (
+        headline
+        + f"@here: <@U123> owns <priority> delivery & review for {pull_url}.\n"
+        + ("delivery evidence and next action\n" * 150)
+        + footer
+    )
     submitted_chunks: list[dict[str, Any]] = []
     stored_texts: list[str] = []
 
-    class _TailTruncatingSlackClient(SlackWebClient):
+    def slack_like_rewrite(value: str) -> str:
+        return (
+            value.replace("&", "&amp;")
+            .replace("<priority>", "&lt;priority&gt;")
+            .replace("@here", "<!here>")
+            .replace(pull_url, f"<{pull_url}>")
+        )
+
+    class _SlackLikeRewriteClient(SlackWebClient):
         async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
             assert method == "chat.postMessage"
             submitted_chunks.append(dict(payload))
-            stored_text = str(payload["text"])[-4000:]
+            stored_text = slack_like_rewrite(str(payload["text"]))
             stored_texts.append(stored_text)
             ts = f"1716900200.{len(submitted_chunks):06d}"
             return {
@@ -1838,7 +1851,7 @@ async def test_post_slack_reply_preserves_oversized_body_across_thread(monkeypat
             }
 
     async def slack_client():
-        return _TailTruncatingSlackClient("xoxb-test")
+        return _SlackLikeRewriteClient("xoxb-test")
 
     monkeypatch.setattr(
         "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
@@ -1863,14 +1876,20 @@ async def test_post_slack_reply_preserves_oversized_body_across_thread(monkeypat
     assert len(body) > 4000
     assert result["ok"] is True
     assert result["submitted_chars"] == len(body)
-    assert result["posted_chars"] == len(body)
+    assert result["posted_chars"] == sum(len(text) for text in stored_texts)
     assert result["truncated"] is False
     assert result["chunk_count"] == len(submitted_chunks) == 2
     assert "thread_ts" not in submitted_chunks[0]
     assert submitted_chunks[1]["thread_ts"] == "1716900200.000001"
     assert stored_texts[0].startswith(headline)
+    assert f"<{pull_url}>" in stored_texts[0]
+    assert "<!here>" in stored_texts[0]
+    assert "&amp;" in stored_texts[0]
+    assert "&lt;priority&gt;" in stored_texts[0]
+    assert "<@U123>" in stored_texts[0]
     assert stored_texts[-1].endswith(footer)
-    assert "".join(stored_texts) == body
+    assert "".join(str(chunk["text"]) for chunk in submitted_chunks) == body
+    assert "".join(stored_texts) != body
 
 
 @pytest.mark.asyncio
@@ -1920,4 +1939,58 @@ async def test_post_slack_reply_surfaces_receiver_side_tail_truncation(monkeypat
     assert result["error"] == "slack_message_delivery_mismatch"
     assert result["submitted_chars"] == len(body)
     assert result["posted_chars"] == 1000
+    assert result["submitted_bytes"] == len(body.encode("utf-8"))
+    assert result["posted_bytes"] == 1000
+    assert result["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_post_slack_reply_surfaces_receiver_side_head_truncation(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+    from brain.systems.slack.client import SlackWebClient
+
+    body = "digest headline\n" + ("evidence\n" * 520) + "Reda | Axel | JB"
+
+    class _HeadTruncatingSlackClient(SlackWebClient):
+        async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert method == "chat.postMessage"
+            stored_text = str(payload["text"])[:1000]
+            return {
+                "ok": True,
+                "channel": payload["channel"],
+                "ts": "1716900200.000001",
+                "message": {"text": stored_text, "ts": "1716900200.000001"},
+            }
+
+    async def slack_client():
+        return _HeadTruncatingSlackClient("xoxb-test")
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 9,
+            "slack_trigger": {
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": None,
+                    "visibility": "public",
+                }
+            },
+        }
+    ):
+        result = json.loads(await _handle_post_slack_reply(body=body))
+
+    assert len(body) > 4000
+    assert result["ok"] is False
+    assert result["error"] == "slack_message_delivery_mismatch"
+    assert result["submitted_chars"] == len(body)
+    assert result["posted_chars"] == 1000
+    assert result["submitted_bytes"] == len(body.encode("utf-8"))
+    assert result["posted_bytes"] == 1000
     assert result["truncated"] is True


### PR DESCRIPTION
Closes #357.

## What we found — and what we did *not*

The 08:00 ET digest reached `#4_software` headless: no headline, no scope line, no per-person sections, starting mid-thought. `post_slack_reply` had returned `{"ok": true, "ts": "1784289836.453909"}`. Illo noticed only because it read the channel back, and posted a Repair brief 33s later.

**Confirmed:** nothing in this repo truncates the outbound text. The full payload leaves intact at `brain/systems/slack/client.py` `_post`. The failure is that `_coerce_response` only ever checked `ok` — it never compared what Slack actually *stored* — and the handler then hard-coded its own `ok: true`. Silent loss behind a success receipt.

**Not confirmed — please read.** The truncation is receiver-side, but that does **not** explain the symptom. Slack's documented behavior for oversized `text` keeps the **head**; the stored artifact (`agent_run_artifacts.id=24456`) kept the **tail**. A plain length-truncation cannot produce a tail. A bounded audit found no rolling buffer, no tail slice, no last-post-only artifact projection, and no silently-failing earlier post between digest composition and `_post`. **So the mechanism that kept the tail is still unknown.** We are not claiming a root cause we haven't got.

What this PR guarantees is that it can never again be *silent*: the next time it happens, the call fails loudly with the exact chunk, the char/byte counts, and the reason. That turns an invisible bug into a reported one.

## What changed

- **Chunk before the boundary.** Text over 4,000 chars posts as a primary message plus threaded continuations — the lede always survives, no truncation needed.
- **Verify what Slack stored.** Each chunk is checked against Slack's echo. A mismatch returns `ok: false`, `truncated: true`, plus submitted/posted char and byte counts.
- **Counts on every result**, so callers can assert integrity without a read-back.
- **Ephemeral messages and file initial-comments** cannot be safely continued, so they refuse to post rather than truncate.
- Illo's read-back-and-repair is **untouched** (belt and braces).

### The subtle part: why not compare text exactly?

Because Slack never echoes `message.text` verbatim — it auto-links raw URLs to `<https://…>`, rewrites `@here` to `<!here>`, and escapes `&`/`<`/`>`. Exact equality would raise `slack_message_delivery_mismatch` on **every digest containing a GitHub link** — trading silent truncation for a total outage of the Slack post path. (The first pass of this branch had exactly that defect; its fakes echoed text back verbatim, which real Slack never does.)

The rule instead flags truncation only on: an explicit `message_truncated` warning, a **material shortfall** (> `max(8 chars, 1%)`), or **loss of the semantic lede** (opening tokens matched *in order*, which tolerates markup Slack inserts). Slack's rewrites preserve those tokens and generally lengthen text — so intact-but-rewritten passes, truncated fails. No attempt is made to reproduce Slack's escaping rules; that would rot.

## How to judge this

No UI. The reviewable question is whether the rule is conservative in both directions — a false alarm kills the digest, a miss is the bug. Verified behavior:

| case | flagged? |
|---|---|
| digest with GitHub URLs + `@here` + `<@U123>` + `&`, delivered intact (Slack rewrites applied) | ✅ no |
| trailing-whitespace strip | ✅ no |
| exact echo | ✅ no |
| **stored = tail only (the actual incident)** | ✅ **yes** |
| stored = head-truncated | ✅ yes |
| lede kept but body gutted | ✅ yes |

Acceptance checks: 1 ✅ · 2 ✅ · 4 ✅ · 3 (one digest post, no `Repair —` follow-up) is a runtime outcome — it should follow from chunking, and the next real digest is the proof.

## Tests

**174 passed** — `tests/test_slack_teammate.py`, `tests/test_slack_channel_monitor.py`, `tests/test_agent_run_runtime.py`.

```
venv/bin/python -m pytest tests/test_slack_teammate.py tests/test_slack_channel_monitor.py tests/test_agent_run_runtime.py -q
```

Key tests: `test_post_slack_reply_accepts_slack_rewrites_without_false_truncation` (the false-alarm guard, digest-shaped body with a real PR URL), plus tail- and head-truncation coverage.

## Assumptions

- Slack's rewrites preserve the opening tokens and do not materially shorten text. This is the load-bearing assumption behind the rule; it is stated in a comment at the check.
- Chunking at 4,000 chars splits on a character boundary, not a word/line boundary — continuations may split mid-sentence. Deliberate: correctness of delivery over prettiness, and the alternative risks unbounded chunk growth.

---
🤖 Drafted by Routine R3 (Codex worker at xhigh + one orchestrator-directed fix pass). The equality defect was caught in orchestrator review, not by the worker's own tests.
