### PR TITLE
feat(alerts): durable provider-alert severity gate + ack ledger (#402)

### DIFF
--- a/brain/platform/db/alembic/versions/0033_provider_alert_ledger.py
+++ b/brain/platform/db/alembic/versions/0033_provider_alert_ledger.py
@@ -1,0 +1,117 @@
+"""Add durable provider-alert signature acknowledgement ledger.
+
+Revision ID: 0033_provider_alert_ledger
+Revises: 0031_scheduler_failure_guard, 0032_chantier_superseded_by
+Create Date: 2026-07-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0033_provider_alert_ledger"
+down_revision = (
+    "0031_scheduler_failure_guard",
+    "0032_chantier_superseded_by",
+)
+branch_labels = None
+depends_on = None
+
+_TABLE = "provider_alert_ledger"
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema=_schema()))
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {
+        index["name"]
+        for index in _inspector().get_indexes(table_name, schema=_schema())
+    }
+
+
+def _uuid_type():
+    if op.get_bind().dialect.name == "postgresql":
+        return postgresql.UUID(as_uuid=False)
+    return sa.String()
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("org_id", _uuid_type(), nullable=False),
+            sa.Column("channel_id", sa.String(length=80), nullable=False),
+            sa.Column("signature", sa.String(length=64), nullable=False),
+            sa.Column("classification", sa.String(length=80), nullable=False),
+            sa.Column("severity", sa.String(length=20), nullable=False),
+            sa.Column("rule_id", sa.String(length=120), nullable=False),
+            sa.Column(
+                "occurrence_count",
+                sa.Integer(),
+                server_default=sa.text("1"),
+                nullable=False,
+            ),
+            sa.Column(
+                "occurrences_at_last_post",
+                sa.Integer(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+            sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_posted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("slack_thread_ts", sa.String(length=40), nullable=True),
+            sa.Column("slack_message_ts", sa.String(length=40), nullable=True),
+            sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("acknowledged_by", sa.String(length=120), nullable=True),
+            sa.Column("acknowledgement", sa.Text(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(["org_id"], ["orgs.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "org_id",
+                "channel_id",
+                "signature",
+                name="uq_provider_alert_ledger_signature",
+            ),
+        )
+    if not _index_exists(_TABLE, "ix_provider_alert_ledger_recent"):
+        op.create_index(
+            "ix_provider_alert_ledger_recent",
+            _TABLE,
+            ["org_id", "channel_id", "last_seen_at"],
+        )
+
+
+def downgrade() -> None:
+    # Preserve acknowledgement history on downgrade. A later upgrade safely
+    # recognizes the existing table and recreates only the missing index.
+    if _index_exists(_TABLE, "ix_provider_alert_ledger_recent"):
+        op.drop_index("ix_provider_alert_ledger_recent", table_name=_TABLE)

--- a/brain/platform/db/models/__init__.py
+++ b/brain/platform/db/models/__init__.py
@@ -32,3 +32,4 @@ from brain.platform.db.models.object_reference import *  # noqa
 from brain.platform.db.models.launch_handoff import *  # noqa
 from brain.platform.db.models.packet_delivery import *  # noqa
 from brain.platform.db.models.workspace_tool import *  # noqa
+from brain.platform.db.models.provider_alert import *  # noqa

--- a/brain/platform/db/models/provider_alert.py
+++ b/brain/platform/db/models/provider_alert.py
@@ -1,0 +1,68 @@
+"""Durable acknowledgement/throttle state for provider-alert signatures."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from brain.platform.db.base import Base, TimestampMixin
+
+
+UUIDString = UUID(as_uuid=False).with_variant(String, "sqlite")
+
+__all__ = ["ProviderAlertLedger"]
+
+
+class ProviderAlertLedger(Base, TimestampMixin):
+    """One durable row per org/channel/typed alert signature."""
+
+    __tablename__ = "provider_alert_ledger"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "channel_id",
+            "signature",
+            name="uq_provider_alert_ledger_signature",
+        ),
+        Index(
+            "ix_provider_alert_ledger_recent",
+            "org_id",
+            "channel_id",
+            "last_seen_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUIDString,
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    channel_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    signature: Mapped[str] = mapped_column(String(64), nullable=False)
+    classification: Mapped[str] = mapped_column(String(80), nullable=False)
+    severity: Mapped[str] = mapped_column(String(20), nullable=False)
+    rule_id: Mapped[str] = mapped_column(String(120), nullable=False)
+    occurrence_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default=text("1"),
+        default=1,
+    )
+    occurrences_at_last_post: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default=text("0"),
+        default=0,
+    )
+    first_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_posted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    slack_thread_ts: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    slack_message_ts: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    acknowledged_by: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    acknowledgement: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/brain/platform/provider_alerts.py
+++ b/brain/platform/provider_alerts.py
@@ -1,0 +1,351 @@
+"""Deterministic provider-alert classification loaded from durable config.
+
+This module deliberately has no dependency on reconstructed/consolidated memory.
+The Slack posting path loads the checked-in map for every alert attempt.  The
+upstream coordinator that composes summaries should apply this same map too;
+the outbound gate remains authoritative when generated text is misclassified.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from brain.kernel import config
+
+
+PROVIDER_ALERT_POLICY_ENV = "ILLO_PROVIDER_ALERT_POLICY_PATH"
+DEFAULT_PROVIDER_ALERT_POLICY_PATH = (
+    Path(config.BRAIN_DIR) / "deploy" / "compose" / "provider-alert-severity.json"
+)
+_ALERT_HEADER = re.compile(
+    r"(?i)(?P<prefix>\bALERT\s*[—–-]\s*)"
+    r"(?:CRITICAL|HIGH|MEDIUM|LOW|CONTENT[ _-]?POLICY)"
+)
+_ALERT_MARKER = re.compile(r"(?i)\bALERT\s*[—–-]")
+_PROVIDER_MARKER = re.compile(
+    r"(?i)\b(?:provider|model (?:call|generation)|seedream|fal|vertex|oom)\b"
+    r"|Runtime\.OutOfMemory"
+)
+_TYPED_REASON_AFTER = re.compile(
+    r"(?i)\b(?:typed\s+)?(?:error[ _-]?reason|reason[ _-]?code|reason|type)"
+    r"\s*[:=]\s*[\"']?([a-z][a-z0-9_. -]{1,40})"
+)
+_TYPED_REASON_BEFORE = re.compile(
+    r"(?i)\b([a-z][a-z0-9_.-]{1,30})\s+(?:typed\s+)?(?:reason|rejection)\b"
+)
+_COUNT = re.compile(
+    r"(?i)\b(?:occurrences?|count|failures?|rejections?|total)\s*[:=]?\s*(\d+)\b"
+)
+_VOLATILE_SIGNATURE_PARTS = (
+    re.compile(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]+Z?\b", re.IGNORECASE),
+    re.compile(r"\b(?:occurrences?|count|total)\s*[:=]?\s*\d+\b", re.IGNORECASE),
+    re.compile(r"\bstill ongoing,?\s*\+\d+\s+since last\b", re.IGNORECASE),
+)
+
+
+class ProviderAlertPolicyError(RuntimeError):
+    """The durable alert policy could not be loaded or validated."""
+
+
+@dataclass(frozen=True)
+class ProviderAlertEvidence:
+    providers: tuple[str, ...]
+    status_code: int | None
+    error_type: str | None
+    typed_reason: str | None
+    occurrence_count: int | None
+
+
+@dataclass(frozen=True)
+class ProviderAlertDecision:
+    original_body: str
+    body: str
+    classification: str
+    severity: str
+    rule_id: str
+    signature: str
+    throttle_minutes: int
+    policy_source: str
+    evidence: ProviderAlertEvidence
+    escalation_reason: str | None = None
+
+
+def _token(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(value or "").casefold()).strip("_")
+
+
+def _policy_path(path: str | Path | None = None) -> Path:
+    configured = path or os.getenv(PROVIDER_ALERT_POLICY_ENV)
+    return Path(configured) if configured else DEFAULT_PROVIDER_ALERT_POLICY_PATH
+
+
+def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]:
+    """Read and validate the source-controlled severity map without caching it."""
+
+    source = _policy_path(path)
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except Exception as exc:  # config failures must never silently emit false HIGHs
+        raise ProviderAlertPolicyError(
+            f"provider alert policy unavailable at {source}: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ProviderAlertPolicyError("provider alert policy must be a JSON object")
+    rules = payload.get("rules")
+    if payload.get("version") != 1 or not isinstance(rules, list) or not rules:
+        raise ProviderAlertPolicyError("provider alert policy requires version=1 and rules")
+    if _token(payload.get("default_severity")) not in {"high", "medium", "low"}:
+        raise ProviderAlertPolicyError("provider alert policy has invalid default_severity")
+    for rule in rules:
+        if not isinstance(rule, dict) or not str(rule.get("id") or "").strip():
+            raise ProviderAlertPolicyError("every provider alert rule requires an id")
+        if _token(rule.get("severity")) not in {"high", "medium", "low"}:
+            raise ProviderAlertPolicyError(
+                f"provider alert rule {rule['id']} has invalid severity"
+            )
+        if not _token(rule.get("classification")):
+            raise ProviderAlertPolicyError(
+                f"provider alert rule {rule['id']} requires a classification"
+            )
+        try:
+            [int(value) for value in rule.get("status_codes") or []]
+        except (TypeError, ValueError) as exc:
+            raise ProviderAlertPolicyError(
+                f"provider alert rule {rule['id']} has an invalid status code"
+            ) from exc
+    try:
+        throttle_minutes = int(payload.get("throttle_minutes"))
+    except (TypeError, ValueError) as exc:
+        raise ProviderAlertPolicyError("provider alert throttle_minutes must be an integer") from exc
+    if throttle_minutes <= 0:
+        raise ProviderAlertPolicyError("provider alert throttle_minutes must be positive")
+    try:
+        abnormal_volume_threshold = int(payload.get("abnormal_volume_threshold") or 20)
+    except (TypeError, ValueError) as exc:
+        raise ProviderAlertPolicyError(
+            "provider alert abnormal_volume_threshold must be an integer"
+        ) from exc
+    if abnormal_volume_threshold <= 0:
+        raise ProviderAlertPolicyError(
+            "provider alert abnormal_volume_threshold must be positive"
+        )
+    signals = payload.get("escalation_signals") or {}
+    if not isinstance(signals, dict):
+        raise ProviderAlertPolicyError("provider alert escalation_signals must be an object")
+    try:
+        for patterns in signals.values():
+            if not isinstance(patterns, list):
+                raise TypeError("each escalation signal must contain a list of patterns")
+            for pattern in patterns:
+                re.compile(str(pattern))
+    except (TypeError, re.error) as exc:
+        raise ProviderAlertPolicyError(
+            f"provider alert escalation_signals contain an invalid pattern: {exc}"
+        ) from exc
+    payload["_source"] = str(source.resolve())
+    return payload
+
+
+def _configured_values(policy: Mapping[str, Any], key: str) -> set[str]:
+    return {
+        _token(value)
+        for rule in policy.get("rules") or []
+        if isinstance(rule, Mapping)
+        for value in rule.get(key) or []
+        if _token(value)
+    }
+
+
+def _typed_reason(body: str, configured_reasons: set[str]) -> str | None:
+    candidates: list[str] = []
+    for pattern in (_TYPED_REASON_AFTER, _TYPED_REASON_BEFORE):
+        candidates.extend(match.group(1) for match in pattern.finditer(body))
+    normalized_body = _token(body)
+    for candidate in candidates:
+        normalized = _token(candidate)
+        for configured in sorted(configured_reasons, key=len, reverse=True):
+            if normalized == configured or normalized.startswith(f"{configured}_"):
+                return configured
+    # Explicit "typed nsfw" is common in compact provider diagnostics.
+    for configured in sorted(configured_reasons, key=len, reverse=True):
+        if f"typed_{configured}" in normalized_body:
+            return configured
+    return None
+
+
+def _provider_alert_evidence(body: str, policy: Mapping[str, Any]) -> ProviderAlertEvidence:
+    normalized_body = _token(body)
+    providers = tuple(
+        sorted(
+            provider
+            for provider in _configured_values(policy, "providers_any")
+            if re.search(rf"(?<![a-z0-9]){re.escape(provider)}(?![a-z0-9])", normalized_body)
+        )
+    )
+    configured_status_codes = {
+        int(value)
+        for rule in policy.get("rules") or []
+        if isinstance(rule, Mapping)
+        for value in rule.get("status_codes") or []
+    }
+    status_pattern = re.compile(
+        r"(?i)\b(?:HTTP(?:\s+status)?\s*[:=]?\s*)?("
+        + "|".join(str(value) for value in sorted(configured_status_codes))
+        + r")\b"
+    )
+    status_match = status_pattern.search(body) if configured_status_codes else None
+    configured_error_types = _configured_values(policy, "error_types")
+    error_type = next(
+        (
+            error
+            for error in sorted(configured_error_types, key=len, reverse=True)
+            if re.search(
+                rf"(?<![a-z0-9]){re.escape(error)}(?![a-z0-9])",
+                normalized_body,
+            )
+        ),
+        None,
+    )
+    count_match = _COUNT.search(body)
+    return ProviderAlertEvidence(
+        providers=providers,
+        status_code=int(status_match.group(1)) if status_match else None,
+        error_type=error_type,
+        typed_reason=_typed_reason(
+            body,
+            _configured_values(policy, "typed_reasons"),
+        ),
+        occurrence_count=int(count_match.group(1)) if count_match else None,
+    )
+
+
+def _rule_matches(rule: Mapping[str, Any], evidence: ProviderAlertEvidence) -> bool:
+    providers = {_token(value) for value in rule.get("providers_any") or []}
+    if providers and not providers.intersection(evidence.providers):
+        return False
+    status_codes = {int(value) for value in rule.get("status_codes") or []}
+    if status_codes and evidence.status_code not in status_codes:
+        return False
+    error_types = {_token(value) for value in rule.get("error_types") or []}
+    if error_types and evidence.error_type not in error_types:
+        return False
+    reasons = {_token(value) for value in rule.get("typed_reasons") or []}
+    if reasons and evidence.typed_reason not in reasons:
+        return False
+    if rule.get("typed_reason_absent") is True and evidence.typed_reason is not None:
+        return False
+    return bool(providers or status_codes or error_types or reasons)
+
+
+def _escalation_reason(
+    body: str,
+    rule: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    evidence: ProviderAlertEvidence,
+) -> str | None:
+    allowed = {_token(value) for value in rule.get("escalate_on") or []}
+    configured = policy.get("escalation_signals") or {}
+    if isinstance(configured, Mapping):
+        for signal in allowed:
+            patterns = configured.get(signal) or []
+            if any(re.search(str(pattern), body, re.IGNORECASE) for pattern in patterns):
+                return signal
+    if "abnormal_volume" in allowed:
+        threshold = int(policy.get("abnormal_volume_threshold") or 20)
+        if evidence.occurrence_count is not None and evidence.occurrence_count >= threshold:
+            return "abnormal_volume"
+    return None
+
+
+def _signature(body: str, evidence: ProviderAlertEvidence, classification: str) -> str:
+    canonical_body = _ALERT_HEADER.sub("ALERT-SEVERITY", body)
+    for pattern in _VOLATILE_SIGNATURE_PARTS:
+        canonical_body = pattern.sub("<volatile>", canonical_body)
+    canonical_body = " ".join(canonical_body.casefold().split())
+    typed = {
+        "providers": evidence.providers,
+        "status_code": evidence.status_code,
+        "error_type": evidence.error_type,
+        "typed_reason": evidence.typed_reason,
+        "classification": classification,
+        "body": canonical_body,
+    }
+    return sha256(json.dumps(typed, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _render_body(body: str, severity: str, classification: str) -> str:
+    label = f"{severity.upper()} · {classification.replace('_', '-')}"
+    if _ALERT_HEADER.search(body):
+        return _ALERT_HEADER.sub(lambda match: f"{match.group('prefix')}{label}", body, count=1)
+    return body
+
+
+def classify_provider_alert_body(
+    body: str,
+    *,
+    policy_path: str | Path | None = None,
+) -> ProviderAlertDecision | None:
+    """Classify and rewrite an alert body, or return ``None`` for ordinary text."""
+
+    original_body = str(body or "")
+    if not _ALERT_MARKER.search(original_body) or not _PROVIDER_MARKER.search(original_body):
+        return None
+    policy = load_provider_alert_policy(policy_path)
+    evidence = _provider_alert_evidence(original_body, policy)
+    matched = next(
+        (
+            rule
+            for rule in policy["rules"]
+            if isinstance(rule, Mapping) and _rule_matches(rule, evidence)
+        ),
+        None,
+    )
+    if matched is None:
+        severity = _token(policy["default_severity"])
+        classification = "provider_failure"
+        rule_id = "default_provider_failure"
+        escalation_reason = None
+    else:
+        severity = _token(matched.get("severity"))
+        classification = _token(matched.get("classification")) or "provider_failure"
+        rule_id = str(matched.get("id") or "unnamed_rule")
+        escalation_reason = _token(matched.get("escalation_reason")) or None
+        detected_escalation = _escalation_reason(
+            original_body,
+            matched,
+            policy,
+            evidence,
+        )
+        if detected_escalation:
+            severity = "high"
+            escalation_reason = detected_escalation
+    body_after_gate = _render_body(original_body, severity, classification)
+    return ProviderAlertDecision(
+        original_body=original_body,
+        body=body_after_gate,
+        classification=classification,
+        severity=severity,
+        rule_id=rule_id,
+        signature=_signature(original_body, evidence, classification),
+        throttle_minutes=int(policy["throttle_minutes"]),
+        policy_source=str(policy["_source"]),
+        evidence=evidence,
+        escalation_reason=escalation_reason,
+    )
+
+
+__all__ = [
+    "DEFAULT_PROVIDER_ALERT_POLICY_PATH",
+    "PROVIDER_ALERT_POLICY_ENV",
+    "ProviderAlertDecision",
+    "ProviderAlertEvidence",
+    "ProviderAlertPolicyError",
+    "classify_provider_alert_body",
+    "load_provider_alert_policy",
+]

--- a/brain/platform/provider_alerts.py
+++ b/brain/platform/provider_alerts.py
@@ -28,10 +28,7 @@ _ALERT_HEADER = re.compile(
     r"(?:CRITICAL|HIGH|MEDIUM|LOW|CONTENT[ _-]?POLICY)"
 )
 _ALERT_MARKER = re.compile(r"(?i)\bALERT\s*[—–-]")
-_PROVIDER_MARKER = re.compile(
-    r"(?i)\b(?:provider|model (?:call|generation)|seedream|fal|vertex|oom)\b"
-    r"|Runtime\.OutOfMemory"
-)
+_GENERIC_PROVIDER_CONTEXT = re.compile(r"(?i)\b(?:provider|model (?:call|generation))\b")
 _TYPED_REASON_AFTER = re.compile(
     r"(?i)\b(?:typed\s+)?(?:error[ _-]?reason|reason[ _-]?code|reason|type)"
     r"\s*[:=]\s*[\"']?([a-z][a-z0-9_. -]{1,40})"
@@ -160,6 +157,25 @@ def _configured_values(policy: Mapping[str, Any], key: str) -> set[str]:
         for value in rule.get(key) or []
         if _token(value)
     }
+
+
+def _provider_alert_candidate(body: str, policy: Mapping[str, Any]) -> bool:
+    # Generic context keeps status-only rules eligible. Named providers and
+    # error types are owned exclusively by the policy below.
+    if _GENERIC_PROVIDER_CONTEXT.search(body):
+        return True
+    configured = _configured_values(policy, "providers_any") | _configured_values(
+        policy,
+        "error_types",
+    )
+    if not configured:
+        return False
+    marker = re.compile(
+        r"(?<![a-z0-9])(?:"
+        + "|".join(re.escape(value) for value in sorted(configured, key=len, reverse=True))
+        + r")(?![a-z0-9])"
+    )
+    return marker.search(_token(body)) is not None
 
 
 def _typed_reason(body: str, configured_reasons: set[str]) -> str | None:
@@ -294,9 +310,11 @@ def classify_provider_alert_body(
     """Classify and rewrite an alert body, or return ``None`` for ordinary text."""
 
     original_body = str(body or "")
-    if not _ALERT_MARKER.search(original_body) or not _PROVIDER_MARKER.search(original_body):
+    if not _ALERT_MARKER.search(original_body):
         return None
     policy = load_provider_alert_policy(policy_path)
+    if not _provider_alert_candidate(original_body, policy):
+        return None
     evidence = _provider_alert_evidence(original_body, policy)
     matched = next(
         (

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -4,14 +4,27 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from typing import Any
 
+from brain.platform.provider_alerts import (
+    ProviderAlertDecision,
+    ProviderAlertPolicyError,
+    classify_provider_alert_body,
+)
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
+from brain.systems.slack.provider_alert_gate import (
+    gate_provider_alert_post,
+    record_provider_alert_posted,
+)
 from brain.systems.slack.thread_mute import read_thread_post_mute
 from brain.systems.slack.uploads import slack_image_upload_from_data_url
+
+
+logger = logging.getLogger(__name__)
 
 
 def _execution_metadata() -> dict[str, Any]:
@@ -71,6 +84,31 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
         if normalized in {"0", "false", "no", "n", "off"}:
             return False
     return bool(value)
+
+
+def _provider_alert_result(decision: ProviderAlertDecision) -> dict[str, Any]:
+    return {
+        "provider_alert": True,
+        "alert_signature": decision.signature,
+        "alert_classification": decision.classification,
+        "alert_severity": decision.severity,
+        "alert_rule_id": decision.rule_id,
+        "alert_policy_source": decision.policy_source,
+        "alert_escalation_reason": decision.escalation_reason,
+    }
+
+
+def _posted_slack_message_ts(response: Any) -> str | None:
+    if not isinstance(response, dict):
+        return None
+    direct = str(response.get("ts") or "").strip()
+    if direct:
+        return direct
+    message = response.get("message")
+    if isinstance(message, dict):
+        nested = str(message.get("ts") or "").strip()
+        return nested or None
+    return None
 
 
 _SLACK_EMOJI_NAME_PATTERN = re.compile(r"^[a-z0-9_+\-]{1,80}$")
@@ -324,7 +362,8 @@ async def _handle_post_slack_reply(
 ) -> str:
     """Post an Illo-authored reply to the originating Slack surface."""
 
-    text = str(body or "")
+    submitted_text = str(body or "")
+    text = submitted_text
     try:
         image_upload = slack_image_upload_from_data_url(
             image_data,
@@ -336,6 +375,25 @@ async def _handle_post_slack_reply(
         return json.dumps({"error": str(exc)})
     if not text.strip() and image_upload is None:
         return json.dumps({"error": "post_slack_reply requires body or image_data"})
+
+    # Coordinator-side generators should apply the same checked-in map while
+    # composing summaries.  This posting-path gate is still the authority, so a
+    # fresh run cannot ship a generated false-HIGH provider alert.
+    try:
+        alert_decision = classify_provider_alert_body(text)
+    except ProviderAlertPolicyError as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "posted": False,
+                "error": "provider_alert_policy_unavailable",
+                "detail": str(exc),
+                "submitted_chars": len(submitted_text),
+                "posted_chars": 0,
+            }
+        )
+    if alert_decision is not None:
+        text = alert_decision.body
 
     trigger = _current_slack_trigger()
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
@@ -360,6 +418,7 @@ async def _handle_post_slack_reply(
     if not target_channel:
         return json.dumps({"error": "post_slack_reply requires channel_id outside a Slack-triggered run"})
 
+    alert_ledger_record_error: str | None = None
     try:
         client = await _slack_client_from_runtime()
         if target_thread_ts:
@@ -392,6 +451,73 @@ async def _handle_post_slack_reply(
                         "truncated": False,
                     }
                 )
+        if alert_decision is not None:
+            target_channel = await _resolve_post_channel(
+                client,
+                target_channel,
+                target_visibility,
+            )
+            alert_org_id = str(
+                getattr(_agent_context, "org_id", None)
+                or _execution_metadata().get("org_id")
+                or ""
+            ).strip()
+            if not alert_org_id:
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "posted": False,
+                        "error": "provider_alert_org_context_required",
+                        "submitted_chars": len(submitted_text),
+                        "posted_chars": 0,
+                        **_provider_alert_result(alert_decision),
+                    }
+                )
+            try:
+                alert_gate = await gate_provider_alert_post(
+                    client,
+                    org_id=alert_org_id,
+                    channel_id=target_channel,
+                    illo_user_id=str(trigger.get("bot_user_id") or "").strip() or None,
+                    decision=alert_decision,
+                )
+            except Exception as exc:
+                logger.exception("provider alert ledger gate failed")
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "posted": False,
+                        "error": "provider_alert_ledger_unavailable",
+                        "detail": str(exc),
+                        "submitted_chars": len(submitted_text),
+                        "posted_chars": 0,
+                        **_provider_alert_result(alert_decision),
+                    }
+                )
+            if alert_gate.suppress:
+                await _clear_processing_status(client, trigger)
+                return json.dumps(
+                    {
+                        "ok": True,
+                        "posted": False,
+                        "suppressed": True,
+                        "reason": alert_gate.reason,
+                        "delta_line": alert_gate.delta_line,
+                        "acknowledged_by": alert_gate.acknowledged_by,
+                        "acknowledged_at": alert_gate.acknowledged_at,
+                        "channel_id": target_channel,
+                        "thread_ts": target_thread_ts,
+                        "visibility": target_visibility,
+                        "counts_as_visible_response": True,
+                        "submitted_chars": len(submitted_text),
+                        "posted_chars": 0,
+                        "submitted_bytes": len(submitted_text.encode("utf-8")),
+                        "posted_bytes": 0,
+                        "chunk_count": 0,
+                        "truncated": False,
+                        **_provider_alert_result(alert_decision),
+                    }
+                )
         target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
         if image_upload is not None:
             response = await client.upload_file(
@@ -420,6 +546,20 @@ async def _handle_post_slack_reply(
                 text=text,
                 thread_ts=target_thread_ts,
             )
+        if alert_decision is not None:
+            try:
+                await record_provider_alert_posted(
+                    org_id=alert_org_id,
+                    channel_id=target_channel,
+                    message_ts=_posted_slack_message_ts(response),
+                    thread_ts=target_thread_ts,
+                    decision=alert_decision,
+                )
+            except Exception as exc:
+                # Slack has already accepted the post. Report the ledger fault
+                # without lying about delivery and inviting an immediate retry.
+                alert_ledger_record_error = str(exc)
+                logger.exception("provider alert post succeeded but ledger finalization failed")
         await _clear_processing_status(client, trigger)
     except SlackDeliveryError as exc:
         return json.dumps(exc.to_result())
@@ -453,6 +593,15 @@ async def _handle_post_slack_reply(
             "chunk_count": int(response.get("chunk_count", 1)),
             "truncated": bool(response.get("truncated", False)),
             "slack": response,
+            **(
+                {
+                    "posted": True,
+                    "alert_ledger_record_error": alert_ledger_record_error,
+                    **_provider_alert_result(alert_decision),
+                }
+                if alert_decision is not None
+                else {}
+            ),
         },
         default=str,
     )

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -3,29 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import json
-import logging
 import re
 from typing import Any
 
 from brain.platform.provider_alerts import (
-    ProviderAlertDecision,
     ProviderAlertPolicyError,
     classify_provider_alert_body,
 )
 from brain.systems.runs.execution_context import get_or_create_agent_run_state
 from brain.systems.runs.tool_catalog.handlers.common import _agent_context, _current_runtime_secret_context
 from brain.systems.slack.client import SlackApiError, SlackDeliveryError
-from brain.systems.slack.provider_alert_gate import (
-    gate_provider_alert_post,
-    record_provider_alert_posted,
-)
+from brain.systems.slack.provider_alert_posting import post_provider_alert
 from brain.systems.slack.thread_mute import read_thread_post_mute
 from brain.systems.slack.uploads import slack_image_upload_from_data_url
-
-
-logger = logging.getLogger(__name__)
-
 
 def _execution_metadata() -> dict[str, Any]:
     metadata = getattr(_agent_context, "execution_metadata", None)
@@ -84,31 +76,6 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
         if normalized in {"0", "false", "no", "n", "off"}:
             return False
     return bool(value)
-
-
-def _provider_alert_result(decision: ProviderAlertDecision) -> dict[str, Any]:
-    return {
-        "provider_alert": True,
-        "alert_signature": decision.signature,
-        "alert_classification": decision.classification,
-        "alert_severity": decision.severity,
-        "alert_rule_id": decision.rule_id,
-        "alert_policy_source": decision.policy_source,
-        "alert_escalation_reason": decision.escalation_reason,
-    }
-
-
-def _posted_slack_message_ts(response: Any) -> str | None:
-    if not isinstance(response, dict):
-        return None
-    direct = str(response.get("ts") or "").strip()
-    if direct:
-        return direct
-    message = response.get("message")
-    if isinstance(message, dict):
-        nested = str(message.get("ts") or "").strip()
-        return nested or None
-    return None
 
 
 _SLACK_EMOJI_NAME_PATTERN = re.compile(r"^[a-z0-9_+\-]{1,80}$")
@@ -349,6 +316,47 @@ async def _clear_processing_status(client: Any, trigger: dict[str, Any]) -> None
         return
 
 
+async def _post_slack_content(
+    client: Any,
+    channel_id: str,
+    *,
+    text: str,
+    thread_ts: str | None,
+    visibility: str,
+    user_id: str | None,
+    trigger: dict[str, Any],
+    image_upload: Any,
+) -> tuple[Any, str | None]:
+    if image_upload is not None:
+        response = await client.upload_file(
+            channel=channel_id,
+            file_bytes=image_upload.file_bytes,
+            filename=image_upload.filename,
+            title=image_upload.title,
+            initial_comment=text if text.strip() else None,
+            thread_ts=thread_ts,
+            alt_txt=image_upload.alt_txt,
+            content_type=image_upload.content_type,
+        )
+    elif visibility == "ephemeral":
+        target_user = str(user_id or trigger.get("slack_user_id") or "").strip()
+        if not target_user:
+            return None, json.dumps({"error": "ephemeral Slack replies require a Slack user id"})
+        response = await client.post_ephemeral(
+            channel=channel_id,
+            user=target_user,
+            text=text,
+            thread_ts=thread_ts,
+        )
+    else:
+        response = await client.post_message(
+            channel=channel_id,
+            text=text,
+            thread_ts=thread_ts,
+        )
+    return response, None
+
+
 async def _handle_post_slack_reply(
     body: str = "",
     channel_id: str | None = None,
@@ -418,7 +426,6 @@ async def _handle_post_slack_reply(
     if not target_channel:
         return json.dumps({"error": "post_slack_reply requires channel_id outside a Slack-triggered run"})
 
-    alert_ledger_record_error: str | None = None
     try:
         client = await _slack_client_from_runtime()
         if target_thread_ts:
@@ -452,114 +459,50 @@ async def _handle_post_slack_reply(
                     }
                 )
         if alert_decision is not None:
-            target_channel = await _resolve_post_channel(
+            return await post_provider_alert(
                 client,
-                target_channel,
-                target_visibility,
-            )
-            alert_org_id = str(
-                getattr(_agent_context, "org_id", None)
-                or _execution_metadata().get("org_id")
-                or ""
-            ).strip()
-            if not alert_org_id:
-                return json.dumps(
-                    {
-                        "ok": False,
-                        "posted": False,
-                        "error": "provider_alert_org_context_required",
-                        "submitted_chars": len(submitted_text),
-                        "posted_chars": 0,
-                        **_provider_alert_result(alert_decision),
-                    }
-                )
-            try:
-                alert_gate = await gate_provider_alert_post(
+                org_id=str(
+                    getattr(_agent_context, "org_id", None)
+                    or _execution_metadata().get("org_id")
+                    or ""
+                ).strip(),
+                channel_id=target_channel,
+                thread_ts=target_thread_ts,
+                visibility=target_visibility,
+                illo_user_id=str(trigger.get("bot_user_id") or "").strip() or None,
+                submitted_body=submitted_text,
+                decision=alert_decision,
+                uploaded_image=image_upload is not None,
+                resolve_channel=partial(
+                    _resolve_post_channel,
                     client,
-                    org_id=alert_org_id,
-                    channel_id=target_channel,
-                    illo_user_id=str(trigger.get("bot_user_id") or "").strip() or None,
-                    decision=alert_decision,
-                )
-            except Exception as exc:
-                logger.exception("provider alert ledger gate failed")
-                return json.dumps(
-                    {
-                        "ok": False,
-                        "posted": False,
-                        "error": "provider_alert_ledger_unavailable",
-                        "detail": str(exc),
-                        "submitted_chars": len(submitted_text),
-                        "posted_chars": 0,
-                        **_provider_alert_result(alert_decision),
-                    }
-                )
-            if alert_gate.suppress:
-                await _clear_processing_status(client, trigger)
-                return json.dumps(
-                    {
-                        "ok": True,
-                        "posted": False,
-                        "suppressed": True,
-                        "reason": alert_gate.reason,
-                        "delta_line": alert_gate.delta_line,
-                        "acknowledged_by": alert_gate.acknowledged_by,
-                        "acknowledged_at": alert_gate.acknowledged_at,
-                        "channel_id": target_channel,
-                        "thread_ts": target_thread_ts,
-                        "visibility": target_visibility,
-                        "counts_as_visible_response": True,
-                        "submitted_chars": len(submitted_text),
-                        "posted_chars": 0,
-                        "submitted_bytes": len(submitted_text.encode("utf-8")),
-                        "posted_bytes": 0,
-                        "chunk_count": 0,
-                        "truncated": False,
-                        **_provider_alert_result(alert_decision),
-                    }
-                )
-        target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
-        if image_upload is not None:
-            response = await client.upload_file(
-                channel=target_channel,
-                file_bytes=image_upload.file_bytes,
-                filename=image_upload.filename,
-                title=image_upload.title,
-                initial_comment=text if text.strip() else None,
-                thread_ts=target_thread_ts,
-                alt_txt=image_upload.alt_txt,
-                content_type=image_upload.content_type,
-            )
-        elif target_visibility == "ephemeral":
-            target_user = str(user_id or trigger.get("slack_user_id") or "").strip()
-            if not target_user:
-                return json.dumps({"error": "ephemeral Slack replies require a Slack user id"})
-            response = await client.post_ephemeral(
-                channel=target_channel,
-                user=target_user,
-                text=text,
-                thread_ts=target_thread_ts,
-            )
-        else:
-            response = await client.post_message(
-                channel=target_channel,
-                text=text,
-                thread_ts=target_thread_ts,
-            )
-        if alert_decision is not None:
-            try:
-                await record_provider_alert_posted(
-                    org_id=alert_org_id,
-                    channel_id=target_channel,
-                    message_ts=_posted_slack_message_ts(response),
+                    visibility=target_visibility,
+                ),
+                post=partial(
+                    _post_slack_content,
+                    client,
+                    text=text,
                     thread_ts=target_thread_ts,
-                    decision=alert_decision,
-                )
-            except Exception as exc:
-                # Slack has already accepted the post. Report the ledger fault
-                # without lying about delivery and inviting an immediate retry.
-                alert_ledger_record_error = str(exc)
-                logger.exception("provider alert post succeeded but ledger finalization failed")
+                    visibility=target_visibility,
+                    user_id=user_id,
+                    trigger=trigger,
+                    image_upload=image_upload,
+                ),
+                clear_processing_status=partial(_clear_processing_status, client, trigger),
+            )
+        target_channel = await _resolve_post_channel(client, target_channel, target_visibility)
+        response, early_result = await _post_slack_content(
+            client,
+            target_channel,
+            text=text,
+            thread_ts=target_thread_ts,
+            visibility=target_visibility,
+            user_id=user_id,
+            trigger=trigger,
+            image_upload=image_upload,
+        )
+        if early_result is not None:
+            return early_result
         await _clear_processing_status(client, trigger)
     except SlackDeliveryError as exc:
         return json.dumps(exc.to_result())
@@ -593,15 +536,6 @@ async def _handle_post_slack_reply(
             "chunk_count": int(response.get("chunk_count", 1)),
             "truncated": bool(response.get("truncated", False)),
             "slack": response,
-            **(
-                {
-                    "posted": True,
-                    "alert_ledger_record_error": alert_ledger_record_error,
-                    **_provider_alert_result(alert_decision),
-                }
-                if alert_decision is not None
-                else {}
-            ),
         },
         default=str,
     )

--- a/brain/systems/slack/provider_alert_gate.py
+++ b/brain/systems/slack/provider_alert_gate.py
@@ -1,0 +1,334 @@
+"""Durable signature throttle and acknowledgement gate for provider alerts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+import re
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import select
+
+from brain.platform.db.models.provider_alert import ProviderAlertLedger
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.platform.provider_alerts import ProviderAlertDecision
+
+
+_ACK_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bknown(?: issue| incident| benign)?\b",
+        r"\bbenign\b",
+        r"\b(?:please\s+)?stop(?: posting| alerting)?\b",
+        r"\bstand down\b",
+        r"\bfalse alarm\b",
+        r"\b(?:safe to )?ignore\b",
+        r"\bno action (?:needed|required)\b",
+    )
+)
+_NEGATED_ACK = re.compile(
+    r"\b(?:(?:not|isn't|is not|wasn't|was not)\s+(?:known|benign|a false alarm)|no known)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ProviderAlertAcknowledgement:
+    user: str
+    ts: str
+    text: str
+
+
+@dataclass(frozen=True)
+class ProviderAlertLedgerSnapshot:
+    occurrence_count: int
+    occurrences_at_last_post: int
+    last_posted_at: datetime | None
+    slack_thread_ts: str | None
+    acknowledged_at: datetime | None
+    acknowledged_by: str | None
+    acknowledgement: str | None
+
+
+@dataclass(frozen=True)
+class ProviderAlertPostGate:
+    suppress: bool
+    reason: str | None = None
+    delta_line: str | None = None
+    acknowledged_by: str | None = None
+    acknowledged_at: str | None = None
+
+
+def _utcnow(now: datetime | None = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+
+
+def _message_key(message: Mapping[str, Any]) -> tuple[int, Decimal, str]:
+    ts = str(message.get("ts") or "").strip()
+    try:
+        return (0, Decimal(ts), "")
+    except InvalidOperation:
+        return (1, Decimal(0), ts)
+
+
+def _human_message(message: Mapping[str, Any], *, illo_user_id: str | None) -> bool:
+    user = str(message.get("user") or "").strip()
+    if not user or message.get("bot_id") or message.get("bot_profile") or message.get("app_id"):
+        return False
+    return not illo_user_id or user.casefold() != str(illo_user_id).strip().casefold()
+
+
+def _author(message: Mapping[str, Any]) -> str:
+    profile = message.get("user_profile")
+    if isinstance(profile, Mapping):
+        for key in ("display_name", "real_name", "name"):
+            value = " ".join(str(profile.get(key) or "").split())
+            if value:
+                return value[:120]
+    return str(message.get("user") or "human")[:120]
+
+
+def find_provider_alert_acknowledgement(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    illo_user_id: str | None = None,
+) -> ProviderAlertAcknowledgement | None:
+    """Return the latest explicit human known/stop/benign acknowledgement."""
+
+    acknowledgement = None
+    for message in sorted(messages, key=_message_key):
+        if not isinstance(message, Mapping) or not _human_message(
+            message,
+            illo_user_id=illo_user_id,
+        ):
+            continue
+        text = " ".join(str(message.get("text") or "").split())
+        if _NEGATED_ACK.search(text) or "?" in text:
+            continue
+        if any(pattern.search(text) for pattern in _ACK_PATTERNS):
+            acknowledgement = ProviderAlertAcknowledgement(
+                user=_author(message),
+                ts=str(message.get("ts") or "").strip(),
+                text=text[:500],
+            )
+    return acknowledgement
+
+
+async def _read_acknowledgement(
+    client: Any,
+    snapshot: ProviderAlertLedgerSnapshot | None,
+    *,
+    channel_id: str,
+    illo_user_id: str | None,
+) -> ProviderAlertAcknowledgement | None:
+    if snapshot is None or not snapshot.slack_thread_ts:
+        return None
+    read_replies = getattr(client, "conversation_replies", None)
+    if not callable(read_replies):
+        return None
+    messages: list[Mapping[str, Any]] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        response = await read_replies(
+            channel=channel_id,
+            thread_ts=snapshot.slack_thread_ts,
+            limit=200,
+            cursor=cursor,
+        )
+        if not isinstance(response, Mapping):
+            break
+        messages.extend(
+            message
+            for message in response.get("messages") or []
+            if isinstance(message, Mapping)
+        )
+        metadata = response.get("response_metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        next_cursor = str(metadata.get("next_cursor") or "").strip()
+        if not next_cursor or next_cursor in seen_cursors:
+            break
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    return find_provider_alert_acknowledgement(messages, illo_user_id=illo_user_id)
+
+
+def _ledger_query(*, org_id: str, channel_id: str, signature: str):
+    return select(ProviderAlertLedger).where(
+        ProviderAlertLedger.org_id == org_id,
+        ProviderAlertLedger.channel_id == channel_id,
+        ProviderAlertLedger.signature == signature,
+    )
+
+
+def _snapshot(row: ProviderAlertLedger) -> ProviderAlertLedgerSnapshot:
+    return ProviderAlertLedgerSnapshot(
+        occurrence_count=int(row.occurrence_count or 0),
+        occurrences_at_last_post=int(row.occurrences_at_last_post or 0),
+        last_posted_at=row.last_posted_at,
+        slack_thread_ts=row.slack_thread_ts,
+        acknowledged_at=row.acknowledged_at,
+        acknowledged_by=row.acknowledged_by,
+        acknowledgement=row.acknowledgement,
+    )
+
+
+async def load_provider_alert_ledger(
+    *,
+    org_id: str,
+    channel_id: str,
+    signature: str,
+) -> ProviderAlertLedgerSnapshot | None:
+    """Load one signature row in a fresh transaction for every post attempt."""
+
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            _ledger_query(
+                org_id=org_id,
+                channel_id=channel_id,
+                signature=signature,
+            )
+        )
+        return _snapshot(row) if row is not None else None
+
+
+async def gate_provider_alert_post(
+    client: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    illo_user_id: str | None,
+    decision: ProviderAlertDecision,
+    now: datetime | None = None,
+) -> ProviderAlertPostGate:
+    """Persist this occurrence and suppress acknowledged/recent duplicates."""
+
+    current_time = _utcnow(now)
+    snapshot = await load_provider_alert_ledger(
+        org_id=org_id,
+        channel_id=channel_id,
+        signature=decision.signature,
+    )
+    acknowledgement = await _read_acknowledgement(
+        client,
+        snapshot,
+        channel_id=channel_id,
+        illo_user_id=illo_user_id,
+    )
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            _ledger_query(
+                org_id=org_id,
+                channel_id=channel_id,
+                signature=decision.signature,
+            ).with_for_update()
+        )
+        if row is None:
+            uow.session.add(
+                ProviderAlertLedger(
+                    org_id=org_id,
+                    channel_id=channel_id,
+                    signature=decision.signature,
+                    classification=decision.classification,
+                    severity=decision.severity,
+                    rule_id=decision.rule_id,
+                    occurrence_count=1,
+                    occurrences_at_last_post=0,
+                    first_seen_at=current_time,
+                    last_seen_at=current_time,
+                )
+            )
+            await uow.session.flush()
+            return ProviderAlertPostGate(suppress=False)
+        row.occurrence_count = int(row.occurrence_count or 0) + 1
+        row.last_seen_at = current_time
+        row.classification = decision.classification
+        row.severity = decision.severity
+        row.rule_id = decision.rule_id
+        if acknowledgement is not None:
+            if row.acknowledged_at is None or row.acknowledgement != acknowledgement.text:
+                row.acknowledged_at = current_time
+            row.acknowledged_by = acknowledgement.user
+            row.acknowledgement = acknowledgement.text
+        delta = max(
+            1,
+            int(row.occurrence_count or 0) - int(row.occurrences_at_last_post or 0),
+        )
+        delta_line = f"still ongoing, +{delta} since last"
+        if row.acknowledged_at is not None:
+            return ProviderAlertPostGate(
+                suppress=True,
+                reason="signature_acknowledged",
+                delta_line=delta_line,
+                acknowledged_by=row.acknowledged_by,
+                acknowledged_at=row.acknowledged_at.isoformat(),
+            )
+        last_posted_at = row.last_posted_at
+        if last_posted_at is not None:
+            last_posted_at = _utcnow(last_posted_at)
+            if current_time - last_posted_at <= timedelta(minutes=decision.throttle_minutes):
+                return ProviderAlertPostGate(
+                    suppress=True,
+                    reason="duplicate_within_throttle",
+                    delta_line=delta_line,
+                )
+        return ProviderAlertPostGate(suppress=False)
+
+
+async def record_provider_alert_posted(
+    *,
+    org_id: str,
+    channel_id: str,
+    message_ts: str | None,
+    thread_ts: str | None,
+    decision: ProviderAlertDecision,
+    now: datetime | None = None,
+) -> None:
+    """Record a confirmed Slack post; failed deliveries never consume throttle."""
+
+    current_time = _utcnow(now)
+    async with UnitOfWork() as uow:
+        row = await uow.session.scalar(
+            _ledger_query(
+                org_id=org_id,
+                channel_id=channel_id,
+                signature=decision.signature,
+            ).with_for_update()
+        )
+        if row is None:
+            row = ProviderAlertLedger(
+                org_id=org_id,
+                channel_id=channel_id,
+                signature=decision.signature,
+                classification=decision.classification,
+                severity=decision.severity,
+                rule_id=decision.rule_id,
+                occurrence_count=1,
+                occurrences_at_last_post=1,
+                first_seen_at=current_time,
+                last_seen_at=current_time,
+            )
+            uow.session.add(row)
+        else:
+            row.classification = decision.classification
+            row.severity = decision.severity
+            row.rule_id = decision.rule_id
+            row.last_seen_at = current_time
+            row.occurrences_at_last_post = int(row.occurrence_count or 1)
+        row.last_posted_at = current_time
+        row.slack_message_ts = message_ts
+        row.slack_thread_ts = thread_ts or message_ts
+        await uow.session.flush()
+
+
+__all__ = [
+    "ProviderAlertAcknowledgement",
+    "ProviderAlertLedgerSnapshot",
+    "ProviderAlertPostGate",
+    "find_provider_alert_acknowledgement",
+    "gate_provider_alert_post",
+    "load_provider_alert_ledger",
+    "record_provider_alert_posted",
+]

--- a/brain/systems/slack/provider_alert_posting.py
+++ b/brain/systems/slack/provider_alert_posting.py
@@ -1,0 +1,165 @@
+"""Prepare, gate, post, and finalize provider alerts sent to Slack."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import json
+import logging
+from typing import Any
+
+from brain.platform.provider_alerts import ProviderAlertDecision
+from brain.systems.slack.provider_alert_gate import (
+    gate_provider_alert_post,
+    record_provider_alert_posted,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _provider_alert_result(decision: ProviderAlertDecision) -> dict[str, Any]:
+    return {
+        "provider_alert": True,
+        "alert_signature": decision.signature,
+        "alert_classification": decision.classification,
+        "alert_severity": decision.severity,
+        "alert_rule_id": decision.rule_id,
+        "alert_policy_source": decision.policy_source,
+        "alert_escalation_reason": decision.escalation_reason,
+    }
+
+
+def _posted_slack_message_ts(response: Any) -> str | None:
+    if not isinstance(response, dict):
+        return None
+    direct = str(response.get("ts") or "").strip()
+    if direct:
+        return direct
+    message = response.get("message")
+    if isinstance(message, dict):
+        nested = str(message.get("ts") or "").strip()
+        return nested or None
+    return None
+
+
+async def post_provider_alert(
+    client: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    thread_ts: str | None,
+    visibility: str,
+    illo_user_id: str | None,
+    submitted_body: str,
+    decision: ProviderAlertDecision,
+    uploaded_image: bool,
+    resolve_channel: Callable[[str], Awaitable[str]],
+    post: Callable[[str], Awaitable[tuple[Any, str | None]]],
+    clear_processing_status: Callable[[], Awaitable[None]],
+) -> str:
+    """Gate one classified alert, post it if allowed, then update its ledger."""
+
+    channel_id = await resolve_channel(channel_id)
+    if not org_id:
+        return json.dumps(
+            {
+                "ok": False,
+                "posted": False,
+                "error": "provider_alert_org_context_required",
+                "submitted_chars": len(submitted_body),
+                "posted_chars": 0,
+                **_provider_alert_result(decision),
+            }
+        )
+    try:
+        alert_gate = await gate_provider_alert_post(
+            client,
+            org_id=org_id,
+            channel_id=channel_id,
+            illo_user_id=illo_user_id,
+            decision=decision,
+        )
+    except Exception as exc:
+        logger.exception("provider alert ledger gate failed")
+        return json.dumps(
+            {
+                "ok": False,
+                "posted": False,
+                "error": "provider_alert_ledger_unavailable",
+                "detail": str(exc),
+                "submitted_chars": len(submitted_body),
+                "posted_chars": 0,
+                **_provider_alert_result(decision),
+            }
+        )
+    if alert_gate.suppress:
+        await clear_processing_status()
+        return json.dumps(
+            {
+                "ok": True,
+                "posted": False,
+                "suppressed": True,
+                "reason": alert_gate.reason,
+                "delta_line": alert_gate.delta_line,
+                "acknowledged_by": alert_gate.acknowledged_by,
+                "acknowledged_at": alert_gate.acknowledged_at,
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "visibility": visibility,
+                "counts_as_visible_response": True,
+                "submitted_chars": len(submitted_body),
+                "posted_chars": 0,
+                "submitted_bytes": len(submitted_body.encode("utf-8")),
+                "posted_bytes": 0,
+                "chunk_count": 0,
+                "truncated": False,
+                **_provider_alert_result(decision),
+            }
+        )
+
+    channel_id = await resolve_channel(channel_id)
+    response, early_result = await post(channel_id)
+    if early_result is not None:
+        return early_result
+    alert_ledger_record_error: str | None = None
+    try:
+        await record_provider_alert_posted(
+            org_id=org_id,
+            channel_id=channel_id,
+            message_ts=_posted_slack_message_ts(response),
+            thread_ts=thread_ts,
+            decision=decision,
+        )
+    except Exception as exc:
+        # Slack has already accepted the post. Report the ledger fault without
+        # lying about delivery and inviting an immediate retry.
+        alert_ledger_record_error = str(exc)
+        logger.exception("provider alert post succeeded but ledger finalization failed")
+    await clear_processing_status()
+
+    body = decision.body
+    submitted_chars = int(response.get("submitted_chars", len(body)))
+    posted_chars = int(response.get("posted_chars", submitted_chars))
+    return json.dumps(
+        {
+            "ok": True,
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "visibility": visibility,
+            "uploaded_image": uploaded_image,
+            "submitted_chars": submitted_chars,
+            "posted_chars": posted_chars,
+            "submitted_bytes": int(response.get("submitted_bytes", len(body.encode("utf-8")))),
+            "posted_bytes": int(response.get("posted_bytes", len(body.encode("utf-8")))),
+            "chunk_count": int(response.get("chunk_count", 1)),
+            "truncated": bool(response.get("truncated", False)),
+            "slack": response,
+            "posted": True,
+            "alert_ledger_record_error": alert_ledger_record_error,
+            **_provider_alert_result(decision),
+        },
+        default=str,
+    )
+
+
+__all__ = ["post_provider_alert"]

--- a/deploy/compose/provider-alert-severity.json
+++ b/deploy/compose/provider-alert-severity.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "default_severity": "high",
+  "throttle_minutes": 30,
+  "abnormal_volume_threshold": 20,
+  "rules": [
+    {
+      "id": "seedream_fal_422_typed_content_policy",
+      "providers_any": ["seedream", "fal"],
+      "status_codes": [422],
+      "typed_reasons": ["nsfw", "user_input", "invalid_user_input", "content_policy"],
+      "classification": "content_policy",
+      "severity": "low",
+      "escalate_on": [
+        "broken_refund_or_fallback",
+        "abnormal_volume",
+        "safe_input_misclassified"
+      ]
+    },
+    {
+      "id": "seedream_fal_422_missing_typed_reason",
+      "providers_any": ["seedream", "fal"],
+      "status_codes": [422],
+      "typed_reason_absent": true,
+      "classification": "provider_failure",
+      "severity": "high",
+      "escalation_reason": "missing_typed_reason"
+    },
+    {
+      "id": "vertex_401",
+      "providers_any": ["vertex"],
+      "status_codes": [401],
+      "classification": "provider_auth_unavailable",
+      "severity": "high"
+    },
+    {
+      "id": "provider_504_timeout",
+      "status_codes": [504],
+      "classification": "provider_timeout",
+      "severity": "high"
+    },
+    {
+      "id": "runtime_out_of_memory",
+      "error_types": ["Runtime.OutOfMemory", "OutOfMemory", "OOM"],
+      "classification": "provider_resource_exhausted",
+      "severity": "high"
+    }
+  ],
+  "escalation_signals": {
+    "broken_refund_or_fallback": [
+      "(?:refund|fallback)[^\\n]{0,60}(?:broken|failed|missing|not working|did not work|didn't work)",
+      "(?:broken|failed|missing)[^\\n]{0,40}(?:refund|fallback)"
+    ],
+    "abnormal_volume": [
+      "abnormal volume",
+      "unexpected (?:spike|surge)",
+      "volume (?:spike|surge)"
+    ],
+    "safe_input_misclassified": [
+      "safe input(?:s)?\\s+(?:was|were|is|are)?\\s*misclassified",
+      "false positive on safe input",
+      "known-safe input"
+    ]
+  }
+}

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -71,6 +71,7 @@ EXPECTED_TABLES = {
     "project_narratives",
     "project_profile_access",
     "project_profiles",
+    "provider_alert_ledger",
     "provider_health_snapshots",
     "resource_leases",
     "reconstruction_evidence",

--- a/tests/test_provider_alert_gate.py
+++ b/tests/test_provider_alert_gate.py
@@ -1,0 +1,306 @@
+"""Regression coverage for the durable provider-alert posting gate (#402)."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
+
+
+SEEDREAM_NSFW_ALERT = (
+    "ALERT — HIGH provider failure\n"
+    "Provider: Seedream/FAL\n"
+    "HTTP 422\n"
+    "typed reason=nsfw\n"
+    "Request rejected before generation."
+)
+ORG_ID = "4b5e2f59-4f88-4956-a660-4f544ccffbd7"
+CHANNEL_ID = "C_ALERTS"
+
+
+@pytest.mark.parametrize(
+    ("body", "classification"),
+    [
+        (
+            "ALERT — LOW provider failure: Vertex HTTP 401 unauthorized",
+            "provider_auth_unavailable",
+        ),
+        (
+            "ALERT — LOW provider failure: model call HTTP 504 timeout",
+            "provider_timeout",
+        ),
+        (
+            "ALERT — LOW provider failure: Runtime.OutOfMemory (OOM)",
+            "provider_resource_exhausted",
+        ),
+    ],
+)
+def test_infrastructure_provider_classes_remain_high(body: str, classification: str):
+    from brain.platform.provider_alerts import classify_provider_alert_body
+
+    decision = classify_provider_alert_body(body)
+
+    assert decision is not None
+    assert decision.severity == "high"
+    assert decision.classification == classification
+    assert "ALERT — HIGH" in decision.body
+
+
+def test_seedream_fal_422_with_typed_nsfw_reason_is_content_policy_not_high():
+    from brain.platform.provider_alerts import classify_provider_alert_body
+
+    decision = classify_provider_alert_body(SEEDREAM_NSFW_ALERT)
+
+    assert decision is not None
+    assert decision.rule_id == "seedream_fal_422_typed_content_policy"
+    assert decision.classification == "content_policy"
+    assert decision.severity == "low"
+    assert "ALERT — HIGH" not in decision.body
+    assert "LOW · content-policy" in decision.body
+
+
+@pytest.mark.parametrize(
+    ("suffix", "escalation_reason"),
+    [
+        ("", "missing_typed_reason"),
+        ("typed reason=nsfw\nFallback failed and refund is missing.", "broken_refund_or_fallback"),
+        ("typed reason=nsfw\nSafe inputs were misclassified.", "safe_input_misclassified"),
+        ("typed reason=nsfw\nOccurrences: 20", "abnormal_volume"),
+    ],
+)
+def test_content_policy_escalates_only_for_configured_exceptions(
+    suffix: str,
+    escalation_reason: str,
+):
+    from brain.platform.provider_alerts import classify_provider_alert_body
+
+    body = f"ALERT — LOW provider failure: Seedream/FAL HTTP 422\n{suffix}"
+    decision = classify_provider_alert_body(body)
+
+    assert decision is not None
+    assert decision.severity == "high"
+    assert decision.escalation_reason == escalation_reason
+
+
+def test_severity_map_is_reloaded_from_durable_config_every_run(tmp_path, monkeypatch):
+    from brain.platform.provider_alerts import (
+        DEFAULT_PROVIDER_ALERT_POLICY_PATH,
+        PROVIDER_ALERT_POLICY_ENV,
+        classify_provider_alert_body,
+    )
+
+    policy_path = tmp_path / "provider-alert-severity.json"
+    policy = json.loads(DEFAULT_PROVIDER_ALERT_POLICY_PATH.read_text(encoding="utf-8"))
+    policy_path.write_text(json.dumps(policy), encoding="utf-8")
+    monkeypatch.setenv(PROVIDER_ALERT_POLICY_ENV, str(policy_path))
+
+    first = classify_provider_alert_body(SEEDREAM_NSFW_ALERT)
+    assert first is not None and first.severity == "low"
+    assert first.policy_source == str(policy_path.resolve())
+
+    policy["rules"][0]["severity"] = "medium"
+    policy_path.write_text(json.dumps(policy), encoding="utf-8")
+    second = classify_provider_alert_body(SEEDREAM_NSFW_ALERT)
+
+    assert second is not None and second.severity == "medium"
+    assert second.policy_source == str(policy_path.resolve())
+
+
+def test_provider_alert_gate_has_no_memory_consolidation_dependency():
+    import brain.platform.provider_alerts as classifier
+    import brain.systems.slack.provider_alert_gate as ledger_gate
+
+    imported_modules: set[str] = set()
+    for module in (classifier, ledger_gate):
+        tree = ast.parse(inspect.getsource(module))
+        imported_modules.update(
+            node.module or ""
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+        )
+        imported_modules.update(
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        )
+
+    assert not any(
+        module.startswith(("brain.systems.memory", "brain.systems.reconstructive_memory"))
+        for module in imported_modules
+    )
+
+
+class _SlackClient:
+    def __init__(self):
+        self.posts: list[dict[str, Any]] = []
+        self.threads: dict[str, list[dict[str, Any]]] = {}
+
+    async def post_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.posts.append(kwargs)
+        message_ts = f"1784493000.{len(self.posts):06d}"
+        self.threads[message_ts] = [
+            {
+                "user": "BILLO",
+                "bot_id": "BILLO",
+                "text": kwargs["text"],
+                "ts": message_ts,
+            }
+        ]
+        return {"ok": True, "channel": kwargs["channel"], "ts": message_ts}
+
+    async def conversation_replies(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "messages": list(self.threads.get(kwargs["thread_ts"], [])),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+
+@pytest.fixture
+async def provider_alert_store(tmp_path, monkeypatch):
+    from brain.platform.db.models.provider_alert import ProviderAlertLedger
+
+    database_path = Path(tmp_path) / "provider-alerts.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.execute(CreateTable(ProviderAlertLedger.__table__))
+
+    class TestUnitOfWork:
+        async def __aenter__(self):
+            self.session = sessions()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            if exc_type:
+                await self.session.rollback()
+            else:
+                await self.session.commit()
+            await self.session.close()
+
+    monkeypatch.setattr(
+        "brain.systems.slack.provider_alert_gate.UnitOfWork",
+        TestUnitOfWork,
+    )
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+async def _post_provider_alert(monkeypatch, client: _SlackClient) -> dict[str, Any]:
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    async def slack_client() -> _SlackClient:
+        return client
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        slack_client,
+    )
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 402,
+            "slack_trigger": {
+                "bot_user_id": "BILLO",
+                "response_target": {
+                    "channel_id": CHANNEL_ID,
+                    "thread_ts": None,
+                    "visibility": "public",
+                },
+            },
+        }
+    ):
+        return json.loads(await _handle_post_slack_reply(body=SEEDREAM_NSFW_ALERT))
+
+
+@pytest.mark.asyncio
+async def test_posting_path_rewrites_typed_benign_alert_and_suppresses_duplicate(
+    monkeypatch,
+    provider_alert_store,
+):
+    client = _SlackClient()
+
+    first = await _post_provider_alert(monkeypatch, client)
+    second = await _post_provider_alert(monkeypatch, client)
+
+    assert first["posted"] is True
+    assert first["alert_severity"] == "low"
+    assert "ALERT — HIGH" not in client.posts[0]["text"]
+    assert "content-policy" in client.posts[0]["text"]
+    assert second["posted"] is False
+    assert second["suppressed"] is True
+    assert second["reason"] == "duplicate_within_throttle"
+    assert second["delta_line"] == "still ongoing, +1 since last"
+    assert len(client.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_human_known_stop_reply_persists_signature_acknowledgement(
+    monkeypatch,
+    provider_alert_store,
+):
+    from brain.platform.db.models.provider_alert import ProviderAlertLedger
+
+    client = _SlackClient()
+    first = await _post_provider_alert(monkeypatch, client)
+    first_ts = first["slack"]["ts"]
+    client.threads[first_ts].append(
+        {
+            "user": "U_REDA",
+            "text": "Known and benign — stop alerting on this signature.",
+            "ts": "1784493050.000001",
+            "user_profile": {"display_name": "Reda"},
+        }
+    )
+
+    second = await _post_provider_alert(monkeypatch, client)
+    third = await _post_provider_alert(monkeypatch, client)
+
+    assert second["reason"] == "signature_acknowledged"
+    assert second["acknowledged_by"] == "Reda"
+    assert third["reason"] == "signature_acknowledged"
+    assert len(client.posts) == 1
+    async with provider_alert_store() as session:
+        ledger = await session.scalar(select(ProviderAlertLedger))
+    assert ledger is not None
+    assert ledger.acknowledged_by == "Reda"
+    assert "Known and benign" in str(ledger.acknowledgement)
+    assert ledger.occurrence_count == 3
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "This is not known or benign; keep investigating.",
+        "Is this a known issue?",
+        "There is no known safe explanation.",
+    ],
+)
+def test_acknowledgement_parser_does_not_treat_uncertainty_as_ack(text: str):
+    from brain.systems.slack.provider_alert_gate import (
+        find_provider_alert_acknowledgement,
+    )
+
+    acknowledgement = find_provider_alert_acknowledgement(
+        [
+            {
+                "user": "U1",
+                "text": text,
+                "ts": "1.0",
+            }
+        ],
+        illo_user_id="BILLO",
+    )
+
+    assert acknowledgement is None


