### PR TITLE
fix(slack): split oversized digests on structural boundaries with marked continuations (#411)

### DIFF
--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -13,6 +13,11 @@ from brain.platform.async_io import async_http_client
 # Split before the API boundary so a receiver-side limit cannot discard the lede.
 SLACK_MESSAGE_TEXT_CHARS = 4000
 
+_SLACK_SECTION_HEADER_RE = re.compile(r"(?m)^\*[^*\n]+\*[ \t]*(?=\n|$)")
+_SLACK_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n")
+_SLACK_BULLET_RE = re.compile(r"(?m)^•[ \t]+")
+_SLACK_ENTITY_RE = re.compile(r"<[^>\n]+>")
+
 
 class SlackConfigurationError(RuntimeError):
     """Raised when the self-hosted Slack connector is not configured."""
@@ -69,13 +74,113 @@ class SlackDeliveryError(SlackApiError):
         }
 
 
-def _message_text_chunks(text: str) -> list[str]:
-    if not text:
-        return [text]
-    return [
-        text[start : start + SLACK_MESSAGE_TEXT_CHARS]
-        for start in range(0, len(text), SLACK_MESSAGE_TEXT_CHARS)
+def _protected_slack_spans(text: str) -> list[tuple[int, int]]:
+    spans = [(match.start(), match.end()) for match in _SLACK_ENTITY_RE.finditer(text)]
+    fence_start: int | None = None
+    for match in re.finditer(r"```", text):
+        if fence_start is None:
+            fence_start = match.start()
+        else:
+            spans.append((fence_start, match.end()))
+            fence_start = None
+    if fence_start is not None:
+        spans.append((fence_start, len(text)))
+    return sorted(spans)
+
+
+def _is_safe_boundary(position: int, protected_spans: list[tuple[int, int]]) -> bool:
+    return not any(start < position < end for start, end in protected_spans)
+
+
+def _last_safe_boundary(
+    positions: list[int],
+    *,
+    limit: int,
+    protected_spans: list[tuple[int, int]],
+) -> int | None:
+    candidates = [
+        position
+        for position in positions
+        if 0 < position <= limit and _is_safe_boundary(position, protected_spans)
     ]
+    return max(candidates, default=None)
+
+
+def _preferred_split_offset(text: str, limit: int) -> int:
+    protected_spans = _protected_slack_spans(text)
+    section_boundaries = [
+        match.start() for match in _SLACK_SECTION_HEADER_RE.finditer(text) if match.start()
+    ]
+    section_boundaries.extend(
+        match.end()
+        for match in _SLACK_BLANK_LINE_RE.finditer(text)
+        if text[: match.start()].strip()
+    )
+    bullet_boundaries = [
+        match.start() for match in _SLACK_BULLET_RE.finditer(text) if match.start()
+    ]
+    line_boundaries = [match.end() for match in re.finditer(r"\n", text)]
+
+    for positions in (section_boundaries, bullet_boundaries, line_boundaries):
+        boundary = _last_safe_boundary(
+            positions,
+            limit=limit,
+            protected_spans=protected_spans,
+        )
+        if boundary is not None:
+            return boundary
+
+    hard_boundary = min(limit, len(text))
+    for start, end in protected_spans:
+        if start < hard_boundary < end:
+            # A normal Slack entity or fenced block fits in a message and can
+            # move whole to the next chunk. If the protected construct alone
+            # exceeds the available budget, keeping it whole is the only way
+            # not to corrupt its Slack rendering.
+            return start if start else end
+    return hard_boundary
+
+
+def _continuation_marker_reserve(text: str) -> int:
+    # A message cannot produce more chunks than it has characters. Reserving
+    # that digit width keeps every finalized chunk within the caller's limit
+    # without a count-and-resplit loop at powers of ten.
+    widest_index = "9" * len(str(max(2, len(text))))
+    first = f"\n\n({widest_index}/{widest_index}) ↓ continued"
+    continuation = f"({widest_index}/{widest_index}) continuation\n\n"
+    return max(len(first), len(continuation))
+
+
+def split_slack_message(text: str, limit: int) -> list[str]:
+    """Split Slack text at structural boundaries and label continuations."""
+
+    submitted_text = str(text)
+    if limit <= 0:
+        raise ValueError("Slack message limit must be positive")
+    if len(submitted_text) <= limit:
+        return [submitted_text]
+
+    content_limit = limit - _continuation_marker_reserve(submitted_text)
+    if content_limit <= 0:
+        raise ValueError("Slack message limit is too small for continuation markers")
+
+    parts: list[str] = []
+    remaining = submitted_text
+    while len(remaining) > content_limit:
+        split_at = _preferred_split_offset(remaining, content_limit)
+        if split_at <= 0:
+            split_at = content_limit
+        parts.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+    parts.append(remaining)
+
+    total = len(parts)
+    chunks = [f"{parts[0]}\n\n(1/{total}) ↓ continued"]
+    chunks.extend(
+        f"({index}/{total}) continuation\n\n{part}"
+        for index, part in enumerate(parts[1:], start=2)
+    )
+    return chunks
 
 
 def _stored_message_text(response: dict[str, Any]) -> str | None:
@@ -191,15 +296,14 @@ class SlackWebClient:
         thread_ts: str | None = None,
     ) -> dict[str, Any]:
         submitted_text = str(text)
