### PR TITLE
fix(chantier): guarantee Domain-1 tracker record on declare completion (#371)

### DIFF
--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -376,6 +376,59 @@ class AsyncAgentRunEngine:
         status: RunStatus = RunStatus.COMPLETED,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
+        row = await self.store.require_run(run_id)
+        if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
+            return to_domain(row)
+        try:
+            from brain.systems.slack.chantier_reconciliation import (
+                ChantierDeclareGuaranteeError,
+                guarantee_chantier_record_for_run,
+            )
+
+            guarantee = await guarantee_chantier_record_for_run(
+                self.store.session,
+                run=row,
+                output=output,
+            )
+        except ChantierDeclareGuaranteeError as exc:
+            failure = str(exc).strip() or "tracker-record verification failed"
+            await self.store.update_metadata(
+                run_id,
+                {
+                    "chantier_declare_guarantee": {
+                        "status": "failed",
+                        "error": failure,
+                    }
+                },
+            )
+            await self.store.append_event(
+                run_event(
+                    run_id,
+                    "run.chantier_declare_guarantee_failed",
+                    {"error": failure},
+                    root_run_id=row.root_run_id,
+                )
+            )
+            return await self.fail(
+                run_id,
+                f"Chantier declare failed: {failure}",
+                final_output=f"Chantier declare failed: {failure}",
+                execution_claim=execution_claim,
+            )
+        if guarantee is not None:
+            guarantee_metadata = guarantee.as_metadata()
+            await self.store.update_metadata(
+                run_id,
+                {"chantier_declare_guarantee": guarantee_metadata},
+            )
+            await self.store.append_event(
+                run_event(
+                    run_id,
+                    "run.chantier_declare_guaranteed",
+                    guarantee_metadata,
+                    root_run_id=row.root_run_id,
+                )
+            )
         async with self._atomic_terminal_write():
             row = await self.store.require_run(run_id)
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:

--- a/brain/systems/slack/chantier_reconciliation.py
+++ b/brain/systems/slack/chantier_reconciliation.py
@@ -1,0 +1,528 @@
+"""Completion-time guarantee and drift checks for chantier declarations.
+
+The explicit Slack declaration door persists its Domain record before the
+agent run starts.  A conversational run can also become declaration-shaped by
+publishing a chantier PRD and announcing it in Slack.  This module recognizes
+that second shape from durable tool events and makes the same Domain record a
+verified precondition of successful completion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import PurePath
+import re
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunEventRow
+from brain.platform.db.models.domain import DomainRecord
+from brain.systems.slack.chantier_declare import (
+    CHANTIER_OBJECT_KEY,
+    MISSING_NEXT_STEP,
+    TRACKER_DOMAIN_SLUG,
+    _guess_kind,
+    _merge_refs,
+    _slugify,
+)
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+_TOOL_COMPLETED_EVENT = "run.tool_completed"
+_PRD_TOOL = "publish_thread_asset"
+_SLACK_ANCHOR_TOOL = "post_slack_reply"
+_DECLARE_ACTION_RE = re.compile(
+    r"\b(?:declare|declared|declaring|declaration)\b",
+    re.IGNORECASE,
+)
+_CHANTIER_RE = re.compile(r"\bchantier\b", re.IGNORECASE)
+_PRD_RE = re.compile(r"\b(?:prd|product requirements? document)\b", re.IGNORECASE)
+_SLUG_LABEL_RE = re.compile(r"\bslug\s*[:=]\s*`?([a-z0-9]+(?:-[a-z0-9]+)*)", re.IGNORECASE)
+_DONE_MEANS_RE = re.compile(r"\bdone\s+means\s*:?[ \t]*(.+?)(?:\r?\n|$)", re.IGNORECASE)
+_KIND_RE = re.compile(r"\bkind\s*:\s*(feature|incident|quality|gtm)\b", re.IGNORECASE)
+_NEXT_STEP_RE = re.compile(r"\bnext[_ ]step\s*:\s*(.+?)(?:\r?\n|$)", re.IGNORECASE)
+_PREVIEW_JSON_SCALAR_RE = re.compile(
+    r'"(?P<key>ok|error|viewer_url|public_url|url|channel_id|thread_ts|channel|ts)"'
+    r'\s*:\s*(?P<value>"(?:\\.|[^"\\])*"|true|false|null)'
+)
+
+
+class ChantierDeclareGuaranteeError(RuntimeError):
+    """A declare-shaped run cannot satisfy its tracker-record precondition."""
+
+
+@dataclass(frozen=True)
+class PublishedChantierPrd:
+    """The deterministic identity and links of one published chantier PRD."""
+
+    slug: str
+    title: str
+    prd_ref: Mapping[str, str] | None = None
+    anchor_ref: Mapping[str, str] | None = None
+    goal: str | None = None
+    kind: str | None = None
+    state: str = "exploring"
+    next_step: str | None = None
+    additional_refs: tuple[Mapping[str, str], ...] = ()
+    record_data: Mapping[str, Any] | None = None
+    source: str = "published_prd"
+
+    def linked_refs(self) -> list[dict[str, str]]:
+        candidates: list[Mapping[str, str]] = list(self.additional_refs)
+        if self.prd_ref is not None:
+            candidates.append(self.prd_ref)
+        if self.anchor_ref is not None:
+            candidates.append(self.anchor_ref)
+        return _merge_refs([], candidates)
+
+
+@dataclass(frozen=True)
+class ChantierReconciliationReport:
+    """Result of checking one published PRD against the Domain tracker."""
+
+    slug: str
+    domain_id: int | None
+    record_id: int | None
+    operation: str
+    drift: tuple[str, ...] = ()
+    repaired: bool = False
+    source: str = "published_prd"
+
+    @property
+    def record_ref(self) -> str | None:
+        return f"domain_record:{self.record_id}" if self.record_id is not None else None
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "status": "repaired" if self.repaired else ("drift" if self.drift else "verified"),
+            "slug": self.slug,
+            "domain_id": self.domain_id,
+            "record_id": self.record_id,
+            "record_ref": self.record_ref,
+            "operation": self.operation,
+            "drift": list(self.drift),
+            "self_healed": self.repaired,
+            "source": self.source,
+        }
+
+
+async def reconcile_published_chantier_prd(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    publication: PublishedChantierPrd,
+    repair: bool = False,
+    actor_user_id: str | None = None,
+    run_id: int | None = None,
+) -> ChantierReconciliationReport:
+    """Report or repair a published PRD whose exact-slug record has drifted."""
+
+    service = AsyncDomainService(session)
+    domain = next(
+        (
+            item
+            for item in await service.list_domains(org_id)
+            if item.slug == TRACKER_DOMAIN_SLUG
+        ),
+        None,
+    )
+    if domain is None:
+        report = ChantierReconciliationReport(
+            slug=publication.slug,
+            domain_id=None,
+            record_id=None,
+            operation="missing_domain",
+            drift=("missing_domain",),
+            source=publication.source,
+        )
+        if repair:
+            raise ChantierDeclareGuaranteeError(
+                f"Domain '{TRACKER_DOMAIN_SLUG}' is missing for chantier {publication.slug!r}"
+            )
+        return report
+
+    await service.get_object_type(domain.id, CHANTIER_OBJECT_KEY, for_update=repair)
+    records = await service.list_records(
+        org_id,
+        domain.id,
+        object_key=CHANTIER_OBJECT_KEY,
+        limit=500,
+        order="updated_asc",
+    )
+    matches = _records_with_slug(records, publication.slug)
+    if len(matches) > 1:
+        ids = ", ".join(str(record.id) for record in matches)
+        if repair:
+            raise ChantierDeclareGuaranteeError(
+                f"Chantier slug {publication.slug!r} resolves to duplicate Domain records: {ids}"
+            )
+        return ChantierReconciliationReport(
+            slug=publication.slug,
+            domain_id=domain.id,
+            record_id=None,
+            operation="duplicate_records",
+            drift=("duplicate_records",),
+            source=publication.source,
+        )
+
+    expected_refs = publication.linked_refs()
+    record = matches[0] if matches else None
+    drift: list[str] = []
+    if record is None:
+        drift.append("missing_record")
+    elif _missing_refs(record, expected_refs):
+        drift.append("missing_refs")
+
+    if not repair or not drift:
+        return ChantierReconciliationReport(
+            slug=publication.slug,
+            domain_id=domain.id,
+            record_id=record.id if record is not None else None,
+            operation="verified" if not drift else drift[0],
+            drift=tuple(drift),
+            source=publication.source,
+        )
+
+    if record is None:
+        data = _new_record_data(publication)
+        record = await service.create_record(
+            org_id,
+            domain.id,
+            CHANTIER_OBJECT_KEY,
+            data=data,
+            actor_id=actor_user_id,
+            actor_kind="agent",
+            run_id=run_id,
+            reason="Declare completion guarantee self-heal",
+        )
+        operation = "created_missing_record"
+    else:
+        merged_refs = _merge_refs((record.data or {}).get("refs"), expected_refs)
+        record = await service.update_record(
+            org_id,
+            domain.id,
+            record.id,
+            data_patch={"refs": merged_refs},
+            expected_version=record.version,
+            actor_id=actor_user_id,
+            actor_kind="agent",
+            run_id=run_id,
+            reason="Declare completion guarantee linked published PRD/Slack anchor",
+        )
+        operation = "linked_missing_refs"
+
+    verified_records = await service.list_records(
+        org_id,
+        domain.id,
+        object_key=CHANTIER_OBJECT_KEY,
+        limit=500,
+        order="updated_asc",
+    )
+    verified_matches = _records_with_slug(verified_records, publication.slug)
+    if len(verified_matches) != 1 or _missing_refs(verified_matches[0], expected_refs):
+        raise ChantierDeclareGuaranteeError(
+            f"Chantier {publication.slug!r} tracker record failed post-repair verification"
+        )
+    verified = verified_matches[0]
+    return ChantierReconciliationReport(
+        slug=publication.slug,
+        domain_id=domain.id,
+        record_id=verified.id,
+        operation=operation,
+        drift=tuple(drift),
+        repaired=True,
+        source=publication.source,
+    )
+
+
+async def guarantee_chantier_record_for_run(
+    session: AsyncSession,
+    *,
+    run: Any,
+    output: str = "",
+) -> ChantierReconciliationReport | None:
+    """Verify/self-heal only runs that carry durable declare-shaped evidence."""
+
+    metadata = dict(getattr(run, "metadata_", None) or {})
+    explicit = metadata.get("chantier_declare")
+    if isinstance(explicit, Mapping):
+        operation = str(explicit.get("operation") or "").strip().lower()
+        if operation == "failed":
+            error = str(explicit.get("error") or "tracker persistence failed").strip()
+            raise ChantierDeclareGuaranteeError(error)
+        publication = _publication_from_explicit_metadata(explicit)
+        if publication is None:
+            raise ChantierDeclareGuaranteeError(
+                "Explicit chantier declaration metadata has no stable slug"
+            )
+    else:
+        publication = await _publication_from_run_events(session, run=run, output=output)
+        if publication is None:
+            return None
+
+    try:
+        return await reconcile_published_chantier_prd(
+            session,
+            org_id=str(getattr(run, "org_id", "") or ""),
+            publication=publication,
+            repair=True,
+            actor_user_id=str(getattr(run, "user_id", "") or "") or None,
+            run_id=int(getattr(run, "id")),
+        )
+    except ChantierDeclareGuaranteeError:
+        raise
+    except Exception as exc:
+        raise ChantierDeclareGuaranteeError(
+            f"Chantier {publication.slug!r} tracker repair failed: {exc}"
+        ) from exc
+
+
+def _publication_from_explicit_metadata(
+    metadata: Mapping[str, Any],
+) -> PublishedChantierPrd | None:
+    data = metadata.get("data")
+    data = dict(data) if isinstance(data, Mapping) else {}
+    slug = _slugify(str(data.get("slug") or ""))
+    if not slug:
+        return None
+    title = str(data.get("title") or slug.replace("-", " ")).strip()
+    refs = tuple(item for item in data.get("refs", []) if isinstance(item, Mapping))
+    return PublishedChantierPrd(
+        slug=slug,
+        title=title,
+        goal=str(data.get("goal") or "").strip() or None,
+        kind=str(data.get("kind") or "").strip() or None,
+        state=str(data.get("state") or "exploring").strip() or "exploring",
+        next_step=str(data.get("next_step") or "").strip() or None,
+        additional_refs=refs,
+        record_data=data,
+        source="explicit_declare",
+    )
+
+
+async def _publication_from_run_events(
+    session: AsyncSession,
+    *,
+    run: Any,
+    output: str,
+) -> PublishedChantierPrd | None:
+    events = list(
+        await session.scalars(
+            select(AgentRunEventRow)
+            .where(
+                AgentRunEventRow.run_id == int(getattr(run, "id")),
+                AgentRunEventRow.event_type == _TOOL_COMPLETED_EVENT,
+            )
+            .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+        )
+    )
+    prd_events = [event for event in events if _is_successful_tool_event(event, _PRD_TOOL)]
+    anchor_events = [
+        event for event in events if _is_successful_tool_event(event, _SLACK_ANCHOR_TOOL)
+    ]
+    if not prd_events or not anchor_events:
+        return None
+
+    prd_event = next(
+        (
+            event
+            for event in reversed(prd_events)
+            if _PRD_RE.search(_asset_identity_text(event))
+        ),
+        None,
+    )
+    if prd_event is None:
+        return None
+    anchor_event = anchor_events[-1]
+
+    input_message = str(getattr(run, "input_message", "") or "")
+    anchor_body = str(_event_args(anchor_event).get("body") or "")
+    asset_identity = _asset_identity_text(prd_event)
+    identity_text = "\n".join((input_message, asset_identity, anchor_body, output))
+    if (
+        _DECLARE_ACTION_RE.search(identity_text) is None
+        and _CHANTIER_RE.search(asset_identity) is None
+    ):
+        return None
+
+    raw_title = _asset_title(prd_event)
+    title = _clean_prd_title(raw_title)
+    explicit_slug = _SLUG_LABEL_RE.search(identity_text)
+    slug = _slugify(explicit_slug.group(1) if explicit_slug else title)
+    if not slug or not title:
+        raise ChantierDeclareGuaranteeError(
+            "Published chantier PRD and Slack anchor do not expose a stable chantier identity"
+        )
+
+    goal_match = _DONE_MEANS_RE.search(identity_text)
+    goal = f"Done means {goal_match.group(1).strip()}" if goal_match else None
+    kind_match = _KIND_RE.search(identity_text)
+    next_step_match = _NEXT_STEP_RE.search(identity_text)
+    return PublishedChantierPrd(
+        slug=slug,
+        title=title,
+        prd_ref=_prd_ref(prd_event, title=raw_title or f"{title} PRD"),
+        anchor_ref=_slack_anchor_ref(anchor_event),
+        goal=goal,
+        kind=kind_match.group(1).lower() if kind_match else _guess_kind(f"{title} {goal or ''}"),
+        next_step=next_step_match.group(1).strip() if next_step_match else None,
+    )
+
+
+def _is_successful_tool_event(event: AgentRunEventRow, tool_name: str) -> bool:
+    payload = dict(event.payload or {})
+    if str(payload.get("tool_name") or payload.get("tool") or "") != tool_name:
+        return False
+    result = _event_result(event)
+    if not isinstance(result, Mapping):
+        return False
+    return not result.get("error") and result.get("ok") is not False
+
+
+def _event_args(event: AgentRunEventRow) -> dict[str, Any]:
+    args = dict((event.payload or {}).get("args") or {})
+    return {str(key): value for key, value in args.items()}
+
+
+def _event_result(event: AgentRunEventRow) -> Any:
+    value = (event.payload or {}).get("result")
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        # Tool events intentionally retain only a bounded result preview.  The
+        # publisher and Slack handlers put identity fields first, so recover
+        # those complete scalars even when a later attachment/message body is
+        # cut before the JSON object's closing brace.
+        recovered: dict[str, Any] = {}
+        for match in _PREVIEW_JSON_SCALAR_RE.finditer(value):
+            key = match.group("key")
+            if key in recovered:
+                continue
+            try:
+                recovered[key] = json.loads(match.group("value"))
+            except json.JSONDecodeError:
+                continue
+        return recovered or None
+
+
+def _asset_identity_text(event: AgentRunEventRow) -> str:
+    args = _event_args(event)
+    return " ".join((str(args.get("title") or ""), str(args.get("file_path") or "")))
+
+
+def _asset_title(event: AgentRunEventRow) -> str:
+    args = _event_args(event)
+    title = str(args.get("title") or "").strip()
+    if title:
+        return title
+    path = str(args.get("file_path") or "").strip().replace("\\", "/")
+    return PurePath(path).stem if path else ""
+
+
+def _clean_prd_title(value: str) -> str:
+    title = PurePath(str(value or "").replace("\\", "/")).stem
+    title = re.sub(r"[\[\](){}]", " ", title)
+    title = _PRD_RE.sub(" ", title)
+    title = re.sub(r"\bchantier\b", " ", title, flags=re.IGNORECASE)
+    title = re.sub(r"[_–—]+", " ", title)
+    title = re.sub(r"\s*-\s*", " ", title)
+    return re.sub(r"\s+", " ", title).strip(" .:-")[:500]
+
+
+def _prd_ref(event: AgentRunEventRow, *, title: str) -> dict[str, str]:
+    result = _event_result(event)
+    result = dict(result) if isinstance(result, Mapping) else {}
+    ref = str(
+        result.get("viewer_url")
+        or result.get("public_url")
+        or result.get("url")
+        or _event_args(event).get("file_path")
+        or ""
+    ).strip()
+    if not ref:
+        raise ChantierDeclareGuaranteeError("Published chantier PRD has no durable reference")
+    return {
+        "source": "url" if ref.startswith(("http://", "https://", "/")) else "doc",
+        "ref": ref,
+        "title": title[:500],
+    }
+
+
+def _slack_anchor_ref(event: AgentRunEventRow) -> dict[str, str]:
+    args = _event_args(event)
+    result = _event_result(event)
+    result = dict(result) if isinstance(result, Mapping) else {}
+    slack = result.get("slack")
+    slack = dict(slack) if isinstance(slack, Mapping) else {}
+    channel = str(
+        result.get("channel_id")
+        or result.get("channel")
+        or slack.get("channel")
+        or args.get("channel_id")
+        or ""
+    ).strip()
+    anchor = str(
+        result.get("thread_ts")
+        or result.get("ts")
+        or slack.get("thread_ts")
+        or slack.get("ts")
+        or args.get("thread_ts")
+        or ""
+    ).strip()
+    if not channel or not anchor:
+        raise ChantierDeclareGuaranteeError(
+            "Published chantier PRD Slack announcement has no durable channel/thread anchor"
+        )
+    return {
+        "source": "slack",
+        "ref": f"slack:{channel}:{anchor}",
+        "title": "Slack declaration anchor",
+    }
+
+
+def _new_record_data(publication: PublishedChantierPrd) -> dict[str, Any]:
+    data = dict(publication.record_data or {})
+    data["slug"] = publication.slug
+    data.setdefault("title", publication.title)
+    data.setdefault("goal", publication.goal or f"Done means {publication.title} reaches its stated outcome.")
+    data.setdefault("kind", publication.kind or _guess_kind(publication.title))
+    data.setdefault("state", publication.state or "exploring")
+    data["refs"] = _merge_refs(data.get("refs"), publication.linked_refs())
+    data.setdefault("next_step", publication.next_step or MISSING_NEXT_STEP)
+    return data
+
+
+def _records_with_slug(records: Sequence[DomainRecord], slug: str) -> list[DomainRecord]:
+    needle = slug.casefold()
+    return [
+        record
+        for record in records
+        if str((record.data or {}).get("slug") or "").casefold() == needle
+    ]
+
+
+def _missing_refs(record: DomainRecord, expected: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
+    existing = {
+        (str(item.get("source") or ""), str(item.get("ref") or ""))
+        for item in (record.data or {}).get("refs", [])
+        if isinstance(item, Mapping)
+    }
+    return [
+        dict(item)
+        for item in expected
+        if (str(item.get("source") or ""), str(item.get("ref") or "")) not in existing
+    ]
+
+
+__all__ = [
+    "ChantierDeclareGuaranteeError",
+    "ChantierReconciliationReport",
+    "PublishedChantierPrd",
+    "guarantee_chantier_record_for_run",
+    "reconcile_published_chantier_prd",
+]

--- a/tests/test_chantier_declare_guarantee.py
+++ b/tests/test_chantier_declare_guarantee.py
@@ -1,0 +1,394 @@
+"""The declare completion boundary owns the Domain-1 chantier guarantee."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+from brain.platform.db.models.agent_run import (
+    AgentRunArtifactRow,
+    AgentRunEventRow,
+    AgentRunRow,
+)
+from brain.platform.db.models.domain import (
+    Domain,
+    DomainEvent,
+    DomainFieldDefinition,
+    DomainObjectType,
+    DomainRecord,
+    DomainRelation,
+    DomainRelationType,
+)
+from brain.systems.runs.domain import AgentRunRequest
+from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.events import run_event
+from brain.systems.runs.status import RunStatus
+from brain.systems.slack.chantier_reconciliation import (
+    PublishedChantierPrd,
+    reconcile_published_chantier_prd,
+)
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+USER_ID = "22222222-2222-4222-8222-222222222222"
+PRD_URL = "https://illo.example/doc?src=/static/uploads/connector-framework-prd.md"
+SLACK_REF = "slack:C_DECLARE:1752800000.000100"
+
+
+def _patch_sqlite_for_pg_types() -> None:
+    if not hasattr(SQLiteTypeCompiler, "visit_JSONB"):
+        SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_BIGINT = lambda self, type_, **kw: "INTEGER"
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_chantier_guarantee_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+        return result
+
+    patched._chantier_guarantee_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    return await async_sqlite_session_factory(
+        [
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainFieldDefinition.__table__,
+            DomainRelationType.__table__,
+            DomainRecord.__table__,
+            DomainRelation.__table__,
+            DomainEvent.__table__,
+        ]
+    )
+
+
+def _chantier_object_definition() -> dict:
+    github_issue_pattern = (
+        r"github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:issue:[1-9][0-9]*"
+    )
+    return {
+        "key": "chantier",
+        "name": "Chantier",
+        "title_field": "title",
+        "fields": [
+            {
+                "key": "slug",
+                "field_type": "text",
+                "required": True,
+                "validation": {
+                    "immutable": True,
+                    "max_length": 80,
+                    "pattern": r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                },
+            },
+            {"key": "title", "field_type": "text", "required": True},
+            {
+                "key": "goal",
+                "field_type": "long_text",
+                "required": True,
+                "validation": {"pattern": r"(?is)^done means\s+\S.*$"},
+            },
+            {
+                "key": "kind",
+                "field_type": "enum",
+                "required": True,
+                "options": ["feature", "incident", "quality", "gtm"],
+            },
+            {
+                "key": "state",
+                "field_type": "enum",
+                "required": True,
+                "options": [
+                    "exploring",
+                    "building",
+                    "shipping",
+                    "verifying",
+                    "done",
+                    "paused",
+                ],
+            },
+            {"key": "owner", "field_type": "text"},
+            {
+                "key": "refs",
+                "field_type": "json",
+                "required": True,
+                "validation": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["source", "ref"],
+                        "additional_properties": False,
+                        "properties": {
+                            "source": {
+                                "type": "string",
+                                "enum": ["github", "doc", "slack", "posthog", "url"],
+                            },
+                            "ref": {"type": "string", "min_length": 1},
+                            "title": {"type": "string", "min_length": 1},
+                        },
+                        "source_ref_patterns": {"github": github_issue_pattern},
+                    },
+                },
+            },
+            {"key": "parent_issue", "field_type": "text"},
+            {
+                "key": "next_step",
+                "field_type": "text",
+                "required": True,
+                "validation": {"pattern": r"^[^\r\n]+$"},
+            },
+            {"key": "progress_note", "field_type": "long_text"},
+        ],
+    }
+
+
+async def _create_tracker(session):
+    return await AsyncDomainService(session).create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+
+
+def _publication() -> PublishedChantierPrd:
+    return PublishedChantierPrd(
+        slug="connector-framework",
+        title="Connector Framework",
+        goal="Done means connectors share one verified declaration contract.",
+        kind="feature",
+        next_step="Implement the first connector against the shared contract.",
+        prd_ref={"source": "url", "ref": PRD_URL, "title": "Connector Framework PRD"},
+        anchor_ref={"source": "slack", "ref": SLACK_REF, "title": "Slack declaration anchor"},
+    )
+
+
+def _record_data() -> dict:
+    publication = _publication()
+    return {
+        "slug": publication.slug,
+        "title": publication.title,
+        "goal": publication.goal,
+        "kind": publication.kind,
+        "state": "exploring",
+        "refs": publication.linked_refs(),
+        "next_step": publication.next_step,
+    }
+
+
+async def _running_engine(session, *, message: str):
+    engine = AsyncAgentRunEngine(session, recipes={})
+    run = await engine.store.create_run(
+        AgentRunRequest(
+            org_id=ORG_ID,
+            user_id=USER_ID,
+            thread_id="thread-371",
+            message=message,
+        )
+    )
+    await engine.store.set_status(run.id, RunStatus.STARTING)
+    await engine.store.set_status(run.id, RunStatus.RUNNING)
+    return engine, await engine.store.require_run(run.id)
+
+
+async def _append_prd_and_anchor_events(
+    engine,
+    run_id: int,
+    *,
+    declaration: bool = True,
+    truncated_results: bool = False,
+) -> None:
+    prd_result = json.dumps(
+        {"ok": True, "viewer_url": PRD_URL, "instruction": "x" * 2_000}
+    )
+    slack_result = json.dumps(
+        {
+            "ok": True,
+            "channel_id": "C_DECLARE",
+            "thread_ts": "1752800000.000100",
+            "slack": {
+                "channel": "C_DECLARE",
+                "ts": "1752800000.000200",
+                "message": {"text": "x" * 2_000},
+            },
+        }
+    )
+    if truncated_results:
+        prd_result = prd_result[:1000]
+        slack_result = slack_result[:1000]
+    await engine.store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "publish_thread_asset",
+                "args": {
+                    "file_path": "/tmp/connector-framework-prd.md",
+                    "title": "Connector Framework PRD",
+                },
+                "result": prd_result,
+            },
+            root_run_id=run_id,
+        )
+    )
+    await engine.store.append_event(
+        run_event(
+            run_id,
+            "run.tool_completed",
+            {
+                "tool_name": "post_slack_reply",
+                "args": {
+                    "body": (
+                        "Declared the connector framework chantier. Slug: connector-framework\n"
+                        "Done means connectors share one verified declaration contract.\n"
+                        "next_step: Implement the first connector against the shared contract."
+                    )
+                    if declaration
+                    else "The connector framework planning document is ready for review."
+                },
+                "result": slack_result,
+            },
+            root_run_id=run_id,
+        )
+    )
+
+
+async def test_declare_with_linked_tracker_record_completes_verified(session):
+    domain = await _create_tracker(session)
+    service = AsyncDomainService(session)
+    existing = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=_record_data(),
+    )
+    engine, run = await _running_engine(
+        session,
+        message="Declare the connector-framework chantier and publish its PRD.",
+    )
+    await _append_prd_and_anchor_events(engine, run.id)
+
+    completed = await engine.complete(run.id, output="Connector framework declared.")
+
+    assert completed.status == RunStatus.COMPLETED
+    stored = await engine.store.require_run(run.id)
+    guarantee = stored.metadata_["chantier_declare_guarantee"]
+    assert guarantee == {
+        "status": "verified",
+        "slug": "connector-framework",
+        "domain_id": domain.id,
+        "record_id": existing.id,
+        "record_ref": f"domain_record:{existing.id}",
+        "operation": "verified",
+        "drift": [],
+        "self_healed": False,
+        "source": "published_prd",
+    }
+    records = await service.list_records(ORG_ID, domain.id, object_key="chantier")
+    assert [record.id for record in records] == [existing.id]
+
+
+async def test_declare_missing_tracker_record_self_heals_before_success_and_digest_sees_it(session):
+    domain = await _create_tracker(session)
+    engine, run = await _running_engine(
+        session,
+        message="Declare the connector-framework chantier and publish its PRD.",
+    )
+    await _append_prd_and_anchor_events(engine, run.id, truncated_results=True)
+
+    completed = await engine.complete(run.id, output="Connector framework declared.")
+
+    assert completed.status == RunStatus.COMPLETED
+    guarantee = (await engine.store.require_run(run.id)).metadata_[
+        "chantier_declare_guarantee"
+    ]
+    assert guarantee["status"] == "repaired"
+    assert guarantee["operation"] == "created_missing_record"
+    assert guarantee["drift"] == ["missing_record"]
+    assert guarantee["self_healed"] is True
+
+    # This is the same Domain/object/slug query used by chantier-primary sweeps.
+    records = await AsyncDomainService(session).list_records(
+        ORG_ID,
+        domain.id,
+        object_key="chantier",
+        filters={"slug": "connector-framework"},
+    )
+    assert len(records) == 1
+    assert records[0].data["slug"] == "connector-framework"
+    refs = {(item["source"], item["ref"]) for item in records[0].data["refs"]}
+    assert ("url", PRD_URL) in refs
+    assert ("slack", SLACK_REF) in refs
+
+
+async def test_reconciliation_reports_published_prd_without_record_ref(session):
+    domain = await _create_tracker(session)
+
+    report = await reconcile_published_chantier_prd(
+        session,
+        org_id=ORG_ID,
+        publication=_publication(),
+        repair=False,
+    )
+
+    assert report.domain_id == domain.id
+    assert report.record_id is None
+    assert report.operation == "missing_record"
+    assert report.drift == ("missing_record",)
+    assert report.repaired is False
+
+
+async def test_non_declare_run_with_prd_and_slack_post_is_unaffected(session):
+    domain = await _create_tracker(session)
+    engine, run = await _running_engine(
+        session,
+        message=(
+            "Summarize the connector-framework chantier in a planning document "
+            "and announce it to Slack."
+        ),
+    )
+    await _append_prd_and_anchor_events(engine, run.id, declaration=False)
+
+    completed = await engine.complete(run.id, output="Chantier planning document published.")
+
+    assert completed.status == RunStatus.COMPLETED
+    stored = await engine.store.require_run(run.id)
+    assert "chantier_declare_guarantee" not in stored.metadata_
+    assert await AsyncDomainService(session).list_records(
+        ORG_ID,
+        domain.id,
+        object_key="chantier",
+    ) == []
+
+
+async def test_declare_fails_loudly_when_tracker_domain_cannot_be_repaired(session):
+    engine, run = await _running_engine(
+        session,
+        message="Declare the connector-framework chantier and publish its PRD.",
+    )
+    await _append_prd_and_anchor_events(engine, run.id)
+
+    failed = await engine.complete(run.id, output="Connector framework declared.")
+
+    assert failed.status == RunStatus.FAILED
+    guarantee = (await engine.store.require_run(run.id)).metadata_[
+        "chantier_declare_guarantee"
+    ]
+    assert guarantee["status"] == "failed"
+    assert "github-ticket-tracker" in guarantee["error"]


