### PR TITLE
fix(routing): move the fleet default back to GPT-5.5 on latency grounds

### DIFF
--- a/brain/platform/db/alembic/versions/0040_default_model_latency_rollback.py
+++ b/brain/platform/db/alembic/versions/0040_default_model_latency_rollback.py
@@ -1,0 +1,48 @@
+"""Move the fleet default back to GPT-5.5 on latency grounds.
+
+GPT-5.6 Sol is a preview model and is 2-4x slower per call than GPT-5.5 at
+every effort tier (measured on illo-dev 2026-07-24: 5.5 ~18-20s; 5.6-sol
+43s at low, 72s at medium, 79s at high). Runs average 20-40 turns, so the
+fleet default at 5.6-sol pushed run duration past 40 minutes, saturated the
+worker, and dropped completions to zero while the queue grew.
+
+Effort routing cannot recover this: 5.6-sol at `low` is still slower than 5.5
+at `high`. The routing layer itself is unchanged and correct — only the model
+the fleet defaults to moves back until 5.6-sol is fast enough to carry it.
+
+Revision ID: 0040_default_model_latency_rollback
+Revises: 0039_clear_revision_model_pins
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0040_default_model_latency_rollback"
+down_revision = "0039_clear_revision_model_pins"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE orgs
+        SET memory_model_config = COALESCE(memory_model_config, '{}'::jsonb)
+            || jsonb_build_object('default_model', 'openai/gpt-5.5')
+        WHERE memory_model_config->>'default_model' = 'openai/gpt-5.6-sol'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE orgs
+        SET memory_model_config = COALESCE(memory_model_config, '{}'::jsonb)
+            || jsonb_build_object('default_model', 'openai/gpt-5.6-sol')
+        WHERE memory_model_config->>'default_model' = 'openai/gpt-5.5'
+        """
+    )

--- a/brain/platform/providers/model_policy.py
+++ b/brain/platform/providers/model_policy.py
@@ -21,7 +21,10 @@ DEFAULT_RUNTIME_PROVIDER = "openai"
 DEFAULT_THINKING_TIER = "high"
 DEFAULT_PROVIDER_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.6-sol",
