### PR TITLE
ci: run 145 hidden tests, drop duplicate job, unify requires_db lane

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -50,6 +50,13 @@ jobs:
               - "frontend/**"
               - ".github/workflows/brain-ci.yml"
             db:
+              # Run the Postgres DB suite whenever backend code or tests change,
+              # not only on DB-infra edits — otherwise the requires_db-marked
+              # coverage (chat routes, cross-channel recall, notifications, etc.)
+              # never runs on ordinary backend PRs. Narrow this back if Postgres
+              # CI cost becomes a concern.
+              - "brain/**"
+              - "tests/**"
               - "brain/platform/db/**"
               - "tests/test_schema_contract.py"
               - "tests/test_db_*.py"
@@ -96,49 +103,6 @@ jobs:
         run: >-
           python3 -m pytest tests/
           -m "not requires_db and not requires_browser and not live_provider"
-          --ignore=tests/test_agency.py
-          --ignore=tests/test_agency_api.py
-          --ignore=tests/test_chat_api_routes.py
-          --ignore=tests/test_chat_websocket.py
-          --ignore=tests/test_cortex_palette.py
-          --ignore=tests/test_cycles_service.py
-          --ignore=tests/test_multiplayer_cortex.py
-          --ignore=tests/test_notifications_api.py
-          --ignore=tests/test_theme_and_workspace_app_design_contracts.py
-          -q
-
-  backend-review:
-    name: Backend review-fix suites
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: python3 -m pip install -r requirements.txt pytest pytest-asyncio
-
-      - name: Run focused review-fix suites
-        run: >-
-          python3 -m pytest
-          tests/test_api_ws.py
-          tests/test_ws_manager.py
-          tests/test_run_events.py
-          tests/test_api_main.py
-          tests/test_browser_sessions.py
-          tests/test_ws_auth.py
-          tests/test_scheduler.py
-          tests/test_alembic_config.py
-          tests/test_tool_policy.py
-          tests/test_agent_run_runtime.py
           -q
 
   frontend:
@@ -175,7 +139,7 @@ jobs:
         run: npm run build
 
   db-contract:
-    name: DB migration contract
+    name: Backend DB suite
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.db == 'true'
@@ -220,8 +184,8 @@ jobs:
       - name: Run database migrations
         run: python3 -m alembic upgrade head
 
-      - name: Run schema contract tests
-        run: python3 -m pytest tests/test_schema_contract.py -v --tb=short
+      - name: Run database test suite
+        run: python3 -m pytest tests/ -m requires_db -v --tb=short
 
   ci-result:
     name: CI result
@@ -229,7 +193,6 @@ jobs:
     needs:
       - changes
       - backend-fast
-      - backend-review
       - frontend
       - db-contract
     if: always()
@@ -240,7 +203,6 @@ jobs:
           for result in \
             "${{ needs.changes.result }}" \
             "${{ needs.backend-fast.result }}" \
-            "${{ needs.backend-review.result }}" \
             "${{ needs.frontend.result }}" \
             "${{ needs.db-contract.result }}"
           do

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,10 +193,16 @@ def sqlite_postgres_ddl_patch():
 TEST_DB_URL = os.environ.get("TEST_DB_URL")
 
 
-requires_db = pytest.mark.skipif(
-    not TEST_DB_URL,
-    reason="TEST_DB_URL not set — run via scripts/test-with-db.sh",
-)
+requires_db = pytest.mark.requires_db
+
+
+def pytest_collection_modifyitems(config, items):
+    if TEST_DB_URL is not None:
+        return
+    skip_db = pytest.mark.skip(reason="TEST_DB_URL not set — run in the Postgres CI lane")
+    for item in items:
+        if "requires_db" in item.keywords:
+            item.add_marker(skip_db)
 
 
 @pytest.fixture

--- a/tests/test_agent_coordination.py
+++ b/tests/test_agent_coordination.py
@@ -11,11 +11,8 @@ from sqlalchemy import text
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
 
 pytestmark = [
-    pytest.mark.skipif(
-        not os.environ.get("TEST_DB_URL"),
-        reason="TEST_DB_URL not set — run via scripts/test-with-db.sh",
-    ),
     pytest.mark.asyncio,
+    pytest.mark.requires_db,
 ]
 
 import brain.platform.db as db

--- a/tests/test_notifications_api.py
+++ b/tests/test_notifications_api.py
@@ -212,6 +212,7 @@ async def test_openapi_registers_notification_routes():
     assert "/api/notifications/read-all" in paths
 
 
+@pytest.mark.requires_db
 async def test_notification_preferences_are_persisted(notification_db_session: AsyncSession):
     request_as = _build_request_as(notification_db_session)
     response = await request_as(USER_2_ID, "GET", "/api/notifications/preferences")
