### PR TITLE
fix(runs): sanitize terminal failure surfaces

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -52,7 +52,13 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound.results import read_inbound_submission_result
 from brain.systems.inbound.service import submit_inbound_envelope as _submit_inbound_envelope
-from brain.systems.runs.cortex.read_models import run_stream_payload
+from brain.systems.runs.cortex.read_models import (
+    public_failed_run_artifact,
+    public_failure_for_run,
+    public_run_debug_event_payload,
+    run_stream_payload,
+)
+from brain.systems.runs.failures import public_run_failure
 
 
 router = APIRouter(tags=["agent-mcp"], dependencies=[Depends(rate_limit)])
@@ -749,22 +755,28 @@ async def _validate_cycle_target_idea(
         raise ValueError("target_idea_id must belong to the current workspace")
 
 
-def _serialize_run_event(event: AgentRunEventRow) -> dict[str, Any]:
+def _serialize_run_event(
+    event: AgentRunEventRow,
+    failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
     return {
         "id": event.id,
         "run_id": event.run_id,
         "root_run_id": event.root_run_id,
         "sequence_no": event.sequence_no,
         "event_type": event.event_type,
-        "payload": event.payload or {},
+        "payload": public_run_debug_event_payload(event, failure),
         "producer": event.producer,
         "visibility": event.visibility,
         "created_at": _iso(event.created_at),
     }
 
 
-def _serialize_run_artifact(artifact: AgentRunArtifactRow) -> dict[str, Any]:
-    return {
+def _serialize_run_artifact(
+    artifact: AgentRunArtifactRow,
+    failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return public_failed_run_artifact({
         "id": artifact.id,
         "run_id": artifact.run_id,
         "root_run_id": artifact.root_run_id,
@@ -775,7 +787,7 @@ def _serialize_run_artifact(artifact: AgentRunArtifactRow) -> dict[str, Any]:
         "uri": artifact.uri,
         "visibility": artifact.visibility,
         "created_at": _iso(artifact.created_at),
-    }
+    }, failure)
 
 
 async def _read_run_get(
@@ -790,8 +802,25 @@ async def _read_run_get(
     if run is None or str(run.org_id or "") != str(principal.org_id):
         raise ValueError("Run not found")
 
+    failure_events = list(
+        (
+            await db.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id == run.id,
+                    AgentRunEventRow.event_type == "run.failed",
+                )
+                .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+                .limit(1)
+            )
+        ).all()
+    )
+    failure = public_failure_for_run(run, failure_events)
     limit = _bounded_limit(arguments.get("limit"), default=50, maximum=200)
-    payload: dict[str, Any] = {"run": run_stream_payload(run)}
+    run_payload = run_stream_payload(run)
+    if failure is not None:
+        run_payload["failure"] = failure
+    payload: dict[str, Any] = {"run": run_payload}
     event_types = _clean_string_list(arguments.get("event_types"))
     include_events = bool(arguments.get("include_events", False))
     include_tool_events = bool(arguments.get("include_tool_events", True))
@@ -804,7 +833,10 @@ async def _read_run_get(
         )
         if event_types:
             event_stmt = event_stmt.where(AgentRunEventRow.event_type.in_(event_types))
-        payload["events"] = [_serialize_run_event(event) for event in (await db.scalars(event_stmt)).all()]
+        payload["events"] = [
+            _serialize_run_event(event, failure)
+            for event in (await db.scalars(event_stmt)).all()
+        ]
     if include_tool_events:
         tool_stmt = (
             select(AgentRunEventRow)
@@ -815,7 +847,10 @@ async def _read_run_get(
             .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
             .limit(limit)
         )
-        payload["tool_events"] = [_serialize_run_event(event) for event in (await db.scalars(tool_stmt)).all()]
+        payload["tool_events"] = [
+            _serialize_run_event(event, failure)
+            for event in (await db.scalars(tool_stmt)).all()
+        ]
     if bool(arguments.get("include_artifacts", True)):
         artifact_stmt = (
             select(AgentRunArtifactRow)
@@ -824,7 +859,7 @@ async def _read_run_get(
             .limit(limit)
         )
         payload["artifacts"] = [
-            _serialize_run_artifact(artifact)
+            _serialize_run_artifact(artifact, failure)
             for artifact in (await db.scalars(artifact_stmt)).all()
         ]
     return payload
@@ -1276,7 +1311,18 @@ async def _tool_get_result(
     )
     if result.mutated_inbound:
         await db.commit()
-    return result.payload
+    payload = result.payload
+    for candidate in (
+        payload.get("event"),
+        payload.get("latest_receipt"),
+    ):
+        failure = dict(candidate.get("failure") or {}) if isinstance(candidate, dict) else {}
+        if not failure:
+            continue
+        public_failure = public_run_failure(failure.get("status"), failure.get("category"))
+        if public_failure is not None:
+            return {**payload, "failure": public_failure}
+    return payload
 
 
 async def _add_thread_trigger_result_if_needed(

--- a/brain/app/api/routers/cortex/_analytics.py
+++ b/brain/app/api/routers/cortex/_analytics.py
@@ -6,22 +6,34 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from sqlalchemy import func, select, text
 
 from brain.app.api.auth import get_current_user
+from brain.app.api.routers.cortex._helpers import _a_require_idea_for_user
 from brain.app.api.routers.cortex._router import router
 from brain.platform.db.constraints import sql_string_list
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
-from brain.platform.db.models.idea import Idea, IdeaStateLog, IdeaThread
+from brain.platform.db.models.idea import IdeaStateLog, IdeaThread
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.status import (
     ANALYTICS_QUEUED_IDEA_STATUS_VALUES,
     SUGGESTED_IDEA_STATUS_VALUES,
 )
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 from brain.systems.runs.presentation import public_tool_event_payload
 
 logger = logging.getLogger(__name__)
+
+
+def _activity_thread_run_id(row: IdeaThread) -> int | None:
+    if str(row.role or "").strip().lower() not in {"illo", "assistant"}:
+        return None
+    return run_id_from_public_message_metadata(row.metadata_)
 
 
 # ── Analytics ──────────────────────────────────────────────────
@@ -64,9 +76,7 @@ async def analytics(user: dict[str, Any] = Depends(get_current_user)):
 @router.get("/ideas/{idea_id}/activity-timeline")
 async def activity_timeline(idea_id: str, user: dict[str, Any] = Depends(get_current_user)):
     async with UnitOfWork() as uow:
-        idea = await uow.session.get(Idea, idea_id)
-        if not idea:
-            raise HTTPException(status_code=404, detail=f"Idea {idea_id} not found")
+        idea = await _a_require_idea_for_user(uow.session, idea_id, user)
 
         events = []
         events.append({
@@ -96,11 +106,30 @@ async def activity_timeline(idea_id: str, user: dict[str, Any] = Depends(get_cur
             .order_by(IdeaThread.created_at)
         )
         role_map = {"user": "You replied", "illo": "Illo replied", "assistant": "Assistant replied"}
-        thread_rows = await uow.session.scalars(stmt)
-        for row in thread_rows.all():
+        thread_rows = list((await uow.session.scalars(stmt)).all())
+        run_ids = {
+            run_id
+            for run_id in (_activity_thread_run_id(row) for row in thread_rows)
+            if run_id is not None
+        }
+        failure_scope: dict[str, str] = {"thread_id": idea_id}
+        if getattr(idea, "org_id", None):
+            failure_scope["org_id"] = str(idea.org_id)
+        failures = await public_failures_for_run_ids(
+            uow.session,
+            run_ids,
+            **failure_scope,
+        )
+        for row in thread_rows:
             prefix = role_map.get(row.role, f"{row.role} replied")
-            snippet = (row.content or "")[:80]
-            if len(row.content or "") > 80:
+            run_id = _activity_thread_run_id(row)
+            content, _metadata = public_run_linked_message(
+                row.content,
+                row.metadata_,
+                failures.get(run_id),
+            )
+            snippet = (content or "")[:80]
+            if len(content or "") > 80:
                 snippet += "..."
             ts = row.created_at
             events.append({

--- a/brain/app/api/routers/cortex/_discussion.py
+++ b/brain/app/api/routers/cortex/_discussion.py
@@ -21,9 +21,15 @@ from brain.systems.cortex.object_references import (
     merge_object_reference_metadata,
     store_object_references_for_source,
 )
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
+THREAD_DISCUSSION_CONVERSATION_PREFIX = "thread-discussion:"
 
 
 class DiscussionCommentCreate(BaseModel):
@@ -37,8 +43,10 @@ def _comment_payload(
     *,
     author_name: str | None = None,
     author_color: str | None = None,
+    failure: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     metadata = comment.metadata_ if isinstance(comment.metadata_, dict) else {}
+    body, metadata = public_run_linked_message(comment.body, metadata, failure)
     return {
         "id": comment.id,
         "thread_id": str(comment.thread_id),
@@ -47,7 +55,7 @@ def _comment_payload(
         "author_kind": comment.author_kind,
         "author_name": author_name,
         "author_color": author_color,
-        "body": comment.body,
+        "body": body,
         "attachments": comment.attachments or [],
         "metadata": metadata,
         "object_references": metadata.get("object_references") or [],
@@ -113,6 +121,7 @@ async def _discussion_comment_payloads(
     *,
     thread_id: str,
     limit: int,
+    org_id: str | None = None,
 ) -> list[dict[str, Any]]:
     stmt = (
         select(ThreadDiscussionComment, User.name.label("author_name"), User.color.label("author_color"))
@@ -121,9 +130,37 @@ async def _discussion_comment_payloads(
         .order_by(ThreadDiscussionComment.created_at.asc(), ThreadDiscussionComment.id.asc())
         .limit(max(1, min(int(limit or 100), 300)))
     )
+    rows = list((await db.execute(stmt)).all())
+    run_ids = {
+        run_id
+        for run_id in (
+            (
+                run_id_from_public_message_metadata(row[0].metadata_)
+                if str(row[0].author_kind or "").lower() == "illo"
+                else None
+            )
+            for row in rows
+        )
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(
+        db,
+        run_ids,
+        thread_id=f"{THREAD_DISCUSSION_CONVERSATION_PREFIX}{thread_id}",
+        org_id=org_id,
+    )
     return [
-        _comment_payload(row[0], author_name=row.author_name, author_color=row.author_color)
-        for row in (await db.execute(stmt)).all()
+        _comment_payload(
+            row[0],
+            author_name=row.author_name,
+            author_color=row.author_color,
+            failure=failures.get(
+                run_id_from_public_message_metadata(row[0].metadata_)
+                if str(row[0].author_kind or "").lower() == "illo"
+                else None
+            ),
+        )
+        for row in rows
     ]
 
 
@@ -158,8 +195,13 @@ async def list_thread_discussion(
     db: AsyncSession = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    await _require_idea_for_user(db, idea_id, user)
-    return await _discussion_comment_payloads(db, thread_id=idea_id, limit=limit)
+    idea = await _require_idea_for_user(db, idea_id, user)
+    return await _discussion_comment_payloads(
+        db,
+        thread_id=idea_id,
+        limit=limit,
+        org_id=str(idea.org_id) if getattr(idea, "org_id", None) else None,
+    )
 
 
 @router.post("/ideas/{idea_id}/discussion", status_code=201)

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -16,13 +16,13 @@ from sqlalchemy.orm import aliased
 
 from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
 from brain.systems.runs.events import run_event
-from brain.systems.runs.presentation import public_tool_event_payload
 from brain.systems.runs.status import (
     RunStatus,
     TERMINAL_RUN_STATUSES,
     coerce_run_status,
 )
 from brain.systems.runs.store import AsyncAgentRunStore
+from brain.systems.runs.ui_events import public_run_event_payload
 from brain.app.api.auth import get_current_user
 from brain.app.api.services.notifications import (
     async_build_notification_summary,
@@ -319,9 +319,7 @@ def _apply_run_events_to_item(item: dict[str, Any], events: list[Any]) -> None:
         event_type = str(getattr(event, "event_type", "") or "")
         if event_type not in _RUN_WORK_EVENT_TYPES:
             continue
-        payload = dict(getattr(event, "payload", None) or {})
-        if event_type in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
-            payload = public_tool_event_payload(payload, event_type)
+        payload = public_run_event_payload(getattr(event, "payload", None), event_type)
         at = _event_created_at(event)
         label = _activity_from_event(event_type, payload)
         if label:

--- a/brain/app/api/routers/cortex/_idea_ops.py
+++ b/brain/app/api/routers/cortex/_idea_ops.py
@@ -27,7 +27,11 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.services.notifications import (
     async_build_notification_summary,
 )
-from brain.systems.runs.cortex.read_models import run_stream_payload
+from brain.systems.runs.cortex.read_models import (
+    public_failed_run_artifact,
+    public_failure_for_run,
+    run_stream_payload,
+)
 from brain.app.api.routers.cortex._helpers import (
     _infer_feedback_tags,
     _parse_message_type,
@@ -127,6 +131,8 @@ async def _append_live_guidance_from_thread_message(
 def _message_run_id(item: dict[str, Any]) -> int | None:
     if item.get("type") != "message":
         return None
+    if str(item.get("role") or "").strip().lower() not in {"illo", "assistant"}:
+        return None
     metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
     if metadata.get("hidden") is True:
         return None
@@ -201,6 +207,27 @@ def _append_final_answer_messages(items: list[dict[str, Any]]) -> None:
             message_run_ids.add(run_id)
             break
     items.extend(additions)
+
+
+def _project_failed_run_message(
+    item: dict[str, Any],
+    failure: dict[str, str] | None,
+) -> None:
+    if failure is None or item.get("type") != "message":
+        return
+    item["content"] = failure["message"]
+    metadata = dict(item.get("metadata") or {})
+    for key in ("error", "final_answer", "output", "reason", "result", "text"):
+        metadata.pop(key, None)
+    metadata["failure"] = dict(failure)
+    item["metadata"] = metadata
+
+
+def _project_run_artifacts(
+    artifacts: list[dict[str, Any]],
+    failure: dict[str, str] | None,
+) -> list[dict[str, Any]]:
+    return [public_failed_run_artifact(artifact, failure) for artifact in artifacts]
 
 
 _RUN_WORK_EVENT_TYPES = {
@@ -310,7 +337,11 @@ def _activity_from_event(event_type: str, payload: dict[str, Any]) -> str | None
     return None
 
 
-def _apply_run_events_to_item(item: dict[str, Any], events: list[Any]) -> None:
+def _apply_run_events_to_item(
+    item: dict[str, Any],
+    events: list[Any],
+    failure: dict[str, str] | None = None,
+) -> None:
     activity_trace: list[dict[str, Any]] = []
     work_log: list[dict[str, Any]] = []
     tool_calls: list[dict[str, Any]] = []
@@ -319,7 +350,11 @@ def _apply_run_events_to_item(item: dict[str, Any], events: list[Any]) -> None:
         event_type = str(getattr(event, "event_type", "") or "")
         if event_type not in _RUN_WORK_EVENT_TYPES:
             continue
-        payload = public_run_event_payload(getattr(event, "payload", None), event_type)
+        payload = public_run_event_payload(
+            getattr(event, "payload", None),
+            event_type,
+            failure=failure,
+        )
         at = _event_created_at(event)
         label = _activity_from_event(event_type, payload)
         if label:
@@ -930,6 +965,24 @@ async def unified_stream_payload(
             if item["type"] == "run":
                 item["tool_calls"] = []
 
+        run_rows_by_id = {int(run.id): run for run in all_run_rows}
+        referenced_run_ids = {
+            run_id
+            for run_id in (_message_run_id(item) for item in items)
+            if run_id is not None
+        }
+        missing_referenced_run_ids = referenced_run_ids.difference(run_rows_by_id)
+        if missing_referenced_run_ids:
+            referenced_runs = (
+                await uow.session.scalars(
+                    select(AgentRun).where(
+                        AgentRun.id.in_(sorted(missing_referenced_run_ids)),
+                        AgentRun.thread_id == idea_id,
+                        _visible_run_clause(),
+                    )
+                )
+            ).all()
+            run_rows_by_id.update({int(run.id): run for run in referenced_runs})
         child_runs: dict[int, list[dict[str, Any]]] = {}
         run_artifacts: dict[int, list[dict[str, Any]]] = {}
         run_events: dict[int, list[Any]] = {}
@@ -961,21 +1014,36 @@ async def unified_stream_payload(
                     "created_at": artifact.created_at.isoformat() if artifact.created_at else None,
                 })
 
-            event_stmt = _run_work_events_stmt(run_ids)
+        event_run_ids = sorted(set(run_ids).union(referenced_run_ids))
+        if event_run_ids:
+            event_stmt = _run_work_events_stmt(event_run_ids)
             for event in (await uow.session.scalars(event_stmt)).all():
                 run_events.setdefault(int(event.run_id), []).append(event)
 
         for item in items:
             if item["type"] == "run":
                 run_id = int(item.get("id", 0))
+                run_row = run_rows_by_id.get(run_id)
                 children = child_runs.get(run_id, [])
-                artifacts = run_artifacts.get(run_id, [])
                 events = run_events.get(run_id, [])
+                failure = public_failure_for_run(run_row, events) if run_row is not None else None
+                if failure is not None:
+                    item["failure"] = failure
+                artifacts = _project_run_artifacts(run_artifacts.get(run_id, []), failure)
                 if children:
                     item["child_runs"] = children
                 if artifacts:
                     item["artifacts"] = artifacts
-                _apply_run_events_to_item(item, events)
+                _apply_run_events_to_item(item, events, failure)
+
+        run_failures = {
+            run_id: public_failure_for_run(run, run_events.get(run_id, []))
+            for run_id, run in run_rows_by_id.items()
+        }
+        for item in items:
+            run_id = _message_run_id(item)
+            if run_id is not None:
+                _project_failed_run_message(item, run_failures.get(run_id))
 
         _append_final_answer_messages(items)
 

--- a/brain/app/api/routers/cortex/_ideas.py
+++ b/brain/app/api/routers/cortex/_ideas.py
@@ -49,6 +49,11 @@ from brain.systems.cortex.thought_lifecycle import (
 from brain.systems.cortex.project_context.resolution import merge_project_context_metadata
 from brain.systems.cortex.thread_links import thread_link_payload
 from brain.systems.cortex.title_generation import generate_and_store_idea_display_title
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -127,13 +132,17 @@ def _apply_thread_link_fields(payload: dict[str, Any], idea_id: Any) -> None:
     payload["thread_url"] = links["thread_url"]
 
 
-def _thread_message_read_payload(message: IdeaThread) -> dict[str, Any]:
+def _thread_message_read_payload(
+    message: IdeaThread,
+    failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
     metadata = message.metadata_ if isinstance(message.metadata_, dict) else {}
+    content, metadata = public_run_linked_message(message.content, metadata, failure)
     return {
         "id": message.id,
         "idea_id": str(message.idea_id) if message.idea_id else None,
         "role": message.role,
-        "content": message.content,
+        "content": content,
         "attachments": message.attachments or [],
         "metadata": metadata,
         "object_references": metadata.get("object_references") or [],
@@ -742,7 +751,32 @@ async def list_threads(
 ):
     await _require_idea_for_user(db, idea_id, user)
     messages = await IdeaThreadRepository(db).a_list_by_idea(idea_id)
-    return [ThreadMessageRead.model_validate(_thread_message_read_payload(message)) for message in messages]
+    run_ids = {
+        run_id
+        for run_id in (
+            (
+                run_id_from_public_message_metadata(message.metadata_)
+                if str(message.role or "").lower() in {"illo", "assistant"}
+                else None
+            )
+            for message in messages
+        )
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(db, run_ids, thread_id=idea_id)
+    return [
+        ThreadMessageRead.model_validate(
+            _thread_message_read_payload(
+                message,
+                failures.get(
+                    run_id_from_public_message_metadata(message.metadata_)
+                    if str(message.role or "").lower() in {"illo", "assistant"}
+                    else None
+                ),
+            )
+        )
+        for message in messages
+    ]
 
 
 @router.get("/ideas/{idea_id}/visual-blocks", response_model=list[VisualBlockRead])

--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -35,6 +35,13 @@ from brain.systems.runs.events import run_event
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore as _AgentRunStore
 from brain.systems.runs.cortex.analytics import RunAuditNotFound, async_build_idea_audit_summary
+from brain.systems.runs.cortex.read_models import (
+    project_run_status,
+    public_failure_for_run,
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 from brain.platform.db.models.agent_run import AgentRunArtifactRow
 from brain.platform.db.models.run import AgentRun, CortexEvent
 from brain.platform.db.models.idea import Idea, IdeaConnection, IdeaStateLog, IdeaThread
@@ -61,6 +68,50 @@ from brain.systems.services.runtime_introspection import async_get_provider_auth
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 
 logger = logging.getLogger(__name__)
+
+_RUN_LINKED_MESSAGE_ROLES = frozenset({"illo", "assistant"})
+
+
+async def _public_thread_message_projections(
+    session: Any,
+    messages: list[IdeaThread],
+    *,
+    idea_id: str,
+) -> list[tuple[IdeaThread, str, dict[str, Any], dict[str, str] | None]]:
+    """Project trusted run-linked messages before they reach another surface."""
+
+    linked_run_ids = {
+        run_id
+        for message in messages
+        for run_id in [
+            (
+                run_id_from_public_message_metadata(message.metadata_)
+                if str(message.role or "").lower() in _RUN_LINKED_MESSAGE_ROLES
+                else None
+            )
+        ]
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(
+        session,
+        linked_run_ids,
+        thread_id=idea_id,
+    )
+    projected = []
+    for message in messages:
+        run_id = (
+            run_id_from_public_message_metadata(message.metadata_)
+            if str(message.role or "").lower() in _RUN_LINKED_MESSAGE_ROLES
+            else None
+        )
+        failure = failures.get(run_id)
+        content, metadata = public_run_linked_message(
+            message.content,
+            message.metadata_,
+            failure,
+        )
+        projected.append((message, str(content or ""), metadata, failure))
+    return projected
 
 
 async def _cancel_active_runs_for_idea(session, idea_id: str, *, reason: str) -> int:
@@ -315,16 +366,24 @@ async def detect_branches(idea_id: str, user: dict[str, Any] = Depends(get_curre
     async with UnitOfWork() as uow:
         await _a_require_idea_for_user(uow.session, idea_id, user)
         stmt = (
-            select(IdeaThread.content, IdeaThread.role)
+            select(IdeaThread)
             .where(IdeaThread.idea_id == idea_id)
             .order_by(IdeaThread.created_at)
         )
-        messages = (await uow.session.execute(stmt)).all()
+        messages = list((await uow.session.scalars(stmt)).all())
+        projected_messages = await _public_thread_message_projections(
+            uow.session,
+            messages,
+            idea_id=idea_id,
+        )
 
     if len(messages) < 8:
         return {"branches": [], "should_split": False, "reason": "Thread too short for meaningful split"}
 
-    thread_text = "\n".join(f"[{m.role}] {m.content[:200]}" for m in messages)
+    thread_text = "\n".join(
+        f"[{message.role}] {content[:200]}"
+        for message, content, _metadata, _failure in projected_messages
+    )
 
     prompt = f"""Analyze this conversation thread and identify distinct sub-topics that have diverged from the original topic. Return ONLY valid JSON, no other text.
 
@@ -369,7 +428,12 @@ async def split_idea(idea_id: str, request: Request, user: dict[str, Any] = Depe
             .where(IdeaThread.idea_id == idea_id)
             .order_by(IdeaThread.created_at)
         )
-        all_messages = (await uow.session.scalars(stmt)).all()
+        all_messages = list((await uow.session.scalars(stmt)).all())
+        projected_messages = await _public_thread_message_projections(
+            uow.session,
+            all_messages,
+            idea_id=idea_id,
+        )
 
         created_ids = []
         for branch in branches:
@@ -394,7 +458,7 @@ async def split_idea(idea_id: str, request: Request, user: dict[str, Any] = Depe
             uow.session.add(child)
 
             indices = set(branch.get("message_indices", []))
-            for idx, msg in enumerate(all_messages):
+            for idx, (msg, content, _metadata, failure) in enumerate(projected_messages):
                 if idx in indices:
                     await post_thread_message(
                         uow.session,
@@ -402,8 +466,13 @@ async def split_idea(idea_id: str, request: Request, user: dict[str, Any] = Depe
                         command=ThreadMessageCommand(
                             idea_id=child_id,
                             role=msg.role,
-                            content=msg.content,
+                            content=content,
                             attachments=msg.attachments or [],
+                            metadata=(
+                                {"failure": dict(failure)}
+                                if failure is not None
+                                else None
+                            ),
                         ),
                         apply_lifecycle=False,
                     )
@@ -675,6 +744,7 @@ async def idea_audit(idea_id: str, user: dict[str, Any] = Depends(get_current_us
     """Aggregate metrics for ALL runs on an idea — pure SQL, no LLM."""
     try:
         async with UnitOfWork() as uow:
+            await _a_require_idea_for_user(uow.session, idea_id, user)
             return await async_build_idea_audit_summary(uow.session, idea_id)
     except RunAuditNotFound:
         raise HTTPException(status_code=404, detail="No runs for this idea")
@@ -688,6 +758,7 @@ async def idea_audit_analyze(
     """Trigger a self-critique run on the idea's conversation audit."""
     # Build a metrics summary to include in the run message
     async with UnitOfWork() as uow:
+        await _a_require_idea_for_user(uow.session, idea_id, user)
         runs = (
             await uow.session.scalars(
                 select(AgentRun)
@@ -715,19 +786,24 @@ async def idea_audit_analyze(
             if isinstance(misses, list):
                 all_misses.extend(misses)
 
-        thread_rows = (
-            await uow.session.execute(
-                text("""
-                    SELECT role, content FROM idea_threads
-                    WHERE idea_id = :idea_id
-                    ORDER BY created_at ASC
-                    LIMIT 50
-                """),
-                {"idea_id": idea_id},
-            )
-        ).fetchall()
+        thread_rows = list(
+            (
+                await uow.session.scalars(
+                    select(IdeaThread)
+                    .where(IdeaThread.idea_id == idea_id)
+                    .order_by(IdeaThread.created_at.asc())
+                    .limit(50)
+                )
+            ).all()
+        )
+        projected_thread_rows = await _public_thread_message_projections(
+            uow.session,
+            thread_rows,
+            idea_id=idea_id,
+        )
         thread_text = "\n".join(
-            f"[{r.role}] {r.content[:500]}" for r in thread_rows
+            f"[{message.role}] {content[:500]}"
+            for message, content, _metadata, _failure in projected_thread_rows
         )
 
         worker_lines: list[str] = []
@@ -802,6 +878,7 @@ async def idea_audit_analysis_result(
     associated with the audit_analyze run.
     """
     async with UnitOfWork() as uow:
+        await _a_require_idea_for_user(uow.session, idea_id, user)
         d = (
             await uow.session.scalars(
                 select(AgentRun)
@@ -817,16 +894,26 @@ async def idea_audit_analysis_result(
         if not d:
             return {"found": False}
 
+        failures = await public_failures_for_run_ids(
+            uow.session,
+            [int(d.id)],
+            thread_id=idea_id,
+        )
+        failure = failures.get(int(d.id)) or public_failure_for_run(d)
+        public_status = project_run_status(d.status)
+
         result: dict[str, Any] = {
             "found": True,
             "run_id": d.id,
-            "status": d.status,
+            "status": public_status,
             "started_at": d.started_at.isoformat() if d.started_at else None,
             "completed_at": d.completed_at.isoformat() if d.completed_at else None,
-            "error": (d.metadata_ or {}).get("error") if isinstance(d.metadata_, dict) else None,
+            "error": failure["message"] if failure is not None else None,
         }
+        if failure is not None:
+            result["failure"] = dict(failure)
 
-        if d.status in ("completed", "failed"):
+        if public_status in ("completed", "failed", "canceled", "expired"):
             msg = (
                 await uow.session.scalars(
                     select(IdeaThread)
@@ -842,8 +929,15 @@ async def idea_audit_analysis_result(
             ).first()
 
             if msg:
-                result["content"] = msg.content
+                content, _metadata = public_run_linked_message(
+                    msg.content,
+                    msg.metadata_,
+                    failure,
+                )
+                result["content"] = str(content or "")
                 result["message_id"] = msg.id
+            elif failure is not None:
+                result["content"] = failure["message"]
             else:
                 fallback = (
                     await uow.session.scalars(
@@ -857,7 +951,12 @@ async def idea_audit_analysis_result(
                     )
                 ).first()
                 if fallback and d.completed_at and d.started_at and fallback.created_at >= d.started_at:
-                    result["content"] = fallback.content
+                    projected_fallback = await _public_thread_message_projections(
+                        uow.session,
+                        [fallback],
+                        idea_id=idea_id,
+                    )
+                    result["content"] = projected_fallback[0][1]
                     result["message_id"] = fallback.id
 
         return result

--- a/brain/app/api/routers/cortex/_run.py
+++ b/brain/app/api/routers/cortex/_run.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 
 from brain.systems.runs.events import run_event
+from brain.systems.runs.presentation import public_tool_event_payload
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.app.api.auth import get_current_user
@@ -133,7 +134,20 @@ async def run_tools(run_id: int, user: dict[str, Any] = Depends(get_current_user
             .order_by(AgentRunEventRow.sequence_no.asc())
         )
         rows = result.all()
-        tools = [{"event_type": row.event_type, "payload": row.payload or {}, "created_at": row.created_at.isoformat()} for row in rows]
+        tools = []
+        for row in rows:
+            payload = public_tool_event_payload(row.payload, row.event_type)
+            if row.event_type == "run.tool_failed":
+                payload.pop("error", None)
+                payload.pop("result", None)
+                payload.pop("result_preview", None)
+            tools.append(
+                {
+                    "event_type": row.event_type,
+                    "payload": payload,
+                    "created_at": row.created_at.isoformat(),
+                }
+            )
         return {"tools": tools, "count": len(tools)}
 
 

--- a/brain/app/cli/agent_cli.py
+++ b/brain/app/cli/agent_cli.py
@@ -7,11 +7,23 @@ Wraps core.agent.run_agent with a CLI-friendly interface.
 """
 
 import json
+import logging
 import os
 import re
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 3))))
+
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
+
+
+logger = logging.getLogger(__name__)
+
+
+def _public_failure_message(error: BaseException | str | None) -> str:
+    category = failure_category_for_error(error)
+    failure = public_run_failure("failed", category)
+    return str((failure or {}).get("message") or "")
 
 
 def call_agent(
@@ -55,7 +67,7 @@ def call_agent(
         result = invoke_direct_agent(spec)
 
         # Check if agent wrote output to a file directly
-        if output_file and os.path.exists(output_file):
+        if result.success and output_file and os.path.exists(output_file):
             with open(output_file) as f:
                 text = f.read()
             if text.strip():
@@ -67,12 +79,15 @@ def call_agent(
             return {"success": False, "text": "", "from_file": False,
                     "error": "Agent returned empty response"}
         else:
+            error = result.error or "Agent failed"
+            logger.warning("agent_cli_failed error=%s", error)
             return {"success": False, "text": "", "from_file": False,
-                    "error": result.error or "Agent failed"}
+                    "error": _public_failure_message(error)}
 
     except Exception as e:
+        logger.exception("agent_cli_exception")
         return {"success": False, "text": "", "from_file": False,
-                "error": str(e)}
+                "error": _public_failure_message(e)}
 
 
 def extract_json(text: str) -> dict | None:

--- a/brain/systems/cortex/encode.py
+++ b/brain/systems/cortex/encode.py
@@ -7,12 +7,45 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Mapping
 
-from sqlalchemy import text
+from sqlalchemy import select, text
 
+from brain.platform.db.models.idea import IdeaThread
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 
 logger = logging.getLogger(__name__)
+
+_RUN_LINKED_MESSAGE_ROLES = frozenset({"illo", "assistant"})
+
+
+def _thread_message_metadata(thread: Mapping[str, object]) -> dict:
+    value = thread.get("metadata") or thread.get("metadata_")
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _thread_message_run_id(thread: Mapping[str, object]) -> int | None:
+    if str(thread.get("role") or "").strip().lower() not in _RUN_LINKED_MESSAGE_ROLES:
+        return None
+    return run_id_from_public_message_metadata(_thread_message_metadata(thread))
+
+
+def _public_thread_message_content(
+    thread: Mapping[str, object],
+    failures: Mapping[int, dict[str, str]],
+) -> object:
+    run_id = _thread_message_run_id(thread)
+    content, _metadata = public_run_linked_message(
+        thread.get("content"),
+        _thread_message_metadata(thread),
+        failures.get(run_id) if run_id is not None else None,
+    )
+    return content
 
 
 async def encode_thought_to_brain(idea_id: str, force: bool = False):
@@ -31,9 +64,30 @@ async def encode_thought_to_brain(idea_id: str, force: bool = False):
             if idea.get("encoded_at") and not force:
                 logger.debug(f"Thought {idea_id[:8]} already encoded, skipping")
                 return
-            threads = (await uow.session.execute(text(
-                "SELECT role, content FROM idea_threads WHERE idea_id = :id ORDER BY created_at"
-            ), {"id": idea_id})).mappings().all()
+            threads = (
+                await uow.session.execute(
+                    select(
+                        IdeaThread.role,
+                        IdeaThread.content,
+                        IdeaThread.metadata_,
+                        IdeaThread.message_type,
+                    )
+                    .where(IdeaThread.idea_id == idea_id)
+                    .order_by(IdeaThread.created_at)
+                )
+            ).mappings().all()
+            linked_run_ids = {
+                run_id
+                for thread in threads
+                for run_id in [_thread_message_run_id(thread)]
+                if run_id is not None
+            }
+            failures = await public_failures_for_run_ids(
+                uow.session,
+                linked_run_ids,
+                thread_id=str(idea.get("id") or idea_id),
+                org_id=str(idea.get("org_id")) if idea.get("org_id") else None,
+            )
 
         title = (idea.get("display_title") or idea.get("title", ""))[:80]
         agent_details = idea.get("agent_details") or []
@@ -43,7 +97,8 @@ async def encode_thought_to_brain(idea_id: str, force: bool = False):
         # Build thread summary for Qwen
         thread_text = f"Title: {title}\n"
         for t in threads[:20]:
-            thread_text += f"[{t['role']}]: {str(t['content'])[:200]}\n"
+            content = _public_thread_message_content(t, failures)
+            thread_text += f"[{t['role']}]: {str(content)[:200]}\n"
         if agent_details:
             thread_text += f"Agent work: {json.dumps(agent_details)[:300]}\n"
         thread_text = thread_text[:1500]

--- a/brain/systems/cortex/thought_lifecycle.py
+++ b/brain/systems/cortex/thought_lifecycle.py
@@ -653,6 +653,7 @@ def _terminal_run_target_status(run_status: str) -> str | None:
         "failed": "failed",
         "canceled": "failed",
         "cancelled": "failed",
+        "expired": "failed",
     }.get(str(run_status or "").strip().lower())
 
 

--- a/brain/systems/cortex/thread_context.py
+++ b/brain/systems/cortex/thread_context.py
@@ -11,6 +11,11 @@ from sqlalchemy import select
 
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
 from brain.platform.db.models.idea import IdeaThread
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 
 DEFAULT_THREAD_CONTEXT_LIMIT = 16
 DEFAULT_THREAD_CONTEXT_CHAR_LIMIT = 8000
@@ -122,17 +127,40 @@ async def _a_thread_message_entries(session: Any, idea_id: str, *, max_rows: int
         .order_by(IdeaThread.created_at.desc(), IdeaThread.id.desc())
         .limit(max(1, int(max_rows)))
     )
-    rows = result.all()
+    rows = list(result.all())
+    run_ids = {
+        run_id
+        for run_id in (
+            (
+                run_id_from_public_message_metadata(row.metadata_)
+                if _normalize_role(row.role) in {"illo", "assistant"}
+                else None
+            )
+            for row in rows
+        )
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(session, run_ids, thread_id=idea_id)
     entries: list[ThreadContextEntry] = []
     for row in rows:
-        content = _clean_content(row.content)
-        if not content:
-            continue
-        role = _normalize_role(row.role)
-        if role not in {"user", "illo", "assistant"}:
-            continue
         metadata = row.metadata_
         metadata = metadata if isinstance(metadata, dict) else {}
+        role = _normalize_role(row.role)
+        run_id = (
+            run_id_from_public_message_metadata(metadata)
+            if role in {"illo", "assistant"}
+            else None
+        )
+        projected_content, _metadata = public_run_linked_message(
+            row.content,
+            metadata,
+            failures.get(run_id),
+        )
+        content = _clean_content(projected_content)
+        if not content:
+            continue
+        if role not in {"user", "illo", "assistant"}:
+            continue
         entries.append(
             ThreadContextEntry(
                 role="illo" if role == "assistant" else role,
@@ -140,7 +168,7 @@ async def _a_thread_message_entries(session: Any, idea_id: str, *, max_rows: int
                 created_at=row.created_at,
                 source="thread",
                 thread_message_id=_coerce_int(row.id),
-                run_id=_coerce_int(metadata.get("run_id")),
+                run_id=run_id,
             )
         )
     return entries
@@ -152,6 +180,7 @@ async def _a_final_answer_entries(session: Any, idea_id: str, *, max_rows: int) 
         .join(AgentRunRow, AgentRunRow.id == AgentRunArtifactRow.run_id)
         .where(
             AgentRunRow.thread_id == str(idea_id),
+            AgentRunRow.status == "completed",
             AgentRunArtifactRow.artifact_type == "final_answer",
         )
         .order_by(AgentRunArtifactRow.created_at.desc(), AgentRunArtifactRow.id.desc())

--- a/brain/systems/external_agents/service.py
+++ b/brain/systems/external_agents/service.py
@@ -41,6 +41,12 @@ from brain.systems.cortex.project_context.search import search_project_contexts
 from brain.systems.cortex.status import EXTERNAL_TASK_STARTABLE_IDEA_STATUSES
 from brain.systems.external_agents.status import EXTERNAL_AGENT_TASK_TERMINAL_STATUSES
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
+from brain.systems.runs.cortex.read_models import (
+    public_failures_for_run_ids,
+    public_failure_for_run,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+)
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 
 
@@ -716,7 +722,30 @@ async def _thread_context(session: AsyncSession, idea_id: str, *, limit: int = 3
         ).all()
     )
     rows.reverse()
-    return [_thread_message_payload(row) for row in rows]
+    run_ids = {
+        run_id
+        for run_id in (
+            (
+                run_id_from_public_message_metadata(row.metadata_)
+                if str(row.role or "").lower() in {"illo", "assistant"}
+                else None
+            )
+            for row in rows
+        )
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(session, run_ids, thread_id=idea_id)
+    return [
+        _thread_message_payload(
+            row,
+            failures.get(
+                run_id_from_public_message_metadata(row.metadata_)
+                if str(row.role or "").lower() in {"illo", "assistant"}
+                else None
+            ),
+        )
+        for row in rows
+    ]
 
 
 async def _idea_for_org(session: AsyncSession, *, idea_id: str, org_id: str) -> Idea:
@@ -937,13 +966,17 @@ async def append_artifact(
     return artifact
 
 
-def _thread_message_payload(message: IdeaThread) -> dict[str, Any]:
+def _thread_message_payload(
+    message: IdeaThread,
+    failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
     metadata = _json_dict(message.metadata_)
+    content, metadata = public_run_linked_message(message.content, metadata, failure)
     return {
         "id": message.id,
         "idea_id": str(message.idea_id) if message.idea_id else None,
         "role": message.role,
-        "content": message.content,
+        "content": content,
         "attachments": message.attachments or [],
         "metadata": metadata,
         "object_references": metadata.get("object_references") or [],
@@ -1170,9 +1203,36 @@ async def search_workspace(
                 .limit(remaining)
             )
         ).all()
+        run_ids = {
+            run_id
+            for run_id in (
+                (
+                    run_id_from_public_message_metadata(row[0].metadata_)
+                    if str(row[0].role or "").lower() in {"illo", "assistant"}
+                    else None
+                )
+                for row in rows
+            )
+            if run_id is not None
+        }
+        failures = await public_failures_for_run_ids(
+            session,
+            run_ids,
+            org_id=principal.org_id,
+        )
         for row in rows:
             thread = row[0]
             idea = row[1]
+            run_id = (
+                run_id_from_public_message_metadata(thread.metadata_)
+                if str(thread.role or "").lower() in {"illo", "assistant"}
+                else None
+            )
+            content, _metadata = public_run_linked_message(
+                thread.content,
+                thread.metadata_,
+                failures.get(run_id),
+            )
             links = thread_link_payload(thread.idea_id)
             results.append(
                 {
@@ -1190,7 +1250,7 @@ async def search_workspace(
                     ),
                     "thread_message_id": thread.id,
                     "role": thread.role,
-                    "content": thread.content[:600],
+                    "content": str(content or "")[:600],
                     "created_at": _iso(thread.created_at),
                 }
             )
@@ -1630,9 +1690,14 @@ async def get_headless_ask(
     run: AgentRunRow | None = await session.get(AgentRunRow, int(task.illo_run_id)) if task.illo_run_id else None
     answer = ""
     run_status = None
+    failure = None
     if run is not None:
         run_status = coerce_run_status(run.status)
-        answer = await _latest_run_artifact_text(session, int(run.id))
+        failure = public_failure_for_run(run)
+        if run_status == RunStatus.COMPLETED:
+            answer = await _latest_run_artifact_text(session, int(run.id))
+        elif failure is not None:
+            answer = failure["message"]
         if run_status in TERMINAL_RUN_STATUSES:
             if run_status == RunStatus.COMPLETED:
                 task.status = "completed"
@@ -1640,7 +1705,7 @@ async def get_headless_ask(
                 task.completed_at = task.completed_at or utcnow()
             elif run_status in {RunStatus.FAILED, RunStatus.CANCELED, RunStatus.EXPIRED}:
                 task.status = "failed" if run_status == RunStatus.FAILED else "cancelled"
-                task.error = task.error or f"Illo ask ended with status {run_status.value}"
+                task.error = failure["message"] if failure is not None else "Illo ask did not complete."
                 task.failed_at = task.failed_at or utcnow()
             await session.flush()
             await _refresh_task_if_supported(session, task)
@@ -1652,6 +1717,7 @@ async def get_headless_ask(
             "thread_id": run.thread_id if run is not None else None,
         },
         "answer": answer,
+        **({"failure": failure} if failure is not None else {}),
     }
 
 

--- a/brain/systems/inbound/admin.py
+++ b/brain/systems/inbound/admin.py
@@ -21,6 +21,7 @@ from brain.platform.db.models.inbound import (
 )
 from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import service as inbound_service
+from brain.systems.runs.failures import public_run_failure
 
 
 DEFAULT_SIGNAL_TOKEN_SCOPES = (external_agents.SCOPE_SIGNAL_SUBMIT,)
@@ -1117,7 +1118,8 @@ def _event_failed(row: InboundEventRow) -> bool:
 
 
 def _source_card_event_summary(row: InboundEventRow) -> dict[str, Any]:
-    return {
+    serialized = serialize_event(row)
+    summary = {
         "id": str(row.id),
         "origin": row.origin,
         "kind": row.kind,
@@ -1125,10 +1127,13 @@ def _source_card_event_summary(row: InboundEventRow) -> dict[str, Any]:
         "policy_id": str(row.policy_id) if row.policy_id else None,
         "domain_projection_id": str(row.domain_projection_id) if row.domain_projection_id else None,
         "action_type": row.action_type,
-        "error": row.error,
+        "error": serialized["error"],
         "created_at": _iso(row.created_at),
         "processed_at": _iso(row.processed_at),
     }
+    if "failure" in serialized:
+        summary["failure"] = serialized["failure"]
+    return summary
 
 
 def _dry_run_projection_error(
@@ -1244,7 +1249,74 @@ def serialize_projection(row: InboundDomainProjectionRow) -> dict[str, Any]:
     }
 
 
+_RUN_FAILURE_STATUSES = frozenset({"failed", "canceled", "expired"})
+
+
+def _direct_public_failure_from_payload(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    payload = dict(value)
+    stored_failure = _json_dict(payload.get("failure"))
+    status = str(
+        stored_failure.get("status")
+        or payload.get("run_status")
+        or (
+            payload.get("status")
+            if stored_failure or payload.get("run_id") or payload.get("failure_category")
+            else ""
+        )
+        or ""
+    ).strip()
+    if status in _RUN_FAILURE_STATUSES:
+        return public_run_failure(
+            status,
+            stored_failure.get("category")
+            or payload.get("failure_category")
+            or payload.get("category"),
+        )
+    return None
+
+
+def _public_failure_from_payload(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    payload = dict(value)
+    direct = _direct_public_failure_from_payload(payload)
+    if direct is not None:
+        return direct
+    for key in ("triage", "handling", "result"):
+        nested = _public_failure_from_payload(payload.get(key))
+        if nested is not None:
+            return nested
+    return None
+
+
+def _public_run_outcome(
+    value: Any,
+    inherited_failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    payload = _json_dict(value)
+    projected = dict(payload)
+    failure = (
+        _direct_public_failure_from_payload(payload)
+        or inherited_failure
+        or _public_failure_from_payload(payload)
+    )
+    for key in ("triage", "handling", "result"):
+        if isinstance(payload.get(key), dict):
+            projected[key] = _public_run_outcome(payload[key], failure)
+
+    if failure is None:
+        return projected
+    for key in ("final_answer", "error", "reason", "failure_category", "category"):
+        projected.pop(key, None)
+    projected["failure"] = failure
+    return projected
+
+
 def serialize_event(row: InboundEventRow, *, include_payload: bool = False) -> dict[str, Any]:
+    action_result = _public_run_outcome(row.action_result)
+    failure = _public_failure_from_payload(action_result)
     data = {
         "id": str(row.id),
         "org_id": str(row.org_id),
@@ -1258,13 +1330,15 @@ def serialize_event(row: InboundEventRow, *, include_payload: bool = False) -> d
         "status": row.status,
         "confidence": row.confidence,
         "action_type": row.action_type,
-        "action_result": _json_dict(row.action_result),
-        "error": row.error,
+        "action_result": action_result,
+        "error": failure["message"] if failure is not None else row.error,
         "source_actor": _json_dict(row.source_actor),
         "authority_user_id": str(row.authority_user_id) if row.authority_user_id else None,
         "created_at": _iso(row.created_at),
         "processed_at": _iso(row.processed_at),
     }
+    if failure is not None:
+        data["failure"] = failure
     if include_payload:
         data.update(
             {
@@ -1278,18 +1352,29 @@ def serialize_event(row: InboundEventRow, *, include_payload: bool = False) -> d
 
 
 def serialize_receipt(row: InboundDecisionReceiptRow) -> dict[str, Any]:
-    return {
+    raw_outcome = _json_dict(row.outcome)
+    raw_tool_use = _json_dict(row.tool_use)
+    failure = (
+        _public_failure_from_payload(raw_outcome)
+        or _public_failure_from_payload(raw_tool_use)
+    )
+    outcome = _public_run_outcome(raw_outcome, failure)
+    tool_use = _public_run_outcome(raw_tool_use, failure)
+    data = {
         "id": str(row.id),
         "event_id": str(row.event_id),
         "org_id": str(row.org_id),
         "connection_id": str(row.connection_id),
         "policy_id": str(row.policy_id) if row.policy_id else None,
         "status": row.status,
-        "outcome": _json_dict(row.outcome),
+        "outcome": outcome,
         "confidence": row.confidence,
         "target": _json_dict(row.target),
-        "tool_use": _json_dict(row.tool_use),
-        "reasoning_summary": row.reasoning_summary,
+        "tool_use": tool_use,
+        "reasoning_summary": None if failure is not None else row.reasoning_summary,
         "reusable_pattern_candidate": _json_dict(row.reusable_pattern_candidate),
         "created_at": _iso(row.created_at),
     }
+    if failure is not None:
+        data["failure"] = failure
+    return data

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -20,6 +20,7 @@ from brain.systems.inbound.preservation import (
 )
 from brain.systems.inbound.status import STATUS_REVIEW_REQUIRED
 from brain.systems.runs.domain import AgentRun, ArtifactType
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
 from brain.systems.runs.interactive_reply import is_interactive_transport_fallback
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 
@@ -181,6 +182,25 @@ async def _run_failure_reason(session: AsyncSession, run_id: int) -> str | None:
         if text:
             return text
     return None
+
+
+async def _run_failure_category(session: AsyncSession, run_id: int) -> Any:
+    rows = (
+        await session.scalars(
+            select(AgentRunEventRow)
+            .where(
+                AgentRunEventRow.run_id == int(run_id),
+                AgentRunEventRow.event_type == "run.failed",
+            )
+            .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+        )
+    ).all()
+    for failure_event in rows:
+        payload = _json_dict(failure_event.payload)
+        category = payload.get("failure_category") or payload.get("category")
+        if category:
+            return category
+    return failure_category_for_error(await _run_failure_reason(session, run_id))
 
 
 def _retry_attempt_from_contract(
@@ -545,6 +565,13 @@ async def reconcile_inbound_triage_run(
     now = datetime.now(timezone.utc)
     terminal_at = _run_datetime(row, status)
     final_answer = await _latest_final_answer(session, run_id)
+    stored_failure_category = _json_dict(metadata.get("failure")).get("category")
+    failure = public_run_failure(
+        status,
+        stored_failure_category
+        or (await _run_failure_category(session, run_id) if status == RunStatus.FAILED else None),
+    )
+    public_final_answer = final_answer if failure is None else None
     attribution = await summarize_inbound_run_attribution(session, run_id=run_id, status=status)
     evidence_contract = preservation_evidence_result(
         preservation_contract_from_run_metadata(metadata),
@@ -559,16 +586,20 @@ async def reconcile_inbound_triage_run(
         status=status,
         reconciled_at=now,
         terminal_at=terminal_at,
-        final_answer=final_answer,
+        final_answer=public_final_answer,
     )
     triage_terminal["status"] = outcome_status
     triage_terminal["evidence_contract"] = evidence_contract
+    if failure is not None:
+        triage_terminal["failure"] = failure
 
     outcome = _json_dict(receipt.outcome)
     tool_use = _json_dict(receipt.tool_use)
     outcome_key = "handling" if tool_use.get("type") == "illo_submit" else "triage"
     handling = _json_dict(outcome.get(outcome_key))
-    result_payload = _triage_result(status, final_answer)
+    result_payload = _triage_result(status, public_final_answer)
+    if failure is not None:
+        result_payload["failure"] = failure
     if evidence_missing:
         result_payload = {
             **result_payload,
@@ -592,6 +623,8 @@ async def reconcile_inbound_triage_run(
     if evidence_missing:
         tool_terminal["status"] = outcome_status
     tool_terminal["evidence_contract"] = evidence_contract
+    if failure is not None:
+        tool_terminal["failure"] = failure
     receipt.tool_use = {
         **tool_use,
         **tool_terminal,
@@ -609,7 +642,7 @@ async def reconcile_inbound_triage_run(
     elif status == RunStatus.COMPLETED:
         event.error = None
     else:
-        event.error = final_answer or f"Illo triage run ended with status {status.value}"
+        event.error = failure["message"] if failure is not None else None
 
     await session.flush()
 

--- a/brain/systems/runs/cortex/read_models.py
+++ b/brain/systems/runs/cortex/read_models.py
@@ -7,6 +7,8 @@ from typing import Any
 from sqlalchemy import select
 
 from brain.systems.runs.cortex.permissions import RunReadScope, run_belongs_to_scope
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
+from brain.systems.runs.presentation import public_tool_event_payload
 from brain.systems.runs.visibility import fetch_visible_run_rows, run_is_headless
 from brain.platform.db.models.agent_run import (
     AgentRunArtifactRow,
@@ -17,6 +19,26 @@ from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES, project_run_status_value
 
 ACTIVE_STATUSES = frozenset(OPEN_RUN_STATUS_VALUES)
+_FAILURE_STATUSES = frozenset({"failed", "canceled", "expired"})
+_FAILURE_DIAGNOSTIC_KEYS = frozenset(
+    {
+        "details",
+        "diagnostic",
+        "error",
+        "errors",
+        "exception",
+        "final_answer",
+        "message",
+        "output",
+        "reason",
+        "result",
+        "result_preview",
+        "stack",
+        "text",
+        "traceback",
+    }
+)
+_FAILURE_CONTAINER_KEYS = frozenset({"failed", "failure", "failures"})
 
 
 def _duration_sec(started_at: Any, completed_at: Any, fallback_end: Any = None) -> int | None:
@@ -40,9 +62,189 @@ def project_run_status(status: str | None, fallback: str | None = None) -> str:
     return project_run_status_value(status, fallback)
 
 
+def _failure_category(run: AgentRunRow, events: list[AgentRunEventRow] | None = None) -> Any:
+    metadata = dict(getattr(run, "metadata_", None) or {})
+    failure = metadata.get("failure") if isinstance(metadata.get("failure"), dict) else {}
+    category = failure.get("category")
+    if category:
+        return category
+    for event in reversed(events or []):
+        if str(getattr(event, "event_type", "") or "") != "run.failed":
+            continue
+        payload = dict(getattr(event, "payload", None) or {})
+        category = payload.get("failure_category") or payload.get("category")
+        if category:
+            return category
+    return None
+
+
+def public_failure_for_run(
+    run: AgentRunRow,
+    events: list[AgentRunEventRow] | None = None,
+) -> dict[str, str] | None:
+    status = project_run_status(getattr(run, "status", None))
+    if status not in _FAILURE_STATUSES:
+        return None
+    return public_run_failure(status, _failure_category(run, events))
+
+
+def _strip_failure_diagnostics(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _strip_failure_diagnostics(item)
+            for key, item in value.items()
+            if str(key).strip().lower() not in _FAILURE_DIAGNOSTIC_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_failure_diagnostics(item) for item in value]
+    if isinstance(value, tuple):
+        return [_strip_failure_diagnostics(item) for item in value]
+    return value
+
+
+def _strip_embedded_failure_diagnostics(value: Any, *, in_failure: bool = False) -> Any:
+    if isinstance(value, dict):
+        status = str(value.get("status") or "").strip().lower()
+        failure_context = in_failure or status in _FAILURE_STATUSES
+        projected = {}
+        for key, item in value.items():
+            normalized_key = str(key).strip().lower()
+            if failure_context and normalized_key in _FAILURE_DIAGNOSTIC_KEYS:
+                continue
+            projected[key] = _strip_embedded_failure_diagnostics(
+                item,
+                in_failure=failure_context or normalized_key in _FAILURE_CONTAINER_KEYS,
+            )
+        return projected
+    if isinstance(value, (list, tuple)):
+        return [
+            _strip_embedded_failure_diagnostics(item, in_failure=in_failure)
+            for item in value
+        ]
+    return value
+
+
+def public_failed_run_artifact(
+    artifact: dict[str, Any],
+    failure: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Return an artifact projection that cannot replay failed-run diagnostics."""
+
+    projected = dict(artifact or {})
+    artifact_payload = (
+        dict(projected.get("payload") or {})
+        if isinstance(projected.get("payload"), dict)
+        else {}
+    )
+    stored_failure = (
+        artifact_payload.get("failure")
+        if isinstance(artifact_payload.get("failure"), dict)
+        else {}
+    )
+    artifact_status = str(
+        stored_failure.get("status") or artifact_payload.get("status") or ""
+    ).strip().lower()
+    if failure is None and artifact_status in _FAILURE_STATUSES:
+        category = (
+            stored_failure.get("category")
+            or artifact_payload.get("failure_category")
+            or artifact_payload.get("category")
+            or failure_category_for_error(
+                artifact_payload.get("error")
+                or artifact_payload.get("output")
+                or projected.get("text")
+            )
+        )
+        failure = public_run_failure(artifact_status, category)
+    if failure is None:
+        return projected
+    artifact_type = str(projected.get("artifact_type") or "")
+    projected["title"] = None
+    projected["payload"] = {"failure": dict(failure)}
+    projected["text"] = failure["message"] if artifact_type == "final_answer" else None
+    projected["uri"] = None
+    return projected
+
+
+def run_id_from_public_message_metadata(metadata: Any) -> int | None:
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("created_by_run_id") or metadata.get("run_id")
+    try:
+        return int(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def public_run_linked_message(
+    content: Any,
+    metadata: Any,
+    failure: dict[str, str] | None,
+) -> tuple[Any, dict[str, Any]]:
+    projected_metadata = dict(metadata or {}) if isinstance(metadata, dict) else {}
+    if failure is None:
+        return content, projected_metadata
+    for key in _FAILURE_DIAGNOSTIC_KEYS:
+        projected_metadata.pop(key, None)
+    projected_metadata["failure"] = dict(failure)
+    return failure["message"], projected_metadata
+
+
+async def public_failures_for_run_ids(
+    session: Any,
+    run_ids: list[int] | set[int] | tuple[int, ...],
+    *,
+    thread_id: str | None = None,
+    org_id: str | None = None,
+) -> dict[int, dict[str, str]]:
+    normalized_ids = sorted({int(run_id) for run_id in run_ids if run_id is not None})
+    if not normalized_ids:
+        return {}
+    run_stmt = select(AgentRunRow).where(AgentRunRow.id.in_(normalized_ids))
+    if thread_id is not None:
+        run_stmt = run_stmt.where(AgentRunRow.thread_id == str(thread_id))
+    if org_id is not None:
+        run_stmt = run_stmt.where(AgentRunRow.org_id == str(org_id))
+    runs = list(
+        (
+            await session.scalars(run_stmt)
+        ).all()
+    )
+    visible_ids = [int(run.id) for run in runs]
+    if not visible_ids:
+        return {}
+    events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id.in_(visible_ids),
+                    AgentRunEventRow.event_type == "run.failed",
+                )
+                .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+            )
+        ).all()
+    )
+    events_by_run: dict[int, list[AgentRunEventRow]] = {}
+    for event in events:
+        events_by_run.setdefault(int(event.run_id), []).append(event)
+    failures = {}
+    for run in runs:
+        failure = public_failure_for_run(run, events_by_run.get(int(run.id), []))
+        if failure is not None:
+            failures[int(run.id)] = failure
+    return failures
+
+
 def run_stream_payload(run: AgentRunRow) -> dict[str, Any]:
     timestamp = _iso(run.created_at)
-    return {
+    status = project_run_status(run.status)
+    failure = public_failure_for_run(run)
+    metadata = _strip_embedded_failure_diagnostics(dict(run.metadata_ or {}))
+    if failure is not None:
+        metadata.pop("failure", None)
+        metadata = _strip_failure_diagnostics(metadata)
+    payload = {
         "type": "run",
         "timestamp": timestamp,
         "id": str(run.id),
@@ -57,12 +259,24 @@ def run_stream_payload(run: AgentRunRow) -> dict[str, Any]:
         "profile": run.profile,
         "requested_run_profile": run.profile,
         "recipe": run.recipe,
-        "status": project_run_status(run.status),
+        "status": status,
         "message": run.input_message,
-        "target_ref": dict(run.target_ref or {}),
-        "workspace_ref": dict(run.workspace_ref or {}),
-        "model_policy": dict(run.model_policy or {}),
-        "metadata": dict(run.metadata_ or {}),
+        "target_ref": (
+            _strip_failure_diagnostics(dict(run.target_ref or {}))
+            if failure
+            else _strip_embedded_failure_diagnostics(dict(run.target_ref or {}))
+        ),
+        "workspace_ref": (
+            _strip_failure_diagnostics(dict(run.workspace_ref or {}))
+            if failure
+            else _strip_embedded_failure_diagnostics(dict(run.workspace_ref or {}))
+        ),
+        "model_policy": (
+            _strip_failure_diagnostics(dict(run.model_policy or {}))
+            if failure
+            else _strip_embedded_failure_diagnostics(dict(run.model_policy or {}))
+        ),
+        "metadata": metadata,
         "created_at": timestamp,
         "updated_at": _iso(run.updated_at),
         "started_at": _iso(run.started_at),
@@ -72,6 +286,9 @@ def run_stream_payload(run: AgentRunRow) -> dict[str, Any]:
         "canceled_at": _iso(run.canceled_at),
         "duration_sec": _duration_sec(run.started_at, run.completed_at or run.failed_at or run.canceled_at, run.updated_at),
     }
+    if failure is not None:
+        payload["failure"] = failure
+    return payload
 
 
 def _visible_query(scope: RunReadScope | None):
@@ -125,33 +342,106 @@ def _debug_payload(
     events: list[AgentRunEventRow],
     artifacts: list[AgentRunArtifactRow],
 ) -> dict[str, Any]:
+    failure = public_failure_for_run(run, events)
+    run_payload = run_stream_payload(run)
+    if failure is not None:
+        run_payload["failure"] = failure
     return {
-        "run": run_stream_payload(run),
+        "run": run_payload,
         "events": [
             {
                 "id": event.id,
                 "sequence_no": event.sequence_no,
                 "event_type": event.event_type,
-                "payload": event.payload or {},
+                "payload": public_run_debug_event_payload(event, failure),
                 "visibility": event.visibility,
                 "created_at": _iso(event.created_at),
             }
             for event in events
         ],
         "artifacts": [
-            {
+            public_failed_run_artifact(
+                {
                 "id": artifact.id,
                 "artifact_type": artifact.artifact_type,
                 "title": artifact.title,
-                "payload": artifact.payload or {},
+                "payload": dict(artifact.payload or {}),
                 "text": artifact.text,
                 "uri": artifact.uri,
                 "visibility": artifact.visibility,
                 "created_at": _iso(artifact.created_at),
-            }
+                },
+                failure,
+            )
             for artifact in artifacts
         ],
     }
+
+
+def public_run_debug_event_payload(
+    event: AgentRunEventRow,
+    failure: dict[str, str] | None,
+) -> dict[str, Any]:
+    payload = dict(event.payload or {})
+    event_type = str(event.event_type or "")
+    if event_type in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
+        payload = public_tool_event_payload(payload, event_type)
+        projected_failure = payload.get("failure")
+        if failure is None and isinstance(projected_failure, dict):
+            failure = projected_failure
+    if failure is None and (
+        "failed" in event_type
+        or (
+            event_type == "run.status_changed"
+            and project_run_status(str(payload.get("to_status") or "")) in _FAILURE_STATUSES
+        )
+    ):
+        stored_failure = payload.get("failure") if isinstance(payload.get("failure"), dict) else {}
+        category = (
+            stored_failure.get("category")
+            or payload.get("failure_category")
+            or payload.get("category")
+            or failure_category_for_error(
+                payload.get("error")
+                or payload.get("reason")
+                or payload.get("result")
+                or payload.get("result_preview")
+            )
+        )
+        failure = public_run_failure("failed", category)
+    if failure is None:
+        return payload
+    if event_type in {"run.failed", "run.canceled", "run.expired"}:
+        return {"failure": failure}
+    if event_type == "run.tool_failed":
+        for key in ("error", "result", "result_preview"):
+            payload.pop(key, None)
+        payload["failure"] = failure
+        return payload
+    if event_type == "run.tool_completed" and isinstance(payload.get("failure"), dict):
+        for key in ("error", "result", "result_preview"):
+            payload.pop(key, None)
+        payload["failure"] = failure
+        return payload
+    if "failed" in event_type:
+        payload = _strip_failure_diagnostics(payload)
+        payload["failure"] = failure
+        return payload
+    if (
+        event_type == "run.status_changed"
+        and project_run_status(str(payload.get("to_status") or "")) in _FAILURE_STATUSES
+    ):
+        for key in ("reason", "error", "message", "text", "final_answer"):
+            payload.pop(key, None)
+        payload["failure"] = failure
+    elif event_type in {"run.text_delta", "run.text_completed"}:
+        for key in ("text", "delta", "error", "message", "final_answer"):
+            payload.pop(key, None)
+        payload["failure"] = failure
+        payload["text"] = failure["message"]
+    else:
+        payload = _strip_failure_diagnostics(payload)
+    return payload
 
 
 async def serialize_active_runs_async(
@@ -228,7 +518,13 @@ def tenant_safe_queue_status(status: dict[str, Any], _scope: RunReadScope | None
 __all__ = [
     "RunReadScope",
     "project_run_status",
+    "public_failed_run_artifact",
+    "public_failures_for_run_ids",
+    "public_failure_for_run",
+    "public_run_linked_message",
+    "public_run_debug_event_payload",
     "run_belongs_to_scope",
+    "run_id_from_public_message_metadata",
     "run_is_headless",
     "run_stream_payload",
     "serialize_active_runs_async",

--- a/brain/systems/runs/cortex/recording.py
+++ b/brain/systems/runs/cortex/recording.py
@@ -16,6 +16,16 @@ from brain.systems.runs.ids import trace_id_for_run_id
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import IdeaThread
+from brain.systems.runs.cortex.read_models import (
+    public_failed_run_artifact,
+    public_failure_for_run,
+    public_failures_for_run_ids,
+    public_run_debug_event_payload,
+    public_run_linked_message,
+    run_id_from_public_message_metadata,
+    run_stream_payload,
+)
+from brain.systems.runs.failures import public_run_failure
 
 
 async def build_run_run_summary_async(session, run_id: int) -> dict[str, Any]:
@@ -41,6 +51,28 @@ def _run_summary(run: AgentRunRow | None, run_id: int) -> dict[str, Any]:
     }
 
 
+def _public_trace_run(run: AgentRunRow) -> dict[str, Any]:
+    projected = run_stream_payload(run)
+    return _cap_jsonable(
+        {
+            **_run_summary(run, int(run.id)),
+            "parent_run_id": projected.get("parent_run_id"),
+            "root_run_id": projected.get("root_run_id"),
+            "input_message": projected.get("message"),
+            "target_ref": projected.get("target_ref") or {},
+            "workspace_ref": projected.get("workspace_ref") or {},
+            "model_policy": projected.get("model_policy") or {},
+            "context_summary": (
+                projected.get("failure", {}).get("message")
+                if isinstance(projected.get("failure"), dict)
+                else getattr(run, "context_summary", None)
+            ),
+            "metadata": projected.get("metadata") or {},
+            **({"failure": projected["failure"]} if "failure" in projected else {}),
+        }
+    )
+
+
 async def build_run_flight_recorder_async(
     session,
     run_id: int,
@@ -48,6 +80,7 @@ async def build_run_flight_recorder_async(
     summary: dict[str, Any] | None = None,
     **_: Any,
 ) -> dict[str, Any]:
+    resolved_summary = summary or await build_run_run_summary_async(session, run_id)
     events_result = await session.scalars(
         select(AgentRunEventRow)
         .where(AgentRunEventRow.run_id == int(run_id))
@@ -60,26 +93,14 @@ async def build_run_flight_recorder_async(
     )
     events = events_result.all()
     artifacts = artifacts_result.all()
-    artifact_payloads = [
-        artifact.payload
-        for artifact in artifacts
-        if isinstance(artifact.payload, dict)
-    ]
-    worker_recordings = _worker_recordings({"run_artifacts": artifact_payloads})
-    return {
-        "schema_version": 1,
-        "summary": summary or await build_run_run_summary_async(session, run_id),
-        "events": [
-            {
-                "id": event.id,
-                "sequence_no": event.sequence_no,
-                "event_type": event.event_type,
-                "payload": event.payload or {},
-                "created_at": _iso(event.created_at),
-            }
-            for event in events
-        ],
-        "artifacts": [
+    summary_status = str(resolved_summary.get("status") or "")
+    failure = (
+        public_run_failure(summary_status)
+        if summary_status in {"failed", "canceled", "cancelled", "expired"}
+        else None
+    )
+    projected_artifacts = [
+        public_failed_run_artifact(
             {
                 "id": artifact.id,
                 "artifact_type": artifact.artifact_type,
@@ -88,9 +109,31 @@ async def build_run_flight_recorder_async(
                 "text": artifact.text,
                 "uri": artifact.uri,
                 "created_at": _iso(artifact.created_at),
+            },
+            failure,
+        )
+        for artifact in artifacts
+    ]
+    artifact_payloads = [
+        artifact["payload"]
+        for artifact in projected_artifacts
+        if isinstance(artifact.get("payload"), dict)
+    ]
+    worker_recordings = _worker_recordings({"run_artifacts": artifact_payloads})
+    return {
+        "schema_version": 1,
+        "summary": resolved_summary,
+        "events": [
+            {
+                "id": event.id,
+                "sequence_no": event.sequence_no,
+                "event_type": event.event_type,
+                "payload": public_run_debug_event_payload(event, failure),
+                "created_at": _iso(event.created_at),
             }
-            for artifact in artifacts
+            for event in events
         ],
+        "artifacts": projected_artifacts,
         "workers": worker_recordings,
     }
 
@@ -147,9 +190,25 @@ async def build_agent_trace_snapshot_async(
     related_runs = await _runs_by_id_async(session, related_run_ids)
     if not related_runs:
         related_runs = [run]
-    messages = await _trace_messages_async(session, run, max_messages=max_messages)
-    events = await _trace_events_async(session, related_run_ids, max_events=max_events)
-    artifacts = await _trace_artifacts_async(session, related_run_ids, max_artifacts=max_artifacts)
+    failures = _public_failure_map(related_runs)
+    messages = await _trace_messages_async(
+        session,
+        run,
+        max_messages=max_messages,
+        failures=failures,
+    )
+    events = await _trace_events_async(
+        session,
+        related_run_ids,
+        max_events=max_events,
+        failures=failures,
+    )
+    artifacts = await _trace_artifacts_async(
+        session,
+        related_run_ids,
+        max_artifacts=max_artifacts,
+        failures=failures,
+    )
     cycle_state = await _trace_cycle_state_async(
         session,
         idea_id=str(run.thread_id) if getattr(run, "thread_id", None) else None,
@@ -199,17 +258,7 @@ def _agent_trace_snapshot_payload(
             "max_string_chars": TRACE_MAX_STRING_CHARS,
             "large_values": "truncated_in_place",
         },
-        "run": _cap_jsonable({
-            **_run_summary(run, int(run.id)),
-            "parent_run_id": getattr(run, "parent_run_id", None),
-            "root_run_id": getattr(run, "root_run_id", None),
-            "input_message": getattr(run, "input_message", None),
-            "target_ref": getattr(run, "target_ref", None) or {},
-            "workspace_ref": getattr(run, "workspace_ref", None) or {},
-            "model_policy": getattr(run, "model_policy", None) or {},
-            "context_summary": getattr(run, "context_summary", None),
-            "metadata": getattr(run, "metadata_", None) or {},
-        }),
+        "run": _public_trace_run(run),
         "thread": {
             "idea_id": getattr(run, "thread_id", None),
             "messages": messages,
@@ -249,9 +298,25 @@ async def build_thread_trace_snapshot_async(
 
     runs = await _thread_runs_async(session, idea_id, max_runs=max_runs)
     run_ids = [int(run.id) for run in runs if _is_int_like(getattr(run, "id", None))]
-    messages = await _trace_thread_messages_async(session, idea_id, max_messages=max_messages)
-    events = await _trace_events_async(session, run_ids, max_events=max_events)
-    artifacts = await _trace_artifacts_async(session, run_ids, max_artifacts=max_artifacts)
+    failures = _public_failure_map(runs)
+    messages = await _trace_thread_messages_async(
+        session,
+        idea_id,
+        max_messages=max_messages,
+        failures=failures,
+    )
+    events = await _trace_events_async(
+        session,
+        run_ids,
+        max_events=max_events,
+        failures=failures,
+    )
+    artifacts = await _trace_artifacts_async(
+        session,
+        run_ids,
+        max_artifacts=max_artifacts,
+        failures=failures,
+    )
     cycle_state = await _trace_cycle_state_async(session, idea_id=idea_id, runs=runs)
     diagnostics = _trace_diagnostics(runs, events, artifacts, cycle_state)
     return _thread_trace_snapshot_payload(
@@ -310,20 +375,7 @@ def _thread_trace_snapshot_payload(
             "selected_message_count": len(messages),
             "message_limit": max_messages,
         },
-        "runs": [
-            _cap_jsonable({
-                **_run_summary(run, int(run.id)),
-                "parent_run_id": getattr(run, "parent_run_id", None),
-                "root_run_id": getattr(run, "root_run_id", None),
-                "input_message": getattr(run, "input_message", None),
-                "target_ref": getattr(run, "target_ref", None) or {},
-                "workspace_ref": getattr(run, "workspace_ref", None) or {},
-                "model_policy": getattr(run, "model_policy", None) or {},
-                "context_summary": getattr(run, "context_summary", None),
-                "metadata": getattr(run, "metadata_", None) or {},
-            })
-            for run in runs
-        ],
+        "runs": [_public_trace_run(run) for run in runs],
         "run_count": len(runs),
         "run_limit": max_runs,
         "related_run_ids": run_ids,
@@ -446,8 +498,19 @@ async def _thread_runs_async(session, idea_id: str, *, max_runs: int) -> list[Ag
     return list(result.all())
 
 
-async def _trace_messages_async(session, run: AgentRunRow, *, max_messages: int) -> list[dict[str, Any]]:
-    return await _trace_thread_messages_async(session, str(run.thread_id), max_messages=max_messages)
+async def _trace_messages_async(
+    session,
+    run: AgentRunRow,
+    *,
+    max_messages: int,
+    failures: dict[int, dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
+    return await _trace_thread_messages_async(
+        session,
+        str(run.thread_id),
+        max_messages=max_messages,
+        failures=failures,
+    )
 
 
 async def _runs_by_id_async(session, run_ids: list[int]) -> list[AgentRunRow]:
@@ -461,11 +524,21 @@ async def _runs_by_id_async(session, run_ids: list[int]) -> list[AgentRunRow]:
     return list(result.all())
 
 
+def _public_failure_map(runs: list[AgentRunRow]) -> dict[int, dict[str, str]]:
+    failures: dict[int, dict[str, str]] = {}
+    for run in runs:
+        failure = public_failure_for_run(run)
+        if failure is not None:
+            failures[int(run.id)] = failure
+    return failures
+
+
 async def _trace_thread_messages_async(
     session,
     idea_id: str,
     *,
     max_messages: int | None,
+    failures: dict[int, dict[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     query = select(IdeaThread).where(IdeaThread.idea_id == str(idea_id))
     if max_messages is None:
@@ -478,19 +551,51 @@ async def _trace_thread_messages_async(
             .limit(max_messages)
         )
         rows = list(reversed(result.all()))
-    return _thread_message_payloads(rows)
+    if failures is None:
+        run_ids = {
+            run_id
+            for run_id in (
+                (
+                    run_id_from_public_message_metadata(row.metadata_)
+                    if str(row.role or "").lower() in {"illo", "assistant"}
+                    else None
+                )
+                for row in rows
+            )
+            if run_id is not None
+        }
+        failures = await public_failures_for_run_ids(
+            session,
+            run_ids,
+            thread_id=idea_id,
+        )
+    return _thread_message_payloads(rows, failures)
 
 
-def _thread_message_payloads(rows: list[IdeaThread]) -> list[dict[str, Any]]:
+def _thread_message_payloads(
+    rows: list[IdeaThread],
+    failures: dict[int, dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
     messages = []
+    failures = failures or {}
     for row in rows:
         metadata = row.metadata_ if isinstance(row.metadata_, dict) else {}
+        run_id = (
+            run_id_from_public_message_metadata(metadata)
+            if str(row.role or "").lower() in {"illo", "assistant"}
+            else None
+        )
+        content, metadata = public_run_linked_message(
+            row.content,
+            metadata,
+            failures.get(run_id),
+        )
         messages.append(_cap_jsonable({
             "id": row.id,
             "role": row.role,
             "created_at": _iso(row.created_at),
             "message_type": row.message_type,
-            "content": row.content,
+            "content": content,
             "attachments_count": len(row.attachments or []),
             "metadata": {
                 "run_id": metadata.get("run_id"),
@@ -502,7 +607,13 @@ def _thread_message_payloads(rows: list[IdeaThread]) -> list[dict[str, Any]]:
     return messages
 
 
-async def _trace_events_async(session, run_ids: list[int], *, max_events: int) -> list[dict[str, Any]]:
+async def _trace_events_async(
+    session,
+    run_ids: list[int],
+    *,
+    max_events: int,
+    failures: dict[int, dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
     if not run_ids:
         return []
     per_run_limit = max(10, max_events // max(len(run_ids), 1))
@@ -515,6 +626,7 @@ async def _trace_events_async(session, run_ids: list[int], *, max_events: int) -
             .limit(per_run_limit)
         )
         rows.extend(result.all())
+    failures = failures or {}
     return [
         _cap_jsonable({
             "id": event.id,
@@ -525,13 +637,22 @@ async def _trace_events_async(session, run_ids: list[int], *, max_events: int) -
             "visibility": event.visibility,
             "producer": event.producer,
             "created_at": _iso(event.created_at),
-            "payload": event.payload or {},
+            "payload": public_run_debug_event_payload(
+                event,
+                failures.get(int(event.run_id)),
+            ),
         })
         for event in rows
     ]
 
 
-async def _trace_artifacts_async(session, run_ids: list[int], *, max_artifacts: int) -> list[dict[str, Any]]:
+async def _trace_artifacts_async(
+    session,
+    run_ids: list[int],
+    *,
+    max_artifacts: int,
+    failures: dict[int, dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
     if not run_ids:
         return []
     per_run_limit = max(5, max_artifacts // max(len(run_ids), 1))
@@ -548,8 +669,9 @@ async def _trace_artifacts_async(session, run_ids: list[int], *, max_artifacts: 
         )
         run_rows = result.all()
         rows.extend(reversed(run_rows))
+    failures = failures or {}
     return [
-        _cap_jsonable({
+        _cap_jsonable(public_failed_run_artifact({
             "id": artifact.id,
             "run_id": artifact.run_id,
             "root_run_id": artifact.root_run_id,
@@ -560,7 +682,7 @@ async def _trace_artifacts_async(session, run_ids: list[int], *, max_artifacts: 
             "created_at": _iso(artifact.created_at),
             "text": artifact.text,
             "payload": artifact.payload or {},
-        })
+        }, failures.get(int(artifact.run_id))))
         for artifact in rows
     ]
 
@@ -617,14 +739,14 @@ async def _trace_cycle_state_async(
         }
         if missing_cycle_ids:
             cycle_rows.extend(await _query_cycles_async(session, idea_id=None, cycle_ids=missing_cycle_ids, limit=max_cycles))
-    except Exception as exc:
+    except Exception:
         return {
             "schema_version": 1,
             "cycles": [],
             "cycle_runs": [],
             "cycle_ids": sorted(cycle_ids),
             "cycle_run_ids": sorted(cycle_run_ids),
-            "error": str(exc),
+            "error": "Cycle diagnostics were unavailable.",
         }
 
     cycles = [_cap_jsonable(_cycle_payload(cycle)) for cycle in cycle_rows]
@@ -711,7 +833,11 @@ def _cycle_payload(cycle: Cycle) -> dict[str, Any]:
         "next_run_at": _iso(cycle.next_run_at),
         "last_run_at": _iso(cycle.last_run_at),
         "last_status": cycle.last_status,
-        "last_error": cycle.last_error,
+        "last_error": (
+            "The last scheduled run did not complete."
+            if getattr(cycle, "last_error", None)
+            else None
+        ),
         "deleted_at": _iso(cycle.deleted_at),
         "created_at": _iso(getattr(cycle, "created_at", None)),
         "updated_at": _iso(getattr(cycle, "updated_at", None)),
@@ -726,7 +852,11 @@ def _cycle_run_payload(cycle_run: CycleRun) -> dict[str, Any]:
         "started_at": _iso(cycle_run.started_at),
         "completed_at": _iso(cycle_run.completed_at),
         "status": cycle_run.status,
-        "error": cycle_run.error,
+        "error": (
+            "The scheduled run did not complete."
+            if getattr(cycle_run, "error", None)
+            else None
+        ),
         "skip_reason": cycle_run.skip_reason,
         "idea_id": cycle_run.idea_id,
         "run_id": cycle_run.run_id,

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -23,7 +23,12 @@ from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_ST
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
 from brain.systems.runs.engine import AsyncAgentRunEngine
 from brain.systems.runs.events import activity_event, run_event
-from brain.systems.runs.failures import coerce_failure_category, safe_terminal_run_message
+from brain.systems.runs.failures import (
+    coerce_failure_category,
+    failure_category_for_error,
+    public_run_failure,
+    safe_terminal_run_message,
+)
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.stream import RunStream
@@ -240,6 +245,7 @@ _TERMINAL_RUN_IDEA_STATUS = {
     "completed": "unread_reply",
     "failed": "failed",
     "canceled": "failed",
+    "expired": "failed",
 }
 _AI_TIMELINE_SURFACES = {"ai_timeline", "thread_timeline", "cortex_thread", "main_thread"}
 _THREAD_DISCUSSION_SURFACE = "thread_discussion"
@@ -422,8 +428,53 @@ async def _latest_final_answer_artifact(session, *, run: AgentRunRow) -> tuple[s
     return text, getattr(artifact, "id", None)
 
 
+async def _public_terminal_run_answer(
+    session,
+    *,
+    run: AgentRunRow,
+) -> tuple[str | None, int | None]:
+    """Use artifacts for successful runs and typed public messages for failures."""
+    run_status = coerce_run_status(getattr(run, "status", None), default=RunStatus.QUEUED)
+    if run_status == RunStatus.COMPLETED:
+        return await _latest_final_answer_artifact(session, run=run)
+    if run_status not in TERMINAL_RUN_STATUSES:
+        return None, None
+
+    failure = public_run_failure(
+        run_status,
+        await _terminal_run_failure_category(session, run=run),
+    )
+    return (failure["message"], None) if failure else (None, None)
+
+
+async def _terminal_run_failure_category(session, *, run: AgentRunRow) -> Any:
+    metadata = _run_metadata(run)
+    failure_metadata = metadata.get("failure") if isinstance(metadata.get("failure"), dict) else {}
+    category = failure_metadata.get("category")
+    if category or not hasattr(session, "scalars"):
+        return category
+    try:
+        events = (
+            await session.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id == int(run.id),
+                    AgentRunEventRow.event_type == "run.failed",
+                )
+                .order_by(AgentRunEventRow.sequence_no.desc(), AgentRunEventRow.id.desc())
+                .limit(1)
+            )
+        ).all()
+    except Exception:
+        return None
+    if not events:
+        return None
+    payload = dict(getattr(events[0], "payload", None) or {})
+    return payload.get("failure_category") or payload.get("category")
+
+
 async def _latest_unmirrored_final_answer(session, *, run: AgentRunRow, idea: Idea) -> tuple[str | None, int | None]:
-    text, artifact_id = await _latest_final_answer_artifact(session, run=run)
+    text, artifact_id = await _public_terminal_run_answer(session, run=run)
     if not text:
         return None, None
     recent_responses = (
@@ -549,7 +600,7 @@ async def _settle_thread_discussion_conversation_run_async(
         return None
     if await _discussion_reply_already_recorded(session, run=run, thread_id=thread_id):
         return None
-    final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
+    final_answer, artifact_id = await _public_terminal_run_answer(session, run=run)
     if not final_answer:
         return None
 
@@ -708,9 +759,9 @@ async def _settle_slack_origin_run_async(
         if await _slack_visible_action_already_recorded(session, run=run):
             return None
     else:
-        metadata = _run_metadata(run)
-        failure = metadata.get("failure") if isinstance(metadata.get("failure"), dict) else {}
-        category = coerce_failure_category(failure.get("category"))
+        category = coerce_failure_category(
+            await _terminal_run_failure_category(session, run=run)
+        )
         final_answer = safe_terminal_run_message(run_status, category)
         if not final_answer:
             return None
@@ -1379,7 +1430,7 @@ async def _async_materialize_project_context(run_id: int) -> tuple[bool, dict[st
             int(run_id),
             "Project context ready" if result.ok else "Project context unavailable",
             workspaces=result.workspaces,
-            errors=result.errors[:3],
+            issue_count=len(result.errors or []),
         )
     if not result.ok:
         details = "; ".join(result.errors[:3]) or "No project workspace was materialized."
@@ -1414,17 +1465,41 @@ async def _mark_run_failed_after_runner_error_async(
         store = AsyncAgentRunStore(uow.session)
         row = await store.require_run(int(run_id))
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
+            category = failure_category_for_error(error)
+            failure = public_run_failure(RunStatus.FAILED, category)
+            await store.update_metadata(
+                int(run_id),
+                {"failure": {"category": category.value}},
+            )
             if final_answer:
-                await store.append_final_answer_once(int(run_id), final_answer, root_run_id=row.root_run_id)
+                # ``final_answer`` is an intent signal from runner setup code. It
+                # can contain materializer diagnostics, so only persist the
+                # canonical public failure message.
+                safe_final_answer = str((failure or {}).get("message") or "")
+                await store.append_final_answer_once(
+                    int(run_id),
+                    safe_final_answer,
+                    root_run_id=row.root_run_id,
+                )
                 await store.append_event(
                     run_event(
                         int(run_id),
                         "run.text_completed",
-                        {"text": final_answer},
+                        {"text": safe_final_answer},
                         root_run_id=row.root_run_id,
                     )
                 )
-            await store.append_event(run_event(int(run_id), "run.failed", {"error": error}, root_run_id=row.root_run_id))
+            await store.append_event(
+                run_event(
+                    int(run_id),
+                    "run.failed",
+                    {
+                        "error": error,
+                        "failure_category": category.value,
+                    },
+                    root_run_id=row.root_run_id,
+                )
+            )
             await store.set_status(int(run_id), RunStatus.FAILED, reason=error[:500])
         return await _settle_terminal_root_run_async(uow.session, int(run_id))
 

--- a/brain/systems/runs/event_log.py
+++ b/brain/systems/runs/event_log.py
@@ -94,7 +94,14 @@ def _run_event_replay_stmt(
     limit: int,
 ):
     stmt = (
-        select(AgentRunEventRow, AgentRunRow.thread_id, AgentRunRow.profile, AgentRunRow.org_id)
+        select(
+            AgentRunEventRow,
+            AgentRunRow.thread_id,
+            AgentRunRow.profile,
+            AgentRunRow.org_id,
+            AgentRunRow.status,
+            AgentRunRow.metadata_,
+        )
         .join(AgentRunRow, AgentRunRow.id == AgentRunEventRow.run_id)
         .where(AgentRunEventRow.id > int(last_event_id))
         .order_by(AgentRunEventRow.id.asc())
@@ -111,10 +118,12 @@ def _run_event_replay_stmt(
 
 def _project_replay_rows(rows) -> list[AgentRunEventRow]:
     events = []
-    for event, thread_id, profile, row_org_id in rows:
+    for event, thread_id, profile, row_org_id, status, metadata in rows:
         setattr(event, "_agent_run_thread_id", thread_id)
         setattr(event, "_agent_run_profile", profile)
         setattr(event, "_agent_run_org_id", row_org_id)
+        setattr(event, "_agent_run_status", status)
+        setattr(event, "_agent_run_metadata", metadata)
         events.append(event)
     return events
 

--- a/brain/systems/runs/failures.py
+++ b/brain/systems/runs/failures.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TypedDict
 
 from brain.platform.integrations.provider_error_sentinel import provider_error_kind
 from brain.platform.integrations.providers import is_transient_transport_disconnect
+from brain.contracts.statuses import project_run_status_value
 from brain.systems.runs.status import RunStatus, coerce_run_status
 
 
@@ -13,6 +15,12 @@ class RunFailureCategory(str, Enum):
     INTERNAL = "internal"
     UPSTREAM = "upstream"
     VERIFICATION = "verification"
+
+
+class PublicRunFailure(TypedDict):
+    status: str
+    category: str
+    message: str
 
 
 DEFAULT_FAILED_RUN_MESSAGE = "I hit a temporary problem while working on that — please retry."
@@ -42,7 +50,12 @@ def safe_terminal_run_message(
     status: RunStatus | str | None,
     category: RunFailureCategory | str | None = None,
 ) -> str | None:
-    run_status = coerce_run_status(status, default=RunStatus.FAILED)
+    normalized_status = (
+        status
+        if isinstance(status, RunStatus)
+        else project_run_status_value(status, RunStatus.FAILED.value)
+    )
+    run_status = coerce_run_status(normalized_status, default=RunStatus.FAILED)
     if run_status == RunStatus.COMPLETED:
         return None
     if run_status == RunStatus.CANCELED:
@@ -58,14 +71,38 @@ def safe_terminal_run_message(
     return DEFAULT_FAILED_RUN_MESSAGE
 
 
+def public_run_failure(
+    status: RunStatus | str | None,
+    category: RunFailureCategory | str | None = None,
+) -> PublicRunFailure | None:
+    """Return the canonical public representation of a terminal run failure."""
+
+    normalized_status = (
+        status
+        if isinstance(status, RunStatus)
+        else project_run_status_value(status, RunStatus.FAILED.value)
+    )
+    run_status = coerce_run_status(normalized_status, default=RunStatus.FAILED)
+    message = safe_terminal_run_message(run_status, category)
+    if message is None:
+        return None
+    return {
+        "status": run_status.value,
+        "category": coerce_failure_category(category).value,
+        "message": message,
+    }
+
+
 __all__ = [
     "CANCELED_RUN_MESSAGE",
     "DEFAULT_FAILED_RUN_MESSAGE",
     "EXPIRED_RUN_MESSAGE",
+    "PublicRunFailure",
     "RunFailureCategory",
     "UPSTREAM_FAILED_RUN_MESSAGE",
     "VERIFICATION_FAILED_RUN_MESSAGE",
     "coerce_failure_category",
     "failure_category_for_error",
+    "public_run_failure",
     "safe_terminal_run_message",
 ]

--- a/brain/systems/runs/presentation.py
+++ b/brain/systems/runs/presentation.py
@@ -1,8 +1,8 @@
 """Public presentation helpers for AgentRun work events.
 
 These helpers intentionally produce a small, user-facing projection from
-durable run events. They are used for live UI and API snapshots; trace exports
-continue to read the raw durable event rows for debugging.
+durable run events. They are used for live UI, API snapshots, and safe trace
+exports; raw durable diagnostics remain backend-only.
 """
 
 from __future__ import annotations
@@ -11,6 +11,9 @@ import json
 import re
 from typing import Any
 from urllib.parse import urlparse
+
+from brain.systems.runs.actions import result_failure_summary
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
 
 
 SENSITIVE_ARG_PARTS = {
@@ -68,7 +71,21 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
     raw = dict(payload or {})
     tool_name = _text(raw.get("tool_name") or raw.get("tool") or "tool") or "tool"
     args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
+    failure_summary = (
+        _text(raw.get("error"))
+        if event_type == "run.tool_failed" and raw.get("error") is not None
+        else result_failure_summary(raw.get("result"))
+        if event_type in {"run.tool_completed", "run.tool_failed"}
+        else None
+    )
+    failure = (
+        public_run_failure("failed", failure_category_for_error(failure_summary))
+        if failure_summary
+        else None
+    )
     status = _status_for_event(event_type, raw.get("status"))
+    if failure is not None:
+        status = "failed"
     display = public_tool_display(tool_name, args, status=status)
 
     public = {
@@ -86,6 +103,11 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
     public["tool_display"] = display
     public["display"] = display
     public["display_label"] = display["label"]
+
+    if failure is not None:
+        public["failure"] = failure
+        public["error"] = failure["message"]
+        return public
 
     if raw.get("error") is not None:
         public["error"] = _redact_text(_text(raw.get("error")) or "")[:500]

--- a/brain/systems/runs/recipes/deep.py
+++ b/brain/systems/runs/recipes/deep.py
@@ -17,6 +17,11 @@ from brain.systems.runs.assignments import AcceptanceCriteria, EvidenceRequireme
 from brain.systems.runs.domain import AgentRun, AgentRunArtifact, ArtifactType, RunProfile, RunRecipe
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failures import (
+    RunFailureCategory,
+    failure_category_for_error,
+    public_run_failure,
+)
 from brain.systems.runs.graph import DeepPlan, RunEdge, RunNode
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
 from brain.systems.runs.recipes.base import BaseRunRecipe
@@ -94,19 +99,41 @@ class DeepRecipe(BaseRunRecipe):
             verification = self._verification_result(verify_payload)
             verify_status = str((verify_payload or {}).get("status") or "")
             if verification is None and verify_status != RunStatus.COMPLETED.value:
-                output = f"Deep verification failed: verify node ended with status {verify_status or 'missing'}"
-                await runtime.text_delta(output)
-                return RunRecipeResult(output=output, status=RunStatus.FAILED)
+                error = f"Deep verification failed: verify node ended with status {verify_status or 'missing'}"
+                failure = public_run_failure(RunStatus.FAILED, RunFailureCategory.VERIFICATION)
+                final_output = str((failure or {}).get("message") or "")
+                await runtime.text_delta(final_output)
+                return RunRecipeResult(
+                    status=RunStatus.FAILED,
+                    error=error,
+                    final_output=final_output,
+                    failure_category=RunFailureCategory.VERIFICATION,
+                )
             if verification is not None and not verification.passed:
-                output = f"Deep verification failed: {verification.warning or 'gate did not pass'}"
-                await runtime.text_delta(output)
-                return RunRecipeResult(output=output, status=RunStatus.FAILED)
+                error = f"Deep verification failed: {verification.warning or 'gate did not pass'}"
+                failure = public_run_failure(RunStatus.FAILED, RunFailureCategory.VERIFICATION)
+                final_output = str((failure or {}).get("message") or "")
+                await runtime.text_delta(final_output)
+                return RunRecipeResult(
+                    status=RunStatus.FAILED,
+                    error=error,
+                    final_output=final_output,
+                    failure_category=RunFailureCategory.VERIFICATION,
+                )
             output = str((node_results.get("synthesize") or {}).get("output") or "").strip()
             if not output:
                 output = self._synthesize_output(node_results)
         except Exception as exc:
             logger.exception("deep_recipe_failed", extra={"run_id": runtime.run.id})
-            return RunRecipeResult(output=f"Deep run failed: {exc}", status=RunStatus.FAILED)
+            error = f"Deep run failed: {exc}"
+            failure_category = failure_category_for_error(exc)
+            failure = public_run_failure(RunStatus.FAILED, failure_category)
+            return RunRecipeResult(
+                status=RunStatus.FAILED,
+                error=error,
+                final_output=str((failure or {}).get("message") or ""),
+                failure_category=failure_category,
+            )
         await runtime.text_delta(output)
         return RunRecipeResult(output=output, status=RunStatus.COMPLETED)
 
@@ -458,8 +485,17 @@ class DeepRecipe(BaseRunRecipe):
         )
         completed = await self._run_existing_child(runtime, child)
         artifacts = await _child_artifacts(runtime.store, child.id)
-        output = _child_output(artifacts)
         status = _status_value(getattr(completed, "status", RunStatus.FAILED))
+        raw_output = _child_output(artifacts)
+        failure = None
+        if status == RunStatus.COMPLETED.value:
+            output = raw_output
+            evidence_artifacts = artifacts
+        else:
+            category = _worker_failure_category(completed, artifacts, raw_output)
+            failure = public_run_failure(status, category)
+            output = str((failure or {}).get("message") or "")
+            evidence_artifacts = _redacted_failed_worker_artifacts(artifacts, failure)
         event_type = "run.worker_completed" if status == RunStatus.COMPLETED.value else "run.worker_failed"
         await runtime.store.append_event(
             run_event(
@@ -477,14 +513,18 @@ class DeepRecipe(BaseRunRecipe):
                 producer="deep",
             )
         )
-        return worker_evidence_from_artifacts(
+        evidence = worker_evidence_from_artifacts(
             run_id=child.id,
             assignment=assignment,
             status=status,
-            artifacts=artifacts,
+            artifacts=evidence_artifacts,
             output=output,
             node_id=node.id,
         )
+        if failure:
+            evidence["failure"] = failure
+            evidence["failure_category"] = failure["category"]
+        return evidence
 
     async def _run_verification_node(
         self,
@@ -796,6 +836,44 @@ def _child_output(artifacts: list[Any]) -> str:
     return latest_final or latest_worker
 
 
+def _worker_failure_category(completed: Any, artifacts: list[Any], raw_output: str) -> Any:
+    for metadata in (
+        getattr(completed, "metadata", None),
+        getattr(completed, "metadata_", None),
+    ):
+        if not isinstance(metadata, Mapping):
+            continue
+        failure = metadata.get("failure")
+        if isinstance(failure, Mapping) and failure.get("category"):
+            return failure.get("category")
+    for artifact in artifact_payloads(artifacts):
+        payload = artifact.get("payload")
+        failure = payload.get("failure") if isinstance(payload, Mapping) else None
+        if isinstance(failure, Mapping) and failure.get("category"):
+            return failure.get("category")
+    return failure_category_for_error(raw_output)
+
+
+def _redacted_failed_worker_artifacts(
+    artifacts: list[Any],
+    failure: dict[str, str] | None,
+) -> list[dict[str, Any]]:
+    """Keep evidence shape while excluding failed-worker diagnostic content."""
+
+    return [
+        {
+            "id": artifact.get("id"),
+            "artifact_type": artifact.get("artifact_type"),
+            "title": None,
+            "payload": {"failure": dict(failure)} if failure else {},
+            "has_text": False,
+            "text": "",
+            "uri": None,
+        }
+        for artifact in artifact_payloads(artifacts)
+    ]
+
+
 async def _coordinator_model_and_thinking(runtime: RunRuntime) -> tuple[str, str]:
     model_policy = dict(runtime.request.model_policy or {})
     model = model_policy.get("coordinator_model") or model_policy.get("model")
@@ -836,18 +914,26 @@ def _worker_synthesis_rows(node_results: dict[str, dict[str, Any]]) -> list[dict
         if not result.get("assignment"):
             continue
         assignment = _assignment_from_worker_result(result)
-        rows.append(
-            {
-                "node_id": result.get("node_id"),
-                "run_id": result.get("run_id") or result.get("child_run_id"),
-                "role": assignment.role,
-                "status": result.get("status"),
-                "objective": assignment.objective,
-                "output": _truncate(str(result.get("output") or ""), limit=4000),
-                "warning": result.get("warning"),
-                "evidence": _synthesis_artifact_summaries(result.get("artifacts")),
-            }
-        )
+        status = _status_value(result.get("status"))
+        row = {
+            "node_id": result.get("node_id"),
+            "run_id": result.get("run_id") or result.get("child_run_id"),
+            "role": assignment.role,
+            "status": result.get("status"),
+            "objective": assignment.objective,
+            "output": _truncate(str(result.get("output") or ""), limit=4000),
+            "warning": result.get("warning"),
+            "evidence": _synthesis_artifact_summaries(result.get("artifacts")),
+        }
+        if status != RunStatus.COMPLETED.value:
+            failure = _public_worker_failure(result, status=status)
+            row["output"] = failure["message"]
+            row["failure"] = failure
+            row["evidence"] = _synthesis_artifact_summaries(
+                result.get("artifacts"),
+                include_content=False,
+            )
+        rows.append(row)
     return rows
 
 
@@ -858,18 +944,39 @@ def _assignment_from_worker_result(result: Mapping[str, Any]) -> WorkerAssignmen
     )
 
 
-def _synthesis_artifact_summaries(value: Any) -> list[dict[str, Any]]:
+def _public_worker_failure(result: Mapping[str, Any], *, status: str) -> dict[str, str]:
+    existing = result.get("failure")
+    category = existing.get("category") if isinstance(existing, Mapping) else result.get("failure_category")
+    if not category:
+        category = failure_category_for_error(result.get("error") or result.get("output"))
+    failure = public_run_failure(status, category)
+    return failure or {
+        "status": RunStatus.FAILED.value,
+        "category": "internal",
+        "message": "",
+    }
+
+
+def _synthesis_artifact_summaries(
+    value: Any,
+    *,
+    include_content: bool = True,
+) -> list[dict[str, Any]]:
     summaries: list[dict[str, Any]] = []
     for artifact in artifact_payloads(value)[:8]:
         payload = artifact.get("payload") if isinstance(artifact.get("payload"), Mapping) else {}
         summaries.append(
             {
                 "artifact_type": artifact.get("artifact_type"),
-                "title": artifact.get("title"),
-                "has_text": bool(artifact.get("has_text")),
-                "text": _truncate(str(artifact.get("text") or ""), limit=1600),
-                "payload": _truncate(json.dumps(payload, sort_keys=True, default=str), limit=1600) if payload else "",
-                "uri": artifact.get("uri"),
+                "title": artifact.get("title") if include_content else None,
+                "has_text": bool(artifact.get("has_text")) if include_content else False,
+                "text": _truncate(str(artifact.get("text") or ""), limit=1600) if include_content else "",
+                "payload": (
+                    _truncate(json.dumps(payload, sort_keys=True, default=str), limit=1600)
+                    if include_content and payload
+                    else ""
+                ),
+                "uri": artifact.get("uri") if include_content else None,
             }
         )
     return summaries

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -148,12 +148,15 @@ class FastRecipe(BaseRunRecipe):
             user_id=runtime.request.user_id,
             org_id=runtime.request.org_id,
         )
+        pending_deltas: list[str] = []
 
         async def _activity(label: str) -> None:
             await runtime.activity(label)
 
         async def _delta(delta: str) -> None:
-            await runtime.text_delta(delta)
+            # A direct provider can emit partial text before returning a failed
+            # result. Publish only after the terminal result is known-good.
+            pending_deltas.append(str(delta))
 
         async def _guidance() -> list[str]:
             return await runtime.drain_steering()
@@ -253,6 +256,8 @@ class FastRecipe(BaseRunRecipe):
             )
         if status == RunStatus.CANCELED:
             return RunRecipeResult(error=str(result_error or "user_canceled"), status=status)
+        for delta in pending_deltas:
+            await runtime.text_delta(delta)
         return RunRecipeResult(
             output=output,
             status=status,

--- a/brain/systems/runs/recipes/phase_barrier.py
+++ b/brain/systems/runs/recipes/phase_barrier.py
@@ -195,7 +195,9 @@ async def review_completed_phase(
         decision = PhaseBarrierDecision.from_payload(parsed or {}, raw_output=raw_output)
     except Exception as exc:
         logger.warning("deep_phase_barrier_review_failed run_id=%s node_id=%s error=%s", runtime.run.id, node.id, exc)
-        decision = PhaseBarrierDecision.no_change(f"Phase review failed open: {exc}")
+        decision = PhaseBarrierDecision.no_change(
+            "Phase review was unavailable; continuing without changes."
+        )
     await runtime.store.append_event(
         run_event(
             runtime.run.id,

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -10,6 +10,7 @@ from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.context import compact_project_reference
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
 from brain.systems.runs.engine import RunRecipeResult, RunRuntime
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
 from brain.systems.runs.recipes.base import BaseRunRecipe
 from brain.systems.runs.recipes.shared import (
     default_run_model,
@@ -98,15 +99,15 @@ class WorkerRecipe(BaseRunRecipe):
             user_id=runtime.request.user_id,
             org_id=runtime.request.org_id,
         )
-        streamed_output = False
+        pending_deltas: list[str] = []
 
         async def _activity(label: str) -> None:
             await runtime.activity(label)
 
         async def _record_delta(delta: str) -> None:
-            nonlocal streamed_output
-            streamed_output = True
-            await runtime.text_delta(delta)
+            # A provider can stream partial diagnostic text before returning a
+            # failed result. Hold deltas until success is known.
+            pending_deltas.append(str(delta))
 
         _delta = _record_delta
 
@@ -164,28 +165,47 @@ class WorkerRecipe(BaseRunRecipe):
             result = await invoke_direct_agent_async(spec)
         except Exception as exc:
             logger.exception("worker_recipe_failed", extra={"run_id": runtime.run.id})
-            output = f"Worker failed: {exc}"
+            error = str(exc)
             status = RunStatus.FAILED
+            failure_category = failure_category_for_error(exc)
+            failure = public_run_failure(status, failure_category)
+            output = ""
             post_completion_tasks = ()
         else:
             output = str(getattr(result, "output", "") or "").strip()
             status = RunStatus.COMPLETED if getattr(result, "success", False) else RunStatus.FAILED
-            if getattr(result, "error", None) and not output:
-                output = str(result.error)
+            error = None
+            failure_category = None
+            failure = None
+            if status == RunStatus.FAILED:
+                error = str(getattr(result, "error", None) or output or "worker_recipe_failed")
+                failure_category = failure_category_for_error(error)
+                failure = public_run_failure(status, failure_category)
+                output = ""
             post_completion_tasks = tuple(getattr(result, "post_completion_tasks", ()) or ())
-        if output and not streamed_output:
-            await runtime.text_delta(output)
+        streamed_output = False
+        if status == RunStatus.COMPLETED:
+            for delta in pending_deltas:
+                await runtime.text_delta(delta)
+            streamed_output = bool(pending_deltas)
+        public_output = output if status == RunStatus.COMPLETED else str((failure or {}).get("message") or "")
+        if public_output and not streamed_output:
+            await runtime.text_delta(public_output)
         worker_result = worker_result_artifact(
             runtime.run.id,
             assignment=assignment,
-            output=output,
+            output=public_output,
             status=status,
             tool_records=tool_records,
             root_run_id=runtime.run.root_run_id,
+            failure=failure,
         )
         return RunRecipeResult(
             output=output,
             status=status,
+            error=error,
+            final_output=public_output if status == RunStatus.FAILED else None,
+            failure_category=failure_category,
             artifacts=(worker_result,),
             post_completion_tasks=post_completion_tasks,
         )
@@ -255,6 +275,7 @@ def worker_result_artifact(
     status: RunStatus,
     tool_records: list[ToolRecord],
     root_run_id: int | None,
+    failure: dict[str, str] | None = None,
 ) -> AgentRunArtifact:
     payload = {
         "status": status.value,
@@ -267,6 +288,8 @@ def worker_result_artifact(
             "artifact_types": sorted({record.artifact_type.value for record in tool_records}),
         },
     }
+    if failure:
+        payload["failure"] = dict(failure)
     return AgentRunArtifact(
         run_id=run_id,
         root_run_id=root_run_id,

--- a/brain/systems/runs/tool_catalog/handlers/chat.py
+++ b/brain/systems/runs/tool_catalog/handlers/chat.py
@@ -436,6 +436,11 @@ async def _handle_read_thread_discussion(
     from brain.platform.db.models.idea import ThreadDiscussionComment
     from brain.platform.db.models.org import User
     from brain.platform.db.repositories.unit_of_work import UnitOfWork
+    from brain.systems.runs.cortex.read_models import (
+        public_failures_for_run_ids,
+        public_run_linked_message,
+        run_id_from_public_message_metadata,
+    )
 
     target_thread_id = str(thread_id or _current_thread_id() or "").strip()
     if not target_thread_id:
@@ -455,10 +460,38 @@ async def _handle_read_thread_discussion(
             .limit(capped_limit)
         )
         rows = list((await uow.session.execute(stmt)).all())
+        run_ids = {
+            run_id
+            for run_id in (
+                (
+                    run_id_from_public_message_metadata(row[0].metadata_)
+                    if str(row[0].author_kind or "").lower() == "illo"
+                    else None
+                )
+                for row in rows
+            )
+            if run_id is not None
+        }
+        failures = await public_failures_for_run_ids(
+            uow.session,
+            run_ids,
+            thread_id=f"{THREAD_DISCUSSION_CONVERSATION_PREFIX}{target_thread_id}",
+            org_id=org_id,
+        )
 
     comments = []
     for row in reversed(rows):
         comment = row[0]
+        run_id = (
+            run_id_from_public_message_metadata(comment.metadata_)
+            if str(comment.author_kind or "").lower() == "illo"
+            else None
+        )
+        body, metadata = public_run_linked_message(
+            comment.body,
+            comment.metadata_,
+            failures.get(run_id),
+        )
         comments.append(
             {
                 "id": comment.id,
@@ -467,9 +500,9 @@ async def _handle_read_thread_discussion(
                 "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
                 "author_name": row.author_name,
                 "author_color": row.author_color,
-                "body": comment.body,
+                "body": body,
                 "attachments": comment.attachments or [],
-                "metadata": comment.metadata_ or {},
+                "metadata": metadata,
                 "created_at": comment.created_at.isoformat() if comment.created_at else None,
             }
         )

--- a/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
+++ b/brain/systems/runs/tool_catalog/handlers/cortex_reply.py
@@ -7,6 +7,13 @@ import json
 
 from brain.systems.runs.tool_catalog.handlers.common import *
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context
+from brain.systems.runs.failures import failure_category_for_error, public_run_failure
+
+
+def _safe_failure_message(diagnostic: object) -> str:
+    category = failure_category_for_error(diagnostic)
+    failure = public_run_failure("failed", category)
+    return str((failure or {}).get("message") or "")
 
 
 def _normalize_reply_whitespace(content: str) -> str:
@@ -53,14 +60,18 @@ def _build_final_reply_check_context() -> str:
                 "artifacts": len(evidence.get("artifacts") or []),
                 "uncertainty": len(unresolved),
             }
-            summary = (worker_result.output or worker_result.error or "").strip().replace("\n", " ")
+            if worker_result.success:
+                summary = str(worker_result.output or "").strip().replace("\n", " ")
+            else:
+                diagnostic = getattr(worker_result, "error", None) or getattr(worker_result, "output", None)
+                summary = _safe_failure_message(diagnostic)
             lines.append(
                 f"Worker {idx} [{worker_result.skill_name or 'unknown'} / {status}]: "
                 f"trust={worker_result.trust_status or 'unknown'}; "
                 f"evidence_counts={evidence_counts}; "
                 f"summary={summary[:350] or '(no output)'}"
             )
-            if unresolved:
+            if unresolved and worker_result.success:
                 lines.append(f"Worker {idx} unresolved: {str(unresolved[:3])[:350]}")
 
     intent_profile = getattr(_agent_context, "intent_satisfaction", None)
@@ -83,11 +94,18 @@ def _build_final_reply_check_context() -> str:
             lines.append(f"Intent satisfaction profile: {str(intent_profile)[:900]}")
 
     for idx, artifact in enumerate(execution_artifacts[-3:], 1):
+        if not isinstance(artifact, dict):
+            lines.append(f"Artifact {idx}: {str(artifact)[:350]}")
+            continue
+        artifact_status = str(artifact.get("status") or "").strip().lower()
+        artifact_summary = artifact.get("summary")
+        if artifact_status in {"error", "failed", "failure"}:
+            artifact_summary = _safe_failure_message(artifact_summary)
         try:
             compact = json.dumps(
                 {
                     "kind": artifact.get("kind"),
-                    "summary": artifact.get("summary"),
+                    "summary": artifact_summary,
                     "path": artifact.get("path"),
                     "status": artifact.get("status"),
                 },
@@ -101,13 +119,16 @@ def _build_final_reply_check_context() -> str:
     for idx, tool_result in enumerate(recent_tool_results[-5:], 1):
         if not isinstance(tool_result, dict):
             continue
+        result_preview = tool_result.get("result_preview")
+        if tool_result.get("is_error"):
+            result_preview = _safe_failure_message(result_preview)
         try:
             compact = json.dumps(
                 {
                     "tool_name": tool_result.get("tool_name"),
                     "args_preview": tool_result.get("args_preview"),
                     "is_error": tool_result.get("is_error"),
-                    "result_preview": tool_result.get("result_preview"),
+                    "result_preview": result_preview,
                 },
                 default=str,
                 sort_keys=True,

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -349,13 +349,15 @@ def _add_error(payload: dict[str, Any], source: str, exc: Exception) -> None:
 async def _latest_run_final_answers(session: Any, run_ids: list[int]) -> dict[int, str]:
     if not run_ids:
         return {}
-    from brain.platform.db.models.agent_run import AgentRunArtifactRow
+    from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
 
     stmt = (
         select(AgentRunArtifactRow.run_id, AgentRunArtifactRow.text)
+        .join(AgentRunRow, AgentRunRow.id == AgentRunArtifactRow.run_id)
         .where(
             AgentRunArtifactRow.run_id.in_(run_ids),
             AgentRunArtifactRow.artifact_type == "final_answer",
+            AgentRunRow.status == "completed",
         )
         .order_by(
             AgentRunArtifactRow.run_id.asc(),
@@ -456,6 +458,7 @@ async def _query_runs(
     limit: int,
 ) -> None:
     from brain.systems.runs.cortex.read_models import project_run_status
+    from brain.systems.runs.failures import public_run_failure
     from brain.platform.db.models.run import AgentRun
     from brain.platform.db.models.idea import Idea
     from brain.platform.db.models.org import User
@@ -494,6 +497,16 @@ async def _query_runs(
         session,
         [int(run.id) for run, _idea, _user in rows],
     )
+    run_failures = {}
+    for run, _idea, _user in rows:
+        status = project_run_status(run.status)
+        if status not in {"failed", "canceled", "expired"}:
+            continue
+        metadata = run.metadata_ if isinstance(run.metadata_, dict) else {}
+        stored_failure = metadata.get("failure") if isinstance(metadata.get("failure"), dict) else {}
+        failure = public_run_failure(status, stored_failure.get("category"))
+        if failure is not None:
+            run_failures[int(run.id)] = failure
     payload["sources"]["runs"] = [
         {
             "id": int(run.id),
@@ -517,14 +530,23 @@ async def _query_runs(
             if isinstance(run.metadata_, dict)
             else (run.model_policy or {}).get("model"),
             "message": _snippet(run.input_message),
-            "last_activity": _snippet(run.context_summary, 240),
-            "output": final_answers.get(int(run.id))
-            or _snippet(
-                ((run.metadata_ or {}).get("final_summary"))
-                if isinstance(run.metadata_, dict)
-                else None,
-                520,
+            "last_activity": (
+                run_failures[int(run.id)]["message"]
+                if int(run.id) in run_failures
+                else _snippet(run.context_summary, 240)
             ),
+            "output": (
+                run_failures[int(run.id)]["message"]
+                if int(run.id) in run_failures
+                else final_answers.get(int(run.id))
+                or _snippet(
+                    ((run.metadata_ or {}).get("final_summary"))
+                    if isinstance(run.metadata_, dict)
+                    else None,
+                    520,
+                )
+            ),
+            **({"failure": run_failures[int(run.id)]} if int(run.id) in run_failures else {}),
             "tool_summary": {
                 "workers_used": ((run.metadata_ or {}).get("usage") or {}).get("workers_used")
                 if isinstance(run.metadata_, dict)
@@ -557,6 +579,11 @@ async def _query_threads(
 ) -> None:
     from brain.platform.db.models.idea import Idea, IdeaThread
     from brain.platform.db.models.org import User
+    from brain.systems.runs.cortex.read_models import (
+        public_failures_for_run_ids,
+        public_run_linked_message,
+        run_id_from_public_message_metadata,
+    )
 
     stmt = (
         select(IdeaThread, Idea, User)
@@ -576,9 +603,37 @@ async def _query_threads(
         stmt = stmt.where(text_match)
 
     rows = await _session_execute_all(session, stmt)
+    run_ids = {
+        run_id
+        for run_id in (
+            (
+                run_id_from_public_message_metadata(thread.metadata_)
+                if str(thread.role or "").lower() in {"illo", "assistant"}
+                else None
+            )
+            for thread, _idea, _user in rows
+        )
+        if run_id is not None
+    }
+    failures = await public_failures_for_run_ids(
+        session,
+        run_ids,
+        thread_id=idea_id,
+        org_id=org_id,
+    )
     thread_rows: list[dict[str, Any]] = []
     for thread, idea, user in rows:
         links = thread_link_payload(thread.idea_id) if thread.idea_id is not None else {}
+        run_id = (
+            run_id_from_public_message_metadata(thread.metadata_)
+            if str(thread.role or "").lower() in {"illo", "assistant"}
+            else None
+        )
+        content, _metadata = public_run_linked_message(
+            thread.content,
+            thread.metadata_,
+            failures.get(run_id),
+        )
         thread_rows.append({
             "id": int(thread.id),
             "type": "thread_message",
@@ -592,7 +647,7 @@ async def _query_threads(
             "message_type": thread.message_type,
             "user_id": str(thread.user_id) if thread.user_id is not None else None,
             "user_name": user.name if user else None,
-            "content": _snippet(thread.content, 520),
+            "content": _snippet(content, 520),
             "provenance": {"table": "idea_threads", "id": int(thread.id)},
         })
     payload["sources"]["threads"] = thread_rows
@@ -670,12 +725,13 @@ async def _query_tool_calls(
     from brain.platform.db.models.agent_run import AgentRunEventRow
     from brain.platform.db.models.run import AgentRun
     from brain.platform.db.models.idea import Idea
+    from brain.systems.runs.presentation import public_tool_event_payload
 
     stmt = (
         select(AgentRunEventRow, AgentRun, Idea)
         .join(AgentRun, AgentRun.id == AgentRunEventRow.run_id)
         .outerjoin(Idea, _uuid_text_equals(Idea.id, AgentRun.thread_id))
-        .where(AgentRunEventRow.event_type == "run.tool_completed")
+        .where(AgentRunEventRow.event_type.in_(("run.tool_completed", "run.tool_failed")))
         .order_by(AgentRunEventRow.created_at.desc().nullslast(), AgentRunEventRow.id.desc())
         .limit(limit)
     )
@@ -695,8 +751,11 @@ async def _query_tool_calls(
         stmt = stmt.where(text_match)
 
     rows = await _session_execute_all(session, stmt)
-    payload["sources"]["tool_calls"] = [
-        {
+    tool_calls = []
+    for event, run, idea in rows:
+        public_event = public_tool_event_payload(event.payload, event.event_type)
+        failure = public_event.get("failure") if isinstance(public_event.get("failure"), dict) else None
+        tool_calls.append({
             "id": int(event.id),
             "type": "tool_call",
             "called_at": _serialize_dt(event.created_at),
@@ -705,14 +764,17 @@ async def _query_tool_calls(
             **_thread_link_fields(idea, run.thread_id),
             "idea_title": _idea_title(idea),
             "run_status": run.status if run else None,
-            "tool_name": (event.payload or {}).get("tool_name"),
-            "source": (event.payload or {}).get("source"),
-            "args": _snippet((event.payload or {}).get("args"), 420),
-            "result": _snippet((event.payload or {}).get("result"), 420),
+            "tool_name": public_event.get("tool_name"),
+            "source": public_event.get("source"),
+            "args": _snippet(public_event.get("args"), 420),
+            "result": _snippet(
+                failure.get("message") if failure else public_event.get("result") or public_event.get("result_preview"),
+                420,
+            ),
+            **({"failure": failure} if failure else {}),
             "provenance": {"table": "agent_run_events", "id": int(event.id)},
-        }
-        for event, run, idea in rows
-    ]
+        })
+    payload["sources"]["tool_calls"] = tool_calls
 
 
 async def _query_project_profiles(

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -344,6 +344,34 @@ class AsyncRunToolExecutor:
                 root_run_id=root_run_id,
                 collector=collector,
             )
+        if failure:
+            await self._append_event(
+                run_event(
+                    run_id,
+                    "run.tool_failed",
+                    _event_payload(tool.name, safe_args, error=failure),
+                    root_run_id=root_run_id,
+                )
+            )
+            record = ToolRecord(
+                tool_name=tool.name,
+                args=safe_args,
+                status="failed",
+                artifact_type=artifact_type,
+                side_effect=side_effect,
+                error=failure[:1000],
+            )
+            if collector is not None:
+                collector.append(record)
+            await self._append_artifact(
+                run_id,
+                root_run_id=root_run_id,
+                artifact_type=artifact_type,
+                title=f"{tool.name} failed",
+                payload=record.to_payload(),
+                text=failure[:4000],
+            )
+            return result
         safe_result = redact_tool_result(tool.name, result)
         await self._append_event(
             run_event(

--- a/brain/systems/runs/ui_events.py
+++ b/brain/systems/runs/ui_events.py
@@ -34,6 +34,21 @@ _INTERNAL_TO_UI_TYPE = {
 }
 
 
+def public_run_event_payload(payload: Any, source_type: str) -> dict[str, Any]:
+    """Project one durable event payload into its safe public representation."""
+
+    projected = dict(payload or {})
+    if source_type in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
+        projected = public_tool_event_payload(projected, source_type)
+    if source_type == "run.failed":
+        category = coerce_failure_category(
+            projected.get("failure_category") or projected.get("category")
+        )
+        projected["failure_category"] = category.value
+        projected["error"] = safe_terminal_run_message("failed", category)
+    return projected
+
+
 def run_event_to_ui_message(
     event: Any,
     *,
@@ -51,9 +66,7 @@ def run_event_to_ui_message(
     if ui_type is None:
         return None
 
-    payload = dict(getattr(event, "payload", None) or {})
-    if source_type in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
-        payload = public_tool_event_payload(payload, source_type)
+    payload = public_run_event_payload(getattr(event, "payload", None), source_type)
     event_id = int(getattr(event, "id", 0) or payload.get("event_id") or 0)
     run_id = int(getattr(event, "run_id", 0) or payload.get("run_id") or 0)
     root_run_id = int(getattr(event, "root_run_id", None) or payload.get("root_run_id") or run_id)
@@ -115,11 +128,6 @@ def _normalize_ui_payload(ui_type: str, source_type: str, message: dict[str, Any
     elif ui_type == "run_completed":
         if source_type == "run.failed":
             message["status"] = "failed"
-            category = coerce_failure_category(
-                message.get("failure_category") or message.get("category")
-            )
-            message["failure_category"] = category.value
-            message["error"] = safe_terminal_run_message("failed", category)
         elif source_type == "run.canceled":
             message["status"] = "canceled"
         else:
@@ -133,4 +141,8 @@ def _text(value: Any) -> str | None:
     return text or None
 
 
-__all__ = ["STABLE_RUN_EVENT_TYPES", "run_event_to_ui_message"]
+__all__ = [
+    "STABLE_RUN_EVENT_TYPES",
+    "public_run_event_payload",
+    "run_event_to_ui_message",
+]

--- a/brain/systems/runs/ui_events.py
+++ b/brain/systems/runs/ui_events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from brain.systems.runs.failures import coerce_failure_category, safe_terminal_run_message
+from brain.systems.runs.failures import public_run_failure
 from brain.systems.runs.presentation import public_tool_event_payload
 from brain.systems.runs.visibility import run_is_headless
 
@@ -31,21 +31,99 @@ _INTERNAL_TO_UI_TYPE = {
     "run.completed": "run_completed",
     "run.failed": "run_completed",
     "run.canceled": "run_completed",
+    "run.expired": "run_completed",
+    "run.status_changed": "run_completed",
 }
 
+_PUBLIC_FAILURE_STATUSES = frozenset({"failed", "canceled", "cancelled", "expired"})
 
-def public_run_event_payload(payload: Any, source_type: str) -> dict[str, Any]:
+
+def _public_failure_for_event(
+    event: Any,
+    *,
+    run: Any | None,
+    source_type: str,
+    payload: dict[str, Any],
+) -> dict[str, str] | None:
+    event_status = {
+        "run.failed": "failed",
+        "run.tool_failed": "failed",
+        "run.canceled": "canceled",
+        "run.expired": "expired",
+    }.get(source_type)
+    status = str(
+        (payload.get("to_status") if source_type == "run.status_changed" else None)
+        or event_status
+        or getattr(run, "status", None)
+        or getattr(event, "_agent_run_status", None)
+        or ""
+    ).strip().lower()
+    if status == "cancelled":
+        status = "canceled"
+    if status not in _PUBLIC_FAILURE_STATUSES:
+        return None
+    metadata = getattr(run, "metadata_", None) or getattr(event, "_agent_run_metadata", None)
+    metadata = metadata if isinstance(metadata, dict) else {}
+    metadata_failure = metadata.get("failure") if isinstance(metadata.get("failure"), dict) else {}
+    payload_failure = payload.get("failure") if isinstance(payload.get("failure"), dict) else {}
+    category = (
+        metadata_failure.get("category")
+        or payload_failure.get("category")
+        or payload.get("failure_category")
+        or payload.get("category")
+    )
+    return public_run_failure(status, category)
+
+
+def public_run_event_payload(
+    payload: Any,
+    source_type: str,
+    *,
+    failure: dict[str, str] | None = None,
+) -> dict[str, Any]:
     """Project one durable event payload into its safe public representation."""
 
     projected = dict(payload or {})
     if source_type in {"run.tool_started", "run.tool_completed", "run.tool_failed"}:
         projected = public_tool_event_payload(projected, source_type)
-    if source_type == "run.failed":
-        category = coerce_failure_category(
+    if source_type in {"run.failed", "run.canceled", "run.expired"} and failure is None:
+        failure = public_run_failure(
+            {
+                "run.failed": "failed",
+                "run.canceled": "canceled",
+                "run.expired": "expired",
+            }[source_type],
             projected.get("failure_category") or projected.get("category")
         )
-        projected["failure_category"] = category.value
-        projected["error"] = safe_terminal_run_message("failed", category)
+    if failure is not None and source_type == "run.tool_failed":
+        projected.pop("result", None)
+        projected.pop("result_preview", None)
+        projected["failure"] = failure
+        projected["error"] = failure["message"]
+    elif failure is not None and source_type in {"run.text_delta", "run.text_completed"}:
+        for key in ("delta", "error", "final_answer", "message", "text"):
+            projected.pop(key, None)
+        projected["failure"] = failure
+        projected["text"] = failure["message"]
+    elif failure is not None and source_type in {"run.failed", "run.canceled", "run.expired"}:
+        for key in ("error", "final_answer", "message", "reason", "text"):
+            projected.pop(key, None)
+        projected["failure"] = failure
+        projected["failure_category"] = failure["category"]
+        projected["error"] = failure["message"]
+    elif failure is not None and source_type == "run.status_changed":
+        projected = {
+            key: value
+            for key, value in projected.items()
+            if key in {"from_status", "to_status"}
+        }
+        projected["failure"] = failure
+        projected["failure_category"] = failure["category"]
+        projected["error"] = failure["message"]
+    elif failure is not None:
+        for key in ("details", "diagnostic", "error", "errors", "exception", "message", "reason", "result", "text", "traceback"):
+            projected.pop(key, None)
+        projected["failure"] = failure
     return projected
 
 
@@ -66,7 +144,22 @@ def run_event_to_ui_message(
     if ui_type is None:
         return None
 
-    payload = public_run_event_payload(getattr(event, "payload", None), source_type)
+    raw_payload = dict(getattr(event, "payload", None) or {})
+    failure = _public_failure_for_event(
+        event,
+        run=run,
+        source_type=source_type,
+        payload=raw_payload,
+    )
+    if failure is not None and source_type == "run.text_delta":
+        # Historical partial deltas may contain the diagnostic that ultimately
+        # failed the run. The terminal event carries the single safe message.
+        return None
+    if source_type == "run.status_changed" and (
+        failure is None or failure.get("status") != "expired"
+    ):
+        return None
+    payload = public_run_event_payload(raw_payload, source_type, failure=failure)
     event_id = int(getattr(event, "id", 0) or payload.get("event_id") or 0)
     run_id = int(getattr(event, "run_id", 0) or payload.get("run_id") or 0)
     root_run_id = int(getattr(event, "root_run_id", None) or payload.get("root_run_id") or run_id)
@@ -130,6 +223,10 @@ def _normalize_ui_payload(ui_type: str, source_type: str, message: dict[str, Any
             message["status"] = "failed"
         elif source_type == "run.canceled":
             message["status"] = "canceled"
+        elif source_type == "run.expired":
+            message["status"] = "expired"
+        elif source_type == "run.status_changed" and isinstance(message.get("failure"), dict):
+            message["status"] = message["failure"]["status"]
         else:
             message.setdefault("status", "completed")
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2346,6 +2346,88 @@ class TestCortexReplyHandler:
         assert "manage_slack" in context
         assert "not_connected" in context
 
+    def test_final_reply_context_hides_failed_worker_diagnostics(self):
+        from types import SimpleNamespace
+
+        from brain.systems.runs.direct_agent import _agent_context
+        from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+
+        raw_error = "peer closed connection without sending complete message body"
+        _agent_context.run = SimpleNamespace(
+            run_id=42,
+            total_tokens=0,
+            worker_results=[
+                SimpleNamespace(
+                    skill_name="inspect",
+                    success=False,
+                    output="",
+                    error=raw_error,
+                    trust_status="untrusted",
+                    evidence={},
+                )
+            ],
+        )
+        _agent_context.execution_artifacts = []
+        _agent_context.recent_tool_results = []
+        _agent_context.intent_satisfaction = None
+
+        try:
+            context = _build_final_reply_check_context()
+        finally:
+            _agent_context.run = None
+            _agent_context.execution_artifacts = []
+            _agent_context.recent_tool_results = []
+            _agent_context.intent_satisfaction = None
+
+        assert UPSTREAM_FAILED_RUN_MESSAGE in context
+        assert raw_error not in context
+
+    def test_final_reply_context_hides_failed_evidence_previews(self):
+        from types import SimpleNamespace
+
+        from brain.systems.runs.direct_agent import _agent_context
+        from brain.systems.runs.tool_catalog.handlers.cortex_reply import _build_final_reply_check_context
+
+        raw_error = "provider request failed with private diagnostic"
+        _agent_context.run = SimpleNamespace(
+            run_id=42,
+            total_tokens=0,
+            worker_results=[
+                SimpleNamespace(
+                    skill_name="inspect",
+                    success=False,
+                    output="",
+                    error=raw_error,
+                    trust_status="untrusted",
+                    evidence={"unresolved_uncertainty": [raw_error]},
+                )
+            ],
+        )
+        _agent_context.execution_artifacts = [
+            {"kind": "provider", "summary": raw_error, "path": None, "status": "failed"}
+        ]
+        _agent_context.recent_tool_results = [
+            {
+                "tool_name": "provider_call",
+                "args_preview": "{}",
+                "is_error": True,
+                "result_preview": raw_error,
+            }
+        ]
+        _agent_context.intent_satisfaction = None
+
+        try:
+            context = _build_final_reply_check_context()
+        finally:
+            _agent_context.run = None
+            _agent_context.execution_artifacts = []
+            _agent_context.recent_tool_results = []
+            _agent_context.intent_satisfaction = None
+
+        assert raw_error not in context
+        assert "temporary problem" in context
+
     def test_cortex_reply_whitespace_normalizer_collapses_punctuation_lines(self):
         from brain.systems.runs.tool_catalog.handlers.cortex_reply import _normalize_reply_whitespace
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -94,22 +94,49 @@ class TestCallAgent:
         assert result["text"] == "File-based output"
         assert result["from_file"] is True
 
-    def test_failure_from_agent(self):
+    def test_failure_from_agent_returns_safe_typed_message(self):
+        from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+        raw_error = "peer closed connection without sending complete message body"
         mock_result = MagicMock()
         mock_result.success = False
         mock_result.output = ""
-        mock_result.error = "Agent failed with error"
+        mock_result.error = raw_error
 
         with patch("brain.systems.runs.direct_agent.run_agent", return_value=mock_result):
             result = call_agent("test-session", "hello")
         assert result["success"] is False
-        assert "Agent failed" in result["error"]
+        assert result["error"] == UPSTREAM_FAILED_RUN_MESSAGE
+        assert raw_error not in json.dumps(result)
 
-    def test_exception_returns_error(self):
-        with patch("brain.systems.runs.direct_agent.run_agent", side_effect=Exception("boom")):
+    def test_failed_agent_does_not_return_output_file_diagnostic(self, tmp_path):
+        from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+        raw_error = "peer closed connection without sending complete message body"
+        output_file = tmp_path / "output.txt"
+        output_file.write_text(raw_error)
+        mock_result = MagicMock(success=False, output="", error=raw_error)
+
+        with patch("brain.systems.runs.direct_agent.run_agent", return_value=mock_result):
+            result = call_agent("test-session", "hello", output_file=str(output_file))
+
+        assert result == {
+            "success": False,
+            "text": "",
+            "from_file": False,
+            "error": UPSTREAM_FAILED_RUN_MESSAGE,
+        }
+        assert raw_error not in json.dumps(result)
+
+    def test_exception_returns_safe_error(self):
+        from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+        raw_error = "provider exploded with request secret"
+        with patch("brain.systems.runs.direct_agent.run_agent", side_effect=Exception(raw_error)):
             result = call_agent("test-session", "hello")
         assert result["success"] is False
-        assert "boom" in result["error"]
+        assert result["error"] == DEFAULT_FAILED_RUN_MESSAGE
+        assert raw_error not in json.dumps(result)
 
     def test_empty_response(self):
         mock_result = MagicMock()

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -464,6 +464,33 @@ async def test_fast_recipe_invokes_direct_agent_with_streaming_and_live_guidance
     assert any(_artifact_type(artifact) == "file_observation" for artifact in runtime.store.artifacts)
 
 
+async def test_fast_recipe_discards_partial_deltas_when_provider_result_fails(monkeypatch):
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.fast import FastRecipe
+    from brain.systems.runs.status import RunStatus
+
+    raw_delta = "partial provider diagnostic token=fast-stream-secret"
+    raw_error = "peer closed connection without sending complete message body"
+
+    async def fake_invoke(spec):
+        await spec.on_stream_delta(raw_delta)
+        return SimpleNamespace(output=raw_delta, success=False, error=raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.fast.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("fast")
+    result = await FastRecipe().execute(runtime)
+    streamed = json.dumps(runtime.stream.messages)
+
+    assert result.status == RunStatus.FAILED
+    assert result.error == raw_error
+    assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
+    assert raw_delta not in streamed
+    assert raw_error not in streamed
+
+
 @pytest.mark.parametrize(
     ("replay_index", "origin"),
     [
@@ -1906,6 +1933,45 @@ async def test_phase_review_payload_excludes_blocked_workers(monkeypatch):
     assert captured["blocked_node_ids"] == ["blocked"]
 
 
+@pytest.mark.asyncio
+async def test_phase_review_recoverable_failure_keeps_diagnostics_internal(monkeypatch):
+    from brain.systems.runs.cortex.read_models import public_run_debug_event_payload
+    from brain.systems.runs.graph import DeepPlan, RunNode
+    from brain.systems.runs.recipes.phase_barrier import review_completed_phase
+
+    raw_diagnostic = "phase provider failed token=phase-secret"
+
+    async def failed_review(_spec):
+        raise RuntimeError(raw_diagnostic)
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.phase_barrier.invoke_direct_agent_async",
+        failed_review,
+    )
+    plan = DeepPlan(
+        nodes=(
+            RunNode(id="scout", kind="scout", recipe="scout", status="completed"),
+            RunNode(id="worker", depends_on=("scout",)),
+        )
+    )
+    runtime = _runtime("deep")
+
+    decision = await review_completed_phase(
+        runtime,
+        plan,
+        plan.require_node("scout"),
+        {"scout": {"status": "completed"}},
+    )
+    completed = next(
+        event for event in runtime.store.events
+        if event.event_type == "run.phase_review_completed"
+    )
+    projected = public_run_debug_event_payload(completed, None)
+
+    assert decision.summary == "Phase review was unavailable; continuing without changes."
+    assert raw_diagnostic not in json.dumps(projected)
+
+
 async def test_deep_coordinator_synthesis_uses_soul_and_owns_final_answer(monkeypatch):
     from brain.systems.runs.domain import AgentRunArtifact
     from brain.systems.runs.recipes.deep import DeepRecipe
@@ -1989,9 +2055,85 @@ async def test_deep_coordinator_synthesis_uses_soul_and_owns_final_answer(monkey
     assert any(event.event_type == "run.coordinator_synthesis_completed" for event in store.events)
 
 
+async def test_deep_synthesis_never_embeds_failed_worker_diagnostics(monkeypatch):
+    from brain.systems.runs.domain import AgentRunArtifact
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.deep import DeepRecipe
+    from brain.systems.runs.status import RunStatus
+
+    raw_error = "peer closed connection without sending complete message body"
+    captured = {}
+
+    async def failed_synthesis(spec):
+        captured["message"] = spec.message
+        return SimpleNamespace(output="", success=False, error="coordinator unavailable")
+
+    monkeypatch.setattr("brain.systems.runs.recipes.deep.invoke_direct_agent_async", failed_synthesis)
+
+    class _ChildEngine:
+        def __init__(self, store):
+            self.store = store
+
+        async def run_existing(self, run_id):
+            run = self.store.runs[run_id]
+            recipe = str(getattr(run.recipe, "value", run.recipe))
+            if recipe == "worker":
+                self.store.append_artifact(
+                    AgentRunArtifact(
+                        run_id=run_id,
+                        root_run_id=42,
+                        artifact_type="worker_result",
+                        title="Failed worker result",
+                        text=raw_error,
+                        payload={"error": raw_error},
+                    )
+                )
+                return SimpleNamespace(
+                    status=RunStatus.FAILED,
+                    id=run_id,
+                    metadata={"failure": {"category": "upstream"}},
+                )
+            self.store.append_artifact(
+                AgentRunArtifact(
+                    run_id=run_id,
+                    root_run_id=42,
+                    artifact_type="final_answer",
+                    title="Scout result",
+                    text="Scout completed.",
+                )
+            )
+            return SimpleNamespace(status=RunStatus.COMPLETED, id=run_id, metadata={})
+
+    store = _Store()
+    runtime = _runtime("deep", message="Inspect the repository.", store=store)
+    runtime.request = replace(
+        runtime.request,
+        metadata={
+            "verification": "skip",
+            "disable_phase_barrier_review": True,
+            "deep_workers": [
+                {"id": "inspect", "role": "inspect", "objective": "Inspect the repository."}
+            ],
+        },
+    )
+    runtime.engine = _ChildEngine(store)
+
+    result = await DeepRecipe().execute(runtime)
+
+    assert result.status == RunStatus.COMPLETED
+    assert UPSTREAM_FAILED_RUN_MESSAGE in result.output
+    assert raw_error not in result.output
+    assert raw_error not in captured["message"]
+    assert raw_error not in json.dumps(runtime.stream.messages)
+    parent_artifacts = [artifact for artifact in store.artifacts if artifact.run_id == runtime.run.id]
+    assert all(raw_error not in str(artifact.text or "") for artifact in parent_artifacts)
+    assert all(raw_error not in json.dumps(artifact.payload, default=str) for artifact in parent_artifacts)
+
+
 async def test_deep_recipe_failed_verification_returns_failed_status(monkeypatch):
     import brain.systems.runs.recipes.deep as deep_module
     from brain.systems.runs.domain import AgentRunArtifact
+    from brain.systems.runs.failures import VERIFICATION_FAILED_RUN_MESSAGE
     from brain.systems.runs.recipes.deep import DeepRecipe
     from brain.systems.runs.status import RunStatus
     _stub_phase_reviews(monkeypatch)
@@ -2018,7 +2160,16 @@ async def test_deep_recipe_failed_verification_returns_failed_status(monkeypatch
     result = await DeepRecipe().execute(runtime)
 
     assert result.status.value == "failed"
-    assert result.output.startswith("Deep verification failed:")
+    assert result.output == ""
+    assert result.error.startswith("Deep verification failed:")
+    assert result.final_output == VERIFICATION_FAILED_RUN_MESSAGE
+    assert result.failure_category.value == "verification"
+    assert sum(
+        event_type == "run.text_delta"
+        and payload.get("delta") == VERIFICATION_FAILED_RUN_MESSAGE
+        for event_type, payload in runtime.stream.messages
+    ) == 1
+    assert "worker run(s) failed" not in json.dumps(runtime.stream.messages)
     verification = [artifact for artifact in store.artifacts if _artifact_type(artifact) == "verifier_evidence"]
     assert verification[-1].payload["passed"] is False
     assert "worker run(s) failed" in verification[-1].payload["warning"]
@@ -2859,6 +3010,35 @@ async def test_runtime_tool_executor_records_policy_blocked_results_as_failed():
     assert runtime.store.artifacts[-1].payload["status"] == "failed"
 
 
+async def test_runtime_tool_executor_classifies_structured_handler_errors_as_failed():
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+    from brain.systems.runs.presentation import public_tool_event_payload
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    raw_diagnostic = "idea update failed token=tool-handler-secret"
+    runtime = _runtime("worker")
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+
+    result = await executor.execute(
+        42,
+        ToolExecution(
+            name="manage_idea",
+            args={"action": "update"},
+            handler=lambda **_kwargs: {"status": "error", "error": raw_diagnostic},
+        ),
+        root_run_id=42,
+    )
+
+    assert result["error"] == raw_diagnostic
+    assert not any(event.event_type == "run.tool_completed" for event in runtime.store.events)
+    failed = next(event for event in runtime.store.events if event.event_type == "run.tool_failed")
+    public = public_tool_event_payload(failed.payload, failed.event_type)
+    assert public["failure"]["message"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert public["error"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(public)
+    assert runtime.store.artifacts[-1].payload["status"] == "failed"
+
+
 async def test_runtime_tool_executor_enforces_policy_before_raw_handler(monkeypatch):
     from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
 
@@ -3648,6 +3828,90 @@ async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_
     assert worker_result.payload["evidence"]["tool_names"] == ["read_file"]
 
 
+async def test_worker_recipe_keeps_failed_provider_diagnostics_internal(monkeypatch):
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.workers import WorkerRecipe
+
+    raw_error = "peer closed connection without sending complete message body"
+
+    async def fake_invoke(_spec):
+        return SimpleNamespace(output="", success=False, error=raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("worker")
+    result = await WorkerRecipe().execute(runtime)
+
+    assert result.status.value == "failed"
+    assert result.output == ""
+    assert result.error == raw_error
+    assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
+    assert result.artifacts[0].text == UPSTREAM_FAILED_RUN_MESSAGE
+    assert result.artifacts[0].payload["failure"] == {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
+    assert raw_error not in json.dumps(runtime.stream.messages)
+    assert raw_error not in json.dumps(result.artifacts[0].payload)
+
+
+async def test_worker_recipe_buffers_partial_deltas_until_success_is_known(monkeypatch):
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.workers import WorkerRecipe
+    from brain.systems.runs.status import RunStatus
+
+    raw_delta = "partial provider diagnostic token=stream-secret"
+    raw_error = "peer closed connection without sending complete message body"
+
+    async def fake_invoke(spec):
+        await spec.on_stream_delta(raw_delta)
+        return SimpleNamespace(output=raw_delta, success=False, error=raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("worker")
+    result = await WorkerRecipe().execute(runtime)
+    streamed = json.dumps(runtime.stream.messages)
+
+    assert result.status == RunStatus.FAILED
+    assert result.error == raw_error
+    assert raw_delta not in streamed
+    assert raw_error not in streamed
+    assert any(
+        event_type == "run.text_delta"
+        and payload.get("delta") == UPSTREAM_FAILED_RUN_MESSAGE
+        for event_type, payload in runtime.stream.messages
+    )
+
+
+async def test_worker_recipe_keeps_unexpected_exception_internal(monkeypatch):
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.workers import WorkerRecipe
+
+    raw_error = "provider exploded with private diagnostic"
+
+    async def fake_invoke(_spec):
+        raise RuntimeError(raw_error)
+
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_agent_tools", lambda _role: [])
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.build_tool_handlers", lambda **_kwargs: {})
+    monkeypatch.setattr("brain.systems.runs.recipes.workers.invoke_direct_agent_async", fake_invoke)
+
+    runtime = _runtime("worker")
+    result = await WorkerRecipe().execute(runtime)
+
+    assert result.error == raw_error
+    assert result.final_output == DEFAULT_FAILED_RUN_MESSAGE
+    assert result.artifacts[0].text == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_error not in json.dumps(runtime.stream.messages)
+    assert raw_error not in json.dumps(result.artifacts[0].payload)
+
+
 async def test_worker_recipe_propagates_headless_tool_policy(monkeypatch):
     from brain.systems.runs.recipes.workers import WorkerRecipe
 
@@ -3786,6 +4050,54 @@ def test_run_stream_payload_is_the_single_cortex_projection():
     assert payload["recipe"] == "fast"
     assert payload["status"] == "running"
     assert payload["model_policy"] == {"model": "openai/gpt-5.5", "thinking": "high"}
+
+
+def test_completed_run_stream_scrubs_embedded_subfailure_diagnostics_only():
+    from brain.systems.runs.cortex.read_models import run_stream_payload
+
+    now = datetime(2026, 5, 3, tzinfo=timezone.utc)
+    raw_diagnostic = "child clone failed token=super-secret"
+    row = SimpleNamespace(
+        id=8,
+        thread_id="idea-1",
+        org_id="org-1",
+        user_id="user-1",
+        parent_run_id=None,
+        root_run_id=8,
+        trace_id="run_8",
+        profile="deep",
+        recipe="deep",
+        status="completed",
+        input_message="Inspect the project",
+        target_ref={"kind": "cortex_idea"},
+        workspace_ref={},
+        model_policy={},
+        metadata_={
+            "safe_summary": "Completed with partial evidence",
+            "evidence_health": {
+                "status": "degraded",
+                "failures": [
+                    {"status": "failed", "error": raw_diagnostic, "resource_id": "repo-1"}
+                ],
+            },
+        },
+        created_at=now,
+        updated_at=now,
+        started_at=now,
+        paused_at=None,
+        completed_at=now,
+        failed_at=None,
+        canceled_at=None,
+    )
+
+    payload = run_stream_payload(row)
+
+    assert payload["status"] == "completed"
+    assert payload["metadata"]["safe_summary"] == "Completed with partial evidence"
+    assert payload["metadata"]["evidence_health"]["failures"] == [
+        {"status": "failed", "resource_id": "repo-1"}
+    ]
+    assert raw_diagnostic not in json.dumps(payload)
 
 
 def _async_work_intake_session(idea, *, attachment=None, profiles=None):

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -892,6 +892,60 @@ async def test_cycle_final_answer_store_never_persists_raw_provider_error(sessio
     assert "help.openai.com" not in direct_artifact.text
 
 
+async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
+    monkeypatch,
+    session_factory,
+):
+    from brain.systems.runs.cortex import runner
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "peer closed connection while cloning token=super-secret"
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(_run_request(thread_id="thread-1", message="materialize"))
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+
+    async def settle(_session, run_id):
+        return {"run_id": run_id}
+
+    monkeypatch.setattr(runner, "_unit_of_work_factory", lambda: lambda: _SessionUoW(session))
+    monkeypatch.setattr(runner, "_settle_terminal_root_run_async", settle)
+
+    result = await runner._mark_run_failed_after_runner_error_async(
+        run.id,
+        raw_diagnostic,
+        final_answer=raw_diagnostic,
+    )
+
+    row = await session.get(AgentRunRow, run.id)
+    artifacts = list(
+        (
+            await session.scalars(
+                select(AgentRunArtifactRow).where(AgentRunArtifactRow.run_id == run.id)
+            )
+        ).all()
+    )
+    text_events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow).where(
+                    AgentRunEventRow.run_id == run.id,
+                    AgentRunEventRow.event_type == "run.text_completed",
+                )
+            )
+        ).all()
+    )
+
+    assert result == {"run_id": run.id}
+    assert row is not None
+    assert row.status == RunStatus.FAILED.value
+    assert row.metadata_["failure"] == {"category": "upstream"}
+    assert [artifact.text for artifact in artifacts] == [UPSTREAM_FAILED_RUN_MESSAGE]
+    assert [event.payload for event in text_events] == [{"text": UPSTREAM_FAILED_RUN_MESSAGE}]
+    assert all(raw_diagnostic not in str(value) for value in (artifacts, text_events))
+
+
 async def test_interactive_slack_transport_failure_never_persists_raw_error_as_final_answer(
     monkeypatch,
     session_factory,

--- a/tests/test_agent_trace_snapshot.py
+++ b/tests/test_agent_trace_snapshot.py
@@ -333,6 +333,103 @@ async def test_thread_trace_snapshot_covers_conversation_and_all_thread_runs():
     assert "not copied" not in str(snapshot)
 
 
+@pytest.mark.asyncio
+async def test_failed_run_trace_snapshot_never_replays_raw_diagnostics():
+    from brain.systems.runs.cortex.recording import build_agent_trace_snapshot_async
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "provider exploded bearer=trace-secret"
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc)
+    run = _run(
+        status="failed",
+        completed_at=None,
+        failed_at=now,
+        context_summary=raw_diagnostic,
+        metadata_={"failure": {"category": "upstream", "error": raw_diagnostic}},
+    )
+    message = SimpleNamespace(
+        id=9,
+        idea_id="idea-1",
+        role="illo",
+        content=raw_diagnostic,
+        attachments=[],
+        metadata_={"run_id": 42, "error": raw_diagnostic},
+        message_type="message",
+        created_at=now,
+    )
+    event = SimpleNamespace(
+        id=99,
+        run_id=42,
+        root_run_id=42,
+        sequence_no=3,
+        event_type="run.failed",
+        payload={"failure_category": "upstream", "error": raw_diagnostic},
+        producer="agent_runtime",
+        visibility="public",
+        created_at=now,
+    )
+    artifact = SimpleNamespace(
+        id=100,
+        run_id=42,
+        root_run_id=42,
+        artifact_type="final_answer",
+        title=raw_diagnostic,
+        payload={"error": raw_diagnostic},
+        text=raw_diagnostic,
+        uri="debug://raw-diagnostic",
+        visibility="public",
+        created_at=now,
+    )
+    session = AsyncMock()
+    session.scalars.side_effect = [
+        _result([42]),
+        _result([run]),
+        _result([message]),
+        _result([event]),
+        _result([artifact]),
+        _result([]),
+        _result([]),
+    ]
+
+    snapshot = await build_agent_trace_snapshot_async(session, run)
+    serialized = json.dumps(snapshot)
+
+    assert raw_diagnostic not in serialized
+    assert snapshot["run"]["failure"]["message"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert snapshot["thread"]["messages"][0]["content"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert snapshot["events"][0]["payload"]["failure"]["message"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert snapshot["artifacts"][0]["text"] == UPSTREAM_FAILED_RUN_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_cycle_trace_state_redacts_stored_and_query_diagnostics():
+    from brain.systems.runs.cortex.recording import (
+        _cycle_payload,
+        _cycle_run_payload,
+        _trace_cycle_state_async,
+    )
+
+    raw_diagnostic = "scheduler database error token=cycle-secret"
+    cycle_payload = _cycle_payload(_cycle(last_status="failed", last_error=raw_diagnostic))
+    cycle_run_payload = _cycle_run_payload(_cycle_run(status="failed", error=raw_diagnostic))
+
+    class FailingSession:
+        async def scalars(self, _stmt):
+            raise RuntimeError(raw_diagnostic)
+
+    failed_state = await _trace_cycle_state_async(
+        FailingSession(),
+        idea_id="idea-1",
+        runs=[_run(metadata_={"cycle_id": 7})],
+    )
+    serialized = json.dumps([cycle_payload, cycle_run_payload, failed_state])
+
+    assert raw_diagnostic not in serialized
+    assert cycle_payload["last_error"] == "The last scheduled run did not complete."
+    assert cycle_run_payload["error"] == "The scheduled run did not complete."
+    assert failed_state["error"] == "Cycle diagnostics were unavailable."
+
+
 def test_agent_trace_export_zip_contains_shareable_trace_files():
     from brain.systems.runs.cortex.recording import (
         agent_trace_export_filename,

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -1154,6 +1154,38 @@ def test_run_events_public_tool_summary_hides_command_secrets():
     assert "ghp_" not in json.dumps(item["tool_calls"])
 
 
+def test_run_events_public_activity_trace_hides_raw_failure_diagnostics():
+    from brain.app.api.routers.cortex._idea_ops import _apply_run_events_to_item
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_error = "peer closed connection without sending complete message body"
+    failed_at = datetime(2026, 5, 3, 22, 0, 5, tzinfo=timezone.utc)
+    item = {
+        "type": "run",
+        "id": "7",
+        "run_id": 7,
+        "profile": "fast",
+        "status": "failed",
+        "failed_at": failed_at.isoformat(),
+    }
+    events = [
+        SimpleNamespace(
+            event_type="run.failed",
+            payload={
+                "error": raw_error,
+                "failure_category": "upstream",
+            },
+            created_at=failed_at,
+            sequence_no=1,
+        ),
+    ]
+
+    _apply_run_events_to_item(item, events)
+
+    assert item["activity_trace"][0]["error"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert raw_error not in json.dumps(item)
+
+
 def test_unified_stream_run_work_events_query_is_bounded():
     from brain.app.api.routers.cortex._idea_ops import (
         _RUN_WORK_EVENT_LIMIT_PER_RUN,

--- a/tests/test_api_cortex.py
+++ b/tests/test_api_cortex.py
@@ -986,6 +986,147 @@ def test_unified_stream_synthesizes_visible_final_answer_from_run_artifact():
     assert reply["metadata"]["synthetic_from_run_artifact"] is True
 
 
+def test_unified_stream_projects_legacy_failed_artifact_and_persisted_message_safely():
+    from brain.app.api.routers.cortex._idea_ops import (
+        _append_final_answer_messages,
+        _project_failed_run_message,
+        _project_run_artifacts,
+    )
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "peer closed connection; password=swordfish"
+    failure = {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
+    run_item = {
+        "type": "run",
+        "id": "7",
+        "run_id": 7,
+        "profile": "fast",
+        "status": "failed",
+        "failure": failure,
+        "artifacts": _project_run_artifacts(
+            [
+                {
+                    "id": 3,
+                    "artifact_type": "final_answer",
+                    "title": raw_diagnostic,
+                    "payload": {"error": raw_diagnostic},
+                    "text": raw_diagnostic,
+                    "uri": f"internal://{raw_diagnostic}",
+                }
+            ],
+            failure,
+        ),
+    }
+    items = [run_item]
+
+    _append_final_answer_messages(items)
+
+    assert run_item["artifacts"] == [
+        {
+            "id": 3,
+            "artifact_type": "final_answer",
+            "title": None,
+            "payload": {"failure": failure},
+            "text": UPSTREAM_FAILED_RUN_MESSAGE,
+            "uri": None,
+        }
+    ]
+    assert items[-1]["content"] == UPSTREAM_FAILED_RUN_MESSAGE
+
+    persisted = {
+        "type": "message",
+        "content": raw_diagnostic,
+        "metadata": {"run_id": 7, "final_answer": raw_diagnostic},
+    }
+    _project_failed_run_message(persisted, failure)
+    assert persisted["content"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert persisted["metadata"] == {"run_id": 7, "failure": failure}
+    assert raw_diagnostic not in json.dumps([items, persisted])
+
+
+@pytest.mark.asyncio
+async def test_legacy_failure_lookup_is_scoped_to_current_thread_and_org():
+    from brain.systems.runs.cortex.read_models import public_failures_for_run_ids
+
+    org_id = "11111111-1111-4111-8111-111111111111"
+    session = SimpleNamespace(
+        scalars=AsyncMock(return_value=SimpleNamespace(all=lambda: [])),
+    )
+
+    failures = await public_failures_for_run_ids(
+        session,
+        {7},
+        thread_id="idea-1",
+        org_id=org_id,
+    )
+
+    assert failures == {}
+    stmt = session.scalars.await_args.args[0]
+    compiled = stmt.compile()
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "agent_runs.id IN (7)" in sql
+    assert "agent_runs.thread_id = 'idea-1'" in sql
+    assert compiled.params["org_id_1"] == org_id
+
+
+def test_legacy_thread_and_discussion_projection_only_rewrites_trusted_illo_rows():
+    from brain.app.api.routers.cortex._discussion import _comment_payload
+    from brain.app.api.routers.cortex._idea_ops import _message_run_id
+    from brain.app.api.routers.cortex._ideas import _thread_message_read_payload
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "legacy failure token=super-secret"
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    user_item = {
+        "type": "message",
+        "role": "user",
+        "content": raw_diagnostic,
+        "metadata": {"run_id": 999},
+    }
+    assert _message_run_id(user_item) is None
+
+    now = datetime(2026, 5, 3, tzinfo=timezone.utc)
+    timeline_message = SimpleNamespace(
+        id=1,
+        idea_id="idea-1",
+        role="illo",
+        content=raw_diagnostic,
+        attachments=[],
+        metadata_={"run_id": 7, "final_answer": raw_diagnostic},
+        user_id=None,
+        created_at=now,
+    )
+    timeline_payload = _thread_message_read_payload(timeline_message, failure)
+    assert timeline_payload["content"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(timeline_payload, default=str)
+
+    discussion_comment = SimpleNamespace(
+        id=2,
+        thread_id="idea-1",
+        org_id="org-1",
+        author_user_id=None,
+        author_kind="illo",
+        body=raw_diagnostic,
+        attachments=[],
+        metadata_={"created_by_run_id": 7, "final_answer": raw_diagnostic},
+        created_at=now,
+    )
+    discussion_payload = _comment_payload(discussion_comment, failure=failure)
+    assert discussion_payload["body"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(discussion_payload, default=str)
+
+    user_comment = SimpleNamespace(**{**discussion_comment.__dict__, "author_kind": "user"})
+    assert _comment_payload(user_comment)["body"] == raw_diagnostic
+
+
 def test_unified_stream_does_not_duplicate_existing_run_reply():
     from brain.app.api.routers.cortex._idea_ops import _append_final_answer_messages
 
@@ -1184,6 +1325,335 @@ def test_run_events_public_activity_trace_hides_raw_failure_diagnostics():
 
     assert item["activity_trace"][0]["error"] == UPSTREAM_FAILED_RUN_MESSAGE
     assert raw_error not in json.dumps(item)
+
+
+def test_failed_run_activity_projection_drops_earlier_diagnostic_fields():
+    from brain.app.api.routers.cortex._idea_ops import _apply_run_events_to_item
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    raw_error = "materializer failed token=activity-secret"
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    item = {"type": "run", "id": "7", "run_id": 7, "status": "failed"}
+    events = [
+        SimpleNamespace(
+            event_type="run.activity",
+            payload={"label": "Project context unavailable", "errors": [raw_error]},
+            created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+            sequence_no=1,
+        )
+    ]
+
+    _apply_run_events_to_item(item, events, failure)
+
+    assert item["activity_trace"][0]["activity"] == "Project context unavailable"
+    assert raw_error not in json.dumps(item)
+
+
+@pytest.mark.asyncio
+async def test_run_debug_projects_failed_run_diagnostics_as_typed_safe_failure():
+    from brain.systems.runs.cortex.read_models import serialize_run_debug_async
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "peer closed connection; bearer=super-secret"
+    failed_at = datetime(2026, 5, 3, 22, 0, 5, tzinfo=timezone.utc)
+    run = SimpleNamespace(
+        id=7,
+        created_at=failed_at,
+        thread_id="idea-1",
+        org_id="org-1",
+        user_id="user-1",
+        parent_run_id=None,
+        root_run_id=7,
+        trace_id="trace-1",
+        profile="fast",
+        recipe="fast",
+        status="failed",
+        input_message="Do the work",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={"failure": {"category": "upstream", "error": raw_diagnostic}},
+        updated_at=failed_at,
+        started_at=failed_at,
+        paused_at=None,
+        completed_at=None,
+        failed_at=failed_at,
+        canceled_at=None,
+    )
+    events = [
+        SimpleNamespace(
+            id=1,
+            run_id=7,
+            sequence_no=1,
+            event_type="run.status_changed",
+            payload={"from_status": "running", "to_status": "failed", "reason": raw_diagnostic},
+            visibility="public",
+            created_at=failed_at,
+        ),
+        SimpleNamespace(
+            id=2,
+            run_id=7,
+            sequence_no=2,
+            event_type="run.failed",
+            payload={"error": raw_diagnostic, "failure_category": "upstream"},
+            visibility="public",
+            created_at=failed_at,
+        ),
+    ]
+    artifacts = [
+        SimpleNamespace(
+            id=3,
+            run_id=7,
+            artifact_type="final_answer",
+            title="Final answer",
+            payload={"error": raw_diagnostic},
+            text=raw_diagnostic,
+            uri=None,
+            visibility="public",
+            created_at=failed_at,
+        )
+    ]
+
+    class _Rows:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _Session:
+        def __init__(self):
+            self._results = iter((events, artifacts))
+
+        async def get(self, _model, run_id):
+            return run if run_id == run.id else None
+
+        async def scalars(self, _stmt):
+            return _Rows(next(self._results))
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    payload = await serialize_run_debug_async(7, uow_factory=_UnitOfWork)
+    failure = {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
+
+    assert payload is not None
+    assert payload["run"]["failure"] == failure
+    assert payload["events"][0]["payload"]["failure"] == failure
+    assert payload["events"][1]["payload"] == {"failure": failure}
+    assert payload["artifacts"][0]["payload"] == {"failure": failure}
+    assert payload["artifacts"][0]["text"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(payload)
+
+
+def test_completed_parent_debug_sanitizes_failed_child_event_and_artifact():
+    from brain.systems.runs.cortex.read_models import (
+        public_failed_run_artifact,
+        public_run_debug_event_payload,
+    )
+
+    raw_diagnostic = "worker failed bearer=super-secret"
+    event = SimpleNamespace(
+        event_type="run.tool_failed",
+        payload={
+            "tool_name": "run_script",
+            "args": {"description": "Check build", "script": raw_diagnostic},
+            "error": raw_diagnostic,
+            "result": raw_diagnostic,
+        },
+    )
+    event_payload = public_run_debug_event_payload(event, None)
+    artifact = public_failed_run_artifact(
+        {
+            "artifact_type": "worker_result",
+            "text": raw_diagnostic,
+            "payload": {"status": "failed", "error": raw_diagnostic},
+            "uri": f"internal://{raw_diagnostic}",
+        },
+        None,
+    )
+
+    assert event_payload["tool_name"] == "run_script"
+    assert event_payload["display"]["status"] == "failed"
+    assert event_payload["failure"]["status"] == "failed"
+    assert artifact["payload"]["failure"]["status"] == "failed"
+    assert artifact["text"] is None
+    assert artifact["uri"] is None
+    assert raw_diagnostic not in json.dumps([event_payload, artifact])
+
+
+def test_completed_run_debug_sanitizes_legacy_completed_tool_error_result():
+    from brain.systems.runs.cortex.read_models import public_run_debug_event_payload
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "provider exploded; password=swordfish"
+    event = SimpleNamespace(
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "manage_idea",
+            "result": {"status": "error", "error": raw_diagnostic},
+        },
+    )
+
+    payload = public_run_debug_event_payload(event, None)
+
+    assert payload["display"]["status"] == "failed"
+    assert payload["failure"]["message"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_run_tools_hides_raw_failed_tool_diagnostics(monkeypatch):
+    from brain.app.api.routers.cortex import _run
+
+    raw_diagnostic = "subprocess failed with bearer=super-secret"
+    failed_at = datetime(2026, 5, 3, 22, 0, 5, tzinfo=timezone.utc)
+    tool_event = SimpleNamespace(
+        event_type="run.tool_failed",
+        payload={
+            "tool_name": "run_script",
+            "args": {"description": "Check the build", "script": "use super-secret"},
+            "error": raw_diagnostic,
+            "result": raw_diagnostic,
+        },
+        created_at=failed_at,
+    )
+
+    class _Rows:
+        def all(self):
+            return [tool_event]
+
+    class _Session:
+        async def scalars(self, _stmt):
+            return _Rows()
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = _Session()
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr(_run, "UnitOfWork", _UnitOfWork)
+    monkeypatch.setattr(_run, "_require_run_for_user", AsyncMock())
+
+    payload = await _run.run_tools(7, user={"org_id": "org-1"})
+
+    assert payload["count"] == 1
+    assert payload["tools"][0]["payload"]["display"]["status"] == "failed"
+    assert "error" not in payload["tools"][0]["payload"]
+    assert "result_preview" not in payload["tools"][0]["payload"]
+    assert raw_diagnostic not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_activity_timeline_projects_only_trusted_legacy_failed_run_messages(monkeypatch):
+    from brain.app.api.routers.cortex import _analytics
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "legacy traceback bearer=activity-timeline-secret"
+    created_at = datetime(2026, 5, 3, 20, 0, tzinfo=timezone.utc)
+    thread_rows = [
+        SimpleNamespace(
+            role="illo",
+            content=raw_diagnostic,
+            metadata_={"created_by_run_id": 7, "error": raw_diagnostic},
+            created_at=datetime(2026, 5, 3, 20, 1, tzinfo=timezone.utc),
+        ),
+        SimpleNamespace(
+            role="user",
+            content="Keep this user-authored message",
+            metadata_={"run_id": 999},
+            created_at=datetime(2026, 5, 3, 20, 2, tzinfo=timezone.utc),
+        ),
+        SimpleNamespace(
+            role="assistant",
+            content="Completed assistant answer",
+            metadata_={"run_id": 8},
+            created_at=datetime(2026, 5, 3, 20, 3, tzinfo=timezone.utc),
+        ),
+    ]
+
+    class _Rows:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _Session:
+        def __init__(self):
+            self._scalar_results = iter([_Rows([]), _Rows(thread_rows)])
+
+        async def get(self, _model, _idea_id):
+            return SimpleNamespace(
+                id="idea-1",
+                org_id="org-1",
+                created_at=created_at,
+            )
+
+        async def scalars(self, _stmt):
+            return next(self._scalar_results)
+
+        async def execute(self, _stmt):
+            return _Rows([])
+
+    session = _Session()
+    idea = SimpleNamespace(
+        id="idea-1",
+        org_id="org-1",
+        created_at=created_at,
+    )
+
+    class _UnitOfWork:
+        async def __aenter__(self):
+            self.session = session
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    failure_lookup = AsyncMock(return_value={7: failure})
+    monkeypatch.setattr(_analytics, "UnitOfWork", _UnitOfWork)
+    require_idea = AsyncMock(return_value=idea)
+    monkeypatch.setattr(_analytics, "_a_require_idea_for_user", require_idea)
+    monkeypatch.setattr(_analytics, "public_failures_for_run_ids", failure_lookup)
+
+    payload = await _analytics.activity_timeline("idea-1", user={"org_id": "org-1"})
+
+    failure_lookup.assert_awaited_once_with(
+        session,
+        {7, 8},
+        thread_id="idea-1",
+        org_id="org-1",
+    )
+    require_idea.assert_awaited_once_with(session, "idea-1", {"org_id": "org-1"})
+    labels = [event["label"] for event in payload if event["type"] == "thread_message"]
+    assert labels == [
+        f'Illo replied: "{DEFAULT_FAILED_RUN_MESSAGE}"',
+        'You replied: "Keep this user-authored message"',
+        'Assistant replied: "Completed assistant answer"',
+    ]
+    assert raw_diagnostic not in json.dumps(payload)
 
 
 def test_unified_stream_run_work_events_query_is_bounded():

--- a/tests/test_cortex_discussion_failure_projection.py
+++ b/tests/test_cortex_discussion_failure_projection.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _JoinedRow:
+    def __init__(self, comment):
+        self.comment = comment
+        self.author_name = None
+        self.author_color = None
+
+    def __getitem__(self, index):
+        if index == 0:
+            return self.comment
+        raise IndexError(index)
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+def _legacy_failed_comment(raw_diagnostic: str):
+    return SimpleNamespace(
+        id=1,
+        thread_id="idea-1",
+        org_id="org-1",
+        author_user_id=None,
+        author_kind="illo",
+        body=raw_diagnostic,
+        attachments=[],
+        metadata_={"created_by_run_id": 7, "error": raw_diagnostic},
+        created_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_discussion_rest_projects_runs_from_the_discussion_conversation(monkeypatch):
+    from brain.app.api.routers.cortex import _discussion
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "legacy traceback token=discussion-secret"
+    comment = _legacy_failed_comment(raw_diagnostic)
+
+    class Session:
+        async def execute(self, _stmt):
+            return _Rows([_JoinedRow(comment)])
+
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    lookup = AsyncMock(return_value={7: failure})
+    monkeypatch.setattr(_discussion, "public_failures_for_run_ids", lookup)
+    session = Session()
+
+    payload = await _discussion._discussion_comment_payloads(
+        session,
+        thread_id="idea-1",
+        limit=50,
+        org_id="org-1",
+    )
+
+    lookup.assert_awaited_once_with(
+        session,
+        {7},
+        thread_id="thread-discussion:idea-1",
+        org_id="org-1",
+    )
+    assert payload[0]["body"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_discussion_read_tool_projects_legacy_failed_comments(monkeypatch):
+    from brain.platform.db.repositories import unit_of_work
+    from brain.systems.runs.cortex import read_models
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+    from brain.systems.runs.tool_catalog.handlers import chat
+
+    raw_diagnostic = "legacy traceback token=tool-secret"
+    comment = _legacy_failed_comment(raw_diagnostic)
+
+    class Session:
+        async def execute(self, _stmt):
+            return _Rows([_JoinedRow(comment)])
+
+    session = Session()
+
+    class UnitOfWork:
+        async def __aenter__(self):
+            self.session = session
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+    lookup = AsyncMock(return_value={7: failure})
+    monkeypatch.setattr(unit_of_work, "UnitOfWork", UnitOfWork)
+    monkeypatch.setattr(read_models, "public_failures_for_run_ids", lookup)
+
+    with bind_agent_context({"org_id": "org-1"}):
+        payload = json.loads(await chat._handle_read_thread_discussion(thread_id="idea-1"))
+
+    lookup.assert_awaited_once_with(
+        session,
+        {7},
+        thread_id="thread-discussion:idea-1",
+        org_id="org-1",
+    )
+    assert payload["comments"][0]["body"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert raw_diagnostic not in json.dumps(payload)

--- a/tests/test_cortex_discussion_failure_projection.py
+++ b/tests/test_cortex_discussion_failure_projection.py
@@ -50,7 +50,7 @@ async def test_discussion_rest_projects_runs_from_the_discussion_conversation(mo
     raw_diagnostic = "legacy traceback token=discussion-secret"
     comment = _legacy_failed_comment(raw_diagnostic)
 
-    class Session:
+    class StubSession:
         async def execute(self, _stmt):
             return _Rows([_JoinedRow(comment)])
 
@@ -61,7 +61,7 @@ async def test_discussion_rest_projects_runs_from_the_discussion_conversation(mo
     }
     lookup = AsyncMock(return_value={7: failure})
     monkeypatch.setattr(_discussion, "public_failures_for_run_ids", lookup)
-    session = Session()
+    session = StubSession()
 
     payload = await _discussion._discussion_comment_payloads(
         session,
@@ -91,11 +91,11 @@ async def test_discussion_read_tool_projects_legacy_failed_comments(monkeypatch)
     raw_diagnostic = "legacy traceback token=tool-secret"
     comment = _legacy_failed_comment(raw_diagnostic)
 
-    class Session:
+    class StubSession:
         async def execute(self, _stmt):
             return _Rows([_JoinedRow(comment)])
 
-    session = Session()
+    session = StubSession()
 
     class UnitOfWork:
         async def __aenter__(self):

--- a/tests/test_cortex_encoder.py
+++ b/tests/test_cortex_encoder.py
@@ -135,6 +135,67 @@ async def test_encode_with_agent_work(mock_add_mem, mock_get_client):
 
 
 @patch("brain.platform.gpu_client.get_client")
+async def test_encode_projects_scoped_legacy_run_failures_before_memory_extraction(mock_get_client):
+    from brain.systems.cortex.encode import encode_thought_to_brain
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    idea_id = "abc12345-0000-0000-0000-000000000000"
+    raw_diagnostic = "legacy provider failure secret=request-token"
+    idea_row = _make_idea_row(title="Mixed legacy thread")
+    thread_rows = [
+        {
+            "role": "user",
+            "content": "User-authored context stays unchanged.",
+            "metadata": {"run_id": 999},
+            "message_type": "message",
+        },
+        {
+            "role": "illo",
+            "content": raw_diagnostic,
+            "metadata": {"run_id": 7},
+            "message_type": "agent_response",
+        },
+        {
+            "role": "assistant",
+            "content": "Completed assistant answer stays unchanged.",
+            "metadata": {"created_by_run_id": 8},
+            "message_type": "agent_response",
+        },
+    ]
+    client = _make_gpu_client("SKIP")
+    mock_get_client.return_value = client
+    failure_lookup = AsyncMock(return_value={
+        7: {
+            "status": "failed",
+            "category": "upstream",
+            "message": UPSTREAM_FAILED_RUN_MESSAGE,
+        }
+    })
+
+    with (
+        patch("brain.systems.cortex.encode.UnitOfWork", side_effect=_make_uow_factory(idea_row, thread_rows)),
+        patch(
+            "brain.systems.cortex.encode.public_failures_for_run_ids",
+            failure_lookup,
+            create=True,
+        ),
+    ):
+        await encode_thought_to_brain(idea_id)
+
+    failure_lookup.assert_awaited_once()
+    assert failure_lookup.await_args.args[1] == {7, 8}
+    assert failure_lookup.await_args.kwargs == {
+        "thread_id": idea_id,
+        "org_id": "org-1",
+    }
+    prompt = client.generate.call_args.kwargs["prompt"]
+    assert UPSTREAM_FAILED_RUN_MESSAGE in prompt
+    assert raw_diagnostic not in prompt
+    assert "User-authored context stays unchanged." in prompt
+    assert "Completed assistant answer stays unchanged." in prompt
+
+
+@patch("brain.platform.gpu_client.get_client")
 @patch("brain.app.cli.memory.add_memory", new_callable=AsyncMock)
 async def test_encode_no_interaction_low_salience(mock_add_mem, mock_get_client):
     """Thought with no interaction should encode with low salience."""

--- a/tests/test_cortex_misc_failure_projection.py
+++ b/tests/test_cortex_misc_failure_projection.py
@@ -1,0 +1,303 @@
+"""Failure-projection regressions for Cortex misc endpoints."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.idea import IdeaThread
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def all(self):
+        return list(self._rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class _Session:
+    def __init__(self, *, runs=(), messages=(), events=()):
+        self._runs = list(runs)
+        self._messages = list(messages)
+        self._events = list(events)
+        self.scalars_calls = 0
+        self.add = MagicMock()
+
+    async def scalars(self, statement):
+        self.scalars_calls += 1
+        entity = statement.column_descriptions[0].get("entity")
+        if entity is AgentRunRow:
+            return _Rows(self._runs)
+        if entity is IdeaThread:
+            return _Rows(self._messages)
+        if entity is AgentRunEventRow:
+            return _Rows(self._events)
+        raise AssertionError(f"Unexpected scalar entity: {entity}")
+
+    async def execute(self, _statement, _params=None):
+        # Legacy audit/analyze queried only role/content with raw SQL.
+        return _Rows(
+            SimpleNamespace(role=message.role, content=message.content)
+            for message in self._messages
+        )
+
+
+class _Uow:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _failed_run(*, run_id: int = 41):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=run_id,
+        thread_id="idea-1",
+        status="failed",
+        input_message="/audit inspect this idea",
+        metadata_={
+            "error": "DATABASE_PASSWORD=raw-secret",
+            "failure": {"category": "upstream"},
+        },
+        started_at=now,
+        completed_at=now,
+        created_at=now,
+    )
+
+
+def _failed_message(*, run_id: int = 41):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=7,
+        idea_id="idea-1",
+        role="illo",
+        content="Traceback: DATABASE_PASSWORD=raw-secret",
+        metadata_={"run_id": run_id, "error": "raw-secret"},
+        attachments=[],
+        created_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_split_projects_legacy_failed_message_before_copying_it():
+    from brain.app.api.routers.cortex import _misc
+
+    run = _failed_run()
+    message = _failed_message()
+    session = _Session(runs=[run], messages=[message])
+    parent = SimpleNamespace(
+        id="idea-1",
+        org_id="org-1",
+        position_x=0,
+        position_y=0,
+        salience_score=5.0,
+        active_agents=0,
+    )
+    request = SimpleNamespace(
+        json=AsyncMock(
+            return_value={
+                "branches": [{"topic": "Safe branch", "message_indices": [0]}],
+            }
+        )
+    )
+    copied_commands = []
+
+    async def capture_message(_session, *, idea, command, apply_lifecycle):
+        copied_commands.append(command)
+        return SimpleNamespace()
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(
+            _misc,
+            "_a_require_idea_for_user",
+            AsyncMock(return_value=parent),
+        ),
+        patch.object(_misc, "post_thread_message", side_effect=capture_message),
+        patch.object(_misc, "transition_thought_status", AsyncMock()),
+        patch.object(_misc, "_cancel_active_runs_for_idea", AsyncMock(return_value=0)),
+        patch("brain.systems.cortex.events.publish"),
+    ):
+        result = await _misc.split_idea(
+            "idea-1",
+            request,
+            user={"id": "user-1", "org_id": "org-1"},
+        )
+
+    assert result["ok"] is True
+    assert len(copied_commands) == 1
+    copied = copied_commands[0]
+    assert "raw-secret" not in copied.content
+    assert copied.metadata == {
+        "failure": {
+            "status": "failed",
+            "category": "upstream",
+            "message": copied.content,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_audit_analyze_authorizes_and_projects_failed_thread_content():
+    from brain.app.api.routers.cortex import _misc
+
+    run = _failed_run()
+    message = _failed_message()
+    session = _Session(runs=[run], messages=[message])
+    authorize = AsyncMock(return_value=SimpleNamespace(id="idea-1"))
+    captured = {}
+
+    async def capture_admission(_session, event):
+        captured["event"] = event
+        return SimpleNamespace(ok=True, run_id=99)
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(_misc, "_a_require_idea_for_user", authorize),
+        patch.object(_misc, "admit_work", side_effect=capture_admission),
+    ):
+        result = await _misc.idea_audit_analyze(
+            "idea-1",
+            MagicMock(),
+            user={"id": "user-1", "org_id": "org-1"},
+        )
+
+    assert result == {"ok": True, "run_id": 99}
+    authorize.assert_awaited_once_with(
+        session,
+        "idea-1",
+        {"id": "user-1", "org_id": "org-1"},
+    )
+    admitted_message = captured["event"].payload["message"]
+    assert "raw-secret" not in admitted_message
+    assert "temporary upstream problem" in admitted_message
+
+
+@pytest.mark.asyncio
+async def test_audit_summary_authorizes_before_building_metrics():
+    from brain.app.api.routers.cortex import _misc
+
+    session = _Session(runs=[_failed_run()])
+    denied = HTTPException(status_code=404, detail="Idea not found")
+    build_summary = AsyncMock()
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(
+            _misc,
+            "_a_require_idea_for_user",
+            AsyncMock(side_effect=denied),
+        ),
+        patch.object(_misc, "async_build_idea_audit_summary", build_summary),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _misc.idea_audit(
+            "idea-1",
+            user={"id": "other-user", "org_id": "other-org"},
+        )
+
+    assert exc_info.value is denied
+    build_summary.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_audit_analyze_authorizes_before_querying_runs():
+    from brain.app.api.routers.cortex import _misc
+
+    session = _Session(runs=[_failed_run()], messages=[_failed_message()])
+    denied = HTTPException(status_code=404, detail="Idea not found")
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(
+            _misc,
+            "_a_require_idea_for_user",
+            AsyncMock(side_effect=denied),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _misc.idea_audit_analyze(
+            "idea-1",
+            MagicMock(),
+            user={"id": "other-user", "org_id": "other-org"},
+        )
+
+    assert exc_info.value is denied
+    assert session.scalars_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_audit_analysis_result_authorizes_before_querying_runs():
+    from brain.app.api.routers.cortex import _misc
+
+    session = _Session(runs=[_failed_run()], messages=[_failed_message()])
+    denied = HTTPException(status_code=404, detail="Idea not found")
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(
+            _misc,
+            "_a_require_idea_for_user",
+            AsyncMock(side_effect=denied),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _misc.idea_audit_analysis_result(
+            "idea-1",
+            user={"id": "other-user", "org_id": "other-org"},
+        )
+
+    assert exc_info.value is denied
+    assert session.scalars_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_audit_analysis_result_returns_typed_failure_without_diagnostics():
+    from brain.app.api.routers.cortex import _misc
+
+    run = _failed_run()
+    message = _failed_message()
+    session = _Session(runs=[run], messages=[message])
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
+        patch.object(
+            _misc,
+            "_a_require_idea_for_user",
+            AsyncMock(return_value=SimpleNamespace(id="idea-1")),
+        ),
+    ):
+        result = await _misc.idea_audit_analysis_result(
+            "idea-1",
+            user={"id": "user-1", "org_id": "org-1"},
+        )
+
+    serialized = json.dumps(result)
+    assert "raw-secret" not in serialized
+    assert "Traceback" not in serialized
+    assert result["status"] == "failed"
+    assert result["error"] == result["failure"]["message"]
+    assert result["content"] == result["failure"]["message"]
+    assert result["failure"] == {
+        "status": "failed",
+        "category": "upstream",
+        "message": result["failure"]["message"],
+    }

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -713,10 +713,121 @@ async def test_hosted_mcp_run_get_returns_tool_events_and_artifacts():
     assert response.status_code == 200
     payload = json.loads(response.json()["result"]["content"][0]["text"])
     assert payload["run"]["run_id"] == 55
-    assert payload["tool_events"][0]["payload"] == {"tool_name": "domain.inspect"}
+    assert payload["tool_events"][0]["payload"]["tool_name"] == "domain.inspect"
+    assert payload["tool_events"][0]["payload"]["display"]["status"] == "completed"
     assert payload["artifacts"][0]["text"] == "Finished."
     assert "events" not in payload
     assert session.order == []
+
+
+async def test_hosted_mcp_run_get_redacts_failed_run_diagnostics():
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    now = datetime.now(timezone.utc)
+    raw_diagnostic = "provider traceback token=run-get-secret"
+    run = SimpleNamespace(
+        id=55,
+        created_at=now,
+        updated_at=now,
+        org_id="org-1",
+        user_id="user-1",
+        thread_id="idea-1",
+        parent_run_id=None,
+        root_run_id=None,
+        trace_id="trace-1",
+        profile="standard",
+        recipe="default",
+        status="failed",
+        input_message="Do work",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={"failure": {"category": "upstream", "error": raw_diagnostic}},
+        context_summary=raw_diagnostic,
+        started_at=now,
+        paused_at=None,
+        completed_at=None,
+        failed_at=now,
+        canceled_at=None,
+    )
+    event = SimpleNamespace(
+        id=91,
+        run_id=55,
+        root_run_id=None,
+        sequence_no=3,
+        event_type="run.failed",
+        payload={"failure_category": "upstream", "error": raw_diagnostic},
+        producer="agent_runtime",
+        visibility="public",
+        created_at=now,
+    )
+    artifact = SimpleNamespace(
+        id=92,
+        run_id=55,
+        root_run_id=None,
+        artifact_type="final_answer",
+        title=raw_diagnostic,
+        payload={"error": raw_diagnostic},
+        text=raw_diagnostic,
+        uri="debug://raw",
+        visibility="public",
+        created_at=now,
+    )
+
+    class ScalarResult:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def all(self):
+            return self.rows
+
+    class RunSession(_AsyncSession):
+        async def get(self, model, row_id):
+            assert row_id == 55
+            return run
+
+        async def scalars(self, stmt):
+            text = str(stmt)
+            if "agent_run_events" in text:
+                return ScalarResult([event])
+            if "agent_run_artifacts" in text:
+                return ScalarResult([artifact])
+            return ScalarResult([])
+
+    with patch(
+        "brain.app.api.routers.agent_mcp.external_agents.authenticate_bridge_token",
+        return_value=_principal(),
+    ):
+        response = await _request(
+            "POST",
+            "/mcp",
+            session=RunSession(),
+            headers={"Authorization": "Bearer bridge-token"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 130,
+                "method": "tools/call",
+                "params": {
+                    "name": "illo_read",
+                    "arguments": {
+                        "capability": "run.get",
+                        "arguments": {
+                            "run_id": 55,
+                            "include_events": True,
+                            "include_tool_events": False,
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    serialized = json.dumps(payload)
+    assert raw_diagnostic not in serialized
+    assert payload["run"]["failure"]["message"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert payload["events"][0]["payload"]["failure"]["message"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert payload["artifacts"][0]["text"] == UPSTREAM_FAILED_RUN_MESSAGE
 
 
 async def test_hosted_mcp_cycle_manage_create_commits_and_publishes_change():

--- a/tests/test_external_agents_service.py
+++ b/tests/test_external_agents_service.py
@@ -374,6 +374,69 @@ async def test_headless_ask_serializes_after_run_admission_without_lazy_loading(
 
 
 @pytest.mark.asyncio
+async def test_failed_headless_ask_returns_only_the_public_failure(external_agent_session):
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_diagnostic = "provider traceback token=headless-secret"
+    principal = service.AgentBridgePrincipal(
+        connection_id="conn-1",
+        org_id="org-1",
+        owner_user_id="user-1",
+        token_id="token-1",
+        scopes=frozenset(service.DEFAULT_BRIDGE_SCOPES),
+        connection_display_name="Codex",
+        agent_kind="codex",
+    )
+    run = AgentRunRow(
+        org_id="org-1",
+        user_id="user-1",
+        thread_id="external-agent:conn-1:ask-failed",
+        trace_id="run:failed-headless",
+        profile="fast",
+        recipe="fast",
+        status="failed",
+        input_message="Private question",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        context_summary=raw_diagnostic,
+        metadata_={"failure": {"category": "upstream", "error": raw_diagnostic}},
+        failed_at=service.utcnow(),
+    )
+    external_agent_session.add(run)
+    await external_agent_session.flush()
+    task = ExternalAgentTaskRow(
+        id="ask-failed",
+        org_id="org-1",
+        connection_id="conn-1",
+        created_by_user_id="user-1",
+        source_surface="bridge_ask_illo",
+        title="Private question",
+        instructions="Private question",
+        input_parts=[],
+        status="submitted",
+        idempotency_key="ask:failed",
+        illo_run_id=run.id,
+        error=raw_diagnostic,
+        metadata_={"headless": True},
+    )
+    external_agent_session.add(task)
+    await external_agent_session.flush()
+
+    payload = await service.get_headless_ask(
+        external_agent_session,
+        principal,
+        ask_id=task.id,
+    )
+    serialized = str(payload)
+
+    assert raw_diagnostic not in serialized
+    assert payload["answer"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert payload["failure"]["message"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert payload["ask"]["error"] == UPSTREAM_FAILED_RUN_MESSAGE
+
+
+@pytest.mark.asyncio
 async def test_workspace_search_returns_visible_project_context_profiles(async_sqlite_session_factory):
     _patch_sqlite_for_external_agent_tables()
     session = await async_sqlite_session_factory(

--- a/tests/test_inbound_admin_tools.py
+++ b/tests/test_inbound_admin_tools.py
@@ -30,7 +30,9 @@ from brain.platform.db.models.inbound import (
 )
 from brain.platform.db.models.org import Org, User
 from brain.systems.external_agents import service as external_agents
+from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound import service as inbound_service
+from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
 from brain.systems.runs.execution_context import AgentExecutionContext, bind_agent_context
 from brain.systems.runs.tool_catalog.handlers.inbound import _handle_manage_inbound
 from brain.systems.user_domains.service import AsyncDomainService
@@ -388,6 +390,89 @@ async def test_illo_can_list_attention_events_for_recovery(
     assert {"value": inbound_service.STATUS_REVIEW_REQUIRED, "count": 1} in attention["summary"]["statuses"]
     assert {"value": inbound_service.STATUS_QUARANTINED, "count": 1} in attention["summary"]["statuses"]
     assert {"value": inbound_service.STATUS_FAILED, "count": 1} in attention["summary"]["statuses"]
+
+
+async def test_failed_inbound_serializers_redact_legacy_run_diagnostics():
+    raw_diagnostic = "provider rejected token=super-secret"
+    legacy_outcome = {
+        "triage": {
+            "status": "failed",
+            "run_status": "failed",
+            "final_answer": raw_diagnostic,
+            "result": {"status": "failed", "final_answer": raw_diagnostic},
+        }
+    }
+    event = InboundEventRow(
+        org_id=ORG_ID,
+        connection_id="33333333-3333-4333-8333-333333333333",
+        kind="signal",
+        origin="custom.failed_run",
+        status=inbound_service.STATUS_FAILED,
+        action_result=legacy_outcome,
+        error=raw_diagnostic,
+    )
+    receipt = InboundDecisionReceiptRow(
+        event_id="44444444-4444-4444-8444-444444444444",
+        org_id=ORG_ID,
+        connection_id="33333333-3333-4333-8333-333333333333",
+        status=inbound_service.STATUS_FAILED,
+        outcome=legacy_outcome,
+        tool_use={
+            "status": "failed",
+            "final_answer": raw_diagnostic,
+            "error": raw_diagnostic,
+        },
+        reasoning_summary=raw_diagnostic,
+    )
+
+    event_payload = inbound_admin.serialize_event(event)
+    receipt_payload = inbound_admin.serialize_receipt(receipt)
+    failure = {
+        "status": "failed",
+        "category": "internal",
+        "message": DEFAULT_FAILED_RUN_MESSAGE,
+    }
+
+    assert event_payload["failure"] == failure
+    assert event_payload["error"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert event_payload["action_result"]["triage"]["failure"] == failure
+    assert receipt_payload["failure"] == failure
+    assert receipt_payload["outcome"]["triage"]["result"]["failure"] == failure
+    assert receipt_payload["tool_use"] == {"status": "failed", "failure": failure}
+    assert receipt_payload["reasoning_summary"] is None
+    assert raw_diagnostic not in json.dumps(event_payload)
+    assert raw_diagnostic not in json.dumps(receipt_payload)
+
+
+async def test_generic_failed_inbound_serializers_preserve_non_run_contract():
+    diagnostic = "projection policy rejected this payload"
+    event = InboundEventRow(
+        org_id=ORG_ID,
+        connection_id="33333333-3333-4333-8333-333333333333",
+        kind="signal",
+        origin="custom.projection_failure",
+        status=inbound_service.STATUS_FAILED,
+        action_result={"status": "failed", "reason": "policy_rejected"},
+        error=diagnostic,
+    )
+    receipt = InboundDecisionReceiptRow(
+        event_id="44444444-4444-4444-8444-444444444444",
+        org_id=ORG_ID,
+        connection_id="33333333-3333-4333-8333-333333333333",
+        status=inbound_service.STATUS_FAILED,
+        outcome={"status": "failed", "reason": "policy_rejected"},
+        reasoning_summary=diagnostic,
+    )
+
+    event_payload = inbound_admin.serialize_event(event)
+    receipt_payload = inbound_admin.serialize_receipt(receipt)
+
+    assert "failure" not in event_payload
+    assert event_payload["error"] == diagnostic
+    assert event_payload["action_result"] == {"status": "failed", "reason": "policy_rejected"}
+    assert "failure" not in receipt_payload
+    assert receipt_payload["outcome"] == {"status": "failed", "reason": "policy_rejected"}
+    assert receipt_payload["reasoning_summary"] == diagnostic
 
 
 async def test_dry_run_uses_same_projection_order_as_runtime(

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -39,6 +39,7 @@ from brain.systems.external_agents import service as external_agents
 from brain.systems.inbound import admin as inbound_admin
 from brain.systems.inbound import service as inbound
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.user_domains.service import AsyncDomainService
@@ -661,33 +662,63 @@ async def test_inbound_triage_receipt_records_tool_attribution(session):
 
 
 async def test_inbound_triage_receipt_reconciles_when_illo_run_fails(session):
-    final_answer = "Illo triage failed before it could decide on the signal."
+    raw_diagnostic = "Illo triage failed: provider token=super-secret"
     triage = await _queue_unmatched_webhook_triage(
         session,
         origin="jira.ticket_updated",
         issue_key="PROJ-2",
         idempotency_key="jira:PROJ-2:updated",
     )
+    run = await session.get(AgentRunRow, int(triage["run_id"]))
+    run.metadata_ = {**dict(run.metadata_ or {}), "failure": {"category": "upstream"}}
     await _finish_triage_run(
         session,
         triage,
         status=RunStatus.FAILED,
-        final_answer=final_answer,
+        final_answer=raw_diagnostic,
         reason="triage worker crashed",
     )
 
     event = (await session.scalars(select(InboundEventRow))).one()
     receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    failure = {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
 
     assert event.status == "failed"
-    assert event.error == final_answer
+    assert event.error == UPSTREAM_FAILED_RUN_MESSAGE
     assert event.action_result["triage"]["status"] == "failed"
+    assert event.action_result["triage"]["failure"] == failure
     assert receipt.status == "failed"
     assert receipt.outcome["triage"]["result"] == {
         "status": "failed",
-        "final_answer": final_answer,
+        "failure": failure,
     }
     assert receipt.tool_use["status"] == "failed"
+    assert raw_diagnostic not in json.dumps(event.action_result)
+    assert raw_diagnostic not in json.dumps(receipt.outcome)
+
+    response = await _post_mcp(
+        session,
+        headers={"Authorization": f"Bearer {RAW_TOKEN}"},
+        json_body={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "illo_get_result",
+                "arguments": {"event_id": str(event.id)},
+            },
+        },
+    )
+    result_payload = json.loads(response.json()["result"]["content"][0]["text"])
+
+    assert result_payload["failure"] == failure
+    assert result_payload["event"]["failure"] == failure
+    assert result_payload["latest_receipt"]["failure"] == failure
+    assert raw_diagnostic not in json.dumps(result_payload)
 
 
 async def test_mcp_submit_rejects_overlong_origin_before_inbound_processing(session):

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1407,7 +1407,8 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
-    monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
+    record_activity = AsyncMock()
+    monkeypatch.setattr(runner, "_async_record_project_activity", record_activity)
     monkeypatch.setattr(
         runner,
         "materialize_project_context_workspaces",
@@ -1431,6 +1432,11 @@ def test_runner_fails_fast_when_project_context_has_no_workspace(monkeypatch):
     assert captured["run_id"] == 49
     assert "Project Context unavailable" in captured["error"]
     assert "did not provide a usable workspace" in captured["final_answer"]
+    public_activity = record_activity.await_args_list[-1]
+    assert public_activity.args[2] == "Project context unavailable"
+    assert public_activity.kwargs["issue_count"] == 1
+    assert "errors" not in public_activity.kwargs
+    assert "repository not found" not in str(public_activity)
 
 
 @pytest.mark.parametrize("materialization_ok", [False, True])

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -169,6 +169,110 @@ def test_run_event_to_message_projects_non_streaming_final_text():
     assert message["profile"] == "fast"
 
 
+def test_failed_run_replay_replaces_legacy_text_completed_diagnostic():
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+
+    raw_error = "peer closed connection; password=swordfish"
+    event = SimpleNamespace(
+        id=9,
+        run_id=42,
+        root_run_id=42,
+        sequence_no=5,
+        event_type="run.text_completed",
+        payload={"text": raw_error},
+        created_at=None,
+        _agent_run_thread_id="idea-1",
+        _agent_run_profile="fast",
+        _agent_run_org_id="org-1",
+        _agent_run_status="failed",
+        _agent_run_metadata={"failure": {"category": "upstream"}},
+    )
+
+    message = run_event_to_message(event, replayed=True)
+
+    assert message["type"] == "text_delta"
+    assert message["delta"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert message["failure"] == {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
+    assert raw_error not in json.dumps(message)
+
+
+@pytest.mark.parametrize(
+    ("event_type", "status", "expected_message"),
+    [
+        ("run.canceled", "canceled", "That run was canceled before it finished."),
+        ("run.expired", "expired", "That run timed out before it finished — please retry."),
+    ],
+)
+def test_non_success_terminal_replay_replaces_raw_reason(event_type, status, expected_message):
+    raw_error = "cancel reason included token=super-secret"
+    event = SimpleNamespace(
+        id=10,
+        run_id=42,
+        root_run_id=42,
+        sequence_no=6,
+        event_type=event_type,
+        payload={"reason": raw_error},
+        created_at=None,
+        _agent_run_status=status,
+        _agent_run_metadata={},
+    )
+
+    message = run_event_to_message(event, replayed=True)
+
+    assert message["type"] == "run_completed"
+    assert message["status"] == status
+    assert message["failure"]["message"] == expected_message
+    assert message["error"] == expected_message
+    assert raw_error not in json.dumps(message)
+
+
+def test_expired_status_transition_emits_one_terminal_message_after_running_transition():
+    base = {
+        "run_id": 42,
+        "root_run_id": 42,
+        "created_at": None,
+        "_agent_run_status": "expired",
+        "_agent_run_metadata": {},
+    }
+    events = [
+        SimpleNamespace(
+            **base,
+            id=11,
+            sequence_no=7,
+            event_type="run.status_changed",
+            payload={"from_status": "starting", "to_status": "running"},
+        ),
+        SimpleNamespace(
+            **base,
+            id=12,
+            sequence_no=8,
+            event_type="run.status_changed",
+            payload={"from_status": "running", "to_status": "expired", "reason": "RAW timeout"},
+        ),
+    ]
+
+    messages = [run_event_to_message(event, replayed=True) for event in events]
+
+    assert messages[0] is None
+    assert messages[1]["status"] == "expired"
+    assert messages[1]["failure"]["status"] == "expired"
+    assert "RAW timeout" not in json.dumps(messages)
+
+
+def test_public_failure_normalizes_legacy_cancelled_alias():
+    from brain.systems.runs.failures import CANCELED_RUN_MESSAGE, public_run_failure
+
+    assert public_run_failure("cancelled") == {
+        "status": "canceled",
+        "category": "internal",
+        "message": CANCELED_RUN_MESSAGE,
+    }
+
+
 def test_run_failed_public_projection_replaces_raw_error_with_safe_message():
     from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
 
@@ -195,6 +299,11 @@ def test_run_failed_public_projection_replaces_raw_error_with_safe_message():
     assert message["status"] == "failed"
     assert message["failure_category"] == "upstream"
     assert message["error"] == UPSTREAM_FAILED_RUN_MESSAGE
+    assert message["failure"] == {
+        "status": "failed",
+        "category": "upstream",
+        "message": UPSTREAM_FAILED_RUN_MESSAGE,
+    }
     assert raw_error not in json.dumps(message)
 
 

--- a/tests/test_terminal_run_surface_settlement.py
+++ b/tests/test_terminal_run_surface_settlement.py
@@ -1,0 +1,247 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def all(self):
+        return list(self._rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+@pytest.mark.parametrize(
+    ("run_status", "failure_category"),
+    [
+        ("failed", "upstream"),
+        ("canceled", "internal"),
+        ("expired", "verification"),
+    ],
+)
+async def test_non_success_discussion_settlement_uses_typed_message_not_final_answer_artifact(
+    monkeypatch,
+    run_status,
+    failure_category,
+):
+    from brain.platform.db.models.idea import IdeaThread, ThreadDiscussionComment
+    from brain.systems.runs.cortex import runner
+    from brain.systems.runs.failures import (
+        CANCELED_RUN_MESSAGE,
+        EXPIRED_RUN_MESSAGE,
+        UPSTREAM_FAILED_RUN_MESSAGE,
+    )
+
+    raw_error = "database password=swordfish host=internal.example"
+    expected_message = {
+        "failed": UPSTREAM_FAILED_RUN_MESSAGE,
+        "canceled": CANCELED_RUN_MESSAGE,
+        "expired": EXPIRED_RUN_MESSAGE,
+    }[run_status]
+    discussion_trigger = {
+        "thread_id": "idea-1",
+        "comment_id": 7,
+        "response_target": {
+            "surface": "thread_discussion",
+            "thread_id": "idea-1",
+            "reply_to_comment_id": 7,
+        },
+    }
+    run = SimpleNamespace(
+        id=91,
+        parent_run_id=None,
+        thread_id="thread-discussion:idea-1",
+        status=run_status,
+        org_id="org-1",
+        target_ref={
+            "kind": "thread_discussion",
+            "idea_id": "idea-1",
+            "parent_thread_id": "idea-1",
+            "discussion_trigger": discussion_trigger,
+        },
+        metadata_={
+            "originating_surface": "thread_discussion",
+            "failure": {"category": failure_category},
+        },
+    )
+    raw_final_artifact = SimpleNamespace(
+        id=201,
+        run_id=91,
+        artifact_type="final_answer",
+        text=raw_error,
+    )
+    added = []
+    published = []
+
+    class FakeSession:
+        def __init__(self):
+            self.scalar_calls = 0
+
+        async def get(self, _model, _key):
+            return run
+
+        async def scalars(self, _stmt):
+            self.scalar_calls += 1
+            if self.scalar_calls == 1:
+                return _ScalarRows([])
+            return _ScalarRows([raw_final_artifact])
+
+        def add(self, obj):
+            if isinstance(obj, ThreadDiscussionComment):
+                obj.id = 8
+            added.append(obj)
+
+        async def flush(self):
+            pass
+
+    monkeypatch.setattr(
+        runner,
+        "publish_safe",
+        lambda event, payload: published.append((event, payload)),
+    )
+
+    session = FakeSession()
+    payload = await runner._settle_terminal_root_run_async(session, 91)
+
+    assert payload == {
+        "surface": "thread_discussion",
+        "idea_id": "idea-1",
+        "run_id": 91,
+        "comment_id": 8,
+    }
+    assert session.scalar_calls == 1
+    assert not any(isinstance(obj, IdeaThread) for obj in added)
+    comment = next(obj for obj in added if isinstance(obj, ThreadDiscussionComment))
+    assert comment.body == expected_message
+    assert comment.attachments == []
+    assert comment.metadata_ == {
+        "source": "agent_run_final_answer",
+        "surface": "thread_discussion",
+        "created_by_run_id": 91,
+        "artifact_id": None,
+        "reply_to_comment_id": 7,
+    }
+    assert published[0][1]["comment"]["body"] == expected_message
+    assert raw_error not in str(added)
+    assert raw_error not in str(published)
+
+
+@pytest.mark.parametrize(
+    ("run_status", "failure_category"),
+    [
+        ("failed", "verification"),
+        ("canceled", "upstream"),
+        ("expired", "internal"),
+    ],
+)
+async def test_non_success_timeline_settlement_uses_typed_message_and_keeps_run_attachments(
+    run_status,
+    failure_category,
+):
+    from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
+    from brain.platform.db.models.idea import (
+        Idea,
+        IdeaStateLog,
+        IdeaThread,
+        ThreadDiscussionComment,
+    )
+    from brain.systems.runs.cortex import runner
+    from brain.systems.runs.failures import (
+        CANCELED_RUN_MESSAGE,
+        EXPIRED_RUN_MESSAGE,
+        VERIFICATION_FAILED_RUN_MESSAGE,
+    )
+
+    idea_id = str(uuid.uuid4())
+    raw_error = "verification rejected token=private-diagnostic"
+    expected_message = {
+        "failed": VERIFICATION_FAILED_RUN_MESSAGE,
+        "canceled": CANCELED_RUN_MESSAGE,
+        "expired": EXPIRED_RUN_MESSAGE,
+    }[run_status]
+    run = SimpleNamespace(
+        id=92,
+        parent_run_id=None,
+        thread_id=idea_id,
+        status=run_status,
+        target_ref={"originating_surface": "ai_timeline"},
+        metadata_={"failure": {"category": failure_category}},
+    )
+    idea = SimpleNamespace(
+        id=idea_id,
+        status="working",
+        org_id=None,
+        user_id="owner-1",
+        agent_details=None,
+        updated_at=None,
+    )
+    raw_final_artifact = SimpleNamespace(
+        id=202,
+        run_id=92,
+        artifact_type="final_answer",
+        text=raw_error,
+    )
+    attachment = {
+        "url": f"/static/uploads/thread-assets/{idea_id}/evidence.png",
+        "kind": "image",
+        "content_type": "image/png",
+    }
+    same_run_comment = SimpleNamespace(
+        id=29,
+        thread_id=idea_id,
+        attachments=[attachment],
+        metadata_={"created_by_run_id": 92},
+    )
+    artifact_queries = 0
+    added = []
+
+    class FakeSession:
+        async def get(self, model, key):
+            if model is AgentRunRow and int(key) == 92:
+                return run
+            if model is Idea and str(key) == idea_id:
+                return idea
+            return None
+
+        async def scalars(self, stmt):
+            nonlocal artifact_queries
+            entity = stmt.column_descriptions[0].get("entity")
+            if entity is AgentRunArtifactRow:
+                artifact_queries += 1
+                return _ScalarRows([raw_final_artifact])
+            if entity is ThreadDiscussionComment:
+                return _ScalarRows([same_run_comment])
+            if entity is IdeaThread:
+                return _ScalarRows([])
+            raise AssertionError(f"Unexpected settlement query: {stmt}")
+
+        def add(self, obj):
+            added.append(obj)
+
+        async def flush(self):
+            pass
+
+    payload = await runner._settle_idea_for_terminal_root_run_async(FakeSession(), 92)
+
+    assert payload == {
+        "idea_id": idea_id,
+        "old_status": "working",
+        "new_status": "failed",
+        "run_id": 92,
+    }
+    assert artifact_queries == 0
+    assert idea.status == "failed"
+    assert any(isinstance(obj, IdeaStateLog) for obj in added)
+    response = next(obj for obj in added if isinstance(obj, IdeaThread))
+    assert response.content == expected_message
+    assert response.attachments == [attachment]
+    assert response.metadata_ == {
+        "run_id": 92,
+        "artifact_id": None,
+        "source": "agent_run_final_answer",
+    }
+    assert raw_error not in str(added)

--- a/tests/test_worker_failure_surface_guards.py
+++ b/tests/test_worker_failure_surface_guards.py
@@ -1,0 +1,201 @@
+"""Source guards for worker diagnostics crossing public run surfaces."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _function(path: str, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    tree = ast.parse((ROOT / path).read_text(encoding="utf-8"), filename=path)
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name
+    )
+
+
+def _call_name(node: ast.Call) -> str:
+    return str(getattr(node.func, "attr", None) or getattr(node.func, "id", None) or "")
+
+
+def _contains_direct_error_access(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Attribute) and child.attr == "error":
+            return True
+        if (
+            isinstance(child, ast.Call)
+            and _call_name(child) == "getattr"
+            and len(child.args) >= 2
+            and isinstance(child.args[1], ast.Constant)
+            and child.args[1].value == "error"
+        ):
+            return True
+    return False
+
+
+def test_worker_public_output_sinks_do_not_receive_agent_error_directly():
+    execute = _function("brain/systems/runs/recipes/workers.py", "execute")
+    calls = [node for node in ast.walk(execute) if isinstance(node, ast.Call)]
+
+    text_deltas = [node for node in calls if _call_name(node) == "text_delta"]
+    assert text_deltas
+    assert all(not _contains_direct_error_access(node) for node in text_deltas)
+    assert {ast.unparse(node.args[0]) for node in text_deltas} == {"delta", "public_output"}
+
+    artifact_call = next(node for node in calls if _call_name(node) == "worker_result_artifact")
+    artifact_output = next(keyword.value for keyword in artifact_call.keywords if keyword.arg == "output")
+    assert ast.unparse(artifact_output) == "public_output"
+    assert not _contains_direct_error_access(artifact_output)
+
+
+def test_deep_failed_final_answer_is_only_used_as_internal_diagnostic():
+    run_worker = _function("brain/systems/runs/recipes/deep.py", "_run_worker_node")
+    completed_branch = next(
+        node
+        for node in ast.walk(run_worker)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "status == RunStatus.COMPLETED.value"
+    )
+    raw_output_assignments = [
+        node
+        for node in ast.walk(run_worker)
+        if isinstance(node, ast.Assign)
+        and ast.unparse(node.value) == "raw_output"
+        and any(ast.unparse(target) == "output" for target in node.targets)
+    ]
+
+    assert len(raw_output_assignments) == 1
+    assert raw_output_assignments[0] in list(ast.walk(completed_branch))
+
+    synthesis_rows = _function("brain/systems/runs/recipes/deep.py", "_worker_synthesis_rows")
+    failed_branch = next(
+        node
+        for node in ast.walk(synthesis_rows)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "status != RunStatus.COMPLETED.value"
+    )
+    failed_assignments = {
+        str(target.slice.value): ast.unparse(node.value)
+        for node in ast.walk(failed_branch)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Subscript)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "row"
+        and isinstance(target.slice, ast.Constant)
+    }
+    assert failed_assignments["output"].replace("'", '"') == 'failure["message"]'
+    assert "include_content=False" in ast.unparse(failed_branch)
+
+
+def test_cli_and_checker_public_error_values_use_safe_failure_projectors():
+    cli = _function("brain/app/cli/agent_cli.py", "call_agent")
+    returned_error_values = []
+    for node in ast.walk(cli):
+        if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Dict):
+            continue
+        for key, value in zip(node.value.keys, node.value.values):
+            if isinstance(key, ast.Constant) and key.value == "error":
+                returned_error_values.append(value)
+
+    assert returned_error_values
+    assert all(not _contains_direct_error_access(value) for value in returned_error_values)
+    assert not any(ast.unparse(value) in {"str(e)", "str(exc)"} for value in returned_error_values)
+
+    checker = _function(
+        "brain/systems/runs/tool_catalog/handlers/cortex_reply.py",
+        "_build_final_reply_check_context",
+    )
+    checker_source = ast.unparse(checker)
+    assert "worker_result.output or worker_result.error" not in checker_source
+    assert "summary = _safe_failure_message(diagnostic)" in checker_source
+
+
+@pytest.mark.parametrize(
+    ("path", "function_name", "required_calls"),
+    [
+        (
+            "brain/systems/runs/cortex/runner.py",
+            "_latest_unmirrored_final_answer",
+            {"_public_terminal_run_answer"},
+        ),
+        (
+            "brain/systems/runs/cortex/runner.py",
+            "_settle_thread_discussion_conversation_run_async",
+            {"_public_terminal_run_answer"},
+        ),
+        (
+            "brain/systems/runs/ui_events.py",
+            "run_event_to_ui_message",
+            {"_public_failure_for_event", "public_run_event_payload"},
+        ),
+        (
+            "brain/systems/runs/cortex/read_models.py",
+            "_debug_payload",
+            {"public_run_debug_event_payload", "public_failed_run_artifact"},
+        ),
+        (
+            "brain/systems/inbound/reconciliation.py",
+            "reconcile_inbound_triage_run",
+            {"public_run_failure"},
+        ),
+        (
+            "brain/systems/inbound/admin.py",
+            "serialize_receipt",
+            {"_public_run_outcome"},
+        ),
+        (
+            "brain/app/api/routers/agent_mcp.py",
+            "_tool_get_result",
+            {"public_run_failure"},
+        ),
+        (
+            "brain/systems/runs/recipes/workers.py",
+            "execute",
+            {"public_run_failure", "worker_result_artifact"},
+        ),
+        (
+            "brain/systems/runs/recipes/deep.py",
+            "_worker_synthesis_rows",
+            {"_public_worker_failure"},
+        ),
+        (
+            "brain/app/cli/agent_cli.py",
+            "call_agent",
+            {"_public_failure_message"},
+        ),
+    ],
+)
+def test_public_failure_sink_inventory_uses_safe_projectors(
+    path,
+    function_name,
+    required_calls,
+):
+    function = _function(path, function_name)
+    call_names = {
+        _call_name(node)
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+    }
+
+    assert required_calls <= call_names
+
+
+def test_timeline_and_discussion_sinks_never_read_final_answer_artifacts_directly():
+    for function_name in (
+        "_latest_unmirrored_final_answer",
+        "_settle_thread_discussion_conversation_run_async",
+    ):
+        function = _function("brain/systems/runs/cortex/runner.py", function_name)
+        call_names = {
+            _call_name(node)
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+        }
+        assert "_latest_final_answer_artifact" not in call_names

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -250,6 +250,53 @@ def test_workspace_query_scope_accepts_thread_url():
     assert scope["org_id"] == "org-1"
 
 
+async def test_workspace_tool_calls_project_legacy_structured_failures_safely():
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    raw_diagnostic = "legacy handler traceback token=workspace-tool-secret"
+    now = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    event = SimpleNamespace(
+        id=11,
+        run_id=7,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "manage_idea",
+            "args": {"action": "update"},
+            "result": json.dumps({"status": "error", "error": raw_diagnostic}),
+        },
+        created_at=now,
+    )
+    run = SimpleNamespace(thread_id="idea-1", status="completed")
+
+    class Result:
+        def all(self):
+            return [(event, run, None)]
+
+    class Session:
+        def execute(self, _stmt):
+            return Result()
+
+    payload = {"sources": {}}
+    await workspace_data._query_tool_calls(
+        Session(),
+        payload,
+        start=None,
+        end=None,
+        org_id=None,
+        user_id=None,
+        person_ids=[],
+        idea_id=None,
+        search=None,
+        limit=10,
+    )
+
+    serialized = json.dumps(payload)
+    assert raw_diagnostic not in serialized
+    assert payload["sources"]["tool_calls"][0]["result"] == DEFAULT_FAILED_RUN_MESSAGE
+    assert payload["sources"]["tool_calls"][0]["failure"]["status"] == "failed"
+
+
 async def test_workspace_data_runs_include_latest_final_answer_artifact():
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -273,13 +273,13 @@ async def test_workspace_tool_calls_project_legacy_structured_failures_safely():
         def all(self):
             return [(event, run, None)]
 
-    class Session:
+    class StubSession:
         def execute(self, _stmt):
             return Result()
 
     payload = {"sources": {}}
     await workspace_data._query_tool_calls(
-        Session(),
+        StubSession(),
         payload,
         start=None,
         end=None,


### PR DESCRIPTION
## Summary

- define one typed public failure representation for terminal run failures
- sanitize Cortex, discussion, WebSocket, debug/ops, inbound/MCP, worker, trace, workspace-data, and CLI projections
- prevent failed partial worker output and structured tool errors from reaching public success surfaces
- preserve raw diagnostics only in internal failure storage and enforce authorization on operational views

## Validation

- affected run-surface suite: 598 passed, 3 skipped
- async DB boundary suite: 38 passed
- independent final sink audit: no remaining #367 blockers
- full local backend gate: 3660 passed, 46 skipped; remaining local-only failures are restricted loopback sockets and a missing PyTorch dylib

Closes #367