### PR TITLE
fix(routing): one model (gpt-5.6-sol) with effort-only routing + single auth-mode rule

### DIFF
--- a/brain/platform/db/alembic/versions/0038_single_model_effort_routing.py
+++ b/brain/platform/db/alembic/versions/0038_single_model_effort_routing.py
@@ -1,0 +1,51 @@
+"""Route one model with per-cycle effort only.
+
+Illo runs a single strong model and varies reasoning effort. Cycles stop
+pinning their own models (`thinking_override` keeps steering effort), and the
+org default moves to GPT-5.6 Sol with an explicit default effort tier.
+
+Revision ID: 0038_single_model_effort_routing
+Revises: 0037_cycle_model_override_cleanup
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0038_single_model_effort_routing"
+down_revision = "0037_cycle_model_override_cleanup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE cycles SET model_override = NULL WHERE model_override IS NOT NULL")
+    op.execute(
+        """
+        UPDATE orgs
+        SET memory_model_config = COALESCE(memory_model_config, '{}'::jsonb)
+            || jsonb_build_object(
+                'default_provider', 'openai',
+                'default_model', 'openai/gpt-5.6-sol',
+                'default_thinking', COALESCE(
+                    memory_model_config->>'default_thinking', 'high'
+                )
+            )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Per-cycle model pins are intentionally not restored: they are the
+    # configuration this migration retires, and the pre-migration values are
+    # recoverable from cycle_revisions when a specific cycle needs one back.
+    op.execute(
+        """
+        UPDATE orgs
+        SET memory_model_config = COALESCE(memory_model_config, '{}'::jsonb)
+            || jsonb_build_object('default_model', 'openai/gpt-5.5')
+        WHERE memory_model_config->>'default_model' = 'openai/gpt-5.6-sol'
+        """
+    )

--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -17,7 +17,7 @@ EFFORT_TIERS = ("none", "low", "medium", "high", "xhigh")
 EFFORT_TIER_SET = frozenset(EFFORT_TIERS)
 DEFAULT_PROVIDER_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.5",