### PR DESCRIPTION
Closes #371

## What this fixes
Run 1744 (connector-framework declare) published the PRD + opened the Slack thread but wrote **NO Domain-1 chantier record** — the chantier was invisible to digests/sweeps until manually backfilled as record 2006. Record creation was agent-discretionary, not a hard step of the declare flow.

## Approach
At run completion, `guarantee_chantier_record_for_run` makes the **exact-slug Domain-1 record a verified precondition** of a successful declare. Two shapes are recognized:
- **Explicit declare door** — reads `chantier_declare` run metadata.
- **Conversational declare** — detects a run that published a PRD asset (`publish_thread_asset`) **and** announced it in Slack (`post_slack_reply`) with declare/chantier language, from durable tool events.

Outcomes: record present → pass; missing record/refs → **self-heal** (create/link) + flag (`run.chantier_declare_guaranteed` event + metadata); repair fails / no stable slug → **run fails loudly** (`run.chantier_declare_guarantee_failed`). `reconcile_published_chantier_prd` is the standalone drift check. **Ordinary runs are untouched** — the guarantee returns `None` when there's no declare evidence.

## Files
- `brain/systems/runs/engine.py` — invoke the guarantee on the completion path
- `brain/systems/slack/chantier_reconciliation.py` *(new)* — detection, verify/self-heal, drift check
- `tests/test_chantier_declare_guarantee.py` *(new)*

