### PR TITLE
fix(slack): require declare intent + thread-context precedence in chantier declaration door

### DIFF
--- a/brain/systems/slack/chantier_declare.py
+++ b/brain/systems/slack/chantier_declare.py
@@ -14,6 +14,7 @@ import json
 import re
 from typing import Any, Mapping, Sequence
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.domain import DomainRecord
@@ -28,6 +29,13 @@ GITHUB_PARENT_MIRROR_TOOL = "create_github_issue"
 GITHUB_SUB_ISSUE_TOOL = "add_github_sub_issue"
 
 _CHANTIER_KEYWORD_RE = re.compile(r"\bchantier\b", re.IGNORECASE)
+_PLAIN_DECLARE_PREFIX_RE = re.compile(
+    r"(?:\b(?:declare|déclare)(?:\s+(?:a|the|new|un))?"
+    r"|\b(?:create|open|start)(?:\s+(?:a|new))?"
+    r"|\bkick\s+off(?:\s+(?:a|new))?"
+    r"|\b(?:new|nouveau))\s*$",
+    re.IGNORECASE,
+)
 _SLACK_MENTION_RE = re.compile(r"<@[A-Z0-9]+>", re.IGNORECASE)
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _KIND_RE = re.compile(
@@ -54,14 +62,6 @@ _GITHUB_ISSUE_URL_RE = re.compile(
     r"^https?://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/"
     r"(?P<repo>[A-Za-z0-9_.-]+)/issues/(?P<number>[1-9][0-9]*)(?:[/?#].*)?$",
     re.IGNORECASE,
-)
-_QUESTION_PREFIXES = (
-    "are there",
-    "list",
-    "show",
-    "status",
-    "what",
-    "which",
 )
 
 
@@ -129,13 +129,7 @@ def parse_chantier_declaration(text: str) -> ChantierDeclaration | None:
     tail = raw[keyword.end() :].strip()
     used_colon = tail.startswith(":")
     tail = tail.lstrip(" \t:-–—")
-    if not tail or (
-        not used_colon
-        and (
-            prefix.startswith(_QUESTION_PREFIXES)
-            or tail.casefold().startswith(_QUESTION_PREFIXES)
-        )
-    ):
+    if not tail or (not used_colon and _PLAIN_DECLARE_PREFIX_RE.search(prefix) is None):
         return None
 
     urls = [_trim_url(url) for url in _URL_RE.findall(tail)]
@@ -199,10 +193,19 @@ async def maybe_declare_chantier_from_slack(
     actor_user_id: str | None,
     origin: str,
     text: str,
+    channel_id: str | None = None,
+    thread_ts: str | None = None,
 ) -> ChantierDeclareResult | None:
     """Create/update a chantier only through the explicit app-mention door."""
 
     if str(origin or "").strip() != SLACK_APP_MENTION_ORIGIN:
+        return None
+    if await _thread_belongs_to_chantier(
+        session,
+        org_id=org_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+    ):
         return None
     declaration = parse_chantier_declaration(text)
     if declaration is None:
@@ -213,6 +216,56 @@ async def maybe_declare_chantier_from_slack(
         actor_user_id=actor_user_id,
         declaration=declaration,
     )
+
+
+async def _thread_belongs_to_chantier(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    channel_id: str | None,
+    thread_ts: str | None,
+) -> bool:
+    clean_thread_ts = str(thread_ts or "").strip()
+    if not clean_thread_ts:
+        return False
+
+    service = AsyncDomainService(session)
+    domain = next(
+        (item for item in await service.list_domains(org_id) if item.slug == TRACKER_DOMAIN_SLUG),
+        None,
+    )
+    if domain is None:
+        return False
+    try:
+        object_type = await service.get_object_type(domain.id, CHANTIER_OBJECT_KEY)
+    except DomainNotFound:
+        return False
+    records = (
+        await session.scalars(
+            select(DomainRecord).where(
+                DomainRecord.org_id == org_id,
+                DomainRecord.domain_id == domain.id,
+                DomainRecord.object_type_id == object_type.id,
+                DomainRecord.archived_at.is_(None),
+            )
+        )
+    ).all()
+    clean_channel_id = str(channel_id or "").strip()
+    suffix = (
+        f":{clean_channel_id}:{clean_thread_ts}"
+        if clean_channel_id
+        else f":{clean_thread_ts}"
+    )
+    for record in records:
+        refs = (record.data or {}).get("refs")
+        for ref in refs if isinstance(refs, list) else ():
+            if not isinstance(ref, Mapping):
+                continue
+            if str(ref.get("source") or "").casefold() != "slack":
+                continue
+            if str(ref.get("ref") or "").strip().endswith(suffix):
+                return True
+    return False
 
 
 async def upsert_chantier_declaration(

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -70,6 +70,8 @@ async def process_slack_message_envelope(
             actor_user_id=authority_user_id,
             origin=str(normalized.get("origin") or ""),
             text=str(slack_payload.get("text") or ""),
+            channel_id=str(slack_payload.get("channel_id") or "") or None,
+            thread_ts=str(slack_payload.get("thread_ts") or "") or None,
         )
     except (DomainError, DomainNotFound) as exc:
         # Missing/mismatched Domain-1 configuration must be visible in the

--- a/tests/test_domains_service.py
+++ b/tests/test_domains_service.py
@@ -341,6 +341,22 @@ def test_slack_chantier_declaration_parses_mechanical_contract():
     assert parse_chantier_declaration("<@BILLO> what chantier are active?") is None
 
 
+def test_slack_chantier_declaration_requires_declare_intent_without_colon():
+    from brain.systems.slack.chantier_declare import parse_chantier_declaration
+
+    assert parse_chantier_declaration("super, so this chantier is locked") is None
+    assert parse_chantier_declaration("is the chantier ready?") is None
+    assert parse_chantier_declaration("the chantier looks good") is None
+    assert parse_chantier_declaration("chantier update please") is None
+
+    declared = parse_chantier_declaration("declare chantier reliability")
+    assert declared is not None and declared.title == "reliability"
+    colon = parse_chantier_declaration("chantier: Reliability push")
+    assert colon is not None and colon.title == "Reliability push"
+    french = parse_chantier_declaration("nouveau chantier fiabilité")
+    assert french is not None and french.title == "fiabilité"
+
+
 async def test_slack_chantier_declare_persists_explicit_sunset_kind(session):
     from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
 
@@ -503,6 +519,46 @@ async def test_slack_chantier_router_does_not_create_without_keyword(session):
     assert ordinary_mention is None
     assert dm_with_keyword is None
     assert records == []
+
+
+async def test_slack_chantier_declare_skips_bound_chantier_thread(session):
+    from brain.systems.slack.chantier_declare import maybe_declare_chantier_from_slack
+
+    service = AsyncDomainService(session)
+    domain = await service.create_domain(
+        ORG_ID,
+        name="GitHub Ticket Tracker",
+        slug="github-ticket-tracker",
+        objects=[_chantier_object_definition()],
+    )
+    data = _chantier_record_data()
+    data["refs"] = [
+        *data["refs"],
+        {
+            "source": "slack",
+            "ref": "slack:TTEAM:CCHANTIER:1784408445.531609",
+        },
+    ]
+    existing = await service.create_record(
+        ORG_ID,
+        domain.id,
+        "chantier",
+        data=data,
+    )
+
+    result = await maybe_declare_chantier_from_slack(
+        session,
+        org_id=ORG_ID,
+        actor_user_id=USER_ID,
+        origin="slack.app_mention",
+        text="<@BILLO> chantier: junk declaration",
+        channel_id="CCHANTIER",
+        thread_ts="1784408445.531609",
+    )
+
+    records = await service.list_records(ORG_ID, domain.id, object_key="chantier")
+    assert result is None
+    assert [record.id for record in records] == [existing.id]
 
 
 async def test_slack_chantier_declare_run_contract_requires_threaded_echo_and_mirror(session):

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompile
 import yaml
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.platform.db.models.org import Org, User
@@ -57,6 +58,9 @@ async def session(async_sqlite_session_factory):
         [
             Org.__table__,
             User.__table__,
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainRecord.__table__,
             ExternalAgentConnectionRow.__table__,
             AgentRunRow.__table__,
             AgentRunEventRow.__table__,


### PR DESCRIPTION
Fixes #388.

## Incident (2026-07-19, run 1937)
Reda replied `super, so this chantier is locked` inside the ACTIVE agent-mcp-repositioning anchor thread. The declaration door keyword-matched `chantier`, declared a junk chantier titled "is locked" (record 2105), and the #376 deterministic guarantee persisted + mirrored it to uwear-backend#1124 — while the real lock on record 1993 went unprocessed.

## Fix (two layers)
1. **Intent, not keyword**: colon-less declarations now require an explicit declare verb immediately governing the keyword — `declare/déclare (a|the|new|un)? chantier`, `create/open/start (a|new)? chantier`, `kick off`, `new/nouveau chantier`. The explicit `chantier: <Title>` door is unchanged. The verbatim incident message now parses to None (regression test).
2. **Thread-context precedence**: `maybe_declare_chantier_from_slack` now receives `channel_id`/`thread_ts` (wired from the inbound envelope) and refuses to declare from any thread whose `slack:` ref is already bound to a non-archived Domain-1 chantier record (anchor + decision threads). Replies inside an active chantier loop can never enter the declaration door, regardless of wording.

## Tests
`tests/test_domains_service.py` 50 passed · `tests/test_slack_teammate.py` 55 passed — includes the verbatim incident message → None, verb-form declarations still parsing, and the bound-thread guard.

## Deploy note
Standard upgrade; recreate `slack-connector` too (compose `slack` profile is skipped by upgrade.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)