-        chunks = _message_text_chunks(submitted_text)
+        chunks = split_slack_message(submitted_text, SLACK_MESSAGE_TEXT_CHARS)
         responses: list[dict[str, Any]] = []
         stored_chunks: list[str] = []
-        continuation_thread_ts = thread_ts
 
         for index, chunk in enumerate(chunks):
             payload: dict[str, Any] = {"channel": channel, "text": chunk}
-            if continuation_thread_ts:
-                payload["thread_ts"] = continuation_thread_ts
+            if thread_ts:
+                payload["thread_ts"] = thread_ts
             try:
                 response = await self._post("chat.postMessage", payload)
             except Exception as exc:
@@ -242,18 +346,6 @@ class SlackWebClient:
                         f"({len(chunk)} chars/{len(chunk.encode('utf-8'))} bytes): {reason}."
                     ),
                 )
-
-            if index == 0 and len(chunks) > 1 and not continuation_thread_ts:
-                continuation_thread_ts = _posted_message_ts(response)
-                if not continuation_thread_ts:
-                    raise SlackDeliveryError(
-                        "slack_message_delivery_unverified",
-                        submitted_text=submitted_text,
-                        posted_text="".join(stored_chunks),
-                        chunk_count=len(responses),
-                        truncated=None,
-                        detail="Slack returned ok without a message timestamp for threaded continuations.",
-                    )
 
         posted_text = "".join(stored_chunks)
         result = dict(responses[0])

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any
+from typing import Any, Literal, NamedTuple
 
 from brain.platform.async_io import async_http_client
 
@@ -17,6 +17,12 @@ _SLACK_SECTION_HEADER_RE = re.compile(r"(?m)^\*[^*\n]+\*[ \t]*(?=\n|$)")
 _SLACK_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n")
 _SLACK_BULLET_RE = re.compile(r"(?m)^•[ \t]+")
 _SLACK_ENTITY_RE = re.compile(r"<[^>\n]+>")
+
+
+class _ProtectedSlackSpan(NamedTuple):
+    kind: Literal["entity", "fenced_block"]
+    start: int
+    end: int
 
 
 class SlackConfigurationError(RuntimeError):
@@ -74,29 +80,32 @@ class SlackDeliveryError(SlackApiError):
         }
 
 
-def _protected_slack_spans(text: str) -> list[tuple[int, int]]:
-    spans = [(match.start(), match.end()) for match in _SLACK_ENTITY_RE.finditer(text)]
+def _protected_slack_spans(text: str) -> list[_ProtectedSlackSpan]:
+    spans = [
+        _ProtectedSlackSpan("entity", match.start(), match.end())
+        for match in _SLACK_ENTITY_RE.finditer(text)
+    ]
     fence_start: int | None = None
     for match in re.finditer(r"```", text):
         if fence_start is None:
             fence_start = match.start()
         else:
