### PR TITLE
feat(scheduler): hourly AWS health scan job spawning a headless skill run (shadow mode)

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -80,6 +80,30 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "timeout_seconds": 7200,
         "retry_policy": {"max_attempts": 2, "backoff_seconds": 0},
     },
+    {
+        "job_key": "uwear_aws_health_scan",
+        "family": "uwear_aws_health_scan",
+        "program_key": "uwear_aws_health_scan",
+        "handler_kind": CATALOG_HANDLER_KIND,
+        "handler_ref": "brain.app.scheduler.programs:uwear_aws_health_scan",
+        "cron_expr": "30 * * * *",
+        "timezone": "UTC",
+        "default_payload": {
+            "name": "Uwear AWS Health Scan",
+            "description": "Hourly read-only AWS production health scan",
+        },
+        "task_contract": {
+            "memory_scope": {"visibility": "system"},
+            "allowed_actions": ["scheduler.run"],
+            "output_channel": "scheduler",
+            "success_criteria": ["AWS health scan agent run completes successfully"],
+        },
+        "priority": 90,
+        "max_concurrency": 1,
+        "timeout_seconds": 900,
+        "retry_policy": {"max_attempts": 2, "backoff_seconds": 0},
+        "misfire_policy": "skip",
+    },
 )
 
 
@@ -361,7 +385,7 @@ async def async_sync_scheduler_catalog(
             handler_ref=str(definition["handler_ref"]),
             cron_expr=str(definition["cron_expr"]),
             owner_mode=owner_mode,
-            timezone_name=timezone_name,
+            timezone_name=str(definition.get("timezone") or timezone_name),
             default_payload=dict(definition.get("default_payload") or {}),
             task_contract=dict(definition.get("task_contract") or {}),
             priority=int(definition.get("priority") or 100),

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -12,6 +12,11 @@ from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 
 DEFAULT_STEP_KIND = "single"
 WRAPPER_STEP_KEY = "nightly_wrapper"
+UWEAR_AWS_HEALTH_SCAN_COMMAND = [
+    "python3",
+    "-m",
+    "brain.jobs.pipelines.aws_health_scan",
+]
 
 
 def _python_one_liner(code: str) -> list[str]:
@@ -431,6 +436,18 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             }
         ]
 
