### PR TITLE
fix(briefing): compute chantier staleness from source movement, not the tracker row's mtime

### DIFF
--- a/brain/systems/briefing/gather.py
+++ b/brain/systems/briefing/gather.py
@@ -41,18 +41,19 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Protocol
 
 from sqlalchemy import select
 
+from brain.kernel.common.coercion import coerce_datetime
 from brain.systems.briefing.core import DossierBudget, SourcePiece
+from brain.systems.chantiers import latest_source_movement
 
 # Conservative same-job reference pattern: explicit owner/repo#N only.
 _GITHUB_REF_RE = re.compile(r"\b([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)\b")
 _MAX_GITHUB_REFS = 4
 _MAX_CHANTIER_MEMBER_RECORDS = 100
-_CHANTIER_STALE_AFTER = timedelta(days=3)
 _SLACK_PAGE_CAP = 50
 _SLACK_MAX_PAGES = 3
 # The ONLY team-visible surface (ingress envelope vocabulary). Everything
@@ -106,27 +107,6 @@ def _text(value: Any) -> str:
 
 def _data(record: Any) -> dict[str, Any]:
     return dict(getattr(record, "data", None) or {})
-
-
-def _timestamp(value: Any) -> datetime | None:
-    """Parse the mixed naive/aware timestamp shapes carried by Domain data."""
-    if isinstance(value, datetime):
-        parsed = value
-    else:
-        raw = _text(value)
-        if not raw:
-            return None
-        try:
-            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 def _no_autoflush(session: Any):
@@ -276,7 +256,7 @@ def slack_provenance(event: Any) -> dict[str, Any] | None:
 
 
 def _record_piece(record: Any) -> SourcePiece | None:
-    data = dict(getattr(record, "data", None) or {})
+    data = _data(record)
     if not data:
         return None
     title = (
@@ -321,80 +301,6 @@ def _tracker_state(record: Any) -> str:
     return _text(data.get("status") or data.get("state")) or "unavailable"
 
 
-def _source_movement_timestamps(record: Any) -> list[datetime]:
-    data = _data(record)
-    return [
-        timestamp
-        for timestamp in (_timestamp(data.get("updated_at")), _timestamp(data.get("created_at")))
-        if timestamp is not None
-    ]
-
-
-def _chantier_last_movement(
-    chantier: Any,
-    *,
-    members_by_external_id: dict[str, Any],
-) -> tuple[datetime | None, str]:
-    """Return the newest already-loaded source movement and its confidence.
-
-    The chantier source timestamps and the source timestamps on batch-loaded
-    GitHub tracker members are real movement signals. The typed-ref contract
-    carries no timestamps for docs/Slack/URLs, and reading those artifacts
-    here would introduce forbidden network fan-out.
-    """
-    source_timestamps = _source_movement_timestamps(chantier)
-    for item in _chantier_refs(chantier):
-        if item["source"] != "github":
-            continue
-        member = members_by_external_id.get(item["ref"])
-        if member is not None:
-            source_timestamps.extend(_source_movement_timestamps(member))
-    if source_timestamps:
-        return max(source_timestamps), "source"
-
-    # Legacy rows may predate source timestamps. Row creation is immutable and
-    # therefore safer than the mutable row mtime; updated_at is an explicit,
-    # visibly uncertain last resort only.
-    created_at = _timestamp(getattr(chantier, "created_at", None))
-    if created_at is not None:
-        return created_at, "row_created"
-    updated_at = _timestamp(getattr(chantier, "updated_at", None))
-    if updated_at is not None:
-        return updated_at, "row_updated"
-    return None, "missing"
-
-
-def _chantier_movement_text(
-    movement_at: datetime | None,
-    *,
-    confidence: str,
-    now: datetime,
-) -> str:
-    if movement_at is None:
-        return "movement: unknown; no source or tracker timestamp is available"
-
-    movement_date = movement_at.date().isoformat()
-    if confidence == "source":
-        if now - movement_at > _CHANTIER_STALE_AFTER:
-            return (
-                f"movement: stale (>3 days); no source movement since {movement_date}; "
-                "tracker row writes do not count"
-            )
-        return (
-            f"movement: recent (within 3 days); last source movement {movement_date}; "
-            "tracker row writes do not count"
-        )
-    if confidence == "row_created":
-        return (
-            "movement: unknown; source timestamps missing; "
-            f"tracker creation {movement_date} is the best available fallback"
-        )
-    return (
-        "movement: unknown; source timestamps missing; "
-        f"tracker row timestamp {movement_date} is used only as a last resort"
-    )
-
-
 def _chantier_piece(
     chantier: Any,
     *,
@@ -409,11 +315,29 @@ def _chantier_piece(
     ``omitted_chars`` markers and floors as every other source.
     """
     data = _data(chantier)
-    movement_at, movement_confidence = _chantier_last_movement(
+    movement_at = latest_source_movement(
         chantier,
         members_by_external_id=members_by_external_id,
     )
-    now = _timestamp(_utc_now()) or datetime.now(timezone.utc)
+    movement_observation = (
+        f"last source movement: {movement_at.date().isoformat()}"
+        if movement_at is not None
+        else "last source movement: unknown"
+    )
+    if movement_at is None:
+        row_written_at = coerce_datetime(
+            getattr(chantier, "updated_at", None),
+            utc=True,
+        ) or coerce_datetime(getattr(chantier, "created_at", None), utc=True)
+        if row_written_at is not None:
+            movement_observation += (
+                f"; tracker row last written {row_written_at.date().isoformat()}"
+            )
+    if member_lookup_capped:
+        movement_observation += (
+            f"; source movement observation partial: {member_lookup_capped} "
+            "additional member records not gathered (cap)"
+        )
     sibling_bits: list[str] = []
     artifact_bits: list[str] = []
     for item in _chantier_refs(chantier):
@@ -434,11 +358,7 @@ def _chantier_piece(
         sibling_bits.append(f"{member_lookup_capped} additional member states not gathered (cap)")
 
     body_bits = [
-        _chantier_movement_text(
-            movement_at,
-            confidence=movement_confidence,
-            now=now,
-        ),
+        movement_observation,
         f"goal: {_text(data.get('goal')) or 'not recorded'}",
         f"state: {_text(data.get('state')) or 'not recorded'}",
         f"kind: {_text(data.get('kind')) or 'not recorded'}",
@@ -473,7 +393,7 @@ async def _chantier_pieces_for_record(
     is one batch DB read for all sibling external ids across all matching
     chantiers — deliberately no GitHub fan-out inside packet minting.
     """
-    subject_data = dict(getattr(record, "data", None) or {})
+    subject_data = _data(record)
     subject_external_id = _text(subject_data.get("external_id"))
     if not subject_external_id:
         return []
@@ -542,7 +462,7 @@ async def _chantier_pieces_for_record(
                 )
             ).scalars().all()
         for member in members:
-            external_id = _text((dict(getattr(member, "data", None) or {})).get("external_id"))
+            external_id = _text(_data(member).get("external_id"))
             if external_id and external_id not in members_by_external_id:
                 members_by_external_id[external_id] = member
 
@@ -621,7 +541,7 @@ def _github_refs(idea: Any, record: Any, event: Any) -> tuple[list[tuple[str, in
         add(hints.get("repo"), hints.get("number"))
 
     # (b) Canonical tracker identity via the existing normalizers.
-    data = dict(getattr(record, "data", None) or {}) if record is not None else {}
+    data = _data(record)
     if data:
         from brain.systems.user_domains.service import (
             _github_pr_key_from_url,
@@ -667,7 +587,7 @@ def _checks_summary(checks: Any) -> str:
 
 
 def _deploy_piece(record: Any) -> SourcePiece | None:
-    data = dict(getattr(record, "data", None) or {}) if record is not None else {}
+    data = _data(record)
     state = _text(data.get("deploy_state"))
     if not state:
         return None
@@ -707,7 +627,7 @@ async def _related_tracker_records(
     for row in rows:
         if exclude_id is not None and getattr(row, "id", None) == exclude_id:
             continue
-        row_repo = _text(dict(getattr(row, "data", None) or {}).get("repo")).lower().rstrip("/")
+        row_repo = _text(_data(row).get("repo")).lower().rstrip("/")
         if not row_repo or any(row_repo.endswith(name) for name in repo_names):
             related.append(row)
     return related

--- a/brain/systems/briefing/gather.py
+++ b/brain/systems/briefing/gather.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
 from sqlalchemy import select
@@ -52,6 +52,7 @@ from brain.systems.briefing.core import DossierBudget, SourcePiece
 _GITHUB_REF_RE = re.compile(r"\b([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)\b")
 _MAX_GITHUB_REFS = 4
 _MAX_CHANTIER_MEMBER_RECORDS = 100
+_CHANTIER_STALE_AFTER = timedelta(days=3)
 _SLACK_PAGE_CAP = 50
 _SLACK_MAX_PAGES = 3
 # The ONLY team-visible surface (ingress envelope vocabulary). Everything
@@ -101,6 +102,31 @@ def _ts_from_slack(ts: Any) -> datetime | None:
 
 def _text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _data(record: Any) -> dict[str, Any]:
+    return dict(getattr(record, "data", None) or {})
+
+
+def _timestamp(value: Any) -> datetime | None:
+    """Parse the mixed naive/aware timestamp shapes carried by Domain data."""
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = _text(value)
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def _no_autoflush(session: Any):
@@ -275,7 +301,7 @@ def _record_piece(record: Any) -> SourcePiece | None:
 
 def _chantier_refs(record: Any) -> list[dict[str, str]]:
     """Return the typed-ref contract, defensively normalized for rendering."""
-    refs = (dict(getattr(record, "data", None) or {})).get("refs") or []
+    refs = _data(record).get("refs") or []
     if not isinstance(refs, list):
         return []
     normalized: list[dict[str, str]] = []
@@ -291,8 +317,82 @@ def _chantier_refs(record: Any) -> list[dict[str, str]]:
 
 
 def _tracker_state(record: Any) -> str:
-    data = dict(getattr(record, "data", None) or {})
+    data = _data(record)
     return _text(data.get("status") or data.get("state")) or "unavailable"
+
+
+def _source_movement_timestamps(record: Any) -> list[datetime]:
+    data = _data(record)
+    return [
+        timestamp
+        for timestamp in (_timestamp(data.get("updated_at")), _timestamp(data.get("created_at")))
+        if timestamp is not None
+    ]
+
+
+def _chantier_last_movement(
+    chantier: Any,
+    *,
+    members_by_external_id: dict[str, Any],
+) -> tuple[datetime | None, str]:
+    """Return the newest already-loaded source movement and its confidence.
+
+    The chantier source timestamps and the source timestamps on batch-loaded
+    GitHub tracker members are real movement signals. The typed-ref contract
+    carries no timestamps for docs/Slack/URLs, and reading those artifacts
+    here would introduce forbidden network fan-out.
+    """
+    source_timestamps = _source_movement_timestamps(chantier)
+    for item in _chantier_refs(chantier):
+        if item["source"] != "github":
+            continue
+        member = members_by_external_id.get(item["ref"])
+        if member is not None:
+            source_timestamps.extend(_source_movement_timestamps(member))
+    if source_timestamps:
+        return max(source_timestamps), "source"
+
+    # Legacy rows may predate source timestamps. Row creation is immutable and
+    # therefore safer than the mutable row mtime; updated_at is an explicit,
+    # visibly uncertain last resort only.
+    created_at = _timestamp(getattr(chantier, "created_at", None))
+    if created_at is not None:
+        return created_at, "row_created"
+    updated_at = _timestamp(getattr(chantier, "updated_at", None))
+    if updated_at is not None:
+        return updated_at, "row_updated"
+    return None, "missing"
+
+
+def _chantier_movement_text(
+    movement_at: datetime | None,
+    *,
+    confidence: str,
+    now: datetime,
+) -> str:
+    if movement_at is None:
+        return "movement: unknown; no source or tracker timestamp is available"
+
+    movement_date = movement_at.date().isoformat()
+    if confidence == "source":
+        if now - movement_at > _CHANTIER_STALE_AFTER:
+            return (
+                f"movement: stale (>3 days); no source movement since {movement_date}; "
+                "tracker row writes do not count"
+            )
+        return (
+            f"movement: recent (within 3 days); last source movement {movement_date}; "
+            "tracker row writes do not count"
+        )
+    if confidence == "row_created":
+        return (
+            "movement: unknown; source timestamps missing; "
+            f"tracker creation {movement_date} is the best available fallback"
+        )
+    return (
+        "movement: unknown; source timestamps missing; "
+        f"tracker row timestamp {movement_date} is used only as a last resort"
+    )
 
 
 def _chantier_piece(
@@ -308,7 +408,12 @@ def _chantier_piece(
     section cut, so oversized goal context receives the same cumulative
     ``omitted_chars`` markers and floors as every other source.
     """
-    data = dict(getattr(chantier, "data", None) or {})
+    data = _data(chantier)
+    movement_at, movement_confidence = _chantier_last_movement(
+        chantier,
+        members_by_external_id=members_by_external_id,
+    )
+    now = _timestamp(_utc_now()) or datetime.now(timezone.utc)
     sibling_bits: list[str] = []
     artifact_bits: list[str] = []
     for item in _chantier_refs(chantier):
@@ -329,6 +434,11 @@ def _chantier_piece(
         sibling_bits.append(f"{member_lookup_capped} additional member states not gathered (cap)")
 
     body_bits = [
+        _chantier_movement_text(
+            movement_at,
+            confidence=movement_confidence,
+            now=now,
+        ),
         f"goal: {_text(data.get('goal')) or 'not recorded'}",
         f"state: {_text(data.get('state')) or 'not recorded'}",
         f"kind: {_text(data.get('kind')) or 'not recorded'}",
@@ -349,7 +459,7 @@ def _chantier_piece(
         ref=f"{JOB_REF_RECORD_PREFIX}{getattr(chantier, 'id', '')}",
         title=title,
         body="; ".join(body_bits),
-        ts=getattr(chantier, "updated_at", None),
+        ts=movement_at,
         weight=10,
     )
 

--- a/brain/systems/chantiers.py
+++ b/brain/systems/chantiers.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 import re
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.coercion import coerce_datetime
 from brain.platform.db.models.domain import DomainRecord
 from brain.systems.user_domains.service import (
     AsyncDomainService,
@@ -439,6 +441,42 @@ async def merge_chantier_records(
     )
 
 
+def latest_source_movement(
+    chantier: Any,
+    *,
+    members_by_external_id: Mapping[str, Any],
+) -> datetime | None:
+    """Return the newest source timestamp among a chantier and its loaded members."""
+
+    chantier_data = _data(chantier)
+    timestamps = [
+        timestamp
+        for timestamp in (
+            coerce_datetime(chantier_data.get("updated_at"), utc=True),
+            coerce_datetime(chantier_data.get("created_at"), utc=True),
+        )
+        if timestamp is not None
+    ]
+    refs = chantier_data.get("refs")
+    if isinstance(refs, (list, tuple)):
+        for item in refs:
+            if not isinstance(item, Mapping):
+                continue
+            if _text(item.get("source")).casefold() != "github":
+                continue
+            member = members_by_external_id.get(_text(item.get("ref")))
+            member_data = _data(member)
+            timestamps.extend(
+                timestamp
+                for timestamp in (
+                    coerce_datetime(member_data.get("updated_at"), utc=True),
+                    coerce_datetime(member_data.get("created_at"), utc=True),
+                )
+                if timestamp is not None
+            )
+    return max(timestamps, default=None)
+
+
 __all__ = [
     "ACTIVE_CHANTIER_STATES",
     "CHANTIER_OBJECT_KEY",
@@ -451,6 +489,7 @@ __all__ = [
     "is_active_chantier",
     "is_placeholder_chantier",
     "is_superseded_chantier",
+    "latest_source_movement",
     "list_all_chantier_records",
     "match_active_chantier",
     "merge_chantier_records",

--- a/tests/test_briefing_gather.py
+++ b/tests/test_briefing_gather.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import brain.systems.briefing.gather as briefing_gather
 from brain.systems.briefing import DossierBudget, assemble_dossier, gather_pieces
 from brain.systems.briefing.compose import compose_packet
 from brain.systems.briefing.gather import DefaultSlackReader, SlackThreadRead
@@ -223,6 +224,47 @@ def _flat_pr(title="Restore backfill", body="adds regression test", total=None, 
     if checks is not None:
         payload["checks"] = checks
     return payload
+
+
+def _movement_chantier(
+    *,
+    data_updated_at,
+    row_updated_at,
+    refs=(),
+    created_at=None,
+    row_created_at=None,
+):
+    data = {
+        "slug": "shopify-app-sunset",
+        "title": "Shopify app sunset",
+        "goal": "Done means the legacy app is retired.",
+        "kind": "sunset",
+        "state": "exploring",
+        "owner": "Reda",
+        "refs": list(refs),
+        "next_step": "Wait for the owner to reply lock.",
+        "updated_at": data_updated_at,
+    }
+    if created_at is not None:
+        data["created_at"] = created_at
+    return SimpleNamespace(
+        id=1995,
+        org_id=_ORG,
+        domain_id=1,
+        object_key="chantier",
+        title="Shopify app sunset",
+        data=data,
+        created_at=row_created_at,
+        updated_at=row_updated_at,
+    )
+
+
+def _movement_piece(chantier, *, members=None):
+    return briefing_gather._chantier_piece(
+        chantier,
+        subject_external_id="github:Illospace/illospace:issue:437",
+        members_by_external_id=members or {},
+    )
 
 
 async def test_happy_path_gathers_all_sources_read_only():
@@ -466,6 +508,141 @@ async def test_related_tracker_records_are_gathered_and_self_excluded():
     assert refs.count("domain_record:1238") == 1  # self not duplicated
 
 
+def test_chantier_surface_states_staleness_from_source_movement_not_row_mtime(monkeypatch):
+    monkeypatch.setattr(
+        briefing_gather,
+        "_utc_now",
+        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
+    )
+    chantier = _movement_chantier(
+        data_updated_at="2026-07-17T19:10:01Z",
+        row_updated_at=datetime(2026, 7, 22, 13, 13, 59, tzinfo=timezone.utc),
+    )
+
+    piece = _movement_piece(chantier)
+
+    assert piece.ts == datetime(2026, 7, 17, 19, 10, 1, tzinfo=timezone.utc)
+    assert (
+        "movement: stale (>3 days); no source movement since 2026-07-17; "
+        "tracker row writes do not count"
+    ) in piece.body
+    assert "2026-07-22" not in piece.body
+
+    dossier = assemble_dossier(
+        [piece],
+        job_ref="domain_record:1995",
+        budget=DossierBudget(),
+    )
+    packet = compose_packet(dossier, org_id=_ORG, ask="Escalate stalled chantiers")
+    chantier_line = next(
+        line for line in packet.human_brief.splitlines() if line.startswith("*Chantier:*")
+    )
+    assert "movement: stale (>3 days)" in chantier_line
+    assert "no source movement since 2026-07-17" in chantier_line
+
+
+def test_bookkeeping_only_row_update_does_not_change_chantier_staleness(monkeypatch):
+    monkeypatch.setattr(
+        briefing_gather,
+        "_utc_now",
+        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
+    )
+    before_refresh = _movement_chantier(
+        data_updated_at="2026-07-17T19:10:01Z",
+        row_updated_at=datetime(2026, 7, 22, 13, 13, 59, tzinfo=timezone.utc),
+    )
+    after_refresh = _movement_chantier(
+        data_updated_at="2026-07-17T19:10:01Z",
+        row_updated_at=datetime(2026, 7, 23, 11, 59, tzinfo=timezone.utc),
+    )
+
+    assert _movement_piece(after_refresh) == _movement_piece(before_refresh)
+
+
+def test_each_available_source_movement_signal_resets_chantier_staleness(monkeypatch):
+    monkeypatch.setattr(
+        briefing_gather,
+        "_utc_now",
+        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
+    )
+    old_source_time = "2026-07-17T19:10:01Z"
+    row_refresh_time = datetime(2026, 7, 23, 11, 59, tzinfo=timezone.utc)
+
+    chantier_update = _movement_chantier(
+        data_updated_at="2026-07-22T09:00:00Z",
+        row_updated_at=row_refresh_time,
+    )
+    from_chantier = _movement_piece(chantier_update)
+    assert from_chantier.ts == datetime(2026, 7, 22, 9, 0, tzinfo=timezone.utc)
+    assert (
+        "movement: recent (within 3 days); last source movement 2026-07-22"
+        in from_chantier.body
+    )
+
+    new_ref = "github:Illospace/illospace:issue:438"
+    chantier_with_new_ref = _movement_chantier(
+        data_updated_at=old_source_time,
+        row_updated_at=row_refresh_time,
+        refs=[{"source": "github", "ref": new_ref, "title": "Fresh member"}],
+    )
+    linked_member = SimpleNamespace(
+        data={
+            "external_id": new_ref,
+            # Deliberately naive: comparison must normalize mixed timestamp shapes.
+            "updated_at": datetime(2026, 7, 22, 10, 30),
+        }
+    )
+    from_new_ref = _movement_piece(
+        chantier_with_new_ref,
+        members={new_ref: linked_member},
+    )
+    assert from_new_ref.ts == datetime(2026, 7, 22, 10, 30, tzinfo=timezone.utc)
+    assert (
+        "movement: recent (within 3 days); last source movement 2026-07-22"
+        in from_new_ref.body
+    )
+
+
+def test_missing_source_updated_at_uses_created_then_explicit_row_fallback(monkeypatch):
+    monkeypatch.setattr(
+        briefing_gather,
+        "_utc_now",
+        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
+    )
+    with_source_creation = _movement_chantier(
+        data_updated_at=" ",
+        created_at="2026-07-16T08:00:00Z",
+        row_updated_at=datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc),
+    )
+    from_creation = _movement_piece(with_source_creation)
+    assert from_creation.ts == datetime(2026, 7, 16, 8, 0, tzinfo=timezone.utc)
+    assert "movement: stale (>3 days); no source movement since 2026-07-16" in from_creation.body
+
+    row_creation_only = _movement_chantier(
+        data_updated_at=None,
+        row_created_at=datetime(2026, 7, 15, 7, 0),
+        row_updated_at=datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc),
+    )
+    from_row_creation = _movement_piece(row_creation_only)
+    assert from_row_creation.ts == datetime(2026, 7, 15, 7, 0, tzinfo=timezone.utc)
+    assert (
+        "movement: unknown; source timestamps missing; "
+        "tracker creation 2026-07-15 is the best available fallback"
+    ) in from_row_creation.body
+
+    row_only = _movement_chantier(
+        data_updated_at=None,
+        row_updated_at=datetime(2026, 7, 22, 13, 0),
+    )
+    from_row = _movement_piece(row_only)
+    assert from_row.ts == datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc)
+    assert (
+        "movement: unknown; source timestamps missing; "
+        "tracker row timestamp 2026-07-22 is used only as a last resort"
+    ) in from_row.body
+    assert "movement: recent" not in from_row.body
+
+
 async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
     subject_external_id = "github:Illospace/illospace:issue:330"
     subject = SimpleNamespace(
@@ -548,8 +725,12 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
     chantier_pieces = [piece for piece in result.pieces if piece.source == "chantier"]
     assert len(chantier_pieces) == 1
     body = chantier_pieces[0].body
+    assert "movement: unknown; source timestamps missing" in body
     assert "goal: Done means no work arrives cold at an item boundary." in body
     assert "state: building" in body
+    assert "kind: feature" in body
+    assert "owner: Reda" in body
+    assert "next_step: Ship chantier context in handoff packets." in body
     assert "Chantier record contract (github:Illospace/illospace:issue:327, state: Done)" in body
     assert "Chantier-aware check-ins (github:Illospace/illospace:issue:331, state: Todo)" in body
     assert "PRD (doc: specs/chantier.md)" in body

--- a/tests/test_briefing_gather.py
+++ b/tests/test_briefing_gather.py
@@ -16,10 +16,10 @@ from types import SimpleNamespace
 
 import pytest
 
-import brain.systems.briefing.gather as briefing_gather
 from brain.systems.briefing import DossierBudget, assemble_dossier, gather_pieces
 from brain.systems.briefing.compose import compose_packet
 from brain.systems.briefing.gather import DefaultSlackReader, SlackThreadRead
+from brain.systems.chantiers import latest_source_movement
 
 _T0 = datetime(2026, 7, 9, 9, 0, tzinfo=timezone.utc)
 _IDEA_ID = "0f6f3f7e-0000-0000-0000-00000000aaaa"
@@ -256,14 +256,6 @@ def _movement_chantier(
         data=data,
         created_at=row_created_at,
         updated_at=row_updated_at,
-    )
-
-
-def _movement_piece(chantier, *, members=None):
-    return briefing_gather._chantier_piece(
-        chantier,
-        subject_external_id="github:Illospace/illospace:issue:437",
-        members_by_external_id=members or {},
     )
 
 
@@ -508,150 +500,110 @@ async def test_related_tracker_records_are_gathered_and_self_excluded():
     assert refs.count("domain_record:1238") == 1  # self not duplicated
 
 
-def test_chantier_surface_states_staleness_from_source_movement_not_row_mtime(monkeypatch):
-    monkeypatch.setattr(
-        briefing_gather,
-        "_utc_now",
-        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
-    )
+@pytest.mark.parametrize(
+    ("chantier_times", "member_times", "refs", "expected"),
+    [
+        (
+            {"created_at": "2026-07-17T19:10:01Z"},
+            {},
+            (),
+            datetime(2026, 7, 17, 19, 10, 1, tzinfo=timezone.utc),
+        ),
+        (
+            {"updated_at": "2026-07-17T19:10:01Z"},
+            {"issue:438": {"updated_at": datetime(2026, 7, 22, 10, 30)}},
+            ("issue:438",),
+            datetime(2026, 7, 22, 10, 30, tzinfo=timezone.utc),
+        ),
+        (
+            {"updated_at": "2026-07-22T11:00:00+00:00"},
+            {"issue:438": {"created_at": "2026-07-20T08:00:00Z"}},
+            ("issue:438",),
+            datetime(2026, 7, 22, 11, 0, tzinfo=timezone.utc),
+        ),
+        ({}, {}, (), None),
+        (
+            {"updated_at": "2026-07-17T19:10:01Z"},
+            {"issue:loaded": {"updated_at": "2026-07-21T14:00:00Z"}},
+            ("issue:loaded", "issue:not-loaded-after-cap"),
+            datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc),
+        ),
+    ],
+    ids=("chantier-only", "member-newer", "chantier-newer", "none-available", "capped-coverage"),
+)
+def test_latest_source_movement_selects_from_loaded_source_data(
+    chantier_times,
+    member_times,
+    refs,
+    expected,
+):
     chantier = _movement_chantier(
-        data_updated_at="2026-07-17T19:10:01Z",
-        row_updated_at=datetime(2026, 7, 22, 13, 13, 59, tzinfo=timezone.utc),
+        data_updated_at=chantier_times.get("updated_at"),
+        created_at=chantier_times.get("created_at"),
+        row_updated_at=datetime(2026, 7, 23, tzinfo=timezone.utc),
+        refs=[{"source": "github", "ref": ref} for ref in refs],
     )
+    members = {
+        ref: SimpleNamespace(data={"external_id": ref, **times})
+        for ref, times in member_times.items()
+    }
 
-    piece = _movement_piece(chantier)
-
-    assert piece.ts == datetime(2026, 7, 17, 19, 10, 1, tzinfo=timezone.utc)
-    assert (
-        "movement: stale (>3 days); no source movement since 2026-07-17; "
-        "tracker row writes do not count"
-    ) in piece.body
-    assert "2026-07-22" not in piece.body
-
-    dossier = assemble_dossier(
-        [piece],
-        job_ref="domain_record:1995",
-        budget=DossierBudget(),
-    )
-    packet = compose_packet(dossier, org_id=_ORG, ask="Escalate stalled chantiers")
-    chantier_line = next(
-        line for line in packet.human_brief.splitlines() if line.startswith("*Chantier:*")
-    )
-    assert "movement: stale (>3 days)" in chantier_line
-    assert "no source movement since 2026-07-17" in chantier_line
+    assert latest_source_movement(
+        chantier,
+        members_by_external_id=members,
+    ) == expected
 
 
-def test_bookkeeping_only_row_update_does_not_change_chantier_staleness(monkeypatch):
-    monkeypatch.setattr(
-        briefing_gather,
-        "_utc_now",
-        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
-    )
+def test_bookkeeping_only_row_write_does_not_change_reported_source_movement():
+    source_time = "2026-07-17T19:10:01Z"
     before_refresh = _movement_chantier(
-        data_updated_at="2026-07-17T19:10:01Z",
-        row_updated_at=datetime(2026, 7, 22, 13, 13, 59, tzinfo=timezone.utc),
+        data_updated_at=source_time,
+        row_updated_at=datetime(2026, 7, 22, tzinfo=timezone.utc),
     )
     after_refresh = _movement_chantier(
-        data_updated_at="2026-07-17T19:10:01Z",
-        row_updated_at=datetime(2026, 7, 23, 11, 59, tzinfo=timezone.utc),
+        data_updated_at=source_time,
+        row_updated_at=datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
 
-    assert _movement_piece(after_refresh) == _movement_piece(before_refresh)
+    before = latest_source_movement(before_refresh, members_by_external_id={})
+    after = latest_source_movement(after_refresh, members_by_external_id={})
 
-
-def test_each_available_source_movement_signal_resets_chantier_staleness(monkeypatch):
-    monkeypatch.setattr(
-        briefing_gather,
-        "_utc_now",
-        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
-    )
-    old_source_time = "2026-07-17T19:10:01Z"
-    row_refresh_time = datetime(2026, 7, 23, 11, 59, tzinfo=timezone.utc)
-
-    chantier_update = _movement_chantier(
-        data_updated_at="2026-07-22T09:00:00Z",
-        row_updated_at=row_refresh_time,
-    )
-    from_chantier = _movement_piece(chantier_update)
-    assert from_chantier.ts == datetime(2026, 7, 22, 9, 0, tzinfo=timezone.utc)
-    assert (
-        "movement: recent (within 3 days); last source movement 2026-07-22"
-        in from_chantier.body
-    )
-
-    new_ref = "github:Illospace/illospace:issue:438"
-    chantier_with_new_ref = _movement_chantier(
-        data_updated_at=old_source_time,
-        row_updated_at=row_refresh_time,
-        refs=[{"source": "github", "ref": new_ref, "title": "Fresh member"}],
-    )
-    linked_member = SimpleNamespace(
-        data={
-            "external_id": new_ref,
-            # Deliberately naive: comparison must normalize mixed timestamp shapes.
-            "updated_at": datetime(2026, 7, 22, 10, 30),
-        }
-    )
-    from_new_ref = _movement_piece(
-        chantier_with_new_ref,
-        members={new_ref: linked_member},
-    )
-    assert from_new_ref.ts == datetime(2026, 7, 22, 10, 30, tzinfo=timezone.utc)
-    assert (
-        "movement: recent (within 3 days); last source movement 2026-07-22"
-        in from_new_ref.body
-    )
-
-
-def test_missing_source_updated_at_uses_created_then_explicit_row_fallback(monkeypatch):
-    monkeypatch.setattr(
-        briefing_gather,
-        "_utc_now",
-        lambda: datetime(2026, 7, 23, 12, 10, tzinfo=timezone.utc),
-    )
-    with_source_creation = _movement_chantier(
-        data_updated_at=" ",
-        created_at="2026-07-16T08:00:00Z",
-        row_updated_at=datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc),
-    )
-    from_creation = _movement_piece(with_source_creation)
-    assert from_creation.ts == datetime(2026, 7, 16, 8, 0, tzinfo=timezone.utc)
-    assert "movement: stale (>3 days); no source movement since 2026-07-16" in from_creation.body
-
-    row_creation_only = _movement_chantier(
-        data_updated_at=None,
-        row_created_at=datetime(2026, 7, 15, 7, 0),
-        row_updated_at=datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc),
-    )
-    from_row_creation = _movement_piece(row_creation_only)
-    assert from_row_creation.ts == datetime(2026, 7, 15, 7, 0, tzinfo=timezone.utc)
-    assert (
-        "movement: unknown; source timestamps missing; "
-        "tracker creation 2026-07-15 is the best available fallback"
-    ) in from_row_creation.body
-
-    row_only = _movement_chantier(
-        data_updated_at=None,
-        row_updated_at=datetime(2026, 7, 22, 13, 0),
-    )
-    from_row = _movement_piece(row_only)
-    assert from_row.ts == datetime(2026, 7, 22, 13, 0, tzinfo=timezone.utc)
-    assert (
-        "movement: unknown; source timestamps missing; "
-        "tracker row timestamp 2026-07-22 is used only as a last resort"
-    ) in from_row.body
-    assert "movement: recent" not in from_row.body
+    assert before == after == datetime(2026, 7, 17, 19, 10, 1, tzinfo=timezone.utc)
 
 
 async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
     subject_external_id = "github:Illospace/illospace:issue:330"
+    capped_refs = [
+        {
+            "source": "github",
+            "ref": f"github:Illospace/illospace:issue:{5000 + index}",
+            "title": f"Capped member {index}",
+        }
+        for index in range(99)
+    ]
+    capped_members = [
+        SimpleNamespace(
+            id=5000 + index,
+            org_id=_ORG,
+            domain_id=1,
+            object_key="ticket",
+            title=f"Capped member {index}",
+            data={"external_id": item["ref"], "status": "Todo"},
+            updated_at=_T0,
+        )
+        for index, item in enumerate(capped_refs)
+    ]
     subject = SimpleNamespace(
         id=1238,
         org_id=_ORG,
         domain_id=1,
         object_key="ticket",
         title="Handoff dossiers inherit chantier context",
-        data={"external_id": subject_external_id, "status": "In Progress"},
+        data={
+            "external_id": subject_external_id,
+            "status": "In Progress",
+            "updated_at": "2026-07-18T12:00:00Z",
+        },
         updated_at=_T0,
     )
     sibling_a = SimpleNamespace(
@@ -663,6 +615,7 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
         data={
             "external_id": "github:Illospace/illospace:issue:327",
             "status": "Done",
+            "created_at": "2026-07-19T08:00:00Z",
         },
         updated_at=_T0,
     )
@@ -675,6 +628,8 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
         data={
             "external_id": "github:Illospace/illospace:issue:331",
             "status": "Todo",
+            # Deliberately naive: source movement comparison must normalize it.
+            "updated_at": datetime(2026, 7, 20, 14, 30),
         },
         updated_at=_T0,
     )
@@ -691,6 +646,7 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
             "kind": "feature",
             "state": "building",
             "owner": "Reda",
+            "updated_at": "2026-07-17T19:10:01Z",
             "refs": [
                 {"source": "github", "ref": subject_external_id, "title": "Handoff dossier"},
                 {
@@ -703,6 +659,7 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
                     "ref": "github:Illospace/illospace:issue:331",
                     "title": "Chantier-aware check-ins",
                 },
+                *capped_refs,
                 {"source": "doc", "ref": "specs/chantier.md", "title": "PRD"},
                 {"source": "url", "ref": "https://figma.example/chantier", "title": "Mockups"},
             ],
@@ -710,7 +667,9 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
         },
         updated_at=_T0,
     )
-    session = WriteForbiddenSession(records=[subject, chantier, sibling_a, sibling_b])
+    session = WriteForbiddenSession(
+        records=[subject, chantier, sibling_a, sibling_b, *capped_members]
+    )
     github = FakeGithub()
 
     result = await gather_pieces(
@@ -724,8 +683,15 @@ async def test_item_in_chantier_gathers_goal_sibling_states_and_artifact_refs():
 
     chantier_pieces = [piece for piece in result.pieces if piece.source == "chantier"]
     assert len(chantier_pieces) == 1
-    body = chantier_pieces[0].body
-    assert "movement: unknown; source timestamps missing" in body
+    piece = chantier_pieces[0]
+    body = piece.body
+    assert piece.ts == datetime(2026, 7, 20, 14, 30, tzinfo=timezone.utc)
+    assert "last source movement: 2026-07-20" in body
+    assert (
+        "source movement observation partial: "
+        "1 additional member records not gathered (cap)"
+    ) in body
+    assert "1 additional member states not gathered (cap)" in body
     assert "goal: Done means no work arrives cold at an item boundary." in body
     assert "state: building" in body
     assert "kind: feature" in body


### PR DESCRIPTION
Closes #437

## What was wrong

Chantier staleness was computed from `domain_records.updated_at` — **when Illo last wrote the row**, not when the work moved. Illo's own no-op refresh therefore reset the staleness clock, and the digest's "must-surface every active chantier untouched 3+ days" guarantee quietly became unenforceable: anything Illo re-read became permanently un-stale.

The two chantiers this hit are the two that most needed escalation — `shopify-app-sunset` and `connector-framework`, both parked waiting for a human to reply the literal word `lock`. Record 1995's row said 2026-07-22; the source had not moved since 2026-07-17.

## What changed

`brain/systems/briefing/gather.py` stamped the chantier `SourcePiece` with the row mtime. It now carries `latest_source_movement()` — a pure function on the chantier owner, `brain/systems/chantiers.py` — computed from the chantier's own `data.updated_at`/`created_at` and the source timestamps of already-loaded linked GitHub tracker members, normalized to UTC through the canonical `coerce_datetime(..., utc=True)`.

The piece now states a **date-only observation** (`last source movement: 2026-07-17`). It deliberately does **not** render a "stale" verdict: the 3-day rule is policy and belongs to the digest consumer reading that date. Row timestamps survive only as explicitly labelled fallback prose for legacy rows that have no source timestamps, and never reach `ts`.

## How to judge it without reading the diff

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-437-chantier-staleness
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_briefing_gather.py tests/test_briefing_compose.py tests/test_briefing_core.py \
  tests/test_briefing_mint.py tests/test_briefing_deliver.py tests/test_briefing_outcomes.py \
  tests/test_chantier_continuation.py tests/test_chantier_declare_guarantee.py \
  tests/test_chantier_digest_migration.py tests/test_chantier_schema_migration.py -q
```

**169 passed** (run by the orchestrator, not just claimed by the worker).

Acceptance checks, mapped to the issue:

1. With record 1995 unchanged at source, the chantier surface reports **2026-07-17** as the last source movement even though the row was written 2026-07-22 — so the >3-day rule fires on it again.
2. A bookkeeping-only write (row mtime moves, `data` unchanged) does **not** change the reported movement date. This is the regression the issue exists for and it has a dedicated test.
3. Real movement resets it, tested independently for the chantier's own timestamps and for a newer linked member.
4. Nothing else in the chantier piece regresses — goal, state, kind, owner, next_step, siblings and artifacts still render.

## Review notes (things worth your eye)

- **A code-quality review blocked the first cut and this is the restructured version.** The first cut made `gather` own a wall-clock verdict plus a stringly-typed confidence tag, and let row timestamps into `ts`. Both are gone; `gather.py` came down 904 → 824 lines.
- **It also caught a real bug**: linked members are capped at 100 *before* movement is computed, so the old code could state categorically "no source movement since X" while a fresh member sat beyond the cap. Removing the verdict dissolves the false-confidence case; capped coverage is now reported as a partial observation.
- **Scope is read-time only.** Persisting `last_movement_at` (the issue's fix item 2) is deliberately **not** here — it lands in `runs/tool_catalog/handlers/domains.py` and `user_domains/service.py`, both rewritten by open PR #431. Worth a follow-up ticket once that merges.
- **Conflict surface with the train:** `chantiers.py` is the only file this shares with an open PR (#431 adds a constant and one `__all__` entry). The new function is appended below the existing ones and its `__all__` entry sits elsewhere in the list, so the overlap should be zero.
- **Known nit left alone:** `gather.py:402` still imports `is_superseded_chantier` lazily inside a function while this change imports `latest_source_movement` at module level. No cycle exists (verified), but the inconsistency is pre-existing and I kept it out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