### PR DESCRIPTION
Closes #402

## What this fixes
Illo posted a Seedream/FAL `HTTP 422` with a typed `nsfw` reason (a content-policy input rejection, **not** an infra failure) as `ALERT — HIGH provider failure` until a human told it to stand down. The reactive fix lived only as a free-text runbook — no code gate enforced it, so the false-HIGH class could recur on a fresh run.

## Change (in-repo, deterministic — no memory-consolidation dependency)
- **Typed-error-class → severity map** as checked-in config: `deploy/compose/provider-alert-severity.json`. `Seedream/FAL 422 + typed nsfw/user-input` → content-policy / **low**; `Vertex 401`, `504`, `Runtime.OutOfMemory` → **HIGH**; `422` with a **missing** typed reason → HIGH; runbook exceptions (broken refund/fallback, abnormal volume, safe-input misclassified) **escalate a low class back to HIGH**.
- **Deterministic classifier** `brain/platform/provider_alerts.py` — loads the JSON **every call** (no cache, no `#385` recall path), **fails closed** if the policy is unreadable (never silently emits a false HIGH), rewrites the alert's severity label before posting.
- **DB-backed signature throttle + acknowledgement ledger** `brain/systems/slack/provider_alert_gate.py` + model/migration (`0033_provider_alert_ledger`, a merge revision that also unifies two prior alembic heads → single head). Duplicate signatures within the throttle window, or signatures a human replied "known/stop/benign" to, are **suppressed and collapsed to a `still ongoing, +N since last` delta** instead of a fresh HIGH. Throttle is consumed **only on a confirmed post**.
- **Wired into the real posting path** (`_handle_post_slack_reply`), extracted into a focused `provider_alert_posting.py` service (one delegation point).

