### PR TITLE
test(gpu): stop the worker suites depending on a working local PyTorch

### DIFF
--- a/tests/test_gpu_server.py
+++ b/tests/test_gpu_server.py
@@ -1,8 +1,20 @@
 import os
+import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
+
+
+def _install_fake_torch(monkeypatch):
+    """Provide the tiny torch surface used by mocked worker request tests."""
+    class FakeOutOfMemoryError(RuntimeError):
+        pass
+
+    fake_torch = ModuleType("torch")
+    fake_torch.cuda = SimpleNamespace(OutOfMemoryError=FakeOutOfMemoryError)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
 
 
 class TestWorkerManifest:
@@ -346,11 +358,12 @@ class TestEmbeddingWorker:
         assert w.truncate_dim == 768
 
     @pytest.mark.asyncio
-    async def test_handle_request_document_mode(self):
+    async def test_handle_request_document_mode(self, monkeypatch):
         from brain.platform.gpu.workers.embedding import EmbeddingWorker
         from brain.platform.gpu.config import WorkerManifest
         import numpy as np
 
+        _install_fake_torch(monkeypatch)
         m = WorkerManifest(name="embedding", model_path="/tmp/model", vram_mb=5000)
         w = EmbeddingWorker(m)
 
@@ -368,11 +381,12 @@ class TestEmbeddingWorker:
         assert len(result["embeddings"]) == 2
 
     @pytest.mark.asyncio
-    async def test_handle_request_query_mode_adds_prefix(self):
+    async def test_handle_request_query_mode_adds_prefix(self, monkeypatch):
         from brain.platform.gpu.workers.embedding import EmbeddingWorker
         from brain.platform.gpu.config import WorkerManifest
         import numpy as np
 
+        _install_fake_torch(monkeypatch)
         m = WorkerManifest(name="embedding", model_path="/tmp/model", vram_mb=5000)
         w = EmbeddingWorker(m)
 

--- a/tests/test_llm_worker.py
+++ b/tests/test_llm_worker.py
@@ -1,14 +1,19 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from contextlib import nullcontext
+from types import SimpleNamespace
 
 
-def _make_worker():
-    from brain.platform.gpu.workers.llm import LLMWorker
+def _make_worker(monkeypatch):
+    from brain.platform.gpu.workers import llm as llm_worker
     from brain.platform.gpu.config import WorkerManifest
-    import torch
+
+    monkeypatch.setattr(
+        llm_worker,
+        "torch",
+        SimpleNamespace(no_grad=nullcontext),
+    )
 
     m = WorkerManifest(name="llm", model_path="Qwen/Qwen3.5-4B", vram_mb=3000)
-    w = LLMWorker(m)
+    w = llm_worker.LLMWorker(m)
 
     class FakeInputIds:
         shape = [1, 3]
@@ -29,7 +34,7 @@ def _make_worker():
 
     class FakeModel:
         def generate(self, **kw):
-            return torch.tensor([[1, 2, 3, 4, 5]])
+            return [[1, 2, 3, 4, 5]]
 
     w.tokenizer = FakeTokenizer()
     w.model = FakeModel()
@@ -44,8 +49,8 @@ class TestLLMWorker:
         w = LLMWorker(m)
         assert w.manifest.name == "llm"
 
-    async def test_handle_request_returns_text(self):
-        w = _make_worker()
+    async def test_handle_request_returns_text(self, monkeypatch):
+        w = _make_worker(monkeypatch)
         result = await w.handle_request({
             "prompt": "test prompt",
             "max_tokens": 100,
@@ -55,9 +60,9 @@ class TestLLMWorker:
         assert result["text"] == "generated text"
         assert "elapsed_ms" in result
 
-    async def test_think_false_strips_thinking_tags(self):
+    async def test_think_false_strips_thinking_tags(self, monkeypatch):
         """When think=False, <think>...</think> blocks are stripped from output."""
-        w = _make_worker()
+        w = _make_worker(monkeypatch)
         w.tokenizer._decode_text = "<think>internal reasoning here</think>Clean title output"
         result = await w.handle_request({
             "prompt": "generate a title",
@@ -68,9 +73,9 @@ class TestLLMWorker:
         assert result["text"] == "Clean title output"
         assert "<think>" not in result["text"]
 
-    async def test_think_true_preserves_thinking_tags(self):
+    async def test_think_true_preserves_thinking_tags(self, monkeypatch):
         """When think=True, thinking tags are preserved."""
-        w = _make_worker()
+        w = _make_worker(monkeypatch)
         w.tokenizer._decode_text = "<think>reasoning</think>Answer"
         result = await w.handle_request({
             "prompt": "test",
@@ -80,9 +85,9 @@ class TestLLMWorker:
         assert "<think>" in result["text"]
         assert "reasoning" in result["text"]
 
-    async def test_think_false_no_tags_passthrough(self):
+    async def test_think_false_no_tags_passthrough(self, monkeypatch):
         """When think=False but no tags present, output is unchanged."""
-        w = _make_worker()
+        w = _make_worker(monkeypatch)
         w.tokenizer._decode_text = "Just a clean response"
         result = await w.handle_request({
             "prompt": "test",
@@ -91,9 +96,9 @@ class TestLLMWorker:
         })
         assert result["text"] == "Just a clean response"
 
-    async def test_think_false_multiline_thinking(self):
+    async def test_think_false_multiline_thinking(self, monkeypatch):
         """Multiline thinking blocks are fully stripped."""
-        w = _make_worker()
+        w = _make_worker(monkeypatch)
         w.tokenizer._decode_text = "<think>\nline1\nline2\nline3\n</think>\nFinal answer"
         result = await w.handle_request({
             "prompt": "test",
@@ -102,7 +107,7 @@ class TestLLMWorker:
         })
         assert result["text"] == "Final answer"
 
-    async def test_empty_prompt_returns_error(self):
-        w = _make_worker()
+    async def test_empty_prompt_returns_error(self, monkeypatch):
+        w = _make_worker(monkeypatch)
         result = await w.handle_request({"prompt": ""})
         assert result == {"error": "prompt required"}


### PR DESCRIPTION
Closes #485.

## Root cause (not what the ticket assumed)
These 8 tests don't need GPU hardware at all. They fail on any machine whose PyTorch install can't load its native library — locally, a missing `libtorch_cpu.dylib`.

- `test_gpu_server.py` already uses a fake NumPy model and only touches PyTorch via `handle_request`'s CUDA OOM cleanup path.
- `test_llm_worker.py` imported PyTorch in its fixture purely to build a tensor and use `no_grad()`.

So this is mocked at that seam rather than skipped — the tests' real subject is our request-handling and think-tag-stripping logic, which stays fully under test. No `requires-gpu` marker was needed.

## Why it mattered
Every full-suite verification was running `--ignore=tests/test_gpu_server.py --ignore=tests/test_llm_worker.py`, so these 8 were effectively untested and any regression inside them was invisible.

## Verification
`pytest tests/test_gpu_server.py tests/test_llm_worker.py` → **54 passed**, no ignore flags. Full suite 4164 passed.

I checked the mocks aren't vacuous: only `torch.no_grad` is stubbed (the single API the worker uses) and a tensor becomes a plain list; every assertion is unchanged.

Implementation by Codex (medium effort — mechanical), reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)