### PR TITLE
feat(memory): add auditable nightly expiry maintenance (#417)

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -252,6 +252,14 @@ def _nightly_wrapper_commands(target_date: date, *, split_steps: bool) -> list[l
 
     return [
         ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"],
+        [
+            "python3",
+            "-m",
+            "brain.jobs.pipelines.nightly_memory_maintenance",
+            "--date",
+            target_date.isoformat(),
+            "--apply",
+        ],
         ["python3", "-m", "brain.app.cli.skills", "evolve"],
         ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"],
         ["python3", "-m", "brain.app.cli.meta_learn", "evolve"],
@@ -275,6 +283,14 @@ def _nightly_wrapper_commands(target_date: date, *, split_steps: bool) -> list[l
 def _nightly_step_commands(step_key: str, target_date: date) -> list[list[str]]:
     mapping: dict[str, list[list[str]]] = {
         "memory_consolidation": [["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"]],
+        "nightly_memory_maintenance": [[
+            "python3",
+            "-m",
+            "brain.jobs.pipelines.nightly_memory_maintenance",
+            "--date",
+            target_date.isoformat(),
+            "--apply",
+        ]],
         "skill_evolution": [["python3", "-m", "brain.app.cli.skills", "evolve"]],
         "meta_learning": [
             ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"],

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -10,6 +10,7 @@ from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 
 NIGHTLY_SLEEP_STEP_KEYS: tuple[str, ...] = (
     "memory_consolidation",
+    "nightly_memory_maintenance",
     "skill_evolution",
     "meta_learning",
     "heuristic_review",
@@ -31,6 +32,10 @@ NIGHTLY_SLEEP_STEP_BUDGET_HINTS: dict[str, dict[str, object]] = {
     "memory_consolidation": {
         "work_type": "memory_conflict_resolution",
         "estimated_tokens": 18_000,
+    },
+    "nightly_memory_maintenance": {
+        "work_type": "memory_conflict_resolution",
+        "estimated_tokens": 1_000,
     },
     "skill_evolution": {
         "work_type": "skill_eval",
@@ -238,6 +243,11 @@ def _nightly_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     target_date = _target_date(job, run)
     return [
         StepSpec("consolidate_all", ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"], "Memory consolidation"),
+        StepSpec(
+            "nightly_memory_maintenance",
+            ["python3", "-m", "brain.jobs.pipelines.nightly_memory_maintenance", "--date", target_date, "--apply"],
+            "Auditable memory expiry maintenance",
+        ),
         StepSpec("skill_evolution", ["python3", "-m", "brain.app.cli.skills", "evolve"], "Skill evolution"),
         StepSpec("meta_learning_cross_pollinate", ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"], "Meta-learning cross-pollination"),
         StepSpec("meta_learning_evolve", ["python3", "-m", "brain.app.cli.meta_learn", "evolve"], "Meta-learning evolve"),

--- a/brain/jobs/pipelines/nightly_memory_maintenance.py
+++ b/brain/jobs/pipelines/nightly_memory_maintenance.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Auditable nightly expiry maintenance for reconstructive memory."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import date, datetime, timedelta, timezone
+from time import perf_counter
+from typing import Any
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+)
+from brain.platform.db.models.system import ConsolidationRun
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.reconstructive_memory.curation import archive_memory_by_policy
+
+EXPIRY_GRACE_DAYS = 7
+EXPIRY_RULE = "explicit_valid_until_at_least_7_days_past"
+EXPIRY_POLICY_VERSION = "evidence-bound-expiry-v1"
+PROTECTED_CONTENT_KINDS = frozenset({"policy", "procedure", "lesson"})
+SUMMARY_CONTENT_KIND = "summary"
+
+
+def _utcnow(now: datetime | None = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _is_protected_kind(node: MemoryNode) -> bool:
+    return str(node.content_kind or "").strip().lower() in PROTECTED_CONTENT_KINDS
+
+
+async def _expired_content_nodes(
+    session: AsyncSession,
+    *,
+    cutoff: datetime,
+    org_id: str | None,
+    lock: bool,
+) -> list[MemoryNode]:
+    statement = (
+        select(MemoryNode)
+        .where(MemoryNode.node_kind == "content")
+        .where(MemoryNode.archived_at.is_(None))
+        .where(MemoryNode.valid_until.isnot(None))
+        .where(MemoryNode.valid_until <= cutoff)
+        .order_by(MemoryNode.id)
+    )
+    if org_id is not None:
+        statement = statement.where(MemoryNode.org_id == org_id)
+    if lock:
+        statement = statement.with_for_update(of=MemoryNode)
+    return list((await session.scalars(statement)).all())
+
+
+async def _active_current_summaries(
+    session: AsyncSession,
+    *,
+    now: datetime,
+    org_id: str | None,
+) -> list[MemoryNode]:
+    statement = (
+        select(MemoryNode)
+        .where(
+            or_(
+                MemoryNode.node_kind == SUMMARY_CONTENT_KIND,
+                MemoryNode.content_kind == SUMMARY_CONTENT_KIND,
+            )
+        )
+        .where(MemoryNode.archived_at.is_(None))
+        .where(MemoryNode.truth_status != "superseded")
+        .where(MemoryNode.freshness_status != "stale")
+        .where(or_(MemoryNode.valid_until.is_(None), MemoryNode.valid_until > now))
+        .order_by(MemoryNode.id)
+    )
+    if org_id is not None:
+        statement = statement.where(MemoryNode.org_id == org_id)
+    return list((await session.scalars(statement)).all())
+
+
+async def _nodes_supporting_active_summaries(
+    session: AsyncSession,
+    *,
+    candidates: list[MemoryNode],
+    summaries: list[MemoryNode],
+) -> set[int]:
+    """Find support by direct graph dependency or shared assertion span lineage."""
+
+    candidate_ids = {node.id for node in candidates}
+    summary_ids = {node.id for node in summaries}
+    if not candidate_ids or not summary_ids:
+        return set()
+
+    edge_rows = (
+        await session.execute(
+            select(MemoryEdgeNode.source_node_id, MemoryEdgeNode.target_node_id).where(
+                or_(
+                    and_(
+                        MemoryEdgeNode.source_node_id.in_(candidate_ids),
+                        MemoryEdgeNode.target_node_id.in_(summary_ids),
+                    ),
+                    and_(
+                        MemoryEdgeNode.source_node_id.in_(summary_ids),
+                        MemoryEdgeNode.target_node_id.in_(candidate_ids),
+                    ),
+                )
+            )
+        )
+    ).all()
+    supporting_ids = {
+        source_id if source_id in candidate_ids else target_id
+        for source_id, target_id in edge_rows
+    }
+
+    assertion_rows = list(
+        (
+            await session.scalars(
+                select(MemoryAssertionNode).where(
+                    MemoryAssertionNode.node_id.in_(candidate_ids | summary_ids)
+                )
+            )
+        ).all()
+    )
+    summary_span_ids = {
+        int(span_id)
+        for assertion in assertion_rows
+        if assertion.node_id in summary_ids
+        for span_id in (assertion.source_span_ids or [])
+        if span_id is not None
+    }
+    if summary_span_ids:
+        supporting_ids.update(
+            assertion.node_id
+            for assertion in assertion_rows
+            if assertion.node_id in candidate_ids
+            and summary_span_ids.intersection(
+                int(span_id)
+                for span_id in (assertion.source_span_ids or [])
+                if span_id is not None
+            )
+        )
+    return supporting_ids
+
+
+def _empty_report(*, apply: bool, cutoff: datetime) -> dict[str, Any]:
+    return {
+        "mode": "apply" if apply else "dry_run",
+        "rule": EXPIRY_RULE,
+        "policy_version": EXPIRY_POLICY_VERSION,
+        "cutoff": cutoff.isoformat(),
+        "candidates": 0,
+        "candidate_node_ids": [],
+        "eligible": 0,
+        "eligible_node_ids": [],
+        "archived": 0,
+        "archived_node_ids": [],
+        "excluded_by_rule": {
+            "protected_kind": 0,
+            "supports_active_current_summary": 0,
+        },
+        "errors": 0,
+        "error_details": [],
+        "duration_ms": 0.0,
+    }
+
+
+async def run_nightly_memory_maintenance(
+    target_date: date,
+    *,
+    org_id: str | None = None,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Report or atomically apply the conservative expiry policy."""
+
+    started = perf_counter()
+    maintenance_now = _utcnow(now)
+    cutoff = maintenance_now - timedelta(days=EXPIRY_GRACE_DAYS)
+    report = _empty_report(apply=apply, cutoff=cutoff)
+
+    async with UnitOfWork() as uow:
+        run = ConsolidationRun(
+            run_date=target_date,
+            phase="nightly_memory_maintenance",
+            status="running",
+            org_id=org_id,
+            memories_created=0,
+            edges_created=0,
+            memories_decayed=0,
+        )
+        uow.session.add(run)
+        await uow.session.flush()
+
+        try:
+            # A savepoint keeps the run ledger writable if candidate planning or
+            # curation fails, while the outer unit of work remains one atomic
+            # database transaction.
+            async with uow.session.begin_nested():
+                candidates = await _expired_content_nodes(
+                    uow.session,
+                    cutoff=cutoff,
+                    org_id=org_id,
+                    lock=apply,
+                )
+                summaries = await _active_current_summaries(
+                    uow.session,
+                    now=maintenance_now,
+                    org_id=org_id,
+                )
+                summary_support_ids = await _nodes_supporting_active_summaries(
+                    uow.session,
+                    candidates=candidates,
+                    summaries=summaries,
+                )
+
+                protected_ids = {node.id for node in candidates if _is_protected_kind(node)}
+                summary_excluded_ids = summary_support_ids - protected_ids
+                eligible_nodes = [
+                    node
+                    for node in candidates
+                    if node.id not in protected_ids and node.id not in summary_support_ids
+                ]
+                report.update(
+                    {
+                        "candidates": len(candidates),
+                        "candidate_node_ids": [node.id for node in candidates],
+                        "eligible": len(eligible_nodes),
+                        "eligible_node_ids": [node.id for node in eligible_nodes],
+                        "excluded_by_rule": {
+                            "protected_kind": len(protected_ids),
+                            "supports_active_current_summary": len(summary_excluded_ids),
+                        },
+                    }
+                )
+
+                if apply:
+                    for node in eligible_nodes:
+                        reason = (
+                            f"The node's explicit valid_until {node.valid_until.isoformat()} "
+                            f"is on or before the seven-day grace cutoff {cutoff.isoformat()}, "
+                            "and no protected kind or active current summary dependency applies."
+                        )
+                        await archive_memory_by_policy(
+                            uow.session,
+                            node=node,
+                            rule=EXPIRY_RULE,
+                            policy_version=EXPIRY_POLICY_VERSION,
+                            run_id=run.id,
+                            reason=reason,
+                        )
+                    report["archived"] = len(eligible_nodes)
+                    report["archived_node_ids"] = [node.id for node in eligible_nodes]
+        except Exception as exc:
+            report["errors"] = 1
+            report["error_details"] = [
+                {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            ]
+            report["archived"] = 0
+            report["archived_node_ids"] = []
+
+        report["duration_ms"] = round((perf_counter() - started) * 1000, 3)
+        report["run_id"] = run.id
+        run.status = "failed" if report["errors"] else "completed"
+        run.completed_at = maintenance_now
+        run.memories_decayed = int(report["archived"])
+        run.summary = json.dumps(report, sort_keys=True)
+        await uow.session.flush()
+
+    return report
+
+
+async def _async_main(args: argparse.Namespace) -> dict[str, Any]:
+    target = (
+        datetime.strptime(args.date, "%Y-%m-%d").date()
+        if args.date
+        else (datetime.now(timezone.utc) - timedelta(days=1)).date()
+    )
+    return await run_nightly_memory_maintenance(
+        target,
+        org_id=args.org_id,
+        apply=args.apply,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", help="Target date (YYYY-MM-DD), default yesterday")
+    parser.add_argument("--org-id")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--apply",
+        dest="apply",
+        action="store_true",
+        help="Soft-archive eligible nodes (default: report-only dry run)",
+    )
+    mode.add_argument(
+        "--dry-run",
+        dest="apply",
+        action="store_false",
+        help="Report eligible nodes without archiving (the default)",
+    )
+    parser.set_defaults(apply=False)
+    args = parser.parse_args()
+    report = asyncio.run(_async_main(args))
+    print(json.dumps(report, sort_keys=True))
+    if report["errors"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/brain/systems/reconstructive_memory/curation.py
+++ b/brain/systems/reconstructive_memory/curation.py
@@ -23,6 +23,7 @@ from brain.platform.db.repositories.reconstructive_memory import (
 from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
 
 CURATION_CREATED_BY = "agent_curation"
+MEMORY_CURATOR_SOURCE_KIND = "memory_curator"
 SUPERSEDED_BY_EDGE = "superseded_by"
 
 
@@ -239,6 +240,69 @@ async def archive_memories(
     }
 
 
+async def archive_memory_by_policy(
+    session: AsyncSession,
+    *,
+    node: MemoryNode,
+    rule: str,
+    policy_version: str,
+    run_id: int | str,
+    reason: str,
+) -> dict[str, Any]:
+    """Soft-archive one selected node with complete curator audit evidence."""
+
+    if node.archived_at is not None:
+        raise ValueError(f"Memory node {node.id} is already archived")
+    normalized_rule = _normalize_audit_field(rule, field="rule")
+    normalized_policy_version = _normalize_audit_field(
+        policy_version,
+        field="policy_version",
+    )
+    normalized_reason = _normalize_reason(reason)
+    audit_text = (
+        f"Rule: {normalized_rule}. Policy version: {normalized_policy_version}. "
+        f"Target node: {node.id}. Run ID: {run_id}. Reason: {normalized_reason}"
+    )
+    curation_source, spans = await MemorySourceRepository(session).create_with_spans(
+        source_kind=MEMORY_CURATOR_SOURCE_KIND,
+        source_ref=f"nightly-memory-maintenance:{run_id}:archive:{node.id}",
+        raw_content=audit_text,
+        spans=[
+            SourceSpanDraft(
+                text=audit_text,
+                locator={
+                    "kind": "memory_curation",
+                    "action": "archive",
+                    "rule": normalized_rule,
+                    "policy_version": normalized_policy_version,
+                    "target_node": node.id,
+                    "run_id": str(run_id),
+                },
+            )
+        ],
+        org_id=node.org_id,
+        user_id=node.user_id,
+        visibility=node.visibility,
+        structured_payload={
+            "action": "archive",
+            "rule": normalized_rule,
+            "policy_version": normalized_policy_version,
+            "target_node": node.id,
+            "run_id": str(run_id),
+            "reason": normalized_reason,
+            "created_by": MEMORY_CURATOR_SOURCE_KIND,
+        },
+        authority_principal=MEMORY_CURATOR_SOURCE_KIND,
+        sensitivity=node.sensitivity,
+    )
+    await ReconstructiveMemoryCompatibilityRepository(session).archive_many([node.id])
+    return {
+        "node_id": node.id,
+        "curation_source_id": curation_source.id,
+        "curation_span_id": spans[0].id,
+    }
+
+
 async def _visible_nodes_exact(
     session: AsyncSession,
     node_ids: Sequence[int],
@@ -311,4 +375,11 @@ def _normalize_reason(value: str) -> str:
     normalized = " ".join(str(value or "").split()).strip()
     if len(normalized) < 3:
         raise ValueError("reason must contain at least 3 characters")
+    return normalized
+
+
+def _normalize_audit_field(value: str, *, field: str) -> str:
+    normalized = " ".join(str(value or "").split()).strip()
+    if not normalized:
+        raise ValueError(f"{field} is required")
     return normalized

--- a/tests/test_nightly_memory_maintenance.py
+++ b/tests/test_nightly_memory_maintenance.py
@@ -1,0 +1,462 @@
+"""Acceptance coverage for auditable nightly memory expiry maintenance."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func, select, text, update
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+from brain.jobs.pipelines.nightly_memory_maintenance import (
+    EXPIRY_POLICY_VERSION,
+    EXPIRY_RULE,
+    run_nightly_memory_maintenance,
+)
+from brain.platform.db.models.org import Org, User
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+    ReconstructionEvidence,
+    ReconstructionFeedback,
+    ReconstructionRun,
+    ReconstructionStep,
+)
+from brain.platform.db.models.system import ConsolidationRun
+from brain.platform.db.repositories.reconstructive_memory import (
+    AssertionDraft,
+    EdgeDraft,
+    MemoryAssertionRepository,
+    MemoryEdgeRepository,
+    MemoryNodeRepository,
+    MemorySourceRepository,
+    NodeDraft,
+    SourceSpanDraft,
+)
+from brain.systems.reconstructive_memory.controller import reconstruct_memory
+from brain.systems.reconstructive_memory.curation import archive_memory_by_policy
+
+SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "JSON"
+SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "VARCHAR(36)"
+
+pytestmark = pytest.mark.asyncio
+
+ORG_ID = "00000000000000000000000000000417"
+USER_ID = "00000000000000000000000000000418"
+NOW = datetime(2026, 7, 22, 12, 0, tzinfo=timezone.utc)
+
+
+async def _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    del sqlite_postgres_ddl_patch
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            MemorySource.__table__,
+            MemorySpan.__table__,
+            MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
+            MemoryEdgeNode.__table__,
+            ConsolidationRun.__table__,
+            ReconstructionRun.__table__,
+            ReconstructionStep.__table__,
+            ReconstructionEvidence.__table__,
+            ReconstructionFeedback.__table__,
+        ],
+        enable_foreign_keys=True,
+    )
+    await session.execute(text("CREATE TABLE IF NOT EXISTS agent_runs (id INTEGER PRIMARY KEY)"))
+    await session.execute(
+        text("INSERT INTO orgs (id, name, slug) VALUES (:id, :name, :slug)"),
+        {"id": ORG_ID, "name": "Memory Maintenance Org", "slug": "memory-maintenance-org"},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO users (id, org_id, name, email) "
+            "VALUES (:id, :org_id, :name, :email)"
+        ),
+        {
+            "id": USER_ID,
+            "org_id": ORG_ID,
+            "name": "Memory Maintainer",
+            "email": "memory-maintainer@example.com",
+        },
+    )
+    return session
+
+
+async def _source_backed_content(
+    session,
+    *,
+    label: str,
+    content_kind: str,
+    valid_until: datetime | None,
+):
+    source, spans = await MemorySourceRepository(session).create_with_spans(
+        source_kind="test_fixture",
+        source_ref=f"fixture:{label}",
+        raw_content=label,
+        spans=[SourceSpanDraft(text=label, locator={"kind": "fixture"})],
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        visibility="org",
+        authority_principal=USER_ID,
+    )
+    node = await MemoryNodeRepository(session).upsert_node(
+        draft=NodeDraft(
+            node_kind="content",
+            content_kind=content_kind,
+            canonical_label=label,
+            text=label,
+            confidence=0.9,
+            truth_status="active",
+            freshness_status="fresh",
+        ),
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        visibility="org",
+    )
+    node.valid_until = valid_until
+    assertion = await MemoryAssertionRepository(session).create_assertion(
+        draft=AssertionDraft(
+            node_id=node.id,
+            claim_text=label,
+            confidence=0.9,
+            truth_status="active",
+            source_span_ids=(spans[0].id,),
+        )
+    )
+    return source, spans[0], node, assertion
+
+
+class _UnitOfWorkForSession:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            await self.session.flush()
+        else:
+            await self.session.rollback()
+        return False
+
+
+async def _recalled_ids(session, monkeypatch, query: str) -> set[int]:
+    async def no_embedding(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "brain.systems.reconstructive_memory.controller.embed_recall_query",
+        no_embedding,
+    )
+    pack = await reconstruct_memory(
+        session,
+        query=query,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        limit=20,
+    )
+    return {item.node_id for item in pack.supporting_evidence}
+
+
+async def test_expiry_maintenance_is_auditable_idempotent_and_recall_safe(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    cutoff = NOW - timedelta(days=7)
+    eligible = await _source_backed_content(
+        session,
+        label="Eligible alpha transient fact",
+        content_kind="fact",
+        valid_until=cutoff,
+    )
+    policy = await _source_backed_content(
+        session,
+        label="Protected policy retention rule",
+        content_kind="policy",
+        valid_until=cutoff - timedelta(days=1),
+    )
+    procedure = await _source_backed_content(
+        session,
+        label="Protected procedure deployment steps",
+        content_kind="procedure",
+        valid_until=cutoff - timedelta(days=1),
+    )
+    lesson = await _source_backed_content(
+        session,
+        label="Protected lesson validation practice",
+        content_kind="lesson",
+        valid_until=cutoff - timedelta(days=1),
+    )
+    summary_support = await _source_backed_content(
+        session,
+        label="Supported beta durable evidence",
+        content_kind="fact",
+        valid_until=cutoff - timedelta(days=1),
+    )
+    recent = await _source_backed_content(
+        session,
+        label="Recent gamma transient fact",
+        content_kind="fact",
+        valid_until=NOW - timedelta(days=6),
+    )
+
+    summary = await MemoryNodeRepository(session).upsert_node(
+        draft=NodeDraft(
+            node_kind="summary",
+            content_kind="summary",
+            canonical_label="Current durable beta summary",
+            text="Current durable beta summary",
+            confidence=0.9,
+            truth_status="active",
+            freshness_status="fresh",
+        ),
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        visibility="org",
+    )
+    await MemoryAssertionRepository(session).create_assertion(
+        draft=AssertionDraft(
+            node_id=summary.id,
+            claim_text="Current durable beta summary",
+            confidence=0.9,
+            truth_status="active",
+            review_status="reviewed",
+            source_span_ids=(summary_support[1].id,),
+        )
+    )
+    summary_edge = await MemoryEdgeRepository(session).upsert_edge(
+        draft=EdgeDraft(
+            source_node_id=summary.id,
+            target_node_id=summary_support[2].id,
+            edge_kind="derived_from",
+            confidence=1.0,
+            evidence_span_ids=(summary_support[1].id,),
+            created_by="test_fixture",
+        ),
+        org_id=ORG_ID,
+        visibility="org",
+    )
+    eligible_cue = await MemoryNodeRepository(session).upsert_node(
+        draft=NodeDraft(node_kind="cue", canonical_label="eligible-alpha", confidence=0.8),
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        visibility="org",
+    )
+    eligible_edge = await MemoryEdgeRepository(session).upsert_edge(
+        draft=EdgeDraft(
+            source_node_id=eligible_cue.id,
+            target_node_id=eligible[2].id,
+            edge_kind="cue_to_content",
+            confidence=0.8,
+            evidence_span_ids=(eligible[1].id,),
+            created_by="test_fixture",
+        ),
+        org_id=ORG_ID,
+        visibility="org",
+    )
+    await session.flush()
+
+    baseline_counts = {
+        model: await session.scalar(select(func.count()).select_from(model))
+        for model in (MemoryNode, MemoryAssertionNode, MemoryEdgeNode)
+    }
+    monkeypatch.setattr(
+        "brain.jobs.pipelines.nightly_memory_maintenance.UnitOfWork",
+        lambda: _UnitOfWorkForSession(session),
+    )
+
+    dry_run = await run_nightly_memory_maintenance(
+        date(2026, 7, 22),
+        org_id=ORG_ID,
+        apply=False,
+        now=NOW,
+    )
+    assert dry_run["mode"] == "dry_run"
+    assert dry_run["candidates"] == 5
+    assert dry_run["eligible_node_ids"] == [eligible[2].id]
+    assert dry_run["archived"] == 0
+    assert dry_run["excluded_by_rule"] == {
+        "protected_kind": 3,
+        "supports_active_current_summary": 1,
+    }
+    assert dry_run["errors"] == 0
+    assert dry_run["error_details"] == []
+    assert (await session.get(MemoryNode, eligible[2].id)).archived_at is None
+    assert await session.scalar(
+        select(func.count()).select_from(MemorySource).where(
+            MemorySource.source_kind == "memory_curator"
+        )
+    ) == 0
+
+    first_apply = await run_nightly_memory_maintenance(
+        date(2026, 7, 22),
+        org_id=ORG_ID,
+        apply=True,
+        now=NOW,
+    )
+    second_apply = await run_nightly_memory_maintenance(
+        date(2026, 7, 22),
+        org_id=ORG_ID,
+        apply=True,
+        now=NOW,
+    )
+    assert first_apply["archived"] == 1
+    assert first_apply["archived_node_ids"] == [eligible[2].id]
+    assert second_apply["archived"] == 0
+    assert second_apply["eligible"] == 0
+    assert (await session.get(MemoryNode, eligible[2].id)).archived_at is not None
+    for fixture in (policy, procedure, lesson, summary_support, recent):
+        assert (await session.get(MemoryNode, fixture[2].id)).archived_at is None
+
+    runs = list(
+        (
+            await session.scalars(
+                select(ConsolidationRun).order_by(ConsolidationRun.id)
+            )
+        ).all()
+    )
+    assert [run.phase for run in runs] == ["nightly_memory_maintenance"] * 3
+    assert [run.status for run in runs] == ["completed"] * 3
+    assert [run.memories_decayed for run in runs] == [0, 1, 0]
+    summaries = [json.loads(run.summary) for run in runs]
+    assert [summary_payload["archived"] for summary_payload in summaries] == [0, 1, 0]
+    assert all(summary_payload["duration_ms"] >= 0 for summary_payload in summaries)
+    assert all(summary_payload["errors"] == 0 for summary_payload in summaries)
+    assert all(summary_payload["error_details"] == [] for summary_payload in summaries)
+
+    curator_source = (
+        await session.scalars(
+            select(MemorySource).where(MemorySource.source_kind == "memory_curator")
+        )
+    ).one()
+    curator_span = (
+        await session.scalars(
+            select(MemorySpan).where(MemorySpan.source_id == curator_source.id)
+        )
+    ).one()
+    assert curator_source.structured_payload == {
+        "action": "archive",
+        "rule": EXPIRY_RULE,
+        "policy_version": EXPIRY_POLICY_VERSION,
+        "target_node": eligible[2].id,
+        "run_id": str(first_apply["run_id"]),
+        "reason": curator_source.structured_payload["reason"],
+        "created_by": "memory_curator",
+    }
+    for expected in (
+        EXPIRY_RULE,
+        EXPIRY_POLICY_VERSION,
+        str(eligible[2].id),
+        str(first_apply["run_id"]),
+        curator_source.structured_payload["reason"],
+    ):
+        assert expected in curator_span.text
+
+    assert await session.get(MemorySource, eligible[0].id) is not None
+    assert await session.get(MemorySpan, eligible[1].id) is not None
+    assert await session.get(MemoryAssertionNode, eligible[3].id) is not None
+    assert await session.get(MemoryEdgeNode, eligible_edge.id) is not None
+    assert await session.get(MemoryEdgeNode, summary_edge.id) is not None
+    assert {
+        model: await session.scalar(select(func.count()).select_from(model))
+        for model in (MemoryNode, MemoryAssertionNode, MemoryEdgeNode)
+    } == baseline_counts
+
+    assert eligible[2].id not in await _recalled_ids(
+        session,
+        monkeypatch,
+        "Eligible alpha transient fact",
+    )
+    for fixture in (policy, procedure, lesson, summary_support):
+        assert fixture[2].id in await _recalled_ids(
+            session,
+            monkeypatch,
+            fixture[2].text,
+        )
+
+    await session.execute(
+        update(MemoryNode)
+        .where(MemoryNode.id == eligible[2].id)
+        .values(archived_at=None)
+    )
+    assert eligible[2].id in await _recalled_ids(
+        session,
+        monkeypatch,
+        "Eligible alpha transient fact",
+    )
+
+
+async def test_apply_error_rolls_back_all_archives_and_records_failure(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    first = await _source_backed_content(
+        session,
+        label="First rollback candidate",
+        content_kind="fact",
+        valid_until=NOW - timedelta(days=8),
+    )
+    second = await _source_backed_content(
+        session,
+        label="Second rollback candidate",
+        content_kind="fact",
+        valid_until=NOW - timedelta(days=8),
+    )
+    monkeypatch.setattr(
+        "brain.jobs.pipelines.nightly_memory_maintenance.UnitOfWork",
+        lambda: _UnitOfWorkForSession(session),
+    )
+    calls = 0
+
+    async def fail_after_first_archive(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("simulated curator failure")
+        return await archive_memory_by_policy(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "brain.jobs.pipelines.nightly_memory_maintenance.archive_memory_by_policy",
+        fail_after_first_archive,
+    )
+
+    report = await run_nightly_memory_maintenance(
+        date(2026, 7, 22),
+        org_id=ORG_ID,
+        apply=True,
+        now=NOW,
+    )
+    await session.refresh(first[2])
+    await session.refresh(second[2])
+
+    assert report["candidates"] == 2
+    assert report["eligible"] == 2
+    assert report["archived"] == 0
+    assert report["errors"] == 1
+    assert report["error_details"] == [
+        {"type": "RuntimeError", "message": "simulated curator failure"}
+    ]
+    assert first[2].archived_at is None
+    assert second[2].archived_at is None
+    assert await session.scalar(
+        select(func.count()).select_from(MemorySource).where(
+            MemorySource.source_kind == "memory_curator"
+        )
+    ) == 0
+    run = await session.get(ConsolidationRun, report["run_id"])
+    assert run.status == "failed"
+    assert run.memories_decayed == 0
+    assert json.loads(run.summary)["errors"] == 1

--- a/tests/test_nightly_pipeline.py
+++ b/tests/test_nightly_pipeline.py
@@ -343,6 +343,7 @@ class TestNightlySchedulerOwnership:
 
         expected_steps = {
             "memory_consolidation",
+            "nightly_memory_maintenance",
             "skill_evolution",
             "reflection",
             "dream",
@@ -354,6 +355,10 @@ class TestNightlySchedulerOwnership:
             "daily_blog",
         }
         assert expected_steps.issubset(set(NIGHTLY_SLEEP_STEP_KEYS))
+        assert NIGHTLY_SLEEP_STEP_KEYS[:2] == (
+            "memory_consolidation",
+            "nightly_memory_maintenance",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -502,8 +502,13 @@ async def test_scheduler_cutover_materializes_and_persists_split_nightly_steps(s
     assert len(created) == 1
     assert created[0].status == "recorded"
     step_plan = build_scheduler_step_plan(job)
-    assert len(step_plan) == 14
+    assert len(step_plan) == 15
     assert "skill_quality" not in {step["step_key"] for step in step_plan}
+    assert [step["step_key"] for step in step_plan[:3]] == [
+        "nightly_wrapper",
+        "memory_consolidation",
+        "nightly_memory_maintenance",
+    ]
     phase_steps = [step for step in step_plan if step["kind"] == "phase"]
     assert phase_steps[0]["payload"]["night_budget"]["work_type"] == "memory_conflict_resolution"
     assert {step["payload"]["night_budget"]["work_type"] for step in phase_steps} >= {
@@ -567,10 +572,69 @@ async def test_nightly_heuristic_review_wrappers_await_and_report_counts(monkeyp
     assert program_command == command
     assert scheduler_executor._nightly_wrapper_commands(
         date(2026, 4, 21), split_steps=False
-    )[4] == command
+    )[5] == command
     assert scheduler_executor._nightly_step_commands(
         "heuristic_review", date(2026, 4, 21)
     ) == [command]
+
+
+async def test_split_nightly_scheduler_reaches_and_settles_memory_maintenance(session):
+    job = _make_scheduler_job(
+        owner_mode="scheduler",
+        default_payload={"name": "Nightly Sleep", "scheduler_split_steps": True},
+    )
+    session.add(job)
+    await session.flush()
+    run = (
+        await async_materialize_due_runs(
+            session,
+            now=datetime(2026, 4, 21, 3, 1, tzinfo=timezone.utc),
+            allowed_owner_modes=("scheduler",),
+        )
+    )[0]
+    commands: list[list[str]] = []
+
+    def runner(command, *, cwd=None):
+        commands.append(list(command))
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    settled = await async_run_scheduler_run(
+        session,
+        run.id,
+        owner_id="memory-maintenance-test",
+        runner=runner,
+        now=datetime(2026, 4, 21, 3, 2, tzinfo=timezone.utc),
+    )
+    steps = list(
+        (
+            await session.scalars(
+                select(SchedulerRunStep)
+                .where(SchedulerRunStep.run_id == run.id)
+                .order_by(SchedulerRunStep.sequence_no)
+            )
+        ).all()
+    )
+    step_by_key = {step.step_key: step for step in steps}
+    command_modules = [
+        command[2]
+        for command in commands
+        if len(command) >= 3 and command[:2] == ["python3", "-m"]
+    ]
+
+    assert settled.status == RUN_STATUS_SETTLED_SUCCESS
+    assert step_by_key["nightly_memory_maintenance"].status == RUN_STATUS_SETTLED_SUCCESS
+    assert step_by_key["nightly_memory_maintenance"].sequence_no == (
+        step_by_key["memory_consolidation"].sequence_no + 1
+    )
+    assert command_modules.index("brain.jobs.pipelines.nightly_memory_maintenance") == (
+        command_modules.index("brain.jobs.pipelines.consolidate") + 1
+    )
+    maintenance_command = next(
+        command
+        for command in commands
+        if "brain.jobs.pipelines.nightly_memory_maintenance" in command
+    )
+    assert maintenance_command[-3:] == ["--date", "2026-04-21", "--apply"]
 
 
 async def test_scheduler_lease_claim_and_reclaim(session):


### PR DESCRIPTION
Closes #417.

First buildable slice of the sleep/dream architecture adopted in #412 / PR #413 (`docs/memory-sleep-architecture-proposal.md` §5). It establishes scheduler reachability, audit evidence, safe forgetting semantics, metrics and rollback-by-unarchive — and deliberately nothing else. No dedup, no contradiction resolution, no decay, no synthesis, **no dream generation** (the proposal is explicit that dream generation must not be the first milestone).

## What it does

A new nightly step, `nightly_memory_maintenance`, runs immediately after `memory_consolidation`. It selects content nodes whose **explicit `valid_until` is at least 7 days past**, then excludes:

- `policy` / `procedure` / `lesson` kinds, and
- anything supporting an **active current summary** — by direct graph edge *or* by shared assertion span lineage.

Everything surviving both filters is **soft-archived**. Nothing is deleted, and retrieval is untouched (it already excludes `archived_at` nodes).

## How to judge it without reading the diff

It is **report-only by default** — you can see exactly what it would do before it does anything:

```bash
python -m brain.jobs.pipelines.nightly_memory_maintenance --date 2026-07-22 --dry-run
```

That prints a JSON report: `candidates`, `eligible`, `eligible_node_ids`, `excluded_by_rule` (broken out by `protected_kind` and `supports_active_current_summary`), `errors`, `duration_ms` — and `archived: 0`, because a dry run archives nothing. Re-run with `--apply` to perform the archive; the scheduled step uses `--apply`.

Every archive writes its own audit trail. For any archived node you can pull the `memory_curator` source and read, in plain text, the rule, policy version, target node, run ID and the reason it was archived.

## Acceptance checks (all verified green)

| Check | Result |
|---|---|
| Scheduler reaches and settles the new phase | ✅ `test_scheduler.py` asserts the step lands at exactly `consolidate + 1` and the command ends `--date <date> --apply` |
| First run archives exactly the eligible fixtures; second archives zero | ✅ archived counts across three runs are `[0, 1, 0]` (dry-run, apply, re-apply) |
| Expired eligible node absent from recall; expired policy/procedure/lesson and summary-supporting nodes still retrievable | ✅ asserted against real recall, per fixture |
| Archived node's source, span, assertion and edges all still exist, and a curation source/span explains the action | ✅ each is fetched back and asserted present after archiving |
| No hard deletes; `consolidation_runs` counts match; report/dry-run before apply | ✅ `memories_decayed` = `[0, 1, 0]`, summary JSON persisted per run |
| Any failure mid-apply rolls back **every** archive | ✅ dedicated test: run settles `failed`, `memories_decayed` 0, both nodes still unarchived |

**Tests:** `pytest tests/test_nightly_memory_maintenance.py tests/test_scheduler.py tests/test_nightly_pipeline.py tests/test_reconstructive_memory.py tests/test_consolidation_restoration.py -q` → **71 passed, 1 skipped** (run by the orchestrator, not just the worker). Worker also reported 3,911 passed on the broader suite. **No migration required.**

## How the binding invariant is honored

Your 2026-07-22 ruling: a derived assertion is admissible only with **complete span lineage AND a declared epistemic status, enforced at write time**. Here that is structural — `archive_memory_by_policy()` writes the curator source and its span through a single `create_with_spans(...)` call, so there is no code path that records a curation action without its lineage. `rule`, `policy_version` and `reason` are each validated at write time and raise if empty.

**Assumption worth your eye:** this slice writes *curation evidence about an archive action*, not a derived assertion — it creates no `MemoryAssertionNode`, so I read the invariant as not yet triggered, and did not add an `epistemic_status` field. Synthesis slices will trigger it. Say so if you want the field stamped now for consistency.

## Reviewer notes

- Rollback is a savepoint around candidate planning + archiving, so a failure rolls back every archive while the run ledger row still commits as `failed` — you keep the audit record of the failed attempt.
- `memories_decayed` carries the archived count. That reuse is **mandated by the ticket** ("until a better-named metric is migrated"), not an oversight.

## Maintainability review — what it found and what I did

This diff went through the thermo-nuclear maintainability pass (Codex, cross-family) before this PR was opened. It returned four findings, three marked blocking. **I judged all three as out of scope for this slice and did not fold them in** — here is that call, so you can overrule it:

| Finding | My verdict |
|---|---|
| **[HIGH]** the nightly step list is duplicated across 5 representations and will drift | **Real, but pre-existing.** Every existing step is registered the same way; this slice added a sixth by following the established pattern. Refactoring the scheduler registry inside a slice scoped to "nothing else" is the wrong place → **filed as #424** |
| **[HIGH]** the run function fuses ledger/planning/exclusion/apply/reporting into one dict, and will become a stage orchestrator | **Deferred deliberately.** The problem materializes when a *second* stage exists; extracting typed `ExpiryPlan`/`ExpiryResult` for one stage today is speculative generality. Revisit in the slice that adds stage two |
| **[MEDIUM]** `archive_memory_by_policy()` forks the existing `archive_memories()` path | **Real, and the closest call.** The two differ in actor, visibility scoping, source kind and evidence shape, so a separate entry point was justified — but the shared "record evidence → archive" spine is duplicated. The remedy reshapes `_record_curation_source()`, which other curation operations depend on and this slice does not touch → **filed as #424** |
| **[LOW, non-blocking]** the 228-line acceptance test bundles many scenarios and uses opaque `eligible[2]` indices | Fair. Left as-is — the coverage is correct and complete; readability cleanup can ride along with #424 |

**#424** captures the two structural ones with acceptance checks. If you'd rather this PR absorb them, say so and I'll fold them in instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
