### PR TITLE
fix(slack): recover interactive reply transport disconnects (#363)

### DIFF
--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Iterator
 
 import anthropic
+import httpx
 
 from brain.platform.integrations.openai_codex_client import (
     OpenAICodexError,
@@ -89,6 +90,10 @@ _RETRYABLE_OPENAI_STREAM_TERMS = (
     "timed out",
 )
 _RETRYABLE_PROVIDER_STATUS_CODES = {408, 409, 429, 500, 502, 503, 529}
+_TRANSIENT_TRANSPORT_DISCONNECT_TERMS = (
+    "incomplete chunked read",
+    "peer closed connection",
+)
 
 
 def _openai_stream_error_message(error: Any) -> str:
@@ -106,6 +111,32 @@ def _openai_stream_error_message(error: Any) -> str:
 def _is_retryable_openai_error_message(message: str) -> bool:
     lowered = str(message or "").lower()
     return any(term in lowered for term in _RETRYABLE_OPENAI_STREAM_TERMS)
+
+
+def is_transient_transport_disconnect(error: BaseException | str | None) -> bool:
+    """Return whether an error is a retry-safe remote protocol disconnect."""
+
+    pending: list[BaseException | str] = [error] if error is not None else []
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if isinstance(current, BaseException):
+            identity = id(current)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            if isinstance(current, httpx.RemoteProtocolError) or (
+                current.__class__.__module__.startswith("httpcore")
+                and current.__class__.__name__ == "RemoteProtocolError"
+            ):
+                return True
+            for nested in (current.__cause__, current.__context__):
+                if nested is not None:
+                    pending.append(nested)
+        lowered = str(current or "").lower()
+        if any(term in lowered for term in _TRANSIENT_TRANSPORT_DISCONNECT_TERMS):
+            return True
+    return False
 
 
 def _provider_error_status_code(exc: Exception) -> int | None:
@@ -297,6 +328,7 @@ class AnthropicProvider(LLMProvider):
             isinstance(exc, anthropic.InternalServerError)
             or status_code in _RETRYABLE_PROVIDER_STATUS_CODES
             or _is_retryable_openai_error_message(str(exc))
+            or is_transient_transport_disconnect(exc)
         )
 
     def is_api_error(self, exc: Exception) -> bool:
@@ -545,7 +577,9 @@ class OpenAIProvider(LLMProvider):
             and exc.__class__.__name__ == "InternalServerError"
         ) or (
             status_code in _RETRYABLE_PROVIDER_STATUS_CODES
-        ) or isinstance(exc, OpenAICodexRetryableError) or _is_retryable_openai_error_message(str(exc))
+        ) or isinstance(exc, OpenAICodexRetryableError) or _is_retryable_openai_error_message(
+            str(exc)
+        ) or is_transient_transport_disconnect(exc)
 
     def is_api_error(self, exc: Exception) -> bool:
         return exc.__class__.__module__.startswith("openai") or isinstance(exc, OpenAICodexError)

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -21,6 +21,7 @@ from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
 from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.interactive_reply import is_interactive_transport_fallback
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -677,12 +678,15 @@ async def _settle_slack_origin_run_async(
 ) -> dict[str, Any] | None:
     if not _run_is_slack_origin(run):
         return None
-    if _run_is_headless(run):
+    if _run_is_headless(run) and run.parent_run_id is not None:
         return None
     final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
     if not final_answer:
         return None
-    if await _slack_reply_already_recorded(session, run=run):
+    transport_fallback = is_interactive_transport_fallback(final_answer)
+    if _run_is_headless(run) and not transport_fallback:
+        return None
+    if not transport_fallback and await _slack_reply_already_recorded(session, run=run):
         return None
 
     target = _slack_response_target(run)

