### PR TITLE
feat(inbound): admit in-app customer reports as a signal lane (#457)

### DIFF
--- a/.review/457-notes.md
+++ b/.review/457-notes.md
@@ -1,0 +1,157 @@
+# Illospace #457 — Illo-side app-report intake
+
+## What changed and why
+
+- Added `app_report` as a registered shared inbound-envelope kind beside
+  `slack_message`.
+- Added `build_app_report_work_intake_payload(...)`, which validates the
+  Uwear app contract and shapes a `customer_request.issue` or
+  `customer_request.idea` event for the canonical `WorkIntakeEvent` /
+  `admit_work(...)` boundary.
+- Added `process_app_report_envelope(...)`, which uses the inbound connection
+  owner as Illo execution authority, admits a headless customer-request run,
+  and completes the existing `InboundEventRow` with `STATUS_PROCESSED`.
+- The normalized app report is retained in run metadata. `generation_ids` and
+  `batch_ids` are also copied into the run target / decision-receipt target, so
+  a later dossier join can use explicit identifiers without guessing.
+- A successful admission returns and records this acknowledgement at
+  `ilo_outcome.ack`:
+
+  ```json
+  {
+    "status": "accepted",
+    "message": "Thanks — your issue was received.",
+    "event_id": "<Illo inbound event UUID>"
+  }
+  ```
+
+- No database schema or public route was added. Existing
+  `InboundEventRow`, `InboundDecisionReceiptRow`, and agent-run storage are
+  sufficient.
+
+## Exact companion `uwearaiapp` change
+
+Use the existing authenticated inbound webhook ingress:
+
+```http
+POST ${ILLO_BASE_URL}/webhooks
+Authorization: Bearer ${ILLO_BRIDGE_TOKEN}
+Content-Type: application/json
+X-Illo-Idempotency-Key: <stable report/delivery id>
+```
+
+The bridge token must have the existing `signal:submit` scope. `POST
+/webhooks` is the correct adapter because it already accepts arbitrary envelope
+kinds and calls the same `submit_inbound_envelope(...)` service as hosted MCP.
+The hosted `illo_submit` tool is not the correct wire contract here: it
+deliberately converts its arguments into a fixed `submission` envelope and
+does not expose a caller-selected kind. No bespoke app-report route or new MCP
+tool is required.
+
+Send this outer envelope:
+
+```json
+{
+  "kind": "app_report",
+  "origin": "uwear.app_report",
+  "payload": {
+    "email": "customer@example.com",
+    "profileId": "uwear-profile-id",
+    "type": "Issue",
+    "message": "The customer's report text",
+    "attachments": [
+      "https://...",
+      {
+        "url": "https://...",
+        "name": "optional structured attachment"
+      }
+    ],
+    "generation_ids": [1234, "another-generation-id"],
+    "batch_ids": [5678, "another-batch-id"]
+  },
+  "summary": "The customer's report text",
+  "desired_outcome": "Admit this customer request for Illo coordination.",
+  "idempotency_key": "<same stable report/delivery id>"
+}
+```
+
+Payload rules:
+
+- `email`, `profileId`, `type`, and `message` are required and non-empty.
+- `type` is `Issue` or `Idea` (case-insensitive at ingress and stored in that
+  canonical casing).
+- `attachments` is a required array and may be empty.
+- `generation_ids` and `batch_ids` are optional arrays of integer or string
+  identifiers.
+
+Companion implementation sequence:
+
+1. In `ContactSupportModal`, capture the relevant recent generation ids and
+   batch ids at the same moment as the screenshot/report. Include those exact
+   ids in the request to `contact-support.js`; do not reconstruct them later
+   from timestamps or reporter identity.
+2. In `contact-support.js`, preserve the existing Retool request and its legacy
+   payload unchanged.
+3. Add an independent call to the Illo endpoint above, projecting the modal
+   fields plus the captured `generation_ids` / `batch_ids` into the
+   `app_report` envelope.
+4. Return or surface `ilo_outcome.ack` to the modal after Illo accepts the
+   report. Retrying with the same idempotency key returns the recorded result
+   without admitting duplicate work.
+
+The Illo call is additive to Retool. A failure in either destination should be
+reported/handled explicitly by the companion implementation rather than
+silently removing the other delivery.
+
+## Acceptance split
+
+### Fully satisfied by this Illo-side change
+
+- The receiving `app_report` lane exists on the same shared inbound and
+  work-intake boundaries used by Slack.
+- A valid app-report envelope creates an admitted customer-request run and
+  completes its inbound event as `processed`.
+- Successful admission returns and durably records a reporter acknowledgement.
+- `generation_ids` and `batch_ids` survive in the admitted run metadata and
+  target / decision receipt for deterministic dossier joins.
+- Existing Retool code and behavior are untouched by this repository.
+
+### Depends on the `uwearaiapp` companion change
+
+- `ContactSupportModal` actually delivers each report to Illo in addition to
+  Retool.
+- The modal captures and sends the correct recent generation and batch ids.
+- The Netlify response relays/displays Illo's returned acknowledgement to the
+  reporter.
+- The existing Retool forward continues to receive its current payload
+  unchanged after the additive Illo call is introduced.
+
+## Verification
+
+Command:
+
+```bash
+/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
+  tests/test_app_report_intake.py \
+  tests/test_inbound_webhooks.py \
+  tests/test_inbound_preservation.py \
+  tests/test_slack_teammate.py \
+  tests/test_slack_channel_monitor.py \
+  tests/test_work_intake.py \
+  tests/test_work_intake_full_architecture.py \
+  tests/test_architecture_boundaries.py -q
+```
+
+Result:
+
+```text
+collected 136 items
+134 passed, 2 skipped in 4.41s
+```
+
+The skips are existing environment-dependent cases in
+`tests/test_inbound_webhooks.py`.
+
+## Migration
+
+No migration was added, so no Alembic head selection was required.

--- a/brain/systems/app_report/__init__.py
+++ b/brain/systems/app_report/__init__.py
@@ -1,0 +1,2 @@
+"""Uwear in-app customer-report intake."""
+

--- a/brain/systems/app_report/inbound.py
+++ b/brain/systems/app_report/inbound.py
@@ -1,0 +1,153 @@
+"""Inbound-envelope processing for customer reports submitted from the Uwear app."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.inbound import InboundEventRow
+from brain.systems.app_report.triggers import (
+    APP_REPORT_ENVELOPE_KIND,
+    AppReportValidationError,
+    build_app_report_work_intake_payload,
+)
+from brain.systems.inbound.service import _clean_optional, _complete_event
+from brain.systems.inbound.status import STATUS_FAILED, STATUS_PROCESSED
+from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+
+ACTION_APP_REPORT_RUN_ADMITTED = "app_report.run_admitted"
+
+
+async def process_app_report_envelope(
+    session: AsyncSession,
+    *,
+    context: Any,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Admit one normalized in-app report as a customer-request work signal."""
+
+    authority_user_id = _clean_optional(context.owner_user_id)
+    if not authority_user_id:
+        return await _complete_event(
+            session,
+            event,
+            policy=None,
+            status=STATUS_FAILED,
+            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
+            action_result={
+                "operation": "app_report_run_admission_failed",
+                "reason": "missing_authority_user",
+                "event_id": str(event.id),
+            },
+            confidence=0.0,
+            error="App-report connection has no authority user",
+            target={"kind": APP_REPORT_ENVELOPE_KIND},
+            tool_use={"type": "app_report_intake", "status": "failed"},
+            reasoning_summary="App reports need a connection owner to admit customer-request work.",
+        )
+
+    try:
+        trigger_payload = build_app_report_work_intake_payload(
+            org_id=context.org_id,
+            authority_user_id=authority_user_id,
+            payload=dict(normalized.get("payload") or {}),
+            inbound_event_id=str(event.id),
+            connection_id=context.connection_id,
+            idempotency_key=_clean_optional(normalized.get("idempotency_key")),
+            origin=_clean_optional(normalized.get("origin")),
+        )
+    except AppReportValidationError as exc:
+        return await _complete_event(
+            session,
+            event,
+            policy=None,
+            status=STATUS_FAILED,
+            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
+            action_result={
+                "operation": "app_report_run_admission_failed",
+                "reason": "invalid_app_report_payload",
+                "event_id": str(event.id),
+            },
+            confidence=0.0,
+            error=str(exc),
+            target={"kind": APP_REPORT_ENVELOPE_KIND},
+            tool_use={"type": "app_report_intake", "status": "failed"},
+            reasoning_summary=str(exc),
+        )
+
+    admission = await admit_work(
+        session,
+        WorkIntakeEvent.from_trigger_payload(trigger_payload),
+    )
+    report = dict((trigger_payload.get("payload") or {}).get("app_report") or {})
+    target = dict(trigger_payload.get("target") or {})
+    if admission.ok:
+        if admission.run_id is not None:
+            target["run_id"] = admission.run_id
+        ack = _reporter_ack(
+            event_id=str(event.id),
+            report_type=str(report.get("type") or "report"),
+        )
+        return await _complete_event(
+            session,
+            event,
+            policy=None,
+            status=STATUS_PROCESSED,
+            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
+            action_result={
+                "operation": "app_report_run_admitted",
+                "run_id": admission.run_id,
+                "event_id": str(event.id),
+                "origin": normalized.get("origin"),
+                "ack": ack,
+            },
+            confidence=1.0,
+            target=target,
+            tool_use={
+                "type": "app_report_intake",
+                "status": "accepted",
+                "run_id": admission.run_id,
+            },
+            reasoning_summary=(
+                "The in-app customer report was acknowledged and admitted through the shared "
+                "work-intake boundary with its deterministic generation and batch references."
+            ),
+            reusable_pattern_candidate={
+                "kind": APP_REPORT_ENVELOPE_KIND,
+                "origin": normalized.get("origin"),
+                "source_kind": context.source_kind,
+            },
+        )
+
+    return await _complete_event(
+        session,
+        event,
+        policy=None,
+        status=STATUS_FAILED,
+        action_type=ACTION_APP_REPORT_RUN_ADMITTED,
+        action_result={
+            "operation": "app_report_run_admission_failed",
+            "reason": admission.skipped_reason or "run_admission_failed",
+            "event_id": str(event.id),
+            "origin": normalized.get("origin"),
+        },
+        confidence=0.0,
+        error=admission.skipped_reason or "run_admission_failed",
+        target=target,
+        tool_use={"type": "app_report_intake", "status": "failed"},
+        reasoning_summary=admission.skipped_reason
+        or "The app report could not be admitted as customer-request work.",
+    )
+
+
+def _reporter_ack(*, event_id: str, report_type: str) -> dict[str, str]:
+    return {
+        "status": "accepted",
+        "message": f"Thanks — your {report_type.lower()} was received.",
+        "event_id": event_id,
+    }
+
+
+__all__ = ["process_app_report_envelope"]

--- a/brain/systems/app_report/triggers.py
+++ b/brain/systems/app_report/triggers.py
@@ -1,0 +1,208 @@
+"""Work-intake shaping for customer reports submitted from the Uwear app."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+APP_REPORT_ENVELOPE_KIND = "app_report"
+APP_REPORT_SOURCE = "app_report"
+APP_REPORT_SURFACE = "uwear_app"
+CUSTOMER_REQUEST_EVENT_PREFIX = "customer_request"
+
+_REPORT_TYPES = {
+    "issue": "Issue",
+    "idea": "Idea",
+}
+
+
+class AppReportValidationError(ValueError):
+    """Raised when an app-report payload does not satisfy the ingress contract."""
+
+
+def build_app_report_work_intake_payload(
+    *,
+    org_id: str,
+    authority_user_id: str,
+    payload: Mapping[str, Any],
+    inbound_event_id: str,
+    connection_id: str | None = None,
+    idempotency_key: str | None = None,
+    origin: str | None = None,
+    priority: int = 0,
+) -> dict[str, Any]:
+    """Build the canonical work-intake trigger for one in-app customer report."""
+
+    report = app_report_payload(payload)
+    event_type = app_report_event_type(report)
+    target = {
+        "kind": APP_REPORT_ENVELOPE_KIND,
+        "event_id": str(inbound_event_id),
+        "thread_id": f"app-report:{inbound_event_id}",
+        "profile_id": report["profileId"],
+        **({"generation_ids": report["generation_ids"]} if "generation_ids" in report else {}),
+        **({"batch_ids": report["batch_ids"]} if "batch_ids" in report else {}),
+    }
+    metadata = {
+        "origin": str(origin or "uwear.app_report"),
+        "signal_kind": "customer_request",
+        "originating_surface": APP_REPORT_SURFACE,
+        "triggering_surface": APP_REPORT_SURFACE,
+        "source_surface": APP_REPORT_SURFACE,
+        "final_answer_target_surface": "headless",
+        "headless": True,
+        "execution_profile": "fast",
+        "app_report": report,
+        "app_report_connection_id": connection_id,
+        "inbound_event": {
+            "event_id": str(inbound_event_id),
+            "origin": str(origin or "uwear.app_report"),
+            "kind": APP_REPORT_ENVELOPE_KIND,
+            "connection_id": connection_id,
+        },
+    }
+    return {
+        "source": APP_REPORT_SOURCE,
+        "event_type": event_type,
+        "actor": {
+            "id": str(authority_user_id),
+            "principal_type": "external_uwear_customer",
+            "role": "customer",
+            "name": report["email"],
+            "org_id": str(org_id),
+            "metadata": {
+                "auth_source": "app_report_connection_authority",
+                "reporter_email": report["email"],
+                "reporter_profile_id": report["profileId"],
+                **({"connection_id": connection_id} if connection_id else {}),
+            },
+        },
+        "org_id": str(org_id),
+        "target": target,
+        "payload": {
+            "app_report": report,
+            "thread_message": report["message"],
+            "run_message": app_report_run_message(report),
+            "workspace_ref": {
+                "source": APP_REPORT_SURFACE,
+                "mode": "customer_request_signal",
+            },
+            "metadata": metadata,
+            "priority": int(priority),
+            "user_id": str(authority_user_id),
+        },
+        "idempotency_key": idempotency_key,
+        "policy": {
+            "route": "run",
+            "run_event": event_type.split(".", 1)[-1],
+            "priority": int(priority),
+            "auth_path": "app_report_connection",
+        },
+    }
+
+
+def app_report_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize the uwearaiapp-to-Illo payload contract."""
+
+    data = dict(payload or {})
+    email = _required_text(data.get("email"), "email")
+    profile_id = _required_text(data.get("profileId"), "profileId")
+    report_type = _report_type(data.get("type"))
+    message = _required_text(data.get("message"), "message")
+    if "attachments" not in data:
+        raise AppReportValidationError("attachments is required")
+    attachments = data["attachments"]
+    if not isinstance(attachments, list):
+        raise AppReportValidationError("attachments must be an array")
+
+    report: dict[str, Any] = {
+        "email": email,
+        "profileId": profile_id,
+        "type": report_type,
+        "message": message,
+        "attachments": list(attachments),
+    }
+    for field_name in ("generation_ids", "batch_ids"):
+        if field_name in data and data[field_name] is not None:
+            report[field_name] = _identifier_list(data[field_name], field_name)
+    return report
+
+
+def app_report_event_type(payload: Mapping[str, Any]) -> str:
+    report_type = _report_type(payload.get("type"))
+    return f"{CUSTOMER_REQUEST_EVENT_PREFIX}.{report_type.lower()}"
+
+
+def app_report_run_message(payload: Mapping[str, Any]) -> str:
+    report = app_report_payload(payload)
+    generation_ids = report.get("generation_ids") or []
+    batch_ids = report.get("batch_ids") or []
+    attachment_preview = _json_preview(report["attachments"], limit=2000)
+    return "\n".join(
+        [
+            f"A Uwear customer submitted an in-app {report['type']} report.",
+            "Treat this as a customer-request signal admitted through Illo's shared work-intake lane.",
+            "Coordinate any follow-up through durable work surfaces; do not execute product changes directly.",
+            "Use only the supplied generation and batch ids for deterministic dossier joins; do not guess a causing generation.",
+            "The inbound admission response already contains the reporter acknowledgement.",
+            "",
+            f"Reporter email: {report['email']}",
+            f"Reporter profile id: {report['profileId']}",
+            f"Generation ids: {json.dumps(generation_ids, ensure_ascii=False)}",
+            f"Batch ids: {json.dumps(batch_ids, ensure_ascii=False)}",
+            f"Attachments: {attachment_preview}",
+            "",
+            f"Customer message: {report['message']}",
+        ]
+    )
+
+
+def _report_type(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    report_type = _REPORT_TYPES.get(normalized)
+    if report_type is None:
+        raise AppReportValidationError("type must be Issue or Idea")
+    return report_type
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise AppReportValidationError(f"{field_name} is required")
+    return text
+
+
+def _identifier_list(value: Any, field_name: str) -> list[int | str]:
+    if not isinstance(value, list):
+        raise AppReportValidationError(f"{field_name} must be an array")
+    identifiers: list[int | str] = []
+    for identifier in value:
+        if isinstance(identifier, bool) or not isinstance(identifier, int | str):
+            raise AppReportValidationError(
+                f"{field_name} entries must be integer or string identifiers"
+            )
+        if isinstance(identifier, str):
+            identifier = identifier.strip()
+            if not identifier:
+                raise AppReportValidationError(f"{field_name} entries cannot be empty")
+        identifiers.append(identifier)
+    return identifiers
+
+
+def _json_preview(value: Any, *, limit: int) -> str:
+    text = json.dumps(value, ensure_ascii=False, default=str)
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(0, limit - 3)].rstrip()}..."
+
+
+__all__ = [
+    "APP_REPORT_ENVELOPE_KIND",
+    "APP_REPORT_SOURCE",
+    "APP_REPORT_SURFACE",
+    "AppReportValidationError",
+    "app_report_event_type",
+    "app_report_payload",
+    "app_report_run_message",
+    "build_app_report_work_intake_payload",
+]

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -49,6 +49,7 @@ ACTION_ILO_REQUIRED = "ilo_required"
 SUBMISSION_ENVELOPE_KIND = "submission"
 ACTION_ILLO_SUBMIT_QUEUED = "illo.submit_queued"
 SPECIAL_ENVELOPE_HANDLER_PATHS = {
+    "app_report": "brain.systems.app_report.inbound:process_app_report_envelope",
     "slack_message": "brain.systems.slack.inbound:process_slack_message_envelope",
 }
 

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -524,14 +524,14 @@ def _external_agent_headless_thread_id(target: dict[str, Any]) -> str:
     raise ValueError("External agent headless ask requires thread_id or connection/task ids")
 
 
