### PR TITLE
fix(runs): explicit result contract per coordinator run_kind (#387)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -29,7 +29,11 @@ from brain.platform.db.models.idea import Idea
 from brain.systems.cortex.thread_links import thread_id_from_reference
 from brain.systems.cortex.project_context.search import search_project_contexts
 from brain.systems.cycles.access import CycleActor, cycle_scope_conditions, target_idea_scope_conditions
-from brain.systems.cycles.common import EXTERNAL_AGENT_TRIGGERED_CYCLE_ORIGIN
+from brain.systems.cycles.common import (
+    EXTERNAL_AGENT_TRIGGERED_CYCLE_ORIGIN,
+    OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
+)
+from brain.systems.cycles.contracts import normalize_cycle_run_kind
 from brain.systems.cycles.commands import (
     UNSET_CYCLE_FIELD,
     async_add_guidance_to_cycle as command_add_cycle_guidance,
@@ -673,6 +677,7 @@ ACT_CAPABILITIES: dict[str, dict[str, Any]] = {
             "config": "object",
             "output_target_id": "integer",
             "rationale": "string",
+            "run_kind": "scheduled_digest | off_slot_material_alert",
         },
     },
     "identity.manage": {
@@ -1172,8 +1177,13 @@ async def _act_manage_cycle(
         return _cycle_mutation_payload("delete", cycle, {"ok": True, "id": cycle.id})
 
     if action == "run":
+        run_kind = normalize_cycle_run_kind(
+            _clean_optional_string(arguments.get("run_kind"))
+            or OFF_SLOT_MATERIAL_ALERT_RUN_KIND
+        )
         result = await async_run_cycle_now(
             cycle.id,
+            run_kind=run_kind,
             launch_context={
                 "origin": EXTERNAL_AGENT_TRIGGERED_CYCLE_ORIGIN,
                 "source": "illo_act.cycle.manage",

--- a/brain/app/api/routers/cycles.py
+++ b/brain/app/api/routers/cycles.py
@@ -23,6 +23,7 @@ from brain.systems.cycles.commands import (
     cycle_change_event,
 )
 from brain.systems.cycles.events import publish_cycle_change
+from brain.systems.cycles.common import SCHEDULED_DIGEST_RUN_KIND
 from brain.systems.cycles.serializers import serialize_cycle, serialize_cycle_run
 from brain.systems.cycles.service import async_run_cycle_now
 from brain.platform.db.models.cycle import Cycle, CycleRun
@@ -217,7 +218,10 @@ async def run_cycle(
         "cycle_id": cycle_id,
         "target_idea_id": cycle.target_idea_id,
     }
-    payload = await async_run_cycle_now(cycle_id)
+    payload = await async_run_cycle_now(
+        cycle_id,
+        run_kind=SCHEDULED_DIGEST_RUN_KIND,
+    )
     publish_cycle_change(
         action="run",
         **event,

--- a/brain/systems/cycles/common.py
+++ b/brain/systems/cycles/common.py
@@ -11,6 +11,8 @@ SCHEDULED_CYCLE_ORIGIN = "scheduled_cycle"
 MANUAL_CYCLE_ORIGIN = "manual_cycle"
 AGENT_TRIGGERED_CYCLE_ORIGIN = "agent_triggered_cycle"
 EXTERNAL_AGENT_TRIGGERED_CYCLE_ORIGIN = "external_agent_triggered_cycle"
+SCHEDULED_DIGEST_RUN_KIND = "scheduled_digest"
+OFF_SLOT_MATERIAL_ALERT_RUN_KIND = "off_slot_material_alert"
 
 
 def validate_nonempty_trimmed(value: str, field_name: str) -> str:
@@ -70,6 +72,7 @@ def cycle_run_launch_context(run) -> dict:
     return {
         "origin": SCHEDULED_CYCLE_ORIGIN,
         "source": "cycle_scheduler",
+        "run_kind": SCHEDULED_DIGEST_RUN_KIND,
     }
 
 

--- a/brain/systems/cycles/contracts.py
+++ b/brain/systems/cycles/contracts.py
@@ -6,17 +6,16 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from brain.systems.cycles.common import SCHEDULED_CYCLE_ORIGIN, json_dict
+from brain.systems.cycles.common import (
+    OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
+    SCHEDULED_CYCLE_ORIGIN,
+    SCHEDULED_DIGEST_RUN_KIND,
+    json_dict,
+)
 
 from brain.systems.cycles.degradation import mandatory_escalations
 
 SCHEDULED_REVIEW_WINDOW_HOURS = 24
-CYCLE_RESULT_CONTRACT_PROFILE_STANDARD = "standard"
-CYCLE_RESULT_CONTRACT_PROFILE_MATERIAL_ALERT = "material_alert"
-VALID_CYCLE_RESULT_CONTRACT_PROFILES = {
-    CYCLE_RESULT_CONTRACT_PROFILE_STANDARD,
-    CYCLE_RESULT_CONTRACT_PROFILE_MATERIAL_ALERT,
-}
 
 # One source of truth for the base result-contract keys and the visible sections
 # named in the launch prompt. The gate validates these same labels/aliases.
@@ -27,6 +26,24 @@ RESULT_CONTRACT_OUTPUT_SECTIONS = {
     "record_next_action_or_blocker": "`Next action:` or `Blocker:`",
     "short_self_review_summary": "`Self-review summary:`",
 }
+
+# Keep each coordinator run kind's complete contract visible here. Do not derive
+# one from the other: their answer formats intentionally have different footers.
+CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND = {
+    SCHEDULED_DIGEST_RUN_KIND: (
+        "answer_the_cycle_mission",
+        "summarize_workspace_evidence_or_explicit_gaps",
+        "report_evidence_health",
+        "record_next_action_or_blocker",
+        "short_self_review_summary",
+    ),
+    OFF_SLOT_MATERIAL_ALERT_RUN_KIND: (
+        "answer_the_cycle_mission",
+        "summarize_workspace_evidence_or_explicit_gaps",
+        "report_evidence_health",
+    ),
+}
+VALID_CYCLE_RUN_KINDS = frozenset(CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND)
 
 
 def _aware_utc(value: datetime | None) -> datetime | None:
@@ -55,36 +72,30 @@ def cycle_scheduled_review_window(scheduled_for: datetime | None) -> dict[str, A
     }
 
 
-def normalize_cycle_result_contract_profile(profile: str | None) -> str:
-    """Return a validated explicit profile, defaulting legacy runs to standard."""
-    clean_profile = str(
-        profile or CYCLE_RESULT_CONTRACT_PROFILE_STANDARD
-    ).strip().lower()
-    if clean_profile not in VALID_CYCLE_RESULT_CONTRACT_PROFILES:
+def normalize_cycle_run_kind(run_kind: str | None) -> str:
+    """Return a validated coordinator run kind."""
+    clean_run_kind = str(run_kind or "").strip().lower()
+    if clean_run_kind not in VALID_CYCLE_RUN_KINDS:
         raise ValueError(
-            "cycle result-contract profile must be one of: "
-            f"{', '.join(sorted(VALID_CYCLE_RESULT_CONTRACT_PROFILES))}"
+            "cycle run_kind must be one of: "
+            f"{', '.join(sorted(VALID_CYCLE_RUN_KINDS))}"
         )
-    return clean_profile
+    return clean_run_kind
 
 
 def cycle_result_contract(
     degradation_tracking: dict[str, Any] | None = None,
     *,
-    profile: str | None = None,
+    run_kind: str,
 ) -> dict[str, Any]:
     """The minimum output contract for autonomous cycle runs."""
-    clean_profile = normalize_cycle_result_contract_profile(profile)
-    required_outputs = list(RESULT_CONTRACT_OUTPUT_SECTIONS)
-    if clean_profile == CYCLE_RESULT_CONTRACT_PROFILE_MATERIAL_ALERT:
-        required_outputs = [
-            "answer_the_cycle_mission",
-            "summarize_workspace_evidence_or_explicit_gaps",
-            "report_evidence_health",
-        ]
+    clean_run_kind = normalize_cycle_run_kind(run_kind)
+    required_outputs = list(
+        CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND[clean_run_kind]
+    )
     contract = {
         "kind": "autonomous_cycle_run_result",
-        "profile": clean_profile,
+        "run_kind": clean_run_kind,
         "required_outputs": required_outputs,
         "degraded_when": [
             "workspace_evidence_sources_fail_or_return_unexpectedly_sparse_results",
@@ -166,6 +177,9 @@ def cycle_launch_receipt(
         "timezone": timezone_name,
         "local_scheduled_for": local_scheduled_for,
         "scheduled_review_window": cycle_scheduled_review_window(scheduled_for),
-        "result_contract": result_contract or cycle_result_contract(),
+        "result_contract": result_contract
+        or cycle_result_contract(
+            run_kind=str(launch.get("run_kind") or SCHEDULED_DIGEST_RUN_KIND)
+        ),
         "evidence_health": pending_evidence_health_receipt(scheduled_for),
     }

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -14,6 +14,7 @@ from brain.platform.db.models.cycle import (
 )
 from brain.systems.cycles.common import (
     CYCLE_LEDGER_OUTPUT_TARGET_TYPE,
+    SCHEDULED_DIGEST_RUN_KIND,
     actor_id,
     actor_type,
     cycle_run_launch_context,
@@ -203,7 +204,9 @@ def _build_cycle_run_memory_snapshot(
     )
     result_contract = cycle_result_contract(
         degradation_tracking,
-        profile=launch_context.get("result_contract_profile"),
+        run_kind=str(
+            launch_context.get("run_kind") or SCHEDULED_DIGEST_RUN_KIND
+        ),
     )
 
     return {

--- a/brain/systems/cycles/prompts.py
+++ b/brain/systems/cycles/prompts.py
@@ -9,6 +9,7 @@ from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea
 from brain.systems.cycles.common import (
     SCHEDULED_CYCLE_ORIGIN,
+    SCHEDULED_DIGEST_RUN_KIND,
     cycle_run_launch_context,
     json_dict,
     json_list,
@@ -28,10 +29,15 @@ _MISSION_SEED_MAX_CHARS = 12_000
 def cycle_launch_envelope(cycle: Cycle, run: CycleRun) -> dict:
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
     degradation_tracking = json_dict(context_snapshot.get("degradation_tracking"))
+    launch_context = cycle_run_launch_context(run)
     result_contract = context_snapshot.get("result_contract")
     if not isinstance(result_contract, dict):
-        result_contract = cycle_result_contract(degradation_tracking)
-    launch_context = cycle_run_launch_context(run)
+        result_contract = cycle_result_contract(
+            degradation_tracking,
+            run_kind=str(
+                launch_context.get("run_kind") or SCHEDULED_DIGEST_RUN_KIND
+            ),
+        )
     origin = str(launch_context.get("origin") or SCHEDULED_CYCLE_ORIGIN)
     timezone_name = str(getattr(cycle, "timezone", None) or "UTC")
     try:

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -19,6 +19,7 @@ from brain.systems.cycles.common import (
     MANUAL_CYCLE_ORIGIN,
     REUSABLE_THREAD_EXECUTION_MODE,
     SCHEDULED_CYCLE_ORIGIN,
+    SCHEDULED_DIGEST_RUN_KIND,
     THREAD_OUTPUT_TARGET_TYPE,
     canonical_execution_mode,
     json_dict,
@@ -26,6 +27,7 @@ from brain.systems.cycles.common import (
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
+from brain.systems.cycles.contracts import normalize_cycle_run_kind
 from brain.systems.cycles.contract_gate import (
     async_prepare_cycle_run_visible_finalization,
     cycle_finalization_status_from_verdict,
@@ -216,13 +218,16 @@ async def _async_append_cycle_auth_blocked_thread_message(
 async def async_run_cycle_now(
     cycle_id: int,
     *,
+    run_kind: str,
     launch_context: dict | None = None,
 ) -> dict:
     scheduled_for = datetime.now(timezone.utc)
+    clean_run_kind = normalize_cycle_run_kind(run_kind)
     launch = {
         "origin": MANUAL_CYCLE_ORIGIN,
         "source": "cycle.run_now",
         **json_dict(launch_context),
+        "run_kind": clean_run_kind,
     }
     async with UnitOfWork() as uow:
         cycle = await uow.session.get(Cycle, cycle_id)
@@ -358,6 +363,7 @@ async def async_schedule_due_cycles_once(*, limit: int = 10) -> list[int]:
                     "launch_context": {
                         "origin": SCHEDULED_CYCLE_ORIGIN,
                         "source": "cycle_scheduler",
+                        "run_kind": SCHEDULED_DIGEST_RUN_KIND,
                     }
                 },
             )

--- a/brain/systems/runs/tool_catalog/definitions/brain.py
+++ b/brain/systems/runs/tool_catalog/definitions/brain.py
@@ -916,12 +916,12 @@ BRAIN_TOOLS = [
                     "type": "string",
                     "description": "Why this Cycle change is useful. Required by convention for autonomous changes.",
                 },
-                "result_contract_profile": {
+                "run_kind": {
                     "type": "string",
-                    "enum": ["standard", "material_alert"],
+                    "enum": ["scheduled_digest", "off_slot_material_alert"],
                     "description": (
-                        "Explicit result-contract profile for action='run'. Use material_alert only for a concise, "
-                        "single-focus alert; omit it for the strict standard contract. Never infer this from time."
+                        "Explicit coordinator run kind for action='run'. Use off_slot_material_alert for a concise, "
+                        "single-focus alert and scheduled_digest for the full digest contract."
                     ),
                 },
                 "output_target_type": {

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -74,8 +74,8 @@ _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
         "delete": {"required": ["id"], "optional": [], "effect": "archive/disable a cycle"},
         "run": {
             "required": ["id"],
-            "optional": ["result_contract_profile", "rationale"],
-            "effect": "run a cycle immediately with an explicit result-contract profile",
+            "optional": ["run_kind", "rationale"],
+            "effect": "run a cycle immediately with an explicit coordinator run kind",
         },
         "add_guidance": {
             "required": ["id", "guidance"],

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -15,8 +15,11 @@ from brain.systems.cycles.access import (
     cycle_scope_conditions,
     target_idea_scope_conditions,
 )
-from brain.systems.cycles.common import AGENT_TRIGGERED_CYCLE_ORIGIN
-from brain.systems.cycles.contracts import normalize_cycle_result_contract_profile
+from brain.systems.cycles.common import (
+    AGENT_TRIGGERED_CYCLE_ORIGIN,
+    OFF_SLOT_MATERIAL_ALERT_RUN_KIND,
+)
+from brain.systems.cycles.contracts import normalize_cycle_run_kind
 from brain.systems.cycles.commands import (
     UNSET_CYCLE_FIELD,
     async_add_guidance_to_cycle,
@@ -52,7 +55,7 @@ class ManageCycleArgs:
     target_idea_id: str | None = None
     guidance: str | None = None
     rationale: str | None = None
-    result_contract_profile: str | None = None
+    run_kind: str | None = None
     output_target_type: str | None = None
     output_target_id: str | None = None
     output_target_label: str | None = None
@@ -83,7 +86,7 @@ async def _handle_manage_cycle(
     target_idea_id: str | None = None,
     guidance: str | None = None,
     rationale: str | None = None,
-    result_contract_profile: str | None = None,
+    run_kind: str | None = None,
     output_target_type: str | None = None,
     output_target_id: str | None = None,
     output_target_label: str | None = None,
@@ -104,7 +107,7 @@ async def _handle_manage_cycle(
         target_idea_id=target_idea_id,
         guidance=guidance,
         rationale=rationale,
-        result_contract_profile=result_contract_profile,
+        run_kind=run_kind,
         output_target_type=output_target_type,
         output_target_id=output_target_id,
         output_target_label=output_target_label,
@@ -127,7 +130,7 @@ async def _handle_manage_cycle_async(
     target_idea_id: str | None = None,
     guidance: str | None = None,
     rationale: str | None = None,
-    result_contract_profile: str | None = None,
+    run_kind: str | None = None,
     output_target_type: str | None = None,
     output_target_id: str | None = None,
     output_target_label: str | None = None,
@@ -159,7 +162,7 @@ async def _handle_manage_cycle_async(
         target_idea_id=target_idea_id,
         guidance=guidance,
         rationale=rationale,
-        result_contract_profile=result_contract_profile,
+        run_kind=run_kind,
         output_target_type=output_target_type,
         output_target_id=output_target_id,
         output_target_label=output_target_label,
@@ -251,14 +254,15 @@ async def _action_delete(ctx: ManageCycleContext) -> dict[str, Any]:
 
 
 async def _action_run(ctx: ManageCycleContext) -> dict[str, Any]:
-    result_contract_profile = normalize_cycle_result_contract_profile(
-        ctx.args.result_contract_profile
+    run_kind = normalize_cycle_run_kind(
+        ctx.args.run_kind or OFF_SLOT_MATERIAL_ALERT_RUN_KIND
     )
     async with UnitOfWork() as uow:
         cycle = await _load_cycle(uow.session, ctx.actor, ctx.args.id)
         event = cycle_change_event(cycle)
     payload = await async_run_cycle_now(
         ctx.args.id,
+        run_kind=run_kind,
         launch_context={
             "origin": AGENT_TRIGGERED_CYCLE_ORIGIN,
             "source": "manage_cycle",
@@ -266,7 +270,6 @@ async def _action_run(ctx: ManageCycleContext) -> dict[str, Any]:
             "actor_id": ctx.actor.source_id,
             "thread_id": getattr(_agent_context, "idea_id", None),
             "rationale": _optional_text(ctx.args.rationale),
-            "result_contract_profile": result_contract_profile,
         },
     )
     publish_cycle_change(action="run", **event)

--- a/tests/test_cycle_degradation.py
+++ b/tests/test_cycle_degradation.py
@@ -130,7 +130,7 @@ def test_required_digest_contract_and_prompt_name_escalated_cause():
         state = _record_degraded_run(state, first_at + timedelta(minutes=30 * offset))
     scheduled_for = datetime(2026, 7, 14, 17, 0, tzinfo=timezone.utc)
     tracking = degradation_tracking_for_run(state, scheduled_for=scheduled_for)
-    contract = cycle_result_contract(tracking)
+    contract = cycle_result_contract(tracking, run_kind="scheduled_digest")
     cause = contract["mandatory_degradation_escalations"][0]
 
     missing = evaluate_cycle_result_contract(

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -14,7 +14,10 @@ from brain.systems.cycles import execution as cycle_execution
 from brain.systems.cycles import prompts as cycle_prompts
 from brain.systems.cycles import service
 from brain.systems.cycles.common import AGENT_TRIGGERED_CYCLE_ORIGIN, MANUAL_CYCLE_ORIGIN
-from brain.systems.cycles.contracts import cycle_result_contract
+from brain.systems.cycles.contracts import (
+    CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND,
+    cycle_result_contract,
+)
 from brain.app.api.routers import cycles as cycles_router
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
@@ -786,7 +789,9 @@ def test_coordinator_launch_prompt_maps_declared_contract_to_visible_sections():
     run.scheduled_for = datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)
     run.guidance_snapshot = []
     run.output_targets_snapshot = []
-    run.context_snapshot = {"result_contract": cycle_result_contract()}
+    run.context_snapshot = {
+        "result_contract": cycle_result_contract(run_kind="scheduled_digest")
+    }
 
     idea = Idea()
     idea.id = "coordinator-digest"
@@ -797,19 +802,49 @@ def test_coordinator_launch_prompt_maps_declared_contract_to_visible_sections():
         "## Cycle Memory", 1
     )[0]
 
-    for key in cycle_result_contract()["required_outputs"]:
+    for key in cycle_result_contract(
+        run_kind="scheduled_digest"
+    )["required_outputs"]:
         assert f"`{key}`" in output_section
     assert "`record_next_action_or_blocker` -> `Next action:` or `Blocker:`" in output_section
     assert "`short_self_review_summary` -> `Self-review summary:`" in output_section
     assert "Example required footer:" in output_section
 
 
+@pytest.mark.parametrize(
+    ("run_kind", "expected_outputs"),
+    [
+        (
+            "scheduled_digest",
+            RESULT_CONTRACT_REQUIRED_OUTPUTS,
+        ),
+        (
+            "off_slot_material_alert",
+            [
+                "answer_the_cycle_mission",
+                "summarize_workspace_evidence_or_explicit_gaps",
+                "report_evidence_health",
+            ],
+        ),
+    ],
+)
+def test_coordinator_run_kind_contracts_are_explicit(run_kind, expected_outputs):
+    contract = cycle_result_contract(run_kind=run_kind)
+
+    assert contract["run_kind"] == run_kind
+    assert contract["required_outputs"] == expected_outputs
+    assert (
+        tuple(expected_outputs)
+        == CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND[run_kind]
+    )
+
+
 def test_material_alert_contract_keeps_evidence_gate_without_digest_footer_fields():
     from brain.systems.cycles.contract_gate import evaluate_cycle_result_contract
 
-    contract = cycle_result_contract(profile="material_alert")
+    contract = cycle_result_contract(run_kind="off_slot_material_alert")
 
-    assert contract["profile"] == "material_alert"
+    assert contract["run_kind"] == "off_slot_material_alert"
     assert contract["required_outputs"] == [
         "answer_the_cycle_mission",
         "summarize_workspace_evidence_or_explicit_gaps",
@@ -828,7 +863,7 @@ def test_material_alert_contract_keeps_evidence_gate_without_digest_footer_field
     )
     strict_review = evaluate_cycle_result_contract(
         candidate_answer=alert,
-        result_contract=cycle_result_contract(),
+        result_contract=cycle_result_contract(run_kind="scheduled_digest"),
         mission="Publish the coordinator digest.",
     )
 
@@ -859,9 +894,11 @@ def test_material_alert_launch_prompt_does_not_request_digest_footer_fields():
         "launch_context": {
             "origin": AGENT_TRIGGERED_CYCLE_ORIGIN,
             "source": "manage_cycle",
-            "result_contract_profile": "material_alert",
+            "run_kind": "off_slot_material_alert",
         },
-        "result_contract": cycle_result_contract(profile="material_alert"),
+        "result_contract": cycle_result_contract(
+            run_kind="off_slot_material_alert"
+        ),
     }
 
     idea = Idea()
@@ -903,7 +940,10 @@ async def test_async_run_cycle_now_uses_native_uow_without_sync_bridges(monkeypa
     monkeypatch.setattr(service, "open_unit_of_work", _fail_sync_bridge, raising=False)
     monkeypatch.setattr(service, "run_unit_of_work_task", _fail_sync_bridge, raising=False)
 
-    payload = await service.async_run_cycle_now(cycle.id)
+    payload = await service.async_run_cycle_now(
+        cycle.id,
+        run_kind="scheduled_digest",
+    )
 
     assert executed_run_ids == [99]
     assert payload["id"] == 99
@@ -913,12 +953,13 @@ async def test_async_run_cycle_now_uses_native_uow_without_sync_bridges(monkeypa
     assert payload["context_snapshot"]["launch_context"] == {
         "origin": MANUAL_CYCLE_ORIGIN,
         "source": "cycle.run_now",
+        "run_kind": "scheduled_digest",
     }
     assert all(uow.entered for uow in factory.uows)
 
 
 @pytest.mark.asyncio
-async def test_async_run_cycle_now_snapshots_material_alert_contract_profile(monkeypatch):
+async def test_async_run_cycle_now_snapshots_off_slot_material_alert_contract(monkeypatch):
     cycle = Cycle()
     cycle.id = 5
     cycle.prompt = "Post one concise material engineering alert"
@@ -941,12 +982,12 @@ async def test_async_run_cycle_now_snapshots_material_alert_contract_profile(mon
 
     await service.async_run_cycle_now(
         cycle.id,
-        launch_context={"result_contract_profile": "material_alert"},
+        run_kind="off_slot_material_alert",
     )
 
     snapshot = created_runs[0].context_snapshot
-    assert snapshot["launch_context"]["result_contract_profile"] == "material_alert"
-    assert snapshot["result_contract"]["profile"] == "material_alert"
+    assert snapshot["launch_context"]["run_kind"] == "off_slot_material_alert"
+    assert snapshot["result_contract"]["run_kind"] == "off_slot_material_alert"
     assert "short_self_review_summary" not in snapshot["result_contract"]["required_outputs"]
 
 
@@ -1053,6 +1094,10 @@ async def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeyp
     assert cycle.last_status == "running"
     assert admissions[0]["metadata"]["origin"] == "cycle"
     assert admissions[0]["metadata"]["launch_envelope"]["origin"] == "scheduled_cycle"
+    assert (
+        admissions[0]["metadata"]["launch_envelope"]["launch_context"]["run_kind"]
+        == "scheduled_digest"
+    )
     assert admissions[0]["metadata"]["launch_envelope"]["launch_mode"] == "background_cycle_run"
     assert admissions[0]["metadata"]["launch_envelope"]["active_instruction_source"] == "cycle.prompt"
     assert admissions[0]["metadata"]["launch_envelope"]["scheduled_review_window"] == {
@@ -1066,6 +1111,7 @@ async def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeyp
         ),
     }
     assert admissions[0]["metadata"]["contract"]["result"]["kind"] == "autonomous_cycle_run_result"
+    assert admissions[0]["metadata"]["contract"]["result"]["run_kind"] == "scheduled_digest"
     assert admissions[0]["metadata"]["evidence_health"]["status"] == "pending"
     assert (
         admissions[0]["metadata"]["launch_receipt"]["scheduled_review_window"]["start_at"]
@@ -1392,8 +1438,9 @@ async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch)
     factory = _AsyncUnitOfWorkFactory([_AsyncCycleListSession([cycle])])
     captured = {}
 
-    async def fake_run_cycle_now(cycle_id, *, launch_context=None):
+    async def fake_run_cycle_now(cycle_id, *, run_kind, launch_context=None):
         captured["cycle_id"] = cycle_id
+        captured["run_kind"] = run_kind
         captured["launch_context"] = launch_context
         return {"id": 99, "cycle_id": cycle_id, "status": "queued"}
 
@@ -1420,6 +1467,7 @@ async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch)
     assert payload["run"]["id"] == 99
     assert captured == {
         "cycle_id": cycle.id,
+        "run_kind": "off_slot_material_alert",
         "launch_context": {
             "origin": AGENT_TRIGGERED_CYCLE_ORIGIN,
             "source": "manage_cycle",
@@ -1427,13 +1475,12 @@ async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch)
             "actor_id": "1438",
             "thread_id": "reflex-thread",
             "rationale": "EVENT_TRIGGER: PR #990 merged and needs deploy",
-            "result_contract_profile": "standard",
         },
     }
 
 
 @pytest.mark.asyncio
-async def test_manage_cycle_run_persists_explicit_material_alert_contract_profile(monkeypatch):
+async def test_manage_cycle_run_can_select_explicit_scheduled_digest_contract(monkeypatch):
     from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
     from brain.systems.runs.execution_context import bind_agent_context
 
@@ -1444,8 +1491,9 @@ async def test_manage_cycle_run_persists_explicit_material_alert_contract_profil
     factory = _AsyncUnitOfWorkFactory([_AsyncCycleListSession([cycle])])
     captured = {}
 
-    async def fake_run_cycle_now(cycle_id, *, launch_context=None):
+    async def fake_run_cycle_now(cycle_id, *, run_kind, launch_context=None):
         captured["cycle_id"] = cycle_id
+        captured["run_kind"] = run_kind
         captured["launch_context"] = launch_context
         return {"id": 99, "cycle_id": cycle_id, "status": "queued"}
 
@@ -1465,24 +1513,24 @@ async def test_manage_cycle_run_persists_explicit_material_alert_contract_profil
             await cycle_handlers._handle_manage_cycle_async(
                 action="run",
                 id=cycle.id,
-                rationale="Uwear material engineering change",
-                result_contract_profile="material_alert",
+                rationale="Re-run the scheduled digest",
+                run_kind="scheduled_digest",
             )
         )
 
     assert payload["run"]["id"] == 99
-    assert captured["launch_context"]["result_contract_profile"] == "material_alert"
+    assert captured["run_kind"] == "scheduled_digest"
 
 
 @pytest.mark.asyncio
-async def test_manage_cycle_run_rejects_unknown_result_contract_profile_before_loading_cycle(
+async def test_manage_cycle_run_rejects_unknown_run_kind_before_loading_cycle(
     monkeypatch,
 ):
     from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
     from brain.systems.runs.execution_context import bind_agent_context
 
     def forbidden_unit_of_work():
-        raise AssertionError("invalid profiles must fail before database access")
+        raise AssertionError("invalid run kinds must fail before database access")
 
     monkeypatch.setattr(cycle_handlers, "UnitOfWork", forbidden_unit_of_work)
 
@@ -1491,12 +1539,15 @@ async def test_manage_cycle_run_rejects_unknown_result_contract_profile_before_l
             await cycle_handlers._handle_manage_cycle_async(
                 action="run",
                 id=2,
-                result_contract_profile="inferred_off_slot",
+                run_kind="inferred_off_slot",
             )
         )
 
     assert payload == {
-        "error": "cycle result-contract profile must be one of: material_alert, standard"
+        "error": (
+            "cycle run_kind must be one of: "
+            "off_slot_material_alert, scheduled_digest"
+        )
     }
 
 
@@ -1820,6 +1871,7 @@ def test_coordinator_posted_digest_scores_one_without_repair_or_repost(monkeypat
         mission=mission,
         answer=answer,
         events=[slack_post],
+        launch_contract=cycle_result_contract(run_kind="scheduled_digest"),
     )
     repair_calls = []
 
@@ -1845,9 +1897,91 @@ def test_coordinator_posted_digest_scores_one_without_repair_or_repost(monkeypat
     assert verdict["settlement_status"] == "mission_success"
     assert verdict["missing_outputs"] == []
     assert verdict["final_missing_outputs"] == []
+    assert verdict["enforced_required_outputs"] == RESULT_CONTRACT_REQUIRED_OUTPUTS
     assert verdict["side_effects_succeeded"] is True
     assert len(session._events) == 1
     assert len(session._artifacts) == 1
+
+
+@pytest.mark.parametrize(
+    ("run_id", "answer"),
+    [
+        (
+            1857,
+            "Material engineering alert: deploy admission now preserves the active release "
+            "when a duplicate trigger arrives. Evidence reviewed: merged change, deploy "
+            "receipt, Slack post, and tracker update. Evidence health: ok. Next action: "
+            "monitor the next trigger.",
+        ),
+        (
+            1884,
+            "Material engineering alert: chantier movement now records the newly blocked "
+            "member and owner in the tracker. Evidence reviewed: current chantier, issue, "
+            "Slack post, and tracker update. Evidence health: ok. Self-review summary: "
+            "single material change verified and posted once.",
+        ),
+    ],
+    ids=["run-1857-no-self-review", "run-1884-no-next-action"],
+)
+def test_off_slot_material_alert_settles_completed_without_digest_footer_fields(
+    monkeypatch,
+    run_id,
+    answer,
+):
+    from brain.systems.cycles import contract_gate
+
+    side_effects = [
+        AgentRunEventRow(
+            id=1,
+            run_id=44,
+            root_run_id=44,
+            sequence_no=1,
+            event_type="run.tool_completed",
+            payload={
+                "tool_name": "post_slack_reply",
+                "result": {"status": "ok", "channel": "4_software"},
+            },
+        ),
+        AgentRunEventRow(
+            id=2,
+            run_id=44,
+            root_run_id=44,
+            sequence_no=2,
+            event_type="run.tool_completed",
+            payload={
+                "tool_name": "update_domain_record",
+                "result": {"status": "ok", "record_id": run_id},
+            },
+        ),
+    ]
+    contract = cycle_result_contract(run_kind="off_slot_material_alert")
+    session, cycle_run, cycle, _ = _contract_finalization_scenario(
+        cycle_id=2,
+        mission="Post one concise material engineering change alert.",
+        answer=answer,
+        events=side_effects,
+        launch_contract=contract,
+    )
+    repair_calls = []
+
+    async def fake_repair(**kwargs):
+        repair_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(contract_gate, "_async_repair_cycle_contract_answer", fake_repair)
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+
+    service.finalize_cycle_run_from_run(44, status="completed")
+
+    assert repair_calls == []
+    assert cycle_run.status == "completed"
+    assert cycle_run.error is None
+    assert cycle.last_status == "completed"
+    verdict = cycle_run.context_snapshot["mission_result_contract_verdict"]
+    assert verdict["settlement_status"] == "mission_success"
+    assert verdict["missing_outputs"] == []
+    assert verdict["final_missing_outputs"] == []
+    assert verdict["enforced_required_outputs"] == contract["required_outputs"]
 
 
 def test_coordinator_unswept_unposted_digest_still_degrades(monkeypatch):
@@ -1871,6 +2005,7 @@ def test_coordinator_unswept_unposted_digest_still_degrades(monkeypatch):
                 },
             )
         ],
+        launch_contract=cycle_result_contract(run_kind="scheduled_digest"),
     )
 
     async def fake_repair(**kwargs):

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -890,8 +890,9 @@ async def test_hosted_mcp_cycle_manage_run_propagates_external_trigger_provenanc
     cycle = _cycle_row()
     captured = {}
 
-    async def run_cycle_now(cycle_id, *, launch_context=None):
+    async def run_cycle_now(cycle_id, *, run_kind, launch_context=None):
         captured["cycle_id"] = cycle_id
+        captured["run_kind"] = run_kind
         captured["launch_context"] = launch_context
         return {"id": 77, "cycle_id": cycle_id, "status": "queued"}
 
@@ -932,6 +933,7 @@ async def test_hosted_mcp_cycle_manage_run_propagates_external_trigger_provenanc
     payload = json.loads(response.json()["result"]["content"][0]["text"])
     assert payload["run"]["id"] == 77
     assert captured["cycle_id"] == cycle.id
+    assert captured["run_kind"] == "off_slot_material_alert"
     assert captured["launch_context"] == {
         "origin": "external_agent_triggered_cycle",
         "source": "illo_act.cycle.manage",

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -606,9 +606,9 @@ def test_manage_cycle_schema_matches_canonical_runtime_policy():
     assert "reopen_archived" not in properties
     assert "add_guidance" in properties["action"]["enum"]
     assert "add_output_target" in properties["action"]["enum"]
-    assert properties["result_contract_profile"]["enum"] == [
-        "standard",
-        "material_alert",
+    assert properties["run_kind"]["enum"] == [
+        "scheduled_digest",
+        "off_slot_material_alert",
     ]
 
 


### PR DESCRIPTION
Closes #387.

## Problem
Off-slot coordinator **material-alert** runs came back `mission_contract_failed` (soft degrade) even when they posted a **correct, complete** alert to Slack. They were held to the full scheduled-digest result contract — required `short_self_review_summary` + `record_next_action_or_blocker` that their shorter single-focus format legitimately does not emit. Sibling of #364 (PR #373), which aligned only the `scheduled_digest` path; the off-slot path was left on the shared/implicit contract.

## Fix — option (b): one explicit contract per run_kind
Single source of truth `CYCLE_RESULT_CONTRACT_REQUIRED_OUTPUTS_BY_RUN_KIND`:
- **`scheduled_digest`** → full 5-output contract (unchanged — #373 preserved: mission answer + evidence summary + evidence health + next-action + self-review).
- **`off_slot_material_alert`** → lighter 3-output contract (mission answer + evidence summary + evidence health; **no** self-review/next-action footer).

No run kind derives its contract from the other — the answer formats intentionally differ.

## ⚠️ Contract change to eyeball
Replaces the implicit `result_contract_profile` selector (`standard` | `material_alert`) on the `illo_act` cycle tool with an **explicit `run_kind`** (`scheduled_digest` | `off_slot_material_alert`). This is a **parameter rename on the coordinator tool schema** — all internal callers, prompts, dispatch, API routers, and the tool-registry test were updated together in this diff; no stale `result_contract_profile` references remain. Please confirm no external caller still passes the old param name.

## How to verify (backend only, no UI)
```
cd <worktree> && venv/bin/python -m pytest \
  tests/test_cycles_service.py tests/test_cycle_degradation.py \
  tests/test_external_agent_routes.py tests/test_tool_registry.py -q
```
Result on this branch: **143 passed** (orchestrator re-ran independently). Worker's full non-DB suite: 3857 passed / 52 skipped (14 unrelated env failures: missing `torch`, sandbox-blocked localhost binds).

## Acceptance checks
1. ✅ A correct off-slot material-alert run settles `completed` (no `mission_contract_failed`).
2. ✅ run_kind → required-outputs mapping explicit for **both** `scheduled_digest` and `off_slot_material_alert` (no shared/implicit contract).
3. ✅ 1857/1884-style scenarios (missing `short_self_review_summary` / `record_next_action_or_blocker`) no longer degrade.
4. ✅ Scheduled digests retain the full #373 contract and stay non-degraded.

## Reviewer notes
- **Draft** — not merge-ready. Eyeball: the run_kind → required-outputs split, and the `result_contract_profile` → `run_kind` tool-param rename.
- Implemented by a Codex worker; diff + tests reviewed and independently re-run by the R3 orchestrator before opening.

🤖 R3 Illospace worker (autonomous) · reviewed by orchestrator