## Acceptance checks (issue #402)
1. ✅ Fresh run: `422` + typed `nsfw` → content-policy / non-HIGH (or suppressed), never `ALERT — HIGH`.
2. ✅ `Vertex 401` / `504` / `OOM` still post HIGH — the gate lowers only typed-benign classes.
3. ✅ Duplicate signature within window, or after a human "known/stop" reply → suppressed / delta line, not a repeated HIGH.
4. ✅ Map + ledger are durable config loaded every run, independent of `#385`.

## Out of scope (surfaced for Reda)
The alert **generator** is upstream — a "separate Codex-side coordinator prompt/config" that composes the summaries and sets the initial HIGH label. This PR patches only Illospace's **posting-path** gate (which is authoritative and catches a generated false-HIGH). **The same severity map should be applied at generation upstream** so the label is correct before Illo ever posts.

## Maintainability review (thermo-nuclear, via Codex)
Two BLOCKING findings were folded into commit `1109948`: extracted the posting service (slack.py 1057→991 lines) and made the JSON the single owner of provider vocab. Two NON-BLOCKING left for a follow-up: (a) parse the policy into immutable typed models instead of `dict[str, Any]` + `_source` mutation; (b) shrink `ProviderAlertLedgerSnapshot`'s public surface.

## Review surface
- Run tests: `PYTHONPATH=<worktree> venv/bin/python -m pytest tests/test_provider_alert_gate.py tests/test_models_all.py -q` → **18 passed**; slack-handler regression `tests/test_slack_thread_post_mute.py` → **11 passed**.
- Single alembic head confirmed: `0033_provider_alert_ledger` (merges `0031`+`0032`).

_Draft PR opened by Routine R3 (Codex-implemented, Claude-reviewed, Codex maintainability pass). Not merged / not marked ready — Reda merges after review._