### PR TITLE
feat(routing): provider-generic effort rendering at the transport boundary

### DIFF
--- a/brain/platform/effort.py
+++ b/brain/platform/effort.py
@@ -1,0 +1,52 @@
+"""Canonical reasoning-effort vocabulary and per-provider renderings.
+
+Illo routes one canonical effort ladder everywhere; each provider transport
+renders a canonical tier into its native API value at the request boundary.
+Routing surfaces never speak provider vocabulary, and transports never
+interpret canonical tiers themselves — this module is the only translation.
+
+Deliberately dependency-free so both the provider policy layer and the
+transports can import it without cycles.
+"""
+
+from __future__ import annotations
+
+EFFORT_TIERS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+EFFORT_TIER_SET: frozenset[str] = frozenset(EFFORT_TIERS)
+
+# Canonical tier -> provider-native effort value. None means "omit the
+# reasoning/thinking configuration entirely" for that provider.
+PROVIDER_EFFORT_RENDERINGS: dict[str, dict[str, str | None]] = {
+    "openai": {
+        "none": None,
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "xhigh",
+    },
+    "anthropic": {
+        "none": None,
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        # Anthropic's ceiling tier is named "max"; canonical xhigh renders to
+        # it so callers can ask for the ceiling without provider vocabulary.
+        "xhigh": "max",
+    },
+}
+
+
+def render_reasoning_effort(provider: str, tier: str | None) -> str | None:
+    """Render a canonical tier to a provider-native effort value.
+
+    Values outside the canonical ladder pass through unchanged so a caller
+    that deliberately speaks a provider's native vocabulary keeps working;
+    "none"/empty always renders to None (omit reasoning).
+    """
+    normalized = str(tier or "").strip().lower()
+    if not normalized or normalized == "none":
+        return None
+    renderings = PROVIDER_EFFORT_RENDERINGS.get(str(provider or "").strip().lower())
+    if renderings is None or normalized not in renderings:
+        return normalized
+    return renderings[normalized]

