### PR TITLE
fix(deploy): ship provider-alert policy in the image (fixes silent alerts channel)

### DIFF
--- a/deploy/docker/api.Dockerfile
+++ b/deploy/docker/api.Dockerfile
@@ -38,6 +38,7 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 COPY brain ./brain
 COPY deploy/compose/runtime-services.json ./deploy/compose/runtime-services.json
 COPY deploy/compose/workspace-tools.json ./deploy/compose/workspace-tools.json
+COPY deploy/compose/provider-alert-severity.json ./deploy/compose/provider-alert-severity.json
 COPY ops/install-browser-runtime.sh ./ops/install-browser-runtime.sh
 COPY README.md LICENSE NOTICE.md ./
 

--- a/tests/test_runtime_asset_packaging.py
+++ b/tests/test_runtime_asset_packaging.py
@@ -1,0 +1,52 @@
+"""Runtime data files the code reads must actually ship in the image.
+
+`deploy/compose/provider-alert-severity.json` was added as a runtime
+dependency without a matching Dockerfile COPY. Nothing failed until the Slack
+connector was recreated on the new image, at which point every provider alert
+raised ProviderAlertPolicyError and Illo went silent in the alerts channel.
+This guards the whole class: any `BRAIN_DIR/deploy/compose/<file>` the code
+resolves at runtime must be copied into the image.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_DOCKERFILE = REPO_ROOT / "deploy" / "docker" / "api.Dockerfile"
+
+# Matches: Path(...BRAIN_DIR) / "deploy" / "compose" / "<name>.json"
+_COMPOSE_ASSET_RE = re.compile(
+    r'BRAIN_DIR\s*\)?\s*/\s*"deploy"\s*/\s*"compose"\s*/\s*"([^"]+)"'
+)
+
+
+def _referenced_compose_assets() -> set[str]:
+    assets: set[str] = set()
+    for path in (REPO_ROOT / "brain").rglob("*.py"):
+        assets.update(_COMPOSE_ASSET_RE.findall(path.read_text(encoding="utf-8")))
+    return assets
+
+
+def test_runtime_compose_assets_are_copied_into_the_image():
+    referenced = _referenced_compose_assets()
+    assert referenced, "expected to find deploy/compose runtime assets referenced in brain/"
+
+    dockerfile = API_DOCKERFILE.read_text(encoding="utf-8")
+    copied = set(re.findall(r"COPY\s+deploy/compose/(\S+)\s", dockerfile))
+
+    missing = sorted(referenced - copied)
+    assert not missing, (
+        "runtime assets read from deploy/compose are missing a COPY line in "
+        f"deploy/docker/api.Dockerfile: {missing}"
+    )
+
+
+def test_referenced_compose_assets_exist_in_the_repo():
+    missing = sorted(
+        name
+        for name in _referenced_compose_assets()
+        if not (REPO_ROOT / "deploy" / "compose" / name).is_file()
+    )
+    assert not missing, f"referenced deploy/compose assets do not exist: {missing}"


### PR DESCRIPTION
**Illo went silent in the Slack alerts channel.** Root cause found and fixed.

## What broke
Every provider alert raised:
```
ProviderAlertPolicyError: provider alert policy unavailable at
/app/deploy/compose/provider-alert-severity.json: No such file or directory
```

`brain/platform/provider_alerts.py:26` resolves that path at runtime, but `deploy/docker/api.Dockerfile` only copied `runtime-services.json` and `workspace-tools.json` out of `deploy/compose/`. The file is in the repo and in the server checkout — it just never made it into the image. Confirmed live: `docker exec illospace-slack-connector-1 ls /app/deploy/compose/` listed exactly two files.

The connector still acked (👀 reactions kept succeeding in the logs) and then threw on ingest — which is precisely "acknowledges but never acts."

## Why now
Latent since the provider-alert severity gate landed (#402/#404). `upgrade.sh` does **not** recreate the `slack-connector` (known gotcha — it's on the `slack` compose profile), so the connector kept running a pre-feature image and never hit the code path. During the 2026-07-24 routing deploy I recreated it manually — correct per the runbook, since otherwise the Slack lane runs stale code — and that surfaced the packaging gap. **My deploy action turned a latent bug into a live one**; the missing COPY predates this work.

## Fix
- The missing `COPY deploy/compose/provider-alert-severity.json`.
- A guard for the whole class: `tests/test_runtime_asset_packaging.py` scans `brain/` for `BRAIN_DIR/deploy/compose/<file>` runtime dependencies and asserts each is copied into the image (and exists in the repo). Verified it **fails** without the Dockerfile fix and passes with it — exactly three such assets exist today.

Needs a rebuild deploy (`upgrade.sh --build --no-pull`) plus a connector recreate to take effect; I'll verify the policy loads in-container and watch a real alert process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)