### PR TITLE
fix(deploy): never leave a second worker behind after a worker restart

### DIFF
--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -90,6 +90,29 @@ container_running() {
   [ "$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null || echo false)" = "true" ]
 }
 
+assert_single_running_worker() {
+  local count=0 id running_ids running_ids_csv
+  if ! running_ids="$(compose ps --status running -q worker 2>/dev/null)"; then
+    echo "Worker invariant check failed: could not list running worker containers." >&2
+    echo "Recovery: inspect workers with: docker compose --env-file \"$ENV_FILE\" -f \"$COMPOSE_FILE\" ps --all worker" >&2
+    return 1
+  fi
+  while IFS= read -r id; do
+    [ -z "$id" ] || count=$((count + 1))
+  done <<< "$running_ids"
+  [ "$count" -eq 1 ] && return 0
+
+  running_ids_csv="${running_ids//$'\n'/,}"
+  echo "Worker invariant failed: expected exactly one running worker container, found $count (container ids: ${running_ids_csv:-none})." >&2
+  echo "Recovery: inspect workers with: docker compose --env-file \"$ENV_FILE\" -f \"$COMPOSE_FILE\" ps --all worker" >&2
+  if [ "$count" -eq 0 ]; then
+    echo "Recovery: start the regular worker with: docker compose --env-file \"$ENV_FILE\" -f \"$COMPOSE_FILE\" up -d --no-deps worker" >&2
+  else
+    echo "Recovery: keep the intended regular worker, stop and remove every extra worker container, then rerun the failed command." >&2
+  fi
+  return 1
+}
+
 start_worker_handoff() {
   compose run \
     -d \
@@ -149,6 +172,22 @@ wait_for_worker_exit() {
   done
 }
 
+remove_worker_handoff_after_drain_timeout() {
+  local handoff_id="$1"
+  local worker_id="$2"
+  echo "Worker: drain timed out; stopping and removing temporary handoff worker $handoff_id before returning." >&2
+  docker update --restart=no "$handoff_id" >/dev/null 2>&1 || true
+  docker kill "$handoff_id" >/dev/null 2>&1 || true
+  if ! docker rm -f "$handoff_id" >/dev/null 2>&1; then
+    if docker inspect "$handoff_id" >/dev/null 2>&1; then
+      echo "Worker: could not remove temporary handoff worker $handoff_id; multiple workers may still be running." >&2
+      return 1
+    fi
+  fi
+  echo "Worker: removed temporary handoff worker $handoff_id; original worker $worker_id is retained as the intended sole worker container." >&2
+  echo "Recovery: let the original worker finish its active AgentRuns, then rerun the failed worker restart or upgrade. New AgentRuns may remain queued until the original worker restarts." >&2
+}
+
 update_worker_after_drain() {
   local snapshot="$1"
   local already_reported="${2:-}"
@@ -175,6 +214,7 @@ update_worker_after_drain() {
   if ! wait_for_worker_exit "$worker_id"; then
     docker update --restart=unless-stopped "$worker_id" >/dev/null 2>&1 || true
     if [ "${ILLO_COMPOSE_FORCE_WORKER_SWAP:-0}" != "1" ]; then
+      remove_worker_handoff_after_drain_timeout "$handoff_id" "$worker_id" || true
       return 1
     fi
     snapshot="$(worker_swap_snapshot)"
@@ -190,11 +230,28 @@ update_worker_after_drain() {
     affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
     echo "Worker: regular worker is restarted; draining handoff worker $handoff_id. Open run ids at handoff shutdown: ${affected_ids:-none}."
     docker kill -s TERM "$handoff_id" >/dev/null 2>&1 || true
-    (
-      docker wait "$handoff_id" >/dev/null 2>&1 || true
-      docker rm "$handoff_id" >/dev/null 2>&1 || true
-    ) &
+    remove_worker_handoff_bounded "$handoff_id"
   fi
+}
+
+# Reap the temporary handoff worker without blocking the deploy indefinitely.
+# It runs with ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS=infinity, so a graceful
+# SIGTERM drain lasts as long as its longest in-flight AgentRun (observed at
+# 40-100 minutes). The regular worker is already up by this point, and runs
+# interrupted here are requeued by the stale-run reaper, so bound the wait and
+# then force removal rather than hanging the caller.
+remove_worker_handoff_bounded() {
+  local handoff_id="$1"
+  local wait_seconds="${COMPOSE_RUNTIME_HANDOFF_REAP_TIMEOUT_SECONDS:-120}"
+  local deadline=$((SECONDS + wait_seconds))
+  while container_running "$handoff_id"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Worker: handoff worker $handoff_id still draining after ${wait_seconds}s; forcing removal so exactly one worker remains. Its open AgentRuns are requeued by the stale-run reaper." >&2
+      break
+    fi
+    sleep 5
+  done
+  docker rm -f "$handoff_id" >/dev/null 2>&1 || true
 }
 
 replace_idle_worker() {
@@ -231,17 +288,19 @@ replace_idle_worker() {
 }
 
 restart_runtime_worker_service() {
-  local action snapshot
+  local action snapshot status=0
   snapshot="$(worker_swap_snapshot)"
   action="$(worker_swap_snapshot_decision "$snapshot")"
   case "$action" in
-    replace) replace_idle_worker ;;
-    drain) update_worker_after_drain "$snapshot" ;;
+    replace) replace_idle_worker || status=$? ;;
+    drain) update_worker_after_drain "$snapshot" || status=$? ;;
     *)
       echo "Cannot safely restart worker because non-terminal AgentRun ids are unknown." >&2
       return 1
       ;;
   esac