-            spans.append((fence_start, match.end()))
+            spans.append(_ProtectedSlackSpan("fenced_block", fence_start, match.end()))
             fence_start = None
     if fence_start is not None:
-        spans.append((fence_start, len(text)))
-    return sorted(spans)
+        spans.append(_ProtectedSlackSpan("fenced_block", fence_start, len(text)))
+    return sorted(spans, key=lambda span: (span.start, span.end))
 
 
-def _is_safe_boundary(position: int, protected_spans: list[tuple[int, int]]) -> bool:
-    return not any(start < position < end for start, end in protected_spans)
+def _is_safe_boundary(position: int, protected_spans: list[_ProtectedSlackSpan]) -> bool:
+    return not any(span.start < position < span.end for span in protected_spans)
 
 
 def _last_safe_boundary(
     positions: list[int],
     *,
     limit: int,
-    protected_spans: list[tuple[int, int]],
+    protected_spans: list[_ProtectedSlackSpan],
 ) -> int | None:
     candidates = [
         position
@@ -104,6 +113,25 @@ def _last_safe_boundary(
         if 0 < position <= limit and _is_safe_boundary(position, protected_spans)
     ]
     return max(candidates, default=None)
+
+
+def _oversized_protected_span_split_offset(
+    span: _ProtectedSlackSpan,
+    *,
+    hard_boundary: int,
+) -> int:
+    """Apply the explicit overflow policy for a construct larger than one chunk."""
+
+    assert span.start == 0 < hard_boundary < span.end
+    if span.kind == "entity":
+        # A Slack entity cannot legitimately exceed the available text budget.
+        # Treat malformed input as ordinary text rather than breaking the limit.
+        return hard_boundary
+    if span.kind == "fenced_block":
+        # Synthetic close/re-open fences would make the concatenated content
+        # differ from the submission. Preserve it byte-for-byte at the hard cut.
+        return hard_boundary
+    raise AssertionError(f"Unknown protected Slack span kind: {span.kind}")
 
 
 def _preferred_split_offset(text: str, limit: int) -> int:
@@ -131,24 +159,30 @@ def _preferred_split_offset(text: str, limit: int) -> int:
             return boundary
 
     hard_boundary = min(limit, len(text))
-    for start, end in protected_spans:
-        if start < hard_boundary < end:
-            # A normal Slack entity or fenced block fits in a message and can
-            # move whole to the next chunk. If the protected construct alone
-            # exceeds the available budget, keeping it whole is the only way
-            # not to corrupt its Slack rendering.
-            return start if start else end
+    for span in protected_spans:
+        if span.start < hard_boundary < span.end:
+            if span.start:
+                return span.start
+            return _oversized_protected_span_split_offset(
+                span,
+                hard_boundary=hard_boundary,
+            )
     return hard_boundary
 
 
-def _continuation_marker_reserve(text: str) -> int:
-    # A message cannot produce more chunks than it has characters. Reserving
-    # that digit width keeps every finalized chunk within the caller's limit
-    # without a count-and-resplit loop at powers of ten.
-    widest_index = "9" * len(str(max(2, len(text))))
-    first = f"\n\n({widest_index}/{widest_index}) ↓ continued"
-    continuation = f"({widest_index}/{widest_index}) continuation\n\n"
-    return max(len(first), len(continuation))
+def _continuation_marker(index: int, total: int) -> str:
+    assert total >= 2
+    assert 1 <= index <= total
+    if index == 1:
+        return f"\n\n(1/{total}) ↓ continued"
+    return f"({index}/{total}) continuation\n\n"
+
+
+def _continuation_marker_reserve(chunk_count: int) -> int:
+    return max(
+        len(_continuation_marker(1, chunk_count)),
+        len(_continuation_marker(chunk_count, chunk_count)),
+    )
 
 
 def split_slack_message(text: str, limit: int) -> list[str]:
@@ -160,26 +194,33 @@ def split_slack_message(text: str, limit: int) -> list[str]:
     if len(submitted_text) <= limit:
         return [submitted_text]
 
-    content_limit = limit - _continuation_marker_reserve(submitted_text)
-    if content_limit <= 0:
-        raise ValueError("Slack message limit is too small for continuation markers")
+    assumed_chunk_count = 2
+    while True:
+        marker_reserve = _continuation_marker_reserve(assumed_chunk_count)
+        content_limit = limit - marker_reserve
+        if content_limit <= 0:
+            raise ValueError("Slack message limit is too small for continuation markers")
 
-    parts: list[str] = []
-    remaining = submitted_text
-    while len(remaining) > content_limit:
-        split_at = _preferred_split_offset(remaining, content_limit)
-        if split_at <= 0:
-            split_at = content_limit
-        parts.append(remaining[:split_at])
-        remaining = remaining[split_at:]
-    parts.append(remaining)
+        parts: list[str] = []
+        remaining = submitted_text
+        while len(remaining) > content_limit:
+            split_at = _preferred_split_offset(remaining, content_limit)
+            assert 1 <= split_at <= content_limit
+            parts.append(remaining[:split_at])
+            remaining = remaining[split_at:]
+        parts.append(remaining)
 
-    total = len(parts)
-    chunks = [f"{parts[0]}\n\n(1/{total}) ↓ continued"]
+        total = len(parts)
+        if _continuation_marker_reserve(total) == marker_reserve:
+            break
+        assumed_chunk_count = total
+
+    chunks = [f"{parts[0]}{_continuation_marker(1, total)}"]
     chunks.extend(
-        f"({index}/{total}) continuation\n\n{part}"
+        f"{_continuation_marker(index, total)}{part}"
         for index, part in enumerate(parts[1:], start=2)
     )
+    assert all(len(chunk) <= limit for chunk in chunks)
     return chunks
 
 

--- a/tests/test_slack_message_chunking.py
+++ b/tests/test_slack_message_chunking.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from brain.systems.slack.client import SlackWebClient, split_slack_message
+
+
+def _unmarked_parts(chunks: list[str]) -> list[str]:
+    if len(chunks) == 1:
+        return chunks
+
+    total = len(chunks)
+    first_marker = f"\n\n(1/{total}) ↓ continued"
+    assert chunks[0].endswith(first_marker)
+    parts = [chunks[0][: -len(first_marker)]]
+    for index, chunk in enumerate(chunks[1:], start=2):
+        marker = f"({index}/{total}) continuation\n\n"
+        assert chunk.startswith(marker)
+        parts.append(chunk[len(marker) :])
+    return parts
+
+
+def _real_defect_payload(limit: int) -> str:
+    heading = "\n\n*Per-person recap*\n"
+    bullet_start = limit - 8
+    lead_length = bullet_start - len(heading)
+    lead = "*13:00 ET daily engineering brief*\n"
+    evidence_line = "Evidence: " + ("detail " * 9) + "item.\n"
+    while len(lead) + len(evidence_line) <= lead_length:
+        lead += evidence_line
+    lead += "x" * (lead_length - len(lead))
+    payload = (
+        lead
+        + heading
+        + "• <@U04R1A6MZST|Reda>: top action — merge staging PR #661.\n"
+        + "• <@U_AXEL|Axel>: top action — review the agent queue.\n"
+        + "• <@U_JB|JB>: top action — verify the deploy.\n\n"
+        + "*Rebalancing*\nNo move recommended."
+    )
+
+    mention_start = payload.index("<@U04R1A6MZST|Reda>")
+    mention_end = payload.index(">", mention_start)
+    assert mention_start < limit < mention_end
+    return payload
+
+
+class _RecordingSlackClient(SlackWebClient):
+    def __init__(self) -> None:
+        super().__init__("xoxb-test")
+        self.posts: list[dict[str, Any]] = []
+
+    async def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+        assert method == "chat.postMessage"
+        self.posts.append(dict(payload))
+        ts = f"1716900200.{len(self.posts):06d}"
+        return {
+            "ok": True,
+            "channel": payload["channel"],
+            "ts": ts,
+            "message": {"text": payload["text"], "ts": ts},
+        }
+
+
+def test_split_slack_message_leaves_under_budget_text_unchanged():
+    body = "*Daily brief*\nAll systems nominal."
+
+    assert split_slack_message(body, 4000) == [body]
+
+
+def test_split_slack_message_reproduces_411_without_splitting_the_mention():
+    limit = 200
+    body = _real_defect_payload(limit)
+
+    chunks = split_slack_message(body, limit)
+    parts = _unmarked_parts(chunks)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= limit for chunk in chunks)
+    assert "".join(parts) == body
+    assert all(part.count("<") == part.count(">") for part in parts)
+    assert all(not part.startswith(":") for part in parts[1:])
+
+
+def test_split_slack_message_prefers_sections_then_bullets():
+    body = (
+        "*Daily brief*\n"
+        + ("Summary " * 7)
+        + "\n\n*Movement*\n"
+        + "• First complete action with supporting evidence.\n"
+        + "• Second complete action with supporting evidence.\n\n"
+        + "*Per-person recap*\n"
+        + "• Reda: merge the release.\n"
+        + "• Axel: review the queue.\n"
+        + "• JB: verify the deploy."
+    )
+
+    chunks = split_slack_message(body, 120)
+    parts = _unmarked_parts(chunks)
+
+    assert "".join(parts) == body
+    assert all(part.startswith(("*", "• ")) for part in parts)
+    assert any(part.startswith("*Movement*") for part in parts[1:])
+    assert any(part.startswith("• ") for part in parts[1:])
+
+
+def test_split_slack_message_does_not_break_a_fenced_code_block():
+    body = (
+        "*Details*\n"
+        + ("x" * 62)
+        + "\n```\nfirst line\nsecond line\n```\n\n"
+        + "*Next*\nShip after review."
+    )
+
+    chunks = split_slack_message(body, 120)
+    parts = _unmarked_parts(chunks)
+
+    assert "".join(parts) == body
+    assert all(part.count("```") % 2 == 0 for part in parts)
+
+
+def test_split_slack_message_does_not_break_a_slack_link():
+    link = "<https://example.com/a/long/path|the complete link label>"
+    body = ("Context " * 7) + link + (" trailing detail" * 7)
+
+    chunks = split_slack_message(body, 100)
+    parts = _unmarked_parts(chunks)
+
+    assert "".join(parts) == body
+    assert all(part.count("<") == part.count(">") for part in parts)
+    assert sum(link in part for part in parts) == 1
+
+
+def test_split_slack_message_hard_cuts_only_as_a_lossless_last_resort():
+    body = "x" * 250
+
+    chunks = split_slack_message(body, 80)
+
+    assert all(len(chunk) <= 80 for chunk in chunks)
+    assert "".join(_unmarked_parts(chunks)) == body
+
+
+@pytest.mark.asyncio
+async def test_post_message_keeps_oversized_channel_digest_in_channel():
+    client = _RecordingSlackClient()
+    body = _real_defect_payload(4000)
+
+    result = await client.post_message(channel="C_SOFTWARE", text=body)
+    posted_chunks = [str(post["text"]) for post in client.posts]
+
+    assert result["chunk_count"] == len(client.posts) > 1
+    assert result["truncated"] is False
+    assert all("thread_ts" not in post for post in client.posts)
+    assert "".join(_unmarked_parts(posted_chunks)) == body
+    assert posted_chunks[0].endswith(f"(1/{len(posted_chunks)}) ↓ continued")
+    assert all(
+        chunk.startswith(f"({index}/{len(posted_chunks)}) continuation\n\n")
+        for index, chunk in enumerate(posted_chunks[1:], start=2)
+    )
+    channel_text = "\n".join(posted_chunks)
+    assert all(name in channel_text for name in ("Reda", "Axel", "JB"))
+
+
+@pytest.mark.asyncio
+async def test_post_message_preserves_an_existing_thread_for_all_chunks():
+    client = _RecordingSlackClient()
+    body = ("Thread evidence line.\n" * 220) + "Done."
+
+    await client.post_message(
+        channel="C_SOFTWARE",
+        text=body,
+        thread_ts="1716900000.000100",
+    )
+
+    assert len(client.posts) > 1
+    assert {post.get("thread_ts") for post in client.posts} == {"1716900000.000100"}
+
+
+@pytest.mark.asyncio
+async def test_post_message_leaves_under_budget_delivery_unchanged():
+    client = _RecordingSlackClient()
+    body = "*Daily brief*\nAll systems nominal."
+
+    result = await client.post_message(channel="C_SOFTWARE", text=body)
+
+    assert client.posts == [{"channel": "C_SOFTWARE", "text": body}]
+    assert result["chunk_count"] == 1
+    assert result["truncated"] is False

