### PR TITLE
fix(scheduler): await nightly meta-evolution, stable failure signatures, Slack repeated-failure alerts

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, timezone
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Sequence
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 from brain.kernel.common.time import ensure_utc
@@ -26,6 +27,8 @@ from brain.platform.db.models.scheduler import (
     SchedulerRun,
     SchedulerRunStep,
 )
+from brain.systems.cortex.thread_links import public_app_base_url
+from brain.systems.slack.client import slack_web_client_from_runtime
 from brain.app.scheduler.catalog import normalize_owner_mode
 from brain.app.scheduler.contracts import validate_scheduler_run_contract
 from brain.app.scheduler.planner import async_materialize_due_runs
@@ -380,6 +383,72 @@ def _retryable_failure_summary(
     return RUN_STATUS_SETTLED_FAILURE, retry_summary
 
 
+async def _resolve_scheduler_alert_channel(client: Any, configured: str) -> str:
+    channel = str(configured or "").strip()
+    if not channel.startswith("#"):
+        return channel
+
+    target_name = channel.removeprefix("#")
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    while True:
+        response = await client.conversations_list(
+            types="public_channel,private_channel",
+            limit=200,
+            cursor=cursor,
+            exclude_archived=True,
+        )
+        for candidate in response.get("channels") or []:
+            if not isinstance(candidate, dict):
+                continue
+            if str(candidate.get("name") or "") == target_name:
+                return str(candidate.get("id") or channel)
+        metadata = response.get("response_metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        next_cursor = str(metadata.get("next_cursor") or "").strip()
+        if not next_cursor or next_cursor in seen_cursors:
+            return channel
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+
+async def async_deliver_scheduler_failure_alert(
+    *,
+    job_key: str,
+    run_id: int,
+    consecutive_failure_count: int,
+    error_text: str,
+) -> None:
+    """Post one scheduler failure-threshold edge through Illo's Slack client."""
+    client = await slack_web_client_from_runtime(
+        requested_by="scheduler_failure_alert",
+        reason="Deliver a repeated scheduler job failure alert to the team.",
+    )
+    configured_channel = (
+        os.getenv("ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL", "").strip()
+        or "#alerts"
+    )
+    channel = await _resolve_scheduler_alert_channel(client, configured_channel)
+    first_error_line = next(
+        (line.strip() for line in str(error_text or "").splitlines() if line.strip()),
+        "Unknown scheduler failure",
+    )
+    job_url = (
+        f"{public_app_base_url()}/api/system/scheduler"
+        f"?job_key={quote(job_key, safe='')}&run_id={run_id}"
+    )
+    await client.post_message(
+        channel=channel,
+        text=(
+            "Scheduler job repeated failure\n"
+            f"Job key: {job_key}\n"
+            f"Consecutive failures: {consecutive_failure_count}\n"
+            f"Error: {first_error_line}\n"
+            f"Job: <{job_url}|open scheduler state>"
+        ),
+    )
+
+
 async def _async_apply_failure_guard(
     session: AsyncSession,
     job: SchedulerJob,
@@ -410,6 +479,20 @@ async def _async_apply_failure_guard(
             guard["failure_signature"],
             error_text,
         )
+        try:
+            await async_deliver_scheduler_failure_alert(
+                job_key=job.job_key,
+                run_id=run.id,
+                consecutive_failure_count=guard["consecutive_failures"],
+                error_text=error_text,
+            )
+        except Exception:
+            logger.exception(
+                "Scheduler job repeated failure Slack delivery failed: "
+                "job_key=%s run_id=%s",
+                job.job_key,
+                run.id,
+            )
     await session.flush()
 
 

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -29,6 +29,18 @@ def nightly_heuristic_review_command() -> list[str]:
     )
 
 
+def nightly_meta_evolution_command() -> list[str]:
+    """Run async meta-evolution from a synchronous scheduler process."""
+    return _python_one_liner(
+        "import asyncio; "
+        "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
+        "stats = asyncio.run(run_meta_evolution()); "
+        "print(f'Insights: {stats[\"insights_total\"]}, "
+        "Regressions: {stats[\"regressions\"]}, "
+        "Adjustments: {len(stats[\"adjustments\"])}')"
+    )
+
+
 @dataclass(frozen=True)
 class StepSpec:
     step_key: str
@@ -134,19 +146,31 @@ NIGHTLY_STEP_REGISTRY: tuple[NightlyStepDefinition, ...] = (
     ),
     NightlyStepDefinition(
         step_key="meta_evolution",
-        command_factory=lambda _target_date: (
-            _python_one_liner(
-                "from brain.systems.feedback.meta_evolution import run_meta_evolution; "
-                "stats = run_meta_evolution(); "
-                "print(f'Insights: {stats[\"insights_total\"]}, Regressions: {stats[\"regressions\"]}, Adjustments: {len(stats[\"adjustments\"])}')"
-            ),
-        ),
+        command_factory=lambda _target_date: (nightly_meta_evolution_command(),),
         description="Meta-evolution",
         budget_hint={
             "work_type": "context_policy_eval",
             "estimated_tokens": 8_000,
         },
         program_steps=(NightlyProgramStep("meta_evolution"),),
+    ),
+    NightlyStepDefinition(
+        step_key="memory_health",
+        command_factory=lambda target_date: (
+            (
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.nightly_memory_health",
+                "--date",
+                target_date.isoformat(),
+            ),
+        ),
+        description="Reconstructive memory health inventory",
+        budget_hint={
+            "work_type": "memory_conflict_resolution",
+            "estimated_tokens": 500,
+        },
+        program_steps=(NightlyProgramStep("memory_health"),),
     ),
     # Issue #424: this StepSpec existed only in the test-only get_step_specs() path
     # and has never been reachable from the production scheduler executor. Keep it

--- a/brain/app/scheduler/runtime.py
+++ b/brain/app/scheduler/runtime.py
@@ -48,6 +48,26 @@ _OWNER_MODES = {
     OWNER_MODE_SCHEDULER,
 }
 
+_FAILURE_MEMORY_ADDRESS_RE = re.compile(r"\b0x[0-9a-f]+\b", re.IGNORECASE)
+_FAILURE_OBJECT_REPR_RE = re.compile(
+    r"<(?P<label>(?:(?:async_)?generator|coroutine) object [^<>\n]+?"
+    r"|[A-Za-z_][\w.]* object) at 0x[0-9a-f]+>",
+    re.IGNORECASE,
+)
+_FAILURE_TASK_ID_RE = re.compile(r"\bTask-\d+\b")
+_FAILURE_UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_FAILURE_TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b"
+)
+_FAILURE_RUNTIME_ID_RE = re.compile(
+    r"\b(?P<label>pid|process_id|thread_id)(?P<separator>\s*[:=]\s*)\d+\b",
+    re.IGNORECASE,
+)
+
 
 def trace_id_for_run_id(run_id: int | str | None) -> str | None:
     try:
@@ -124,6 +144,32 @@ def scheduler_failure_alert_threshold() -> int:
     return max(1, configured)
 
 
+def normalize_scheduler_failure_identity(failure_identity: str) -> str:
+    """Remove volatile runtime tokens before identifying a failure streak."""
+    normalized = str(failure_identity or "").strip()
+    normalized = _FAILURE_OBJECT_REPR_RE.sub(
+        lambda match: f"<{match.group('label')}>",
+        normalized,
+    )
+    normalized = _FAILURE_MEMORY_ADDRESS_RE.sub("0x<address>", normalized)
+    normalized = _FAILURE_TASK_ID_RE.sub("Task-<id>", normalized)
+    normalized = _FAILURE_UUID_RE.sub("<uuid>", normalized)
+    normalized = _FAILURE_TIMESTAMP_RE.sub("<timestamp>", normalized)
+    normalized = _FAILURE_RUNTIME_ID_RE.sub(
+        lambda match: (
+            f"{match.group('label')}{match.group('separator')}<id>"
+        ),
+        normalized,
+    )
+    return "\n".join(line.rstrip() for line in normalized.splitlines())
+
+
+def scheduler_failure_signature(failure_identity: str) -> str:
+    """Return a stable digest for one normalized scheduler failure class."""
+    normalized = normalize_scheduler_failure_identity(failure_identity)
+    return sha256(normalized.encode("utf-8")).hexdigest()
+
+
 def _scheduler_failure_guard_state(job: SchedulerJob) -> dict[str, Any]:
     return {
         "failure_signature": job.failure_signature,
@@ -153,7 +199,7 @@ async def async_record_scheduler_job_failure(
     if locked_job is None:
         raise ValueError(f"Scheduler job {job.id} not found")
 
-    signature = sha256(failure_identity.strip().encode("utf-8")).hexdigest()
+    signature = scheduler_failure_signature(failure_identity)
     if locked_job.failure_signature == signature:
         locked_job.consecutive_failure_count = int(
             locked_job.consecutive_failure_count or 0

--- a/brain/jobs/pipelines/nightly_memory_health.py
+++ b/brain/jobs/pipelines/nightly_memory_health.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Record the nightly reconstructive-memory health inventory."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import date
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.reconstructive_memory import MemoryNode
+from brain.platform.db.repositories.memory_health import MemoryHealthRepository
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+
+CHECK_TYPE = "reconstructive_inventory"
+
+
+async def record_nightly_memory_health(
+    session: AsyncSession,
+    target_date: date,
+    *,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist one source-backed inventory check for the nightly run."""
+    statement = select(func.count(MemoryNode.id)).where(
+        MemoryNode.archived_at.is_(None)
+    )
+    if org_id is not None:
+        statement = statement.where(MemoryNode.org_id == org_id)
+    active_memory_nodes = int(await session.scalar(statement) or 0)
+    details = {
+        "target_date": target_date.isoformat(),
+        "active_memory_nodes": active_memory_nodes,
+        "memory_system": "reconstructive",
+    }
+    entry = await MemoryHealthRepository(session).a_log_check(
+        CHECK_TYPE,
+        "ok",
+        details,
+        org_id=org_id,
+    )
+    return {
+        "id": entry.id,
+        "check_type": entry.check_type,
+        "status": entry.status,
+        "details": details,
+    }
+
+
+async def run_nightly_memory_health(
+    target_date: date,
+    *,
+    org_id: str | None = None,
+) -> dict[str, Any]:
+    async with UnitOfWork() as uow:
+        return await record_nightly_memory_health(
+            uow.session,
+            target_date,
+            org_id=org_id,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", type=date.fromisoformat, default=date.today())
+    parser.add_argument("--org-id")
+    args = parser.parse_args()
+    result = asyncio.run(
+        run_nightly_memory_health(args.date, org_id=args.org_id)
+    )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nightly_memory_health.py
+++ b/tests/test_nightly_memory_health.py
@@ -1,0 +1,72 @@
+"""Tests for the scheduled reconstructive-memory health inventory."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date
+
+from sqlalchemy import func, select, text
+
+from brain.jobs.pipelines.nightly_memory_health import (
+    CHECK_TYPE,
+    record_nightly_memory_health,
+)
+from brain.platform.db.models.memory_health import MemoryHealthLog
+
+
+async def test_record_nightly_memory_health_persists_inventory_row(
+    async_sqlite_session_factory,
+):
+    sqlite3.register_adapter(dict, json.dumps)
+    session = await async_sqlite_session_factory([])
+    await session.execute(
+        text(
+            """
+            CREATE TABLE memory_nodes (
+                id INTEGER PRIMARY KEY,
+                org_id TEXT,
+                archived_at DATETIME
+            )
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            CREATE TABLE memory_health_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                check_type VARCHAR(50) NOT NULL,
+                status VARCHAR(20) NOT NULL,
+                details JSON,
+                org_id TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO memory_nodes (id, org_id, archived_at)
+            VALUES (1, NULL, NULL), (2, NULL, NULL), (3, NULL, CURRENT_TIMESTAMP)
+            """
+        )
+    )
+
+    result = await record_nightly_memory_health(session, date(2026, 7, 23))
+    count = await session.scalar(select(func.count()).select_from(MemoryHealthLog))
+    row = await session.scalar(select(MemoryHealthLog))
+
+    assert result == {
+        "id": 1,
+        "check_type": CHECK_TYPE,
+        "status": "ok",
+        "details": {
+            "target_date": "2026-07-23",
+            "active_memory_nodes": 2,
+            "memory_system": "reconstructive",
+        },
+    }
+    assert count == 1
+    assert row is not None
+    assert row.details["active_memory_nodes"] == 2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,6 +8,7 @@ import re
 import uuid
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import func, select
@@ -43,6 +44,7 @@ from brain.app.scheduler.programs import (
     build_scheduler_step_plan,
     get_step_specs,
     nightly_heuristic_review_command,
+    nightly_meta_evolution_command,
 )
 from brain.app.scheduler.runtime import (
     RUN_STATUS_EXPIRED,
@@ -52,6 +54,7 @@ from brain.app.scheduler.runtime import (
     async_ensure_run_steps,
     async_reclaim_expired_leases,
     async_update_run_step,
+    scheduler_failure_signature,
 )
 from brain.platform.db.models.scheduler import SchedulerJob, SchedulerLease, SchedulerRun, SchedulerRunStep
 
@@ -505,7 +508,7 @@ async def test_scheduler_cutover_materializes_and_persists_split_nightly_steps(s
     assert len(created) == 1
     assert created[0].status == "recorded"
     step_plan = build_scheduler_step_plan(job)
-    assert len(step_plan) == 15
+    assert len(step_plan) == 16
     assert "skill_quality" not in {step["step_key"] for step in step_plan}
     assert [step["step_key"] for step in step_plan[:3]] == [
         "nightly_wrapper",
@@ -578,6 +581,59 @@ async def test_nightly_heuristic_review_wrappers_await_and_report_counts(monkeyp
     )[5] == command
     assert scheduler_executor._nightly_step_commands(
         "heuristic_review", date(2026, 4, 21)
+    ) == [command]
+
+
+async def test_nightly_meta_evolution_wrapper_awaits_and_reports_stats(monkeypatch, capsys):
+    from brain.systems.feedback import meta_evolution
+
+    awaited = False
+
+    async def fake_run_meta_evolution():
+        nonlocal awaited
+        awaited = True
+        return {
+            "insights_total": 3,
+            "regressions": 1,
+            "adjustments": {"heuristic_prune_threshold": {"new": 0.15}},
+        }
+
+    monkeypatch.setattr(
+        meta_evolution,
+        "run_meta_evolution",
+        fake_run_meta_evolution,
+    )
+    command = nightly_meta_evolution_command()
+    namespace = {}
+
+    await asyncio.to_thread(exec, command[2], namespace)
+
+    assert awaited is True
+    assert namespace["stats"] == {
+        "insights_total": 3,
+        "regressions": 1,
+        "adjustments": {"heuristic_prune_threshold": {"new": 0.15}},
+    }
+    assert not asyncio.iscoroutine(namespace["stats"])
+    assert capsys.readouterr().out.strip() == (
+        "Insights: 3, Regressions: 1, Adjustments: 1"
+    )
+
+    job = _make_scheduler_job()
+    run = SimpleNamespace(
+        scheduled_for=datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc)
+    )
+    program_command = next(
+        step.command
+        for step in get_step_specs(job, run)
+        if step.step_key == "meta_evolution"
+    )
+    assert program_command == command
+    assert scheduler_executor._nightly_wrapper_commands(
+        date(2026, 4, 21), split_steps=False
+    )[6] == command
+    assert scheduler_executor._nightly_step_commands(
+        "meta_evolution", date(2026, 4, 21)
     ) == [command]
 
 
@@ -697,6 +753,63 @@ async def test_split_nightly_scheduler_reaches_and_settles_memory_maintenance(se
         if "brain.jobs.pipelines.nightly_memory_maintenance" in command
     )
     assert maintenance_command[-3:] == ["--date", "2026-04-21", "--apply"]
+
+
+async def test_split_nightly_scheduler_runs_memory_health_after_meta_evolution(session):
+    job = _make_scheduler_job(
+        owner_mode="scheduler",
+        default_payload={
+            "name": "Nightly Sleep",
+            "scheduler_split_steps": True,
+            "night_budget_allowed_steps": ["meta_evolution", "memory_health"],
+        },
+    )
+    session.add(job)
+    await session.flush()
+    run = (
+        await async_materialize_due_runs(
+            session,
+            now=datetime(2026, 4, 21, 3, 1, tzinfo=timezone.utc),
+            allowed_owner_modes=("scheduler",),
+        )
+    )[0]
+    commands: list[list[str]] = []
+
+    def runner(command, *, cwd=None, env=None, timeout_seconds=None):
+        commands.append(list(command))
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    settled = await async_run_scheduler_run(
+        session,
+        run.id,
+        owner_id="memory-health-test",
+        runner=runner,
+        now=datetime(2026, 4, 21, 3, 2, tzinfo=timezone.utc),
+    )
+    steps = list(
+        (
+            await session.scalars(
+                select(SchedulerRunStep)
+                .where(SchedulerRunStep.run_id == run.id)
+                .order_by(SchedulerRunStep.sequence_no)
+            )
+        ).all()
+    )
+    step_by_key = {step.step_key: step for step in steps}
+
+    assert settled.status == RUN_STATUS_SETTLED_SUCCESS
+    assert step_by_key["meta_evolution"].status == RUN_STATUS_SETTLED_SUCCESS
+    assert step_by_key["memory_health"].status == RUN_STATUS_SETTLED_SUCCESS
+    assert step_by_key["memory_health"].sequence_no == (
+        step_by_key["meta_evolution"].sequence_no + 1
+    )
+    assert commands[-1] == [
+        "python3",
+        "-m",
+        "brain.jobs.pipelines.nightly_memory_health",
+        "--date",
+        "2026-04-21",
+    ]
 
 
 async def test_scheduler_lease_claim_and_reclaim(session):
@@ -1121,9 +1234,78 @@ async def test_scheduler_step_crash_is_persisted_in_snapshot_without_log_storm(s
     assert "Scheduler step crashed" not in caplog.text
 
 
+async def test_failure_signature_normalizes_volatile_runtime_identity():
+    first = """scheduler_step:meta_evolution
+Traceback (most recent call last):
+  File \"<string>\", line 1, in <module>
+RuntimeError: worker=<Worker object at 0x7f12ab90> coroutine=<coroutine object run at 0x7f12bc10> task=Task-12 request_id=0f6f39da-37cd-4d8a-9fb7-818beed63aa1 pid=417 at 2026-07-23T03:00:01Z
+"""
+    second = """scheduler_step:meta_evolution
+Traceback (most recent call last):
+  File \"<string>\", line 1, in <module>
+RuntimeError: worker=<Worker object at 0x8e23cd01> coroutine=<coroutine object run at 0x8e23de20> task=Task-98 request_id=9a0247bb-6b0a-4c34-bd9d-d684781aba2c pid=991 at 2026-07-24T03:00:09Z
+"""
+
+    assert scheduler_failure_signature(first) == scheduler_failure_signature(second)
+
+
+async def test_scheduler_failure_alert_uses_vault_first_slack_client(monkeypatch):
+    calls: dict[str, object] = {}
+
+    class FakeSlackClient:
+        async def conversations_list(self, **kwargs):
+            calls["list_kwargs"] = kwargs
+            return {"channels": [{"id": "C_ALERTS", "name": "alerts"}]}
+
+        async def post_message(self, *, channel, text):
+            calls["post"] = {"channel": channel, "text": text}
+            return {"ok": True, "message": {"text": text}}
+
+    async def fake_client_from_runtime(*, requested_by, reason):
+        calls["runtime"] = {"requested_by": requested_by, "reason": reason}
+        return FakeSlackClient()
+
+    monkeypatch.setenv("ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL", "#alerts")
+    monkeypatch.setenv("ILLO_PUBLIC_URL", "https://illo.example.com")
+    monkeypatch.setattr(
+        scheduler_executor,
+        "slack_web_client_from_runtime",
+        fake_client_from_runtime,
+    )
+
+    await scheduler_executor.async_deliver_scheduler_failure_alert(
+        job_key="nightly_sleep",
+        run_id=42,
+        consecutive_failure_count=3,
+        error_text="RuntimeError: failed\nvolatile traceback details",
+    )
+
+    assert calls["runtime"] == {
+        "requested_by": "scheduler_failure_alert",
+        "reason": "Deliver a repeated scheduler job failure alert to the team.",
+    }
+    assert calls["post"] == {
+        "channel": "C_ALERTS",
+        "text": (
+            "Scheduler job repeated failure\n"
+            "Job key: nightly_sleep\n"
+            "Consecutive failures: 3\n"
+            "Error: RuntimeError: failed\n"
+            "Job: <https://illo.example.com/api/system/scheduler"
+            "?job_key=nightly_sleep&run_id=42|open scheduler state>"
+        ),
+    }
+
+
 async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session, caplog, monkeypatch):
     monkeypatch.setenv("SCHEDULER_FAILURE_ALERT_THRESHOLD", "3")
     caplog.set_level(logging.ERROR, logger="brain.app.scheduler.executor")
+    slack_sender = AsyncMock()
+    monkeypatch.setattr(
+        scheduler_executor,
+        "async_deliver_scheduler_failure_alert",
+        slack_sender,
+    )
     job = _make_scheduler_job(
         retry_policy={"max_attempts": 5, "backoff_seconds": 0},
         default_payload={
@@ -1175,6 +1357,12 @@ async def test_repeated_heuristic_review_failure_emits_one_durable_alert(session
     assert alert_timestamps[:2] == [None, None]
     assert alert_timestamps[2] is not None
     assert alert_timestamps[3] == alert_timestamps[2]
+    slack_sender.assert_awaited_once_with(
+        job_key="nightly_sleep",
+        run_id=run.id,
+        consecutive_failure_count=3,
+        error_text=failure_text,
+    )
     assert snapshot["alerts"] == [
         {
             "type": "repeated_scheduler_job_failure",


### PR DESCRIPTION
Fixes #441. Three fixes + the missing memory_health writer:

1. **Awaited coroutine** — the meta_evolution night-budget step now runs `asyncio.run(run_meta_evolution())`; the `'coroutine' object is not subscriptable` crash is gone.
2. **Stable failure signatures** — `failure_identity` is normalized (object reprs, `0x` addresses, Task ids, UUIDs, timestamps, pid/tid) before hashing, so identical crash classes accumulate a single streak instead of resetting (live evidence in the issue: 4 identical failures counted as 2).
3. **Human-visible delivery** — the threshold-edge alert now posts to Slack (default `#alerts`, `ILLO_SCHEDULER_FAILURE_ALERT_CHANNEL` override) through the existing Vault-first client. Delivery failure is caught + logged and never breaks run settlement. `logger.error` kept.
4. **memory_health_log writer** — new nightly `memory_health` step records one reconstructive-inventory row after meta_evolution (the table had no scheduled writer at all, so acceptance could never turn true otherwise).

Tests: 61 passed (new: awaited wrapper stats, health-after-meta ordering, signature normalization stability, one-shot Vault-first Slack delivery, health-row persistence). `alembic heads` = 1 (`0034_provider_alert_surges`).

Gate for the AWS monitor port (#444) — merge this first.

Implemented by Codex (gpt-5.6-sol, xhigh); directed + reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)