### PR TITLE
fix(triage): slug-resolve chantier playbooks + forward-only cycle-2 deactivation (#356)

### DIFF
--- a/brain/app/cli/activate_uwear_engineering_triage.py
+++ b/brain/app/cli/activate_uwear_engineering_triage.py
@@ -1,0 +1,437 @@
+"""Activate the live Uwear engineering triage documents by stable slug.
+
+This command intentionally has no implicit write mode. Use ``--apply`` to
+perform the transactional activation and ``--check`` for read-only verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from brain.kernel import config
+
+
+DOMAIN_ID = 37
+CORE_RECORD_ID = 1155
+CORE_SLUG = "uwear-engineering-triage"
+CORE_REQUIRED_CURRENT_VERSION = 7
+CORE_ACTIVATED_MINIMUM_VERSION = 8
+BUNDLE_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "systems"
+    / "skills"
+    / "builtin_skill_bundles"
+    / "uwear-engineering-triage"
+)
+
+
+class ActivationError(RuntimeError):
+    """The live records cannot be activated without ambiguity or data loss."""
+
+
+@dataclass(frozen=True)
+class DocumentSpec:
+    slug: str
+    title: str
+    relative_path: str
+
+
+@dataclass(frozen=True)
+class ActivationResult:
+    created: tuple[str, ...]
+    updated: tuple[str, ...]
+    unchanged: tuple[str, ...]
+
+
+PLAYBOOKS = (
+    DocumentSpec(
+        "uwear-engineering-triage-customer-support",
+        "Uwear Engineering Triage — Direct Customer Support",
+        "references/customer-support.md",
+    ),
+    DocumentSpec(
+        "uwear-engineering-triage-creating-work-items",
+        "Uwear Engineering Triage — Creating Work Items",
+        "references/creating-work-items.md",
+    ),
+    DocumentSpec(
+        "uwear-engineering-triage-backlog-maintenance",
+        "Uwear Engineering Triage — Backlog Maintenance",
+        "references/backlog-maintenance.md",
+    ),
+    DocumentSpec(
+        "uwear-engineering-triage-chantier-operations",
+        "Uwear Engineering Triage — Chantier Operations",
+        "references/chantier-operations.md",
+    ),
+    DocumentSpec(
+        "uwear-engineering-triage-memory",
+        "Uwear Engineering Triage — Memory Playbook",
+        "references/memory.md",
+    ),
+)
+PLAYBOOK_SLUGS = tuple(spec.slug for spec in PLAYBOOKS)
+_ALL_SLUGS = (CORE_SLUG, *PLAYBOOK_SLUGS)
+
+
+def _table(bind: sa.Connection, metadata: sa.MetaData, name: str) -> sa.Table:
+    try:
+        return sa.Table(name, metadata, autoload_with=bind)
+    except sa.exc.NoSuchTableError as exc:
+        raise ActivationError(f"Required table {name} is missing") from exc
+
+
+def _record_slug(row: sa.RowMapping) -> str:
+    data = row.get("data")
+    return str(data.get("slug") or "") if isinstance(data, dict) else ""
+
+
+def _is_archived(row: sa.RowMapping) -> bool:
+    return "archived_at" in row and row["archived_at"] is not None
+
+
+def _content(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ActivationError(f"Cannot read bundled activation asset {path}: {exc}") from exc
+
+
+def _search_text(title: str, slug: str) -> str:
+    return f"{title} {slug}".lower()
+
+
+def _update_values(
+    table: sa.Table,
+    *,
+    data: dict[str, Any],
+    title: str | None,
+    version: int,
+    search_text: str | None,
+) -> dict[str, Any]:
+    values: dict[str, Any] = {"data": data, "version": version}
+    if title is not None:
+        values["title"] = title
+    if search_text is not None and "search_text" in table.c:
+        values["search_text"] = search_text
+    if "updated_at" in table.c:
+        values["updated_at"] = sa.func.now()
+    return values
+
+
+def _assert_single_target(
+    rows: list[sa.RowMapping],
+    *,
+    slug: str,
+    object_type_id: int,
+    org_id: object,
+) -> sa.RowMapping | None:
+    matches = [row for row in rows if _record_slug(row) == slug]
+    if len(matches) > 1:
+        locations = ", ".join(
+            f"id {row['id']} in Domain {row['domain_id']}" for row in matches
+        )
+        raise ActivationError(f"Target slug {slug} resolves to multiple records: {locations}")
+    if not matches:
+        return None
+
+    row = matches[0]
+    if int(row["domain_id"]) != DOMAIN_ID:
+        raise ActivationError(
+            f"Target slug {slug} is occupied by record {row['id']} in Domain "
+            f"{row['domain_id']}"
+        )
+    if int(row["object_type_id"]) != object_type_id:
+        raise ActivationError(
+            f"Target slug {slug} is occupied by Domain 37 record {row['id']} "
+            "with an object type other than doc_page"
+        )
+    if str(row["org_id"]) != str(org_id):
+        raise ActivationError(
+            f"Target slug {slug} belongs to org {row['org_id']}, expected {org_id}"
+        )
+    if _is_archived(row):
+        raise ActivationError(f"Target slug {slug} is occupied by archived record {row['id']}")
+    return row
+
+
+def _verify_document(row: sa.RowMapping, spec: DocumentSpec, expected: str) -> None:
+    data = row.get("data")
+    if not isinstance(data, dict):
+        raise ActivationError(f"Record {row['id']} for slug {spec.slug} has invalid data")
+    if (
+        row["title"] != spec.title
+        or data.get("slug") != spec.slug
+        or data.get("title") != spec.title
+        or data.get("content") != expected
+    ):
+        raise ActivationError(
+            f"Record {row['id']} for slug {spec.slug} failed byte-identity verification"
+        )
+
+
+def _activate(
+    bind: sa.Connection,
+    *,
+    apply: bool,
+    bundle_root: Path = BUNDLE_ROOT,
+) -> ActivationResult:
+    metadata = sa.MetaData()
+    records = _table(bind, metadata, "domain_records")
+    object_types = _table(bind, metadata, "domain_object_types")
+
+    if apply and bind.dialect.name == "postgresql":
+        # Slugs are JSON fields rather than a unique indexed column. This lock
+        # closes the check/insert race for the short activation transaction.
+        bind.execute(sa.text("LOCK TABLE domain_records IN SHARE ROW EXCLUSIVE MODE"))
+
+    object_type_stmt = sa.select(object_types).where(
+        object_types.c.domain_id == DOMAIN_ID,
+        object_types.c.key == "doc_page",
+    )
+    if "archived_at" in object_types.c:
+        object_type_stmt = object_type_stmt.where(object_types.c.archived_at.is_(None))
+    if apply:
+        object_type_stmt = object_type_stmt.with_for_update()
+    doc_types = bind.execute(object_type_stmt).mappings().all()
+    if len(doc_types) != 1:
+        raise ActivationError(
+            f"Expected exactly one active Domain 37 doc_page object type, found {len(doc_types)}"
+        )
+    object_type_id = int(doc_types[0]["id"])
+
+    slug_expression = records.c.data["slug"].as_string()
+    target_stmt = sa.select(records).where(
+        sa.or_(
+            records.c.id == CORE_RECORD_ID,
+            slug_expression.in_(_ALL_SLUGS),
+        )
+    )
+    if apply:
+        target_stmt = target_stmt.with_for_update()
+    target_rows = bind.execute(target_stmt).mappings().all()
+
+    core_rows = [row for row in target_rows if int(row["id"]) == CORE_RECORD_ID]
+    if not core_rows:
+        raise ActivationError("Core target record 1155 is missing")
+    core = core_rows[0]
+    if int(core["domain_id"]) != DOMAIN_ID:
+        raise ActivationError(
+            f"Core target id 1155 is occupied by a record from Domain {core['domain_id']}"
+        )
+    if int(core["object_type_id"]) != object_type_id:
+        raise ActivationError("Core target record 1155 is not a Domain 37 doc_page")
+    if _is_archived(core):
+        raise ActivationError("Core target record 1155 is archived")
+    if _record_slug(core) != CORE_SLUG:
+        raise ActivationError(
+            f"Core target record 1155 has slug {_record_slug(core)!r}, expected {CORE_SLUG!r}"
+        )
+    duplicate_core = [
+        row
+        for row in target_rows
+        if _record_slug(row) == CORE_SLUG and int(row["id"]) != CORE_RECORD_ID
+    ]
+    if duplicate_core:
+        raise ActivationError(
+            f"Core slug {CORE_SLUG} is duplicated by record {duplicate_core[0]['id']}"
+        )
+
+    # Preserve the reflected driver's native UUID representation for inserts.
+    org_id = core["org_id"]
+    expected_by_slug = {
+        spec.slug: _content(bundle_root / spec.relative_path) for spec in PLAYBOOKS
+    }
+    core_expected = _content(bundle_root / "SKILL.md")
+    existing = {
+        spec.slug: _assert_single_target(
+            target_rows,
+            slug=spec.slug,
+            object_type_id=object_type_id,
+            org_id=org_id,
+        )
+        for spec in PLAYBOOKS
+    }
+
+    changes_needed = []
+    for spec in PLAYBOOKS:
+        row = existing[spec.slug]
+        if row is None:
+            changes_needed.append(f"create {spec.slug}")
+            continue
+        data = row.get("data")
+        if (
+            row["title"] != spec.title
+            or not isinstance(data, dict)
+            or data.get("title") != spec.title
+            or data.get("content") != expected_by_slug[spec.slug]
+        ):
+            changes_needed.append(f"update {spec.slug}")
+
+    core_data = core.get("data")
+    core_content_matches = (
+        isinstance(core_data, dict) and core_data.get("content") == core_expected
+    )
+    core_version = int(core["version"])
+    if not core_content_matches or core_version < CORE_ACTIVATED_MINIMUM_VERSION:
+        changes_needed.append(f"update {CORE_SLUG}")
+
+    if not core_content_matches and core_version != CORE_REQUIRED_CURRENT_VERSION:
+        raise ActivationError(
+            "Core record 1155 content differs from the bundle at version "
+            f"{core_version}; expected v7 before activation. Reconcile the newer edit first."
+        )
+    if core_content_matches and core_version < CORE_REQUIRED_CURRENT_VERSION:
+        raise ActivationError(
+            f"Core record 1155 is unexpectedly version {core_version}; expected v7 or newer."
+        )
+    if changes_needed and not apply:
+        raise ActivationError(
+            "Activation is not current: " + ", ".join(changes_needed) + ". Run with --apply."
+        )
+
+    created: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+    ids_by_slug: dict[str, int] = {}
+
+    for spec in PLAYBOOKS:
+        expected = expected_by_slug[spec.slug]
+        row = existing[spec.slug]
+        if row is None:
+            data = {"slug": spec.slug, "title": spec.title, "content": expected}
+            values: dict[str, Any] = {
+                "org_id": org_id,
+                "domain_id": DOMAIN_ID,
+                "object_type_id": object_type_id,
+                "title": spec.title,
+                "data": data,
+                "version": 1,
+            }
+            if "search_text" in records.c:
+                values["search_text"] = _search_text(spec.title, spec.slug)
+            result = bind.execute(records.insert().values(**values))
+            ids_by_slug[spec.slug] = int(result.inserted_primary_key[0])
+            created.append(spec.slug)
+            continue
+
+        ids_by_slug[spec.slug] = int(row["id"])
+        data = dict(row["data"] or {})
+        if (
+            row["title"] == spec.title
+            and data.get("title") == spec.title
+            and data.get("content") == expected
+        ):
+            unchanged.append(spec.slug)
+            continue
+        data.update({"slug": spec.slug, "title": spec.title, "content": expected})
+        expected_version = int(row["version"])
+        result = bind.execute(
+            records.update()
+            .where(
+                records.c.id == row["id"],
+                records.c.version == expected_version,
+            )
+            .values(
+                **_update_values(
+                    records,
+                    data=data,
+                    title=spec.title,
+                    version=expected_version + 1,
+                    search_text=_search_text(spec.title, spec.slug),
+                )
+            )
+        )
+        if result.rowcount != 1:
+            raise ActivationError(f"Concurrent update detected for slug {spec.slug}")
+        updated.append(spec.slug)
+
+    if not core_content_matches or core_version < CORE_ACTIVATED_MINIMUM_VERSION:
+        next_data = dict(core_data or {})
+        next_data["content"] = core_expected
+        result = bind.execute(
+            records.update()
+            .where(
+                records.c.id == CORE_RECORD_ID,
+                records.c.version == core_version,
+            )
+            .values(
+                **_update_values(
+                    records,
+                    data=next_data,
+                    title=None,
+                    version=core_version + 1,
+                    search_text=None,
+                )
+            )
+        )
+        if result.rowcount != 1:
+            raise ActivationError("Concurrent update detected for core record 1155")
+        updated.append(CORE_SLUG)
+    else:
+        unchanged.append(CORE_SLUG)
+
+    verify_ids = [CORE_RECORD_ID, *ids_by_slug.values()]
+    verified_rows = {
+        int(row["id"]): row
+        for row in bind.execute(
+            sa.select(records).where(records.c.id.in_(verify_ids))
+        ).mappings()
+    }
+    for spec in PLAYBOOKS:
+        _verify_document(verified_rows[ids_by_slug[spec.slug]], spec, expected_by_slug[spec.slug])
+    verified_core = verified_rows[CORE_RECORD_ID]
+    if (
+        _record_slug(verified_core) != CORE_SLUG
+        or verified_core["data"].get("content") != core_expected
+        or int(verified_core["version"]) < CORE_ACTIVATED_MINIMUM_VERSION
+    ):
+        raise ActivationError("Core record 1155 failed post-write v8 byte verification")
+
+    return ActivationResult(tuple(created), tuple(updated), tuple(unchanged))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--apply", action="store_true", help="Apply the activation transaction")
+    mode.add_argument("--check", action="store_true", help="Verify without writing")
+    return parser
+
+
+async def _run(*, apply: bool) -> ActivationResult:
+    engine = create_async_engine(config.DB_URL)
+    try:
+        if apply:
+            async with engine.begin() as connection:
+                return await connection.run_sync(lambda bind: _activate(bind, apply=True))
+        async with engine.connect() as connection:
+            return await connection.run_sync(lambda bind: _activate(bind, apply=False))
+    finally:
+        await engine.dispose()
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        result = asyncio.run(_run(apply=args.apply))
+    except ActivationError as exc:
+        raise SystemExit(f"Activation failed: {exc}") from exc
+
+    print(
+        "Activation verified: "
+        f"created={len(result.created)} updated={len(result.updated)} "
+        f"unchanged={len(result.unchanged)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/app/cli/activate_uwear_engineering_triage.py
+++ b/brain/app/cli/activate_uwear_engineering_triage.py
@@ -23,6 +23,33 @@ CORE_RECORD_ID = 1155
 CORE_SLUG = "uwear-engineering-triage"
 CORE_REQUIRED_CURRENT_VERSION = 7
 CORE_ACTIVATED_MINIMUM_VERSION = 8
+COORDINATOR_CYCLE_ID = 2
+COORDINATOR_CYCLE_NAME = "Uwear Ticket Coordinator Check-ins"
+MISSION_CONTRACT_MARKER = "Chantier-primary digest contract v2:"
+MISSION_CONTRACT = (
+    "Chantier-primary digest contract v2: Load Enterprise Documentation Domain 37 "
+    "record 1155 and resolve the Domain 37 chantier-operations playbook by slug "
+    "uwear-engineering-triage-chantier-operations before each digest or new-work "
+    "filing. This v2 block supersedes any earlier owner-primary digest shape in this "
+    "mission. Keep exact issue, PR, repo, and active tracker counts and add the exact "
+    "active-chantier count. Give each materially moving chantier its own section with "
+    "state, one goal-progress line, movement since the last digest, next step, blockers, "
+    "and owners; roll quiet chantiers into one line; keep ungrouped tickets in Loose "
+    "items. End every digest with a Per-person recap footer naming Reda, Axel, and JB: "
+    "top next action, or the existing exact-assignee/GitHub-issue/authored-PR/"
+    "builder-candidate empty checks plus a rebalancing recommendation. In Phase B, "
+    "persist chantier state, member refs, blockers, and next step alongside the existing "
+    "per-person snapshot items; a chantier may not depart silently. Material chantier "
+    "movement means state change, member gain/loss, or blocker hit/clear. Before filing, "
+    "match active chantiers by refs/external ids and title/root cause; attach exact "
+    "matches and only propose, never auto-create, a chantier for an ungrouped family. "
+    "Must-surface every active chantier untouched 3+ days, missing next_step, or blocked. "
+    "When deploy-verified member states meet the goal, propose close-out with an outcome "
+    "summary in goal language, not PR counts."
+)
+MISSION_REVISION_RATIONALE = (
+    "Activate the slug-resolved chantier digest contract with Domain 37 doc 1155 v8."
+)
 BUNDLE_ROOT = (
     Path(__file__).resolve().parents[2]
     / "systems"
@@ -48,6 +75,7 @@ class ActivationResult:
     created: tuple[str, ...]
     updated: tuple[str, ...]
     unchanged: tuple[str, ...]
+    mission_updated: bool
 
 
 PLAYBOOKS = (
@@ -106,6 +134,60 @@ def _content(path: Path) -> str:
 
 def _search_text(title: str, slug: str) -> str:
     return f"{title} {slug}".lower()
+
+
+def _mission_prompt(prompt: str) -> str:
+    clean_prompt = str(prompt or "").strip()
+    if clean_prompt.startswith(MISSION_CONTRACT_MARKER):
+        _, separator, remainder = clean_prompt.partition("\n\n")
+        return (
+            f"{MISSION_CONTRACT}\n\n{remainder}"
+            if separator and remainder
+            else MISSION_CONTRACT
+        )
+    if MISSION_CONTRACT_MARKER in clean_prompt:
+        raise ActivationError(
+            "Coordinator cycle 2 contains an embedded chantier v2 contract that cannot "
+            "be replaced safely"
+        )
+    if not clean_prompt:
+        return MISSION_CONTRACT
+    return f"{MISSION_CONTRACT}\n\n{clean_prompt}"
+
+
+def _record_cycle_revision(
+    bind: sa.Connection,
+    revisions: sa.Table,
+    cycle: sa.RowMapping,
+    latest: sa.RowMapping | None,
+    prompt: str,
+) -> bool:
+    if latest is not None and latest["prompt"] == prompt:
+        return False
+
+    bind.execute(
+        revisions.insert().values(
+            cycle_id=cycle["id"],
+            revision_number=(int(latest["revision_number"]) + 1 if latest else 1),
+            source_type="system",
+            source_id=None,
+            rationale=MISSION_REVISION_RATIONALE,
+            name=cycle["name"],
+            prompt=prompt,
+            schedule_expr=cycle["schedule_expr"],
+            timezone=cycle["timezone"],
+            enabled=cycle["enabled"],
+            model_override=cycle["model_override"],
+            thinking_override=cycle["thinking_override"],
+            target_idea_id=cycle["target_idea_id"],
+            context_policy=(
+                latest["context_policy"]
+                if latest is not None and latest["context_policy"]
+                else {}
+            ),
+        )
+    )
+    return True
 
 
 def _update_values(
@@ -186,6 +268,8 @@ def _activate(
     metadata = sa.MetaData()
     records = _table(bind, metadata, "domain_records")
     object_types = _table(bind, metadata, "domain_object_types")
+    cycles = _table(bind, metadata, "cycles")
+    revisions = _table(bind, metadata, "cycle_revisions")
 
     if apply and bind.dialect.name == "postgresql":
         # Slugs are JSON fields rather than a unique indexed column. This lock
@@ -206,6 +290,40 @@ def _activate(
             f"Expected exactly one active Domain 37 doc_page object type, found {len(doc_types)}"
         )
     object_type_id = int(doc_types[0]["id"])
+
+    cycle_stmt = sa.select(
+        cycles.c.id,
+        cycles.c.name,
+        cycles.c.prompt,
+        cycles.c.schedule_expr,
+        cycles.c.timezone,
+        cycles.c.enabled,
+        cycles.c.model_override,
+        cycles.c.thinking_override,
+        cycles.c.target_idea_id,
+    ).where(
+        cycles.c.id == COORDINATOR_CYCLE_ID,
+        cycles.c.name == COORDINATOR_CYCLE_NAME,
+    )
+    if apply:
+        cycle_stmt = cycle_stmt.with_for_update()
+    cycle = bind.execute(cycle_stmt).mappings().first()
+    if cycle is None:
+        raise ActivationError(
+            "Coordinator cycle 2 is missing; refusing to activate documents without "
+            "the matching mission"
+        )
+
+    latest_revision_stmt = (
+        sa.select(revisions)
+        .where(revisions.c.cycle_id == COORDINATOR_CYCLE_ID)
+        .order_by(revisions.c.revision_number.desc(), revisions.c.id.desc())
+        .limit(1)
+    )
+    if apply:
+        latest_revision_stmt = latest_revision_stmt.with_for_update()
+    latest_revision = bind.execute(latest_revision_stmt).mappings().first()
+    mission_prompt = _mission_prompt(str(cycle["prompt"] or ""))
 
     slug_expression = records.c.data["slug"].as_string()
     target_stmt = sa.select(records).where(
@@ -282,6 +400,12 @@ def _activate(
     core_version = int(core["version"])
     if not core_content_matches or core_version < CORE_ACTIVATED_MINIMUM_VERSION:
         changes_needed.append(f"update {CORE_SLUG}")
+    if (
+        cycle["prompt"] != mission_prompt
+        or latest_revision is None
+        or latest_revision["prompt"] != mission_prompt
+    ):
+        changes_needed.append("update coordinator cycle 2 mission")
 
     if not core_content_matches and core_version != CORE_REQUIRED_CURRENT_VERSION:
         raise ActivationError(
@@ -395,7 +519,49 @@ def _activate(
     ):
         raise ActivationError("Core record 1155 failed post-write v8 byte verification")
 
-    return ActivationResult(tuple(created), tuple(updated), tuple(unchanged))
+    mission_updated = False
+    if cycle["prompt"] != mission_prompt:
+        mission_values: dict[str, object] = {"prompt": mission_prompt}
+        if "updated_at" in cycles.c:
+            mission_values["updated_at"] = sa.func.now()
+        result = bind.execute(
+            cycles.update()
+            .where(
+                cycles.c.id == COORDINATOR_CYCLE_ID,
+                cycles.c.prompt == cycle["prompt"],
+            )
+            .values(**mission_values)
+        )
+        if result.rowcount != 1:
+            raise ActivationError("Concurrent update detected for coordinator cycle 2")
+        mission_updated = True
+    if _record_cycle_revision(
+        bind,
+        revisions,
+        cycle,
+        latest_revision,
+        mission_prompt,
+    ):
+        mission_updated = True
+
+    verified_mission = bind.execute(
+        sa.select(cycles.c.prompt).where(cycles.c.id == COORDINATOR_CYCLE_ID)
+    ).scalar_one()
+    verified_revision = bind.execute(
+        sa.select(revisions.c.prompt)
+        .where(revisions.c.cycle_id == COORDINATOR_CYCLE_ID)
+        .order_by(revisions.c.revision_number.desc(), revisions.c.id.desc())
+        .limit(1)
+    ).scalar_one()
+    if verified_mission != mission_prompt or verified_revision != mission_prompt:
+        raise ActivationError("Coordinator cycle 2 failed post-write mission verification")
+
+    return ActivationResult(
+        tuple(created),
+        tuple(updated),
+        tuple(unchanged),
+        mission_updated,
+    )
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -428,7 +594,8 @@ def main() -> int:
     print(
         "Activation verified: "
         f"created={len(result.created)} updated={len(result.updated)} "
-        f"unchanged={len(result.unchanged)}"
+        f"unchanged={len(result.unchanged)} "
+        f"mission_updated={str(result.mission_updated).lower()}"
     )
     return 0
 

--- a/brain/platform/db/alembic/versions/0027_chantier_digest_v2.py
+++ b/brain/platform/db/alembic/versions/0027_chantier_digest_v2.py
@@ -24,31 +24,26 @@ depends_on = None
 
 _COORDINATOR_CYCLE_ID = 2
 _COORDINATOR_CYCLE_NAME = "Uwear Ticket Coordinator Check-ins"
-_CORE_DOC_ID = 1155
-_CORE_DOC_DOMAIN_ID = 37
-_CORE_DOC_SLUG = "uwear-engineering-triage"
-_CORE_DOC_MINIMUM_VERSION = 8
 _MISSION_CONTRACT_MARKER = "Chantier-primary digest contract v2:"
 _MISSION_CONTRACT = (
     "Chantier-primary digest contract v2: Load Enterprise Documentation Domain 37 "
-    "record 1155 and resolve the Domain 37 chantier-operations playbook by slug "
-    "uwear-engineering-triage-chantier-operations before each digest or new-work "
-    "filing. This v2 block supersedes any earlier owner-primary digest shape in this "
-    "mission. Keep exact issue, PR, repo, and active tracker counts and add the exact "
-    "active-chantier count. Give each materially moving chantier its own section with "
-    "state, one goal-progress line, movement since the last digest, next step, blockers, "
-    "and owners; roll quiet chantiers into one line; keep ungrouped tickets in Loose "
-    "items. End every digest with a Per-person recap footer naming Reda, Axel, and JB: "
-    "top next action, or the existing exact-assignee/GitHub-issue/authored-PR/"
-    "builder-candidate empty checks plus a rebalancing recommendation. In Phase B, "
-    "persist chantier state, member refs, blockers, and next step alongside the existing "
-    "per-person snapshot items; a chantier may not depart silently. Material chantier "
-    "movement means state change, member gain/loss, or blocker hit/clear. Before filing, "
-    "match active chantiers by refs/external ids and title/root cause; attach exact "
-    "matches and only propose, never auto-create, a chantier for an ungrouped family. "
-    "Must-surface every active chantier untouched 3+ days, missing next_step, or blocked. "
-    "When deploy-verified member states meet the goal, propose close-out with an outcome "
-    "summary in goal language, not PR counts."
+    "record 1155 and the chantier-operations playbook record 1274 before each digest "
+    "or new-work filing. This v2 block supersedes any earlier owner-primary digest "
+    "shape in this mission. Keep exact issue, PR, repo, and active tracker counts and "
+    "add the exact active-chantier count. Give each materially moving chantier its own "
+    "section with state, one goal-progress line, movement since the last digest, next "
+    "step, blockers, and owners; roll quiet chantiers into one line; keep ungrouped "
+    "tickets in Loose items. End every digest with a Per-person recap footer naming "
+    "Reda, Axel, and JB: top next action, or the existing exact-assignee/GitHub-issue/"
+    "authored-PR/builder-candidate empty checks plus a rebalancing recommendation. "
+    "In Phase B, persist chantier state, member refs, blockers, and next step alongside "
+    "the existing per-person snapshot items; a chantier may not depart silently. "
+    "Material chantier movement means state change, member gain/loss, or blocker hit/"
+    "clear. Before filing, match active chantiers by refs/external ids and title/root "
+    "cause; attach exact matches and only propose, never auto-create, a chantier for "
+    "an ungrouped family. Must-surface every active chantier untouched 3+ days, missing "
+    "next_step, or blocked. When deploy-verified member states meet the goal, propose "
+    "close-out with an outcome summary in goal language, not PR counts."
 )
 _REVISION_RATIONALE = (
     "Seed chantier-primary digest v2, attach-at-triage, freshness, and close-out rules."
@@ -74,13 +69,6 @@ def _table(bind: sa.Connection, metadata: sa.MetaData, table_name: str) -> sa.Ta
 
 def _mission_prompt(prompt: str) -> str:
     clean_prompt = str(prompt or "").strip()
-    if clean_prompt.startswith(_MISSION_CONTRACT_MARKER):
-        _, separator, remainder = clean_prompt.partition("\n\n")
-        return (
-            f"{_MISSION_CONTRACT}\n\n{remainder}"
-            if separator and remainder
-            else _MISSION_CONTRACT
-        )
     if _MISSION_CONTRACT_MARKER in clean_prompt:
         return clean_prompt
     if not clean_prompt:
@@ -88,40 +76,6 @@ def _mission_prompt(prompt: str) -> str:
     # Put v2 first so it stays visible even when the launch envelope must trim
     # the tail of a near-12K legacy mission.
     return f"{_MISSION_CONTRACT}\n\n{clean_prompt}"
-
-
-def _require_core_doc_v8(bind: sa.Connection) -> None:
-    if not _table_exists(bind, "domain_records"):
-        raise RuntimeError(
-            "Cannot seed chantier digest v2: domain_records is missing, so Domain 37 "
-            "record 1155 cannot be verified as v8."
-        )
-
-    metadata = sa.MetaData()
-    records = _table(bind, metadata, "domain_records")
-    core = bind.execute(
-        sa.select(
-            records.c.domain_id,
-            records.c.version,
-            records.c.data,
-        ).where(records.c.id == _CORE_DOC_ID)
-    ).mappings().first()
-    if (
-        core is None
-        or int(core["domain_id"]) != _CORE_DOC_DOMAIN_ID
-        or int(core["version"]) < _CORE_DOC_MINIMUM_VERSION
-        or not isinstance(core["data"], Mapping)
-        or core["data"].get("slug") != _CORE_DOC_SLUG
-    ):
-        raise RuntimeError(
-            "Cannot seed chantier digest v2: Domain 37 record 1155 must be v8 or "
-            "newer with slug uwear-engineering-triage."
-        )
-    if "chantier" not in str(core["data"].get("content") or "").lower():
-        raise RuntimeError(
-            "Cannot seed chantier digest v2: Domain 37 record 1155 v8 does not "
-            "contain the chantier operating model."
-        )
 
 
 def _record_cycle_revision(
@@ -195,8 +149,6 @@ def _upgrade(bind: sa.Connection) -> None:
     ).mappings().first()
     if cycle is None:
         return
-
-    _require_core_doc_v8(bind)
 
     prompt = _mission_prompt(str(cycle["prompt"] or ""))
     if prompt != cycle["prompt"]:

--- a/brain/platform/db/alembic/versions/0027_chantier_digest_v2.py
+++ b/brain/platform/db/alembic/versions/0027_chantier_digest_v2.py
@@ -24,26 +24,31 @@ depends_on = None
 
 _COORDINATOR_CYCLE_ID = 2
 _COORDINATOR_CYCLE_NAME = "Uwear Ticket Coordinator Check-ins"
+_CORE_DOC_ID = 1155
+_CORE_DOC_DOMAIN_ID = 37
+_CORE_DOC_SLUG = "uwear-engineering-triage"
+_CORE_DOC_MINIMUM_VERSION = 8
 _MISSION_CONTRACT_MARKER = "Chantier-primary digest contract v2:"
 _MISSION_CONTRACT = (
     "Chantier-primary digest contract v2: Load Enterprise Documentation Domain 37 "
-    "record 1155 and the chantier-operations playbook record 1274 before each digest "
-    "or new-work filing. This v2 block supersedes any earlier owner-primary digest "
-    "shape in this mission. Keep exact issue, PR, repo, and active tracker counts and "
-    "add the exact active-chantier count. Give each materially moving chantier its own "
-    "section with state, one goal-progress line, movement since the last digest, next "
-    "step, blockers, and owners; roll quiet chantiers into one line; keep ungrouped "
-    "tickets in Loose items. End every digest with a Per-person recap footer naming "
-    "Reda, Axel, and JB: top next action, or the existing exact-assignee/GitHub-issue/"
-    "authored-PR/builder-candidate empty checks plus a rebalancing recommendation. "
-    "In Phase B, persist chantier state, member refs, blockers, and next step alongside "
-    "the existing per-person snapshot items; a chantier may not depart silently. "
-    "Material chantier movement means state change, member gain/loss, or blocker hit/"
-    "clear. Before filing, match active chantiers by refs/external ids and title/root "
-    "cause; attach exact matches and only propose, never auto-create, a chantier for "
-    "an ungrouped family. Must-surface every active chantier untouched 3+ days, missing "
-    "next_step, or blocked. When deploy-verified member states meet the goal, propose "
-    "close-out with an outcome summary in goal language, not PR counts."
+    "record 1155 and resolve the Domain 37 chantier-operations playbook by slug "
+    "uwear-engineering-triage-chantier-operations before each digest or new-work "
+    "filing. This v2 block supersedes any earlier owner-primary digest shape in this "
+    "mission. Keep exact issue, PR, repo, and active tracker counts and add the exact "
+    "active-chantier count. Give each materially moving chantier its own section with "
+    "state, one goal-progress line, movement since the last digest, next step, blockers, "
+    "and owners; roll quiet chantiers into one line; keep ungrouped tickets in Loose "
+    "items. End every digest with a Per-person recap footer naming Reda, Axel, and JB: "
+    "top next action, or the existing exact-assignee/GitHub-issue/authored-PR/"
+    "builder-candidate empty checks plus a rebalancing recommendation. In Phase B, "
+    "persist chantier state, member refs, blockers, and next step alongside the existing "
+    "per-person snapshot items; a chantier may not depart silently. Material chantier "
+    "movement means state change, member gain/loss, or blocker hit/clear. Before filing, "
+    "match active chantiers by refs/external ids and title/root cause; attach exact "
+    "matches and only propose, never auto-create, a chantier for an ungrouped family. "
+    "Must-surface every active chantier untouched 3+ days, missing next_step, or blocked. "
+    "When deploy-verified member states meet the goal, propose close-out with an outcome "
+    "summary in goal language, not PR counts."
 )
 _REVISION_RATIONALE = (
     "Seed chantier-primary digest v2, attach-at-triage, freshness, and close-out rules."
@@ -69,6 +74,13 @@ def _table(bind: sa.Connection, metadata: sa.MetaData, table_name: str) -> sa.Ta
 
 def _mission_prompt(prompt: str) -> str:
     clean_prompt = str(prompt or "").strip()
+    if clean_prompt.startswith(_MISSION_CONTRACT_MARKER):
+        _, separator, remainder = clean_prompt.partition("\n\n")
+        return (
+            f"{_MISSION_CONTRACT}\n\n{remainder}"
+            if separator and remainder
+            else _MISSION_CONTRACT
+        )
     if _MISSION_CONTRACT_MARKER in clean_prompt:
         return clean_prompt
     if not clean_prompt:
@@ -76,6 +88,40 @@ def _mission_prompt(prompt: str) -> str:
     # Put v2 first so it stays visible even when the launch envelope must trim
     # the tail of a near-12K legacy mission.
     return f"{_MISSION_CONTRACT}\n\n{clean_prompt}"
+
+
+def _require_core_doc_v8(bind: sa.Connection) -> None:
+    if not _table_exists(bind, "domain_records"):
+        raise RuntimeError(
+            "Cannot seed chantier digest v2: domain_records is missing, so Domain 37 "
+            "record 1155 cannot be verified as v8."
+        )
+
+    metadata = sa.MetaData()
+    records = _table(bind, metadata, "domain_records")
+    core = bind.execute(
+        sa.select(
+            records.c.domain_id,
+            records.c.version,
+            records.c.data,
+        ).where(records.c.id == _CORE_DOC_ID)
+    ).mappings().first()
+    if (
+        core is None
+        or int(core["domain_id"]) != _CORE_DOC_DOMAIN_ID
+        or int(core["version"]) < _CORE_DOC_MINIMUM_VERSION
+        or not isinstance(core["data"], Mapping)
+        or core["data"].get("slug") != _CORE_DOC_SLUG
+    ):
+        raise RuntimeError(
+            "Cannot seed chantier digest v2: Domain 37 record 1155 must be v8 or "
+            "newer with slug uwear-engineering-triage."
+        )
+    if "chantier" not in str(core["data"].get("content") or "").lower():
+        raise RuntimeError(
+            "Cannot seed chantier digest v2: Domain 37 record 1155 v8 does not "
+            "contain the chantier operating model."
+        )
 
 
 def _record_cycle_revision(
@@ -149,6 +195,8 @@ def _upgrade(bind: sa.Connection) -> None:
     ).mappings().first()
     if cycle is None:
         return
+
+    _require_core_doc_v8(bind)
 
     prompt = _mission_prompt(str(cycle["prompt"] or ""))
     if prompt != cycle["prompt"]:

--- a/brain/platform/db/alembic/versions/0028_deactivate_pinned_chantier_digest.py
+++ b/brain/platform/db/alembic/versions/0028_deactivate_pinned_chantier_digest.py
@@ -1,0 +1,198 @@
+"""Deactivate the coordinator contract that pinned a chantier playbook record id.
+
+Revision ID: 0028_deactivate_pinned_chantier_digest
+Revises: 0027_chantier_digest_v2
+Create Date: 2026-07-17
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0028_deactivate_pinned_chantier_digest"
+down_revision = "0027_chantier_digest_v2"
+branch_labels = None
+depends_on = None
+
+
+_LOGGER = logging.getLogger(__name__)
+_COORDINATOR_CYCLE_ID = 2
+_COORDINATOR_CYCLE_NAME = "Uwear Ticket Coordinator Check-ins"
+_MISSION_CONTRACT_MARKER = "Chantier-primary digest contract v2:"
+_INVALID_PLAYBOOK_REFERENCE = "record 1274"
+_SAFE_FALLBACK_MISSION = "Run the existing owner-primary coordinator mission."
+_REVISION_RATIONALE = (
+    "Deactivate the pinned-record chantier digest contract until slug-based activation."
+)
+
+
+def _schema(bind: sa.Connection) -> str | None:
+    return "public" if bind.dialect.name == "postgresql" else None
+
+
+def _table_exists(bind: sa.Connection, table_name: str) -> bool:
+    return table_name in set(sa.inspect(bind).get_table_names(schema=_schema(bind)))
+
+
+def _table(bind: sa.Connection, metadata: sa.MetaData, table_name: str) -> sa.Table:
+    return sa.Table(
+        table_name,
+        metadata,
+        schema=_schema(bind),
+        autoload_with=bind,
+    )
+
+
+def _without_pinned_contract(prompt: str) -> str | None:
+    clean_prompt = str(prompt or "").strip()
+    first_block, separator, remainder = clean_prompt.partition("\n\n")
+    if not (
+        first_block.startswith(_MISSION_CONTRACT_MARKER)
+        and _INVALID_PLAYBOOK_REFERENCE in first_block
+    ):
+        return None
+    if separator and remainder.strip():
+        return remainder.strip()
+    return _SAFE_FALLBACK_MISSION
+
+
+def _core_doc_is_active(bind: sa.Connection) -> bool:
+    if not _table_exists(bind, "domain_records"):
+        return False
+    metadata = sa.MetaData()
+    records = _table(bind, metadata, "domain_records")
+    required_columns = {"id", "domain_id", "version", "data"}
+    if not required_columns.issubset(records.c.keys()):
+        return False
+    core = bind.execute(
+        sa.select(records.c.domain_id, records.c.version, records.c.data).where(
+            records.c.id == 1155
+        )
+    ).mappings().first()
+    data = core["data"] if core is not None else None
+    return bool(
+        core is not None
+        and int(core["domain_id"]) == 37
+        and int(core["version"]) >= 8
+        and isinstance(data, Mapping)
+        and data.get("slug") == "uwear-engineering-triage"
+    )
+
+
+def _record_cycle_revision(
+    bind: sa.Connection,
+    revisions: sa.Table,
+    cycle: Mapping[str, object],
+    prompt: str,
+) -> None:
+    latest = bind.execute(
+        sa.select(revisions)
+        .where(revisions.c.cycle_id == cycle["id"])
+        .order_by(
+            revisions.c.revision_number.desc(),
+            revisions.c.id.desc(),
+        )
+        .limit(1)
+    ).mappings().first()
+    if latest is not None and latest["prompt"] == prompt:
+        return
+
+    bind.execute(
+        revisions.insert().values(
+            cycle_id=cycle["id"],
+            revision_number=(int(latest["revision_number"]) + 1 if latest else 1),
+            source_type="system",
+            source_id=None,
+            rationale=_REVISION_RATIONALE,
+            name=cycle["name"],
+            prompt=prompt,
+            schedule_expr=cycle["schedule_expr"],
+            timezone=cycle["timezone"],
+            enabled=cycle["enabled"],
+            model_override=cycle["model_override"],
+            thinking_override=cycle["thinking_override"],
+            target_idea_id=cycle["target_idea_id"],
+            context_policy=(
+                latest["context_policy"]
+                if latest is not None and latest["context_policy"]
+                else {}
+            ),
+        )
+    )
+
+
+def _upgrade(bind: sa.Connection) -> None:
+    required_tables = {"cycles", "cycle_revisions"}
+    missing_tables = sorted(
+        table_name for table_name in required_tables if not _table_exists(bind, table_name)
+    )
+    if missing_tables:
+        _LOGGER.warning(
+            "Cannot deactivate the pinned chantier digest contract because required "
+            "tables are missing: %s. Leaving coordinator state unchanged.",
+            ", ".join(missing_tables),
+        )
+        return
+
+    metadata = sa.MetaData()
+    cycles = _table(bind, metadata, "cycles")
+    revisions = _table(bind, metadata, "cycle_revisions")
+    cycle = bind.execute(
+        sa.select(
+            cycles.c.id,
+            cycles.c.name,
+            cycles.c.prompt,
+            cycles.c.schedule_expr,
+            cycles.c.timezone,
+            cycles.c.enabled,
+            cycles.c.model_override,
+            cycles.c.thinking_override,
+            cycles.c.target_idea_id,
+        ).where(
+            cycles.c.id == _COORDINATOR_CYCLE_ID,
+            cycles.c.name == _COORDINATOR_CYCLE_NAME,
+        )
+    ).mappings().first()
+    if cycle is None:
+        _LOGGER.warning(
+            "Coordinator cycle 2 was not found; leaving coordinator state unchanged. "
+            "Slug-based activation remains pending."
+        )
+        return
+
+    safe_prompt = _without_pinned_contract(str(cycle["prompt"] or ""))
+    if safe_prompt is None:
+        if not _core_doc_is_active(bind):
+            _LOGGER.warning(
+                "Domain 37 doc 1155 is not activated at v8, but coordinator cycle 2 "
+                "does not contain the known pinned record-1274 contract. Leaving it "
+                "unchanged; slug-based activation remains pending."
+            )
+        return
+
+    update_values: dict[str, object] = {"prompt": safe_prompt}
+    if "updated_at" in cycles.c:
+        update_values["updated_at"] = sa.func.now()
+    bind.execute(
+        cycles.update().where(cycles.c.id == cycle["id"]).values(**update_values)
+    )
+    _record_cycle_revision(bind, revisions, cycle, safe_prompt)
+    _LOGGER.warning(
+        "Deactivated coordinator cycle 2's pinned record-1274 chantier contract. "
+        "The deploy remains usable; run the slug activation CLI to atomically activate "
+        "Domain 37 doc 1155 and the corrected mission."
+    )
+
+
+def upgrade() -> None:
+    _upgrade(op.get_bind())
+
+
+def downgrade() -> None:
+    # Never restore a mission known to point at a record from another domain.
+    return None

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -23,29 +23,36 @@ separate Domain `37` records; their live versions override bundled
 ## On-demand Run Modes
 
 Full playbooks stay in separate Domain `37` `doc_page` records so this core
-read remains untruncated. On entering a listed mode, fetch its record FIRST
-with `manage_domain` `action=get_record` `domain_id=37`, then follow it. If
-that fails, use `skill_asset` `name="uwear-engineering-triage"` with the path
-below. If both fail, say so and defer the mode's writes.
+read remains untruncated. Resolve each live record by slug: call `manage_domain`
+`action=query_records` `domain_id=37` `object_key=doc_page` with the slug as
+`search`, inspect all pages, and require exactly one active match whose
+`data.slug` exactly matches. Then call `action=get_record` with its id. Missing,
+duplicate, wrong-type, or cross-domain results fail the live read. Fall back to
+`skill_asset` `name="uwear-engineering-triage"` with the path below; if both
+reads fail, say so and defer writes.
 
-- **Direct customer support** — record `1271`, asset
+- **Direct customer support** — slug `uwear-engineering-triage-customer-support`,
+  asset
   `references/customer-support.md`. Fetch on a customer-support report;
   investigate the generation read-only and form a hypothesis before filing or
   assigning. Always-on: customer-generation issues have NO owner until that
   hypothesis exists (see **Ownership**).
-- **Creating work items** — record `1272`, asset
+- **Creating work items** — slug `uwear-engineering-triage-creating-work-items`,
+  asset
   `references/creating-work-items.md`. Fetch before `create_github_issue` or a
   Domain `1` tracker write. Always-on: one problem = one issue; search open and
   closed GitHub issues plus Domain `1` for the error signature or Rollbar id
   (prefer `rollbar_item`; exact matches never expire). Any match, even closed
   or `Done`, uses the **Deploy-State Ladder**, never a refile; never describe
   an internal tracker record as a GitHub issue.
-- **Backlog maintenance** — record `1273`, asset
+- **Backlog maintenance** — slug `uwear-engineering-triage-backlog-maintenance`,
+  asset
   `references/backlog-maintenance.md`. Covers seeding and `process-design`,
   `no-write-audit`, `live-hygiene-run`; fetch only on a human request, never in
   a scheduled digest. Always-on: never close GitHub issues or PRs without
   delegated authority.
-- **Chantier operations** — record `1274`, asset
+- **Chantier operations** — slug `uwear-engineering-triage-chantier-operations`,
+  asset
   `references/chantier-operations.md`. Fetch before every scheduled digest and
   before filing or recording a new work item. Always-on: check active
   chantiers; attach an exact match, only PROPOSE (never auto-create) an
@@ -65,8 +72,8 @@ counts, run summaries, or “posted to Slack” receipts. Use `confidence=0.9` f
 human-stated facts or approvals; cap inferences at `0.7` and use the lower value
 when mixed.
 
-For selection, dedup wording, and examples, fetch Domain `37` record `1275`,
-asset `references/memory.md`, using the live-first fallback above.
+For selection and dedup examples, resolve slug `uwear-engineering-triage-memory`
+in Domain `37`, asset `references/memory.md`, using the live-first fallback.
 
 ## Coordination Pipeline
 

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/memory.md
@@ -1,6 +1,6 @@
 # Uwear Engineering Triage — Memory Playbook
-> On-demand mode playbook for Enterprise Documentation Domain `37` record
-> `1275`, slug `uwear-engineering-triage-memory`.
+> On-demand mode playbook for Enterprise Documentation Domain `37`, slug
+> `uwear-engineering-triage-memory`.
 > Core doc: Domain `37` record `1155` (bundled skill
 > `uwear-engineering-triage`); fetch per its **Memory** section.
 

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/skill.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 name = "uwear-engineering-triage"
 display_name = "Uwear Engineering Triage"
-version = "1.7.0"
+version = "1.8.0"
 description = "Uwear engineering operating model for triaging GitHub issues and PRs, assigning Reda/Axel/JB, and moving work through backlog, staging, review, merge, and closure."
 license = "UNLICENSED"
 source = "self_hosted"

--- a/docs/329-live-delta.md
+++ b/docs/329-live-delta.md
@@ -1,72 +1,102 @@
-# Issue #329 deploy note — Domain 37 live delta
+# Issue #356 activation — Domain 37 Uwear triage documents
 
-This branch intentionally performs no live/SSH write. Deployment must apply
-the following exact Domain `37` changes after the commit lands.
+This branch performs no live, SSH, deployment, or production database write.
+After the code is deployed, Reda must run the activation command below against
+the intended environment. The command replaces the manual #329/#344 record-id
+runbooks; playbook ids come from the global database sequence and are never
+predicted or pinned.
 
-## 1. Create the on-demand chantier operations record
+## Slug resolution contract
 
-Create a `doc_page` with:
+The bundled core document resolves each on-demand playbook in Domain `37` by
+slug. It queries active `doc_page` records using the slug as search text,
+requires exactly one result whose `data.slug` is an exact match, and only then
+reads that returned record id in full. The bundled asset remains the explicit
+fallback.
 
-- intended record id: `1274` (the core pointer is pinned to this id; assert the
-  returned id before continuing);
-- slug: `uwear-engineering-triage-chantier-operations`;
-- title: `Uwear Engineering Triage — Chantier Operations`; and
-- content: the exact UTF-8 contents of
-  `brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md`.
+The activation command installs or verifies these mirrors:
 
-Expected content fingerprint:
+| slug | bundled source | characters | bytes | SHA-256 |
+|---|---|---:|---:|---|
+| `uwear-engineering-triage-customer-support` | `references/customer-support.md` | `2599` | `2609` | `ccd9e6ded301f69fb493e6557c0f17312f05fdf8c8eba90f734101e73ebc9be8` |
+| `uwear-engineering-triage-creating-work-items` | `references/creating-work-items.md` | `2576` | `2592` | `05acf69d6e473b64579eb84ace2bb995b923dc14c7887afe3cebde0f890b6c18` |
+| `uwear-engineering-triage-backlog-maintenance` | `references/backlog-maintenance.md` | `2554` | `2558` | `1c2bc475b50a974f0b5efb5a41375c059cb13839e4b70c95d113f42faabe0abc` |
+| `uwear-engineering-triage-chantier-operations` | `references/chantier-operations.md` | `11557` | `11565` | `61e78f92198db86916c5ebe753244fb862cb529a7295ec5a89df4d962efa9751` |
+| `uwear-engineering-triage-memory` | `references/memory.md` | `4872` | `4898` | `fd42aad5b3af22c28982f3a49fb49d11606587ca0d7adb16cf37a63d8a0df503` |
 
-- characters: `8352`;
-- bytes: `8358`; and
-- SHA-256: `e98123651c41fe935918bf79b0a5598bc7831ad73a91c7ee73442d7a8f28e006`.
+Expected memory mirror fingerprint:
 
-After creation, read record `1274` back and require byte identity with the
-bundled reference. If id `1274` is already occupied or the content differs,
-stop deployment: do not update core record `1155` to point at a missing or
-different playbook.
+- characters: `4872`;
+- bytes: `4898`; and
+- SHA-256: `fd42aad5b3af22c28982f3a49fb49d11606587ca0d7adb16cf37a63d8a0df503`.
 
-## 2. Replace core record 1155 with doc v8
+Core record `1155`, slug `uwear-engineering-triage`, must become the exact
+mirror of `SKILL.md`:
 
-Read Enterprise Documentation Domain `37`, `doc_page` record `1155`, and
-verify slug `uwear-engineering-triage`. It is expected to be v7 immediately
-before this activation. Apply `manage_domain` `action=update_record` by
-`record_id=1155` with the just-read `expected_version`, preserving all record
-fields except:
+- characters: `33943` (must remain `< 34000`);
+- bytes: `34075`; and
+- SHA-256: `6c318a9c20e2a8c3ce66fbacb2c0edf095d30a85e913c0caa855e6da452b0f9a`.
 
-- set `data.content` to the exact UTF-8 contents of
-  `brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md`.
+## Safety and idempotency
 
-This is a whole-content replacement, not a hand-edited approximation. The
-target v8 content adds exactly these operating-model changes:
+`brain.app.cli.activate_uwear_engineering_triage` runs in one transaction. On
+PostgreSQL it briefly locks `domain_records` against concurrent inserts so the
+global slug check and the following creates cannot race.
 
-- the record-1274 fetch trigger and always-on chantier invariants;
-- active-chantier coverage and freshness in Phase A;
-- chantier state/member/blocker data in the Phase-B snapshot, including
-  no-silent-departure;
-- chantier-primary digest v2: exact chantier count, moved-chantier sections,
-  quiet roll-up, `Loose items`, and the mandatory Reda/Axel/JB recap footer;
-- attach-at-triage/induction invariants before new-work filing; and
-- freshness and goal-language close-out gates in Before Posting.
+Before writing, it requires:
 
-Expected v8 fingerprint:
+- record `1155` to be the active Domain `37` `doc_page` with slug
+  `uwear-engineering-triage`;
+- exactly one active Domain `37` `doc_page` object type;
+- every existing target slug to resolve globally to at most one record, in
+  Domain `37`, in that `doc_page` type, and in the core record's organization;
+- core content that differs from the bundle to still be v7, so a newer live
+  edit is never overwritten silently; and
+- every bundled source file to be readable.
 
-- characters: `33834` (must remain `< 34000`);
-- bytes: `33972`; and
-- SHA-256: `1a98c7eb2b4112e7fed5a70e34554616cc4afcabf40c4343cd1e14ee788467bc`.
+A missing playbook is created with a database-assigned id. A correct existing
+playbook is left untouched; stale content is replaced with the bundled bytes
+using its locked current version. Core record `1155` is updated last and must
+be v8 or newer afterward. Every record is then read back and byte-verified
+before commit.
 
-If record `1155` is no longer v7, re-read and compare before writing. Do not
-silently overwrite a later live edit; reconcile it into the bundle first so
-the final record and bundled `SKILL.md` remain byte-identical.
+Any missing core target, occupied or duplicate slug, cross-domain/wrong-type
+record, archived target, concurrent version change, unreadable asset, or
+post-write mismatch raises an error and rolls back the entire transaction.
+Once all six records match, another `--apply` changes no rows or versions.
 
-## 3. Verification
+## Production activation (Reda)
 
-After both writes:
+Run from the deployed checkout after the image containing this change is
+available. This is the step that changes doc `1155` from live v7 to v8; merging
+this code alone does not activate it.
 
-1. Read records `1155` and `1274` back in full.
-2. Confirm record `1155` is v8 and its content exactly matches bundled
-   `SKILL.md` by byte count and SHA-256.
-3. Confirm record `1274` exactly matches bundled
-   `references/chantier-operations.md` by byte count and SHA-256.
-4. Confirm the core pointer names record `1274` and the matching asset path.
-5. Run one read-only coordinator dry run and verify the digest plan is
-   chantier-primary while the footer still covers Reda, Axel, and JB.
+```bash
+cd ~/illospace
+
+docker compose --env-file deploy/compose/.env \
+  -f deploy/compose/docker-compose.yml \
+  run --rm --no-deps api \
+  python -m brain.app.cli.activate_uwear_engineering_triage --apply
+
+docker compose --env-file deploy/compose/.env \
+  -f deploy/compose/docker-compose.yml \
+  run --rm --no-deps api \
+  python -m brain.app.cli.activate_uwear_engineering_triage --apply
+
+docker compose --env-file deploy/compose/.env \
+  -f deploy/compose/docker-compose.yml \
+  run --rm --no-deps api \
+  python -m brain.app.cli.activate_uwear_engineering_triage --check
+```
+
+The first command reports the required creates/updates. The second proves the
+write path is a no-op (`created=0 updated=0 unchanged=6`). The final read-only
+check must also report six unchanged documents.
+
+Afterward, verify the live acceptance query separately and run one read-only
+coordinator dry run. The query for record `1155` must return v8, `true`, and its
+content must be byte-identical to the deployed `SKILL.md`. Each of the five
+slugs above must resolve to exactly one active Domain `37` `doc_page` with the
+listed fingerprint. The dry-run digest plan must be chantier-primary while its
+footer still covers Reda, Axel, and JB.

--- a/docs/329-live-delta.md
+++ b/docs/329-live-delta.md
@@ -6,6 +6,14 @@ the intended environment. The command replaces the manual #329/#344 record-id
 runbooks; playbook ids come from the global database sequence and are never
 predicted or pinned.
 
+Deployment first runs forward-only migration
+`0028_deactivate_pinned_chantier_digest`. Revision `0027_chantier_digest_v2`
+is historical and remains byte-identical to `main`; `0028` removes its live
+record-`1274` contract from coordinator cycle `2` and appends a safe revision.
+It does not require doc `1155` v8 and never raises merely because activation is
+pending. Missing prerequisites are logged and left unchanged, so migration
+replay cannot hold a deployment behind this operator-run activation.
+
 ## Slug resolution contract
 
 The bundled core document resolves each on-demand playbook in Domain `37` by
@@ -52,24 +60,31 @@ Before writing, it requires:
   Domain `37`, in that `doc_page` type, and in the core record's organization;
 - core content that differs from the bundle to still be v7, so a newer live
   edit is never overwritten silently; and
+- coordinator cycle `2` plus its revision history to be present and
+  unambiguous; and
 - every bundled source file to be readable.
 
 A missing playbook is created with a database-assigned id. A correct existing
 playbook is left untouched; stale content is replaced with the bundled bytes
 using its locked current version. Core record `1155` is updated last and must
-be v8 or newer afterward. Every record is then read back and byte-verified
-before commit.
+be v8 or newer afterward. Every record is then read back and byte-verified.
+Only after that verification does the same transaction set cycle `2` and its
+new latest revision to the slug-based v2 mission. If either half fails, both
+the documents and mission roll back.
 
 Any missing core target, occupied or duplicate slug, cross-domain/wrong-type
 record, archived target, concurrent version change, unreadable asset, or
 post-write mismatch raises an error and rolls back the entire transaction.
 Once all six records match, another `--apply` changes no rows or versions.
+It also leaves the already-correct mission and revision untouched.
 
 ## Production activation (Reda)
 
 Run from the deployed checkout after the image containing this change is
 available. This is the step that changes doc `1155` from live v7 to v8; merging
-this code alone does not activate it.
+this code alone does not activate it. The normal deploy's Alembic step runs
+`0028` before these commands, so the coordinator no longer points at unrelated
+record `1274` while activation is pending.
 
 ```bash
 cd ~/illospace
@@ -90,13 +105,17 @@ docker compose --env-file deploy/compose/.env \
   python -m brain.app.cli.activate_uwear_engineering_triage --check
 ```
 
-The first command reports the required creates/updates. The second proves the
-write path is a no-op (`created=0 updated=0 unchanged=6`). The final read-only
-check must also report six unchanged documents.
+The first command reports the required creates/updates and
+`mission_updated=true`. The second proves the write path is a no-op
+(`created=0 updated=0 unchanged=6 mission_updated=false`). The final read-only
+check must also report six unchanged documents and `mission_updated=false`.
 
 Afterward, verify the live acceptance query separately and run one read-only
 coordinator dry run. The query for record `1155` must return v8, `true`, and its
 content must be byte-identical to the deployed `SKILL.md`. Each of the five
 slugs above must resolve to exactly one active Domain `37` `doc_page` with the
 listed fingerprint. The dry-run digest plan must be chantier-primary while its
-footer still covers Reda, Axel, and JB.
+footer still covers Reda, Axel, and JB. Coordinator cycle `2` and its latest
+revision must contain slug `uwear-engineering-triage-chantier-operations` and
+must not contain `record 1274`; historical revision `47` remains append-only
+evidence of the superseded mission.

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -53,7 +53,7 @@ def test_uwear_engineering_triage_includes_dependency_monitor():
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
 
-    assert bundle.manifest.version == "1.7.0"
+    assert bundle.manifest.version == "1.8.0"
     procedure = bundle.skill_markdown
     for expected in (
         "## Dependency Monitor",
@@ -88,7 +88,7 @@ def test_uwear_triage_bundle_packages_chantier_operations_v2():
     procedure = bundle.skill_markdown
     playbook = _uwear_triage_asset(bundle, "references/chantier-operations.md")
 
-    assert "record `1274`" in procedure
+    assert "slug `uwear-engineering-triage-chantier-operations`" in procedure
     assert "before every scheduled digest" in procedure
     assert "before filing or recording a new work item" in procedure
     for expected in (
@@ -160,7 +160,7 @@ def test_uwear_triage_scheduled_memory_contract():
         "What future runs need:",
         "confidence=0.9",
         "cap inferences at `0.7`",
-        "record `1275`",
+        "slug `uwear-engineering-triage-memory`",
         "`references/memory.md`",
     ):
         assert expected in procedure
@@ -186,7 +186,7 @@ def test_uwear_triage_memory_delta_fingerprints_exact_bundle_mirrors():
     from brain.systems.skills.bundles import load_skill_bundle
 
     bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
-    note = (Path(__file__).parents[1] / "docs" / "344-live-delta.md").read_text()
+    note = (Path(__file__).parents[1] / "docs" / "329-live-delta.md").read_text()
     mirrors = (
         (bundle.skill_markdown, "v9"),
         (
@@ -342,6 +342,30 @@ def test_builtin_skills_have_structured_routing_metadata():
         assert _has_text_items(skill["triggers"], "pattern")
         assert _has_text_items(skill["guardrails"], "text")
         assert all(item.get("severity") for item in skill["guardrails"])
+
+
+def test_uwear_triage_resolves_every_on_demand_playbook_by_exact_slug():
+    from brain.systems.skills.builtin import BUILTIN_SKILL_BUNDLE_ROOT
+    from brain.systems.skills.bundles import load_skill_bundle
+
+    bundle = load_skill_bundle(BUILTIN_SKILL_BUNDLE_ROOT / "uwear-engineering-triage")
+    procedure = bundle.skill_markdown
+
+    for slug in (
+        "uwear-engineering-triage-customer-support",
+        "uwear-engineering-triage-creating-work-items",
+        "uwear-engineering-triage-backlog-maintenance",
+        "uwear-engineering-triage-chantier-operations",
+        "uwear-engineering-triage-memory",
+    ):
+        assert f"slug `{slug}`" in procedure
+
+    normalized = " ".join(procedure.split())
+    assert "whose `data.slug` exactly matches" in normalized
+    assert "require exactly one active match" in normalized
+    assert "action=get_record" in normalized
+    for record_id in range(1271, 1276):
+        assert f"record `{record_id}`" not in procedure
 
 
 def test_builtin_skills_have_explicit_role_boundaries():

--- a/tests/test_chantier_digest_migration.py
+++ b/tests/test_chantier_digest_migration.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import importlib
 
-import pytest
 import sqlalchemy as sa
 
 
 MIGRATION_MODULE = "brain.platform.db.alembic.versions.0027_chantier_digest_v2"
+REPAIR_MODULE = (
+    "brain.platform.db.alembic.versions.0028_deactivate_pinned_chantier_digest"
+)
 
 
 def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
@@ -192,8 +194,9 @@ def test_v2_contract_stays_visible_at_front_of_near_cap_mission():
     assert prompt.endswith("z" * 12_000)
 
 
-def test_migration_fails_before_mutating_cycle_when_doc_1155_is_still_v7():
+def test_migration_replay_with_cycle_2_and_doc_1155_v7_does_not_raise(caplog):
     migration = importlib.import_module(MIGRATION_MODULE)
+    repair = importlib.import_module(REPAIR_MODULE)
     engine = sa.create_engine("sqlite://")
     metadata, tables = _schema()
     metadata.create_all(engine)
@@ -207,21 +210,29 @@ def test_migration_fails_before_mutating_cycle_when_doc_1155_is_still_v7():
             .values(version=7, data={"slug": "uwear-engineering-triage", "content": "v7"})
         )
 
-        with pytest.raises(RuntimeError, match="record 1155.*v8"):
-            migration._upgrade(connection)
+        migration._upgrade(connection)
+        repair._upgrade(connection)
+        repair._upgrade(connection)
 
         prompt = connection.execute(
             sa.select(tables["cycles"].c.prompt).where(tables["cycles"].c.id == 2)
         ).scalar_one()
-        revision_count = connection.execute(
-            sa.select(sa.func.count()).select_from(tables["cycle_revisions"])
-        ).scalar_one()
+        revisions = connection.execute(
+            sa.select(tables["cycle_revisions"])
+            .where(tables["cycle_revisions"].c.cycle_id == 2)
+            .order_by(tables["cycle_revisions"].c.revision_number)
+        ).mappings().all()
         assert prompt == "Run the existing owner-primary coordinator mission."
-        assert revision_count == 3
+        assert "record 1274" in revisions[-2]["prompt"]
+        assert revisions[-1]["prompt"] == prompt
+        assert [row["revision_number"] for row in revisions] == [1, 2, 3]
+        assert "deploy remains usable" in caplog.text
 
 
-def test_migration_fails_when_doc_1155_v8_does_not_contain_chantier_contract():
-    migration = importlib.import_module(MIGRATION_MODULE)
+def test_repair_migration_no_ops_loudly_when_unactivated_cycle_has_no_pinned_contract(
+    caplog,
+):
+    repair = importlib.import_module(REPAIR_MODULE)
     engine = sa.create_engine("sqlite://")
     metadata, tables = _schema()
     metadata.create_all(engine)
@@ -232,30 +243,9 @@ def test_migration_fails_when_doc_1155_v8_does_not_contain_chantier_contract():
             tables["domain_records"]
             .update()
             .where(tables["domain_records"].c.id == 1155)
-            .values(data={"slug": "uwear-engineering-triage", "content": "unrelated v8"})
+            .values(version=7, data={"slug": "uwear-engineering-triage", "content": "v7"})
         )
 
-        with pytest.raises(RuntimeError, match="chantier operating model"):
-            migration._upgrade(connection)
+        repair._upgrade(connection)
 
-
-def test_mission_contract_resolves_chantier_playbook_by_slug():
-    migration = importlib.import_module(MIGRATION_MODULE)
-
-    assert "uwear-engineering-triage-chantier-operations" in migration._MISSION_CONTRACT
-    assert "record 1274" not in migration._MISSION_CONTRACT
-
-
-def test_mission_prompt_replaces_an_older_v2_block_without_losing_legacy_mission():
-    migration = importlib.import_module(MIGRATION_MODULE)
-    legacy = "Keep the owner-primary details that are not superseded."
-    old_prompt = (
-        "Chantier-primary digest contract v2: Load playbook record 1274."
-        f"\n\n{legacy}"
-    )
-
-    prompt = migration._mission_prompt(old_prompt)
-
-    assert prompt.startswith(migration._MISSION_CONTRACT)
-    assert prompt.endswith(legacy)
-    assert "record 1274" not in prompt
+        assert "slug-based activation remains pending" in caplog.text

--- a/tests/test_chantier_digest_migration.py
+++ b/tests/test_chantier_digest_migration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
 import sqlalchemy as sa
 
 
@@ -54,6 +55,14 @@ def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
             ),
             sa.UniqueConstraint("cycle_id", "revision_number"),
         ),
