### PR TITLE
fix(openai): stop asking the Codex backend for prompt_cache_retention

### DIFF
--- a/brain/systems/runs/direct_loop/request.py
+++ b/brain/systems/runs/direct_loop/request.py
@@ -8,6 +8,7 @@ import re
 from hashlib import sha256
 
 from brain.platform.integrations.providers import LLMRequest
+from brain.platform.providers.model_policy import required_openai_auth_mode
 
 _PROMPT_CACHE_KEY_MAX_LEN = 64
 _PROMPT_CACHE_KEY_DIGEST_LEN = 24
@@ -160,9 +161,17 @@ def _prompt_cache_scope(session_id: str, persist_session: bool, operation_type: 
 
 
 def get_extended_prompt_cache_retention(model: str) -> str | None:
-    """Return an extended retention hint for OpenAI models that support it."""
+    """Return an extended retention hint for OpenAI models that support it.
+
+    The ChatGPT/Codex backend rejects `prompt_cache_retention` outright, so
+    models that route there must not ask for it: every such request 400s and is
+    retried without the parameter, paying a wasted round trip per call and
+    never getting extended retention anyway.
+    """
 
     normalized = normalize_model_name(model)
+    if required_openai_auth_mode(normalized) == "chatgpt":
+        return None
     supported_prefixes = (
         "gpt-5",
         "gpt-4.1",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -270,10 +270,21 @@ class TestCachePolicy:
     def test_openai_cache_retention_matches_extended_cache_support(self):
         from brain.systems.runs.direct_agent import _get_openai_cache_retention
 
-        assert _get_openai_cache_retention("openai/gpt-5.5") == "24h"
         assert _get_openai_cache_retention("openai/gpt-5.4") == "24h"
         assert _get_openai_cache_retention("openai/gpt-4.1-mini") == "24h"
         assert _get_openai_cache_retention("openai/gpt-4o-mini") is None
+
+    def test_chatgpt_backend_models_do_not_request_cache_retention(self):
+        """The Codex backend 400s on prompt_cache_retention.
+
+        Asking anyway costs a wasted round trip on every single call and never
+        yields extended retention, so these models must not send it.
+        """
+        from brain.systems.runs.direct_agent import _get_openai_cache_retention
+
+        assert _get_openai_cache_retention("openai/gpt-5.5") is None
+        assert _get_openai_cache_retention("openai/gpt-5.6-sol") is None
+        assert _get_openai_cache_retention("gpt-5.6-sol") is None
 
     @patch("brain.systems.runs.direct_agent.async_resolve_llm_client")
     @patch("brain.systems.runs.direct_agent._load_session", return_value=([], None))

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -141,7 +141,8 @@ def test_request_runtime_preserves_cache_policy_and_facade_wrappers():
         True,
         operation_type="coordinator",
     )
-    assert _get_extended_prompt_cache_retention("openai/gpt-5.5") == "24h"
+    assert _get_extended_prompt_cache_retention("openai/gpt-5.5") is None
+    assert _get_extended_prompt_cache_retention("openai/gpt-5.4") == "24h"
     assert _get_openai_cache_retention("openai/gpt-5.4") == "24h"
     assert _get_openai_cache_retention("openai/gpt-4.1-mini") == "24h"
     assert _get_openai_cache_retention("openai/gpt-4o-mini") is None


### PR DESCRIPTION
Every LLM call has been making **two HTTP round trips instead of one**.

## The defect
`get_extended_prompt_cache_retention()` returns `"24h"` for anything starting with `gpt-5`, including the ChatGPT/Codex-backed models (`gpt-5.5`, `gpt-5.6*`). That backend rejects the parameter:

```
POST https://chatgpt.com/backend-api/codex/responses "HTTP/1.1 400 Bad Request"
Retrying OpenAI request without prompt_cache_retention after unsupported-parameter error
```

The provider catches it and retries without the param — so it works, silently, at the cost of a wasted request on **every single call** and never actually getting extended retention. Observed on illo-dev: **117 retries in one hour, one per call.**

Verified directly against the live backend — both models fail identically in ~0.2s with `Unsupported parameter: prompt_cache_retention`.

## Fix
Models that route to the Codex backend (via the shared `required_openai_auth_mode` helper) don't request retention. API-key-backed OpenAI models keep `24h`. The provider-side retry stays as a safety net.

```
gpt-5.5        -> None      gpt-5.4       -> 24h
gpt-5.6-sol    -> None      gpt-4.1       -> 24h
```

## On the latency scare
This is **not** what made runs slow, and I want to correct my earlier claim on the record. A controlled A/B against the live backend:

| context | gpt-5.5 | gpt-5.6-sol |
|---|---|---|
| minimal | 1.3s | 1.3s |
| ~30k tokens, medium | 2.6s | **2.2s** |
| ~30k tokens, high | 2.7s | **1.7s** |

**gpt-5.6-sol is equal or faster** — Reda was right. My earlier "2-4x slower" reading compared 5.5 on an idle system against 5.6-sol on a saturated one. Production's 55-70s calls are genuine reasoning on heavy chantier turns (`turn 32, tools=83`, dozens of GitHub blob fetches). The rollback PR (#470) is closed; the default stays gpt-5.6-sol.

4110 passed, 76 skipped. Two pre-existing main failures excluded (async-DB debt metric, GPU/worker env tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)