### PR TITLE
fix(reflection): bind date cutoffs directly instead of untyped INTERVAL arithmetic (#452)

### DIFF
--- a/brain/jobs/pipelines/nightly_reflect.py
+++ b/brain/jobs/pipelines/nightly_reflect.py
@@ -20,7 +20,7 @@ import json
 import os
 import sys
 from collections import defaultdict
-from datetime import datetime, date
+from datetime import date, datetime, timedelta
 
 from sqlalchemy import text
 
@@ -121,11 +121,12 @@ async def gather_context(target_date: date, org_id: str | None = None) -> dict:
         context["new_memories"] = [dict(r) for r in result.mappings().all()]
 
         # 8. Previous daily metrics (for comparison)
+        metrics_cutoff = target_date - timedelta(days=7)
         result = await uow.session.execute(text("""
             SELECT * FROM daily_metrics
-            WHERE metric_date >= :target_date - INTERVAL '7 days'
+            WHERE metric_date >= :metrics_cutoff
             ORDER BY metric_date DESC
-        """), {"target_date": target_date})
+        """), {"metrics_cutoff": metrics_cutoff})
         context["previous_metrics"] = [dict(r) for r in result.mappings().all()]
 
         # 9. Agent run activity.

--- a/brain/systems/memory/retrieval_feedback.py
+++ b/brain/systems/memory/retrieval_feedback.py
@@ -18,6 +18,7 @@ Automatic feedback (memory-DAG):
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import text
@@ -192,6 +193,7 @@ async def analyze_missed_memories(*, cur=None, min_misses: int = 3, days: int = 
 
     Returns list of {memory_id, content, miss_count, hit_count, salience}.
     """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     async with UnitOfWork() as uow:
         result = await uow.session.execute(text("""
             SELECT rl.top_result_id as memory_id,
@@ -201,13 +203,13 @@ async def analyze_missed_memories(*, cur=None, min_misses: int = 3, days: int = 
                    COUNT(*) FILTER (WHERE rl.feedback = 'hit') as hit_count
             FROM retrieval_log rl
             JOIN memory_nodes m ON m.id = rl.top_result_id
-            WHERE rl.timestamp >= NOW() - INTERVAL '1 day' * :days
+            WHERE rl.timestamp >= :cutoff
               AND rl.top_result_id IS NOT NULL
               AND rl.feedback IS NOT NULL
             GROUP BY rl.top_result_id, COALESCE(m.text, m.canonical_label), m.confidence
             HAVING COUNT(*) FILTER (WHERE rl.feedback = 'miss') >= :min_misses
             ORDER BY miss_count DESC
-        """), {"days": days, "min_misses": min_misses})
+        """), {"cutoff": cutoff, "min_misses": min_misses})
         return [dict(r) for r in result.mappings().all()]
 
 

--- a/tests/test_nightly_reflect.py
+++ b/tests/test_nightly_reflect.py
@@ -86,6 +86,30 @@ class TestGatherContext:
 class TestGatherContextRegressions:
     """Regression tests for known bugs in gather_context."""
 
+    async def test_previous_metrics_binds_python_date_cutoff(self, patch_reflect_uow):
+        """Regression: asyncpg cannot type an uncast date bind used with INTERVAL."""
+        target = date(2026, 7, 24)
+
+        with patch("brain.kernel.config.JOURNAL_DIR", "/nonexistent/journal"), \
+             patch(
+                 "brain.systems.memory.retrieval_feedback.analyze_missed_memories",
+                 new=AsyncMock(return_value=[]),
+             ):
+            from brain.jobs.pipelines.nightly_reflect import gather_context
+            await gather_context(target)
+
+        metrics_calls = [
+            execute_call
+            for execute_call in patch_reflect_uow.session.execute.call_args_list
+            if "FROM daily_metrics" in str(execute_call.args[0])
+        ]
+        assert len(metrics_calls) == 1
+
+        statement, params = metrics_calls[0].args
+        assert "WHERE metric_date >= :metrics_cutoff" in str(statement)
+        assert "INTERVAL" not in str(statement)
+        assert params == {"metrics_cutoff": date(2026, 7, 17)}
+
     def test_connection_uses_context_manager(self):
         """Regression: must use a UnitOfWork/db connection context manager."""
         import inspect

--- a/tests/test_retrieval_feedback.py
+++ b/tests/test_retrieval_feedback.py
@@ -7,6 +7,7 @@ Zero test data leaks to production DB.
 
 import sys
 import os
+from datetime import datetime, timedelta, timezone
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 1))))
 
 import pytest
@@ -172,6 +173,32 @@ class TestAnalyzeMissedMemories:
             missed = await analyze_missed_memories(min_misses=3, days=30)
         missed_ids = [m["memory_id"] for m in missed]
         assert mid not in missed_ids
+
+
+class TestAnalyzeMissedMemoriesQuery:
+    async def test_binds_python_cutoff_without_interval_arithmetic(self):
+        now = datetime(2026, 7, 24, 12, 0, tzinfo=timezone.utc)
+        result = MagicMock()
+        result.mappings.return_value.all.return_value = []
+        uow = MagicMock()
+        uow.__aenter__ = AsyncMock(return_value=uow)
+        uow.__aexit__ = AsyncMock(return_value=False)
+        uow.session.execute = AsyncMock(return_value=result)
+
+        with patch(
+            "brain.systems.memory.retrieval_feedback.UnitOfWork",
+            return_value=uow,
+        ), patch("brain.systems.memory.retrieval_feedback.datetime") as mock_datetime:
+            mock_datetime.now.return_value = now
+            await analyze_missed_memories(min_misses=3, days=30)
+
+        statement, params = uow.session.execute.await_args.args
+        assert "WHERE rl.timestamp >= :cutoff" in str(statement)
+        assert "INTERVAL" not in str(statement)
+        assert params == {
+            "cutoff": now - timedelta(days=30),
+            "min_misses": 3,
+        }
 
 
 class TestAttentionUsefulnessAttribution:


### PR DESCRIPTION
Closes #452

## What
The `reflection` step's `daily_metrics` query in `nightly_reflect.py` used
`:target_date - INTERVAL '7 days'` with an untyped asyncpg parameter. asyncpg
can't resolve the `-` operator on an untyped param, so the statement failed and
the nightly aborted at step 9/16 — `dream`, `wake_up_index`, `file_sync` and
everything downstream stayed `recorded` (never executed).

## Fix
- Compute the 7-day cutoff in Python (`target_date - timedelta(days=7)`) and bind
  it directly. **Result window and ordering unchanged.**
- Scanned `nightly_reflect.py` for the same pattern; other date filters use direct
  comparisons and needed no change.
- Fixed the adjacent `analyze_missed_memories()` query in
  `systems/memory/retrieval_feedback.py` (`NOW() - INTERVAL '1 day' * :days`),
  same untyped-arithmetic class, now a Python-computed UTC cutoff.
- Regression tests added for both queries.

## How to verify (no live DB needed)
```
cd <worktree> && venv/bin/python -m pytest tests/test_nightly_reflect.py tests/test_retrieval_feedback.py -q -m "not requires_db and not integration"
```
→ 14 passed (9 DB-live deselected).

## Acceptance
- [x] `gather_context()` daily_metrics query executes without the asyncpg
  type-resolution error → nightly can settle `nightly_sleep` end-to-end and reach
  `dream` onward.
- [x] Same 7-day window, same ordering (no behavior change to the result set).
- [x] Sibling untyped-INTERVAL query fixed the same way.
- [x] Regression coverage added.

Reviewer eyeball: the two query bindings — cutoff computed in Python, no
`INTERVAL` arithmetic on a bound param.

🤖 Draft opened by Routine R3 (Codex-authored, Claude-reviewed). Do not merge/ready — Reda reviews.