### PR TITLE
fix(triage): thread-scoped post-mute after human stand-down (#392)

### DIFF
--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 import tempfile
 import threading
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import uuid
 
 from sqlalchemy import func, select
@@ -46,6 +46,9 @@ from brain.systems.cortex.project_context.materializer import (
 from brain.systems.cortex.thought_lifecycle import TerminalRunSettlementCommand, settle_terminal_run
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.idea import Idea, IdeaThread, ThreadDiscussionComment
+
+if TYPE_CHECKING:
+    from brain.systems.slack.thread_mute import ThreadPostMute
 
 logger = logging.getLogger(__name__)
 UnitOfWork = None
@@ -740,6 +743,31 @@ async def _clear_slack_processing_status(client: Any, trigger: dict[str, Any]) -
         await set_status(channel_id=channel_id, thread_ts=thread_ts, status="")
 
 
+async def _record_slack_thread_mute(
+    session,
+    *,
+    run: AgentRunRow,
+    mute: ThreadPostMute,
+    channel_id: str,
+    thread_ts: str,
+) -> None:
+    await AsyncAgentRunStore(session).append_event(
+        run_event(
+            int(run.id),
+            "run.slack_post_suppressed",
+            {
+                "reason": "thread_post_muted",
+                "ledger_line": mute.ledger_line,
+                "muted_by": mute.user,
+                "muted_at": mute.ts,
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+            },
+            root_run_id=run.root_run_id,
+        )
+    )
+
+
 async def _settle_slack_origin_run_async(
     session,
     run: AgentRunRow,
@@ -772,6 +800,33 @@ async def _settle_slack_origin_run_async(
         return None
     try:
         client = await _slack_client_for_run(run)
+        if target["thread_ts"]:
+            from brain.systems.slack.thread_mute import read_thread_post_mute
+
+            mute = await read_thread_post_mute(
+                client,
+                channel_id=channel_id,
+                thread_ts=target["thread_ts"],
+                illo_user_id=str(target["trigger"].get("bot_user_id") or "").strip() or None,
+            )
+            if mute is not None:
+                await _clear_slack_processing_status(client, target["trigger"])
+                await _record_slack_thread_mute(
+                    session,
+                    run=run,
+                    mute=mute,
+                    channel_id=channel_id,
+                    thread_ts=target["thread_ts"],
+                )
+                return {
+                    "surface": _SLACK_SURFACE,
+                    "run_id": int(run.id),
+                    "artifact_id": artifact_id,
+                    "channel_id": channel_id,
+                    "thread_ts": target["thread_ts"],
+                    "suppressed": True,
+                    "ledger_line": mute.ledger_line,
+                }
         response = await client.post_message(
             channel=channel_id,
             text=final_answer,

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -10,6 +10,7 @@ from typing import Any
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
+from brain.systems.slack.thread_mute import read_thread_post_mute
 from brain.systems.slack.uploads import slack_image_upload_from_data_url
 
 
@@ -361,6 +362,36 @@ async def _handle_post_slack_reply(
 
     try:
         client = await _slack_client_from_runtime()
+        if target_thread_ts:
+            mute = await read_thread_post_mute(
+                client,
+                channel_id=target_channel,
+                thread_ts=target_thread_ts,
+                illo_user_id=str(trigger.get("bot_user_id") or "").strip() or None,
+            )
+            if mute is not None:
+                await _clear_processing_status(client, trigger)
+                return json.dumps(
+                    {
+                        "ok": True,
+                        "posted": False,
+                        "suppressed": True,
+                        "reason": "thread_post_muted",
+                        "ledger_line": mute.ledger_line,
+                        "muted_by": mute.user,
+                        "muted_at": mute.ts,
+                        "channel_id": target_channel,
+                        "thread_ts": target_thread_ts,
+                        "visibility": target_visibility,
+                        "counts_as_visible_response": True,
+                        "submitted_chars": len(text),
+                        "posted_chars": 0,
+                        "submitted_bytes": len(text.encode("utf-8")),
+                        "posted_bytes": 0,
+                        "chunk_count": 0,
+                        "truncated": False,
+                    }
+                )
         target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
         if image_upload is not None:
             response = await client.upload_file(

--- a/brain/systems/slack/thread_mute.py
+++ b/brain/systems/slack/thread_mute.py
@@ -1,0 +1,173 @@
+"""Thread-scoped Slack post-mute policy for explicit human stand-downs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+import re
+from typing import Any, Mapping, Sequence
+import unicodedata
+
+
+_ILLO_NAME_PATTERN = re.compile(r"(?<![\w@])@?illo\b", re.IGNORECASE)
+_DISMISSAL_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bnot\s+for\s+you\b",
+        r"\bthis\s+is\s+for\s+(?:the\s+)?team\b",
+        r"\bleave\s+(?:this|it)\s+to\s+us\b",
+        r"\b(?:we(?:'ve|\s+have)\s+got|we\s+got)\s+(?:this|it)\b",
+        r"\bon\s+g[èe]re\b",
+        r"\bc['’]?est\s+pour\s+l['’]?[ée]quipe\b",
+        r"\blaisse(?:z)?[- ]nous\s+g[ée]rer\b",
+    )
+)
+_REINVITE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:can|could|would|will)\s+you\b",
+        r"\bplease\s+(?:help|check|look|investigate|take|handle|review|join)\b",
+        r"\b(?:peux|pourrais|pouvez|pourriez)[- ](?:tu|vous)\b",
+        r"\best-ce\s+que\s+(?:tu\s+peux|vous\s+pouvez)\b",
+    )
+)
+
+
+@dataclass(frozen=True)
+class ThreadPostMute:
+    """The latest active human stand-down in a Slack thread."""
+
+    user: str
+    ts: str
+
+    @property
+    def ledger_line(self) -> str:
+        return f"thread muted by {self.user} at {self.ts}"
+
+
+def _normalized_text(value: Any) -> str:
+    return (
+        unicodedata.normalize("NFKC", str(value or ""))
+        .casefold()
+        .replace("’", "'")
+    )
+
+
+def _addresses_illo(text: str, *, illo_user_id: str | None) -> bool:
+    if illo_user_id:
+        mention = re.compile(
+            rf"<@{re.escape(str(illo_user_id).casefold())}(?:\|[^>]+)?>",
+            re.IGNORECASE,
+        )
+        if mention.search(text):
+            return True
+    return bool(_ILLO_NAME_PATTERN.search(text))
+
+
+def _is_human_message(message: Mapping[str, Any], *, illo_user_id: str | None) -> bool:
+    user = str(message.get("user") or "").strip()
+    if not user:
+        return False
+    if illo_user_id and user.casefold() == str(illo_user_id).strip().casefold():
+        return False
+    if message.get("bot_id") or message.get("bot_profile") or message.get("app_id"):
+        return False
+    return str(message.get("subtype") or "").strip() != "bot_message"
+
+
+def _author_label(message: Mapping[str, Any]) -> str:
+    profile = message.get("user_profile")
+    if isinstance(profile, Mapping):
+        for key in ("display_name", "real_name", "name"):
+            label = " ".join(str(profile.get(key) or "").split())
+            if label:
+                return label[:80]
+    return " ".join(str(message.get("user") or "human").split())[:80] or "human"
+
+
+def _message_ts_key(message: Mapping[str, Any]) -> tuple[int, Decimal, str]:
+    ts = str(message.get("ts") or "").strip()
+    try:
+        return (0, Decimal(ts), "")
+    except InvalidOperation:
+        return (1, Decimal(0), ts)
+
+
+def _matches_any(patterns: Sequence[re.Pattern[str]], text: str) -> bool:
+    return any(pattern.search(text) for pattern in patterns)
+
+
+def find_thread_post_mute(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    illo_user_id: str | None = None,
+) -> ThreadPostMute | None:
+    """Return the active mute after applying human directives chronologically.
+
+    A directive must both address Illo and use a conservative stand-down or
+    re-invite phrase. A dismissal wins over a re-invite in the same message, so
+    requests such as "can you leave this to us" cannot accidentally lift a mute.
+    """
+
+    active_mute: ThreadPostMute | None = None
+    for message in sorted(messages, key=_message_ts_key):
+        if not isinstance(message, Mapping) or not _is_human_message(
+            message,
+            illo_user_id=illo_user_id,
+        ):
+            continue
+        text = _normalized_text(message.get("text"))
+        if not _addresses_illo(text, illo_user_id=illo_user_id):
+            continue
+        if _matches_any(_DISMISSAL_PATTERNS, text):
+            active_mute = ThreadPostMute(
+                user=_author_label(message),
+                ts=str(message.get("ts") or "").strip(),
+            )
+        elif _matches_any(_REINVITE_PATTERNS, text):
+            active_mute = None
+    return active_mute
+
+
+async def read_thread_post_mute(
+    client: Any,
+    *,
+    channel_id: str,
+    thread_ts: str,
+    illo_user_id: str | None = None,
+) -> ThreadPostMute | None:
+    """Read the complete Slack thread and resolve its current post-mute state."""
+
+    read_replies = getattr(client, "conversation_replies", None)
+    if not callable(read_replies):
+        return None
+
+    messages: list[Mapping[str, Any]] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        response = await read_replies(
+            channel=channel_id,
+            thread_ts=thread_ts,
+            limit=200,
+            cursor=cursor,
+        )
+        if not isinstance(response, Mapping):
+            break
+        messages.extend(
+            message
+            for message in response.get("messages") or []
+            if isinstance(message, Mapping)
+        )
+        metadata = response.get("response_metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        next_cursor = str(metadata.get("next_cursor") or "").strip()
+        if not next_cursor or next_cursor in seen_cursors:
+            break
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    return find_thread_post_mute(messages, illo_user_id=illo_user_id)
+
+
+__all__ = ["ThreadPostMute", "find_thread_post_mute", "read_thread_post_mute"]

--- a/tests/test_slack_thread_post_mute.py
+++ b/tests/test_slack_thread_post_mute.py
@@ -1,0 +1,287 @@
+"""Regression tests for Slack thread-scoped post mutes."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+THREAD_TS = "1784484952.946099"
+MUTE_TS = "1784485035.715559"
+
+
+def _message(user: str, text: str, ts: str, **extra: Any) -> dict[str, Any]:
+    return {"user": user, "text": text, "ts": ts, **extra}
+
+
+def _trigger(thread_ts: str = THREAD_TS) -> dict[str, Any]:
+    return {
+        "channel_id": "C082SUKQKJL",
+        "channel_type": "channel",
+        "message_ts": "1784492958.128739",
+        "thread_ts": thread_ts,
+        "bot_user_id": "BILLO",
+        "response_target": {
+            "channel_id": "C082SUKQKJL",
+            "thread_ts": thread_ts,
+            "visibility": "public",
+        },
+    }
+
+
+class _SlackClient:
+    def __init__(self, threads: dict[str, list[dict[str, Any]]]):
+        self.threads = threads
+        self.posts: list[dict[str, Any]] = []
+        self.reads: list[dict[str, Any]] = []
+
+    async def conversation_replies(self, **kwargs: Any) -> dict[str, Any]:
+        self.reads.append(kwargs)
+        return {
+            "ok": True,
+            "messages": list(self.threads.get(kwargs["thread_ts"], [])),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    async def post_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.posts.append(kwargs)
+        return {"ok": True, "channel": kwargs["channel"], "ts": "1784493000.000001"}
+
+
+async def _post(monkeypatch, client: _SlackClient, *, thread_ts: str = THREAD_TS) -> dict[str, Any]:
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    async def slack_client() -> _SlackClient:
+        return client
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+    with bind_agent_context({"run_id": 392, "slack_trigger": _trigger(thread_ts)}):
+        return json.loads(await _handle_post_slack_reply(body="I am re-entering the incident."))
+
+
+def test_incident_stand_down_message_parses_as_thread_mute():
+    from brain.systems.slack.thread_mute import find_thread_post_mute
+
+    mute = find_thread_post_mute(
+        [
+            _message(
+                "human",
+                "@Illo not for you Illo, this is for the team",
+                MUTE_TS,
+            )
+        ],
+        illo_user_id="BILLO",
+    )
+
+    assert mute is not None
+    assert mute.user == "human"
+    assert mute.ts == MUTE_TS
+    assert mute.ledger_line == f"thread muted by human at {MUTE_TS}"
+
+
+@pytest.mark.asyncio
+async def test_thread_stand_down_suppresses_post_and_records_ledger_line(monkeypatch):
+    client = _SlackClient(
+        {
+            THREAD_TS: [
+                _message("U_REDA", "Production incident", THREAD_TS),
+                _message(
+                    "human",
+                    "@Illo not for you Illo, this is for the team",
+                    MUTE_TS,
+                ),
+                _message("U_TEAM", "Still investigating", "1784492900.000001"),
+            ]
+        }
+    )
+
+    result = await _post(monkeypatch, client)
+
+    assert result["ok"] is True
+    assert result["suppressed"] is True
+    assert result["ledger_line"] == f"thread muted by human at {MUTE_TS}"
+    assert client.posts == []
+    assert [read["thread_ts"] for read in client.reads] == [THREAD_TS]
+
+
+@pytest.mark.asyncio
+async def test_thread_mute_does_not_affect_another_thread(monkeypatch):
+    other_thread_ts = "1784500000.000001"
+    client = _SlackClient(
+        {
+            THREAD_TS: [
+                _message("human", "@Illo leave this to us", MUTE_TS),
+            ],
+            other_thread_ts: [
+                _message("U_OTHER", "New unrelated incident", other_thread_ts),
+            ],
+        }
+    )
+
+    result = await _post(monkeypatch, client, thread_ts=other_thread_ts)
+
+    assert result["ok"] is True
+    assert result.get("suppressed") is not True
+    assert client.posts == [
+        {
+            "channel": "C082SUKQKJL",
+            "text": "I am re-entering the incident.",
+            "thread_ts": other_thread_ts,
+        }
+    ]
+    assert [read["thread_ts"] for read in client.reads] == [other_thread_ts]
+
+
+@pytest.mark.asyncio
+async def test_later_explicit_reinvite_lifts_thread_mute(monkeypatch):
+    client = _SlackClient(
+        {
+            THREAD_TS: [
+                _message(
+                    "human",
+                    "<@BILLO> can you check the latest deploy now?",
+                    "1784492900.000001",
+                ),
+                _message("human", "@Illo leave this to us", MUTE_TS),
+            ]
+        }
+    )
+
+    result = await _post(monkeypatch, client)
+
+    assert result["ok"] is True
+    assert result.get("suppressed") is not True
+    assert len(client.posts) == 1
+
+
+@pytest.mark.parametrize(
+    ("text", "extra"),
+    [
+        ("@Illo the team is still checking the database metrics.", {}),
+        ("Leave this to us while we check the database metrics.", {}),
+        ("@Illo leave this to us", {"bot_id": "B_OTHER"}),
+    ],
+)
+def test_thread_mute_requires_human_address_and_dismissal(text, extra):
+    from brain.systems.slack.thread_mute import find_thread_post_mute
+
+    mute = find_thread_post_mute(
+        [_message("U_OTHER", text, MUTE_TS, **extra)],
+        illo_user_id="BILLO",
+    )
+
+    assert mute is None
+
+
+@pytest.mark.asyncio
+async def test_ordinary_human_reply_does_not_mute_thread(monkeypatch):
+    client = _SlackClient(
+        {
+            THREAD_TS: [
+                _message("U_REDA", "Production incident", THREAD_TS),
+                _message(
+                    "human",
+                    "The team is still checking the database metrics.",
+                    MUTE_TS,
+                ),
+            ]
+        }
+    )
+
+    result = await _post(monkeypatch, client)
+
+    assert result["ok"] is True
+    assert result.get("suppressed") is not True
+    assert len(client.posts) == 1
+
+
+def test_french_stand_down_directed_at_illo_mutes_thread():
+    from brain.systems.slack.thread_mute import find_thread_post_mute
+
+    mute = find_thread_post_mute(
+        [_message("human", "@Illo merci, on gère.", MUTE_TS)],
+        illo_user_id="BILLO",
+    )
+
+    assert mute is not None
+    assert mute.ledger_line == f"thread muted by human at {MUTE_TS}"
+
+
+@pytest.mark.asyncio
+async def test_terminal_slack_settlement_also_suppresses_muted_thread(monkeypatch):
+    from brain.systems.runs.cortex import runner
+
+    client = _SlackClient(
+        {THREAD_TS: [_message("human", "@Illo we've got this", MUTE_TS)]}
+    )
+    recorded: list[dict[str, Any]] = []
+    run = SimpleNamespace(
+        id=392,
+        parent_run_id=None,
+        root_run_id=392,
+        thread_id=f"slack:T789:C082SUKQKJL:{THREAD_TS}",
+        status="completed",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={"kind": "slack_message", "slack_trigger": _trigger()},
+        metadata_={"final_answer_target_surface": "slack"},
+    )
+
+    async def latest_final_answer(_session, *, run):
+        return "This settlement must stay silent.", 101
+
+    async def visible_action(_session, *, run):
+        return False
+
+    async def slack_client(run_arg):
+        assert run_arg is run
+        return client
+
+    async def record_mute(_session, **kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(runner, "_latest_final_answer_artifact", latest_final_answer)
+    monkeypatch.setattr(runner, "_slack_visible_action_already_recorded", visible_action)
+    monkeypatch.setattr(runner, "_slack_client_for_run", slack_client)
+    monkeypatch.setattr(runner, "_record_slack_thread_mute", record_mute)
+
+    result = await runner._settle_slack_origin_run_async(object(), run)
+
+    assert result["suppressed"] is True
+    assert result["ledger_line"] == f"thread muted by human at {MUTE_TS}"
+    assert client.posts == []
+    assert recorded[0]["mute"].ledger_line == result["ledger_line"]
+
+
+@pytest.mark.asyncio
+async def test_muted_thread_remains_readable_for_tracker_state(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_read_slack_conversation
+
+    messages = [
+        _message("U_REDA", "Production incident", THREAD_TS),
+        _message("human", "@Illo leave this to us", MUTE_TS),
+        _message("U_TEAM", "Tracker: mitigation deployed", "1784492900.000001"),
+    ]
+    client = _SlackClient({THREAD_TS: messages})
+
+    async def slack_client() -> _SlackClient:
+        return client
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+    with bind_agent_context({"run_id": 392, "slack_trigger": _trigger()}):
+        result = json.loads(await _handle_read_slack_conversation())
+
+    assert result["ok"] is True
+    assert result["messages"] == messages
+    assert result["count"] == 3


### PR DESCRIPTION
Closes #392

## What
Gives Illo a **thread-scoped outbound post-mute**. When a human addresses Illo in a thread and dismisses it ("not for you", "this is for the team", "on gère", "laissez-nous gérer", etc.), Illo stops posting in that thread until an explicit re-invite ("can you…", "peux-tu…"). Reads are unaffected — Illo still ingests the thread for tracker state.

## How
- New `brain/systems/slack/thread_mute.py`: conservative EN+FR dismissal/re-invite matching, applied chronologically over human messages only (bots/apps excluded); a dismissal wins over a re-invite in the same message. Pagination-safe thread read.
- Gate wired into `_settle_slack_origin_run_async` (`runner.py`): before `post_message`, resolve the thread mute; if muted, clear the processing status, record a `run.slack_post_suppressed` ledger event (`thread muted by <user> at <ts>`), and return `suppressed: True` **without posting**.
- `read_slack_conversation` handler untouched on the read path (muted thread stays fully readable).

## Acceptance checks (all verified by tests)
1. Human "not for you, this is for the team" → later run produces **zero** posts + logs `thread muted by human at <ts>`.
2. Mute is thread-scoped; a later explicit re-invite lifts it.
3. The verbatim incident message (ts `1784485035`) parses as a mute; ordinary/one-sided/bot replies do **not** mute.
4. A muted thread is still fully readable for tracker/coordinator state.

## Review surface (backend, no preview)
- Behavior to eyeball: an incident thread where a teammate tells Illo to stand down → Illo goes silent there but keeps tracking; a later "@Illo can you…" re-invites it.
- Tests: `venv/bin/python -m pytest tests/test_slack_thread_post_mute.py -q` → **11 passed**. Worker full run: 220 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)