+        "domain_records": sa.Table(
+            "domain_records",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("version", sa.Integer, nullable=False),
+            sa.Column("data", sa.JSON, nullable=False),
+        ),
     }
     return metadata, tables
 
@@ -100,6 +109,18 @@ def _seed(connection: sa.Connection, tables: dict[str, sa.Table]) -> None:
             }
             for cycle_id, name, schedule, timezone in cycles
         ],
+    )
+    connection.execute(
+        tables["domain_records"].insert(),
+        {
+            "id": 1155,
+            "domain_id": 37,
+            "version": 8,
+            "data": {
+                "slug": "uwear-engineering-triage",
+                "content": "The verified chantier operating model.",
+            },
+        },
     )
 
 
@@ -169,3 +190,72 @@ def test_v2_contract_stays_visible_at_front_of_near_cap_mission():
 
     assert prompt.startswith("Chantier-primary digest contract v2:")
     assert prompt.endswith("z" * 12_000)
+
+
+def test_migration_fails_before_mutating_cycle_when_doc_1155_is_still_v7():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        connection.execute(
+            tables["domain_records"]
+            .update()
+            .where(tables["domain_records"].c.id == 1155)
+            .values(version=7, data={"slug": "uwear-engineering-triage", "content": "v7"})
+        )
+
+        with pytest.raises(RuntimeError, match="record 1155.*v8"):
+            migration._upgrade(connection)
+
+        prompt = connection.execute(
+            sa.select(tables["cycles"].c.prompt).where(tables["cycles"].c.id == 2)
+        ).scalar_one()
+        revision_count = connection.execute(
+            sa.select(sa.func.count()).select_from(tables["cycle_revisions"])
+        ).scalar_one()
+        assert prompt == "Run the existing owner-primary coordinator mission."
+        assert revision_count == 3
+
+
+def test_migration_fails_when_doc_1155_v8_does_not_contain_chantier_contract():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        connection.execute(
+            tables["domain_records"]
+            .update()
+            .where(tables["domain_records"].c.id == 1155)
+            .values(data={"slug": "uwear-engineering-triage", "content": "unrelated v8"})
+        )
+
+        with pytest.raises(RuntimeError, match="chantier operating model"):
+            migration._upgrade(connection)
+
+
+def test_mission_contract_resolves_chantier_playbook_by_slug():
+    migration = importlib.import_module(MIGRATION_MODULE)
+
+    assert "uwear-engineering-triage-chantier-operations" in migration._MISSION_CONTRACT
+    assert "record 1274" not in migration._MISSION_CONTRACT
+
+
+def test_mission_prompt_replaces_an_older_v2_block_without_losing_legacy_mission():
+    migration = importlib.import_module(MIGRATION_MODULE)
+    legacy = "Keep the owner-primary details that are not superseded."
+    old_prompt = (
+        "Chantier-primary digest contract v2: Load playbook record 1274."
+        f"\n\n{legacy}"
+    )
+
+    prompt = migration._mission_prompt(old_prompt)
+
+    assert prompt.startswith(migration._MISSION_CONTRACT)
+    assert prompt.endswith(legacy)
+    assert "record 1274" not in prompt

