### PR TITLE
fix(cycles): honor model/thinking overrides on scheduled runs + one effort vocabulary (routing slice 1)

### DIFF
--- a/brain/platform/db/alembic/versions/0037_cycle_model_override_cleanup.py
+++ b/brain/platform/db/alembic/versions/0037_cycle_model_override_cleanup.py
@@ -1,0 +1,31 @@
+"""Clear legacy default Cycle model overrides.
+
+Revision ID: 0037_cycle_model_override_cleanup
+Revises: 0036_chantier_members_blockers, 0036_exception_ping_state
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0037_cycle_model_override_cleanup"
+down_revision = (
+    "0036_chantier_members_blockers",
+    "0036_exception_ping_state",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE cycles "
+        "SET model_override = NULL "
+        "WHERE model_override IN ('', 'default')"
+    )
+
+
+def downgrade() -> None:
+    return None

--- a/brain/platform/providers/__init__.py
+++ b/brain/platform/providers/__init__.py
@@ -1,6 +1,8 @@
 """Provider policy and invocation support."""
 
 from brain.platform.providers.model_policy import (
+    EFFORT_TIERS,
+    EFFORT_TIER_SET,
     SkillRuntimeConfig,
     async_get_default_model,
     get_default_model,
@@ -10,6 +12,8 @@ from brain.platform.providers.model_policy import (
 )
 
 __all__ = [
+    "EFFORT_TIERS",
+    "EFFORT_TIER_SET",
     "SkillRuntimeConfig",
     "async_get_default_model",
     "get_default_model",

--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -13,6 +13,8 @@ from brain.platform.integrations.providers import get_active_provider
 
 DEFAULT_RUNTIME_PROVIDER = "openai"
 DEFAULT_THINKING_TIER = "high"
+EFFORT_TIERS = ("none", "low", "medium", "high", "xhigh")
+EFFORT_TIER_SET = frozenset(EFFORT_TIERS)
 DEFAULT_PROVIDER_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
     "openai": "gpt-5.5",
@@ -43,13 +45,7 @@ PROVIDER_MODEL_OPTIONS: dict[str, tuple[str, ...]] = {
     ),
 }
 
-THINKING_MAP = {
-    "none": "none",
-    "low": "low",
-    "medium": "medium",
-    "high": "high",
-    "xhigh": "xhigh",
-}
+THINKING_MAP = {tier: tier for tier in EFFORT_TIERS}
 
 OPENAI_MODEL_ALIASES = set(PROVIDER_MODEL_OPTIONS["openai"])
 

--- a/brain/systems/context/budget.py
+++ b/brain/systems/context/budget.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import os
 from typing import Any
 
-from brain.platform.providers.model_policy import infer_provider_from_model
+from brain.platform.providers.model_policy import EFFORT_TIER_SET, infer_provider_from_model
 
 DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000
 
@@ -45,6 +45,7 @@ _REASONING_RESERVES = {
     "high": 16_384,
     "xhigh": 24_576,
 }
+assert frozenset(_REASONING_RESERVES) == EFFORT_TIER_SET
 
 
 @dataclass(frozen=True)
@@ -204,4 +205,3 @@ def resolve_model_context_budget(
         target_tokens=target,
         emergency_target_tokens=emergency_target,
     )
-

--- a/brain/systems/cycles/commands.py
+++ b/brain/systems/cycles/commands.py
@@ -7,6 +7,7 @@ from brain.platform.db.models.cycle import Cycle
 from brain.systems.cycles.access import CycleActor
 from brain.systems.cycles.common import (
     canonical_execution_mode,
+    validate_model_override,
     validate_nonempty_trimmed,
     validate_thinking_override,
 )
@@ -62,7 +63,7 @@ async def async_create_cycle(
         schedule_expr=expr,
         timezone=tz_name,
         enabled=enabled,
-        model_override=(model_override or "").strip() or None,
+        model_override=validate_model_override(model_override),
         thinking_override=validate_thinking_override(thinking_override),
         execution_mode=canonical_execution_mode(),
         target_idea_id=target_idea_id,
@@ -116,6 +117,16 @@ async def async_update_cycle(
 ) -> Cycle:
     next_timezone = validate_timezone_name(timezone_name) if _has_patch_value(timezone_name) else cycle.timezone
     next_schedule_expr = cycle.schedule_expr
+    next_model_override = (
+        validate_model_override(model_override)
+        if _is_patch_field_set(model_override)
+        else UNSET_CYCLE_FIELD
+    )
+    next_thinking_override = (
+        validate_thinking_override(thinking_override)
+        if _is_patch_field_set(thinking_override)
+        else UNSET_CYCLE_FIELD
+    )
     if _has_patch_value(run_at):
         next_schedule_expr = build_one_time_schedule_expr(run_at, next_timezone)
     elif _has_patch_value(schedule_expr):
@@ -129,10 +140,10 @@ async def async_update_cycle(
     cycle.schedule_expr = next_schedule_expr
     if _is_patch_field_set(enabled) and enabled is not None:
         cycle.enabled = enabled
-    if _is_patch_field_set(model_override):
-        cycle.model_override = (model_override or "").strip() or None
-    if _is_patch_field_set(thinking_override):
-        cycle.thinking_override = validate_thinking_override(thinking_override)
+    if _is_patch_field_set(next_model_override):
+        cycle.model_override = next_model_override
+    if _is_patch_field_set(next_thinking_override):
+        cycle.thinking_override = next_thinking_override
     if _is_patch_field_set(target_idea_id):
         cycle.target_idea_id = target_idea_id
 

--- a/brain/systems/cycles/common.py
+++ b/brain/systems/cycles/common.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from brain.platform.providers.model_policy import (
+    EFFORT_TIER_SET,
+    PROVIDER_MODEL_OPTIONS,
+    normalize_model_name,
+)
+
 REUSABLE_THREAD_EXECUTION_MODE = "reuse_same_idea"
-VALID_THINKING_OVERRIDES = {"none", "low", "medium", "high", "xhigh"}
+VALID_THINKING_OVERRIDES = EFFORT_TIER_SET
 CYCLE_LEDGER_OUTPUT_TARGET_TYPE = "cycle_ledger"
 THREAD_OUTPUT_TARGET_TYPE = "thread"
 SCHEDULED_CYCLE_ORIGIN = "scheduled_cycle"
@@ -13,6 +19,12 @@ AGENT_TRIGGERED_CYCLE_ORIGIN = "agent_triggered_cycle"
 EXTERNAL_AGENT_TRIGGERED_CYCLE_ORIGIN = "external_agent_triggered_cycle"
 SCHEDULED_DIGEST_RUN_KIND = "scheduled_digest"
 OFF_SLOT_MATERIAL_ALERT_RUN_KIND = "off_slot_material_alert"
+
+_VALID_MODEL_OVERRIDES = frozenset(
+    f"{provider}/{model}"
+    for provider, models in PROVIDER_MODEL_OPTIONS.items()
+    for model in models
+)
 
 
 def validate_nonempty_trimmed(value: str, field_name: str) -> str:
@@ -35,6 +47,28 @@ def validate_thinking_override(value: str | None) -> str | None:
             f"thinking_override must be one of: {', '.join(sorted(VALID_THINKING_OVERRIDES))}"
         )
     return normalized
+
+
+def validate_model_override(value: str | None) -> str | None:
+    raw = str(value or "").strip()
+    if not raw or raw.lower() == "default":
+        return None
+
+    candidate = raw.replace(":", "/", 1)
+    if "/" not in candidate:
+        matches = [
+            f"{provider}/{candidate}"
+            for provider, models in PROVIDER_MODEL_OPTIONS.items()
+            if candidate in models
+        ]
+        candidate = matches[0] if len(matches) == 1 else candidate
+
+    if candidate not in _VALID_MODEL_OVERRIDES:
+        raise ValueError(
+            f"Unknown model_override {raw!r}. Valid options: "
+            f"{', '.join(sorted(_VALID_MODEL_OVERRIDES))}"
+        )
+    return normalize_model_name(candidate)
 
 
 def string_or_none(value) -> str | None:

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
+from brain.platform.providers.model_policy import EFFORT_TIER_SET, normalize_model_name
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
@@ -128,6 +129,7 @@ async def _async_admit_cycle_run(
     user_id: str | None,
     metadata: dict | None,
     cycle_run_id: int,
+    model_policy: dict | None = None,
 ) -> int | None:
     result = await admit_work(
         session,
@@ -137,7 +139,11 @@ async def _async_admit_cycle_run(
             org_id=str((metadata or {}).get("org_id") or ""),
             actor={"id": user_id, "org_id": (metadata or {}).get("org_id")},
             target={"kind": "cortex_idea", "idea_id": idea_id},
-            payload={"message": message, "metadata": dict(metadata or {})},
+            payload={
+                "message": message,
+                "metadata": dict(metadata or {}),
+                "model_policy": dict(model_policy or {}),
+            },
             policy={
                 "priority": priority,
                 "producer": "cycle",
@@ -147,6 +153,32 @@ async def _async_admit_cycle_run(
         ),
     )
     return result.run_id if result.ok else None
+
+
+def _cycle_run_model_policy(cycle: Cycle, run: CycleRun) -> dict[str, str]:
+    context_snapshot = json_dict(getattr(run, "context_snapshot", None))
+    revision_snapshot = context_snapshot.get("revision")
+    if isinstance(revision_snapshot, dict):
+        overrides = revision_snapshot
+    else:
+        overrides = {
+            "model_override": cycle.model_override,
+            "thinking_override": cycle.thinking_override,
+        }
+
+    policy: dict[str, str] = {}
+    raw_model = str(overrides.get("model_override") or "").strip()
+    if raw_model and raw_model.lower() != "default":
+        policy["model"] = normalize_model_name(raw_model)
+
+    thinking = str(overrides.get("thinking_override") or "").strip().lower()
+    if thinking in EFFORT_TIER_SET:
+        policy["thinking"] = thinking
+    elif thinking:
+        logger.warning(
+            "Ignoring invalid thinking_override in CycleRun revision snapshot",
+        )
+    return policy
 
 
 async def _async_maybe_harvest_alert_resolution(session, cycle: Cycle, run: CycleRun) -> dict | None:
@@ -486,6 +518,7 @@ async def async_execute_cycle_run(run_id: int) -> None:
 
         cycle_name = cycle.name
         cycle_user_id = cycle.user_id
+        run_model_policy = _cycle_run_model_policy(cycle, run)
         owner = await uow.session.get(User, cycle.user_id)
         cycle.execution_mode = REUSABLE_THREAD_EXECUTION_MODE
         cycle.reopen_archived = True
@@ -551,6 +584,7 @@ async def async_execute_cycle_run(run_id: int) -> None:
                 user_id=cycle_user_id,
                 metadata=run_metadata,
                 cycle_run_id=run.id,
+                model_policy=run_model_policy,
             )
             if agent_run_id is None:
                 await _finalize_cycle_run(

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 from typing import Any
@@ -10,6 +11,7 @@ from typing import Any
 from sqlalchemy import text
 
 from brain.platform.db.models.idea import Idea
+from brain.platform.providers.model_policy import EFFORT_TIER_SET
 from brain.systems.cortex.project_context.resolution import resolve_effective_project_context
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
@@ -17,11 +19,12 @@ from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill
 from brain.systems.runs.status_questions import build_status_question_context
 from brain.systems.runs.store import AsyncAgentRunStore
 
-_VALID_EFFORT_LEVELS = {"none", "low", "medium", "high", "xhigh"}
 _VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
 THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
+
+logger = logging.getLogger("work_intake")
 
 
 @dataclass(frozen=True)
@@ -164,7 +167,7 @@ def _merge_trigger_metadata(
 def metadata_choice(
     metadata: dict[str, Any],
     keys: tuple[str, ...],
-    valid_values: set[str],
+    valid_values: set[str] | frozenset[str],
     default: str,
 ) -> str:
     for key in keys:
@@ -174,6 +177,10 @@ def metadata_choice(
         value = str(raw).strip().lower()
         if value in valid_values:
             return value
+        logger.warning(
+            "Ignoring invalid metadata value for %s; falling through to lower-priority keys",
+            key,
+        )
     return default
 
 
@@ -183,7 +190,7 @@ def model_policy_from_metadata(metadata: dict[str, Any] | None) -> dict[str, str
     thinking = metadata_choice(
         metadata,
         ("thinking_tier", "effort", "effort_level", "thinking"),
-        _VALID_EFFORT_LEVELS,
+        EFFORT_TIER_SET,
         "",
     )
     if thinking:
@@ -757,6 +764,7 @@ async def _build_agent_run_request(
     idea_id = str(target.get("idea_id") or "")
     if not idea_id:
         raise ValueError("Work intake target requires idea_id for Cortex run admission")
+    payload_model_policy = dict(event.payload or {}).get("model_policy")
     return await _agent_run_request_for_cortex(
         session,
         idea_id=idea_id,
@@ -768,6 +776,9 @@ async def _build_agent_run_request(
         source=event.source,
         producer=producer,
         idempotency_key=idempotency_key,
+        payload_model_policy=(
+            payload_model_policy if isinstance(payload_model_policy, dict) else None
+        ),
     )
 
 
@@ -887,6 +898,7 @@ async def _agent_run_request_for_cortex(
     source: str | None = None,
     producer: str | None = None,
     idempotency_key: str | None = None,
+    payload_model_policy: dict[str, Any] | None = None,
 ) -> AgentRunRequest:
     idea = await _a_get_idea_for_intake(session, idea_id, fallback_user_id=user_id)
     if idea is None:
@@ -942,7 +954,11 @@ async def _agent_run_request_for_cortex(
         recipe=recipe,
         target_ref=target_ref,
         workspace_ref=workspace_ref,
-        model_policy=model_policy_from_metadata(metadata),
+        model_policy=(
+            dict(payload_model_policy)
+            if payload_model_policy
+            else model_policy_from_metadata(metadata)
+        ),
         metadata={
             **metadata,
             "event": event,

--- a/brain/systems/runtime_settings/models.py
+++ b/brain/systems/runtime_settings/models.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.org import Org, User
 from brain.platform.providers.model_policy import (
+    EFFORT_TIERS,
     PROVIDER_MODEL_OPTIONS,
     async_get_default_model,
     async_get_default_thinking,
@@ -27,12 +28,20 @@ OPENAI_MODEL_OPTIONS = [
     RuntimeOption(key="gpt-4.1-mini", label="GPT-4.1 Mini", description="Legacy lightweight fallback."),
 ]
 
+_THINKING_OPTION_DETAILS = {
+    "none": ("None", "No additional reasoning effort."),
+    "low": ("Low", "Faster responses with light reasoning."),
+    "medium": ("Medium", "Balanced reasoning effort."),
+    "high": ("High", "More reasoning for difficult work."),
+    "xhigh": ("Extra High", "Maximum supported reasoning effort."),
+}
 THINKING_OPTIONS = [
-    RuntimeOption(key="none", label="None", description="No additional reasoning effort."),
-    RuntimeOption(key="low", label="Low", description="Faster responses with light reasoning."),
-    RuntimeOption(key="medium", label="Medium", description="Balanced reasoning effort."),
-    RuntimeOption(key="high", label="High", description="More reasoning for difficult work."),
-    RuntimeOption(key="xhigh", label="Extra High", description="Maximum supported reasoning effort."),
+    RuntimeOption(
+        key=tier,
+        label=_THINKING_OPTION_DETAILS[tier][0],
+        description=_THINKING_OPTION_DETAILS[tier][1],
+    )
+    for tier in EFFORT_TIERS
 ]
 
 

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -537,6 +537,55 @@ def test_cycle_router_bad_request_returns_400():
     assert caught.value.detail == "Unknown timezone: Mars/Base"
 
 
+@pytest.mark.parametrize("raw_model", [None, "", "default", "DEFAULT"])
+def test_cycle_run_model_policy_treats_absent_and_default_models_as_org_fallback(
+    raw_model,
+):
+    cycle = Cycle()
+    cycle.model_override = "openai/gpt-5.5"
+    cycle.thinking_override = "high"
+    run = CycleRun()
+    run.context_snapshot = {
+        "revision": {
+            "model_override": raw_model,
+            "thinking_override": None,
+        }
+    }
+
+    assert service._cycle_run_model_policy(cycle, run) == {}
+
+
+def test_cycle_run_model_policy_uses_bound_revision_instead_of_live_cycle():
+    cycle = Cycle()
+    cycle.model_override = "anthropic/claude-opus-4-6"
+    cycle.thinking_override = "low"
+    run = CycleRun()
+    run.context_snapshot = {
+        "revision": {
+            "model_override": "gpt-5.4-mini",
+            "thinking_override": "xhigh",
+        }
+    }
+
+    assert service._cycle_run_model_policy(cycle, run) == {
+        "model": "openai/gpt-5.4-mini",
+        "thinking": "xhigh",
+    }
+
+
+def test_cycle_run_model_policy_falls_back_to_live_cycle_without_snapshot():
+    cycle = Cycle()
+    cycle.model_override = "openai/gpt-5.4-mini"
+    cycle.thinking_override = "low"
+    run = CycleRun()
+    run.context_snapshot = None
+
+    assert service._cycle_run_model_policy(cycle, run) == {
+        "model": "openai/gpt-5.4-mini",
+        "thinking": "low",
+    }
+
+
 def _cycle_for_serialization(*, schedule_expr: str, timezone_name: str) -> Cycle:
     now = datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc)
     cycle = Cycle()
@@ -654,6 +703,55 @@ async def test_cycle_update_validation_failure_does_not_mutate_or_flush():
     assert cycle.timezone == "America/Toronto"
     assert cycle.schedule_expr == "0 9 * * *"
     assert db.flushed is False
+
+
+@pytest.mark.asyncio
+async def test_cycle_update_rejects_unknown_model_with_valid_options():
+    cycle = _cycle_for_serialization(
+        schedule_expr="0 9 * * *",
+        timezone_name="America/Toronto",
+    )
+    db = _RouterCycleSession(cycle)
+
+    with pytest.raises(cycles_router.HTTPException) as caught:
+        await cycles_router.update_cycle(
+            cycle.id,
+            cycles_router.CycleUpdate(model_override="openai/not-a-model"),
+            db=db,
+            user={"id": cycle.user_id, "org_id": None},
+        )
+
+    assert caught.value.status_code == 400
+    assert "Unknown model_override 'openai/not-a-model'" in caught.value.detail
+    assert "openai/gpt-5.4-mini" in caught.value.detail
+    assert cycle.model_override is None
+    assert db.flushed is False
+
+
+@pytest.mark.asyncio
+async def test_cycle_update_stores_canonical_model_and_clears_default():
+    cycle = _cycle_for_serialization(
+        schedule_expr="0 9 * * *",
+        timezone_name="America/Toronto",
+    )
+    db = _RouterCycleSession(cycle)
+
+    response = await cycles_router.update_cycle(
+        cycle.id,
+        cycles_router.CycleUpdate(model_override="gpt-5.4-mini"),
+        db=db,
+        user={"id": cycle.user_id, "org_id": None},
+    )
+    assert response["model_override"] == "openai/gpt-5.4-mini"
+
+    response = await cycles_router.update_cycle(
+        cycle.id,
+        cycles_router.CycleUpdate(model_override="DeFaUlT"),
+        db=db,
+        user={"id": cycle.user_id, "org_id": None},
+    )
+    assert response["model_override"] is None
+
 
 def test_serialize_cycle_does_not_raise_for_legacy_bad_timezone():
     cycle = _cycle_for_serialization(
@@ -1043,6 +1141,18 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
     monkeypatch.setattr(service, "admit_work", fake_admit)
     session = object()
 
+    cycle = Cycle()
+    cycle.model_override = "anthropic/claude-opus-4-6"
+    cycle.thinking_override = "low"
+    cycle_run = CycleRun()
+    cycle_run.context_snapshot = {
+        "revision": {
+            "model_override": "gpt-5.4-mini",
+            "thinking_override": "high",
+        }
+    }
+    model_policy = service._cycle_run_model_policy(cycle, cycle_run)
+
     run_id = await service._async_admit_cycle_run(
         session,
         idea_id="idea-1",
@@ -1051,6 +1161,7 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
         user_id="user-1",
         metadata={"source": "cycle", "cycle_run_id": 12},
         cycle_run_id=12,
+        model_policy=model_policy,
     )
 
     assert run_id == 77
@@ -1061,6 +1172,10 @@ async def test_cycle_run_creation_uses_typed_admission(monkeypatch):
     assert event.target == {"kind": "cortex_idea", "idea_id": "idea-1"}
     assert event.payload["metadata"]["source"] == "cycle"
     assert event.payload["metadata"]["cycle_run_id"] == 12
+    assert event.payload["model_policy"] == {
+        "model": "openai/gpt-5.4-mini",
+        "thinking": "high",
+    }
     assert event.policy["producer"] == "cycle"
     assert event.policy["idempotency_key"] == "cycle_run:12"
     assert event.policy["run_event"] == "thread_reply"

--- a/tests/test_effort_vocabulary.py
+++ b/tests/test_effort_vocabulary.py
@@ -1,0 +1,28 @@
+from brain.platform.db.schemas import skills as skill_schemas
+from brain.platform.providers.model_policy import EFFORT_TIERS, EFFORT_TIER_SET
+from brain.systems.runs.tool_catalog.definitions.brain import BRAIN_TOOLS
+from brain.systems.runs.tool_catalog.handlers import common as handler_common
+from brain.systems.skills import bundles
+
+
+def _tool(name: str) -> dict:
+    return next(tool for tool in BRAIN_TOOLS if tool["name"] == name)
+
+
+def test_effort_vocabulary_contract_matches_all_schema_boundaries():
+    canonical = set(EFFORT_TIER_SET)
+    assert tuple(EFFORT_TIERS) == ("none", "low", "medium", "high", "xhigh")
+
+    manage_skill = _tool("manage_skill")["input_schema"]["properties"]
+    manage_cycle = _tool("manage_cycle")["input_schema"]["properties"]
+    schema_enums = (
+        manage_skill["thinking_tier"]["enum"],
+        manage_skill["skills"]["items"]["properties"]["thinking_tier"]["enum"],
+        manage_cycle["thinking_override"]["enum"],
+    )
+    for enum in schema_enums:
+        assert set(enum) == canonical
+
+    assert set(skill_schemas._REASONING_EFFORTS) == canonical
+    assert set(handler_common._REASONING_EFFORTS) == canonical
+    assert set(bundles._REASONING_EFFORTS) == canonical

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -397,5 +397,109 @@ def test_legacy_routing_logic_is_removed_from_adapters():
         assert not (defined_or_imported & forbidden_names), filename
 
 
+def test_invalid_high_priority_metadata_warns_before_valid_fallback(caplog):
+    from brain.systems.runs.work_intake import model_policy_from_metadata
+
+    with caplog.at_level("WARNING", logger="work_intake"):
+        policy = model_policy_from_metadata(
+            {
+                "thinking_tier": "turbo",
+                "effort": "high",
+            }
+        )
+
+    assert policy["thinking"] == "high"
+    assert (
+        "Ignoring invalid metadata value for thinking_tier; "
+        "falling through to lower-priority keys"
+    ) in caplog.messages
+
+
 def test_cortex_thread_binding_compatibility_shell_is_removed():
     assert not Path("brain/systems/runs/cortex/thread_binding.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_cycle_payload_model_policy_reaches_cortex_run_request(monkeypatch):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    class _Session:
+        async def get(self, _model, _idea_id):
+            return SimpleNamespace(
+                id="idea-1",
+                title="Cycle thread",
+                org_id="org-1",
+                user_id="owner-1",
+                agent_details=None,
+            )
+
+        async def scalars(self, *_args, **_kwargs):
+            return SimpleNamespace(first=lambda: None)
+
+    async def fake_thread_context(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "brain.systems.runs.work_intake.async_build_agent_visible_thread_context",
+        fake_thread_context,
+    )
+
+    trigger = _trigger_payload(
+        source="cycle",
+        event_type="cycle.due_run",
+        target={"idea_id": "idea-1"},
+        payload={
+            "message": "Run the mission",
+            "metadata": {"source": "cycle", "cycle_run_id": 12},
+            "model_policy": {"model": "openai/gpt-5.4-mini", "thinking": "low"},
+        },
+        policy={"priority": 1, "run_event": "thread_reply"},
+        idempotency_key="cycle_run:12",
+    )
+
+    request = await build_agent_run_request(_Session(), WorkIntakeEvent.from_trigger_payload(trigger))
+
+    assert request.model_policy == {"model": "openai/gpt-5.4-mini", "thinking": "low"}
+
+
+@pytest.mark.asyncio
+async def test_empty_payload_model_policy_falls_back_to_metadata_parse(monkeypatch):
+    from brain.systems.runs.work_intake import WorkIntakeEvent, build_agent_run_request
+
+    class _Session:
+        async def get(self, _model, _idea_id):
+            return SimpleNamespace(
+                id="idea-1",
+                title="Cycle thread",
+                org_id="org-1",
+                user_id="owner-1",
+                agent_details=None,
+            )
+
+        async def scalars(self, *_args, **_kwargs):
+            return SimpleNamespace(first=lambda: None)
+
+    async def fake_thread_context(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "brain.systems.runs.work_intake.async_build_agent_visible_thread_context",
+        fake_thread_context,
+    )
+
+    trigger = _trigger_payload(
+        source="cycle",
+        event_type="cycle.due_run",
+        target={"idea_id": "idea-1"},
+        payload={
+            "message": "Run the mission",
+            "metadata": {"source": "cycle", "thinking_tier": "medium"},
+            "model_policy": {},
+        },
+        policy={"priority": 1, "run_event": "thread_reply"},
+        idempotency_key="cycle_run:13",
+    )
+
+    request = await build_agent_run_request(_Session(), WorkIntakeEvent.from_trigger_payload(trigger))
+
+    assert request.model_policy == {"thinking": "medium"}


### PR DESCRIPTION
Slice 1 of the model/effort routing PRD (#460). Fixes the headline bug: **cycle `model_override`/`thinking_override` have never routed actual runs** — all 9 prod cycles carry overrides, and their runs land with `model_policy = {}` (verified live on illo-dev 2026-07-24). GitHub Reflex configured for `gpt-5.4-mini`/`low` has been burning `gpt-5.5`/`high` every 15 minutes.

## What changed
- **Admission**: `async_execute_cycle_run` builds `{model, thinking}` from the run's **bound revision snapshot** (`context_snapshot.revision`) — captured before the snapshot refresh, so editing a cycle while a run is queued cannot reroute that run; legacy runs without a snapshot fall back to the live cycle. Passed as `payload.model_policy`.
- **Cortex builder**: now honors a non-empty `payload.model_policy` before falling back to metadata parsing (previously only the headless/inbound builders did — without this the payload was silently dropped and the fix was a no-op; caught in director review with an end-to-end test added).
- **Vocabulary**: canonical `EFFORT_TIERS` in `model_policy.py` replaces five redeclarations; contract test pins the non-importable copies (tool JSON schemas, skill schemas, bundles).
- **Validation**: `model_override` validated at the shared cycle command layer (all three write surfaces — REST, MCP `manage_cycle`, tool handler — route through it). Bare names canonicalize to provider-prefixed; `''`/`'default'` clear; unknown models rejected with the valid options.
- **Migration 0037**: clears legacy `'default'` values AND **merges the two pre-existing 0036 alembic heads** (`0036_chantier_members_blockers` + `0036_exception_ping_state` — main currently has two heads; this restores one). `alembic heads` → exactly `0037_cycle_model_override_cleanup`.
- `metadata_choice` warn-logs invalid higher-priority metadata values before falling through (previously silent).

No-override behavior is byte-identical (empty payload policy falls through to today's metadata parse → org defaults).

## Verification
- 294 tests green across touched surfaces: `test_effort_vocabulary` (new), `test_cycles_service` (+5 new incl. queued-run isolation, write-path rejection, canonical storage), `test_work_intake` (+3 new incl. end-to-end payload→run-request), `test_model_policy`, `test_runtime_settings`, `test_work_intake_full_architecture`, `test_notify_routing`, `test_slash_skill_commands`, `test_cycle_scheduler`, `test_agent_run_runtime`.
- Post-deploy receipt: bump cycle 8 `next_run_at` → new run admits with `model_policy = {"model": "openai/gpt-5.4-mini", "thinking": "low"}`; cycle 2 lands its first real `xhigh` (confirmed intended by Reda).

Implementation: Codex (gpt-5.6-sol, high) per the PRD spec; directed + reviewed by Claude (the payload-drop no-op and empty-dict masking were review catches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)