+    # GPT-5.6 Sol stays selectable, but it is a preview model measured at 2-4x
+    # GPT-5.5's per-call latency at every effort tier, which saturates the
+    # worker at fleet scale. Revisit when its latency lands near 5.5.
+    "openai": "gpt-5.5",
 }
 PROVIDER_MODEL_OPTIONS: dict[str, tuple[str, ...]] = {
     "anthropic": (

--- a/tests/test_model_policy.py
+++ b/tests/test_model_policy.py
@@ -33,7 +33,7 @@ class TestModelPolicy:
         from brain.platform.providers.model_policy import get_default_model
 
         with patch("brain.platform.providers.model_policy.get_active_provider", return_value="openai"):
-            assert get_default_model() == "openai/gpt-5.6-sol"
+            assert get_default_model() == "openai/gpt-5.5"
 
     def test_openai_model_options_use_native_defaults(self):
         from brain.platform.providers.model_policy import get_provider_model_options
@@ -167,9 +167,9 @@ class TestModelPolicy:
         model, thinking = await async_resolve_skill_model(session, "deploy", user_id="user-1")
 
         assert runtime.provider == "openai"
-        assert runtime.model_name == "gpt-5.6-sol"
+        assert runtime.model_name == "gpt-5.5"
         assert runtime.reasoning_effort == "xhigh"
-        assert model == "openai/gpt-5.6-sol"
+        assert model == "openai/gpt-5.5"
         assert thinking == "xhigh"
 
     def test_run_resolve_model_fallback_uses_selected_provider(self):
@@ -241,7 +241,7 @@ class TestModelPolicy:
             user_id="user-1",
         )
 
-        assert catalogs["openai"]["default"] == "gpt-5.6-sol"
+        assert catalogs["openai"]["default"] == "gpt-5.5"
         assert "gpt-5.5" in catalogs["openai"]["options"]
         assert catalogs["anthropic"]["default"] == "claude-sonnet-4-6"
 

--- a/tests/test_predict_rlm_backend.py
+++ b/tests/test_predict_rlm_backend.py
@@ -107,7 +107,7 @@ def test_get_agent_worker_backend_settings_remaps_cross_provider_sub_lm(monkeypa
 
     settings = get_agent_worker_backend_settings(org_id="org-1", provider="openai")
 
-    assert settings.predict_rlm_sub_lm == "openai/gpt-5.6-sol"
+    assert settings.predict_rlm_sub_lm == "openai/gpt-5.5"
 
 
 def test_get_agent_worker_backend_settings_falls_back_when_deno_missing(monkeypatch):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -904,7 +904,7 @@ class TestModelCatalog:
 
     def test_get_default_model_openai(self):
         from brain.platform.providers.model_policy import get_default_model
-        assert get_default_model(provider="openai", include_provider_prefix=False) == "gpt-5.6-sol"
+        assert get_default_model(provider="openai", include_provider_prefix=False) == "gpt-5.5"
 
     def test_get_model_options_default(self):
         from brain.platform.providers.model_policy import get_provider_model_options
@@ -918,7 +918,7 @@ class TestModelCatalog:
         from brain.platform.providers.model_policy import get_provider_model_catalogs
         catalogs = get_provider_model_catalogs()
         assert catalogs["anthropic"]["default"] == "claude-sonnet-4-6"
-        assert catalogs["openai"]["default"] == "gpt-5.6-sol"
+        assert catalogs["openai"]["default"] == "gpt-5.5"
         assert "claude-opus-4-6" in catalogs["anthropic"]["options"]
         assert "gpt-5.5" in catalogs["openai"]["options"]
 


### PR DESCRIPTION
**Ready to merge on your word — this reverses your "only 5.6 SOL" call, so I'm not merging it unilaterally.** Data first.

## What happened
After the routing deploy moved the org default to gpt-5.6-sol, Illo stopped completing work. Throughput per hour, from `agent_runs`:

| hour | created | completed |
|---|---|---|
| 16:00 | 4 | 4 |
| 17:00 | 7 | 7 |
| 18:00 | 7 | 7 |
| 19:00 (deploy) | 13 | 4 |
| 20:00 | 5 | **0** |

13 active runs, 8 queued and growing. Runs were alive and progressing — no errors, zero failed API calls — just far too slow, so the worker's slots stayed occupied for 40–80 minutes per run and everything else queued behind.

## Cause: 5.6-sol is 2–4x slower per call
From `agent_api_calls` (last 3h):

| model | effort | avg latency |
|---|---|---|
| gpt-5.5 | high/medium | **~18–20s** |
| gpt-5.6-sol | low | 43.4s |
| gpt-5.6-sol | medium | 72.4s |
| gpt-5.6-sol | high | 78.5s |

Run 2557 straddled the deploy and isolates the model as the only variable: **5 calls on 5.5 at 17.9s, then 43 calls on 5.6-sol at 53.9s for the same task.** At 20–40 turns per run, that is the whole outage.

**Effort routing cannot fix this**: 5.6-sol at `low` (43s) is still slower than 5.5 at `high` (20s). It's a model property, not a tier property — 5.6-sol is a preview model (the composer literally labels it "Preview model for eligible personal connections") and is very likely capacity-limited.

## What this changes
Only the *default model*. Migration 0040 moves org config back to `openai/gpt-5.5` and the code default follows. **The routing layer is untouched and still correct** — cycle overrides honored, canonical effort tiers, provider-generic rendering, one-model principle. 5.6-sol stays fully selectable per cycle, per run, and in the composer, so you can put it on judgment-heavy lanes where 80s/call is fine.

Recommendation: merge this to restore throughput, then decide whether 5.6-sol goes on cycle 2 (Coordinator) specifically, where quality matters more than latency. Revisit the fleet default when 5.6-sol's latency lands near 5.5.

Tests updated for the default flip: 176 passed across model_policy/providers/predict_rlm/effort_rendering/cycles_service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)