### PR TITLE
fix(scheduler): a misfire_policy="skip" job never materialised any run

### DIFF
--- a/brain/app/scheduler/planner.py
+++ b/brain/app/scheduler/planner.py
@@ -142,7 +142,10 @@ async def async_materialize_due_runs(
         if policy not in {"record", "skip", "catch_up"}:
             policy = "record"
 
-        if policy == "skip":
+        # "skip" drops MISSED windows; it must not drop the window that is firing
+        # now, or a skip job never materialises a run at all.
+        current_minute = now.replace(second=0, microsecond=0)
+        if policy == "skip" and scheduled_for < current_minute:
             job.next_run_at = next_run_after(job.cron_expr, job.timezone, now)
             continue
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -380,6 +380,26 @@ async def test_due_run_materialization_skip_misfire_drops_backlog(session):
     assert job.next_run_at.isoformat().startswith("2026-04-24T03:00:00")
 
 
+async def test_due_run_materialization_skip_runs_current_cron_minute(session):
+    """A skip job must still run the window that is firing right now."""
+    job = _make_scheduler_job(
+        misfire_policy="skip",
+        next_run_at=datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc),
+    )
+    session.add(job)
+    await session.flush()
+
+    created = await async_materialize_due_runs(
+        session,
+        now=datetime(2026, 4, 21, 3, 0, 30, tzinfo=timezone.utc),
+    )
+    await session.refresh(job)
+
+    assert len(created) == 1
+    assert created[0].scheduled_for.isoformat().startswith("2026-04-21T03:00:00")
+    assert job.next_run_at.isoformat().startswith("2026-04-22T03:00:00")
+
+
 async def test_due_run_materialization_catch_up_records_missed_fires(session):
     job = _make_scheduler_job(
         misfire_policy="catch_up",


### PR DESCRIPTION
## The hourly AWS health scan you just merged will never run

PR #446 shipped the `uwear_aws_health_scan` catalog row with `misfire_policy: "skip"`
and cron `30 * * * *`. On current `main` the planner treats **every** `skip` job as a
misfire:

```python
if policy == "skip":
    job.next_run_at = next_run_after(job.cron_expr, job.timezone, now)
    continue          # <- no run is ever materialised
```

The `continue` runs whether or not the window is actually late, so a `skip` job is
skipped on every tick — including the window firing right now. **It never executes a
single time.**

This was invisible because the only existing test for the policy
(`test_due_run_materialization_skip_misfire_drops_backlog`) fires the job **two days
late** and asserts nothing is created — which is correct behaviour for a genuine
misfire, and passes either way.

## The fix

Limit skipping to windows that have genuinely been missed:

```python
current_minute = now.replace(second=0, microsecond=0)
if policy == "skip" and scheduled_for < current_minute:
```

The existing two-days-late test still drops the backlog. A new test covers the on-time
fire.

## How I verified it

Controlled, both directions, on a clean worktree of merged `main` (`e296f0b`):

| | on `main` | on this branch |
|---|---|---|
| `test_due_run_materialization_skip_runs_current_cron_minute` | **FAILS** — `assert 0 == 1`, zero runs materialised | passes |
| `test_due_run_materialization_skip_misfire_drops_backlog` | passes | passes |

- `pytest tests/test_scheduler.py tests/test_scheduler_cli.py -q` → **42 passed**
- Full suite → **4030 passed, 76 skipped, 8 failed**. The 8 are `test_gpu_server.py` (2)
  and `test_llm_worker.py` (6), all from a local venv with a broken `torch`
  (`libtorch_cpu.dylib` missing) — pre-existing and unrelated to this change.

## Acceptance checks

1. After deploy, `scheduler_runs` gets a `uwear_aws_health_scan` row within the hour —
   today it would stay permanently empty.
2. `scheduler_jobs.next_run_at` for that job still advances each tick (unchanged).
3. A job whose window is genuinely late (worker down for hours) still drops its backlog
   instead of replaying it — the 66h-wedge precedent that motivated `skip`.
4. `nightly_sleep` and `curiosity_cron` are unaffected: neither sets `misfire_policy`, so
   both stay on `record`.

## Assumption worth a second opinion

The tolerance is **one wall-clock minute**: a fire at `03:30:00` materialises while `now`
is inside `03:30`, and is dropped from `03:31:00`. If the scheduler tick can drift past
the fire minute, an hourly job silently loses that hour. A grace window (e.g. skip only
when more than one cron interval late) would be more forgiving. I kept the minute-tight
version because it is the smallest change that matches the existing test's semantics —
say the word and I'll widen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