-def _inbound_submission_thread_id(target: dict[str, Any]) -> str:
+def _inbound_signal_thread_id(target: dict[str, Any]) -> str:
     thread_id = str(target.get("thread_id") or "")
     if thread_id:
         return thread_id
     event_id = str(target.get("event_id") or "")
     if event_id:
         return f"inbound:{event_id}"
-    raise ValueError("Inbound submission requires event_id or thread_id")
+    raise ValueError("Inbound signal requires event_id or thread_id")
 
 
 def _build_external_agent_headless_request(
@@ -566,7 +566,7 @@ def _build_external_agent_headless_request(
     )
 
 
-def _build_inbound_submission_request(
+def _build_inbound_signal_request(
     event: WorkIntakeEvent,
     *,
     target: dict[str, Any],
@@ -580,7 +580,7 @@ def _build_inbound_submission_request(
     return AgentRunRequest(
         org_id=_event_org_id(event),
         user_id=_event_actor_user_id(event),
-        thread_id=_inbound_submission_thread_id(target),
+        thread_id=_inbound_signal_thread_id(target),
         message=message,
         profile=profile,
         recipe=recipe_for_profile(profile, metadata),
@@ -743,8 +743,8 @@ async def _build_agent_run_request(
             priority=priority,
         )
 
-    if target.get("kind") == "inbound_submission":
-        return _build_inbound_submission_request(
+    if target.get("kind") in {"app_report", "inbound_submission"}:
+        return _build_inbound_signal_request(
             event,
             target=target,
             metadata=metadata,

--- a/tests/test_app_report_intake.py
+++ b/tests/test_app_report_intake.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.db.models.open_ask import OpenAsk
+from brain.platform.db.models.org import Org, User
+
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+USER_ID = "22222222-2222-4222-8222-222222222222"
+CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            ExternalAgentConnectionRow.__table__,
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            OpenAsk.__table__,
+            InboundEventRow.__table__,
+            InboundDecisionReceiptRow.__table__,
+        ]
+    )
+
+
+async def _seed_app_report_connection(session):
+    session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    connection = ExternalAgentConnectionRow(
+        id=CONNECTION_ID,
+        org_id=ORG_ID,
+        owner_user_id=USER_ID,
+        display_name="Uwear app support reports",
+        agent_kind="uwear_app",
+        transport="webhook",
+        status="online",
+        remote_agent_card={},
+        capabilities={"app_report": True},
+        auth_metadata={},
+        metadata_={},
+    )
+    session.add(connection)
+    await session.flush()
+    return connection
+
+
+def _report_payload() -> dict:
+    return {
+        "email": "customer@example.com",
+        "profileId": "profile-123",
+        "type": "Issue",
+        "message": "The generation completed, but the result stayed blank.",
+        "attachments": [
+            "https://cdn.example.com/support/screenshot.png",
+            {"url": "https://cdn.example.com/support/log.txt", "name": "log.txt"},
+        ],
+        "generation_ids": [901, "gen-902"],
+        "batch_ids": [77, "batch-78"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_app_report_work_intake_carries_customer_request_contract():
+    from brain.systems.app_report.triggers import build_app_report_work_intake_payload
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    trigger = build_app_report_work_intake_payload(
+        org_id=ORG_ID,
+        authority_user_id=USER_ID,
+        payload=_report_payload(),
+        inbound_event_id="inbound-1",
+        connection_id=CONNECTION_ID,
+        idempotency_key="app-report:profile-123:1",
+        origin="uwear.app_report",
+    )
+    request = await build_agent_run_request(
+        object(),
+        WorkIntakeEvent.from_trigger_payload(trigger),
+    )
+
+    assert trigger["source"] == "app_report"
+    assert trigger["event_type"] == "customer_request.issue"
+    assert trigger["target"]["kind"] == "app_report"
+    assert trigger["payload"]["app_report"] == _report_payload()
+    assert request.thread_id == "app-report:inbound-1"
+    assert request.target_ref["generation_ids"] == [901, "gen-902"]
+    assert request.target_ref["batch_ids"] == [77, "batch-78"]
+    assert request.metadata["app_report"]["generation_ids"] == [901, "gen-902"]
+    assert request.metadata["app_report"]["batch_ids"] == [77, "batch-78"]
+    assert request.metadata["signal_kind"] == "customer_request"
+    assert request.metadata["headless"] is True
+    assert request.metadata["work_intake"]["source"] == "app_report"
+    assert "do not guess a causing generation" in request.message
+
+
+@pytest.mark.asyncio
+async def test_app_report_envelope_is_admitted_and_acknowledged_as_processed(session):
+    from brain.systems.inbound.service import submit_inbound_envelope
+
+    connection = await _seed_app_report_connection(session)
+    payload = _report_payload()
+    result = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope={
+            "kind": "app_report",
+            "origin": "uwear.app_report",
+            "payload": payload,
+            "summary": payload["message"],
+            "desired_outcome": "Admit this customer request for Illo coordination.",
+            "idempotency_key": "app-report:profile-123:1",
+        },
+        ingress_context={"surface": "webhook", "source": "contact-support"},
+    )
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    run = (await session.scalars(select(AgentRunRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert result["status"] == "processed"
+    assert result["ilo_outcome"]["operation"] == "app_report_run_admitted"
+    assert result["ilo_outcome"]["run_id"] == run.id
+    assert result["ilo_outcome"]["ack"] == {
+        "status": "accepted",
+        "message": "Thanks — your issue was received.",
+        "event_id": str(event.id),
+    }
+    assert event.kind == "app_report"
+    assert event.origin == "uwear.app_report"
+    assert event.status == "processed"
+    assert event.action_type == "app_report.run_admitted"
+    assert event.raw_payload == payload
+    assert event.ingress_context == {
+        "surface": "webhook",
+        "source": "contact-support",
+    }
+    assert run.thread_id == f"app-report:{event.id}"
+    assert run.target_ref["kind"] == "app_report"
+    assert run.target_ref["generation_ids"] == [901, "gen-902"]
+    assert run.target_ref["batch_ids"] == [77, "batch-78"]
+    assert run.metadata_["app_report"] == payload
+    assert run.metadata_["inbound_event"]["event_id"] == str(event.id)
+    assert run.metadata_["work_intake"]["event_type"] == "customer_request.issue"
+    assert receipt.target["kind"] == "app_report"
+    assert receipt.target["generation_ids"] == [901, "gen-902"]
+    assert receipt.target["batch_ids"] == [77, "batch-78"]
+    assert receipt.outcome["ack"] == result["ilo_outcome"]["ack"]
+    assert receipt.tool_use["type"] == "app_report_intake"
+    assert receipt.tool_use["status"] == "accepted"


### PR DESCRIPTION
Closes #457.

Illo-side spine of the #440 north-star slice (Reda decision, 2026-07-24): make an in-app "report issue" enter Illo as a **customer-request signal**, in the same lane as the Slack ingest, acked back, and enriched with the reporter's recent generation/batch ids for a deterministic dossier join. **Intake + signal only** — triage/fix/reply, email sweep, cadence/SLA, escalation, watchdogs are out of scope.

## What this delivers (Illo side)
- New `brain/systems/app_report/` package: `build_app_report_work_intake_payload` (validates the app→Illo contract) + `process_app_report_envelope` (admits a customer-request run through the shared `WorkIntakeEvent`/`admit_work` boundary, completes the inbound event `processed` with a reporter ack).
- Registered as an `app_report` envelope kind beside `slack_message` in `SPECIAL_ENVELOPE_HANDLER_PATHS` — reuses the existing `submit_inbound_envelope` (`/webhooks`) ingress; **no bespoke route, no DB migration**.
- `generation_ids` / `batch_ids` survive into run metadata + the decision-receipt target, so a dossier join uses explicit ids, not guesswork.

## ⚠️ Cross-repo — this PR is only half
The `uwearaiapp` `ContactSupportModal` → `contact-support.js` change (call the new Illo intake in addition to Retool, capturing recent generation ids at report time) is a **companion change in that repo**. The exact wire contract (endpoint, envelope shape, payload rules) is in [`.review/457-notes.md`](../blob/illo-qa/457-app-report-intake-signal/.review/457-notes.md). Until it lands, the Retool forward is unchanged and app reports simply aren't yet delivered to Illo.

**Acceptance split:** the receiving lane + ack + id-passthrough are fully satisfied and tested here; "a ContactSupportModal submission produces a signal in Illo" and "reporter sees the ack" depend on the uwearaiapp companion change.

## Verification
`venv/bin/python -m pytest tests/test_app_report_intake.py tests/test_inbound_webhooks.py tests/test_work_intake.py tests/test_slack_teammate.py tests/test_architecture_boundaries.py -q` → **90 passed, 2 skipped** (skips are pre-existing env-dependent inbound_webhooks cases). Worker's broader run: 134 passed, 2 skipped.

## Known maintainability follow-ups (deferred on purpose — NOT blocking this slice)
A thermo-nuclear maintainability review (Codex, cross-family) raised two structural findings, both deliberately deferred because resolving them would refactor the **already-merged Slack lane** + the headless-ask builder — far higher blast radius than this intake spine, and speculative until a third lane exists:
1. The app_report lane **follows** the existing per-lane procedural pattern (authority→trigger→admission→receipt) rather than extracting a shared "surface-admission template" from Slack + app_report. Correct DRY move once there's a third caller; doing it now would rewrite working merged code.
2. The `_inbound_submission_* → _inbound_signal_*` rename generalizes the request builder to `{app_report, inbound_submission}` (inbound signals that thread on `event_id`) but not Slack/headless, which thread differently. The broader "unify all headless target builders" cleanup is its own refactor.

Both are captured as a follow-up refactor ticket. This PR intentionally keeps to the sliced scope.
