### PR TITLE
test(ci): fix the four tests PR #408 un-hides (#434)

### DIFF
--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -23,7 +23,7 @@ from tests.test_chat_api_routes import (
 )
 
 
-pytestmark = pytest.mark.anyio
+pytestmark = pytest.mark.asyncio
 
 
 def _claims(user_id: str, org_id: str = "org-1") -> WsTokenClaims:

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -1296,11 +1296,17 @@ async def test_postgres_merged_main_envelope_flips_record_and_emits_domain_event
             }
         ],
     )
-    from brain.systems.deploy_state_sweep import ensure_deploy_state_fields
+    from brain.systems.deploy_state_sweep import (
+        DEPLOY_STATE_FIELD_DEFINITIONS,
+        ensure_deploy_state_fields,
+    )
 
     first_fields = await ensure_deploy_state_fields(db_session, org_id=ORG_ID)
     second_fields = await ensure_deploy_state_fields(db_session, org_id=ORG_ID)
-    assert first_fields["fields_added"] == 10
+    # The canonical set is currently ten lifecycle fields plus five
+    # alert-resolution provenance fields. This fresh object starts with none of
+    # them, so the first pass installs the full set and the second is idempotent.
+    assert first_fields["fields_added"] == len(DEPLOY_STATE_FIELD_DEFINITIONS)
     assert second_fields["fields_added"] == 0
     record = await domain_service.create_record(
         ORG_ID,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -4,12 +4,10 @@ import sys
 import os
 from unittest.mock import patch
 
-import numpy as np
 from sqlalchemy import text
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
 from brain.systems.quality.checks import check_content_quality, cap_salience
-from brain.systems.memory.embeddings import vec_to_pg
 
 _HAS_DB = bool(os.environ.get("TEST_DB_URL"))
 
@@ -83,19 +81,12 @@ class TestSalienceCap:
 
 @pytest.mark.skipif(not _HAS_DB, reason="TEST_DB_URL not set — requires live database")
 class TestDeduplication:
-    """Test near-duplicate detection at write time (requires live DB)."""
+    """Test normalized exact-duplicate detection at write time (requires live DB)."""
 
     ORG_ID = "50000000-0000-0000-0000-000000000001"
     USER_ID = "60000000-0000-0000-0000-000000000001"
     OTHER_ORG_ID = "50000000-0000-0000-0000-000000000002"
     OTHER_USER_ID = "60000000-0000-0000-0000-000000000002"
-
-    def _embedding(self, index: int = 0):
-        from brain.kernel.config import MEMORY_SEMANTIC_EMBEDDING_DIM
-
-        vec = np.zeros(MEMORY_SEMANTIC_EMBEDDING_DIM, dtype=np.float32)
-        vec[index] = 1.0
-        return vec
 
     async def _ensure_principal(self, db_session, *, org_id: str, user_id: str, slug: str, email: str) -> None:
         await db_session.execute(text("""
@@ -114,7 +105,6 @@ class TestDeduplication:
         db_session,
         *,
         content: str,
-        embedding,
         user_id: str,
         org_id: str,
         visibility: str = "private",
@@ -156,16 +146,14 @@ class TestDeduplication:
             email="quality-test-other@example.com",
         )
         content = "A scoped duplicate memory should only match visible tenant memories."
-        embedding = self._embedding(0)
         memory_id = await self._insert_memory(
             db_session,
             content=content,
-            embedding=embedding,
             user_id=self.USER_ID,
             org_id=self.ORG_ID,
         )
         await db_session.flush()
-        return {"id": memory_id, "content": content, "embedding": embedding}
+        return {"id": memory_id, "content": content}
 
     async def test_exact_duplicate_detected(self, scoped_memory, unit_of_work_for_session):
         """An exact copy of an existing memory should be flagged as duplicate."""
@@ -173,7 +161,6 @@ class TestDeduplication:
         with patch("brain.systems.quality.checks.UnitOfWork", unit_of_work_for_session):
             is_dupe, details = await check_duplicate(
                 scoped_memory["content"],
-                embedding=scoped_memory["embedding"],
                 user_id=self.USER_ID,
                 org_id=self.ORG_ID,
             )
@@ -188,7 +175,6 @@ class TestDeduplication:
             is_dupe, details = await check_duplicate(
                 "This is a completely unique test memory about quantum flamingos "
                 "dancing on the surface of Mars during a solar eclipse in the year 3042.",
-                embedding=self._embedding(1),
                 user_id=self.USER_ID,
                 org_id=self.ORG_ID,
             )
@@ -198,11 +184,9 @@ class TestDeduplication:
         """An identical hidden memory in another org should not block this tenant."""
         from brain.systems.quality.checks import check_duplicate
 
-        same_embedding = self._embedding(2)
         await self._insert_memory(
             db_session,
             content="Same vector in another tenant should stay isolated.",
-            embedding=same_embedding,
             user_id=self.OTHER_USER_ID,
             org_id=self.OTHER_ORG_ID,
             visibility="org",
@@ -212,17 +196,15 @@ class TestDeduplication:
         with patch("brain.systems.quality.checks.UnitOfWork", unit_of_work_for_session):
             is_dupe, _details = await check_duplicate(
                 "Same vector in another tenant should stay isolated.",
-                embedding=same_embedding,
                 user_id=self.USER_ID,
                 org_id=None,
             )
         assert not is_dupe
 
     async def test_validate_memory_rejects_duplicate(self, scoped_memory, unit_of_work_for_session):
-        """Full validation pipeline should reject near-duplicates."""
+        """Full validation pipeline should reject a normalized exact duplicate."""
         from brain.systems.quality.checks import validate_memory
-        with patch("brain.systems.quality.checks.UnitOfWork", unit_of_work_for_session), \
-             patch("brain.systems.quality.checks.embed_document", return_value=scoped_memory["embedding"]):
+        with patch("brain.systems.quality.checks.UnitOfWork", unit_of_work_for_session):
             accepted, reason, details = await validate_memory(
                 scoped_memory["content"],
                 user_id=self.USER_ID,


### PR DESCRIPTION
Closes #434.

Fixes the four tests that [PR #408](https://github.com/Illospace/illospace/pull/408) un-hides. They were already broken on `main` — the deleted `--ignore=` flags and the narrow `db` path filter meant nothing ever ran them. **All four are harness rot; none is a product bug.**

## What was wrong, and why each fix is the right one

| Test | Cause | Fix |
|---|---|---|
| `test_chat_websocket.py` (×2) | The file carried the repo's **lone** `pytest.mark.anyio`, while `pytest.ini` sets `asyncio_mode = auto` and 19 other suites use `pytest.mark.asyncio`. The anyio runner's loop differed from the one the live asyncpg fixtures were created on → `got Future ... attached to a different loop`. | Aligned to the repo convention. |
| `test_inbound_webhooks.py` | `fields_added` moved 10 → 15: five alert-resolution provenance fields joined the canonical set. | Assert `len(DEPLOY_STATE_FIELD_DEFINITIONS)` — the tuple `ensure_deploy_state_fields` actually iterates — so it can't drift again. Idempotence assertion untouched. |
| `test_quality.py` | It patched `brain.systems.quality.checks.embed_document`, which **no longer exists** — the patch itself raised. | Dedup is now normalized exact matching. `check_duplicate`'s `embedding` parameter is vestigial (`del embedding` in the body), so dropping it from the call sites exercises the identical path. |

I specifically checked that the `15` is not a renumbering: it is derived from the canonical definition tuple, and I verified that tuple has 15 unique entries and is the one the implementation iterates.

## Acceptance checks

1. `Backend DB suite` green on #408's branch once this lands — **no test skipped, xfailed, or re-ignored** to get there.
2. The `15` is derived from `DEPLOY_STATE_FIELD_DEFINITIONS`, not hardcoded.
3. No `--ignore=` entry added back; `.github/workflows/brain-ci.yml` is **untouched** (PR #408 owns that file, so these two PRs cannot conflict).
4. Each fix is attributed to harness rot vs product bug — all four are harness rot.

## Honest limits

Three of these are `requires_db`. **The worker had no Postgres and no SQLAlchemy locally, so no fix was executed locally — all four are reasoned from the code and the CI traceback.** CI is the real verifier here. I verified the *claims* against the source by hand (that `embed_document` is gone, that `del embedding` makes the parameter vestigial, that the definitions tuple has 15 unique entries and is what the implementation iterates, and that `asyncio_mode = auto` with 19 sibling suites makes the marker change the conventional one).

**How to judge this without reading the diff:** merge it, then hit **Update branch** on #408 and watch `Backend DB suite`. Green means all four were harness rot as diagnosed; a remaining failure names the one that is actually a product bug.
