### PR TITLE
fix(deploy): drain, requeue and honestly report runs killed by a worker swap (#422)

### DIFF
--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -73,7 +73,6 @@ def _run_cancel_token(run_id: int):
 _stop_event = threading.Event()
 _runner_lock = threading.Lock()
 _runner_in_flight_lock = threading.Lock()
-_in_flight_runs = 0
 _in_flight_run_ids: set[int] = set()
 _runner_supervisor_thread: threading.Thread | None = None
 _runner_slots: list[tuple[asyncio.Task[None], asyncio.Event]] = []
@@ -133,25 +132,19 @@ def _active_runner_count() -> int:
         return sum(1 for task, stop_event in _runner_slots if not task.done() and not stop_event.is_set())
 
 
-def _increment_in_flight_runs(run_id: int | None = None) -> None:
-    global _in_flight_runs
+def _increment_in_flight_runs(run_id: int) -> None:
     with _runner_in_flight_lock:
-        _in_flight_runs += 1
-        if run_id is not None:
-            _in_flight_run_ids.add(int(run_id))
+        _in_flight_run_ids.add(int(run_id))
 
 
-def _decrement_in_flight_runs(run_id: int | None = None) -> None:
-    global _in_flight_runs
+def _decrement_in_flight_runs(run_id: int) -> None:
     with _runner_in_flight_lock:
-        _in_flight_runs -= 1
-        if run_id is not None:
-            _in_flight_run_ids.discard(int(run_id))
+        _in_flight_run_ids.discard(int(run_id))
 
 
 def runner_in_flight_count() -> int:
     with _runner_in_flight_lock:
-        return _in_flight_runs
+        return len(_in_flight_run_ids)
 
 
 def runner_in_flight_ids() -> tuple[int, ...]:

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -26,6 +26,7 @@ from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
+    interrupted_run_message,
     public_run_failure,
     safe_terminal_run_message,
 )
@@ -73,6 +74,7 @@ _stop_event = threading.Event()
 _runner_lock = threading.Lock()
 _runner_in_flight_lock = threading.Lock()
 _in_flight_runs = 0
+_in_flight_run_ids: set[int] = set()
 _runner_supervisor_thread: threading.Thread | None = None
 _runner_slots: list[tuple[asyncio.Task[None], asyncio.Event]] = []
 _runner_thread_index = 0
@@ -131,21 +133,30 @@ def _active_runner_count() -> int:
         return sum(1 for task, stop_event in _runner_slots if not task.done() and not stop_event.is_set())
 
 
-def _increment_in_flight_runs() -> None:
+def _increment_in_flight_runs(run_id: int | None = None) -> None:
     global _in_flight_runs
     with _runner_in_flight_lock:
         _in_flight_runs += 1
+        if run_id is not None:
+            _in_flight_run_ids.add(int(run_id))
 
 
-def _decrement_in_flight_runs() -> None:
+def _decrement_in_flight_runs(run_id: int | None = None) -> None:
     global _in_flight_runs
     with _runner_in_flight_lock:
         _in_flight_runs -= 1
+        if run_id is not None:
+            _in_flight_run_ids.discard(int(run_id))
 
 
 def runner_in_flight_count() -> int:
     with _runner_in_flight_lock:
         return _in_flight_runs
+
+
+def runner_in_flight_ids() -> tuple[int, ...]:
+    with _runner_in_flight_lock:
+        return tuple(sorted(_in_flight_run_ids))
 
 
 def runner_health_snapshot() -> dict[str, int | bool]:
@@ -768,32 +779,13 @@ async def _record_slack_thread_mute(
     )
 
 