--- a/tests/test_uwear_triage_activation.py
+++ b/tests/test_uwear_triage_activation.py
@@ -7,6 +7,15 @@ import sqlalchemy as sa
 
 
 ACTIVATION_MODULE = "brain.app.cli.activate_uwear_engineering_triage"
+REPAIR_MIGRATION_MODULE = (
+    "brain.platform.db.alembic.versions.0028_deactivate_pinned_chantier_digest"
+)
+LEGACY_MISSION = "Run the existing owner-primary coordinator mission."
+PINNED_MISSION = (
+    "Chantier-primary digest contract v2: Load Enterprise Documentation Domain 37 "
+    "record 1155 and the chantier-operations playbook record 1274 before each digest."
+    f"\n\n{LEGACY_MISSION}"
+)
 
 
 def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
@@ -35,6 +44,41 @@ def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
             sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         ),
+        "cycles": sa.Table(
+            "cycles",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.Text, nullable=False),
+            sa.Column("prompt", sa.Text, nullable=False),
+            sa.Column("schedule_expr", sa.Text, nullable=False),
+            sa.Column("timezone", sa.Text, nullable=False),
+            sa.Column("enabled", sa.Boolean, nullable=False),
+            sa.Column("model_override", sa.Text),
+            sa.Column("thinking_override", sa.Text),
+            sa.Column("target_idea_id", sa.Text),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        ),
+        "cycle_revisions": sa.Table(
+            "cycle_revisions",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("cycle_id", sa.Integer, nullable=False),
+            sa.Column("revision_number", sa.Integer, nullable=False),
+            sa.Column("source_type", sa.Text, nullable=False),
+            sa.Column("source_id", sa.Text),
+            sa.Column("rationale", sa.Text),
+            sa.Column("name", sa.Text, nullable=False),
+            sa.Column("prompt", sa.Text, nullable=False),
+            sa.Column("schedule_expr", sa.Text, nullable=False),
+            sa.Column("timezone", sa.Text, nullable=False),
+            sa.Column("enabled", sa.Boolean, nullable=False),
+            sa.Column("model_override", sa.Text),
+            sa.Column("thinking_override", sa.Text),
+            sa.Column("target_idea_id", sa.Text),
+            sa.Column("context_policy", sa.JSON, nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.UniqueConstraint("cycle_id", "revision_number"),
+        ),
     }
     return metadata, tables
 
