### PR TITLE
fix(ci): document activation CLI DB boundary

### DIFF
--- a/scripts/async_db_debt_metrics.py
+++ b/scripts/async_db_debt_metrics.py
@@ -43,6 +43,16 @@ REQUIRED_SQLALCHEMY_RUN_SYNC_REASON = (
     "SQLAlchemy's async schema tooling requires AsyncConnection.run_sync to "
     "enter metadata inspection/DDL helpers that are synchronous by design."
 )
+REQUIRED_ACTIVATION_CLI_RUN_SYNC = {
+    "brain/app/cli/activate_uwear_engineering_triage.py": {
+        "session_run_sync",
+    },
+}
+REQUIRED_ACTIVATION_CLI_RUN_SYNC_REASON = (
+    "The one-shot Uwear triage activation CLI uses one AsyncConnection.run_sync "
+    "boundary to execute its reflection-heavy, atomic SQLAlchemy Core migration; "
+    "it is not imported by the application runtime."
+)
 OFFLINE_SQLITE_BENCH_SURFACES = {
     "scripts/bench_agent_run_deep_child_runs.py": {
         "sqlalchemy_create_engine",
@@ -99,6 +109,10 @@ LEGACY_SYNC_TEST_HARNESSES = {
     "tests/test_workspace_apps_service.py": {
         "sqlalchemy_create_engine",
         "sqlalchemy_sync_session",
+    },
+    "tests/test_uwear_triage_activation.py": {
+        "sqlalchemy_create_engine",
+        "sync_session_method_call",
     },
 }
 LEGACY_SYNC_TEST_HARNESS_REASON = (
@@ -486,6 +500,8 @@ def iter_matches(paths: Iterable[Path]) -> Iterable[Match]:
 def zero_target_exemption_reason(match: Match) -> str | None:
     if match.category in REQUIRED_SQLALCHEMY_RUN_SYNC.get(match.path, set()):
         return REQUIRED_SQLALCHEMY_RUN_SYNC_REASON
+    if match.category in REQUIRED_ACTIVATION_CLI_RUN_SYNC.get(match.path, set()):
+        return REQUIRED_ACTIVATION_CLI_RUN_SYNC_REASON
     if match.category in OFFLINE_SQLITE_BENCH_SURFACES.get(match.path, set()):
         return OFFLINE_SQLITE_BENCH_REASON
     if match.category in LEGACY_SYNC_TEST_HARNESSES.get(match.path, set()):
@@ -516,6 +532,10 @@ def summarize(matches: list[Match], *, top: int) -> dict[str, object]:
     required_sqlalchemy_run_sync_refs = sum(
         1 for match in matches
         if zero_target_exemption_reason(match) == REQUIRED_SQLALCHEMY_RUN_SYNC_REASON
+    )
+    required_activation_cli_run_sync_refs = sum(
+        1 for match in matches
+        if zero_target_exemption_reason(match) == REQUIRED_ACTIVATION_CLI_RUN_SYNC_REASON
     )
     offline_sqlite_bench_refs = sum(
         1 for match in matches
@@ -548,6 +568,7 @@ def summarize(matches: list[Match], *, top: int) -> dict[str, object]:
         "cli_and_script_refs": by_scope["cli"] + by_scope["scripts"],
         "test_refs": by_scope["tests"],
         "required_sqlalchemy_run_sync_refs": required_sqlalchemy_run_sync_refs,
+        "required_activation_cli_run_sync_refs": required_activation_cli_run_sync_refs,
         "offline_sqlite_bench_refs": offline_sqlite_bench_refs,
         "legacy_sync_test_harness_refs": legacy_sync_test_harness_refs,
     }
@@ -572,6 +593,10 @@ def summarize(matches: list[Match], *, top: int) -> dict[str, object]:
             "required_sqlalchemy_run_sync_refs": {
                 "count": required_sqlalchemy_run_sync_refs,
                 "reason": REQUIRED_SQLALCHEMY_RUN_SYNC_REASON,
+            },
+            "required_activation_cli_run_sync_refs": {
+                "count": required_activation_cli_run_sync_refs,
+                "reason": REQUIRED_ACTIVATION_CLI_RUN_SYNC_REASON,
             },
             "offline_sqlite_bench_refs": {
                 "count": offline_sqlite_bench_refs,

--- a/tests/test_async_db_boundaries.py
+++ b/tests/test_async_db_boundaries.py
@@ -20,6 +20,9 @@ CENTRAL_SESSION_BRIDGES = {
 REQUIRED_ALEMBIC_BRIDGES = {
     Path("brain/platform/db/alembic/env.py"),
 }
+REQUIRED_ACTIVATION_CLI_BRIDGES = {
+    Path("brain/app/cli/activate_uwear_engineering_triage.py"),
+}
 SYNC_DB_API_NAMES = {
     "open_unit_of_work",
     "run_unit_of_work_task",
@@ -145,6 +148,7 @@ def test_production_db_references_are_async_shaped():
             if (
                 relative_path not in CENTRAL_SESSION_BRIDGES
                 and relative_path not in REQUIRED_ALEMBIC_BRIDGES
+                and relative_path not in REQUIRED_ACTIVATION_CLI_BRIDGES
                 and RUN_SYNC_REFERENCE.search(line)
             ):
                 offenders.append(f"{relative_path}:{line_number}: {line.strip()}")
@@ -185,6 +189,7 @@ def test_production_async_db_debt_metric_is_zero():
         name: payload["metrics"].get(name)
         for name in zero_target_metrics
     } == {name: 0 for name in zero_target_metrics}
+    assert payload["metrics"]["required_activation_cli_run_sync_refs"] == 2
 
 
 def test_external_agent_sync_session_bridge_is_removed():

--- a/tests/test_async_db_debt_metrics.py
+++ b/tests/test_async_db_debt_metrics.py
@@ -291,3 +291,41 @@ def test_metric_reports_but_exempts_required_sqlalchemy_run_sync():
     assert summary["metrics"]["required_sqlalchemy_run_sync_refs"] == 1
     payload = metrics.matches_payload(matches)
     assert [item["zero_target_exempt"] for item in payload] == [True, False]
+
+
+def test_metric_exempts_only_the_documented_activation_cli_sync_boundary():
+    metrics = _load_metrics_module()
+    path = "brain/app/cli/activate_uwear_engineering_triage.py"
+    matches = [
+        metrics.Match(
+            path=path,
+            line_number=580,
+            category="session_run_sync",
+            scope="cli",
+            in_async_function=True,
+            line="return await connection.run_sync(lambda bind: _activate(bind, apply=True))",
+        ),
+        metrics.Match(
+            path=path,
+            line_number=582,
+            category="session_run_sync",
+            scope="cli",
+            in_async_function=True,
+            line="return await connection.run_sync(lambda bind: _activate(bind, apply=False))",
+        ),
+        metrics.Match(
+            path="brain/app/cli/another_command.py",
+            line_number=10,
+            category="session_run_sync",
+            scope="cli",
+            in_async_function=True,
+            line="await connection.run_sync(work)",
+        ),
+    ]
+
+    summary = metrics.summarize(matches, top=10)
+
+    assert summary["metrics"]["repo_wide_sync_shaped_refs"] == 1
+    assert summary["metrics"]["required_activation_cli_run_sync_refs"] == 2
+    payload = metrics.matches_payload(matches)
+    assert [item["zero_target_exempt"] for item in payload] == [True, True, False]


### PR DESCRIPTION
## What

Documents the intentional SQLAlchemy sync boundaries introduced by the one-shot Uwear triage activation tooling:

- exactly two `AsyncConnection.run_sync` calls in the reflection-heavy activation CLI;
- the sync-only SQLAlchemy harness in `tests/test_uwear_triage_activation.py`.

The production/API zero targets remain at zero, and a regression test proves another CLI cannot inherit the exemption.

## Why

The activation CLI and its tests landed without registering their deliberate boundaries in the async-DB debt guard. That makes every backend PR fail the same two architecture tests even though the application runtime remains async-native.

## Verification

- `pytest tests/test_async_db_boundaries.py tests/test_async_db_debt_metrics.py -q` — 46 passed
- `python scripts/async_db_debt_metrics.py --json --target production` — exit 0; all zero-target metrics are 0
- `git diff --check`
