### PR TITLE
fix(cycles): clear model pins in the revision ledger, not just the cycle row

### DIFF
--- a/brain/platform/db/alembic/versions/0039_clear_revision_model_pins.py
+++ b/brain/platform/db/alembic/versions/0039_clear_revision_model_pins.py
@@ -1,0 +1,67 @@
+"""Retire per-cycle model pins in the revision ledger too.
+
+Migration 0038 cleared `cycles.model_override`, but scheduled runs resolve
+their routing from the revision snapshot bound to the run — which is built
+from the newest `cycle_revisions` row, not the live cycle. A cleared cycle
+with a pinned latest revision therefore still routed to the pinned model.
+
+Revisions are an immutable ledger, so this records a new revision per affected
+cycle (carrying the current cycle configuration with no model pin) instead of
+rewriting history. Prior pins stay readable in earlier revisions.
+
+Revision ID: 0039_clear_revision_model_pins
+Revises: 0038_single_model_effort_routing
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0039_clear_revision_model_pins"
+down_revision = "0038_single_model_effort_routing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO cycle_revisions (
+            cycle_id, revision_number, source_type, source_id, rationale,
+            name, prompt, schedule_expr, timezone, enabled,
+            model_override, thinking_override, target_idea_id, context_policy,
+            created_at
+        )
+        SELECT
+            c.id,
+            latest.revision_number + 1,
+            'system',
+            NULL,
+            'Retire per-cycle model pinning: Illo routes one model and varies effort only.',
+            c.name, c.prompt, c.schedule_expr, c.timezone, c.enabled,
+            NULL,
+            c.thinking_override,
+            c.target_idea_id,
+            latest.context_policy,
+            now()
+        FROM cycles c
+        JOIN LATERAL (
+            SELECT revision_number, model_override, context_policy
+            FROM cycle_revisions
+            WHERE cycle_id = c.id
+            ORDER BY revision_number DESC, id DESC
+            LIMIT 1
+        ) latest ON true
+        WHERE c.deleted_at IS NULL
+          AND latest.model_override IS NOT NULL
+          AND btrim(latest.model_override) <> ''
+        """
+    )
+
+
+def downgrade() -> None:
+    # The recorded revisions are ledger history; leave them in place. Restoring
+    # a specific pin means writing a new revision, not deleting this one.
+    return None

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -2752,3 +2752,30 @@ def test_finalize_cycle_run_from_run_skips_terminal_runs(monkeypatch):
 
     assert cycle_run.status == "completed"
     assert cycle.last_status is None
+
+
+def test_cycle_run_model_policy_ignores_live_cycle_when_snapshot_pins_a_model():
+    """A cleared cycle whose bound revision still pins a model keeps the pin.
+
+    This is why migration 0039 records a pin-free revision: clearing
+    `cycles.model_override` alone does not change what a run resolves, because
+    routing reads the revision snapshot bound to the run.
+    """
+    cycle = Cycle()
+    cycle.model_override = None
+    cycle.thinking_override = "low"
+    run = CycleRun()
+    run.context_snapshot = {
+        "revision": {"model_override": "gpt-5.4-mini", "thinking_override": "low"}
+    }
+
+    assert service._cycle_run_model_policy(cycle, run) == {
+        "model": "openai/gpt-5.4-mini",
+        "thinking": "low",
+    }
+
+    run.context_snapshot = {
+        "revision": {"model_override": None, "thinking_override": "low"}
+    }
+
+    assert service._cycle_run_model_policy(cycle, run) == {"thinking": "low"}


### PR DESCRIPTION
Caught during pre-deploy verification against live illo-dev data — **migration 0038 does not actually retire the model pins.**

## The bug
Slice 1 deliberately routes from the **revision snapshot bound to the run** (newest `cycle_revisions` row), not the live cycle — that's what makes queued runs immune to later edits. Migration 0038 only cleared `cycles.model_override`.

Live state on illo-dev right now:
- `cycles.model_override` (cycle 8) = `gpt-5.4-mini` → 0038 would clear it ✅
- `cycle_revisions` revision 5 (cycle 8) = `gpt-5.4-mini` → **untouched** ❌

Since `_cycle_run_model_policy` prefers the snapshot, the next Reflex run would still resolve `{"model": "openai/gpt-5.4-mini", "thinking": "low"}` — the pin Reda retired, plus the API-key auth path that comes with any non-5.6 model. 0038's intent would have silently not landed.

## The fix
0039 records a **new pin-free revision** per affected cycle (carrying current cycle config, `model_override = NULL`) rather than rewriting the immutable ledger — prior pins stay auditable, and 0038's own downgrade note ("recoverable from cycle_revisions") stays true. New revision becomes the newest by `revision_number`, which is exactly what the snapshot selects (`ORDER BY revision_number DESC, id DESC LIMIT 1`).

Regression test pins snapshot-wins semantics in both directions.

## Verification
- `tests/test_cycles_service.py`: 70 passed.
- `alembic heads` → single head `0039_clear_revision_model_pins`.

Same failure class as the Slice 1 review catch: the fix touched the value the *sender* holds, not the one the *consumer* reads.

Note: main-tip CI is currently red on `test_production_async_db_debt_metric_is_zero` (4 un-exempted sync refs) — pre-existing, unrelated to routing, confirmed by stashing on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)