### PR TITLE
fix(chantier): add 'sunset' to chantier record kind contract (#372)

### DIFF
--- a/brain/platform/db/alembic/versions/0029_chantier_sunset_kind.py
+++ b/brain/platform/db/alembic/versions/0029_chantier_sunset_kind.py
@@ -1,0 +1,145 @@
+"""Add sunset to the chantier kind contract.
+
+Revision ID: 0029_chantier_sunset_kind
+Revises: 0028_deactivate_pinned_chantier_digest
+Create Date: 2026-07-18
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0029_chantier_sunset_kind"
+down_revision = "0028_deactivate_pinned_chantier_digest"
+branch_labels = None
+depends_on = None
+
+
+_TRACKER_SLUG = "github-ticket-tracker"
+_OBJECT_KEY = "chantier"
+_FIELD_KEY = "kind"
+_SUNSET_KIND = "sunset"
+_SUNSET_RECORD_SLUG = "shopify-app-sunset"
+
+
+def _schema(bind: sa.Connection) -> str | None:
+    return "public" if bind.dialect.name == "postgresql" else None
+
+
+def _table_exists(bind: sa.Connection, table_name: str) -> bool:
+    return table_name in set(sa.inspect(bind).get_table_names(schema=_schema(bind)))
+
+
+def _table(bind: sa.Connection, metadata: sa.MetaData, table_name: str) -> sa.Table:
+    return sa.Table(
+        table_name,
+        metadata,
+        schema=_schema(bind),
+        autoload_with=bind,
+    )
+
+
+def _active_condition(table: sa.Table) -> sa.ColumnElement[bool]:
+    if "archived_at" not in table.c:
+        return sa.true()
+    return table.c.archived_at.is_(None)
+
+
+def _upgrade(bind: sa.Connection) -> None:
+    required_tables = {
+        "domains",
+        "domain_object_types",
+        "domain_field_definitions",
+    }
+    if not all(_table_exists(bind, table_name) for table_name in required_tables):
+        return
+
+    metadata = sa.MetaData()
+    domains = _table(bind, metadata, "domains")
+    object_types = _table(bind, metadata, "domain_object_types")
+    fields = _table(bind, metadata, "domain_field_definitions")
+    records = (
+        _table(bind, metadata, "domain_records")
+        if _table_exists(bind, "domain_records")
+        else None
+    )
+
+    chantier_rows = bind.execute(
+        sa.select(object_types.c.id, object_types.c.domain_id)
+        .join(domains, domains.c.id == object_types.c.domain_id)
+        .where(
+            domains.c.slug == _TRACKER_SLUG,
+            object_types.c.key == _OBJECT_KEY,
+            _active_condition(domains),
+            _active_condition(object_types),
+        )
+    ).mappings().all()
+
+    for chantier in chantier_rows:
+        kind_field = bind.execute(
+            sa.select(fields).where(
+                fields.c.object_type_id == chantier["id"],
+                fields.c.key == _FIELD_KEY,
+                _active_condition(fields),
+            )
+        ).mappings().first()
+        if kind_field is not None:
+            options = list(kind_field.get("options") or [])
+            if _SUNSET_KIND not in options:
+                values: dict[str, object] = {"options": [*options, _SUNSET_KIND]}
+                if "updated_at" in fields.c:
+                    values["updated_at"] = sa.func.now()
+                bind.execute(
+                    fields.update()
+                    .where(fields.c.id == kind_field["id"])
+                    .values(**values)
+                )
+
+        if records is not None:
+            _migrate_sunset_record(bind, records, int(chantier["id"]))
+
+
+def _migrate_sunset_record(
+    bind: sa.Connection,
+    records: sa.Table,
+    object_type_id: int,
+) -> None:
+    required_columns = {"id", "object_type_id", "data"}
+    if not required_columns.issubset(records.c.keys()):
+        return
+
+    rows = bind.execute(
+        sa.select(records).where(
+            records.c.object_type_id == object_type_id,
+            _active_condition(records),
+        )
+    ).mappings().all()
+    for row in rows:
+        data = row.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        if data.get("slug") != _SUNSET_RECORD_SLUG or data.get("kind") != "quality":
+            continue
+        updated_data = dict(data)
+        updated_data["kind"] = _SUNSET_KIND
+        values: dict[str, object] = {"data": updated_data}
+        if "version" in records.c:
+            values["version"] = int(row.get("version") or 0) + 1
+        if "updated_at" in records.c:
+            values["updated_at"] = sa.func.now()
+        bind.execute(
+            records.update().where(records.c.id == row["id"]).values(**values)
+        )
+
+
+def upgrade() -> None:
+    _upgrade(op.get_bind())
+
+
+def downgrade() -> None:
+    # Deliberate no-op: removing an accepted value could invalidate records.
+    return None

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-record-contract.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-record-contract.md
@@ -25,7 +25,7 @@ creates, updates, and query results.
 | `slug` | text | yes | Stable after creation; lowercase kebab-case, maximum 80 characters. |
 | `title` | text | yes | Human-readable chantier title, maximum 500 characters. |
 | `goal` | long text | yes | Outcome hook beginning with `Done means …`, maximum 4,000 characters. |
-| `kind` | enum | yes | `feature`, `incident`, `quality`, or `gtm`. |
+| `kind` | enum | yes | `feature`, `incident`, `quality`, `gtm`, or `sunset`. |
 | `state` | enum | yes | `exploring`, `building`, `shipping`, `verifying`, `done`, or `paused`. This chantier state composes with, and does not replace, member tickets' Deploy-State Ladder. |
 | `owner` | text | no | Next-action owner, using the ticket record's builder-first ownership semantics; maximum 120 characters. |
 | `refs` | JSON array | yes | Typed references with the item shape below. An empty array is valid. |

--- a/brain/systems/slack/chantier_declare.py
+++ b/brain/systems/slack/chantier_declare.py
@@ -30,7 +30,10 @@ GITHUB_SUB_ISSUE_TOOL = "add_github_sub_issue"
 _CHANTIER_KEYWORD_RE = re.compile(r"\bchantier\b", re.IGNORECASE)
 _SLACK_MENTION_RE = re.compile(r"<@[A-Z0-9]+>", re.IGNORECASE)
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
-_KIND_RE = re.compile(r"\bkind\s*:\s*(feature|incident|quality|gtm)\b", re.IGNORECASE)
+_KIND_RE = re.compile(
+    r"\bkind\s*:\s*(feature|incident|quality|gtm|sunset)\b",
+    re.IGNORECASE,
+)
 _LABELED_VALUE_BOUNDARY = (
     r"(?=\s+(?:kind|owner|goal|next[_ ]step)\s*:|\s+https?://|$)"
 )

--- a/brain/systems/slack/chantier_reconciliation.py
+++ b/brain/systems/slack/chantier_reconciliation.py
@@ -42,7 +42,10 @@ _CHANTIER_RE = re.compile(r"\bchantier\b", re.IGNORECASE)
 _PRD_RE = re.compile(r"\b(?:prd|product requirements? document)\b", re.IGNORECASE)
 _SLUG_LABEL_RE = re.compile(r"\bslug\s*[:=]\s*`?([a-z0-9]+(?:-[a-z0-9]+)*)", re.IGNORECASE)
 _DONE_MEANS_RE = re.compile(r"\bdone\s+means\s*:?[ \t]*(.+?)(?:\r?\n|$)", re.IGNORECASE)
-_KIND_RE = re.compile(r"\bkind\s*:\s*(feature|incident|quality|gtm)\b", re.IGNORECASE)
+_KIND_RE = re.compile(
+    r"\bkind\s*:\s*(feature|incident|quality|gtm|sunset)\b",
+    re.IGNORECASE,
+)
 _NEXT_STEP_RE = re.compile(r"\bnext[_ ]step\s*:\s*(.+?)(?:\r?\n|$)", re.IGNORECASE)
 _PREVIEW_JSON_SCALAR_RE = re.compile(
     r'"(?P<key>ok|error|viewer_url|public_url|url|channel_id|thread_ts|channel|ts)"'

--- a/tests/test_builtin_skill_suite.py
+++ b/tests/test_builtin_skill_suite.py
@@ -74,7 +74,7 @@ def test_uwear_triage_bundle_packages_chantier_record_contract():
     contract = _uwear_triage_asset(bundle, "references/chantier-record-contract.md")
 
     assert "# Domain 1 Chantier Record Contract" in contract
-    assert "`feature`, `incident`, `quality`, or `gtm`" in contract
+    assert "`feature`, `incident`, `quality`, `gtm`, or `sunset`" in contract
     assert "`exploring`, `building`, `shipping`, `verifying`, `done`, or `paused`" in contract
     assert contract.count("```json") == 1
     assert '"parent_issue": "github:Illospace/illospace:issue:326"' in contract

--- a/tests/test_chantier_declare_guarantee.py
+++ b/tests/test_chantier_declare_guarantee.py
@@ -108,7 +108,7 @@ def _chantier_object_definition() -> dict:
                 "key": "kind",
                 "field_type": "enum",
                 "required": True,
-                "options": ["feature", "incident", "quality", "gtm"],
+                "options": ["feature", "incident", "quality", "gtm", "sunset"],
             },
             {
                 "key": "state",
@@ -172,7 +172,7 @@ def _publication() -> PublishedChantierPrd:
         slug="connector-framework",
         title="Connector Framework",
         goal="Done means connectors share one verified declaration contract.",
-        kind="feature",
+        kind="sunset",
         next_step="Implement the first connector against the shared contract.",
         prd_ref={"source": "url", "ref": PRD_URL, "title": "Connector Framework PRD"},
         anchor_ref={"source": "slack", "ref": SLACK_REF, "title": "Slack declaration anchor"},
@@ -257,6 +257,7 @@ async def _append_prd_and_anchor_events(
                     "body": (
                         "Declared the connector framework chantier. Slug: connector-framework\n"
                         "Done means connectors share one verified declaration contract.\n"
+                        "kind: sunset\n"
                         "next_step: Implement the first connector against the shared contract."
                     )
                     if declaration
@@ -332,6 +333,7 @@ async def test_declare_missing_tracker_record_self_heals_before_success_and_dige
     )
     assert len(records) == 1
     assert records[0].data["slug"] == "connector-framework"
+    assert records[0].data["kind"] == "sunset"
     refs = {(item["source"], item["ref"]) for item in records[0].data["refs"]}
     assert ("url", PRD_URL) in refs
     assert ("slack", SLACK_REF) in refs

--- a/tests/test_chantier_schema_migration.py
+++ b/tests/test_chantier_schema_migration.py
@@ -7,6 +7,9 @@ import sqlalchemy as sa
 
 
 MIGRATION_MODULE = "brain.platform.db.alembic.versions.0026_chantier_object_type"
+SUNSET_MIGRATION_MODULE = (
+    "brain.platform.db.alembic.versions.0029_chantier_sunset_kind"
+)
 
 
 def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
@@ -53,6 +56,17 @@ def _schema() -> tuple[sa.MetaData, dict[str, sa.Table]]:
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
             sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
             sa.UniqueConstraint("object_type_id", "key"),
+        ),
+        "domain_records": sa.Table(
+            "domain_records",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("domain_id", sa.Integer, nullable=False),
+            sa.Column("object_type_id", sa.Integer, nullable=False),
+            sa.Column("data", sa.JSON, nullable=False),
+            sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+            sa.Column("archived_at", sa.DateTime(timezone=True)),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         ),
     }
     return metadata, tables
@@ -262,3 +276,59 @@ def test_migration_is_a_noop_when_domain_schema_tables_are_absent():
 
     with engine.begin() as connection:
         migration._upgrade(connection)
+
+
+def test_sunset_migration_extends_contract_and_rekinds_target_record_idempotently():
+    contract_migration = importlib.import_module(MIGRATION_MODULE)
+    sunset_migration = importlib.import_module(SUNSET_MIGRATION_MODULE)
+    engine = sa.create_engine("sqlite://")
+    metadata, tables = _schema()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _seed(connection, tables)
+        contract_migration._upgrade(connection)
+        chantier = connection.execute(
+            sa.select(tables["domain_object_types"]).where(
+                tables["domain_object_types"].c.domain_id == 1,
+                tables["domain_object_types"].c.key == "chantier",
+            )
+        ).mappings().one()
+        connection.execute(
+            tables["domain_records"].insert(),
+            [
+                {
+                    "id": 10,
+                    "domain_id": 1,
+                    "object_type_id": chantier["id"],
+                    "data": {"slug": "shopify-app-sunset", "kind": "quality"},
+                    "version": 4,
+                },
+                {
+                    "id": 11,
+                    "domain_id": 1,
+                    "object_type_id": chantier["id"],
+                    "data": {"slug": "another-quality-chantier", "kind": "quality"},
+                    "version": 2,
+                },
+            ],
+        )
+
+        sunset_migration._upgrade(connection)
+        sunset_migration._upgrade(connection)
+
+        kind = connection.execute(
+            sa.select(tables["domain_field_definitions"]).where(
+                tables["domain_field_definitions"].c.object_type_id == chantier["id"],
+                tables["domain_field_definitions"].c.key == "kind",
+            )
+        ).mappings().one()
+        records = connection.execute(
+            sa.select(tables["domain_records"]).order_by(tables["domain_records"].c.id)
+        ).mappings().all()
+
+        assert kind["options"] == ["feature", "incident", "quality", "gtm", "sunset"]
+        assert records[0]["data"]["kind"] == "sunset"
+        assert records[0]["version"] == 5
+        assert records[1]["data"]["kind"] == "quality"
+        assert records[1]["version"] == 2

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -224,7 +224,7 @@ def _chantier_object_definition() -> dict:
                 "key": "kind",
                 "field_type": "enum",
                 "required": True,
-                "options": ["feature", "incident", "quality", "gtm"],
+                "options": ["feature", "incident", "quality", "gtm", "sunset"],
             },
             {
                 "key": "state",
@@ -339,6 +339,35 @@ def test_slack_chantier_declaration_parses_mechanical_contract():
         {"source": "url", "ref": "https://example.com/spec"},
     )
     assert parse_chantier_declaration("<@BILLO> what chantier are active?") is None
+
+
+async def test_slack_chantier_declare_persists_explicit_sunset_kind(session):
+    from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+
+    result = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text=(
+            "<@BILLO> chantier: shopify app sunset — "
+            "done means the retired app is removed with its rider kind: sunset"
+        ),
+    )
+
+    records = await service.list_records(ORG_ID, domain.id, object_key="chantier")
+    assert result is not None and result.operation == "created"
+    assert result.data["kind"] == "sunset"
+    assert len(records) == 1
+    assert records[0].data["kind"] == "sunset"
 
 
 async def test_slack_chantier_duplicate_declare_updates_one_record(session):
@@ -897,6 +926,28 @@ async def test_chantier_contract_creates_updates_and_queries_full_records(sessio
         "updated_at": "2026-07-16T16:00:00Z",
     }
     assert [record.id for record in queried] == [created.id]
+
+
+@pytest.mark.parametrize("kind", ["feature", "incident", "quality", "gtm"])
+async def test_chantier_contract_still_accepts_existing_kinds(session, kind):
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    data = _chantier_record_data()
+    data.update(slug=f"{kind}-chantier", title=f"{kind.title()} chantier", kind=kind)
+
+    record = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=data,
+    )
+
+    assert record.data["kind"] == kind
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #372

## What
Adds `sunset` as a first-class chantier record `kind` so meeting-decided kill/sunset work (removals with a rider) can be recorded truthfully instead of being mis-kinded as `quality`.

## Changes
- `kind` validator regex in `chantier_declare.py` and `chantier_reconciliation.py` now accepts `sunset`.
- Contract reference doc (`chantier-record-contract.md`) updated to list `sunset`.
- Forward migration `0029_chantier_sunset_kind`:
  - adds `sunset` to the Domain-1 chantier `kind` field's options (idempotent — skips if already present);
  - re-kinds the existing `shopify-app-sunset` record from `quality` → `sunset` (idempotent — only touches that slug when still `quality`).
  - `downgrade()` is a deliberate no-op (dropping an accepted value could invalidate persisted records).

## Verification
`venv/bin/python -m pytest tests/test_chantier_declare_guarantee.py tests/test_chantier_schema_migration.py tests/test_domains_service.py tests/test_builtin_skill_suite.py -q` → **80 passed** (declare accepts `sunset`, existing-kind regression, schema-migration + data-migration + idempotency coverage).

## Acceptance checks
- [x] A `declare` with `kind=sunset` persists as `sunset`.
- [x] Existing kinds (`feature`/`incident`/`quality`/`gtm`) still validate — no regression.
- [x] Test asserts `sunset` accepted end-to-end; schema-migration test covers the new value.

## Notes for reviewer
- The live C4 `shopify-app-sunset` record flip happens when this migration runs at deploy (alembic upgrade) — no live tracker data was mutated from the worker branch.

🤖 Draft PR opened by Routine R3 (Codex-implemented, Claude-reviewed). Do not merge until you've eyeballed it.