### PR TITLE
fix(runs): keep same-thread status replies honest (#420)

### DIFF
--- a/brain/systems/runs/context.py
+++ b/brain/systems/runs/context.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 from brain.systems.runs.skill_commands import parse_slash_skill_names
+from brain.systems.runs.status_questions import format_status_question_context
 
 PROMPT_REFERENCE_CHAR_LIMIT = 12_000
 PROMPT_SCALAR_CHAR_LIMIT = 1_200
@@ -192,6 +193,7 @@ class RunContext:
     skills: list[str] = field(default_factory=list)
     handoff: dict[str, Any] = field(default_factory=dict)
     request_source: dict[str, Any] = field(default_factory=dict)
+    status_question_context: dict[str, Any] = field(default_factory=dict)
     scheduled_result_contract: bool = False
 
     def prompt_context(self) -> str:
@@ -240,6 +242,9 @@ class RunContext:
             )
         if self.memory:
             parts.append("Memory:\n" + "\n".join(f"- {item}" for item in self.memory))
+        status_context = format_status_question_context(self.status_question_context)
+        if status_context:
+            parts.append(status_context)
         return "\n\n".join(parts)
 
 
@@ -262,6 +267,11 @@ class RunContextLoader:
             workspace_ref=dict(workspace_ref or {}),
             thread_context=dict(thread_context) if isinstance(thread_context, dict) else {},
             request_source=_request_source_from_metadata(metadata),
+            status_question_context=(
+                dict(metadata.get("status_question_context") or {})
+                if isinstance(metadata.get("status_question_context"), dict)
+                else {}
+            ),
             skills=_skill_names_from_metadata(metadata, message),
             scheduled_result_contract=has_scheduled_result_contract(metadata),
         )

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -103,6 +103,38 @@ _TRACKER_ARTIFACT_RE = re.compile(
     r"\b(?:tracker\s+(?:record|mirror)|linked\s+(?:tracker\s+)?record|domain\s+record)\b",
     re.IGNORECASE,
 )
+_STATUS_IN_PROGRESS_RE = re.compile(
+    r"\b(?:in progress|still (?:running|working|underway|ongoing)|"
+    r"not (?:done|complete|completed|finished)|not done yet)\b",
+    re.IGNORECASE,
+)
+_UNRESOLVED_RE = re.compile(
+    r"\b(?:unresolved|outstanding|pending|missing|not (?:created|opened|filed|done)|"
+    r"has not been (?:created|opened|filed|done)|hasn't been (?:created|opened|filed|done)|"
+    r"still (?:needed|missing|outstanding|pending))\b",
+    re.IGNORECASE,
+)
+_FAILURE_ACK_RE = re.compile(
+    r"\b(?:fail(?:ed|ing|ure)?|error|could not|couldn't|unable|stopped retrying|"
+    r"timed out|timeout|blocked)\b",
+    re.IGNORECASE,
+)
+_GITHUB_REF_RE = re.compile(
+    r"(?:https?://github\.com/[^\s)]+/(?:issues|pull)/(?P<url_number>\d+)|"
+    r"\bgithub\s+(?:issue|ticket)\s+#?(?P<label_number>\d+)\b)",
+    re.IGNORECASE,
+)
+_RECORD_WORD_RE = re.compile(r"\b(?:record|domain|tracker)\b", re.IGNORECASE)
+_ASSIGNED_RE = re.compile(r"\b(?:assign(?:ed|ment)?|assignee)\b", re.IGNORECASE)
+_SUCCESS_ACTION_RE = re.compile(
+    r"\b(?:created|opened|filed|logged|assigned|completed|succeeded|successful)\b",
+    re.IGNORECASE,
+)
+_NEGATION_TAIL_RE = re.compile(
+    r"(?:\bnot\b|\bnever\b|\bno\b|\bcould not\b|\bcouldn't\b|\bfailed to\b|"
+    r"\bhas not been\b|\bhasn't been\b|\bwas not\b|\bwasn't\b)\s*$",
+    re.IGNORECASE,
+)
 
 
 class FinalReplyEnforcement(str, Enum):