-async def _settle_slack_origin_run_async(
+async def _post_slack_run_message_async(
     session,
+    *,
     run: AgentRunRow,
+    text: str,
+    artifact_id: int | None = None,
 ) -> dict[str, Any] | None:
-    if not _run_is_slack_origin(run):
-        return None
-    if _run_is_headless(run) and run.parent_run_id is not None:
-        return None
-    run_status = coerce_run_status(getattr(run, "status", None), default=RunStatus.QUEUED)
-    if run_status not in TERMINAL_RUN_STATUSES:
-        return None
-    artifact_id = None
-    if run_status == RunStatus.COMPLETED:
-        final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
-        if not final_answer or _run_is_headless(run):
-            return None
-        if await _slack_visible_action_already_recorded(session, run=run):
-            return None
-    else:
-        category = coerce_failure_category(
-            await _terminal_run_failure_category(session, run=run)
-        )
-        final_answer = safe_terminal_run_message(run_status, category)
-        if not final_answer:
-            return None
-
     target = _slack_response_target(run)
     channel_id = target["channel_id"]
     if not channel_id:
@@ -829,12 +821,12 @@ async def _settle_slack_origin_run_async(
                 }
         response = await client.post_message(
             channel=channel_id,
-            text=final_answer,
+            text=text,
             thread_ts=target["thread_ts"],
         )
         await _clear_slack_processing_status(client, target["trigger"])
     except Exception as exc:
-        logger.info("slack_final_answer_settlement_failed: %s", exc, extra={"run_id": int(run.id)})
+        logger.info("slack_run_message_failed: %s", exc, extra={"run_id": int(run.id)})
         return None
     return {
         "surface": _SLACK_SURFACE,
@@ -844,6 +836,63 @@ async def _settle_slack_origin_run_async(
         "thread_ts": target["thread_ts"],
         "slack": response,
     }
+
+
+async def _settle_slack_interrupted_run_async(
+    session,
+    run: AgentRunRow,
+    *,
+    interrupted_at: datetime | str | None,
+    requeued: bool,
+) -> dict[str, Any] | None:
+    if not _run_is_slack_origin(run):
+        return None
+    if _run_is_headless(run) and run.parent_run_id is not None:
+        return None
+    message = interrupted_run_message(
+        int(run.id),
+        interrupted_at=interrupted_at,
+        requeued=requeued,
+    )
+    return await _post_slack_run_message_async(
+        session,
+        run=run,
+        text=message,
+    )
+
+
+async def _settle_slack_origin_run_async(
+    session,
+    run: AgentRunRow,
+) -> dict[str, Any] | None:
+    if not _run_is_slack_origin(run):
+        return None
+    if _run_is_headless(run) and run.parent_run_id is not None:
+        return None
+    run_status = coerce_run_status(getattr(run, "status", None), default=RunStatus.QUEUED)
+    if run_status not in TERMINAL_RUN_STATUSES:
+        return None
+    artifact_id = None
+    if run_status == RunStatus.COMPLETED:
+        final_answer, artifact_id = await _latest_final_answer_artifact(session, run=run)
+        if not final_answer or _run_is_headless(run):
+            return None
+        if await _slack_visible_action_already_recorded(session, run=run):
+            return None
+    else:
+        category = coerce_failure_category(
+            await _terminal_run_failure_category(session, run=run)
+        )
+        final_answer = safe_terminal_run_message(run_status, category)
+        if not final_answer:
+            return None
+
+    return await _post_slack_run_message_async(
+        session,
+        run=run,
+        text=final_answer,
+        artifact_id=artifact_id,
+    )
 
 
 async def _settle_terminal_root_run_async(session, run_id: int) -> dict[str, Any] | None:
@@ -1241,6 +1290,63 @@ def _run_liveness_at(
     return max(live) if live else None
 
 
+async def _notify_interrupted_run_async(run_id: int) -> dict[str, Any] | None:
+    async with _unit_of_work_factory()() as uow:
+        run = await uow.session.get(AgentRunRow, int(run_id))
+        if run is None:
+            return None
+        metadata = _run_metadata(run)
+        interruption = metadata.get("interruption")
+        interruption = dict(interruption) if isinstance(interruption, dict) else {}
+        return await _settle_slack_interrupted_run_async(
+            uow.session,
+            run,
+            interrupted_at=interruption.get("interrupted_at"),
+            requeued=bool(interruption.get("requeued")),
+        )
+
+
+async def interrupt_and_requeue_run_ids(
+    run_ids: list[int] | tuple[int, ...],
+    *,
+    reason: str,
+    interrupted_at: datetime | None = None,
+) -> tuple[int, ...]:
+    """Durably fence worker-owned attempts, requeue them, and notify Slack."""
+
+    interrupted_at = interrupted_at or datetime.now(timezone.utc)
+    changed_ids: list[int] = []
+    async with _unit_of_work_factory()() as uow:
+        store = AsyncAgentRunStore(uow.session)
+        for run_id in sorted({int(value) for value in run_ids}):
+            _run, changed = await store.interrupt_and_requeue(
+                run_id,
+                reason=reason,
+                interrupted_at=interrupted_at,
+            )
+            if changed:
+                changed_ids.append(run_id)
+
+    for run_id in changed_ids:
+        await _notify_interrupted_run_async(run_id)
+    return tuple(changed_ids)
+
+
+def _interrupt_in_flight_runs(
+    run_ids: tuple[int, ...],
+    *,
+    reason: str,
+) -> tuple[int, ...]:
+    if not run_ids:
+        return ()
+    return asyncio.run(
+        interrupt_and_requeue_run_ids(
+            run_ids,
+            reason=reason,
+        )
+    )
+
+
 async def _reap_stale_candidate(
     session,
     store: AsyncAgentRunStore,
@@ -1249,7 +1355,7 @@ async def _reap_stale_candidate(
     root_run_id: int,
     cutoff: datetime,
     stale_after_seconds: float,
-) -> tuple[bool, dict[str, Any] | None]:
+) -> tuple[bool, int | None]:
     candidate_tx = await session.begin_nested()
     try:
         locked = await store.lock_run_liveness(int(row.id), root_run_id)
@@ -1279,7 +1385,6 @@ async def _reap_stale_candidate(
         heartbeat = metadata.get("runner_heartbeat")
         heartbeat = dict(heartbeat) if isinstance(heartbeat, dict) else {}
         payload = {
-            "error": "runner heartbeat stale",
             "reason": "runner_heartbeat_stale",
             "stale_after_seconds": int(stale_after_seconds),
             "last_heartbeat_at": heartbeat.get("at"),
@@ -1287,28 +1392,16 @@ async def _reap_stale_candidate(
             "last_liveness_at": last_liveness_at.isoformat() if last_liveness_at else None,
             "last_run_update_at": row.updated_at.isoformat() if row.updated_at else None,
         }
-        _failed_run, changed = await store.set_status_with_result(
+        _requeued_run, changed = await store.interrupt_and_requeue(
             int(row.id),
-            RunStatus.FAILED,
             reason="runner_heartbeat_stale",
-            expected_updated_at=row.updated_at,
-            expected_execution_token=row.execution_token,
-            expected_execution_attempt=int(row.execution_attempt or 0),
-            rollback_on_conflict=False,
+            details=payload,
         )
         if not changed:
             await candidate_tx.rollback()
             return False, None
-        event = run_event(int(row.id), "run.failed", payload, root_run_id=row.root_run_id)
-        event_row = await store.append_event(event)
-        await _project_live_event_async(
-            session,
-            event.event_type,
-            _event_stream_payload(event, event_row, row),
-        )
-        status_payload = await _settle_terminal_root_run_async(session, int(row.id))
         await candidate_tx.commit()
-        return True, status_payload
+        return True, int(row.id)
     except BaseException:
         if candidate_tx.is_active:
             await candidate_tx.rollback()
@@ -1324,7 +1417,7 @@ async def reap_stale_active_runs(
     now = now or datetime.now(timezone.utc)
     stale_after_seconds = stale_after_seconds if stale_after_seconds is not None else _stale_run_seconds()
     cutoff = now - timedelta(seconds=float(stale_after_seconds))
-    status_payloads: list[dict[str, Any]] = []
+    interrupted_run_ids: list[int] = []
     reaped = 0
 
     async with _unit_of_work_factory()() as uow:
@@ -1353,7 +1446,7 @@ async def reap_stale_active_runs(
             )
             if last_liveness_at is not None and last_liveness_at > cutoff:
                 continue
-            candidate_reaped, status_payload = await _reap_stale_candidate(
+            candidate_reaped, interrupted_run_id = await _reap_stale_candidate(
                 uow.session,
                 store,
                 row,
@@ -1363,14 +1456,21 @@ async def reap_stale_active_runs(
             )
             if not candidate_reaped:
                 continue
-            if status_payload:
-                status_payloads.append(status_payload)
+            if interrupted_run_id is not None:
+                interrupted_run_ids.append(interrupted_run_id)
             reaped += 1
 
-    for payload in status_payloads:
-        publish_safe("status_change", payload)
+    for run_id in interrupted_run_ids:
+        await _notify_interrupted_run_async(run_id)
     if reaped:
-        logger.warning("agent_run_stale_reaped", extra={"count": reaped, "stale_after_seconds": stale_after_seconds})
+        logger.warning(
+            "agent_run_stale_interrupted_requeued",
+            extra={
+                "count": reaped,
+                "run_ids": interrupted_run_ids,
+                "stale_after_seconds": stale_after_seconds,
+            },
+        )
     return reaped
 
 
@@ -1629,7 +1729,7 @@ async def _run_queued_once_async(*, limit: int = 1) -> int:
         async with _unit_of_work_factory()() as uow:
             ids = await AsyncAgentRunStore(uow.session).claim_next_run_ids(limit=limit)
             for _run_id in ids:
-                _increment_in_flight_runs()
+                _increment_in_flight_runs(int(_run_id))
                 remaining_in_flight += 1
 
         for run_id in ids:
@@ -1637,11 +1737,12 @@ async def _run_queued_once_async(*, limit: int = 1) -> int:
                 if await _process_claimed_run_async(int(run_id)):
                     processed += 1
             finally:
-                _decrement_in_flight_runs()
+                _decrement_in_flight_runs(int(run_id))
                 remaining_in_flight -= 1
     finally:
-        for _ in range(remaining_in_flight):
-            _decrement_in_flight_runs()
+        if remaining_in_flight:
+            for run_id in ids[-remaining_in_flight:]:
+                _decrement_in_flight_runs(int(run_id))
     return processed
 
 
@@ -1810,6 +1911,7 @@ def _runner_teardown_timeout_seconds() -> float:
 def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
     global _runner_supervisor_thread
     request_runner_stop()
+    timed_out_run_ids: tuple[int, ...] = ()
 
     deadline = None
     if drain_timeout_seconds is not None:
@@ -1821,9 +1923,11 @@ def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
             if remaining <= 0:
                 in_flight_runs = runner_in_flight_count()
                 if in_flight_runs > 0:
+                    timed_out_run_ids = runner_in_flight_ids()
                     logger.warning(
-                        "runner drain timed out with %s in-flight run(s); proceeding to teardown",
+                        "runner drain timed out with %s in-flight run(s); affected run ids: %s",
                         in_flight_runs,
+                        list(timed_out_run_ids) or "unknown",
                     )
                 break
             time.sleep(min(0.2, remaining))
@@ -1842,6 +1946,24 @@ def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
         )
     elif _runner_supervisor_thread is supervisor_thread:
         _runner_supervisor_thread = None
+
+    if timed_out_run_ids:
+        try:
+            requeued_run_ids = _interrupt_in_flight_runs(
+                timed_out_run_ids,
+                reason="worker_shutdown_drain_timeout",
+            )
+        except Exception:
+            logger.exception(
+                "runner shutdown could not requeue affected run ids: %s",
+                list(timed_out_run_ids),
+            )
+        else:
+            if requeued_run_ids:
+                logger.warning(
+                    "runner shutdown interrupted and requeued run ids: %s",
+                    list(requeued_run_ids),
+                )
 
 
 async def queue_status_async(*, consumer_running: bool | None = None, org_id: str | None = None) -> dict[str, Any]:
@@ -1874,6 +1996,7 @@ __all__ = [
     "request_runner_stop",
     "runner_health_snapshot",
     "runner_in_flight_count",
+    "runner_in_flight_ids",
     "run_queued_once",
     "start_runner",
     "stop_runner",

--- a/brain/systems/runs/failures.py
+++ b/brain/systems/runs/failures.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TypedDict
 
@@ -28,6 +29,34 @@ UPSTREAM_FAILED_RUN_MESSAGE = "I hit a temporary upstream problem — please ret
 VERIFICATION_FAILED_RUN_MESSAGE = "I couldn't safely verify the result — please retry."
 CANCELED_RUN_MESSAGE = "That run was canceled before it finished."
 EXPIRED_RUN_MESSAGE = "That run timed out before it finished — please retry."
+
+
+def interrupted_run_message(
+    run_id: int,
+    *,
+    interrupted_at: datetime | str | None = None,
+    requeued: bool,
+) -> str:
+    """Return the public status update for a worker-interrupted run."""
+
+    occurred_at = interrupted_at
+    if isinstance(occurred_at, str):
+        try:
+            occurred_at = datetime.fromisoformat(occurred_at.replace("Z", "+00:00"))
+        except ValueError:
+            occurred_at = None
+    if not isinstance(occurred_at, datetime):
+        occurred_at = datetime.now(timezone.utc)
+    if occurred_at.tzinfo is None:
+        occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+    time_label = occurred_at.astimezone(timezone.utc).strftime("%H:%M UTC")
+    prefix = f"I was interrupted by a system restart at {time_label} (run {int(run_id)})"
+    if requeued:
+        return f"{prefix}; I've re-queued it and will reply here when it finishes."
+    return (
+        f"{prefix}; I could not re-queue it. Work completed before the interruption "
+        "was preserved, but the run did not finish."
+    )
 
 
 def coerce_failure_category(value: RunFailureCategory | str | None) -> RunFailureCategory:
@@ -97,6 +126,7 @@ __all__ = [
     "CANCELED_RUN_MESSAGE",
     "DEFAULT_FAILED_RUN_MESSAGE",
     "EXPIRED_RUN_MESSAGE",
+    "interrupted_run_message",
     "PublicRunFailure",
     "RunFailureCategory",
     "UPSTREAM_FAILED_RUN_MESSAGE",

--- a/brain/systems/runs/status.py
+++ b/brain/systems/runs/status.py
@@ -50,11 +50,42 @@ assert PROCESSING_RUN_STATUS_VALUES == tuple(
 assert RUN_FAILED_STATUS_VALUE == RunStatus.FAILED.value
 
 ALLOWED_RUN_TRANSITIONS: dict[RunStatus, frozenset[RunStatus]] = {
-    RunStatus.QUEUED: frozenset({RunStatus.STARTING, RunStatus.CANCELED, RunStatus.EXPIRED, RunStatus.FAILED}),
-    RunStatus.STARTING: frozenset({RunStatus.RUNNING, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.EXPIRED}),
-    RunStatus.RUNNING: frozenset({RunStatus.PAUSED, RunStatus.VERIFYING, RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.EXPIRED}),
-    RunStatus.PAUSED: frozenset({RunStatus.RUNNING, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.EXPIRED}),
-    RunStatus.VERIFYING: frozenset({RunStatus.RUNNING, RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELED, RunStatus.EXPIRED}),
+    RunStatus.QUEUED: frozenset({
+        RunStatus.STARTING,
+        RunStatus.CANCELED,
+        RunStatus.EXPIRED,
+        RunStatus.FAILED,
+    }),
+    RunStatus.STARTING: frozenset({
+        RunStatus.QUEUED,
+        RunStatus.RUNNING,
+        RunStatus.FAILED,
+        RunStatus.CANCELED,
+        RunStatus.EXPIRED,
+    }),
+    RunStatus.RUNNING: frozenset({
+        RunStatus.QUEUED,
+        RunStatus.PAUSED,
+        RunStatus.VERIFYING,
+        RunStatus.COMPLETED,
+        RunStatus.FAILED,
+        RunStatus.CANCELED,
+        RunStatus.EXPIRED,
+    }),
+    RunStatus.PAUSED: frozenset({
+        RunStatus.RUNNING,
+        RunStatus.FAILED,
+        RunStatus.CANCELED,
+        RunStatus.EXPIRED,
+    }),
+    RunStatus.VERIFYING: frozenset({
+        RunStatus.QUEUED,
+        RunStatus.RUNNING,
+        RunStatus.COMPLETED,
+        RunStatus.FAILED,
+        RunStatus.CANCELED,
+        RunStatus.EXPIRED,
+    }),
     RunStatus.COMPLETED: frozenset(),
     RunStatus.FAILED: frozenset(),
     RunStatus.CANCELED: frozenset(),
@@ -76,13 +107,26 @@ def coerce_run_status(value: str | RunStatus | None, *, default: RunStatus = Run
     return default
 
 
-def ensure_run_transition(from_status: str | RunStatus | None, to_status: str | RunStatus) -> tuple[RunStatus, RunStatus]:
+def ensure_run_transition(
+    from_status: str | RunStatus | None,
+    to_status: str | RunStatus,
+    *,
+    allow_interrupted_requeue: bool = False,
+) -> tuple[RunStatus, RunStatus]:
     current = coerce_run_status(from_status)
     target = coerce_run_status(to_status)
     if target == current:
         return current, target
     if target not in ALLOWED_RUN_TRANSITIONS[current]:
         raise RunTransitionError(f"Invalid run transition {current.value!r} -> {target.value!r}")
+    if (
+        current in PROCESSING_RUN_STATUSES
+        and target == RunStatus.QUEUED
+        and not allow_interrupted_requeue
+    ):
+        raise RunTransitionError(
+            f"Invalid run transition {current.value!r} -> {target.value!r} outside interrupted requeue"
+        )
     return current, target
 
 

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -34,7 +34,13 @@ from brain.systems.runs.domain import (
 )
 from brain.systems.runs.events import run_event, status_changed_event
 from brain.systems.runs.ids import trace_id_for_run_id
-from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status, ensure_run_transition
+from brain.systems.runs.status import (
+    RunStatus,
+    RunTransitionError,
+    TERMINAL_RUN_STATUSES,
+    coerce_run_status,
+    ensure_run_transition,
+)
 from brain.systems.runs.steering import SteeringMessage
 from brain.platform.db.models.agent_run import (
     AgentRunArtifactRow,
@@ -886,11 +892,15 @@ class AsyncAgentRunStore:
 
         row = await self._locked_run(run_id)
         current = coerce_run_status(row.status, default=RunStatus.FAILED)
-        if current not in {
-            RunStatus.STARTING,
-            RunStatus.RUNNING,
-            RunStatus.VERIFYING,
-        }:
+        try:
+            current, target = ensure_run_transition(
+                current,
+                RunStatus.QUEUED,
+                allow_interrupted_requeue=True,
+            )
+        except RunTransitionError:
+            return to_domain(row), False
+        if current == target:
             return to_domain(row), False
 
         interrupted_at = interrupted_at or datetime.now(timezone.utc)
@@ -910,42 +920,47 @@ class AsyncAgentRunStore:
         metadata["interruption_count"] = previous_count + 1
         metadata.pop("failure", None)
 
-        row.status = RunStatus.QUEUED.value
-        row.execution_token = None
-        row.paused_at = None
-        row.updated_at = interrupted_at
-        row.metadata_ = metadata
-        await self.session.flush()
-        await self.append_event(
-            run_event(
+        auto_commit = self.auto_commit
+        self.auto_commit = False
+        try:
+            transitioned_run, changed = await self.set_status_with_result(
                 int(row.id),
-                "run.interrupted",
-                interruption,
-                root_run_id=row.root_run_id,
-                producer="worker_shutdown",
+                target,
+                reason=interruption["reason"],
+                transitioned_at=interrupted_at,
+                metadata_update=metadata,
+                allow_interrupted_requeue=True,
+                expected_updated_at=row.updated_at,
+                expected_execution_token=row.execution_token,
+                expected_execution_attempt=int(row.execution_attempt or 0),
+                before_status_events=(
+                    run_event(
+                        int(row.id),
+                        "run.interrupted",
+                        interruption,
+                        root_run_id=row.root_run_id,
+                        producer="worker_shutdown",
+                    ),
+                ),
+                after_status_events=(
+                    run_event(
+                        int(row.id),
+                        "run.requeued",
+                        interruption,
+                        root_run_id=row.root_run_id,
+                        producer="worker_shutdown",
+                    ),
+                ),
             )
-        )
-        await self.append_event(
-            status_changed_event(
-                int(row.id),
-                from_status=current.value,
-                to_status=RunStatus.QUEUED.value,
-                root_run_id=row.root_run_id,
-                reason=str(reason or "worker_shutdown"),
-            )
-        )
-        await self.append_event(
-            run_event(
-                int(row.id),
-                "run.requeued",
-                interruption,
-                root_run_id=row.root_run_id,
-                producer="worker_shutdown",
-            )
-        )
-        if self.auto_commit:
-            await self.session.commit()
-        return to_domain(await self.refresh_run(run_id)), True
+            if auto_commit:
+                await self.session.commit()
+            return transitioned_run, changed
+        except BaseException:
+            if auto_commit:
+                await self.session.rollback()
+            raise
+        finally:
+            self.auto_commit = auto_commit
 
     async def set_status_with_result(
         self,
@@ -958,6 +973,11 @@ class AsyncAgentRunStore:
         expected_execution_token: str | None | object = _UNSET,
         expected_execution_attempt: int | object = _UNSET,
         rollback_on_conflict: bool = True,
+        transitioned_at: datetime | None = None,
+        metadata_update: dict[str, Any] | None = None,
+        allow_interrupted_requeue: bool = False,
+        before_status_events: tuple[AgentRunEvent, ...] = (),
+        after_status_events: tuple[AgentRunEvent, ...] = (),
     ) -> tuple[AgentRun, bool]:
         if execution_claim is not None and execution_claim.lost.is_set():
             raise ExecutionClaimLost(
@@ -976,12 +996,18 @@ class AsyncAgentRunStore:
             )
         if persisted_status in TERMINAL_RUN_STATUSES:
             return to_domain(row), False
-        current, target = ensure_run_transition(row.status, status)
+        current, target = ensure_run_transition(
+            row.status,
+            status,
+            allow_interrupted_requeue=allow_interrupted_requeue,
+        )
         if current == target:
             if execution_claim is not None:
                 await self.assert_execution_claim(execution_claim)
             return to_domain(row), False
-        now = datetime.now(timezone.utc)
+        now = transitioned_at or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
         values: dict[str, Any] = {
             "status": target.value,
             "updated_at": now,
@@ -996,8 +1022,12 @@ class AsyncAgentRunStore:
             values["failed_at"] = now
         elif target == RunStatus.CANCELED:
             values["canceled_at"] = now
-        if target in TERMINAL_RUN_STATUSES or target == RunStatus.PAUSED:
+        if target == RunStatus.QUEUED:
+            values["paused_at"] = None
+        if target in TERMINAL_RUN_STATUSES or target in {RunStatus.PAUSED, RunStatus.QUEUED}:
             values["execution_token"] = None
+        if metadata_update is not None:
+            values["metadata_"] = dict(metadata_update)
 
         predicates = [
             AgentRunRow.id == int(run_id),
@@ -1031,6 +1061,8 @@ class AsyncAgentRunStore:
                 )
             return to_domain(await self.refresh_run(run_id)), False
 
+        for event in before_status_events:
+            await self.append_event(event)
         await self.append_event(
             status_changed_event(
                 int(run_id),
@@ -1040,6 +1072,8 @@ class AsyncAgentRunStore:
                 reason=reason,
             )
         )
+        for event in after_status_events:
+            await self.append_event(event)
         row = await self.refresh_run(run_id)
         if target in TERMINAL_RUN_STATUSES:
             await _reconcile_inbound_triage_run_if_needed(self.session, row)

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -869,6 +869,84 @@ class AsyncAgentRunStore:
         )
         return run
 
+    async def interrupt_and_requeue(
+        self,
+        run_id: int,
+        *,
+        reason: str = "worker_shutdown",
+        interrupted_at: datetime | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> tuple[AgentRun, bool]:
+        """Fence an abandoned execution attempt and return it to the queue.
+
+        ``interrupted`` is intentionally an audited event/metadata state rather
+        than a durable row status: claimers already consume ``queued`` rows, so
+        recovery remains atomic and requires no intermediate-state sweeper.
+        """
+
+        row = await self._locked_run(run_id)
+        current = coerce_run_status(row.status, default=RunStatus.FAILED)
+        if current not in {
+            RunStatus.STARTING,
+            RunStatus.RUNNING,
+            RunStatus.VERIFYING,
+        }:
+            return to_domain(row), False
+
+        interrupted_at = interrupted_at or datetime.now(timezone.utc)
+        if interrupted_at.tzinfo is None:
+            interrupted_at = interrupted_at.replace(tzinfo=timezone.utc)
+        metadata = dict(row.metadata_ or {})
+        previous_count = _coerce_int(metadata.get("interruption_count"), default=0)
+        interruption = {
+            **dict(details or {}),
+            "reason": str(reason or "worker_shutdown"),
+            "interrupted_at": interrupted_at.isoformat(),
+            "from_status": current.value,
+            "execution_attempt": int(row.execution_attempt or 0),
+            "requeued": True,
+        }
+        metadata["interruption"] = interruption
+        metadata["interruption_count"] = previous_count + 1
+        metadata.pop("failure", None)
+
+        row.status = RunStatus.QUEUED.value
+        row.execution_token = None
+        row.paused_at = None
+        row.updated_at = interrupted_at
+        row.metadata_ = metadata
+        await self.session.flush()
+        await self.append_event(
+            run_event(
+                int(row.id),
+                "run.interrupted",
+                interruption,
+                root_run_id=row.root_run_id,
+                producer="worker_shutdown",
+            )
+        )
+        await self.append_event(
+            status_changed_event(
+                int(row.id),
+                from_status=current.value,
+                to_status=RunStatus.QUEUED.value,
+                root_run_id=row.root_run_id,
+                reason=str(reason or "worker_shutdown"),
+            )
+        )
+        await self.append_event(
+            run_event(
+                int(row.id),
+                "run.requeued",
+                interruption,
+                root_run_id=row.root_run_id,
+                producer="worker_shutdown",
+            )
+        )
+        if self.auto_commit:
+            await self.session.commit()
+        return to_domain(await self.refresh_run(run_id)), True
+
     async def set_status_with_result(
         self,
         run_id: int,

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -68,17 +68,52 @@ expand_runtime_services() {
   printf '%s\n' "${expanded_services[@]}"
 }
 
-active_agent_run_count() {
-  local count
-  if count="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "
-SELECT count(*) FROM agent_runs WHERE status IN ('\''starting'\'', '\''running'\'', '\''paused'\'', '\''verifying'\'');
-"' 2>/dev/null | tr -d '[:space:]')"; then
-    if [[ "$count" =~ ^[0-9]+$ ]]; then
-      printf '%s\n' "$count"
+nonterminal_agent_run_details() {
+  local details
+  if details="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -AtF: -c "
+SELECT id, status FROM agent_runs
+WHERE status IN ('\''queued'\'', '\''starting'\'', '\''running'\'', '\''paused'\'', '\''verifying'\'')
+ORDER BY id;
+"' 2>/dev/null | paste -sd, - | tr -d '[:space:]')"; then
+    if [ -z "$details" ] || [[ "$details" =~ ^[0-9]+:(queued|starting|running|paused|verifying)(,[0-9]+:(queued|starting|running|paused|verifying))*$ ]]; then
+      printf '%s\n' "$details"
       return 0
     fi
   fi
   printf 'unknown\n'
+}
+
+agent_run_count_from_details() {
+  local details="$1"
+  if [ -z "$details" ]; then
+    printf '0\n'
+    return 0
+  fi
+  if [ "$details" = "unknown" ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  awk -F, '{print NF}' <<< "$details"
+}
+
+agent_run_ids_from_details() {
+  local details="$1"
+  [ -n "$details" ] && [ "$details" != "unknown" ] || return 0
+  printf '%s\n' "$details" | sed -E 's/:[^,]+//g'
+}
+
+active_agent_run_count() {
+  local details
+  details="$(nonterminal_agent_run_details)"
+  agent_run_count_from_details "$details"
+}
+
+report_nonterminal_agent_runs() {
+  local details="$1"
+  local count ids
+  count="$(agent_run_count_from_details "$details")"
+  ids="$(agent_run_ids_from_details "$details")"
+  echo "Worker pre-swap check: $count interactive run(s) in flight (run ids: $ids; id/status: $details)."
 }
 
 worker_container_id() {
@@ -101,9 +136,13 @@ start_worker_handoff() {
 }
 
 record_worker_drain_timeout() {
+  local details="${1:-unknown}"
+  local ids
   [ -n "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE:-}" ] || return 0
+  ids="$(agent_run_ids_from_details "$details")"
   mkdir -p "$(dirname "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE")" 2>/dev/null || true
-  printf '{"status":"worker_draining","updated_at":"%s"}\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  printf '{"status":"worker_draining","updated_at":"%s","affected_run_ids":"%s","affected_runs":"%s"}\n' \
+    "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$ids" "$details" \
     > "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
 }
 
@@ -115,11 +154,13 @@ wait_for_worker_exit() {
   local wait_iterations=0
   local consecutive_zero_checks=0
   local hint_printed=0
-  local active_runs elapsed
+  local active_runs affected_runs affected_ids elapsed
   while container_running "$id"; do
     if [ "$SECONDS" -ge "$deadline" ]; then
-      echo "Worker did not drain within ${wait_seconds}s; leaving it running to avoid interrupting active AgentRuns." >&2
-      record_worker_drain_timeout
+      affected_runs="$(nonterminal_agent_run_details)"
+      affected_ids="$(agent_run_ids_from_details "$affected_runs")"
+      echo "Worker did not drain within ${wait_seconds}s; refusing to kill it. Affected run ids: ${affected_ids:-unknown} (id/status: $affected_runs)." >&2
+      record_worker_drain_timeout "$affected_runs"
       return 1
     fi
     sleep 5
@@ -131,8 +172,7 @@ wait_for_worker_exit() {
         if [ "$consecutive_zero_checks" -ge 2 ] && [ "$hint_printed" = "0" ]; then
           elapsed=$((SECONDS - started_at))
           echo "Hint: worker has 0 active AgentRuns but its process has not exited after ${elapsed}s." >&2
-          echo "Pre-hardening worker images can wedge on SIGTERM (stray non-daemon threads). To force replacement now: docker stop -t 30 $id && compose up -d --no-deps worker, or" >&2
-          echo "deploy/scripts/runtime-services.sh restart worker." >&2
+          echo "Do not force-remove this worker; the deploy remains blocked until it exits safely." >&2
           hint_printed=1
         fi
       else
@@ -143,28 +183,43 @@ wait_for_worker_exit() {
 }
 
 update_worker_after_drain() {
-  local active_runs="$1"
-  local worker_id handoff_id
+  local run_details="$1"
+  local already_reported="${2:-}"
+  local active_runs affected_ids worker_id handoff_id
+  active_runs="$(agent_run_count_from_details "$run_details")"
+  affected_ids="$(agent_run_ids_from_details "$run_details")"
   worker_id="$(worker_container_id)"
+  if [ "$already_reported" != "reported" ]; then
+    report_nonterminal_agent_runs "$run_details"
+  fi
 
   if [ -z "$worker_id" ]; then
-    echo "Worker container is not running; starting worker."
+    echo "Worker container is not running; starting worker to recover affected run ids: $affected_ids."
     compose up -d --force-recreate --no-deps worker
     return 0
   fi
 
   handoff_id="$(start_worker_handoff)"
   echo "Worker: started handoff worker ${handoff_id:-unknown} for new AgentRuns."
-  echo "Worker: ${active_runs} active AgentRun(s); signaling existing worker to drain."
+  echo "Worker: ${active_runs} interactive AgentRun(s); signaling existing worker to drain. Affected run ids: $affected_ids."
   docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
   if ! wait_for_worker_exit "$worker_id"; then
     docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
-    return 0
+    if [ "${ILLO_COMPOSE_FORCE_WORKER_SWAP:-0}" != "1" ]; then
+      return 1
+    fi
+    run_details="$(nonterminal_agent_run_details)"
+    affected_ids="$(agent_run_ids_from_details "$run_details")"
+    echo "FORCED WORKER SWAP: killing old worker; affected run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
+    docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
+    docker kill "$worker_id" >/dev/null 2>&1 || true
   fi
   compose up -d --force-recreate --no-deps worker
   if [ -n "$handoff_id" ]; then
-    echo "Worker: regular worker is restarted; draining handoff worker $handoff_id."
+    run_details="$(nonterminal_agent_run_details)"
+    affected_ids="$(agent_run_ids_from_details "$run_details")"
+    echo "Worker: regular worker is restarted; draining handoff worker $handoff_id. Open run ids at handoff shutdown: ${affected_ids:-none}."
     docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
     (
       docker wait "$handoff_id" >/dev/null 2>&1 || true
@@ -174,9 +229,8 @@ update_worker_after_drain() {
 }
 
 replace_idle_worker() {
-  local worker_id stop_seconds
+  local run_details affected_ids worker_id
   worker_id="$(worker_container_id)"
-  stop_seconds="${ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS:-30}"
 
   if [ -z "$worker_id" ]; then
     echo "Worker container is not running; starting worker."
@@ -184,26 +238,38 @@ replace_idle_worker() {
     return 0
   fi
 
-  echo "Worker: no active AgentRuns; replacing worker with a ${stop_seconds}s stop timeout."
+  run_details="$(nonterminal_agent_run_details)"
+  if [ "$run_details" = "unknown" ]; then
+    echo "Cannot safely replace worker because the non-terminal AgentRun ids are unknown." >&2
+    return 1
+  fi
+  if [ -n "$run_details" ]; then
+    affected_ids="$(agent_run_ids_from_details "$run_details")"
+    echo "Worker replacement blocked: interactive runs appeared after the pre-swap check. Affected run ids: $affected_ids (id/status: $run_details)." >&2
+    return 1
+  fi
+
+  echo "Worker: no interactive AgentRuns; signaling a graceful replacement."
   docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
-  if ! docker stop -t "$stop_seconds" "$worker_id" >/dev/null 2>&1; then
-    echo "Worker did not stop within ${stop_seconds}s despite no active AgentRuns; forcing replacement." >&2
-    docker kill "$worker_id" >/dev/null 2>&1 || true
+  docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
+  if ! wait_for_worker_exit "$worker_id"; then
+    docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
+    return 1
   fi
   compose up -d --force-recreate --no-deps worker
 }
 
 restart_runtime_worker_service() {
-  local active_runs
-  active_runs="$(active_agent_run_count)"
-  if [ "$active_runs" = "unknown" ]; then
-    echo "Cannot safely restart worker because active AgentRun count is unknown." >&2
+  local run_details
+  run_details="$(nonterminal_agent_run_details)"
+  if [ "$run_details" = "unknown" ]; then
+    echo "Cannot safely restart worker because non-terminal AgentRun ids are unknown." >&2
     return 1
   fi
-  if [ "$active_runs" = "0" ]; then
+  if [ -z "$run_details" ]; then
     replace_idle_worker
   else
-    update_worker_after_drain "$active_runs"
+    update_worker_after_drain "$run_details"
   fi
 }
 

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -100,16 +100,21 @@ fi
 
 compose up -d postgres
 compose run --rm migrate
-ACTIVE_RUNS="$(active_agent_run_count)"
-if [ "$ACTIVE_RUNS" = "0" ]; then
+NONTERMINAL_RUNS="$(nonterminal_agent_run_details)"
+if [ "$NONTERMINAL_RUNS" = "unknown" ]; then
+  echo "Cannot safely swap worker because non-terminal AgentRun ids are unknown." >&2
+  exit 1
+fi
+if [ -z "$NONTERMINAL_RUNS" ]; then
   mapfile -t runtime_services < <(all_runtime_services)
   compose up -d --force-recreate --remove-orphans "${runtime_services[@]}"
   replace_idle_worker
 else
+  report_nonterminal_agent_runs "$NONTERMINAL_RUNS"
   echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
   mapfile -t services < <(non_worker_services)
   compose up -d --force-recreate --no-deps "${services[@]}"
-  update_worker_after_drain "$ACTIVE_RUNS"
+  update_worker_after_drain "$NONTERMINAL_RUNS" reported
 fi
 
 "$SCRIPT_DIR/doctor.sh"

--- a/illo
+++ b/illo
@@ -546,21 +546,22 @@ systemd_user_ready() {
 restart_or_drain_production_worker() {
   run_logged_timeout 10 systemctl --user enable cortex-worker.service >/dev/null 2>&1 || return 1
 
-  local active_runs
-  active_runs="$(active_agent_run_count || echo unknown)"
-  if [ "$active_runs" = "0" ]; then
-    run_logged_timeout 15 systemctl --user restart cortex-worker.service >/dev/null 2>&1
-    dim "cortex-worker restarted for this checkout"
-    return $?
+  local active_runs affected_ids run_details
+  run_details="$(nonterminal_agent_run_details || echo unknown)"
+  if [ "$run_details" = "unknown" ]; then
+    warn "Could not list non-terminal AgentRuns; refusing to restart cortex-worker"
+    return 1
   fi
-  if [ "$active_runs" = "unknown" ]; then
-    warn "Could not count active AgentRuns; restarting cortex-worker so this checkout owns the queue"
+  if [ -z "$run_details" ]; then
     run_logged_timeout 15 systemctl --user restart cortex-worker.service >/dev/null 2>&1
     dim "cortex-worker restarted for this checkout"
     return $?
   fi
 
-  warn "$active_runs AgentRun(s) active; draining cortex-worker instead of restarting it"
+  active_runs="$(awk -F, '{print NF}' <<< "$run_details")"
+  affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
+  warn "Worker pre-swap check: $active_runs interactive run(s) in flight (run ids: $affected_ids; id/status: $run_details)"
+  warn "$active_runs AgentRun(s) active; draining cortex-worker instead of restarting it; affected run ids: $affected_ids"
   run_logged_timeout 10 systemctl --user kill --kill-who=main --signal=TERM cortex-worker.service >/dev/null 2>&1 || true
 }
 
@@ -695,9 +696,9 @@ import asyncio
 
 from sqlalchemy import func, select
 
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.status_contracts import ACTIVE_RUN_STATUS_VALUES
 
 
 async def main() -> None:
@@ -705,9 +706,36 @@ async def main() -> None:
         count = await uow.session.scalar(
             select(func.count())
             .select_from(AgentRunRow)
-            .where(AgentRunRow.status.in_(ACTIVE_RUN_STATUS_VALUES))
+            .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
         )
     print(int(count or 0))
+
+
+asyncio.run(main())
+PY
+}
+
+nonterminal_agent_run_details() {
+  "$ROOT/venv/bin/python3" - <<'PY' 2>/dev/null
+import asyncio
+
+from sqlalchemy import select
+
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+
+async def main() -> None:
+    async with UnitOfWork() as uow:
+        rows = (
+            await uow.session.execute(
+                select(AgentRunRow.id, AgentRunRow.status)
+                .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
+                .order_by(AgentRunRow.id.asc())
+            )
+        ).all()
+    print(",".join(f"{run_id}:{status}" for run_id, status in rows))
 
 
 asyncio.run(main())
@@ -726,9 +754,9 @@ import os
 
 from sqlalchemy import select
 
+from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.status_contracts import ACTIVE_RUN_STATUS_VALUES
 
 
 async def main() -> None:

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -285,8 +285,20 @@ stop_legacy_docker_app_containers() {
     illospace-worker-1
     illospace-scheduler-1
   )
-  local running
+  local affected_ids run_details running
   running="$(docker ps --format '{{.Names}}' 2>/dev/null || true)"
+  if printf '%s\n' "$running" | grep -qx illospace-worker-1; then
+    run_details="$(nonterminal_agent_run_details || echo unknown)"
+    if [ "$run_details" = "unknown" ]; then
+      echo "Refusing to stop legacy Docker worker because non-terminal AgentRun ids are unknown." >&2
+      return 1
+    fi
+    if [ -n "$run_details" ]; then
+      affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
+      echo "Refusing to stop legacy Docker worker with interactive runs in flight. Affected run ids: $affected_ids (id/status: $run_details)." >&2
+      return 1
+    fi
+  fi
   local to_stop=()
   local name
   for name in "${names[@]}"; do
@@ -318,19 +330,49 @@ PY
 
 active_agent_run_count() {
   "$PYTHON_BIN" - <<'PY'
+import asyncio
+
 from sqlalchemy import func, select
 
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.platform.status_contracts import ACTIVE_RUN_STATUS_VALUES
 
-with UnitOfWork() as uow:
-    count = uow.session.scalar(
-        select(func.count())
-        .select_from(AgentRunRow)
-        .where(AgentRunRow.status.in_(ACTIVE_RUN_STATUS_VALUES))
-    )
-print(int(count or 0))
+async def main() -> None:
+    async with UnitOfWork() as uow:
+        count = await uow.session.scalar(
+            select(func.count())
+            .select_from(AgentRunRow)
+            .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
+        )
+    print(int(count or 0))
+
+asyncio.run(main())
+PY
+}
+
+nonterminal_agent_run_details() {
+  "$PYTHON_BIN" - <<'PY'
+import asyncio
+
+from sqlalchemy import select
+
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+async def main() -> None:
+    async with UnitOfWork() as uow:
+        rows = (
+            await uow.session.execute(
+                select(AgentRunRow.id, AgentRunRow.status)
+                .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
+                .order_by(AgentRunRow.id.asc())
+            )
+        ).all()
+    print(",".join(f"{run_id}:{status}" for run_id, status in rows))
+
+asyncio.run(main())
 PY
 }
 
@@ -341,15 +383,22 @@ restart_or_drain_worker() {
   fi
 
   systemctl --user enable cortex-worker
-  local active_runs
-  active_runs="$(active_agent_run_count)"
-  if [ "$active_runs" = "0" ]; then
+  local active_runs affected_ids run_details
+  run_details="$(nonterminal_agent_run_details || echo unknown)"
+  if [ "$run_details" = "unknown" ]; then
+    echo "Worker:    refusing restart because non-terminal AgentRun ids are unknown" >&2
+    return 1
+  fi
+  if [ -z "$run_details" ]; then
     systemctl --user restart cortex-worker
-    echo "Worker:    restarted (no active AgentRuns)"
+    echo "Worker:    restarted (no interactive AgentRuns)"
     return 0
   fi
 
-  echo "Worker:    $active_runs active AgentRun(s); signaling drain instead of restart"
+  active_runs="$(awk -F, '{print NF}' <<< "$run_details")"
+  affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
+  echo "Worker pre-swap check: $active_runs interactive run(s) in flight (run ids: $affected_ids; id/status: $run_details)."
+  echo "Worker:    $active_runs interactive AgentRun(s); signaling drain instead of restart; affected run ids: $affected_ids"
   echo "           It will stop claiming new runs and restart on the new version after active runs finish."
   local old_pid handoff_pid
   old_pid="$(worker_service_main_pid)"

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -149,6 +149,30 @@ def test_stop_runner_waits_for_in_flight_runs():
         runner._stop_event.clear()
 
 
+def test_stop_runner_requeues_named_runs_when_shutdown_drain_times_out(monkeypatch, caplog):
+    from brain.systems.runs.cortex import runner
+
+    runner.stop_runner()
+    requeue_calls: list[tuple[tuple[int, ...], str]] = []
+
+    def interrupt(run_ids, *, reason):
+        requeue_calls.append((run_ids, reason))
+        return run_ids
+
+    monkeypatch.setattr(runner, "_interrupt_in_flight_runs", interrupt)
+    caplog.set_level(logging.WARNING, logger=runner.__name__)
+    runner._increment_in_flight_runs(2330)
+    try:
+        runner.stop_runner(drain_timeout_seconds=0)
+
+        assert requeue_calls == [((2330,), "worker_shutdown_drain_timeout")]
+        assert "affected run ids: [2330]" in caplog.text
+        assert "interrupted and requeued run ids: [2330]" in caplog.text
+    finally:
+        runner._decrement_in_flight_runs(2330)
+        runner._stop_event.clear()
+
+
 async def test_run_queued_once_skips_claim_when_stopping(monkeypatch):
     from brain.systems.runs.cortex import runner
 
@@ -198,10 +222,12 @@ async def test_run_queued_once_tracks_claims_before_uow_exit(monkeypatch):
     try:
         await asyncio.wait_for(uow_exit_started.wait(), timeout=1)
         assert runner.runner_in_flight_count() == 1
+        assert runner.runner_in_flight_ids() == (42,)
 
         release_uow_exit.set()
         assert await asyncio.wait_for(task, timeout=1) == 1
         assert runner.runner_in_flight_count() == 0
+        assert runner.runner_in_flight_ids() == ()
     finally:
         release_uow_exit.set()
         if not task.done():

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -129,11 +129,11 @@ def test_stop_runner_waits_for_in_flight_runs():
 
     runner.stop_runner()
     assert runner.runner_in_flight_count() == 0
-    runner._increment_in_flight_runs()
+    runner._increment_in_flight_runs(2329)
 
     def finish_run():
         time.sleep(0.2)
-        runner._decrement_in_flight_runs()
+        runner._decrement_in_flight_runs(2329)
 
     finisher = threading.Thread(target=finish_run)
     finisher.start()
@@ -146,6 +146,20 @@ def test_stop_runner_waits_for_in_flight_runs():
         assert 0.15 <= elapsed < 2
     finally:
         finisher.join(timeout=1)
+        runner._stop_event.clear()
+
+
+def test_in_flight_count_is_derived_from_unique_run_ids():
+    from brain.systems.runs.cortex import runner
+
+    runner.stop_runner()
+    runner._increment_in_flight_runs(2328)
+    runner._increment_in_flight_runs(2328)
+    try:
+        assert runner.runner_in_flight_ids() == (2328,)
+        assert runner.runner_in_flight_count() == 1
+    finally:
+        runner._decrement_in_flight_runs(2328)
         runner._stop_event.clear()
 
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -4587,6 +4587,65 @@ async def test_runner_reports_slack_origin_final_answer_back_to_slack(monkeypatc
     ]
 
 
+async def test_runner_reports_interruption_run_id_and_requeue_status_to_slack(monkeypatch):
+    from brain.systems.runs.cortex import runner
+    from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
+
+    run = SimpleNamespace(
+        id=2330,
+        parent_run_id=None,
+        thread_id="slack:T789:C456:1716900000.000100",
+        status="queued",
+        org_id="org-1",
+        user_id="user-1",
+        target_ref={
+            "kind": "slack_message",
+            "slack_trigger": {
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "response_target": {"channel_id": "C456", "thread_ts": None},
+            },
+        },
+        metadata_={"final_answer_target_surface": "slack"},
+    )
+    calls = []
+
+    class FakeSlackClient:
+        async def post_message(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True, "channel": kwargs["channel"], "ts": "1716900400.000500"}
+
+        async def set_assistant_status(self, **_kwargs):
+            return {"ok": True}
+
+    async def fake_client_for_run(run_arg):
+        assert run_arg is run
+        return FakeSlackClient()
+
+    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+
+    result = await runner._settle_slack_interrupted_run_async(
+        object(),
+        run,
+        interrupted_at=datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc),
+        requeued=True,
+    )
+
+    assert result["surface"] == "slack"
+    assert calls == [
+        {
+            "channel": "C456",
+            "text": (
+                "I was interrupted by a system restart at 17:55 UTC (run 2330); "
+                "I've re-queued it and will reply here when it finishes."
+            ),
+            "thread_ts": None,
+        }
+    ]
+    assert DEFAULT_FAILED_RUN_MESSAGE not in calls[0]["text"]
+
+
 async def test_runner_does_not_override_model_authored_slack_reply(monkeypatch):
     from brain.systems.runs.cortex import runner
 

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -18,7 +18,12 @@ from sqlalchemy.schema import CreateTable
 
 from brain.systems.runs.domain import AgentRunRequest as _AgentRunRequest, RunRecipe
 from brain.systems.runs.engine import AsyncAgentRunEngine, RunRecipeResult, RunRuntime, StaticAnswerRecipe
-from brain.systems.runs.status import RunStatus
+from brain.systems.runs.status import (
+    ALLOWED_RUN_TRANSITIONS,
+    RunStatus,
+    RunTransitionError,
+    ensure_run_transition,
+)
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 
@@ -71,6 +76,21 @@ class _SessionUoW:
         if exc_type is None:
             await self.session.flush()
         return False
+
+
+@pytest.mark.parametrize(
+    "from_status",
+    (RunStatus.STARTING, RunStatus.RUNNING, RunStatus.VERIFYING),
+)
+def test_interrupted_requeue_transition_is_declared_but_scoped(from_status: RunStatus):
+    assert RunStatus.QUEUED in ALLOWED_RUN_TRANSITIONS[from_status]
+    assert ensure_run_transition(
+        from_status,
+        RunStatus.QUEUED,
+        allow_interrupted_requeue=True,
+    ) == (from_status, RunStatus.QUEUED)
+    with pytest.raises(RunTransitionError, match="outside interrupted requeue"):
+        ensure_run_transition(from_status, RunStatus.QUEUED)
 
 
 async def test_restart_resume_skips_completed_steps_from_persisted_cursor(session_factory):
@@ -1358,10 +1378,14 @@ async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned
     assert row is not None
     row.created_at = old
     row.started_at = old
+    row.paused_at = old
     row.updated_at = old
     row.execution_token = "abandoned-owner"
     row.execution_attempt = 3
-    row.metadata_ = {"runner_heartbeat": {"at": old.isoformat(), "reason": "runner_running"}}
+    row.metadata_ = {
+        "failure": {"category": "runner_failed"},
+        "runner_heartbeat": {"at": old.isoformat(), "reason": "runner_running"},
+    }
     for event in (await session.scalars(select(AgentRunEventRow).where(AgentRunEventRow.run_id == run.id))).all():
         event.created_at = old
     await session.commit()
@@ -1378,22 +1402,35 @@ async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned
     assert row is not None
     assert row.status == RunStatus.QUEUED.value
     assert row.execution_token is None
+    assert row.paused_at is None
+    assert "failure" not in row.metadata_
+    candidate_events = (await session.scalars(
+        select(AgentRunEventRow).where(
+            AgentRunEventRow.run_id == run.id,
+            AgentRunEventRow.event_type.in_(
+                ("run.interrupted", "run.status_changed", "run.requeued", "run.failed")
+            ),
+        )
+        .order_by(AgentRunEventRow.sequence_no.asc())
+    )).all()
     interruption_events = [
         event
-        for event in (await session.scalars(
-            select(AgentRunEventRow).where(
-                AgentRunEventRow.run_id == run.id,
-                AgentRunEventRow.event_type.in_(("run.interrupted", "run.requeued", "run.failed")),
-            )
-            .order_by(AgentRunEventRow.sequence_no.asc())
-        )).all()
+        for event in candidate_events
+        if event.event_type != "run.status_changed"
+        or event.payload.get("to_status") == RunStatus.QUEUED.value
     ]
     assert [event.event_type for event in interruption_events] == [
         "run.interrupted",
+        "run.status_changed",
         "run.requeued",
     ]
     assert interruption_events[0].payload["reason"] == "runner_heartbeat_stale"
     assert interruption_events[0].payload["requeued"] is True
+    assert interruption_events[1].payload == {
+        "from_status": RunStatus.RUNNING.value,
+        "to_status": RunStatus.QUEUED.value,
+        "reason": "runner_heartbeat_stale",
+    }
     assert row.metadata_["interruption"]["from_status"] == RunStatus.RUNNING.value
 
     retried = await AsyncAgentRunStore(session).claim_next()

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1344,7 +1344,7 @@ async def test_cancel_runs_for_idea_records_run_canceled_event(session_factory):
     assert events.count("run.canceled") == 1
 
 
-async def test_stale_active_run_reaper_fails_abandoned_runs(session_factory):
+async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned_runs(session_factory):
     from brain.systems.runs.cortex import runner
 
     session = session_factory()
@@ -1366,13 +1366,8 @@ async def test_stale_active_run_reaper_fails_abandoned_runs(session_factory):
         event.created_at = old
     await session.commit()
 
-    live_events: list[tuple[str, dict]] = []
     with (
         patch("brain.systems.runs.cortex.runner.UnitOfWork", return_value=_SessionUoW(session)),
-        patch(
-            "brain.systems.runs.cortex.runner.publish_live_safe",
-            lambda event, payload: live_events.append((event, payload)),
-        ),
         patch("brain.systems.runs.cortex.runner.publish_safe"),
         patch("brain.systems.runs.cortex.runner._settle_idea_for_terminal_root_run_async", return_value=None),
     ):
@@ -1381,19 +1376,30 @@ async def test_stale_active_run_reaper_fails_abandoned_runs(session_factory):
     row = await session.get(AgentRunRow, run.id)
     assert count == 1
     assert row is not None
-    assert row.status == RunStatus.FAILED.value
+    assert row.status == RunStatus.QUEUED.value
     assert row.execution_token is None
-    failed_events = [
+    interruption_events = [
         event
         for event in (await session.scalars(
-            select(AgentRunEventRow)
-            .where(AgentRunEventRow.run_id == run.id, AgentRunEventRow.event_type == "run.failed")
+            select(AgentRunEventRow).where(
+                AgentRunEventRow.run_id == run.id,
+                AgentRunEventRow.event_type.in_(("run.interrupted", "run.requeued", "run.failed")),
+            )
             .order_by(AgentRunEventRow.sequence_no.asc())
         )).all()
     ]
-    assert len(failed_events) == 1
-    assert failed_events[0].payload["reason"] == "runner_heartbeat_stale"
-    assert live_events and live_events[-1][0] == "run_completed"
+    assert [event.event_type for event in interruption_events] == [
+        "run.interrupted",
+        "run.requeued",
+    ]
+    assert interruption_events[0].payload["reason"] == "runner_heartbeat_stale"
+    assert interruption_events[0].payload["requeued"] is True
+    assert row.metadata_["interruption"]["from_status"] == RunStatus.RUNNING.value
+
+    retried = await AsyncAgentRunStore(session).claim_next()
+    assert retried is not None
+    assert retried.id == run.id
+    assert retried.status == RunStatus.STARTING
 
 
 async def test_stale_active_run_reaper_uses_recent_events_as_liveness(session_factory):

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
 
 
 def _shell_function_body(content: str, name: str) -> str:
@@ -108,7 +108,8 @@ def test_ops_deploy_drains_worker_instead_of_restarting_active_runs():
     service = (Path(__file__).resolve().parents[1] / "ops" / "cortex-worker.service").read_text()
     assert service.count("ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1") == 1
     assert "systemctl --user kill --kill-who=main --signal=TERM cortex-worker" in content
-    assert "active AgentRun(s); signaling drain instead of restart" in content
+    assert "AgentRun(s); signaling drain instead of restart; affected run ids:" in content
+    assert "Worker pre-swap check:" in content
 
 
 def test_ops_deploy_leaves_embedder_running_when_agent_runs_are_active():
@@ -363,7 +364,7 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     combined = upgrade + runtime_lib
 
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in upgrade
-    assert "active_agent_run_count" in runtime_lib
+    assert "nonterminal_agent_run_details" in runtime_lib
     assert "status IN" in runtime_lib
     assert "non_worker_services" in upgrade
     assert "api scheduler web updater" in upgrade
@@ -382,8 +383,9 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "compose up -d --force-recreate --no-deps worker" in runtime_lib
     assert "compose up -d --force-recreate --remove-orphans" in upgrade
     assert "replace_idle_worker" in combined
-    assert "ILLO_COMPOSE_IDLE_WORKER_STOP_TIMEOUT_SECONDS" in runtime_lib
-    assert "no active AgentRuns" in runtime_lib
+    assert "no interactive AgentRuns" in runtime_lib
+    assert "refusing to kill it" in runtime_lib
+    assert "FORCED WORKER SWAP: killing old worker; affected run ids:" in runtime_lib
     assert "ILLO_COMPOSE_BUILD_NO_CACHE" in upgrade
     assert "ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE" in upgrade
 
@@ -407,7 +409,27 @@ def test_compose_runtime_service_restart_supports_one_many_or_all_services():
     assert "restart_runtime_worker_service" in runtime_lib
     assert "active_agent_run_count" in runtime_lib
     assert "started handoff worker" in runtime_lib
-    assert "avoid interrupting active AgentRuns" in runtime_lib
+    assert "refusing to kill it" in runtime_lib
+
+
+def test_compose_pre_swap_check_reports_nonterminal_run_ids():
+    runtime_lib = Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "compose-runtime-lib.sh"
+    script = f'''
+source "{runtime_lib}"
+compose() {{
+  printf '2327:paused\\n2330:running\\n2331:queued\\n'
+}}
+details="$(nonterminal_agent_run_details)"
+report_nonterminal_agent_runs "$details"
+'''
+
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "Worker pre-swap check: 3 interactive run(s) in flight "
+        "(run ids: 2327,2330,2331; id/status: 2327:paused,2330:running,2331:queued)."
+    )
 
 
 def test_safe_deploy_active_run_guards_match_canonical_active_statuses():
@@ -417,9 +439,10 @@ def test_safe_deploy_active_run_guards_match_canonical_active_statuses():
     ops_deploy = (root / "ops" / "deploy.sh").read_text()
     runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
 
-    for status in ACTIVE_RUN_STATUS_VALUES:
+    for status in OPEN_RUN_STATUS_VALUES:
         assert repr(status) in upgrade + runtime_lib
+    assert repr("queued") in upgrade + runtime_lib
     assert "ACTIVE_RUN_STATUS_VALUES" in launcher
-    assert "ACTIVE_RUN_STATUS_VALUES" in ops_deploy
+    assert "OPEN_RUN_STATUS_VALUES" in ops_deploy
     assert '("starting", "running", "verifying")' not in launcher
     assert '("starting", "running", "verifying")' not in ops_deploy


### PR DESCRIPTION
Closes #422

## What was broken

A deploy killed two in-flight interactive runs (2327 and 2330, one second apart, ~5 min after the new worker came up). The human's only signal was **"I hit a temporary problem while working on that — please retry."** No cause, no run id, no requeue — the recovery burden landed on a human, mid-conversation, on a customer issue.

The swap is *designed* to drain (`stop_grace_period: 24h`, drain timeout `infinity`). It did not protect these runs: the pre-swap check did not count them.

## What this changes

1. **The pre-swap check now counts every non-terminal run** — including `queued`, which the old `ACTIVE_RUN_STATUS_VALUES` set omitted — and reports them by id before anything is torn down:
   `Worker pre-swap check: 3 interactive run(s) in flight (run ids: 2327,2330,2331; …)`.
2. **Requeue, don't fail.** A run terminated by worker shutdown is fenced and returned to `queued` with an audited `run.interrupted` + `run.requeued` event pair, so the existing claimer picks it up on the new worker. No new row status and **no migration** — `interrupted` is an audited event/metadata state, so recovery stays atomic and needs no intermediate-state sweeper.
3. **An honest user-facing message** — *"I was interrupted by a system restart at 17:55 UTC (run 2330); I've re-queued it and will reply here when it finishes."* The bare "temporary problem — please retry" string no longer reaches a human.
4. **A forced swap logs what it killed** — `FORCED WORKER SWAP: killing old worker; affected run ids: …` instead of two silent `failed` rows that read like an application bug.

## How to judge this without reading the diff

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-422-deploy-drain
venv/bin/python -m pytest tests/test_safe_deploy.py tests/test_agent_run_runner.py tests/test_agent_run_runtime.py tests/test_agent_run_state_machine.py tests/test_cortex_worker.py tests/test_runtime_settings.py -q
```

**263 passed, 1 skipped** — I ran this myself, not just the worker.

### Acceptance checks
- [x] A swap with a non-terminal run in flight blocks and names the run ids (`refusing to kill it`).
- [x] A shutdown-killed run lands `queued` with `run.interrupted` / `run.requeued` events, not `failed`.
- [x] The restart message names the interruption, the run id and the requeue status.
- [x] A forced swap emits the affected run ids in the deploy path.
- [x] No DB migration required.

## Assumptions worth your eye
- **Blocking beats draining, by choice.** The pre-swap check *refuses* the swap rather than waiting the runs out. A hurried deploy now gets a clear refusal naming the run ids, and the forced path stays available (and now logs what it kills). If you would rather a deploy always proceed and drain in the background, say so — that's a different tradeoff, not a bug.
- **Nothing here was exercised against a real docker host.** By design: the worker was explicitly forbidden from running any deploy/docker command. Verification is the repo's own `test_safe_deploy.py` (which asserts against the script text) plus shell syntax checks. **The scripts' real-world behavior on illo-dev is unproven and is the thing worth watching on the next deploy.**

---

## Review passes run before this PR was opened

**Correctness:** I reviewed the diff and ran the suite myself (not just the worker) — **267 passed, 1 skipped**.

**Maintainability (thermo-nuclear rubric, executed by Codex — cross-family):** returned 1 BLOCKING, 2 SHOULD-FIX, 1 NIT.

- **BLOCKING — folded in (commit 2).** `interrupt_and_requeue()` bypassed `ensure_run_transition()` / `ALLOWED_RUN_TRANSITIONS`, creating a second status-transition engine. I verified this against the code before acting: the normal path (`store.py:979`) calls `ensure_run_transition`, the new one called it **zero** times — and `ALLOWED_RUN_TRANSITIONS[RUNNING]` did not contain `QUEUED`, so the new path performed a transition the declared state machine **forbids**, and only got away with it by not asking.
  The fix declares `STARTING/RUNNING/VERIFYING → QUEUED` so the table describes reality, but gates it behind an explicit `allow_interrupted_requeue` opt-in so ordinary status changes stay illegal, and routes the mutation + status event through the canonical primitive.
- **NIT — folded in (commit 2).** `_in_flight_runs` (a count) and `_in_flight_run_ids` (a set) were two representations of the same fact with an optional-id API; the count is now derived from the set.
- **2 SHOULD-FIX — deliberately deferred to #426**, both targeting pre-existing structure this change deepened rather than created: the `runner.py` monolith absorbing interruption persistence + Slack transport, and the in-flight-run query being implemented **three times** across `compose-runtime-lib.sh`, `illo` and `ops/deploy.sh`.

**Worth your attention on that second one:** the triplication is plausibly *how this incident happened*. The drain check that failed to protect runs 2327 and 2330 was one of three independent implementations — only one of them had to be wrong. #426 tracks collapsing them.