--- a/brain/platform/integrations/transports/anthropic.py
+++ b/brain/platform/integrations/transports/anthropic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from brain.platform.effort import render_reasoning_effort
 from brain.platform.integrations.transports.base import (
     LLMRequest,
     Provider,
@@ -31,9 +32,10 @@ class AnthropicMessagesTransport:
             kwargs["system"] = request.system
         if request.tools:
             kwargs["tools"] = request.tools
-        if request.reasoning_effort and request.reasoning_effort != "none":
+        effort = render_reasoning_effort("anthropic", request.reasoning_effort)
+        if effort:
             kwargs["thinking"] = {"type": "adaptive"}
-            kwargs["output_config"] = {"effort": request.reasoning_effort}
+            kwargs["output_config"] = {"effort": effort}
         if request.extra_headers:
             kwargs["extra_headers"] = dict(request.extra_headers)
         return kwargs

--- a/brain/platform/integrations/transports/openai_responses.py
+++ b/brain/platform/integrations/transports/openai_responses.py
@@ -8,6 +8,7 @@ import os
 import uuid
 from typing import Any
 
+from brain.platform.effort import render_reasoning_effort
 from brain.platform.integrations.openai_cache import normalize_openai_request_kwargs
 from brain.platform.integrations.transports.base import (
     ContentBlock,
@@ -595,8 +596,9 @@ class OpenAIResponsesTransport:
         if tools:
             openai_kwargs["tools"] = tools
 
-        if request.reasoning_effort and request.reasoning_effort != "none":
-            reasoning = {"effort": request.reasoning_effort}
+        effort = render_reasoning_effort("openai", request.reasoning_effort)
+        if effort:
+            reasoning = {"effort": effort}
             summary = self._reasoning_summary_setting()
             if summary:
                 reasoning["summary"] = summary

--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -8,13 +8,17 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.platform.effort import (
+    EFFORT_TIER_SET,
+    EFFORT_TIERS,
+    PROVIDER_EFFORT_RENDERINGS,
+    render_reasoning_effort,
+)
 from brain.platform.integrations.providers import get_active_provider
 
 
 DEFAULT_RUNTIME_PROVIDER = "openai"
 DEFAULT_THINKING_TIER = "high"
-EFFORT_TIERS = ("none", "low", "medium", "high", "xhigh")
-EFFORT_TIER_SET = frozenset(EFFORT_TIERS)
 DEFAULT_PROVIDER_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
     "openai": "gpt-5.6-sol",
@@ -44,8 +48,6 @@ PROVIDER_MODEL_OPTIONS: dict[str, tuple[str, ...]] = {
         "o3-mini",
     ),
 }
-
-THINKING_MAP = {tier: tier for tier in EFFORT_TIERS}
 
 OPENAI_MODEL_ALIASES = set(PROVIDER_MODEL_OPTIONS["openai"])
 
@@ -374,7 +376,7 @@ def _configured_default_model(config: dict[str, Any], provider: str) -> str | No
 
 def _configured_default_thinking(config: dict[str, Any]) -> str | None:
     value = str(config.get("default_thinking") or "").strip().lower()
-    return value if value in THINKING_MAP else None
+    return value if value in EFFORT_TIER_SET else None
 
 
 def get_default_model(
@@ -472,7 +474,7 @@ def resolve_skill_runtime(
         user_id=user_id,
         org_id=org_id,
     )
-    reasoning_effort = THINKING_MAP.get(thinking_tier, "medium")
+    reasoning_effort = thinking_tier if thinking_tier in EFFORT_TIER_SET else "medium"
 
     return SkillRuntimeConfig(
         provider=provider,
@@ -507,7 +509,7 @@ async def async_resolve_skill_runtime(
         user_id=user_id,
         org_id=org_id,
     )
-    reasoning_effort = THINKING_MAP.get(thinking_tier, "medium")
+    reasoning_effort = thinking_tier if thinking_tier in EFFORT_TIER_SET else "medium"
 
     return SkillRuntimeConfig(
         provider=provider,
@@ -530,7 +532,7 @@ def resolve_skill_routing_profile(
     thinking_tier = row.get("thinking_tier") or "medium"
     return SkillRoutingProfile(
         skill_name=skill_name,
-        reasoning_effort=THINKING_MAP.get(thinking_tier, "medium"),
+        reasoning_effort=thinking_tier if thinking_tier in EFFORT_TIER_SET else "medium",
         thinking_tier=thinking_tier,
     )
 
@@ -544,7 +546,7 @@ async def async_resolve_skill_routing_profile(
     thinking_tier = row.get("thinking_tier") or "medium"
     return SkillRoutingProfile(
         skill_name=skill_name,
-        reasoning_effort=THINKING_MAP.get(thinking_tier, "medium"),
+        reasoning_effort=thinking_tier if thinking_tier in EFFORT_TIER_SET else "medium",
         thinking_tier=thinking_tier,
     )
 

--- a/docs/prd-model-effort-routing.md
+++ b/docs/prd-model-effort-routing.md
@@ -315,7 +315,19 @@ run has a skill anchor.
    set is defined once; providers get an explicit translation (not an identity
    pass-through); invalid declarations are rejected at admission, not silently
    skipped.
-5. **Compatibility constraints.** The two-provider architecture
+5. **Provider-generic core (Reda, 2026-07-24).** Illo happens to run on the
+   ChatGPT/Codex backend today, but nothing outside the provider layer may
+   know that. Routing surfaces (cycles, spawn_worker, headless asks, org
+   config, composer) speak canonical effort tiers and provider-prefixed model
+   ids only. All provider-specific knowledge — native effort vocabulary and
+   its rendering, model catalog, auth requirements, availability fallbacks,
+   pricing, context windows — lives in the provider layer: the effort
+   renderings in `brain/platform/effort.py` (transports render at the request
+   boundary) and, as Slice 6 lands, the per-model catalog contract.
+   Connecting a new provider = a transport + an effort rendering + catalog
+   entries; zero changes to routing surfaces. The completeness contract test
+   fails any provider whose rendering doesn't cover the full ladder.
+6. **Compatibility constraints.** The two-provider architecture
    (`providers.py`) and `memory_model_config` schema are untouched; cycle
    `model_override`/`thinking_override` semantics are preserved (and finally
    honored). No feature gates: each slice is live behavior on merge, verified
@@ -336,14 +348,15 @@ code). `xhigh` is claimed by declaration (cycle override, skill tier, spawn
 parameter, composer pick) — never the ambient default, which also means the
 composer stops defaulting to it (Finding 2 fix).
 
-**Per-provider rendering** (replaces the identity `THINKING_MAP`): canonical
-tiers translate per provider — OpenAI `reasoning.effort` `low/medium/high/
-xhigh`, `none` → omit; Anthropic `output_config.effort` `low/medium/high` with
-`xhigh → max`, `none` → omit (documented floor differences noted in the
-translation table); non-reasoning models get no reasoning kwargs at all. Exact
-accepted values per provider/model are validated at implementation time
-against the live APIs, and the catalog records which efforts each model
-supports (Slice 6 contract).
+**Per-provider rendering** (shipped — replaced the identity `THINKING_MAP`):
+`brain/platform/effort.py` owns the canonical ladder and a per-provider
+rendering table; transports render at the request boundary. Today: OpenAI
+`reasoning.effort` `low/medium/high/xhigh`, `none` → omit; Anthropic
+`output_config.effort` `low/medium/high` with `xhigh → max`, `none` → omit.
+Provider-native values pass through untranslated so deliberate native usage
+keeps working, and a contract test fails any provider whose rendering doesn't
+cover the full ladder. Per-model effort support (non-reasoning models get no
+reasoning kwargs at all) lands with the Slice 6 catalog contract.
 
 ### Routing Surfaces
 
@@ -511,11 +524,27 @@ Shipped alongside Slice 1 after Reda's single-model call (2026-07-24):
   moved to 5.6-sol. A contract test now fails if any module redeclares the
   rule.
 
+### Slice 1.6 — Provider-Generic Effort Rendering (shipped)
+
+Shipped after Reda's provider-genericity direction (2026-07-24):
+
+- Canonical ladder + per-provider renderings moved to the dependency-free
+  leaf `brain/platform/effort.py` (`model_policy` re-exports, so importers
+  are unchanged); both transports render canonical tiers at the request
+  boundary (`render_reasoning_effort`), fixing the latent `xhigh`-on-Anthropic
+  failure (`xhigh → max`, `none` → omit).
+- The misleading identity `THINKING_MAP` is gone; its uses were membership
+  checks, now against `EFFORT_TIER_SET`.
+- Completeness contract test: every provider rendering must cover the full
+  canonical ladder; native values pass through untranslated.
+
 ### Slice 2 — spawn_worker Effort Overrides
 
 - Optional `model` + `effort` parameters on the tool schema; handler validates
   (catalog + tier set + provider-supported efforts) and merges field-by-field
-  over the inherited policy.
+  over the inherited policy. The `model` value may be a provider-prefixed id
+  or a bare provider name meaning "that provider's default model" — the
+  provider-generic spelling of the cross-provider verifier.
 - Child policy is **materialized at spawn**: when inheriting, the parent's
   effective values (not the unresolved dict) are written to the child, so an
   org-config change between spawn and execution cannot silently reroute a

--- a/tests/test_effort_rendering.py
+++ b/tests/test_effort_rendering.py
@@ -1,0 +1,45 @@
+import pytest
+
+from brain.platform.effort import (
+    EFFORT_TIER_SET,
+    EFFORT_TIERS,
+    PROVIDER_EFFORT_RENDERINGS,
+    render_reasoning_effort,
+)
+
+
+def test_every_provider_renders_the_full_canonical_ladder():
+    """Adding a provider without a complete effort mapping must fail loudly."""
+    for provider, renderings in PROVIDER_EFFORT_RENDERINGS.items():
+        assert frozenset(renderings) == EFFORT_TIER_SET, provider
+
+
+@pytest.mark.parametrize("tier", [t for t in EFFORT_TIERS if t != "none"])
+def test_openai_rendering_is_native(tier):
+    assert render_reasoning_effort("openai", tier) == tier
+
+
+def test_anthropic_ceiling_renders_to_max():
+    assert render_reasoning_effort("anthropic", "xhigh") == "max"
+    assert render_reasoning_effort("anthropic", "high") == "high"
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "unknown-provider"])
+@pytest.mark.parametrize("tier", ["none", "", None, "  NONE  "])
+def test_none_and_empty_always_omit_reasoning(provider, tier):
+    assert render_reasoning_effort(provider, tier) is None
+
+
+def test_native_and_unknown_values_pass_through():
+    # A caller deliberately speaking provider vocabulary keeps working.
+    assert render_reasoning_effort("anthropic", "max") == "max"
+    # Unknown providers get the canonical value untranslated.
+    assert render_reasoning_effort("some-new-provider", "xhigh") == "xhigh"
+
+
+def test_model_policy_reexports_the_leaf_vocabulary():
+    from brain.platform import effort
+    from brain.platform.providers import model_policy
+
+    assert model_policy.EFFORT_TIERS is effort.EFFORT_TIERS
+    assert model_policy.EFFORT_TIER_SET is effort.EFFORT_TIER_SET

--- a/tests/test_provider_transports.py
+++ b/tests/test_provider_transports.py
@@ -391,3 +391,54 @@ def test_openai_response_tool_call_output_is_typed():
     assert unified.content[0].id == "call_123"
     assert unified.content[0].name == "brain_recall"
     assert unified.content[0].input == {"query": "typed"}
+
+
+def test_anthropic_transport_renders_canonical_xhigh_as_max():
+    from brain.platform.integrations.transports.anthropic import AnthropicMessagesTransport
+    from brain.platform.integrations.transports.base import LLMRequest
+
+    request = LLMRequest(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning_effort="xhigh",
+    )
+
+    kwargs = AnthropicMessagesTransport().build_kwargs(request)
+
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"] == {"effort": "max"}
+
+
+def test_anthropic_transport_omits_reasoning_for_none_tier():
+    from brain.platform.integrations.transports.anthropic import AnthropicMessagesTransport
+    from brain.platform.integrations.transports.base import LLMRequest
+
+    request = LLMRequest(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning_effort="none",
+    )
+
+    kwargs = AnthropicMessagesTransport().build_kwargs(request)
+
+    assert "thinking" not in kwargs
+    assert "output_config" not in kwargs
+
+
+def test_openai_transport_keeps_canonical_xhigh_and_omits_none():
+    from brain.platform.integrations.transports.base import LLMRequest
+    from brain.platform.integrations.transports.openai_responses import OpenAIResponsesTransport
+
+    ceiling = LLMRequest(
+        model="openai/gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning_effort="xhigh",
+    )
+    assert OpenAIResponsesTransport().build_kwargs(ceiling)["reasoning"]["effort"] == "xhigh"
+
+    silent = LLMRequest(
+        model="openai/gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning_effort="none",
+    )
+    assert "reasoning" not in OpenAIResponsesTransport().build_kwargs(silent)


### PR DESCRIPTION
Lands your "stay generic" direction as an enforced seam, not prose: **routing surfaces speak only canonical effort tiers; each provider transport renders them into its native vocabulary at the request boundary.**

## Changes
- **New leaf `brain/platform/effort.py`** owns the canonical ladder (`none/low/medium/high/xhigh`) + per-provider renderings. `model_policy` re-exports, so all Slice-1 importers are untouched. Leaf placement is deliberate — transports can't import from `brain.platform.providers` without a circular import through `integrations/providers.py`.
- **Transports render at the boundary**: Anthropic `xhigh → max` (previously passed verbatim — an Anthropic route at ceiling effort would have 400'd, the adversarial review's blocker #1), `none → omit` on both providers. Provider-native values pass through untranslated, so deliberate native usage keeps working.
- **`THINKING_MAP` deleted** — it was an identity map that never mapped anything; its five uses were membership checks, now against `EFFORT_TIER_SET`.
- **Completeness contract test**: every provider rendering must cover the full canonical ladder — wiring a new provider with a partial effort map fails loudly. Connecting a provider = transport + rendering + catalog entries; zero routing-surface changes.
- **PRD**: provider-generic core added as principle 5 (nothing outside the provider layer may know we're on Codex); Slice 1.6 recorded shipped; Slice 2's cross-provider verifier spelled generically (bare provider name = that provider's default model).

## Verification
- 4096 passed, 76 skipped (same exclusions as #465: the pre-existing async-DB debt metric + GPU/LLM-worker env tests).
- New: `test_effort_rendering.py` (ladder completeness, per-provider renderings, native passthrough, re-export identity) + transport cases asserting `xhigh → max` reaches Anthropic `output_config` and `none` omits reasoning on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)