### PR TITLE
fix(inbound): re-admit failed monitored-channel events once on transient failure (#368)

### DIFF
--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -9,8 +9,9 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.integrations.providers import is_transient_transport_disconnect
 from brain.systems.inbound.attribution import summarize_inbound_run_attribution
 from brain.systems.inbound.preservation import (
     PRESERVATION_MISSING_REASON,
@@ -19,6 +20,7 @@ from brain.systems.inbound.preservation import (
 )
 from brain.systems.inbound.status import STATUS_REVIEW_REQUIRED
 from brain.systems.runs.domain import AgentRun, ArtifactType
+from brain.systems.runs.interactive_reply import is_interactive_transport_fallback
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 
 logger = logging.getLogger(__name__)
@@ -26,9 +28,13 @@ logger = logging.getLogger(__name__)
 # Receipt lanes. Triage/submit receipts are written NON-terminal at admission
 # and this module transitions them when the run finishes; the slack-teammate
 # lane writes its receipt already-terminal ("run admitted" IS its decision),
-# so it gets a mint check here but never a receipt/event rewrite.
+# so it normally gets only a mint check here. The monitored-channel transient
+# failure path is the deliberate exception: it rewrites the receipt/event once
+# to follow the replacement run.
 _TRIAGE_RECEIPT_TYPES = frozenset({"illo_triage", "illo_submit"})
 _ACTIONABLE_RECEIPT_TYPES = frozenset({"slack_teammate_run"})
+_MONITORED_CHANNEL_ORIGIN = "slack.channel_message"
+_MAX_MONITORED_CHANNEL_RETRY_ATTEMPTS = 1
 
 
 def _json_dict(value: Any) -> dict[str, Any]:
@@ -144,6 +150,252 @@ async def _inbound_receipt_for_run(
     return None
 
 
+async def _run_failure_reason(session: AsyncSession, run_id: int) -> str | None:
+    """Read the durable, typed run-failure record used by terminal reconciliation.
+
+    ``set_status`` appends ``run.status_changed`` before invoking this module;
+    ``run.failed`` is appended slightly later by the engine. Supporting both
+    keeps explicit reconciliation of an already-failed run equivalent to the
+    inline terminal-status path without classifying arbitrary event/output text.
+    """
+
+    rows = (
+        await session.scalars(
+            select(AgentRunEventRow)
+            .where(
+                AgentRunEventRow.run_id == int(run_id),
+                AgentRunEventRow.event_type.in_(("run.status_changed", "run.failed")),
+            )
+            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+        )
+    ).all()
+    for failure_event in rows:
+        payload = _json_dict(failure_event.payload)
+        if failure_event.event_type == "run.status_changed":
+            if str(payload.get("to_status") or "") != RunStatus.FAILED.value:
+                continue
+            reason = payload.get("reason")
+        else:
+            reason = payload.get("error")
+        text = str(reason or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _retry_attempt_from_contract(
+    *,
+    event: InboundEventRow,
+    receipt: InboundDecisionReceiptRow,
+    run_metadata: dict[str, Any],
+) -> int:
+    values = [
+        run_metadata.get("retry_attempt"),
+        _json_dict(run_metadata.get("inbound_event")).get("retry_attempt"),
+        _json_dict(event.action_result).get("retry_attempt"),
+        _json_dict(receipt.tool_use).get("retry_attempt"),
+        _json_dict(receipt.outcome).get("retry_attempt"),
+    ]
+    attempts = []
+    for value in values:
+        try:
+            attempts.append(int(value or 0))
+        except (TypeError, ValueError):
+            continue
+    return max(attempts, default=0)
+
+
+def _stored_event_envelope(event: InboundEventRow) -> dict[str, Any]:
+    envelope = _json_dict(event.envelope)
+    if envelope:
+        return envelope
+    normalized = _json_dict(event.normalized_payload)
+    if normalized:
+        return normalized
+    return {
+        "kind": event.kind,
+        "origin": event.origin,
+        "payload": _json_dict(event.raw_payload),
+        "idempotency_key": event.idempotency_key,
+    }
+
+
+def _attempt_idempotency_key(
+    event: InboundEventRow,
+    run_row: AgentRunRow | AgentRun,
+    *,
+    retry_attempt: int,
+) -> str | None:
+    envelope = _stored_event_envelope(event)
+    candidates = (
+        envelope.get("idempotency_key"),
+        event.idempotency_key,
+        getattr(run_row, "source_idempotency_key", None),
+    )
+    base_key = next((str(value).strip() for value in candidates if str(value or "").strip()), "")
+    if not base_key.startswith("slack:"):
+        return None
+    return f"{base_key}:attempt:{retry_attempt}"
+
+
+def _retry_lineage(original_run_id: int, replacement_run_id: int) -> list[dict[str, int]]:
+    return [
+        {"run_id": int(original_run_id), "retry_attempt": 0},
+        {"run_id": int(replacement_run_id), "retry_attempt": 1},
+    ]
+
+
+def _record_readmission(
+    *,
+    event: InboundEventRow,
+    receipt: InboundDecisionReceiptRow,
+    original_run_id: int,
+    replacement_run_id: int,
+    idempotency_key: str,
+) -> None:
+    lineage = _retry_lineage(original_run_id, replacement_run_id)
+    retry_contract = {
+        "run_id": int(replacement_run_id),
+        "original_run_id": int(original_run_id),
+        "replacement_run_id": int(replacement_run_id),
+        "retry_attempt": 1,
+        "retry_lineage": lineage,
+        "retry_idempotency_key": idempotency_key,
+    }
+
+    action_result = _json_dict(event.action_result)
+    slack = _json_dict(action_result.get("slack"))
+    if slack:
+        action_result["slack"] = {**slack, "run_id": int(replacement_run_id)}
+    event.action_result = {**action_result, **retry_contract}
+
+    receipt.outcome = {**_json_dict(receipt.outcome), **event.action_result}
+    receipt.target = {**_json_dict(receipt.target), **retry_contract}
+    receipt.tool_use = {**_json_dict(receipt.tool_use), **retry_contract}
+
+
+async def _readmit_failed_monitored_channel_once(
+    session: AsyncSession,
+    *,
+    event: InboundEventRow,
+    receipt: InboundDecisionReceiptRow,
+    run_row: AgentRunRow | AgentRun,
+    run_metadata: dict[str, Any],
+    run_id: int,
+) -> bool:
+    """Admit one replacement run for a typed transient monitor failure."""
+
+    if str(event.origin or "") != _MONITORED_CHANNEL_ORIGIN:
+        return False
+    retry_attempt = _retry_attempt_from_contract(
+        event=event,
+        receipt=receipt,
+        run_metadata=run_metadata,
+    )
+    if retry_attempt >= _MAX_MONITORED_CHANNEL_RETRY_ATTEMPTS:
+        return False
+
+    failure_reason = await _run_failure_reason(session, run_id)
+    if not (
+        is_transient_transport_disconnect(failure_reason)
+        or is_interactive_transport_fallback(failure_reason)
+    ):
+        return False
+
+    next_attempt = retry_attempt + 1
+    idempotency_key = _attempt_idempotency_key(
+        event,
+        run_row,
+        retry_attempt=next_attempt,
+    )
+    authority_user_id = str(
+        getattr(run_row, "user_id", None) or event.authority_user_id or ""
+    ).strip()
+    if not idempotency_key or not authority_user_id:
+        logger.warning(
+            "monitored channel re-admission skipped: event=%s run=%s missing=%s",
+            event.id,
+            run_id,
+            "idempotency_key" if not idempotency_key else "authority_user_id",
+        )
+        return False
+
+    from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+    from brain.systems.slack.triggers import build_slack_work_intake_payload
+
+    envelope = _stored_event_envelope(event)
+    trigger_payload = build_slack_work_intake_payload(
+        org_id=str(event.org_id),
+        authority_user_id=authority_user_id,
+        payload=_json_dict(envelope.get("payload")),
+        inbound_event_id=str(event.id),
+        connection_id=str(event.connection_id),
+        idempotency_key=idempotency_key,
+    )
+    payload = _json_dict(trigger_payload.get("payload"))
+    metadata = _json_dict(payload.get("metadata"))
+    inbound_event = _json_dict(metadata.get("inbound_event"))
+    metadata.update(
+        {
+            "retry_attempt": next_attempt,
+            "retry_lineage": [{"run_id": int(run_id), "retry_attempt": retry_attempt}],
+            "inbound_event": {
+                **inbound_event,
+                "retry_attempt": next_attempt,
+                "original_run_id": int(run_id),
+            },
+        }
+    )
+    trigger_payload["payload"] = {**payload, "metadata": metadata}
+
+    admission = await admit_work(
+        session,
+        WorkIntakeEvent.from_trigger_payload(trigger_payload),
+    )
+    if not admission.ok or admission.run_id is None:
+        logger.warning(
+            "monitored channel re-admission failed: event=%s run=%s reason=%s",
+            event.id,
+            run_id,
+            admission.skipped_reason or "run_admission_failed",
+        )
+        return False
+
+    replacement_run_id = int(admission.run_id)
+    replacement = await session.get(AgentRunRow, replacement_run_id)
+    if replacement is not None:
+        replacement_metadata = _json_dict(replacement.metadata_)
+        replacement_inbound_event = _json_dict(replacement_metadata.get("inbound_event"))
+        lineage = _retry_lineage(run_id, replacement_run_id)
+        replacement.metadata_ = {
+            **replacement_metadata,
+            "retry_attempt": next_attempt,
+            "retry_lineage": lineage,
+            "inbound_event": {
+                **replacement_inbound_event,
+                "retry_attempt": next_attempt,
+                "original_run_id": int(run_id),
+                "replacement_run_id": replacement_run_id,
+            },
+        }
+    _record_readmission(
+        event=event,
+        receipt=receipt,
+        original_run_id=run_id,
+        replacement_run_id=replacement_run_id,
+        idempotency_key=idempotency_key,
+    )
+    await session.flush()
+    logger.info(
+        "monitored channel re-admitted: event=%s original_run=%s replacement_run=%s retry_attempt=%s",
+        event.id,
+        run_id,
+        replacement_run_id,
+        next_attempt,
+    )
+    return True
+
+
 # Benign repeat outcomes on the poll-driven submit lane: the FIRST decision
 # already logged at INFO; every later illo_get_result poll re-derives the
 # same skip, which is churn, not signal.
@@ -251,11 +503,34 @@ async def reconcile_inbound_triage_run(
         session, event_id=event_id, run_id=run_id, receipt_types=_TRIAGE_RECEIPT_TYPES
     )
     if receipt is None:
-        # Not the triage/submit lane. The slack-teammate lane lands here —
-        # its receipt closed at admission, but a COMPLETED run that created
-        # durable work still owes a handoff packet (the gate that silently
-        # never fired in prod: this lane is where actionable runs actually
-        # complete).
+        # Not the triage/submit lane. The slack-teammate lane lands here. A
+        # monitored-channel transport failure gets one replacement admission;
+        # every other terminal outcome retains the lane's existing mint-only
+        # behavior.
+        actionable_receipt = await _inbound_receipt_for_run(
+            session,
+            event_id=event_id,
+            run_id=run_id,
+            receipt_types=_ACTIONABLE_RECEIPT_TYPES,
+        )
+        if (
+            status == RunStatus.FAILED
+            and actionable_receipt is not None
+            and await _readmit_failed_monitored_channel_once(
+                session,
+                event=event,
+                receipt=actionable_receipt,
+                run_row=row,
+                run_metadata=metadata,
+                run_id=run_id,
+            )
+        ):
+            return actionable_receipt
+
+        # The receipt normally closed at admission, but a COMPLETED run that
+        # created durable work still owes a handoff packet (the gate that
+        # silently never fired in prod: this lane is where actionable runs
+        # actually complete).
         await _mint_for_actionable_run(
             session, event=event, run_row=row, status=status, event_id=event_id, run_id=run_id
         )

--- a/brain/systems/inbound/results.py
+++ b/brain/systems/inbound/results.py
@@ -18,6 +18,22 @@ class InboundSubmissionResult:
     mutated_inbound: bool = False
 
 
+def _result_handling(action_result: dict[str, Any]) -> dict[str, Any]:
+    handling = action_result.get("handling")
+    if isinstance(handling, dict):
+        return dict(handling)
+    if action_result.get("operation") == "slack_run_admitted":
+        return dict(action_result)
+    return {}
+
+
+def _run_id(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 async def read_inbound_submission_result(
     session: AsyncSession,
     *,
@@ -32,21 +48,27 @@ async def read_inbound_submission_result(
         raise ValueError("Inbound event not found")
 
     action_result = dict(event.action_result or {})
-    handling = dict(action_result.get("handling") or {})
+    handling = _result_handling(action_result)
     reconciled = False
     current_run_status = None
-    if handling.get("run_id") is not None:
-        try:
-            run_id = int(handling["run_id"])
-        except (TypeError, ValueError):
-            run_id = None
-        if run_id is not None:
-            run = await session.get(AgentRunRow, run_id)
-            current_run_status = getattr(run, "status", None) if run is not None else None
-            receipt = await reconcile_inbound_triage_run(session, run_id)
-            reconciled = receipt is not None
-            if reconciled:
-                await session.refresh(event)
+    selected_run_id = _run_id(handling.get("run_id"))
+    if selected_run_id is not None:
+        run = await session.get(AgentRunRow, selected_run_id)
+        current_run_status = getattr(run, "status", None) if run is not None else None
+        receipt = await reconcile_inbound_triage_run(session, selected_run_id)
+        reconciled = receipt is not None
+        if reconciled:
+            await session.refresh(event)
+
+    # Reconciliation can replace a failed monitored-channel run. Re-read the
+    # event-owned contract so illo_get_result follows the replacement rather
+    # than returning the original terminal run forever.
+    action_result = dict(event.action_result or {})
+    handling = _result_handling(action_result)
+    current_run_id = _run_id(handling.get("run_id"))
+    if current_run_id is not None and current_run_id != selected_run_id:
+        current_run = await session.get(AgentRunRow, current_run_id)
+        current_run_status = getattr(current_run, "status", None) if current_run is not None else None
 
     receipts = await inbound_admin.list_receipts(
         session,
@@ -57,8 +79,6 @@ async def read_inbound_submission_result(
     receipt_payloads = [inbound_admin.serialize_receipt(receipt) for receipt in receipts]
     event_payload = inbound_admin.serialize_event(event, include_payload=include_payload)
 
-    action_result = dict(event.action_result or {})
-    handling = dict(action_result.get("handling") or {})
     preservation = dict(action_result.get("preservation") or {})
     evidence_contract = dict(handling.get("evidence_contract") or {})
     requires_evidence = bool(
@@ -79,6 +99,10 @@ async def read_inbound_submission_result(
             "handling_status": handling.get("status"),
             "run_id": handling.get("run_id"),
             "run_status": handling.get("run_status") or current_run_status,
+            "retry_attempt": handling.get("retry_attempt"),
+            "original_run_id": handling.get("original_run_id"),
+            "replacement_run_id": handling.get("replacement_run_id"),
+            "retry_lineage": handling.get("retry_lineage"),
             "requires_durable_evidence": requires_evidence,
             "evidence_status": evidence_status,
             "evidence_contract": evidence_contract or preservation or None,

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -41,6 +41,10 @@ from brain.platform.db.models.packet_delivery import PacketBriefDelivery
 from brain.systems.briefing.deliver import deliver_pending_briefs
 from brain.systems.briefing.gather import SlackThreadRead
 from brain.systems.inbound.reconciliation import reconcile_inbound_triage_run
+from brain.systems.runs.events import run_event
+from brain.systems.runs.interactive_reply import INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE
+from brain.systems.runs.status import RunStatus
+from brain.systems.runs.store import AsyncAgentRunStore
 
 _ORG = str(uuid.uuid4())
 _CONN = str(uuid.uuid4())
@@ -157,25 +161,39 @@ def posts(monkeypatch):
 def _slack_envelope() -> dict:
     return {
         "kind": "slack_message",
+        "origin": "slack.channel_message",
+        "idempotency_key": "slack:T1:C0ALERTS:1752600000.0",
         "summary": "Rollbar: generation pipeline exploding",
         "payload": {
+            "origin": "slack.channel_message",
+            "event_kind": "channel_message",
+            "team_id": "T1",
             "channel_id": "C0ALERTS",
             "channel_type": "channel",
             "thread_ts": "1752600000.0",
             "message_ts": "1752600000.0",
+            "slack_user_id": "U0AXEL",
             "bot_user_id": "B0ILLO",
+            "text": "Rollbar: generation pipeline exploding",
         },
         "hints": {},
     }
 
 
-async def _seed_slack_lane(session, *, tool_results, run_status="completed") -> tuple[str, int]:
+async def _seed_slack_lane(
+    session,
+    *,
+    tool_results,
+    run_status="completed",
+) -> tuple[str, int]:
     """One slack_teammate_run admission, receipt terminal at admission (the
     production shape written by brain/systems/slack/inbound.py)."""
     event = InboundEventRow(
         org_id=_ORG,
         connection_id=_CONN,
+        kind="slack_message",
         origin="slack.channel_message",
+        idempotency_key="slack:T1:C0ALERTS:1752600000.0",
         envelope=_slack_envelope(),
         status="processed",
         action_type="slack.run_admitted",
@@ -188,10 +206,18 @@ async def _seed_slack_lane(session, *, tool_results, run_status="completed") -> 
         user_id=_RUN_USER,
         thread_id=f"slack:T1:C0ALERTS:1752600000.0",
         profile="fast",
-        recipe="illo",
+        recipe="fast",
         status=run_status,
         input_message="monitor triage",
-        metadata_={"inbound_event": {"event_id": str(event.id)}},
+        target_ref={"kind": "slack_message", "slack_thread_id": "slack:T1:C0ALERTS:1752600000.0"},
+        metadata_={
+            "origin": "slack_channel_monitor",
+            "slack_monitor": True,
+            "headless": True,
+            "inbound_event": {"event_id": str(event.id)},
+        },
+        source_idempotency_scope="slack",
+        source_idempotency_key="slack:T1:C0ALERTS:1752600000.0",
         completed_at=_NOW if run_status == "completed" else None,
         failed_at=_NOW if run_status == "failed" else None,
     )
@@ -346,6 +372,132 @@ async def test_failed_slack_run_never_mints(session, posts, caplog):
     skipped = [r for r in caplog.records if "packet mint skipped" in r.getMessage()]
     assert len(skipped) == 1
     assert "run_status=failed" in skipped[0].getMessage()
+
+
+async def test_transient_failed_monitor_run_readmits_once_and_replacement_replies(session, posts):
+    event_id, original_run_id = await _seed_slack_lane(
+        session,
+        tool_results=[],
+        run_status="running",
+    )
+
+    store = AsyncAgentRunStore(session)
+    await store.set_status(
+        original_run_id,
+        RunStatus.FAILED,
+        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+    )
+
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    runs = list((await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id.asc()))).all())
+    assert len(runs) == 2
+    replacement = runs[1]
+    assert replacement.source_idempotency_scope == "slack"
+    assert replacement.source_idempotency_key == "slack:T1:C0ALERTS:1752600000.0:attempt:1"
+    assert replacement.metadata_["retry_attempt"] == 1
+    assert replacement.metadata_["inbound_event"]["retry_attempt"] == 1
+    assert replacement.metadata_["inbound_event"]["original_run_id"] == original_run_id
+
+    event = await session.get(InboundEventRow, event_id)
+    assert event.action_result["run_id"] == replacement.id
+    assert event.action_result["original_run_id"] == original_run_id
+    assert event.action_result["replacement_run_id"] == replacement.id
+    assert event.action_result["retry_attempt"] == 1
+    assert event.action_result["retry_lineage"] == [
+        {"run_id": original_run_id, "retry_attempt": 0},
+        {"run_id": replacement.id, "retry_attempt": 1},
+    ]
+    assert receipt.tool_use["run_id"] == replacement.id
+    assert receipt.target["run_id"] == replacement.id
+
+    # Re-processing the original terminal run before the replacement executes
+    # is inert: the receipt already follows attempt 1.
+    await reconcile_inbound_triage_run(session, original_run_id)
+    assert len(list((await session.scalars(select(AgentRunRow))).all())) == 2
+
+    # The replacement executes the original monitored-channel contract and
+    # explicitly posts a Slack reply. Reconciliation must not mint a third run.
+    await store.set_status(replacement.id, RunStatus.STARTING)
+    await store.set_status(replacement.id, RunStatus.RUNNING)
+    await store.append_event(run_event(
+        replacement.id,
+        "run.tool_completed",
+        {"tool_name": "post_slack_reply", "args": {}, "result": _REPLY_RESULT},
+        root_run_id=replacement.root_run_id,
+    ))
+    await store.set_status(replacement.id, RunStatus.COMPLETED)
+    await reconcile_inbound_triage_run(session, original_run_id)
+
+    runs = list((await session.scalars(select(AgentRunRow))).all())
+    assert len(runs) == 2
+    reply_events = list((await session.scalars(
+        select(AgentRunEventRow).where(
+            AgentRunEventRow.run_id == replacement.id,
+            AgentRunEventRow.event_type == "run.tool_completed",
+        )
+    )).all())
+    assert [event.payload["tool_name"] for event in reply_events] == ["post_slack_reply"]
+
+
+async def test_second_transient_failure_is_terminal_and_result_shows_retry_lineage(session, posts):
+    from brain.systems.inbound.results import read_inbound_submission_result
+
+    event_id, original_run_id = await _seed_slack_lane(
+        session,
+        tool_results=[],
+        run_status="running",
+    )
+    store = AsyncAgentRunStore(session)
+    await store.set_status(
+        original_run_id,
+        RunStatus.FAILED,
+        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+    )
+    replacement = (await session.scalars(
+        select(AgentRunRow).where(AgentRunRow.id != original_run_id)
+    )).one()
+    await store.set_status(
+        replacement.id,
+        RunStatus.FAILED,
+        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+    )
+    await reconcile_inbound_triage_run(session, replacement.id)
+
+    assert len(list((await session.scalars(select(AgentRunRow))).all())) == 2
+    result = await read_inbound_submission_result(
+        session,
+        org_id=_ORG,
+        connection_id=_CONN,
+        event_id=event_id,
+    )
+    assert result.payload["run_id"] == replacement.id
+    assert result.payload["run_status"] == "failed"
+    assert result.payload["retry_attempt"] == 1
+    assert result.payload["original_run_id"] == original_run_id
+    assert result.payload["replacement_run_id"] == replacement.id
+    assert result.payload["retry_lineage"] == [
+        {"run_id": original_run_id, "retry_attempt": 0},
+        {"run_id": replacement.id, "retry_attempt": 1},
+    ]
+
+
+async def test_non_transient_failed_monitor_run_is_not_readmitted(session, posts):
+    event_id, original_run_id = await _seed_slack_lane(
+        session,
+        tool_results=[],
+        run_status="running",
+    )
+
+    await AsyncAgentRunStore(session).set_status(
+        original_run_id,
+        RunStatus.FAILED,
+        reason="Refused because the requested operation violates policy",
+    )
+
+    assert len(list((await session.scalars(select(AgentRunRow))).all())) == 1
+    event = await session.get(InboundEventRow, event_id)
+    assert event.action_result["run_id"] == original_run_id
+    assert "retry_attempt" not in event.action_result
 
 
 async def test_submit_lane_mints_on_durable_work_without_post(session, posts):


### PR DESCRIPTION
Closes #368

## What this fixes
A monitored-channel Slack message whose triage run **failed was lost forever** — admission finalized the inbound event as `processed`, Slack-lane reconciliation skipped failed runs, and the connector had already acked so Slack never redelivered. Incident 2026-07-17: Reda's `je pense que tout marche bien sauf Qwen encore bloqué` (run 1785) dropped with no reply and no recovery. Companion to #363 (retry) and #366 (graceful failure): even with both, a terminally-dead run must not vanish the human's message.

## Approach
On a **typed transient provider failure** of a `slack.channel_message`-origin run, reconciliation re-admits the stored envelope **exactly once**:
- `retry_attempt=1` + an **attempt-qualified idempotency key** (`…:attempt:1`) so the second failure is terminal and no loop forms (AgentRun uniqueness is respected).
- Reuses the **#363 transient classifier** (`is_transient_transport_disconnect` / interactive fallback) — genuine logic/refusal failures are never retried.
- Fires **automatically on terminal-status reconciliation** (`store.py` → `_reconcile_inbound_triage_run_if_needed`), not only on a poll, so the dropped turn recovers on failure.
- `illo_get_result` follows the replacement run and exposes the **retry lineage** (original/replacement ids, `retry_attempt`).

Scoped strictly to the inbound re-admission path — no run-output/error-surface changes (#366), no model-call retries (#363).

## Files
- `brain/systems/inbound/reconciliation.py` — once-only re-admit logic
- `brain/systems/inbound/results.py` — `illo_get_result` follows the replacement + lineage fields
- `tests/test_inbound_reconciliation.py` — new coverage

## How to verify
```
cd <worktree-or-checkout>
./venv/bin/python -m pytest tests/test_slack_channel_monitor.py tests/test_inbound_reconciliation.py tests/test_inbound_webhooks.py -q
```
Verified locally by the worker: **41 passed** (channel-monitor + reconciliation) + **23 passed / 1 skipped** (webhooks); the #363 transport tests still green (6 + 1). Reviewer independently confirmed: origin constant `"slack.channel_message"` matches real monitored-channel `event.origin`, and reconciliation is invoked on terminal status (`store.py:966`, gated `target in TERMINAL_RUN_STATUSES`).

## Acceptance checks
1. ✅ Transient monitored-channel failure → exactly one `:attempt:1` replacement run executes and replies.
2. ✅ Replacement also fails → terminal at two runs; `retry_attempt=1` prevents a third admission (no loop).
3. ✅ `illo_get_result` exposes original/replacement ids + `retry_lineage`.
4. ✅ Non-transient (refusal/logic) failure is not re-admitted — scoped to typed transient provider failures only.

🤖 Draft opened by Routine R3 (Illospace ticket worker). Do not merge without Reda's review.