## How to verify
```
cd <worktree-or-checkout>
./venv/bin/python -m pytest tests/test_chantier_declare_guarantee.py tests/test_agent_run_runtime.py tests/test_agent_run_state_machine.py tests/test_domains_service.py -q
```
Verified locally: **5 guarantee + 185 regression passed / 1 skipped** (worker's combined run: 190 passed / 1 skipped).

## 👀 Reviewer notes (worth your eye, @redawear)
- **Scope of the conversational-declare heuristic:** the gate trips only when a run *both* publishes a PRD asset *and* posts a Slack anchor *and* carries declare/chantier language. A trip on a legit run that already has its record is a **no-op verify**; a trip with a missing record **self-heals**. The only hard-fail path is a declare-shaped run that can't expose a stable slug/title — narrow, but eyeball the false-positive surface for your real declare copy.
- **Per-completion cost:** the detector runs one `tool_completed` event scan on completing runs without the explicit metadata flag. Indexed query, but it's on the common path.

## Acceptance checks
1. ✅ A declare producing a PRD + anchor without a tracker record is impossible — fails loudly or self-heals + flags.
2. ✅ After a successful declare the sweep sees the chantier (record with slug + PRD/anchor refs).
3. ✅ `reconcile_published_chantier_prd()` reports (and optionally repairs) an orphaned PRD.
4. ✅ Gate scoped to declare-shaped runs; ordinary runs unchanged.

🤖 Draft opened by Routine R3 (Illospace ticket worker). Do not merge without Reda's review.