+    "openai": "gpt-5.6-sol",
 }
 PROVIDER_MODEL_OPTIONS: dict[str, tuple[str, ...]] = {
     "anthropic": (
@@ -317,6 +317,22 @@ async def async_resolve_default_provider(
             preferred_provider=preferred_provider,
         )
     ).provider
+
+
+def required_openai_auth_mode(model: str | None) -> str | None:
+    """Return the OpenAI auth mode a model requires, or None when either works.
+
+    GPT-5.5 and every GPT-5.6 variant are only reachable through the
+    ChatGPT/Codex subscription backend, never an API key. Callers pass the
+    result to credential resolution so a run validates and uses the credential
+    it will actually need.
+    """
+    value = str(model or "").strip().lower()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            value = value[len(prefix):]
+            break
+    return "chatgpt" if value == "gpt-5.5" or value.startswith("gpt-5.6") else None
 
 
 def infer_provider_from_model(model: str | None, default: str | None = None) -> str:

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -10,6 +10,7 @@ from brain.platform.integrations.llm import async_resolve_llm_client
 from brain.platform.providers.model_policy import (
     async_get_default_model,
     infer_provider_from_model,
+    required_openai_auth_mode,
 )
 
 
@@ -43,10 +44,6 @@ def _normalize_model(model: str) -> str:
         if value.startswith(prefix):
             return value[len(prefix):]
     return value
-
-
-def _required_openai_auth_mode(model: str) -> str | None:
-    return "chatgpt" if _normalize_model(model).lower() == "gpt-5.5" else None
 
 
 def _credential_label(model: str, auth_mode: str | None, error_text: str = "") -> str:
@@ -89,7 +86,7 @@ async def async_preflight_cycle_external_auth(
     if provider != "openai":
         return CycleAuthPreflightResult(status="skipped", provider=provider, model=model)
 
-    auth_mode = _required_openai_auth_mode(model)
+    auth_mode = required_openai_auth_mode(model)
     try:
         await async_resolve_llm_client(
             user_id=user_id,

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -49,6 +49,7 @@ from brain.platform.integrations.provider_error_sentinel import (
 from brain.platform.providers.model_policy import (
     async_get_default_model,
     infer_provider_from_model,
+    required_openai_auth_mode,
 )
 from brain.systems.runs import introspection as run_introspection
 from brain.systems.runs.direct_loop.final_reply_checker import (
@@ -193,12 +194,6 @@ def _normalize_model(model: str) -> str:
         if model.startswith(prefix):
             return model[len(prefix):]
     return model
-
-
-def _required_openai_auth_mode(model: str) -> str | None:
-    """Return the OpenAI auth mode required by model availability."""
-    normalized = _normalize_model(model).lower()
-    return "chatgpt" if normalized == "gpt-5.5" or normalized.startswith("gpt-5.6") else None
 
 
 _AUTO_OPENAI_AUTH_MODE = object()
@@ -407,7 +402,7 @@ async def _init_llm_async(
     if resolved_llm is None:
         requested_provider = infer_provider_from_model(model)
         auth_mode = (
-            _required_openai_auth_mode(model)
+            required_openai_auth_mode(model)
             if auth_mode_override is _AUTO_OPENAI_AUTH_MODE
             else auth_mode_override
         )

--- a/brain/systems/runs/direct_loop/final_reply_checker.py
+++ b/brain/systems/runs/direct_loop/final_reply_checker.py
@@ -17,6 +17,7 @@ from brain.systems.sessions.harvest import _extract_text
 from brain.platform.providers.model_policy import (
     get_default_model,
     infer_provider_from_model,
+    required_openai_auth_mode,
     resolve_default_provider,
 )
 from brain.systems.runs.direct_loop.final_reply import (
@@ -210,11 +211,6 @@ class FinalReplyReview:
         return payload
 
 
-def _required_openai_auth_mode(model: str) -> str | None:
-    normalized = normalize_model_name(model).lower()
-    return "chatgpt" if normalized == "gpt-5.5" or normalized.startswith("gpt-5.6") else None
-
-
 def _init_llm(
     user_id: str | None,
     session_id: str,
@@ -228,7 +224,7 @@ def _init_llm(
         user_id=user_id,
         org_id=org_id,
         provider=requested_provider,
-        auth_mode=_required_openai_auth_mode(model) if requested_provider == "openai" else None,
+        auth_mode=required_openai_auth_mode(model) if requested_provider == "openai" else None,
     )
     provider = get_provider(llm.provider, llm.client)
     extra_headers = llm.build_request_headers(session_id=session_id)

--- a/brain/systems/runs/predict_rlm_backend.py
+++ b/brain/systems/runs/predict_rlm_backend.py
@@ -25,7 +25,6 @@ from brain.platform.integrations.llm import _resolve_key_from_env, resolve_llm_c
 from brain.platform.integrations.providers import LLMRequest, _merge_streamed_output_into_response, get_provider
 from brain.systems.runs.direct_agent import (
     AgentResult,
-    _required_openai_auth_mode,
     _agent_context,
 )
 from brain.systems.runs.execution_context import snapshot_agent_context
@@ -39,6 +38,7 @@ from brain.platform.providers.model_policy import (
     get_default_model,
     infer_provider_from_model,
     normalize_runtime_provider,
+    required_openai_auth_mode,
     resolve_default_provider,
 )
 
@@ -695,7 +695,7 @@ def _build_openai_illo_dspy_lm(
     session_id: str | None,
 ) -> Any:
     import dspy
-    required_auth_mode = _required_openai_auth_mode(model)
+    required_auth_mode = required_openai_auth_mode(model)
 
     class IlloOpenAIDSPyLM(dspy.LM):
         def __init__(self, model_name: str):

--- a/docs/prd-model-effort-routing.md
+++ b/docs/prd-model-effort-routing.md
@@ -35,13 +35,12 @@ Illo runs everything strong and hot, and almost none of it is intentional:
   and the levers that should distinguish them are broken, fragmented, or dead.
 
 The intended end state, mirroring the director/workhorse routing Reda uses in
-Claude Code: **one default strong model** (org default today `gpt-5.5`;
-`gpt-5.6-sol` when available — the availability fallback for that already
-exists), with **effort as the primary routed knob** — `xhigh` for
-judgment-heavy work, `high` for standard work, `medium`/`low` for
-execution-heavy or reflex work — plus the ability to spawn workers at
-explicitly lower effort or on explicitly cheaper models, and escalation on
-failure instead of defaulting to the ceiling.
+Claude Code: **one model — `gpt-5.6-sol` — everywhere**, with **effort as the
+only routed knob**: `xhigh` for judgment-heavy work, `high` for standard work,
+`medium`/`low` for execution-heavy or reflex work, plus the ability to spawn
+workers at explicitly lower effort, and escalation on failure instead of
+defaulting to the ceiling. Cheaper models are not part of the design; the
+availability fallback to `gpt-5.5` exists only for a 5.6-sol outage.
 
 The stale "fast/deep mode" predates this thinking and should be retired, and
 the audit shows a meaningful amount of model-selection code is dead and should
@@ -257,8 +256,9 @@ run has a skill anchor.
   runtime-settings UI list (`runtime_settings/models.py:15-28`, unprefixed,
   OpenAI-only, rejects non-OpenAI at `:39-51`) and the composer list
   (`runSettings.ts:25-31`, provider-prefixed) are two more hand-maintained
-  copies with different value shapes. The frontend default model is
-  `openai/gpt-5.6-sol` while the backend default is `gpt-5.5`.
+  copies with different value shapes. The frontend default model was
+  `openai/gpt-5.6-sol` while the backend default was `gpt-5.5` (resolved in
+  Slice 1.5 — both are `gpt-5.6-sol` now).
 - The Anthropic side is stale: default `claude-sonnet-4-6`
   (`model_policy.py:17`), a hardcoded `claude-sonnet-4-6` key-verify ping
   (`cortex/_key_utils.py:125`), and no Anthropic-valid effort translation
@@ -293,10 +293,15 @@ run has a skill anchor.
 
 ### Principles
 
-1. **One default strong model; effort is the routed knob.** Model overrides are
-   the sanctioned exception, not the mechanism: a reflex lane may pin a mini
-   model; a verifier may pin the other provider. Everything else varies effort
-   on the org default model.
+1. **One model; effort is the only routed knob.** Illo runs `gpt-5.6-sol`
+   everywhere and varies reasoning effort. Cheap work is cheap because it
+   thinks less, not because it runs on a weaker model: a mini model on a
+   reflex lane trades quality for a saving the effort tiers already deliver,
+   and it splits the fleet across two credential paths (only `gpt-5.5` and
+   `gpt-5.6*` reach the ChatGPT/Codex backend — anything else needs an API
+   key). Model overrides survive for one genuine exception: routing a
+   verifier to the *other provider* for independent review. No cycle pins a
+   model (Reda, 2026-07-24).
 2. **Declarative routing, no LLM router.** Tiers come from configuration
    (org default, cycle override, skill tier) and from the acting agent's
    explicit choice at spawn time. We never spend a model call deciding which
@@ -323,7 +328,7 @@ run has a skill anchor.
 | `xhigh` | Maximum reasoning; judgment where a wrong call is expensive | Coordinator digest/triage verdicts (cycle 2), self-critique audit analysis, adversarial review, prioritization calls |
 | `high` | Default for real work | Interactive chat/thread runs, chantier implementation, promotion-readiness checks (cycle 9), contract repair |
 | `medium` | Execution-heavy, clear-spec | Headless bridge asks (status quo), tracker writes, sweeps, data pulls, formatting, readbacks |
-| `low` | Reflex: classify, filter, ack | GitHub Reflex event lane (cycle 8), Slack monitored-channel triage, title generation, final-reply checker, truth adjudication |
+| `low` | Reflex: classify, filter, ack | GitHub Reflex event lane (cycle 8 — `low` effort on the one model, no mini pin), Slack monitored-channel triage, title generation, final-reply checker, truth adjudication |
 | `none` | No reasoning pass | Pure templating/exports |
 
 Org default stays `high` (made explicit in config rather than implicit in
@@ -352,21 +357,19 @@ value per field), and the effective post-fallback route is recorded at
 execution. The `provider` policy key is retired: provider follows the
 canonical provider-prefixed model id, as execution already re-infers it.
 
-- **Org default** — unchanged mechanism (`memory_model_config`). Rollout flips
-  `default_model` to `openai/gpt-5.6-sol` when available; the availability
-  fallback already covers the transition. `default_thinking: high` gets
-  written explicitly.
+- **Org default** — unchanged mechanism (`memory_model_config`), now
+  `openai/gpt-5.6-sol` with an explicit `default_thinking: high` (migration
+  `0038`); the availability fallback to `gpt-5.5` covers a 5.6-sol outage.
 - **Cycles** — `model_override`/`thinking_override` keep their exact meaning
   and start working (Slice 1), sourced from the run's immutable revision
-  snapshot. Reflex cycles pin cheap models + `low`; judgment cycles pin
-  `xhigh`; everything else inherits.
-- **Per-spawn worker overrides** (Slice 2) — `spawn_worker` gains optional
-  `model` and `effort` parameters, validated against the catalog and tier set,
-  merged over the inherited parent policy field-by-field. This enables the
-  director/workhorse split (coordinator at `xhigh` fanning out `low`/`medium`
-  readers) and the cross-family pattern: both providers are integrated, so a
-  coordinator can spawn a verifier on the other provider (by prefixed model
-  id) for independent review.
+  snapshot. In practice only `thinking_override` is used: reflex cycles
+  declare `low`, judgment cycles `xhigh`, everything else inherits.
+  Migration `0038` clears every existing model pin.
+- **Per-spawn worker overrides** (Slice 2) — `spawn_worker` gains an `effort`
+  parameter (the everyday knob: a coordinator at `xhigh` fans out `low`/
+  `medium` readers on the same model) plus an optional `model` reserved for
+  the cross-provider verifier — both validated, merged field-by-field over
+  the inherited parent policy.
 - **Headless asks** (Slice 3) — caller-suppliable `effort` through a
   whitelist; default `medium`; the dead `tier` key dies; security stamps stay
   forced.
@@ -488,11 +491,27 @@ feature gates. Suggested order; 1–3 are the core value.
 - Tests: snapshot-sourced policy lands on the run; queued-run isolation from
   live cycle edits; absent overrides fall through to org defaults; invalid
   model rejected at write; vocabulary contract test.
-- Live receipt after deploy: bump cycle 8 `next_run_at`, confirm the new run's
-  `model_policy = {"model": "openai/gpt-5.4-mini", "thinking": "low"}` and
-  cycle 2 lands `xhigh`.
+- Live receipt after deploy (with Slice 1.5 applied): bump cycle 8
+  `next_run_at`, confirm the new run's `model_policy = {"thinking": "low"}`
+  on the org-default model, and cycle 2 lands `xhigh`.
 
-### Slice 2 — spawn_worker Model/Effort Overrides
+### Slice 1.5 — Single Model, Shared Auth-Mode Rule (shipped)
+
+Shipped alongside Slice 1 after Reda's single-model call (2026-07-24):
+
+- Org default model is `openai/gpt-5.6-sol` in code
+  (`DEFAULT_PROVIDER_MODELS`) and in org config (migration `0038`, which also
+  writes `default_thinking: high` explicitly and clears every cycle
+  `model_override`).
+- `required_openai_auth_mode` moved into `model_policy.py` as the single
+  owner, replacing three copies. The cycle-preflight copy recognized only
+  `gpt-5.5`, so on a GPT-5.6 default it validated an interchangeable
+  credential while the run required ChatGPT/Codex — the preflight's actionable
+  "reconnect OpenAI" block would have stopped firing exactly when the default
+  moved to 5.6-sol. A contract test now fails if any module redeclares the
+  rule.
+
+### Slice 2 — spawn_worker Effort Overrides
 
 - Optional `model` + `effort` parameters on the tool schema; handler validates
   (catalog + tier set + provider-supported efforts) and merges field-by-field
@@ -574,10 +593,10 @@ feature gates. Suggested order; 1–3 are the core value.
   breakdowns; fix or retire the audit endpoint's stale `metadata["usage"]`
   read.
 
-Runtime rollout steps (not PRs): write `default_thinking: high` explicitly into
-org config; flip `default_model` to `gpt-5.6-sol` when available; update doc
-1155 / cycle missions with the routing guidance (Illo-owned prose, versioned at
-runtime).
+Runtime rollout: the org-default and cycle-pin changes ship as migration `0038`
+rather than manual production writes. The one remaining runtime step is
+updating doc 1155 / cycle missions with the routing guidance (Illo-owned prose,
+versioned at runtime).
 
 ## Out Of Scope
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -73,11 +73,11 @@ class TestModelNormalization:
 
 class TestProviderInference:
     def test_direct_agent_requires_chatgpt_auth_for_subscription_models(self):
-        from brain.systems.runs.direct_agent import _required_openai_auth_mode
+        from brain.systems.runs.direct_agent import required_openai_auth_mode
 
-        assert _required_openai_auth_mode("openai/gpt-5.5") == "chatgpt"
-        assert _required_openai_auth_mode("openai/gpt-5.6-sol") == "chatgpt"
-        assert _required_openai_auth_mode("openai/gpt-5.4") is None
+        assert required_openai_auth_mode("openai/gpt-5.5") == "chatgpt"
+        assert required_openai_auth_mode("openai/gpt-5.6-sol") == "chatgpt"
+        assert required_openai_auth_mode("openai/gpt-5.4") is None
 
     def test_preview_model_falls_back_only_for_model_availability_errors(self):
         from brain.systems.runs.direct_loop.model_fallback import (

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -33,7 +33,7 @@ class TestModelPolicy:
         from brain.platform.providers.model_policy import get_default_model
 
         with patch("brain.platform.providers.model_policy.get_active_provider", return_value="openai"):
-            assert get_default_model() == "openai/gpt-5.5"
+            assert get_default_model() == "openai/gpt-5.6-sol"
 
     def test_openai_model_options_use_native_defaults(self):
         from brain.platform.providers.model_policy import get_provider_model_options
@@ -167,9 +167,9 @@ class TestModelPolicy:
         model, thinking = await async_resolve_skill_model(session, "deploy", user_id="user-1")
 
         assert runtime.provider == "openai"
-        assert runtime.model_name == "gpt-5.5"
+        assert runtime.model_name == "gpt-5.6-sol"
         assert runtime.reasoning_effort == "xhigh"
-        assert model == "openai/gpt-5.5"
+        assert model == "openai/gpt-5.6-sol"
         assert thinking == "xhigh"
 
     def test_run_resolve_model_fallback_uses_selected_provider(self):
@@ -241,7 +241,7 @@ class TestModelPolicy:
             user_id="user-1",
         )
 
-        assert catalogs["openai"]["default"] == "gpt-5.5"
+        assert catalogs["openai"]["default"] == "gpt-5.6-sol"
         assert "gpt-5.5" in catalogs["openai"]["options"]
         assert catalogs["anthropic"]["default"] == "claude-sonnet-4-6"
 

--- a/tests/test_openai_auth_mode.py
+++ b/tests/test_openai_auth_mode.py
@@ -1,0 +1,48 @@
+import pytest
+
+from brain.platform.providers.model_policy import required_openai_auth_mode
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.5",
+        "openai/gpt-5.5",
+        "openai:gpt-5.5",
+        "GPT-5.5",
+        "gpt-5.6-sol",
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6",
+    ],
+)
+def test_subscription_only_models_require_chatgpt_auth(model):
+    assert required_openai_auth_mode(model) == "chatgpt"
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.4", "openai/gpt-5.4-mini", "gpt-4.1", "anthropic/claude-sonnet-4-6", "", None],
+)
+def test_other_models_do_not_pin_an_auth_mode(model):
+    assert required_openai_auth_mode(model) is None
+
+
+def test_cycle_preflight_and_run_agree_on_required_auth_mode():
+    """The preflight must validate the credential the run will actually use.
+
+    A divergent copy in the cycle preflight recognized only gpt-5.5, so a
+    GPT-5.6 cycle validated an interchangeable credential and lost the
+    actionable auth-blocked message when the ChatGPT credential was dead.
+    """
+    from brain.systems.cycles import auth_preflight
+    from brain.systems.runs import direct_agent
+    from brain.systems.runs.direct_loop import final_reply_checker
+
+    for module in (auth_preflight, direct_agent, final_reply_checker):
+        assert not hasattr(module, "_required_openai_auth_mode"), (
+            f"{module.__name__} redeclares the auth-mode rule; import the shared helper"
+        )
+
+    assert auth_preflight.required_openai_auth_mode is required_openai_auth_mode
+    assert direct_agent.required_openai_auth_mode is required_openai_auth_mode
+    assert final_reply_checker.required_openai_auth_mode is required_openai_auth_mode

--- a/tests/test_predict_rlm_backend.py
+++ b/tests/test_predict_rlm_backend.py
@@ -107,7 +107,7 @@ def test_get_agent_worker_backend_settings_remaps_cross_provider_sub_lm(monkeypa
 
     settings = get_agent_worker_backend_settings(org_id="org-1", provider="openai")
 
-    assert settings.predict_rlm_sub_lm == "openai/gpt-5.5"
+    assert settings.predict_rlm_sub_lm == "openai/gpt-5.6-sol"
 
 
 def test_get_agent_worker_backend_settings_falls_back_when_deno_missing(monkeypatch):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -904,7 +904,7 @@ class TestModelCatalog:
 
     def test_get_default_model_openai(self):
         from brain.platform.providers.model_policy import get_default_model
-        assert get_default_model(provider="openai", include_provider_prefix=False) == "gpt-5.5"
+        assert get_default_model(provider="openai", include_provider_prefix=False) == "gpt-5.6-sol"
 
     def test_get_model_options_default(self):
         from brain.platform.providers.model_policy import get_provider_model_options
@@ -918,7 +918,7 @@ class TestModelCatalog:
         from brain.platform.providers.model_policy import get_provider_model_catalogs
         catalogs = get_provider_model_catalogs()
         assert catalogs["anthropic"]["default"] == "claude-sonnet-4-6"
-        assert catalogs["openai"]["default"] == "gpt-5.5"
+        assert catalogs["openai"]["default"] == "gpt-5.6-sol"
         assert "claude-opus-4-6" in catalogs["anthropic"]["options"]
         assert "gpt-5.5" in catalogs["openai"]["options"]
 


### PR DESCRIPTION
Your call: **one model, effort is the only knob.** No cheap-model lanes. This lands that and fixes a bug that was directly in its path.

## Why this was urgent
Slice 1 (#463) made cycle overrides live for the first time — including cycle 8's `model_override = gpt-5.4-mini`. On the next deploy that would have moved the Reflex lane (every 15 min) onto **API-key auth**, because only `gpt-5.5` and `gpt-5.6*` reach the ChatGPT/Codex backend. Clearing the pins removes that, and is what you asked for anyway.

## Changes
- **One model**: `DEFAULT_PROVIDER_MODELS["openai"]` → `gpt-5.6-sol`. Migration **0038** sets the org default, writes `default_thinking: high` explicitly, and clears **every** cycle `model_override`. `thinking_override` keeps steering effort (`low` for Reflex, `xhigh` for Coordinator). Shipping this as a migration rather than manual prod SQL keeps it reviewable and revertible.
- **Auth-mode bug**: `required_openai_auth_mode` now lives once in `model_policy.py`, replacing three copies. The **cycle-preflight copy recognized only `gpt-5.5`** — so the moment the default became 5.6-sol, preflight would validate an interchangeable credential while the run required ChatGPT/Codex, and the actionable "reconnect OpenAI in Settings" block would silently stop firing. A contract test now fails if any module redeclares the rule.
- **PRD** updated: single-model principle replaces "reflex lanes pin cheap models"; Slice 2 becomes effort-first with `model` reserved for the cross-provider verifier; Slice 1.5 recorded as shipped.

## Verification
- **4073 passed**, 76 skipped. Test-expectation updates are limited to the intentional default flip (`gpt-5.5` → `gpt-5.6-sol` in `test_model_policy`, `test_providers`, `test_predict_rlm_backend`).
- `alembic heads` → single head `0038_single_model_effort_routing`.
- Two pre-existing failures on main, unrelated and confirmed by stashing this branch: `test_production_async_db_debt_metric_is_zero` (4 un-exempted sync refs) and 8 GPU/LLM-worker env tests.

**Correction on my earlier report:** I said two auth-mode copies were broken. Only the preflight one was — `final_reply_checker` imports a *different* `normalize_model_name` (from `direct_loop.request`) that strips the prefix, so it was correct. Two same-named functions with opposite behavior is its own footgun, noted for the Slice 6 catalog cleanup.

Post-deploy receipt: bump cycle 8 `next_run_at` → run admits `model_policy = {"thinking": "low"}` on gpt-5.6-sol; cycle 2 lands `xhigh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)