### PR TITLE
fix(ci): green main — document the exception-ping migration test as a sync harness + let the debt gate guard itself

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -38,8 +38,13 @@ jobs:
         with:
           filters: |
             backend:
+              # scripts/** is backend surface too: fast-suite tests read those
+              # files directly (the async-DB debt gate, scripts/verify.py), so a
+              # script-only change that breaks its own guard test would otherwise
+              # skip the suite that guards it and only fail once it reaches main.
               - "brain/**"
               - "tests/**"
+              - "scripts/**"
               - "requirements*.txt"
               - "requirements-gpu.txt"
               - "pyproject.toml"

--- a/scripts/async_db_debt_metrics.py
+++ b/scripts/async_db_debt_metrics.py
@@ -98,6 +98,10 @@ LEGACY_SYNC_TEST_HARNESSES = {
         "sqlalchemy_create_engine",
         "sync_session_method_call",
     },
+    "tests/test_exception_ping_gate.py": {
+        "sqlalchemy_create_engine",
+        "sync_session_method_call",
+    },
     "tests/test_pr_tracker_schema_migration.py": {
         "sqlalchemy_create_engine",
         "sync_session_method_call",


### PR DESCRIPTION
Turns `main` green. Two parts, one concern: **the async-DB debt gate should hold, and CI should be able to say so.**

## 1. Document the exception-ping migration test as a sync harness (4 lines)
`test_production_async_db_debt_metric_is_zero` fails on `main` with `sync_sqlalchemy_surface_refs: 4` (budget 0). All 4 refs are in `tests/test_exception_ping_gate.py`, which landed with #454 via #456. That test drives alembic `Operations` — a sync-only API — exactly like the three sibling migration tests already in `LEGACY_SYNC_TEST_HARNESSES`. It was simply never added.

The entry is scoped to `sqlalchemy_create_engine` + `sync_session_method_call`. A *new* kind of sync usage in that file still trips the gate, and no production surface is exempted (`production_sync_shaped_refs` / `api_sync_shaped_refs` / `direct_sync_unit_of_work_refs` stay 0).

## 2. Route `scripts/**` to the backend suite (the reason part 1 was invisible)
The gate script is `scripts/async_db_debt_metrics.py`; its guard test runs in the **backend fast suite**. The changes filter lists `scripts/async_*db*.py` under `db:` only — so a script-only diff selects the DB suite, skips the fast suite, and the one test that guards the gate never runs. That is why this PR's own first CI run showed `Backend fast suite: SKIPPED`. `scripts/**` now selects the backend lane.

## Verification
- `python scripts/async_db_debt_metrics.py --target production` → exit 0; `sync_sqlalchemy_surface_refs` 4 → 0.
- `pytest tests/test_async_db_boundaries.py tests/test_async_db_debt_metrics.py tests/test_exception_ping_gate.py -q` → **59 passed**. Baseline `main` = 1 failed on the same test.
- `origin/main` merged in (at `cfaf82e`), so this PR's CI now runs the fast suite and proves part 1 rather than skipping it.

## Acceptance checks
1. `Backend fast suite` runs on this PR (not skipped) and is green.
2. `test_production_async_db_debt_metric_is_zero` passes; the three production/API zero targets are still 0.
3. `tests/test_exception_ping_gate.py` still passes (13 tests) — behaviour untouched.
4. After merge, `main` CI is green, which unblocks #458, #462 and #466 (all three inherit only this red).

## Not in scope
The double alembic `0036` head is **already resolved on `main`** by #463's `0037_cycle_model_override_cleanup` merge revision — `ScriptDirectory.get_heads()` → `['0038_single_model_effort_routing']`. PR #461 attacked that with a renumber and is now superseded; see the comment there.
