### PR TITLE
refactor(runs): one typed tool-failure classifier; localise manage_idea UUID parsing (#428)

### DIFF
--- a/brain/systems/runs/direct_loop/loop_control.py
+++ b/brain/systems/runs/direct_loop/loop_control.py
@@ -7,6 +7,8 @@ from enum import Enum
 import logging
 from typing import TYPE_CHECKING
 
+from brain.systems.runs.tool_outcomes import DEFAULT_TOOL_FAILURE_CATEGORY
+
 if TYPE_CHECKING:
     from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
 
@@ -91,13 +93,14 @@ class LoopControlPolicy:
 
         if self.termination is not None:
             return self.termination
-        if not resolved.is_error:
+        failure = resolved.outcome.failure
+        if failure is None:
             self.consecutive_failures = 0
             self.consecutive_tool_name = None
             return None
 
         tool_name = resolved.tool_name or "unknown_tool"
-        error_class = resolved.error_class or "ToolError"
+        error_class = failure.category or DEFAULT_TOOL_FAILURE_CATEGORY
         if (
             tool_name == self.consecutive_tool_name
             and error_class == self.last_error_class
@@ -116,7 +119,7 @@ class LoopControlPolicy:
 
     def _failure_circuit_termination(self) -> LoopTermination:
         tool_name = self.consecutive_tool_name or "unknown_tool"
-        error_class = self.last_error_class or "ToolError"
+        error_class = self.last_error_class or DEFAULT_TOOL_FAILURE_CATEGORY
         detail = (self.last_error_message or "No error detail was returned.").strip()
         if len(detail) > 500:
             detail = f"{detail[:497]}..."

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -10,6 +10,40 @@ from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
 from brain.systems.runs.direct_loop.result import TokenAccumulator
 
 
+@dataclass(frozen=True)
+class ToolFailure:
+    """Stable failure identity shared by tool handlers and loop policy."""
+
+    message: str
+    category: str
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """Typed answer to whether a tool result failed and how."""
+
+    failure: ToolFailure | None = None
+
+    @classmethod
+    def failed(cls, *, message: str, category: str) -> ToolOutcome:
+        return cls(failure=ToolFailure(message=message, category=category))
+
+    @property
+    def is_failure(self) -> bool:
+        return self.failure is not None
+
+
+class ClassifiedToolResult(str):
+    """String-compatible handler result carrying an internal typed outcome."""
+
+    outcome: ToolOutcome
+
+    def __new__(cls, value: str, outcome: ToolOutcome) -> ClassifiedToolResult:
+        instance = super().__new__(cls, value)
+        instance.outcome = outcome
+        return instance
+
+
 @dataclass
 class AgentLoopState:
     """State that evolves across provider turns in the agent loop."""

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -10,40 +10,6 @@ from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
 from brain.systems.runs.direct_loop.result import TokenAccumulator
 
 
-@dataclass(frozen=True)
-class ToolFailure:
-    """Stable failure identity shared by tool handlers and loop policy."""
-
-    message: str
-    category: str
-
-
-@dataclass(frozen=True)
-class ToolOutcome:
-    """Typed answer to whether a tool result failed and how."""
-
-    failure: ToolFailure | None = None
-
-    @classmethod
-    def failed(cls, *, message: str, category: str) -> ToolOutcome:
-        return cls(failure=ToolFailure(message=message, category=category))
-
-    @property
-    def is_failure(self) -> bool:
-        return self.failure is not None
-
-
-class ClassifiedToolResult(str):
-    """String-compatible handler result carrying an internal typed outcome."""
-
-    outcome: ToolOutcome
-
-    def __new__(cls, value: str, outcome: ToolOutcome) -> ClassifiedToolResult:
-        instance = super().__new__(cls, value)
-        instance.outcome = outcome
-        return instance
-
-
 @dataclass
 class AgentLoopState:
     """State that evolves across provider turns in the agent loop."""

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -18,16 +18,17 @@ from brain.platform.async_io import (
 )
 from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy, LoopTermination
-from brain.systems.runs.direct_loop.state import (
-    ClassifiedToolResult,
-    ToolOutcome,
-)
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
 from brain.systems.runs.direct_loop.final_reply_evidence import ToolResultEvidence
 from brain.systems.runs.tool_catalog.registry import (
     action_policy_for_tool,
     get_tool_registration,
     output_budget_chars_for_tool,
+)
+from brain.systems.runs.tool_outcomes import (
+    DEFAULT_TOOL_FAILURE_CATEGORY,
+    ToolHandlerResult,
+    ToolOutcome,
 )
 
 logger = logging.getLogger("agent")
@@ -57,15 +58,6 @@ class ResolvedToolCall:
     outcome: ToolOutcome = field(default_factory=ToolOutcome)
     result_content: Any | None = None
     result_value: Any | None = None
-
-    @property
-    def is_error(self) -> bool:
-        return self.outcome.is_failure
-
-    @property
-    def error_class(self) -> str | None:
-        failure = self.outcome.failure
-        return failure.category if failure is not None else None
 
 
 @dataclass(frozen=True)
@@ -155,12 +147,15 @@ def _timeout_result(request: PendingToolCall, timeout_seconds: float) -> Resolve
 def classify_tool_result(result: object) -> ToolOutcome:
     """Classify one handler result without exposing failure identity in JSON."""
 
-    if isinstance(result, ClassifiedToolResult):
+    if isinstance(result, ToolHandlerResult):
         return result.outcome
     failure_message = result_failure_summary(result)
     if failure_message is None:
         return ToolOutcome()
-    return ToolOutcome.failed(message=failure_message, category="ToolError")
+    return ToolOutcome.failed(
+        message=failure_message,
+        category=DEFAULT_TOOL_FAILURE_CATEGORY,
+    )
 
 
 def _must_finish_before_reporting(request: PendingToolCall) -> bool:
@@ -219,9 +214,11 @@ def _extract_model_visible_tool_content(result: Any) -> tuple[Any, Any | None]:
 
 
 def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedToolCall:
+    outcome = classify_tool_result(result)
+    if isinstance(result, ToolHandlerResult):
+        result = result.value
     result, model_content = _extract_model_visible_tool_content(result)
     result_text = json.dumps(result, default=str)
-    outcome = classify_tool_result(result)
     failure = outcome.failure
 
     if request.tool_name == "brain_encode" and failure is not None:
@@ -282,7 +279,7 @@ def _record_agent_tool_result(agent_context, resolved: ResolvedToolCall, result_
         recent.append(ToolResultEvidence.capture(
             tool_name=resolved.tool_name,
             arguments=evidence_arguments,
-            is_error=resolved.is_error,
+            is_error=resolved.outcome.failure is not None,
             result=evidence_result,
         ))
         setattr(agent_context, "recent_tool_results", recent[-_RECENT_TOOL_RESULT_LIMIT:])
@@ -531,7 +528,7 @@ def emit_resolved_tool_call(
         "type": "tool_result",
         "tool_use_id": resolved.block_id,
         "content": resolved.result_content if resolved.result_content is not None else resolved.result_text,
-        **({"is_error": True} if resolved.is_error else {}),
+        **({"is_error": True} if resolved.outcome.failure is not None else {}),
     })
     callback_result_text = resolved.result_text
     if resolved.tool_name == "brain_vault":

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import inspect
 import json
 import logging
@@ -18,6 +18,10 @@ from brain.platform.async_io import (
 )
 from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy, LoopTermination
+from brain.systems.runs.direct_loop.state import (
+    ClassifiedToolResult,
+    ToolOutcome,
+)
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
 from brain.systems.runs.direct_loop.final_reply_evidence import ToolResultEvidence
 from brain.systems.runs.tool_catalog.registry import (
@@ -50,10 +54,18 @@ class ResolvedToolCall:
     tool_name: str
     tool_input: dict
     result_text: str
-    is_error: bool = False
-    error_class: str | None = None
+    outcome: ToolOutcome = field(default_factory=ToolOutcome)
     result_content: Any | None = None
     result_value: Any | None = None
+
+    @property
+    def is_error(self) -> bool:
+        return self.outcome.is_failure
+
+    @property
+    def error_class(self) -> str | None:
+        failure = self.outcome.failure
+        return failure.category if failure is not None else None
 
 
 @dataclass(frozen=True)
@@ -122,32 +134,33 @@ def _format_timeout(seconds: float) -> str:
 
 def _timeout_result(request: PendingToolCall, timeout_seconds: float) -> ResolvedToolCall:
     timeout_text = _format_timeout(timeout_seconds)
+    result_text = (
+        f"Tool {request.tool_name!r} timed out after {timeout_text}. "
+        "The runtime stopped waiting for this tool call. Treat it as failed, "
+        "try a narrower or faster tool call if needed, or explain the blocker to the user."
+    )
     return ResolvedToolCall(
         block_id=request.block_id,
         tool_name=request.tool_name,
         tool_input=request.tool_input,
-        result_text=(
-            f"Tool {request.tool_name!r} timed out after {timeout_text}. "
-            "The runtime stopped waiting for this tool call. Treat it as failed, "
-            "try a narrower or faster tool call if needed, or explain the blocker to the user."
+        result_text=result_text,
+        outcome=ToolOutcome.failed(
+            message=result_text,
+            category="ToolTimeoutError",
         ),
-        is_error=True,
         result_value={"error": "tool_timeout", "timeout_seconds": timeout_seconds},
-        error_class="ToolTimeoutError",
     )
 
 
-def _structured_error_class(result: Any) -> str | None:
-    payload = result
-    if isinstance(payload, str):
-        try:
-            payload = json.loads(payload)
-        except (TypeError, ValueError):
-            return None
-    if not isinstance(payload, dict):
-        return None
-    value = payload.get("error_class")
-    return str(value).strip() if value else None
+def classify_tool_result(result: object) -> ToolOutcome:
+    """Classify one handler result without exposing failure identity in JSON."""
+
+    if isinstance(result, ClassifiedToolResult):
+        return result.outcome
+    failure_message = result_failure_summary(result)
+    if failure_message is None:
+        return ToolOutcome()
+    return ToolOutcome.failed(message=failure_message, category="ToolError")
 
 
 def _must_finish_before_reporting(request: PendingToolCall) -> bool:
@@ -208,13 +221,10 @@ def _extract_model_visible_tool_content(result: Any) -> tuple[Any, Any | None]:
 def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedToolCall:
     result, model_content = _extract_model_visible_tool_content(result)
     result_text = json.dumps(result, default=str)
-    failure_summary = result_failure_summary(result)
-    is_error = failure_summary is not None
-    error_class = _structured_error_class(result) if is_error else None
-    if is_error and not error_class:
-        error_class = "ToolError"
+    outcome = classify_tool_result(result)
+    failure = outcome.failure
 
-    if request.tool_name == "brain_encode" and failure_summary:
+    if request.tool_name == "brain_encode" and failure is not None:
         result_text += (
             "\n\n[System: brain_encode failed. Do not retry brain_encode in this run. "
             "Move on and end your turn unless another required tool remains.]"
@@ -232,8 +242,7 @@ def _resolved_tool_result(request: PendingToolCall, result: Any) -> ResolvedTool
         tool_name=request.tool_name,
         tool_input=request.tool_input,
         result_text=truncate_tool_result_text(request.tool_name, result_text),
-        is_error=is_error,
-        error_class=error_class,
+        outcome=outcome,
         result_content=model_content,
         result_value=result,
     )
@@ -246,8 +255,7 @@ def _failed_tool_result(request: PendingToolCall, exc: Exception) -> ResolvedToo
         tool_name=request.tool_name,
         tool_input=request.tool_input,
         result_text=f"Error [{error_class}]: {exc}",
-        is_error=True,
-        error_class=error_class,
+        outcome=ToolOutcome.failed(message=str(exc), category=error_class),
         result_value={"error": str(exc)},
     )
 

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -15,7 +15,6 @@ import os
 import re as _re
 import sys
 import time
-import uuid
 import inspect
 
 from brain.kernel import config as brain_config
@@ -57,56 +56,6 @@ _PARALLEL_BATCH_SAFE_TOOL_NAMES = parallel_safe_tool_names(scope="batch")
 _MAX_PARALLEL_BATCH_OPERATIONS = int(os.environ.get("AGENT_PARALLEL_BATCH_MAX_OPS", "12"))
 _MAX_PARALLEL_BATCH_WORKERS = int(os.environ.get("AGENT_PARALLEL_BATCH_MAX_WORKERS", "6"))
 _ACTION_MANIFEST_TOOL_NAMES = action_manifest_tool_names()
-
-_EMPTY_OPTIONAL_IDENTIFIER_VALUES = {
-    "",
-    "none",
-    "null",
-    "00000000-0000-0000-0000-000000000000",
-}
-
-
-class ToolValidationError(ValueError):
-    """Actionable caller-input error that is safe to return to the model."""
-
-
-def normalize_optional_identifier(value: Any) -> str | None:
-    """Normalize model-emitted empty sentinels at a tool boundary."""
-
-    if value is None:
-        return None
-    normalized = str(value).strip()
-    if normalized.lower() in _EMPTY_OPTIONAL_IDENTIFIER_VALUES:
-        return None
-    return normalized
-
-
-def normalize_optional_uuid(
-    value: Any,
-    *,
-    field_name: str,
-    error_message: str | None = None,
-) -> str | None:
-    """Return a canonical optional UUID without allowing empty binds to reach SQL."""
-
-    normalized = normalize_optional_identifier(value)
-    if normalized is None:
-        return None
-    try:
-        return str(uuid.UUID(normalized))
-    except (AttributeError, TypeError, ValueError) as exc:
-        raise ToolValidationError(
-            error_message or f"{field_name} must be a valid id or omitted"
-        ) from exc
-
-
-def tool_error_payload(exc: Exception) -> dict[str, str]:
-    """Build the shared typed error shape consumed by the run loop."""
-
-    return {
-        "error": str(exc),
-        "error_class": type(exc).__name__,
-    }
 
 _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
     "manage_cycle": {

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+from dataclasses import dataclass
 from typing import Any, Mapping
 
 from fastapi import HTTPException
@@ -14,8 +16,91 @@ from brain.systems.cortex.thought_lifecycle import (
     post_thread_message,
     transition_thought_status,
 )
+from brain.systems.runs.direct_loop.state import ClassifiedToolResult, ToolOutcome
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.systems.runs.tool_catalog.handlers.common import *
+
+
+_EMPTY_MANAGE_IDEA_IDENTIFIERS = {
+    "",
+    "none",
+    "null",
+    "00000000-0000-0000-0000-000000000000",
+}
+
+
+class ToolValidationError(ValueError):
+    """Actionable manage_idea input error that is safe to return to the model."""
+
+
+@dataclass(frozen=True)
+class _ManageIdeaIdentifiers:
+    parent_id: str | None
+    user_id: str | None
+    orbit_anchor_id: str | None
+    origin_ref: str | None
+
+
+def _parse_manage_idea_identifiers(
+    *,
+    parent_id: Any,
+    user_id: Any,
+    orbit_anchor_id: Any,
+    origin_ref: Any,
+) -> _ManageIdeaIdentifiers:
+    """Normalize and validate optional identifiers at the manage_idea boundary."""
+
+    def optional_identifier(value: Any) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        if normalized.lower() in _EMPTY_MANAGE_IDEA_IDENTIFIERS:
+            return None
+        return normalized
+
+    def optional_uuid(value: Any, *, error_message: str) -> str | None:
+        normalized = optional_identifier(value)
+        if normalized is None:
+            return None
+        try:
+            return str(uuid.UUID(normalized))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ToolValidationError(error_message) from exc
+
+    return _ManageIdeaIdentifiers(
+        parent_id=optional_uuid(
+            parent_id,
+            error_message="parent_id must be an existing idea id or omitted",
+        ),
+        user_id=optional_uuid(
+            user_id,
+            error_message="user_id must be an existing user id or omitted",
+        ),
+        orbit_anchor_id=optional_uuid(
+            orbit_anchor_id,
+            error_message="orbit_anchor_id must be an existing user or pin id or omitted",
+        ),
+        origin_ref=optional_identifier(origin_ref),
+    )
+
+
+def _tool_failure_result(
+    exc: Exception,
+    *,
+    message: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> ClassifiedToolResult:
+    """Adapt a manage_idea exception to JSON plus internal typed failure identity."""
+
+    failure_message = message if message is not None else str(exc)
+    payload = {"error": failure_message, **dict(details or {})}
+    return ClassifiedToolResult(
+        json.dumps(payload),
+        ToolOutcome.failed(
+            message=failure_message,
+            category=type(exc).__name__,
+        ),
+    )
 
 
 def _idea_tool_context() -> tuple[str | None, str | None, str | None]:
@@ -521,22 +606,16 @@ async def _handle_manage_idea(
     event: tuple[str, dict[str, Any]] | None = None
 
     try:
-        parent_id = normalize_optional_uuid(
-            parent_id,
-            field_name="parent_id",
-            error_message="parent_id must be an existing idea id or omitted",
+        identifiers = _parse_manage_idea_identifiers(
+            parent_id=parent_id,
+            user_id=user_id,
+            orbit_anchor_id=orbit_anchor_id,
+            origin_ref=origin_ref,
         )
-        user_id = normalize_optional_uuid(
-            user_id,
-            field_name="user_id",
-            error_message="user_id must be an existing user id or omitted",
-        )
-        orbit_anchor_id = normalize_optional_uuid(
-            orbit_anchor_id,
-            field_name="orbit_anchor_id",
-            error_message="orbit_anchor_id must be an existing user or pin id or omitted",
-        )
-        origin_ref = normalize_optional_identifier(origin_ref)
+        parent_id = identifiers.parent_id
+        user_id = identifiers.user_id
+        orbit_anchor_id = identifiers.orbit_anchor_id
+        origin_ref = identifiers.origin_ref
 
         async with UnitOfWork() as uow:
             if normalized_action == "list":
@@ -754,16 +833,16 @@ async def _handle_manage_idea(
             publish_safe(event[0], event[1])
         return json.dumps(result, default=str)
     except ToolValidationError as exc:
-        return json.dumps(tool_error_payload(exc))
+        return _tool_failure_result(exc)
     except HTTPException as exc:
-        return json.dumps({
-            **tool_error_payload(exc),
-            "error": str(exc.detail),
-            "status_code": exc.status_code,
-        })
+        return _tool_failure_result(
+            exc,
+            message=str(exc.detail),
+            details={"status_code": exc.status_code},
+        )
     except Exception as exc:
         logger.exception("manage_idea failed: %s", exc)
-        return json.dumps(tool_error_payload(exc))
+        return _tool_failure_result(exc)
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/brain/systems/runs/tool_catalog/handlers/ideas.py
+++ b/brain/systems/runs/tool_catalog/handlers/ideas.py
@@ -16,9 +16,9 @@ from brain.systems.cortex.thought_lifecycle import (
     post_thread_message,
     transition_thought_status,
 )
-from brain.systems.runs.direct_loop.state import ClassifiedToolResult, ToolOutcome
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.systems.runs.tool_catalog.handlers.common import *
+from brain.systems.runs.tool_outcomes import ToolHandlerResult, ToolOutcome
 
 
 _EMPTY_MANAGE_IDEA_IDENTIFIERS = {
@@ -89,14 +89,14 @@ def _tool_failure_result(
     *,
     message: str | None = None,
     details: Mapping[str, Any] | None = None,
-) -> ClassifiedToolResult:
+) -> ToolHandlerResult:
     """Adapt a manage_idea exception to JSON plus internal typed failure identity."""
 
     failure_message = message if message is not None else str(exc)
     payload = {"error": failure_message, **dict(details or {})}
-    return ClassifiedToolResult(
-        json.dumps(payload),
-        ToolOutcome.failed(
+    return ToolHandlerResult(
+        value=json.dumps(payload),
+        outcome=ToolOutcome.failed(
             message=failure_message,
             category=type(exc).__name__,
         ),
@@ -591,7 +591,7 @@ async def _handle_manage_idea(
     search: str | None = None,
     include_archived: bool = False,
     limit: int | None = 20,
-) -> str:
+) -> str | ToolHandlerResult:
     normalized_action = str(action or "").strip().lower()
     if normalized_action in {"help", "schema"}:
         return _manage_tool_guide("manage_idea", operation)

--- a/brain/systems/runs/tool_outcomes.py
+++ b/brain/systems/runs/tool_outcomes.py
@@ -1,0 +1,36 @@
+"""Typed outcome contracts shared by tool handlers and execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_TOOL_FAILURE_CATEGORY = "ToolError"
+
+
+@dataclass(frozen=True)
+class ToolFailure:
+    """Stable failure identity shared by tool handlers and loop policy."""
+
+    message: str
+    category: str
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """Typed answer to whether a tool result failed and how."""
+
+    failure: ToolFailure | None = None
+
+    @classmethod
+    def failed(cls, *, message: str, category: str) -> ToolOutcome:
+        return cls(failure=ToolFailure(message=message, category=category))
+
+
+@dataclass(frozen=True)
+class ToolHandlerResult:
+    """A handler value paired with its explicit execution outcome."""
+
+    value: Any
+    outcome: ToolOutcome

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1205,7 +1205,7 @@ class TestAgentLoop:
 
         resolved = _resolve_tool_call(request)
 
-        assert resolved.is_error is True
+        assert resolved.outcome.failure is not None
         assert "Continue working and plan another pipeline" in resolved.result_text
 
     @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -3167,7 +3167,7 @@ async def test_direct_loop_returns_timeout_as_tool_error(monkeypatch):
 
     resolved = await async_resolve_tool_call(PendingToolCall("tool-1", "slow_tool", {}, slow_handler))
 
-    assert resolved.is_error is True
+    assert resolved.outcome.failure is not None
     assert "slow_tool" in resolved.result_text
     assert "timed out" in resolved.result_text
 
@@ -3197,7 +3197,7 @@ async def test_direct_loop_cancels_production_async_adapter_at_timeout(monkeypat
         PendingToolCall("tool-1", "manage_cycle", {"action": "list"}, handler)
     )
 
-    assert resolved.is_error is True
+    assert resolved.outcome.failure is not None
     assert "timed out" in resolved.result_text
     assert canceled.is_set()
 
@@ -3223,7 +3223,7 @@ async def test_direct_loop_detects_unmarked_sync_adapter_returning_coroutine(mon
         PendingToolCall("tool-1", "unregistered_read", {}, unmarked_adapter)
     )
 
-    assert resolved.is_error is True
+    assert resolved.outcome.failure is not None
     assert "timed out" in resolved.result_text
     assert canceled.is_set()
 
@@ -3527,7 +3527,7 @@ async def test_direct_loop_watchdog_tracks_public_blocking_helper(monkeypatch):
     )
     elapsed = time.monotonic() - started_at
 
-    assert resolved.is_error is True
+    assert resolved.outcome.failure is not None
     assert "timed out" in resolved.result_text
     assert elapsed < 0.08
     assert not finished.is_set()
@@ -3571,7 +3571,7 @@ async def test_direct_loop_waits_for_sync_action_before_reporting_outcome(monkey
         PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, wrapped)
     )
 
-    assert resolved.is_error is False
+    assert resolved.outcome.failure is None
     assert json.loads(resolved.result_text) == {"ok": True}
     assert completed.is_set()
     assert len(records) == 1
@@ -3606,7 +3606,7 @@ async def test_direct_loop_waits_for_async_mutation_before_reporting_outcome(mon
         PendingToolCall("tool-1", "manage_cycle", {"action": "create"}, wrapped)
     )
 
-    assert resolved.is_error is False
+    assert resolved.outcome.failure is None
     assert json.loads(resolved.result_text) == {"ok": True}
     assert completions == [{"manifest_id": 1, "outcome_status": "succeeded", "outcome_error": None}]
 

--- a/tests/test_manage_idea.py
+++ b/tests/test_manage_idea.py
@@ -153,6 +153,7 @@ async def test_manage_idea_create_rejects_missing_parent_before_insert(
     from fastapi import HTTPException
 
     from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.direct_loop.tool_execution import classify_tool_result
     from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
 
     missing_parent_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
@@ -164,17 +165,42 @@ async def test_manage_idea_create_rejects_missing_parent_before_insert(
     monkeypatch.setattr(idea_tools, "_require_idea_for_actor", missing_parent)
 
     with bind_agent_context({"org_id": "org-1", "user_id": "user-1"}):
-        payload = json.loads(
-            await idea_tools._handle_manage_idea(
-                action="create",
-                title="Child of missing idea",
-                parent_id=missing_parent_id,
-            )
+        result = await idea_tools._handle_manage_idea(
+            action="create",
+            title="Child of missing idea",
+            parent_id=missing_parent_id,
         )
+    payload = json.loads(result)
 
     assert payload == {
         "error": "parent_id must be an existing idea id or omitted",
-        "error_class": "ToolValidationError",
     }
+    failure = classify_tool_result(result).failure
+    assert failure is not None
+    assert failure.message == payload["error"]
+    assert failure.category == "ToolValidationError"
     fake_manage_idea_uow.session.add.assert_not_called()
     fake_manage_idea_uow.session.flush.assert_not_called()
+
+
+async def test_manage_idea_rejects_bogus_uuid_with_typed_validation_error(
+    fake_manage_idea_uow,
+):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.direct_loop.tool_execution import classify_tool_result
+    from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
+
+    with bind_agent_context({"org_id": "org-1", "user_id": "user-1"}):
+        result = await idea_tools._handle_manage_idea(
+            action="create",
+            title="Invalid parent",
+            parent_id="not-a-uuid",
+        )
+
+    assert json.loads(result) == {
+        "error": "parent_id must be an existing idea id or omitted",
+    }
+    failure = classify_tool_result(result).failure
+    assert failure is not None
+    assert failure.category == "ToolValidationError"
+    fake_manage_idea_uow.session.add.assert_not_called()

--- a/tests/test_manage_idea.py
+++ b/tests/test_manage_idea.py
@@ -153,8 +153,8 @@ async def test_manage_idea_create_rejects_missing_parent_before_insert(
     from fastapi import HTTPException
 
     from brain.systems.runs.execution_context import bind_agent_context
-    from brain.systems.runs.direct_loop.tool_execution import classify_tool_result
     from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
+    from brain.systems.runs.tool_outcomes import ToolHandlerResult
 
     missing_parent_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 
@@ -170,12 +170,13 @@ async def test_manage_idea_create_rejects_missing_parent_before_insert(
             title="Child of missing idea",
             parent_id=missing_parent_id,
         )
-    payload = json.loads(result)
+    assert isinstance(result, ToolHandlerResult)
+    payload = json.loads(result.value)
 
     assert payload == {
         "error": "parent_id must be an existing idea id or omitted",
     }
-    failure = classify_tool_result(result).failure
+    failure = result.outcome.failure
     assert failure is not None
     assert failure.message == payload["error"]
     assert failure.category == "ToolValidationError"
@@ -187,8 +188,8 @@ async def test_manage_idea_rejects_bogus_uuid_with_typed_validation_error(
     fake_manage_idea_uow,
 ):
     from brain.systems.runs.execution_context import bind_agent_context
-    from brain.systems.runs.direct_loop.tool_execution import classify_tool_result
     from brain.systems.runs.tool_catalog.handlers import ideas as idea_tools
+    from brain.systems.runs.tool_outcomes import ToolHandlerResult
 
     with bind_agent_context({"org_id": "org-1", "user_id": "user-1"}):
         result = await idea_tools._handle_manage_idea(
@@ -197,10 +198,11 @@ async def test_manage_idea_rejects_bogus_uuid_with_typed_validation_error(
             parent_id="not-a-uuid",
         )
 
-    assert json.loads(result) == {
+    assert isinstance(result, ToolHandlerResult)
+    assert json.loads(result.value) == {
         "error": "parent_id must be an existing idea id or omitted",
     }
-    failure = classify_tool_result(result).failure
+    failure = result.outcome.failure
     assert failure is not None
     assert failure.category == "ToolValidationError"
     fake_manage_idea_uow.session.add.assert_not_called()

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -10,12 +10,18 @@ from brain.systems.runs.direct_loop.loop_control import (
     LoopControlPolicy,
     LoopTerminationReason,
 )
+from brain.systems.runs.direct_loop.state import (
+    ClassifiedToolResult,
+    ToolFailure,
+    ToolOutcome,
+)
 from brain.systems.runs.direct_loop.tool_execution import (
     PendingToolCall,
     ResolvedToolCall,
     async_execute_parallel_tool_batch,
     async_execute_tool_calls,
     async_resolve_tool_call,
+    classify_tool_result,
     execute_parallel_tool_batch,
     execute_tool_calls,
     resolve_tool_call,
@@ -266,29 +272,78 @@ async def test_failure_policy_stops_parallel_batch_before_fourth_attempt():
     assert execution.termination.consecutive_failures == 3
 
 
-def test_resolve_tool_call_preserves_structured_error_class():
+def test_failure_policy_stops_typed_result_before_fourth_attempt():
+    attempts = []
+    handler_result = ClassifiedToolResult(
+        json.dumps({"error": "invalid tool input"}),
+        ToolOutcome.failed(
+            message="invalid tool input",
+            category="ToolValidationError",
+        ),
+    )
+
+    def handler():
+        attempts.append("attempt")
+        return handler_result
+
+    execution = _execute_sync(
+        _response(*[
+            (f"call-{index}", "manage_idea", {})
+            for index in range(4)
+        ]),
+        {"manage_idea": handler},
+    )
+
+    assert len(attempts) == 3
+    assert execution.termination is not None
+    assert execution.termination.reason is LoopTerminationReason.TOOL_FAILURE_CIRCUIT
+    assert execution.termination.error_class == "ToolValidationError"
+    assert execution.termination.consecutive_failures == 3
+
+
+def test_classifier_ignores_legacy_payload_category():
+    outcome = classify_tool_result({
+        "error": "invalid tool input",
+        "error_class": "UndocumentedPayloadCategory",
+    })
+
+    assert outcome.failure == ToolFailure(
+        message="invalid tool input",
+        category="ToolError",
+    )
+
+
+def test_resolve_tool_call_preserves_typed_failure_outcome():
+    handler_result = ClassifiedToolResult(
+        json.dumps({"error": "parent_id must be an existing idea id or omitted"}),
+        ToolOutcome.failed(
+            message="parent_id must be an existing idea id or omitted",
+            category="ToolValidationError",
+        ),
+    )
     request = PendingToolCall(
         block_id="tool_419",
         tool_name="manage_idea",
         tool_input={"action": "create"},
-        handler=lambda **_: json.dumps({
-            "error": "parent_id must be an existing idea id or omitted",
-            "error_class": "ToolValidationError",
-        }),
+        handler=lambda **_: handler_result,
     )
 
     resolved = resolve_tool_call(request)
 
     assert resolved.is_error is True
+    assert resolved.outcome == handler_result.outcome
     assert resolved.error_class == "ToolValidationError"
     assert "parent_id must be an existing idea id or omitted" in resolved.result_text
 
 
 async def test_resolved_failures_preserve_error_class_and_result_value(monkeypatch):
-    handler_failure = {
-        "error": "invalid tool input",
-        "error_class": "ToolValidationError",
-    }
+    handler_failure = ClassifiedToolResult(
+        json.dumps({"error": "invalid tool input"}),
+        ToolOutcome.failed(
+            message="invalid tool input",
+            category="ToolValidationError",
+        ),
+    )
     returned_failure = resolve_tool_call(PendingToolCall(
         block_id="handler-failure",
         tool_name="manage_idea",

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import threading
+from dataclasses import asdict
 from types import SimpleNamespace
 
 from brain.systems.runs.direct_loop.gates import GateState, check_gate_violations
@@ -10,8 +11,9 @@ from brain.systems.runs.direct_loop.loop_control import (
     LoopControlPolicy,
     LoopTerminationReason,
 )
-from brain.systems.runs.direct_loop.state import (
-    ClassifiedToolResult,
+from brain.systems.runs.tool_outcomes import (
+    DEFAULT_TOOL_FAILURE_CATEGORY,
+    ToolHandlerResult,
     ToolFailure,
     ToolOutcome,
 )
@@ -274,9 +276,9 @@ async def test_failure_policy_stops_parallel_batch_before_fourth_attempt():
 
 def test_failure_policy_stops_typed_result_before_fourth_attempt():
     attempts = []
-    handler_result = ClassifiedToolResult(
-        json.dumps({"error": "invalid tool input"}),
-        ToolOutcome.failed(
+    handler_result = ToolHandlerResult(
+        value=json.dumps({"error": "invalid tool input"}),
+        outcome=ToolOutcome.failed(
             message="invalid tool input",
             category="ToolValidationError",
         ),
@@ -309,14 +311,38 @@ def test_classifier_ignores_legacy_payload_category():
 
     assert outcome.failure == ToolFailure(
         message="invalid tool input",
-        category="ToolError",
+        category=DEFAULT_TOOL_FAILURE_CATEGORY,
     )
 
 
+def test_tool_handler_result_keeps_outcome_in_identity_and_serialization():
+    value = json.dumps({"error": "invalid tool input"})
+    failure = ToolHandlerResult(
+        value=value,
+        outcome=ToolOutcome.failed(
+            message="invalid tool input",
+            category="ToolValidationError",
+        ),
+    )
+    success = ToolHandlerResult(value=value, outcome=ToolOutcome())
+
+    assert failure != success
+    assert len({failure, success}) == 2
+    assert asdict(failure) == {
+        "value": value,
+        "outcome": {
+            "failure": {
+                "message": "invalid tool input",
+                "category": "ToolValidationError",
+            },
+        },
+    }
+
+
 def test_resolve_tool_call_preserves_typed_failure_outcome():
-    handler_result = ClassifiedToolResult(
-        json.dumps({"error": "parent_id must be an existing idea id or omitted"}),
-        ToolOutcome.failed(
+    handler_result = ToolHandlerResult(
+        value=json.dumps({"error": "parent_id must be an existing idea id or omitted"}),
+        outcome=ToolOutcome.failed(
             message="parent_id must be an existing idea id or omitted",
             category="ToolValidationError",
         ),
@@ -330,16 +356,18 @@ def test_resolve_tool_call_preserves_typed_failure_outcome():
 
     resolved = resolve_tool_call(request)
 
-    assert resolved.is_error is True
     assert resolved.outcome == handler_result.outcome
-    assert resolved.error_class == "ToolValidationError"
+    assert resolved.outcome.failure is not None
+    assert resolved.outcome.failure.category == "ToolValidationError"
+    assert resolved.result_value == handler_result.value
+    assert resolved.result_text == json.dumps(handler_result.value)
     assert "parent_id must be an existing idea id or omitted" in resolved.result_text
 
 
 async def test_resolved_failures_preserve_error_class_and_result_value(monkeypatch):
-    handler_failure = ClassifiedToolResult(
-        json.dumps({"error": "invalid tool input"}),
-        ToolOutcome.failed(
+    handler_failure = ToolHandlerResult(
+        value=json.dumps({"error": "invalid tool input"}),
+        outcome=ToolOutcome.failed(
             message="invalid tool input",
             category="ToolValidationError",
         ),
@@ -372,11 +400,14 @@ async def test_resolved_failures_preserve_error_class_and_result_value(monkeypat
         handler=never_finishes,
     ))
 
-    assert returned_failure.error_class == "ToolValidationError"
-    assert returned_failure.result_value == handler_failure
-    assert raised_failure.error_class == "ValueError"
+    assert returned_failure.outcome.failure is not None
+    assert returned_failure.outcome.failure.category == "ToolValidationError"
+    assert returned_failure.result_value == handler_failure.value
+    assert raised_failure.outcome.failure is not None
+    assert raised_failure.outcome.failure.category == "ValueError"
     assert raised_failure.result_value == {"error": "handler raised"}
-    assert timeout_failure.error_class == "ToolTimeoutError"
+    assert timeout_failure.outcome.failure is not None
+    assert timeout_failure.outcome.failure.category == "ToolTimeoutError"
     assert timeout_failure.result_value == {
         "error": "tool_timeout",
         "timeout_seconds": 0.001,


### PR DESCRIPTION
Closes #428.

## What this does
Structural / maintainability refactor (no behaviour change) from the thermo-nuclear review of the merged #419 PR.

- **One typed tool-failure classifier.** Adds `ToolFailure`/`ToolOutcome` and a single `classify_tool_result()`; removes the old `"error_class"` payload-key parsed twice. `ResolvedToolCall` carries the typed outcome; loop-control consumers read `resolved.outcome.failure` directly.
- **UUID normalisation — localised.** Dropped the shared helpers from the 1.1k-line wildcard `common.py`; `manage_idea` owns a private `_parse_manage_idea_identifiers`. The three UUID parsers stay separate on purpose (each has a genuinely different null/error policy — review agreed).
- **Neutral contract module.** `ToolFailure`/`ToolOutcome`/`ToolHandlerResult` live in a new `brain/systems/runs/tool_outcomes.py`, not in the mutable agent-loop `state.py`.

## Review verdict (mine)
Reviewed the diff + ran tests. Green. A cross-family thermo-nuclear review (Codex) returned FIX-THEN-SHIP with 3 blocking structural findings; **all folded into the fix-pass commit** (`c20b4a5`): the `ClassifiedToolResult(str)` leaky side-channel → explicit `ToolHandlerResult` envelope; contracts moved out of `state.py`; the `is_error`/`error_class` property sediment deleted (no consumer needed them). `"ToolError"` magic string → `DEFAULT_TOOL_FAILURE_CATEGORY` constant.

## How to run / verify
```bash
cd illospace-project && git fetch && git checkout illo-qa/428-typed-tool-failure-classifier
venv/bin/python -m pytest tests/test_tool_execution.py tests/test_manage_idea.py tests/test_agent_run_runtime.py -q
```

## Acceptance checks
- [ ] One typed classifier answers "did this tool call fail, and how"; no consumer re-parses JSON for a magic key.
- [ ] The failure circuit and `ResolvedToolCall` consume the typed outcome, not `Any`.
- [ ] Exactly one optional-UUID normalisation helper reachable from tool handlers (localised to `manage_idea`; choice recorded).
- [ ] Behaviour unchanged: empty/nil-UUID → NULL, bogus id → typed validation error, 3-strike breaker fires identically.

## Merge-order note
Touches `handlers/ideas.py`, which #436 (open-ask ledger) also edits. If both land, expect a small merge in `ideas.py` — no logical conflict (this changes identifier parsing; #436 adds origin_ref threading). Suggest merging this first.

---
🤖 Draft opened by R3 (Codex-implemented, Claude-reviewed). Not merge-ready until Reda's review.
