### PR TITLE
fix(launch-handoffs): stop minting one handoff per Rollbar refire (#409)

### DIFF
--- a/brain/systems/launch_handoffs.py
+++ b/brain/systems/launch_handoffs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -26,6 +27,37 @@ _URL_CANDIDATE_RE = re.compile(
     re.IGNORECASE,
 )
 _TRAILING_PUNCTUATION = ".,;:!?"
+_DERIVED_IDEMPOTENCY_KEY_PREFIX = "derived:launch-handoff:v1:"
+_ROLLBAR_ITEM_URL_RE = re.compile(
+    r"https?://app\.rollbar\.com/[^\s|>]+/item/"
+    r"(?P<project>[^/\s|>]+)/(?P<item>\d+)",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_URL_RE = re.compile(
+    r"https?://github\.com/(?P<repo>[^/\s|>]+/[^/\s|>]+)/"
+    r"(?P<kind>issues|pull)/(?P<number>\d+)",
+    re.IGNORECASE,
+)
+_TRACKED_IDENTITY_FIELDS = (
+    "external_id",
+    "rollbar_item",
+    "rollbar_item_id",
+    "tracked_item_id",
+    "tracked_issue_id",
+    "issue_ref",
+)
+_TRACKED_ITEM_CONTAINERS = (
+    "tracked_item",
+    "tracked_issue",
+    "tracker_record",
+    "issue",
+)
+_OWNER_IDENTITY_FIELDS = (
+    "owner_user_id",
+    "assignee_user_id",
+    "assignee_id",
+    "assignee",
+)
 
 
 class LaunchHandoffError(ValueError):
@@ -90,6 +122,178 @@ def _uuid_or_none(value: Any) -> str | None:
         return str(uuid.UUID(text))
     except ValueError:
         return None
+
+
+def _identity_text(value: Any) -> str | None:
+    if isinstance(value, bool) or value is None or isinstance(value, (dict, list, tuple, set)):
+        return None
+    return _clean_optional_string(value)
+
+
+def _rollbar_identity_from_url(value: Any) -> str | None:
+    text = _identity_text(value)
+    if not text:
+        return None
+    rollbar_match = _ROLLBAR_ITEM_URL_RE.search(text)
+    if rollbar_match:
+        return (
+            f"rollbar:{rollbar_match.group('project')}#{rollbar_match.group('item')}"
+        ).casefold()
+    return None
+
+
+def _identity_from_url(value: Any) -> str | None:
+    rollbar_identity = _rollbar_identity_from_url(value)
+    if rollbar_identity:
+        return rollbar_identity
+    text = _identity_text(value)
+    if not text:
+        return None
+    github_match = _GITHUB_ISSUE_URL_RE.search(text)
+    if github_match:
+        kind = "pull" if github_match.group("kind").casefold() == "pull" else "issue"
+        return (
+            f"github:{github_match.group('repo')}:{kind}:{github_match.group('number')}"
+        ).casefold()
+    return None
+
+
+def _field_identity(field_name: str, value: Any) -> str | None:
+    from_url = _identity_from_url(value)
+    if from_url:
+        return from_url
+    text = _identity_text(value)
+    if not text:
+        return None
+    if field_name in {"rollbar_item", "rollbar_item_id"}:
+        return f"rollbar:{text}".casefold()
+    return f"{field_name}:{text}".casefold()
+
+
+def _identity_from_tracked_container(
+    value: Any,
+    *,
+    allow_generic_id: bool = True,
+    depth: int = 0,
+) -> str | None:
+    if depth > 6:
+        return None
+    if not isinstance(value, dict):
+        return None
+
+    for field_name in _TRACKED_IDENTITY_FIELDS:
+        identity = _field_identity(field_name, value.get(field_name))
+        if identity:
+            return identity
+
+    repo = _identity_text(value.get("repo") or value.get("repository"))
+    issue_number = _identity_text(value.get("issue_number") or value.get("number"))
+    if repo and issue_number:
+        return f"github:{repo}:issue:{issue_number}".casefold()
+
+    if allow_generic_id:
+        for field_name in ("id", "key", "ref", "url"):
+            identity = _field_identity("tracked_item", value.get(field_name))
+            if identity:
+                return identity
+
+    for nested in value.values():
+        if isinstance(nested, dict):
+            identity = _identity_from_tracked_container(
+                nested,
+                allow_generic_id=allow_generic_id,
+                depth=depth + 1,
+            )
+            if identity:
+                return identity
+    return None
+
+
+def _identity_url_in_source_ref(value: Any, *, depth: int = 0) -> str | None:
+    if depth > 8:
+        return None
+    identity = _rollbar_identity_from_url(value)
+    if identity:
+        return identity
+    if isinstance(value, dict):
+        nested_values = value.values()
+    elif isinstance(value, (list, tuple)):
+        nested_values = value
+    else:
+        return None
+    for nested in nested_values:
+        identity = _identity_url_in_source_ref(nested, depth=depth + 1)
+        if identity:
+            return identity
+    return None
+
+
+def _tracked_item_identity(source_ref: dict[str, Any]) -> str | None:
+    for field_name in _TRACKED_IDENTITY_FIELDS:
+        identity = _field_identity(field_name, source_ref.get(field_name))
+        if identity:
+            return identity
+    for field_name in _TRACKED_ITEM_CONTAINERS:
+        if field_name not in source_ref:
+            continue
+        container = source_ref[field_name]
+        if isinstance(container, dict):
+            identity = _identity_from_tracked_container(container)
+        else:
+            text = _identity_text(container)
+            identity = f"{field_name}:{text}".casefold() if text else None
+        if identity:
+            return identity
+    record = source_ref.get("record")
+    if isinstance(record, dict):
+        identity = _identity_from_tracked_container(record, allow_generic_id=False)
+        if identity:
+            return identity
+    return _identity_url_in_source_ref(source_ref)
+
+
+def _owner_identity(
+    source_ref: dict[str, Any],
+    metadata: dict[str, Any],
+    created_by_user_id: Any,
+) -> str:
+    for container in (metadata, source_ref):
+        for field_name in _OWNER_IDENTITY_FIELDS:
+            value = container.get(field_name)
+            if isinstance(value, dict):
+                value = value.get("id") or value.get("user_id") or value.get("name")
+            text = _identity_text(value)
+            if text:
+                return text.casefold()
+    return (_identity_text(created_by_user_id) or "unassigned").casefold()
+
+
+def derive_launch_handoff_idempotency_key(
+    source_ref: dict[str, Any] | None,
+    *,
+    created_by_user_id: Any = None,
+    metadata: dict[str, Any] | None = None,
+) -> str | None:
+    """Derive a namespaced key from a tracked item and its intended owner."""
+    clean_source_ref = _json_dict(source_ref)
+    identity = _tracked_item_identity(clean_source_ref)
+    if not identity:
+        return None
+    owner = _owner_identity(clean_source_ref, _json_dict(metadata), created_by_user_id)
+    digest = sha256(f"{identity}\0{owner}".encode("utf-8")).hexdigest()
+    return f"{_DERIVED_IDEMPOTENCY_KEY_PREFIX}{digest}"
+
+
+def _refire_metadata(metadata: Any) -> dict[str, Any]:
+    updated = _json_dict(metadata)
+    raw_count = updated.get("refire_count", 0)
+    try:
+        current_count = int(raw_count)
+    except (TypeError, ValueError):
+        current_count = 0
+    updated["refire_count"] = max(0, current_count) + 1
+    updated["last_refire_at"] = datetime.now(timezone.utc).isoformat()
+    return updated
 
 
 def parse_member_agent_targets(raw: str | None) -> dict[str, str]:
@@ -225,6 +429,10 @@ async def create_launch_handoff_with_status(
 ) -> tuple[LaunchHandoff, bool]:
     """Create a handoff, or return the existing row on an idempotency hit.
 
+    Missing keys are derived only from a stable tracked-item identity plus the
+    intended owner. A reused row records the refire in metadata without
+    replacing its original handoff contents.
+
     The boolean is the caller's noise gate: a REUSED row (``False``) means
     the packet already went out — mint must post nothing to Slack.
     """
@@ -232,7 +440,15 @@ async def create_launch_handoff_with_status(
     clean_title = _required_string(handoff_input.title, "title")
     clean_instructions = _required_string(handoff_input.instructions, "instructions")
     clean_target_tool = (_clean_optional_string(handoff_input.target_tool) or TARGET_CODEX).lower()
-    clean_idempotency_key = _clean_optional_string(handoff_input.idempotency_key)
+    clean_source_ref = _json_dict(handoff_input.source_ref)
+    clean_metadata = _json_dict(handoff_input.metadata)
+    clean_idempotency_key = _clean_optional_string(handoff_input.idempotency_key) or (
+        derive_launch_handoff_idempotency_key(
+            clean_source_ref,
+            created_by_user_id=handoff_input.created_by_user_id,
+            metadata=clean_metadata,
+        )
+    )
     if clean_idempotency_key:
         existing = await session.scalar(
             select(LaunchHandoff).where(
@@ -241,13 +457,15 @@ async def create_launch_handoff_with_status(
             )
         )
         if existing is not None:
+            existing.metadata_ = _refire_metadata(existing.metadata_)
+            await session.flush()
             return existing, False
 
     row = LaunchHandoff(
         org_id=clean_org_id,
         created_by_user_id=_uuid_or_none(handoff_input.created_by_user_id),
         source_surface=_clean_optional_string(handoff_input.source_surface) or "illo",
-        source_ref=_json_dict(handoff_input.source_ref),
+        source_ref=clean_source_ref,
         target_tool=clean_target_tool,
         title=clean_title,
         summary=_clean_optional_string(handoff_input.summary),
@@ -257,7 +475,7 @@ async def create_launch_handoff_with_status(
         repo_origin_url=_clean_optional_string(handoff_input.repo_origin_url),
         branch_hint=_clean_optional_string(handoff_input.branch_hint),
         idempotency_key=clean_idempotency_key,
-        metadata_=_json_dict(handoff_input.metadata),
+        metadata_=clean_metadata,
     )
     session.add(row)
     await session.flush()

--- a/brain/systems/launch_handoffs.py
+++ b/brain/systems/launch_handoffs.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-from hashlib import sha256
 import re
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import StrEnum
+from hashlib import sha256
 from typing import Any
 from urllib.parse import quote, unquote, urlencode, urlsplit
 
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.launch_handoff import LaunchHandoff
 from brain.systems.cortex.thread_links import public_app_base_url
+from brain.systems.deploy_state import parse_rollbar_alert
 
 LAUNCH_HANDOFF_OBJECT_TYPE = "launch_handoff"
 TARGET_CODEX = "codex"
@@ -28,36 +30,11 @@ _URL_CANDIDATE_RE = re.compile(
 )
 _TRAILING_PUNCTUATION = ".,;:!?"
 _DERIVED_IDEMPOTENCY_KEY_PREFIX = "derived:launch-handoff:v1:"
-_ROLLBAR_ITEM_URL_RE = re.compile(
-    r"https?://app\.rollbar\.com/[^\s|>]+/item/"
-    r"(?P<project>[^/\s|>]+)/(?P<item>\d+)",
-    re.IGNORECASE,
-)
-_GITHUB_ISSUE_URL_RE = re.compile(
-    r"https?://github\.com/(?P<repo>[^/\s|>]+/[^/\s|>]+)/"
-    r"(?P<kind>issues|pull)/(?P<number>\d+)",
-    re.IGNORECASE,
-)
-_TRACKED_IDENTITY_FIELDS = (
-    "external_id",
-    "rollbar_item",
-    "rollbar_item_id",
-    "tracked_item_id",
-    "tracked_issue_id",
-    "issue_ref",
-)
-_TRACKED_ITEM_CONTAINERS = (
-    "tracked_item",
-    "tracked_issue",
-    "tracker_record",
-    "issue",
-)
-_OWNER_IDENTITY_FIELDS = (
-    "owner_user_id",
-    "assignee_user_id",
-    "assignee_id",
-    "assignee",
-)
+_RETIRED_IDEMPOTENCY_KEY_PREFIX = "retired:lh:v1:"
+_SYSTEM_METADATA_NAMESPACE = "_illo_system"
+_IDEMPOTENCY_METADATA_NAMESPACE = "idempotency"
+_DERIVED_KEY_KIND = "rollbar_slack"
+_RETIREMENT_REASON = "derived_key_holder_not_actionable"
 
 
 class LaunchHandoffError(ValueError):
@@ -66,6 +43,17 @@ class LaunchHandoffError(ValueError):
 
 class LaunchHandoffNotFound(LaunchHandoffError):
     """Raised when a handoff is missing or outside the caller's org."""
+
+
+class _ReuseScope(StrEnum):
+    STRICT = "strict"
+    ACTIONABLE = "actionable"
+
+
+@dataclass(frozen=True, slots=True)
+class _IdempotencyDecision:
+    key: str | None
+    reuse_scope: _ReuseScope
 
 
 @dataclass(frozen=True)
@@ -124,176 +112,96 @@ def _uuid_or_none(value: Any) -> str | None:
         return None
 
 
-def _identity_text(value: Any) -> str | None:
-    if isinstance(value, bool) or value is None or isinstance(value, (dict, list, tuple, set)):
-        return None
-    return _clean_optional_string(value)
-
-
-def _rollbar_identity_from_url(value: Any) -> str | None:
-    text = _identity_text(value)
-    if not text:
-        return None
-    rollbar_match = _ROLLBAR_ITEM_URL_RE.search(text)
-    if rollbar_match:
-        return (
-            f"rollbar:{rollbar_match.group('project')}#{rollbar_match.group('item')}"
-        ).casefold()
-    return None
-
-
-def _identity_from_url(value: Any) -> str | None:
-    rollbar_identity = _rollbar_identity_from_url(value)
-    if rollbar_identity:
-        return rollbar_identity
-    text = _identity_text(value)
-    if not text:
-        return None
-    github_match = _GITHUB_ISSUE_URL_RE.search(text)
-    if github_match:
-        kind = "pull" if github_match.group("kind").casefold() == "pull" else "issue"
-        return (
-            f"github:{github_match.group('repo')}:{kind}:{github_match.group('number')}"
-        ).casefold()
-    return None
-
-
-def _field_identity(field_name: str, value: Any) -> str | None:
-    from_url = _identity_from_url(value)
-    if from_url:
-        return from_url
-    text = _identity_text(value)
-    if not text:
-        return None
-    if field_name in {"rollbar_item", "rollbar_item_id"}:
-        return f"rollbar:{text}".casefold()
-    return f"{field_name}:{text}".casefold()
-
-
-def _identity_from_tracked_container(
-    value: Any,
-    *,
-    allow_generic_id: bool = True,
-    depth: int = 0,
-) -> str | None:
-    if depth > 6:
-        return None
-    if not isinstance(value, dict):
-        return None
-
-    for field_name in _TRACKED_IDENTITY_FIELDS:
-        identity = _field_identity(field_name, value.get(field_name))
-        if identity:
-            return identity
-
-    repo = _identity_text(value.get("repo") or value.get("repository"))
-    issue_number = _identity_text(value.get("issue_number") or value.get("number"))
-    if repo and issue_number:
-        return f"github:{repo}:issue:{issue_number}".casefold()
-
-    if allow_generic_id:
-        for field_name in ("id", "key", "ref", "url"):
-            identity = _field_identity("tracked_item", value.get(field_name))
-            if identity:
-                return identity
-
-    for nested in value.values():
-        if isinstance(nested, dict):
-            identity = _identity_from_tracked_container(
-                nested,
-                allow_generic_id=allow_generic_id,
-                depth=depth + 1,
-            )
-            if identity:
-                return identity
-    return None
-
-
-def _identity_url_in_source_ref(value: Any, *, depth: int = 0) -> str | None:
-    if depth > 8:
-        return None
-    identity = _rollbar_identity_from_url(value)
-    if identity:
-        return identity
-    if isinstance(value, dict):
-        nested_values = value.values()
-    elif isinstance(value, (list, tuple)):
-        nested_values = value
-    else:
-        return None
-    for nested in nested_values:
-        identity = _identity_url_in_source_ref(nested, depth=depth + 1)
-        if identity:
-            return identity
-    return None
-
-
-def _tracked_item_identity(source_ref: dict[str, Any]) -> str | None:
-    for field_name in _TRACKED_IDENTITY_FIELDS:
-        identity = _field_identity(field_name, source_ref.get(field_name))
-        if identity:
-            return identity
-    for field_name in _TRACKED_ITEM_CONTAINERS:
-        if field_name not in source_ref:
-            continue
-        container = source_ref[field_name]
-        if isinstance(container, dict):
-            identity = _identity_from_tracked_container(container)
-        else:
-            text = _identity_text(container)
-            identity = f"{field_name}:{text}".casefold() if text else None
-        if identity:
-            return identity
-    record = source_ref.get("record")
-    if isinstance(record, dict):
-        identity = _identity_from_tracked_container(record, allow_generic_id=False)
-        if identity:
-            return identity
-    return _identity_url_in_source_ref(source_ref)
-
-
-def _owner_identity(
-    source_ref: dict[str, Any],
-    metadata: dict[str, Any],
-    created_by_user_id: Any,
-) -> str:
-    for container in (metadata, source_ref):
-        for field_name in _OWNER_IDENTITY_FIELDS:
-            value = container.get(field_name)
-            if isinstance(value, dict):
-                value = value.get("id") or value.get("user_id") or value.get("name")
-            text = _identity_text(value)
-            if text:
-                return text.casefold()
-    return (_identity_text(created_by_user_id) or "unassigned").casefold()
-
-
 def derive_launch_handoff_idempotency_key(
     source_ref: dict[str, Any] | None,
     *,
     created_by_user_id: Any = None,
-    metadata: dict[str, Any] | None = None,
 ) -> str | None:
-    """Derive a namespaced key from a tracked item and its intended owner."""
-    clean_source_ref = _json_dict(source_ref)
-    identity = _tracked_item_identity(clean_source_ref)
-    if not identity:
+    """Derive from Rollbar Slack text and ``created_by_user_id`` or ``unassigned``."""
+    slack_trigger = _json_dict(_json_dict(source_ref).get("slack_trigger"))
+    text = slack_trigger.get("text")
+    if not isinstance(text, str):
         return None
-    owner = _owner_identity(clean_source_ref, _json_dict(metadata), created_by_user_id)
-    digest = sha256(f"{identity}\0{owner}".encode("utf-8")).hexdigest()
+    alert = parse_rollbar_alert(text)
+    if alert is None:
+        return None
+    owner = (_clean_optional_string(created_by_user_id) or "unassigned").casefold()
+    digest = sha256(f"{alert.signature}\0{owner}".encode("utf-8")).hexdigest()
     return f"{_DERIVED_IDEMPOTENCY_KEY_PREFIX}{digest}"
 
 
-def _refire_metadata(metadata: Any) -> dict[str, Any]:
+def _idempotency_metadata(metadata: Any) -> tuple[dict[str, Any], dict[str, Any]]:
     updated = _json_dict(metadata)
-    raw_count = updated.get("refire_count", 0)
+    system = _json_dict(updated.get(_SYSTEM_METADATA_NAMESPACE))
+    idempotency = _json_dict(system.get(_IDEMPOTENCY_METADATA_NAMESPACE))
+    system[_IDEMPOTENCY_METADATA_NAMESPACE] = idempotency
+    updated[_SYSTEM_METADATA_NAMESPACE] = system
+    return updated, idempotency
+
+
+def _record_refire(row: LaunchHandoff, now: datetime) -> None:
+    updated, idempotency = _idempotency_metadata(row.metadata_)
+    raw_count = idempotency.get("refire_count", 0)
     try:
         current_count = int(raw_count)
     except (TypeError, ValueError):
         current_count = 0
-    updated["refire_count"] = max(0, current_count) + 1
-    updated["last_refire_at"] = datetime.now(timezone.utc).isoformat()
-    return updated
+    idempotency["refire_count"] = max(0, current_count) + 1
+    idempotency["last_refire_at"] = now.isoformat()
+    row.metadata_ = updated
+    row.updated_at = now
+
+
+def _retire_derived_key(row: LaunchHandoff, now: datetime) -> None:
+    """Retire one non-actionable derived-key holder without erasing its history."""
+    retired_key = _clean_optional_string(row.idempotency_key)
+    updated, idempotency = _idempotency_metadata(row.metadata_)
+    if (
+        not retired_key
+        or not retired_key.startswith(_DERIVED_IDEMPOTENCY_KEY_PREFIX)
+        or idempotency.get("key_kind") != _DERIVED_KEY_KIND
+    ):
+        raise LaunchHandoffError("Refusing to retire a caller-supplied idempotency key")
+
+    retired_at = now.isoformat()
+    idempotency.update(
+        {
+            "retired_key": retired_key,
+            "retired_at": retired_at,
+            "retirement_reason": _RETIREMENT_REASON,
+        }
+    )
+    digest = sha256(f"{retired_key}\0{row.id}\0{retired_at}".encode("utf-8")).hexdigest()
+    row.idempotency_key = f"{_RETIRED_IDEMPOTENCY_KEY_PREFIX}{digest}"
+    row.metadata_ = updated
+    row.updated_at = now
+
+
+def _resolve_idempotency(
+    handoff_input: LaunchHandoffCreateInput,
+    source_ref: dict[str, Any],
+    *,
+    derive_rollbar_idempotency: bool,
+) -> _IdempotencyDecision:
+    explicit_key = _clean_optional_string(handoff_input.idempotency_key)
+    if explicit_key:
+        return _IdempotencyDecision(explicit_key, _ReuseScope.STRICT)
+    if derive_rollbar_idempotency:
+        return _IdempotencyDecision(
+            derive_launch_handoff_idempotency_key(
+                source_ref,
+                created_by_user_id=handoff_input.created_by_user_id,
+            ),
+            _ReuseScope.ACTIONABLE,
+        )
+    return _IdempotencyDecision(None, _ReuseScope.STRICT)
+
+
+def _is_actionable(row: LaunchHandoff, now: datetime) -> bool:
+    expires_at = row.expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return row.status == "open" and (expires_at is None or expires_at > now)
 
 
 def parse_member_agent_targets(raw: str | None) -> dict[str, str]:
@@ -418,20 +326,27 @@ def codex_deep_link_for_handoff(row: LaunchHandoff) -> str:
 async def create_launch_handoff(
     session: AsyncSession,
     handoff_input: LaunchHandoffCreateInput,
+    *,
+    derive_rollbar_idempotency: bool = False,
 ) -> LaunchHandoff:
-    row, _created = await create_launch_handoff_with_status(session, handoff_input)
+    row, _created = await create_launch_handoff_with_status(
+        session,
+        handoff_input,
+        derive_rollbar_idempotency=derive_rollbar_idempotency,
+    )
     return row
 
 
 async def create_launch_handoff_with_status(
     session: AsyncSession,
     handoff_input: LaunchHandoffCreateInput,
+    *,
+    derive_rollbar_idempotency: bool = False,
 ) -> tuple[LaunchHandoff, bool]:
     """Create a handoff, or return the existing row on an idempotency hit.
 
-    Missing keys are derived only from a stable tracked-item identity plus the
-    intended owner. A reused row records the refire in metadata without
-    replacing its original handoff contents.
+    The launch tool may opt into actionable Rollbar reuse. All other callers
+    get strict reuse only when they supply an idempotency key.
 
     The boolean is the caller's noise gate: a REUSED row (``False``) means
     the packet already went out — mint must post nothing to Slack.
@@ -442,66 +357,34 @@ async def create_launch_handoff_with_status(
     clean_target_tool = (_clean_optional_string(handoff_input.target_tool) or TARGET_CODEX).lower()
     clean_source_ref = _json_dict(handoff_input.source_ref)
     clean_metadata = _json_dict(handoff_input.metadata)
-    explicit_idempotency_key = _clean_optional_string(handoff_input.idempotency_key)
-    derived_idempotency_key = None
-    if explicit_idempotency_key is None:
-        derived_idempotency_key = derive_launch_handoff_idempotency_key(
-            clean_source_ref,
-            created_by_user_id=handoff_input.created_by_user_id,
-            metadata=clean_metadata,
-        )
-    clean_idempotency_key = explicit_idempotency_key or derived_idempotency_key
+    clean_metadata.pop(_SYSTEM_METADATA_NAMESPACE, None)
+    decision = _resolve_idempotency(
+        handoff_input,
+        clean_source_ref,
+        derive_rollbar_idempotency=derive_rollbar_idempotency,
+    )
+    if decision.key and decision.reuse_scope is _ReuseScope.ACTIONABLE:
+        clean_metadata, idempotency = _idempotency_metadata(clean_metadata)
+        idempotency["key_kind"] = _DERIVED_KEY_KIND
 
+    now = datetime.now(timezone.utc)
     existing = None
-    if explicit_idempotency_key:
-        # A caller-supplied key promises this is the exact same request, so
-        # preserve strict idempotency across every status and expiry state.
-        existing = await session.scalar(
+    if decision.key:
+        holder = await session.scalar(
             select(LaunchHandoff).where(
                 LaunchHandoff.org_id == clean_org_id,
-                LaunchHandoff.idempotency_key == explicit_idempotency_key,
+                LaunchHandoff.idempotency_key == decision.key,
             )
         )
-    elif derived_idempotency_key:
-        # A derived key only infers that tracked work is the same. Reuse it
-        # while the handoff is still actionable; completed or expired work
-        # must not suppress a legitimate recurrence.
-        now = datetime.now(timezone.utc)
-        existing = await session.scalar(
-            select(LaunchHandoff)
-            .where(
-                LaunchHandoff.org_id == clean_org_id,
-                LaunchHandoff.idempotency_key == derived_idempotency_key,
-                LaunchHandoff.status == "open",
-                or_(
-                    LaunchHandoff.expires_at.is_(None),
-                    LaunchHandoff.expires_at > now,
-                ),
-            )
-            .order_by(LaunchHandoff.created_at.desc(), LaunchHandoff.id.desc())
-            .limit(1)
-        )
-
-        if existing is None:
-            # The schema's strict (org_id, idempotency_key) uniqueness still
-            # applies. Retire the key from its non-actionable holder so the
-            # new live occurrence can carry the stable derived key. This is
-            # key lifecycle maintenance, not an idempotency reuse.
-            stale_key_holder = await session.scalar(
-                select(LaunchHandoff)
-                .where(
-                    LaunchHandoff.org_id == clean_org_id,
-                    LaunchHandoff.idempotency_key == derived_idempotency_key,
-                )
-                .order_by(LaunchHandoff.created_at.desc(), LaunchHandoff.id.desc())
-                .limit(1)
-            )
-            if stale_key_holder is not None:
-                stale_key_holder.idempotency_key = None
+        if holder is not None:
+            if decision.reuse_scope is _ReuseScope.STRICT or _is_actionable(holder, now):
+                existing = holder
+            else:
+                _retire_derived_key(holder, now)
                 await session.flush()
 
     if existing is not None:
-        existing.metadata_ = _refire_metadata(existing.metadata_)
+        _record_refire(existing, now)
         await session.flush()
         return existing, False
 
@@ -518,7 +401,7 @@ async def create_launch_handoff_with_status(
         context_parts=_json_object_list(handoff_input.context_parts),
         repo_origin_url=_clean_optional_string(handoff_input.repo_origin_url),
         branch_hint=_clean_optional_string(handoff_input.branch_hint),
-        idempotency_key=clean_idempotency_key,
+        idempotency_key=decision.key,
         metadata_=clean_metadata,
     )
     session.add(row)

--- a/brain/systems/launch_handoffs.py
+++ b/brain/systems/launch_handoffs.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote, unquote, urlencode, urlsplit
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.launch_handoff import LaunchHandoff
@@ -442,24 +442,68 @@ async def create_launch_handoff_with_status(
     clean_target_tool = (_clean_optional_string(handoff_input.target_tool) or TARGET_CODEX).lower()
     clean_source_ref = _json_dict(handoff_input.source_ref)
     clean_metadata = _json_dict(handoff_input.metadata)
-    clean_idempotency_key = _clean_optional_string(handoff_input.idempotency_key) or (
-        derive_launch_handoff_idempotency_key(
+    explicit_idempotency_key = _clean_optional_string(handoff_input.idempotency_key)
+    derived_idempotency_key = None
+    if explicit_idempotency_key is None:
+        derived_idempotency_key = derive_launch_handoff_idempotency_key(
             clean_source_ref,
             created_by_user_id=handoff_input.created_by_user_id,
             metadata=clean_metadata,
         )
-    )
-    if clean_idempotency_key:
+    clean_idempotency_key = explicit_idempotency_key or derived_idempotency_key
+
+    existing = None
+    if explicit_idempotency_key:
+        # A caller-supplied key promises this is the exact same request, so
+        # preserve strict idempotency across every status and expiry state.
         existing = await session.scalar(
             select(LaunchHandoff).where(
                 LaunchHandoff.org_id == clean_org_id,
-                LaunchHandoff.idempotency_key == clean_idempotency_key,
+                LaunchHandoff.idempotency_key == explicit_idempotency_key,
             )
         )
-        if existing is not None:
-            existing.metadata_ = _refire_metadata(existing.metadata_)
-            await session.flush()
-            return existing, False
+    elif derived_idempotency_key:
+        # A derived key only infers that tracked work is the same. Reuse it
+        # while the handoff is still actionable; completed or expired work
+        # must not suppress a legitimate recurrence.
+        now = datetime.now(timezone.utc)
+        existing = await session.scalar(
+            select(LaunchHandoff)
+            .where(
+                LaunchHandoff.org_id == clean_org_id,
+                LaunchHandoff.idempotency_key == derived_idempotency_key,
+                LaunchHandoff.status == "open",
+                or_(
+                    LaunchHandoff.expires_at.is_(None),
+                    LaunchHandoff.expires_at > now,
+                ),
+            )
+            .order_by(LaunchHandoff.created_at.desc(), LaunchHandoff.id.desc())
+            .limit(1)
+        )
+
+        if existing is None:
+            # The schema's strict (org_id, idempotency_key) uniqueness still
+            # applies. Retire the key from its non-actionable holder so the
+            # new live occurrence can carry the stable derived key. This is
+            # key lifecycle maintenance, not an idempotency reuse.
+            stale_key_holder = await session.scalar(
+                select(LaunchHandoff)
+                .where(
+                    LaunchHandoff.org_id == clean_org_id,
+                    LaunchHandoff.idempotency_key == derived_idempotency_key,
+                )
+                .order_by(LaunchHandoff.created_at.desc(), LaunchHandoff.id.desc())
+                .limit(1)
+            )
+            if stale_key_holder is not None:
+                stale_key_holder.idempotency_key = None
+                await session.flush()
+
+    if existing is not None:
+        existing.metadata_ = _refire_metadata(existing.metadata_)
+        await session.flush()
+        return existing, False
 
     row = LaunchHandoff(
         org_id=clean_org_id,

--- a/brain/systems/runs/tool_catalog/handlers/launch_handoffs.py
+++ b/brain/systems/runs/tool_catalog/handlers/launch_handoffs.py
@@ -93,7 +93,7 @@ async def _handle_create_launch_handoff(
     }
     try:
         async with UnitOfWork() as uow:
-            row = await launch_handoffs.create_launch_handoff(
+            row, created = await launch_handoffs.create_launch_handoff_with_status(
                 uow.session,
                 launch_handoffs.LaunchHandoffCreateInput(
                     org_id=org_id,
@@ -111,11 +111,20 @@ async def _handle_create_launch_handoff(
                     idempotency_key=idempotency_key,
                     metadata=handoff_metadata,
                 ),
+                derive_rollbar_idempotency=True,
             )
             payload = launch_handoffs.serialize_launch_handoff(row)
     except launch_handoffs.LaunchHandoffError as exc:
         return json.dumps({"error": str(exc)})
-    return json.dumps({"ok": True, "handoff": payload, "launch_url": payload["launch_url"]}, default=str)
+    return json.dumps(
+        {
+            "ok": True,
+            "reused": not created,
+            "handoff": payload,
+            "launch_url": payload["launch_url"],
+        },
+        default=str,
+    )
 
 
 __all__ = ["_handle_create_launch_handoff"]

--- a/brain/systems/runs/tool_catalog/handlers/launch_handoffs.py
+++ b/brain/systems/runs/tool_catalog/handlers/launch_handoffs.py
@@ -39,6 +39,9 @@ def _current_source_ref(explicit: dict[str, Any] | None = None) -> dict[str, Any
     trigger = getattr(_agent_context, "chat_trigger", None)
     if isinstance(trigger, dict) and trigger:
         source_ref.setdefault("trigger", trigger)
+    slack_trigger = getattr(_agent_context, "slack_trigger", None)
+    if isinstance(slack_trigger, dict) and slack_trigger:
+        source_ref.setdefault("slack_trigger", slack_trigger)
     run_id = getattr(_agent_context, "run_id", None)
     if run_id is not None:
         source_ref.setdefault("illo_run_id", run_id)
@@ -70,6 +73,18 @@ async def _handle_create_launch_handoff(
     if not org_id:
         return json.dumps({"error": "create_launch_handoff could not access this workspace context"})
 
+    clean_context_parts = _clean_object_list(context_parts or [])
+    clean_acceptance_criteria = _clean_list(acceptance_criteria or [])
+    if not clean_context_parts and not clean_acceptance_criteria:
+        return json.dumps(
+            {
+                "error": (
+                    "create_launch_handoff requires context_parts or "
+                    "acceptance_criteria evidence"
+                )
+            }
+        )
+
     actor_user_id = str(getattr(_agent_context, "user_id", "") or "").strip() or None
     handoff_metadata = {
         **_clean_dict(metadata),
@@ -89,8 +104,8 @@ async def _handle_create_launch_handoff(
                     summary=summary,
                     source_surface=_current_source_surface(source_surface),
                     source_ref=_current_source_ref(source_ref),
-                    context_parts=_clean_object_list(context_parts or []),
-                    acceptance_criteria=_clean_list(acceptance_criteria or []),
+                    context_parts=clean_context_parts,
+                    acceptance_criteria=clean_acceptance_criteria,
                     repo_origin_url=repo_origin_url,
                     branch_hint=branch_hint,
                     idempotency_key=idempotency_key,

--- a/tests/test_launch_handoffs_idempotency.py
+++ b/tests/test_launch_handoffs_idempotency.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import select
 
 from brain.app.api.routers import launch_handoffs as launch_handoffs_router
 from brain.app.api.schemas.launch_handoffs import LaunchHandoffCreateRequest
 from brain.platform.db.models.launch_handoff import LaunchHandoff
 from brain.systems.launch_handoffs import (
     LaunchHandoffCreateInput,
+    LaunchHandoffError,
+    _retire_derived_key,
     create_launch_handoff_with_status,
     derive_launch_handoff_idempotency_key,
 )
@@ -20,60 +24,15 @@ from brain.systems.runs.tool_catalog.handlers.launch_handoffs import (
 )
 
 
-pytestmark = pytest.mark.asyncio
-
 _ORG_ID = "11111111-1111-4111-8111-111111111111"
 _OWNER_ID = "22222222-2222-4222-8222-222222222222"
-
-
-class _LaunchHandoffSession:
-    def __init__(self) -> None:
-        self.rows = []
-        self.flush_count = 0
-
-    async def scalar(self, statement):
-        values = {str(value) for value in statement.compile().params.values()}
-        rows = [
-            row
-            for row in self.rows
-            if str(row.org_id) in values and str(row.idempotency_key) in values
-        ]
-        sql = str(statement)
-        if "launch_handoffs.status =" in sql:
-            rows = [row for row in rows if row.status == "open"]
-        if "launch_handoffs.expires_at IS NULL" in sql:
-            now = next(
-                value
-                for value in statement.compile().params.values()
-                if isinstance(value, datetime)
-            )
-            rows = [
-                row
-                for row in rows
-                if row.expires_at is None or row.expires_at > now
-            ]
-        if "launch_handoffs.created_at DESC" in sql:
-            rows.sort(
-                key=lambda row: (row.created_at, str(row.id)),
-                reverse=True,
-            )
-        return rows[0] if rows else None
-
-    def add(self, row) -> None:
-        if not row.id:
-            row.id = f"handoff-{len(self.rows) + 1}"
-        if row.status is None:
-            row.status = "open"
-        if row.launch_count is None:
-            row.launch_count = 0
-        self.rows.append(row)
-
-    async def flush(self) -> None:
-        self.flush_count += 1
+_OTHER_OWNER_ID = "33333333-3333-4333-8333-333333333333"
+_DERIVED_PREFIX = "derived:launch-handoff:v1:"
+_RETIRED_PREFIX = "retired:lh:v1:"
 
 
 class _UnitOfWork:
-    def __init__(self, session: _LaunchHandoffSession) -> None:
+    def __init__(self, session) -> None:
         self.session = session
 
     async def __aenter__(self):
@@ -81,6 +40,24 @@ class _UnitOfWork:
 
     async def __aexit__(self, *_args):
         return False
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    return await async_sqlite_session_factory([LaunchHandoff.__table__])
+
+
+def _rollbar_source(item_number: int = 2206, occurrence: int = 1) -> dict:
+    return {
+        "slack_trigger": {
+            "text": (
+                f"<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/{item_number}|"
+                f"#{item_number} {occurrence}th occurrence: ClientError>"
+            ),
+            "thread_ts": f"1784700{occurrence}.000001",
+        },
+        "illo_run_id": occurrence,
+    }
 
 
 def _payload(
@@ -104,305 +81,263 @@ def _payload(
     )
 
 
-async def test_replaying_thirty_alerts_for_four_rollbar_items_mints_four_rows():
-    session = _LaunchHandoffSession()
+def _idempotency_state(row: LaunchHandoff) -> dict:
+    return row.metadata_["_illo_system"]["idempotency"]
 
-    for alert_index in range(30):
-        item_number = 2200 + (alert_index % 4)
-        source_ref = {
-            "trigger": {
-                "text": (
-                    f"<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/{item_number}|"
-                    f"#{item_number} {alert_index + 1}th occurrence: ClientError>"
-                ),
-                "thread_ts": f"1784700{alert_index}.000001",
+
+@pytest.mark.parametrize(
+    ("source_ref", "owner"),
+    [
+        ({}, _OWNER_ID),
+        ({"slack_trigger": {}}, _OWNER_ID),
+        ({"slack_trigger": {"text": None}}, _OWNER_ID),
+        (
+            {
+                "slack_trigger": {
+                    "text": {"url": _rollbar_source()["slack_trigger"]["text"]}
+                }
             },
-            "illo_run_id": alert_index + 1000,
-        }
-        await create_launch_handoff_with_status(session, _payload(source_ref=source_ref))
-
-    assert len(session.rows) == 4
-    assert {row.metadata_["refire_count"] for row in session.rows} == {6, 7}
-
-
-async def test_existing_open_handoff_reports_an_idempotency_hit():
-    session = _LaunchHandoffSession()
-    source_ref = {"external_id": "github:Illospace/illospace:issue:409"}
-
-    row, created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-    row.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-    replayed, replay_created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-
-    assert row.status == "open"
-    assert replayed is row
-    assert created is True
-    assert replay_created is False
-    assert len(session.rows) == 1
+            _OWNER_ID,
+        ),
+        ({"trigger": _rollbar_source()["slack_trigger"]}, _OWNER_ID),
+        ({"external_id": "Uwear-API#2206"}, _OWNER_ID),
+        ({"url": "https://github.com/Illospace/illospace/issues/409"}, _OWNER_ID),
+        ({"slack_trigger": {"text": "ordinary Slack message mentioning #2206"}}, _OWNER_ID),
+    ],
+)
+def test_key_derivation_fails_closed_without_the_rollbar_slack_contract(source_ref, owner):
+    assert derive_launch_handoff_idempotency_key(
+        source_ref,
+        created_by_user_id=owner,
+    ) is None
 
 
-async def test_launched_derived_handoff_does_not_suppress_a_new_mint():
-    session = _LaunchHandoffSession()
-    source_ref = {"external_id": "github:Illospace/illospace:issue:409"}
-    launched, _ = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-    launched.status = "launched"
-    original_refire_count = launched.metadata_.get("refire_count")
+@pytest.mark.parametrize(
+    ("occurrence", "owner", "identity_owner"),
+    [
+        (1, _OWNER_ID, _OWNER_ID),
+        (30, _OWNER_ID, _OWNER_ID),
+        (30, None, "unassigned"),
+    ],
+)
+def test_key_derivation_uses_rollbar_signature_and_explicit_owner(
+    occurrence,
+    owner,
+    identity_owner,
+):
+    expected_digest = sha256(
+        f"Uwear-API#2206\0{identity_owner}".encode("utf-8")
+    ).hexdigest()
 
-    replacement, created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-
-    assert created is True
-    assert replacement is not launched
-    assert replacement.status == "open"
-    assert launched.status == "launched"
-    assert launched.metadata_.get("refire_count") == original_refire_count
-    assert len(session.rows) == 2
-
-
-async def test_expired_derived_handoff_does_not_suppress_a_new_mint():
-    session = _LaunchHandoffSession()
-    source_ref = {"external_id": "rollbar:Uwear-API#2206"}
-    expired, _ = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-    expired.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
-    original_refire_count = expired.metadata_.get("refire_count")
-
-    replacement, created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-
-    assert created is True
-    assert replacement is not expired
-    assert expired.metadata_.get("refire_count") == original_refire_count
-    assert len(session.rows) == 2
+    assert derive_launch_handoff_idempotency_key(
+        _rollbar_source(occurrence=occurrence),
+        created_by_user_id=owner,
+    ) == f"{_DERIVED_PREFIX}{expected_digest}"
 
 
-async def test_derived_key_reuses_the_most_recent_actionable_handoff():
-    session = _LaunchHandoffSession()
-    source_ref = {"external_id": "tracked-item-with-duplicate-open-rows"}
-    derived_key = derive_launch_handoff_idempotency_key(
+def test_key_derivation_is_scoped_to_the_created_by_user():
+    source_ref = _rollbar_source()
+
+    assert derive_launch_handoff_idempotency_key(
         source_ref,
         created_by_user_id=_OWNER_ID,
-    )
-    assert derived_key is not None
-    older = LaunchHandoff(
-        id="handoff-older",
-        org_id=_ORG_ID,
-        created_by_user_id=_OWNER_ID,
-        source_ref=source_ref,
-        title="Older open handoff",
-        instructions="Older instructions",
-        idempotency_key=derived_key,
-        status="open",
-        expires_at=None,
-        metadata_={},
-    )
-    older.created_at = datetime(2026, 7, 20, tzinfo=timezone.utc)
-    newer = LaunchHandoff(
-        id="handoff-newer",
-        org_id=_ORG_ID,
-        created_by_user_id=_OWNER_ID,
-        source_ref=source_ref,
-        title="Newer open handoff",
-        instructions="Newer instructions",
-        idempotency_key=derived_key,
-        status="open",
-        expires_at=None,
-        metadata_={},
-    )
-    newer.created_at = datetime(2026, 7, 21, tzinfo=timezone.utc)
-    session.rows.extend([older, newer])
-
-    reused, created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
+    ) != derive_launch_handoff_idempotency_key(
+        source_ref,
+        created_by_user_id=_OTHER_OWNER_ID,
     )
 
-    assert created is False
-    assert reused is newer
-    assert newer.metadata_["refire_count"] == 1
-    assert older.metadata_ == {}
+
+async def test_replaying_thirty_alerts_for_four_rollbar_items_mints_four_rows(session):
+    for alert_index in range(30):
+        item_number = 2200 + (alert_index % 4)
+        await create_launch_handoff_with_status(
+            session,
+            _payload(source_ref=_rollbar_source(item_number, alert_index + 1)),
+            derive_rollbar_idempotency=True,
+        )
+
+    rows = list((await session.scalars(select(LaunchHandoff))).all())
+    assert len(rows) == 4
+    assert {_idempotency_state(row)["refire_count"] for row in rows} == {6, 7}
 
 
-async def test_stale_row_releases_derived_key_before_real_database_insert(
-    async_sqlite_session_factory,
-):
-    session = await async_sqlite_session_factory([LaunchHandoff.__table__])
-    source_ref = {"external_id": "tracked-item-recurrence"}
-    launched, _ = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-    launched.status = "launched"
-    await session.flush()
-    derived_key = launched.idempotency_key
-
-    replacement, created = await create_launch_handoff_with_status(
-        session, _payload(source_ref=source_ref)
-    )
-
-    assert created is True
-    assert replacement.idempotency_key == derived_key
-    assert launched.idempotency_key is None
-
-
-async def test_repeated_hits_bump_occurrence_metadata_without_overwriting_the_handoff():
-    session = _LaunchHandoffSession()
-    source_ref = {"tracked_issue": {"external_id": "Uwear-API#2206"}}
-    original, _ = await create_launch_handoff_with_status(
+async def test_actionable_derived_key_reuses_without_overwriting_the_handoff(session):
+    source_ref = _rollbar_source()
+    original, created = await create_launch_handoff_with_status(
         session,
         _payload(
             source_ref=source_ref,
             title="Original title",
             instructions="Original instructions",
-            metadata={"kept": "value"},
+            metadata={
+                "kept": "value",
+                "refire_count": "caller-owned",
+                "_illo_system": {"idempotency": {"refire_count": 999}},
+            },
         ),
+        derive_rollbar_idempotency=True,
+    )
+    original.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    replayed, replay_created = await create_launch_handoff_with_status(
+        session,
+        _payload(
+            source_ref=_rollbar_source(occurrence=2),
+            title="Replacement title",
+            instructions="Replacement instructions",
+            metadata={"replacement": True},
+        ),
+        derive_rollbar_idempotency=True,
     )
 
-    for replay_index in range(1, 4):
-        replayed, created = await create_launch_handoff_with_status(
-            session,
-            _payload(
-                source_ref={**source_ref, "alert_event_id": f"event-{replay_index}"},
-                title=f"Replacement title {replay_index}",
-                instructions=f"Replacement instructions {replay_index}",
-                metadata={"replacement": replay_index},
-            ),
-        )
-        assert replayed is original
-        assert created is False
-        assert replayed.metadata_["refire_count"] == replay_index
-        assert replayed.metadata_["last_refire_at"].endswith("+00:00")
-
+    assert created is True
+    assert replay_created is False
+    assert replayed is original
     assert original.title == "Original title"
     assert original.instructions == "Original instructions"
     assert original.source_ref == source_ref
     assert original.metadata_["kept"] == "value"
+    assert original.metadata_["refire_count"] == "caller-owned"
     assert "replacement" not in original.metadata_
+    assert _idempotency_state(original)["refire_count"] == 1
+    assert _idempotency_state(original)["last_refire_at"].endswith("+00:00")
 
 
-async def test_explicit_idempotency_key_takes_precedence_over_tracked_identity():
-    session = _LaunchHandoffSession()
-
-    first, first_created = await create_launch_handoff_with_status(
+@pytest.mark.parametrize(
+    ("status", "expires_at"),
+    [
+        ("launched", None),
+        ("open", datetime.now(timezone.utc) - timedelta(seconds=1)),
+    ],
+)
+async def test_non_actionable_derived_holder_is_retired_before_replacement(
+    session,
+    status,
+    expires_at,
+):
+    holder, _ = await create_launch_handoff_with_status(
         session,
-        _payload(
-            source_ref={"external_id": "ticket-A"},
-            idempotency_key="caller:shared-key",
-        ),
+        _payload(source_ref=_rollbar_source()),
+        derive_rollbar_idempotency=True,
     )
-    second, second_created = await create_launch_handoff_with_status(
+    holder.status = status
+    holder.expires_at = expires_at
+    await session.flush()
+    derived_key = holder.idempotency_key
+
+    replacement, created = await create_launch_handoff_with_status(
         session,
-        _payload(
-            source_ref={"external_id": "ticket-B"},
-            idempotency_key="caller:shared-key",
-        ),
+        _payload(source_ref=_rollbar_source(occurrence=2)),
+        derive_rollbar_idempotency=True,
     )
 
-    assert first.idempotency_key == "caller:shared-key"
-    assert first_created is True
-    assert second is first
-    assert second_created is False
-    assert len(session.rows) == 1
+    assert created is True
+    assert replacement is not holder
+    assert replacement.idempotency_key == derived_key
+    assert holder.idempotency_key.startswith(_RETIRED_PREFIX)
+    assert len(holder.idempotency_key) <= 120
+    state = _idempotency_state(holder)
+    assert state["retired_key"] == derived_key
+    assert state["retired_at"].endswith("+00:00")
+    assert state["retirement_reason"] == "derived_key_holder_not_actionable"
+    assert len((await session.scalars(select(LaunchHandoff))).all()) == 2
 
 
-async def test_explicit_key_still_dedupes_against_a_launched_handoff():
-    session = _LaunchHandoffSession()
+async def test_retired_tombstones_are_unique_across_recurrences(session):
+    first, _ = await create_launch_handoff_with_status(
+        session,
+        _payload(source_ref=_rollbar_source()),
+        derive_rollbar_idempotency=True,
+    )
+    first.status = "launched"
+    second, _ = await create_launch_handoff_with_status(
+        session,
+        _payload(source_ref=_rollbar_source(occurrence=2)),
+        derive_rollbar_idempotency=True,
+    )
+    second.status = "launched"
+    await create_launch_handoff_with_status(
+        session,
+        _payload(source_ref=_rollbar_source(occurrence=3)),
+        derive_rollbar_idempotency=True,
+    )
+
+    assert first.idempotency_key != second.idempotency_key
+    assert first.idempotency_key.startswith(_RETIRED_PREFIX)
+    assert second.idempotency_key.startswith(_RETIRED_PREFIX)
+
+
+@pytest.mark.parametrize(
+    "caller_key",
+    ["caller:strict-key", f"{_DERIVED_PREFIX}caller-controlled"],
+)
+def test_retirement_refuses_a_caller_supplied_key(caller_key):
+    row = LaunchHandoff(
+        id="44444444-4444-4444-8444-444444444444",
+        org_id=_ORG_ID,
+        title="Caller keyed",
+        instructions="Keep strict",
+        idempotency_key=caller_key,
+        metadata_={},
+    )
+
+    with pytest.raises(LaunchHandoffError, match="caller-supplied"):
+        _retire_derived_key(row, datetime.now(timezone.utc))
+
+    assert row.idempotency_key == caller_key
+    assert row.metadata_ == {}
+
+
+async def test_explicit_key_remains_strict_after_launch(session):
     explicit_key = "caller:strict-request-key"
     launched, _ = await create_launch_handoff_with_status(
         session,
-        _payload(source_ref={}, idempotency_key=explicit_key),
+        _payload(source_ref=_rollbar_source(), idempotency_key=explicit_key),
+        derive_rollbar_idempotency=True,
     )
     launched.status = "launched"
 
     replayed, created = await create_launch_handoff_with_status(
         session,
-        _payload(source_ref={}, idempotency_key=explicit_key),
+        _payload(source_ref=_rollbar_source(occurrence=2), idempotency_key=explicit_key),
+        derive_rollbar_idempotency=True,
     )
 
     assert created is False
     assert replayed is launched
-    assert replayed.status == "launched"
-    assert replayed.metadata_["refire_count"] == 1
-    assert len(session.rows) == 1
+    assert replayed.idempotency_key == explicit_key
+    assert _idempotency_state(replayed)["refire_count"] == 1
 
 
-async def test_missing_tracked_identity_preserves_null_key_and_mints_each_time():
-    session = _LaunchHandoffSession()
+async def test_missing_rollbar_identity_keeps_null_key_and_mints_each_time(session):
+    source_ref = {
+        "external_id": "Uwear-API#2206",
+        "record": {"id": 2206, "url": _rollbar_source()["slack_trigger"]["text"]},
+    }
 
-    for run_id in (100, 101):
+    for _ in range(2):
         _row, created = await create_launch_handoff_with_status(
             session,
-            _payload(
-                source_ref={
-                    "illo_run_id": run_id,
-                    "thread_ts": f"1784700{run_id}.000001",
-                    "alert_event_id": f"event-{run_id}",
-                    "record": {
-                        "id": run_id,
-                        "title": "Alert event",
-                        "status": "open",
-                    },
-                }
-            ),
+            _payload(source_ref=source_ref),
+            derive_rollbar_idempotency=True,
         )
         assert created is True
 
-    assert len(session.rows) == 2
-    assert [row.idempotency_key for row in session.rows] == [None, None]
+    rows = list((await session.scalars(select(LaunchHandoff))).all())
+    assert [row.idempotency_key for row in rows] == [None, None]
 
 
-async def test_derived_key_is_owner_scoped_and_ignores_volatile_source_fields():
-    first_ref = {
-        "rollbar_item": "Uwear-API#2206",
-        "illo_run_id": 1,
-        "thread_ts": "1784700000.000001",
-    }
-    second_ref = {
-        "rollbar_item": "uwear-api#2206",
-        "illo_run_id": 2,
-        "thread_ts": "1784709999.000001",
-    }
-
-    first = derive_launch_handoff_idempotency_key(
-        first_ref, created_by_user_id=_OWNER_ID
-    )
-    second = derive_launch_handoff_idempotency_key(
-        second_ref, created_by_user_id=_OWNER_ID
-    )
-    other_owner = derive_launch_handoff_idempotency_key(
-        first_ref,
-        created_by_user_id="33333333-3333-4333-8333-333333333333",
-    )
-
-    assert first == second
-    assert first is not None and first.startswith("derived:launch-handoff:v1:")
-    assert other_owner != first
-
-
-async def test_tool_handler_rejects_evidence_free_mint_and_accepts_evidence():
-    session = _LaunchHandoffSession()
-    uow = _UnitOfWork(session)
+async def test_tool_handler_opts_into_rollbar_identity_and_requires_evidence(session):
     context = {
         "org_id": _ORG_ID,
         "user_id": _OWNER_ID,
         "run_id": 409,
-        "slack_trigger": {
-            "text": (
-                "<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2206|"
-                "#2206 30th occurrence: ClientError>"
-            )
-        },
+        "slack_trigger": _rollbar_source()["slack_trigger"],
     }
 
     with bind_agent_context(context), patch(
         "brain.platform.db.repositories.unit_of_work.UnitOfWork",
-        return_value=uow,
+        return_value=_UnitOfWork(session),
     ):
         rejected = json.loads(
             await _handle_create_launch_handoff(
@@ -412,36 +347,51 @@ async def test_tool_handler_rejects_evidence_free_mint_and_accepts_evidence():
                 acceptance_criteria=[],
             )
         )
-        accepted = json.loads(
+        first = json.loads(
             await _handle_create_launch_handoff(
                 title="Alert with evidence",
                 instructions="Investigate it.",
                 context_parts=[{"source": "rollbar", "ref": "Uwear-API#2206"}],
-                acceptance_criteria=[],
+            )
+        )
+        replay = json.loads(
+            await _handle_create_launch_handoff(
+                title="Repeated alert",
+                instructions="Investigate it again.",
+                acceptance_criteria=["Confirm the failure."],
             )
         )
 
     assert rejected == {
         "error": "create_launch_handoff requires context_parts or acceptance_criteria evidence"
     }
-    assert accepted["ok"] is True
-    assert len(session.rows) == 1
-    assert session.rows[0].source_ref["slack_trigger"] == context["slack_trigger"]
-    assert session.rows[0].idempotency_key.startswith("derived:launch-handoff:v1:")
+    assert first["ok"] is True
+    assert first["reused"] is False
+    assert replay["handoff"]["id"] == first["handoff"]["id"]
+    # A refire must be distinguishable from the first mint so the caller can post
+    # the annotation line without a second Launch: block (issue #409, check 2).
+    assert replay["reused"] is True
+    rows = list((await session.scalars(select(LaunchHandoff))).all())
+    assert len(rows) == 1
+    assert rows[0].source_ref["slack_trigger"] == context["slack_trigger"]
+    assert rows[0].idempotency_key.startswith(_DERIVED_PREFIX)
 
 
-async def test_api_router_still_accepts_an_evidence_free_handoff():
-    session = _LaunchHandoffSession()
-
-    result = await launch_handoffs_router.create_launch_handoff(
-        LaunchHandoffCreateRequest(
-            title="Human-authored sparse handoff",
-            instructions="The human will add details after launch.",
-        ),
-        db=session,
-        user={"id": _OWNER_ID, "org_id": _ORG_ID},
+async def test_api_router_does_not_opt_into_rollbar_identity(session):
+    payload = LaunchHandoffCreateRequest(
+        title="Human-authored sparse handoff",
+        instructions="The human will add details after launch.",
+        source_ref=_rollbar_source(),
     )
 
-    assert result["handoff"]["context_parts"] == []
-    assert result["handoff"]["acceptance_criteria"] == []
-    assert len(session.rows) == 1
+    for _ in range(2):
+        result = await launch_handoffs_router.create_launch_handoff(
+            payload,
+            db=session,
+            user={"id": _OWNER_ID, "org_id": _ORG_ID},
+        )
+        assert result["handoff"]["context_parts"] == []
+        assert result["handoff"]["acceptance_criteria"] == []
+
+    rows = list((await session.scalars(select(LaunchHandoff))).all())
+    assert [row.idempotency_key for row in rows] == [None, None]

--- a/tests/test_launch_handoffs_idempotency.py
+++ b/tests/test_launch_handoffs_idempotency.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
 
 from brain.app.api.routers import launch_handoffs as launch_handoffs_router
 from brain.app.api.schemas.launch_handoffs import LaunchHandoffCreateRequest
+from brain.platform.db.models.launch_handoff import LaunchHandoff
 from brain.systems.launch_handoffs import (
     LaunchHandoffCreateInput,
     create_launch_handoff_with_status,
@@ -31,14 +33,31 @@ class _LaunchHandoffSession:
 
     async def scalar(self, statement):
         values = {str(value) for value in statement.compile().params.values()}
-        return next(
-            (
+        rows = [
+            row
+            for row in self.rows
+            if str(row.org_id) in values and str(row.idempotency_key) in values
+        ]
+        sql = str(statement)
+        if "launch_handoffs.status =" in sql:
+            rows = [row for row in rows if row.status == "open"]
+        if "launch_handoffs.expires_at IS NULL" in sql:
+            now = next(
+                value
+                for value in statement.compile().params.values()
+                if isinstance(value, datetime)
+            )
+            rows = [
                 row
-                for row in self.rows
-                if str(row.org_id) in values and str(row.idempotency_key) in values
-            ),
-            None,
-        )
+                for row in rows
+                if row.expires_at is None or row.expires_at > now
+            ]
+        if "launch_handoffs.created_at DESC" in sql:
+            rows.sort(
+                key=lambda row: (row.created_at, str(row.id)),
+                reverse=True,
+            )
+        return rows[0] if rows else None
 
     def add(self, row) -> None:
         if not row.id:
@@ -113,6 +132,7 @@ async def test_existing_open_handoff_reports_an_idempotency_hit():
     row, created = await create_launch_handoff_with_status(
         session, _payload(source_ref=source_ref)
     )
+    row.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
     replayed, replay_created = await create_launch_handoff_with_status(
         session, _payload(source_ref=source_ref)
     )
@@ -122,6 +142,113 @@ async def test_existing_open_handoff_reports_an_idempotency_hit():
     assert created is True
     assert replay_created is False
     assert len(session.rows) == 1
+
+
+async def test_launched_derived_handoff_does_not_suppress_a_new_mint():
+    session = _LaunchHandoffSession()
+    source_ref = {"external_id": "github:Illospace/illospace:issue:409"}
+    launched, _ = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+    launched.status = "launched"
+    original_refire_count = launched.metadata_.get("refire_count")
+
+    replacement, created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+
+    assert created is True
+    assert replacement is not launched
+    assert replacement.status == "open"
+    assert launched.status == "launched"
+    assert launched.metadata_.get("refire_count") == original_refire_count
+    assert len(session.rows) == 2
+
+
+async def test_expired_derived_handoff_does_not_suppress_a_new_mint():
+    session = _LaunchHandoffSession()
+    source_ref = {"external_id": "rollbar:Uwear-API#2206"}
+    expired, _ = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+    expired.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    original_refire_count = expired.metadata_.get("refire_count")
+
+    replacement, created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+
+    assert created is True
+    assert replacement is not expired
+    assert expired.metadata_.get("refire_count") == original_refire_count
+    assert len(session.rows) == 2
+
+
+async def test_derived_key_reuses_the_most_recent_actionable_handoff():
+    session = _LaunchHandoffSession()
+    source_ref = {"external_id": "tracked-item-with-duplicate-open-rows"}
+    derived_key = derive_launch_handoff_idempotency_key(
+        source_ref,
+        created_by_user_id=_OWNER_ID,
+    )
+    assert derived_key is not None
+    older = LaunchHandoff(
+        id="handoff-older",
+        org_id=_ORG_ID,
+        created_by_user_id=_OWNER_ID,
+        source_ref=source_ref,
+        title="Older open handoff",
+        instructions="Older instructions",
+        idempotency_key=derived_key,
+        status="open",
+        expires_at=None,
+        metadata_={},
+    )
+    older.created_at = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    newer = LaunchHandoff(
+        id="handoff-newer",
+        org_id=_ORG_ID,
+        created_by_user_id=_OWNER_ID,
+        source_ref=source_ref,
+        title="Newer open handoff",
+        instructions="Newer instructions",
+        idempotency_key=derived_key,
+        status="open",
+        expires_at=None,
+        metadata_={},
+    )
+    newer.created_at = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    session.rows.extend([older, newer])
+
+    reused, created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+
+    assert created is False
+    assert reused is newer
+    assert newer.metadata_["refire_count"] == 1
+    assert older.metadata_ == {}
+
+
+async def test_stale_row_releases_derived_key_before_real_database_insert(
+    async_sqlite_session_factory,
+):
+    session = await async_sqlite_session_factory([LaunchHandoff.__table__])
+    source_ref = {"external_id": "tracked-item-recurrence"}
+    launched, _ = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+    launched.status = "launched"
+    await session.flush()
+    derived_key = launched.idempotency_key
+
+    replacement, created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+
+    assert created is True
+    assert replacement.idempotency_key == derived_key
+    assert launched.idempotency_key is None
 
 
 async def test_repeated_hits_bump_occurrence_metadata_without_overwriting_the_handoff():
@@ -181,6 +308,27 @@ async def test_explicit_idempotency_key_takes_precedence_over_tracked_identity()
     assert first_created is True
     assert second is first
     assert second_created is False
+    assert len(session.rows) == 1
+
+
+async def test_explicit_key_still_dedupes_against_a_launched_handoff():
+    session = _LaunchHandoffSession()
+    explicit_key = "caller:strict-request-key"
+    launched, _ = await create_launch_handoff_with_status(
+        session,
+        _payload(source_ref={}, idempotency_key=explicit_key),
+    )
+    launched.status = "launched"
+
+    replayed, created = await create_launch_handoff_with_status(
+        session,
+        _payload(source_ref={}, idempotency_key=explicit_key),
+    )
+
+    assert created is False
+    assert replayed is launched
+    assert replayed.status == "launched"
+    assert replayed.metadata_["refire_count"] == 1
     assert len(session.rows) == 1
 
 

--- a/tests/test_launch_handoffs_idempotency.py
+++ b/tests/test_launch_handoffs_idempotency.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from brain.app.api.routers import launch_handoffs as launch_handoffs_router
+from brain.app.api.schemas.launch_handoffs import LaunchHandoffCreateRequest
+from brain.systems.launch_handoffs import (
+    LaunchHandoffCreateInput,
+    create_launch_handoff_with_status,
+    derive_launch_handoff_idempotency_key,
+)
+from brain.systems.runs.execution_context import bind_agent_context
+from brain.systems.runs.tool_catalog.handlers.launch_handoffs import (
+    _handle_create_launch_handoff,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+_ORG_ID = "11111111-1111-4111-8111-111111111111"
+_OWNER_ID = "22222222-2222-4222-8222-222222222222"
+
+
+class _LaunchHandoffSession:
+    def __init__(self) -> None:
+        self.rows = []
+        self.flush_count = 0
+
+    async def scalar(self, statement):
+        values = {str(value) for value in statement.compile().params.values()}
+        return next(
+            (
+                row
+                for row in self.rows
+                if str(row.org_id) in values and str(row.idempotency_key) in values
+            ),
+            None,
+        )
+
+    def add(self, row) -> None:
+        if not row.id:
+            row.id = f"handoff-{len(self.rows) + 1}"
+        if row.status is None:
+            row.status = "open"
+        if row.launch_count is None:
+            row.launch_count = 0
+        self.rows.append(row)
+
+    async def flush(self) -> None:
+        self.flush_count += 1
+
+
+class _UnitOfWork:
+    def __init__(self, session: _LaunchHandoffSession) -> None:
+        self.session = session
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _payload(
+    *,
+    source_ref: dict,
+    title: str = "Investigate Rollbar alert",
+    instructions: str = "Fetch the evidence and fix the tracked issue.",
+    idempotency_key: str | None = None,
+    metadata: dict | None = None,
+) -> LaunchHandoffCreateInput:
+    return LaunchHandoffCreateInput(
+        org_id=_ORG_ID,
+        created_by_user_id=_OWNER_ID,
+        title=title,
+        instructions=instructions,
+        source_ref=source_ref,
+        context_parts=[{"source": "rollbar", "ref": "Uwear-API#2206"}],
+        acceptance_criteria=["The tracked failure no longer refires."],
+        idempotency_key=idempotency_key,
+        metadata=metadata or {},
+    )
+
+
+async def test_replaying_thirty_alerts_for_four_rollbar_items_mints_four_rows():
+    session = _LaunchHandoffSession()
+
+    for alert_index in range(30):
+        item_number = 2200 + (alert_index % 4)
+        source_ref = {
+            "trigger": {
+                "text": (
+                    f"<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/{item_number}|"
+                    f"#{item_number} {alert_index + 1}th occurrence: ClientError>"
+                ),
+                "thread_ts": f"1784700{alert_index}.000001",
+            },
+            "illo_run_id": alert_index + 1000,
+        }
+        await create_launch_handoff_with_status(session, _payload(source_ref=source_ref))
+
+    assert len(session.rows) == 4
+    assert {row.metadata_["refire_count"] for row in session.rows} == {6, 7}
+
+
+async def test_existing_open_handoff_reports_an_idempotency_hit():
+    session = _LaunchHandoffSession()
+    source_ref = {"external_id": "github:Illospace/illospace:issue:409"}
+
+    row, created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+    replayed, replay_created = await create_launch_handoff_with_status(
+        session, _payload(source_ref=source_ref)
+    )
+
+    assert row.status == "open"
+    assert replayed is row
+    assert created is True
+    assert replay_created is False
+    assert len(session.rows) == 1
+
+
+async def test_repeated_hits_bump_occurrence_metadata_without_overwriting_the_handoff():
+    session = _LaunchHandoffSession()
+    source_ref = {"tracked_issue": {"external_id": "Uwear-API#2206"}}
+    original, _ = await create_launch_handoff_with_status(
+        session,
+        _payload(
+            source_ref=source_ref,
+            title="Original title",
+            instructions="Original instructions",
+            metadata={"kept": "value"},
+        ),
+    )
+
+    for replay_index in range(1, 4):
+        replayed, created = await create_launch_handoff_with_status(
+            session,
+            _payload(
+                source_ref={**source_ref, "alert_event_id": f"event-{replay_index}"},
+                title=f"Replacement title {replay_index}",
+                instructions=f"Replacement instructions {replay_index}",
+                metadata={"replacement": replay_index},
+            ),
+        )
+        assert replayed is original
+        assert created is False
+        assert replayed.metadata_["refire_count"] == replay_index
+        assert replayed.metadata_["last_refire_at"].endswith("+00:00")
+
+    assert original.title == "Original title"
+    assert original.instructions == "Original instructions"
+    assert original.source_ref == source_ref
+    assert original.metadata_["kept"] == "value"
+    assert "replacement" not in original.metadata_
+
+
+async def test_explicit_idempotency_key_takes_precedence_over_tracked_identity():
+    session = _LaunchHandoffSession()
+
+    first, first_created = await create_launch_handoff_with_status(
+        session,
+        _payload(
+            source_ref={"external_id": "ticket-A"},
+            idempotency_key="caller:shared-key",
+        ),
+    )
+    second, second_created = await create_launch_handoff_with_status(
+        session,
+        _payload(
+            source_ref={"external_id": "ticket-B"},
+            idempotency_key="caller:shared-key",
+        ),
+    )
+
+    assert first.idempotency_key == "caller:shared-key"
+    assert first_created is True
+    assert second is first
+    assert second_created is False
+    assert len(session.rows) == 1
+
+
+async def test_missing_tracked_identity_preserves_null_key_and_mints_each_time():
+    session = _LaunchHandoffSession()
+
+    for run_id in (100, 101):
+        _row, created = await create_launch_handoff_with_status(
+            session,
+            _payload(
+                source_ref={
+                    "illo_run_id": run_id,
+                    "thread_ts": f"1784700{run_id}.000001",
+                    "alert_event_id": f"event-{run_id}",
+                    "record": {
+                        "id": run_id,
+                        "title": "Alert event",
+                        "status": "open",
+                    },
+                }
+            ),
+        )
+        assert created is True
+
+    assert len(session.rows) == 2
+    assert [row.idempotency_key for row in session.rows] == [None, None]
+
+
+async def test_derived_key_is_owner_scoped_and_ignores_volatile_source_fields():
+    first_ref = {
+        "rollbar_item": "Uwear-API#2206",
+        "illo_run_id": 1,
+        "thread_ts": "1784700000.000001",
+    }
+    second_ref = {
+        "rollbar_item": "uwear-api#2206",
+        "illo_run_id": 2,
+        "thread_ts": "1784709999.000001",
+    }
+
+    first = derive_launch_handoff_idempotency_key(
+        first_ref, created_by_user_id=_OWNER_ID
+    )
+    second = derive_launch_handoff_idempotency_key(
+        second_ref, created_by_user_id=_OWNER_ID
+    )
+    other_owner = derive_launch_handoff_idempotency_key(
+        first_ref,
+        created_by_user_id="33333333-3333-4333-8333-333333333333",
+    )
+
+    assert first == second
+    assert first is not None and first.startswith("derived:launch-handoff:v1:")
+    assert other_owner != first
+
+
+async def test_tool_handler_rejects_evidence_free_mint_and_accepts_evidence():
+    session = _LaunchHandoffSession()
+    uow = _UnitOfWork(session)
+    context = {
+        "org_id": _ORG_ID,
+        "user_id": _OWNER_ID,
+        "run_id": 409,
+        "slack_trigger": {
+            "text": (
+                "<https://app.rollbar.com/a/uwear/fix/item/Uwear-API/2206|"
+                "#2206 30th occurrence: ClientError>"
+            )
+        },
+    }
+
+    with bind_agent_context(context), patch(
+        "brain.platform.db.repositories.unit_of_work.UnitOfWork",
+        return_value=uow,
+    ):
+        rejected = json.loads(
+            await _handle_create_launch_handoff(
+                title="Evidence-free alert",
+                instructions="Investigate it.",
+                context_parts=[],
+                acceptance_criteria=[],
+            )
+        )
+        accepted = json.loads(
+            await _handle_create_launch_handoff(
+                title="Alert with evidence",
+                instructions="Investigate it.",
+                context_parts=[{"source": "rollbar", "ref": "Uwear-API#2206"}],
+                acceptance_criteria=[],
+            )
+        )
+
+    assert rejected == {
+        "error": "create_launch_handoff requires context_parts or acceptance_criteria evidence"
+    }
+    assert accepted["ok"] is True
+    assert len(session.rows) == 1
+    assert session.rows[0].source_ref["slack_trigger"] == context["slack_trigger"]
+    assert session.rows[0].idempotency_key.startswith("derived:launch-handoff:v1:")
+
+
+async def test_api_router_still_accepts_an_evidence_free_handoff():
+    session = _LaunchHandoffSession()
+
+    result = await launch_handoffs_router.create_launch_handoff(
+        LaunchHandoffCreateRequest(
+            title="Human-authored sparse handoff",
+            instructions="The human will add details after launch.",
+        ),
+        db=session,
+        user={"id": _OWNER_ID, "org_id": _ORG_ID},
+    )
+
+    assert result["handoff"]["context_parts"] == []
+    assert result["handoff"]["acceptance_criteria"] == []
+    assert len(session.rows) == 1


### PR DESCRIPTION
Closes #409

## What this fixes

During the 2026-07-21 prod Rollbar storm, Illo minted roughly one launch handoff
per alert — `packets.outcomes` reported **37 minted / 0 launched / 37 pending in
30h, 31 of them to a single member**. Triage *correctly* recognised the refires
("Known Rollbar refire — not filing a duplicate") but the mint path had no
equivalent gate.

Root cause: `idempotency_key` was **optional and purely caller-supplied**.
`create_launch_handoff_with_status` deduped correctly *when a key was present* —
and the runtime agent never supplied one, so every refire was a fresh row. The
dedup machinery existed and was never engaged.

This adds a durable guard that holds **regardless of what triage concludes**:

1. **Identity-derived key.** When the launch tool mints without an explicit key,
   the key is derived from the Rollbar item in `slack_trigger.text` (via the
   repo's existing `parse_rollbar_alert`) plus the intended owner. No Rollbar
   identity → **fail closed**: key stays `NULL` and behaviour is unchanged.
2. **Actionable-only reuse.** A derived key matches only a still-`open`,
   unexpired handoff. A launched or expired row must never suppress a legitimate
   recurrence — that would turn a noise bug into work loss. Caller-supplied keys
   keep today's strict, unfiltered idempotency (the API/MCP routers depend on it).
3. **Refire recorded, not swallowed.** A reuse bumps `refire_count` /
   `last_refire_at` under a namespaced `_illo_system.idempotency` blob, and the
   tool now returns `reused: true` so a refire posts the annotation line without
   a second `Launch:` block.
4. **Evidence gate.** The tool handler refuses to mint when there is neither
   `context_parts` nor `acceptance_criteria`, returning a structured error rather
   than a packet that renders `Evidence: none gathered`. Applied in the tool
   handler only — the human/API routers may still create sparse handoffs.

No schema change and no migration: `status`, `expires_at` and `idempotency_key`
already exist.

## How to check it without reading the diff

```
python -m pytest -q tests/test_launch_handoffs_idempotency.py tests/test_deploy_state.py \
  tests/test_external_agent_routes.py tests/test_tool_registry.py tests/test_models_all.py
```

**311 passed** on the full reviewed suite (run by the orchestrator, not only by
the implementer). The headline test replays 30 alerts across 4 distinct Rollbar
items and asserts **4 rows**, not 30.

Acceptance checks, mapped to the issue:
1. ✅ Replaying the 4-signature / ~30-message sequence creates ≤ 4 rows —
   `test_replaying_thirty_alerts_for_four_rollbar_items_mints_four_rows`.
2. ✅ A second alert on an item with an open handoff creates no new row and is
   flagged `reused: true` so no second `Launch:` block is posted.
3. ✅ No packet is minted whose brief would render `Evidence: none gathered`.
4. ⏳ Observational — verify with `illo_read packets.outcomes since_hours=24` after
   this ships.

## What I deliberately left out

- **The triage-skill refire gate** (the issue's fix #1). That wording lives in the
  `uwear-engineering-triage` bundle, which **PR #415 is currently rewriting** —
  editing it here would collide. This PR is the code-level defence; the prompt-level
  gate should follow once #415 lands.
- **The brief-body field dump** (the issue's fix #4, the packet quoting Rollbar
  #2269 for an alert about #2295). The issue notes that template is
  runtime-authored and not in this repo.
- **Documenting `reused` in the tool schema.** That description lives in
  `tool_catalog/registry.py`, another file #415 owns. Worth a one-line follow-up
  after #415 merges so the agent is told explicitly what `reused: true` means.

## Review notes worth your eye

- Two defects were caught before this opened, both written into the history:
  first, the derived key made the previously-dormant unfiltered lookup fire
  forever, so an already-launched handoff would silently suppress a real
  recurrence; second, a maintainability review found the original identity
  extraction matched field shapes **no producer emits** — they existed only in the
  PR's own tests — with a generic nested-id fallback that could collapse distinct
  handoffs behind a hash. Cutting it back to the real Rollbar contract shrank the
  service diff from 278 to 165 lines.
- `parse_rollbar_alert` is imported from `brain.systems.deploy_state`. PR #415
  moves the implementation to `brain.platform.provider_alerts` but keeps it
  importable from `deploy_state`, so this import is correct both before and after
  #415. If that re-export is ever dropped, this import moves with it.
- Concurrency: two simultaneous recurrences can race between the retire and the
  insert and one may hit the `uq_launch_handoffs_org_idempotency` constraint. That
  race predates this change; it is transient and not worth a lock here, but it is
  a real edge.