@@ -349,6 +381,297 @@ def _requested_github_artifact_contract_violated(
     return not _reply_names_failed_artifact(candidate_output, _GITHUB_ARTIFACT_RE)
 
 
+def _claims_request_complete(candidate_output: str) -> bool:
+    """Detect a top-level completion claim without treating partial progress as done."""
+
+    candidate = " ".join(str(candidate_output or "").split())
+    if re.match(r"^(?:yes\b|done\b)", candidate, re.IGNORECASE):
+        return True
+    completion_re = re.compile(
+        r"\b(?:(?:it|that|this|the\s+(?:request|work|task)|everything|all\s+of\s+it)\s+"
+        r"(?:is|was|has been)\s+)?(?:done|complete|completed|finished)\b",
+        re.IGNORECASE,
+    )
+    for match in completion_re.finditer(candidate):
+        prefix = candidate[max(0, match.start() - 24):match.start()]
+        if not _NEGATION_TAIL_RE.search(prefix):
+            return True
+    return False
+
+
+def _asserts_success(candidate_output: str) -> bool:
+    if _claims_request_complete(candidate_output):
+        return True
+    candidate = str(candidate_output or "")
+    for match in _SUCCESS_ACTION_RE.finditer(candidate):
+        prefix = candidate[max(0, match.start() - 32):match.start()]
+        if not _NEGATION_TAIL_RE.search(prefix):
+            return True
+    return False
+
+
+def _reply_names_tool_failures(
+    candidate_output: str,
+    evidence: FinalReplyEvidence,
+) -> bool:
+    candidate = str(candidate_output or "").lower()
+    if not _FAILURE_ACK_RE.search(candidate):
+        return False
+    for tool_name in evidence.failed_tool_names:
+        variants = {
+            tool_name.lower(),
+            tool_name.lower().replace("_", " "),
+            tool_name.lower().replace("-", " "),
+        }
+        if not any(variant and variant in candidate for variant in variants):
+            return False
+    return True
+
+
+def _tool_failure_success_issue(
+    candidate_output: str,
+    evidence: FinalReplyEvidence,
+) -> str | None:
+    if not evidence.failure_threshold_reached:
+        return None
+    if not _asserts_success(candidate_output):
+        return None
+    if _reply_names_tool_failures(candidate_output, evidence):
+        return None
+    state = evidence.tool_failure_state
+    failure_count = max(
+        3,
+        int(getattr(state, "consecutive_failures", 0) or 0),
+        int(getattr(state, "total_failures", 0) or 0),
+        sum(1 for item in evidence.tool_results if item.failed),
+    )
+    tools = ", ".join(f"`{name}`" for name in evidence.failed_tool_names) or "the failing tool"
+    return (
+        f"The run reached the tool-failure threshold after {failure_count} failures involving "
+        f"{tools}, but the candidate asserts success without naming those failures."
+    )
+
+
+def _github_refs(value: str) -> tuple[str, ...]:
+    refs: list[str] = []
+    for match in _GITHUB_REF_RE.finditer(str(value or "")):
+        ref = match.group("url_number") or match.group("label_number")
+        if ref and ref not in refs:
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _record_ids(value: Any, *, in_record: bool = False) -> tuple[str, ...]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized_key = str(key or "").strip().lower()
+            nested_record = in_record or normalized_key in {
+                "record",
+                "records",
+                "domain_record",
+                "tracker_record",
+            }
+            if normalized_key in {"record_id", "domain_record_id", "tracker_record_id"}:
+                candidate = str(item or "").strip()
+                if candidate and candidate not in found:
+                    found.append(candidate)
+            elif normalized_key == "id" and in_record:
+                candidate = str(item or "").strip()
+                if candidate and candidate not in found:
+                    found.append(candidate)
+            for candidate in _record_ids(item, in_record=nested_record):
+                if candidate not in found:
+                    found.append(candidate)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            for candidate in _record_ids(item, in_record=in_record):
+                if candidate not in found:
+                    found.append(candidate)
+    return tuple(found)
+
+
+def _successful_record_ids(evidence: FinalReplyEvidence) -> tuple[str, ...]:
+    found: list[str] = []
+    for item in evidence.tool_results:
+        if not item.succeeded:
+            continue
+        for record_id in _record_ids(item.result):
+            if record_id not in found:
+                found.append(record_id)
+    return tuple(found)
+
+
+def _mapping_values_for_keys(value: Any, keys: frozenset[str]) -> tuple[str, ...]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key or "").strip().lower() in keys:
+                candidate = str(item or "").strip()
+                if candidate and candidate not in found:
+                    found.append(candidate)
+            for candidate in _mapping_values_for_keys(item, keys):
+                if candidate not in found:
+                    found.append(candidate)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            for candidate in _mapping_values_for_keys(item, keys):
+                if candidate not in found:
+                    found.append(candidate)
+    return tuple(found)
+
+
+def _successful_assignees(evidence: FinalReplyEvidence) -> tuple[str, ...]:
+    found: list[str] = []
+    for item in evidence.tool_results:
+        if not item.succeeded:
+            continue
+        for assignee in _mapping_values_for_keys(
+            item.result,
+            frozenset({"assignee", "assigned_to", "assignee_name"}),
+        ):
+            if assignee not in found:
+                found.append(assignee)
+    return tuple(found)
+
+
+def _status_question_contract_issue(
+    candidate_output: str,
+    evidence: FinalReplyEvidence,
+) -> str | None:
+    status = evidence.status_question
+    if status is None:
+        return None
+    candidate = str(candidate_output or "")
+    claims_complete = _claims_request_complete(candidate)
+    origin = status.originating_run
+
+    if status.lookup_status != "verified":
+        if claims_complete:
+            return (
+                "The same-thread run lookup did not verify an originating outcome, so the "
+                "status reply cannot assert completion."
+            )
+        return None
+    if origin is None:
+        if claims_complete:
+            return (
+                "No originating run outcome was found on this thread, so the status reply "
+                "cannot assert completion from an incidental artifact."
+            )
+        return None
+
+    if status.has_live_sibling:
+        live = status.live_sibling_runs[0]
+        if claims_complete:
+            return (
+                f"Sibling run {live.run_id} is still {live.status}; the status reply must say "
+                "the request is in progress and cannot say yes/done."
+            )
+        if not _STATUS_IN_PROGRESS_RE.search(candidate):
+            return (
+                f"Sibling run {live.run_id} is still {live.status}, but the reply does not "
+                "explicitly say the request is in progress."
+            )
+
+    record_ids = _successful_record_ids(evidence)
+    if status.has_live_sibling and record_ids:
+        names_a_record = bool(_RECORD_WORD_RE.search(candidate))
+        names_known_ref = any(record_id in candidate for record_id in record_ids)
+        if not (names_a_record and names_known_ref):
+            return (
+                "The reply omits the concrete partial record already present in execution "
+                f"evidence (record {record_ids[0]})."
+            )
+
+    source_output = (
+        str(origin.final_output or "")
+        if origin.status == "completed"
+        else ""
+    )
+    github_refs = list(_github_refs(source_output))
+    for result in evidence.results_for("create_github_issue"):
+        if not result.succeeded:
+            continue
+        result_refs = _github_refs(_compact_json(result.result, limit=5000))
+        for ref in result_refs:
+            if ref not in github_refs:
+                github_refs.append(ref)
+        if isinstance(result.result, dict):
+            number = result.result.get("number") or result.result.get("issue_number")
+            if number not in (None, "") and str(number) not in github_refs:
+                github_refs.append(str(number))
+
+    for deliverable in status.deliverables:
+        if deliverable.kind == "github_issue":
+            if github_refs:
+                if claims_complete and not any(ref in candidate for ref in github_refs):
+                    return (
+                        "The completed status claim omits the verified GitHub issue ref "
+                        f"({github_refs[0]})."
+                    )
+            else:
+                if claims_complete:
+                    return (
+                        "The originating ask requires a GitHub ticket, but no verified "
+                        "GitHub ref exists; the reply cannot report the request as done."
+                    )
+                if not (
+                    _GITHUB_ARTIFACT_RE.search(candidate)
+                    and _UNRESOLVED_RE.search(candidate)
+                ):
+                    return (
+                        "The originating ask requires a GitHub ticket, but no verified GitHub "
+                        "ref exists; the reply must name that ticket as unresolved."
+                    )
+        elif deliverable.kind == "assignment":
+            assignees = list(_successful_assignees(evidence))
+            if source_output and _ASSIGNED_RE.search(source_output):
+                source_assignees = re.findall(
+                    r"\bassigned(?:\s+it)?\s+to\s+@?([\w.-]+)",
+                    source_output,
+                    re.IGNORECASE,
+                )
+                for assignee in source_assignees:
+                    if assignee not in assignees:
+                        assignees.append(assignee)
+            if assignees:
+                if not (
+                    _ASSIGNED_RE.search(candidate)
+                    and any(assignee.lower() in candidate.lower() for assignee in assignees)
+                ):
+                    return (
+                        "The reply omits the verified ticket assignment "
+                        f"to {assignees[0]}."
+                    )
+            else:
+                if claims_complete:
+                    return (
+                        "The originating ask includes ticket assignment, but no verified "
+                        "assignment exists; the reply cannot report the request as done."
+                    )
+                if not (
+                    _ASSIGNED_RE.search(candidate)
+                    and _UNRESOLVED_RE.search(candidate)
+                ):
+                    return (
+                        "The originating ask includes ticket assignment, but no verified "
+                        "assignment exists; the reply must state that it is unresolved."
+                    )
+
+    if claims_complete and origin.status != "completed":
+        return (
+            f"Originating run {origin.run_id} is {origin.status}, not completed; "
+            "the status reply cannot assert completion."
+        )
+    if claims_complete and not source_output:
+        return (
+            f"Originating run {origin.run_id} has no verified final outcome with refs, "
+            "so the status reply cannot assert completion."
+        )
+    return None
+
+
 def _token_resolution_verdict(
     provider,
     llm,
@@ -424,6 +747,40 @@ def review_candidate_final_reply(
     """Run the final-reply checker and return a dict-compatible review payload."""
 
     structured_evidence = evidence or FinalReplyEvidence()
+    tool_failure_issue = _tool_failure_success_issue(
+        candidate_output,
+        structured_evidence,
+    )
+    if tool_failure_issue:
+        return FinalReplyReview(
+            status="continue",
+            approved=False,
+            rationale=tool_failure_issue,
+            missing_requirements=(
+                "Name the failing tool(s), the repeated failures, and the incomplete "
+                "tool-dependent work before ending the run.",
+            ),
+            raw_output="deterministic_tool_failure_honesty_contract",
+            enforcement=FinalReplyEnforcement.BLOCK,
+        ).to_dict()
+
+    status_question_issue = _status_question_contract_issue(
+        candidate_output,
+        structured_evidence,
+    )
+    if status_question_issue:
+        return FinalReplyReview(
+            status="continue",
+            approved=False,
+            rationale=status_question_issue,
+            missing_requirements=(
+                "Report a live sibling as in progress; enumerate every originating "
+                "deliverable with its verified ref or unresolved state.",
+            ),
+            raw_output="deterministic_status_question_contract",
+            enforcement=FinalReplyEnforcement.BLOCK,
+        ).to_dict()
+
     grounding_issue = _ungrounded_product_surface_issue(candidate_output, structured_evidence)
     if grounding_issue:
         return FinalReplyReview(

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -24,8 +24,13 @@ from brain.systems.runs.direct_loop.final_reply import (
     cached_final_reply_review,
     parse_checker_payload,
 )
-from brain.systems.runs.direct_loop.final_reply_evidence import FinalReplyEvidence, ToolResultEvidence
+from brain.systems.runs.direct_loop.final_reply_evidence import (
+    DEFAULT_TOOL_FAILURE_THRESHOLD,
+    FinalReplyEvidence,
+    ToolResultEvidence,
+)
 from brain.systems.runs.direct_loop.request import build_api_request, normalize_model_name
+from brain.systems.runs.status import RunStatus
 from brain.systems.sessions import _content_to_dicts
 
 logger = logging.getLogger("agent")
@@ -122,6 +127,11 @@ _FAILURE_ACK_RE = re.compile(
 _GITHUB_REF_RE = re.compile(
     r"(?:https?://github\.com/[^\s)]+/(?:issues|pull)/(?P<url_number>\d+)|"
     r"\bgithub\s+(?:issue|ticket)\s+#?(?P<label_number>\d+)\b)",
+    re.IGNORECASE,
+)
+_TICKET_REF_RE = re.compile(
+    r"\b(?:ticket|issue)(?:\s+(?:ref(?:erence)?|id))?\s*#?"
+    r"(?P<ref>[A-Za-z][A-Za-z0-9_-]*-\d+|\d+)\b",
     re.IGNORECASE,
 )
 _RECORD_WORD_RE = re.compile(r"\b(?:record|domain|tracker)\b", re.IGNORECASE)
@@ -440,7 +450,7 @@ def _tool_failure_success_issue(
         return None
     state = evidence.tool_failure_state
     failure_count = max(
-        3,
+        DEFAULT_TOOL_FAILURE_THRESHOLD,
         int(getattr(state, "consecutive_failures", 0) or 0),
         int(getattr(state, "total_failures", 0) or 0),
         sum(1 for item in evidence.tool_results if item.failed),
@@ -456,6 +466,15 @@ def _github_refs(value: str) -> tuple[str, ...]:
     refs: list[str] = []
     for match in _GITHUB_REF_RE.finditer(str(value or "")):
         ref = match.group("url_number") or match.group("label_number")
+        if ref and ref not in refs:
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _ticket_refs(value: str) -> tuple[str, ...]:
+    refs: list[str] = []
+    for match in _TICKET_REF_RE.finditer(str(value or "")):
+        ref = match.group("ref")
         if ref and ref not in refs:
             refs.append(ref)
     return tuple(refs)
@@ -586,7 +605,7 @@ def _status_question_contract_issue(
 
     source_output = (
         str(origin.final_output or "")
-        if origin.status == "completed"
+        if origin.status == RunStatus.COMPLETED
         else ""
     )
     github_refs = list(_github_refs(source_output))
@@ -601,6 +620,23 @@ def _status_question_contract_issue(
             number = result.result.get("number") or result.result.get("issue_number")
             if number not in (None, "") and str(number) not in github_refs:
                 github_refs.append(str(number))
+    ticket_refs = list(_ticket_refs(source_output))
+    for result in evidence.tool_results:
+        if not result.succeeded:
+            continue
+        for ref in _mapping_values_for_keys(
+            result.result,
+            frozenset(
+                {
+                    "issue_id",
+                    "issue_number",
+                    "ticket_id",
+                    "ticket_number",
+                }
+            ),
+        ):
+            if ref not in ticket_refs:
+                ticket_refs.append(ref)
 
     for deliverable in status.deliverables:
         if deliverable.kind == "github_issue":
@@ -658,8 +694,60 @@ def _status_question_contract_issue(
                         "The originating ask includes ticket assignment, but no verified "
                         "assignment exists; the reply must state that it is unresolved."
                     )
+        elif deliverable.kind == "ticket":
+            if ticket_refs:
+                if claims_complete and not any(
+                    ref in candidate for ref in ticket_refs
+                ):
+                    return (
+                        "The completed status claim omits the verified ticket ref "
+                        f"({ticket_refs[0]})."
+                    )
+            else:
+                if claims_complete:
+                    return (
+                        f"The {deliverable.label} has no verified ref; the reply cannot "
+                        "report the request as done."
+                    )
+                if not (
+                    deliverable.label.lower() in candidate.lower()
+                    and _UNRESOLVED_RE.search(candidate)
+                ):
+                    return (
+                        f"The {deliverable.label} has no verified ref; the reply must "
+                        "state that it is unresolved."
+                    )
+        elif deliverable.kind == "request":
+            if not source_output:
+                if claims_complete:
+                    return (
+                        "The originating request has no verified final outcome; the reply "
+                        "cannot report it as done."
+                    )
+                if not (
+                    _STATUS_IN_PROGRESS_RE.search(candidate)
+                    or _UNRESOLVED_RE.search(candidate)
+                ):
+                    return (
+                        "The originating request has no verified final outcome; the reply "
+                        "must state that it is unresolved or in progress."
+                    )
+        else:
+            if claims_complete:
+                return (
+                    f"The {deliverable.label} has no verified resolution for deliverable "
+                    f"kind {deliverable.kind!r}; the reply cannot report the request as done."
+                )
+            if not (
+                deliverable.label.lower() in candidate.lower()
+                and _UNRESOLVED_RE.search(candidate)
+            ):
+                return (
+                    f"The {deliverable.label} has no verified resolution for deliverable "
+                    f"kind {deliverable.kind!r}; the reply must state that it is unresolved."
+                )
 
-    if claims_complete and origin.status != "completed":
+    if claims_complete and origin.status != RunStatus.COMPLETED:
         return (
             f"Originating run {origin.run_id} is {origin.status}, not completed; "
             "the status reply cannot assert completion."

--- a/brain/systems/runs/direct_loop/final_reply_evidence.py
+++ b/brain/systems/runs/direct_loop/final_reply_evidence.py
@@ -97,12 +97,224 @@ class ToolResultEvidence:
 
 
 @dataclass(frozen=True)
+class ToolFailureStateEvidence:
+    """Read-only projection of the direct loop's tool-failure circuit state."""
+
+    failure_threshold: int = 3
+    consecutive_failures: int = 0
+    total_failures: int = 0
+    tool_name: str | None = None
+    error_class: str | None = None
+    termination_reason: str | None = None
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ToolFailureStateEvidence | None":
+        if value is None:
+            return None
+        if isinstance(value, Mapping):
+            return cls(
+                failure_threshold=_coerce_positive_int(
+                    value.get("failure_threshold"),
+                    default=3,
+                ),
+                consecutive_failures=_coerce_nonnegative_int(
+                    value.get("consecutive_failures")
+                ),
+                total_failures=_coerce_nonnegative_int(value.get("total_failures")),
+                tool_name=(
+                    str(value.get("tool_name")).strip()
+                    if value.get("tool_name")
+                    else None
+                ),
+                error_class=(
+                    str(value.get("error_class")).strip()
+                    if value.get("error_class")
+                    else None
+                ),
+                termination_reason=(
+                    str(value.get("termination_reason") or value.get("reason")).strip()
+                    if value.get("termination_reason") or value.get("reason")
+                    else None
+                ),
+            )
+        termination = getattr(value, "termination", None)
+        if termination is None and getattr(value, "reason", None) is not None:
+            termination = value
+        termination_reason = getattr(termination, "reason", None)
+        if hasattr(termination_reason, "value"):
+            termination_reason = termination_reason.value
+        tool_name = (
+            getattr(termination, "tool_name", None)
+            or getattr(value, "consecutive_tool_name", None)
+        )
+        error_class = (
+            getattr(termination, "error_class", None)
+            or getattr(value, "last_error_class", None)
+        )
+        return cls(
+            failure_threshold=_coerce_positive_int(
+                getattr(value, "failure_threshold", None),
+                default=3,
+            ),
+            consecutive_failures=_coerce_nonnegative_int(
+                getattr(value, "consecutive_failures", None)
+            ),
+            total_failures=_coerce_nonnegative_int(
+                getattr(value, "total_failures", None)
+            ),
+            tool_name=str(tool_name).strip() if tool_name else None,
+            error_class=str(error_class).strip() if error_class else None,
+            termination_reason=(
+                str(termination_reason).strip() if termination_reason else None
+            ),
+        )
+
+    @property
+    def threshold_reached(self) -> bool:
+        threshold = max(1, int(self.failure_threshold))
+        return bool(
+            self.termination_reason == "tool_failure_circuit"
+            or self.consecutive_failures >= threshold
+            or self.total_failures >= threshold
+        )
+
+    def cache_payload(self) -> dict[str, Any]:
+        return {
+            "failure_threshold": self.failure_threshold,
+            "consecutive_failures": self.consecutive_failures,
+            "total_failures": self.total_failures,
+            "tool_name": self.tool_name,
+            "error_class": self.error_class,
+            "termination_reason": self.termination_reason,
+        }
+
+
+@dataclass(frozen=True)
+class StatusRunEvidence:
+    """One prior same-thread run relevant to a status question."""
+
+    run_id: int | None = None
+    status: str = ""
+    request: str = ""
+    final_output: str | None = None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "StatusRunEvidence":
+        return cls(
+            run_id=_coerce_optional_int(value.get("run_id")),
+            status=str(value.get("status") or "").strip().lower(),
+            request=str(value.get("request") or ""),
+            final_output=(
+                str(value.get("final_output")).strip()
+                if value.get("final_output")
+                else None
+            ),
+        )
+
+    def cache_payload(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "request": self.request,
+            "final_output": self.final_output,
+        }
+
+
+@dataclass(frozen=True)
+class StatusDeliverableEvidence:
+    """A deliverable that a status reply must account for individually."""
+
+    kind: str
+    label: str
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, Any],
+    ) -> "StatusDeliverableEvidence | None":
+        kind = str(value.get("kind") or "").strip().lower()
+        label = str(value.get("label") or kind).strip()
+        return cls(kind=kind, label=label) if kind and label else None
+
+    def cache_payload(self) -> dict[str, str]:
+        return {"kind": self.kind, "label": self.label}
+
+
+@dataclass(frozen=True)
+class StatusQuestionEvidence:
+    """Typed snapshot of the originating and live same-thread runs."""
+
+    thread_id: str = ""
+    lookup_status: str = ""
+    lookup_error: str | None = None
+    originating_run: StatusRunEvidence | None = None
+    live_sibling_runs: tuple[StatusRunEvidence, ...] = ()
+    deliverables: tuple[StatusDeliverableEvidence, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "StatusQuestionEvidence":
+        origin = value.get("originating_run")
+        live_runs = tuple(
+            StatusRunEvidence.from_mapping(item)
+            for item in list(value.get("live_sibling_runs") or [])
+            if isinstance(item, Mapping)
+        )
+        deliverables: list[StatusDeliverableEvidence] = []
+        for item in list(value.get("deliverables") or []):
+            if not isinstance(item, Mapping):
+                continue
+            deliverable = StatusDeliverableEvidence.from_mapping(item)
+            if deliverable is not None:
+                deliverables.append(deliverable)
+        return cls(
+            thread_id=str(value.get("thread_id") or "").strip(),
+            lookup_status=str(value.get("lookup_status") or "").strip().lower(),
+            lookup_error=(
+                str(value.get("lookup_error")).strip()
+                if value.get("lookup_error")
+                else None
+            ),
+            originating_run=(
+                StatusRunEvidence.from_mapping(origin)
+                if isinstance(origin, Mapping)
+                else None
+            ),
+            live_sibling_runs=live_runs,
+            deliverables=tuple(deliverables),
+        )
+
+    @property
+    def has_live_sibling(self) -> bool:
+        return bool(self.live_sibling_runs)
+
+    def cache_payload(self) -> dict[str, Any]:
+        return {
+            "thread_id": self.thread_id,
+            "lookup_status": self.lookup_status,
+            "lookup_error": self.lookup_error,
+            "originating_run": (
+                self.originating_run.cache_payload()
+                if self.originating_run is not None
+                else None
+            ),
+            "live_sibling_runs": [
+                item.cache_payload() for item in self.live_sibling_runs
+            ],
+            "deliverables": [
+                item.cache_payload() for item in self.deliverables
+            ],
+        }
+
+
+@dataclass(frozen=True)
 class FinalReplyEvidence:
     """Typed evidence boundary shared by deterministic final-reply policies."""
 
     tool_results: tuple[ToolResultEvidence, ...] = ()
     execution_artifacts: tuple[Mapping[str, Any], ...] = ()
     worker_results: tuple[Mapping[str, Any], ...] = ()
+    status_question: StatusQuestionEvidence | None = None
+    tool_failure_state: ToolFailureStateEvidence | None = None
 
     @classmethod
     def from_agent_context(cls, agent_context: Any) -> "FinalReplyEvidence":
@@ -129,10 +341,14 @@ class FinalReplyEvidence:
                     "evidence": getattr(item, "evidence", None),
                 }
             )
+        status_question = _status_question_evidence_from_context(agent_context)
+        failure_state = _tool_failure_state_from_context(agent_context, tool_results)
         return cls(
             tool_results=tuple(tool_results),
             execution_artifacts=artifacts,
             worker_results=tuple(workers),
+            status_question=status_question,
+            tool_failure_state=failure_state,
         )
 
     def results_for(self, tool_name: str) -> tuple[ToolResultEvidence, ...]:
@@ -165,14 +381,138 @@ class FinalReplyEvidence:
         ).lower()
         return all(term in text for term in terms)
 
+    @property
+    def failed_tool_names(self) -> tuple[str, ...]:
+        names: list[str] = []
+        state_name = (
+            self.tool_failure_state.tool_name
+            if self.tool_failure_state is not None
+            else None
+        )
+        for name in [
+            state_name,
+            *(item.tool_name for item in self.tool_results if item.failed),
+        ]:
+            clean_name = str(name or "").strip()
+            if clean_name and clean_name not in names:
+                names.append(clean_name)
+        return tuple(names)
+
+    @property
+    def failure_threshold_reached(self) -> bool:
+        if (
+            self.tool_failure_state is not None
+            and self.tool_failure_state.threshold_reached
+        ):
+            return True
+        return sum(1 for item in self.tool_results if item.failed) >= 3
+
     def cache_fingerprint(self) -> str:
         payload = {
             "tool_results": [item.cache_payload() for item in self.tool_results],
             "execution_artifacts": self.execution_artifacts,
             "worker_results": self.worker_results,
+            "status_question": (
+                self.status_question.cache_payload()
+                if self.status_question is not None
+                else None
+            ),
+            "tool_failure_state": (
+                self.tool_failure_state.cache_payload()
+                if self.tool_failure_state is not None
+                else None
+            ),
         }
         serialized = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
         return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
-__all__ = ["FinalReplyEvidence", "ToolResultEvidence"]
+def _coerce_optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_positive_int(value: Any, *, default: int) -> int:
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return max(1, int(default))
+
+
+def _find_status_question_mapping(value: Any, *, depth: int = 0) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping) or depth > 3:
+        return None
+    direct = value.get("status_question_context")
+    if isinstance(direct, Mapping):
+        return direct
+    for key in ("execution_provenance", "metadata", "request_metadata"):
+        nested = value.get(key)
+        found = _find_status_question_mapping(nested, depth=depth + 1)
+        if found is not None:
+            return found
+    return None
+
+
+def _status_question_evidence_from_context(agent_context: Any) -> StatusQuestionEvidence | None:
+    execution_metadata = getattr(agent_context, "execution_metadata", None)
+    mapping = _find_status_question_mapping(execution_metadata)
+    if mapping is None:
+        mapping = _find_status_question_mapping(getattr(agent_context, "metadata", None))
+    return StatusQuestionEvidence.from_mapping(mapping) if mapping is not None else None
+
+
+def _tool_failure_state_from_context(
+    agent_context: Any,
+    tool_results: list[ToolResultEvidence],
+) -> ToolFailureStateEvidence | None:
+    candidates = [
+        getattr(agent_context, "loop_control", None),
+        getattr(getattr(agent_context, "state", None), "loop_control", None),
+        getattr(getattr(agent_context, "run", None), "loop_control", None),
+        getattr(agent_context, "termination", None),
+        getattr(getattr(agent_context, "run", None), "termination", None),
+    ]
+    for candidate in candidates:
+        state = ToolFailureStateEvidence.from_value(candidate)
+        if state is not None:
+            return state
+
+    failures = [item for item in tool_results if item.failed]
+    if len(failures) < 3:
+        return None
+    names = {item.tool_name for item in failures if item.tool_name}
+    last_result = failures[-1].result
+    error_class = (
+        str(last_result.get("error_class")).strip()
+        if isinstance(last_result, Mapping) and last_result.get("error_class")
+        else None
+    )
+    return ToolFailureStateEvidence(
+        failure_threshold=3,
+        consecutive_failures=len(failures) if len(names) == 1 else 0,
+        total_failures=len(failures),
+        tool_name=next(iter(names)) if len(names) == 1 else None,
+        error_class=error_class,
+        termination_reason=None,
+    )
+
+
+__all__ = [
+    "FinalReplyEvidence",
+    "StatusDeliverableEvidence",
+    "StatusQuestionEvidence",
+    "StatusRunEvidence",
+    "ToolFailureStateEvidence",
+    "ToolResultEvidence",
+]

--- a/brain/systems/runs/direct_loop/final_reply_evidence.py
+++ b/brain/systems/runs/direct_loop/final_reply_evidence.py
@@ -7,6 +7,11 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
+from brain.systems.runs.status import RunStatus, coerce_run_status
+
+
+DEFAULT_TOOL_FAILURE_THRESHOLD = 3
+
 
 def _structured_value(value: Any) -> Any:
     """Decode a handler's original JSON result without consulting prompt text."""
@@ -100,7 +105,7 @@ class ToolResultEvidence:
 class ToolFailureStateEvidence:
     """Read-only projection of the direct loop's tool-failure circuit state."""
 
-    failure_threshold: int = 3
+    failure_threshold: int = DEFAULT_TOOL_FAILURE_THRESHOLD
     consecutive_failures: int = 0
     total_failures: int = 0
     tool_name: str | None = None
@@ -115,7 +120,7 @@ class ToolFailureStateEvidence:
             return cls(
                 failure_threshold=_coerce_positive_int(
                     value.get("failure_threshold"),
-                    default=3,
+                    default=DEFAULT_TOOL_FAILURE_THRESHOLD,
                 ),
                 consecutive_failures=_coerce_nonnegative_int(
                     value.get("consecutive_failures")
@@ -154,7 +159,7 @@ class ToolFailureStateEvidence:
         return cls(
             failure_threshold=_coerce_positive_int(
                 getattr(value, "failure_threshold", None),
-                default=3,
+                default=DEFAULT_TOOL_FAILURE_THRESHOLD,
             ),
             consecutive_failures=_coerce_nonnegative_int(
                 getattr(value, "consecutive_failures", None)
@@ -194,7 +199,7 @@ class StatusRunEvidence:
     """One prior same-thread run relevant to a status question."""
 
     run_id: int | None = None
-    status: str = ""
+    status: RunStatus = RunStatus.FAILED
     request: str = ""
     final_output: str | None = None
 
@@ -202,7 +207,10 @@ class StatusRunEvidence:
     def from_mapping(cls, value: Mapping[str, Any]) -> "StatusRunEvidence":
         return cls(
             run_id=_coerce_optional_int(value.get("run_id")),
-            status=str(value.get("status") or "").strip().lower(),
+            status=coerce_run_status(
+                value.get("status"),
+                default=RunStatus.FAILED,
+            ),
             request=str(value.get("request") or ""),
             final_output=(
                 str(value.get("final_output")).strip()
@@ -405,7 +413,10 @@ class FinalReplyEvidence:
             and self.tool_failure_state.threshold_reached
         ):
             return True
-        return sum(1 for item in self.tool_results if item.failed) >= 3
+        return (
+            sum(1 for item in self.tool_results if item.failed)
+            >= DEFAULT_TOOL_FAILURE_THRESHOLD
+        )
 
     def cache_fingerprint(self) -> str:
         payload = {
@@ -489,7 +500,7 @@ def _tool_failure_state_from_context(
             return state
 
     failures = [item for item in tool_results if item.failed]
-    if len(failures) < 3:
+    if len(failures) < DEFAULT_TOOL_FAILURE_THRESHOLD:
         return None
     names = {item.tool_name for item in failures if item.tool_name}
     last_result = failures[-1].result
@@ -499,7 +510,7 @@ def _tool_failure_state_from_context(
         else None
     )
     return ToolFailureStateEvidence(
-        failure_threshold=3,
+        failure_threshold=DEFAULT_TOOL_FAILURE_THRESHOLD,
         consecutive_failures=len(failures) if len(names) == 1 else 0,
         total_failures=len(failures),
         tool_name=next(iter(names)) if len(names) == 1 else None,
@@ -509,6 +520,7 @@ def _tool_failure_state_from_context(
 
 
 __all__ = [
+    "DEFAULT_TOOL_FAILURE_THRESHOLD",
     "FinalReplyEvidence",
     "StatusDeliverableEvidence",
     "StatusQuestionEvidence",

--- a/brain/systems/runs/status_questions.py
+++ b/brain/systems/runs/status_questions.py
@@ -1,0 +1,247 @@
+"""Typed same-thread run context for honest status-question answers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Mapping
+
+from sqlalchemy import select
+
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
+
+logger = logging.getLogger(__name__)
+
+_STATUS_QUESTION_RE = re.compile(
+    r"(?:"
+    r"\b(?:was|is|are)\s+(?:it|that|this|the\s+(?:work|task|ticket|issue))\s+"
+    r"(?:done|complete|completed|finished|ready)\b|"
+    r"\bdid\s+(?:you|illo|it)\s+(?:do|finish|complete|create|file|open|send|assign)\b|"
+    r"\b(?:what(?:'s| is)\s+the\s+status|status\s+update|any\s+(?:update|progress)|"
+    r"how(?:'s| is)\s+(?:it|that|the\s+(?:work|task))\s+going)\b"
+    r")",
+    re.IGNORECASE,
+)
+_TICKET_RE = re.compile(r"\b(?:ticket|issue)\b", re.IGNORECASE)
+_GITHUB_RE = re.compile(r"\bgithub\b", re.IGNORECASE)
+_CUSTOMER_BUG_RE = re.compile(
+    r"\b(?:bug|customer|client|support|email|reported|complaint)\b",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_RE = re.compile(
+    r"\b(?:assign(?:ed|ment)?|owner|assignee)\b",
+    re.IGNORECASE,
+)
+_LIVE_SIBLING_STATUSES = frozenset({"queued", "starting", "running", "paused"})
+
+
+def is_status_question(message: str | None) -> bool:
+    """Return whether the current message is asking about prior work's status."""
+
+    return bool(_STATUS_QUESTION_RE.search(str(message or "")))
+
+
+def enumerate_status_deliverables(request: str | None) -> list[dict[str, str]]:
+    """Enumerate the status-relevant deliverables declared by an originating ask."""
+
+    text = str(request or "")
+    deliverables: list[dict[str, str]] = []
+    if _TICKET_RE.search(text):
+        if _GITHUB_RE.search(text) or _CUSTOMER_BUG_RE.search(text):
+            deliverables.append({"kind": "github_issue", "label": "GitHub ticket"})
+        else:
+            deliverables.append({"kind": "ticket", "label": "ticket"})
+    if _ASSIGNMENT_RE.search(text):
+        deliverables.append({"kind": "assignment", "label": "ticket assignment"})
+    if not deliverables:
+        deliverables.append({"kind": "request", "label": "originating request"})
+    return deliverables
+
+
+async def build_status_question_context(
+    session: Any,
+    *,
+    thread_id: str,
+    message: str,
+    org_id: str | None = None,
+    limit: int = 32,
+) -> dict[str, Any] | None:
+    """Snapshot the prior same-thread run that a status question refers to."""
+
+    if not is_status_question(message):
+        return None
+    clean_thread_id = str(thread_id or "").strip()
+    if not clean_thread_id:
+        return {
+            "thread_id": "",
+            "lookup_status": "failed",
+            "lookup_error": "missing thread id",
+            "originating_run": None,
+            "live_sibling_runs": [],
+            "deliverables": [],
+        }
+    if not hasattr(session, "scalars"):
+        return {
+            "thread_id": clean_thread_id,
+            "lookup_status": "failed",
+            "lookup_error": "run lookup unavailable",
+            "originating_run": None,
+            "live_sibling_runs": [],
+            "deliverables": [],
+        }
+
+    try:
+        statement = select(AgentRunRow).where(AgentRunRow.thread_id == clean_thread_id)
+        clean_org_id = str(org_id or "").strip()
+        if clean_org_id:
+            statement = statement.where(AgentRunRow.org_id == clean_org_id)
+        result = await session.scalars(
+            statement
+            .order_by(AgentRunRow.created_at.desc(), AgentRunRow.id.desc())
+            .limit(max(1, int(limit)))
+        )
+        rows = list(result.all())
+    except Exception as exc:
+        logger.warning(
+            "status_question_run_lookup_failed thread_id=%s error=%s",
+            clean_thread_id,
+            exc,
+        )
+        return {
+            "thread_id": clean_thread_id,
+            "lookup_status": "failed",
+            "lookup_error": "same-thread run lookup failed",
+            "originating_run": None,
+            "live_sibling_runs": [],
+            "deliverables": [],
+        }
+
+    live_runs = [
+        {
+            "run_id": int(row.id),
+            "status": str(row.status),
+        }
+        for row in rows
+        if str(getattr(row, "status", "") or "").strip().lower()
+        in _LIVE_SIBLING_STATUSES
+    ]
+    origin = next(
+        (
+            row
+            for row in rows
+            if not is_status_question(getattr(row, "input_message", None))
+        ),
+        None,
+    )
+    origin_payload: dict[str, Any] | None = None
+    if origin is not None:
+        final_output = await _latest_final_output(session, int(origin.id))
+        origin_payload = {
+            "run_id": int(origin.id),
+            "status": str(origin.status),
+            "request": str(origin.input_message or ""),
+            "final_output": final_output or None,
+        }
+
+    return {
+        "thread_id": clean_thread_id,
+        "lookup_status": "verified",
+        "originating_run": origin_payload,
+        "live_sibling_runs": live_runs,
+        "deliverables": enumerate_status_deliverables(
+            origin_payload.get("request") if origin_payload else None
+        ),
+    }
+
+
+async def _latest_final_output(session: Any, run_id: int) -> str:
+    try:
+        result = await session.scalars(
+            select(AgentRunArtifactRow)
+            .where(
+                AgentRunArtifactRow.run_id == int(run_id),
+                AgentRunArtifactRow.artifact_type == "final_answer",
+            )
+            .order_by(
+                AgentRunArtifactRow.created_at.desc(),
+                AgentRunArtifactRow.id.desc(),
+            )
+            .limit(1)
+        )
+        artifact = result.first()
+    except Exception:
+        logger.debug(
+            "status_question_final_output_lookup_failed run_id=%s",
+            run_id,
+            exc_info=True,
+        )
+        return ""
+    return str(getattr(artifact, "text", None) or "") if artifact is not None else ""
+
+
+def format_status_question_context(value: Mapping[str, Any] | None) -> str:
+    """Render typed status evidence as an authoritative prompt section."""
+
+    if not isinstance(value, Mapping) or not value:
+        return ""
+    lines = ["Authoritative status-check evidence:"]
+    lookup_status = str(value.get("lookup_status") or "").strip().lower()
+    origin = value.get("originating_run")
+    origin = origin if isinstance(origin, Mapping) else None
+    live_runs = [
+        item for item in list(value.get("live_sibling_runs") or [])
+        if isinstance(item, Mapping)
+    ]
+
+    if lookup_status != "verified":
+        lines.append(
+            "The same-thread run lookup could not verify an originating outcome. "
+            "Do not report the prior request as done."
+        )
+    elif origin is None:
+        lines.append(
+            "No originating run outcome was found on this thread. "
+            "Do not infer completion from an incidental record."
+        )
+    else:
+        run_id = origin.get("run_id")
+        status = str(origin.get("status") or "unknown")
+        request = " ".join(str(origin.get("request") or "").split())
+        lines.append(f"Originating run {run_id} status: {status}.")
+        if request:
+            lines.append(f"Originating ask: {request}")
+
+    for run in live_runs:
+        lines.append(
+            f"Sibling run {run.get('run_id')} is {run.get('status')}; "
+            "you must report the request as in progress, never yes/done."
+        )
+
+    deliverables = [
+        str(item.get("label") or item.get("kind") or "").strip()
+        for item in list(value.get("deliverables") or [])
+        if isinstance(item, Mapping)
+    ]
+    deliverables = [item for item in deliverables if item]
+    if deliverables:
+        lines.append("Deliverables to verify individually: " + ", ".join(deliverables) + ".")
+
+    final_output = str((origin or {}).get("final_output") or "").strip()
+    if final_output:
+        lines.append("Originating run final outcome: " + final_output[:1600])
+    elif origin is not None:
+        lines.append("The originating run has no verified final outcome with refs yet.")
+
+    lines.append(
+        "A downstream Domain/tracker record proves only that a partial step ran. "
+        "State each unresolved deliverable explicitly."
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "build_status_question_context",
+    "enumerate_status_deliverables",
+    "format_status_question_context",
+    "is_status_question",
+]

--- a/brain/systems/runs/status_questions.py
+++ b/brain/systems/runs/status_questions.py
@@ -9,6 +9,11 @@ from typing import Any, Mapping
 from sqlalchemy import select
 
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
+from brain.systems.runs.status import (
+    OPEN_RUN_STATUSES,
+    RunStatus,
+    coerce_run_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +37,6 @@ _ASSIGNMENT_RE = re.compile(
     r"\b(?:assign(?:ed|ment)?|owner|assignee)\b",
     re.IGNORECASE,
 )
-_LIVE_SIBLING_STATUSES = frozenset({"queued", "starting", "running", "paused"})
 
 
 def is_status_question(message: str | None) -> bool:
@@ -116,29 +120,39 @@ async def build_status_question_context(
             "deliverables": [],
         }
 
+    rows_with_status = [
+        (
+            row,
+            coerce_run_status(
+                getattr(row, "status", None),
+                default=RunStatus.FAILED,
+            ),
+        )
+        for row in rows
+    ]
     live_runs = [
         {
             "run_id": int(row.id),
-            "status": str(row.status),
+            "status": status,
         }
-        for row in rows
-        if str(getattr(row, "status", "") or "").strip().lower()
-        in _LIVE_SIBLING_STATUSES
+        for row, status in rows_with_status
+        if status in OPEN_RUN_STATUSES
     ]
-    origin = next(
+    origin_with_status = next(
         (
-            row
-            for row in rows
+            (row, status)
+            for row, status in rows_with_status
             if not is_status_question(getattr(row, "input_message", None))
         ),
         None,
     )
     origin_payload: dict[str, Any] | None = None
-    if origin is not None:
+    if origin_with_status is not None:
+        origin, origin_status = origin_with_status
         final_output = await _latest_final_output(session, int(origin.id))
         origin_payload = {
             "run_id": int(origin.id),
-            "status": str(origin.status),
+            "status": origin_status,
             "request": str(origin.input_message or ""),
             "final_output": final_output or None,
         }

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 from typing import Any
 
@@ -14,6 +14,7 @@ from brain.systems.cortex.project_context.resolution import resolve_effective_pr
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
+from brain.systems.runs.status_questions import build_status_question_context
 from brain.systems.runs.store import AsyncAgentRunStore
 
 _VALID_EFFORT_LEVELS = {"none", "low", "medium", "high", "xhigh"}
@@ -598,6 +599,28 @@ def _build_inbound_submission_request(
 
 
 async def build_agent_run_request(
+    session: Any,
+    event: WorkIntakeEvent,
+) -> AgentRunRequest:
+    request = await _build_agent_run_request(session, event)
+    status_context = await build_status_question_context(
+        session,
+        thread_id=request.thread_id,
+        org_id=request.org_id,
+        message=request.message,
+    )
+    if status_context is None:
+        return request
+    return replace(
+        request,
+        metadata={
+            **request.metadata,
+            "status_question_context": status_context,
+        },
+    )
+
+
+async def _build_agent_run_request(
     session: Any,
     event: WorkIntakeEvent,
 ) -> AgentRunRequest:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1989,6 +1989,13 @@ class TestFinalReplyReview:
             StatusQuestionEvidence,
             ToolResultEvidence,
         )
+        from brain.systems.runs.status import (
+            OPEN_RUN_STATUSES,
+            RunStatus,
+            coerce_run_status,
+        )
+
+        run_status = coerce_run_status(status, default=RunStatus.FAILED)
 
         return FinalReplyEvidence(
             tool_results=(
@@ -2014,7 +2021,7 @@ class TestFinalReplyReview:
                     "lookup_status": "verified",
                     "originating_run": {
                         "run_id": 2327,
-                        "status": status,
+                        "status": run_status,
                         "request": (
                             "we may have a bug, email from a customer, "
                             "assign ticket to me"
@@ -2022,8 +2029,8 @@ class TestFinalReplyReview:
                         "final_output": final_output,
                     },
                     "live_sibling_runs": (
-                        [{"run_id": 2327, "status": status}]
-                        if status in {"queued", "starting", "running", "paused"}
+                        [{"run_id": 2327, "status": run_status}]
+                        if run_status in OPEN_RUN_STATUSES
                         else []
                     ),
                     "deliverables": [
@@ -2040,7 +2047,10 @@ class TestFinalReplyReview:
             ),
         )
 
-    @pytest.mark.parametrize("status", ["queued", "starting", "running", "paused"])
+    @pytest.mark.parametrize(
+        "status",
+        ["queued", "starting", "running", "paused", "verifying"],
+    )
     def test_status_question_rejects_done_while_originating_run_is_live(self, status):
         from brain.systems.runs.direct_agent import review_candidate_final_reply
         from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
@@ -2063,6 +2073,58 @@ class TestFinalReplyReview:
         assert "run 2327" in result["rationale"]
         assert status in result["rationale"]
         assert "in progress" in " ".join(result["missing_requirements"]).lower()
+        provider.create.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("kind", "label"),
+        [
+            ("ticket", "ticket"),
+            ("future_kind", "future deliverable"),
+        ],
+    )
+    def test_status_question_rejects_done_for_deliverable_without_verified_ref(
+        self,
+        kind,
+        label,
+    ):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
+        from brain.systems.runs.direct_loop.final_reply_evidence import (
+            FinalReplyEvidence,
+            StatusQuestionEvidence,
+        )
+
+        evidence = FinalReplyEvidence(
+            status_question=StatusQuestionEvidence.from_mapping(
+                {
+                    "thread_id": "thread-1",
+                    "lookup_status": "verified",
+                    "originating_run": {
+                        "run_id": 2327,
+                        "status": "completed",
+                        "request": f"create the {label}",
+                        "final_output": f"Worked on the {label}.",
+                    },
+                    "live_sibling_runs": [],
+                    "deliverables": [{"kind": kind, "label": label}],
+                }
+            )
+        )
+        provider = MagicMock()
+
+        result = review_candidate_final_reply(
+            user_request="was it done?",
+            candidate_output=f"Yes — done. The {label} was completed.",
+            evidence=evidence,
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["enforcement"] is FinalReplyEnforcement.BLOCK
+        assert label in result["rationale"]
+        assert "verified" in result["rationale"]
         provider.create.assert_not_called()
 
     def test_1744_replay_names_partial_record_and_missing_github_ticket(self):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1966,6 +1966,197 @@ class TestExecToolHandlers:
 
 
 class TestFinalReplyReview:
+    @staticmethod
+    def _resolved_checker_provider():
+        provider = MagicMock()
+        response = MagicMock()
+        response.content = [
+            SimpleNamespace(
+                type="text",
+                text=(
+                    '{"status":"resolved","rationale":"Status is fully and honestly reported.",'
+                    '"missing_requirements":[]}'
+                ),
+            )
+        ]
+        provider.create.return_value = response
+        return provider
+
+    @staticmethod
+    def _incident_status_evidence(*, status: str, final_output: str | None = None):
+        from brain.systems.runs.direct_loop.final_reply_evidence import (
+            FinalReplyEvidence,
+            StatusQuestionEvidence,
+            ToolResultEvidence,
+        )
+
+        return FinalReplyEvidence(
+            tool_results=(
+                ToolResultEvidence.capture(
+                    tool_name="read_team_activity",
+                    arguments={"query": "customer ticket"},
+                    is_error=False,
+                    result={
+                        "records": [
+                            {
+                                "id": 2383,
+                                "domain": "Customer Support Tickets",
+                                "assignee": "Reda",
+                                "status": "triaging",
+                            }
+                        ]
+                    },
+                ),
+            ),
+            status_question=StatusQuestionEvidence.from_mapping(
+                {
+                    "thread_id": "slack:T_ALERTS:C_ALERTS:1784741844.000100",
+                    "lookup_status": "verified",
+                    "originating_run": {
+                        "run_id": 2327,
+                        "status": status,
+                        "request": (
+                            "we may have a bug, email from a customer, "
+                            "assign ticket to me"
+                        ),
+                        "final_output": final_output,
+                    },
+                    "live_sibling_runs": (
+                        [{"run_id": 2327, "status": status}]
+                        if status in {"queued", "starting", "running", "paused"}
+                        else []
+                    ),
+                    "deliverables": [
+                        {
+                            "kind": "github_issue",
+                            "label": "GitHub ticket",
+                        },
+                        {
+                            "kind": "assignment",
+                            "label": "ticket assignment",
+                        },
+                    ],
+                }
+            ),
+        )
+
+    @pytest.mark.parametrize("status", ["queued", "starting", "running", "paused"])
+    def test_status_question_rejects_done_while_originating_run_is_live(self, status):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
+
+        provider = MagicMock()
+        result = review_candidate_final_reply(
+            user_request="was it done?",
+            candidate_output=(
+                "Yes — done. It is logged in Customer Support Tickets as #2383, "
+                "assigned to Reda."
+            ),
+            evidence=self._incident_status_evidence(status=status),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["enforcement"] is FinalReplyEnforcement.BLOCK
+        assert "run 2327" in result["rationale"]
+        assert status in result["rationale"]
+        assert "in progress" in " ".join(result["missing_requirements"]).lower()
+        provider.create.assert_not_called()
+
+    def test_1744_replay_names_partial_record_and_missing_github_ticket(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+
+        provider = self._resolved_checker_provider()
+        result = review_candidate_final_reply(
+            user_request="was it done?",
+            candidate_output=(
+                "It is still in progress. Customer Support record #2383 exists and is "
+                "assigned to Reda, but the GitHub ticket has not been created and remains unresolved."
+            ),
+            evidence=self._incident_status_evidence(status="running"),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "resolved"
+        assert result["approved"] is True
+        provider.create.assert_called_once()
+
+    def test_three_failed_tool_calls_block_success_claim_without_failure_names(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+        from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement
+        from brain.systems.runs.direct_loop.final_reply_evidence import (
+            FinalReplyEvidence,
+            ToolFailureStateEvidence,
+            ToolResultEvidence,
+        )
+
+        failures = tuple(
+            ToolResultEvidence.capture(
+                tool_name="manage_idea",
+                arguments={"action": "create"},
+                is_error=True,
+                result={"error": "parent_id validation failed"},
+            )
+            for _ in range(3)
+        )
+        evidence = FinalReplyEvidence(
+            tool_results=failures,
+            tool_failure_state=ToolFailureStateEvidence(
+                failure_threshold=3,
+                consecutive_failures=3,
+                total_failures=3,
+                tool_name="manage_idea",
+                error_class="ToolValidationError",
+                termination_reason="tool_failure_circuit",
+            ),
+        )
+        provider = MagicMock()
+
+        result = review_candidate_final_reply(
+            user_request="Assign a ticket to me.",
+            candidate_output="Yes — done. The ticket is logged and assigned.",
+            evidence=evidence,
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "continue"
+        assert result["enforcement"] is FinalReplyEnforcement.BLOCK
+        assert "manage_idea" in result["rationale"]
+        assert "3" in result["rationale"]
+        provider.create.assert_not_called()
+
+    def test_status_question_allows_done_after_originating_run_completed_with_refs(self):
+        from brain.systems.runs.direct_agent import review_candidate_final_reply
+
+        provider = self._resolved_checker_provider()
+        result = review_candidate_final_reply(
+            user_request="was it done?",
+            candidate_output=(
+                "Done — GitHub issue #1210 was created and assigned to Reda; "
+                "the linked Customer Support record is #2383."
+            ),
+            evidence=self._incident_status_evidence(
+                status="completed",
+                final_output=(
+                    "Created GitHub issue #1210, assigned it to Reda, and linked "
+                    "Customer Support record #2383."
+                ),
+            ),
+            provider=provider,
+            llm=_mock_llm_client(MagicMock(), provider="openai"),
+            model="openai/gpt-5.5",
+        )
+
+        assert result["status"] == "resolved"
+        assert result["approved"] is True
+        provider.create.assert_called_once()
+
     def test_checker_rejects_customer_bug_issue_without_tracker_mirror(self):
         from brain.systems.runs.direct_agent import review_candidate_final_reply
         from brain.systems.runs.direct_loop.final_reply_checker import FinalReplyEnforcement

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -552,6 +552,7 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
         ToolResultEvidence,
     )
     from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+    from brain.systems.runs.status import RunStatus
 
     loop_control = LoopControlPolicy(failure_threshold=3)
     loop_control.consecutive_failures = 3
@@ -595,7 +596,12 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
     assert evidence.status_question is not None
     assert evidence.status_question.originating_run is not None
     assert evidence.status_question.originating_run.run_id == 2327
+    assert evidence.status_question.originating_run.status is RunStatus.RUNNING
     assert evidence.status_question.has_live_sibling is True
+    assert (
+        evidence.status_question.live_sibling_runs[0].status
+        is RunStatus.RUNNING
+    )
     assert evidence.tool_failure_state is not None
     assert evidence.tool_failure_state.threshold_reached is True
     assert evidence.tool_failure_state.tool_name == "manage_idea"

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -546,6 +546,61 @@ def test_final_reply_checker_runtime_returns_dict_compatible_review():
     assert calls == ["More soon", "More soon", "More soon", "More soon"]
 
 
+def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_context():
+    from brain.systems.runs.direct_loop.final_reply_evidence import (
+        FinalReplyEvidence,
+        ToolResultEvidence,
+    )
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    loop_control = LoopControlPolicy(failure_threshold=3)
+    loop_control.consecutive_failures = 3
+    loop_control.total_failures = 3
+    loop_control.consecutive_tool_name = "manage_idea"
+    loop_control.last_error_class = "ToolValidationError"
+    context = SimpleNamespace(
+        recent_tool_results=[
+            ToolResultEvidence.capture(
+                tool_name="manage_idea",
+                arguments={"action": "create"},
+                is_error=True,
+                result={"error": "invalid parent", "error_class": "ToolValidationError"},
+            )
+        ],
+        execution_artifacts=[],
+        run=SimpleNamespace(worker_results=[]),
+        loop_control=loop_control,
+        execution_metadata={
+            "execution_provenance": {
+                "status_question_context": {
+                    "thread_id": "thread-1",
+                    "lookup_status": "verified",
+                    "originating_run": {
+                        "run_id": 2327,
+                        "status": "running",
+                        "request": "assign ticket to me",
+                    },
+                    "live_sibling_runs": [{"run_id": 2327, "status": "running"}],
+                    "deliverables": [
+                        {"kind": "github_issue", "label": "GitHub ticket"},
+                        {"kind": "assignment", "label": "ticket assignment"},
+                    ],
+                }
+            }
+        },
+    )
+
+    evidence = FinalReplyEvidence.from_agent_context(context)
+
+    assert evidence.status_question is not None
+    assert evidence.status_question.originating_run is not None
+    assert evidence.status_question.originating_run.run_id == 2327
+    assert evidence.status_question.has_live_sibling is True
+    assert evidence.tool_failure_state is not None
+    assert evidence.tool_failure_state.threshold_reached is True
+    assert evidence.tool_failure_state.tool_name == "manage_idea"
+
+
 def test_final_reply_helpers_parse_json_and_cache_review():
     from brain.systems.runs.direct_loop.final_reply import (
         cache_final_reply_review,

--- a/tests/test_cortex_thread_context.py
+++ b/tests/test_cortex_thread_context.py
@@ -148,6 +148,7 @@ async def test_work_intake_attaches_prior_visible_context_without_current_messag
 
 
 async def test_status_question_context_tracks_live_then_completed_originating_run(session):
+    from brain.systems.runs.status import RunStatus
     from brain.systems.runs.status_questions import build_status_question_context
 
     started_at = datetime(2026, 7, 22, 17, 37, 24, tzinfo=timezone.utc)
@@ -158,7 +159,7 @@ async def test_status_question_context_tracks_live_then_completed_originating_ru
         thread_id=IDEA_ID,
         profile="fast",
         recipe="fast",
-        status="running",
+        status="verifying",
         input_message="we may have a bug, email from a customer, assign ticket to me",
         target_ref={},
         workspace_ref={},
@@ -179,8 +180,10 @@ async def test_status_question_context_tracks_live_then_completed_originating_ru
 
     assert live_context is not None
     assert live_context["originating_run"]["run_id"] == 2327
-    assert live_context["originating_run"]["status"] == "running"
-    assert live_context["live_sibling_runs"] == [{"run_id": 2327, "status": "running"}]
+    assert live_context["originating_run"]["status"] is RunStatus.VERIFYING
+    assert live_context["live_sibling_runs"] == [
+        {"run_id": 2327, "status": RunStatus.VERIFYING}
+    ]
     assert [item["kind"] for item in live_context["deliverables"]] == [
         "github_issue",
         "assignment",

--- a/tests/test_cortex_thread_context.py
+++ b/tests/test_cortex_thread_context.py
@@ -147,6 +147,138 @@ async def test_work_intake_attaches_prior_visible_context_without_current_messag
     assert "fantastic I added it" not in thread_context["formatted"]
 
 
+async def test_status_question_context_tracks_live_then_completed_originating_run(session):
+    from brain.systems.runs.status_questions import build_status_question_context
+
+    started_at = datetime(2026, 7, 22, 17, 37, 24, tzinfo=timezone.utc)
+    origin = AgentRunRow(
+        id=2327,
+        org_id=ORG_ID,
+        user_id=USER_ID,
+        thread_id=IDEA_ID,
+        profile="fast",
+        recipe="fast",
+        status="running",
+        input_message="we may have a bug, email from a customer, assign ticket to me",
+        target_ref={},
+        workspace_ref={},
+        model_policy={},
+        metadata_={},
+        created_at=started_at,
+        started_at=started_at,
+    )
+    session.add(origin)
+    await session.flush()
+
+    live_context = await build_status_question_context(
+        session,
+        thread_id=IDEA_ID,
+        org_id=ORG_ID,
+        message="was it done?",
+    )
+
+    assert live_context is not None
+    assert live_context["originating_run"]["run_id"] == 2327
+    assert live_context["originating_run"]["status"] == "running"
+    assert live_context["live_sibling_runs"] == [{"run_id": 2327, "status": "running"}]
+    assert [item["kind"] for item in live_context["deliverables"]] == [
+        "github_issue",
+        "assignment",
+    ]
+
+    origin.status = "completed"
+    origin.completed_at = started_at + timedelta(minutes=18)
+    session.add(
+        AgentRunArtifactRow(
+            run_id=2327,
+            root_run_id=2327,
+            artifact_type="final_answer",
+            text=(
+                "Created GitHub issue #1210, assigned it to Reda, and linked "
+                "Customer Support record #2383."
+            ),
+            payload={},
+            visibility="public",
+            created_at=origin.completed_at,
+        )
+    )
+    await session.flush()
+
+    completed_context = await build_status_question_context(
+        session,
+        thread_id=IDEA_ID,
+        org_id=ORG_ID,
+        message="was it done?",
+    )
+
+    assert completed_context is not None
+    assert completed_context["originating_run"]["status"] == "completed"
+    assert completed_context["live_sibling_runs"] == []
+    assert "GitHub issue #1210" in completed_context["originating_run"]["final_output"]
+    assert "#2383" in completed_context["originating_run"]["final_output"]
+
+
+async def test_slack_work_intake_attaches_same_thread_status_context(session):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    thread_ts = "1784741844.000100"
+    slack_thread_id = f"slack:T_ALERTS:C_ALERTS:{thread_ts}"
+    session.add(
+        AgentRunRow(
+            id=2328,
+            org_id=ORG_ID,
+            user_id=USER_ID,
+            thread_id=slack_thread_id,
+            profile="fast",
+            recipe="fast",
+            status="running",
+            input_message=(
+                "we may have a bug, email from a customer, assign ticket to me"
+            ),
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={},
+            created_at=datetime(2026, 7, 22, 17, 37, 24, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+
+    request = await build_agent_run_request(
+        session,
+        WorkIntakeEvent(
+            source="slack",
+            event_type="slack.message",
+            org_id=ORG_ID,
+            actor={"id": USER_ID, "org_id": ORG_ID, "internal": False},
+            target={
+                "kind": "slack_message",
+                "team_id": "T_ALERTS",
+                "channel_id": "C_ALERTS",
+                "thread_ts": thread_ts,
+            },
+            payload={
+                "message": "was it done?",
+                "metadata": {
+                    "slack_trigger": {
+                        "team_id": "T_ALERTS",
+                        "channel_id": "C_ALERTS",
+                        "thread_ts": thread_ts,
+                    }
+                },
+            },
+        ),
+    )
+
+    status_context = request.metadata["status_question_context"]
+    assert request.thread_id == slack_thread_id
+    assert status_context["originating_run"]["run_id"] == 2328
+    assert status_context["originating_run"]["status"] == "running"
+    assert status_context["live_sibling_runs"] == [
+        {"run_id": 2328, "status": "running"}
+    ]
+
+
 def test_run_context_prompt_includes_thread_context():
     from brain.systems.runs.context import RunContextLoader
 
@@ -163,6 +295,39 @@ def test_run_context_prompt_includes_thread_context():
     prompt_context = context.prompt_context()
     assert "Thread so far, before the current user message:" in prompt_context
     assert "Illo: earlier answer" in prompt_context
+
+
+def test_run_context_prompt_marks_live_status_work_as_in_progress():
+    from brain.systems.runs.context import RunContextLoader
+
+    context = RunContextLoader().load(
+        thread_id="idea-1",
+        message="was it done?",
+        metadata={
+            "status_question_context": {
+                "thread_id": "idea-1",
+                "lookup_status": "verified",
+                "originating_run": {
+                    "run_id": 2327,
+                    "status": "running",
+                    "request": "assign ticket to me",
+                },
+                "live_sibling_runs": [{"run_id": 2327, "status": "running"}],
+                "deliverables": [
+                    {"kind": "github_issue", "label": "GitHub ticket"},
+                    {"kind": "assignment", "label": "ticket assignment"},
+                ],
+            }
+        },
+    )
+
+    prompt_context = context.prompt_context()
+
+    assert "Authoritative status-check evidence" in prompt_context
+    assert "run 2327 is running" in prompt_context
+    assert "must report the request as in progress" in prompt_context
+    assert "GitHub ticket" in prompt_context
+    assert "ticket assignment" in prompt_context
 
 
 def test_run_context_prompt_compacts_large_project_context_references():


### PR DESCRIPTION
Closes #420.

## What this does
Fixes the 2026-07-22 incident where a follow-up run reported a still-running sibling run's work as **done** — the honesty defect that made a human trust a wrong answer.

- **New `status_questions.py`**: detects a status question, finds the originating same-thread run, distinguishes a **live** sibling (canonical `OPEN_RUN_STATUSES`) from a completed one, and enumerates the ask's deliverables.
- **Gate in `final_reply_checker`/`final_reply_evidence`**: a "yes/done" is blocked when a live sibling run exists, or when an enumerated deliverable (the GitHub ticket, the assignment) has no verified ref — a Domain record is partial evidence, never proof. A run with ≥3 failed tool calls can't assert success without naming the failures (reads the existing tool-failure circuit read-only).
- A genuinely completed run still answers "done" with its refs (regression).

## Review verdict (mine)
Reviewed + tests green (176). Cross-family thermo-nuclear review (Codex) returned FIX-THEN-SHIP. I folded the **two correctness findings** into fix-pass `ec3aee2`:
- The live-status set was hand-rolled and had **drifted** (missing `verifying`) → now uses canonical `OPEN_RUN_STATUSES`/`coerce_run_status`, so a `verifying` sibling is correctly seen as live.
- Deliverable evaluation is now **exhaustive** — an unrecognised/unresolvable kind defaults to UNRESOLVED (blocks a false "done") instead of being silently dropped.

## ⚠️ Deferred structural findings (review-flagged, NOT addressed — for your call)
These are a redesign larger than the bug fix and reach shared infra; left for a dedicated refactor:
1. Status detection uses regex-as-NLU and "most-recent non-matching message" to pick the origin run — better as a typed `StatusInquiry` with an explicit `target_run_id` from reply/run linkage.
2. Completion contract is reconstructed from keywords — better persisted as a typed `CompletionContract` on the originating run.
3. `final_reply_checker` is growing into a god-function — decompose into `FinalReplyRule` implementations.
4. `ToolFailureStateEvidence` reflectively re-derives loop-control state — `LoopControlPolicy` should expose one typed `LoopFailureSnapshot`.
5. `work_intake.py` is near 1k lines and lacks a request-enrichment boundary. **(Same finding surfaced on #436 — shared pre-existing debt; a separate `work_intake` decomposition ticket may be warranted.)**

## How to verify
```bash
cd illospace-project && git fetch && git checkout illo-qa/420-sibling-run-status-honesty
venv/bin/python -m pytest tests/test_agent.py tests/test_cortex_thread_context.py tests/test_agent_runtime_modules.py -q
```

## Acceptance checks
- [ ] Live sibling run on the thread → reply is "in progress" with partial state, never "yes/done".
- [ ] 17:44-vs-17:37 replay names BOTH the created record AND the missing GitHub ticket.
- [ ] A run with ≥3 failed tool calls can't assert success without naming the failures.
- [ ] Regression: a status question after genuine completion still answers "done" with refs.

## Merge-order note
Touches `work_intake.py`, which #436 also edits (both wrap the admission path). Expect a small merge; suggest a deliberate order (this + #436) rather than parallel merge.

---
🤖 Draft opened by R3 (Codex-implemented, Claude-reviewed). Not merge-ready until your review.