@@ -48,6 +92,33 @@ def _seed(
     connection.execute(
         tables["domain_object_types"].insert(),
         {"id": 75, "domain_id": 37, "key": "doc_page"},
+    )
+    connection.execute(
+        tables["cycles"].insert(),
+        {
+            "id": 2,
+            "name": "Uwear Ticket Coordinator Check-ins",
+            "prompt": PINNED_MISSION,
+            "schedule_expr": "0 8,13 * * *",
+            "timezone": "America/Toronto",
+            "enabled": True,
+        },
+    )
+    connection.execute(
+        tables["cycle_revisions"].insert(),
+        {
+            "id": 47,
+            "cycle_id": 2,
+            "revision_number": 9,
+            "source_type": "system",
+            "rationale": "Seed the original pinned chantier digest contract.",
+            "name": "Uwear Ticket Coordinator Check-ins",
+            "prompt": PINNED_MISSION,
+            "schedule_expr": "0 8,13 * * *",
+            "timezone": "America/Toronto",
+            "enabled": True,
+            "context_policy": {"workspace_id": "workspace-1"},
+        },
     )
     rows = [
         {
@@ -108,9 +179,11 @@ def test_activation_ignores_legacy_id_collisions_and_is_idempotent():
 
         assert len(first.created) == 5
         assert first.updated == ("uwear-engineering-triage",)
+        assert first.mission_updated is True
         assert second.created == ()
         assert second.updated == ()
         assert len(second.unchanged) == 6
+        assert second.mission_updated is False
         assert after_second == after_first
 
         targets = {
@@ -124,6 +197,120 @@ def test_activation_ignores_legacy_id_collisions_and_is_idempotent():
         }
         assert all(targets[slug]["id"] > 1275 for slug in activation.PLAYBOOK_SLUGS)
         assert targets["uwear-engineering-triage"]["version"] == 8
+
+
+def test_activation_repairs_live_revision_47_atomically_with_doc_1155_v8():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    repair = importlib.import_module(REPAIR_MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+
+        revision_47 = connection.execute(
+            sa.select(tables["cycle_revisions"]).where(
+                tables["cycle_revisions"].c.id == 47
+            )
+        ).mappings().one()
+        assert "record 1274" in revision_47["prompt"]
+
+        repair._upgrade(connection)
+
+        pre_activation_core_version = connection.execute(
+            sa.select(tables["domain_records"].c.version).where(
+                tables["domain_records"].c.id == 1155
+            )
+        ).scalar_one()
+        pre_activation_mission = connection.execute(
+            sa.select(tables["cycles"].c.prompt).where(tables["cycles"].c.id == 2)
+        ).scalar_one()
+        assert pre_activation_core_version == 7
+        assert "record 1274" not in pre_activation_mission
+        assert "Chantier-primary digest contract v2:" not in pre_activation_mission
+
+        result = activation._activate(connection, apply=True)
+
+        core = connection.execute(
+            sa.select(tables["domain_records"]).where(
+                tables["domain_records"].c.id == 1155
+            )
+        ).mappings().one()
+        live_mission = connection.execute(
+            sa.select(tables["cycles"].c.prompt).where(tables["cycles"].c.id == 2)
+        ).scalar_one()
+        latest_revision = connection.execute(
+            sa.select(tables["cycle_revisions"])
+            .where(tables["cycle_revisions"].c.cycle_id == 2)
+            .order_by(
+                tables["cycle_revisions"].c.revision_number.desc(),
+                tables["cycle_revisions"].c.id.desc(),
+            )
+            .limit(1)
+        ).mappings().one()
+
+        assert result.mission_updated is True
+        assert core["version"] == 8
+        assert core["data"]["content"] == (activation.BUNDLE_ROOT / "SKILL.md").read_text()
+        assert "uwear-engineering-triage-chantier-operations" in live_mission
+        assert "record 1274" not in live_mission
+        assert latest_revision["id"] != 47
+        assert latest_revision["prompt"] == live_mission
+
+
+def test_activation_rolls_back_documents_when_mission_revision_write_fails(monkeypatch):
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        before_records = _records(connection, tables["domain_records"])
+
+    def fail_revision_write(*args, **kwargs):
+        raise activation.ActivationError("simulated mission revision failure")
+
+    monkeypatch.setattr(activation, "_record_cycle_revision", fail_revision_write)
+    with pytest.raises(activation.ActivationError, match="simulated mission revision failure"):
+        with engine.begin() as connection:
+            activation._activate(connection, apply=True)
+
+    with engine.connect() as connection:
+        after_records = _records(connection, tables["domain_records"])
+        mission = connection.execute(
+            sa.select(tables["cycles"].c.prompt).where(tables["cycles"].c.id == 2)
+        ).scalar_one()
+        revision_count = connection.execute(
+            sa.select(sa.func.count()).select_from(tables["cycle_revisions"])
+        ).scalar_one()
+
+        assert after_records == before_records
+        assert mission == PINNED_MISSION
+        assert revision_count == 1
+
+
+def test_mission_contract_resolves_chantier_playbook_by_slug():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+
+    assert "uwear-engineering-triage-chantier-operations" in activation.MISSION_CONTRACT
+    assert "record 1274" not in activation.MISSION_CONTRACT
+
+
+def test_mission_prompt_replaces_pinned_v2_block_without_losing_legacy_mission():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    legacy = "Keep the owner-primary details that are not superseded."
+    old_prompt = (
+        "Chantier-primary digest contract v2: Load playbook record 1274."
+        f"\n\n{legacy}"
+    )
+
+    prompt = activation._mission_prompt(old_prompt)
+
+    assert prompt.startswith(activation.MISSION_CONTRACT)
+    assert prompt.endswith(legacy)
+    assert "record 1274" not in prompt
 
 
 def test_activation_fails_loudly_on_cross_domain_slug_collision():

--- a/tests/test_uwear_triage_activation.py
+++ b/tests/test_uwear_triage_activation.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+
+
+ACTIVATION_MODULE = "brain.app.cli.activate_uwear_engineering_triage"
+
+
+def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
+    metadata = sa.MetaData()
+    tables = {
+        "domain_object_types": sa.Table(
+            "domain_object_types",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("key", sa.Text, nullable=False),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+        ),
+        "domain_records": sa.Table(
+            "domain_records",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("org_id", sa.Text, nullable=False),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("object_type_id", sa.Integer, nullable=False),
+            sa.Column("title", sa.Text, nullable=False),
+            sa.Column("data", sa.JSON, nullable=False),
+            sa.Column("search_text", sa.Text, nullable=False, server_default=""),
+            sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        ),
+    }
+    return metadata, tables
+
+
+def _seed(
+    connection: sa.Connection,
+    tables: dict[str, sa.Table],
+    *,
+    include_core: bool = True,
+) -> None:
+    connection.execute(
+        tables["domain_object_types"].insert(),
+        {"id": 75, "domain_id": 37, "key": "doc_page"},
+    )
+    rows = [
+        {
+            "id": 1274,
+            "org_id": "org-1",
+            "domain_id": 1,
+            "object_type_id": 1,
+            "title": "Unrelated pull request",
+            "data": {"slug": "github-uwear-backend-pr-910"},
+            "version": 1,
+        },
+        {
+            "id": 1275,
+            "org_id": "org-1",
+            "domain_id": 40,
+            "object_type_id": 40,
+            "title": "Unrelated audit plan",
+            "data": {"slug": "route-database-audit-pickup-plan"},
+            "version": 1,
+        },
+    ]
+    if include_core:
+        rows.insert(
+            0,
+            {
+                "id": 1155,
+                "org_id": "org-1",
+                "domain_id": 37,
+                "object_type_id": 75,
+                "title": "Uwear Engineering Triage",
+                "data": {"slug": "uwear-engineering-triage", "content": "v7"},
+                "version": 7,
+            },
+        )
+    connection.execute(tables["domain_records"].insert(), rows)
+
+
+def _records(connection: sa.Connection, table: sa.Table) -> list[dict[str, object]]:
+    return [
+        dict(row)
+        for row in connection.execute(sa.select(table).order_by(table.c.id)).mappings()
+    ]
+
+
+def test_activation_ignores_legacy_id_collisions_and_is_idempotent():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+
+        first = activation._activate(connection, apply=True)
+        after_first = _records(connection, tables["domain_records"])
+        second = activation._activate(connection, apply=True)
+        after_second = _records(connection, tables["domain_records"])
+
+        assert len(first.created) == 5
+        assert first.updated == ("uwear-engineering-triage",)
+        assert second.created == ()
+        assert second.updated == ()
+        assert len(second.unchanged) == 6
+        assert after_second == after_first
+
+        targets = {
+            row["data"]["slug"]: row
+            for row in after_second
+            if row["domain_id"] == 37
+        }
+        assert set(targets) == {
+            "uwear-engineering-triage",
+            *activation.PLAYBOOK_SLUGS,
+        }
+        assert all(targets[slug]["id"] > 1275 for slug in activation.PLAYBOOK_SLUGS)
+        assert targets["uwear-engineering-triage"]["version"] == 8
+
+
+def test_activation_fails_loudly_on_cross_domain_slug_collision():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        connection.execute(
+            tables["domain_records"]
+            .update()
+            .where(tables["domain_records"].c.id == 1274)
+            .values(data={"slug": "uwear-engineering-triage-chantier-operations"})
+        )
+
+        with pytest.raises(
+            activation.ActivationError,
+            match="chantier-operations.*occupied.*Domain 1",
+        ):
+            activation._activate(connection, apply=True)
+
+
+def test_activation_fails_loudly_when_core_target_is_missing():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables, include_core=False)
+
+        with pytest.raises(activation.ActivationError, match="record 1155 is missing"):
+            activation._activate(connection, apply=True)
+
+
+def test_activation_fails_loudly_when_core_id_is_occupied_cross_domain():
+    activation = importlib.import_module(ACTIVATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        connection.execute(
+            tables["domain_records"]
+            .update()
+            .where(tables["domain_records"].c.id == 1155)
+            .values(domain_id=1)
+        )
+
+        with pytest.raises(
+            activation.ActivationError,
+            match="id 1155.*Domain 1",
+        ):
+            activation._activate(connection, apply=True)


### PR DESCRIPTION
Closes #356

## What this does (code half only — production activation stays Reda's)

The chantier layer is half-activated: cycle-2's mission is the chantier-primary v2 digest, but it points at **record `1274`**, which is a Domain 1 PR record (id collision — record ids come from a global sequence, not per-domain). Doc `1155` is still v7 and has never heard of chantiers. This PR removes every hardcoded record-id pin and makes activation a scripted, idempotent, loud-failing operation.

### The fix, in four parts
1. **Slug resolution, no pinned ids.** On-demand playbooks resolve by slug (e.g. `uwear-engineering-triage-chantier-operations`) in both the bundled `SKILL.md` and `docs/329-live-delta.md`. The other pins (`1271`/`1272`/`1273`) — correct today but pinned by the same broken assumption — are converted too. Zero record-id pins remain in `SKILL.md`/`memory.md`; the only `1274` mentions left in docs are prose explaining that `0028` *removes* it.
2. **Forward-only migration `0028_deactivate_pinned_chantier_digest`.** `0027` is already deployed, so a gate added inside it would be inert and editing it retroactively is bad alembic hygiene — this PR **reverts `0027` to byte-identical-to-`main`** and adds `0028` instead. `0028` strips the known-broken record-`1274` contract from live coordinator cycle 2 and appends a safe revision. It is **defensive**: idempotent (re-run = no-op), no-downgrade, and if prerequisites are absent (tables/cycle missing, or an unrecognized contract) it **logs and leaves state unchanged** rather than guessing.
3. **Atomic slug activation CLI** (`brain/app/cli/activate_uwear_engineering_triage.py`): resolves/creates the Domain 37 playbooks by slug, updates doc `1155` last, byte-verifies every record, and only then sets cycle 2 to the slug-based mission — all in one transaction that rolls back both halves on any failure (missing/occupied/cross-domain/archived target, version drift, unreadable asset, post-write mismatch).
4. **Bundle version `1.7.0 → 1.8.0`**, clearing the #352/#354 dual-content-under-one-version smudge; `tests/test_builtin_skill_suite.py` assert updated.

## Tests
`tests/test_builtin_skill_suite.py` + `tests/test_uwear_triage_activation.py` + `tests/test_chantier_digest_migration.py` — **35 passed** (venv python). Covers acceptance checks **#2** (slug resolution; cross-domain/missing target fails loudly) and **#4** (idempotent re-run; loud failure on occupied/cross-domain id).

## ⚠️ Reda — read before merging + deploying
Merging + deploying this runs migration **`0028` on the next alembic step**, which **mutates live coordinator cycle 2** (strips the record-1274 contract, appends a revision). That is the "live rollback of cycle 2 — Reda's call" the ticket drew a line around. A draft PR runs nothing; it executes only when *you* merge and deploy, so the call stays yours. It's designed deploy-safe (defensive, idempotent, forward-only) — but confirm you want the auto-deactivation on deploy, or say the word and I'll drop `0028` and ship code-only.

**Acceptance check #1 (doc 1155 reads v8 in the live DB) is NOT satisfied by this PR** — it needs the production activation run. This PR makes it *achievable*. To activate, from the deployed checkout after the image ships:
```
# deploy runs 0028 automatically; then:
python -m brain.app.cli.activate_uwear_engineering_triage --check   # reports required creates/updates
python -m brain.app.cli.activate_uwear_engineering_triage --apply   # atomic activation
python -m brain.app.cli.activate_uwear_engineering_triage --check   # proves no-op (created=0 updated=0 unchanged=6)
```
(exact docker compose invocation in `docs/329-live-delta.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
