### PR TITLE
fix(db): guard 0031 scheduler columns against fresh-baseline replay (green CI)

### DIFF
--- a/brain/platform/db/alembic/versions/0031_scheduler_failure_guard.py
+++ b/brain/platform/db/alembic/versions/0031_scheduler_failure_guard.py
@@ -17,32 +17,54 @@ branch_labels = None
 depends_on = None
 
 
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _column_exists(column_name: str) -> bool:
+    return column_name in {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns(
+            "scheduler_jobs",
+            schema=_schema(),
+        )
+    }
+
+
 def upgrade() -> None:
-    op.add_column(
-        "scheduler_jobs",
-        sa.Column("failure_signature", sa.String(length=64), nullable=True),
-    )
-    op.add_column(
-        "scheduler_jobs",
-        sa.Column(
-            "consecutive_failure_count",
-            sa.Integer(),
-            server_default=sa.text("0"),
-            nullable=False,
-        ),
-    )
-    op.add_column(
-        "scheduler_jobs",
-        sa.Column("failure_alerted_at", sa.DateTime(timezone=True), nullable=True),
-    )
-    op.add_column(
-        "scheduler_jobs",
-        sa.Column("last_failure_error", sa.Text(), nullable=True),
-    )
+    if not _column_exists("failure_signature"):
+        op.add_column(
+            "scheduler_jobs",
+            sa.Column("failure_signature", sa.String(length=64), nullable=True),
+        )
+    if not _column_exists("consecutive_failure_count"):
+        op.add_column(
+            "scheduler_jobs",
+            sa.Column(
+                "consecutive_failure_count",
+                sa.Integer(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+        )
+    if not _column_exists("failure_alerted_at"):
+        op.add_column(
+            "scheduler_jobs",
+            sa.Column("failure_alerted_at", sa.DateTime(timezone=True), nullable=True),
+        )
+    if not _column_exists("last_failure_error"):
+        op.add_column(
+            "scheduler_jobs",
+            sa.Column("last_failure_error", sa.Text(), nullable=True),
+        )
 
 
 def downgrade() -> None:
-    op.drop_column("scheduler_jobs", "last_failure_error")
-    op.drop_column("scheduler_jobs", "failure_alerted_at")
-    op.drop_column("scheduler_jobs", "consecutive_failure_count")
-    op.drop_column("scheduler_jobs", "failure_signature")
+    if _column_exists("last_failure_error"):
+        op.drop_column("scheduler_jobs", "last_failure_error")
+    if _column_exists("failure_alerted_at"):
+        op.drop_column("scheduler_jobs", "failure_alerted_at")
+    if _column_exists("consecutive_failure_count"):
+        op.drop_column("scheduler_jobs", "consecutive_failure_count")
+    if _column_exists("failure_signature"):
+        op.drop_column("scheduler_jobs", "failure_signature")

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -117,6 +117,25 @@ def _literal_create_table_names(calls: list[ast.Call]) -> list[str]:
     return names
 
 
+def _literal_add_column_names(calls: list[ast.Call]) -> list[tuple[str, str]]:
+    names: list[tuple[str, str]] = []
+    for call in calls:
+        if _call_name(call.func) != "op.add_column" or len(call.args) < 2:
+            continue
+        table_arg, column_arg = call.args[:2]
+        if not (
+            isinstance(table_arg, ast.Constant)
+            and isinstance(table_arg.value, str)
+            and isinstance(column_arg, ast.Call)
+            and column_arg.args
+            and isinstance(column_arg.args[0], ast.Constant)
+            and isinstance(column_arg.args[0].value, str)
+        ):
+            continue
+        names.append((table_arg.value, column_arg.args[0].value))
+    return names
+
+
 def _normalized_sql(sql: str) -> str:
     return re.sub(r"\s+", " ", sql).strip().upper()
 
@@ -292,6 +311,41 @@ def test_post_baseline_model_table_migrations_guard_fresh_baseline_replay():
     assert violations == [], (
         "Post-baseline migrations that create model-owned tables must guard fresh "
         f"baseline replay because Base.metadata.create_all already created them: {violations}"
+    )
+
+
+def test_post_baseline_model_column_migrations_guard_fresh_baseline_replay():
+    """Fresh installs already have current model columns after the baseline."""
+    from brain.platform.db.base import Base
+    import brain.platform.db.models  # noqa: F401
+
+    model_columns = {
+        table_name: set(table.c.keys())
+        for table_name, table in Base.metadata.tables.items()
+    }
+    violations: list[str] = []
+    for path in _material_schema_migration_files():
+        if path.name == PUBLIC_BASELINE:
+            continue
+        module = ast.parse(path.read_text(), filename=str(path))
+        added_model_columns = [
+            (table_name, column_name)
+            for table_name, column_name in _literal_add_column_names(
+                _function_body_calls(module, "upgrade")
+            )
+            if column_name in model_columns.get(table_name, set())
+        ]
+        if not added_model_columns:
+            continue
+
+        content = path.read_text()
+        if "get_columns" not in content:
+            violations.append(f"{path.name}: {added_model_columns}")
+
+    assert violations == [], (
+        "Post-baseline migrations that add model-owned columns must guard fresh "
+        "baseline replay because Base.metadata.create_all already added them: "
+        f"{violations}"
     )
 
 


### PR DESCRIPTION
## Why CI has been red on `main`
The **DB migration contract** job (fresh `pgvector/pg16` + `python3 -m alembic upgrade head`) fails:

```
asyncpg.exceptions.DuplicateColumnError: column "failure_signature" of relation "scheduler_jobs" already exists
```

This is a **real deploy-blocker**, not an obsolete test: a clean database cannot migrate. (The two backend test suites were also red on a *separate* real issue — divergent migration heads — already fixed by the `0033` merge migration in #402/#404.)

## Root cause
`0001_public_schema_baseline` runs `Base.metadata.create_all()` on the **current** models. So a fresh DB already contains `scheduler_jobs.failure_signature` (+ `consecutive_failure_count`, `failure_alerted_at`, `last_failure_error`) *before* Alembic reaches `0031_scheduler_failure_guard`, whose **unguarded** `op.add_column` then collides. It was masked until the `0031`/`0032` heads were merged by `0033` (which itself was written idempotently for exactly this reason). Alembic applies `0031` only once — the diamond/merge is not the cause.

## Fix (behavior-preserving; matches `0033`'s existing pattern)
- Guard each add in `0031.upgrade()` with a schema-inspection column check; make the `downgrade` drops symmetric. On a real incremental DB (columns absent) it still adds them; on a fresh baseline DB (columns already present) it skips.
- Add `tests/test_alembic_config.py::test_post_baseline_model_column_migrations_guard_fresh_baseline_replay` — the column-level analog of the existing table guard — so any future migration that adds a model-owned column without a `get_columns` guard fails the contract test. **The guardrail tests are strengthened, not weakened.**

## Verified on a real fresh `pgvector/pg16` (mirrors the CI job)
| | `alembic upgrade head` | `test_schema_contract.py` | `test_alembic_config.py` |
|---|---|---|---|
| `origin/main` (unfixed) | ❌ DuplicateColumnError | — | — |
| this branch | ✅ exit 0, single head `0033` | ✅ 1 passed | ✅ 14 passed (incl. new guard) |

## Follow-up (not in this PR)
The deeper smell is `0001_public_schema_baseline` calling `create_all()` on live model metadata — it makes every post-baseline `add_column`/`create_table` a fresh-DB landmine. The two AST contract tests now catch the class, but freezing the baseline to a static snapshot would remove the trap entirely. Flagging for a separate decision.

_Draft PR — Codex root-caused & fixed, Claude reviewed and reproduced the fix against real Postgres. Not merged / not ready — merge after review._