### PR TITLE
Public /doc viewer + viewer_url so Illo can share PRDs as readable links

### DIFF
--- a/brain/systems/cortex/thread_assets.py
+++ b/brain/systems/cortex/thread_assets.py
@@ -7,7 +7,9 @@ import os
 import re
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import quote, urlencode
 
+from brain.systems.cortex.thread_links import public_app_base_url
 from brain.systems.cortex.upload_preview import (
     normalize_static_upload_url,
     public_static_upload_url,
@@ -144,6 +146,28 @@ def _asset_markdown(*, label: str, url: str, kind: str) -> str:
     return f"[{clean_label}]({url})"
 
 
+def _viewer_url(*, url: str, public_url: str, kind: str, label: str) -> str:
+    """Absolute link teammates can open in a browser (no session required).
+
+    Images render natively, so they keep the direct upload URL. Documents go
+    through the public /doc viewer page, which renders markdown readably
+    instead of serving the raw file as plain text.
+    """
+
+    if kind == "image":
+        return public_url
+    query = urlencode({"src": url, "title": label}, quote_via=quote, safe="/")
+    return f"{public_app_base_url()}/doc?{query}"
+
+
+_PUBLISH_INSTRUCTION = (
+    "To show this in a Thread, write the returned markdown or /static/uploads route "
+    "in post_thread_discussion_reply or post_ai_timeline_message. Valid upload routes "
+    "are promoted to visible attachments automatically. When sharing outside the app "
+    "(e.g. a Slack message), link viewer_url — it opens as a readable page with no sign-in."
+)
+
+
 def publish_thread_asset(
     file_path: str,
     *,
@@ -170,14 +194,16 @@ def publish_thread_asset(
                 "published_path": str(published_path),
                 "url": url,
                 "public_url": attachment["download_url"],
+                "viewer_url": _viewer_url(
+                    url=url,
+                    public_url=attachment["download_url"],
+                    kind=attachment["kind"],
+                    label=attachment["label"],
+                ),
                 "markdown": _asset_markdown(label=attachment["label"], url=url, kind=attachment["kind"]),
                 "attachment": attachment,
                 "already_published": True,
-                "instruction": (
-                    "To show this in a Thread, write the returned markdown or /static/uploads route "
-                    "in post_thread_discussion_reply or post_ai_timeline_message. Valid upload routes "
-                    "are promoted to visible attachments automatically."
-                ),
+                "instruction": _PUBLISH_INSTRUCTION,
             }
         except ValueError:
             pass
@@ -226,13 +252,15 @@ def publish_thread_asset(
         "published_path": str(destination),
         "url": url,
         "public_url": attachment["download_url"],
+        "viewer_url": _viewer_url(
+            url=url,
+            public_url=attachment["download_url"],
+            kind=kind,
+            label=label,
+        ),
         "markdown": _asset_markdown(label=label, url=url, kind=kind),
         "attachment": attachment,
-        "instruction": (
-            "To show this in a Thread, write the returned markdown or /static/uploads route "
-            "in post_thread_discussion_reply or post_ai_timeline_message. Valid upload routes "
-            "are promoted to visible attachments automatically."
-        ),
+        "instruction": _PUBLISH_INSTRUCTION,
     }
 
 

--- a/brain/systems/cortex/thread_assets.py
+++ b/brain/systems/cortex/thread_assets.py
@@ -25,6 +25,7 @@ VIEWER_EXTENSIONS = {
     "csv",
     "json",
     "log",
+    "markdown",
     "md",
     "pdf",
     "text",
@@ -43,6 +44,7 @@ CONTENT_TYPE_BY_EXTENSION = {
     "jpg": "image/jpeg",
     "json": "application/json",
     "log": "text/plain",
+    "markdown": "text/markdown",
     "md": "text/markdown",
     "pdf": "application/pdf",
     "png": "image/png",
@@ -146,16 +148,9 @@ def _asset_markdown(*, label: str, url: str, kind: str) -> str:
     return f"[{clean_label}]({url})"
 
 
-def _viewer_url(*, url: str, public_url: str, kind: str, label: str) -> str:
-    """Absolute link teammates can open in a browser (no session required).
+def _viewer_url(*, url: str, label: str) -> str:
+    """Absolute /doc link teammates can open without a session."""
 
-    Images render natively, so they keep the direct upload URL. Documents go
-    through the public /doc viewer page, which renders markdown readably
-    instead of serving the raw file as plain text.
-    """
-
-    if kind == "image":
-        return public_url
     query = urlencode({"src": url, "title": label}, quote_via=quote, safe="/")
     return f"{public_app_base_url()}/doc?{query}"
 
@@ -196,8 +191,6 @@ def publish_thread_asset(
                 "public_url": attachment["download_url"],
                 "viewer_url": _viewer_url(
                     url=url,
-                    public_url=attachment["download_url"],
-                    kind=attachment["kind"],
                     label=attachment["label"],
                 ),
                 "markdown": _asset_markdown(label=attachment["label"], url=url, kind=attachment["kind"]),
@@ -254,8 +247,6 @@ def publish_thread_asset(
         "public_url": attachment["download_url"],
         "viewer_url": _viewer_url(
             url=url,
-            public_url=attachment["download_url"],
-            kind=kind,
             label=label,
         ),
         "markdown": _asset_markdown(label=label, url=url, kind=kind),

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -236,7 +236,9 @@ CHAT_TOOLS = [
             "attachment object. To show the asset in a Thread, write the returned markdown "
             "or /static/uploads/... route in post_thread_discussion_reply or "
             "post_ai_timeline_message; those tools persist visible attachments from valid "
-            "upload routes automatically."
+            "upload routes automatically. The result also includes viewer_url, an absolute "
+            "no-login link that renders documents as readable pages; share viewer_url when "
+            "linking the asset outside the app (for example in Slack)."
         ),
         "input_schema": {
             "type": "object",

--- a/frontend/src/lib/styles/components.css
+++ b/frontend/src/lib/styles/components.css
@@ -289,6 +289,33 @@
   background: var(--content-code-background);
 }
 
+.constellation-prose .md-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.constellation-prose .md-table-wrap table {
+  width: max-content;
+  min-width: min(100%, 320px);
+  border-collapse: collapse;
+  font-size: 0.94em;
+  line-height: var(--leading-normal);
+}
+
+.constellation-prose .md-table-wrap th,
+.constellation-prose .md-table-wrap td {
+  border: 1px solid var(--border-2);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.constellation-prose .md-table-wrap th {
+  color: var(--constellation-prose-heading);
+  background: var(--content-code-background);
+  font-weight: var(--weight-semibold);
+}
+
 .constellation-prose .md-code-block code {
   border: 0;
   padding: 0;

--- a/frontend/src/lib/utils/docViewer.test.js
+++ b/frontend/src/lib/utils/docViewer.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  docViewerFilename,
+  docViewerRenderMode,
+  docViewerTitle,
+  firstMarkdownHeading,
+  normalizeDocViewerSrc,
+} from './docViewer.ts';
+
+test('accepts only /static/uploads sources', () => {
+  assert.equal(
+    normalizeDocViewerSrc('/static/uploads/thread-assets/t1/prd-abc123.md'),
+    '/static/uploads/thread-assets/t1/prd-abc123.md',
+  );
+  assert.equal(normalizeDocViewerSrc('  /static/uploads/a.md  '), '/static/uploads/a.md');
+
+  assert.equal(normalizeDocViewerSrc(null), null);
+  assert.equal(normalizeDocViewerSrc(''), null);
+  assert.equal(normalizeDocViewerSrc('/etc/passwd'), null);
+  assert.equal(normalizeDocViewerSrc('https://evil.example/static/uploads/a.md'), null);
+  assert.equal(normalizeDocViewerSrc('//evil.example/static/uploads/a.md'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads/../secrets.md'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads/a/../../b.md'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads//double.md'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads/dir/'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads/a.md?x=1'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads/a.md#frag'), null);
+  assert.equal(normalizeDocViewerSrc('/static/uploads\\a.md'), null);
+});
+
+test('picks a render mode from the file extension', () => {
+  assert.equal(docViewerRenderMode('/static/uploads/t/prd.md'), 'markdown');
+  assert.equal(docViewerRenderMode('/static/uploads/t/prd.MARKDOWN'), 'markdown');
+  assert.equal(docViewerRenderMode('/static/uploads/t/spec.pdf'), 'pdf');
+  assert.equal(docViewerRenderMode('/static/uploads/t/data.csv'), 'text');
+  assert.equal(docViewerRenderMode('/static/uploads/t/noext'), 'text');
+});
+
+test('extracts the first markdown heading and strips inline markers', () => {
+  assert.equal(firstMarkdownHeading('intro\n\n## Chantier **Mémoire** PRD ##\ntext'), 'Chantier Mémoire PRD');
+  assert.equal(firstMarkdownHeading('no headings here'), '');
+  assert.equal(firstMarkdownHeading(''), '');
+});
+
+test('decodes the filename segment of a src path', () => {
+  assert.equal(docViewerFilename('/static/uploads/t/aws%20mini.svg'), 'aws mini.svg');
+  assert.equal(docViewerFilename(null), '');
+});
+
+test('title prefers the explicit param, then heading, then filename', () => {
+  assert.equal(docViewerTitle('Chantier PRD', '/static/uploads/t/x.md', '# Other'), 'Chantier PRD');
+  assert.equal(docViewerTitle('', '/static/uploads/t/x.md', '# From Heading'), 'From Heading');
+  assert.equal(docViewerTitle(null, '/static/uploads/t/plan%20v2.md', 'plain text'), 'plan v2.md');
+  assert.equal(docViewerTitle(null, null, ''), 'Shared document');
+});

--- a/frontend/src/lib/utils/docViewer.test.js
+++ b/frontend/src/lib/utils/docViewer.test.js
@@ -30,10 +30,29 @@ test('accepts only /static/uploads sources', () => {
   assert.equal(normalizeDocViewerSrc('/static/uploads\\a.md'), null);
 });
 
+test('rejects percent-encoded traversal while preserving valid encoded paths', () => {
+  assert.equal(
+    normalizeDocViewerSrc('/static/uploads/%252e%252e/%252e%252e/api/runtime/settings'),
+    null,
+  );
+  assert.equal(normalizeDocViewerSrc('/static/uploads/%2e%2e/x'), null);
+  assert.equal(
+    normalizeDocViewerSrc('/static/uploads/foo/My%20Doc.md'),
+    '/static/uploads/foo/My%20Doc.md',
+  );
+  assert.equal(
+    normalizeDocViewerSrc('/static/uploads/thread-assets/shared/prd-abc.md'),
+    '/static/uploads/thread-assets/shared/prd-abc.md',
+  );
+});
+
 test('picks a render mode from the file extension', () => {
   assert.equal(docViewerRenderMode('/static/uploads/t/prd.md'), 'markdown');
   assert.equal(docViewerRenderMode('/static/uploads/t/prd.MARKDOWN'), 'markdown');
   assert.equal(docViewerRenderMode('/static/uploads/t/spec.pdf'), 'pdf');
+  for (const extension of ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg']) {
+    assert.equal(docViewerRenderMode(`/static/uploads/t/image.${extension}`), 'image');
+  }
   assert.equal(docViewerRenderMode('/static/uploads/t/data.csv'), 'text');
   assert.equal(docViewerRenderMode('/static/uploads/t/noext'), 'text');
 });

--- a/frontend/src/lib/utils/docViewer.ts
+++ b/frontend/src/lib/utils/docViewer.ts
@@ -1,0 +1,57 @@
+const STATIC_UPLOAD_PREFIX = '/static/uploads/';
+
+export type DocViewerRenderMode = 'markdown' | 'pdf' | 'text';
+
+/**
+ * Validate the public doc viewer's `src` query param.
+ *
+ * The viewer only ever fetches same-origin files under the auth-free
+ * /static/uploads mount; anything else (absolute URLs, traversal, other
+ * routes) is rejected so the page cannot be used to frame arbitrary content.
+ */
+export function normalizeDocViewerSrc(raw: string | null | undefined): string | null {
+  const value = (raw || '').trim();
+  if (!value.startsWith(STATIC_UPLOAD_PREFIX)) return null;
+  if (value.includes('\\') || /[?#\s]/.test(value)) return null;
+  const segments = value.slice(1).split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) return null;
+  return value;
+}
+
+export function docViewerRenderMode(src: string): DocViewerRenderMode {
+  const filename = (src || '').split('/').pop() || '';
+  const extension = filename.includes('.') ? (filename.split('.').pop() || '').toLowerCase() : '';
+  if (extension === 'md' || extension === 'markdown') return 'markdown';
+  if (extension === 'pdf') return 'pdf';
+  return 'text';
+}
+
+export function firstMarkdownHeading(markdown: string): string {
+  for (const line of (markdown || '').split('\n')) {
+    const match = line.trim().match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (match) return match[1].replace(/[*_`]/g, '').trim();
+  }
+  return '';
+}
+
+export function docViewerFilename(src: string | null | undefined): string {
+  const segment = (src || '').split('/').pop() || '';
+  try {
+    return decodeURIComponent(segment).trim();
+  } catch {
+    return segment.trim();
+  }
+}
+
+/** Title precedence: explicit ?title= param, first markdown heading, filename. */
+export function docViewerTitle(
+  titleParam: string | null | undefined,
+  src: string | null | undefined,
+  documentText = '',
+): string {
+  const explicit = (titleParam || '').trim();
+  if (explicit) return explicit;
+  const heading = firstMarkdownHeading(documentText);
+  if (heading) return heading;
+  return docViewerFilename(src) || 'Shared document';
+}

--- a/frontend/src/lib/utils/docViewer.ts
+++ b/frontend/src/lib/utils/docViewer.ts
@@ -1,6 +1,8 @@
 const STATIC_UPLOAD_PREFIX = '/static/uploads/';
+const PERCENT_ESCAPE = /%[0-9a-f]{2}/i;
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg']);
 
-export type DocViewerRenderMode = 'markdown' | 'pdf' | 'text';
+export type DocViewerRenderMode = 'image' | 'markdown' | 'pdf' | 'text';
 
 /**
  * Validate the public doc viewer's `src` query param.
@@ -13,8 +15,20 @@ export function normalizeDocViewerSrc(raw: string | null | undefined): string | 
   const value = (raw || '').trim();
   if (!value.startsWith(STATIC_UPLOAD_PREFIX)) return null;
   if (value.includes('\\') || /[?#\s]/.test(value)) return null;
-  const segments = value.slice(1).split('/');
+
+  let decoded = value;
+  for (let iteration = 0; iteration < 5 && PERCENT_ESCAPE.test(decoded); iteration += 1) {
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      return null;
+    }
+  }
+  if (PERCENT_ESCAPE.test(decoded)) return null;
+  if (!decoded.startsWith(STATIC_UPLOAD_PREFIX) || decoded.includes('\\')) return null;
+  const segments = decoded.slice(1).split('/');
   if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) return null;
+
   return value;
 }
 
@@ -23,6 +37,7 @@ export function docViewerRenderMode(src: string): DocViewerRenderMode {
   const extension = filename.includes('.') ? (filename.split('.').pop() || '').toLowerCase() : '';
   if (extension === 'md' || extension === 'markdown') return 'markdown';
   if (extension === 'pdf') return 'pdf';
+  if (IMAGE_EXTENSIONS.has(extension)) return 'image';
   return 'text';
 }
 

--- a/frontend/src/lib/utils/readableMarkdown.test.js
+++ b/frontend/src/lib/utils/readableMarkdown.test.js
@@ -90,6 +90,48 @@ test('does not render remote markdown images inline', () => {
   assert.equal(html, '<p>Remote diagram</p>');
 });
 
+test('renders markdown tables inside a horizontal scroll wrapper', () => {
+  const html = renderReadableMarkdown([
+    'Slice plan:',
+    '',
+    '| Slice | Owner |',
+    '| --- | :---: |',
+    '| S1 | **JB** |',
+    '| S2 | `worker` |',
+    '',
+    'Next steps.',
+  ].join('\n'));
+
+  assert.equal(
+    html,
+    '<p>Slice plan:</p>'
+      + '<div class="md-table-wrap"><table><thead><tr><th>Slice</th><th>Owner</th></tr></thead>'
+      + '<tbody><tr><td>S1</td><td><strong>JB</strong></td></tr>'
+      + '<tr><td>S2</td><td><code class="md-inline-code">worker</code></td></tr></tbody></table></div>'
+      + '<p>Next steps.</p>',
+  );
+});
+
+test('escapes unsafe html inside table cells', () => {
+  const html = renderReadableMarkdown([
+    '| Col |',
+    '| --- |',
+    '| <script>alert(1)</script> |',
+  ].join('\n'));
+
+  assert.equal(
+    html,
+    '<div class="md-table-wrap"><table><thead><tr><th>Col</th></tr></thead>'
+      + '<tbody><tr><td>&lt;script&gt;alert(1)&lt;/script&gt;</td></tr></tbody></table></div>',
+  );
+});
+
+test('keeps pipe-delimited lines without a separator row as plain paragraphs', () => {
+  const html = renderReadableMarkdown('| just | text |\n| more | text |');
+
+  assert.equal(html, '<p>| just | text |<br/>| more | text |</p>');
+});
+
 test('preserves query parameters in bare url hrefs', () => {
   const html = renderReadableMarkdown('Open https://example.com/search?q=illo&sort=new');
 

--- a/frontend/src/lib/utils/readableMarkdown.ts
+++ b/frontend/src/lib/utils/readableMarkdown.ts
@@ -96,6 +96,38 @@ function renderParagraph(lines: string[]): string {
   return `<p>${applyInlineMarkdown(lines.join('<br/>'))}</p>`;
 }
 
+function isTableRow(line: string): boolean {
+  return /^\|.*\|$/.test(line) && line.length > 1;
+}
+
+function splitTableRow(line: string): string[] {
+  return line
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+function isTableSeparatorRow(line: string): boolean {
+  if (!isTableRow(line)) return false;
+  const cells = splitTableRow(line);
+  return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell));
+}
+
+function renderTable(headerCells: string[], bodyRows: string[][]): string {
+  const head = headerCells.map((cell) => `<th>${applyInlineMarkdown(cell)}</th>`).join('');
+  const body = bodyRows
+    .map((cells) => {
+      const columns = headerCells
+        .map((_cell, index) => `<td>${applyInlineMarkdown(cells[index] ?? '')}</td>`)
+        .join('');
+      return `<tr>${columns}</tr>`;
+    })
+    .join('');
+  const bodyHtml = body ? `<tbody>${body}</tbody>` : '';
+  return `<div class="md-table-wrap"><table><thead><tr>${head}</tr></thead>${bodyHtml}</table></div>`;
+}
+
 function restorePlaceholders(html: string, codeBlocks: string[], inlineCodes: string[]): string {
   return html
     .replace(new RegExp(`${CODE_BLOCK_TOKEN}(\\d+)\\u0000`, 'g'), (_match, idx) => codeBlocks[Number(idx)] || '')
@@ -156,11 +188,29 @@ export function renderReadableMarkdown(markdown: string): string {
     orderedContinuationStart = null;
   };
 
-  for (const line of processed.split('\n')) {
+  const lines = processed.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const trimmed = line.trim();
     if (!trimmed) {
       flushParagraph();
       flushList();
+      continue;
+    }
+
+    if (isTableRow(trimmed) && isTableSeparatorRow((lines[index + 1] ?? '').trim())) {
+      flushParagraph();
+      flushList();
+      resetOrderedContinuation();
+      const headerCells = splitTableRow(trimmed);
+      const bodyRows: string[][] = [];
+      let cursor = index + 2;
+      while (cursor < lines.length && isTableRow(lines[cursor].trim())) {
+        bodyRows.push(splitTableRow(lines[cursor].trim()));
+        cursor += 1;
+      }
+      blocks.push(renderTable(headerCells, bodyRows));
+      index = cursor - 1;
       continue;
     }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -40,7 +40,10 @@
   let isCyclesPreviewPage = $derived(
     dev && currentPath === '/cycles' && $page.url.searchParams.get('preview') === '1',
   );
-  let isPreviewPage = $derived(isVaultPreviewPage || isCyclesPreviewPage);
+  // /doc is the public share viewer for published /static/uploads documents:
+  // it renders without a session, nav rail, or login redirect (also in prod).
+  let isDocViewerPage = $derived(currentPath === '/doc');
+  let isPreviewPage = $derived(isVaultPreviewPage || isCyclesPreviewPage || isDocViewerPage);
   let showNavRail = $derived(!auth.loading && !isLoginPage && !isPreviewPage && !isOnboardingPage);
   let showSearch = $state(false);
   let navRailArrivalActive = $state(false);

--- a/frontend/src/routes/doc/+page.svelte
+++ b/frontend/src/routes/doc/+page.svelte
@@ -32,8 +32,14 @@
       || firstMarkdownHeading(documentText) !== pageTitle,
   );
 
+  function handleImageError() {
+    status = 'error';
+    errorMessage = 'Image not found. It may have been removed, or the link is incomplete.';
+  }
+
   $effect(() => {
     const target = src;
+    const mode = target ? docViewerRenderMode(target) : 'text';
     let cancelled = false;
     let objectUrl: string | null = null;
     status = 'loading';
@@ -46,6 +52,8 @@
       errorMessage =
         'This viewer can only open documents published to /static/uploads on this workspace. '
         + 'Check that the link includes a complete src parameter.';
+    } else if (mode === 'image') {
+      status = 'ready';
     } else {
       (async () => {
         try {
@@ -61,7 +69,7 @@
               : 'Document not found. It may have been removed, or the link is incomplete.';
             return;
           }
-          if (docViewerRenderMode(target) === 'pdf') {
+          if (mode === 'pdf') {
             const blob = await response.blob();
             if (cancelled) return;
             objectUrl = URL.createObjectURL(
@@ -101,7 +109,7 @@
     <div class="doc-error" role="alert">
       <h1>Can't open this document</h1>
       <p>{errorMessage}</p>
-      {#if src}
+      {#if src && renderMode !== 'image'}
         <p class="doc-error-hint">
           <a href={src} target="_blank" rel="noopener">Try the raw file instead</a>
         </p>
@@ -115,12 +123,18 @@
       {#if filename}
         <p class="doc-meta">
           <span>{filename}</span>
-          <span aria-hidden="true">·</span>
-          <a href={src} target="_blank" rel="noopener">Open raw file</a>
+          {#if renderMode !== 'image'}
+            <span aria-hidden="true">·</span>
+            <a href={src} target="_blank" rel="noopener">Open raw file</a>
+          {/if}
         </p>
       {/if}
     </header>
-    {#if renderMode === 'markdown'}
+    {#if renderMode === 'image'}
+      <div class="doc-image">
+        <img src={src} alt={pageTitle} onerror={handleImageError} />
+      </div>
+    {:else if renderMode === 'markdown'}
       <!-- renderReadableMarkdown escapes all source HTML; only its own safe markup is injected. -->
       <article class="constellation-prose doc-prose">{@html markdownHtml}</article>
     {:else if renderMode === 'pdf'}
@@ -208,6 +222,18 @@
 
   .doc-prose {
     --constellation-prose-font-size: var(--text-lg);
+  }
+
+  .doc-image {
+    display: grid;
+    place-items: center;
+    width: 100%;
+  }
+
+  .doc-image img {
+    display: block;
+    max-width: 100%;
+    height: auto;
   }
 
   .doc-pdf iframe {

--- a/frontend/src/routes/doc/+page.svelte
+++ b/frontend/src/routes/doc/+page.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { renderReadableMarkdown } from '$lib/utils/readableMarkdown';
+  import {
+    docViewerFilename,
+    docViewerRenderMode,
+    docViewerTitle,
+    firstMarkdownHeading,
+    normalizeDocViewerSrc,
+  } from '$lib/utils/docViewer';
+
+  const src = $derived(normalizeDocViewerSrc($page.url.searchParams.get('src')));
+  const titleParam = $derived($page.url.searchParams.get('title'));
+  const renderMode = $derived(src ? docViewerRenderMode(src) : 'text');
+
+  let status = $state<'loading' | 'ready' | 'error'>('loading');
+  let errorMessage = $state('');
+  let documentText = $state('');
+  let pdfUrl = $state('');
+
+  const pageTitle = $derived(
+    docViewerTitle(titleParam, src, renderMode === 'markdown' ? documentText : ''),
+  );
+  const markdownHtml = $derived(
+    status === 'ready' && renderMode === 'markdown' ? renderReadableMarkdown(documentText) : '',
+  );
+  const filename = $derived(docViewerFilename(src));
+  // Skip the page-level heading when the markdown itself opens with the same title.
+  const showTitleHeading = $derived(
+    renderMode !== 'markdown'
+      || status !== 'ready'
+      || firstMarkdownHeading(documentText) !== pageTitle,
+  );
+
+  $effect(() => {
+    const target = src;
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    status = 'loading';
+    errorMessage = '';
+    documentText = '';
+    pdfUrl = '';
+
+    if (!target) {
+      status = 'error';
+      errorMessage =
+        'This viewer can only open documents published to /static/uploads on this workspace. '
+        + 'Check that the link includes a complete src parameter.';
+    } else {
+      (async () => {
+        try {
+          const response = await fetch(target);
+          if (cancelled) return;
+          // The backend serves the SPA index (200, text/html) for missing
+          // uploads instead of a plain 404, so treat both as "not found".
+          const contentType = (response.headers.get('content-type') || '').toLowerCase();
+          if (!response.ok || contentType.includes('text/html')) {
+            status = 'error';
+            errorMessage = !response.ok && response.status !== 404
+              ? `The document could not be loaded (HTTP ${response.status}).`
+              : 'Document not found. It may have been removed, or the link is incomplete.';
+            return;
+          }
+          if (docViewerRenderMode(target) === 'pdf') {
+            const blob = await response.blob();
+            if (cancelled) return;
+            objectUrl = URL.createObjectURL(
+              blob.type === 'application/pdf' ? blob : new Blob([blob], { type: 'application/pdf' }),
+            );
+            pdfUrl = objectUrl;
+          } else {
+            const text = await response.text();
+            if (cancelled) return;
+            documentText = text;
+          }
+          status = 'ready';
+        } catch {
+          if (!cancelled) {
+            status = 'error';
+            errorMessage = 'The document could not be loaded. Check your connection and try again.';
+          }
+        }
+      })();
+    }
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  });
+</script>
+
+<svelte:head>
+  <title>{pageTitle} · Illospace</title>
+</svelte:head>
+
+<div class="doc-viewer">
+  {#if status === 'loading'}
+    <p class="doc-status" role="status">Loading document…</p>
+  {:else if status === 'error'}
+    <div class="doc-error" role="alert">
+      <h1>Can't open this document</h1>
+      <p>{errorMessage}</p>
+      {#if src}
+        <p class="doc-error-hint">
+          <a href={src} target="_blank" rel="noopener">Try the raw file instead</a>
+        </p>
+      {/if}
+    </div>
+  {:else}
+    <header class="doc-header">
+      {#if showTitleHeading}
+        <h1 class="doc-title">{pageTitle}</h1>
+      {/if}
+      {#if filename}
+        <p class="doc-meta">
+          <span>{filename}</span>
+          <span aria-hidden="true">·</span>
+          <a href={src} target="_blank" rel="noopener">Open raw file</a>
+        </p>
+      {/if}
+    </header>
+    {#if renderMode === 'markdown'}
+      <!-- renderReadableMarkdown escapes all source HTML; only its own safe markup is injected. -->
+      <article class="constellation-prose doc-prose">{@html markdownHtml}</article>
+    {:else if renderMode === 'pdf'}
+      <div class="doc-pdf">
+        <iframe src={pdfUrl} title={pageTitle}></iframe>
+      </div>
+    {:else}
+      <pre class="doc-plain">{documentText}</pre>
+    {/if}
+  {/if}
+  <footer class="doc-footer">Published from an Illospace thread.</footer>
+</div>
+
+<style>
+  .doc-viewer {
+    max-width: 68ch;
+    margin: 0 auto;
+    padding: clamp(14px, 4vw, 44px) 0 40px;
+    min-width: 0;
+  }
+
+  .doc-status {
+    color: var(--text-3);
+    font-size: var(--text-md);
+  }
+
+  .doc-error {
+    display: grid;
+    gap: 10px;
+    border: 1px solid var(--warning-border);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+    background: var(--warning-surface);
+    color: var(--text-2);
+    font-size: var(--text-md);
+    line-height: var(--leading-normal);
+  }
+
+  .doc-error h1 {
+    color: var(--text-1);
+    font-size: var(--text-lg);
+    font-weight: var(--weight-semibold);
+  }
+
+  .doc-error-hint a {
+    color: var(--content-link);
+  }
+
+  .doc-header {
+    display: grid;
+    gap: 8px;
+    margin-bottom: 26px;
+  }
+
+  .doc-header:empty {
+    display: none;
+  }
+
+  .doc-title {
+    color: var(--text-1);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-snug);
+    overflow-wrap: anywhere;
+  }
+
+  .doc-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--text-3);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .doc-meta a {
+    color: var(--text-3);
+    text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  }
+
+  .doc-meta a:hover {
+    color: var(--content-link);
+  }
+
+  .doc-prose {
+    --constellation-prose-font-size: var(--text-lg);
+  }
+
+  .doc-pdf iframe {
+    display: block;
+    width: 100%;
+    height: 82vh;
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius-md);
+    background: #fff;
+  }
+
+  .doc-plain {
+    overflow-x: auto;
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius-md);
+    padding: 14px 16px;
+    background: var(--content-code-background);
+    color: var(--text-1);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+    white-space: pre;
+  }
+
+  .doc-footer {
+    margin-top: 44px;
+    border-top: 1px solid var(--border-1);
+    padding-top: 14px;
+    color: var(--text-3);
+    font-size: var(--text-sm);
+  }
+</style>

--- a/tests/test_thread_assets.py
+++ b/tests/test_thread_assets.py
@@ -71,6 +71,85 @@ def test_publish_thread_asset_accepts_existing_static_upload_url(tmp_path: Path)
     assert result["attachment"]["content_type"] == "image/png"
 
 
+def test_publish_thread_asset_builds_doc_viewer_url_for_markdown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example")
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    md_path = source_root / "chantier-prd.md"
+    md_path.write_text("# Chantier PRD\n\nScope and slices.")
+
+    result = publish_thread_asset(
+        str(md_path),
+        thread_id="thread-one",
+        title="Chantier PRD",
+        upload_dir=tmp_path / "uploads",
+        source_roots=[source_root],
+    )
+
+    assert result["viewer_url"] == (
+        f"https://illo.example/doc?src={result['url']}&title=Chantier%20PRD"
+    )
+    assert "viewer_url" in result["instruction"]
+
+
+def test_publish_thread_asset_viewer_url_falls_back_to_local_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("ILLO_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("ILLO_DASHBOARD_URL", raising=False)
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    md_path = source_root / "notes.md"
+    md_path.write_text("# Notes")
+
+    result = publish_thread_asset(
+        str(md_path),
+        upload_dir=tmp_path / "uploads",
+        source_roots=[source_root],
+    )
+
+    assert result["viewer_url"].startswith("http://localhost:8080/doc?src=/static/uploads/")
+
+
+def test_publish_thread_asset_keeps_direct_viewer_url_for_images(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example")
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    svg_path = source_root / "diagram.svg"
+    svg_path.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+
+    result = publish_thread_asset(
+        str(svg_path),
+        upload_dir=tmp_path / "uploads",
+        source_roots=[source_root],
+    )
+
+    assert result["viewer_url"] == result["public_url"]
+    assert result["viewer_url"].startswith("https://illo.example/static/uploads/")
+
+
+def test_already_published_markdown_gets_doc_viewer_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example")
+    upload_dir = tmp_path / "uploads"
+    asset_dir = upload_dir / "thread-assets" / "thread-one"
+    asset_dir.mkdir(parents=True)
+    asset = asset_dir / "prd.md"
+    asset.write_text("# PRD")
+    url = static_upload_url_for("thread-assets", "thread-one", "prd.md")
+
+    result = publish_thread_asset(url, upload_dir=upload_dir, title="PRD v2")
+
+    assert result["already_published"] is True
+    assert result["viewer_url"] == f"https://illo.example/doc?src={url}&title=PRD%20v2"
+    assert "viewer_url" in result["instruction"]
+
+
 def test_infers_thread_asset_attachments_from_body(tmp_path: Path):
     upload_dir = tmp_path / "uploads"
     asset_dir = upload_dir / "thread-assets" / "thread-one"

--- a/tests/test_thread_assets.py
+++ b/tests/test_thread_assets.py
@@ -113,7 +113,7 @@ def test_publish_thread_asset_viewer_url_falls_back_to_local_base(
     assert result["viewer_url"].startswith("http://localhost:8080/doc?src=/static/uploads/")
 
 
-def test_publish_thread_asset_keeps_direct_viewer_url_for_images(
+def test_publish_thread_asset_builds_doc_viewer_url_for_images(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example")
@@ -128,8 +128,26 @@ def test_publish_thread_asset_keeps_direct_viewer_url_for_images(
         source_roots=[source_root],
     )
 
-    assert result["viewer_url"] == result["public_url"]
-    assert result["viewer_url"].startswith("https://illo.example/static/uploads/")
+    assert result["viewer_url"] == (
+        f"https://illo.example/doc?src={result['url']}&title=diagram.svg"
+    )
+    assert result["public_url"].startswith("https://illo.example/static/uploads/")
+
+
+def test_publish_thread_asset_accepts_markdown_extension(tmp_path: Path):
+    source_root = tmp_path / "artifacts"
+    source_root.mkdir()
+    markdown_path = source_root / "notes.markdown"
+    markdown_path.write_text("# Notes")
+
+    result = publish_thread_asset(
+        str(markdown_path),
+        upload_dir=tmp_path / "uploads",
+        source_roots=[source_root],
+    )
+
+    assert result["url"].endswith(".markdown")
+    assert result["attachment"]["content_type"] == "text/markdown"
 
 
 def test_already_published_markdown_gets_doc_viewer_url(


### PR DESCRIPTION
## Why
For the chantier PRD loop (umbrella #326), Illo needs to share long PRD markdown documents in Slack. Raw `/static/uploads/*.md` links render as ugly plain text in a browser. This adds a readable viewer page and a ready-made link in the publish tool result so agent runs never hand-assemble URLs.

## What
- **Backend** (`brain/systems/cortex/thread_assets.py`): `publish_thread_asset()` now returns a `viewer_url` in both branches — always an absolute `{ILLO_PUBLIC_URL}/doc?src=…&title=…` link. The instruction text + tool description tell runs to share `viewer_url` in Slack.
- **Frontend**: new **public** `/doc` route (no session — the tailnet is the perimeter, same as `/static/uploads`). Validates `src` to `/static/uploads/` only, fetches same-origin, renders markdown via the app's existing **escaping** `renderReadableMarkdown` (raw HTML escaped, not injected); images via `<img>`; PDFs via blob iframe; readable 68ch column, light/dark, mobile-safe, tables/code scroll in their own containers.
- Minimal GFM table support added to the shared renderer (same escaping semantics).

## Review story
Built by a Claude subagent, then adversarially reviewed by Codex (gpt-5.6-sol, xhigh). Codex caught **two real security issues**, both fixed in `3b67617` and re-verified by hand:
1. **SVG stored-XSS (blocker)** — SVG counts as an image, so its `viewer_url` was a raw same-origin file; the app CSP allows inline script, so a top-level SVG would execute in-origin. Fix: every `viewer_url` is now a `/doc` link, and `/doc` renders images via `<img>` (script-safe even for SVG).
2. **Multi-encoded path traversal (major)** — `%252e%252e` slipped past the `..` check (param decoded once on read, again by `fetch`). Fix: validation fully percent-decodes (up to 5 passes, fail-closed) before the segment check, and fetches the original encoded form.

Deferred: escaped-pipe table cells (cosmetic, v1 limitation).

## Verification
- Backend: `pytest tests/test_thread_assets.py` (9) + `tests/test_api_cortex.py tests/test_tool_registry.py` (124) — pass.
- Frontend: `npm test` (244), `npm run check` (0 errors), `npm run build` — pass.
- Traced both exploit payloads through the post-fix validation by hand.

## Deploy note
Adds a public unauthenticated route (data source already public; access gated by the tailnet). After merge, needs the `--build --no-pull` deploy to illo-dev; `ILLO_PUBLIC_URL` is already set there.

Part of #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)