### PR TITLE
refactor(scheduler,memory): one nightly step registry + one curation evidence builder (#424)

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -33,7 +33,8 @@ from brain.app.scheduler.programs import (
     NIGHTLY_SLEEP_STEP_KEYS,
     WRAPPER_STEP_KEY,
     build_scheduler_step_plan,
-    nightly_heuristic_review_command,
+    nightly_commands,
+    nightly_commands_for_step,
 )
 from brain.app.scheduler.runtime import (
     LEASE_TTL_SECONDS,
@@ -250,72 +251,11 @@ def _nightly_wrapper_commands(target_date: date, *, split_steps: bool) -> list[l
             )
         ]
 
-    return [
-        ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"],
-        [
-            "python3",
-            "-m",
-            "brain.jobs.pipelines.nightly_memory_maintenance",
-            "--date",
-            target_date.isoformat(),
-            "--apply",
-        ],
-        ["python3", "-m", "brain.app.cli.skills", "evolve"],
-        ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"],
-        ["python3", "-m", "brain.app.cli.meta_learn", "evolve"],
-        nightly_heuristic_review_command(),
-        _python_one_liner(
-            "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
-            "stats = run_meta_evolution(); "
-            "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
-        ),
-        ["python3", "-m", "brain.jobs.pipelines.nightly_reflect", "--date", target_date.isoformat()],
-        ["python3", "-m", "brain.jobs.pipelines.nightly_dream", "--date", target_date.isoformat()],
-        ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "index"],
-        ["python3", "-m", "brain.jobs.pipelines.sync_brain_to_files"],
-        ["python3", "-m", "brain.jobs.pipelines.project_draft_cleanup"],
-        ["python3", "-m", "brain.jobs.pipelines.nightly_assess", "--date", target_date.isoformat()],
-        ["python3", "-m", "brain.jobs.pipelines.nightly_implement", "--date", target_date.isoformat()],
-        ["python3", str(Path("content") / "blog" / "generate_blog.py"), "--date", target_date.isoformat()],
-    ]
+    return nightly_commands(target_date)
 
 
 def _nightly_step_commands(step_key: str, target_date: date) -> list[list[str]]:
-    mapping: dict[str, list[list[str]]] = {
-        "memory_consolidation": [["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"]],
-        "nightly_memory_maintenance": [[
-            "python3",
-            "-m",
-            "brain.jobs.pipelines.nightly_memory_maintenance",
-            "--date",
-            target_date.isoformat(),
-            "--apply",
-        ]],
-        "skill_evolution": [["python3", "-m", "brain.app.cli.skills", "evolve"]],
-        "meta_learning": [
-            ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"],
-            ["python3", "-m", "brain.app.cli.meta_learn", "evolve"],
-        ],
-        "heuristic_review": [
-            nightly_heuristic_review_command(),
-        ],
-        "meta_evolution": [
-            _python_one_liner(
-                "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
-                "stats = run_meta_evolution(); "
-                "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
-            ),
-        ],
-        "reflection": [["python3", "-m", "brain.jobs.pipelines.nightly_reflect", "--date", target_date.isoformat()]],
-        "dream": [["python3", "-m", "brain.jobs.pipelines.nightly_dream", "--date", target_date.isoformat()]],
-        "wake_up_index": [["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "index"]],
-        "file_sync": [["python3", "-m", "brain.jobs.pipelines.sync_brain_to_files"]],
-        "project_draft_cleanup": [["python3", "-m", "brain.jobs.pipelines.project_draft_cleanup"]],
-        "experiment_assessment": [["python3", "-m", "brain.jobs.pipelines.nightly_assess", "--date", target_date.isoformat()]],
-        "self_improvement": [["python3", "-m", "brain.jobs.pipelines.nightly_implement", "--date", target_date.isoformat()]],
-        "daily_blog": [["python3", str(Path("content") / "blog" / "generate_blog.py"), "--date", target_date.isoformat()]],
-    }
-    return mapping.get(step_key, [])
+    return nightly_commands_for_step(step_key, target_date)
 
 
 def _command_to_argv(command: Any) -> list[str]:

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -1,91 +1,327 @@
 """Scheduler program step definitions."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 import shlex
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 
-NIGHTLY_SLEEP_STEP_KEYS: tuple[str, ...] = (
-    "memory_consolidation",
-    "nightly_memory_maintenance",
-    "skill_evolution",
-    "meta_learning",
-    "heuristic_review",
-    "meta_evolution",
-    "reflection",
-    "dream",
-    "wake_up_index",
-    "file_sync",
-    "project_draft_cleanup",
-    "experiment_assessment",
-    "self_improvement",
-    "daily_blog",
-)
-
 DEFAULT_STEP_KIND = "single"
 WRAPPER_STEP_KEY = "nightly_wrapper"
 
+
+def _python_one_liner(code: str) -> list[str]:
+    return ["python3", "-c", code]
+
+
+def nightly_heuristic_review_command() -> list[str]:
+    """Run the async heuristic review from a synchronous scheduler process."""
+    return _python_one_liner(
+        "import asyncio; "
+        "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
+        "r = asyncio.run(nightly_heuristic_review()); "
+        "print(f'Nightly heuristic review ran: pruned={r[\"pruned\"]}, "
+        "skills_updated={r[\"skills_updated\"]}')"
+    )
+
+
+@dataclass(frozen=True)
+class StepSpec:
+    step_key: str
+    command: list[str]
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class NightlyProgramStep:
+    """Metadata for one command exposed by the legacy StepSpec API."""
+
+    step_key: str
+    description: str | None = None
+
+
+NightlyCommandFactory = Callable[[date], Sequence[Sequence[str]]]
+
+
+@dataclass(frozen=True)
+class NightlyStepDefinition:
+    """One nightly phase and every representation derived from it."""
+
+    step_key: str
+    command_factory: NightlyCommandFactory
+    description: str
+    budget_hint: dict[str, object]
+    program_steps: tuple[NightlyProgramStep, ...]
+    runs_in_executor: bool = True
+
+    def commands_for(self, target_date: date) -> list[list[str]]:
+        commands = [list(command) for command in self.command_factory(target_date)]
+        if len(commands) != len(self.program_steps):
+            raise RuntimeError(
+                f"Nightly step {self.step_key!r} produced {len(commands)} commands "
+                f"for {len(self.program_steps)} program step definitions"
+            )
+        return commands
+
+
+NIGHTLY_STEP_REGISTRY: tuple[NightlyStepDefinition, ...] = (
+    NightlyStepDefinition(
+        step_key="memory_consolidation",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"),
+        ),
+        description="Memory consolidation",
+        budget_hint={
+            "work_type": "memory_conflict_resolution",
+            "estimated_tokens": 18_000,
+        },
+        program_steps=(NightlyProgramStep("consolidate_all"),),
+    ),
+    NightlyStepDefinition(
+        step_key="nightly_memory_maintenance",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_memory_maintenance",
+                "--date",
+                target_date.isoformat(),
+                "--apply",
+            ),
+        ),
+        description="Auditable memory expiry maintenance",
+        budget_hint={
+            "work_type": "memory_conflict_resolution",
+            "estimated_tokens": 1_000,
+        },
+        program_steps=(NightlyProgramStep("nightly_memory_maintenance"),),
+    ),
+    NightlyStepDefinition(
+        step_key="skill_evolution",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.app.cli.skills", "evolve"),
+        ),
+        description="Skill evolution",
+        budget_hint={"work_type": "skill_eval", "estimated_tokens": 12_000},
+        program_steps=(NightlyProgramStep("skill_evolution"),),
+    ),
+    NightlyStepDefinition(
+        step_key="meta_learning",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"),
+            ("python3", "-m", "brain.app.cli.meta_learn", "evolve"),
+        ),
+        description="Meta-learning",
+        budget_hint={"work_type": "skill_eval", "estimated_tokens": 10_000},
+        program_steps=(
+            NightlyProgramStep(
+                "meta_learning_cross_pollinate",
+                "Meta-learning cross-pollination",
+            ),
+            NightlyProgramStep("meta_learning_evolve", "Meta-learning evolve"),
+        ),
+    ),
+    NightlyStepDefinition(
+        step_key="heuristic_review",
+        command_factory=lambda _target_date: (nightly_heuristic_review_command(),),
+        description="Heuristic review",
+        budget_hint={"work_type": "skill_eval", "estimated_tokens": 4_000},
+        program_steps=(NightlyProgramStep("heuristic_review"),),
+    ),
+    NightlyStepDefinition(
+        step_key="meta_evolution",
+        command_factory=lambda _target_date: (
+            _python_one_liner(
+                "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
+                "stats = run_meta_evolution(); "
+                "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
+            ),
+        ),
+        description="Meta-evolution",
+        budget_hint={
+            "work_type": "context_policy_eval",
+            "estimated_tokens": 8_000,
+        },
+        program_steps=(NightlyProgramStep("meta_evolution"),),
+    ),
+    # Issue #424: this StepSpec existed only in the test-only get_step_specs() path
+    # and has never been reachable from the production scheduler executor. Keep it
+    # explicit but non-scheduled until maintainers make the product decision about
+    # whether context policy evaluation should actually run nightly.
+    NightlyStepDefinition(
+        step_key="context_policy_eval",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_context_eval",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Context policy shadow evaluation",
+        budget_hint={},
+        program_steps=(NightlyProgramStep("context_policy_eval"),),
+        runs_in_executor=False,
+    ),
+    NightlyStepDefinition(
+        step_key="reflection",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_reflect",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="LLM reflection",
+        budget_hint={
+            "work_type": "reflection_dream",
+            "estimated_tokens": 10_000,
+        },
+        program_steps=(NightlyProgramStep("nightly_reflect"),),
+    ),
+    NightlyStepDefinition(
+        step_key="dream",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_dream",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Dream synthesis",
+        budget_hint={
+            "work_type": "reflection_dream",
+            "estimated_tokens": 10_000,
+        },
+        program_steps=(NightlyProgramStep("nightly_dream"),),
+    ),
+    NightlyStepDefinition(
+        step_key="wake_up_index",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "index"),
+        ),
+        description="Wake-up index",
+        budget_hint={
+            "work_type": "memory_conflict_resolution",
+            "estimated_tokens": 4_000,
+        },
+        program_steps=(NightlyProgramStep("wake_up_index"),),
+    ),
+    NightlyStepDefinition(
+        step_key="file_sync",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.jobs.pipelines.sync_brain_to_files"),
+        ),
+        description="Brain to files sync",
+        budget_hint={
+            "work_type": "repo_summary_refresh",
+            "estimated_tokens": 3_000,
+        },
+        program_steps=(NightlyProgramStep("brain_to_files_sync"),),
+    ),
+    NightlyStepDefinition(
+        step_key="project_draft_cleanup",
+        command_factory=lambda _target_date: (
+            ("python3", "-m", "brain.jobs.pipelines.project_draft_cleanup"),
+        ),
+        description="Project draft cleanup",
+        budget_hint={"work_type": "storage_cleanup", "estimated_tokens": 500},
+        program_steps=(NightlyProgramStep("project_draft_cleanup"),),
+    ),
+    NightlyStepDefinition(
+        step_key="experiment_assessment",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_assess",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Experiment assessment",
+        budget_hint={
+            "work_type": "context_policy_eval",
+            "estimated_tokens": 6_000,
+        },
+        program_steps=(NightlyProgramStep("experiment_assessment"),),
+    ),
+    NightlyStepDefinition(
+        step_key="self_improvement",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_implement",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Self-improvement",
+        budget_hint={"work_type": "skill_eval", "estimated_tokens": 12_000},
+        program_steps=(NightlyProgramStep("self_improvement"),),
+    ),
+    NightlyStepDefinition(
+        step_key="daily_blog",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                str(Path("content") / "blog" / "generate_blog.py"),
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Daily blog",
+        budget_hint={
+            "work_type": "reflection_dream",
+            "estimated_tokens": 3_000,
+        },
+        program_steps=(NightlyProgramStep("daily_blog"),),
+    ),
+)
+
+NIGHTLY_SLEEP_STEP_KEYS: tuple[str, ...] = tuple(
+    definition.step_key
+    for definition in NIGHTLY_STEP_REGISTRY
+    if definition.runs_in_executor
+)
+
 NIGHTLY_SLEEP_STEP_BUDGET_HINTS: dict[str, dict[str, object]] = {
-    "memory_consolidation": {
-        "work_type": "memory_conflict_resolution",
-        "estimated_tokens": 18_000,
-    },
-    "nightly_memory_maintenance": {
-        "work_type": "memory_conflict_resolution",
-        "estimated_tokens": 1_000,
-    },
-    "skill_evolution": {
-        "work_type": "skill_eval",
-        "estimated_tokens": 12_000,
-    },
-    "meta_learning": {
-        "work_type": "skill_eval",
-        "estimated_tokens": 10_000,
-    },
-    "heuristic_review": {
-        "work_type": "skill_eval",
-        "estimated_tokens": 4_000,
-    },
-    "meta_evolution": {
-        "work_type": "context_policy_eval",
-        "estimated_tokens": 8_000,
-    },
-    "reflection": {
-        "work_type": "reflection_dream",
-        "estimated_tokens": 10_000,
-    },
-    "dream": {
-        "work_type": "reflection_dream",
-        "estimated_tokens": 10_000,
-    },
-    "wake_up_index": {
-        "work_type": "memory_conflict_resolution",
-        "estimated_tokens": 4_000,
-    },
-    "file_sync": {
-        "work_type": "repo_summary_refresh",
-        "estimated_tokens": 3_000,
-    },
-    "project_draft_cleanup": {
-        "work_type": "storage_cleanup",
-        "estimated_tokens": 500,
-    },
-    "experiment_assessment": {
-        "work_type": "context_policy_eval",
-        "estimated_tokens": 6_000,
-    },
-    "self_improvement": {
-        "work_type": "skill_eval",
-        "estimated_tokens": 12_000,
-    },
-    "daily_blog": {
-        "work_type": "reflection_dream",
-        "estimated_tokens": 3_000,
-    },
+    definition.step_key: dict(definition.budget_hint)
+    for definition in NIGHTLY_STEP_REGISTRY
+    if definition.runs_in_executor
 }
+
+_NIGHTLY_SCHEDULER_STEPS_BY_KEY = {
+    definition.step_key: definition
+    for definition in NIGHTLY_STEP_REGISTRY
+    if definition.runs_in_executor
+}
+
+
+def nightly_commands(target_date: date) -> list[list[str]]:
+    return [
+        command
+        for definition in NIGHTLY_STEP_REGISTRY
+        if definition.runs_in_executor
+        for command in definition.commands_for(target_date)
+    ]
+
+
+def nightly_commands_for_step(step_key: str, target_date: date) -> list[list[str]]:
+    definition = _NIGHTLY_SCHEDULER_STEPS_BY_KEY.get(step_key)
+    if definition is None:
+        return []
+    return definition.commands_for(target_date)
 
 
 def _night_budget_hint(step_key: str) -> dict[str, object]:
@@ -206,13 +442,6 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
     ]
 
 
-@dataclass(frozen=True)
-class StepSpec:
-    step_key: str
-    command: list[str]
-    description: str = ""
-
-
 def _timezone(job: SchedulerJob) -> ZoneInfo:
     try:
         return ZoneInfo(job.timezone)
@@ -220,61 +449,28 @@ def _timezone(job: SchedulerJob) -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
-def _target_date(job: SchedulerJob, run: SchedulerRun) -> str:
-    return run.scheduled_for.astimezone(_timezone(job)).date().isoformat()
-
-
-def _python_one_liner(code: str) -> list[str]:
-    return ["python3", "-c", code]
-
-
-def nightly_heuristic_review_command() -> list[str]:
-    """Run the async heuristic review from a synchronous scheduler process."""
-    return _python_one_liner(
-        "import asyncio; "
-        "from brain.systems.feedback.heuristics import nightly_heuristic_review; "
-        "r = asyncio.run(nightly_heuristic_review()); "
-        "print(f'Nightly heuristic review ran: pruned={r[\"pruned\"]}, "
-        "skills_updated={r[\"skills_updated\"]}')"
-    )
+def _target_date(job: SchedulerJob, run: SchedulerRun) -> date:
+    return run.scheduled_for.astimezone(_timezone(job)).date()
 
 
 def _nightly_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     target_date = _target_date(job, run)
-    return [
-        StepSpec("consolidate_all", ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "all"], "Memory consolidation"),
-        StepSpec(
-            "nightly_memory_maintenance",
-            ["python3", "-m", "brain.jobs.pipelines.nightly_memory_maintenance", "--date", target_date, "--apply"],
-            "Auditable memory expiry maintenance",
-        ),
-        StepSpec("skill_evolution", ["python3", "-m", "brain.app.cli.skills", "evolve"], "Skill evolution"),
-        StepSpec("meta_learning_cross_pollinate", ["python3", "-m", "brain.app.cli.meta_learn", "cross-pollinate"], "Meta-learning cross-pollination"),
-        StepSpec("meta_learning_evolve", ["python3", "-m", "brain.app.cli.meta_learn", "evolve"], "Meta-learning evolve"),
-        StepSpec(
-            "heuristic_review",
-            nightly_heuristic_review_command(),
-            "Heuristic review",
-        ),
-        StepSpec(
-            "meta_evolution",
-            _python_one_liner(
-                "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
-                "stats = run_meta_evolution(); "
-                "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
-            ),
-            "Meta-evolution",
-        ),
-        StepSpec("context_policy_eval", ["python3", "-m", "brain.jobs.pipelines.nightly_context_eval", "--date", target_date], "Context policy shadow evaluation"),
-        StepSpec("nightly_reflect", ["python3", "-m", "brain.jobs.pipelines.nightly_reflect", "--date", target_date], "LLM reflection"),
-        StepSpec("nightly_dream", ["python3", "-m", "brain.jobs.pipelines.nightly_dream", "--date", target_date], "Dream synthesis"),
-        StepSpec("wake_up_index", ["python3", "-m", "brain.jobs.pipelines.consolidate", "--phase", "index"], "Wake-up index"),
-        StepSpec("brain_to_files_sync", ["python3", "-m", "brain.jobs.pipelines.sync_brain_to_files"], "Brain to files sync"),
-        StepSpec("project_draft_cleanup", ["python3", "-m", "brain.jobs.pipelines.project_draft_cleanup"], "Project draft cleanup"),
-        StepSpec("experiment_assessment", ["python3", "-m", "brain.jobs.pipelines.nightly_assess", "--date", target_date], "Experiment assessment"),
-        StepSpec("self_improvement", ["python3", "-m", "brain.jobs.pipelines.nightly_implement", "--date", target_date], "Self-improvement"),
-        StepSpec("daily_blog", ["python3", str(Path("content") / "blog" / "generate_blog.py"), "--date", target_date], "Daily blog"),
-    ]
+    steps: list[StepSpec] = []
+    for definition in NIGHTLY_STEP_REGISTRY:
+        commands = definition.commands_for(target_date)
+        steps.extend(
+            StepSpec(
+                program_step.step_key,
+                command,
+                program_step.description or definition.description,
+            )
+            for program_step, command in zip(
+                definition.program_steps,
+                commands,
+                strict=True,
+            )
+        )
+    return steps
 
 
 def _curiosity_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:

--- a/brain/systems/reconstructive_memory/curation.py
+++ b/brain/systems/reconstructive_memory/curation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy import select
@@ -25,6 +26,21 @@ from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
 CURATION_CREATED_BY = "agent_curation"
 MEMORY_CURATOR_SOURCE_KIND = "memory_curator"
 SUPERSEDED_BY_EDGE = "superseded_by"
+
+
+@dataclass(frozen=True)
+class _ArchiveAuditContext:
+    node_ids: list[int]
+    source_kind: str
+    source_ref: str
+    raw_content: str
+    span_drafts: list[SourceSpanDraft]
+    structured_payload: dict[str, Any]
+    user_id: str | None
+    org_id: str | None
+    authority_principal: str
+    visibility: str
+    sensitivity: str
 
 
 async def link_memories(
@@ -218,17 +234,33 @@ async def archive_memories(
         org_id=org_id,
     )
     normalized_reason = _normalize_reason(reason)
-    curation_source, _ = await _record_curation_source(
+    curation_source, _ = await _archive_with_curation(
         session,
-        action="archive",
-        reason=normalized_reason,
-        payload={"node_ids": unique_ids},
-        user_id=user_id,
-        org_id=org_id,
-        visibility=_curation_visibility(nodes),
-        run_id=run_id,
+        context=_ArchiveAuditContext(
+            node_ids=unique_ids,
+            source_kind=CURATION_CREATED_BY,
+            source_ref=f"{run_id or 'direct'}:archive:{uuid.uuid4()}",
+            raw_content=normalized_reason,
+            span_drafts=[
+                SourceSpanDraft(
+                    text=normalized_reason,
+                    locator={"kind": "curation_reason", "action": "archive"},
+                )
+            ],
+            structured_payload={
+                "action": "archive",
+                "reason": normalized_reason,
+                "created_by": CURATION_CREATED_BY,
+                "run_id": str(run_id) if run_id is not None else None,
+                "node_ids": unique_ids,
+            },
+            user_id=user_id,
+            org_id=org_id,
+            authority_principal=user_id,
+            visibility=_curation_visibility(nodes),
+            sensitivity="low",
+        ),
     )
-    await ReconstructiveMemoryCompatibilityRepository(session).archive_many(unique_ids)
     return {
         "memory_system": "reconstructive",
         "action": "archive",
@@ -263,39 +295,42 @@ async def archive_memory_by_policy(
         f"Rule: {normalized_rule}. Policy version: {normalized_policy_version}. "
         f"Target node: {node.id}. Run ID: {run_id}. Reason: {normalized_reason}"
     )
-    curation_source, spans = await MemorySourceRepository(session).create_with_spans(
-        source_kind=MEMORY_CURATOR_SOURCE_KIND,
-        source_ref=f"nightly-memory-maintenance:{run_id}:archive:{node.id}",
-        raw_content=audit_text,
-        spans=[
-            SourceSpanDraft(
-                text=audit_text,
-                locator={
-                    "kind": "memory_curation",
-                    "action": "archive",
-                    "rule": normalized_rule,
-                    "policy_version": normalized_policy_version,
-                    "target_node": node.id,
-                    "run_id": str(run_id),
-                },
-            )
-        ],
-        org_id=node.org_id,
-        user_id=node.user_id,
-        visibility=node.visibility,
-        structured_payload={
-            "action": "archive",
-            "rule": normalized_rule,
-            "policy_version": normalized_policy_version,
-            "target_node": node.id,
-            "run_id": str(run_id),
-            "reason": normalized_reason,
-            "created_by": MEMORY_CURATOR_SOURCE_KIND,
-        },
-        authority_principal=MEMORY_CURATOR_SOURCE_KIND,
-        sensitivity=node.sensitivity,
+    curation_source, spans = await _archive_with_curation(
+        session,
+        context=_ArchiveAuditContext(
+            node_ids=[node.id],
+            source_kind=MEMORY_CURATOR_SOURCE_KIND,
+            source_ref=f"nightly-memory-maintenance:{run_id}:archive:{node.id}",
+            raw_content=audit_text,
+            span_drafts=[
+                SourceSpanDraft(
+                    text=audit_text,
+                    locator={
+                        "kind": "memory_curation",
+                        "action": "archive",
+                        "rule": normalized_rule,
+                        "policy_version": normalized_policy_version,
+                        "target_node": node.id,
+                        "run_id": str(run_id),
+                    },
+                )
+            ],
+            structured_payload={
+                "action": "archive",
+                "rule": normalized_rule,
+                "policy_version": normalized_policy_version,
+                "target_node": node.id,
+                "run_id": str(run_id),
+                "reason": normalized_reason,
+                "created_by": MEMORY_CURATOR_SOURCE_KIND,
+            },
+            user_id=node.user_id,
+            org_id=node.org_id,
+            authority_principal=MEMORY_CURATOR_SOURCE_KIND,
+            visibility=node.visibility,
+            sensitivity=node.sensitivity,
+        ),
     )
-    await ReconstructiveMemoryCompatibilityRepository(session).archive_many([node.id])
     return {
         "node_id": node.id,
         "curation_source_id": curation_source.id,
@@ -321,6 +356,29 @@ async def _visible_nodes_exact(
     if missing:
         raise LookupError(f"Memory nodes are missing, archived, or not visible: {missing}")
     return nodes
+
+
+async def _archive_with_curation(
+    session: AsyncSession,
+    *,
+    context: _ArchiveAuditContext,
+):
+    curation_source, spans = await MemorySourceRepository(session).create_with_spans(
+        source_kind=context.source_kind,
+        source_ref=context.source_ref,
+        raw_content=context.raw_content,
+        spans=context.span_drafts,
+        org_id=context.org_id,
+        user_id=context.user_id,
+        visibility=context.visibility,
+        structured_payload=context.structured_payload,
+        authority_principal=context.authority_principal,
+        sensitivity=context.sensitivity,
+    )
+    await ReconstructiveMemoryCompatibilityRepository(session).archive_many(
+        context.node_ids
+    )
+    return curation_source, spans
 
 
 async def _record_curation_source(

--- a/brain/systems/reconstructive_memory/curation.py
+++ b/brain/systems/reconstructive_memory/curation.py
@@ -234,26 +234,21 @@ async def archive_memories(
         org_id=org_id,
     )
     normalized_reason = _normalize_reason(reason)
+    source_ref, span_drafts, structured_payload = _build_agent_curation_evidence(
+        action="archive",
+        reason=normalized_reason,
+        run_id=run_id,
+        payload={"node_ids": unique_ids},
+    )
     curation_source, _ = await _archive_with_curation(
         session,
         context=_ArchiveAuditContext(
             node_ids=unique_ids,
             source_kind=CURATION_CREATED_BY,
-            source_ref=f"{run_id or 'direct'}:archive:{uuid.uuid4()}",
+            source_ref=source_ref,
             raw_content=normalized_reason,
-            span_drafts=[
-                SourceSpanDraft(
-                    text=normalized_reason,
-                    locator={"kind": "curation_reason", "action": "archive"},
-                )
-            ],
-            structured_payload={
-                "action": "archive",
-                "reason": normalized_reason,
-                "created_by": CURATION_CREATED_BY,
-                "run_id": str(run_id) if run_id is not None else None,
-                "node_ids": unique_ids,
-            },
+            span_drafts=span_drafts,
+            structured_payload=structured_payload,
             user_id=user_id,
             org_id=org_id,
             authority_principal=user_id,
@@ -381,6 +376,31 @@ async def _archive_with_curation(
     return curation_source, spans
 
 
+def _build_agent_curation_evidence(
+    *,
+    action: str,
+    reason: str,
+    run_id: int | str | None,
+    payload: dict[str, Any],
+) -> tuple[str, list[SourceSpanDraft], dict[str, Any]]:
+    return (
+        f"{run_id or 'direct'}:{action}:{uuid.uuid4()}",
+        [
+            SourceSpanDraft(
+                text=reason,
+                locator={"kind": "curation_reason", "action": action},
+            )
+        ],
+        {
+            "action": action,
+            "reason": reason,
+            "created_by": CURATION_CREATED_BY,
+            "run_id": str(run_id) if run_id is not None else None,
+            **payload,
+        },
+    )
+
+
 async def _record_curation_source(
     session: AsyncSession,
     *,
@@ -392,21 +412,21 @@ async def _record_curation_source(
     visibility: str,
     run_id: int | str | None,
 ):
+    source_ref, spans, structured_payload = _build_agent_curation_evidence(
+        action=action,
+        reason=reason,
+        run_id=run_id,
+        payload=payload,
+    )
     return await MemorySourceRepository(session).create_with_spans(
         source_kind=CURATION_CREATED_BY,
-        source_ref=f"{run_id or 'direct'}:{action}:{uuid.uuid4()}",
+        source_ref=source_ref,
         raw_content=reason,
-        spans=[SourceSpanDraft(text=reason, locator={"kind": "curation_reason", "action": action})],
+        spans=spans,
         org_id=org_id,
         user_id=user_id,
         visibility=visibility,
-        structured_payload={
-            "action": action,
-            "reason": reason,
-            "created_by": CURATION_CREATED_BY,
-            "run_id": str(run_id) if run_id is not None else None,
-            **payload,
-        },
+        structured_payload=structured_payload,
         authority_principal=user_id,
     )
 

--- a/tests/test_curation_archive_primitive.py
+++ b/tests/test_curation_archive_primitive.py
@@ -1,0 +1,196 @@
+"""Archive curation entry points share one audit-and-archive primitive."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import brain.systems.reconstructive_memory.curation as curation
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_user_archive_supplies_its_existing_audit_contract(monkeypatch):
+    visible_nodes = [
+        SimpleNamespace(visibility="org"),
+        SimpleNamespace(visibility="private"),
+    ]
+    monkeypatch.setattr(
+        curation,
+        "_visible_nodes_exact",
+        AsyncMock(return_value=visible_nodes),
+    )
+    archive_with_curation = AsyncMock(
+        return_value=(SimpleNamespace(id=41), [SimpleNamespace(id=42)])
+    )
+    monkeypatch.setattr(curation, "_archive_with_curation", archive_with_curation)
+
+    result = await curation.archive_memories(
+        SimpleNamespace(),
+        node_ids=[7, 7, 9],
+        reason="  Obsolete   duplicate memory. ",
+        user_id="user:test",
+        org_id="org:test",
+        run_id=123,
+    )
+
+    context = archive_with_curation.await_args.kwargs["context"]
+    assert context.node_ids == [7, 9]
+    assert context.source_kind == curation.CURATION_CREATED_BY
+    assert context.source_ref.startswith("123:archive:")
+    assert context.raw_content == "Obsolete duplicate memory."
+    assert context.span_drafts[0].text == context.raw_content
+    assert context.span_drafts[0].locator == {
+        "kind": "curation_reason",
+        "action": "archive",
+    }
+    assert context.structured_payload == {
+        "action": "archive",
+        "reason": "Obsolete duplicate memory.",
+        "created_by": curation.CURATION_CREATED_BY,
+        "run_id": "123",
+        "node_ids": [7, 9],
+    }
+    assert context.user_id == "user:test"
+    assert context.org_id == "org:test"
+    assert context.authority_principal == "user:test"
+    assert context.visibility == "private"
+    assert context.sensitivity == "low"
+    assert result == {
+        "memory_system": "reconstructive",
+        "action": "archive",
+        "node_ids": [7, 9],
+        "archived_count": 2,
+        "created_by": curation.CURATION_CREATED_BY,
+        "reason": "Obsolete duplicate memory.",
+        "curation_source_id": 41,
+    }
+
+
+async def test_policy_archive_supplies_its_existing_audit_contract(monkeypatch):
+    archive_with_curation = AsyncMock(
+        return_value=(SimpleNamespace(id=51), [SimpleNamespace(id=52)])
+    )
+    monkeypatch.setattr(curation, "_archive_with_curation", archive_with_curation)
+    node = SimpleNamespace(
+        id=17,
+        archived_at=None,
+        org_id="org:test",
+        user_id="user:test",
+        visibility="team",
+        sensitivity="high",
+    )
+
+    result = await curation.archive_memory_by_policy(
+        SimpleNamespace(),
+        node=node,
+        rule=" expired transient fact ",
+        policy_version=" v1 ",
+        run_id=456,
+        reason="  Expired   by policy. ",
+    )
+
+    context = archive_with_curation.await_args.kwargs["context"]
+    assert context.node_ids == [17]
+    assert context.source_kind == curation.MEMORY_CURATOR_SOURCE_KIND
+    assert context.source_ref == "nightly-memory-maintenance:456:archive:17"
+    assert context.raw_content == (
+        "Rule: expired transient fact. Policy version: v1. Target node: 17. "
+        "Run ID: 456. Reason: Expired by policy."
+    )
+    assert context.span_drafts[0].text == context.raw_content
+    assert context.span_drafts[0].locator == {
+        "kind": "memory_curation",
+        "action": "archive",
+        "rule": "expired transient fact",
+        "policy_version": "v1",
+        "target_node": 17,
+        "run_id": "456",
+    }
+    assert context.structured_payload == {
+        "action": "archive",
+        "rule": "expired transient fact",
+        "policy_version": "v1",
+        "target_node": 17,
+        "run_id": "456",
+        "reason": "Expired by policy.",
+        "created_by": curation.MEMORY_CURATOR_SOURCE_KIND,
+    }
+    assert context.user_id == "user:test"
+    assert context.org_id == "org:test"
+    assert context.authority_principal == curation.MEMORY_CURATOR_SOURCE_KIND
+    assert context.visibility == "team"
+    assert context.sensitivity == "high"
+    assert result == {
+        "node_id": 17,
+        "curation_source_id": 51,
+        "curation_span_id": 52,
+    }
+
+
+async def test_archive_primitive_records_evidence_before_soft_archive(monkeypatch):
+    calls: list[tuple[str, object]] = []
+    source = SimpleNamespace(id=61)
+    spans = [SimpleNamespace(id=62)]
+
+    class SourceRepository:
+        def __init__(self, session):
+            calls.append(("source_repository", session))
+
+        async def create_with_spans(self, **kwargs):
+            calls.append(("create_with_spans", kwargs))
+            return source, spans
+
+    class CompatibilityRepository:
+        def __init__(self, session):
+            calls.append(("compatibility_repository", session))
+
+        async def archive_many(self, node_ids):
+            calls.append(("archive_many", node_ids))
+
+    monkeypatch.setattr(curation, "MemorySourceRepository", SourceRepository)
+    monkeypatch.setattr(
+        curation,
+        "ReconstructiveMemoryCompatibilityRepository",
+        CompatibilityRepository,
+    )
+    session = SimpleNamespace()
+    context = curation._ArchiveAuditContext(
+        node_ids=[23],
+        source_kind="audit-kind",
+        source_ref="audit-ref",
+        raw_content="audit text",
+        span_drafts=[],
+        structured_payload={"action": "archive"},
+        user_id="user:test",
+        org_id="org:test",
+        authority_principal="actor:test",
+        visibility="org",
+        sensitivity="low",
+    )
+
+    result = await curation._archive_with_curation(session, context=context)
+
+    assert result == (source, spans)
+    assert calls == [
+        ("source_repository", session),
+        (
+            "create_with_spans",
+            {
+                "source_kind": "audit-kind",
+                "source_ref": "audit-ref",
+                "raw_content": "audit text",
+                "spans": [],
+                "org_id": "org:test",
+                "user_id": "user:test",
+                "visibility": "org",
+                "structured_payload": {"action": "archive"},
+                "authority_principal": "actor:test",
+                "sensitivity": "low",
+            },
+        ),
+        ("compatibility_repository", session),
+        ("archive_many", [23]),
+    ]

--- a/tests/test_curation_archive_primitive.py
+++ b/tests/test_curation_archive_primitive.py
@@ -12,6 +12,35 @@ import brain.systems.reconstructive_memory.curation as curation
 pytestmark = pytest.mark.asyncio
 
 
+def _record_archive_repository_calls(monkeypatch, *, source_id, span_id):
+    calls: list[tuple[str, object]] = []
+    source = SimpleNamespace(id=source_id)
+    spans = [SimpleNamespace(id=span_id)]
+
+    class SourceRepository:
+        def __init__(self, session):
+            pass
+
+        async def create_with_spans(self, **kwargs):
+            calls.append(("create_with_spans", kwargs))
+            return source, spans
+
+    class CompatibilityRepository:
+        def __init__(self, session):
+            pass
+
+        async def archive_many(self, node_ids):
+            calls.append(("archive_many", node_ids))
+
+    monkeypatch.setattr(curation, "MemorySourceRepository", SourceRepository)
+    monkeypatch.setattr(
+        curation,
+        "ReconstructiveMemoryCompatibilityRepository",
+        CompatibilityRepository,
+    )
+    return calls
+
+
 async def test_user_archive_supplies_its_existing_audit_contract(monkeypatch):
     visible_nodes = [
         SimpleNamespace(visibility="org"),
@@ -22,13 +51,16 @@ async def test_user_archive_supplies_its_existing_audit_contract(monkeypatch):
         "_visible_nodes_exact",
         AsyncMock(return_value=visible_nodes),
     )
-    archive_with_curation = AsyncMock(
-        return_value=(SimpleNamespace(id=41), [SimpleNamespace(id=42)])
+    monkeypatch.setattr(curation.uuid, "uuid4", lambda: "evidence-uuid")
+    calls = _record_archive_repository_calls(
+        monkeypatch,
+        source_id=41,
+        span_id=42,
     )
-    monkeypatch.setattr(curation, "_archive_with_curation", archive_with_curation)
 
+    session = SimpleNamespace()
     result = await curation.archive_memories(
-        SimpleNamespace(),
+        session,
         node_ids=[7, 7, 9],
         reason="  Obsolete   duplicate memory. ",
         user_id="user:test",
@@ -36,28 +68,35 @@ async def test_user_archive_supplies_its_existing_audit_contract(monkeypatch):
         run_id=123,
     )
 
-    context = archive_with_curation.await_args.kwargs["context"]
-    assert context.node_ids == [7, 9]
-    assert context.source_kind == curation.CURATION_CREATED_BY
-    assert context.source_ref.startswith("123:archive:")
-    assert context.raw_content == "Obsolete duplicate memory."
-    assert context.span_drafts[0].text == context.raw_content
-    assert context.span_drafts[0].locator == {
-        "kind": "curation_reason",
-        "action": "archive",
-    }
-    assert context.structured_payload == {
-        "action": "archive",
-        "reason": "Obsolete duplicate memory.",
-        "created_by": curation.CURATION_CREATED_BY,
-        "run_id": "123",
-        "node_ids": [7, 9],
-    }
-    assert context.user_id == "user:test"
-    assert context.org_id == "org:test"
-    assert context.authority_principal == "user:test"
-    assert context.visibility == "private"
-    assert context.sensitivity == "low"
+    assert calls == [
+        (
+            "create_with_spans",
+            {
+                "source_kind": curation.CURATION_CREATED_BY,
+                "source_ref": "123:archive:evidence-uuid",
+                "raw_content": "Obsolete duplicate memory.",
+                "spans": [
+                    curation.SourceSpanDraft(
+                        text="Obsolete duplicate memory.",
+                        locator={"kind": "curation_reason", "action": "archive"},
+                    )
+                ],
+                "org_id": "org:test",
+                "user_id": "user:test",
+                "visibility": "private",
+                "structured_payload": {
+                    "action": "archive",
+                    "reason": "Obsolete duplicate memory.",
+                    "created_by": curation.CURATION_CREATED_BY,
+                    "run_id": "123",
+                    "node_ids": [7, 9],
+                },
+                "authority_principal": "user:test",
+                "sensitivity": "low",
+            },
+        ),
+        ("archive_many", [7, 9]),
+    ]
     assert result == {
         "memory_system": "reconstructive",
         "action": "archive",
@@ -70,10 +109,11 @@ async def test_user_archive_supplies_its_existing_audit_contract(monkeypatch):
 
 
 async def test_policy_archive_supplies_its_existing_audit_contract(monkeypatch):
-    archive_with_curation = AsyncMock(
-        return_value=(SimpleNamespace(id=51), [SimpleNamespace(id=52)])
+    calls = _record_archive_repository_calls(
+        monkeypatch,
+        source_id=51,
+        span_id=52,
     )
-    monkeypatch.setattr(curation, "_archive_with_curation", archive_with_curation)
     node = SimpleNamespace(
         id=17,
         archived_at=None,
@@ -92,37 +132,48 @@ async def test_policy_archive_supplies_its_existing_audit_contract(monkeypatch):
         reason="  Expired   by policy. ",
     )
 
-    context = archive_with_curation.await_args.kwargs["context"]
-    assert context.node_ids == [17]
-    assert context.source_kind == curation.MEMORY_CURATOR_SOURCE_KIND
-    assert context.source_ref == "nightly-memory-maintenance:456:archive:17"
-    assert context.raw_content == (
+    audit_text = (
         "Rule: expired transient fact. Policy version: v1. Target node: 17. "
         "Run ID: 456. Reason: Expired by policy."
     )
-    assert context.span_drafts[0].text == context.raw_content
-    assert context.span_drafts[0].locator == {
-        "kind": "memory_curation",
-        "action": "archive",
-        "rule": "expired transient fact",
-        "policy_version": "v1",
-        "target_node": 17,
-        "run_id": "456",
-    }
-    assert context.structured_payload == {
-        "action": "archive",
-        "rule": "expired transient fact",
-        "policy_version": "v1",
-        "target_node": 17,
-        "run_id": "456",
-        "reason": "Expired by policy.",
-        "created_by": curation.MEMORY_CURATOR_SOURCE_KIND,
-    }
-    assert context.user_id == "user:test"
-    assert context.org_id == "org:test"
-    assert context.authority_principal == curation.MEMORY_CURATOR_SOURCE_KIND
-    assert context.visibility == "team"
-    assert context.sensitivity == "high"
+    assert calls == [
+        (
+            "create_with_spans",
+            {
+                "source_kind": curation.MEMORY_CURATOR_SOURCE_KIND,
+                "source_ref": "nightly-memory-maintenance:456:archive:17",
+                "raw_content": audit_text,
+                "spans": [
+                    curation.SourceSpanDraft(
+                        text=audit_text,
+                        locator={
+                            "kind": "memory_curation",
+                            "action": "archive",
+                            "rule": "expired transient fact",
+                            "policy_version": "v1",
+                            "target_node": 17,
+                            "run_id": "456",
+                        },
+                    )
+                ],
+                "org_id": "org:test",
+                "user_id": "user:test",
+                "visibility": "team",
+                "structured_payload": {
+                    "action": "archive",
+                    "rule": "expired transient fact",
+                    "policy_version": "v1",
+                    "target_node": 17,
+                    "run_id": "456",
+                    "reason": "Expired by policy.",
+                    "created_by": curation.MEMORY_CURATOR_SOURCE_KIND,
+                },
+                "authority_principal": curation.MEMORY_CURATOR_SOURCE_KIND,
+                "sensitivity": "high",
+            },
+        ),
+        ("archive_many", [17]),
+    ]
     assert result == {
         "node_id": 17,
         "curation_source_id": 51,
@@ -130,67 +181,154 @@ async def test_policy_archive_supplies_its_existing_audit_contract(monkeypatch):
     }
 
 
-async def test_archive_primitive_records_evidence_before_soft_archive(monkeypatch):
-    calls: list[tuple[str, object]] = []
-    source = SimpleNamespace(id=61)
-    spans = [SimpleNamespace(id=62)]
-
-    class SourceRepository:
-        def __init__(self, session):
-            calls.append(("source_repository", session))
-
-        async def create_with_spans(self, **kwargs):
-            calls.append(("create_with_spans", kwargs))
-            return source, spans
-
-    class CompatibilityRepository:
-        def __init__(self, session):
-            calls.append(("compatibility_repository", session))
-
-        async def archive_many(self, node_ids):
-            calls.append(("archive_many", node_ids))
-
-    monkeypatch.setattr(curation, "MemorySourceRepository", SourceRepository)
+async def test_link_persists_the_shared_agent_curation_evidence_contract(monkeypatch):
     monkeypatch.setattr(
         curation,
-        "ReconstructiveMemoryCompatibilityRepository",
-        CompatibilityRepository,
+        "_visible_nodes_exact",
+        AsyncMock(
+            return_value=[
+                SimpleNamespace(visibility="org"),
+                SimpleNamespace(visibility="team"),
+            ]
+        ),
     )
-    session = SimpleNamespace()
-    context = curation._ArchiveAuditContext(
-        node_ids=[23],
-        source_kind="audit-kind",
-        source_ref="audit-ref",
-        raw_content="audit text",
-        span_drafts=[],
-        structured_payload={"action": "archive"},
+    monkeypatch.setattr(curation.uuid, "uuid4", lambda: "link-uuid")
+    source_repository = SimpleNamespace(
+        create_with_spans=AsyncMock(
+            return_value=(SimpleNamespace(id=61), [SimpleNamespace(id=62)])
+        )
+    )
+    edge_repository = SimpleNamespace(
+        upsert_edge=AsyncMock(
+            return_value=SimpleNamespace(id=63, created_by=curation.CURATION_CREATED_BY)
+        )
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemorySourceRepository",
+        lambda session: source_repository,
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemoryEdgeRepository",
+        lambda session: edge_repository,
+    )
+
+    await curation.link_memories(
+        SimpleNamespace(),
+        source_node_id=7,
+        target_node_id=9,
+        relationship=" supports guidance ",
+        reason="  Same   verified guidance. ",
         user_id="user:test",
         org_id="org:test",
-        authority_principal="actor:test",
-        visibility="org",
-        sensitivity="low",
+        run_id=234,
     )
 
-    result = await curation._archive_with_curation(session, context=context)
+    source_repository.create_with_spans.assert_awaited_once_with(
+        source_kind=curation.CURATION_CREATED_BY,
+        source_ref="234:link:link-uuid",
+        raw_content="Same verified guidance.",
+        spans=[
+            curation.SourceSpanDraft(
+                text="Same verified guidance.",
+                locator={"kind": "curation_reason", "action": "link"},
+            )
+        ],
+        org_id="org:test",
+        user_id="user:test",
+        visibility="team",
+        structured_payload={
+            "action": "link",
+            "reason": "Same verified guidance.",
+            "created_by": curation.CURATION_CREATED_BY,
+            "run_id": "234",
+            "source_node": 7,
+            "target_node": 9,
+            "relationship": "supports_guidance",
+        },
+        authority_principal="user:test",
+    )
 
-    assert result == (source, spans)
-    assert calls == [
-        ("source_repository", session),
-        (
-            "create_with_spans",
-            {
-                "source_kind": "audit-kind",
-                "source_ref": "audit-ref",
-                "raw_content": "audit text",
-                "spans": [],
-                "org_id": "org:test",
-                "user_id": "user:test",
-                "visibility": "org",
-                "structured_payload": {"action": "archive"},
-                "authority_principal": "actor:test",
-                "sensitivity": "low",
-            },
+
+async def test_supersede_persists_the_shared_agent_curation_evidence_contract(monkeypatch):
+    old_node = SimpleNamespace(visibility="org")
+    monkeypatch.setattr(
+        curation,
+        "_visible_nodes_exact",
+        AsyncMock(
+            side_effect=[
+                [old_node],
+                [old_node, SimpleNamespace(visibility="private")],
+            ]
         ),
-        ("compatibility_repository", session),
-        ("archive_many", [23]),
-    ]
+    )
+    monkeypatch.setattr(curation.uuid, "uuid4", lambda: "supersede-uuid")
+    source_repository = SimpleNamespace(
+        create_with_spans=AsyncMock(
+            return_value=(SimpleNamespace(id=71), [SimpleNamespace(id=72)])
+        )
+    )
+    node_repository = SimpleNamespace(mark_superseded=AsyncMock())
+    assertion_repository = SimpleNamespace(mark_superseded_for_node=AsyncMock())
+    edge_repository = SimpleNamespace(
+        upsert_edge=AsyncMock(
+            return_value=SimpleNamespace(id=73, created_by=curation.CURATION_CREATED_BY)
+        )
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemorySourceRepository",
+        lambda session: source_repository,
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemoryNodeRepository",
+        lambda session: node_repository,
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemoryAssertionRepository",
+        lambda session: assertion_repository,
+    )
+    monkeypatch.setattr(
+        curation,
+        "MemoryEdgeRepository",
+        lambda session: edge_repository,
+    )
+    session = SimpleNamespace()
+    session.scalar = AsyncMock(return_value=None)
+
+    await curation.supersede_memory(
+        session,
+        old_node_id=23,
+        new_node_id=29,
+        reason="  Replaced   by verified guidance. ",
+        user_id="user:test",
+        org_id="org:test",
+        run_id=None,
+    )
+
+    source_repository.create_with_spans.assert_awaited_once_with(
+        source_kind=curation.CURATION_CREATED_BY,
+        source_ref="direct:supersede:supersede-uuid",
+        raw_content="Replaced by verified guidance.",
+        spans=[
+            curation.SourceSpanDraft(
+                text="Replaced by verified guidance.",
+                locator={"kind": "curation_reason", "action": "supersede"},
+            )
+        ],
+        org_id="org:test",
+        user_id="user:test",
+        visibility="private",
+        structured_payload={
+            "action": "supersede",
+            "reason": "Replaced by verified guidance.",
+            "created_by": curation.CURATION_CREATED_BY,
+            "run_id": None,
+            "old_node": 23,
+            "new_node": 29,
+        },
+        authority_principal="user:test",
+    )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -37,6 +37,9 @@ from brain.app.scheduler.executor import (
 )
 from brain.app.scheduler.planner import async_materialize_due_runs
 from brain.app.scheduler.programs import (
+    NIGHTLY_SLEEP_STEP_BUDGET_HINTS,
+    NIGHTLY_SLEEP_STEP_KEYS,
+    NIGHTLY_STEP_REGISTRY,
     build_scheduler_step_plan,
     get_step_specs,
     nightly_heuristic_review_command,
@@ -576,6 +579,65 @@ async def test_nightly_heuristic_review_wrappers_await_and_report_counts(monkeyp
     assert scheduler_executor._nightly_step_commands(
         "heuristic_review", date(2026, 4, 21)
     ) == [command]
+
+
+async def test_nightly_registry_generates_every_command_representation():
+    target_date = date(2026, 4, 21)
+    scheduled_definitions = tuple(
+        definition
+        for definition in NIGHTLY_STEP_REGISTRY
+        if definition.runs_in_executor
+    )
+
+    assert NIGHTLY_SLEEP_STEP_KEYS == tuple(
+        definition.step_key for definition in scheduled_definitions
+    )
+    assert NIGHTLY_SLEEP_STEP_BUDGET_HINTS == {
+        definition.step_key: definition.budget_hint
+        for definition in scheduled_definitions
+    }
+
+    per_key_commands = [
+        scheduler_executor._nightly_step_commands(step_key, target_date)
+        for step_key in NIGHTLY_SLEEP_STEP_KEYS
+    ]
+    assert all(
+        NIGHTLY_SLEEP_STEP_BUDGET_HINTS[step_key]
+        for step_key in NIGHTLY_SLEEP_STEP_KEYS
+    )
+    assert all(per_key_commands)
+    assert scheduler_executor._nightly_wrapper_commands(
+        target_date,
+        split_steps=False,
+    ) == [command for commands in per_key_commands for command in commands]
+
+    job = _make_scheduler_job()
+    run = SimpleNamespace(
+        scheduled_for=datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc)
+    )
+    expected_program_steps = [
+        (
+            program_step.step_key,
+            command,
+            program_step.description or definition.description,
+        )
+        for definition in NIGHTLY_STEP_REGISTRY
+        for program_step, command in zip(
+            definition.program_steps,
+            definition.commands_for(target_date),
+            strict=True,
+        )
+    ]
+    assert [
+        (step.step_key, step.command, step.description)
+        for step in get_step_specs(job, run)
+    ] == expected_program_steps
+
+    assert [
+        definition.step_key
+        for definition in NIGHTLY_STEP_REGISTRY
+        if not definition.runs_in_executor
+    ] == ["context_policy_eval"]
 
 
 async def test_split_nightly_scheduler_reaches_and_settles_memory_maintenance(session):


### PR DESCRIPTION
Closes #424

Pure structural refactor — **no behaviour change**. Two duplications collapsed.

## 1. Five nightly step representations → one registry

Adding a nightly step used to mean editing five places by hand, with nothing enforcing that they agree. All five are now derived from one ordered `NIGHTLY_STEP_REGISTRY` (key → command factory, description, budget hint): `NIGHTLY_SLEEP_STEP_KEYS`, `NIGHTLY_SLEEP_STEP_BUDGET_HINTS`, `_nightly_steps()`, `_nightly_wrapper_commands()`, `_nightly_step_commands()`. `executor.py` loses its two duplicate command tables and shrinks 1,087 → 1,027 lines.

## 2. Two archive paths → one primitive, one evidence builder

`archive_memories()` (user-initiated) and `archive_memory_by_policy()` (system-initiated) now share `_archive_with_curation()`, while keeping their distinct source kinds, actor metadata, evidence shape and return values. `_build_agent_curation_evidence()` is the single definition site for the agent-curation evidence schema, used by both `archive_memories()` and `_record_curation_source()`. Link and supersede are untouched.

## The drift this found — a live one, deliberately not fixed here 👀

`context_policy_eval` (→ `brain.jobs.pipelines.nightly_context_eval`) was declared in **exactly one** of the five representations, and that representation has **no production caller** — `build_scheduler_step_plan()` (`executor.py:573`) is the production path and never calls `get_step_specs()`. So **that nightly step has never actually run.**

Making it run is a product decision, not a refactor's, so this PR makes the divergence explicit (`runs_in_executor=False`, commented, naming #424) instead of silently resolving it in either direction. **The decision, and the cleanup that follows from it, are filed as #432.**

## How this was verified

- **Behaviour neutrality, proven by snapshot diff.** Step keys, budget hints, wrapper commands (both split modes), every per-key command, unknown-key handling, planned-step filtering, step payloads, the step plan and all 16 `StepSpec`s were captured from `origin/main` and from this branch: 11,428 bytes each, SHA-256 `d0a2463a…` identical.
- **The new drift guard was mutation-tested.** Defining `dream` independently inside `executor.py` makes `test_nightly_registry_generates_every_command_representation` fail — the guard has teeth, it is not decorative.
- **82 passed** — `tests/test_scheduler.py tests/test_nightly_pipeline.py tests/test_project_context_draft_lifecycle.py tests/test_reconstructive_memory.py tests/test_nightly_memory_maintenance.py tests/test_curation_archive_primitive.py`.
- One behaviour risk checked and cleared: `archive_memories()` now passes `sensitivity="low"` explicitly where it previously omitted the argument — `create_with_spans` defaults to `"low"`, so nothing changed.

## Maintainability review — 2 BLOCKING findings, 1 folded, 1 refused

Reviewed by a separate Codex pass against the thermo-nuclear rubric. Its verdict: net maintainability improvement, "executable scheduler commands now have a canonical owner."

- **Folded (commit 2):** the first commit had `archive_memories()` hand-restating the evidence schema `_record_curation_source()` still owned — duplication this ticket exists to remove, added by the ticket itself. Now one builder. The new tests also asserted the private `_ArchiveAuditContext` field layout; they now assert the repository calls made through the public entry points.
- **Refused, filed as #432:** delete `StepSpec` / `get_step_specs()` / `context_policy_eval` outright. The diagnosis is right and its premise verified, but the remedy is a deletion gated on the unmade `nightly_context_eval` decision — if that step *should* run you wire it in, if it shouldn't you delete it. Opposite directions; folding either would guess on the maintainer's behalf. Also outside this ticket's declared scope.

## Acceptance checks

1. Adding a nightly step requires editing exactly one registry — `test_nightly_registry_generates_every_command_representation` fails if any representation is defined independently (mutation-tested).
2. Nightly step order, commands and budget hints are unchanged — byte-identical generated output.
3. Both archive paths share one primitive and one evidence builder, keeping their distinct source kinds, actor metadata and evidence shape.
4. Existing curation tests pass untouched — link and supersede behaviour is unchanged.