@@ -240,6 +241,7 @@ async def test_notification_preferences_are_persisted(notification_db_session: A
     assert user.message_notifications_enabled is False
 
 
+@pytest.mark.requires_db
 async def test_workspace_notification_read_marks_user_mentions_seen(notification_db_session: AsyncSession):
     notification_id = await _seed_workspace_notification(notification_db_session)
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -11,9 +11,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".
 from brain.systems.quality.checks import check_content_quality, cap_salience
 from brain.systems.memory.embeddings import vec_to_pg
 
-_HAS_DB = bool(os.environ.get("TEST_DB_URL"))
-
-
 class TestContentQuality:
     def test_rejects_empty(self):
         ok, reason = check_content_quality("")
@@ -81,7 +78,7 @@ class TestSalienceCap:
         assert cap_salience(4.0, "research") == 4.0
 
 
-@pytest.mark.skipif(not _HAS_DB, reason="TEST_DB_URL not set — requires live database")
+@pytest.mark.requires_db
 class TestDeduplication:
     """Test near-duplicate detection at write time (requires live DB)."""
 

--- a/tests/test_retrieval_feedback.py
+++ b/tests/test_retrieval_feedback.py
@@ -13,11 +13,6 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from sqlalchemy import text
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TEST_DB_URL"),
-    reason="TEST_DB_URL not set — run via scripts/test-with-db.sh",
-)
-
 from brain.systems.memory.retrieval_feedback import (
     analyze_missed_memories,
     apply_retrieval_feedback,
@@ -80,6 +75,7 @@ async def _ensure_retrieval_log(db_session, memory_id, query="test query"):
     return row["id"]
 
 
+@pytest.mark.requires_db
 class TestApplyRetrievalFeedback:
     async def test_hit_boosts_salience(self, db_session, scoped_principal, unit_of_work_for_session):
         mid = await _ensure_test_memory(db_session, "hit test", salience=5.0)
@@ -151,6 +147,7 @@ class TestApplyRetrievalFeedback:
         assert row["feedback"] == "miss"
 
 
+@pytest.mark.requires_db
 class TestAnalyzeMissedMemories:
     async def test_identifies_consistently_missed(self, db_session, scoped_principal, unit_of_work_for_session):
         mid = await _ensure_test_memory(db_session, "always missed", salience=5.0)


### PR DESCRIPTION
From the CI test-suite audit. The test *bodies* are healthy — the staleness was in **CI selection**.

## Changes
- **Un-hide ~145 currently-passing tests.** Removed 9 fast-job `--ignore` lines: 2 are dead (`test_agency*.py` no longer exist), 7 hid real passing coverage (`test_cortex_palette`, `test_cycles_service`, `test_multiplayer_cortex`, `test_theme_and_workspace_app_design_contracts`, `test_chat_*`, `test_notifications_api`). The fast job now selects purely by marker.
- **Drop the duplicate `backend-review` job** — its 299 tests were a subset of the fast job (pure wasted CI).
- **Unify DB selection on the `requires_db` marker.** `conftest.py` exports `pytest.mark.requires_db` + a collection hook that skips marked tests when `TEST_DB_URL` is unset (local runs still skip; `-m requires_db` is now authoritative). Converted ad-hoc `skipif` gates in 4 DB test files to the marker; one genuinely-pure retrieval test moves into the fast lane.
- **DB lane now runs the real suite:** `pytest tests/ -m requires_db` (62 tests — schema contract, chat routes, cross-channel, notifications, docker smoke, …) instead of a single file.

## ⚠️ One decision for you (I made a default, easy to change)
I broadened the `db` change-filter to trigger on `brain/**` + `tests/**`, not just DB-infra paths — otherwise the newly-marked DB tests (e.g. the cross-channel fix in #407) would **never run on an ordinary backend PR**, defeating the point. Trade-off: Postgres now spins on every backend PR (one extra parallel job, ~slower CI). If you'd rather keep Postgres CI narrow, revert that one filter block (commented in the diff) and DB tests run only on DB-infra changes.

## Verified (no DB needed for the plumbing)
- `-m requires_db` selects **62** tests; run without `TEST_DB_URL` → all **skip cleanly** (hook), zero connection errors.
- Previously-hidden pure files → **pass in the fast lane** (e.g. multiplayer_cortex + retrieval-feedback pure test).
- Workflow YAML parses.

## Merge order
After **#405** (so the DB lane's `alembic upgrade head` succeeds) and after **#406 / #407** (so their re-enabled `requires_db` tests exist for the expanded lane). Marker-based routing means order won't break anything, but that sequence gives the cleanest green.

_Draft PR — Codex-implemented (with an approved scope expansion to unify the marker), Claude-reviewed and verified. Merge after review._