### PR TITLE
refactor(inbound): extract a shared surface-admission template (#459)

### DIFF
--- a/brain/systems/app_report/inbound.py
+++ b/brain/systems/app_report/inbound.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.coercion import optional_text
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.systems.app_report.triggers import (
     APP_REPORT_ENVELOPE_KIND,
@@ -15,7 +16,6 @@ from brain.systems.app_report.triggers import (
 from brain.systems.inbound.handlers import (
     InboundEventCompleter,
     InboundHandlerContext,
-    optional_text,
 )
 from brain.systems.inbound.surface_admission import (
     SurfaceAdmissionSpec,

--- a/brain/systems/app_report/inbound.py
+++ b/brain/systems/app_report/inbound.py
@@ -12,9 +12,17 @@ from brain.systems.app_report.triggers import (
     AppReportValidationError,
     build_app_report_work_intake_payload,
 )
-from brain.systems.inbound.service import _clean_optional, _complete_event
-from brain.systems.inbound.status import STATUS_FAILED, STATUS_PROCESSED
-from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.inbound.handlers import (
+    InboundEventCompleter,
+    InboundHandlerContext,
+    optional_text,
+)
+from brain.systems.inbound.surface_admission import (
+    SurfaceAdmissionSpec,
+    SurfaceIdentity,
+    SurfaceTarget,
+    admit_surface_envelope,
+)
 
 ACTION_APP_REPORT_RUN_ADMITTED = "app_report.run_admitted"
 
@@ -22,124 +30,69 @@ ACTION_APP_REPORT_RUN_ADMITTED = "app_report.run_admitted"
 async def process_app_report_envelope(
     session: AsyncSession,
     *,
-    context: Any,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
+    complete: InboundEventCompleter,
 ) -> dict[str, Any]:
     """Admit one normalized in-app report as a customer-request work signal."""
 
-    authority_user_id = _clean_optional(context.owner_user_id)
-    if not authority_user_id:
-        return await _complete_event(
-            session,
-            event,
-            policy=None,
-            status=STATUS_FAILED,
-            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
-            action_result={
-                "operation": "app_report_run_admission_failed",
-                "reason": "missing_authority_user",
-                "event_id": str(event.id),
-            },
-            confidence=0.0,
-            error="App-report connection has no authority user",
-            target={"kind": APP_REPORT_ENVELOPE_KIND},
-            tool_use={"type": "app_report_intake", "status": "failed"},
-            reasoning_summary="App reports need a connection owner to admit customer-request work.",
-        )
-
-    try:
-        trigger_payload = build_app_report_work_intake_payload(
-            org_id=context.org_id,
-            authority_user_id=authority_user_id,
-            payload=dict(normalized.get("payload") or {}),
-            inbound_event_id=str(event.id),
-            connection_id=context.connection_id,
-            idempotency_key=_clean_optional(normalized.get("idempotency_key")),
-            origin=_clean_optional(normalized.get("origin")),
-        )
-    except AppReportValidationError as exc:
-        return await _complete_event(
-            session,
-            event,
-            policy=None,
-            status=STATUS_FAILED,
-            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
-            action_result={
-                "operation": "app_report_run_admission_failed",
-                "reason": "invalid_app_report_payload",
-                "event_id": str(event.id),
-            },
-            confidence=0.0,
-            error=str(exc),
-            target={"kind": APP_REPORT_ENVELOPE_KIND},
-            tool_use={"type": "app_report_intake", "status": "failed"},
-            reasoning_summary=str(exc),
-        )
-
-    admission = await admit_work(
+    return await admit_surface_envelope(
         session,
-        WorkIntakeEvent.from_trigger_payload(trigger_payload),
+        context=context,
+        event=event,
+        normalized=normalized,
+        complete=complete,
+        spec=APP_REPORT_ADMISSION,
     )
+
+
+async def _resolve_app_report_identity(
+    _session: AsyncSession,
+    context: InboundHandlerContext,
+    _normalized: Mapping[str, Any],
+) -> SurfaceIdentity:
+    return SurfaceIdentity(authority_user_id=optional_text(context.owner_user_id))
+
+
+async def _build_app_report_payload(
+    _session: AsyncSession,
+    context: InboundHandlerContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+    identity: SurfaceIdentity,
+) -> dict[str, Any]:
+    return build_app_report_work_intake_payload(
+        org_id=context.org_id,
+        authority_user_id=str(identity.authority_user_id),
+        payload=dict(normalized.get("payload") or {}),
+        inbound_event_id=str(event.id),
+        connection_id=context.connection_id,
+        idempotency_key=optional_text(normalized.get("idempotency_key")),
+        origin=optional_text(normalized.get("origin")),
+    )
+
+
+def _app_report_target(
+    trigger_payload: Mapping[str, Any],
+    _normalized: Mapping[str, Any],
+) -> SurfaceTarget:
+    return SurfaceTarget(value=dict(trigger_payload.get("target") or {}))
+
+
+def _app_report_ack(
+    event_id: str,
+    _normalized: Mapping[str, Any],
+    trigger_payload: Mapping[str, Any],
+    _target: Mapping[str, Any],
+) -> Mapping[str, Any]:
     report = dict((trigger_payload.get("payload") or {}).get("app_report") or {})
-    target = dict(trigger_payload.get("target") or {})
-    if admission.ok:
-        if admission.run_id is not None:
-            target["run_id"] = admission.run_id
-        ack = _reporter_ack(
-            event_id=str(event.id),
+    return {
+        "ack": _reporter_ack(
+            event_id=event_id,
             report_type=str(report.get("type") or "report"),
         )
-        return await _complete_event(
-            session,
-            event,
-            policy=None,
-            status=STATUS_PROCESSED,
-            action_type=ACTION_APP_REPORT_RUN_ADMITTED,
-            action_result={
-                "operation": "app_report_run_admitted",
-                "run_id": admission.run_id,
-                "event_id": str(event.id),
-                "origin": normalized.get("origin"),
-                "ack": ack,
-            },
-            confidence=1.0,
-            target=target,
-            tool_use={
-                "type": "app_report_intake",
-                "status": "accepted",
-                "run_id": admission.run_id,
-            },
-            reasoning_summary=(
-                "The in-app customer report was acknowledged and admitted through the shared "
-                "work-intake boundary with its deterministic generation and batch references."
-            ),
-            reusable_pattern_candidate={
-                "kind": APP_REPORT_ENVELOPE_KIND,
-                "origin": normalized.get("origin"),
-                "source_kind": context.source_kind,
-            },
-        )
-
-    return await _complete_event(
-        session,
-        event,
-        policy=None,
-        status=STATUS_FAILED,
-        action_type=ACTION_APP_REPORT_RUN_ADMITTED,
-        action_result={
-            "operation": "app_report_run_admission_failed",
-            "reason": admission.skipped_reason or "run_admission_failed",
-            "event_id": str(event.id),
-            "origin": normalized.get("origin"),
-        },
-        confidence=0.0,
-        error=admission.skipped_reason or "run_admission_failed",
-        target=target,
-        tool_use={"type": "app_report_intake", "status": "failed"},
-        reasoning_summary=admission.skipped_reason
-        or "The app report could not be admitted as customer-request work.",
-    )
+    }
 
 
 def _reporter_ack(*, event_id: str, report_type: str) -> dict[str, str]:
@@ -148,6 +101,33 @@ def _reporter_ack(*, event_id: str, report_type: str) -> dict[str, str]:
         "message": f"Thanks — your {report_type.lower()} was received.",
         "event_id": event_id,
     }
+
+
+APP_REPORT_ADMISSION = SurfaceAdmissionSpec(
+    kind=APP_REPORT_ENVELOPE_KIND,
+    action_type=ACTION_APP_REPORT_RUN_ADMITTED,
+    success_operation="app_report_run_admitted",
+    failure_operation="app_report_run_admission_failed",
+    tool_type="app_report_intake",
+    resolve_identity=_resolve_app_report_identity,
+    build_payload=_build_app_report_payload,
+    build_target=_app_report_target,
+    build_ack=_app_report_ack,
+    success_tool_status="accepted",
+    success_reasoning=(
+        "The in-app customer report was acknowledged and admitted through the shared "
+        "work-intake boundary with its deterministic generation and batch references."
+    ),
+    admission_failure_reasoning=(
+        "The app report could not be admitted as customer-request work."
+    ),
+    missing_authority_error="App-report connection has no authority user",
+    missing_authority_reasoning=(
+        "App reports need a connection owner to admit customer-request work."
+    ),
+    payload_error_types=(AppReportValidationError,),
+    invalid_payload_reason="invalid_app_report_payload",
+)
 
 
 __all__ = ["process_app_report_envelope"]

--- a/brain/systems/inbound/handlers.py
+++ b/brain/systems/inbound/handlers.py
@@ -1,0 +1,132 @@
+"""Public contracts and registry for specialized inbound envelope handlers."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.inbound import (
+    InboundEventRow,
+    InboundSourcePolicyRow,
+)
+
+
+@dataclass(frozen=True)
+class InboundHandlerContext:
+    """Resolved connection authority exposed to registered envelope handlers."""
+
+    connection_id: str
+    org_id: str
+    owner_user_id: str | None
+    token_id: str | None
+    scopes: frozenset[str] | None
+    display_name: str | None
+    source_kind: str | None
+
+
+@dataclass(frozen=True)
+class InboundCompletion:
+    """The typed completion requested by an inbound envelope handler."""
+
+    status: str
+    action_type: str
+    action_result: Mapping[str, Any]
+    confidence: float | None
+    policy: InboundSourcePolicyRow | None = None
+    error: str | None = None
+    target: Mapping[str, Any] = field(default_factory=dict)
+    tool_use: Mapping[str, Any] = field(default_factory=dict)
+    reasoning_summary: str | None = None
+    reusable_pattern_candidate: Mapping[str, Any] = field(default_factory=dict)
+
+
+class InboundEventCompleter(Protocol):
+    """Bound receipt/finalization callback supplied by the inbound service."""
+
+    async def __call__(self, completion: InboundCompletion, /) -> dict[str, Any]: ...
+
+
+class InboundEnvelopeHandler(Protocol):
+    """Callable contract for one registered inbound envelope kind."""
+
+    async def __call__(
+        self,
+        session: AsyncSession,
+        *,
+        context: InboundHandlerContext,
+        event: InboundEventRow,
+        normalized: Mapping[str, Any],
+        complete: InboundEventCompleter,
+    ) -> dict[str, Any]: ...
+
+
+InboundHandlerReference = InboundEnvelopeHandler | str
+
+_HANDLERS: dict[str, InboundHandlerReference] = {}
+
+
+def register_inbound_envelope_handler(
+    kind: str,
+    handler: InboundHandlerReference,
+) -> InboundHandlerReference | None:
+    """Register a handler callable or lazy ``module:function`` reference."""
+
+    normalized_kind = str(kind or "").strip()
+    if not normalized_kind:
+        raise ValueError("Inbound envelope handler kind is required")
+    if isinstance(handler, str) and ":" not in handler:
+        raise ValueError("Inbound envelope handler path must be module:function")
+    previous = _HANDLERS.get(normalized_kind)
+    _HANDLERS[normalized_kind] = handler
+    return previous
+
+
+def unregister_inbound_envelope_handler(kind: str) -> InboundHandlerReference | None:
+    """Remove a registration, primarily for isolated extension tests."""
+
+    return _HANDLERS.pop(str(kind or "").strip(), None)
+
+
+def resolve_inbound_envelope_handler(kind: str) -> InboundEnvelopeHandler | None:
+    """Resolve a registered handler without importing unrelated surface modules."""
+
+    reference = _HANDLERS.get(str(kind or "").strip())
+    if reference is None:
+        return None
+    if not isinstance(reference, str):
+        return reference
+    module_name, function_name = reference.split(":", 1)
+    handler = getattr(importlib.import_module(module_name), function_name)
+    return cast(InboundEnvelopeHandler, handler)
+
+
+def optional_text(value: Any) -> str | None:
+    """Return a stripped string or ``None`` for an empty optional value."""
+
+    text = str(value or "").strip()
+    return text or None
+
+
+register_inbound_envelope_handler(
+    "app_report",
+    "brain.systems.app_report.inbound:process_app_report_envelope",
+)
+register_inbound_envelope_handler(
+    "slack_message",
+    "brain.systems.slack.inbound:process_slack_message_envelope",
+)
+
+
+__all__ = [
+    "InboundCompletion",
+    "InboundEnvelopeHandler",
+    "InboundEventCompleter",
+    "InboundHandlerContext",
+    "optional_text",
+    "register_inbound_envelope_handler",
+    "resolve_inbound_envelope_handler",
+    "unregister_inbound_envelope_handler",
+]

--- a/brain/systems/inbound/handlers.py
+++ b/brain/systems/inbound/handlers.py
@@ -103,13 +103,6 @@ def resolve_inbound_envelope_handler(kind: str) -> InboundEnvelopeHandler | None
     return cast(InboundEnvelopeHandler, handler)
 
 
-def optional_text(value: Any) -> str | None:
-    """Return a stripped string or ``None`` for an empty optional value."""
-
-    text = str(value or "").strip()
-    return text or None
-
-
 register_inbound_envelope_handler(
     "app_report",
     "brain.systems.app_report.inbound:process_app_report_envelope",
@@ -125,7 +118,6 @@ __all__ = [
     "InboundEnvelopeHandler",
     "InboundEventCompleter",
     "InboundHandlerContext",
-    "optional_text",
     "register_inbound_envelope_handler",
     "resolve_inbound_envelope_handler",
     "unregister_inbound_envelope_handler",

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import logging
 import os
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 from typing import Any, Mapping, Sequence
@@ -27,6 +25,12 @@ from brain.platform.db.models.inbound import (
 )
 from brain.systems.external_agents import service as external_agents
 from brain.systems.cortex.thread_links import thread_link_payload
+from brain.systems.inbound.handlers import (
+    InboundCompletion,
+    InboundHandlerContext,
+    optional_text,
+    resolve_inbound_envelope_handler,
+)
 from brain.systems.inbound.status import (
     STATUS_FAILED,
     STATUS_PROCESSED,
@@ -48,10 +52,6 @@ ACTION_DOMAIN_PROJECTION_UPSERT = "domain_projection.upsert"
 ACTION_ILO_REQUIRED = "ilo_required"
 SUBMISSION_ENVELOPE_KIND = "submission"
 ACTION_ILLO_SUBMIT_QUEUED = "illo.submit_queued"
-SPECIAL_ENVELOPE_HANDLER_PATHS = {
-    "app_report": "brain.systems.app_report.inbound:process_app_report_envelope",
-    "slack_message": "brain.systems.slack.inbound:process_slack_message_envelope",
-}
 
 DOMAIN_PROJECTION_ACTIONS = frozenset(
     {ACTION_DOMAIN_PROJECTION_UPSERT, "domain_projection", "create_domain_record"}
@@ -68,17 +68,6 @@ MAX_TRIAGE_PAYLOAD_CHARS = 5000
 
 class InboundValidationError(ValueError):
     """Raised when an inbound envelope or configured projection is invalid."""
-
-
-@dataclass(frozen=True)
-class _ConnectionContext:
-    connection_id: str
-    org_id: str
-    owner_user_id: str | None
-    token_id: str | None
-    scopes: frozenset[str] | None
-    display_name: str | None
-    source_kind: str | None
 
 
 def utcnow() -> datetime:
@@ -113,7 +102,7 @@ async def create_source_policy(
         priority=int(priority),
         origin_patterns=[_nonempty(pattern, "origin pattern") for pattern in origin_patterns],
         envelope_kinds=[str(kind or "signal").strip() for kind in (envelope_kinds or ["signal"])],
-        instructions=_clean_optional(instructions),
+        instructions=optional_text(instructions),
         schema_config=dict(schema_config or {}),
         allowed_actions=[str(action).strip() for action in (allowed_actions or []) if str(action).strip()],
         auto_execute_actions=[
@@ -157,7 +146,7 @@ async def create_domain_projection(
         external_id_path=_nonempty(external_id_path, "external_id_path"),
         external_id_field=_nonempty(external_id_field, "external_id_field"),
         field_mapping={str(key): str(value) for key, value in dict(field_mapping).items()},
-        title_path=_clean_optional(title_path),
+        title_path=optional_text(title_path),
         upsert_mode=str(upsert_mode or "upsert"),
         validation_failure_status=str(validation_failure_status or STATUS_REVIEW_REQUIRED),
         metadata_=dict(metadata or {}),
@@ -437,9 +426,9 @@ async def match_source_policy(
 async def _resolve_connection_context(
     session: AsyncSession,
     connection: external_agents.AgentBridgePrincipal | ExternalAgentConnectionRow | Mapping[str, Any],
-) -> _ConnectionContext:
+) -> InboundHandlerContext:
     if isinstance(connection, external_agents.AgentBridgePrincipal):
-        return _ConnectionContext(
+        return InboundHandlerContext(
             connection_id=str(connection.connection_id),
             org_id=str(connection.org_id),
             owner_user_id=str(connection.owner_user_id),
@@ -450,7 +439,7 @@ async def _resolve_connection_context(
         )
 
     if isinstance(connection, ExternalAgentConnectionRow):
-        return _ConnectionContext(
+        return InboundHandlerContext(
             connection_id=str(connection.id),
             org_id=str(connection.org_id),
             owner_user_id=str(connection.owner_user_id),
@@ -463,9 +452,9 @@ async def _resolve_connection_context(
     data = dict(connection)
     connection_id = str(data.get("connection_id") or data.get("id") or "").strip()
     org_id = str(data.get("org_id") or "").strip()
-    owner_user_id = _clean_optional(data.get("owner_user_id") or data.get("authority_user_id"))
-    display_name = _clean_optional(data.get("display_name") or data.get("connection_display_name"))
-    source_kind = _clean_optional(data.get("agent_kind") or data.get("source_kind"))
+    owner_user_id = optional_text(data.get("owner_user_id") or data.get("authority_user_id"))
+    display_name = optional_text(data.get("display_name") or data.get("connection_display_name"))
+    source_kind = optional_text(data.get("agent_kind") or data.get("source_kind"))
     if connection_id and (not org_id or not owner_user_id or not display_name or not source_kind):
         row = await session.get(ExternalAgentConnectionRow, connection_id)
         if row is not None:
@@ -477,18 +466,18 @@ async def _resolve_connection_context(
         raise InboundValidationError("connection_id and org_id are required")
     raw_scopes = data.get("scopes")
     scopes = frozenset(str(scope) for scope in _as_list(raw_scopes)) if raw_scopes is not None else None
-    return _ConnectionContext(
+    return InboundHandlerContext(
         connection_id=connection_id,
         org_id=org_id,
         owner_user_id=owner_user_id,
-        token_id=_clean_optional(data.get("token_id")),
+        token_id=optional_text(data.get("token_id")),
         scopes=scopes,
         display_name=display_name,
         source_kind=source_kind,
     )
 
 
-def _require_signal_scope(context: _ConnectionContext) -> None:
+def _require_signal_scope(context: InboundHandlerContext) -> None:
     if context.scopes is None:
         return
     required = getattr(external_agents, "SCOPE_SIGNAL_SUBMIT", "signal:submit")
@@ -518,10 +507,10 @@ def _normalize_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "kind": kind,
         "origin": origin,
         "payload": dict(payload),
-        "summary": _clean_optional(data.get("summary")),
+        "summary": optional_text(data.get("summary")),
         "hints": dict(hints),
-        "desired_outcome": _clean_optional(data.get("desired_outcome")),
-        "idempotency_key": _clean_optional(data.get("idempotency_key")),
+        "desired_outcome": optional_text(data.get("desired_outcome")),
+        "idempotency_key": optional_text(data.get("idempotency_key")),
     }
     if kind == SUBMISSION_ENVELOPE_KIND:
         normalized.update(_normalize_submission_fields(data, normalized["payload"]))
@@ -531,7 +520,7 @@ def _normalize_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _normalize_submission_fields(data: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
-    message = _clean_optional(data.get("message")) or _clean_optional(payload.get("message"))
+    message = optional_text(data.get("message")) or optional_text(payload.get("message"))
     source = data.get("source", payload.get("source", {}))
     constraints = data.get("constraints", payload.get("constraints", {}))
     correlation = data.get("correlation", payload.get("correlation", {}))
@@ -571,7 +560,7 @@ def _normalize_submission_fields(data: Mapping[str, Any], payload: Mapping[str, 
 
 async def _find_idempotent_event(
     session: AsyncSession,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     idempotency_key: str | None,
 ) -> InboundEventRow | None:
     if not idempotency_key:
@@ -589,7 +578,7 @@ async def _find_idempotent_event(
 
 async def _store_inbound_event(
     session: AsyncSession,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
 ) -> tuple[InboundEventRow, bool]:
     try:
@@ -607,18 +596,37 @@ async def _store_inbound_event(
 async def _process_registered_envelope(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
 ) -> dict[str, Any] | None:
-    handler_path = SPECIAL_ENVELOPE_HANDLER_PATHS.get(str(normalized.get("kind") or ""))
-    if handler_path is None:
+    handler = resolve_inbound_envelope_handler(str(normalized.get("kind") or ""))
+    if handler is None:
         return None
 
-    module_name, function_name = handler_path.split(":", 1)
-    module = importlib.import_module(module_name)
-    handler = getattr(module, function_name)
-    return await handler(session, context=context, event=event, normalized=normalized)
+    async def complete(completion: InboundCompletion) -> dict[str, Any]:
+        return await _complete_event(
+            session,
+            event,
+            policy=completion.policy,
+            status=completion.status,
+            action_type=completion.action_type,
+            action_result=completion.action_result,
+            confidence=completion.confidence,
+            error=completion.error,
+            target=completion.target,
+            tool_use=completion.tool_use,
+            reasoning_summary=completion.reasoning_summary,
+            reusable_pattern_candidate=completion.reusable_pattern_candidate,
+        )
+
+    return await handler(
+        session,
+        context=context,
+        event=event,
+        normalized=normalized,
+        complete=complete,
+    )
 
 
 async def _projection_for_policy(
@@ -640,7 +648,7 @@ async def _projection_for_policy(
 async def _apply_domain_projection(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     envelope: Mapping[str, Any],
     projection: InboundDomainProjectionRow,
@@ -767,7 +775,7 @@ async def _get_projection_key(
 async def _claim_projection_key(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     projection: InboundDomainProjectionRow,
     external_id: str,
     record_id: int | None = None,
@@ -887,7 +895,7 @@ async def _complete_event_with_illo_triage(
     session: AsyncSession,
     event: InboundEventRow,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     normalized: Mapping[str, Any],
     policy: InboundSourcePolicyRow | None,
     status: str,
@@ -945,7 +953,7 @@ def _github_repo_from_origin(origin: "str | None") -> "str | None":
 async def _queue_illo_triage(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
     policy: InboundSourcePolicyRow | None,
@@ -1098,7 +1106,7 @@ async def _queue_illo_triage(
 
 def _triage_thread_message(
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
     policy: InboundSourcePolicyRow | None,
@@ -1141,7 +1149,7 @@ def _triage_thread_message(
 
 
 def _inbound_event_metadata(
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
     policy: InboundSourcePolicyRow | None,
@@ -1182,7 +1190,7 @@ def _triage_tool_use(triage: Mapping[str, Any]) -> dict[str, Any]:
 async def _process_submission_envelope(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -1222,7 +1230,7 @@ async def _process_submission_envelope(
 async def _queue_illo_submission(
     session: AsyncSession,
     *,
-    context: _ConnectionContext,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -1335,7 +1343,7 @@ def _submission_tool_use(handling: Mapping[str, Any]) -> dict[str, Any]:
 
 def _with_thread_links(outcome: Mapping[str, Any]) -> dict[str, Any]:
     result = dict(outcome or {})
-    thread_id = _clean_optional(result.get("thread_id") or result.get("idea_id"))
+    thread_id = optional_text(result.get("thread_id") or result.get("idea_id"))
     if not thread_id:
         return result
     links = thread_link_payload(thread_id)
@@ -1414,7 +1422,7 @@ def _result_from_event(event: InboundEventRow, *, idempotent_replay: bool = Fals
     }
 
 
-def _source_actor(context: _ConnectionContext) -> dict[str, Any]:
+def _source_actor(context: InboundHandlerContext) -> dict[str, Any]:
     return {
         "type": "external_source_connection",
         "connection_id": context.connection_id,
@@ -1483,13 +1491,8 @@ def _as_list(value: Any) -> list[Any]:
     return [value]
 
 
-def _clean_optional(value: Any) -> str | None:
-    text = str(value or "").strip()
-    return text or None
-
-
 def _nonempty(value: Any, field_name: str) -> str:
-    text = _clean_optional(value)
+    text = optional_text(value)
     if text is None:
         raise InboundValidationError(f"{field_name} is required")
     return text

--- a/brain/systems/inbound/service.py
+++ b/brain/systems/inbound/service.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.coercion import optional_text
 from brain.platform.db.models.domain import DomainRecord
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.idea import Idea, IdeaThread
@@ -28,7 +29,6 @@ from brain.systems.cortex.thread_links import thread_link_payload
 from brain.systems.inbound.handlers import (
     InboundCompletion,
     InboundHandlerContext,
-    optional_text,
     resolve_inbound_envelope_handler,
 )
 from brain.systems.inbound.status import (

--- a/brain/systems/inbound/surface_admission.py
+++ b/brain/systems/inbound/surface_admission.py
@@ -1,0 +1,233 @@
+"""Shared authority-to-receipt lifecycle for direct inbound surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.inbound import InboundEventRow
+from brain.systems.inbound.handlers import (
+    InboundCompletion,
+    InboundEventCompleter,
+    InboundHandlerContext,
+)
+from brain.systems.inbound.status import STATUS_FAILED, STATUS_PROCESSED
+from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+
+
+@dataclass(frozen=True)
+class SurfaceIdentity:
+    """Resolved execution authority plus optional lane-specific identity data."""
+
+    authority_user_id: str | None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SurfaceTarget:
+    """Lane-specific receipt target and successful tool-use context."""
+
+    value: Mapping[str, Any]
+    tool_context: Mapping[str, Any] = field(default_factory=dict)
+
+
+AuthorityResolver = Callable[
+    [AsyncSession, InboundHandlerContext, Mapping[str, Any]],
+    Awaitable[SurfaceIdentity],
+]
+PayloadBuilder = Callable[
+    [
+        AsyncSession,
+        InboundHandlerContext,
+        InboundEventRow,
+        Mapping[str, Any],
+        SurfaceIdentity,
+    ],
+    Awaitable[dict[str, Any]],
+]
+TargetBuilder = Callable[
+    [Mapping[str, Any], Mapping[str, Any]],
+    SurfaceTarget,
+]
+AckBuilder = Callable[
+    [str, Mapping[str, Any], Mapping[str, Any], Mapping[str, Any]],
+    Mapping[str, Any],
+]
+
+
+@dataclass(frozen=True)
+class SurfaceAdmissionSpec:
+    """Everything that genuinely differs between direct inbound surfaces."""
+
+    kind: str
+    action_type: str
+    success_operation: str
+    failure_operation: str
+    tool_type: str
+    resolve_identity: AuthorityResolver
+    build_payload: PayloadBuilder
+    build_target: TargetBuilder
+    success_reasoning: str
+    admission_failure_reasoning: str
+    missing_authority_error: str
+    missing_authority_reasoning: str
+    build_ack: AckBuilder | None = None
+    success_tool_status: str | None = None
+    outcome_target_key: str | None = None
+    payload_error_types: tuple[type[Exception], ...] = ()
+    invalid_payload_reason: str = "invalid_payload"
+
+
+async def admit_surface_envelope(
+    session: AsyncSession,
+    *,
+    context: InboundHandlerContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+    complete: InboundEventCompleter,
+    spec: SurfaceAdmissionSpec,
+) -> dict[str, Any]:
+    """Resolve authority, build a trigger, admit work, and complete its receipt."""
+
+    identity = await spec.resolve_identity(session, context, normalized)
+    if not identity.authority_user_id:
+        return await _complete_failure(
+            complete,
+            spec=spec,
+            event=event,
+            reason="missing_authority_user",
+            error=spec.missing_authority_error,
+            target={"kind": spec.kind},
+            reasoning_summary=spec.missing_authority_reasoning,
+        )
+
+    try:
+        trigger_payload = await spec.build_payload(
+            session,
+            context,
+            event,
+            normalized,
+            identity,
+        )
+    except spec.payload_error_types as exc:
+        return await _complete_failure(
+            complete,
+            spec=spec,
+            event=event,
+            reason=spec.invalid_payload_reason,
+            error=str(exc),
+            target={"kind": spec.kind},
+            reasoning_summary=str(exc),
+        )
+
+    surface_target = spec.build_target(trigger_payload, normalized)
+    target = dict(surface_target.value)
+    admission = await admit_work(
+        session,
+        WorkIntakeEvent.from_trigger_payload(trigger_payload),
+    )
+    if not admission.ok:
+        reason = admission.skipped_reason or "run_admission_failed"
+        return await _complete_failure(
+            complete,
+            spec=spec,
+            event=event,
+            reason=reason,
+            error=reason,
+            target=target,
+            reasoning_summary=admission.skipped_reason or spec.admission_failure_reasoning,
+            origin=normalized.get("origin"),
+            include_target_copy=True,
+        )
+
+    if admission.run_id is not None:
+        target["run_id"] = admission.run_id
+    action_result: dict[str, Any] = {
+        "operation": spec.success_operation,
+        "run_id": admission.run_id,
+        "event_id": str(event.id),
+        "origin": normalized.get("origin"),
+    }
+    if spec.outcome_target_key:
+        action_result[spec.outcome_target_key] = target
+    if spec.build_ack is not None:
+        action_result.update(
+            spec.build_ack(
+                str(event.id),
+                normalized,
+                trigger_payload,
+                target,
+            )
+        )
+
+    tool_use = {
+        "type": spec.tool_type,
+        **(
+            {"status": spec.success_tool_status}
+            if spec.success_tool_status is not None
+            else {}
+        ),
+        "run_id": admission.run_id,
+        **dict(surface_target.tool_context),
+    }
+    return await complete(
+        InboundCompletion(
+            status=STATUS_PROCESSED,
+            action_type=spec.action_type,
+            action_result=action_result,
+            confidence=1.0,
+            target=target,
+            tool_use=tool_use,
+            reasoning_summary=spec.success_reasoning,
+            reusable_pattern_candidate={
+                "kind": spec.kind,
+                "origin": normalized.get("origin"),
+                "source_kind": context.source_kind,
+            },
+        )
+    )
+
+
+async def _complete_failure(
+    complete: InboundEventCompleter,
+    *,
+    spec: SurfaceAdmissionSpec,
+    event: InboundEventRow,
+    reason: str,
+    error: str,
+    target: Mapping[str, Any],
+    reasoning_summary: str,
+    origin: Any = None,
+    include_target_copy: bool = False,
+) -> dict[str, Any]:
+    action_result: dict[str, Any] = {
+        "operation": spec.failure_operation,
+        "reason": reason,
+        "event_id": str(event.id),
+    }
+    if origin is not None:
+        action_result["origin"] = origin
+    if include_target_copy and spec.outcome_target_key:
+        action_result[spec.outcome_target_key] = dict(target)
+    return await complete(
+        InboundCompletion(
+            status=STATUS_FAILED,
+            action_type=spec.action_type,
+            action_result=action_result,
+            confidence=0.0,
+            error=error,
+            target=target,
+            tool_use={"type": spec.tool_type, "status": "failed"},
+            reasoning_summary=reasoning_summary,
+        )
+    )
+
+
+__all__ = [
+    "SurfaceAdmissionSpec",
+    "SurfaceIdentity",
+    "SurfaceTarget",
+    "admit_surface_envelope",
+]

--- a/brain/systems/runs/direct_targets.py
+++ b/brain/systems/runs/direct_targets.py
@@ -1,0 +1,63 @@
+"""Typed registry for direct/headless work-intake targets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class DirectHeadlessTarget:
+    """A registered direct run target with a stable required thread id."""
+
+    kind: str
+    thread_id: str
+    value: Mapping[str, Any]
+
+    @classmethod
+    def from_mapping(cls, target: Mapping[str, Any]) -> "DirectHeadlessTarget":
+        kind = str(target.get("kind") or "").strip()
+        thread_id = str(target.get("thread_id") or "").strip()
+        if not thread_id:
+            raise ValueError(f"{kind or 'Direct/headless'} target requires thread_id")
+        return cls(kind=kind, thread_id=thread_id, value=dict(target))
+
+
+_REGISTERED_DIRECT_TARGET_KINDS: set[str] = set()
+
+
+def register_direct_target_kind(kind: str) -> None:
+    """Register a target kind for the shared direct/headless request builder."""
+
+    normalized_kind = str(kind or "").strip()
+    if not normalized_kind:
+        raise ValueError("Direct/headless target kind is required")
+    _REGISTERED_DIRECT_TARGET_KINDS.add(normalized_kind)
+
+
+def unregister_direct_target_kind(kind: str) -> None:
+    """Remove a registration, primarily for isolated extension tests."""
+
+    _REGISTERED_DIRECT_TARGET_KINDS.discard(str(kind or "").strip())
+
+
+def resolve_direct_target(target: Mapping[str, Any]) -> DirectHeadlessTarget | None:
+    """Normalize a registered target or return ``None`` for another route."""
+
+    kind = str(target.get("kind") or "").strip()
+    if kind not in _REGISTERED_DIRECT_TARGET_KINDS:
+        return None
+    return DirectHeadlessTarget.from_mapping(target)
+
+
+register_direct_target_kind("app_report")
+register_direct_target_kind("external_agent_headless_ask")
+register_direct_target_kind("inbound_submission")
+
+
+__all__ = [
+    "DirectHeadlessTarget",
+    "register_direct_target_kind",
+    "resolve_direct_target",
+    "unregister_direct_target_kind",
+]

--- a/brain/systems/runs/direct_targets.py
+++ b/brain/systems/runs/direct_targets.py
@@ -1,4 +1,8 @@
-"""Typed registry for direct/headless work-intake targets."""
+"""Typed routing for direct/headless work-intake targets.
+
+Legacy per-kind thread-id derivation was deliberately dropped. Direct/headless
+producers must now supply the stable ``thread_id`` required by the target contract.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +12,7 @@ from typing import Any, Mapping
 
 @dataclass(frozen=True)
 class DirectHeadlessTarget:
-    """A registered direct run target with a stable required thread id."""
+    """A supported direct run target with a stable required thread id."""
 
     kind: str
     thread_id: str
@@ -23,41 +27,26 @@ class DirectHeadlessTarget:
         return cls(kind=kind, thread_id=thread_id, value=dict(target))
 
 
-_REGISTERED_DIRECT_TARGET_KINDS: set[str] = set()
-
-
-def register_direct_target_kind(kind: str) -> None:
-    """Register a target kind for the shared direct/headless request builder."""
-
-    normalized_kind = str(kind or "").strip()
-    if not normalized_kind:
-        raise ValueError("Direct/headless target kind is required")
-    _REGISTERED_DIRECT_TARGET_KINDS.add(normalized_kind)
-
-
-def unregister_direct_target_kind(kind: str) -> None:
-    """Remove a registration, primarily for isolated extension tests."""
-
-    _REGISTERED_DIRECT_TARGET_KINDS.discard(str(kind or "").strip())
+DIRECT_TARGET_KINDS: frozenset[str] = frozenset(
+    {
+        "app_report",
+        "external_agent_headless_ask",
+        "inbound_submission",
+    }
+)
 
 
 def resolve_direct_target(target: Mapping[str, Any]) -> DirectHeadlessTarget | None:
     """Normalize a registered target or return ``None`` for another route."""
 
     kind = str(target.get("kind") or "").strip()
-    if kind not in _REGISTERED_DIRECT_TARGET_KINDS:
+    if kind not in DIRECT_TARGET_KINDS:
         return None
     return DirectHeadlessTarget.from_mapping(target)
 
 
-register_direct_target_kind("app_report")
-register_direct_target_kind("external_agent_headless_ask")
-register_direct_target_kind("inbound_submission")
-
-
 __all__ = [
+    "DIRECT_TARGET_KINDS",
     "DirectHeadlessTarget",
-    "register_direct_target_kind",
     "resolve_direct_target",
-    "unregister_direct_target_kind",
 ]

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -14,6 +14,10 @@ from brain.platform.db.models.idea import Idea
 from brain.platform.providers.model_policy import EFFORT_TIER_SET
 from brain.systems.cortex.project_context.resolution import resolve_effective_project_context
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
+from brain.systems.runs.direct_targets import (
+    DirectHeadlessTarget,
+    resolve_direct_target,
+)
 from brain.systems.runs.domain import AgentRunRequest, RunProfile, RunRecipe
 from brain.systems.runs.skill_commands import annotate_metadata_with_slash_skill_commands
 from brain.systems.runs.status_questions import build_status_question_context
@@ -520,31 +524,10 @@ async def _agent_run_request_for_thread_discussion(
     )
 
 
-def _external_agent_headless_thread_id(target: dict[str, Any]) -> str:
-    thread_id = str(target.get("thread_id") or "")
-    if thread_id:
-        return thread_id
-    connection_id = str(target.get("external_agent_connection_id") or "")
-    task_id = str(target.get("external_agent_task_id") or "")
-    if connection_id and task_id:
-        return f"external-agent:{connection_id}:{task_id}"
-    raise ValueError("External agent headless ask requires thread_id or connection/task ids")
-
-
-def _inbound_signal_thread_id(target: dict[str, Any]) -> str:
-    thread_id = str(target.get("thread_id") or "")
-    if thread_id:
-        return thread_id
-    event_id = str(target.get("event_id") or "")
-    if event_id:
-        return f"inbound:{event_id}"
-    raise ValueError("Inbound signal requires event_id or thread_id")
-
-
-def _build_external_agent_headless_request(
+def _build_direct_target_request(
     event: WorkIntakeEvent,
     *,
-    target: dict[str, Any],
+    target: DirectHeadlessTarget,
     metadata: dict[str, Any],
     message: str,
     producer: str,
@@ -555,43 +538,11 @@ def _build_external_agent_headless_request(
     return AgentRunRequest(
         org_id=_event_org_id(event),
         user_id=_event_actor_user_id(event),
-        thread_id=_external_agent_headless_thread_id(target),
+        thread_id=target.thread_id,
         message=message,
         profile=profile,
         recipe=recipe_for_profile(profile, metadata),
-        target_ref=target,
-        workspace_ref=_event_workspace_ref(event),
-        model_policy=_event_model_policy(event, metadata),
-        metadata={
-            **metadata,
-            "event": _event_run_event(event),
-            "priority": priority,
-            "source": event.source,
-            "producer": producer,
-            "idempotency_key": idempotency_key,
-        },
-    )
-
-
-def _build_inbound_signal_request(
-    event: WorkIntakeEvent,
-    *,
-    target: dict[str, Any],
-    metadata: dict[str, Any],
-    message: str,
-    producer: str,
-    idempotency_key: str | None,
-    priority: int,
-) -> AgentRunRequest:
-    profile = profile_from_metadata(metadata)
-    return AgentRunRequest(
-        org_id=_event_org_id(event),
-        user_id=_event_actor_user_id(event),
-        thread_id=_inbound_signal_thread_id(target),
-        message=message,
-        profile=profile,
-        recipe=recipe_for_profile(profile, metadata),
-        target_ref=target,
+        target_ref=dict(target.value),
         workspace_ref=_event_workspace_ref(event),
         model_policy=_event_model_policy(event, metadata),
         metadata={
@@ -739,21 +690,11 @@ async def _build_agent_run_request(
             }
         )
 
-    if target.get("kind") == "external_agent_headless_ask":
-        return _build_external_agent_headless_request(
+    direct_target = resolve_direct_target(target)
+    if direct_target is not None:
+        return _build_direct_target_request(
             event,
-            target=target,
-            metadata=metadata,
-            message=message,
-            producer=producer,
-            idempotency_key=idempotency_key,
-            priority=priority,
-        )
-
-    if target.get("kind") in {"app_report", "inbound_submission"}:
-        return _build_inbound_signal_request(
-            event,
-            target=target,
+            target=direct_target,
             metadata=metadata,
             message=message,
             producer=producer,

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -9,10 +9,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.org import User
-from brain.systems.inbound.service import _clean_optional, _complete_event
-from brain.systems.inbound.status import STATUS_FAILED, STATUS_PROCESSED
+from brain.systems.inbound.handlers import (
+    InboundEventCompleter,
+    InboundHandlerContext,
+    optional_text,
+)
+from brain.systems.inbound.surface_admission import (
+    SurfaceAdmissionSpec,
+    SurfaceIdentity,
+    SurfaceTarget,
+    admit_surface_envelope,
+)
 from brain.systems.personality.person_context import normalize_person_context
-from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.systems.slack.chantier_declare import (
     ChantierDeclareResult,
     apply_chantier_declare_run_contract,
@@ -30,36 +38,46 @@ ACTION_SLACK_RUN_ADMITTED = "slack.run_admitted"
 async def process_slack_message_envelope(
     session: AsyncSession,
     *,
-    context: Any,
+    context: InboundHandlerContext,
     event: InboundEventRow,
     normalized: Mapping[str, Any],
+    complete: InboundEventCompleter,
 ) -> dict[str, Any]:
     """Admit an Illo run for a normalized Slack mention or DM."""
 
+    return await admit_surface_envelope(
+        session,
+        context=context,
+        event=event,
+        normalized=normalized,
+        complete=complete,
+        spec=SLACK_ADMISSION,
+    )
+
+
+async def _resolve_slack_identity(
+    session: AsyncSession,
+    context: InboundHandlerContext,
+    normalized: Mapping[str, Any],
+) -> SurfaceIdentity:
     authority_user_id, person_context = await _slack_run_identity(
         session,
         context=context,
         normalized=normalized,
     )
-    if not authority_user_id:
-        return await _complete_event(
-            session,
-            event,
-            policy=None,
-            status=STATUS_FAILED,
-            action_type=ACTION_SLACK_RUN_ADMITTED,
-            action_result={
-                "operation": "slack_run_admission_failed",
-                "reason": "missing_authority_user",
-                "event_id": str(event.id),
-            },
-            confidence=0.0,
-            error="Slack connection has no authority user",
-            target={"kind": "slack_message"},
-            tool_use={"type": "slack_teammate_run", "status": "failed"},
-            reasoning_summary="Slack events need a connection owner for the permissive self-hosted MVP.",
-        )
+    return SurfaceIdentity(
+        authority_user_id=authority_user_id,
+        details={"person_context": person_context},
+    )
 
+
+async def _build_slack_payload(
+    session: AsyncSession,
+    context: InboundHandlerContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+    identity: SurfaceIdentity,
+) -> dict[str, Any]:
     slack_payload = dict(normalized.get("payload") or {})
     chantier_declare: ChantierDeclareResult | None = None
     chantier_declare_error: str | None = None
@@ -67,7 +85,7 @@ async def process_slack_message_envelope(
         chantier_declare = await maybe_declare_chantier_from_slack(
             session,
             org_id=str(context.org_id),
-            actor_user_id=authority_user_id,
+            actor_user_id=str(identity.authority_user_id),
             origin=str(normalized.get("origin") or ""),
             text=str(slack_payload.get("text") or ""),
             channel_id=str(slack_payload.get("channel_id") or "") or None,
@@ -81,12 +99,12 @@ async def process_slack_message_envelope(
     slack_thread_id = _slack_conversation_thread_id(slack_payload)
     trigger_payload = build_slack_work_intake_payload(
         org_id=context.org_id,
-        authority_user_id=authority_user_id,
+        authority_user_id=str(identity.authority_user_id),
         payload=slack_payload,
         inbound_event_id=str(event.id),
         connection_id=context.connection_id,
-        idempotency_key=_clean_optional(normalized.get("idempotency_key")),
-        person_context=person_context,
+        idempotency_key=optional_text(normalized.get("idempotency_key")),
+        person_context=identity.details.get("person_context"),
     )
     if chantier_declare is not None or chantier_declare_error is not None:
         apply_chantier_declare_run_contract(
@@ -100,10 +118,15 @@ async def process_slack_message_envelope(
         **dict(trigger_payload.get("payload") or {}),
         "metadata": trigger_metadata,
     }
-    admission = await admit_work(
-        session,
-        WorkIntakeEvent.from_trigger_payload(trigger_payload),
-    )
+    return trigger_payload
+
+
+def _slack_target(
+    _trigger_payload: Mapping[str, Any],
+    normalized: Mapping[str, Any],
+) -> SurfaceTarget:
+    slack_payload = dict(normalized.get("payload") or {})
+    slack_thread_id = _slack_conversation_thread_id(slack_payload)
     target = {
         "kind": "slack_message",
         "team_id": slack_payload.get("team_id"),
@@ -112,58 +135,9 @@ async def process_slack_message_envelope(
         "thread_ts": slack_payload.get("thread_ts"),
         "slack_thread_id": slack_thread_id,
     }
-    if admission.ok:
-        if admission.run_id is not None:
-            target["run_id"] = admission.run_id
-        return await _complete_event(
-            session,
-            event,
-            policy=None,
-            status=STATUS_PROCESSED,
-            action_type=ACTION_SLACK_RUN_ADMITTED,
-            action_result={
-                "operation": "slack_run_admitted",
-                "run_id": admission.run_id,
-                "event_id": str(event.id),
-                "origin": normalized.get("origin"),
-                "slack": target,
-            },
-            confidence=1.0,
-            target=target,
-            tool_use={
-                "type": "slack_teammate_run",
-                "run_id": admission.run_id,
-                "slack_thread_id": slack_thread_id,
-            },
-            reasoning_summary=(
-                "Slack mention or DM was admitted as a surface-aware Illo run. Illo decides "
-                "whether to answer directly or create durable Cortex/worker follow-up."
-            ),
-            reusable_pattern_candidate={
-                "kind": SLACK_MESSAGE_ENVELOPE_KIND,
-                "origin": normalized.get("origin"),
-                "source_kind": context.source_kind,
-            },
-        )
-
-    return await _complete_event(
-        session,
-        event,
-        policy=None,
-        status=STATUS_FAILED,
-        action_type=ACTION_SLACK_RUN_ADMITTED,
-        action_result={
-            "operation": "slack_run_admission_failed",
-            "reason": admission.skipped_reason or "run_admission_failed",
-            "event_id": str(event.id),
-            "origin": normalized.get("origin"),
-            "slack": target,
-        },
-        confidence=0.0,
-        error=admission.skipped_reason or "run_admission_failed",
-        target=target,
-        tool_use={"type": "slack_teammate_run", "status": "failed"},
-        reasoning_summary=admission.skipped_reason or "Slack event could not be admitted as an Illo run.",
+    return SurfaceTarget(
+        value=target,
+        tool_context={"slack_thread_id": slack_thread_id},
     )
 
 
@@ -179,7 +153,7 @@ def _slack_conversation_thread_id(payload: Mapping[str, Any]) -> str:
 async def _slack_run_user_id(
     session: AsyncSession,
     *,
-    context: Any,
+    context: InboundHandlerContext,
     normalized: Mapping[str, Any],
 ) -> str | None:
     """Resolve Slack actor mapping, falling back to connection authority."""
@@ -195,13 +169,13 @@ async def _slack_run_user_id(
 async def _slack_run_identity(
     session: AsyncSession,
     *,
-    context: Any,
+    context: InboundHandlerContext,
     normalized: Mapping[str, Any],
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Resolve execution authority and a separate verified speaker identity."""
 
     payload = dict(normalized.get("payload") or {})
-    slack_user_id = _clean_optional(payload.get("slack_user_id"))
+    slack_user_id = optional_text(payload.get("slack_user_id"))
     if slack_user_id:
         connection = await session.get(ExternalAgentConnectionRow, context.connection_id)
         if connection is not None:
@@ -210,7 +184,7 @@ async def _slack_run_identity(
             if isinstance(slack_metadata, Mapping):
                 identity_map = slack_metadata.get("identity_map")
                 if isinstance(identity_map, Mapping):
-                    mapped_user_id = _clean_optional(identity_map.get(slack_user_id))
+                    mapped_user_id = optional_text(identity_map.get(slack_user_id))
                     if mapped_user_id:
                         user = await session.get(User, mapped_user_id)
                         if user is not None and str(user.org_id) == str(context.org_id):
@@ -242,7 +216,7 @@ def _linked_slack_person_context(
     raw_link = slack_links.get(slack_user_id)
     if not isinstance(raw_link, Mapping):
         return None
-    if _clean_optional(raw_link.get("user_id")) != mapped_user_id:
+    if optional_text(raw_link.get("user_id")) != mapped_user_id:
         return None
 
     link_metadata = raw_link.get("metadata")
@@ -250,7 +224,7 @@ def _linked_slack_person_context(
     raw_preferences = link_metadata.get("communication_preferences")
     preferences = dict(raw_preferences) if isinstance(raw_preferences, Mapping) else {}
     if str(channel_type or "").strip().lower() == "im":
-        address_as = _clean_optional(raw_link.get("display_name"))
+        address_as = optional_text(raw_link.get("display_name"))
         if address_as:
             preferences.setdefault("address_as", address_as)
     else:
@@ -266,6 +240,28 @@ def _linked_slack_person_context(
         verified_user_id=mapped_user_id,
     )
     return person_context or None
+
+
+SLACK_ADMISSION = SurfaceAdmissionSpec(
+    kind=SLACK_MESSAGE_ENVELOPE_KIND,
+    action_type=ACTION_SLACK_RUN_ADMITTED,
+    success_operation="slack_run_admitted",
+    failure_operation="slack_run_admission_failed",
+    tool_type="slack_teammate_run",
+    resolve_identity=_resolve_slack_identity,
+    build_payload=_build_slack_payload,
+    build_target=_slack_target,
+    outcome_target_key="slack",
+    success_reasoning=(
+        "Slack mention or DM was admitted as a surface-aware Illo run. Illo decides "
+        "whether to answer directly or create durable Cortex/worker follow-up."
+    ),
+    admission_failure_reasoning="Slack event could not be admitted as an Illo run.",
+    missing_authority_error="Slack connection has no authority user",
+    missing_authority_reasoning=(
+        "Slack events need a connection owner for the permissive self-hosted MVP."
+    ),
+)
 
 
 __all__ = ["process_slack_message_envelope"]

--- a/brain/systems/slack/inbound.py
+++ b/brain/systems/slack/inbound.py
@@ -6,13 +6,13 @@ from typing import Any, Mapping
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from brain.kernel.common.coercion import optional_text
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.org import User
 from brain.systems.inbound.handlers import (
     InboundEventCompleter,
     InboundHandlerContext,
-    optional_text,
 )
 from brain.systems.inbound.surface_admission import (
     SurfaceAdmissionSpec,

--- a/tests/test_surface_admission.py
+++ b/tests/test_surface_admission.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.db.models.open_ask import OpenAsk
+from brain.platform.db.models.org import Org, User
+from brain.systems.inbound.handlers import (
+    InboundEventCompleter,
+    InboundHandlerContext,
+    register_inbound_envelope_handler,
+    unregister_inbound_envelope_handler,
+)
+from brain.systems.inbound.surface_admission import (
+    SurfaceAdmissionSpec,
+    SurfaceIdentity,
+    SurfaceTarget,
+    admit_surface_envelope,
+)
+from brain.systems.runs.direct_targets import (
+    register_direct_target_kind,
+    unregister_direct_target_kind,
+)
+
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+USER_ID = "22222222-2222-4222-8222-222222222222"
+CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
+THIRD_SURFACE_KIND = "hypothetical_third_surface"
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            ExternalAgentConnectionRow.__table__,
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            OpenAsk.__table__,
+            InboundEventRow.__table__,
+            InboundDecisionReceiptRow.__table__,
+        ]
+    )
+
+
+async def _seed_connection(session: AsyncSession) -> ExternalAgentConnectionRow:
+    session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
+    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    connection = ExternalAgentConnectionRow(
+        id=CONNECTION_ID,
+        org_id=ORG_ID,
+        owner_user_id=USER_ID,
+        display_name="Hypothetical surface",
+        agent_kind=THIRD_SURFACE_KIND,
+        transport="webhook",
+        status="online",
+        remote_agent_card={},
+        capabilities={THIRD_SURFACE_KIND: True},
+        auth_metadata={},
+        metadata_={},
+    )
+    session.add(connection)
+    await session.flush()
+    return connection
+
+
+async def _resolve_identity(
+    _session: AsyncSession,
+    context: InboundHandlerContext,
+    _normalized: Mapping[str, Any],
+) -> SurfaceIdentity:
+    return SurfaceIdentity(authority_user_id=context.owner_user_id)
+
+
+async def _build_payload(
+    _session: AsyncSession,
+    context: InboundHandlerContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+    identity: SurfaceIdentity,
+) -> dict[str, Any]:
+    return {
+        "source": THIRD_SURFACE_KIND,
+        "event_type": "hypothetical.requested",
+        "org_id": context.org_id,
+        "actor": {
+            "id": identity.authority_user_id,
+            "org_id": context.org_id,
+            "principal_type": "hypothetical_user",
+        },
+        "target": {
+            "kind": THIRD_SURFACE_KIND,
+            "event_id": str(event.id),
+            "thread_id": f"hypothetical:{event.id}",
+        },
+        "payload": {
+            "run_message": str(
+                (normalized.get("payload") or {}).get("message") or ""
+            ),
+            "workspace_ref": {"source": THIRD_SURFACE_KIND, "mode": "headless"},
+            "metadata": {
+                "headless": True,
+                "execution_profile": "fast",
+            },
+            "user_id": identity.authority_user_id,
+        },
+        "idempotency_key": normalized.get("idempotency_key"),
+        "policy": {
+            "producer": THIRD_SURFACE_KIND,
+            "run_event": "requested",
+        },
+    }
+
+
+def _build_target(
+    trigger_payload: Mapping[str, Any],
+    _normalized: Mapping[str, Any],
+) -> SurfaceTarget:
+    return SurfaceTarget(value=dict(trigger_payload.get("target") or {}))
+
+
+def _build_ack(
+    event_id: str,
+    _normalized: Mapping[str, Any],
+    _trigger_payload: Mapping[str, Any],
+    _target: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return {"ack": {"status": "accepted", "event_id": event_id}}
+
+
+THIRD_SURFACE_ADMISSION = SurfaceAdmissionSpec(
+    kind=THIRD_SURFACE_KIND,
+    action_type="hypothetical.run_admitted",
+    success_operation="hypothetical_run_admitted",
+    failure_operation="hypothetical_run_admission_failed",
+    tool_type="hypothetical_intake",
+    resolve_identity=_resolve_identity,
+    build_payload=_build_payload,
+    build_target=_build_target,
+    build_ack=_build_ack,
+    success_tool_status="accepted",
+    success_reasoning="The hypothetical request was admitted.",
+    admission_failure_reasoning="The hypothetical request could not be admitted.",
+    missing_authority_error="Hypothetical surface has no authority user",
+    missing_authority_reasoning="Hypothetical requests require an authority user.",
+)
+
+
+async def _process_third_surface(
+    session: AsyncSession,
+    *,
+    context: InboundHandlerContext,
+    event: InboundEventRow,
+    normalized: Mapping[str, Any],
+    complete: InboundEventCompleter,
+) -> dict[str, Any]:
+    return await admit_surface_envelope(
+        session,
+        context=context,
+        event=event,
+        normalized=normalized,
+        complete=complete,
+        spec=THIRD_SURFACE_ADMISSION,
+    )
+
+
+def _register_third_surface() -> None:
+    register_direct_target_kind(THIRD_SURFACE_KIND)
+    register_inbound_envelope_handler(THIRD_SURFACE_KIND, _process_third_surface)
+
+
+def _unregister_third_surface() -> None:
+    unregister_inbound_envelope_handler(THIRD_SURFACE_KIND)
+    unregister_direct_target_kind(THIRD_SURFACE_KIND)
+
+
+@pytest.mark.asyncio
+async def test_registered_third_surface_admits_without_work_intake_kind_edit(session):
+    from brain.systems.inbound.service import submit_inbound_envelope
+
+    connection = await _seed_connection(session)
+    work_intake_source = (
+        Path(__file__).resolve().parents[1]
+        / "brain/systems/runs/work_intake.py"
+    ).read_text(encoding="utf-8")
+    assert THIRD_SURFACE_KIND not in work_intake_source
+
+    _register_third_surface()
+    try:
+        result = await submit_inbound_envelope(
+            session,
+            connection=connection,
+            envelope={
+                "kind": THIRD_SURFACE_KIND,
+                "origin": "test.hypothetical",
+                "payload": {"message": "Handle this third-surface request."},
+                "idempotency_key": "hypothetical:1",
+            },
+        )
+    finally:
+        _unregister_third_surface()
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    run = (await session.scalars(select(AgentRunRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert result["status"] == "processed"
+    assert result["ilo_outcome"]["operation"] == "hypothetical_run_admitted"
+    assert run.thread_id == f"hypothetical:{event.id}"
+    assert run.target_ref["kind"] == THIRD_SURFACE_KIND
+    assert receipt.status == "processed"
+    assert receipt.target["kind"] == THIRD_SURFACE_KIND
+    assert receipt.tool_use == {
+        "type": "hypothetical_intake",
+        "status": "accepted",
+        "run_id": run.id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_surface_template_owns_failed_admission_completion(
+    session,
+    monkeypatch,
+):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.runs.work_intake import WorkIntakeResult
+
+    async def reject_work(_session, _event):
+        return WorkIntakeResult(ok=False, skipped_reason="synthetic admission rejection")
+
+    monkeypatch.setattr(
+        "brain.systems.inbound.surface_admission.admit_work",
+        reject_work,
+    )
+    connection = await _seed_connection(session)
+    _register_third_surface()
+    try:
+        result = await submit_inbound_envelope(
+            session,
+            connection=connection,
+            envelope={
+                "kind": THIRD_SURFACE_KIND,
+                "origin": "test.hypothetical",
+                "payload": {"message": "Reject this request."},
+                "idempotency_key": "hypothetical:failed",
+            },
+        )
+    finally:
+        _unregister_third_surface()
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+
+    assert result["status"] == "failed"
+    assert result["error"] == "synthetic admission rejection"
+    assert event.action_type == "hypothetical.run_admitted"
+    assert event.action_result == {
+        "operation": "hypothetical_run_admission_failed",
+        "reason": "synthetic admission rejection",
+        "event_id": str(event.id),
+        "origin": "test.hypothetical",
+    }
+    assert receipt.status == "failed"
+    assert receipt.target == {
+        "kind": THIRD_SURFACE_KIND,
+        "event_id": str(event.id),
+        "thread_id": f"hypothetical:{event.id}",
+    }
+    assert receipt.tool_use == {
+        "type": "hypothetical_intake",
+        "status": "failed",
+    }
+
+
+def test_registered_lane_handlers_use_the_public_typed_contract():
+    root = Path(__file__).resolve().parents[1]
+    for relative_path in (
+        "brain/systems/slack/inbound.py",
+        "brain/systems/app_report/inbound.py",
+    ):
+        source = (root / relative_path).read_text(encoding="utf-8")
+        assert "from brain.systems.inbound.service import" not in source
+        assert "context: Any" not in source
+        assert "_complete_event" not in source
+        assert "_clean_optional" not in source
+        assert "context: InboundHandlerContext" in source
+        assert "complete: InboundEventCompleter" in source
+
+
+def test_registered_direct_target_requires_thread_id():
+    from brain.systems.runs.direct_targets import resolve_direct_target
+
+    register_direct_target_kind(THIRD_SURFACE_KIND)
+    try:
+        with pytest.raises(
+            ValueError,
+            match="hypothetical_third_surface target requires thread_id",
+        ):
+            resolve_direct_target({"kind": THIRD_SURFACE_KIND, "event_id": "event-1"})
+    finally:
+        unregister_direct_target_kind(THIRD_SURFACE_KIND)

--- a/tests/test_surface_admission.py
+++ b/tests/test_surface_admission.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
@@ -8,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
 from brain.platform.db.models.open_ask import OpenAsk
@@ -24,16 +24,14 @@ from brain.systems.inbound.surface_admission import (
     SurfaceTarget,
     admit_surface_envelope,
 )
-from brain.systems.runs.direct_targets import (
-    register_direct_target_kind,
-    unregister_direct_target_kind,
-)
+from brain.systems.runs.direct_targets import DIRECT_TARGET_KINDS
 
 
 ORG_ID = "11111111-1111-4111-8111-111111111111"
 USER_ID = "22222222-2222-4222-8222-222222222222"
 CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
 THIRD_SURFACE_KIND = "hypothetical_third_surface"
+THIRD_SURFACE_TARGET_KIND = "inbound_submission"
 
 
 @pytest.fixture
@@ -42,6 +40,9 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
         [
             Org.__table__,
             User.__table__,
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainRecord.__table__,
             ExternalAgentConnectionRow.__table__,
             AgentRunRow.__table__,
             AgentRunEventRow.__table__,
@@ -52,25 +53,91 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
     )
 
 
-async def _seed_connection(session: AsyncSession) -> ExternalAgentConnectionRow:
+async def _seed_connection(
+    session: AsyncSession,
+    *,
+    surface_kind: str = THIRD_SURFACE_KIND,
+    owner_user_id: str | None = USER_ID,
+) -> ExternalAgentConnectionRow:
     session.add(Org(id=ORG_ID, name="Test Org", slug="test-org"))
-    session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
+    if owner_user_id is not None:
+        session.add(User(id=USER_ID, org_id=ORG_ID, name="Reda", email="reda@example.com"))
     connection = ExternalAgentConnectionRow(
         id=CONNECTION_ID,
         org_id=ORG_ID,
-        owner_user_id=USER_ID,
-        display_name="Hypothetical surface",
-        agent_kind=THIRD_SURFACE_KIND,
+        owner_user_id=owner_user_id,
+        display_name=f"{surface_kind} surface",
+        agent_kind=surface_kind,
         transport="webhook",
         status="online",
         remote_agent_card={},
-        capabilities={THIRD_SURFACE_KIND: True},
+        capabilities={surface_kind: True},
         auth_metadata={},
         metadata_={},
     )
     session.add(connection)
     await session.flush()
     return connection
+
+
+def _surface_envelope(surface_kind: str) -> dict[str, Any]:
+    if surface_kind == "app_report":
+        return {
+            "kind": "app_report",
+            "origin": "uwear.app_report",
+            "payload": {
+                "email": "customer@example.com",
+                "profileId": "profile-123",
+                "type": "Issue",
+                "message": "The generation completed, but the result stayed blank.",
+                "attachments": [],
+                "generation_ids": [901, "gen-902"],
+                "batch_ids": [77, "batch-78"],
+            },
+            "idempotency_key": "app-report:profile-123:surface-test",
+        }
+    if surface_kind == "slack_message":
+        return {
+            "kind": "slack_message",
+            "origin": "slack.app_mention",
+            "payload": {
+                "event_kind": "mention",
+                "team_id": "T789",
+                "channel_id": "C456",
+                "channel_type": "channel",
+                "message_ts": "1716900000.000100",
+                "thread_ts": "1716900000.000100",
+                "slack_user_id": "U123",
+                "text": "<@BILLO> turn this into work",
+            },
+            "idempotency_key": "slack:T789:C456:1716900000.000100",
+        }
+    raise AssertionError(f"Unsupported test surface: {surface_kind}")
+
+
+def _assert_failed_surface_receipt(
+    event: InboundEventRow,
+    receipt: InboundDecisionReceiptRow,
+    *,
+    action_type: str,
+    outcome: Mapping[str, Any],
+    error: str,
+    target: Mapping[str, Any],
+    tool_type: str,
+    reasoning_summary: str,
+) -> None:
+    assert event.status == "failed"
+    assert event.action_type == action_type
+    assert event.action_result == outcome
+    assert event.confidence == 0.0
+    assert event.error == error
+    assert receipt.status == "failed"
+    assert receipt.outcome == outcome
+    assert receipt.confidence == 0.0
+    assert receipt.target == target
+    assert receipt.tool_use == {"type": tool_type, "status": "failed"}
+    assert receipt.reasoning_summary == reasoning_summary
+    assert receipt.reusable_pattern_candidate == {}
 
 
 async def _resolve_identity(
@@ -98,7 +165,7 @@ async def _build_payload(
             "principal_type": "hypothetical_user",
         },
         "target": {
-            "kind": THIRD_SURFACE_KIND,
+            "kind": THIRD_SURFACE_TARGET_KIND,
             "event_id": str(event.id),
             "thread_id": f"hypothetical:{event.id}",
         },
@@ -174,25 +241,18 @@ async def _process_third_surface(
 
 
 def _register_third_surface() -> None:
-    register_direct_target_kind(THIRD_SURFACE_KIND)
     register_inbound_envelope_handler(THIRD_SURFACE_KIND, _process_third_surface)
 
 
 def _unregister_third_surface() -> None:
     unregister_inbound_envelope_handler(THIRD_SURFACE_KIND)
-    unregister_direct_target_kind(THIRD_SURFACE_KIND)
 
 
 @pytest.mark.asyncio
-async def test_registered_third_surface_admits_without_work_intake_kind_edit(session):
+async def test_registered_third_surface_uses_the_direct_target_manifest(session):
     from brain.systems.inbound.service import submit_inbound_envelope
 
     connection = await _seed_connection(session)
-    work_intake_source = (
-        Path(__file__).resolve().parents[1]
-        / "brain/systems/runs/work_intake.py"
-    ).read_text(encoding="utf-8")
-    assert THIRD_SURFACE_KIND not in work_intake_source
 
     _register_third_surface()
     try:
@@ -216,9 +276,9 @@ async def test_registered_third_surface_admits_without_work_intake_kind_edit(ses
     assert result["status"] == "processed"
     assert result["ilo_outcome"]["operation"] == "hypothetical_run_admitted"
     assert run.thread_id == f"hypothetical:{event.id}"
-    assert run.target_ref["kind"] == THIRD_SURFACE_KIND
+    assert run.target_ref["kind"] == THIRD_SURFACE_TARGET_KIND
     assert receipt.status == "processed"
-    assert receipt.target["kind"] == THIRD_SURFACE_KIND
+    assert receipt.target["kind"] == THIRD_SURFACE_TARGET_KIND
     assert receipt.tool_use == {
         "type": "hypothetical_intake",
         "status": "accepted",
@@ -271,7 +331,7 @@ async def test_surface_template_owns_failed_admission_completion(
     }
     assert receipt.status == "failed"
     assert receipt.target == {
-        "kind": THIRD_SURFACE_KIND,
+        "kind": THIRD_SURFACE_TARGET_KIND,
         "event_id": str(event.id),
         "thread_id": f"hypothetical:{event.id}",
     }
@@ -281,30 +341,218 @@ async def test_surface_template_owns_failed_admission_completion(
     }
 
 
-def test_registered_lane_handlers_use_the_public_typed_contract():
-    root = Path(__file__).resolve().parents[1]
-    for relative_path in (
-        "brain/systems/slack/inbound.py",
-        "brain/systems/app_report/inbound.py",
-    ):
-        source = (root / relative_path).read_text(encoding="utf-8")
-        assert "from brain.systems.inbound.service import" not in source
-        assert "context: Any" not in source
-        assert "_complete_event" not in source
-        assert "_clean_optional" not in source
-        assert "context: InboundHandlerContext" in source
-        assert "complete: InboundEventCompleter" in source
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface_kind", "action_type", "operation", "tool_type", "error", "reasoning"),
+    [
+        (
+            "app_report",
+            "app_report.run_admitted",
+            "app_report_run_admission_failed",
+            "app_report_intake",
+            "App-report connection has no authority user",
+            "App reports need a connection owner to admit customer-request work.",
+        ),
+        (
+            "slack_message",
+            "slack.run_admitted",
+            "slack_run_admission_failed",
+            "slack_teammate_run",
+            "Slack connection has no authority user",
+            "Slack events need a connection owner for the permissive self-hosted MVP.",
+        ),
+    ],
+    ids=["app-report", "slack"],
+)
+async def test_actual_surface_missing_authority_receipt_shape(
+    session,
+    monkeypatch,
+    surface_kind,
+    action_type,
+    operation,
+    tool_type,
+    error,
+    reasoning,
+):
+    from brain.systems.inbound.service import submit_inbound_envelope
+
+    connection = await _seed_connection(session, surface_kind=surface_kind)
+
+    async def resolve_without_authority(_session, _connection):
+        return InboundHandlerContext(
+            connection_id=str(connection.id),
+            org_id=str(connection.org_id),
+            owner_user_id=None,
+            token_id=None,
+            scopes=None,
+            display_name=connection.display_name,
+            source_kind=connection.agent_kind,
+        )
+
+    monkeypatch.setattr(
+        "brain.systems.inbound.service._resolve_connection_context",
+        resolve_without_authority,
+    )
+    result = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=_surface_envelope(surface_kind),
+    )
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    outcome = {
+        "operation": operation,
+        "reason": "missing_authority_user",
+        "event_id": str(event.id),
+    }
+
+    assert result["status"] == "failed"
+    assert result["ilo_outcome"] == outcome
+    assert result["error"] == error
+    _assert_failed_surface_receipt(
+        event,
+        receipt,
+        action_type=action_type,
+        outcome=outcome,
+        error=error,
+        target={"kind": surface_kind},
+        tool_type=tool_type,
+        reasoning_summary=reasoning,
+    )
+
+
+@pytest.mark.asyncio
+async def test_actual_app_report_validation_failure_receipt_shape(session):
+    from brain.systems.inbound.service import submit_inbound_envelope
+
+    connection = await _seed_connection(session, surface_kind="app_report")
+    envelope = _surface_envelope("app_report")
+    envelope["payload"].pop("email")
+    result = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=envelope,
+    )
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    outcome = {
+        "operation": "app_report_run_admission_failed",
+        "reason": "invalid_app_report_payload",
+        "event_id": str(event.id),
+    }
+
+    assert result["status"] == "failed"
+    assert result["ilo_outcome"] == outcome
+    assert result["error"] == "email is required"
+    _assert_failed_surface_receipt(
+        event,
+        receipt,
+        action_type="app_report.run_admitted",
+        outcome=outcome,
+        error="email is required",
+        target={"kind": "app_report"},
+        tool_type="app_report_intake",
+        reasoning_summary="email is required",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface_kind", "action_type", "operation", "tool_type"),
+    [
+        (
+            "app_report",
+            "app_report.run_admitted",
+            "app_report_run_admission_failed",
+            "app_report_intake",
+        ),
+        (
+            "slack_message",
+            "slack.run_admitted",
+            "slack_run_admission_failed",
+            "slack_teammate_run",
+        ),
+    ],
+    ids=["app-report", "slack"],
+)
+async def test_actual_surface_rejected_admission_receipt_shape(
+    session,
+    monkeypatch,
+    surface_kind,
+    action_type,
+    operation,
+    tool_type,
+):
+    from brain.systems.inbound.service import submit_inbound_envelope
+    from brain.systems.runs.work_intake import WorkIntakeResult
+
+    async def reject_work(_session, _event):
+        return WorkIntakeResult(ok=False, skipped_reason="synthetic admission rejection")
+
+    monkeypatch.setattr(
+        "brain.systems.inbound.surface_admission.admit_work",
+        reject_work,
+    )
+    connection = await _seed_connection(session, surface_kind=surface_kind)
+    envelope = _surface_envelope(surface_kind)
+    result = await submit_inbound_envelope(
+        session,
+        connection=connection,
+        envelope=envelope,
+    )
+
+    event = (await session.scalars(select(InboundEventRow))).one()
+    receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
+    if surface_kind == "app_report":
+        target = {
+            "kind": "app_report",
+            "event_id": str(event.id),
+            "thread_id": f"app-report:{event.id}",
+            "profile_id": "profile-123",
+            "generation_ids": [901, "gen-902"],
+            "batch_ids": [77, "batch-78"],
+        }
+    else:
+        target = {
+            "kind": "slack_message",
+            "team_id": "T789",
+            "channel_id": "C456",
+            "message_ts": "1716900000.000100",
+            "thread_ts": "1716900000.000100",
+            "slack_thread_id": "slack:T789:C456:1716900000.000100",
+        }
+    outcome = {
+        "operation": operation,
+        "reason": "synthetic admission rejection",
+        "event_id": str(event.id),
+        "origin": envelope["origin"],
+    }
+    if surface_kind == "slack_message":
+        outcome["slack"] = target
+
+    assert result["status"] == "failed"
+    assert result["ilo_outcome"] == outcome
+    assert result["error"] == "synthetic admission rejection"
+    _assert_failed_surface_receipt(
+        event,
+        receipt,
+        action_type=action_type,
+        outcome=outcome,
+        error="synthetic admission rejection",
+        target=target,
+        tool_type=tool_type,
+        reasoning_summary="synthetic admission rejection",
+    )
 
 
 def test_registered_direct_target_requires_thread_id():
     from brain.systems.runs.direct_targets import resolve_direct_target
 
-    register_direct_target_kind(THIRD_SURFACE_KIND)
-    try:
-        with pytest.raises(
-            ValueError,
-            match="hypothetical_third_surface target requires thread_id",
-        ):
-            resolve_direct_target({"kind": THIRD_SURFACE_KIND, "event_id": "event-1"})
-    finally:
-        unregister_direct_target_kind(THIRD_SURFACE_KIND)
+    assert isinstance(DIRECT_TARGET_KINDS, frozenset)
+    with pytest.raises(
+        ValueError,
+        match="inbound_submission target requires thread_id",
+    ):
+        resolve_direct_target({"kind": THIRD_SURFACE_TARGET_KIND, "event_id": "event-1"})


### PR DESCRIPTION
Closes #459.

## What this does

Slack and app_report had copied the same inbound lifecycle twice — resolve authority → build payload → `admit_work(...)` → complete the event — including parallel FAILED branches. Two copies means status, target, tool-use and failure semantics drift apart as each lane is touched. This extracts that lifecycle once into `brain/systems/inbound/surface_admission.py`, so there is **one owner** for admission and completion semantics, and both lanes call it.

Two supporting changes came with it:

- `work_intake.py` no longer routes on a hard-coded target-kind set. The two structurally identical headless request builders collapse into one `_build_direct_target_request`, and the router drops from 1,056 to 997 lines.
- Registered envelope handlers get a public typed context + completion contract (`brain/systems/inbound/handlers.py`) instead of `context: Any` plus direct imports of private `brain.systems.inbound.service` internals (`_clean_optional`, `_complete_event`).

**No wire-contract, schema or migration change.** No behaviour change to the Slack or app_report contracts.

## How to judge it without reading the diff

There is no UI here — this is an internal backend refactor, so the review surface is the test suite and two structural facts:

```bash
git fetch origin && git checkout illo-qa/459-surface-admission-template-fix1
venv/bin/python -m pytest tests/test_surface_admission.py tests/test_app_report_intake.py \
  tests/test_inbound_admin_tools.py tests/test_inbound_attribution.py tests/test_inbound_preservation.py \
  tests/test_inbound_reconciliation.py tests/test_inbound_webhooks.py tests/test_runs.py \
  tests/test_slack_channel_monitor.py tests/test_slack_teammate.py tests/test_work_intake.py \
  tests/test_work_intake_full_architecture.py tests/test_external_agents_service.py -q
```

**213 passed, 3 skipped** (verified by the orchestrator, not just the worker). No existing test *expectation* was changed — only imports — which is the evidence that behaviour held.

### Acceptance checks

1. **Duplicated completion branches gone, one owner for status/target/tool-use/failure** — yes. Both lane handlers make a single `admit_surface_envelope(...)` call; the parallel success/FAILED branches are deleted.
2. **A third lane needs no edit to a hard-coded kind set in `work_intake.py`** — yes, *with a caveat worth your attention*: the literal set is gone from the 1k-line router, but a new direct/headless lane must still add its kind to the `DIRECT_TARGET_KINDS` frozenset in the small dedicated `direct_targets.py`. The set moved and shrank; it did not vanish. That was a deliberate choice (see below).
3. **Handlers no longer import private service internals nor accept `context: Any`** — yes.
4. **Existing tests green, no wire-contract change** — yes.

## Two things I want you to see

**1. A deliberate contract narrowing, not a behaviour-neutral change.** The old code derived a `thread_id` when a producer omitted one (`external-agent:{conn}:{task}`, `inbound:{event_id}`). The typed target now *requires* `thread_id` and raises otherwise — which #459 explicitly asked for. I verified every current producer already supplies it: `aws_health_scan.py`, `external_agents/service.py`, `inbound/service.py` and `app_report/triggers.py` all set it explicitly, and `external_agents/service.py` passes the exact string the old fallback would have derived. The one producer without a `thread_id` (`_submission_target`) is a completion/receipt target that never reaches the run builder. So the fallbacks were unreachable in production — but this is a contract change, and it is fair to call it one rather than hide it under "pure refactor."

**2. The code-quality review's main finding is unresolved, on purpose.** A thermo-nuclear maintainability review (Codex, cross-family) returned BLOCKING FINDINGS. One was fixed in the follow-up commit — the mutable direct-target registry became an immutable manifest, because a process-global set with register/unregister APIs meant a lane needed two independent registrations and "what is direct?" had two answers.

The other is a genuine design call I did not want to make for you: **`SurfaceAdmissionSpec` is arguably a callback bag rather than an abstraction** — 3 required callbacks plus mode switches, while the lane files barely shrank (app_report 153→133, slack 271→267) against a new 233-line shared module. The reviewer proposed cohesive `prepare_*_admission` adapters returning a typed plan. That was attempted in full and reverted: it grew production code 633→652 lines, enlarged *both* lane modules (app_report 133→166, slack 267→310) and needed a target-template token to preserve Slack's nested target — relocating the same variation while making the lanes harder to read. Numbers are in the review, not vibes.

So the duplication genuinely went away and completion semantics have one owner; whether the shared thing is the *right* shape is the open question. If you want the other shape, it is a follow-up ticket, not a tweak.

Also declined this pass and worth a follow-up: `InboundCompletion` still exposes ten persistence-shaped fields including an ORM row type, so the "typed contract" is closer to a public copy of the persistence helper's signature than a clean domain boundary.

Full review: `state/evidence/459-thermo-review.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