+    if job.program_key == "uwear_aws_health_scan" or "uwear_aws_health_scan" in identity:
+        return [
+            {
+                "step_key": "uwear_aws_health_scan",
+                "sequence_no": 1,
+                "kind": "single",
+                "handler_ref": job.handler_ref,
+                "payload": {"program": "uwear_aws_health_scan"},
+                "command": UWEAR_AWS_HEALTH_SCAN_COMMAND,
+            }
+        ]
+
     return [
         {
             "step_key": job.program_key or "scheduler_job",
@@ -479,6 +496,16 @@ def _curiosity_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     ]
 
 
+def _uwear_aws_health_scan_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
+    return [
+        StepSpec(
+            "uwear_aws_health_scan",
+            UWEAR_AWS_HEALTH_SCAN_COMMAND,
+            "Uwear AWS production health scan",
+        ),
+    ]
+
+
 def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     payload = job.default_payload or {}
     command = payload.get("command")
@@ -491,6 +518,8 @@ def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
 
 def get_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     key = _job_identity(job)
+    if "uwear_aws_health_scan" in key:
+        return _uwear_aws_health_scan_steps(job, run)
     if "curiosity" in key:
         return _curiosity_steps(job, run)
     if "nightly" in key or "sleep" in key:

--- a/brain/jobs/pipelines/aws_health_scan.py
+++ b/brain/jobs/pipelines/aws_health_scan.py
@@ -1,0 +1,156 @@
+"""Run the hourly Uwear AWS health scan as one headless AgentRun."""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+
+from sqlalchemy import select
+
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.org import User
+from brain.platform.db.models.skill_bundle import SkillInstallation
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
+from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+
+SKILL_NAME = "uwear-aws-health-scan"
+RUN_TIMEOUT_SECONDS = 840
+POLL_INTERVAL_SECONDS = 2.0
+
+
+async def _skill_actor(session, skill_installation_id: int | None) -> User:
+    """Resolve the installed skill's user, falling back to the oldest workspace user."""
+    installation = None
+    if skill_installation_id is not None:
+        installation = await session.get(SkillInstallation, int(skill_installation_id))
+
+    if installation is not None:
+        actor_id = installation.user_id or installation.installed_by_user_id
+        if actor_id:
+            actor = await session.get(User, str(actor_id))
+            if actor is None:
+                raise LookupError(f"Skill installation user '{actor_id}' not found")
+            return actor
+
+    stmt = select(User).order_by(User.created_at.asc(), User.id.asc()).limit(1)
+    if installation is not None and installation.org_id:
+        stmt = stmt.where(User.org_id == str(installation.org_id))
+    actor = (await session.scalars(stmt)).first()
+    if actor is None:
+        raise LookupError("No Illospace user is available to run the AWS health scan")
+    return actor
+
+
+async def spawn_health_scan_run() -> int:
+    """Admit exactly one headless run through the canonical work-intake boundary."""
+    invocation_id = str(uuid.uuid4())
+    async with UnitOfWork() as uow:
+        skill = await uow.skills.get_by_name(SKILL_NAME)
+        if skill is None:
+            raise LookupError(f"Skill '{SKILL_NAME}' not found")
+
+        actor = await _skill_actor(uow.session, skill.skill_installation_id)
+        result = await admit_work(
+            uow.session,
+            WorkIntakeEvent(
+                source="internal",
+                event_type="internal.manual",
+                org_id=str(actor.org_id),
+                actor={"id": str(actor.id), "org_id": str(actor.org_id)},
+                target={
+                    "kind": "external_agent_headless_ask",
+                    "thread_id": f"headless:{SKILL_NAME}:{invocation_id}",
+                    "headless": True,
+                    "final_answer_target_surface": "headless",
+                },
+                payload={
+                    "message": (
+                        f"/{SKILL_NAME}\n\n"
+                        "Execute this skill exactly once. Load and follow its full procedure, "
+                        "then return its required health verdict and evidence."
+                    ),
+                    "workspace_ref": {"source": "scheduler", "mode": "headless"},
+                    "metadata": {
+                        "origin": "scheduler",
+                        "originating_surface": "scheduler",
+                        "source_surface": "scheduler",
+                        "triggering_surface": "scheduler",
+                        "final_answer_target_surface": "headless",
+                        "headless": True,
+                        "execution_profile": "fast",
+                        "recipe": "fast",
+                        "thinking_tier": skill.thinking_tier,
+                        "skill_name": SKILL_NAME,
+                        "slash_skill_names": [SKILL_NAME],
+                    },
+                },
+                policy={
+                    "producer": "scheduler",
+                    "idempotency_key": f"uwear_aws_health_scan:{invocation_id}",
+                    "run_event": "uwear_aws_health_scan",
+                },
+            ),
+        )
+        if not result.ok or result.run_id is None:
+            raise RuntimeError(result.skipped_reason or "Failed to admit AWS health scan run")
+        return int(result.run_id)
+
+
+async def _read_run_status(run_id: int) -> RunStatus:
+    async with UnitOfWork() as uow:
+        run = await uow.session.get(AgentRunRow, int(run_id))
+        if run is None:
+            raise LookupError(f"Agent run {run_id} not found")
+        return coerce_run_status(run.status)
+
+
+async def wait_for_terminal_run(
+    run_id: int,
+    *,
+    timeout_seconds: float = RUN_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+) -> RunStatus:
+    """Poll the admitted run until it settles or the pipeline wait budget expires."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, float(timeout_seconds))
+    while True:
+        status = await _read_run_status(run_id)
+        if status in TERMINAL_RUN_STATUSES:
+            return status
+
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Agent run {run_id} did not reach a terminal state within {timeout_seconds:g}s"
+            )
+        await asyncio.sleep(min(max(0.01, poll_interval_seconds), remaining))
+
+
+async def async_main(*, timeout_seconds: float = RUN_TIMEOUT_SECONDS) -> int:
+    try:
+        run_id = await spawn_health_scan_run()
+    except Exception as exc:  # noqa: BLE001 - process boundary must fail cleanly
+        print(f"AWS health scan spawn failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        status = await wait_for_terminal_run(run_id, timeout_seconds=timeout_seconds)
+    except Exception as exc:  # noqa: BLE001 - process boundary must fail cleanly
+        print(f"AWS health scan run {run_id} wait failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({"run_id": run_id, "status": status.value}, sort_keys=True))
+    if status != RunStatus.COMPLETED:
+        print(f"AWS health scan run {run_id} ended with status {status.value}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -12,6 +12,7 @@ greenlet>=3.2
 numpy>=2.0
 scikit-learn>=1.8
 httpx>=0.28
+boto3>=1.40
 websockets>=15.0
 readability-lxml>=0.8
 pyyaml>=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ greenlet>=3.2
 numpy>=2.0
 scikit-learn>=1.8
 httpx>=0.28
+boto3>=1.40
 websockets>=15.0
 readability-lxml>=0.8
 pyyaml>=6.0

--- a/tests/test_aws_health_scan.py
+++ b/tests/test_aws_health_scan.py
@@ -1,0 +1,20 @@
+"""Tests for the scheduler-launched AWS health scan pipeline."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from brain.jobs.pipelines import aws_health_scan
+
+
+@pytest.mark.asyncio
+async def test_pipeline_exits_nonzero_when_headless_run_spawn_fails(monkeypatch, capsys):
+    spawn = AsyncMock(side_effect=RuntimeError("admission unavailable"))
+    monkeypatch.setattr(aws_health_scan, "spawn_health_scan_run", spawn)
+
+    exit_code = await aws_health_scan.async_main()
+
+    assert exit_code != 0
+    spawn.assert_awaited_once_with()
+    assert "AWS health scan spawn failed: admission unavailable" in capsys.readouterr().err

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -136,9 +136,9 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     await session.flush()
 
-    assert result == {"upserted": 2, "retired": 0}
+    assert result == {"upserted": 3, "retired": 0}
     jobs = {job["job_key"]: job for job in await async_list_scheduler_jobs(session)}
-    assert set(jobs) == {"curiosity_cron", "nightly_sleep"}
+    assert set(jobs) == {"curiosity_cron", "nightly_sleep", "uwear_aws_health_scan"}
     assert jobs["nightly_sleep"]["owner_mode"] == "scheduler"
     assert jobs["nightly_sleep"]["handler_kind"] == "scheduler_builtin"
     assert jobs["nightly_sleep"]["default_payload"]["scheduler_split_steps"] is True
@@ -148,6 +148,30 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
         assert not job["handler_ref"].endswith(".sh")
         assert "script_path" not in job["default_payload"]
         assert "legacy_cron_retired" not in job["default_payload"]
+
+
+async def test_uwear_aws_health_scan_catalog_config(session):
+    now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
+
+    await async_sync_scheduler_catalog(session, timezone_name="America/Toronto", now=now)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+    job = jobs["uwear_aws_health_scan"]
+
+    assert job.cron_expr == "30 * * * *"
+    assert job.timezone == "UTC"
+    assert job.misfire_policy == "skip"
+    assert job.timeout_seconds == 900
+    assert job.max_concurrency == 1
+    assert build_scheduler_step_plan(job) == [
+        {
+            "step_key": "uwear_aws_health_scan",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": "brain.app.scheduler.programs:uwear_aws_health_scan",
+            "payload": {"program": "uwear_aws_health_scan"},
+            "command": ["python3", "-m", "brain.jobs.pipelines.aws_health_scan"],
+        }
+    ]
 
 
 async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_restart(session):
@@ -160,8 +184,8 @@ async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_resta
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=restart)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 2, "retired": 0}
-    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 2
+    assert result == {"upserted": 3, "retired": 0}
+    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 3
     assert {key: job.id for key, job in jobs.items()} == first_ids
     assert all(job.next_run_at > restart for job in jobs.values())
     assert await async_materialize_due_runs(session, now=restart) == []
