### PR TITLE
feat(alerts): detect alert surges and declare one consolidated incident (#410)

### DIFF
--- a/brain/platform/db/alembic/versions/0034_provider_alert_surges.py
+++ b/brain/platform/db/alembic/versions/0034_provider_alert_surges.py
@@ -1,0 +1,173 @@
+"""Add durable provider-alert occurrence and surge state.
+
+Revision ID: 0034_provider_alert_surges
+Revises: 0033_provider_alert_ledger
+Create Date: 2026-07-22
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0034_provider_alert_surges"
+down_revision = "0033_provider_alert_ledger"
+branch_labels = None
+depends_on = None
+
+_OCCURRENCES = "provider_alert_occurrences"
+_SURGES = "provider_alert_surges"
+
+
+def _schema() -> str | None:
+    return "public" if op.get_bind().dialect.name == "postgresql" else None
+
+
+def _inspector():
+    return sa.inspect(op.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in set(_inspector().get_table_names(schema=_schema()))
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {
+        index["name"]
+        for index in _inspector().get_indexes(table_name, schema=_schema())
+    }
+
+
+def _uuid_type():
+    if op.get_bind().dialect.name == "postgresql":
+        return postgresql.UUID(as_uuid=False)
+    return sa.String()
+
+
+def upgrade() -> None:
+    if not _table_exists(_OCCURRENCES):
+        op.create_table(
+            _OCCURRENCES,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("org_id", _uuid_type(), nullable=False),
+            sa.Column("channel_id", sa.String(length=80), nullable=False),
+            sa.Column("slack_message_ts", sa.String(length=40), nullable=False),
+            sa.Column("service", sa.String(length=120), nullable=False),
+            sa.Column("subsystem", sa.String(length=120), nullable=False),
+            sa.Column("external_id", sa.String(length=180), nullable=False),
+            sa.Column("signature", sa.String(length=64), nullable=False),
+            sa.Column("signature_title", sa.Text(), nullable=False),
+            sa.Column("occurrence_milestone", sa.Integer(), nullable=True),
+            sa.Column(
+                "is_new_error",
+                sa.Boolean(),
+                server_default=sa.text("false"),
+                nullable=False,
+            ),
+            sa.Column(
+                "is_new_signature",
+                sa.Boolean(),
+                server_default=sa.text("false"),
+                nullable=False,
+            ),
+            sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(["org_id"], ["orgs.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "org_id",
+                "channel_id",
+                "slack_message_ts",
+                name="uq_provider_alert_occurrence_message",
+            ),
+        )
+    if not _index_exists(_OCCURRENCES, "ix_provider_alert_occurrence_window"):
+        op.create_index(
+            "ix_provider_alert_occurrence_window",
+            _OCCURRENCES,
+            ["org_id", "channel_id", "service", "occurred_at"],
+        )
+    if not _index_exists(_OCCURRENCES, "ix_provider_alert_occurrence_signature"):
+        op.create_index(
+            "ix_provider_alert_occurrence_signature",
+            _OCCURRENCES,
+            ["org_id", "service", "subsystem", "signature"],
+        )
+
+    if not _table_exists(_SURGES):
+        op.create_table(
+            _SURGES,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("org_id", _uuid_type(), nullable=False),
+            sa.Column("source_channel_id", sa.String(length=80), nullable=False),
+            sa.Column("service", sa.String(length=120), nullable=False),
+            sa.Column("subsystem", sa.String(length=120), nullable=False),
+            sa.Column("window_started_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("opened_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("trigger_reason", sa.String(length=80), nullable=False),
+            sa.Column("message_count", sa.Integer(), nullable=False),
+            sa.Column("signatures_json", sa.Text(), nullable=False),
+            sa.Column("external_ids_json", sa.Text(), nullable=False),
+            sa.Column("owner", sa.String(length=180), nullable=False),
+            sa.Column("next_action", sa.Text(), nullable=False),
+            sa.Column("material_channel", sa.String(length=80), nullable=False),
+            sa.Column("material_message_ts", sa.String(length=40), nullable=True),
+            sa.Column("material_post_claimed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("material_posted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(["org_id"], ["orgs.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "org_id",
+                "source_channel_id",
+                "service",
+                name="uq_provider_alert_surge_service",
+            ),
+        )
+    if not _index_exists(_SURGES, "ix_provider_alert_surge_open"):
+        op.create_index(
+            "ix_provider_alert_surge_open",
+            _SURGES,
+            ["org_id", "last_seen_at"],
+        )
+
+
+def downgrade() -> None:
+    # Preserve alert/incident history. A later upgrade recognizes both tables
+    # and recreates only missing indexes, matching the durable 0033 ledger.
+    if _index_exists(_SURGES, "ix_provider_alert_surge_open"):
+        op.drop_index("ix_provider_alert_surge_open", table_name=_SURGES)
+    if _index_exists(_OCCURRENCES, "ix_provider_alert_occurrence_signature"):
+        op.drop_index(
+            "ix_provider_alert_occurrence_signature",
+            table_name=_OCCURRENCES,
+        )
+    if _index_exists(_OCCURRENCES, "ix_provider_alert_occurrence_window"):
+        op.drop_index("ix_provider_alert_occurrence_window", table_name=_OCCURRENCES)

--- a/brain/platform/db/models/provider_alert.py
+++ b/brain/platform/db/models/provider_alert.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,7 +13,11 @@ from brain.platform.db.base import Base, TimestampMixin
 
 UUIDString = UUID(as_uuid=False).with_variant(String, "sqlite")
 
-__all__ = ["ProviderAlertLedger"]
+__all__ = [
+    "ProviderAlertLedger",
+    "ProviderAlertOccurrence",
+    "ProviderAlertSurge",
+]
 
 
 class ProviderAlertLedger(Base, TimestampMixin):
@@ -66,3 +70,107 @@ class ProviderAlertLedger(Base, TimestampMixin):
     acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     acknowledged_by: Mapped[str | None] = mapped_column(String(120), nullable=True)
     acknowledgement: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class ProviderAlertOccurrence(Base, TimestampMixin):
+    """One idempotent Rollbar message observed on a monitored Slack channel."""
+
+    __tablename__ = "provider_alert_occurrences"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "channel_id",
+            "slack_message_ts",
+            name="uq_provider_alert_occurrence_message",
+        ),
+        Index(
+            "ix_provider_alert_occurrence_window",
+            "org_id",
+            "channel_id",
+            "service",
+            "occurred_at",
+        ),
+        Index(
+            "ix_provider_alert_occurrence_signature",
+            "org_id",
+            "service",
+            "subsystem",
+            "signature",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUIDString,
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    channel_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    slack_message_ts: Mapped[str] = mapped_column(String(40), nullable=False)
+    service: Mapped[str] = mapped_column(String(120), nullable=False)
+    subsystem: Mapped[str] = mapped_column(String(120), nullable=False)
+    external_id: Mapped[str] = mapped_column(String(180), nullable=False)
+    signature: Mapped[str] = mapped_column(String(64), nullable=False)
+    signature_title: Mapped[str] = mapped_column(Text, nullable=False)
+    occurrence_milestone: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    is_new_error: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        default=False,
+    )
+    is_new_signature: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        default=False,
+    )
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class ProviderAlertSurge(Base, TimestampMixin):
+    """Current material-surge state for one service on one source channel."""
+
+    __tablename__ = "provider_alert_surges"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "source_channel_id",
+            "service",
+            name="uq_provider_alert_surge_service",
+        ),
+        Index(
+            "ix_provider_alert_surge_open",
+            "org_id",
+            "last_seen_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[str] = mapped_column(
+        UUIDString,
+        ForeignKey("orgs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_channel_id: Mapped[str] = mapped_column(String(80), nullable=False)
+    service: Mapped[str] = mapped_column(String(120), nullable=False)
+    subsystem: Mapped[str] = mapped_column(String(120), nullable=False)
+    window_started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    opened_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    trigger_reason: Mapped[str] = mapped_column(String(80), nullable=False)
+    message_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    signatures_json: Mapped[str] = mapped_column(Text, nullable=False)
+    external_ids_json: Mapped[str] = mapped_column(Text, nullable=False)
+    owner: Mapped[str] = mapped_column(String(180), nullable=False)
+    next_action: Mapped[str] = mapped_column(Text, nullable=False)
+    material_channel: Mapped[str] = mapped_column(String(80), nullable=False)
+    material_message_ts: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    material_post_claimed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    material_posted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )

--- a/brain/platform/provider_alerts.py
+++ b/brain/platform/provider_alerts.py
@@ -21,6 +21,7 @@ from brain.kernel import config
 
 PROVIDER_ALERT_POLICY_ENV = "ILLO_PROVIDER_ALERT_POLICY_PATH"
 PROVIDER_ALERT_MATERIAL_CHANNEL_ENV = "ILLO_PROVIDER_ALERT_MATERIAL_CHANNEL"
+DEFAULT_PROVIDER_ALERT_SURGE_CLAIM_TTL_SECONDS = 180
 DEFAULT_PROVIDER_ALERT_POLICY_PATH = (
     Path(config.BRAIN_DIR) / "deploy" / "compose" / "provider-alert-severity.json"
 )
@@ -110,6 +111,7 @@ class ProviderAlertSurgePolicy:
     material_channel: str
     owner: str
     next_action: str
+    claim_ttl_seconds: int = DEFAULT_PROVIDER_ALERT_SURGE_CLAIM_TTL_SECONDS
 
 
 @dataclass(frozen=True)
@@ -147,8 +149,10 @@ def _policy_path(path: str | Path | None = None) -> Path:
     return Path(configured) if configured else DEFAULT_PROVIDER_ALERT_POLICY_PATH
 
 
-def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]:
-    """Read and validate the source-controlled severity map without caching it."""
+def _load_provider_alert_policy_document(
+    path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Read the shared policy document without coupling subsection validation."""
 
     source = _policy_path(path)
     try:
@@ -159,6 +163,14 @@ def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]
         ) from exc
     if not isinstance(payload, dict):
         raise ProviderAlertPolicyError("provider alert policy must be a JSON object")
+    payload["_source"] = str(source.resolve())
+    return payload
+
+
+def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]:
+    """Read and validate only the source-controlled severity map."""
+
+    payload = _load_provider_alert_policy_document(path)
     rules = payload.get("rules")
     if payload.get("version") != 1 or not isinstance(rules, list) or not rules:
         raise ProviderAlertPolicyError("provider alert policy requires version=1 and rules")
@@ -210,29 +222,6 @@ def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]
         raise ProviderAlertPolicyError(
             f"provider alert escalation_signals contain an invalid pattern: {exc}"
         ) from exc
-    surge = payload.get("surge")
-    if not isinstance(surge, dict):
-        raise ProviderAlertPolicyError("provider alert policy requires a surge object")
-    for key in (
-        "message_threshold",
-        "window_minutes",
-        "milestone_threshold",
-        "new_signature_threshold",
-    ):
-        try:
-            value = int(surge.get(key))
-        except (TypeError, ValueError) as exc:
-            raise ProviderAlertPolicyError(
-                f"provider alert surge {key} must be an integer"
-            ) from exc
-        if value <= 0:
-            raise ProviderAlertPolicyError(
-                f"provider alert surge {key} must be positive"
-            )
-    for key in ("material_channel", "owner", "next_action"):
-        if not str(surge.get(key) or "").strip():
-            raise ProviderAlertPolicyError(f"provider alert surge {key} is required")
-    payload["_source"] = str(source.resolve())
     return payload
 
 
@@ -241,12 +230,51 @@ def provider_alert_surge_policy(
 ) -> ProviderAlertSurgePolicy:
     """Load the named surge thresholds and material-incident destination."""
 
