### PR TITLE
feat(runs): generic worker join/continuation primitive

### DIFF
--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -1,4 +1,8 @@
-"""Event-driven continuation for chantier-scoped worker fan-outs."""
+"""Event-driven continuation for worker fan-outs.
+
+The chantier continuation remains the primary, backwards-compatible scope.
+Opted-in non-chantier fan-outs fall back to their parent run's own thread.
+"""
 
 from __future__ import annotations
 
@@ -16,11 +20,17 @@ from brain.systems.runs.domain import ArtifactType
 from brain.systems.runs.events import run_event
 from brain.systems.runs.status import TERMINAL_RUN_STATUSES, RunStatus, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
-from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.runs.work_intake import (
+    AGENT_RUN_CONTINUATION_TARGET,
+    WorkIntakeEvent,
+    admit_work,
+)
 
 
 CONTINUATION_QUEUED_EVENT = "run.chantier_continuation_queued"
 CONTINUATION_SOURCE = "chantier_continuation"
+GENERIC_CONTINUATION_QUEUED_EVENT = "run.worker_continuation_queued"
+GENERIC_CONTINUATION_SOURCE = "worker_continuation"
 _MAX_CHILD_OUTPUT_CHARS = 6_000
 _MAX_OUTPUTS_CHARS = 24_000
 
@@ -37,11 +47,13 @@ async def queue_chantier_continuation_for_terminal_run(
     *,
     terminal_run_id: int,
 ) -> int | None:
-    """Queue one continuation after a chantier fan-out reaches its barrier.
+    """Queue one continuation after a worker fan-out reaches its barrier.
 
     The fan-out parent row is the serialization boundary. The continuation's
     source idempotency key is also derived from that parent, so a retry or two
     workers reaching terminal state together cannot admit duplicate runs.