--- a/brain/systems/runs/interactive_reply.py
+++ b/brain/systems/runs/interactive_reply.py
@@ -1,0 +1,58 @@
+"""Failure handling shared by interactive Slack reply runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from brain.platform.integrations.providers import is_transient_transport_disconnect
+
+
+INTERACTIVE_SLACK_ORIGINS = frozenset({"slack_teammate", "slack_channel_monitor"})
+INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE = (
+    "⚠️ I dropped that — my model connection cut out mid-reply. "
+    "Re-send it and I'll pick it back up."
+)
+
+
+def is_interactive_slack_reply_context(*contexts: Mapping | None) -> bool:
+    """Recognize the two conversational Slack origins through nested provenance."""
+
+    pending = [context for context in contexts if isinstance(context, Mapping)]
+    seen: set[int] = set()
+    while pending:
+        context = pending.pop()
+        identity = id(context)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if str(context.get("origin") or "").strip().lower() in INTERACTIVE_SLACK_ORIGINS:
+            return True
+        for key in ("execution_provenance", "target_ref"):
+            nested = context.get(key)
+            if isinstance(nested, Mapping):
+                pending.append(nested)
+    return False
+
+
+def interactive_transport_fallback(
+    error: BaseException | str | None,
+    *contexts: Mapping | None,
+) -> str | None:
+    if not is_interactive_slack_reply_context(*contexts):
+        return None
+    if not is_transient_transport_disconnect(error):
+        return None
+    return INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+
+
+def is_interactive_transport_fallback(text: str | None) -> bool:
+    return str(text or "").strip() == INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+
+
+__all__ = [
+    "INTERACTIVE_SLACK_ORIGINS",
+    "INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE",
+    "interactive_transport_fallback",
+    "is_interactive_slack_reply_context",
+    "is_interactive_transport_fallback",
+]

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -9,6 +9,7 @@ from brain.systems.runs.engine import RunRecipeResult, RunRuntime, cancel_event_
 from brain.systems.runs.tools import wrap_tool_handlers
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
+from brain.systems.runs.interactive_reply import interactive_transport_fallback
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 from brain.systems.runs.recipes.base import BaseRunRecipe
 from brain.systems.runs.recipes.shared import (
@@ -208,6 +209,13 @@ class FastRecipe(BaseRunRecipe):
             result = await invoke_direct_agent_async(spec)
         except Exception as exc:
             logger.exception("fast_recipe_failed", extra={"run_id": runtime.run.id})
+            fallback = interactive_transport_fallback(
+                exc,
+                runtime.request.metadata,
+                runtime.request.target_ref,
+            )
+            if fallback:
+                return RunRecipeResult(output=fallback, status=RunStatus.FAILED)
             return RunRecipeResult(output=f"Fast run failed: {exc}", status=RunStatus.FAILED)
 
         output = str(getattr(result, "output", "") or "").strip()
@@ -216,8 +224,16 @@ class FastRecipe(BaseRunRecipe):
         status = RunStatus.COMPLETED if getattr(result, "success", False) else RunStatus.FAILED
         if str(getattr(result, "error", "") or "") == "Cancelled by runner":
             status = RunStatus.CANCELED
-        if getattr(result, "error", None) and not output:
-            output = str(result.error)
+        result_error = getattr(result, "error", None)
+        fallback = interactive_transport_fallback(
+            result_error,
+            runtime.request.metadata,
+            runtime.request.target_ref,
+        )
+        if fallback:
+            output = fallback
+        elif result_error and not output:
+            output = str(result_error)
         return RunRecipeResult(
             output=output,
             status=status,

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -464,6 +464,80 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert any(_artifact_type(artifact) == "file_observation" for artifact in runtime.store.artifacts)
 
 
+@pytest.mark.parametrize(
+    ("replay_index", "origin"),
+    [
+        (1, "slack_teammate"),
+        (2, "slack_channel_monitor"),
+        (3, "slack_teammate"),
+        (4, "slack_channel_monitor"),
+    ],
+)
+async def test_fast_interactive_slack_transport_failure_returns_plain_language_fallback(
+    monkeypatch,
+    replay_index,
+    origin,
+):
+    from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+    from brain.systems.runs.recipes.fast import FastRecipe
+
+    raw_error = (
+        "peer closed connection without sending complete message body "
+        "(incomplete chunked read)"
+    )
+    calls = []
+
+    async def fake_invoke(_spec):
+        calls.append(replay_index)
+        return SimpleNamespace(output="", success=False, error=raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("fast")
+    runtime.request = replace(
+        runtime.request,
+        metadata={"origin": origin, "originating_surface": "slack"},
+        target_ref={"kind": "slack_message", "originating_surface": "slack"},
+    )
+
+    result = await FastRecipe().execute(runtime)
+
+    assert calls == [replay_index]
+    assert result.status.value == "failed"
+    assert result.output == INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+    assert raw_error not in result.output
+
+
+async def test_fast_interactive_slack_logic_failure_is_not_rewritten_or_retried(monkeypatch):
+    from brain.systems.runs.recipes.fast import FastRecipe
+
+    logic_error = "Final reply policy rejected an invalid response"
+    calls = []
+
+    async def fake_invoke(_spec):
+        calls.append("invoke")
+        return SimpleNamespace(output="", success=False, error=logic_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("fast")
+    runtime.request = replace(
+        runtime.request,
+        metadata={"origin": "slack_teammate", "originating_surface": "slack"},
+        target_ref={"kind": "slack_message", "originating_surface": "slack"},
+    )
+
+    result = await FastRecipe().execute(runtime)
+
+    assert calls == ["invoke"]
+    assert result.status.value == "failed"
+    assert result.output == logic_error
+
+
 async def test_fast_discussion_run_can_ack_visibly_before_spawning_child(monkeypatch):
     from brain.systems.runs.domain import RunRecipe
     from brain.systems.runs.events import run_event
@@ -4261,6 +4335,91 @@ async def test_runner_keeps_headless_slack_child_silent(monkeypatch):
     monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
 
     assert await runner._settle_slack_origin_run_async(object(), run) is None
+
+
+async def test_runner_posts_transport_fallback_for_headless_slack_monitor(monkeypatch):
+    from brain.systems.runs.cortex import runner
+    from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+
+    run = SimpleNamespace(
+        id=81,
+        parent_run_id=None,
+        root_run_id=81,
+        thread_id="slack:T789:C456:1716900000.000100",
+        status="failed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "response_target": {
+                    "channel_id": "C456",
+                    "thread_ts": "1716900000.000100",
+                },
+            },
+        },
+        metadata_={
+            "origin": "slack_channel_monitor",
+            "originating_surface": "slack",
+            "final_answer_target_surface": "headless",
+            "headless": True,
+        },
+    )
+    final_artifact = SimpleNamespace(
+        id=104,
+        run_id=81,
+        artifact_type="final_answer",
+        text=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+    )
+    earlier_progress_reply = SimpleNamespace(
+        payload={
+            "tool_name": "post_slack_reply",
+            "args": {"body": "I’m checking that now."},
+            "result": '{"ok": true, "ts": "1716900001.000200"}',
+        }
+    )
+    calls = []
+
+    class FakeSession:
+        def __init__(self):
+            self.scalar_calls = 0
+
+        async def scalars(self, _stmt):
+            self.scalar_calls += 1
+            if self.scalar_calls == 1:
+                return _ScalarRows([final_artifact])
+            return _ScalarRows([earlier_progress_reply])
+
+    class FakeSlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "channel": kwargs["channel"], "ts": "1716900400.000500"}
+
+        async def set_assistant_status(self, **_kwargs):
+            return {"ok": True}
+
+    async def fake_client_for_run(run_arg):
+        assert run_arg is run
+        return FakeSlackClient()
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+
+    session = FakeSession()
+    result = await runner._settle_slack_origin_run_async(session, run)
+
+    assert result["surface"] == "slack"
+    assert session.scalar_calls == 1
+    assert calls == [
+        {
+            "channel": "C456",
+            "text": INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+            "thread_ts": "1716900000.000100",
+        }
+    ]
 
 
 async def test_runner_does_not_mirror_after_same_run_ai_timeline_tool_message():

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -892,6 +892,55 @@ async def test_cycle_final_answer_store_never_persists_raw_provider_error(sessio
     assert "help.openai.com" not in direct_artifact.text
 
 
+async def test_interactive_slack_transport_failure_never_persists_raw_error_as_final_answer(
+    monkeypatch,
+    session_factory,
+):
+    from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+    from brain.systems.runs.recipes.fast import FastRecipe
+
+    raw_error = (
+        "peer closed connection without sending complete message body "
+        "(incomplete chunked read)"
+    )
+
+    async def fake_invoke(_spec):
+        return SimpleNamespace(output="", success=False, error=raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent_async", fake_invoke)
+
+    session = session_factory()
+    result = await AsyncAgentRunEngine(
+        session,
+        recipes={"fast": FastRecipe()},
+    ).run(
+        _run_request(
+            thread_id="slack:T789:C456:1716900000.000100",
+            message="Continue the design conversation",
+            target_ref={"kind": "slack_message", "originating_surface": "slack"},
+            model_policy={"model": "openai/gpt-5.4", "thinking": "high"},
+            metadata={"origin": "slack_teammate", "originating_surface": "slack"},
+        )
+    )
+
+    final_answers = list(
+        (
+            await session.scalars(
+                select(AgentRunArtifactRow).where(
+                    AgentRunArtifactRow.run_id == result.id,
+                    AgentRunArtifactRow.artifact_type == "final_answer",
+                )
+            )
+        ).all()
+    )
+
+    assert result.status == RunStatus.FAILED
+    assert [artifact.text for artifact in final_answers] == [INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE]
+    assert all(raw_error not in str(artifact.text) for artifact in final_answers)
+
+
 async def test_failed_cycle_engine_events_do_not_surface_raw_provider_error(session_factory):
     raw_provider_error = (
         "An error occurred while processing your request. Contact help.openai.com with request ID "

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -100,6 +100,131 @@ async def test_scheduled_cycle_retries_provider_error_text_before_returning_safe
     assert streamed_deltas == []
 
 
+async def test_interactive_slack_transport_disconnect_retries_stream_and_completes(monkeypatch):
+    import httpx
+
+    from brain.platform.integrations.providers import is_transient_transport_disconnect
+    from brain.systems.runs import direct_agent
+
+    raw_error = (
+        "peer closed connection without sending complete message body "
+        "(incomplete chunked read)"
+    )
+    provider_calls = []
+
+    class FakeStream:
+        def __init__(self, attempt):
+            self.attempt = attempt
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def __iter__(self):
+            if self.attempt == 1:
+                yield SimpleNamespace(type="text", text="Partial answer")
+                raise httpx.RemoteProtocolError(raw_error)
+            yield SimpleNamespace(type="text", text="Recovered answer")
+
+        def get_final_message(self):
+            return _response("Recovered answer")
+
+    class FakeProvider:
+        def stream(self, request):
+            provider_calls.append(request)
+            return FakeStream(len(provider_calls))
+
+        def create(self, _request):
+            raise AssertionError("Interactive calls should stream")
+
+        def is_api_error(self, _exc):
+            return False
+
+        def is_retryable_error(self, exc):
+            return is_transient_transport_disconnect(exc)
+
+    monkeypatch.setattr(direct_agent, "get_provider", lambda *_args, **_kwargs: FakeProvider())
+    monkeypatch.setattr(direct_agent, "_API_RETRY_DELAYS", (0,))
+
+    result = await direct_agent.run_agent_async(
+        message="Continue the design conversation",
+        model="claude-sonnet-4-6",
+        tools=[],
+        persist_session=False,
+        session_id="interactive-transport-retry",
+        resolved_llm=_FakeLLM(),
+        on_stream_delta=lambda _delta: None,
+        metadata={"execution_provenance": {"origin": "slack_teammate"}},
+    )
+
+    assert len(provider_calls) == 2
+    assert result.success is True
+    assert result.output == "Recovered answer"
+    assert result.error is None
+
+
+async def test_interactive_slack_transport_disconnect_retry_is_bounded(monkeypatch):
+    import httpx
+
+    from brain.platform.integrations.providers import is_transient_transport_disconnect
+    from brain.systems.runs import direct_agent
+
+    raw_error = (
+        "peer closed connection without sending complete message body "
+        "(incomplete chunked read)"
+    )
+    provider_calls = []
+
+    class BrokenStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def __iter__(self):
+            raise httpx.RemoteProtocolError(raw_error)
+            yield  # pragma: no cover - make this a generator
+
+        def get_final_message(self):
+            raise AssertionError("A disconnected stream has no final message")
+
+    class FakeProvider:
+        def stream(self, request):
+            provider_calls.append(request)
+            return BrokenStream()
+
+        def create(self, _request):
+            raise AssertionError("Interactive calls should stream")
+
+        def is_api_error(self, _exc):
+            return False
+
+        def is_retryable_error(self, exc):
+            return is_transient_transport_disconnect(exc)
+
+    monkeypatch.setattr(direct_agent, "get_provider", lambda *_args, **_kwargs: FakeProvider())
+    monkeypatch.setattr(direct_agent, "_API_RETRY_DELAYS", (0,))
+
+    result = await direct_agent.run_agent_async(
+        message="Continue the design conversation",
+        model="claude-sonnet-4-6",
+        tools=[],
+        persist_session=False,
+        session_id="interactive-transport-exhausted",
+        resolved_llm=_FakeLLM(),
+        on_stream_delta=lambda _delta: None,
+        metadata={"execution_provenance": {"origin": "slack_teammate"}},
+    )
+
+    assert len(provider_calls) == 2
+    assert result.success is False
+    assert result.output == ""
+    assert result.error == raw_error
+
+
 async def test_run_agent_async_basic_completion_uses_async_session_hooks(monkeypatch):
     from brain.systems.runs import direct_agent
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import httpx
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -327,10 +328,28 @@ class TestAnthropicProvider:
 
         assert not p.is_retryable_error(ProviderStatusError("bad request"))
 
+    def test_remote_protocol_disconnect_is_retryable(self):
+        p = AnthropicProvider(MagicMock())
+
+        assert p.is_retryable_error(
+            httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body (incomplete chunked read)"
+            )
+        )
+
 
 # ── OpenAIProvider ────────────────────────────────────────────────
 
 class TestOpenAIProvider:
+    def test_remote_protocol_disconnect_is_retryable(self):
+        p = OpenAIProvider(MagicMock())
+
+        assert p.is_retryable_error(
+            httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body (incomplete chunked read)"
+            )
+        )
+
     def test_stream_translates_request_to_responses_api(self):
         client = MagicMock()
         mock_resp = MagicMock()


### PR DESCRIPTION
Closes #363

## What this fixes
Interactive Slack-triggered runs (`recipe=fast`, origins `slack_teammate` / `slack_channel_monitor`) died on upstream transport disconnects — `incomplete chunked read` / peer-closed-connection / `httpx.RemoteProtocolError` — and **silently dropped the human's turn**: no retry, no reply, and the run's only `final_answer` artifact was the raw error string. In the audit window all 4 runtime failures were this one cause, dropping 3 of Reda's `@Illo` replies mid-steer. Distinct from the closed #289 (scheduled Cycle `server_error` leak) — this is the interactive/conversational lane, a transport-level error, and the harm is a dead turn in a live thread.

## Approach
- **Retry (AC1):** new `is_transient_transport_disconnect()` classifier (httpx/httpcore `RemoteProtocolError` + the specific peer-closed / incomplete-chunked-read signatures, walking `__cause__`/`__context__`) wired into **both** providers' retryable-error predicate, so the **existing bounded retry loop** now covers these transient, idempotent-safe disconnects. Genuine logic/refusal errors are unchanged and never retried (**AC4**).
- **Fallback (AC2/AC3):** new `interactive_reply` module — on retry exhaustion in the interactive Slack lane, emit a plain-language fallback (`⚠️ I dropped that — my model connection cut out mid-reply. Re-send it and I'll pick it back up.`) instead of persisting the raw exception as `final_answer`. The Slack settle path posts it even for headless channel-monitor runs or after an earlier progress reply, so the human always learns the turn dropped.

## Files
- `brain/platform/integrations/providers.py` — transport-disconnect classifier + wiring
- `brain/systems/runs/interactive_reply.py` *(new)* — fallback message + interactive-context detection
- `brain/systems/runs/recipes/fast.py` — emit fallback instead of raw error
- `brain/systems/runs/cortex/runner.py` — always post the fallback in the Slack settle path
- tests: `test_providers.py`, `test_direct_agent_async_contract.py`, `test_agent_run_runtime.py`, `test_agent_run_state_machine.py`

## How to verify
```
cd <worktree-or-checkout>
./venv/bin/python -m pytest tests/test_providers.py tests/test_direct_agent_async_contract.py tests/test_agent_run_runtime.py tests/test_agent_run_state_machine.py tests/test_slack_channel_monitor.py tests/test_slack_teammate.py tests/test_architecture_boundaries.py -q
```
Verified locally: **278 passed / 1 skipped** (worker's own broad run: 300 passed / 1 skipped).

## Acceptance checks
1. ✅ Mid-stream `RemoteProtocolError` enters the bounded retry loop; a successful retry returns the real answer, run ends `completed`.
2. ✅ Exhaustion → plain-language fallback persisted as `final_answer` (never the raw `incomplete chunked read` string), posted even for headless / already-replied runs.
3. ✅ Four replayed dropped-turn scenarios across both Slack origins all produce a non-empty fallback — 0 silently dropped.
4. ✅ Classification scoped to transport disconnects only; genuine logic failures surface normally and are invoked once (no silent retry into a different answer).

🤖 Draft opened by Routine R3 (Illospace ticket worker). Do not merge without Reda's review.