+  assert_single_running_worker || status=1
+  return "$status"
 }
 
 restart_runtime_service() {

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -101,24 +101,29 @@ fi
 compose up -d postgres
 compose run --rm migrate
 WORKER_SWAP_SNAPSHOT="$(worker_swap_snapshot)"
+WORKER_RESTART_STATUS=0
 case "$(worker_swap_snapshot_decision "$WORKER_SWAP_SNAPSHOT")" in
   replace)
     mapfile -t runtime_services < <(all_runtime_services)
     compose up -d --force-recreate --remove-orphans "${runtime_services[@]}"
-    replace_idle_worker
+    replace_idle_worker || WORKER_RESTART_STATUS=$?
     ;;
   drain)
     echo "$(worker_swap_snapshot_report "$WORKER_SWAP_SNAPSHOT")."
     echo "Updating API, scheduler, and web while preserving active worker AgentRuns."
     mapfile -t services < <(non_worker_services)
     compose up -d --force-recreate --no-deps "${services[@]}"
-    update_worker_after_drain "$WORKER_SWAP_SNAPSHOT" reported
+    update_worker_after_drain "$WORKER_SWAP_SNAPSHOT" reported || WORKER_RESTART_STATUS=$?
     ;;
   *)
     echo "Cannot safely swap worker because non-terminal AgentRun ids are unknown." >&2
     exit 1
     ;;
 esac
+assert_single_running_worker || WORKER_RESTART_STATUS=1
+if [ "$WORKER_RESTART_STATUS" -ne 0 ]; then
+  exit "$WORKER_RESTART_STATUS"
+fi
 
 "$SCRIPT_DIR/doctor.sh"
 schedule_updater_refresh_after_self_update

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -396,9 +396,67 @@ def test_compose_upgrade_drains_worker_when_agent_runs_are_active():
     assert "replace_idle_worker" in combined
     assert "no interactive AgentRuns" in runtime_lib
     assert "refusing to kill it" in runtime_lib
+    assert "remove_worker_handoff_after_drain_timeout" in runtime_lib
+    assert 'docker rm -f "$handoff_id"' in runtime_lib
     assert "FORCED WORKER SWAP: killing old worker; affected run ids:" in runtime_lib
+    assert "assert_single_running_worker" in runtime_lib
+    assert "assert_single_running_worker" in upgrade
     assert "ILLO_COMPOSE_BUILD_NO_CACHE" in upgrade
     assert "ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_FILE" in upgrade
