### PR TITLE
fix(alembic): resolve double 0036 head — renumber exception_ping_state to 0037

### DIFF
--- a/brain/platform/db/alembic/versions/0037_exception_ping_state.py
+++ b/brain/platform/db/alembic/versions/0037_exception_ping_state.py
@@ -1,7 +1,7 @@
 """Add shared per-Cycle exception-ping throttle state.
 
-Revision ID: 0036_exception_ping_state
-Revises: 0035_open_ask_ledger
+Revision ID: 0037_exception_ping_state
+Revises: 0036_chantier_members_blockers
 Create Date: 2026-07-24
 """
 
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 
-revision = "0036_exception_ping_state"
-down_revision = "0035_open_ask_ledger"
+revision = "0037_exception_ping_state"
+down_revision = "0036_chantier_members_blockers"
 branch_labels = None
 depends_on = None
 

--- a/tests/test_exception_ping_gate.py
+++ b/tests/test_exception_ping_gate.py
@@ -43,7 +43,7 @@ class _SlackClient:
 
 def test_exception_ping_migration_adds_shared_cycle_state_once(monkeypatch):
     migration = importlib.import_module(
-        "brain.platform.db.alembic.versions.0036_exception_ping_state"
+        "brain.platform.db.alembic.versions.0037_exception_ping_state"
     )
     engine = sa.create_engine("sqlite://")
     with engine.begin() as connection:


### PR DESCRIPTION
## What
`main` currently has **two alembic heads**, so `alembic heads` returns two revisions and CI fails for every PR on `tests/test_alembic_config.py::test_alembic_revision_chain_has_single_head` (incl. the unrelated #457 intake PR #458).

**Root cause:** #453 (`0036_chantier_members_blockers`) and #456 (`0036_exception_ping_state`) merged **17 seconds apart** (13:47:02Z / 13:47:19Z), each independently numbered `0036` with `down_revision = "0035_open_ask_ledger"` → a fork with two leaf heads. This is the known parallel-worker migration-number collision.

## Fix
Per **"second-to-merge renumbers"**: `0036_exception_ping_state` (merged second) → `0037_exception_ping_state`, chained after `0036_chantier_members_blockers`.

- Linear chain restored: `0035_open_ask_ledger → 0036_chantier_members_blockers → 0037_exception_ping_state`.
- Both migrations still run; `0037` is a pure column-add so re-ordering after `0036_chantier` is safe.
- Updated the one code reference: `tests/test_exception_ping_gate.py` module-import path.

## Verify (no DB needed)
\`\`\`
cd <worktree> && venv/bin/python -m pytest tests/test_alembic_config.py tests/test_exception_ping_gate.py -q
\`\`\`
- ✅ 27 passed locally, incl. `test_alembic_revision_chain_has_single_head`.
- ✅ `ScriptDirectory.get_heads()` → `['0037_exception_ping_state']` (single head).

## Acceptance
1. `alembic heads` returns exactly one head.
2. Both the chantier-blockers and exception-ping migrations remain applied in order.
3. `test_alembic_revision_chain_has_single_head` goes green — unblocking CI for all open PRs.

## NOT in scope
`main` also fails `tests/test_async_db_boundaries.py::test_production_async_db_debt_metric_is_zero` — a **separate** pre-existing debt-budget regression, not touched here. Flagged for its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)