### PR TITLE
feat(routing): per-spawn effort and model overrides on spawn_worker

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -120,6 +120,10 @@ from brain.systems.runs.direct_loop.tool_execution import (
     resolve_tool_call as _runtime_resolve_tool_call,
 )
 from brain.systems.runs.context import has_scheduled_result_contract
+from brain.systems.runs.routing_metadata import (
+    effective_routing_snapshot,
+    routing_metadata_with_effective,
+)
 from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems import sessions as _session_store
@@ -194,6 +198,17 @@ def _normalize_model(model: str) -> str:
         if model.startswith(prefix):
             return model[len(prefix):]
     return model
+
+
+def _publish_effective_routing(
+    execution_metadata: dict[str, Any],
+    effective_routing: dict[str, Any],
+) -> None:
+    execution_metadata["routing"] = routing_metadata_with_effective(
+        execution_metadata,
+        effective_routing,
+    )
+    _agent_context.execution_metadata = execution_metadata
 
 
 _AUTO_OPENAI_AUTH_MODE = object()
@@ -1118,6 +1133,7 @@ def _make_result(
     worker_results: list | None = None,
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
+    effective_routing: dict[str, Any] | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common fields."""
     return _runtime_make_result(
@@ -1131,6 +1147,7 @@ def _make_result(
         worker_results=worker_results,
         termination=termination,
         post_completion_tasks=post_completion_tasks,
+        effective_routing=effective_routing,
     )
 
 
@@ -1386,6 +1403,7 @@ async def run_agent_async(
         context_attrs["run_id"] = run_id
     _agent_agent_context = bind_agent_context(context_attrs)
     _agent_agent_context.__enter__()
+    effective_routing: dict[str, Any] = {}
 
     try:
         _agent_context.session_id = session_id
@@ -1417,6 +1435,7 @@ async def run_agent_async(
                 start_time,
                 state.tool_calls_made,
                 error="Cancelled by runner",
+                effective_routing=effective_routing,
             )
 
         model = await _resolve_model_async(
@@ -1460,6 +1479,13 @@ async def run_agent_async(
                 model,
             )
         state.provider_name = llm.provider
+        effective_routing = effective_routing_snapshot(
+            model,
+            thinking,
+            provider=state.provider_name,
+            auth_mode=getattr(llm, "auth_mode", None),
+        )
+        _publish_effective_routing(execution_metadata, effective_routing)
         owns_semantic_compactor = semantic_compactor is None
         owns_thread_handoff_compactor = thread_handoff_compactor is None
         if semantic_compactor is None:
@@ -1533,6 +1559,7 @@ async def run_agent_async(
                     start_time,
                     state.tool_calls_made,
                     error="Cancelled by runner",
+                    effective_routing=effective_routing,
                 )
 
             before_guidance_len = len(state.messages)
@@ -1645,6 +1672,16 @@ async def run_agent_async(
                         preferred_model = model
                         model = _normalize_model(fallback)
                         model_fallback_used = True
+                        effective_routing = effective_routing_snapshot(
+                            model,
+                            thinking,
+                            provider=state.provider_name,
+                            auth_mode=getattr(llm, "auth_mode", None),
+                        )
+                        _publish_effective_routing(
+                            execution_metadata,
+                            effective_routing,
+                        )
                         logger.warning(
                             "Agent %s turn %d: model unavailable; falling back %s -> %s",
                             session_id,
@@ -1757,6 +1794,7 @@ async def run_agent_async(
                     )
                     _call_start = time.time()
             if isinstance(response, AgentResult):
+                response.effective_routing = dict(effective_routing)
                 return response  # Cancellation during streaming
 
             _call_ms = int((time.time() - _call_start) * 1000)
@@ -2000,6 +2038,7 @@ async def run_agent_async(
             state.tool_calls_made,
             termination=termination,
             post_completion_tasks=post_completion_tasks,
+            effective_routing=effective_routing,
         )
 
     except Exception as e:
@@ -2024,9 +2063,19 @@ async def run_agent_async(
                 start_time,
                 state.tool_calls_made,
                 error=f"API error: {e}",
+                effective_routing=effective_routing,
             )
         logger.error("Agent %s: error: %s", session_id, e)
-        return _make_result("", False, session_id, state.tokens, start_time, state.tool_calls_made, error=str(e))
+        return _make_result(
+            "",
+            False,
+            session_id,
+            state.tokens,
+            start_time,
+            state.tool_calls_made,
+            error=str(e),
+            effective_routing=effective_routing,
+        )
 
     finally:
         try:

--- a/brain/systems/runs/direct_loop/result.py
+++ b/brain/systems/runs/direct_loop/result.py
@@ -46,6 +46,7 @@ class AgentResult:
     error: str | None = None
     termination: LoopTermination | None = None
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = ()
+    effective_routing: dict[str, Any] = field(default_factory=dict)
 
 
 def make_result(
@@ -59,6 +60,7 @@ def make_result(
     worker_results: list | None = None,
     termination: LoopTermination | None = None,
     post_completion_tasks: tuple[Callable[[], Awaitable[Any]], ...] = (),
+    effective_routing: dict[str, Any] | None = None,
 ) -> AgentResult:
     """Construct an AgentResult with common runtime fields."""
 
@@ -76,4 +78,5 @@ def make_result(
         termination=termination,
         worker_results=worker_results or [],
         post_completion_tasks=post_completion_tasks,
+        effective_routing=dict(effective_routing or {}),
     )

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -20,6 +20,10 @@ from brain.systems.runs.recipes.shared import (
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.tools import AsyncRunToolExecutor, ToolRecord, ToolScope, wrap_tool_handlers
 from brain.systems.runs.invocation import build_direct_agent_invocation, invoke_direct_agent_async
+from brain.systems.runs.routing_metadata import (
+    effective_routing_snapshot,
+    routing_metadata_with_effective,
+)
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 from brain.systems.runs.recipes.surface_guidance import response_surface_guidance
 
@@ -42,6 +46,29 @@ Rules:
 
 
 WorkerScope = WorkerAssignment
+
+
+def _result_routing(result: Any, *, model: str, effort: str) -> dict[str, Any]:
+    routing = getattr(result, "effective_routing", None)
+    if not isinstance(routing, dict) or not routing.get("model"):
+        return effective_routing_snapshot(model, effort)
+    return effective_routing_snapshot(
+        routing["model"],
+        routing.get("effort") or effort,
+        provider=routing.get("provider"),
+        auth_mode=routing.get("auth_mode"),
+    )
+
+
+async def _record_effective_routing(
+    runtime: RunRuntime,
+    effective: dict[str, Any],
+) -> None:
+    routing = routing_metadata_with_effective(
+        runtime.request.metadata,
+        effective,
+    )
+    await runtime.store.update_metadata(runtime.run.id, {"routing": routing})
 
 
 def _thread_attachment_context(runtime: RunRuntime) -> dict[str, Any] | None:
@@ -161,6 +188,7 @@ class WorkerRecipe(BaseRunRecipe):
                 else {},
             },
         )
+        effective_routing = effective_routing_snapshot(str(model), str(thinking))
         try:
             result = await invoke_direct_agent_async(spec)
         except Exception as exc:
@@ -172,6 +200,11 @@ class WorkerRecipe(BaseRunRecipe):
             output = ""
             post_completion_tasks = ()
         else:
+            effective_routing = _result_routing(
+                result,
+                model=str(model),
+                effort=str(thinking),
+            )
             output = str(getattr(result, "output", "") or "").strip()
             status = RunStatus.COMPLETED if getattr(result, "success", False) else RunStatus.FAILED
             error = None
@@ -183,6 +216,7 @@ class WorkerRecipe(BaseRunRecipe):
                 failure = public_run_failure(status, failure_category)
                 output = ""
             post_completion_tasks = tuple(getattr(result, "post_completion_tasks", ()) or ())
+        await _record_effective_routing(runtime, effective_routing)
         streamed_output = False
         if status == RunStatus.COMPLETED:
             for delta in pending_deltas:
@@ -199,6 +233,7 @@ class WorkerRecipe(BaseRunRecipe):
             tool_records=tool_records,
             root_run_id=runtime.run.root_run_id,
             failure=failure,
+            routing=effective_routing,
         )
         return RunRecipeResult(
             output=output,
@@ -276,6 +311,7 @@ def worker_result_artifact(
     tool_records: list[ToolRecord],
     root_run_id: int | None,
     failure: dict[str, str] | None = None,
+    routing: dict[str, Any] | None = None,
 ) -> AgentRunArtifact:
     payload = {
         "status": status.value,
@@ -290,6 +326,8 @@ def worker_result_artifact(
     }
     if failure:
         payload["failure"] = dict(failure)
+    if routing:
+        payload["routing"] = dict(routing)
     return AgentRunArtifact(
         run_id=run_id,
         root_run_id=root_run_id,

--- a/brain/systems/runs/routing_metadata.py
+++ b/brain/systems/runs/routing_metadata.py
@@ -1,0 +1,74 @@
+"""Canonical requested/effective routing metadata helpers for AgentRuns."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from brain.platform.providers.model_policy import (
+    infer_provider_from_model,
+    required_openai_auth_mode,
+)
+
+
+_INFER_AUTH_MODE = object()
+
+
+def effective_routing_snapshot(
+    model: str,
+    effort: str | None,
+    *,
+    provider: str | None = None,
+    auth_mode: Any = _INFER_AUTH_MODE,
+) -> dict[str, Any]:
+    """Return the canonical route selected for one model execution."""
+
+    resolved_provider = str(
+        provider or infer_provider_from_model(model)
+    ).strip().lower()
+    model_name = str(model or "").strip()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if model_name.startswith(prefix):
+            model_name = model_name[len(prefix):]
+            break
+    canonical_model = (
+        model_name
+        if model_name == "local"
+        else f"{resolved_provider}/{model_name}"
+    )
+    if auth_mode is _INFER_AUTH_MODE:
+        resolved_auth_mode = (
+            required_openai_auth_mode(canonical_model)
+            if resolved_provider == "openai"
+            else None
+        )
+    else:
+        resolved_auth_mode = (
+            str(auth_mode).strip()
+            if isinstance(auth_mode, str) and auth_mode.strip()
+            else None
+        )
+    return {
+        "model": canonical_model,
+        "effort": str(effort or "none").strip().lower(),
+        "provider": resolved_provider,
+        "auth_mode": resolved_auth_mode,
+    }
+
+
+def routing_metadata_with_effective(
+    metadata: Mapping[str, Any] | None,
+    effective: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge an effective snapshot without discarding routing provenance."""
+
+    routing_value = (metadata or {}).get("routing")
+    routing = dict(routing_value) if isinstance(routing_value, Mapping) else {}
+    routing.update({
+        "model": effective["model"],
+        "effort": effective["effort"],
+        "effective": dict(effective),
+    })
+    return routing
+
+
+__all__ = ["effective_routing_snapshot", "routing_metadata_with_effective"]

--- a/brain/systems/runs/tool_catalog/definitions/workers.py
+++ b/brain/systems/runs/tool_catalog/definitions/workers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from brain.platform.effort import EFFORT_TIERS
+
 
 WORKER_SPAWN_TOOLS = [
     {
@@ -12,7 +14,11 @@ WORKER_SPAWN_TOOLS = [
             "file/report an internal bug or blocker in the background. Set headless=true for "
             "background reporting or investigation that should not create visible thread content; "
             "leave headless=false when the delegated run should be able to report visible progress "
-            "or a final update back through the inherited originating surface."
+            "or a final update back through the inherited originating surface. Route primarily with "
+            "effort: xhigh for costly judgment, high for standard work, medium for clear execution, "
+            "and low for reflex work. Use the director/workhorse split: a high-effort coordinator "
+            "should fan out cheaper low/medium readers. Reserve model for a cross-provider verifier, "
+            "preferably using a bare provider such as model='anthropic' to select its default model."
         ),
         "input_schema": {
             "type": "object",
@@ -29,6 +35,15 @@ WORKER_SPAWN_TOOLS = [
                 "message": {
                     "type": "string",
                     "description": "Optional full instruction to run. Defaults to the objective.",
+                },
+                "effort": {
+                    "type": "string",
+                    "enum": list(EFFORT_TIERS),
+                    "description": "Optional canonical effort override for this child. Inherits the parent's effective effort when omitted.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Exceptional cross-provider override: a provider-prefixed catalog id or a bare provider name selecting that provider's default model.",
                 },
                 "headless": {
                     "type": "boolean",

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -10,10 +10,18 @@ import uuid
 from typing import Any
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.platform.effort import EFFORT_TIERS, EFFORT_TIER_SET
+from brain.platform.providers.model_policy import (
+    DEFAULT_PROVIDER_MODELS,
+    PROVIDER_MODEL_OPTIONS,
+    async_get_default_model,
+    async_get_default_thinking,
+)
 from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.domain import RunRecipe
 from brain.systems.runs.events import run_event
 from brain.systems.runs.execution_context import _agent_context
+from brain.systems.runs.routing_metadata import effective_routing_snapshot
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.tool_policy import normalize_tool_policy
 
@@ -98,6 +106,128 @@ def _current_mapping(name: str) -> dict[str, Any]:
         if isinstance(value, Mapping):
             return dict(value)
     return {}
+
+
+def _current_effective_routing() -> dict[str, Any]:
+    execution_metadata = getattr(_agent_context, "execution_metadata", None)
+    if not isinstance(execution_metadata, Mapping):
+        return {}
+    routing = execution_metadata.get("routing")
+    if not isinstance(routing, Mapping):
+        return {}
+    effective = routing.get("effective")
+    return dict(effective) if isinstance(effective, Mapping) else {}
+
+
+def _validate_spawn_effort(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized not in EFFORT_TIER_SET:
+        accepted = ", ".join(EFFORT_TIERS)
+        raise ValueError(
+            f"spawn_worker effort must be one of: {accepted}; got {value!r}"
+        )
+    return normalized
+
+
+def _validate_spawn_model(value: Any) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, None
+    requested = str(value).strip().lower()
+    providers = ", ".join(sorted(DEFAULT_PROVIDER_MODELS))
+    if requested in DEFAULT_PROVIDER_MODELS:
+        return f"{requested}/{DEFAULT_PROVIDER_MODELS[requested]}", requested
+
+    normalized = requested.replace(":", "/", 1)
+    if "/" not in normalized:
+        raise ValueError(
+            "spawn_worker model must be a provider name "
+            f"({providers}) or a provider-prefixed catalog id such as "
+            "'anthropic/claude-sonnet-4-6'"
+        )
+    provider, model_name = normalized.split("/", 1)
+    if provider not in PROVIDER_MODEL_OPTIONS:
+        raise ValueError(
+            f"spawn_worker model provider must be one of: {providers}; got {provider!r}"
+        )
+    options = PROVIDER_MODEL_OPTIONS[provider]
+    if model_name not in options:
+        raise ValueError(
+            f"spawn_worker model for provider {provider!r} must be one of: "
+            f"{', '.join(options)}; got {model_name!r}"
+        )
+    return f"{provider}/{model_name}", requested
+
+
+def _canonical_inherited_model(value: Any) -> str:
+    model = str(value or "").strip()
+    normalized = model.replace(":", "/", 1)
+    if "/" in normalized:
+        provider, model_name = normalized.split("/", 1)
+        if model_name in PROVIDER_MODEL_OPTIONS.get(provider, ()):
+            return f"{provider}/{model_name}"
+        return model
+    for provider, options in PROVIDER_MODEL_OPTIONS.items():
+        if normalized in options:
+            return f"{provider}/{normalized}"
+    return model
+
+
+async def _materialized_parent_policy(session: Any, parent: Any) -> dict[str, Any]:
+    policy = dict(parent.model_policy or {})
+    live_routing = _current_effective_routing()
+
+    model = str(live_routing.get("model") or policy.get("model") or "").strip()
+    if not model:
+        model = await async_get_default_model(
+            session,
+            include_provider_prefix=True,
+            user_id=parent.user_id,
+            org_id=parent.org_id,
+        )
+    policy["model"] = _canonical_inherited_model(model)
+
+    thinking = str(
+        live_routing.get("effort")
+        or live_routing.get("thinking")
+        or policy.get("thinking")
+        or ""
+    ).strip().lower()
+    if not thinking:
+        thinking = await async_get_default_thinking(
+            session,
+            user_id=parent.user_id,
+            org_id=parent.org_id,
+        )
+    policy["thinking"] = thinking
+    return policy
+
+
+def _requested_routing(
+    *,
+    model: str,
+    effort: str,
+    requested_model: str | None,
+    effort_overridden: bool,
+) -> dict[str, Any]:
+    model_request: dict[str, Any] = {
+        "value": model,
+        "source": "spawn_worker.model" if requested_model is not None else "parent_effective",
+    }
+    if requested_model is not None and requested_model != model:
+        model_request["requested_value"] = requested_model
+    return {
+        "model": model_request,
+        "effort": {
+            "value": effort,
+            "source": "spawn_worker.effort" if effort_overridden else "parent_effective",
+        },
+    }
+
+
+def _routing_summary(model: str, effort: str) -> dict[str, Any]:
+    return effective_routing_snapshot(model, effort)
 
 
 def _inherited_run_mapping(
@@ -220,6 +350,8 @@ async def _handle_spawn_worker(
     objective: str,
     role: str = "worker",
     message: str | None = None,
+    effort: str | None = None,
+    model: str | None = None,
     headless: bool = False,
     idempotency_key: str | None = None,
     allowed_files: list[str] | None = None,
@@ -238,6 +370,12 @@ async def _handle_spawn_worker(
     objective_text = str(objective or "").strip()
     if not objective_text:
         return json.dumps({"error": "spawn_worker requires objective"})
+
+    try:
+        effort_override = _validate_spawn_effort(effort)
+        model_override, requested_model = _validate_spawn_model(model)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
 
     parent_run_id = _coerce_run_id(_runtime_run_id) or _current_run_id()
     if parent_run_id is None:
@@ -289,6 +427,23 @@ async def _handle_spawn_worker(
     async with UnitOfWork() as uow:
         store = AsyncAgentRunStore(uow.session)
         parent = await store.require_run(parent_run_id)
+        child_policy = await _materialized_parent_policy(uow.session, parent)
+        if model_override is not None:
+            child_policy["model"] = model_override
+        if effort_override is not None:
+            child_policy["thinking"] = effort_override
+        inherited_routing = (
+            dict(worker_metadata.get("routing") or {})
+            if isinstance(worker_metadata.get("routing"), Mapping)
+            else {}
+        )
+        inherited_routing["requested"] = _requested_routing(
+            model=str(child_policy["model"]),
+            effort=str(child_policy["thinking"]),
+            requested_model=requested_model,
+            effort_overridden=effort_override is not None,
+        )
+        worker_metadata["routing"] = inherited_routing
         child, created = await store.create_child_run_with_result(
             parent,
             recipe=RunRecipe.WORKER,
@@ -304,10 +459,16 @@ async def _handle_spawn_worker(
                 parent.workspace_ref,
                 _current_mapping("workspace_ref"),
             ),
-            model_policy=dict(parent.model_policy or {}),
+            model_policy=child_policy,
             metadata=worker_metadata,
         )
         deduplicated = not created
+        persisted_policy = dict(getattr(child, "model_policy", None) or child_policy)
+        child_model = str(persisted_policy.get("model") or child_policy["model"])
+        child_effort = str(
+            persisted_policy.get("thinking") or child_policy["thinking"]
+        )
+        child_routing = _routing_summary(child_model, child_effort)
         if created:
             await store.append_event(
                 run_event(
@@ -319,6 +480,7 @@ async def _handle_spawn_worker(
                         "headless": bool(headless),
                         "role": assignment.role,
                         "objective": assignment.objective,
+                        "routing": child_routing,
                     },
                     root_run_id=parent.root_run_id or parent.id,
                     producer="spawn_worker",
@@ -338,6 +500,9 @@ async def _handle_spawn_worker(
             "headless": bool(headless),
             "step_key": step_key,
             "deduplicated": deduplicated,
+            "model": child_model,
+            "effort": child_effort,
+            "routing": child_routing,
             "next_action": _delegation_next_action(
                 tool_name="spawn_worker",
                 response_tool=response_tool_text,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -143,6 +143,35 @@ class TestProviderInference:
             assert mock_resolve.call_args.kwargs["provider"] == "openai"
             assert mock_resolve.call_args.kwargs["auth_mode"] == "chatgpt"
 
+    @pytest.mark.asyncio
+    async def test_cross_provider_worker_selects_anthropic_transport_without_openai_auth_mode(
+        self,
+        monkeypatch,
+    ):
+        from brain.platform.integrations.providers import AnthropicProvider
+        from brain.platform.integrations.transports.anthropic import AnthropicMessagesTransport
+        from brain.systems.runs.direct_agent import _init_llm_async
+
+        llm = _mock_llm_client(MagicMock(), provider="anthropic")
+        resolve = AsyncMock(return_value=llm)
+        monkeypatch.setattr(
+            "brain.systems.runs.direct_agent.async_resolve_llm_client",
+            resolve,
+        )
+
+        resolved, provider, _headers = await _init_llm_async(
+            "user-1",
+            "worker-session",
+            "anthropic/claude-sonnet-4-6",
+            org_id="org-1",
+        )
+
+        assert resolved is llm
+        assert resolve.await_args.kwargs["provider"] == "anthropic"
+        assert resolve.await_args.kwargs["auth_mode"] is None
+        assert isinstance(provider, AnthropicProvider)
+        assert isinstance(provider.transport, AnthropicMessagesTransport)
+
 
 @pytest.mark.asyncio
 async def test_agent_retries_gpt_5_6_on_gpt_5_5_when_account_lacks_entitlement(monkeypatch):
@@ -194,6 +223,12 @@ async def test_agent_retries_gpt_5_6_on_gpt_5_5_when_account_lacks_entitlement(m
     assert result.output == "Fallback succeeded"
     assert [request.model for request in requests] == ["gpt-5.6-sol", "gpt-5.5"]
     assert any("unavailable" in item and "gpt-5.5" in item for item in activity)
+    assert result.effective_routing == {
+        "model": "openai/gpt-5.5",
+        "effort": "xhigh",
+        "provider": "openai",
+        "auth_mode": "chatgpt",
+    }
 
 
 @pytest.mark.asyncio
@@ -243,6 +278,12 @@ async def test_agent_uses_shared_key_fallback_when_personal_codex_connection_is_
     assert result.success is True
     assert seen_models == ["gpt-5.5"]
     assert [call.kwargs["auth_mode"] for call in resolve.await_args_list] == ["chatgpt", None]
+    assert result.effective_routing == {
+        "model": "openai/gpt-5.5",
+        "effort": "xhigh",
+        "provider": "openai",
+        "auth_mode": "api_key",
+    }
 
 class TestLiveGuidance:
     async def test_append_live_guidance_adds_user_message(self):

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -44,6 +44,7 @@ class _Store:
     def __init__(self):
         self.events = []
         self.artifacts = []
+        self.metadata_updates = []
         self.created_requests = []
         self.child_initial_statuses = []
         self.runs = {}
@@ -59,6 +60,10 @@ class _Store:
     def append_artifact(self, artifact):
         self.artifacts.append(artifact)
         return _AwaitableValue(artifact)
+
+    def update_metadata(self, run_id, patch):
+        self.metadata_updates.append((run_id, dict(patch)))
+        return _AwaitableValue(dict(patch))
 
     def create_run(self, request, *, initial_status=None):
         from brain.systems.runs.domain import AgentRun
@@ -1509,6 +1514,281 @@ def test_headless_worker_policy_uses_canonical_disabled_tools():
         "cortex_reply",
         "post_ai_timeline_message",
     }
+
+
+async def _captured_spawn_worker(
+    monkeypatch,
+    *,
+    parent_model_policy,
+    child_model_policy=None,
+    execution_metadata=None,
+    created_here=True,
+    **spawn_kwargs,
+):
+    from brain.systems.runs.domain import RunProfile, RunRecipe
+    from brain.systems.runs.execution_context import bind_agent_context
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    parent = SimpleNamespace(
+        id=42,
+        org_id="org-1",
+        user_id="user-1",
+        root_run_id=42,
+        profile=RunProfile.FAST,
+        target_ref={"kind": "cortex_idea", "idea_id": "idea-1"},
+        workspace_ref={"workspace_root": "/tmp/work"},
+        model_policy=dict(parent_model_policy),
+    )
+    captured = {}
+    events = []
+
+    class _Uow:
+        session = object()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+    class _Store:
+        def __init__(self, session):
+            self.session = session
+
+        async def require_run(self, run_id):
+            assert run_id == parent.id
+            return parent
+
+        async def create_child_run_with_result(self, parent_arg, **kwargs):
+            assert parent_arg is parent
+            captured.update(kwargs)
+            actual_policy = (
+                dict(child_model_policy)
+                if child_model_policy is not None
+                else dict(kwargs["model_policy"])
+            )
+            return (
+                SimpleNamespace(
+                    id=99,
+                    root_run_id=42,
+                    recipe=RunRecipe.WORKER,
+                    model_policy=actual_policy,
+                    metadata=dict(kwargs["metadata"]),
+                ),
+                created_here,
+            )
+
+        async def append_event(self, event):
+            events.append(event)
+
+    monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
+    monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
+
+    with bind_agent_context(
+        run=SimpleNamespace(id=parent.id),
+        execution_metadata=dict(execution_metadata or {}),
+    ):
+        payload = json.loads(
+            await worker_handlers._handle_spawn_worker(
+                objective="Inspect the routing contract.",
+                **spawn_kwargs,
+            )
+        )
+    return payload, captured, events
+
+
+async def test_spawn_worker_effort_override_merges_over_materialized_parent_policy(monkeypatch):
+    payload, captured, events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "xhigh",
+            "future_policy_key": "preserved",
+        },
+        effort="low",
+    )
+
+    assert captured["model_policy"] == {
+        "model": "openai/gpt-5.6-sol",
+        "thinking": "low",
+        "future_policy_key": "preserved",
+    }
+    requested = captured["metadata"]["routing"]["requested"]
+    assert requested["model"] == {
+        "value": "openai/gpt-5.6-sol",
+        "source": "parent_effective",
+    }
+    assert requested["effort"] == {
+        "value": "low",
+        "source": "spawn_worker.effort",
+    }
+    assert payload["model"] == "openai/gpt-5.6-sol"
+    assert payload["effort"] == "low"
+    assert payload["routing"]["provider"] == "openai"
+    assert payload["routing"]["auth_mode"] == "chatgpt"
+    assert events[0].payload["routing"]["effort"] == "low"
+
+
+async def test_spawn_worker_without_overrides_materializes_parent_effective_defaults(monkeypatch):
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    async def default_model(session, **kwargs):
+        assert session is not None
+        assert kwargs == {
+            "include_provider_prefix": True,
+            "user_id": "user-1",
+            "org_id": "org-1",
+        }
+        return "openai/gpt-5.6-sol"
+
+    async def default_thinking(session, **kwargs):
+        assert session is not None
+        assert kwargs == {"user_id": "user-1", "org_id": "org-1"}
+        return "medium"
+
+    monkeypatch.setattr(worker_handlers, "async_get_default_model", default_model)
+    monkeypatch.setattr(worker_handlers, "async_get_default_thinking", default_thinking)
+
+    payload, captured, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={},
+    )
+
+    assert captured["model_policy"] == {
+        "model": "openai/gpt-5.6-sol",
+        "thinking": "medium",
+    }
+    assert captured["metadata"]["routing"]["requested"] == {
+        "model": {
+            "value": "openai/gpt-5.6-sol",
+            "source": "parent_effective",
+        },
+        "effort": {
+            "value": "medium",
+            "source": "parent_effective",
+        },
+    }
+    assert payload["model"] == "openai/gpt-5.6-sol"
+    assert payload["effort"] == "medium"
+
+
+async def test_spawn_worker_inherits_live_parent_route_after_parent_fallback(monkeypatch):
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    async def unexpected_default(*_args, **_kwargs):
+        raise AssertionError("live parent effective routing should win over late defaults")
+
+    monkeypatch.setattr(worker_handlers, "async_get_default_model", unexpected_default)
+    monkeypatch.setattr(worker_handlers, "async_get_default_thinking", unexpected_default)
+
+    _payload, captured, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={},
+        execution_metadata={
+            "routing": {
+                "effective": {
+                    "model": "openai/gpt-5.5",
+                    "effort": "high",
+                    "provider": "openai",
+                    "auth_mode": "chatgpt",
+                }
+            }
+        },
+    )
+
+    assert captured["model_policy"] == {
+        "model": "openai/gpt-5.5",
+        "thinking": "high",
+    }
+
+
+async def test_spawn_worker_bare_provider_resolves_provider_default_and_transport(monkeypatch):
+    payload, captured, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "high",
+        },
+        model="anthropic",
+        effort="xhigh",
+    )
+
+    assert captured["model_policy"] == {
+        "model": "anthropic/claude-sonnet-4-6",
+        "thinking": "xhigh",
+    }
+    assert captured["metadata"]["routing"]["requested"]["model"] == {
+        "value": "anthropic/claude-sonnet-4-6",
+        "source": "spawn_worker.model",
+        "requested_value": "anthropic",
+    }
+    assert payload["model"] == "anthropic/claude-sonnet-4-6"
+    assert payload["effort"] == "xhigh"
+    assert payload["routing"] == {
+        "model": "anthropic/claude-sonnet-4-6",
+        "effort": "xhigh",
+        "provider": "anthropic",
+        "auth_mode": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("spawn_kwargs", "message"),
+    [
+        ({"effort": "ultra"}, "effort must be one of"),
+        ({"model": "gpt-5.6-sol"}, "model must be a provider name"),
+        (
+            {"model": "anthropic/not-a-real-model"},
+            "model for provider 'anthropic' must be one of",
+        ),
+    ],
+)
+async def test_spawn_worker_rejects_invalid_routing_before_creating_child(
+    monkeypatch,
+    spawn_kwargs,
+    message,
+):
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    class _UnexpectedUow:
+        async def __aenter__(self):
+            raise AssertionError("invalid routing must be rejected before persistence")
+
+        async def __aexit__(self, *_):
+            return None
+
+    monkeypatch.setattr(worker_handlers, "UnitOfWork", _UnexpectedUow)
+
+    payload = json.loads(
+        await worker_handlers._handle_spawn_worker(
+            objective="Inspect the routing contract.",
+            **spawn_kwargs,
+        )
+    )
+
+    assert message in payload["error"]
+
+
+async def test_spawn_worker_deduplicated_result_echoes_existing_child_route(monkeypatch):
+    payload, _captured, events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "high",
+        },
+        child_model_policy={
+            "model": "anthropic/claude-sonnet-4-6",
+            "thinking": "medium",
+        },
+        created_here=False,
+        idempotency_key="stable-verifier",
+        effort="low",
+    )
+
+    assert payload["deduplicated"] is True
+    assert payload["model"] == "anthropic/claude-sonnet-4-6"
+    assert payload["effort"] == "medium"
+    assert events == []
 
 
 @pytest.mark.parametrize("created_here", [True, False])
@@ -3806,7 +4086,17 @@ async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_
         read_result = await spec.tool_handlers["read_file"](path="README.md")
         assert read_result["content"] == "setup steps"
         await spec.on_stream_delta("Found setup steps")
-        return SimpleNamespace(output="README setup documented", success=True, error=None)
+        return SimpleNamespace(
+            output="README setup documented",
+            success=True,
+            error=None,
+            effective_routing={
+                "model": "anthropic/claude-sonnet-4-6",
+                "effort": "xhigh",
+                "provider": "anthropic",
+                "auth_mode": "api_key",
+            },
+        )
 
     monkeypatch.setattr("brain.systems.runs.recipes.workers.build_agent_tools", lambda role: [{"name": "read_file"}])
     monkeypatch.setattr(
@@ -3828,6 +4118,29 @@ async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_
     assert worker_result.artifact_type == ArtifactType.WORKER_RESULT
     assert worker_result.payload["scope"]["allowed_files"] == ["README.md"]
     assert worker_result.payload["evidence"]["tool_names"] == ["read_file"]
+    assert runtime.store.metadata_updates == [
+        (
+            42,
+            {
+                "routing": {
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "effort": "xhigh",
+                    "effective": {
+                        "model": "anthropic/claude-sonnet-4-6",
+                        "effort": "xhigh",
+                        "provider": "anthropic",
+                        "auth_mode": "api_key",
+                    },
+                }
+            },
+        )
+    ]
+    assert worker_result.payload["routing"] == {
+        "model": "anthropic/claude-sonnet-4-6",
+        "effort": "xhigh",
+        "provider": "anthropic",
+        "auth_mode": "api_key",
+    }
 
 
 async def test_worker_recipe_keeps_failed_provider_diagnostics_internal(monkeypatch):

--- a/tests/test_effort_vocabulary.py
+++ b/tests/test_effort_vocabulary.py
@@ -1,12 +1,17 @@
 from brain.platform.db.schemas import skills as skill_schemas
 from brain.platform.providers.model_policy import EFFORT_TIERS, EFFORT_TIER_SET
 from brain.systems.runs.tool_catalog.definitions.brain import BRAIN_TOOLS
+from brain.systems.runs.tool_catalog.definitions.workers import WORKER_SPAWN_TOOLS
 from brain.systems.runs.tool_catalog.handlers import common as handler_common
 from brain.systems.skills import bundles
 
 
 def _tool(name: str) -> dict:
-    return next(tool for tool in BRAIN_TOOLS if tool["name"] == name)
+    return next(
+        tool
+        for tool in (*BRAIN_TOOLS, *WORKER_SPAWN_TOOLS)
+        if tool["name"] == name
+    )
 
 
 def test_effort_vocabulary_contract_matches_all_schema_boundaries():
@@ -15,14 +20,28 @@ def test_effort_vocabulary_contract_matches_all_schema_boundaries():
 
     manage_skill = _tool("manage_skill")["input_schema"]["properties"]
     manage_cycle = _tool("manage_cycle")["input_schema"]["properties"]
+    spawn_worker = _tool("spawn_worker")["input_schema"]["properties"]
     schema_enums = (
         manage_skill["thinking_tier"]["enum"],
         manage_skill["skills"]["items"]["properties"]["thinking_tier"]["enum"],
         manage_cycle["thinking_override"]["enum"],
+        spawn_worker["effort"]["enum"],
     )
     for enum in schema_enums:
         assert set(enum) == canonical
 
+    assert spawn_worker["model"]["type"] == "string"
     assert set(skill_schemas._REASONING_EFFORTS) == canonical
     assert set(handler_common._REASONING_EFFORTS) == canonical
     assert set(bundles._REASONING_EFFORTS) == canonical
+
+
+def test_spawn_worker_description_teaches_routing_patterns():
+    description = _tool("spawn_worker")["description"].lower()
+
+    assert "xhigh" in description and "judgment" in description
+    assert "high" in description and "standard" in description
+    assert "medium" in description and "execution" in description
+    assert "low" in description and "reflex" in description
+    assert "director" in description and "workhorse" in description
+    assert "cross-provider verifier" in description


### PR DESCRIPTION
Closes #479. Slice 2 of `docs/prd-model-effort-routing.md` — the seam the whole routing layer exists to open.

## Problem
`spawn_worker` copied the parent's **stored** `model_policy` verbatim and had no routing parameters, so a coordinator at `xhigh` fanned out every worker at `xhigh`. No cheap readers, no cross-provider verifier.

## Changes
- **`effort`** — the everyday knob, validated against the canonical tier set.
- **`model`** — reserved for the cross-provider verifier. Accepts a provider-prefixed catalog id *or* a **bare provider name** meaning "that provider's default model", so callers never hardcode a foreign model id. Invalid values return an actionable JSON error rather than raising.
- Overrides merge **field-by-field**, preserving unknown policy keys.
- **Child policy is materialized at spawn** from the parent's effective route (live post-fallback routing → stored policy → org default).
- **Requested routing + provenance** recorded at admission; **effective post-fallback routing** recorded at execution and echoed in `spawn_worker` results and the worker artifact.
- Tool description teaches the ladder, the director/workhorse split, and the verifier pattern.

## Review notes
**Why materialization matters:** previously an empty parent policy left the child to re-resolve org defaults at *its own* execution time, so a config change or availability fallback in between silently rerouted it. I verified the new path uses the same `async_get_default_model` call with the same `include_provider_prefix` and user/org scope as `recipes/shared.default_run_model` — so **a spawn with no parameters lands on exactly the same route as before**, just resolved earlier.

**One deliberate consequence worth knowing:** because inheritance now takes the parent's *effective* route, a child spawned while the parent is on an availability fallback (e.g. `gpt-5.6-sol → gpt-5.5`) inherits the fallback for its lifetime rather than re-resolving. That is the intended consistency semantic, and it's bounded — the next run resolves fresh — but it's a real behavior change, not an accident.

**Effective-routing visibility** is what makes escalate-on-failure auditable. Its absence is precisely how the cycle-override bug went unnoticed for weeks.

## Verification
Full suite in this worktree: **4167 passed**, 76 skipped. The only 8 failures are the PyTorch/GPU tests fixed separately in #487 (this branch predates it) — unrelated to this change.

Implementation by Codex at `xhigh` (cross-cutting, with a real inheritance hazard), reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)