+    Chantier-scoped fan-outs retain their original behavior; other fan-outs
+    must explicitly opt in through worker metadata.
     """
 
     terminal_run = await session.get(AgentRunRow, int(terminal_run_id))
@@ -68,7 +80,12 @@ async def queue_chantier_continuation_for_terminal_run(
 
     scope = await _resolve_chantier_scope(session, anchor)
     if scope is None:
-        return None
+        return await _queue_generic_continuation(
+            session,
+            store=store,
+            anchor=anchor,
+            workers=workers,
+        )
 
     child_results = await _child_results(session, workers)
     idempotency_key = f"chantier:continuation:{anchor.id}"
@@ -131,6 +148,74 @@ async def queue_chantier_continuation_for_terminal_run(
     return int(admission.run_id)
 
 
+async def _queue_generic_continuation(
+    session: AsyncSession,
+    *,
+    store: AsyncAgentRunStore,
+    anchor: AgentRunRow,
+    workers: list[AgentRunRow],
+) -> int | None:
+    if not _wants_generic_continuation(workers):
+        return None
+    if await store.has_event_type(anchor.id, GENERIC_CONTINUATION_QUEUED_EVENT):
+        return await _existing_generic_continuation_run_id(session, anchor.id)
+
+    child_results = await _child_results(session, workers)
+    idempotency_key = f"worker:continuation:{anchor.id}"
+    admission = await admit_work(
+        session,
+        WorkIntakeEvent(
+            source=GENERIC_CONTINUATION_SOURCE,
+            event_type="worker.child_runs_completed",
+            org_id=str(anchor.org_id or ""),
+            actor={
+                "id": anchor.user_id,
+                "org_id": anchor.org_id,
+                "principal_type": "agent_runtime",
+                "name": "worker continuation hook",
+            },
+            target=_generic_continuation_target(anchor),
+            payload={
+                "message": _generic_continuation_message(
+                    anchor=anchor,
+                    child_results=child_results,
+                ),
+                "workspace_ref": dict(anchor.workspace_ref or {}),
+                "model_policy": dict(anchor.model_policy or {}),
+                "metadata": _generic_continuation_metadata(
+                    anchor,
+                    worker_ids=[int(worker.id) for worker in workers],
+                ),
+            },
+            policy={
+                "producer": "run_completion_hook",
+                "idempotency_key": idempotency_key,
+                "run_event": "worker_continuation",
+            },
+        ),
+    )
+    if not admission.ok or admission.run_id is None:
+        raise RuntimeError(
+            "Worker continuation admission failed for fan-out "
+            f"{anchor.id}: {admission.skipped_reason or 'missing run id'}"
+        )
+
+    await store.append_event(
+        run_event(
+            anchor.id,
+            GENERIC_CONTINUATION_QUEUED_EVENT,
+            {
+                "continuation_run_id": int(admission.run_id),
+                "anchor_thread_id": anchor.thread_id,
+                "worker_run_ids": [int(worker.id) for worker in workers],
+            },
+            root_run_id=anchor.root_run_id or anchor.id,
+            producer="run_completion_hook",
+        )
+    )
+    return int(admission.run_id)
+
+
 async def _fanout_anchor_id(
     session: AsyncSession,
     terminal_run: AgentRunRow,
@@ -174,6 +259,16 @@ def _is_spawned_worker(metadata: Mapping[str, Any]) -> bool:
     return bool(
         metadata.get("spawned_by_tool")
         or str(metadata.get("origin") or "") == "spawn_worker"
+    )
+
+
+def _wants_generic_continuation(workers: list[AgentRunRow]) -> bool:
+    return any(
+        (worker.metadata_ if isinstance(worker.metadata_, dict) else {}).get(
+            "join_parent"
+        )
+        is True
+        for worker in workers
     )
 
 
@@ -301,6 +396,47 @@ def _continuation_metadata(
     return metadata
 
 
+def _generic_continuation_target(anchor: AgentRunRow) -> dict[str, Any]:
+    return {
+        "kind": AGENT_RUN_CONTINUATION_TARGET,
+        "thread_id": anchor.thread_id,
+        "target_ref": dict(anchor.target_ref or {}),
+    }
+
+
+def _generic_continuation_metadata(
+    anchor: AgentRunRow,
+    *,
+    worker_ids: list[int],
+) -> dict[str, Any]:
+    source_metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
+    metadata: dict[str, Any] = {
+        "execution_profile": anchor.profile,
+        "worker_continuation": {
+            "anchor_run_id": int(anchor.id),
+            "anchor_thread_id": anchor.thread_id,
+            "completed_fanout_run_id": int(anchor.id),
+            "worker_run_ids": worker_ids,
+        },
+    }
+    for key in (
+        "slack_trigger",
+        "slack_thread_id",
+        "discussion_trigger",
+        "originating_surface",
+        "triggering_surface",
+        "source_surface",
+        "required_response_tool",
+        "final_answer_target_surface",
+    ):
+        value = source_metadata.get(key)
+        if value not in (None, "", {}, []):
+            metadata[key] = value
+    for key, value in dict(anchor.model_policy or {}).items():
+        metadata.setdefault(str(key), value)
+    return metadata
+
+
 async def _child_results(
     session: AsyncSession,
     workers: list[AgentRunRow],
@@ -393,6 +529,34 @@ def _continuation_message(
     return "\n".join(lines)
 
 
+def _generic_continuation_message(
+    *,
+    anchor: AgentRunRow,
+    child_results: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "Automated worker continuation: the worker fan-out has reached its terminal barrier.",
+        "No human follow-up triggered this run.",
+        "",
+        f"Anchor thread: {anchor.thread_id}",
+        f"Completed fan-out run: {anchor.id}",
+        "",
+        "Consume every durable worker result below. Synthesize their evidence, continue the "
+        "parent thread's work, and decide the next step. Ask genuinely blocking questions on "
+        "the parent surface when needed. Do not wait for a human nudge merely because the "
+        "fan-out parent already ended.",
+    ]
+    for result in child_results:
+        lines.extend(
+            [
+                "",
+                f"## Worker run {result['run_id']} ({result['role']}, {result['status']})",
+                str(result["output"] or "[No textual artifact was recorded.]"),
+            ]
+        )
+    return "\n".join(lines)
+
+
 async def _existing_continuation_run_id(
     session: AsyncSession,
     fanout_run_id: int,
@@ -406,8 +570,29 @@ async def _existing_continuation_run_id(
     )
 
 
+async def _existing_generic_continuation_run_id(
+    session: AsyncSession,
+    fanout_run_id: int,
+) -> int | None:
+    key = f"worker:continuation:{fanout_run_id}"
+    return await session.scalar(
+        select(AgentRunRow.id)
+        .where(AgentRunRow.source_idempotency_key == key)
+        .order_by(AgentRunRow.id.asc())
+        .limit(1)
+    )
+
+
+queue_worker_continuation_for_terminal_run = (
+    queue_chantier_continuation_for_terminal_run
+)
+
+
 __all__ = [
     "CONTINUATION_QUEUED_EVENT",
     "CONTINUATION_SOURCE",
+    "GENERIC_CONTINUATION_QUEUED_EVENT",
+    "GENERIC_CONTINUATION_SOURCE",
     "queue_chantier_continuation_for_terminal_run",
+    "queue_worker_continuation_for_terminal_run",
 ]

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -177,11 +177,11 @@ def _source_idempotency_parts(request: AgentRunRequest) -> tuple[str | None, str
             break
     if not key:
         return None, None
-    # Slack can deliver one human mention through multiple event shapes and the
-    # chantier completion hook can race across terminal workers. Lock both
-    # canonical event identities at the run boundary without changing
-    # idempotency semantics for unrelated sources.
-    if not key.startswith(("slack:", "chantier:")):
+    # Slack can deliver one human mention through multiple event shapes, while
+    # chantier and opted-in worker continuation hooks can race across terminal
+    # workers. Lock those canonical event identities at the run boundary
+    # without changing idempotency semantics for unrelated sources.
+    if not key.startswith(("slack:", "chantier:", "worker:continuation:")):
         return None, None
 
     work_intake = metadata.get("work_intake")

--- a/brain/systems/runs/tool_catalog/definitions/workers.py
+++ b/brain/systems/runs/tool_catalog/definitions/workers.py
@@ -50,6 +50,15 @@ WORKER_SPAWN_TOOLS = [
                     "default": False,
                     "description": "When true, hide the worker from visible thread history and block visible reply tools.",
                 },
+                "join_parent": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "When true, queue one continuation on the parent thread after the parent "
+                        "and all of its spawn_worker children reach terminal state. Has no effect "
+                        "on existing fire-and-forget calls when omitted."
+                    ),
+                },
                 "idempotency_key": {
                     "type": "string",
                     "description": "Optional stable key to avoid duplicate workers for the same background task.",

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -353,6 +353,7 @@ async def _handle_spawn_worker(
     effort: str | None = None,
     model: str | None = None,
     headless: bool = False,
+    join_parent: bool = False,
     idempotency_key: str | None = None,
     allowed_files: list[str] | None = None,
     forbidden_files: list[str] | None = None,
@@ -420,6 +421,10 @@ async def _handle_spawn_worker(
         "tool_policy": merged_tool_policy,
         "thread_attachment_context": inherited_metadata.get("thread_attachment_context"),
     }
+    if join_parent:
+        worker_metadata["join_parent"] = True
+    else:
+        worker_metadata.pop("join_parent", None)
     worker_metadata = {key: value for key, value in worker_metadata.items() if value is not None}
     response_tool = _current_agent_value("required_response_tool")
     response_tool_text = str(response_tool).strip() if response_tool else None

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -23,6 +23,7 @@ _VALID_MODEL_PROVIDERS = {"anthropic", "openai"}
 THREAD_DISCUSSION_SURFACE = "thread_discussion"
 THREAD_DISCUSSION_REPLY_TOOL = "post_thread_discussion_reply"
 THREAD_DISCUSSION_THREAD_PREFIX = "thread-discussion:"
+AGENT_RUN_CONTINUATION_TARGET = "agent_run_continuation"
 
 logger = logging.getLogger("work_intake")
 
@@ -605,6 +606,44 @@ def _build_inbound_signal_request(
     )
 
 
+def _build_agent_run_continuation_request(
+    event: WorkIntakeEvent,
+    *,
+    target: dict[str, Any],
+    metadata: dict[str, Any],
+    message: str,
+    producer: str,
+    idempotency_key: str | None,
+    priority: int,
+) -> AgentRunRequest:
+    thread_id = str(target.get("thread_id") or "").strip()
+    if not thread_id:
+        raise ValueError("Agent run continuation requires thread_id")
+    target_ref = target.get("target_ref")
+    if not isinstance(target_ref, dict):
+        raise ValueError("Agent run continuation requires target_ref")
+    profile = profile_from_metadata(metadata)
+    return AgentRunRequest(
+        org_id=_event_org_id(event),
+        user_id=_event_actor_user_id(event),
+        thread_id=thread_id,
+        message=message,
+        profile=profile,
+        recipe=recipe_for_profile(profile, metadata),
+        target_ref=dict(target_ref),
+        workspace_ref=_event_workspace_ref(event),
+        model_policy=_event_model_policy(event, metadata),
+        metadata={
+            **metadata,
+            "event": _event_run_event(event),
+            "priority": priority,
+            "source": event.source,
+            "producer": producer,
+            "idempotency_key": idempotency_key,
+        },
+    )
+
+
 async def build_agent_run_request(
     session: Any,
     event: WorkIntakeEvent,
@@ -752,6 +791,17 @@ async def _build_agent_run_request(
 
     if target.get("kind") in {"app_report", "inbound_submission"}:
         return _build_inbound_signal_request(
+            event,
+            target=target,
+            metadata=metadata,
+            message=message,
+            producer=producer,
+            idempotency_key=idempotency_key,
+            priority=priority,
+        )
+
+    if target.get("kind") == AGENT_RUN_CONTINUATION_TARGET:
+        return _build_agent_run_continuation_request(
             event,
             target=target,
             metadata=metadata,
@@ -1043,6 +1093,7 @@ async def admit_work(
 
 
 __all__ = [
+    "AGENT_RUN_CONTINUATION_TARGET",
     "build_agent_run_request",
     "admit_work",
     "model_policy_from_metadata",

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1672,6 +1672,27 @@ async def test_spawn_worker_without_overrides_materializes_parent_effective_defa
     assert payload["effort"] == "medium"
 
 
+async def test_spawn_worker_join_parent_metadata_is_strictly_opt_in(monkeypatch):
+    _payload, fire_and_forget, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "medium",
+        },
+    )
+    _payload, joined, _events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "medium",
+        },
+        join_parent=True,
+    )
+
+    assert "join_parent" not in fire_and_forget["metadata"]
+    assert joined["metadata"]["join_parent"] is True
+
+
 async def test_spawn_worker_inherits_live_parent_route_after_parent_fallback(monkeypatch):
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -1,0 +1,420 @@
+"""Generic worker fan-out continuation coverage."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.schema import CreateTable
+
+from brain.platform.db.models.agent_run import (
+    AgentRunArtifactRow,
+    AgentRunEventRow,
+    AgentRunRow,
+)
+from brain.systems.runs.chantier_continuation import (
+    CONTINUATION_QUEUED_EVENT,
+    GENERIC_CONTINUATION_QUEUED_EVENT,
+    GENERIC_CONTINUATION_SOURCE,
+    _lock_run,
+    queue_worker_continuation_for_terminal_run,
+)
+from brain.systems.runs.domain import AgentRunRequest, RunRecipe
+from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.status import RunStatus
+from brain.systems.runs.store import AsyncAgentRunStore
+from brain.systems.runs.tool_catalog.definitions.workers import WORKER_SPAWN_TOOLS
+
+
+async def _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    return await async_sqlite_session_factory(
+        [
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+        ]
+    )
+
+
+def _parent_target() -> dict:
+    return {
+        "kind": "custom_parent_surface",
+        "thread_id": "thread-generic-join",
+        "resource_id": "resource-482",
+    }
+
+
+def _slack_target() -> dict:
+    slack_trigger = {
+        "team_id": "T482",
+        "channel_id": "CGENERIC",
+        "message_ts": "1785000000.000100",
+        "thread_ts": "1785000000.000100",
+    }
+    return {
+        "kind": "slack_message",
+        **slack_trigger,
+        "slack_thread_id": "slack:T482:CGENERIC:1785000000.000100",
+        "slack_trigger": slack_trigger,
+    }
+
+
+async def _anchor(
+    store: AsyncAgentRunStore,
+    *,
+    target: dict | None = None,
+    metadata: dict | None = None,
+    terminal: bool = True,
+):
+    target = dict(target or _parent_target())
+    anchor = await store.create_run(
+        AgentRunRequest(
+            org_id="org-482",
+            user_id="user-482",
+            thread_id=str(target.get("thread_id") or target.get("slack_thread_id")),
+            message="Coordinate the fan-out and synthesize its results.",
+            target_ref=target,
+            workspace_ref={"workspace_root": "/tmp/worker-join"},
+            model_policy={"model": "openai/gpt-5.5", "thinking": "high"},
+            metadata=dict(metadata or {}),
+        )
+    )
+    await store.set_status(anchor.id, RunStatus.STARTING)
+    await store.set_status(anchor.id, RunStatus.RUNNING)
+    if terminal:
+        await store.set_status(anchor.id, RunStatus.COMPLETED)
+    return anchor
+
+
+async def _worker(
+    store: AsyncAgentRunStore,
+    anchor,
+    *,
+    step: str,
+    role: str,
+    join_parent: bool | None,
+):
+    metadata = {
+        "origin": "spawn_worker",
+        "spawned_by_tool": True,
+        "worker_role": role,
+    }
+    if join_parent is not None:
+        metadata["join_parent"] = join_parent
+    child = await store.create_child_run(
+        anchor,
+        recipe=RunRecipe.WORKER,
+        message=f"Complete the {role} slice.",
+        step_key=f"spawn_worker:{step}",
+        metadata=metadata,
+        initial_status=RunStatus.STARTING,
+    )
+    await store.set_status(child.id, RunStatus.RUNNING)
+    return child
+
+
+async def _generic_continuations(session) -> list[AgentRunRow]:
+    return list(
+        (
+            await session.scalars(
+                select(AgentRunRow)
+                .where(
+                    AgentRunRow.source_idempotency_key.like(
+                        "worker:continuation:%"
+                    )
+                )
+                .order_by(AgentRunRow.id.asc())
+            )
+        ).all()
+    )
+
+
+async def test_all_children_terminal_queues_one_generic_continuation_on_parent_thread(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    anchor = await _anchor(store)
+    reader = await _worker(
+        store,
+        anchor,
+        step="reader",
+        role="repository reader",
+        join_parent=True,
+    )
+    verifier = await _worker(
+        store,
+        anchor,
+        step="verifier",
+        role="independent verifier",
+        join_parent=True,
+    )
+    engine = AsyncAgentRunEngine(session, recipes={})
+
+    await engine.complete(reader.id, output="Reader found the relevant contract.")
+    assert await _generic_continuations(session) == []
+
+    await engine.complete(verifier.id, output="Verifier confirmed the contract.")
+    continuations = await _generic_continuations(session)
+
+    assert len(continuations) == 1
+    continuation = continuations[0]
+    assert continuation.thread_id == anchor.thread_id
+    assert continuation.target_ref == anchor.target_ref
+    assert continuation.workspace_ref == anchor.workspace_ref
+    assert continuation.model_policy == anchor.model_policy
+    assert continuation.source_idempotency_scope == GENERIC_CONTINUATION_SOURCE
+    assert continuation.metadata_["worker_continuation"] == {
+        "anchor_run_id": anchor.id,
+        "anchor_thread_id": anchor.thread_id,
+        "completed_fanout_run_id": anchor.id,
+        "worker_run_ids": [reader.id, verifier.id],
+    }
+    assert "Reader found the relevant contract." in continuation.input_message
+    assert "Verifier confirmed the contract." in continuation.input_message
+
+    replay_id = await queue_worker_continuation_for_terminal_run(
+        session,
+        terminal_run_id=verifier.id,
+    )
+    assert replay_id == continuation.id
+    assert len(await _generic_continuations(session)) == 1
+
+    events = (
+        await session.scalars(
+            select(AgentRunEventRow).where(
+                AgentRunEventRow.run_id == anchor.id,
+                AgentRunEventRow.event_type
+                == GENERIC_CONTINUATION_QUEUED_EVENT,
+            )
+        )
+    ).all()
+    assert len(events) == 1
+    assert events[0].payload["continuation_run_id"] == continuation.id
+
+
+async def test_generic_continuation_waits_for_terminal_parent(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    anchor = await _anchor(store, terminal=False)
+    worker = await _worker(
+        store,
+        anchor,
+        step="early",
+        role="early finisher",
+        join_parent=True,
+    )
+    engine = AsyncAgentRunEngine(session, recipes={})
+
+    await engine.complete(worker.id, output="Worker finished before its parent.")
+    assert await _generic_continuations(session) == []
+
+    await engine.complete(anchor.id, output="Parent has now reached terminal state.")
+    continuations = await _generic_continuations(session)
+    assert len(continuations) == 1
+    assert "Worker finished before its parent." in continuations[0].input_message
+
+
+async def test_spawn_worker_without_join_flag_remains_fire_and_forget(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    anchor = await _anchor(store)
+    worker = await _worker(
+        store,
+        anchor,
+        step="fire-and-forget",
+        role="background reporter",
+        join_parent=None,
+    )
+
+    await AsyncAgentRunEngine(session, recipes={}).complete(
+        worker.id,
+        output="Background report complete.",
+    )
+
+    assert await _generic_continuations(session) == []
+    assert not await store.has_event_type(
+        anchor.id,
+        GENERIC_CONTINUATION_QUEUED_EVENT,
+    )
+
+
+async def test_chantier_scope_keeps_original_continuation_contract_when_join_opted_in(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    target = _slack_target()
+    anchor = await _anchor(
+        store,
+        target=target,
+        metadata={
+            "slack_trigger": target["slack_trigger"],
+            "chantier_declare": {
+                "domain_id": 48,
+                "record_id": 482,
+                "record_ref": "domain_record:482",
+            },
+        },
+    )
+    worker = await _worker(
+        store,
+        anchor,
+        step="chantier",
+        role="chantier verifier",
+        join_parent=True,
+    )
+
+    await AsyncAgentRunEngine(session, recipes={}).complete(
+        worker.id,
+        output="Chantier verification complete.",
+    )
+
+    chantier = list(
+        (
+            await session.scalars(
+                select(AgentRunRow).where(
+                    AgentRunRow.source_idempotency_key
+                    == f"chantier:continuation:{anchor.id}"
+                )
+            )
+        ).all()
+    )
+    assert len(chantier) == 1
+    assert await _generic_continuations(session) == []
+    assert chantier[0].target_ref["chantier"] == {
+        "record_id": 482,
+        "domain_id": 48,
+        "anchor_thread_id": anchor.thread_id,
+        "completed_fanout_run_id": anchor.id,
+    }
+    assert "worker_continuation" not in chantier[0].metadata_
+    assert await store.has_event_type(anchor.id, CONTINUATION_QUEUED_EVENT)
+    assert not await store.has_event_type(
+        anchor.id,
+        GENERIC_CONTINUATION_QUEUED_EVENT,
+    )
+
+
+async def test_concurrent_terminal_children_admit_only_one_generic_continuation(
+    tmp_path,
+    sqlite_postgres_ddl_patch,
+):
+    database = tmp_path / "generic-worker-continuation-race.sqlite3"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{database}",
+        connect_args={"timeout": 5},
+    )
+    async with engine.begin() as connection:
+        for table in (
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
+        ):
+            await connection.execute(CreateTable(table, if_not_exists=True))
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with factory() as setup_session:
+            setup_store = AsyncAgentRunStore(setup_session)
+            anchor = await _anchor(setup_store)
+            first = await _worker(
+                setup_store,
+                anchor,
+                step="race-a",
+                role="race worker A",
+                join_parent=True,
+            )
+            second = await _worker(
+                setup_store,
+                anchor,
+                step="race-b",
+                role="race worker B",
+                join_parent=True,
+            )
+            await setup_session.commit()
+            anchor_id = anchor.id
+            first_id = first.id
+            second_id = second.id
+
+        first_session = factory()
+        second_session = factory()
+        try:
+            await asyncio.gather(
+                AsyncAgentRunEngine(
+                    first_session,
+                    recipes={},
+                    auto_commit_events=True,
+                ).complete(first_id, output="Race result A."),
+                AsyncAgentRunEngine(
+                    second_session,
+                    recipes={},
+                    auto_commit_events=True,
+                ).complete(second_id, output="Race result B."),
+            )
+        finally:
+            await first_session.close()
+            await second_session.close()
+
+        async with factory() as inspection_session:
+            continuations = await _generic_continuations(inspection_session)
+            assert len(continuations) == 1
+            assert continuations[0].source_idempotency_key == (
+                f"worker:continuation:{anchor_id}"
+            )
+            events = (
+                await inspection_session.scalars(
+                    select(AgentRunEventRow).where(
+                        AgentRunEventRow.run_id == anchor_id,
+                        AgentRunEventRow.event_type
+                        == GENERIC_CONTINUATION_QUEUED_EVENT,
+                    )
+                )
+            ).all()
+            assert len(events) == 1
+    finally:
+        await engine.dispose()
+
+
+def test_spawn_worker_schema_exposes_opt_in_join_flag():
+    spawn_worker = next(
+        tool for tool in WORKER_SPAWN_TOOLS if tool["name"] == "spawn_worker"
+    )
+    join_parent = spawn_worker["input_schema"]["properties"]["join_parent"]
+
+    assert join_parent["type"] == "boolean"
+    assert join_parent["default"] is False
+
+
+async def test_fanout_anchor_lock_uses_select_for_update():
+    captured = {}
+    anchor = object()
+
+    class _ScalarResult:
+        def one_or_none(self):
+            return anchor
+
+    class _CapturingSession:
+        async def scalars(self, statement):
+            captured["statement"] = statement
+            return _ScalarResult()
+
+    assert await _lock_run(_CapturingSession(), 482) is anchor
+    sql = str(
+        captured["statement"].compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    assert "WHERE agent_runs.id = 482" in sql
+    assert sql.rstrip().endswith("FOR UPDATE")


### PR DESCRIPTION
**Unblocks #482.** Deleting the `deep` recipe would remove a capability today, because deep is the only generic fan-out → join → synthesize mechanism: `spawn_worker` is fire-and-forget and the only automatic rejoin is chantier-specific (`recipes/fast.py` even tells the agent to use deep for multi-wave synthesis). This ships the replacement.

## Approach
`chantier_continuation` already implemented nearly all of this generically — anchor lookup, `SELECT … FOR UPDATE` on the anchor, all-children-terminal, the `has_event_type` idempotency guard, child-result gathering. The **only** chantier-specific part was scope resolution, which no-oped everything else when it returned `None`. So this generalizes at that seam rather than writing a parallel mechanism.

- **Chantier behavior unchanged** — the generic path is reached only when no chantier scope resolves, so existing chantier tests pass untouched.
- **Opt-in per spawn** via a `join_parent` flag on `spawn_worker`, so every existing fire-and-forget caller is unaffected.
- Generic continuations target the **parent run's own thread** and carry the child results.
- **Race safety preserved**: anchor row still locked, parent and every child must be terminal, and the generic path has its own event type (`run.worker_continuation_queued`) and idempotency key (`worker:continuation:<anchor>`) so it cannot collide with a chantier continuation.

Tests cover simultaneous child completion, replay, opt-out, and the compiled PostgreSQL locking SQL.

**4191 passed**, 76 skipped. No migration needed.

Implementation by Codex at `xhigh` (concurrency + idempotency are the hard part), reviewed.

## What this leaves for #482
Precondition B (join primitive) is satisfied by this PR. Precondition A — a quiet window on the deep→fast coercion log from #481 — still needs real elapsed time after that deploys, and I won't fake it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)