### PR TITLE
fix(cycles): align coordinator digest result-contract with prompt sections (#364)

### DIFF
--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -12,6 +12,16 @@ from brain.systems.cycles.degradation import mandatory_escalations
 
 SCHEDULED_REVIEW_WINDOW_HOURS = 24
 
+# One source of truth for the base result-contract keys and the visible sections
+# named in the launch prompt. The gate validates these same labels/aliases.
+RESULT_CONTRACT_OUTPUT_SECTIONS = {
+    "answer_the_cycle_mission": "the mission result body (no extra label required)",
+    "summarize_workspace_evidence_or_explicit_gaps": "`Evidence reviewed:`",
+    "report_evidence_health": "`Evidence health:`",
+    "record_next_action_or_blocker": "`Next action:` or `Blocker:`",
+    "short_self_review_summary": "`Self-review summary:`",
+}
+
 
 def _aware_utc(value: datetime | None) -> datetime | None:
     if value is not None and value.tzinfo is None:
@@ -45,13 +55,7 @@ def cycle_result_contract(
     """The minimum output contract for autonomous cycle runs."""
     contract = {
         "kind": "autonomous_cycle_run_result",
-        "required_outputs": [
-            "answer_the_cycle_mission",
-            "summarize_workspace_evidence_or_explicit_gaps",
-            "report_evidence_health",
-            "record_next_action_or_blocker",
-            "short_self_review_summary",
-        ],
+        "required_outputs": list(RESULT_CONTRACT_OUTPUT_SECTIONS),
         "degraded_when": [
             "workspace_evidence_sources_fail_or_return_unexpectedly_sparse_results",
             "the_run_cannot_access_required_context_or_output_targets",

--- a/brain/systems/cycles/prompts.py
+++ b/brain/systems/cycles/prompts.py
@@ -14,6 +14,7 @@ from brain.systems.cycles.common import (
     json_list,
 )
 from brain.systems.cycles.contracts import (
+    RESULT_CONTRACT_OUTPUT_SECTIONS,
     cycle_launch_receipt,
     cycle_result_contract,
     cycle_scheduled_review_window,
@@ -158,6 +159,7 @@ def cycle_run_message(idea: Idea, cycle: Cycle, run: CycleRun) -> str:
         "- End with a short self-review summary suitable for the Cycle ledger and visible outputs.\n\n"
         "## Result Contract\n"
         f"{_json_block(result_contract)}\n\n"
+        f"{_required_output_sections(result_contract)}"
         "## Cycle Memory\n"
         f"{_json_block(cycle_memory_payload(run))}\n\n"
         "## Cycle Mission\n"
@@ -173,6 +175,35 @@ def _mission_block(prompt: str) -> str:
         f"{prompt[:_MISSION_SEED_MAX_CHARS]}\n\n"
         f"[Cycle mission truncated for launch: {omitted} chars omitted. The full mission remains "
         "authoritative - read it with manage_cycle before deviating from it.]"
+    )
+
+
+def _required_output_sections(result_contract: dict) -> str:
+    required_outputs = [
+        str(value or "").strip()
+        for value in json_list(result_contract.get("required_outputs"))
+        if str(value or "").strip()
+    ]
+    mappings = []
+    for key in required_outputs:
+        section = RESULT_CONTRACT_OUTPUT_SECTIONS.get(key)
+        if section is None:
+            section = "the contract-specific content named by this key"
+        mappings.append(f"- `{key}` -> {section}")
+    if not mappings:
+        return ""
+    mapping_lines = "\n".join(mappings)
+    return (
+        "## Required Output Sections\n"
+        "The declared `required_outputs` keys map to the visible answer sections below. "
+        "Include every mapped section on the first pass; posting the mission body to an "
+        "output target does not replace this requirement, and must not trigger a second post.\n"
+        f"{mapping_lines}\n\n"
+        "Example required footer:\n"
+        "Evidence reviewed: workspace sources swept, or explicit source gaps named.\n"
+        "Evidence health: ok — required readers completed without unresolved warnings.\n"
+        "Next action: name the single next action.\n"
+        "Self-review summary: mission sweep and delivery completed; contract fields checked.\n\n"
     )
 
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -14,6 +14,7 @@ from brain.systems.cycles import execution as cycle_execution
 from brain.systems.cycles import prompts as cycle_prompts
 from brain.systems.cycles import service
 from brain.systems.cycles.common import AGENT_TRIGGERED_CYCLE_ORIGIN, MANUAL_CYCLE_ORIGIN
+from brain.systems.cycles.contracts import cycle_result_contract
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
@@ -768,6 +769,39 @@ def test_on_demand_cycle_launch_exposes_provenance_and_local_anchor():
     assert "2026-07-15T09:02:31-04:00 (America/New_York)" in message
     assert "EVENT_TRIGGER: merged PR now requires deploy" in message
     assert "## Scheduled Cycle Launch" not in message
+
+
+def test_coordinator_launch_prompt_maps_declared_contract_to_visible_sections():
+    cycle = Cycle()
+    cycle.id = 2
+    cycle.name = "Uwear Ticket Coordinator Check-ins"
+    cycle.prompt = "Publish the chantier-primary coordinator digest."
+    cycle.timezone = "America/Toronto"
+    cycle.model_override = None
+    cycle.thinking_override = None
+
+    run = CycleRun()
+    run.id = 1364
+    run.cycle_id = cycle.id
+    run.scheduled_for = datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)
+    run.guidance_snapshot = []
+    run.output_targets_snapshot = []
+    run.context_snapshot = {"result_contract": cycle_result_contract()}
+
+    idea = Idea()
+    idea.id = "coordinator-digest"
+    idea.title = "Uwear Ticket Coordinator Runs"
+
+    message = cycle_prompts.cycle_run_message(idea, cycle, run)
+    output_section = message.split("## Required Output Sections", 1)[1].split(
+        "## Cycle Memory", 1
+    )[0]
+
+    for key in cycle_result_contract()["required_outputs"]:
+        assert f"`{key}`" in output_section
+    assert "`record_next_action_or_blocker` -> `Next action:` or `Blocker:`" in output_section
+    assert "`short_self_review_summary` -> `Self-review summary:`" in output_section
+    assert "Example required footer:" in output_section
 
 
 @pytest.mark.asyncio
@@ -1575,25 +1609,39 @@ def test_reflex_cycle_satisfied_launch_contract_completes(
     assert session._artifacts[-1] is final_answer
 
 
-def test_coordinator_tracking_summary_does_not_add_undeclared_requirement(monkeypatch):
+def test_coordinator_posted_digest_scores_one_without_repair_or_repost(monkeypatch):
     from brain.systems.cycles import contract_gate
 
     mission = (
-        "Publish the coordinator digest and include its domain-tracking summary line, "
-        "evidence health, next action, and self-review."
+        "Publish the chantier-primary coordinator digest with exact tracker counts, "
+        "moving chantiers, loose items, and the per-person recap."
     )
     answer = (
-        "Coordinator result: the workspace digest completed and all scheduled work is current.\n"
-        "Evidence reviewed: current assignments and workspace activity were inspected.\n"
-        "Evidence health: ok; the available sources were complete.\n"
-        "Tracking summary: the coordination ledger is current.\n"
-        "Next action: review new assignments at the next scheduled run.\n"
-        "Self-review: the advertised result contract is satisfied."
+        "Chantier-primary digest: 3 active chantiers, 8 open issues, and 4 open PRs.\n"
+        "Moving chantier — coordinator reliability: the contract fix is ready for review; "
+        "Reda owns the merge and there are no blockers.\n"
+        "Loose items: none. Per-person recap: Reda reviews; Axel and JB have no queued work.\n"
+        "Evidence reviewed: workspace trackers, GitHub issues, PRs, and chantier records.\n"
+        "Evidence health: ok — every required reader completed and the Slack post succeeded.\n"
+        "Next action: Reda reviews the coordinator contract fix.\n"
+        "Self-review summary: full sweep, reconciled counts, and one complete digest posted."
+    )
+    slack_post = AgentRunEventRow(
+        id=1,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=1,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "post_slack_reply",
+            "result": {"status": "ok", "channel": "uwear-engineering"},
+        },
     )
     session, cycle_run, cycle, _ = _contract_finalization_scenario(
         cycle_id=2,
         mission=mission,
         answer=answer,
+        events=[slack_post],
     )
     repair_calls = []
 
@@ -1611,6 +1659,62 @@ def test_coordinator_tracking_summary_does_not_add_undeclared_requirement(monkey
     assert cycle_run.error is None
     assert cycle.last_status == "completed"
     assert cycle.last_error is None
+    evaluation = next(
+        item for item in session.added if item.__class__.__name__ == "CycleRunEvaluation"
+    )
+    assert evaluation.score == 1
+    verdict = evaluation.details["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_success"
+    assert verdict["missing_outputs"] == []
+    assert verdict["final_missing_outputs"] == []
+    assert verdict["side_effects_succeeded"] is True
+    assert len(session._events) == 1
+    assert len(session._artifacts) == 1
+
+
+def test_coordinator_unswept_unposted_digest_still_degrades(monkeypatch):
+    from brain.systems.cycles import contract_gate
+
+    session, cycle_run, cycle, _ = _contract_finalization_scenario(
+        cycle_id=2,
+        mission="Sweep the workspace and publish the chantier-primary coordinator digest.",
+        answer="The coordinator could not sweep the workspace or post the digest to Slack.",
+        events=[
+            AgentRunEventRow(
+                id=1,
+                run_id=44,
+                root_run_id=44,
+                sequence_no=1,
+                event_type="run.tool_failed",
+                payload={
+                    "tool_name": "post_slack_reply",
+                    "is_error": True,
+                    "error": "Slack output target unavailable",
+                },
+            )
+        ],
+    )
+
+    async def fake_repair(**kwargs):
+        return None
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert cycle_run.status == "degraded"
+    assert cycle_run.error.startswith("mission_contract_failed: missing")
+    assert cycle.last_status == "degraded"
+    evaluation = next(
+        item for item in session.added if item.__class__.__name__ == "CycleRunEvaluation"
+    )
+    assert evaluation.score == 0
+    verdict = evaluation.details["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_contract_failed"
+    assert verdict["side_effects_succeeded"] is False
+    assert "report_evidence_health" in verdict["final_missing_outputs"]
+    assert "short_self_review_summary" in verdict["final_missing_outputs"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #364

## What this fixes
The **coordinator digest lane (cycle 2)** result-contract-degraded (`score=0`, `mission_contract_failed`) on missing `short_self_review_summary` / `record_next_action_or_blocker` **even when it posted a complete, correct digest to Slack** — 4 of 13 in-window cycle-2 runs, incl. 2 of 3 scheduled digests on 2026-07-17. It's the coordinator-lane recurrence of the #310/#322 desync class (whose fix covered only the Reflex `failure_map` field). The ledger/alerting were desynced from reality; the digests themselves were fine.

## Approach (option (a) from the issue)
Align the declared `result_contract` required-output keys with the visible sections the mission prompt asks the model to emit — do **not** weaken the gate.
- New single source of truth `RESULT_CONTRACT_OUTPUT_SECTIONS` in `contracts.py` maps each key → its visible section label.
- New `## Required Output Sections` block + explicit footer example injected into the launch prompt (`prompts.py`) so the model reliably emits every mapped section on the first pass.
- Field mapping: `record_next_action_or_blocker → Next action:/Blocker:`, `short_self_review_summary → Self-review summary:`.
- No blind-retry path introduced — a flagged-but-successful digest is never re-posted (#310 footgun stays closed).

## Files
- `brain/systems/cycles/contracts.py`
- `brain/systems/cycles/prompts.py`
- `tests/test_cycles_service.py` (new coverage)

## How to verify
```
cd <worktree-or-checkout>
./venv/bin/python -m pytest tests/test_cycles_service.py -q -k 'coordinator_launch_prompt_maps or coordinator_posted_digest_scores or coordinator_unswept_unposted'
# broad regression:
./venv/bin/python -m pytest tests/test_cycles_service.py tests/test_cycle_degradation.py tests/test_agent_run_runtime.py -q
```
Verified locally: **3 targeted passed**, **160 regression passed** (worker's own broad run: 202 passed / 1 skipped).

## Acceptance checks
1. ✅ Complete digest with one successful `post_slack_reply` → `score=1`, no missing outputs, no repair.
2. ✅ Unswept/unposted digest still degrades (`score=0`) — gate preserved.
3. ✅ Declared `result_contract` keys now map 1:1 to the prompt's visible section labels (single source of truth).
4. ✅ Success path keeps exactly one Slack-post event + one final-answer artifact — no repair, no repost.

🤖 Draft opened by Routine R3 (Illospace ticket worker). Do not merge without Reda's review.