@@ -193,10 +217,12 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 1, "retired": 1}
+    assert result == {"upserted": 1, "retired": 2}
     assert jobs["nightly_sleep"].enabled is True
     assert jobs["curiosity_cron"].enabled is False
     assert jobs["curiosity_cron"].pause_reason == "removed from scheduler catalog"
+    assert jobs["uwear_aws_health_scan"].enabled is False
+    assert jobs["uwear_aws_health_scan"].pause_reason == "removed from scheduler catalog"
 
     repeated = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     assert repeated == {"upserted": 1, "retired": 0}
@@ -208,9 +234,9 @@ async def test_scheduler_daemon_startup_syncs_catalog_before_snapshot(session):
     result = await async_scheduler_daemon_startup(session, now=now, timezone_name="UTC")
 
     assert result["ok"] is True
-    assert result["catalog"] == {"upserted": 2, "retired": 0}
-    assert result["snapshot"]["summary"]["jobs_total"] == 2
-    assert result["snapshot"]["summary"]["jobs_enabled"] == 2
+    assert result["catalog"] == {"upserted": 3, "retired": 0}
+    assert result["snapshot"]["summary"]["jobs_total"] == 3
+    assert result["snapshot"]["summary"]["jobs_enabled"] == 3
     assert all(job["next_run_at"] > now.isoformat() for job in result["snapshot"]["jobs"])
 
 


### PR DESCRIPTION
Part of #444 (AWS prod monitor port, P1 under #440). Strictly additive next to the #441 branch.

- **boto3** in `requirements.txt` + `requirements-production.txt` (worker image installs the latter; container has no aws CLI — scans use boto3 from Python).
- **`brain/jobs/pipelines/aws_health_scan.py`** — admits ONE headless AgentRun executing skill `uwear-aws-health-scan` through the canonical `admit_work` boundary (same convergence point as the internal-trigger router and Slack work intake), polls to terminal state with an 840s budget nested inside the job timeout, and exits non-zero on spawn failure / timeout / non-completed status so the scheduler failure guard (#441) counts it.
- **Catalog entry** `uwear_aws_health_scan`: cron `30 * * * *` UTC (offset from the laptop twin at :00), `timeout_seconds=900`, `max_concurrency=1`, `misfire_policy=skip` — a recovered worker never catch-up-replays stale hour windows. Plus a small sync fix: per-definition `timezone` is now honored.
- Skill 52 (`uwear-aws-health-scan`) already exists server-side with its PARALLEL-RUN shadow section ACTIVE: the run files nothing on GitHub and posts nothing to Slack until parity acceptance vs the laptop monitor.

Tests: 40 focused (pipeline, scheduler, scheduler CLI, architecture) passed; full non-DB suite failures are pre-existing local env issues (Torch libs, sandboxed socket binding), untouched by this diff. `alembic heads` = 1.

Depends on #441's PR — merge that first.

Implemented by Codex (gpt-5.6-sol, high); directed + reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)