### PR TITLE
refactor(runs,deploy): one canonical worker-swap policy; extract interruption (#426)

### DIFF
--- a/brain/app/api/main.py
+++ b/brain/app/api/main.py
@@ -245,8 +245,24 @@ async def lifespan(app):
             try:
                 from brain.systems.runs.cortex import stop_runner
                 from brain.systems.cycles import stop_cycle_scheduler
+                from brain.systems.runs.interruption import interrupt_and_requeue_run_ids
+
                 stop_cycle_scheduler()
-                stop_runner()
+                drain_result = stop_runner()
+                if drain_result.timed_out_run_ids:
+                    interruptions = await interrupt_and_requeue_run_ids(
+                        drain_result.timed_out_run_ids,
+                        reason="worker_shutdown_drain_timeout",
+                    )
+                    if interruptions:
+                        logger.warning(
+                            "runner_shutdown_interrupted_requeued",
+                            run_ids=[
+                                interruption.run_id
+                                for interruption in interruptions
+                            ],
+                            mode="inline",
+                        )
             except Exception as e:
                 logger.warning("run_worker_stop_failed", error=str(e), mode="inline")
 

--- a/brain/app/cli/worker_swap_snapshot.py
+++ b/brain/app/cli/worker_swap_snapshot.py
@@ -1,0 +1,32 @@
+"""Read the canonical worker-swap snapshot from the application database."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select
+
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.contracts.worker_swap import WorkerSwapSnapshot, worker_swap_snapshot
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+
+async def read_worker_swap_snapshot() -> WorkerSwapSnapshot:
+    async with UnitOfWork() as uow:
+        rows = (
+            await uow.session.execute(
+                select(AgentRunRow.id, AgentRunRow.status)
+                .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
+                .order_by(AgentRunRow.id.asc())
+            )
+        ).all()
+    return worker_swap_snapshot(rows)
+
+
+def main() -> None:
+    print(asyncio.run(read_worker_swap_snapshot()).as_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/brain/contracts/worker_swap.py
+++ b/brain/contracts/worker_swap.py
@@ -1,0 +1,222 @@
+"""Canonical worker-swap policy snapshot and presentation."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import StrEnum
+import json
+import sys
+from typing import Any, Iterable, Sequence
+
+from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+
+
+class WorkerSwapDecision(StrEnum):
+    """The deployment action implied by one database snapshot."""
+
+    UNKNOWN = "unknown"
+    REPLACE = "replace"
+    DRAIN = "drain"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerSwapRun:
+    id: int
+    status: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", int(self.id))
+        object.__setattr__(self, "status", str(self.status))
+        if self.status not in OPEN_RUN_STATUS_VALUES:
+            raise ValueError(f"{self.status!r} is not a worker-swap blocking status")
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {"id": self.id, "status": self.status}
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerSwapSnapshot:
+    """Structured result consumed by every worker replacement path."""
+
+    known: bool
+    runs: tuple[WorkerSwapRun, ...] = ()
+
+    def __post_init__(self) -> None:
+        ordered = tuple(sorted(self.runs, key=lambda run: run.id))
+        if not self.known and ordered:
+            raise ValueError("an unknown worker-swap snapshot cannot contain runs")
+        if len({run.id for run in ordered}) != len(ordered):
+            raise ValueError("worker-swap snapshot contains duplicate run ids")
+        object.__setattr__(self, "runs", ordered)
+
+    @property
+    def decision(self) -> WorkerSwapDecision:
+        if not self.known:
+            return WorkerSwapDecision.UNKNOWN
+        if self.runs:
+            return WorkerSwapDecision.DRAIN
+        return WorkerSwapDecision.REPLACE
+
+    @property
+    def count(self) -> int | None:
+        return len(self.runs) if self.known else None
+
+    @property
+    def run_ids(self) -> tuple[int, ...]:
+        return tuple(run.id for run in self.runs)
+
+    @property
+    def run_ids_csv(self) -> str:
+        return ",".join(str(run_id) for run_id in self.run_ids)
+
+    @property
+    def details(self) -> str:
+        if not self.known:
+            return "unknown"
+        return ",".join(f"{run.id}:{run.status}" for run in self.runs)
+
+    @property
+    def report(self) -> str:
+        return (
+            f"Worker pre-swap check: {self.count} interactive run(s) in flight "
+            f"(run ids: {self.run_ids_csv}; id/status: {self.details})"
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "known": self.known,
+            "decision": self.decision.value,
+            "count": self.count,
+            "run_ids": list(self.run_ids),
+            "runs": [run.as_dict() for run in self.runs],
+            "policy_statuses": list(OPEN_RUN_STATUS_VALUES),
+        }
+
+    def as_json(self) -> str:
+        return json.dumps(self.as_dict(), separators=(",", ":"))
+
+
+def worker_swap_snapshot(rows: Iterable[Sequence[Any] | dict[str, Any]]) -> WorkerSwapSnapshot:
+    normalized: list[WorkerSwapRun] = []
+    for row in rows:
+        if isinstance(row, dict):
+            run_id, status = row.get("id"), row.get("status")
+        else:
+            run_id, status = row
+        normalized.append(WorkerSwapRun(id=int(run_id), status=str(status)))
+    return WorkerSwapSnapshot(known=True, runs=tuple(normalized))
+
+
+def unknown_worker_swap_snapshot() -> WorkerSwapSnapshot:
+    return WorkerSwapSnapshot(known=False)
+
+
+def parse_worker_swap_snapshot(raw: str) -> WorkerSwapSnapshot:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("worker-swap snapshot must be a JSON object")
+    policy_statuses = payload.get("policy_statuses")
+    if policy_statuses != list(OPEN_RUN_STATUS_VALUES):
+        raise ValueError("worker-swap snapshot was not derived from the canonical policy")
+    known = payload.get("known")
+    if not isinstance(known, bool):
+        raise ValueError("worker-swap snapshot known flag must be boolean")
+    rows = payload.get("runs")
+    if not isinstance(rows, list):
+        raise ValueError("worker-swap snapshot runs must be a list")
+    snapshot = (
+        worker_swap_snapshot(rows)
+        if known
+        else unknown_worker_swap_snapshot()
+    )
+    if payload.get("decision") != snapshot.decision.value:
+        raise ValueError("worker-swap snapshot decision does not match its runs")
+    if payload.get("count") != snapshot.count:
+        raise ValueError("worker-swap snapshot count does not match its runs")
+    if payload.get("run_ids") != list(snapshot.run_ids):
+        raise ValueError("worker-swap snapshot run ids do not match its runs")
+    return snapshot
+
+
+def worker_swap_rows_sql() -> str:
+    """Return the Compose adapter query derived from the canonical policy."""
+
+    statuses = ", ".join("'" + status.replace("'", "''") + "'" for status in OPEN_RUN_STATUS_VALUES)
+    return (
+        "SELECT COALESCE("
+        "json_agg(json_build_object('id', id, 'status', status) ORDER BY id), "
+        "'[]'::json"
+        ") FROM agent_runs "
+        f"WHERE status IN ({statuses});"
+    )
+
+
+def _field_value(snapshot: WorkerSwapSnapshot, field: str) -> str:
+    if field == "decision":
+        return snapshot.decision.value
+    if field == "count":
+        return str(snapshot.count) if snapshot.count is not None else "unknown"
+    if field == "ids":
+        return snapshot.run_ids_csv
+    if field == "details":
+        return snapshot.details
+    if field == "known":
+        return "true" if snapshot.known else "false"
+    if field == "report":
+        return snapshot.report
+    raise ValueError(f"unknown worker-swap snapshot field: {field}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("unknown")
+    subparsers.add_parser("sql")
+    subparsers.add_parser("from-rows")
+    subparsers.add_parser("validate")
+    field_parser = subparsers.add_parser("field")
+    field_parser.add_argument(
+        "name",
+        choices=("decision", "count", "ids", "details", "known", "report"),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "unknown":
+        print(unknown_worker_swap_snapshot().as_json())
+        return 0
+    if args.command == "sql":
+        print(worker_swap_rows_sql())
+        return 0
+
+    raw = sys.stdin.read()
+    if args.command == "from-rows":
+        rows = json.loads(raw)
+        if not isinstance(rows, list):
+            raise ValueError("worker-swap query result must be a JSON list")
+        print(worker_swap_snapshot(rows).as_json())
+        return 0
+
+    snapshot = parse_worker_swap_snapshot(raw)
+    if args.command == "validate":
+        return 0
+    print(_field_value(snapshot, args.name))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "WorkerSwapDecision",
+    "WorkerSwapRun",
+    "WorkerSwapSnapshot",
+    "parse_worker_swap_snapshot",
+    "unknown_worker_swap_snapshot",
+    "worker_swap_rows_sql",
+    "worker_swap_snapshot",
+]

--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -11,11 +11,13 @@ import time
 
 from brain.systems.runs.cortex.queue_health import QueueStallMonitor, queued_backlog_health_snapshot_async
 from brain.systems.runs.cortex.runner import (
+    DrainResult,
     request_runner_stop,
     runner_health_snapshot,
     start_runner,
     stop_runner,
 )
+from brain.systems.runs.interruption import interrupt_and_requeue_run_ids
 from brain.systems.cycles import (
     seconds_since_last_cycle_tick,
     start_cycle_scheduler,
@@ -122,6 +124,31 @@ def _cycle_scheduler_enabled() -> bool:
     return enabled in {"1", "true", "yes", "on"}
 
 
+def _recover_timed_out_runs(drain_result: DrainResult) -> None:
+    run_ids = drain_result.timed_out_run_ids
+    if not run_ids:
+        return
+    try:
+        interruptions = asyncio.run(
+            interrupt_and_requeue_run_ids(
+                run_ids,
+                reason="worker_shutdown_drain_timeout",
+            )
+        )
+    except Exception:
+        logger.exception(
+            "runner shutdown could not requeue affected run ids: %s",
+            list(run_ids),
+        )
+        return
+    requeued_run_ids = [interruption.run_id for interruption in interruptions]
+    if requeued_run_ids:
+        logger.warning(
+            "runner shutdown interrupted and requeued run ids: %s",
+            requeued_run_ids,
+        )
+
+
 def main() -> None:
     exit_code = 0
     cycle_scheduler_enabled = False
@@ -191,7 +218,10 @@ def main() -> None:
         exit_code = 1
         raise
     finally:
-        stop_runner(drain_timeout_seconds=_shutdown_drain_timeout_seconds())
+        drain_result = stop_runner(
+            drain_timeout_seconds=_shutdown_drain_timeout_seconds()
+        )
+        _recover_timed_out_runs(drain_result)
         if cycle_scheduler_enabled:
             stop_cycle_scheduler()
         logger.info("agent-run worker stopped")

--- a/brain/systems/runs/cortex/__init__.py
+++ b/brain/systems/runs/cortex/__init__.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from brain.systems.runs.events import run_event
 from brain.systems.runs.skill_commands import iter_slash_skill_commands, parse_slash_skill_names
-from brain.systems.runs.cortex.runner import queue_status, queue_status_async, start_runner, stop_runner
+from brain.systems.runs.cortex.runner import (
+    DrainResult,
+    queue_status,
+    queue_status_async,
+    start_runner,
+    stop_runner,
+)
 
 UnitOfWork = None
 
@@ -125,6 +131,7 @@ supersede_runs_for_idea = async_cancel_runs_for_idea
 
 
 __all__ = [
+    "DrainResult",
     "_get_adaptation_history",
     "_parse_skill_mentions",
     "_parse_skill_override",

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import json
 import logging
 import os
@@ -13,7 +14,7 @@ from types import SimpleNamespace
 import tempfile
 import threading
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 import uuid
 
 from sqlalchemy import func, select
@@ -26,9 +27,19 @@ from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
-    interrupted_run_message,
     public_run_failure,
     safe_terminal_run_message,
+)
+from brain.systems.runs.interruption import (
+    RunInterruption,
+    interrupt_and_requeue_run,
+    notify_run_interruption,
+)
+from brain.systems.runs.slack_delivery import (
+    SLACK_SURFACE as _SLACK_SURFACE,
+    is_slack_origin as _run_is_slack_origin,
+    post_slack_run_message as _post_slack_run_message_async,
+    run_is_headless as _run_is_headless,
 )
 from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -47,9 +58,6 @@ from brain.systems.cortex.project_context.materializer import (
 from brain.systems.cortex.thought_lifecycle import TerminalRunSettlementCommand, settle_terminal_run
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.idea import Idea, IdeaThread, ThreadDiscussionComment
-
-if TYPE_CHECKING:
-    from brain.systems.slack.thread_mute import ThreadPostMute
 
 logger = logging.getLogger(__name__)
 UnitOfWork = None
@@ -88,6 +96,13 @@ _last_queued_watchdog_monotonic = 0.0
 _queued_watchdog_tasks: set[asyncio.Task[int]] = set()
 
 _PROCESS_ACTIVE_STATUS_VALUES = PROCESSING_RUN_STATUS_VALUES
+
+
+@dataclass(frozen=True, slots=True)
+class DrainResult:
+    """Runner lifecycle result; recovery belongs to the owning entry point."""
+
+    timed_out_run_ids: tuple[int, ...] = ()
 
 
 def _coerce_float(value: Any, *, default: float, minimum: float) -> float:
@@ -283,13 +298,6 @@ def _run_context_maps(run: AgentRunRow):
     for container in (_run_target_ref(run), _run_metadata(run)):
         if container:
             yield container
-
-
-def _run_is_headless(run: AgentRunRow) -> bool:
-    for container in _run_context_maps(run):
-        if bool(container.get("headless")):
-            return True
-    return False
 
 
 def _run_is_thread_discussion_conversation(run: AgentRunRow) -> bool:
@@ -508,27 +516,6 @@ def _run_discussion_trigger(run: AgentRunRow) -> dict[str, Any]:
     return {}
 
 
-def _run_slack_trigger(run: AgentRunRow) -> dict[str, Any]:
-    for container in _run_context_maps(run):
-        trigger = container.get("slack_trigger")
-        if isinstance(trigger, dict):
-            return dict(trigger)
-    return {}
-
-
-def _run_is_slack_origin(run: AgentRunRow) -> bool:
-    if _run_slack_trigger(run):
-        return True
-    for container in _run_context_maps(run):
-        if container.get("originating_surface") == _SLACK_SURFACE:
-            return True
-        if container.get("source_surface") == _SLACK_SURFACE:
-            return True
-        if container.get("final_answer_target_surface") == _SLACK_SURFACE:
-            return True
-    return False
-
-
 def _run_discussion_thread_id(run: AgentRunRow) -> str:
     trigger = _run_discussion_trigger(run)
     response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
@@ -693,165 +680,6 @@ async def _slack_visible_action_already_recorded(
         if tool_name in _SLACK_VISIBLE_ACTION_TOOLS:
             return True
     return False
-
-
-def _slack_response_target(run: AgentRunRow) -> dict[str, Any]:
-    trigger = _run_slack_trigger(run)
-    response_target = trigger.get("response_target") if isinstance(trigger.get("response_target"), dict) else {}
-    channel_id = str(response_target.get("channel_id") or trigger.get("channel_id") or "").strip()
-    thread_ts = response_target.get("thread_ts")
-    if thread_ts is not None:
-        thread_ts = str(thread_ts or "").strip() or None
-    trigger_channel_type = str(trigger.get("channel_type") or "").strip()
-    trigger_message_ts = str(trigger.get("message_ts") or "").strip()
-    if trigger_channel_type == "im":
-        thread_ts = None
-    elif not response_target.get("thread_ts") and thread_ts == trigger_message_ts:
-        thread_ts = None
-    return {
-        "channel_id": channel_id,
-        "thread_ts": thread_ts,
-        "trigger": trigger,
-    }
-
-
-async def _slack_client_for_run(run: AgentRunRow):
-    from brain.systems.slack.client import SlackWebClient
-    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
-
-    token = await read_runtime_secret(
-        "SLACK_BOT_TOKEN",
-        context=RuntimeSecretContext(
-            actor_user_id=str(getattr(run, "user_id", "") or "").strip() or None,
-            org_id=str(getattr(run, "org_id", "") or "").strip() or None,
-            run_id=int(run.id),
-            idea_id=str(getattr(run, "thread_id", "") or "").strip() or None,
-        ),
-        reason="Report a completed Slack-origin Illo run back to Slack.",
-        requested_by="slack_run_settlement",
-        access="service",
-        allow_env_fallback=True,
-    )
-    return SlackWebClient(token)
-
-
-async def _clear_slack_processing_status(client: Any, trigger: dict[str, Any]) -> None:
-    set_status = getattr(client, "set_assistant_status", None)
-    if not callable(set_status):
-        return
-    channel_id = str(trigger.get("channel_id") or "").strip()
-    thread_ts = str(trigger.get("thread_ts") or trigger.get("message_ts") or "").strip()
-    if not channel_id or not thread_ts:
-        return
-    with suppress(Exception):
-        await set_status(channel_id=channel_id, thread_ts=thread_ts, status="")
-
-
-async def _record_slack_thread_mute(
-    session,
-    *,
-    run: AgentRunRow,
-    mute: ThreadPostMute,
-    channel_id: str,
-    thread_ts: str,
-) -> None:
-    await AsyncAgentRunStore(session).append_event(
-        run_event(
-            int(run.id),
-            "run.slack_post_suppressed",
-            {
-                "reason": "thread_post_muted",
-                "ledger_line": mute.ledger_line,
-                "muted_by": mute.user,
-                "muted_at": mute.ts,
-                "channel_id": channel_id,
-                "thread_ts": thread_ts,
-            },
-            root_run_id=run.root_run_id,
-        )
-    )
-
-
-async def _post_slack_run_message_async(
-    session,
-    *,
-    run: AgentRunRow,
-    text: str,
-    artifact_id: int | None = None,
-) -> dict[str, Any] | None:
-    target = _slack_response_target(run)
-    channel_id = target["channel_id"]
-    if not channel_id:
-        return None
-    try:
-        client = await _slack_client_for_run(run)
-        if target["thread_ts"]:
-            from brain.systems.slack.thread_mute import read_thread_post_mute
-
-            mute = await read_thread_post_mute(
-                client,
-                channel_id=channel_id,
-                thread_ts=target["thread_ts"],
-                illo_user_id=str(target["trigger"].get("bot_user_id") or "").strip() or None,
-            )
-            if mute is not None:
-                await _clear_slack_processing_status(client, target["trigger"])
-                await _record_slack_thread_mute(
-                    session,
-                    run=run,
-                    mute=mute,
-                    channel_id=channel_id,
-                    thread_ts=target["thread_ts"],
-                )
-                return {
-                    "surface": _SLACK_SURFACE,
-                    "run_id": int(run.id),
-                    "artifact_id": artifact_id,
-                    "channel_id": channel_id,
-                    "thread_ts": target["thread_ts"],
-                    "suppressed": True,
-                    "ledger_line": mute.ledger_line,
-                }
-        response = await client.post_message(
-            channel=channel_id,
-            text=text,
-            thread_ts=target["thread_ts"],
-        )
-        await _clear_slack_processing_status(client, target["trigger"])
-    except Exception as exc:
-        logger.info("slack_run_message_failed: %s", exc, extra={"run_id": int(run.id)})
-        return None
-    return {
-        "surface": _SLACK_SURFACE,
-        "run_id": int(run.id),
-        "artifact_id": artifact_id,
-        "channel_id": channel_id,
-        "thread_ts": target["thread_ts"],
-        "slack": response,
-    }
-
-
-async def _settle_slack_interrupted_run_async(
-    session,
-    run: AgentRunRow,
-    *,
-    interrupted_at: datetime | str | None,
-    requeued: bool,
-) -> dict[str, Any] | None:
-    if not _run_is_slack_origin(run):
-        return None
-    if _run_is_headless(run) and run.parent_run_id is not None:
-        return None
-    message = interrupted_run_message(
-        int(run.id),
-        interrupted_at=interrupted_at,
-        requeued=requeued,
-    )
-    return await _post_slack_run_message_async(
-        session,
-        run=run,
-        text=message,
-    )
 
 
 async def _settle_slack_origin_run_async(
@@ -1283,63 +1111,6 @@ def _run_liveness_at(
     return max(live) if live else None
 
 
-async def _notify_interrupted_run_async(run_id: int) -> dict[str, Any] | None:
-    async with _unit_of_work_factory()() as uow:
-        run = await uow.session.get(AgentRunRow, int(run_id))
-        if run is None:
-            return None
-        metadata = _run_metadata(run)
-        interruption = metadata.get("interruption")
-        interruption = dict(interruption) if isinstance(interruption, dict) else {}
-        return await _settle_slack_interrupted_run_async(
-            uow.session,
-            run,
-            interrupted_at=interruption.get("interrupted_at"),
-            requeued=bool(interruption.get("requeued")),
-        )
-
-
-async def interrupt_and_requeue_run_ids(
-    run_ids: list[int] | tuple[int, ...],
-    *,
-    reason: str,
-    interrupted_at: datetime | None = None,
-) -> tuple[int, ...]:
-    """Durably fence worker-owned attempts, requeue them, and notify Slack."""
-
-    interrupted_at = interrupted_at or datetime.now(timezone.utc)
-    changed_ids: list[int] = []
-    async with _unit_of_work_factory()() as uow:
-        store = AsyncAgentRunStore(uow.session)
-        for run_id in sorted({int(value) for value in run_ids}):
-            _run, changed = await store.interrupt_and_requeue(
-                run_id,
-                reason=reason,
-                interrupted_at=interrupted_at,
-            )
-            if changed:
-                changed_ids.append(run_id)
-
-    for run_id in changed_ids:
-        await _notify_interrupted_run_async(run_id)
-    return tuple(changed_ids)
-
-
-def _interrupt_in_flight_runs(
-    run_ids: tuple[int, ...],
-    *,
-    reason: str,
-) -> tuple[int, ...]:
-    if not run_ids:
-        return ()
-    return asyncio.run(
-        interrupt_and_requeue_run_ids(
-            run_ids,
-            reason=reason,
-        )
-    )
-
-
 async def _reap_stale_candidate(
     session,
     store: AsyncAgentRunStore,
@@ -1348,7 +1119,7 @@ async def _reap_stale_candidate(
     root_run_id: int,
     cutoff: datetime,
     stale_after_seconds: float,
-) -> tuple[bool, int | None]:
+) -> tuple[bool, RunInterruption | None]:
     candidate_tx = await session.begin_nested()
     try:
         locked = await store.lock_run_liveness(int(row.id), root_run_id)
@@ -1385,16 +1156,17 @@ async def _reap_stale_candidate(
             "last_liveness_at": last_liveness_at.isoformat() if last_liveness_at else None,
             "last_run_update_at": row.updated_at.isoformat() if row.updated_at else None,
         }
-        _requeued_run, changed = await store.interrupt_and_requeue(
+        interruption = await interrupt_and_requeue_run(
+            store,
             int(row.id),
             reason="runner_heartbeat_stale",
             details=payload,
         )
-        if not changed:
+        if interruption is None:
             await candidate_tx.rollback()
             return False, None
         await candidate_tx.commit()
-        return True, int(row.id)
+        return True, interruption
     except BaseException:
         if candidate_tx.is_active:
             await candidate_tx.rollback()
@@ -1410,7 +1182,7 @@ async def reap_stale_active_runs(
     now = now or datetime.now(timezone.utc)
     stale_after_seconds = stale_after_seconds if stale_after_seconds is not None else _stale_run_seconds()
     cutoff = now - timedelta(seconds=float(stale_after_seconds))
-    interrupted_run_ids: list[int] = []
+    interruptions: list[RunInterruption] = []
     reaped = 0
 
     async with _unit_of_work_factory()() as uow:
@@ -1439,7 +1211,7 @@ async def reap_stale_active_runs(
             )
             if last_liveness_at is not None and last_liveness_at > cutoff:
                 continue
-            candidate_reaped, interrupted_run_id = await _reap_stale_candidate(
+            candidate_reaped, interruption = await _reap_stale_candidate(
                 uow.session,
                 store,
                 row,
@@ -1449,18 +1221,18 @@ async def reap_stale_active_runs(
             )
             if not candidate_reaped:
                 continue
-            if interrupted_run_id is not None:
-                interrupted_run_ids.append(interrupted_run_id)
+            if interruption is not None:
+                interruptions.append(interruption)
             reaped += 1
 
-    for run_id in interrupted_run_ids:
-        await _notify_interrupted_run_async(run_id)
+    for interruption in interruptions:
+        await notify_run_interruption(interruption)
     if reaped:
         logger.warning(
             "agent_run_stale_interrupted_requeued",
             extra={
                 "count": reaped,
-                "run_ids": interrupted_run_ids,
+                "run_ids": [interruption.run_id for interruption in interruptions],
                 "stale_after_seconds": stale_after_seconds,
             },
         )
@@ -1901,7 +1673,7 @@ def _runner_teardown_timeout_seconds() -> float:
     )
 
 
-def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
+def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> DrainResult:
     global _runner_supervisor_thread
     request_runner_stop()
     timed_out_run_ids: tuple[int, ...] = ()
@@ -1940,23 +1712,7 @@ def stop_runner(*, drain_timeout_seconds: float | None = 2.0) -> None:
     elif _runner_supervisor_thread is supervisor_thread:
         _runner_supervisor_thread = None
 
-    if timed_out_run_ids:
-        try:
-            requeued_run_ids = _interrupt_in_flight_runs(
-                timed_out_run_ids,
-                reason="worker_shutdown_drain_timeout",
-            )
-        except Exception:
-            logger.exception(
-                "runner shutdown could not requeue affected run ids: %s",
-                list(timed_out_run_ids),
-            )
-        else:
-            if requeued_run_ids:
-                logger.warning(
-                    "runner shutdown interrupted and requeued run ids: %s",
-                    list(requeued_run_ids),
-                )
+    return DrainResult(timed_out_run_ids=timed_out_run_ids)
 
 
 async def queue_status_async(*, consumer_running: bool | None = None, org_id: str | None = None) -> dict[str, Any]:
@@ -1983,6 +1739,7 @@ def queue_status(*, consumer_running: bool | None = None, org_id: str | None = N
 
 
 __all__ = [
+    "DrainResult",
     "queue_status",
     "queue_status_async",
     "reap_stale_active_runs",

--- a/brain/systems/runs/failures.py
+++ b/brain/systems/runs/failures.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from enum import Enum
 from typing import TypedDict
 
@@ -29,34 +28,6 @@ UPSTREAM_FAILED_RUN_MESSAGE = "I hit a temporary upstream problem — please ret
 VERIFICATION_FAILED_RUN_MESSAGE = "I couldn't safely verify the result — please retry."
 CANCELED_RUN_MESSAGE = "That run was canceled before it finished."
 EXPIRED_RUN_MESSAGE = "That run timed out before it finished — please retry."
-
-
-def interrupted_run_message(
-    run_id: int,
-    *,
-    interrupted_at: datetime | str | None = None,
-    requeued: bool,
-) -> str:
-    """Return the public status update for a worker-interrupted run."""
-
-    occurred_at = interrupted_at
-    if isinstance(occurred_at, str):
-        try:
-            occurred_at = datetime.fromisoformat(occurred_at.replace("Z", "+00:00"))
-        except ValueError:
-            occurred_at = None
-    if not isinstance(occurred_at, datetime):
-        occurred_at = datetime.now(timezone.utc)
-    if occurred_at.tzinfo is None:
-        occurred_at = occurred_at.replace(tzinfo=timezone.utc)
-    time_label = occurred_at.astimezone(timezone.utc).strftime("%H:%M UTC")
-    prefix = f"I was interrupted by a system restart at {time_label} (run {int(run_id)})"
-    if requeued:
-        return f"{prefix}; I've re-queued it and will reply here when it finishes."
-    return (
-        f"{prefix}; I could not re-queue it. Work completed before the interruption "
-        "was preserved, but the run did not finish."
-    )
 
 
 def coerce_failure_category(value: RunFailureCategory | str | None) -> RunFailureCategory:
@@ -126,7 +97,6 @@ __all__ = [
     "CANCELED_RUN_MESSAGE",
     "DEFAULT_FAILED_RUN_MESSAGE",
     "EXPIRED_RUN_MESSAGE",
-    "interrupted_run_message",
     "PublicRunFailure",
     "RunFailureCategory",
     "UPSTREAM_FAILED_RUN_MESSAGE",

--- a/brain/systems/runs/interruption.py
+++ b/brain/systems/runs/interruption.py
@@ -1,0 +1,160 @@
+"""Application service for durable, non-terminal AgentRun interruption."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.systems.runs.slack_delivery import (
+    is_slack_origin,
+    post_slack_run_message,
+    run_is_headless,
+)
+from brain.systems.runs.store import AsyncAgentRunStore
+
+
+UnitOfWork = None
+
+
+def _unit_of_work_factory():
+    global UnitOfWork
+    if UnitOfWork is None:
+        from brain.platform.db.repositories.unit_of_work import UnitOfWork as _UnitOfWork
+
+        UnitOfWork = _UnitOfWork
+    return UnitOfWork
+
+
+def _utc_datetime(value: datetime | str | None) -> datetime:
+    parsed = value
+    if isinstance(parsed, str):
+        try:
+            parsed = datetime.fromisoformat(parsed.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if not isinstance(parsed, datetime):
+        parsed = datetime.now(timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class RunInterruption:
+    """Committed interruption outcome used for post-commit notification."""
+
+    run_id: int
+    reason: str
+    interrupted_at: datetime
+    requeued: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", int(self.run_id))
+        object.__setattr__(self, "reason", str(self.reason))
+        object.__setattr__(self, "interrupted_at", _utc_datetime(self.interrupted_at))
+        object.__setattr__(self, "requeued", bool(self.requeued))
+
+
+def run_interruption_from_run(run: Any) -> RunInterruption:
+    metadata = getattr(run, "metadata_", None)
+    if not isinstance(metadata, dict):
+        metadata = getattr(run, "metadata", None)
+    metadata = dict(metadata or {}) if isinstance(metadata, dict) else {}
+    interruption = metadata.get("interruption")
+    interruption = dict(interruption) if isinstance(interruption, dict) else {}
+    return RunInterruption(
+        run_id=int(run.id),
+        reason=str(interruption.get("reason") or "worker_shutdown"),
+        interrupted_at=_utc_datetime(interruption.get("interrupted_at")),
+        requeued=bool(interruption.get("requeued")),
+    )
+
+
+def interrupted_run_message(interruption: RunInterruption) -> str:
+    """Return the public status update for a worker-interrupted run."""
+
+    time_label = interruption.interrupted_at.strftime("%H:%M UTC")
+    prefix = (
+        f"I was interrupted by a system restart at {time_label} "
+        f"(run {int(interruption.run_id)})"
+    )
+    if interruption.requeued:
+        return f"{prefix}; I've re-queued it and will reply here when it finishes."
+    return (
+        f"{prefix}; I could not re-queue it. Work completed before the interruption "
+        "was preserved, but the run did not finish."
+    )
+
+
+async def notify_run_interruption(interruption: RunInterruption) -> dict[str, Any] | None:
+    """Notify the originating surface after the interruption commit succeeds."""
+
+    async with _unit_of_work_factory()() as uow:
+        run = await uow.session.get(AgentRunRow, int(interruption.run_id))
+        if run is None or not is_slack_origin(run):
+            return None
+        if run_is_headless(run) and run.parent_run_id is not None:
+            return None
+        return await post_slack_run_message(
+            uow.session,
+            run=run,
+            text=interrupted_run_message(interruption),
+        )
+
+
+async def interrupt_and_requeue_run(
+    store: AsyncAgentRunStore,
+    run_id: int,
+    *,
+    reason: str,
+    interrupted_at: datetime | None = None,
+    details: dict[str, Any] | None = None,
+) -> RunInterruption | None:
+    """Persist one interruption inside the caller's transaction."""
+
+    options: dict[str, Any] = {"reason": reason}
+    if interrupted_at is not None:
+        options["interrupted_at"] = interrupted_at
+    if details is not None:
+        options["details"] = details
+    run, changed = await store.interrupt_and_requeue(int(run_id), **options)
+    return run_interruption_from_run(run) if changed else None
+
+
+async def interrupt_and_requeue_run_ids(
+    run_ids: Iterable[int],
+    *,
+    reason: str,
+    interrupted_at: datetime | None = None,
+) -> tuple[RunInterruption, ...]:
+    """Fence worker-owned attempts, commit their requeue, then notify."""
+
+    occurred_at = _utc_datetime(interrupted_at)
+    interruptions: list[RunInterruption] = []
+    async with _unit_of_work_factory()() as uow:
+        store = AsyncAgentRunStore(uow.session)
+        for run_id in sorted({int(value) for value in run_ids}):
+            interruption = await interrupt_and_requeue_run(
+                store,
+                run_id,
+                reason=reason,
+                interrupted_at=occurred_at,
+            )
+            if interruption is not None:
+                interruptions.append(interruption)
+
+    for interruption in interruptions:
+        await notify_run_interruption(interruption)
+    return tuple(interruptions)
+
+
+__all__ = [
+    "RunInterruption",
+    "interrupt_and_requeue_run",
+    "interrupt_and_requeue_run_ids",
+    "interrupted_run_message",
+    "notify_run_interruption",
+    "run_interruption_from_run",
+]

--- a/brain/systems/runs/slack_delivery.py
+++ b/brain/systems/runs/slack_delivery.py
@@ -1,0 +1,206 @@
+"""Shared Slack delivery boundary for AgentRun settlement messages."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import logging
+from typing import TYPE_CHECKING, Any
+
+from brain.systems.runs.events import run_event
+from brain.systems.runs.store import AsyncAgentRunStore
+
+if TYPE_CHECKING:
+    from brain.systems.slack.thread_mute import ThreadPostMute
+
+
+logger = logging.getLogger(__name__)
+
+SLACK_SURFACE = "slack"
+
+
+def _run_context_maps(run: Any):
+    target_ref = getattr(run, "target_ref", None)
+    metadata = getattr(run, "metadata_", None)
+    if not isinstance(metadata, dict):
+        metadata = getattr(run, "metadata", None)
+    for container in (target_ref, metadata):
+        if isinstance(container, dict) and container:
+            yield container
+
+
+def run_is_headless(run: Any) -> bool:
+    return any(bool(container.get("headless")) for container in _run_context_maps(run))
+
+
+def slack_trigger(run: Any) -> dict[str, Any]:
+    for container in _run_context_maps(run):
+        trigger = container.get("slack_trigger")
+        if isinstance(trigger, dict):
+            return dict(trigger)
+    return {}
+
+
+def is_slack_origin(run: Any) -> bool:
+    if slack_trigger(run):
+        return True
+    for container in _run_context_maps(run):
+        if container.get("originating_surface") == SLACK_SURFACE:
+            return True
+        if container.get("source_surface") == SLACK_SURFACE:
+            return True
+        if container.get("final_answer_target_surface") == SLACK_SURFACE:
+            return True
+    return False
+
+
+def slack_response_target(run: Any) -> dict[str, Any]:
+    trigger = slack_trigger(run)
+    response_target = (
+        trigger.get("response_target")
+        if isinstance(trigger.get("response_target"), dict)
+        else {}
+    )
+    channel_id = str(response_target.get("channel_id") or trigger.get("channel_id") or "").strip()
+    thread_ts = response_target.get("thread_ts")
+    if thread_ts is not None:
+        thread_ts = str(thread_ts or "").strip() or None
+    trigger_channel_type = str(trigger.get("channel_type") or "").strip()
+    trigger_message_ts = str(trigger.get("message_ts") or "").strip()
+    if trigger_channel_type == "im":
+        thread_ts = None
+    elif not response_target.get("thread_ts") and thread_ts == trigger_message_ts:
+        thread_ts = None
+    return {
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "trigger": trigger,
+    }
+
+
+async def slack_client_for_run(run: Any):
+    from brain.systems.slack.client import SlackWebClient
+    from brain.systems.vault.runtime_secrets import RuntimeSecretContext, read_runtime_secret
+
+    token = await read_runtime_secret(
+        "SLACK_BOT_TOKEN",
+        context=RuntimeSecretContext(
+            actor_user_id=str(getattr(run, "user_id", "") or "").strip() or None,
+            org_id=str(getattr(run, "org_id", "") or "").strip() or None,
+            run_id=int(run.id),
+            idea_id=str(getattr(run, "thread_id", "") or "").strip() or None,
+        ),
+        reason="Report a completed Slack-origin Illo run back to Slack.",
+        requested_by="slack_run_settlement",
+        access="service",
+        allow_env_fallback=True,
+    )
+    return SlackWebClient(token)
+
+
+async def clear_slack_processing_status(client: Any, trigger: dict[str, Any]) -> None:
+    set_status = getattr(client, "set_assistant_status", None)
+    if not callable(set_status):
+        return
+    channel_id = str(trigger.get("channel_id") or "").strip()
+    thread_ts = str(trigger.get("thread_ts") or trigger.get("message_ts") or "").strip()
+    if not channel_id or not thread_ts:
+        return
+    with suppress(Exception):
+        await set_status(channel_id=channel_id, thread_ts=thread_ts, status="")
+
+
+async def record_slack_thread_mute(
+    session,
+    *,
+    run: Any,
+    mute: ThreadPostMute,
+    channel_id: str,
+    thread_ts: str,
+) -> None:
+    await AsyncAgentRunStore(session).append_event(
+        run_event(
+            int(run.id),
+            "run.slack_post_suppressed",
+            {
+                "reason": "thread_post_muted",
+                "ledger_line": mute.ledger_line,
+                "muted_by": mute.user,
+                "muted_at": mute.ts,
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+            },
+            root_run_id=run.root_run_id,
+        )
+    )
+
+
+async def post_slack_run_message(
+    session,
+    *,
+    run: Any,
+    text: str,
+    artifact_id: int | None = None,
+) -> dict[str, Any] | None:
+    target = slack_response_target(run)
+    channel_id = target["channel_id"]
+    if not channel_id:
+        return None
+    try:
+        client = await slack_client_for_run(run)
+        if target["thread_ts"]:
+            from brain.systems.slack.thread_mute import read_thread_post_mute
+
+            mute = await read_thread_post_mute(
+                client,
+                channel_id=channel_id,
+                thread_ts=target["thread_ts"],
+                illo_user_id=str(target["trigger"].get("bot_user_id") or "").strip() or None,
+            )
+            if mute is not None:
+                await clear_slack_processing_status(client, target["trigger"])
+                await record_slack_thread_mute(
+                    session,
+                    run=run,
+                    mute=mute,
+                    channel_id=channel_id,
+                    thread_ts=target["thread_ts"],
+                )
+                return {
+                    "surface": SLACK_SURFACE,
+                    "run_id": int(run.id),
+                    "artifact_id": artifact_id,
+                    "channel_id": channel_id,
+                    "thread_ts": target["thread_ts"],
+                    "suppressed": True,
+                    "ledger_line": mute.ledger_line,
+                }
+        response = await client.post_message(
+            channel=channel_id,
+            text=text,
+            thread_ts=target["thread_ts"],
+        )
+        await clear_slack_processing_status(client, target["trigger"])
+    except Exception as exc:
+        logger.info("slack_run_message_failed: %s", exc, extra={"run_id": int(run.id)})
+        return None
+    return {
+        "surface": SLACK_SURFACE,
+        "run_id": int(run.id),
+        "artifact_id": artifact_id,
+        "channel_id": channel_id,
+        "thread_ts": target["thread_ts"],
+        "slack": response,
+    }
+
+
+__all__ = [
+    "SLACK_SURFACE",
+    "clear_slack_processing_status",
+    "is_slack_origin",
+    "post_slack_run_message",
+    "record_slack_thread_mute",
+    "run_is_headless",
+    "slack_client_for_run",
+    "slack_response_target",
+    "slack_trigger",
+]

--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -5,9 +5,21 @@ ROOT="${ROOT:-$(cd "$COMPOSE_RUNTIME_LIB_DIR/../.." && pwd)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/deploy/compose/docker-compose.yml}"
 ENV_FILE="${ENV_FILE:-${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}}"
 RUNTIME_SERVICE_CATALOG="${RUNTIME_SERVICE_CATALOG:-$ROOT/deploy/compose/runtime-services.json}"
+WORKER_SWAP_PYTHON_BIN="${WORKER_SWAP_PYTHON_BIN:-python3}"
+
+source "$COMPOSE_RUNTIME_LIB_DIR/worker-swap-lib.sh"
 
 compose() {
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" "$@"
+}
+
+worker_swap_snapshot_acquire() {
+  local rows
+  rows="$(
+    worker_swap_contract sql \
+      | compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At' 2>/dev/null
+  )" || return 1
+  printf '%s\n' "$rows" | worker_swap_contract from-rows
 }
 
 runtime_service_ids() {
@@ -68,54 +80,6 @@ expand_runtime_services() {
   printf '%s\n' "${expanded_services[@]}"
 }
 
-nonterminal_agent_run_details() {
-  local details
-  if details="$(compose exec -T postgres sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -AtF: -c "
-SELECT id, status FROM agent_runs
-WHERE status IN ('\''queued'\'', '\''starting'\'', '\''running'\'', '\''paused'\'', '\''verifying'\'')
-ORDER BY id;
-"' 2>/dev/null | paste -sd, - | tr -d '[:space:]')"; then
-    if [ -z "$details" ] || [[ "$details" =~ ^[0-9]+:(queued|starting|running|paused|verifying)(,[0-9]+:(queued|starting|running|paused|verifying))*$ ]]; then
-      printf '%s\n' "$details"
-      return 0
-    fi
-  fi
-  printf 'unknown\n'
-}
-
-agent_run_count_from_details() {
-  local details="$1"
-  if [ -z "$details" ]; then
-    printf '0\n'
-    return 0
-  fi
-  if [ "$details" = "unknown" ]; then
-    printf 'unknown\n'
-    return 0
-  fi
-  awk -F, '{print NF}' <<< "$details"
-}
-
-agent_run_ids_from_details() {
-  local details="$1"
-  [ -n "$details" ] && [ "$details" != "unknown" ] || return 0
-  printf '%s\n' "$details" | sed -E 's/:[^,]+//g'
-}
-
-active_agent_run_count() {
-  local details
-  details="$(nonterminal_agent_run_details)"
-  agent_run_count_from_details "$details"
-}
-
-report_nonterminal_agent_runs() {
-  local details="$1"
-  local count ids
-  count="$(agent_run_count_from_details "$details")"
-  ids="$(agent_run_ids_from_details "$details")"
-  echo "Worker pre-swap check: $count interactive run(s) in flight (run ids: $ids; id/status: $details)."
-}
-
 worker_container_id() {
   compose ps -q worker 2>/dev/null || true
 }
@@ -136,10 +100,11 @@ start_worker_handoff() {
 }
 
 record_worker_drain_timeout() {
-  local details="${1:-unknown}"
-  local ids
+  local snapshot="$1"
+  local details ids
   [ -n "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE:-}" ] || return 0
-  ids="$(agent_run_ids_from_details "$details")"
+  details="$(worker_swap_snapshot_details "$snapshot")"
+  ids="$(worker_swap_snapshot_run_ids "$snapshot")"
   mkdir -p "$(dirname "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE")" 2>/dev/null || true
   printf '{"status":"worker_draining","updated_at":"%s","affected_run_ids":"%s","affected_runs":"%s"}\n' \
     "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$ids" "$details" \
@@ -154,19 +119,21 @@ wait_for_worker_exit() {
   local wait_iterations=0
   local consecutive_zero_checks=0
   local hint_printed=0
-  local active_runs affected_runs affected_ids elapsed
+  local active_runs affected_runs affected_ids elapsed snapshot
   while container_running "$id"; do
     if [ "$SECONDS" -ge "$deadline" ]; then
-      affected_runs="$(nonterminal_agent_run_details)"
-      affected_ids="$(agent_run_ids_from_details "$affected_runs")"
+      snapshot="$(worker_swap_snapshot)"
+      affected_runs="$(worker_swap_snapshot_details "$snapshot")"
+      affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
       echo "Worker did not drain within ${wait_seconds}s; refusing to kill it. Affected run ids: ${affected_ids:-unknown} (id/status: $affected_runs)." >&2
-      record_worker_drain_timeout "$affected_runs"
+      record_worker_drain_timeout "$snapshot"
       return 1
     fi
     sleep 5
     wait_iterations=$((wait_iterations + 1))
     if [ $((wait_iterations % 6)) -eq 0 ] && container_running "$id"; then
-      active_runs="$(active_agent_run_count)"
+      snapshot="$(worker_swap_snapshot)"
+      active_runs="$(worker_swap_snapshot_count "$snapshot")"
       if [ "$active_runs" = "0" ]; then
         consecutive_zero_checks=$((consecutive_zero_checks + 1))
         if [ "$consecutive_zero_checks" -ge 2 ] && [ "$hint_printed" = "0" ]; then
@@ -183,14 +150,15 @@ wait_for_worker_exit() {
 }
 
 update_worker_after_drain() {
-  local run_details="$1"
+  local snapshot="$1"
   local already_reported="${2:-}"
-  local active_runs affected_ids worker_id handoff_id
-  active_runs="$(agent_run_count_from_details "$run_details")"
-  affected_ids="$(agent_run_ids_from_details "$run_details")"
+  local active_runs affected_ids worker_id handoff_id run_details
+  active_runs="$(worker_swap_snapshot_count "$snapshot")"
+  affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
+  run_details="$(worker_swap_snapshot_details "$snapshot")"
   worker_id="$(worker_container_id)"
   if [ "$already_reported" != "reported" ]; then
-    report_nonterminal_agent_runs "$run_details"
+    echo "$(worker_swap_snapshot_report "$snapshot")."
   fi
 
   if [ -z "$worker_id" ]; then
@@ -209,16 +177,17 @@ update_worker_after_drain() {
     if [ "${ILLO_COMPOSE_FORCE_WORKER_SWAP:-0}" != "1" ]; then
       return 1
     fi
-    run_details="$(nonterminal_agent_run_details)"
-    affected_ids="$(agent_run_ids_from_details "$run_details")"
+    snapshot="$(worker_swap_snapshot)"
+    run_details="$(worker_swap_snapshot_details "$snapshot")"
+    affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
     echo "FORCED WORKER SWAP: killing old worker; affected run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
     docker update --restart=no "$worker_id" >/dev/null 2>&1 || true
     docker kill "$worker_id" >/dev/null 2>&1 || true
   fi
   compose up -d --force-recreate --no-deps worker
   if [ -n "$handoff_id" ]; then
-    run_details="$(nonterminal_agent_run_details)"
-    affected_ids="$(agent_run_ids_from_details "$run_details")"
+    snapshot="$(worker_swap_snapshot)"
+    affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
     echo "Worker: regular worker is restarted; draining handoff worker $handoff_id. Open run ids at handoff shutdown: ${affected_ids:-none}."
     docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
     (
@@ -229,7 +198,7 @@ update_worker_after_drain() {
 }
 
 replace_idle_worker() {
-  local run_details affected_ids worker_id
+  local action affected_ids run_details snapshot worker_id
   worker_id="$(worker_container_id)"
 
   if [ -z "$worker_id" ]; then
@@ -238,13 +207,15 @@ replace_idle_worker() {
     return 0
   fi
 
-  run_details="$(nonterminal_agent_run_details)"
-  if [ "$run_details" = "unknown" ]; then
+  snapshot="$(worker_swap_snapshot)"
+  action="$(worker_swap_snapshot_decision "$snapshot")"
+  if [ "$action" = "unknown" ]; then
     echo "Cannot safely replace worker because the non-terminal AgentRun ids are unknown." >&2
     return 1
   fi
-  if [ -n "$run_details" ]; then
-    affected_ids="$(agent_run_ids_from_details "$run_details")"
+  if [ "$action" = "drain" ]; then
+    run_details="$(worker_swap_snapshot_details "$snapshot")"
+    affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
     echo "Worker replacement blocked: interactive runs appeared after the pre-swap check. Affected run ids: $affected_ids (id/status: $run_details)." >&2
     return 1
   fi
@@ -260,17 +231,17 @@ replace_idle_worker() {
 }
 
 restart_runtime_worker_service() {
-  local run_details
-  run_details="$(nonterminal_agent_run_details)"
-  if [ "$run_details" = "unknown" ]; then
-    echo "Cannot safely restart worker because non-terminal AgentRun ids are unknown." >&2
-    return 1
-  fi
-  if [ -z "$run_details" ]; then
-    replace_idle_worker
-  else
-    update_worker_after_drain "$run_details"
-  fi
+  local action snapshot
+  snapshot="$(worker_swap_snapshot)"
+  action="$(worker_swap_snapshot_decision "$snapshot")"
+  case "$action" in
+    replace) replace_idle_worker ;;
+    drain) update_worker_after_drain "$snapshot" ;;
+    *)
+      echo "Cannot safely restart worker because non-terminal AgentRun ids are unknown." >&2
+      return 1
+      ;;
+  esac
 }
 
 restart_runtime_service() {

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -100,22 +100,25 @@ fi
 
 compose up -d postgres
 compose run --rm migrate
-NONTERMINAL_RUNS="$(nonterminal_agent_run_details)"
-if [ "$NONTERMINAL_RUNS" = "unknown" ]; then
-  echo "Cannot safely swap worker because non-terminal AgentRun ids are unknown." >&2
-  exit 1
-fi
-if [ -z "$NONTERMINAL_RUNS" ]; then
-  mapfile -t runtime_services < <(all_runtime_services)
-  compose up -d --force-recreate --remove-orphans "${runtime_services[@]}"
-  replace_idle_worker
-else
-  report_nonterminal_agent_runs "$NONTERMINAL_RUNS"
-  echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
-  mapfile -t services < <(non_worker_services)
-  compose up -d --force-recreate --no-deps "${services[@]}"
-  update_worker_after_drain "$NONTERMINAL_RUNS" reported
-fi
+WORKER_SWAP_SNAPSHOT="$(worker_swap_snapshot)"
+case "$(worker_swap_snapshot_decision "$WORKER_SWAP_SNAPSHOT")" in
+  replace)
+    mapfile -t runtime_services < <(all_runtime_services)
+    compose up -d --force-recreate --remove-orphans "${runtime_services[@]}"
+    replace_idle_worker
+    ;;
+  drain)
+    echo "$(worker_swap_snapshot_report "$WORKER_SWAP_SNAPSHOT")."
+    echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
+    mapfile -t services < <(non_worker_services)
+    compose up -d --force-recreate --no-deps "${services[@]}"
+    update_worker_after_drain "$WORKER_SWAP_SNAPSHOT" reported
+    ;;
+  *)
+    echo "Cannot safely swap worker because non-terminal AgentRun ids are unknown." >&2
+    exit 1
+    ;;
+esac
 
 "$SCRIPT_DIR/doctor.sh"
 schedule_updater_refresh_after_self_update

--- a/deploy/scripts/worker-swap-lib.sh
+++ b/deploy/scripts/worker-swap-lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Shared worker-swap snapshot parsing, presentation, and decision helpers.
+
+worker_swap_python_bin() {
+  printf '%s\n' "${WORKER_SWAP_PYTHON_BIN:-python3}"
+}
+
+worker_swap_contract() {
+  local python_bin
+  python_bin="$(worker_swap_python_bin)"
+  PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+    "$python_bin" -m brain.contracts.worker_swap "$@"
+}
+
+worker_swap_snapshot_acquire() {
+  local python_bin
+  python_bin="$(worker_swap_python_bin)"
+  PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+    "$python_bin" -m brain.app.cli.worker_swap_snapshot
+}
+
+worker_swap_snapshot() {
+  local snapshot
+  if snapshot="$(worker_swap_snapshot_acquire 2>/dev/null)" \
+    && printf '%s\n' "$snapshot" | worker_swap_contract validate >/dev/null 2>&1; then
+    printf '%s\n' "$snapshot"
+    return 0
+  fi
+  worker_swap_contract unknown
+}
+
+worker_swap_snapshot_field() {
+  local snapshot="$1"
+  local field="$2"
+  printf '%s\n' "$snapshot" | worker_swap_contract field "$field"
+}
+
+worker_swap_snapshot_decision() {
+  worker_swap_snapshot_field "$1" decision
+}
+
+worker_swap_snapshot_count() {
+  worker_swap_snapshot_field "$1" count
+}
+
+worker_swap_snapshot_run_ids() {
+  worker_swap_snapshot_field "$1" ids
+}
+
+worker_swap_snapshot_details() {
+  worker_swap_snapshot_field "$1" details
+}
+
+worker_swap_snapshot_report() {
+  worker_swap_snapshot_field "$1" report
+}

--- a/illo
+++ b/illo
@@ -266,6 +266,12 @@ launcher_python_bin() {
   fi
 }
 
+source "$ROOT/deploy/scripts/worker-swap-lib.sh"
+
+worker_swap_python_bin() {
+  launcher_python_bin
+}
+
 production_env_file_path() {
   if [ -n "${ILLO_PRODUCTION_ENV_FILE:-}" ]; then
     case "$ILLO_PRODUCTION_ENV_FILE" in
@@ -546,23 +552,27 @@ systemd_user_ready() {
 restart_or_drain_production_worker() {
   run_logged_timeout 10 systemctl --user enable cortex-worker.service >/dev/null 2>&1 || return 1
 
-  local active_runs affected_ids run_details
-  run_details="$(nonterminal_agent_run_details || echo unknown)"
-  if [ "$run_details" = "unknown" ]; then
-    warn "Could not list non-terminal AgentRuns; refusing to restart cortex-worker"
-    return 1
-  fi
-  if [ -z "$run_details" ]; then
-    run_logged_timeout 15 systemctl --user restart cortex-worker.service >/dev/null 2>&1
-    dim "cortex-worker restarted for this checkout"
-    return $?
-  fi
-
-  active_runs="$(awk -F, '{print NF}' <<< "$run_details")"
-  affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
-  warn "Worker pre-swap check: $active_runs interactive run(s) in flight (run ids: $affected_ids; id/status: $run_details)"
-  warn "$active_runs AgentRun(s) active; draining cortex-worker instead of restarting it; affected run ids: $affected_ids"
-  run_logged_timeout 10 systemctl --user kill --kill-who=main --signal=TERM cortex-worker.service >/dev/null 2>&1 || true
+  local action active_runs affected_ids snapshot
+  snapshot="$(worker_swap_snapshot)"
+  action="$(worker_swap_snapshot_decision "$snapshot")"
+  case "$action" in
+    replace)
+      run_logged_timeout 15 systemctl --user restart cortex-worker.service >/dev/null 2>&1
+      dim "cortex-worker restarted for this checkout"
+      return $?
+      ;;
+    drain)
+      active_runs="$(worker_swap_snapshot_count "$snapshot")"
+      affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
+      warn "$(worker_swap_snapshot_report "$snapshot")"
+      warn "$active_runs AgentRun(s) active; draining cortex-worker instead of restarting it; affected run ids: $affected_ids"
+      run_logged_timeout 10 systemctl --user kill --kill-who=main --signal=TERM cortex-worker.service >/dev/null 2>&1 || true
+      ;;
+    *)
+      warn "Could not list non-terminal AgentRuns; refusing to restart cortex-worker"
+      return 1
+      ;;
+  esac
 }
 
 ensure_production_user_services() {
@@ -688,58 +698,6 @@ stop_conflicting_services() {
       launch_log "user service not installed or unavailable: $svc"
     fi
   done
-}
-
-active_agent_run_count() {
-  "$ROOT/venv/bin/python3" - <<'PY' 2>/dev/null
-import asyncio
-
-from sqlalchemy import func, select
-
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-from brain.platform.db.models.agent_run import AgentRunRow
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
-
-
-async def main() -> None:
-    async with UnitOfWork() as uow:
-        count = await uow.session.scalar(
-            select(func.count())
-            .select_from(AgentRunRow)
-            .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
-        )
-    print(int(count or 0))
-
-
-asyncio.run(main())
-PY
-}
-
-nonterminal_agent_run_details() {
-  "$ROOT/venv/bin/python3" - <<'PY' 2>/dev/null
-import asyncio
-
-from sqlalchemy import select
-
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-from brain.platform.db.models.agent_run import AgentRunRow
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
-
-
-async def main() -> None:
-    async with UnitOfWork() as uow:
-        rows = (
-            await uow.session.execute(
-                select(AgentRunRow.id, AgentRunRow.status)
-                .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
-                .order_by(AgentRunRow.id.asc())
-            )
-        ).all()
-    print(",".join(f"{run_id}:{status}" for run_id, status in rows))
-
-
-asyncio.run(main())
-PY
 }
 
 api_owned_active_run_count() {
@@ -2030,8 +1988,9 @@ run_prod() {
   sync_frontend_dependencies
 
   log_phase "production: prepare GPU/runtime environment"
-  local active_runs_for_runtime
-  active_runs_for_runtime="$(active_agent_run_count || echo unknown)"
+  local active_runs_for_runtime worker_swap_runtime_snapshot
+  worker_swap_runtime_snapshot="$(worker_swap_snapshot)"
+  active_runs_for_runtime="$(worker_swap_snapshot_count "$worker_swap_runtime_snapshot")"
   if [ "$active_runs_for_runtime" = "0" ]; then
     offload_ollama_models
   else

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT=$(pwd)
 PYTHON_BIN="$ROOT/venv/bin/python3"
+WORKER_SWAP_PYTHON_BIN="$PYTHON_BIN"
+
+source "$ROOT/deploy/scripts/worker-swap-lib.sh"
 
 runtime_env_file_path() {
   if [ -n "${ILLO_RUNTIME_ENV_FILE:-}" ]; then
@@ -285,16 +288,18 @@ stop_legacy_docker_app_containers() {
     illospace-worker-1
     illospace-scheduler-1
   )
-  local affected_ids run_details running
+  local action affected_ids run_details running snapshot
   running="$(docker ps --format '{{.Names}}' 2>/dev/null || true)"
   if printf '%s\n' "$running" | grep -qx illospace-worker-1; then
-    run_details="$(nonterminal_agent_run_details || echo unknown)"
-    if [ "$run_details" = "unknown" ]; then
+    snapshot="$(worker_swap_snapshot)"
+    action="$(worker_swap_snapshot_decision "$snapshot")"
+    if [ "$action" = "unknown" ]; then
       echo "Refusing to stop legacy Docker worker because non-terminal AgentRun ids are unknown." >&2
       return 1
     fi
-    if [ -n "$run_details" ]; then
-      affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
+    if [ "$action" = "drain" ]; then
+      run_details="$(worker_swap_snapshot_details "$snapshot")"
+      affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
       echo "Refusing to stop legacy Docker worker with interactive runs in flight. Affected run ids: $affected_ids (id/status: $run_details)." >&2
       return 1
     fi
@@ -328,54 +333,6 @@ dest.write_text(text, encoding="utf-8")
 PY
 }
 
-active_agent_run_count() {
-  "$PYTHON_BIN" - <<'PY'
-import asyncio
-
-from sqlalchemy import func, select
-
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-from brain.platform.db.models.agent_run import AgentRunRow
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
-
-async def main() -> None:
-    async with UnitOfWork() as uow:
-        count = await uow.session.scalar(
-            select(func.count())
-            .select_from(AgentRunRow)
-            .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
-        )
-    print(int(count or 0))
-
-asyncio.run(main())
-PY
-}
-
-nonterminal_agent_run_details() {
-  "$PYTHON_BIN" - <<'PY'
-import asyncio
-
-from sqlalchemy import select
-
-from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
-from brain.platform.db.models.agent_run import AgentRunRow
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
-
-async def main() -> None:
-    async with UnitOfWork() as uow:
-        rows = (
-            await uow.session.execute(
-                select(AgentRunRow.id, AgentRunRow.status)
-                .where(AgentRunRow.status.in_(OPEN_RUN_STATUS_VALUES))
-                .order_by(AgentRunRow.id.asc())
-            )
-        ).all()
-    print(",".join(f"{run_id}:{status}" for run_id, status in rows))
-
-asyncio.run(main())
-PY
-}
-
 restart_or_drain_worker() {
   if ! have_user_service cortex-worker; then
     echo "Worker:    missing user service (expected cortex-worker)"
@@ -383,29 +340,32 @@ restart_or_drain_worker() {
   fi
 
   systemctl --user enable cortex-worker
-  local active_runs affected_ids run_details
-  run_details="$(nonterminal_agent_run_details || echo unknown)"
-  if [ "$run_details" = "unknown" ]; then
-    echo "Worker:    refusing restart because non-terminal AgentRun ids are unknown" >&2
-    return 1
-  fi
-  if [ -z "$run_details" ]; then
-    systemctl --user restart cortex-worker
-    echo "Worker:    restarted (no interactive AgentRuns)"
-    return 0
-  fi
-
-  active_runs="$(awk -F, '{print NF}' <<< "$run_details")"
-  affected_ids="$(printf '%s\n' "$run_details" | sed -E 's/:[^,]+//g')"
-  echo "Worker pre-swap check: $active_runs interactive run(s) in flight (run ids: $affected_ids; id/status: $run_details)."
-  echo "Worker:    $active_runs interactive AgentRun(s); signaling drain instead of restart; affected run ids: $affected_ids"
-  echo "           It will stop claiming new runs and restart on the new version after active runs finish."
-  local old_pid handoff_pid
-  old_pid="$(worker_service_main_pid)"
-  handoff_pid="$(start_worker_handoff)"
-  echo "Worker:    started temporary handoff worker $handoff_pid for new AgentRuns"
-  systemctl --user kill --kill-who=main --signal=TERM cortex-worker || true
-  monitor_worker_handoff "$old_pid" "$handoff_pid"
+  local action active_runs affected_ids handoff_pid old_pid snapshot
+  snapshot="$(worker_swap_snapshot)"
+  action="$(worker_swap_snapshot_decision "$snapshot")"
+  case "$action" in
+    replace)
+      systemctl --user restart cortex-worker
+      echo "Worker:    restarted (no interactive AgentRuns)"
+      return 0
+      ;;
+    drain)
+      active_runs="$(worker_swap_snapshot_count "$snapshot")"
+      affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
+      echo "$(worker_swap_snapshot_report "$snapshot")."
+      echo "Worker:    $active_runs interactive AgentRun(s); signaling drain instead of restart; affected run ids: $affected_ids"
+      echo "           It will stop claiming new runs and restart on the new version after active runs finish."
+      old_pid="$(worker_service_main_pid)"
+      handoff_pid="$(start_worker_handoff)"
+      echo "Worker:    started temporary handoff worker $handoff_pid for new AgentRuns"
+      systemctl --user kill --kill-who=main --signal=TERM cortex-worker || true
+      monitor_worker_handoff "$old_pid" "$handoff_pid"
+      ;;
+    *)
+      echo "Worker:    refusing restart because non-terminal AgentRun ids are unknown" >&2
+      return 1
+      ;;
+  esac
 }
 
 should_run_local_embedder() {
@@ -524,7 +484,8 @@ disable_user_service_if_present illo-dashboard
 stop_legacy_docker_app_containers
 
 echo "=== Restarting services ==="
-ACTIVE_RUNS="$(active_agent_run_count)"
+WORKER_SWAP_RUNTIME_SNAPSHOT="$(worker_swap_snapshot)"
+ACTIVE_RUNS="$(worker_swap_snapshot_count "$WORKER_SWAP_RUNTIME_SNAPSHOT")"
 EMBED_SERVICE=""
 if ! should_run_local_embedder; then
   echo "Embedder:  skipped (EMBEDDING_BACKEND=${EMBEDDING_BACKEND:-api})"

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -163,25 +163,22 @@ def test_in_flight_count_is_derived_from_unique_run_ids():
         runner._stop_event.clear()
 
 
-def test_stop_runner_requeues_named_runs_when_shutdown_drain_times_out(monkeypatch, caplog):
+def test_stop_runner_returns_named_runs_without_recovery_side_effects(monkeypatch, caplog):
     from brain.systems.runs.cortex import runner
 
     runner.stop_runner()
-    requeue_calls: list[tuple[tuple[int, ...], str]] = []
-
-    def interrupt(run_ids, *, reason):
-        requeue_calls.append((run_ids, reason))
-        return run_ids
-
-    monkeypatch.setattr(runner, "_interrupt_in_flight_runs", interrupt)
+    monkeypatch.setattr(
+        runner,
+        "_unit_of_work_factory",
+        lambda: (_ for _ in ()).throw(AssertionError("stop_runner must not open the database")),
+    )
     caplog.set_level(logging.WARNING, logger=runner.__name__)
     runner._increment_in_flight_runs(2330)
     try:
-        runner.stop_runner(drain_timeout_seconds=0)
+        result = runner.stop_runner(drain_timeout_seconds=0)
 
-        assert requeue_calls == [((2330,), "worker_shutdown_drain_timeout")]
+        assert result == runner.DrainResult(timed_out_run_ids=(2330,))
         assert "affected run ids: [2330]" in caplog.text
-        assert "interrupted and requeued run ids: [2330]" in caplog.text
     finally:
         runner._decrement_in_flight_runs(2330)
         runner._stop_event.clear()

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -12,6 +12,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from brain.systems.runs import slack_delivery
+
 
 class _AwaitableValue:
     def __init__(self, value):
@@ -4560,7 +4562,7 @@ async def test_runner_reports_slack_origin_final_answer_back_to_slack(monkeypatc
         assert run_arg is run
         return FakeSlackClient()
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fake_client_for_run)
 
     result = await runner._settle_slack_origin_run_async(FakeSession(), run)
 
@@ -4588,7 +4590,7 @@ async def test_runner_reports_slack_origin_final_answer_back_to_slack(monkeypatc
 
 
 async def test_runner_reports_interruption_run_id_and_requeue_status_to_slack(monkeypatch):
-    from brain.systems.runs.cortex import runner
+    from brain.systems.runs import interruption
     from brain.systems.runs.failures import DEFAULT_FAILED_RUN_MESSAGE
 
     run = SimpleNamespace(
@@ -4623,13 +4625,30 @@ async def test_runner_reports_interruption_run_id_and_requeue_status_to_slack(mo
         assert run_arg is run
         return FakeSlackClient()
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fake_client_for_run)
 
-    result = await runner._settle_slack_interrupted_run_async(
-        object(),
-        run,
-        interrupted_at=datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc),
-        requeued=True,
+    class FakeSession:
+        async def get(self, _model, run_id):
+            assert run_id == 2330
+            return run
+
+    class FakeUnitOfWork:
+        session = FakeSession()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            return None
+
+    monkeypatch.setattr(interruption, "UnitOfWork", FakeUnitOfWork)
+    result = await interruption.notify_run_interruption(
+        interruption.RunInterruption(
+            run_id=2330,
+            reason="worker_shutdown_drain_timeout",
+            interrupted_at=datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc),
+            requeued=True,
+        )
     )
 
     assert result["surface"] == "slack"
@@ -4696,7 +4715,7 @@ async def test_runner_does_not_override_model_authored_slack_reply(monkeypatch):
     async def fail_client_for_run(_run):
         raise AssertionError("Slack client should not be requested after post_slack_reply")
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fail_client_for_run)
 
     assert await runner._settle_slack_origin_run_async(FakeSession(), run) is None
 
@@ -4754,7 +4773,7 @@ async def test_runner_does_not_post_text_after_model_authored_slack_reaction(mon
     async def fail_client_for_run(_run):
         raise AssertionError("Slack client should not post text after a successful reaction")
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fail_client_for_run)
 
     assert await runner._settle_slack_origin_run_async(FakeSession(), run) is None
 
@@ -4847,7 +4866,7 @@ async def test_runner_reports_non_headless_slack_child_final_answer_back_to_slac
         assert run_arg is run
         return FakeSlackClient()
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fake_client_for_run)
 
     result = await runner._settle_terminal_root_run_async(FakeSession(), 79)
 
@@ -4925,7 +4944,7 @@ async def test_runner_replaces_failed_run_artifact_with_typed_safe_message(monke
         assert run_arg is run
         return FakeSlackClient()
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fake_client_for_run)
 
     session = FakeSession()
     result = await runner._settle_slack_origin_run_async(session, run)
@@ -4966,7 +4985,7 @@ async def test_runner_keeps_headless_slack_child_silent(monkeypatch):
     async def fail_client_for_run(_run):
         raise AssertionError("Headless child should not request a Slack client")
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fail_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fail_client_for_run)
 
     assert await runner._settle_slack_origin_run_async(object(), run) is None
 
@@ -5041,7 +5060,7 @@ async def test_runner_posts_typed_failure_for_headless_slack_monitor(monkeypatch
         assert run_arg is run
         return FakeSlackClient()
 
-    monkeypatch.setattr(runner, "_slack_client_for_run", fake_client_for_run)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", fake_client_for_run)
 
     session = FakeSession()
     result = await runner._settle_slack_origin_run_async(session, run)

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1394,6 +1394,7 @@ async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned
         patch("brain.systems.runs.cortex.runner.UnitOfWork", return_value=_SessionUoW(session)),
         patch("brain.systems.runs.cortex.runner.publish_safe"),
         patch("brain.systems.runs.cortex.runner._settle_idea_for_terminal_root_run_async", return_value=None),
+        patch("brain.systems.runs.cortex.runner.notify_run_interruption", return_value=None),
     ):
         count = await runner.reap_stale_active_runs(now=now, stale_after_seconds=120)
 

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -198,14 +198,56 @@ def test_inline_runner_env_can_disable_launcher_dispatcher(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_lifespan_can_start_inline_runner_when_enabled():
+    from brain.systems.runs.cortex import DrainResult
+
     with patch("brain.app.api.main._should_start_inline_runner", return_value=True):
         with patch("brain.systems.cortex.events.set_publisher") as mock_set_publisher:
             with patch("brain.systems.runs.cortex.start_runner") as mock_start_runner:
                 with patch("brain.systems.cycles.start_cycle_scheduler"), patch(
                     "brain.systems.cycles.stop_cycle_scheduler",
-                ), patch("brain.systems.runs.cortex.stop_runner"):
+                ), patch(
+                    "brain.systems.runs.cortex.stop_runner",
+                    return_value=DrainResult(),
+                ):
                     async with api_main.lifespan(app):
                         pass
 
     mock_set_publisher.assert_called_once()
     mock_start_runner.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_recovers_inline_runs_that_time_out_during_drain():
+    from datetime import datetime, timezone
+
+    from brain.systems.runs.cortex import DrainResult
+    from brain.systems.runs.interruption import RunInterruption
+
+    recovered = (
+        RunInterruption(
+            run_id=2330,
+            reason="worker_shutdown_drain_timeout",
+            interrupted_at=datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc),
+            requeued=True,
+        ),
+    )
+    recover = AsyncMock(return_value=recovered)
+    with patch("brain.app.api.main._should_start_inline_runner", return_value=True):
+        with patch("brain.systems.cortex.events.set_publisher"):
+            with patch("brain.systems.runs.cortex.start_runner"):
+                with patch("brain.systems.cycles.start_cycle_scheduler"), patch(
+                    "brain.systems.cycles.stop_cycle_scheduler",
+                ), patch(
+                    "brain.systems.runs.cortex.stop_runner",
+                    return_value=DrainResult(timed_out_run_ids=(2330,)),
+                ), patch(
+                    "brain.systems.runs.interruption.interrupt_and_requeue_run_ids",
+                    new=recover,
+                ):
+                    async with api_main.lifespan(app):
+                        pass
+
+    recover.assert_awaited_once_with(
+        (2330,),
+        reason="worker_shutdown_drain_timeout",
+    )

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -1,4 +1,5 @@
 import signal
+from datetime import datetime, timezone
 
 import pytest
 from unittest.mock import patch
@@ -154,7 +155,7 @@ def test_worker_exits_when_cycle_scheduler_heartbeat_is_stale(monkeypatch, caplo
     monkeypatch.setattr(worker, "runner_health_snapshot", lambda: {"runner_running": True})
     monkeypatch.setattr(worker, "QueueStallMonitor", lambda **_kwargs: QueueStallMonitorStub())
     monkeypatch.setattr(worker, "seconds_since_last_cycle_tick", lambda: 301.0)
-    monkeypatch.setattr(worker, "stop_runner", lambda **_kwargs: None)
+    monkeypatch.setattr(worker, "stop_runner", lambda **_kwargs: worker.DrainResult())
     monkeypatch.setattr(worker, "stop_cycle_scheduler", lambda: None)
     monkeypatch.setattr(worker.logging, "shutdown", lambda: None)
     monkeypatch.setattr(worker, "_terminate_process", terminate_calls.append)
@@ -177,7 +178,11 @@ def test_worker_term_path_calls_terminate_process_with_zero(monkeypatch):
     monkeypatch.setattr(worker, "_cycle_scheduler_enabled", lambda: True)
     monkeypatch.setattr(worker, "start_cycle_scheduler", lambda: None)
     monkeypatch.setattr(worker, "start_runner", lambda: None)
-    monkeypatch.setattr(worker, "stop_runner", lambda **_kwargs: calls.append("stop_runner"))
+    monkeypatch.setattr(
+        worker,
+        "stop_runner",
+        lambda **_kwargs: calls.append("stop_runner") or worker.DrainResult(),
+    )
     monkeypatch.setattr(worker, "stop_cycle_scheduler", lambda: calls.append("stop_cycle_scheduler"))
     monkeypatch.setattr(worker.logging, "shutdown", lambda: calls.append("logging.shutdown"))
     monkeypatch.setattr(worker, "_terminate_process", lambda code: calls.append(("terminate", code)))
@@ -190,6 +195,34 @@ def test_worker_term_path_calls_terminate_process_with_zero(monkeypatch):
         "logging.shutdown",
         ("terminate", 0),
     ]
+
+
+def test_worker_entry_point_recovers_timed_out_runs(monkeypatch, caplog):
+    from brain.systems.cortex import worker
+    from brain.systems.runs.interruption import RunInterruption
+
+    calls = []
+    occurred_at = datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc)
+
+    async def interrupt(run_ids, *, reason):
+        calls.append((run_ids, reason))
+        return (
+            RunInterruption(
+                run_id=2330,
+                reason=reason,
+                interrupted_at=occurred_at,
+                requeued=True,
+            ),
+        )
+
+    monkeypatch.setattr(worker, "interrupt_and_requeue_run_ids", interrupt)
+
+    worker._recover_timed_out_runs(
+        worker.DrainResult(timed_out_run_ids=(2330,))
+    )
+
+    assert calls == [((2330,), "worker_shutdown_drain_timeout")]
+    assert "interrupted and requeued run ids: [2330]" in caplog.text
 
 
 def test_signal_handler_requests_runner_stop(monkeypatch):

--- a/tests/test_launcher_uninstall_env_reset.py
+++ b/tests/test_launcher_uninstall_env_reset.py
@@ -26,6 +26,18 @@ def _write_launcher_functions(tmp_path: Path) -> Path:
 
     functions_file = tmp_path / "illo-functions.sh"
     functions_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # The launcher sources the canonical worker-swap policy from
+    # $ROOT/deploy/scripts/worker-swap-lib.sh, and $ROOT resolves to tmp_path when
+    # these extracted functions are sourced. Mirror the real dependency here rather
+    # than making the launcher's `source` conditional: a missing canonical lib must
+    # stay a hard failure, because degrading it silently would strip the status
+    # policy from the deploy drain guard.
+    lib_relpath = Path("deploy") / "scripts" / "worker-swap-lib.sh"
+    staged_lib = tmp_path / lib_relpath
+    staged_lib.parent.mkdir(parents=True, exist_ok=True)
+    staged_lib.write_text((ROOT / lib_relpath).read_text(encoding="utf-8"), encoding="utf-8")
+
     return functions_file
 
 

--- a/tests/test_run_interruption.py
+++ b/tests/test_run_interruption.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+
+async def test_interruption_service_returns_typed_results_and_notifies_after_commit(
+    monkeypatch,
+):
+    from brain.systems.runs import interruption
+
+    events = []
+    occurred_at = datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc)
+
+    class FakeUnitOfWork:
+        session = object()
+
+        async def __aenter__(self):
+            events.append("enter")
+            return self
+
+        async def __aexit__(self, *_exc_info):
+            events.append("commit")
+
+    class FakeStore:
+        def __init__(self, session):
+            assert session is FakeUnitOfWork.session
+
+        async def interrupt_and_requeue(self, run_id, *, reason, interrupted_at):
+            events.append(("persist", run_id))
+            return (
+                SimpleNamespace(
+                    id=run_id,
+                    metadata={
+                        "interruption": {
+                            "reason": reason,
+                            "interrupted_at": interrupted_at.isoformat(),
+                            "requeued": True,
+                        }
+                    },
+                ),
+                True,
+            )
+
+    async def notify(result):
+        events.append(("notify", result.run_id))
+
+    monkeypatch.setattr(interruption, "UnitOfWork", FakeUnitOfWork)
+    monkeypatch.setattr(interruption, "AsyncAgentRunStore", FakeStore)
+    monkeypatch.setattr(interruption, "notify_run_interruption", notify)
+
+    results = await interruption.interrupt_and_requeue_run_ids(
+        [2330, 2327, 2330],
+        reason="worker_shutdown_drain_timeout",
+        interrupted_at=occurred_at,
+    )
+
+    assert results == (
+        interruption.RunInterruption(
+            run_id=2327,
+            reason="worker_shutdown_drain_timeout",
+            interrupted_at=occurred_at,
+            requeued=True,
+        ),
+        interruption.RunInterruption(
+            run_id=2330,
+            reason="worker_shutdown_drain_timeout",
+            interrupted_at=occurred_at,
+            requeued=True,
+        ),
+    )
+    assert events == [
+        "enter",
+        ("persist", 2327),
+        ("persist", 2330),
+        "commit",
+        ("notify", 2327),
+        ("notify", 2330),
+    ]
+
+
+def test_interruption_presentation_is_not_a_terminal_failure():
+    from brain.systems.runs import failures, interruption
+
+    result = interruption.RunInterruption(
+        run_id=2330,
+        reason="worker_shutdown_drain_timeout",
+        interrupted_at=datetime(2026, 7, 22, 17, 55, tzinfo=timezone.utc),
+        requeued=True,
+    )
+
+    assert interruption.interrupted_run_message(result) == (
+        "I was interrupted by a system restart at 17:55 UTC (run 2330); "
+        "I've re-queued it and will reply here when it finishes."
+    )
+    assert not hasattr(failures, "interrupted_run_message")

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -5,6 +5,12 @@ import subprocess
 from pathlib import Path
 
 from brain.contracts.statuses import OPEN_RUN_STATUS_VALUES
+from brain.contracts.worker_swap import (
+    WorkerSwapDecision,
+    parse_worker_swap_snapshot,
+    worker_swap_rows_sql,
+    worker_swap_snapshot,
+)
 
 
 def _shell_function_body(content: str, name: str) -> str:
@@ -99,8 +105,12 @@ def test_docker_build_context_excludes_local_brain_env():
 def test_ops_deploy_drains_worker_instead_of_restarting_active_runs():
     deploy_path = Path(__file__).resolve().parents[1] / "ops" / "deploy.sh"
     content = deploy_path.read_text()
+    worker_swap_lib = (
+        Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "worker-swap-lib.sh"
+    ).read_text()
 
-    assert "active_agent_run_count" in content
+    assert 'source "$ROOT/deploy/scripts/worker-swap-lib.sh"' in content
+    assert "worker_swap_snapshot" in content
     assert "restart_or_drain_worker" in content
     assert "start_worker_handoff" in content
     assert "monitor_worker_handoff" in content
@@ -109,7 +119,8 @@ def test_ops_deploy_drains_worker_instead_of_restarting_active_runs():
     assert service.count("ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1") == 1
     assert "systemctl --user kill --kill-who=main --signal=TERM cortex-worker" in content
     assert "AgentRun(s); signaling drain instead of restart; affected run ids:" in content
-    assert "Worker pre-swap check:" in content
+    assert "worker_swap_snapshot_report" in content
+    assert "worker_swap_snapshot_report" in worker_swap_lib
 
 
 def test_ops_deploy_leaves_embedder_running_when_agent_runs_are_active():
@@ -214,17 +225,17 @@ def test_illo_refuses_to_kill_api_owned_agent_runs_without_force():
     assert "Refusing to kill API pid(s)" in content
 
 
-def test_illo_agent_run_count_helpers_use_async_unit_of_work():
+def test_illo_api_owned_run_count_helper_uses_async_unit_of_work():
     illo_path = Path(__file__).resolve().parents[1] / "illo"
     content = illo_path.read_text()
 
-    for helper in ("active_agent_run_count", "api_owned_active_run_count"):
-        body = _shell_function_body(content, helper)
-        assert "import asyncio" in body
-        assert "async with UnitOfWork()" in body
-        assert "await uow.session" in body
-        assert "asyncio.run(main())" in body
-        assert "with UnitOfWork()" not in body.replace("async with UnitOfWork()", "")
+    body = _shell_function_body(content, "api_owned_active_run_count")
+    assert "import asyncio" in body
+    assert "async with UnitOfWork()" in body
+    assert "await uow.session" in body
+    assert "asyncio.run(main())" in body
+    assert "with UnitOfWork()" not in body.replace("async with UnitOfWork()", "")
+    assert 'source "$ROOT/deploy/scripts/worker-swap-lib.sh"' in content
 
 
 def test_illo_refuses_to_kill_unknown_port_processes_without_force():
@@ -364,8 +375,8 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     combined = upgrade + runtime_lib
 
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in upgrade
-    assert "nonterminal_agent_run_details" in runtime_lib
-    assert "status IN" in runtime_lib
+    assert 'source "$COMPOSE_RUNTIME_LIB_DIR/worker-swap-lib.sh"' in runtime_lib
+    assert "worker_swap_snapshot_acquire" in runtime_lib
     assert "non_worker_services" in upgrade
     assert "api scheduler web updater" in upgrade
     assert "ILLO_COMPOSE_SKIP_UPDATER_RESTART" in upgrade
@@ -407,7 +418,7 @@ def test_compose_runtime_service_restart_supports_one_many_or_all_services():
     assert "runtime-services.json" in runtime_lib
     assert "compose up -d --force-recreate --no-deps" in runtime_lib
     assert "restart_runtime_worker_service" in runtime_lib
-    assert "active_agent_run_count" in runtime_lib
+    assert "worker_swap_snapshot" in runtime_lib
     assert "started handoff worker" in runtime_lib
     assert "refusing to kill it" in runtime_lib
 
@@ -417,10 +428,10 @@ def test_compose_pre_swap_check_reports_nonterminal_run_ids():
     script = f'''
 source "{runtime_lib}"
 compose() {{
-  printf '2327:paused\\n2330:running\\n2331:queued\\n'
+  printf '[{{"id":2327,"status":"paused"}},{{"id":2330,"status":"running"}},{{"id":2331,"status":"queued"}}]\\n'
 }}
-details="$(nonterminal_agent_run_details)"
-report_nonterminal_agent_runs "$details"
+snapshot="$(worker_swap_snapshot)"
+echo "$(worker_swap_snapshot_report "$snapshot")."
 '''
 
     result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
@@ -432,17 +443,53 @@ report_nonterminal_agent_runs "$details"
     )
 
 
-def test_safe_deploy_active_run_guards_match_canonical_active_statuses():
-    root = Path(__file__).resolve().parents[1]
-    upgrade = (root / "deploy" / "scripts" / "upgrade.sh").read_text()
-    launcher = (root / "illo").read_text()
-    ops_deploy = (root / "ops" / "deploy.sh").read_text()
-    runtime_lib = (root / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
+def test_worker_swap_snapshot_derives_decision_and_presentation_from_canonical_policy():
+    snapshot = worker_swap_snapshot(
+        [
+            (2331, "queued"),
+            (2327, "paused"),
+            (2330, "running"),
+        ]
+    )
+    parsed = parse_worker_swap_snapshot(snapshot.as_json())
 
+    assert parsed.decision is WorkerSwapDecision.DRAIN
+    assert parsed.count == 3
+    assert parsed.run_ids == (2327, 2330, 2331)
+    assert parsed.details == "2327:paused,2330:running,2331:queued"
     for status in OPEN_RUN_STATUS_VALUES:
-        assert repr(status) in upgrade + runtime_lib
-    assert repr("queued") in upgrade + runtime_lib
-    assert "ACTIVE_RUN_STATUS_VALUES" in launcher
-    assert "OPEN_RUN_STATUS_VALUES" in ops_deploy
-    assert '("starting", "running", "verifying")' not in launcher
-    assert '("starting", "running", "verifying")' not in ops_deploy
+        assert repr(status) in worker_swap_rows_sql()
+
+
+def test_safe_deploy_scripts_cannot_restate_worker_swap_status_policy():
+    root = Path(__file__).resolve().parents[1]
+    consumers = [
+        root / "illo",
+        root / "ops" / "deploy.sh",
+        root / "deploy" / "scripts" / "compose-runtime-lib.sh",
+        root / "deploy" / "scripts" / "upgrade.sh",
+        root / "deploy" / "scripts" / "runtime-services.sh",
+        root / "deploy" / "scripts" / "worker-swap-lib.sh",
+    ]
+    forbidden = (
+        "OPEN_RUN_STATUS_VALUES",
+        "SELECT id, status FROM agent_runs",
+        "nonterminal_agent_run_details",
+        "active_agent_run_count",
+    )
+
+    for path in consumers:
+        content = path.read_text()
+        for copied_policy_shape in forbidden:
+            assert copied_policy_shape not in content, (
+                f"{path.relative_to(root)} restates the worker-swap policy via "
+                f"{copied_policy_shape!r}"
+            )
+        for status in OPEN_RUN_STATUS_VALUES:
+            assert repr(status) not in content
+            assert f'"{status}"' not in content
+
+    contract = (root / "brain" / "contracts" / "worker_swap.py").read_text()
+    native_adapter = (root / "brain" / "app" / "cli" / "worker_swap_snapshot.py").read_text()
+    assert "OPEN_RUN_STATUS_VALUES" in contract
+    assert "OPEN_RUN_STATUS_VALUES" in native_adapter

--- a/tests/test_slack_thread_post_mute.py
+++ b/tests/test_slack_thread_post_mute.py
@@ -216,6 +216,7 @@ def test_french_stand_down_directed_at_illo_mutes_thread():
 
 @pytest.mark.asyncio
 async def test_terminal_slack_settlement_also_suppresses_muted_thread(monkeypatch):
+    from brain.systems.runs import slack_delivery
     from brain.systems.runs.cortex import runner
 
     client = _SlackClient(
@@ -249,8 +250,8 @@ async def test_terminal_slack_settlement_also_suppresses_muted_thread(monkeypatc
 
     monkeypatch.setattr(runner, "_latest_final_answer_artifact", latest_final_answer)
     monkeypatch.setattr(runner, "_slack_visible_action_already_recorded", visible_action)
-    monkeypatch.setattr(runner, "_slack_client_for_run", slack_client)
-    monkeypatch.setattr(runner, "_record_slack_thread_mute", record_mute)
+    monkeypatch.setattr(slack_delivery, "slack_client_for_run", slack_client)
+    monkeypatch.setattr(slack_delivery, "record_slack_thread_mute", record_mute)
 
     result = await runner._settle_slack_origin_run_async(object(), run)
 


### PR DESCRIPTION
Closes #426

Structural refactor only — **no behaviour change**. Both parts come from the thermo-nuclear review of #422 and were judged real but out of scope for that incident fix.

## Part 1 — one canonical worker-swap policy

The in-flight-run query was implemented independently in `compose-runtime-lib.sh`, `illo` and `ops/deploy.sh`, and #422 added the richer "which runs are in flight" query **three more times** with a bespoke comma-delimited `id:status` protocol. `brain/contracts/worker_swap.py` is now the single owner, derived from `OPEN_RUN_STATUS_VALUES`; the shells consume it via `deploy/scripts/worker-swap-lib.sh` and a thin CLI adapter.

**The most useful thing this surfaced:** the three copies agreed on status *membership* but disagreed *structurally* —
- `compose-runtime-lib.sh` hard-coded the statuses **twice** (SQL **and** a regex),
- native deploys issued **separate** count and detail queries, so the two could disagree under load,
- acquisition failures degraded to `unknown` in compose and `illo`, but could **abort** `ops/deploy.sh` under `set -e`.

That is the shape of the original incident: the drain check that failed to protect runs 2327/2330 was one of three implementations, and only one had to be wrong.

## Part 2 — interruption extracted from `runner.py`

`runner.py` **−313 lines**. `runs/interruption.py` returns a typed `RunInterruption` and owns post-commit notification; `stop_runner()` returns a `DrainResult` with no DB or Slack side effects; Slack delivery moves to `runs/slack_delivery.py`; `failures.py` is terminal-only again.

## Verification

```bash
cd <worktree> && /Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python \
  -m pytest -q --ignore=tests/test_gpu_server.py --ignore=tests/test_llm_worker.py
```
**3981 passed, 76 skipped, 0 failed.** (The two ignored suites fail on a broken local `torch` and fail identically on clean `main`.)

**Acceptance check 2 proven by negative control:** appending `STATUSES="running"` to `ops/deploy.sh` makes `test_safe_deploy_scripts_cannot_restate_worker_swap_status_policy` fail as designed. Adding a status really is a one-place edit.

⚠️ **A regression was caught and fixed during review, worth knowing about:** the first pass shipped red. Adding an unconditional `source $ROOT/deploy/scripts/worker-swap-lib.sh` to `illo` broke all 9 tests in `test_launcher_uninstall_env_reset.py`, which extracts `illo`'s function block into a temp dir where the lib doesn't exist. Fixed in the **test fixture**, deliberately *not* by making the `source` conditional — a `[ -f ] &&` guard would let a missing canonical lib silently strip the status policy from the deploy drain guard, i.e. fail open on exactly the guard whose triplication caused the incident.

## Code-quality gate (thermo-nuclear rubric, run through Codex)

**No BLOCKING findings.** Verdict: the duplication is genuinely collapsed, not relocated — the `id:status` format survives only as presentation output and is no longer parsed or used as a transport contract.

Two **IMPORTANT** findings recorded here rather than fixed, since both are refinements beyond this ticket's scope (same pattern that produced #426 itself from #422's review):
1. `brain/contracts/worker_swap.py:142` — the *model* is cohesive but the *module* isn't: a `brain.contracts` module also owns Compose-specific SQL generation, `argparse`, stdin/stdout and `main()`, giving shell callers two Python entry points. Suggested: move the CLI half into `brain/app/cli/worker_swap_snapshot.py` and keep `worker_swap.py` to the typed snapshot, decisions and serialization.
2. `brain/systems/runs/interruption.py:60` — `RunInterruption` is typed only after a permissive `Any` boundary that defaults the reason, converts malformed timestamps to "now" and coerces requeue state with `bool()`, making the dataclass look more authoritative than its construction invariant is.

Happy to file these as a follow-up ticket if you want them done.