--- a/tests/test_slack_message_chunking.py
+++ b/tests/test_slack_message_chunking.py
@@ -141,6 +141,35 @@ def test_split_slack_message_hard_cuts_only_as_a_lossless_last_resort():
     assert "".join(_unmarked_parts(chunks)) == body
 
 
+@pytest.mark.parametrize("limit", [32, 47, 80])
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param("```\n" + ("fenced-content\n" * 20) + "```", id="giant-fence"),
+        pytest.param("<@" + ("U" * 240) + "|oversized-mention>", id="giant-entity"),
+        pytest.param("x" * 257, id="no-whitespace"),
+    ],
+)
+def test_split_slack_message_is_bounded_and_lossless_for_adversarial_input(
+    body: str,
+    limit: int,
+):
+    chunks = split_slack_message(body, limit)
+
+    assert all(len(chunk) <= limit for chunk in chunks)
+    assert "".join(_unmarked_parts(chunks)) == body
+
+
+def test_split_slack_message_sizes_markers_from_the_stable_chunk_count():
+    body = "x" * 1000
+
+    chunks = split_slack_message(body, 26)
+
+    assert len(chunks) >= 100
+    assert all(len(chunk) <= 26 for chunk in chunks)
+    assert "".join(_unmarked_parts(chunks)) == body
+
+
 @pytest.mark.asyncio
 async def test_post_message_keeps_oversized_channel_digest_in_channel():
     client = _RecordingSlackClient()

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -2353,7 +2353,7 @@ async def test_manage_slack_link_identity_persists_communication_profile(
 async def test_post_slack_reply_accepts_slack_rewrites_without_false_truncation(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
-    from brain.systems.slack.client import SlackWebClient
+    from brain.systems.slack.client import SlackWebClient, split_slack_message
 
     headline = "*Uwear 08:00 ET daily engineering brief*\n"
     pull_url = "https://github.com/uwear-ai/illospace/pull/357"
@@ -2418,8 +2418,7 @@ async def test_post_slack_reply_accepts_slack_rewrites_without_false_truncation(
     assert result["posted_chars"] == sum(len(text) for text in stored_texts)
     assert result["truncated"] is False
     assert result["chunk_count"] == len(submitted_chunks) == 2
-    assert "thread_ts" not in submitted_chunks[0]
-    assert submitted_chunks[1]["thread_ts"] == "1716900200.000001"
+    assert all("thread_ts" not in chunk for chunk in submitted_chunks)
     assert stored_texts[0].startswith(headline)
     assert f"<{pull_url}>" in stored_texts[0]
     assert "<!here>" in stored_texts[0]
@@ -2427,7 +2426,7 @@ async def test_post_slack_reply_accepts_slack_rewrites_without_false_truncation(
     assert "&lt;priority&gt;" in stored_texts[0]
     assert "<@U123>" in stored_texts[0]
     assert stored_texts[-1].endswith(footer)
-    assert "".join(str(chunk["text"]) for chunk in submitted_chunks) == body
+    assert [str(chunk["text"]) for chunk in submitted_chunks] == split_slack_message(body, 4000)
     assert "".join(stored_texts) != body
 
 
@@ -2435,7 +2434,7 @@ async def test_post_slack_reply_accepts_slack_rewrites_without_false_truncation(
 async def test_post_slack_reply_surfaces_receiver_side_tail_truncation(monkeypatch):
     from brain.systems.runs.execution_context import bind_agent_context
     from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
-    from brain.systems.slack.client import SlackWebClient
+    from brain.systems.slack.client import SlackWebClient, split_slack_message
 
     body = "digest headline\n" + ("evidence\n" * 520) + "Reda | Axel | JB"
 
@@ -2479,7 +2478,8 @@ async def test_post_slack_reply_surfaces_receiver_side_tail_truncation(monkeypat
     assert result["submitted_chars"] == len(body)
     assert result["posted_chars"] == 1000
     assert result["submitted_bytes"] == len(body.encode("utf-8"))
-    assert result["posted_bytes"] == 1000
+    first_chunk_tail = split_slack_message(body, 4000)[0][-1000:]
+    assert result["posted_bytes"] == len(first_chunk_tail.encode("utf-8"))
     assert result["truncated"] is True
 
 


### PR DESCRIPTION
Closes #411.

The 13:00 digest on 2026-07-21 was cut in the middle of the Per-person recap: the channel message ended on the dangling bullet `• <@U04R1A6MZST|Reda>` and the rest — Axel, JB, and the rebalancing recommendation — went to an **unmarked thread reply**. Cause: `_message_text_chunks` sliced every 4,000 characters, blind to structure, and the first chunk's `ts` was used to thread the rest.

## What changed
- **`split_slack_message(text, limit)`** — a pure, separately testable function replaces the blind slice. Boundary preference: section header / blank line → bullet → line break → hard cut as last resort. It never cuts inside a `<@mention>`, a `<link|label>`, or a fenced block.
- **Continuations are labelled** — `(1/N) ↓ continued` on the first chunk, `(N/N) continuation` leading each subsequent one, each on its own line so it can never merge into a sentence. Under-budget messages are byte-identical to before: `chunk_count: 1`, no marker, no thread.
- **Channel digests stay in the channel** — `post_message` no longer promotes the first chunk into a thread parent. A message explicitly targeting an existing thread still stays in that thread. This is fix item 3's first branch, so the Per-person recap can no longer land out of channel view.

## Review trail (two commits, deliberately not squashed)
`7d18e0b` is the implementation. `7fc752c` is a fix-pass for a **blocking finding from a thermo-nuclear code-quality review** run by Codex against the first commit: the splitter could return a chunk **larger than the limit** when a single protected span exceeded the budget — demonstrated at 121 and 127 characters with `limit=80`. The contract was false exactly in the over-budget case the feature exists for. Now:
- an oversized fenced block or a malformed giant entity is **hard-cut**, chosen over synthetic fence close/reopen so concatenation stays byte-for-byte lossless (the #357 "nothing is silently lost" property is preserved);
- marker grammar lives in one renderer, and the reserve is sized from the stabilised chunk count rather than a `len(text)` digit-width upper bound;
- the invariant is asserted in the function and tested against adversarial inputs.

The reviewer explicitly cleared the boundary-preference ladder — making the boundary kinds data-driven now would be decorative.

## Verification
- `167 passed, 1 skipped, 3847 deselected` — `pytest tests/test_slack_message_chunking.py tests/ -k "slack or chunk" -m "not requires_db and not integration"`, run by me in the worktree, no DB or Docker needed.
- **Independent fuzz I ran myself** (not Codex's tests): 4,000 random payloads built from mentions, links, fences, bullets, headers, emoji and multibyte text across limits 20–4000 — **zero chunks over the limit, zero content loss**.
- Acceptance-check coverage: (1) the real #411 mention cut plus section/bullet/fence boundaries; (2) first-chunk pointer + numbered markers; (3) Reda, Axel and JB all present in top-level channel posts; (4) under-budget message unchanged.

## Known trade-off, stated plainly
A fenced block longer than the Slack limit is hard-cut, so its markup renders broken across the two chunks. The alternative — synthesising a closing and reopening fence — would make the posted text differ from the submitted text, which is the property #357 exists to protect. Lossless-but-ugly beat pretty-but-lossy. This only bites on a >4,000-character single fence in a digest, which no current digest produces.

**Behaviour change worth knowing before you merge:** an over-budget digest now posts as N sequential *channel* messages instead of 1 channel message + a hidden thread. That is what the issue asked for, and it is the part best judged in production.