-    surge = load_provider_alert_policy(path)["surge"]
+    payload = _load_provider_alert_policy_document(path)
+    surge = payload.get("surge")
+    if not isinstance(surge, dict):
+        raise ProviderAlertPolicyError("provider alert policy requires a surge object")
+    integer_values: dict[str, int] = {}
+    for key in (
+        "message_threshold",
+        "window_minutes",
+        "milestone_threshold",
+        "new_signature_threshold",
+    ):
+        try:
+            integer_values[key] = int(surge.get(key))
+        except (TypeError, ValueError) as exc:
+            raise ProviderAlertPolicyError(
+                f"provider alert surge {key} must be an integer"
+            ) from exc
+        if integer_values[key] <= 0:
+            raise ProviderAlertPolicyError(
+                f"provider alert surge {key} must be positive"
+            )
+    try:
+        integer_values["claim_ttl_seconds"] = int(
+            surge.get(
+                "claim_ttl_seconds",
+                DEFAULT_PROVIDER_ALERT_SURGE_CLAIM_TTL_SECONDS,
+            )
+        )
+    except (TypeError, ValueError) as exc:
+        raise ProviderAlertPolicyError(
+            "provider alert surge claim_ttl_seconds must be an integer"
+        ) from exc
+    if integer_values["claim_ttl_seconds"] <= 0:
+        raise ProviderAlertPolicyError(
+            "provider alert surge claim_ttl_seconds must be positive"
+        )
+    for key in ("material_channel", "owner", "next_action"):
+        if not str(surge.get(key) or "").strip():
+            raise ProviderAlertPolicyError(f"provider alert surge {key} is required")
     return ProviderAlertSurgePolicy(
-        message_threshold=int(surge["message_threshold"]),
-        window_minutes=int(surge["window_minutes"]),
-        milestone_threshold=int(surge["milestone_threshold"]),
-        new_signature_threshold=int(surge["new_signature_threshold"]),
+        message_threshold=integer_values["message_threshold"],
+        window_minutes=integer_values["window_minutes"],
+        milestone_threshold=integer_values["milestone_threshold"],
+        new_signature_threshold=integer_values["new_signature_threshold"],
+        claim_ttl_seconds=integer_values["claim_ttl_seconds"],
         material_channel=(
             str(os.getenv(PROVIDER_ALERT_MATERIAL_CHANNEL_ENV) or "").strip()
             or str(surge["material_channel"]).strip()
@@ -557,6 +585,7 @@ def classify_provider_alert_body(
 __all__ = [
     "AlertSignature",
     "DEFAULT_PROVIDER_ALERT_POLICY_PATH",
+    "DEFAULT_PROVIDER_ALERT_SURGE_CLAIM_TTL_SECONDS",
     "PROVIDER_ALERT_MATERIAL_CHANNEL_ENV",
     "PROVIDER_ALERT_POLICY_ENV",
     "ProviderAlertDecision",

--- a/brain/platform/provider_alerts.py
+++ b/brain/platform/provider_alerts.py
@@ -20,6 +20,7 @@ from brain.kernel import config
 
 
 PROVIDER_ALERT_POLICY_ENV = "ILLO_PROVIDER_ALERT_POLICY_PATH"
+PROVIDER_ALERT_MATERIAL_CHANNEL_ENV = "ILLO_PROVIDER_ALERT_MATERIAL_CHANNEL"
 DEFAULT_PROVIDER_ALERT_POLICY_PATH = (
     Path(config.BRAIN_DIR) / "deploy" / "compose" / "provider-alert-severity.json"
 )
@@ -44,10 +45,71 @@ _VOLATILE_SIGNATURE_PARTS = (
     re.compile(r"\b(?:occurrences?|count|total)\s*[:=]?\s*\d+\b", re.IGNORECASE),
     re.compile(r"\bstill ongoing,?\s*\+\d+\s+since last\b", re.IGNORECASE),
 )
+_ROLLBAR_ITEM_RE = re.compile(
+    r"https?://app\.rollbar\.com/[^\s|>]+/item/"
+    r"(?P<project>[^/\s|>]+)/(?P<item>\d+)"
+    r"(?:[^|>]*\|(?P<label>[^>]*))?",
+    re.IGNORECASE,
+)
+_ROLLBAR_MILESTONE_RE = re.compile(
+    r"\b(?P<count>\d+)(?:st|nd|rd|th)\s+(?:error|occurrence)\s*:\s*",
+    re.IGNORECASE,
+)
+_ROLLBAR_NEW_ITEM_RE = re.compile(
+    r"\bnew\s+(?P<kind>item|error)\b\s*:?\s*",
+    re.IGNORECASE,
+)
+_ROLLBAR_ITEM_PREFIX_RE = re.compile(r"^\s*#?\d+\s*")
+_SUBSYSTEM_RE = re.compile(
+    r"(?im)^\s*subsystem\s*[:=]\s*(?P<subsystem>[^\n|>]{1,120})"
+)
 
 
 class ProviderAlertPolicyError(RuntimeError):
     """The durable alert policy could not be loaded or validated."""
+
+
+@dataclass(frozen=True, slots=True)
+class AlertSignature:
+    """Structured identity and occurrence information from a Rollbar alert."""
+
+    project: str
+    item_number: int
+    title: str
+    occurrence_milestone: int | None = None
+    is_new_error: bool = False
+
+    @property
+    def signature(self) -> str:
+        return f"{self.project}#{self.item_number}"
+
+    @property
+    def milestone(self) -> int | None:
+        return self.occurrence_milestone
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAlertIngest:
+    """Normalized identity used for durable alert-ingest surge accounting."""
+
+    service: str
+    subsystem: str
+    external_id: str
+    signature: str
+    signature_title: str
+    occurrence_milestone: int | None
+    is_new_error: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAlertSurgePolicy:
+    message_threshold: int
+    window_minutes: int
+    milestone_threshold: int
+    new_signature_threshold: int
+    material_channel: str
+    owner: str
+    next_action: str
 
 
 @dataclass(frozen=True)
@@ -57,6 +119,9 @@ class ProviderAlertEvidence:
     error_type: str | None
     typed_reason: str | None
     occurrence_count: int | None
+    external_id: str | None
+    signature_title: str | None
+    is_new_error: bool
 
 
 @dataclass(frozen=True)
@@ -145,8 +210,122 @@ def load_provider_alert_policy(path: str | Path | None = None) -> dict[str, Any]
         raise ProviderAlertPolicyError(
             f"provider alert escalation_signals contain an invalid pattern: {exc}"
         ) from exc
+    surge = payload.get("surge")
+    if not isinstance(surge, dict):
+        raise ProviderAlertPolicyError("provider alert policy requires a surge object")
+    for key in (
+        "message_threshold",
+        "window_minutes",
+        "milestone_threshold",
+        "new_signature_threshold",
+    ):
+        try:
+            value = int(surge.get(key))
+        except (TypeError, ValueError) as exc:
+            raise ProviderAlertPolicyError(
+                f"provider alert surge {key} must be an integer"
+            ) from exc
+        if value <= 0:
+            raise ProviderAlertPolicyError(
+                f"provider alert surge {key} must be positive"
+            )
+    for key in ("material_channel", "owner", "next_action"):
+        if not str(surge.get(key) or "").strip():
+            raise ProviderAlertPolicyError(f"provider alert surge {key} is required")
     payload["_source"] = str(source.resolve())
     return payload
+
+
+def provider_alert_surge_policy(
+    path: str | Path | None = None,
+) -> ProviderAlertSurgePolicy:
+    """Load the named surge thresholds and material-incident destination."""
+
+    surge = load_provider_alert_policy(path)["surge"]
+    return ProviderAlertSurgePolicy(
+        message_threshold=int(surge["message_threshold"]),
+        window_minutes=int(surge["window_minutes"]),
+        milestone_threshold=int(surge["milestone_threshold"]),
+        new_signature_threshold=int(surge["new_signature_threshold"]),
+        material_channel=(
+            str(os.getenv(PROVIDER_ALERT_MATERIAL_CHANNEL_ENV) or "").strip()
+            or str(surge["material_channel"]).strip()
+        ),
+        owner=str(surge["owner"]).strip(),
+        next_action=str(surge["next_action"]).strip(),
+    )
+
+
+def parse_rollbar_alert(text: str | None) -> AlertSignature | None:
+    """Parse a Rollbar Slack fallback into stable item and title identity."""
+
+    if not text:
+        return None
+    match = _ROLLBAR_ITEM_RE.search(str(text))
+    if not match:
+        return None
+
+    label = (match.group("label") or "").strip()
+    label = _ROLLBAR_ITEM_PREFIX_RE.sub("", label, count=1)
+    milestone_match = _ROLLBAR_MILESTONE_RE.search(label)
+    new_item_match = _ROLLBAR_NEW_ITEM_RE.search(label)
+    if milestone_match:
+        title = label[milestone_match.end() :]
+    elif new_item_match:
+        title = label[new_item_match.end() :]
+    else:
+        title = label
+    return AlertSignature(
+        project=match.group("project"),
+        item_number=int(match.group("item")),
+        title=title.strip().rstrip("> "),
+        occurrence_milestone=(
+            int(milestone_match.group("count")) if milestone_match else None
+        ),
+        is_new_error=(
+            bool(new_item_match)
+            and str(new_item_match.group("kind") or "").casefold() == "error"
+        ),
+    )
+
+
+def _tracked_title_signature(service: str, title: str, external_id: str) -> str:
+    canonical_title = title
+    for pattern in _VOLATILE_SIGNATURE_PARTS:
+        canonical_title = pattern.sub("<volatile>", canonical_title)
+    canonical_title = " ".join(canonical_title.casefold().split())
+    identity = {
+        "service": _token(service),
+        "title": canonical_title or _token(external_id),
+    }
+    return sha256(json.dumps(identity, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def classify_provider_alert_ingest(body: str) -> ProviderAlertIngest | None:
+    """Classify one incoming Rollbar message for signature-aware surge tracking."""
+
+    parsed = parse_rollbar_alert(body)
+    if parsed is None:
+        return None
+    subsystem_match = _SUBSYSTEM_RE.search(str(body or ""))
+    subsystem = (
+        " ".join(subsystem_match.group("subsystem").split())
+        if subsystem_match
+        else parsed.project
+    )
+    return ProviderAlertIngest(
+        service=parsed.project,
+        subsystem=subsystem,
+        external_id=parsed.signature,
+        signature=_tracked_title_signature(
+            parsed.project,
+            parsed.title,
+            parsed.signature,
+        ),
+        signature_title=parsed.title,
+        occurrence_milestone=parsed.milestone,
+        is_new_error=parsed.is_new_error,
+    )
 
 
 def _configured_values(policy: Mapping[str, Any], key: str) -> set[str]:
@@ -196,6 +375,7 @@ def _typed_reason(body: str, configured_reasons: set[str]) -> str | None:
 
 
 def _provider_alert_evidence(body: str, policy: Mapping[str, Any]) -> ProviderAlertEvidence:
+    rollbar = parse_rollbar_alert(body)
     normalized_body = _token(body)
     providers = tuple(
         sorted(
@@ -237,7 +417,16 @@ def _provider_alert_evidence(body: str, policy: Mapping[str, Any]) -> ProviderAl
             body,
             _configured_values(policy, "typed_reasons"),
         ),
-        occurrence_count=int(count_match.group(1)) if count_match else None,
+        occurrence_count=(
+            int(count_match.group(1))
+            if count_match
+            else rollbar.occurrence_milestone
+            if rollbar
+            else None
+        ),
+        external_id=rollbar.signature if rollbar else None,
+        signature_title=rollbar.title if rollbar else None,
+        is_new_error=bool(rollbar and rollbar.is_new_error),
     )
 
 
@@ -280,6 +469,13 @@ def _escalation_reason(
 
 
 def _signature(body: str, evidence: ProviderAlertEvidence, classification: str) -> str:
+    if evidence.external_id and evidence.signature_title:
+        service = evidence.external_id.split("#", 1)[0]
+        return _tracked_title_signature(
+            service,
+            evidence.signature_title,
+            evidence.external_id,
+        )
     canonical_body = _ALERT_HEADER.sub("ALERT-SEVERITY", body)
     for pattern in _VOLATILE_SIGNATURE_PARTS:
         canonical_body = pattern.sub("<volatile>", canonical_body)
@@ -359,11 +555,18 @@ def classify_provider_alert_body(
 
 
 __all__ = [
+    "AlertSignature",
     "DEFAULT_PROVIDER_ALERT_POLICY_PATH",
+    "PROVIDER_ALERT_MATERIAL_CHANNEL_ENV",
     "PROVIDER_ALERT_POLICY_ENV",
     "ProviderAlertDecision",
     "ProviderAlertEvidence",
+    "ProviderAlertIngest",
     "ProviderAlertPolicyError",
+    "ProviderAlertSurgePolicy",
+    "classify_provider_alert_ingest",
     "classify_provider_alert_body",
     "load_provider_alert_policy",
+    "parse_rollbar_alert",
+    "provider_alert_surge_policy",
 ]

--- a/brain/systems/deploy_state.py
+++ b/brain/systems/deploy_state.py
@@ -14,10 +14,11 @@ unchanged rather than guessing that a fix did or did not ship.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Mapping
+
+from brain.platform.provider_alerts import AlertSignature, parse_rollbar_alert
 
 
 class DeployState(StrEnum):
@@ -48,70 +49,6 @@ class MergeKind(StrEnum):
     HOTFIX = "hotfix"
     FIX_TO_STAGING = "fix_to_staging"
     OTHER = "other"
-
-
-@dataclass(frozen=True, slots=True)
-class AlertSignature:
-    """Structured identity and occurrence information from a Rollbar alert."""
-
-    project: str
-    item_number: int
-    title: str
-    occurrence_milestone: int | None = None
-
-    @property
-    def signature(self) -> str:
-        return f"{self.project}#{self.item_number}"
-
-    @property
-    def milestone(self) -> int | None:
-        """Short alias used by triage callers."""
-        return self.occurrence_milestone
-
-
-_ROLLBAR_ITEM_RE = re.compile(
-    r"https?://app\.rollbar\.com/[^\s|>]+/item/"
-    r"(?P<project>[^/\s|>]+)/(?P<item>\d+)"
-    r"(?:[^|>]*\|(?P<label>[^>]*))?",
-    re.IGNORECASE,
-)
-_MILESTONE_RE = re.compile(
-    r"\b(?P<count>\d+)(?:st|nd|rd|th)\s+(?:error|occurrence)\s*:\s*",
-    re.IGNORECASE,
-)
-_NEW_ITEM_RE = re.compile(r"\bnew\s+item\b\s*:?\s*", re.IGNORECASE)
-_ITEM_PREFIX_RE = re.compile(r"^\s*#?\d+\s*")
-
-
-def parse_rollbar_alert(text: str | None) -> AlertSignature | None:
-    """Parse Rollbar's Slack attachment fallback into a stable signature.
-
-    The caller assembles the text (including attachment fallback/title text).
-    Messages without a Rollbar item URL return ``None`` even if they contain an
-    issue-like ``#123`` fragment, avoiding false matches on ordinary Slack text.
-    """
-    if not text:
-        return None
-    match = _ROLLBAR_ITEM_RE.search(str(text))
-    if not match:
-        return None
-
-    label = (match.group("label") or "").strip()
-    label = _ITEM_PREFIX_RE.sub("", label, count=1)
-    milestone_match = _MILESTONE_RE.search(label)
-    milestone = int(milestone_match.group("count")) if milestone_match else None
-    if milestone_match:
-        title = label[milestone_match.end():]
-    else:
-        title = _NEW_ITEM_RE.sub("", label, count=1)
-    title = title.strip().rstrip("> ")
-
-    return AlertSignature(
-        project=match.group("project"),
-        item_number=int(match.group("item")),
-        title=title,
-        occurrence_milestone=milestone,
-    )
 
 
 def as_utc_datetime(value: datetime | str | None) -> datetime | None:

--- a/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
+++ b/brain/systems/runs/tool_catalog/definitions/cortex_thread.py
@@ -474,6 +474,8 @@ CHAT_TOOLS = [
             "users. To make Illo watch a channel's every message (acknowledging each with a 👀 reaction and "
             "triaging automated alerts or user-reported issues into tickets), use action='monitor_channel' "
             "with the channel_id; action='unmonitor_channel' to stop; action='list_monitored' to review. The "
+            "read-only action='open_alert_surges' returns material provider-alert incidents that are still "
+            "inside their rolling window, for scheduled digest ordering. The "
             "bot must be a member of the channel and the Slack app needs the channels:history and "
             "reactions:write scopes."
         ),
@@ -491,6 +493,7 @@ CHAT_TOOLS = [
                         "list_monitored",
                         "monitor_channel",
                         "unmonitor_channel",
+                        "open_alert_surges",
                     ],
                     "description": "Slack management action.",
                 },

--- a/brain/systems/runs/tool_catalog/handlers/slack.py
+++ b/brain/systems/runs/tool_catalog/handlers/slack.py
@@ -847,6 +847,24 @@ async def _handle_manage_slack(
                 default=str,
             )
 
+        if normalized_action == "open_alert_surges":
+            from brain.systems.slack.provider_alert_surge import (
+                list_open_provider_alert_surges,
+            )
+
+            surges = await list_open_provider_alert_surges(
+                uow.session,
+                org_id=org_id,
+            )
+            return json.dumps(
+                {
+                    "ok": True,
+                    "open_alert_surges": surges,
+                    "count": len(surges),
+                },
+                default=str,
+            )
+
         connection, error = await _slack_connection_for_tool(
             uow.session,
             org_id=org_id,
@@ -978,7 +996,7 @@ async def _handle_manage_slack(
             "error": (
                 "manage_slack action must be status, list_channels, list_mappings, "
                 "link_identity, unlink_identity, list_monitored, monitor_channel, "
-                "or unmonitor_channel"
+                "unmonitor_channel, or open_alert_surges"
             )
         }
     )

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -973,6 +973,13 @@ def action_policy_for_tool(
         return None
     if tool_name == "manage_domain" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "query_records", "get_record", "events"}:
         return None
+    if tool_name == "manage_slack" and _arg_at(
+        args_tuple,
+        kwargs_dict,
+        "action",
+        0,
+    ) in {"status", "list_channels", "list_mappings", "list_monitored", "open_alert_surges"}:
+        return None
     if tool_name == "manage_inbound" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {
         "help",
         "schema",

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md
@@ -77,9 +77,8 @@ in Domain `37`, asset `references/memory.md`, using the live-first fallback.
 
 ## Coordination Pipeline
 
-Every scheduled coordinator run follows three phases, in order: sweep
-everything, diff against what was last posted, and only then judge and post.
-Do not compose a workset or a Slack post from the first convenient listing.
+Every scheduled run sweeps everything, diffs the last post, then judges and
+posts; never compose from the first convenient listing.
 
 ### Phase A — Sweep everything
 
@@ -94,6 +93,8 @@ Build the complete picture before forming any opinion. Required sources:
   time.
 - GitHub Event Feed Domain id `38` events since the last run.
 - Teammate check-in and alert-resolution replies (Slack and Cortex threads).
+- At digest run start, read durable rolling-window incidents with
+  `manage_slack` `action="open_alert_surges"`.
 
 **Fan out workers — and collect them honestly.** `spawn_worker` is
 fire-and-forget: it returns a queued `child_run_id`; there is no join
@@ -180,13 +181,14 @@ continuity keeps pointing at the last good digest.
 
 ## Team Digest Contract
 
-The daily brief is chantier-primary and ends with accountability for all three
-humans. Its shape is a contract, not a style suggestion:
+The daily brief is chantier-primary, ends with all-three-human accountability,
+and has this mandatory shape:
 
-- Include a scope line with exact Phase-A item counts plus the exact active
-  chantier count, e.g. `Scope: 128 open issues + 12 open PRs across 4 repos,
-  45 active tracker records, 6 active chantiers; posting movement, not the full
-  backlog.`
+- Any open surge is the lead incident section, before `Scope`; name its
+  subsystem, window, signatures, owner, and next action. Its ticket alone is
+  not a substitute.
+- Include a scope line with exact Phase-A issue, PR, tracker, and active
+  chantier counts.
 - Give every active chantier with material movement its own section: state,
   one goal-progress line, what moved since the last digest, next step,
   blockers, and owner(s). Collapse the others into a one-line `Quiet chantiers`

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/chantier-operations.md
@@ -101,17 +101,20 @@ DEGRADED posts do not advance it.
 
 Write the visible digest in this order:
 
-1. Scope line with exact item and active-chantier counts.
-2. One section per active chantier with material movement. Each section names
+1. When `manage_slack(action="open_alert_surges")` returned an incident at
+   run start, a lead incident section naming its subsystem, window,
+   signatures, owner, and next action.
+2. Scope line with exact item and active-chantier counts.
+3. One section per active chantier with material movement. Each section names
    the chantier state, one line of progress toward the `Done means ...` goal,
    what moved since the last digest, next step, blockers (or `none`), and all
    next-action owners represented by that chantier.
-3. One-line `Quiet chantiers` roll-up listing every other active chantier.
-4. `Loose items` for tickets that belong to no chantier. Never force-group
+4. One-line `Quiet chantiers` roll-up listing every other active chantier.
+5. `Loose items` for tickets that belong to no chantier. Never force-group
    them. Keep the existing state, owner, blocker, and next-action evidence.
-5. Optional `Unclaimed pool` and `Cleanup — safe to close` sections when
+6. Optional `Unclaimed pool` and `Cleanup — safe to close` sections when
    non-empty.
-6. A mandatory `Per-person recap` footer with Reda, Axel, and JB, every time.
+7. A mandatory `Per-person recap` footer with Reda, Axel, and JB, every time.
    Each line gives that person's top next action across chantier and loose
    work. If empty, repeat the core contract's exact evidence checks: exact
    tracker `assignee`, GitHub issues assigned to the person's handle, PRs they

--- a/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
+++ b/brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/references/creating-work-items.md
@@ -19,9 +19,13 @@ Decide as follows:
 
 - **One problem = one issue — check before filing.** Before calling
   `create_github_issue`, search open AND closed GitHub issues and Domain 1
-  tracker records for the same error signature, Rollbar id (prefer the
-  structured `rollbar_item` field — an exact `rollbar_item`/signature match
-  has no recency cutoff), endpoint, profile id, or root cause. If a match
+  tracker records for the same tracked error signature, Rollbar id (prefer
+  the structured `rollbar_item` field), endpoint, profile id, or root cause.
+  A Rollbar `New error:` title with a different tracked signature is a
+  different failure mode even when a related parent issue exists: file it or
+  add an explicit new-signature entry to that parent; never silently absorb
+  it based only on item id or similar timeout vocabulary. An exact tracked
+  signature match has no recency cutoff. If a match
   exists — even if closed or `Done` — do NOT file a new issue and do NOT
   blindly skip: follow the **Deploy-State Ladder** in the core operating doc
   (record `1155`). Never split one error/Rollbar alert into multiple issues.

--- a/brain/systems/slack/connector.py
+++ b/brain/systems/slack/connector.py
@@ -327,6 +327,11 @@ async def process_socket_payload(
         # channel knows Illo has seen it, independent of whether the ensuing
         # triage run decides to reply.
         await _acknowledge_monitored_message(config, envelope)
+        await _handle_monitored_provider_alert(
+            connection=connection,
+            config=config,
+            envelope=envelope,
+        )
     inbound = await submit_inbound_envelope(
         session,
         connection=connection,
@@ -343,6 +348,61 @@ async def process_socket_payload(
     ):
         await _set_processing_status(config, envelope)
     return {"ack": ack, "ignored": False, "inbound": inbound}
+
+
+def _slack_message_datetime(message_ts: str) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(float(message_ts), tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+async def _handle_monitored_provider_alert(
+    *,
+    connection: ExternalAgentConnectionRow | Mapping[str, Any],
+    config: SlackConnectorConfig,
+    envelope: dict[str, Any],
+) -> None:
+    """Record Rollbar alert identity before the corresponding triage run starts."""
+
+    from brain.systems.slack.provider_alert_surge import (
+        handle_provider_alert_ingest_durable,
+    )
+
+    payload = dict(envelope.get("payload") or {})
+    org_id = _connection_org_id(connection)
+    channel_id = str(payload.get("channel_id") or "").strip()
+    message_ts = str(payload.get("message_ts") or "").strip()
+    text = str(payload.get("text") or "")
+    if not org_id or not channel_id or not message_ts:
+        return
+    try:
+        result = await handle_provider_alert_ingest_durable(
+            SlackWebClient(config.bot_token),
+            org_id=org_id,
+            channel_id=channel_id,
+            message_ts=message_ts,
+            text=text,
+            occurred_at=_slack_message_datetime(message_ts),
+        )
+    except Exception as exc:
+        logger.exception("provider_alert_ingest_failed: %s", exc)
+        return
+    if result is None:
+        return
+    payload["provider_alert"] = {
+        "service": result.alert.service,
+        "subsystem": result.alert.subsystem,
+        "external_id": result.alert.external_id,
+        "tracked_signature": result.alert.signature,
+        "signature_title": result.alert.signature_title,
+        "occurrence_milestone": result.alert.occurrence_milestone,
+        "is_new_error": result.alert.is_new_error,
+        "surge_open": result.surge is not None,
+        "material_posted": result.material_posted,
+        "material_post_error": result.material_post_error,
+    }
+    envelope["payload"] = payload
 
 
 def _connection_org_id(connection: ExternalAgentConnectionRow | Mapping[str, Any]) -> str | None:

--- a/brain/systems/slack/provider_alert_surge.py
+++ b/brain/systems/slack/provider_alert_surge.py
@@ -1,0 +1,606 @@
+"""Durable rolling-window surge detection for monitored provider alerts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import select
+
+from brain.platform.db.models.provider_alert import (
+    ProviderAlertOccurrence,
+    ProviderAlertSurge,
+)
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.platform.provider_alerts import (
+    ProviderAlertIngest,
+    ProviderAlertSurgePolicy,
+    classify_provider_alert_ingest,
+    provider_alert_surge_policy,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAlertSurgeSnapshot:
+    id: int
+    service: str
+    subsystem: str
+    window_started_at: datetime
+    opened_at: datetime
+    last_seen_at: datetime
+    trigger_reason: str
+    message_count: int
+    signatures: tuple[dict[str, str], ...]
+    external_ids: tuple[str, ...]
+    owner: str
+    next_action: str
+    material_channel: str
+    material_message_ts: str | None
+    material_post_claimed_at: datetime | None
+    material_posted_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAlertIngestResult:
+    alert: ProviderAlertIngest
+    surge: ProviderAlertSurgeSnapshot | None
+    material_posted: bool = False
+    material_post_error: str | None = None
+
+
+def _utcnow(now: datetime | None = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _json_list(value: str) -> list[Any]:
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _snapshot(row: ProviderAlertSurge) -> ProviderAlertSurgeSnapshot:
+    signatures = tuple(
+        {
+            "signature": str(item.get("signature") or ""),
+            "title": str(item.get("title") or ""),
+        }
+        for item in _json_list(row.signatures_json)
+        if isinstance(item, dict) and item.get("signature")
+    )
+    return ProviderAlertSurgeSnapshot(
+        id=int(row.id),
+        service=row.service,
+        subsystem=row.subsystem,
+        window_started_at=_utcnow(row.window_started_at),
+        opened_at=_utcnow(row.opened_at),
+        last_seen_at=_utcnow(row.last_seen_at),
+        trigger_reason=row.trigger_reason,
+        message_count=int(row.message_count),
+        signatures=signatures,
+        external_ids=tuple(str(value) for value in _json_list(row.external_ids_json)),
+        owner=row.owner,
+        next_action=row.next_action,
+        material_channel=row.material_channel,
+        material_message_ts=row.material_message_ts,
+        material_post_claimed_at=(
+            _utcnow(row.material_post_claimed_at)
+            if row.material_post_claimed_at
+            else None
+        ),
+        material_posted_at=(
+            _utcnow(row.material_posted_at) if row.material_posted_at else None
+        ),
+    )
+
+
+def _surge_payload(snapshot: ProviderAlertSurgeSnapshot) -> dict[str, Any]:
+    return {
+        "id": snapshot.id,
+        "service": snapshot.service,
+        "subsystem": snapshot.subsystem,
+        "window_started_at": snapshot.window_started_at.isoformat(),
+        "opened_at": snapshot.opened_at.isoformat(),
+        "last_seen_at": snapshot.last_seen_at.isoformat(),
+        "trigger_reason": snapshot.trigger_reason,
+        "message_count": snapshot.message_count,
+        "signatures": list(snapshot.signatures),
+        "external_ids": list(snapshot.external_ids),
+        "owner": snapshot.owner,
+        "next_action": snapshot.next_action,
+        "material_channel": snapshot.material_channel,
+        "material_message_ts": snapshot.material_message_ts,
+        "material_post_claimed_at": (
+            snapshot.material_post_claimed_at.isoformat()
+            if snapshot.material_post_claimed_at
+            else None
+        ),
+        "material_posted_at": (
+            snapshot.material_posted_at.isoformat()
+            if snapshot.material_posted_at
+            else None
+        ),
+    }
+
+
+def _surge_query(
+    *,
+    org_id: str,
+    channel_id: str,
+    alert: ProviderAlertIngest,
+):
+    return select(ProviderAlertSurge).where(
+        ProviderAlertSurge.org_id == org_id,
+        ProviderAlertSurge.source_channel_id == channel_id,
+        ProviderAlertSurge.service == alert.service,
+    )
+
+
+def _window_signature_data(
+    occurrences: list[ProviderAlertOccurrence],
+) -> tuple[list[dict[str, str]], list[str]]:
+    signatures: dict[str, str] = {}
+    external_ids: set[str] = set()
+    for occurrence in occurrences:
+        signatures.setdefault(occurrence.signature, occurrence.signature_title)
+        external_ids.add(occurrence.external_id)
+    return (
+        [
+            {"signature": signature, "title": title}
+            for signature, title in sorted(signatures.items(), key=lambda item: item[1])
+        ],
+        sorted(external_ids),
+    )
+
+
+def _trigger_reason(
+    occurrences: list[ProviderAlertOccurrence],
+    *,
+    alert: ProviderAlertIngest,
+    policy: ProviderAlertSurgePolicy,
+) -> str | None:
+    if len(occurrences) >= policy.message_threshold:
+        return "message_volume"
+    if (
+        alert.occurrence_milestone is not None
+        and alert.occurrence_milestone >= policy.milestone_threshold
+    ):
+        return "occurrence_milestone"
+    new_signatures = {
+        occurrence.signature
+        for occurrence in occurrences
+        if occurrence.subsystem == alert.subsystem and occurrence.is_new_signature
+    }
+    if len(new_signatures) >= policy.new_signature_threshold:
+        return "distinct_new_signatures"
+    return None
+
+
+async def _existing_occurrence(
+    session: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    message_ts: str,
+) -> ProviderAlertOccurrence | None:
+    return await session.scalar(
+        select(ProviderAlertOccurrence).where(
+            ProviderAlertOccurrence.org_id == org_id,
+            ProviderAlertOccurrence.channel_id == channel_id,
+            ProviderAlertOccurrence.slack_message_ts == message_ts,
+        )
+    )
+
+
+async def record_provider_alert_occurrence(
+    session: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    message_ts: str,
+    alert: ProviderAlertIngest,
+    occurred_at: datetime | None = None,
+    policy: ProviderAlertSurgePolicy | None = None,
+) -> tuple[ProviderAlertSurgeSnapshot | None, bool]:
+    """Record one message and atomically claim at most one open material surge."""
+
+    current_time = _utcnow(occurred_at)
+    surge_policy = policy or provider_alert_surge_policy()
+    if await _existing_occurrence(
+        session,
+        org_id=org_id,
+        channel_id=channel_id,
+        message_ts=message_ts,
+    ):
+        return None, False
+
+    prior_signature = await session.scalar(
+        select(ProviderAlertOccurrence.id)
+        .where(
+            ProviderAlertOccurrence.org_id == org_id,
+            ProviderAlertOccurrence.service == alert.service,
+            ProviderAlertOccurrence.subsystem == alert.subsystem,
+            ProviderAlertOccurrence.signature == alert.signature,
+        )
+        .limit(1)
+    )
+    occurrence = ProviderAlertOccurrence(
+        org_id=org_id,
+        channel_id=channel_id,
+        slack_message_ts=message_ts,
+        service=alert.service,
+        subsystem=alert.subsystem,
+        external_id=alert.external_id,
+        signature=alert.signature,
+        signature_title=alert.signature_title,
+        occurrence_milestone=alert.occurrence_milestone,
+        is_new_error=alert.is_new_error,
+        is_new_signature=prior_signature is None,
+        occurred_at=current_time,
+    )
+    session.add(occurrence)
+    await session.flush()
+
+    window_start = current_time - timedelta(minutes=surge_policy.window_minutes)
+    occurrences = list(
+        (
+            await session.scalars(
+                select(ProviderAlertOccurrence)
+                .where(
+                    ProviderAlertOccurrence.org_id == org_id,
+                    ProviderAlertOccurrence.channel_id == channel_id,
+                    ProviderAlertOccurrence.service == alert.service,
+                    ProviderAlertOccurrence.occurred_at >= window_start,
+                    ProviderAlertOccurrence.occurred_at <= current_time,
+                )
+                .order_by(
+                    ProviderAlertOccurrence.occurred_at.asc(),
+                    ProviderAlertOccurrence.id.asc(),
+                )
+            )
+        ).all()
+    )
+    reason = _trigger_reason(
+        occurrences,
+        alert=alert,
+        policy=surge_policy,
+    )
+    row = await session.scalar(
+        _surge_query(
+            org_id=org_id,
+            channel_id=channel_id,
+            alert=alert,
+        ).with_for_update()
+    )
+    active = bool(
+        row is not None and _utcnow(row.last_seen_at) >= window_start
+    )
+    if not active and reason is None:
+        return None, False
+
+    signatures, external_ids = _window_signature_data(occurrences)
+    surge_subsystem = (
+        alert.service if reason == "message_volume" else alert.subsystem
+    )
+    if row is None:
+        row = ProviderAlertSurge(
+            org_id=org_id,
+            source_channel_id=channel_id,
+            service=alert.service,
+            subsystem=surge_subsystem,
+            window_started_at=_utcnow(occurrences[0].occurred_at),
+            opened_at=current_time,
+            last_seen_at=current_time,
+            trigger_reason=str(reason),
+            message_count=len(occurrences),
+            signatures_json=json.dumps(signatures, sort_keys=True),
+            external_ids_json=json.dumps(external_ids),
+            owner=surge_policy.owner,
+            next_action=surge_policy.next_action,
+            material_channel=surge_policy.material_channel,
+        )
+        session.add(row)
+    elif active:
+        row.last_seen_at = current_time
+        row.message_count = len(occurrences)
+        row.signatures_json = json.dumps(signatures, sort_keys=True)
+        row.external_ids_json = json.dumps(external_ids)
+    else:
+        row.subsystem = surge_subsystem
+        row.window_started_at = _utcnow(occurrences[0].occurred_at)
+        row.opened_at = current_time
+        row.last_seen_at = current_time
+        row.trigger_reason = str(reason)
+        row.message_count = len(occurrences)
+        row.signatures_json = json.dumps(signatures, sort_keys=True)
+        row.external_ids_json = json.dumps(external_ids)
+        row.owner = surge_policy.owner
+        row.next_action = surge_policy.next_action
+        row.material_channel = surge_policy.material_channel
+        row.material_message_ts = None
+        row.material_post_claimed_at = None
+        row.material_posted_at = None
+    should_post = (
+        row.material_posted_at is None and row.material_post_claimed_at is None
+    )
+    if should_post:
+        row.material_post_claimed_at = current_time
+    await session.flush()
+    return _snapshot(row), should_post
+
+
+def render_provider_alert_surge(snapshot: ProviderAlertSurgeSnapshot) -> str:
+    signature_lines = ", ".join(
+        f"{item['title']} ({item['signature'][:10]})"
+        for item in snapshot.signatures
+    )
+    external_ids = ", ".join(snapshot.external_ids)
+    return "\n".join(
+        (
+            "*Material incident — alert surge*",
+            f"Subsystem: {snapshot.subsystem}",
+            (
+                "Window: "
+                f"{snapshot.window_started_at.isoformat()} to "
+                f"{snapshot.last_seen_at.isoformat()} "
+                f"({snapshot.message_count} alerts; trigger={snapshot.trigger_reason})"
+            ),
+            f"Signatures: {signature_lines}",
+            f"Rollbar items: {external_ids}",
+            f"Owner: {snapshot.owner}",
+            f"Next action: {snapshot.next_action}",
+        )
+    )
+
+
+async def _resolve_material_channel(client: Any, configured: str) -> str:
+    channel = str(configured or "").strip()
+    if not channel.startswith("#"):
+        return channel
+    list_channels = getattr(client, "conversations_list", None)
+    if not callable(list_channels):
+        return channel
+    target_name = channel.removeprefix("#")
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        response = await list_channels(
+            types="public_channel,private_channel",
+            limit=200,
+            cursor=cursor,
+            exclude_archived=True,
+        )
+        for candidate in response.get("channels") or []:
+            if not isinstance(candidate, dict):
+                continue
+            if str(candidate.get("name") or "") == target_name:
+                return str(candidate.get("id") or channel)
+        metadata = response.get("response_metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        next_cursor = str(metadata.get("next_cursor") or "").strip()
+        if not next_cursor or next_cursor in seen_cursors:
+            return channel
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+
+def _posted_message_ts(response: Any) -> str | None:
+    if not isinstance(response, dict):
+        return None
+    direct = str(response.get("ts") or "").strip()
+    if direct:
+        return direct
+    message = response.get("message")
+    if isinstance(message, dict):
+        return str(message.get("ts") or "").strip() or None
+    return None
+
+
+async def _post_material_surge(
+    client: Any,
+    surge: ProviderAlertSurgeSnapshot,
+) -> tuple[str, str | None]:
+    material_channel = await _resolve_material_channel(
+        client,
+        surge.material_channel,
+    )
+    response = await client.post_message(
+        channel=material_channel,
+        text=render_provider_alert_surge(surge),
+    )
+    return material_channel, _posted_message_ts(response)
+
+
+async def _record_material_surge_posted(
+    session: Any,
+    *,
+    surge: ProviderAlertSurgeSnapshot,
+    material_channel: str,
+    message_ts: str | None,
+    posted_at: datetime | None,
+) -> ProviderAlertSurgeSnapshot:
+    row = await session.scalar(
+        select(ProviderAlertSurge)
+        .where(ProviderAlertSurge.id == surge.id)
+        .with_for_update()
+    )
+    if row is None:
+        return surge
+    row.material_channel = material_channel
+    row.material_message_ts = message_ts
+    row.material_posted_at = _utcnow(posted_at)
+    await session.flush()
+    return _snapshot(row)
+
+
+async def handle_provider_alert_ingest(
+    session: Any,
+    client: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    message_ts: str,
+    text: str,
+    occurred_at: datetime | None = None,
+) -> ProviderAlertIngestResult | None:
+    """Classify, persist, and material-post one incoming monitored alert."""
+
+    alert = classify_provider_alert_ingest(text)
+    if alert is None:
+        return None
+    policy = provider_alert_surge_policy()
+    surge, should_post = await record_provider_alert_occurrence(
+        session,
+        org_id=org_id,
+        channel_id=channel_id,
+        message_ts=message_ts,
+        alert=alert,
+        occurred_at=occurred_at,
+        policy=policy,
+    )
+    if surge is None or not should_post:
+        return ProviderAlertIngestResult(alert=alert, surge=surge)
+
+    try:
+        material_channel, posted_message_ts = await _post_material_surge(
+            client,
+            surge,
+        )
+        surge = await _record_material_surge_posted(
+            session,
+            surge=surge,
+            material_channel=material_channel,
+            message_ts=posted_message_ts,
+            posted_at=occurred_at,
+        )
+        return ProviderAlertIngestResult(
+            alert=alert,
+            surge=surge,
+            material_posted=True,
+        )
+    except Exception as exc:
+        logger.exception("provider alert surge material post failed")
+        return ProviderAlertIngestResult(
+            alert=alert,
+            surge=surge,
+            material_post_error=str(exc),
+        )
+
+
+async def handle_provider_alert_ingest_durable(
+    client: Any,
+    *,
+    org_id: str,
+    channel_id: str,
+    message_ts: str,
+    text: str,
+    occurred_at: datetime | None = None,
+) -> ProviderAlertIngestResult | None:
+    """Commit the one-post claim before Slack delivery and run admission."""
+
+    alert = classify_provider_alert_ingest(text)
+    if alert is None:
+        return None
+    policy = provider_alert_surge_policy()
+    async with UnitOfWork() as uow:
+        surge, should_post = await record_provider_alert_occurrence(
+            uow.session,
+            org_id=org_id,
+            channel_id=channel_id,
+            message_ts=message_ts,
+            alert=alert,
+            occurred_at=occurred_at,
+            policy=policy,
+        )
+    if surge is None or not should_post:
+        return ProviderAlertIngestResult(alert=alert, surge=surge)
+
+    try:
+        material_channel, posted_message_ts = await _post_material_surge(
+            client,
+            surge,
+        )
+    except Exception as exc:
+        logger.exception("provider alert surge material post failed")
+        return ProviderAlertIngestResult(
+            alert=alert,
+            surge=surge,
+            material_post_error=str(exc),
+        )
+
+    try:
+        async with UnitOfWork() as uow:
+            surge = await _record_material_surge_posted(
+                uow.session,
+                surge=surge,
+                material_channel=material_channel,
+                message_ts=posted_message_ts,
+                posted_at=occurred_at,
+            )
+    except Exception as exc:
+        # The committed claim remains authoritative if Slack accepted the post
+        # but finalization failed, preventing a redelivery duplicate.
+        logger.exception("provider alert surge post finalization failed")
+        return ProviderAlertIngestResult(
+            alert=alert,
+            surge=surge,
+            material_posted=True,
+            material_post_error=str(exc),
+        )
+    return ProviderAlertIngestResult(
+        alert=alert,
+        surge=surge,
+        material_posted=True,
+    )
+
+
+async def list_open_provider_alert_surges(
+    session: Any,
+    *,
+    org_id: str,
+    now: datetime | None = None,
+    policy: ProviderAlertSurgePolicy | None = None,
+) -> list[dict[str, Any]]:
+    """Return queryable material surges still open at the requested instant."""
+
+    current_time = _utcnow(now)
+    surge_policy = policy or provider_alert_surge_policy()
+    cutoff = current_time - timedelta(minutes=surge_policy.window_minutes)
+    rows = list(
+        (
+            await session.scalars(
+                select(ProviderAlertSurge)
+                .where(
+                    ProviderAlertSurge.org_id == org_id,
+                    ProviderAlertSurge.opened_at <= current_time,
+                    ProviderAlertSurge.last_seen_at >= cutoff,
+                )
+                .order_by(
+                    ProviderAlertSurge.opened_at.asc(),
+                    ProviderAlertSurge.id.asc(),
+                )
+            )
+        ).all()
+    )
+    return [_surge_payload(_snapshot(row)) for row in rows]
+
+
+__all__ = [
+    "ProviderAlertIngestResult",
+    "ProviderAlertSurgeSnapshot",
+    "handle_provider_alert_ingest",
+    "handle_provider_alert_ingest_durable",
+    "list_open_provider_alert_surges",
+    "record_provider_alert_occurrence",
+    "render_provider_alert_surge",
+]

--- a/brain/systems/slack/provider_alert_surge.py
+++ b/brain/systems/slack/provider_alert_surge.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import json
 import logging
-from typing import Any
+from typing import Any, Sequence
 
 from sqlalchemy import select
 
@@ -52,6 +52,20 @@ class ProviderAlertIngestResult:
     surge: ProviderAlertSurgeSnapshot | None
     material_posted: bool = False
     material_post_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAlertSurgeDecision:
+    """Pure rolling-window evaluation for one service's occurrences."""
+
+    trigger_reason: str | None
+    window_cutoff: datetime
+    window_started_at: datetime | None
+    window_ended_at: datetime
+    message_count: int
+    signatures: tuple[dict[str, str], ...]
+    external_ids: tuple[str, ...]
+    subsystem: str | None
 
 
 def _utcnow(now: datetime | None = None) -> datetime:
@@ -147,43 +161,204 @@ def _surge_query(
 
 
 def _window_signature_data(
-    occurrences: list[ProviderAlertOccurrence],
-) -> tuple[list[dict[str, str]], list[str]]:
+    occurrences: Sequence[ProviderAlertOccurrence],
+) -> tuple[tuple[dict[str, str], ...], tuple[str, ...]]:
     signatures: dict[str, str] = {}
     external_ids: set[str] = set()
     for occurrence in occurrences:
         signatures.setdefault(occurrence.signature, occurrence.signature_title)
         external_ids.add(occurrence.external_id)
     return (
-        [
+        tuple(
             {"signature": signature, "title": title}
             for signature, title in sorted(signatures.items(), key=lambda item: item[1])
-        ],
-        sorted(external_ids),
+        ),
+        tuple(sorted(external_ids)),
     )
 
 
-def _trigger_reason(
-    occurrences: list[ProviderAlertOccurrence],
-    *,
-    alert: ProviderAlertIngest,
+def _surge_window_cutoff(
     policy: ProviderAlertSurgePolicy,
-) -> str | None:
-    if len(occurrences) >= policy.message_threshold:
-        return "message_volume"
-    if (
-        alert.occurrence_milestone is not None
-        and alert.occurrence_milestone >= policy.milestone_threshold
+    now: datetime,
+) -> datetime:
+    return _utcnow(now) - timedelta(minutes=policy.window_minutes)
+
+
+def evaluate_provider_alert_surge(
+    occurrences: Sequence[ProviderAlertOccurrence],
+    policy: ProviderAlertSurgePolicy,
+    now: datetime,
+) -> ProviderAlertSurgeDecision:
+    """Evaluate surge rules without a session or any other I/O."""
+
+    current_time = _utcnow(now)
+    window_cutoff = _surge_window_cutoff(policy, current_time)
+    window_occurrences = sorted(
+        (
+            occurrence
+            for occurrence in occurrences
+            if window_cutoff <= _utcnow(occurrence.occurred_at) <= current_time
+        ),
+        key=lambda occurrence: (
+            _utcnow(occurrence.occurred_at),
+            int(occurrence.id or 0),
+        ),
+    )
+    signatures, external_ids = _window_signature_data(window_occurrences)
+    if not window_occurrences:
+        return ProviderAlertSurgeDecision(
+            trigger_reason=None,
+            window_cutoff=window_cutoff,
+            window_started_at=None,
+            window_ended_at=current_time,
+            message_count=0,
+            signatures=signatures,
+            external_ids=external_ids,
+            subsystem=None,
+        )
+
+    latest = window_occurrences[-1]
+    reason: str | None = None
+    if len(window_occurrences) >= policy.message_threshold:
+        reason = "message_volume"
+    elif (
+        latest.occurrence_milestone is not None
+        and latest.occurrence_milestone >= policy.milestone_threshold
     ):
-        return "occurrence_milestone"
+        reason = "occurrence_milestone"
     new_signatures = {
         occurrence.signature
-        for occurrence in occurrences
-        if occurrence.subsystem == alert.subsystem and occurrence.is_new_signature
+        for occurrence in window_occurrences
+        if occurrence.subsystem == latest.subsystem and occurrence.is_new_signature
     }
-    if len(new_signatures) >= policy.new_signature_threshold:
-        return "distinct_new_signatures"
-    return None
+    if reason is None and len(new_signatures) >= policy.new_signature_threshold:
+        reason = "distinct_new_signatures"
+    return ProviderAlertSurgeDecision(
+        trigger_reason=reason,
+        window_cutoff=window_cutoff,
+        window_started_at=_utcnow(window_occurrences[0].occurred_at),
+        window_ended_at=current_time,
+        message_count=len(window_occurrences),
+        signatures=signatures,
+        external_ids=external_ids,
+        subsystem=(latest.service if reason == "message_volume" else latest.subsystem),
+    )
+
+
+class ProviderAlertSurgeTransitions:
+    """The single owner of mutations to a provider-alert surge row."""
+
+    @staticmethod
+    def open(
+        row: ProviderAlertSurge | None,
+        *,
+        org_id: str,
+        channel_id: str,
+        service: str,
+        decision: ProviderAlertSurgeDecision,
+        policy: ProviderAlertSurgePolicy,
+        now: datetime,
+    ) -> ProviderAlertSurge:
+        if decision.trigger_reason is None or decision.window_started_at is None:
+            raise ValueError("a surge can only open from a triggered decision")
+        if row is None:
+            return ProviderAlertSurge(
+                org_id=org_id,
+                source_channel_id=channel_id,
+                service=service,
+                subsystem=str(decision.subsystem or service),
+                window_started_at=decision.window_started_at,
+                opened_at=now,
+                last_seen_at=now,
+                trigger_reason=decision.trigger_reason,
+                message_count=decision.message_count,
+                signatures_json=json.dumps(decision.signatures, sort_keys=True),
+                external_ids_json=json.dumps(decision.external_ids),
+                owner=policy.owner,
+                next_action=policy.next_action,
+                material_channel=policy.material_channel,
+            )
+        row.subsystem = str(decision.subsystem or service)
+        row.window_started_at = decision.window_started_at
+        row.opened_at = now
+        row.last_seen_at = now
+        row.trigger_reason = decision.trigger_reason
+        row.message_count = decision.message_count
+        row.signatures_json = json.dumps(decision.signatures, sort_keys=True)
+        row.external_ids_json = json.dumps(decision.external_ids)
+        row.owner = policy.owner
+        row.next_action = policy.next_action
+        row.material_channel = policy.material_channel
+        row.material_message_ts = None
+        row.material_post_claimed_at = None
+        row.material_posted_at = None
+        return row
+
+    @staticmethod
+    def update(
+        row: ProviderAlertSurge,
+        *,
+        decision: ProviderAlertSurgeDecision,
+        now: datetime,
+    ) -> None:
+        row.last_seen_at = now
+        row.message_count = decision.message_count
+        row.signatures_json = json.dumps(decision.signatures, sort_keys=True)
+        row.external_ids_json = json.dumps(decision.external_ids)
+
+    @staticmethod
+    def claim(row: ProviderAlertSurge, *, claimed_at: datetime) -> bool:
+        if row.material_posted_at is not None or row.material_post_claimed_at is not None:
+            return False
+        row.material_post_claimed_at = claimed_at
+        return True
+
+    @staticmethod
+    def reclaim(
+        row: ProviderAlertSurge,
+        *,
+        claimed_at: datetime,
+        claim_ttl_seconds: int,
+    ) -> bool:
+        prior_claim = row.material_post_claimed_at
+        if row.material_posted_at is not None or prior_claim is None:
+            return False
+        claim_expired_at = _utcnow(prior_claim) + timedelta(seconds=claim_ttl_seconds)
+        if claim_expired_at > claimed_at:
+            return False
+        row.material_post_claimed_at = claimed_at
+        return True
+
+    @staticmethod
+    def mark_posted(
+        row: ProviderAlertSurge,
+        *,
+        material_channel: str,
+        message_ts: str | None,
+        posted_at: datetime,
+    ) -> None:
+        if row.material_posted_at is not None:
+            return
+        row.material_channel = material_channel
+        row.material_message_ts = message_ts
+        row.material_posted_at = posted_at
+
+    @staticmethod
+    def release_claim(
+        row: ProviderAlertSurge,
+        *,
+        expected_claimed_at: datetime | None,
+    ) -> bool:
+        current_claim = row.material_post_claimed_at
+        if (
+            row.material_posted_at is not None
+            or current_claim is None
+            or expected_claimed_at is None
+            or _utcnow(current_claim) != _utcnow(expected_claimed_at)
+        ):
+            return False
+        row.material_post_claimed_at = None
+        return True
 
 
 async def _existing_occurrence(
@@ -251,7 +426,6 @@ async def record_provider_alert_occurrence(
     session.add(occurrence)
     await session.flush()
 
-    window_start = current_time - timedelta(minutes=surge_policy.window_minutes)
     occurrences = list(
         (
             await session.scalars(
@@ -260,7 +434,8 @@ async def record_provider_alert_occurrence(
                     ProviderAlertOccurrence.org_id == org_id,
                     ProviderAlertOccurrence.channel_id == channel_id,
                     ProviderAlertOccurrence.service == alert.service,
-                    ProviderAlertOccurrence.occurred_at >= window_start,
+                    ProviderAlertOccurrence.occurred_at
+                    >= _surge_window_cutoff(surge_policy, current_time),
                     ProviderAlertOccurrence.occurred_at <= current_time,
                 )
                 .order_by(
@@ -270,10 +445,10 @@ async def record_provider_alert_occurrence(
             )
         ).all()
     )
-    reason = _trigger_reason(
+    decision = evaluate_provider_alert_surge(
         occurrences,
-        alert=alert,
-        policy=surge_policy,
+        surge_policy,
+        current_time,
     )
     row = await session.scalar(
         _surge_query(
@@ -282,59 +457,40 @@ async def record_provider_alert_occurrence(
             alert=alert,
         ).with_for_update()
     )
+    is_new_row = row is None
     active = bool(
-        row is not None and _utcnow(row.last_seen_at) >= window_start
+        row is not None and _utcnow(row.last_seen_at) >= decision.window_cutoff
     )
-    if not active and reason is None:
+    if not active and decision.trigger_reason is None:
         return None, False
 
-    signatures, external_ids = _window_signature_data(occurrences)
-    surge_subsystem = (
-        alert.service if reason == "message_volume" else alert.subsystem
-    )
-    if row is None:
-        row = ProviderAlertSurge(
-            org_id=org_id,
-            source_channel_id=channel_id,
-            service=alert.service,
-            subsystem=surge_subsystem,
-            window_started_at=_utcnow(occurrences[0].occurred_at),
-            opened_at=current_time,
-            last_seen_at=current_time,
-            trigger_reason=str(reason),
-            message_count=len(occurrences),
-            signatures_json=json.dumps(signatures, sort_keys=True),
-            external_ids_json=json.dumps(external_ids),
-            owner=surge_policy.owner,
-            next_action=surge_policy.next_action,
-            material_channel=surge_policy.material_channel,
+    if active:
+        assert row is not None
+        ProviderAlertSurgeTransitions.update(
+            row,
+            decision=decision,
+            now=current_time,
         )
-        session.add(row)
-    elif active:
-        row.last_seen_at = current_time
-        row.message_count = len(occurrences)
-        row.signatures_json = json.dumps(signatures, sort_keys=True)
-        row.external_ids_json = json.dumps(external_ids)
     else:
-        row.subsystem = surge_subsystem
-        row.window_started_at = _utcnow(occurrences[0].occurred_at)
-        row.opened_at = current_time
-        row.last_seen_at = current_time
-        row.trigger_reason = str(reason)
-        row.message_count = len(occurrences)
-        row.signatures_json = json.dumps(signatures, sort_keys=True)
-        row.external_ids_json = json.dumps(external_ids)
-        row.owner = surge_policy.owner
-        row.next_action = surge_policy.next_action
-        row.material_channel = surge_policy.material_channel
-        row.material_message_ts = None
-        row.material_post_claimed_at = None
-        row.material_posted_at = None
-    should_post = (
-        row.material_posted_at is None and row.material_post_claimed_at is None
+        row = ProviderAlertSurgeTransitions.open(
+            row,
+            org_id=org_id,
+            channel_id=channel_id,
+            service=alert.service,
+            decision=decision,
+            policy=surge_policy,
+            now=current_time,
+        )
+        if is_new_row:
+            session.add(row)
+    should_post = ProviderAlertSurgeTransitions.claim(
+        row,
+        claimed_at=current_time,
+    ) or ProviderAlertSurgeTransitions.reclaim(
+        row,
+        claimed_at=current_time,
+        claim_ttl_seconds=surge_policy.claim_ttl_seconds,
     )
-    if should_post:
-        row.material_post_claimed_at = current_time
     await session.flush()
     return _snapshot(row), should_post
 
@@ -421,7 +577,7 @@ async def _post_material_surge(
     return material_channel, _posted_message_ts(response)
 
 
-async def _record_material_surge_posted(
+async def _mark_material_surge_posted(
     session: Any,
     *,
     surge: ProviderAlertSurgeSnapshot,
@@ -436,9 +592,32 @@ async def _record_material_surge_posted(
     )
     if row is None:
         return surge
-    row.material_channel = material_channel
-    row.material_message_ts = message_ts
-    row.material_posted_at = _utcnow(posted_at)
+    ProviderAlertSurgeTransitions.mark_posted(
+        row,
+        material_channel=material_channel,
+        message_ts=message_ts,
+        posted_at=_utcnow(posted_at),
+    )
+    await session.flush()
+    return _snapshot(row)
+
+
+async def _release_material_surge_claim(
+    session: Any,
+    *,
+    surge: ProviderAlertSurgeSnapshot,
+) -> ProviderAlertSurgeSnapshot:
+    row = await session.scalar(
+        select(ProviderAlertSurge)
+        .where(ProviderAlertSurge.id == surge.id)
+        .with_for_update()
+    )
+    if row is None:
+        return surge
+    ProviderAlertSurgeTransitions.release_claim(
+        row,
+        expected_claimed_at=surge.material_post_claimed_at,
+    )
     await session.flush()
     return _snapshot(row)
 
@@ -476,25 +655,40 @@ async def handle_provider_alert_ingest(
             client,
             surge,
         )
-        surge = await _record_material_surge_posted(
+    except Exception as exc:
+        logger.exception("provider alert surge material post failed")
+        error = str(exc)
+        try:
+            surge = await _release_material_surge_claim(session, surge=surge)
+        except Exception as release_exc:
+            logger.exception("provider alert surge claim release failed")
+            error = f"{error}; claim release failed: {release_exc}"
+        return ProviderAlertIngestResult(
+            alert=alert,
+            surge=surge,
+            material_post_error=error,
+        )
+    try:
+        surge = await _mark_material_surge_posted(
             session,
             surge=surge,
             material_channel=material_channel,
             message_ts=posted_message_ts,
             posted_at=occurred_at,
         )
+    except Exception as exc:
+        logger.exception("provider alert surge post finalization failed")
         return ProviderAlertIngestResult(
             alert=alert,
             surge=surge,
             material_posted=True,
-        )
-    except Exception as exc:
-        logger.exception("provider alert surge material post failed")
-        return ProviderAlertIngestResult(
-            alert=alert,
-            surge=surge,
             material_post_error=str(exc),
         )
+    return ProviderAlertIngestResult(
+        alert=alert,
+        surge=surge,
+        material_posted=True,
+    )
 
 
 async def handle_provider_alert_ingest_durable(
@@ -506,7 +700,7 @@ async def handle_provider_alert_ingest_durable(
     text: str,
     occurred_at: datetime | None = None,
 ) -> ProviderAlertIngestResult | None:
-    """Commit the one-post claim before Slack delivery and run admission."""
+    """Commit a retryable post lease before Slack delivery and run admission."""
 
     alert = classify_provider_alert_ingest(text)
     if alert is None:
@@ -532,15 +726,25 @@ async def handle_provider_alert_ingest_durable(
         )
     except Exception as exc:
         logger.exception("provider alert surge material post failed")
+        error = str(exc)
+        try:
+            async with UnitOfWork() as uow:
+                surge = await _release_material_surge_claim(
+                    uow.session,
+                    surge=surge,
+                )
+        except Exception as release_exc:
+            logger.exception("provider alert surge claim release failed")
+            error = f"{error}; claim release failed: {release_exc}"
         return ProviderAlertIngestResult(
             alert=alert,
             surge=surge,
-            material_post_error=str(exc),
+            material_post_error=error,
         )
 
     try:
         async with UnitOfWork() as uow:
-            surge = await _record_material_surge_posted(
+            surge = await _mark_material_surge_posted(
                 uow.session,
                 surge=surge,
                 material_channel=material_channel,
@@ -548,8 +752,7 @@ async def handle_provider_alert_ingest_durable(
                 posted_at=occurred_at,
             )
     except Exception as exc:
-        # The committed claim remains authoritative if Slack accepted the post
-        # but finalization failed, preventing a redelivery duplicate.
+        # Slack accepted the post, so do not release the claim as if delivery failed.
         logger.exception("provider alert surge post finalization failed")
         return ProviderAlertIngestResult(
             alert=alert,
@@ -575,7 +778,7 @@ async def list_open_provider_alert_surges(
 
     current_time = _utcnow(now)
     surge_policy = policy or provider_alert_surge_policy()
-    cutoff = current_time - timedelta(minutes=surge_policy.window_minutes)
+    cutoff = _surge_window_cutoff(surge_policy, current_time)
     rows = list(
         (
             await session.scalars(
@@ -597,7 +800,10 @@ async def list_open_provider_alert_surges(
 
 __all__ = [
     "ProviderAlertIngestResult",
+    "ProviderAlertSurgeDecision",
     "ProviderAlertSurgeSnapshot",
+    "ProviderAlertSurgeTransitions",
+    "evaluate_provider_alert_surge",
     "handle_provider_alert_ingest",
     "handle_provider_alert_ingest_durable",
     "list_open_provider_alert_surges",

--- a/brain/systems/slack/triggers.py
+++ b/brain/systems/slack/triggers.py
@@ -310,7 +310,8 @@ def slack_channel_monitor_message(
         "citing the issue number and URL so the team knows it was captured. Only if the ask is "
         "too vague to act on, or it duplicates an existing open issue, comment on the existing "
         "issue or stay silent instead.",
-        "- An alert that matches an EXISTING ticket or issue (same Rollbar id/error signature): "
+        "- An alert that matches an EXISTING ticket or issue (same tracked error signature; a "
+        "Rollbar item id alone is not enough when the title names a different failure mode): "
         "do NOT refile and do NOT blindly skip — follow the triage skill's Deploy-State Ladder: "
         "note occurrences while unfixed; a fix merged to staging but not promoted is expected "
         "noise (annotate, no owner re-ping, even if the ticket was closed early); a fix deployed "
@@ -333,11 +334,45 @@ def slack_channel_monitor_message(
         "origin in the structured alert_slack_channel and alert_slack_thread_ts fields when the "
         "schema exposes them, so future sweeps can re-read human resolution replies.",
         "",
-        f"Channel: {channel_id}" + (f" ({channel_name})" if channel_name else ""),
-        f"Team: {slack_trigger_payload.get('team_id')}",
-        f"Message ts: {slack_trigger_payload.get('message_ts')}",
-        f"Author (Slack id): {author}",
     ]
+    provider_alert = payload.get("provider_alert")
+    if isinstance(provider_alert, Mapping):
+        lines.extend(
+            [
+                "Deterministic provider-alert identity (use this for ticket dedup):",
+                f"- Service/subsystem: {provider_alert.get('service')} / {provider_alert.get('subsystem')}",
+                f"- External id: {provider_alert.get('external_id')}",
+                f"- Tracked signature: {provider_alert.get('tracked_signature')}",
+                f"- Signature title: {provider_alert.get('signature_title')}",
+            ]
+        )
+        if provider_alert.get("is_new_error"):
+            lines.append(
+                "- Rollbar marked this `New error:`. Dedup only against a ticket whose tracked "
+                "signature matches; otherwise file it or add an explicit new-signature entry to "
+                "the parent issue."
+            )
+        if provider_alert.get("surge_open"):
+            if provider_alert.get("material_posted"):
+                lines.append(
+                    "- The ingest gate already posted the ONE consolidated material incident to "
+                    "the software channel. Do not post another consolidated incident; continue "
+                    "only the normal per-alert annotation/ticket action."
+                )
+            elif provider_alert.get("material_post_error"):
+                lines.append(
+                    "- A material surge is open, but its consolidated Slack post failed: "
+                    f"{provider_alert.get('material_post_error')}. Surface that delivery failure."
+                )
+        lines.append("")
+    lines.extend(
+        [
+            f"Channel: {channel_id}" + (f" ({channel_name})" if channel_name else ""),
+            f"Team: {slack_trigger_payload.get('team_id')}",
+            f"Message ts: {slack_trigger_payload.get('message_ts')}",
+            f"Author (Slack id): {author}",
+        ]
+    )
     if slack_trigger_payload.get("permalink"):
         lines.append(f"Permalink: {slack_trigger_payload.get('permalink')}")
     lines.extend(["", f"Message text: {text}"])

--- a/deploy/compose/provider-alert-severity.json
+++ b/deploy/compose/provider-alert-severity.json
@@ -3,6 +3,15 @@
   "default_severity": "high",
   "throttle_minutes": 30,
   "abnormal_volume_threshold": 20,
+  "surge": {
+    "message_threshold": 8,
+    "window_minutes": 30,
+    "milestone_threshold": 100,
+    "new_signature_threshold": 2,
+    "material_channel": "#4_software",
+    "owner": "Uwear engineering on-call",
+    "next_action": "Confirm production impact, assign an incident owner, and coordinate mitigation in this channel."
+  },
   "rules": [
     {
       "id": "seedream_fal_422_typed_content_policy",

--- a/deploy/compose/provider-alert-severity.json
+++ b/deploy/compose/provider-alert-severity.json
@@ -8,6 +8,7 @@
     "window_minutes": 30,
     "milestone_threshold": 100,
     "new_signature_threshold": 2,
+    "claim_ttl_seconds": 180,
     "material_channel": "#4_software",
     "owner": "Uwear engineering on-call",
     "next_action": "Confirm production impact, assign an incident owner, and coordinate mitigation in this channel."

--- a/docs/329-live-delta.md
+++ b/docs/329-live-delta.md
@@ -27,9 +27,9 @@ The activation command installs or verifies these mirrors:
 | slug | bundled source | characters | bytes | SHA-256 |
 |---|---|---:|---:|---|
 | `uwear-engineering-triage-customer-support` | `references/customer-support.md` | `2599` | `2609` | `ccd9e6ded301f69fb493e6557c0f17312f05fdf8c8eba90f734101e73ebc9be8` |
-| `uwear-engineering-triage-creating-work-items` | `references/creating-work-items.md` | `2576` | `2592` | `05acf69d6e473b64579eb84ace2bb995b923dc14c7887afe3cebde0f890b6c18` |
+| `uwear-engineering-triage-creating-work-items` | `references/creating-work-items.md` | `2858` | `2872` | `d027c689ed08caa5fba348c96a41706326fbc35752707c64a55583ae19a59d5e` |
 | `uwear-engineering-triage-backlog-maintenance` | `references/backlog-maintenance.md` | `2554` | `2558` | `1c2bc475b50a974f0b5efb5a41375c059cb13839e4b70c95d113f42faabe0abc` |
-| `uwear-engineering-triage-chantier-operations` | `references/chantier-operations.md` | `11557` | `11565` | `61e78f92198db86916c5ebe753244fb862cb529a7295ec5a89df4d962efa9751` |
+| `uwear-engineering-triage-chantier-operations` | `references/chantier-operations.md` | `14526` | `14536` | `e0a589a6627eba13930354b17899bc7d0b90b1c98a60196b34c855be101dc822` |
 | `uwear-engineering-triage-memory` | `references/memory.md` | `4872` | `4898` | `fd42aad5b3af22c28982f3a49fb49d11606587ca0d7adb16cf37a63d8a0df503` |
 
 Expected memory mirror fingerprint:
@@ -41,9 +41,9 @@ Expected memory mirror fingerprint:
 Core record `1155`, slug `uwear-engineering-triage`, must become the exact
 mirror of `SKILL.md`:
 
-- characters: `33945` (must remain `< 34000`);
-- bytes: `34077`; and
-- SHA-256: `2d634b8caad5dcd172de8cba6b56d04bbab3806ff1429b9aebc5cb3301809fa6`.
+- characters: `33956` (must remain `< 34000`);
+- bytes: `34088`; and
+- SHA-256: `ac7dd770341d9597133fde60de24e43979f796b6c0cf3a35a516eb481f9bf983`.
 
 ## Safety and idempotency
 

--- a/docs/331-live-delta.md
+++ b/docs/331-live-delta.md
@@ -15,9 +15,9 @@ contents of:
 
 Expected content fingerprint:
 
-- characters: `14344`;
-- bytes: `14354`; and
-- SHA-256: `f448a9cc10928d7e320f0c469bda06dcf40b3dc87e47468f6f1e15b2aa4092bf`.
+- characters: `14526`;
+- bytes: `14536`; and
+- SHA-256: `e0a589a6627eba13930354b17899bc7d0b90b1c98a60196b34c855be101dc822`.
 
 Read record `1274` back and require byte identity. Do not overwrite a newer
 unreconciled live edit. Domain `1` has the base chantier schema from #327; run

--- a/tests/test_models_all.py
+++ b/tests/test_models_all.py
@@ -72,6 +72,8 @@ EXPECTED_TABLES = {
     "project_profile_access",
     "project_profiles",
     "provider_alert_ledger",
+    "provider_alert_occurrences",
+    "provider_alert_surges",
     "provider_health_snapshots",
     "resource_leases",
     "reconstruction_evidence",

--- a/tests/test_provider_alert_gate.py
+++ b/tests/test_provider_alert_gate.py
@@ -113,6 +113,42 @@ def test_severity_map_is_reloaded_from_durable_config_every_run(tmp_path, monkey
     assert second.policy_source == str(policy_path.resolve())
 
 
+@pytest.mark.parametrize(
+    "invalid_surge",
+    [None, {"message_threshold": "invalid"}],
+    ids=["missing", "malformed"],
+)
+def test_invalid_surge_config_does_not_disable_authoritative_severity_gate(
+    tmp_path,
+    invalid_surge,
+):
+    from brain.platform.provider_alerts import (
+        DEFAULT_PROVIDER_ALERT_POLICY_PATH,
+        ProviderAlertPolicyError,
+        classify_provider_alert_body,
+        provider_alert_surge_policy,
+    )
+
+    policy_path = tmp_path / "provider-alert-severity.json"
+    policy = json.loads(DEFAULT_PROVIDER_ALERT_POLICY_PATH.read_text(encoding="utf-8"))
+    if invalid_surge is None:
+        policy.pop("surge")
+    else:
+        policy["surge"] = invalid_surge
+    policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+    decision = classify_provider_alert_body(
+        SEEDREAM_NSFW_ALERT,
+        policy_path=policy_path,
+    )
+
+    assert decision is not None
+    assert decision.severity == "low"
+    assert decision.classification == "content_policy"
+    with pytest.raises(ProviderAlertPolicyError, match="surge"):
+        provider_alert_surge_policy(policy_path)
+
+
 def test_provider_alert_gate_has_no_memory_consolidation_dependency():
     import brain.platform.provider_alerts as classifier
     import brain.systems.slack.provider_alert_gate as ledger_gate

--- a/tests/test_provider_alert_surge.py
+++ b/tests/test_provider_alert_surge.py
@@ -1,0 +1,547 @@
+"""Regression coverage for provider-alert surge handling (#410)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
+
+
+ORG_ID = "4b5e2f59-4f88-4956-a660-4f544ccffbd7"
+ALERTS_CHANNEL_ID = "C_ALERTS"
+OUTAGE_START = datetime(2026, 7, 21, 16, 40, tzinfo=timezone.utc)
+
+
+def _rollbar_alert(item: int, marker: str, title: str) -> str:
+    return (
+        "<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/"
+        f"{item}|#{item} {marker}: {title}>"
+    )
+
+
+class _SlackClient:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.threads: dict[str, list[dict[str, Any]]] = {}
+
+    async def conversations_list(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "channels": [{"id": "C_SOFTWARE", "name": "4_software"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    async def post_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.posts.append(kwargs)
+        response = {
+            "ok": True,
+            "channel": kwargs["channel"],
+            "ts": f"1784650000.{len(self.posts):06d}",
+        }
+        self.threads[response["ts"]] = []
+        return response
+
+    async def conversation_replies(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "messages": self.threads.get(kwargs["thread_ts"], []),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+
+@pytest.fixture
+async def surge_store(tmp_path, monkeypatch):
+    from brain.platform.db.models.provider_alert import (
+        ProviderAlertLedger,
+        ProviderAlertOccurrence,
+        ProviderAlertSurge,
+    )
+
+    database_path = Path(tmp_path) / "provider-alert-surges.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.execute(CreateTable(ProviderAlertLedger.__table__))
+        await connection.execute(CreateTable(ProviderAlertOccurrence.__table__))
+        await connection.execute(CreateTable(ProviderAlertSurge.__table__))
+
+    class TestUnitOfWork:
+        async def __aenter__(self):
+            self.session = sessions()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            if exc_type:
+                await self.session.rollback()
+            else:
+                await self.session.commit()
+            await self.session.close()
+
+    monkeypatch.setattr(
+        "brain.systems.slack.provider_alert_surge.UnitOfWork",
+        TestUnitOfWork,
+    )
+    monkeypatch.setattr(
+        "brain.systems.slack.provider_alert_gate.UnitOfWork",
+        TestUnitOfWork,
+    )
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_replay_posts_exactly_one_material_incident_by_eighth_alert(surge_store):
+    """Acceptance 1: replay the outage across four Rollbar item ids."""
+
+    from brain.systems.slack.provider_alert_surge import (
+        handle_provider_alert_ingest_durable,
+    )
+
+    timeout = "TimeoutError: Garment description generation timed out"
+    concurrency = "TimeoutError: Description LLM concurrency budget exhausted"
+    sequence = [
+        (2278, "New error", timeout),
+        (2279, "New error", timeout),
+        (2278, "2nd error", timeout),
+        (2279, "2nd error", timeout),
+        (2278, "3rd error", timeout),
+        (2279, "3rd error", timeout),
+        (2278, "4th error", timeout),
+        (2279, "4th error", timeout),
+        (2278, "5th error", timeout),
+        (2279, "5th error", timeout),
+        (2293, "10th error", concurrency),
+        (2295, "New error", concurrency),
+        (2278, "100th error", timeout),
+    ]
+    while len(sequence) < 30:
+        item = (2278, 2279, 2293, 2295)[len(sequence) % 4]
+        title = concurrency if item in {2293, 2295} else timeout
+        sequence.append((item, f"{len(sequence) + 1}th error", title))
+
+    client = _SlackClient()
+    material_post_indexes: list[int] = []
+    for index, (item, marker, title) in enumerate(sequence, start=1):
+        minute = round((index - 1) * 60 / (len(sequence) - 1))
+        result = await handle_provider_alert_ingest_durable(
+            client,
+            org_id=ORG_ID,
+            channel_id=ALERTS_CHANNEL_ID,
+            message_ts=f"178464{index:04d}.000000",
+            text=_rollbar_alert(item, marker, title),
+            occurred_at=OUTAGE_START + timedelta(minutes=minute),
+        )
+        if result is not None and result.material_posted:
+            material_post_indexes.append(index)
+
+    replayed = await handle_provider_alert_ingest_durable(
+        client,
+        org_id=ORG_ID,
+        channel_id=ALERTS_CHANNEL_ID,
+        message_ts="1784640008.000000",
+        text=_rollbar_alert(*sequence[7]),
+        occurred_at=OUTAGE_START + timedelta(minutes=14),
+    )
+
+    assert material_post_indexes == [8]
+    assert replayed is not None and replayed.material_posted is False
+    assert len(client.posts) == 1
+    assert client.posts[0]["channel"] == "C_SOFTWARE"
+    assert "Material incident — alert surge" in client.posts[0]["text"]
+    assert "Subsystem: Uwear-API" in client.posts[0]["text"]
+    assert "Owner: Uwear engineering on-call" in client.posts[0]["text"]
+    assert "Next action:" in client.posts[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_new_error_title_is_a_distinct_tracked_signature(surge_store):
+    """Acceptance 2: a distinct New error title is never folded into timeout."""
+
+    from brain.platform.db.models.provider_alert import ProviderAlertOccurrence
+    from brain.platform.provider_alerts import (
+        classify_provider_alert_body,
+        classify_provider_alert_ingest,
+    )
+    from brain.systems.slack.provider_alert_surge import handle_provider_alert_ingest
+
+    timeout = _rollbar_alert(
+        2278,
+        "New error",
+        "TimeoutError: Garment description generation timed out",
+    )
+    concurrency_2293 = _rollbar_alert(
+        2293,
+        "10th error",
+        "TimeoutError: Description LLM concurrency budget exhausted",
+    )
+    concurrency_2295 = _rollbar_alert(
+        2295,
+        "New error",
+        "TimeoutError: Description LLM concurrency budget exhausted",
+    )
+
+    timeout_alert = classify_provider_alert_ingest(timeout)
+    concurrency_alert = classify_provider_alert_ingest(concurrency_2295)
+    assert timeout_alert is not None and concurrency_alert is not None
+    assert concurrency_alert.is_new_error is True
+    assert timeout_alert.signature != concurrency_alert.signature
+    timeout_reply = classify_provider_alert_body(
+        f"ALERT — HIGH provider failure\n{timeout}"
+    )
+    concurrency_reply = classify_provider_alert_body(
+        f"ALERT — HIGH provider failure\n{concurrency_2295}"
+    )
+    concurrency_refire_reply = classify_provider_alert_body(
+        f"ALERT — HIGH provider failure\n{concurrency_2293}"
+    )
+    assert timeout_reply is not None and concurrency_reply is not None
+    assert concurrency_refire_reply is not None
+    assert timeout_reply.signature != concurrency_reply.signature
+    assert concurrency_refire_reply.signature == concurrency_reply.signature
+    assert concurrency_reply.evidence.is_new_error is True
+
+    client = _SlackClient()
+    async with surge_store() as session:
+        for index, text in enumerate((timeout, concurrency_2293, concurrency_2295), start=1):
+            await handle_provider_alert_ingest(
+                session,
+                client,
+                org_id=ORG_ID,
+                channel_id=ALERTS_CHANNEL_ID,
+                message_ts=f"178464100{index}.000000",
+                text=text,
+                occurred_at=OUTAGE_START + timedelta(minutes=index),
+            )
+        await session.commit()
+        rows = list(
+            (
+                await session.scalars(
+                    select(ProviderAlertOccurrence).order_by(
+                        ProviderAlertOccurrence.occurred_at.asc()
+                    )
+                )
+            ).all()
+        )
+
+    assert rows[0].signature != rows[1].signature
+    assert rows[1].signature == rows[2].signature
+    assert rows[1].signature_title == "TimeoutError: Description LLM concurrency budget exhausted"
+    assert rows[1].is_new_signature is True
+    assert rows[2].is_new_signature is False
+
+
+@pytest.mark.asyncio
+async def test_digest_query_returns_open_surge_and_skill_requires_lead_section(surge_store):
+    """Acceptance 3: the digest has a queryable incident to render first."""
+
+    from brain.systems.slack.provider_alert_surge import (
+        handle_provider_alert_ingest,
+        list_open_provider_alert_surges,
+    )
+
+    client = _SlackClient()
+    async with surge_store() as session:
+        for index in range(8):
+            await handle_provider_alert_ingest(
+                session,
+                client,
+                org_id=ORG_ID,
+                channel_id=ALERTS_CHANNEL_ID,
+                message_ts=f"178464200{index}.000000",
+                text=_rollbar_alert(
+                    2278 + (index % 2),
+                    "New error" if index < 2 else f"{index + 1}th error",
+                    "TimeoutError: Garment description generation timed out",
+                ),
+                occurred_at=OUTAGE_START + timedelta(minutes=index),
+            )
+        await session.commit()
+
+        open_surges = await list_open_provider_alert_surges(
+            session,
+            org_id=ORG_ID,
+            now=OUTAGE_START + timedelta(minutes=22),
+        )
+        closed_surges = await list_open_provider_alert_surges(
+            session,
+            org_id=ORG_ID,
+            now=OUTAGE_START + timedelta(minutes=38),
+        )
+
+    assert len(open_surges) == 1
+    assert open_surges[0]["subsystem"] == "Uwear-API"
+    assert open_surges[0]["message_count"] == 8
+    assert open_surges[0]["trigger_reason"] == "message_volume"
+    assert closed_surges == []
+
+    skill = Path(
+        "brain/systems/skills/builtin_skill_bundles/uwear-engineering-triage/SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert 'manage_slack` `action="open_alert_surges"' in skill
+    assert "lead incident section" in skill
+
+
+@pytest.mark.asyncio
+async def test_digest_can_read_open_surges_through_manage_slack(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_manage_slack
+    from brain.systems.runs.tool_catalog.registry import action_policy_for_tool
+
+    expected = [{"subsystem": "Uwear-API", "trigger_reason": "message_volume"}]
+
+    class _UnitOfWork:
+        session = object()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+    async def _open_surges(session, *, org_id, **_kwargs):
+        assert session is _UnitOfWork.session
+        assert org_id == ORG_ID
+        return expected
+
+    monkeypatch.setattr(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        _UnitOfWork,
+    )
+    monkeypatch.setattr(
+        "brain.systems.slack.provider_alert_surge.list_open_provider_alert_surges",
+        _open_surges,
+    )
+
+    with bind_agent_context({"org_id": ORG_ID}):
+        payload = json.loads(await _handle_manage_slack(action="open_alert_surges"))
+
+    assert payload == {"ok": True, "open_alert_surges": expected, "count": 1}
+    assert (
+        action_policy_for_tool(
+            "manage_slack",
+            kwargs={"action": "open_alert_surges"},
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_quiet_single_refire_keeps_annotation_without_material_incident(
+    surge_store,
+    monkeypatch,
+):
+    """Acceptance 4: one ordinary refire keeps the per-alert-only behavior."""
+
+    from brain.systems.slack.provider_alert_surge import handle_provider_alert_ingest
+
+    client = _SlackClient()
+    async with surge_store() as session:
+        result = await handle_provider_alert_ingest(
+            session,
+            client,
+            org_id=ORG_ID,
+            channel_id=ALERTS_CHANNEL_ID,
+            message_ts="1784643000.000000",
+            text=_rollbar_alert(
+                2278,
+                "2nd error",
+                "TimeoutError: Garment description generation timed out",
+            ),
+            occurred_at=OUTAGE_START,
+        )
+        await session.commit()
+
+    assert result is not None
+    assert result.surge is None
+    assert result.material_posted is False
+    assert client.posts == []
+
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers.slack import _handle_post_slack_reply
+
+    async def _slack_client():
+        return client
+
+    monkeypatch.setattr(
+        "brain.systems.runs.tool_catalog.handlers.slack._slack_client_from_runtime",
+        _slack_client,
+    )
+    with bind_agent_context(
+        {
+            "org_id": ORG_ID,
+            "run_id": 410,
+            "slack_trigger": {
+                "bot_user_id": "BILLO",
+                "response_target": {
+                    "channel_id": ALERTS_CHANNEL_ID,
+                    "thread_ts": "1784643000.000000",
+                    "visibility": "public",
+                },
+            },
+        }
+    ):
+        annotation = json.loads(
+            await _handle_post_slack_reply(
+                body=(
+                    "ALERT — HIGH provider failure\n"
+                    "Provider: Vertex\nHTTP 504\n"
+                    "Quiet refire annotated on the existing incident."
+                )
+            )
+        )
+
+    assert annotation["posted"] is True
+    assert len(client.posts) == 1
+    assert client.posts[0]["thread_ts"] == "1784643000.000000"
+
+
+@pytest.mark.asyncio
+async def test_message_volume_predicate_uses_a_rolling_window(surge_store):
+    from brain.systems.slack.provider_alert_surge import handle_provider_alert_ingest
+
+    client = _SlackClient()
+    offsets = [0, 1, 2, 3, 4, 5, 6, 37]
+    async with surge_store() as session:
+        for index, minute in enumerate(offsets):
+            result = await handle_provider_alert_ingest(
+                session,
+                client,
+                org_id=ORG_ID,
+                channel_id=ALERTS_CHANNEL_ID,
+                message_ts=f"178464350{index}.000000",
+                text=_rollbar_alert(
+                    2278,
+                    f"{index + 2}th error",
+                    "TimeoutError: Garment description generation timed out",
+                ),
+                occurred_at=OUTAGE_START + timedelta(minutes=minute),
+            )
+            assert result is not None and result.surge is None
+        await session.commit()
+
+    assert client.posts == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("alerts", "expected_reason"),
+    [
+        (
+            [
+                (2278, "100th error", "TimeoutError: generation timed out"),
+            ],
+            "occurrence_milestone",
+        ),
+        (
+            [
+                (2293, "New error", "TimeoutError: generation timed out"),
+                (2295, "New error", "RuntimeError: concurrency budget exhausted"),
+            ],
+            "distinct_new_signatures",
+        ),
+    ],
+)
+async def test_non_volume_surge_predicates(alerts, expected_reason, surge_store):
+    from brain.systems.slack.provider_alert_surge import handle_provider_alert_ingest
+
+    client = _SlackClient()
+    last_result = None
+    async with surge_store() as session:
+        for index, (item, marker, title) in enumerate(alerts):
+            last_result = await handle_provider_alert_ingest(
+                session,
+                client,
+                org_id=ORG_ID,
+                channel_id=ALERTS_CHANNEL_ID,
+                message_ts=f"178464400{index}.000000",
+                text=_rollbar_alert(item, marker, title),
+                occurred_at=OUTAGE_START + timedelta(minutes=index),
+            )
+        await session.commit()
+
+    assert last_result is not None and last_result.surge is not None
+    assert last_result.surge.trigger_reason == expected_reason
+    assert len(client.posts) == 1
+
+
+def test_surge_thresholds_are_loaded_from_named_config():
+    from brain.platform.provider_alerts import provider_alert_surge_policy
+
+    policy = provider_alert_surge_policy()
+
+    assert policy.message_threshold == 8
+    assert policy.window_minutes == 30
+    assert policy.milestone_threshold == 100
+    assert policy.new_signature_threshold == 2
+    assert policy.material_channel == "#4_software"
+
+
+@pytest.mark.asyncio
+async def test_monitored_connector_records_alert_before_run_admission(monkeypatch):
+    from brain.systems.slack.connector import (
+        SlackConnectorConfig,
+        _handle_monitored_provider_alert,
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def _handle(client, **kwargs):
+        captured.update({"client": client, **kwargs})
+        return SimpleNamespace(
+            alert=SimpleNamespace(
+                service="Uwear-API",
+                subsystem="Uwear-API",
+                external_id="Uwear-API#2295",
+                signature="tracked-signature",
+                signature_title="Description LLM concurrency budget exhausted",
+                occurrence_milestone=None,
+                is_new_error=True,
+            ),
+            surge=object(),
+            material_posted=True,
+            material_post_error=None,
+        )
+
+    monkeypatch.setattr(
+        "brain.systems.slack.provider_alert_surge.handle_provider_alert_ingest_durable",
+        _handle,
+    )
+    envelope = {
+        "payload": {
+            "channel_id": ALERTS_CHANNEL_ID,
+            "message_ts": "1784643000.000000",
+            "text": _rollbar_alert(
+                2295,
+                "New error",
+                "Description LLM concurrency budget exhausted",
+            ),
+        }
+    }
+    await _handle_monitored_provider_alert(
+        connection={"org_id": ORG_ID},
+        config=SlackConnectorConfig(bot_token="xoxb-test", app_token="xapp-test"),
+        envelope=envelope,
+    )
+
+    assert captured["org_id"] == ORG_ID
+    assert envelope["payload"]["provider_alert"] == {
+        "service": "Uwear-API",
+        "subsystem": "Uwear-API",
+        "external_id": "Uwear-API#2295",
+        "tracked_signature": "tracked-signature",
+        "signature_title": "Description LLM concurrency budget exhausted",
+        "occurrence_milestone": None,
+        "is_new_error": True,
+        "surge_open": True,
+        "material_posted": True,
+        "material_post_error": None,
+    }

--- a/tests/test_provider_alert_surge.py
+++ b/tests/test_provider_alert_surge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
@@ -54,6 +55,18 @@ class _SlackClient:
             "messages": self.threads.get(kwargs["thread_ts"], []),
             "response_metadata": {"next_cursor": ""},
         }
+
+
+class _FailOnceSlackClient(_SlackClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.post_attempts = 0
+
+    async def post_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.post_attempts += 1
+        if self.post_attempts == 1:
+            raise RuntimeError("temporary Slack delivery failure")
+        return await super().post_message(**kwargs)
 
 
 @pytest.fixture
@@ -160,6 +173,135 @@ async def test_replay_posts_exactly_one_material_incident_by_eighth_alert(surge_
     assert "Subsystem: Uwear-API" in client.posts[0]["text"]
     assert "Owner: Uwear engineering on-call" in client.posts[0]["text"]
     assert "Next action:" in client.posts[0]["text"]
+
+
+def test_rule_evaluator_is_pure_and_owns_window_and_signature_decisions():
+    from brain.platform.provider_alerts import provider_alert_surge_policy
+    from brain.systems.slack.provider_alert_surge import evaluate_provider_alert_surge
+
+    policy = replace(provider_alert_surge_policy(), message_threshold=3)
+    occurrences = [
+        SimpleNamespace(
+            id=1,
+            occurred_at=OUTAGE_START - timedelta(minutes=31),
+            service="Uwear-API",
+            subsystem="garment-generation",
+            external_id="Uwear-API#old",
+            signature="old",
+            signature_title="Old timeout",
+            occurrence_milestone=None,
+            is_new_signature=True,
+        ),
+        *(
+            SimpleNamespace(
+                id=index + 2,
+                occurred_at=OUTAGE_START + timedelta(minutes=index),
+                service="Uwear-API",
+                subsystem="garment-generation",
+                external_id=f"Uwear-API#{index}",
+                signature=f"signature-{index % 2}",
+                signature_title=f"Timeout {index % 2}",
+                occurrence_milestone=None,
+                is_new_signature=index < 2,
+            )
+            for index in range(3)
+        ),
+    ]
+
+    decision = evaluate_provider_alert_surge(
+        occurrences,
+        policy,
+        OUTAGE_START + timedelta(minutes=2),
+    )
+
+    assert decision.trigger_reason == "message_volume"
+    assert decision.window_started_at == OUTAGE_START
+    assert decision.window_ended_at == OUTAGE_START + timedelta(minutes=2)
+    assert decision.message_count == 3
+    assert decision.subsystem == "Uwear-API"
+    assert decision.signatures == (
+        {"signature": "signature-0", "title": "Timeout 0"},
+        {"signature": "signature-1", "title": "Timeout 1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_delivery_releases_claim_and_next_alert_retries_once(surge_store):
+    from brain.systems.slack.provider_alert_surge import (
+        handle_provider_alert_ingest_durable,
+    )
+
+    client = _FailOnceSlackClient()
+    results = []
+    for index, marker in enumerate(("100th error", "101st error", "102nd error")):
+        results.append(
+            await handle_provider_alert_ingest_durable(
+                client,
+                org_id=ORG_ID,
+                channel_id=ALERTS_CHANNEL_ID,
+                message_ts=f"178464050{index}.000000",
+                text=_rollbar_alert(2278, marker, "TimeoutError: generation timed out"),
+                occurred_at=OUTAGE_START + timedelta(minutes=index),
+            )
+        )
+
+    assert results[0] is not None
+    assert results[0].material_post_error == "temporary Slack delivery failure"
+    assert results[0].surge is not None
+    assert results[0].surge.material_post_claimed_at is None
+    assert results[1] is not None and results[1].material_posted is True
+    assert results[2] is not None and results[2].material_posted is False
+    assert client.post_attempts == 2
+    assert len(client.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_undelivered_claim_is_reclaimed(surge_store):
+    from brain.platform.provider_alerts import (
+        classify_provider_alert_ingest,
+        provider_alert_surge_policy,
+    )
+    from brain.systems.slack.provider_alert_surge import (
+        handle_provider_alert_ingest_durable,
+        record_provider_alert_occurrence,
+    )
+
+    policy = provider_alert_surge_policy()
+    alert = classify_provider_alert_ingest(
+        _rollbar_alert(2278, "100th error", "TimeoutError: generation timed out")
+    )
+    assert alert is not None
+    async with surge_store() as session:
+        claimed, should_post = await record_provider_alert_occurrence(
+            session,
+            org_id=ORG_ID,
+            channel_id=ALERTS_CHANNEL_ID,
+            message_ts="1784640600.000000",
+            alert=alert,
+            occurred_at=OUTAGE_START,
+            policy=policy,
+        )
+        await session.commit()
+
+    assert should_post is True
+    assert claimed is not None
+    assert claimed.material_post_claimed_at == OUTAGE_START
+
+    client = _SlackClient()
+    reclaimed_at = OUTAGE_START + timedelta(seconds=policy.claim_ttl_seconds + 1)
+    result = await handle_provider_alert_ingest_durable(
+        client,
+        org_id=ORG_ID,
+        channel_id=ALERTS_CHANNEL_ID,
+        message_ts="1784640601.000000",
+        text=_rollbar_alert(2278, "2nd error", "TimeoutError: generation timed out"),
+        occurred_at=reclaimed_at,
+    )
+
+    assert result is not None and result.material_posted is True
+    assert result.surge is not None
+    assert result.surge.material_post_claimed_at == reclaimed_at
+    assert len(client.posts) == 1
 
 
 @pytest.mark.asyncio
@@ -482,7 +624,22 @@ def test_surge_thresholds_are_loaded_from_named_config():
     assert policy.window_minutes == 30
     assert policy.milestone_threshold == 100
     assert policy.new_signature_threshold == 2
+    assert policy.claim_ttl_seconds == 180
     assert policy.material_channel == "#4_software"
+
+
+def test_surge_claim_ttl_uses_small_default_when_omitted(tmp_path):
+    from brain.platform.provider_alerts import (
+        DEFAULT_PROVIDER_ALERT_POLICY_PATH,
+        provider_alert_surge_policy,
+    )
+
+    policy_path = tmp_path / "provider-alert-severity.json"
+    payload = json.loads(DEFAULT_PROVIDER_ALERT_POLICY_PATH.read_text(encoding="utf-8"))
+    payload["surge"].pop("claim_ttl_seconds")
+    policy_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert provider_alert_surge_policy(policy_path).claim_ttl_seconds == 180
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack_teammate.py
+++ b/tests/test_slack_teammate.py
@@ -1677,6 +1677,7 @@ def test_manage_slack_tool_definition_has_no_operator_setup_action():
         "list_monitored",
         "monitor_channel",
         "unmonitor_channel",
+        "open_alert_surges",
     ]
     assert {"display_name", "communication_preferences"} <= set(properties)
     assert properties["communication_preferences"]["properties"]["humour"]["enum"] == [


### PR DESCRIPTION
Closes #410.

On 2026-07-21, prod description generation failed for an hour, Rollbar fired ~30 alerts across four signatures, two humans asked in `#alerts` whether there was an outage — and Illo answered them per-thread while never declaring an incident, never mentioning it in the 13:00 digest it posted *mid-outage*, and folding the genuinely new "concurrency budget exhausted" failure into an issue about timeouts.

## What changed
- **Surge predicate on alert ingest** — 8 alerts for one service in a rolling 30 min, any Rollbar milestone ≥100, or 2 distinct first-seen signatures on one subsystem in 30 min escalates from per-thread annotation to **one** consolidated material-change post naming subsystem, window, signatures, owner and next action. Thresholds are config (`deploy/compose/provider-alert-severity.json`), not literals — they will need tuning once you see them fire.
- **Distinct signatures** — the tracked signature hashes a normalised `(service, title)` excluding item number and milestone, so #2293/#2295 ("concurrency budget exhausted") are one signature, distinct from the timeout signature, instead of being deduped into #1098.
- **The digest can lead with an open surge** — `manage_slack(action="open_alert_surges")` plus the triage skill-bundle contract (and its checksum fingerprints in `docs/329-live-delta.md` / `docs/331-live-delta.md`).
- **Rollbar parsing got one owner** — `AlertSignature` / `parse_rollbar_alert` moved out of `deploy_state.py` into `brain/platform/provider_alerts.py`. That is the `-67` lines in `deploy_state.py`: a move, not a deletion.
- New tables `provider_alert_occurrences` + `provider_alert_surges` via `0034_provider_alert_surges.py`, guarded against fresh-baseline replay the way #405 taught us.

## Two defects I caught before this reached you
**1. A red suite the worker reported as green.** The implementation claimed a clean regression run but had not run `tests/test_models_all.py`, which was failing on both `test_no_extra_tables` and `test_table_count` — the two new tables were never registered in `EXPECTED_TABLES`. Fixed in the first commit.

**2. A silent re-introduction of this very bug** (second commit, `b3025df`). A thermo-nuclear code-quality review flagged it and I confirmed it in the code: `material_post_claimed_at` was stamped and flushed *before* Slack delivery and was only ever cleared when a **new** window opened. So if the consolidated post failed to deliver — 5xx, rate limit, network — the claim latched for the life of the active surge and the incident post was **never made**, while the ledger showed a surge that looked handled. The claim is now a lease: released immediately on delivery failure, reclaimable after `claim_ttl_seconds` (180s, in config), terminal once `material_posted_at` is set. Tests cover retry-after-failure and reclaim-after-expiry; "exactly one post" still holds.

That fix-pass also extracted the seams it needed — a pure `evaluate_provider_alert_surge(occurrences, policy, now)`, a `ProviderAlertSurgeTransitions` owner for the row lifecycle, Slack delivery at the caller edge — and made the severity and surge config sections load independently, so a malformed surge section can no longer take down the **authoritative #404 outbound gate**.

## Verification (all run by me in the worktree, no DB or Docker needed)
- `tests/test_provider_alert_gate.py + test_provider_alert_surge.py + test_models_all.py + test_alembic_config.py + test_deploy_state.py` → **116 passed**.
- Broader `-k "slack or alert or deploy_state or triage or skill"` → **564 passed, 1 skipped**.
- Acceptance check 4's no-regression bar: **#404's gate suite is green and unchanged in intent** — the only edit to it is one *added* test proving the gate survives invalid surge config.
- AC1 is a real replay test (the 12:40–13:40 sequence, exactly one post at alert 8, including redelivery); AC2 asserts #2293/#2295 stay distinct from the timeout signature.

## Known trade-offs, stated plainly
- **Deferred follow-up (worth its own ticket):** alert identity has one file but no canonical contract — `AlertSignature.signature` means Rollbar `project#item` while `ProviderAlertIngest/Decision.signature` mean a title hash, and consumers add channel/subsystem scope themselves. The right fix is one `ProviderAlertIdentity`, but that means reworking the merged #404 gate, which is exactly what acceptance check 4 forbids regressing here.
- If the Slack post succeeds but the follow-up DB write recording it fails, the claim expires after 180s and a later alert could post a **duplicate** incident message. Narrow (a DB failure between two adjacent statements) and deliberately chosen: a duplicate incident post is far less harmful than a missing one.
- Surge rule *identity and precedence* are still a conditional chain — only the thresholds are config. A fourth rule means coordinated edits. Flagged, not fixed, to keep this pass bounded.

Thresholds and wording are the parts worth watching in production; nothing here fires until an actual surge does.