+
+
+def test_compose_worker_drain_timeout_removes_handoff_and_preserves_original_worker(tmp_path):
+    runtime_lib = Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "compose-runtime-lib.sh"
+    docker_log = tmp_path / "docker.log"
+    script = f'''
+source "{runtime_lib}"
+worker_swap_snapshot_count() {{ printf '1\\n'; }}
+worker_swap_snapshot_run_ids() {{ printf '477\\n'; }}
+worker_swap_snapshot_details() {{ printf '477:running\\n'; }}
+worker_swap_snapshot_report() {{ printf 'Worker pre-swap check'; }}
+worker_container_id() {{ printf 'original-worker\\n'; }}
+start_worker_handoff() {{ printf 'handoff-worker\\n'; }}
+wait_for_worker_exit() {{ return 1; }}
+docker() {{
+  printf '%s\\n' "$*" >> "{docker_log}"
+  if [ "$1" = "inspect" ]; then
+    return 1
+  fi
+}}
+update_worker_after_drain snapshot
+'''
+
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 1
+    docker_calls = docker_log.read_text()
+    assert "update --restart=unless-stopped original-worker" in docker_calls
+    assert "rm -f handoff-worker" in docker_calls
+    assert "rm -f original-worker" not in docker_calls
+    assert "removed temporary handoff worker handoff-worker" in result.stderr
+    assert "New AgentRuns may remain queued" in result.stderr
+
+
+def test_compose_worker_restart_asserts_exactly_one_running_worker():
+    runtime_lib = Path(__file__).resolve().parents[1] / "deploy" / "scripts" / "compose-runtime-lib.sh"
+    script = f'''
+source "{runtime_lib}"
+worker_swap_snapshot() {{ printf 'snapshot\\n'; }}
+worker_swap_snapshot_decision() {{ printf 'replace\\n'; }}
+replace_idle_worker() {{ return 0; }}
+compose() {{
+  if [ "$*" = "ps --status running -q worker" ]; then
+    printf 'regular-worker\\nhandoff-worker\\n'
+  fi
+}}
+restart_runtime_worker_service
+'''
+
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 1
+    assert "expected exactly one running worker container, found 2" in result.stderr
+    assert "keep the intended regular worker" in result.stderr
 
 
 def test_compose_runtime_service_restart_supports_one_many_or_all_services():


### PR DESCRIPTION
Closes #477.

## The bug
On drain timeout, `restart_runtime_worker_service` refuses to kill the old worker and skips the recreate — that refusal is intended. What wasn't intended: the temporary `illospace-worker-run-<hash>` container **keeps running forever**. It's a full worker that keeps claiming *new* runs, so it never drains on its own. Observed live on illo-dev still executing runs 2 hours later, giving **double** the configured `ILLO_AGENT_RUNNER_CONCURRENCY` while every container looked healthy.

## Changes
- **Drain timeout now removes the handoff worker** before returning, leaving the original worker as sole owner, and prints recovery guidance.
- **Every worker restart path asserts exactly one running worker container**, failing loudly with actionable recovery steps otherwise.
- **Bounded handoff reaping on the success path.**

## Two things I verified beyond the tests
1. **Does the guard actually see the leak?** It uses `compose ps --status running -q worker`, and Compose excludes one-off `run` containers in some versions — which would have made the guard blind to the exact container it targets. Tested against a live throwaway one-off on illo-dev: `compose ps --status running -q worker` returned **2**, so it does count them. Guard works.
2. **The success path was made synchronous** (`docker wait` replacing a backgrounded subshell) so the invariant could be asserted. But the handoff worker runs with `ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS=infinity`, so an unbounded wait would hang the deploy for the length of its longest in-flight run — 40–100 minutes in today's observations. Replaced with a bounded wait (default 120s, `COMPOSE_RUNTIME_HANDOFF_REAP_TIMEOUT_SECONDS`) followed by forced removal. Safe because the regular worker is already up and interrupted runs are requeued by the stale-run reaper (`agent_run_stale_interrupted_requeued`, verified 3x today, no work lost).

`bash -n` clean on all three scripts; `tests/test_safe_deploy.py` 31 passed (incl. new timeout-cleanup and duplicate-worker regression tests).

Implementation by Codex (high effort); the bounded-reap fix and the two verifications above are from director review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)