### PR TITLE
fix(scheduler): await nightly_heuristic_review coroutine (#401)

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -29,7 +29,12 @@ from brain.platform.db.models.scheduler import (
 from brain.app.scheduler.catalog import normalize_owner_mode
 from brain.app.scheduler.contracts import validate_scheduler_run_contract
 from brain.app.scheduler.planner import async_materialize_due_runs
-from brain.app.scheduler.programs import NIGHTLY_SLEEP_STEP_KEYS, WRAPPER_STEP_KEY, build_scheduler_step_plan
+from brain.app.scheduler.programs import (
+    NIGHTLY_SLEEP_STEP_KEYS,
+    WRAPPER_STEP_KEY,
+    build_scheduler_step_plan,
+    nightly_heuristic_review_command,
+)
 from brain.app.scheduler.runtime import (
     LEASE_TTL_SECONDS,
     RUN_STATUS_CLAIMED,
@@ -250,11 +255,7 @@ def _nightly_wrapper_commands(target_date: date, *, split_steps: bool) -> list[l
         ["python3", "-m", "brain.app.cli.skills", "evolve"],
         ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"],
         ["python3", "-m", "brain.app.cli.meta_learn", "evolve"],
-        _python_one_liner(
-            "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
-            "r = nightly_heuristic_review(); "
-            "print(f'Pruned: {r[\"pruned\"]}, Fitness updated: {r[\"skills_updated\"]}')"
-        ),
+        nightly_heuristic_review_command(),
         _python_one_liner(
             "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
             "stats = run_meta_evolution(); "
@@ -280,11 +281,7 @@ def _nightly_step_commands(step_key: str, target_date: date) -> list[list[str]]:
             ["python3", "-m", "brain.app.cli.meta_learn", "evolve"],
         ],
         "heuristic_review": [
-            _python_one_liner(
-                "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
-                "r = nightly_heuristic_review(); "
-                "print(f'Pruned: {r[\"pruned\"]}, Fitness updated: {r[\"skills_updated\"]}')"
-            ),
+            nightly_heuristic_review_command(),
         ],
         "meta_evolution": [
             _python_one_liner(

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -223,6 +223,17 @@ def _python_one_liner(code: str) -> list[str]:
     return ["python3", "-c", code]
 
 
+def nightly_heuristic_review_command() -> list[str]:
+    """Run the async heuristic review from a synchronous scheduler process."""
+    return _python_one_liner(
+        "import asyncio; "
+        "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
+        "r = asyncio.run(nightly_heuristic_review()); "
+        "print(f'Nightly heuristic review ran: pruned={r[\"pruned\"]}, "
+        "skills_updated={r[\"skills_updated\"]}')"
+    )
+
+
 def _nightly_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     target_date = _target_date(job, run)
     return [
@@ -232,11 +243,7 @@ def _nightly_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
         StepSpec("meta_learning_evolve", ["python3", "-m", "brain.app.cli.meta_learn", "evolve"], "Meta-learning evolve"),
         StepSpec(
             "heuristic_review",
-            _python_one_liner(
-                "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
-                "r = nightly_heuristic_review(); "
-                "print(f'Pruned: {r[\"pruned\"]}, Fitness updated: {r[\"skills_updated\"]}')"
-            ),
+            nightly_heuristic_review_command(),
             "Heuristic review",
         ),
         StepSpec(

--- a/brain/systems/feedback/heuristics.py
+++ b/brain/systems/feedback/heuristics.py
@@ -514,7 +514,7 @@ async def nightly_heuristic_review():
 
         logger.info(
             f"Nightly heuristic review: pruned={stats['pruned']}, "
-            f"fitness_updated={stats['skills_updated']}/{len(skills)}"
+            f"skills_updated={stats['skills_updated']}/{len(skills)}"
         )
     except Exception as e:
         logger.warning(f"Nightly heuristic review failed: {e}")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,11 +1,12 @@
 """Scheduler catalog and due-run materialization tests."""
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -13,6 +14,8 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 
 import brain.app.scheduler.catalog as scheduler_catalog
+import brain.app.scheduler.executor as scheduler_executor
+import brain.systems.feedback.heuristics as heuristics
 from brain.app.scheduler.catalog import async_list_scheduler_jobs, async_sync_scheduler_catalog
 from brain.app.scheduler.contracts import (
     extract_declared_actions,
@@ -33,7 +36,11 @@ from brain.app.scheduler.executor import (
     async_set_scheduler_job_paused,
 )
 from brain.app.scheduler.planner import async_materialize_due_runs
-from brain.app.scheduler.programs import build_scheduler_step_plan
+from brain.app.scheduler.programs import (
+    build_scheduler_step_plan,
+    get_step_specs,
+    nightly_heuristic_review_command,
+)
 from brain.app.scheduler.runtime import (
     RUN_STATUS_EXPIRED,
     RUN_STATUS_SETTLED_SUCCESS,
@@ -531,6 +538,41 @@ async def test_nightly_step_plan_can_accept_budget_allowed_step_subset(session):
     assert step_plan[2]["payload"]["night_budget"]["work_type"] == "reflection_dream"
 
 
+async def test_nightly_heuristic_review_wrappers_await_and_report_counts(monkeypatch, capsys):
+    awaited = False
+
+    async def fake_nightly_heuristic_review():
+        nonlocal awaited
+        awaited = True
+        return {"pruned": 0, "skills_updated": 2}
+
+    monkeypatch.setattr(heuristics, "nightly_heuristic_review", fake_nightly_heuristic_review)
+    command = nightly_heuristic_review_command()
+    namespace = {}
+
+    await asyncio.to_thread(exec, command[2], namespace)
+
+    assert awaited is True
+    assert namespace["r"] == {"pruned": 0, "skills_updated": 2}
+    assert not asyncio.iscoroutine(namespace["r"])
+    assert capsys.readouterr().out.strip() == (
+        "Nightly heuristic review ran: pruned=0, skills_updated=2"
+    )
+
+    job = _make_scheduler_job()
+    run = SimpleNamespace(scheduled_for=datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc))
+    program_command = next(
+        step.command for step in get_step_specs(job, run) if step.step_key == "heuristic_review"
+    )
+    assert program_command == command
+    assert scheduler_executor._nightly_wrapper_commands(
+        date(2026, 4, 21), split_steps=False
+    )[4] == command
+    assert scheduler_executor._nightly_step_commands(
+        "heuristic_review", date(2026, 4, 21)
+    ) == [command]
+
+
 async def test_scheduler_lease_claim_and_reclaim(session):
     job = _make_scheduler_job(
         owner_mode="scheduler",
@@ -895,20 +937,15 @@ async def test_scheduler_step_crash_is_persisted_in_snapshot_without_log_storm(s
     assert "Scheduler step crashed" not in caplog.text
 
 
-async def test_identical_scheduler_failures_emit_one_durable_alert(session, caplog, monkeypatch):
+async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session, caplog, monkeypatch):
     monkeypatch.setenv("SCHEDULER_FAILURE_ALERT_THRESHOLD", "3")
     caplog.set_level(logging.ERROR, logger="brain.app.scheduler.executor")
     job = _make_scheduler_job(
         retry_policy={"max_attempts": 5, "backoff_seconds": 0},
         default_payload={
             "name": "Nightly Sleep",
-            "step_plan": [
-                {
-                    "step_key": "memory_consolidation",
-                    "sequence_no": 1,
-                    "command": "python3 -m brain.jobs.pipelines.consolidate --phase all",
-                }
-            ],
+            "scheduler_split_steps": True,
+            "night_budget_allowed_steps": ["heuristic_review"],
         },
     )
     session.add(job)
@@ -920,12 +957,12 @@ async def test_identical_scheduler_failures_emit_one_durable_alert(session, capl
         )
     )[0]
 
-    failure_text = (
-        "asyncpg.exceptions.StringDataRightTruncationError: "
-        "value too long for type character varying(20)"
-    )
+    failure_text = "RuntimeError: nightly heuristic review failed"
 
-    def failing_runner(command, *, cwd=None):
+    def failing_runner(command, *, cwd=None, env=None, timeout_seconds=None):
+        if "nightly scheduler wrapper initialized" in " ".join(command):
+            return SimpleNamespace(returncode=0, stdout="wrapper ready", stderr="")
+        assert command == nightly_heuristic_review_command()
         return SimpleNamespace(returncode=1, stdout="", stderr=failure_text)
 
     alert_timestamps = []
@@ -948,7 +985,9 @@ async def test_identical_scheduler_failures_emit_one_durable_alert(session, capl
     )
 
     assert len(alerts) == 1
+    assert caplog.text.count(failure_text) == 1
     assert job.consecutive_failure_count == 4
+    assert failed.result_summary["failed_step"] == "heuristic_review"
     assert alert_timestamps[:2] == [None, None]
     assert alert_timestamps[2] is not None
     assert alert_timestamps[3] == alert_timestamps[2]
@@ -967,12 +1006,28 @@ async def test_identical_scheduler_failures_emit_one_durable_alert(session, capl
         session,
         run.id,
         owner_id="tester",
-        runner=lambda command, *, cwd=None: SimpleNamespace(returncode=0, stdout="ok", stderr=""),
+        runner=lambda command, *, cwd=None: SimpleNamespace(
+            returncode=0,
+            stdout="Nightly heuristic review ran: pruned=0, skills_updated=0",
+            stderr="",
+        ),
         now=datetime(2026, 4, 21, 3, 6, tzinfo=timezone.utc),
     )
     await session.refresh(job)
 
+    success_snapshot = await async_scheduler_health_snapshot(
+        session,
+        now=datetime(2026, 4, 21, 3, 6, tzinfo=timezone.utc),
+    )
+    heuristic_step = next(
+        step for step in success_snapshot["runs"][0]["result_summary"]["steps"]
+        if step["step_key"] == "heuristic_review"
+    )
+
     assert succeeded.status == RUN_STATUS_SETTLED_SUCCESS
+    assert heuristic_step["results"][0]["stdout_tail"] == (
+        "Nightly heuristic review ran: pruned=0, skills_updated=0"
+    )
     assert job.consecutive_failure_count == 0
     assert job.failure_signature is None
     assert job.failure_alerted_at is None


### PR DESCRIPTION
Closes #401

## What this fixes
`nightly_heuristic_review()` is an async coroutine, but three scheduler wrappers called it **synchronously** and then subscripted the result — so it was **never awaited** (`TypeError: 'coroutine' object is not subscriptable` + `RuntimeWarning: coroutine ... never awaited`, reprinted ~80×/10min on `illospace-scheduler-1`). The nightly heuristic prune + skill-fitness update had therefore **never executed**.

## Change
- New `nightly_heuristic_review_command()` helper (`brain/app/scheduler/programs.py`) wraps the call in `asyncio.run(...)` and prints `pruned` / `skills_updated` (including zeros). All three inline call sites — the step spec in `programs.py` and the two wrappers in `executor.py` — now use it (de-duplicates the triplicated one-liner).
- Success log label aligned to `skills_updated`.
- Regression test proves the wrapper **awaits and returns a real dict** (not a coroutine) and reports counts; the repeated-failure test now exercises the `heuristic_review` path through the **existing durable one-shot alert guard** (`SCHEDULER_FAILURE_ALERT_THRESHOLD`) so a persistent failure emits **one** alert, not a per-run traceback storm.

## Acceptance checks (issue #401)
1. ✅ Runs to completion, returns a dict, logs non-null `pruned`/`skills_updated` (even 0), no `never awaited` warning.
2. ✅ Persistent failure → single guarded health alert, not ~80 reprints (covered by `test_repeated_heuristic_review_failure_emits_one_durable_alert`).
3. ✅ Health snapshot retains the success summary line (`stdout_tail` assertion).
- Check 2's log-volume-in-prod is a deploy-time observation once merged.

## Review surface
- Run tests: `PYTHONPATH=<worktree> venv/bin/python -m pytest tests/test_scheduler.py -q` → **32 passed** (0.8s).
- Files: `brain/app/scheduler/programs.py`, `brain/app/scheduler/executor.py`, `brain/systems/feedback/heuristics.py`, `tests/test_scheduler.py`.

_Draft PR opened by Routine R3 (Codex-implemented, Claude-reviewed). Not merged / not marked ready — Reda merges after review._