### PR TITLE
fix(scheduler): await the meta-evolution coroutine in the nightly step (#441)

### DIFF
--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -29,6 +29,18 @@ def nightly_heuristic_review_command() -> list[str]:
     )
 
 
+def nightly_meta_evolution_command() -> list[str]:
+    """Run async meta-evolution from a synchronous scheduler process."""
+    return _python_one_liner(
+        "import asyncio; "
+        "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
+        "stats = asyncio.run(run_meta_evolution()); "
+        "print(f'Insights: {stats[\"insights_total\"]}, "
+        "Regressions: {stats[\"regressions\"]}, "
+        "Adjustments: {len(stats[\"adjustments\"])}')"
+    )
+
+
 @dataclass(frozen=True)
 class StepSpec:
     step_key: str
@@ -134,13 +146,7 @@ NIGHTLY_STEP_REGISTRY: tuple[NightlyStepDefinition, ...] = (
     ),
     NightlyStepDefinition(
         step_key="meta_evolution",
-        command_factory=lambda _target_date: (
-            _python_one_liner(
-                "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
-                "stats = run_meta_evolution(); "
-                "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
-            ),
-        ),
+        command_factory=lambda _target_date: (nightly_meta_evolution_command(),),
         description="Meta-evolution",
         budget_hint={
             "work_type": "context_policy_eval",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -581,6 +581,59 @@ async def test_nightly_heuristic_review_wrappers_await_and_report_counts(monkeyp
     ) == [command]
 
 
+async def test_nightly_meta_evolution_wrapper_awaits_and_reports_stats(monkeypatch, capsys):
+    from brain.systems.feedback import meta_evolution
+
+    awaited = False
+
+    async def fake_run_meta_evolution():
+        nonlocal awaited
+        awaited = True
+        return {
+            "insights_total": 3,
+            "regressions": 1,
+            "adjustments": {"heuristic_prune_threshold": {"new": 0.15}},
+        }
+
+    monkeypatch.setattr(
+        meta_evolution,
+        "run_meta_evolution",
+        fake_run_meta_evolution,
+    )
+    command = scheduler_executor._nightly_step_commands(
+        "meta_evolution",
+        date(2026, 4, 21),
+    )[0]
+    namespace = {}
+
+    await asyncio.to_thread(exec, command[2], namespace)
+
+    assert awaited is True
+    assert namespace["stats"] == {
+        "insights_total": 3,
+        "regressions": 1,
+        "adjustments": {"heuristic_prune_threshold": {"new": 0.15}},
+    }
+    assert not asyncio.iscoroutine(namespace["stats"])
+    assert capsys.readouterr().out.strip() == (
+        "Insights: 3, Regressions: 1, Adjustments: 1"
+    )
+
+    job = _make_scheduler_job()
+    run = SimpleNamespace(
+        scheduled_for=datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc)
+    )
+    program_command = next(
+        step.command
+        for step in get_step_specs(job, run)
+        if step.step_key == "meta_evolution"
+    )
+    assert program_command == command
+    assert scheduler_executor._nightly_wrapper_commands(
+        date(2026, 4, 21), split_steps=False
+    )[6] == command
+
+
 async def test_nightly_registry_generates_every_command_representation():
     target_date = date(2026, 4, 21)
     scheduled_definitions = tuple(
@@ -1150,6 +1203,7 @@ async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session
         return SimpleNamespace(returncode=1, stdout="", stderr=failure_text)
 
     alert_timestamps = []
+    alert_edges = []
     for minute in range(2, 6):
         failed = await async_run_scheduler_run(
             session,
@@ -1160,6 +1214,9 @@ async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session
         )
         await session.refresh(job)
         alert_timestamps.append(job.failure_alerted_at)
+        alert_edges.append(
+            failed.result_summary["failure_guard"]["alert_emitted"]
+        )
         assert failed.status == "retryable"
 
     alerts = [record for record in caplog.records if record.getMessage().startswith("Scheduler job repeated failure alert")]
@@ -1175,6 +1232,7 @@ async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session
     assert alert_timestamps[:2] == [None, None]
     assert alert_timestamps[2] is not None
     assert alert_timestamps[3] == alert_timestamps[2]
+    assert alert_edges == [False, False, True, False]
     assert snapshot["alerts"] == [
         {
             "type": "repeated_scheduler_job_failure",


### PR DESCRIPTION
Closes #441

## What was broken

The `meta_evolution` nightly step built an inline python one-liner that called `run_meta_evolution()` **synchronously**, but that function is `async def` (`brain/systems/feedback/meta_evolution.py:305`). So the step raised `TypeError: 'coroutine' object is not subscriptable` on every run — which is verbatim what production's `scheduler_jobs.last_failure_error` holds for `nightly_sleep`.

The existing tests in `test_meta_evolution.py` all `await` it correctly, which is why nothing caught the scheduler call site.

## The fix

Extracted `nightly_meta_evolution_command()` wrapping the call in `asyncio.run(...)`. This **follows the existing `nightly_heuristic_review_command()` pattern** in the same module rather than introducing a second shape for "nightly step that runs a coroutine".

## Two of the issue's three claims were misdiagnosed — read before merging

The issue was filed from a production inspection and guessed at causes. Verified against the code:

**Item 2 — the NULL alert is CORRECT, not a bug.** The issue saw `consecutive_failure_count = 2` with `failure_alerted_at` NULL and guessed "threshold above 2 or doesn't fire". `SCHEDULER_FAILURE_ALERT_THRESHOLD_DEFAULT = 3` (`brain/app/scheduler/runtime.py:39`) and the guard fires exactly once at the threshold. **The threshold is deliberately left at 3 here.** This PR only adds a test proving the alert edge sequence is `[False, False, True, False]` and resets on success.

⚠️ There *is* a real gap underneath, deliberately **not** fixed here: when the alert does fire, its only consumer (`brain/app/scheduler/executor.py:403`) emits a `logger.error()` and nothing else — no Slack, no thread post, no Illo record. A nightly job can fail forever with no one told. Where that alert should land is a product decision, raised separately.

**Item 3 — `memory_health_log` is empty for a different reason.** The issue assumed the health phase "is never reached after the crash". In fact `MemoryHealthRepository.record()` has **no production caller at all** (only the model, the repository, and two tests). **Fixing this crash will not produce rows.** Nothing was invented to fill the table; whether a nightly memory-health phase should exist is a design question, not a bug fix.

## Verification

```bash
cd <worktree> && /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python \
  -m pytest tests/test_scheduler.py tests/test_meta_evolution.py -q
```
**59 passed.**

**Negative control** (the test has teeth): reverting `programs.py` and re-running the new test reproduces the exact production error —
`TypeError: 'coroutine' object is not subscriptable`. The test executes the production-composed command string rather than grepping it for `asyncio.run`.

## Acceptance checks

1. `nightly_sleep`'s `meta_evolution` step completes and prints its stats line instead of raising.
2. The regression test fails without the fix and passes with it (verified above).
3. The repeated-failure guard opens exactly one alert at the 3rd identical failure and resets after success — threshold unchanged at 3.
4. No unrequested behaviour change to the scheduler, the guard, or memory health.