### PR TITLE
feat(routing): retire the fast/deep mode surface + composer workspace defaults

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -852,7 +852,12 @@ async def idea_audit_analyze(
                 target={"kind": "cortex_idea", "idea_id": idea_id},
                 payload={
                     "message": f"/audit {summary}",
-                    "metadata": {"run_profile": "deep", "recipe": "deep", "source": "audit"},
+                    "metadata": {
+                        "run_profile": "fast",
+                        "recipe": "fast",
+                        "thinking_tier": "xhigh",
+                        "source": "audit",
+                    },
                 },
                 policy={
                     "priority": 2,

--- a/brain/systems/runs/__init__.py
+++ b/brain/systems/runs/__init__.py
@@ -1,8 +1,5 @@
 """Canonical agent-run runtime."""
 
-from dataclasses import dataclass
-from typing import Any
-
 from brain.systems.runs.domain import (
     AgentRun,
     AgentRunArtifact,
@@ -34,70 +31,6 @@ from brain.systems.runs.graph import (
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 
-
-@dataclass(frozen=True)
-class RunProfilePolicy:
-    profile: RunProfile
-    stream_live_reply: bool
-    allow_lazy_skills: bool
-    requires_run_graph: bool
-
-
-@dataclass(frozen=True)
-class RunRuntimeSelection:
-    profile: RunProfile
-    run_graph: bool
-    stream_live_reply: bool
-
-
-def requested_run_profile(metadata: dict[str, Any] | None) -> str:
-    metadata = metadata or {}
-    value = (
-        metadata.get("requested_run_profile")
-        or metadata.get("executionProfile")
-        or metadata.get("execution_profile")
-        or metadata.get("run_profile")
-        or metadata.get("profile")
-        or RunProfile.FAST.value
-    )
-    try:
-        return RunProfile(str(value).strip().lower()).value
-    except Exception:
-        return RunProfile.FAST.value
-
-
-def run_execution_profile(metadata: dict[str, Any] | None) -> str:
-    return requested_run_profile(metadata)
-
-
-def run_profile_policy(profile: RunProfile | str) -> RunProfilePolicy:
-    try:
-        normalized = RunProfile(str(profile).strip().lower())
-    except Exception:
-        normalized = RunProfile.FAST
-    if normalized is RunProfile.DEEP:
-        return RunProfilePolicy(
-            profile=normalized,
-            stream_live_reply=False,
-            allow_lazy_skills=True,
-            requires_run_graph=True,
-        )
-    return RunProfilePolicy(
-        profile=RunProfile.FAST,
-        stream_live_reply=True,
-        allow_lazy_skills=True,
-        requires_run_graph=False,
-    )
-
-
-def select_run_runtime(policy: RunProfilePolicy | RunProfile | str) -> RunRuntimeSelection:
-    profile_policy = policy if isinstance(policy, RunProfilePolicy) else run_profile_policy(policy)
-    return RunRuntimeSelection(
-        profile=profile_policy.profile,
-        run_graph=profile_policy.requires_run_graph,
-        stream_live_reply=profile_policy.stream_live_reply,
-    )
-
 __all__ = [
     "AcceptanceCriteria",
     "AgentRun",
@@ -114,8 +47,6 @@ __all__ = [
     "RunRecipe",
     "RunRecipeResult",
     "RunRuntime",
-    "RunProfilePolicy",
-    "RunRuntimeSelection",
     "RunEdge",
     "RunGraph",
     "RunGraphCycleError",
@@ -129,9 +60,5 @@ __all__ = [
     "build_tool_handlers",
     "current_agent_context",
     "get_agent_context_value",
-    "requested_run_profile",
-    "run_execution_profile",
-    "run_profile_policy",
-    "select_run_runtime",
     "snapshot_agent_context",
 ]

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -210,6 +210,35 @@ def model_policy_from_metadata(metadata: dict[str, Any] | None) -> dict[str, str
     return policy
 
 
+def _routing_metadata_source(metadata: dict[str, Any]) -> str:
+    source = str(metadata.get("source") or "").strip()
+    if source:
+        return source
+    for container_key in ("work_intake", "illo_trigger"):
+        container = metadata.get(container_key)
+        if isinstance(container, dict):
+            source = str(container.get("source") or "").strip()
+            if source:
+                return source
+    return "unknown"
+
+
+def _warn_deep_coercion(metadata: dict[str, Any], *, field: str) -> None:
+    source = _routing_metadata_source(metadata)
+    logger.warning(
+        "Coercing retired deep run %s to fast (source=%s)",
+        field,
+        source,
+        extra={
+            "event": "deep_run_coerced",
+            "routing_source": source,
+            "routing_field": field,
+            "requested_value": "deep",
+            "coerced_value": "fast",
+        },
+    )
+
+
 def profile_from_metadata(metadata: dict[str, Any] | None) -> RunProfile:
     metadata = metadata or {}
     raw = (
@@ -220,19 +249,31 @@ def profile_from_metadata(metadata: dict[str, Any] | None) -> RunProfile:
         or "fast"
     )
     try:
-        return RunProfile(str(raw).strip().lower())
+        profile = RunProfile(str(raw).strip().lower())
     except Exception:
         return RunProfile.FAST
+    if profile is RunProfile.DEEP:
+        _warn_deep_coercion(metadata, field="profile")
+        return RunProfile.FAST
+    return profile
 
 
 def recipe_for_profile(profile: RunProfile, metadata: dict[str, Any] | None) -> RunRecipe:
-    raw_recipe = (metadata or {}).get("recipe")
+    metadata = metadata or {}
+    raw_recipe = metadata.get("recipe")
     if raw_recipe:
         try:
-            return RunRecipe(str(raw_recipe).strip().lower())
+            recipe = RunRecipe(str(raw_recipe).strip().lower())
         except Exception:
             pass
-    return RunRecipe.DEEP if profile is RunProfile.DEEP else RunRecipe.FAST
+        else:
+            if recipe is RunRecipe.DEEP:
+                _warn_deep_coercion(metadata, field="recipe")
+                return RunRecipe.FAST
+            return recipe
+    if profile is RunProfile.DEEP:
+        _warn_deep_coercion(metadata, field="profile")
+    return RunRecipe.FAST
 
 
 def _chat_thread_id(chat_trigger: dict[str, Any], target: dict[str, Any]) -> str:

--- a/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposer.svelte
@@ -448,18 +448,16 @@
   canSubmit={(isVoiceRecording || inputValue.trim().length > 0 || pendingAttachments.length > 0) && projectContextValid}
   footerStatusActive={isVoiceRecording}
   settingsGroups={buildRunSettingsGroups({
-    mode: cortex.executionProfile,
     model: cortex.model,
     effort: cortex.effortLevel,
     modelCatalog: cortex.modelCatalog,
   })}
   onSettingsChange={(key, nextValue) =>
     applyRunSetting(key, nextValue, {
-      setExecutionProfile: (value) => cortex.setExecutionProfile(value),
       setModel: (value) => cortex.setModel(value),
       setEffortLevel: (value) => cortex.setEffortLevel(value),
     })}
-  settingsAriaLabel="Mode, Model, and Effort"
+  settingsAriaLabel="Model and Effort"
   attachments={pendingAttachments}
   context={context}
   disabled={sending}

--- a/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
+++ b/frontend/src/lib/features/composer/components/WorkspaceComposerAdapter.svelte
@@ -40,7 +40,7 @@
     settingsGroups,
     onSettingsOpen,
     onSettingsChange,
-    settingsAriaLabel = 'Mode, Model, and Effort',
+    settingsAriaLabel = 'Model and Effort',
     attachments = [],
     onAttach,
     onRemoveAttachment,

--- a/frontend/src/lib/features/composer/domain/runSettings.ts
+++ b/frontend/src/lib/features/composer/domain/runSettings.ts
@@ -1,29 +1,25 @@
-import type {
-  CortexEffortLevel,
-  CortexExecutionProfile,
-} from '$lib/stores/cortex.svelte';
+import {
+  WORKSPACE_DEFAULT_RUN_SETTING,
+  type CortexEffortSelection,
+} from '$lib/features/cortex/controllers/runSettingsController';
 import type {
   CortexWorkspaceComposerSettingsGroup,
   CortexWorkspaceComposerIntentOption,
 } from '$lib/features/composer/domain/composerAdapter';
 import type { RuntimeModelCatalogEntry } from '$lib/types/runtimeSettings';
 
-export const EXECUTION_PROFILE_OPTIONS = [
-  {
-    value: 'fast',
-    label: 'Fast',
-    description: 'Direct single-session work',
-    icon: 'bolt',
-  },
-  {
-    value: 'deep',
-    label: 'Deep',
-    description: 'Run graph with coordinator and workers',
-    icon: 'route',
-  },
-] as const satisfies readonly CortexWorkspaceComposerIntentOption[];
+const WORKSPACE_DEFAULT_MODEL_OPTION = {
+  value: WORKSPACE_DEFAULT_RUN_SETTING,
+  label: 'Workspace default',
+  description: 'Use the model configured for this workspace',
+} as const satisfies CortexWorkspaceComposerIntentOption;
 
 export const EFFORT_OPTIONS = [
+  {
+    value: WORKSPACE_DEFAULT_RUN_SETTING,
+    label: 'Workspace default',
+    description: 'Use the effort configured for this workspace',
+  },
   { value: 'none', label: 'None', description: 'No additional reasoning effort' },
   { value: 'low', label: 'Low', description: 'Quick reasoning pass' },
   { value: 'medium', label: 'Medium', description: 'Balanced reasoning depth' },
@@ -42,38 +38,46 @@ function modelOptions(
   catalog: readonly RuntimeModelCatalogEntry[],
   selectedModel: string,
 ): readonly CortexWorkspaceComposerIntentOption[] {
-  const options = catalog.map((entry) => ({
+  const catalogOptions = catalog.map((entry) => ({
     value: entry.id,
     label: entry.label,
     description: entry.description,
   }));
-  if (options.length > 0 || !selectedModel) return options;
-  return [{
-    value: selectedModel,
-    label: selectedModel.split('/', 2).at(-1) || selectedModel,
-    description: 'Current workspace model',
-  }];
+  if (
+    catalogOptions.length === 0
+    && selectedModel
+    && selectedModel !== WORKSPACE_DEFAULT_RUN_SETTING
+  ) {
+    return [
+      WORKSPACE_DEFAULT_MODEL_OPTION,
+      {
+        value: selectedModel,
+        label: selectedModel.split('/', 2).at(-1) || selectedModel,
+        description: 'Current model selection',
+      },
+    ];
+  }
+  return [WORKSPACE_DEFAULT_MODEL_OPTION, ...catalogOptions];
 }
 
 export function buildRunSettingsGroups(values: {
-  mode: CortexExecutionProfile;
   model: string;
-  effort: CortexEffortLevel;
   modelCatalog: readonly RuntimeModelCatalogEntry[];
+  effort: CortexEffortSelection;
 }): readonly CortexWorkspaceComposerSettingsGroup[] {
-  const selectedCatalogEntry = values.modelCatalog.find((entry) => entry.id === values.model);
+  const selectedCatalogEntry = values.modelCatalog.find((entry) =>
+    values.model === WORKSPACE_DEFAULT_RUN_SETTING
+      ? entry.default_provenance.workspace_default
+      : entry.id === values.model);
+  const [workspaceDefaultEffortOption, ...explicitEffortOptions] = EFFORT_OPTIONS;
   const effortOptions = selectedCatalogEntry
-    ? EFFORT_OPTIONS.filter((option) =>
-        selectedCatalogEntry.supported_effort_tiers.includes(option.value))
+    ? [
+        workspaceDefaultEffortOption,
+        ...explicitEffortOptions.filter((option) =>
+          selectedCatalogEntry.supported_effort_tiers.includes(option.value)),
+      ]
     : EFFORT_OPTIONS;
   return [
-    {
-      key: 'mode',
-      label: 'Mode',
-      options: EXECUTION_PROFILE_OPTIONS,
-      value: values.mode,
-      ariaLabel: 'Mode',
-    },
     {
       key: 'model',
       label: 'Model',
@@ -95,12 +99,10 @@ export function applyRunSetting(
   key: string,
   value: string,
   handlers: {
-    setExecutionProfile: (value: CortexExecutionProfile) => void;
     setModel: (value: string) => void;
-    setEffortLevel: (value: CortexEffortLevel) => void;
+    setEffortLevel: (value: CortexEffortSelection) => void;
   },
 ): void {
-  if (key === 'mode') handlers.setExecutionProfile(value as CortexExecutionProfile);
   if (key === 'model') handlers.setModel(value);
-  if (key === 'effort') handlers.setEffortLevel(value as CortexEffortLevel);
+  if (key === 'effort') handlers.setEffortLevel(value as CortexEffortSelection);
 }

--- a/frontend/src/lib/features/cortex/controllers/runSettingsController.ts
+++ b/frontend/src/lib/features/cortex/controllers/runSettingsController.ts
@@ -1,49 +1,63 @@
 import type {
   AgentRunOptions,
   CortexEffortLevel,
-  CortexExecutionProfile,
 } from '$lib/types/cortex';
 
-export type CortexRunSettings = Required<
-  Pick<AgentRunOptions, 'executionProfile' | 'model' | 'effortLevel'>
->;
+export const WORKSPACE_DEFAULT_RUN_SETTING = 'workspace-default' as const;
+export type CortexEffortSelection =
+  | CortexEffortLevel
+  | typeof WORKSPACE_DEFAULT_RUN_SETTING;
+
+export interface CortexRunSettings {
+  model: string;
+  effortLevel: CortexEffortSelection;
+}
 
 export type CortexRunSettingsInput = {
-  executionProfile?: unknown;
   model?: unknown;
   effortLevel?: unknown;
 };
 
-export type RunSettingsStorage = Pick<Storage, 'getItem' | 'setItem'>;
-
-export const DEFAULT_RUN_MODEL = 'openai/gpt-5.6-sol';
+export type RunSettingsStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 export const CORTEX_RUN_SETTINGS_STORAGE_KEYS = {
-  executionProfile: 'illo:cortex:execution-profile',
   model: 'illo:cortex:model',
   effortLevel: 'illo:cortex:effort-level',
+  workspaceDefaultMigration: 'illo:cortex:workspace-default-migration',
 } as const;
 
+const LEGACY_EXECUTION_PROFILE_STORAGE_KEY = 'illo:cortex:execution-profile';
+const WORKSPACE_DEFAULT_MIGRATION_VERSION = '1';
+
 export const DEFAULT_CORTEX_RUN_SETTINGS: CortexRunSettings = {
-  executionProfile: 'fast',
-  model: DEFAULT_RUN_MODEL,
-  effortLevel: 'xhigh',
+  model: WORKSPACE_DEFAULT_RUN_SETTING,
+  effortLevel: WORKSPACE_DEFAULT_RUN_SETTING,
 };
 
-export function normalizeExecutionProfile(value: unknown): CortexExecutionProfile {
-  return String(value || '').trim().toLowerCase() === 'deep' ? 'deep' : 'fast';
+export function isWorkspaceDefaultRunSetting(
+  value: unknown,
+): value is typeof WORKSPACE_DEFAULT_RUN_SETTING {
+  return String(value || '').trim().toLowerCase() === WORKSPACE_DEFAULT_RUN_SETTING;
 }
 
-export function normalizeModel(value: unknown, fallback = DEFAULT_RUN_MODEL): string {
+export function normalizeModel(
+  value: unknown,
+  fallback: string = WORKSPACE_DEFAULT_RUN_SETTING,
+): string {
   const normalized = String(value || '').trim().replace(':', '/');
+  if (isWorkspaceDefaultRunSetting(normalized)) return WORKSPACE_DEFAULT_RUN_SETTING;
   return normalized || fallback;
 }
 
-export function normalizeEffortLevel(value: unknown): CortexEffortLevel {
+export function normalizeEffortLevel(
+  value: unknown,
+  fallback: CortexEffortSelection = WORKSPACE_DEFAULT_RUN_SETTING,
+): CortexEffortSelection {
   const normalized = String(value || '').trim().toLowerCase();
+  if (isWorkspaceDefaultRunSetting(normalized)) return WORKSPACE_DEFAULT_RUN_SETTING;
   return normalized === 'none' || normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh'
     ? normalized
-    : 'high';
+    : fallback;
 }
 
 export function normalizeRunSettings(
@@ -51,32 +65,58 @@ export function normalizeRunSettings(
   fallback: CortexRunSettings = DEFAULT_CORTEX_RUN_SETTINGS,
 ): CortexRunSettings {
   return {
-    executionProfile: normalizeExecutionProfile(settings?.executionProfile ?? fallback.executionProfile),
     model: normalizeModel(settings?.model ?? fallback.model, fallback.model),
-    effortLevel: normalizeEffortLevel(settings?.effortLevel ?? fallback.effortLevel),
+    effortLevel: normalizeEffortLevel(
+      settings?.effortLevel ?? fallback.effortLevel,
+      fallback.effortLevel,
+    ),
   };
 }
 
 export function runSettingsOptions(
   settings: CortexRunSettingsInput,
-): Pick<AgentRunOptions, 'executionProfile' | 'model' | 'effortLevel'> {
-  return normalizeRunSettings(settings);
+): Pick<AgentRunOptions, 'model' | 'effortLevel'> {
+  const normalized = normalizeRunSettings(settings);
+  const options: Pick<AgentRunOptions, 'model' | 'effortLevel'> = {};
+  if (!isWorkspaceDefaultRunSetting(normalized.model)) {
+    options.model = normalized.model;
+  }
+  if (!isWorkspaceDefaultRunSetting(normalized.effortLevel)) {
+    options.effortLevel = normalized.effortLevel;
+  }
+  return options;
 }
 
 export function normalizeRunOptions(
   options: AgentRunOptions = {},
   currentSettings: CortexRunSettingsInput = DEFAULT_CORTEX_RUN_SETTINGS,
 ): AgentRunOptions {
-  const settings = normalizeRunSettings({
-    executionProfile: options.executionProfile ?? currentSettings.executionProfile,
+  const settings = runSettingsOptions({
     model: options.model ?? currentSettings.model,
     effortLevel: options.effortLevel ?? currentSettings.effortLevel,
   });
+  const {
+    model: _model,
+    effortLevel: _effortLevel,
+    ...remainingOptions
+  } = options;
   return {
-    ...options,
+    ...remainingOptions,
     ...settings,
     metadata: { ...(options.metadata || {}) },
   };
+}
+
+export function routingMetadataForRunOptions(
+  options: AgentRunOptions,
+): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  if (options.model) metadata.model = options.model;
+  if (options.effortLevel) {
+    metadata.thinking_tier = options.effortLevel;
+    metadata.effort = options.effortLevel;
+  }
+  return metadata;
 }
 
 export function loadRunSettings(
@@ -85,8 +125,20 @@ export function loadRunSettings(
 ): CortexRunSettings {
   if (!storage) return { ...fallback };
   try {
+    if (
+      storage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.workspaceDefaultMigration)
+      !== WORKSPACE_DEFAULT_MIGRATION_VERSION
+    ) {
+      storage.removeItem(LEGACY_EXECUTION_PROFILE_STORAGE_KEY);
+      storage.removeItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model);
+      storage.removeItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel);
+      storage.setItem(
+        CORTEX_RUN_SETTINGS_STORAGE_KEYS.workspaceDefaultMigration,
+        WORKSPACE_DEFAULT_MIGRATION_VERSION,
+      );
+      return { ...fallback };
+    }
     return normalizeRunSettings({
-      executionProfile: storage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.executionProfile),
       model: storage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model),
       effortLevel: storage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel),
     }, fallback);
@@ -101,20 +153,25 @@ export function persistRunSettings(
 ): boolean {
   if (!storage) return false;
   try {
-    if (settings.executionProfile !== undefined) {
-      storage.setItem(
-        CORTEX_RUN_SETTINGS_STORAGE_KEYS.executionProfile,
-        normalizeExecutionProfile(settings.executionProfile),
-      );
-    }
+    storage.setItem(
+      CORTEX_RUN_SETTINGS_STORAGE_KEYS.workspaceDefaultMigration,
+      WORKSPACE_DEFAULT_MIGRATION_VERSION,
+    );
     if (settings.model !== undefined) {
-      storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model, normalizeModel(settings.model));
+      const model = normalizeModel(settings.model);
+      if (isWorkspaceDefaultRunSetting(model)) {
+        storage.removeItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model);
+      } else {
+        storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model, model);
+      }
     }
     if (settings.effortLevel !== undefined) {
-      storage.setItem(
-        CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel,
-        normalizeEffortLevel(settings.effortLevel),
-      );
+      const effortLevel = normalizeEffortLevel(settings.effortLevel);
+      if (isWorkspaceDefaultRunSetting(effortLevel)) {
+        storage.removeItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel);
+      } else {
+        storage.setItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel, effortLevel);
+      }
     }
     return true;
   } catch {

--- a/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
+++ b/frontend/src/lib/features/threads/components/ThreadStageScreen.svelte
@@ -22,6 +22,7 @@
     type ProjectContextPickerState,
   } from '$lib/utils/projectContext';
   import { ATTACHMENT_INPUT_ACCEPT } from '$lib/utils/attachmentPreview';
+  import { WORKSPACE_DEFAULT_RUN_SETTING } from '$lib/features/cortex/controllers/runSettingsController';
   import {
     getWorkspaceComposerDropFiles,
     getWorkspaceComposerInputFiles,
@@ -388,32 +389,20 @@
     working: 'Working',
     done: 'Unread',
   };
-  const RUN_SETTING_MODEL_LABELS: Record<string, string> = {
-    'openai/gpt-5.6-sol': 'GPT-5.6 Sol',
-    'openai/gpt-5.5': 'GPT-5.5',
-    'openai/gpt-5.4': 'GPT-5.4',
-    'openai/gpt-5.4-mini': 'GPT-5.4 Mini',
-    'openai/gpt-5-mini': 'GPT-5 Mini',
-  };
 
   function buildRunSettingsPlaceholderGroups(values: {
-    mode: string;
     model: string;
     effort: string;
-    modelCatalog?: readonly unknown[];
+    modelCatalog?: readonly { id: string; label: string }[];
   }) {
+    const modelLabel = values.model === WORKSPACE_DEFAULT_RUN_SETTING
+      ? 'Workspace default'
+      : values.modelCatalog?.find((entry) => entry.id === values.model)?.label ?? values.model;
     return [
-      {
-        key: 'mode',
-        label: 'Mode',
-        options: [{ value: values.mode, label: values.mode === 'deep' ? 'Deep' : 'Fast' }],
-        value: values.mode,
-        ariaLabel: 'Mode',
-      },
       {
         key: 'model',
         label: 'Model',
-        options: [{ value: values.model, label: RUN_SETTING_MODEL_LABELS[values.model] ?? values.model }],
+        options: [{ value: values.model, label: modelLabel }],
         value: values.model,
         ariaLabel: 'Model',
       },
@@ -422,9 +411,11 @@
         label: 'Effort',
         options: [{
           value: values.effort,
-          label: values.effort === 'xhigh'
-            ? 'xHigh'
-            : `${values.effort.slice(0, 1).toUpperCase()}${values.effort.slice(1)}`,
+          label: values.effort === WORKSPACE_DEFAULT_RUN_SETTING
+            ? 'Workspace default'
+            : values.effort === 'xhigh'
+              ? 'xHigh'
+              : `${values.effort.slice(0, 1).toUpperCase()}${values.effort.slice(1)}`,
         }],
         value: values.effort,
         ariaLabel: 'Effort',
@@ -435,7 +426,6 @@
   let idea = $derived(cortex.selectedIdea);
   const runSettingsGroups = $derived(
     (buildRunSettingsGroups ?? buildRunSettingsPlaceholderGroups)({
-      mode: cortex.executionProfile,
       model: cortex.model,
       effort: cortex.effortLevel,
       modelCatalog: cortex.modelCatalog,
@@ -943,7 +933,6 @@
     pendingAttachments = [];
     try {
       await cortex.sendMessage(text || '(attachment)', attachments, {
-        executionProfile: cortex.executionProfile,
         skipRun: Boolean(fastSteerTarget && !queueAfterTarget),
         metadata: fastSteerTarget
           ? queueAfterTarget
@@ -970,13 +959,17 @@
   }
 
   function setRunSetting(key: string, value: string) {
-    if (key === 'mode' && (value === 'fast' || value === 'deep')) {
-      cortex.setExecutionProfile(value);
-    }
     if (key === 'model') cortex.setModel(value);
     if (
       key === 'effort'
-      && (value === 'none' || value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh')
+      && (
+        value === WORKSPACE_DEFAULT_RUN_SETTING
+        || value === 'none'
+        || value === 'low'
+        || value === 'medium'
+        || value === 'high'
+        || value === 'xhigh'
+      )
     ) {
       cortex.setEffortLevel(value);
     }
@@ -1533,7 +1526,7 @@
         settingsGroups={runSettingsGroups}
         onSettingsOpen={() => ensureThreadModuleLoaded('run-settings')}
         onSettingsChange={setRunSetting}
-        settingsAriaLabel="Mode, Model, and Effort"
+        settingsAriaLabel="Model and Effort"
         secondaryIntentOptions={activeFastRun() ? STEERING_INTENT_OPTIONS : undefined}
         secondaryIntentValue={activeFastRun() ? activeRunMessageIntent : undefined}
         secondaryIntentAriaLabel="Message intent"

--- a/frontend/src/lib/stores/cortex.svelte.ts
+++ b/frontend/src/lib/stores/cortex.svelte.ts
@@ -2,11 +2,14 @@ import { browser, dev } from '$app/environment';
 import { api, type CortexBootstrapPayload, type ThreadStreamPage } from '$lib/api/client';
 import { auth } from '$lib/stores/auth.svelte';
 import {
-  CORTEX_RUN_SETTINGS_STORAGE_KEYS,
+  WORKSPACE_DEFAULT_RUN_SETTING,
   loadRunSettings,
   normalizeRunOptions as normalizeCortexRunOptions,
   normalizeRunSettings,
   persistRunSettings,
+  routingMetadataForRunOptions,
+  runSettingsOptions as selectedRunSettingsOptions,
+  type CortexEffortSelection,
 } from '$lib/features/cortex/controllers/runSettingsController';
 import {
   hasWorkingIdeas as hasWorkingCortexIdeas,
@@ -76,8 +79,6 @@ import type {
   BrowserFrame,
   BrowserSessionState,
   Connection,
-  CortexEffortLevel,
-  CortexExecutionProfile,
   Idea,
   StreamItem,
   VaultAgentGrantPrompt,
@@ -120,10 +121,9 @@ class CortexStore {
   loading = $state(true);
   teamMembersLoaded = $state(false);
   view = $state<'canvas' | 'list'>('canvas');
-  executionProfile = $state<CortexExecutionProfile>('fast');
-  model = $state<string>('openai/gpt-5.6-sol');
+  model = $state<string>(WORKSPACE_DEFAULT_RUN_SETTING);
   modelCatalog = $state<RuntimeModelCatalogEntry[]>([]);
-  effortLevel = $state<CortexEffortLevel>('xhigh');
+  effortLevel = $state<CortexEffortSelection>(WORKSPACE_DEFAULT_RUN_SETTING);
   constellationMode = $state(false);
   canvasOpen = $state(false);
   browserSession = $state<BrowserSessionState | null>(null);
@@ -194,31 +194,19 @@ class CortexStore {
     this._loadRunSettings();
   }
 
-  private _normalizeExecutionProfile(value: unknown): CortexExecutionProfile {
-    return normalizeRunSettings({ executionProfile: value }).executionProfile;
-  }
-
   private _normalizeModel(value: unknown): string {
     return normalizeRunSettings({ model: value }).model;
   }
 
-  private _normalizeEffortLevel(value: unknown): CortexEffortLevel {
+  private _normalizeEffortLevel(value: unknown): CortexEffortSelection {
     return normalizeRunSettings({ effortLevel: value }).effortLevel;
   }
 
   private _loadRunSettings() {
     if (typeof localStorage === 'undefined') return;
     const settings = loadRunSettings(localStorage);
-    this.executionProfile = settings.executionProfile;
     this.model = settings.model;
     this.effortLevel = settings.effortLevel;
-  }
-
-  setExecutionProfile(profile: CortexExecutionProfile) {
-    this.executionProfile = this._normalizeExecutionProfile(profile);
-    if (typeof localStorage !== 'undefined') {
-      persistRunSettings(localStorage, { executionProfile: this.executionProfile });
-    }
   }
 
   setModel(model: string) {
@@ -226,16 +214,17 @@ class CortexStore {
     if (typeof localStorage !== 'undefined') {
       persistRunSettings(localStorage, { model: this.model });
     }
-    const catalogEntry = this.modelCatalog.find((entry) => entry.id === this.model);
+    const catalogEntry = this._selectedCatalogEntry();
     if (
       catalogEntry &&
+      this.effortLevel !== WORKSPACE_DEFAULT_RUN_SETTING &&
       !catalogEntry.supported_effort_tiers.includes(this.effortLevel)
     ) {
-      this.setEffortLevel(catalogEntry.supported_effort_tiers[0] || 'none');
+      this.setEffortLevel(WORKSPACE_DEFAULT_RUN_SETTING);
     }
   }
 
-  setEffortLevel(level: CortexEffortLevel) {
+  setEffortLevel(level: CortexEffortSelection) {
     this.effortLevel = this._normalizeEffortLevel(level);
     if (typeof localStorage !== 'undefined') {
       persistRunSettings(localStorage, { effortLevel: this.effortLevel });
@@ -244,43 +233,42 @@ class CortexStore {
 
   applyWorkspaceRunDefaults(
     model: string,
-    effortLevel: unknown,
+    _effortLevel: unknown,
     modelCatalog: RuntimeModelCatalogEntry[] = [],
   ) {
     this.modelCatalog = modelCatalog;
-    if (typeof localStorage === 'undefined') {
-      this.model = this._normalizeModel(model);
-      this.effortLevel = this._normalizeEffortLevel(effortLevel);
-      return;
-    }
-    const storedModel = localStorage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.model);
-    const selectedModelIsCataloged = modelCatalog.some(
-      (entry) => entry.id === this.model,
+    const selectedModelIsCataloged = (
+      this.model === WORKSPACE_DEFAULT_RUN_SETTING
+      || modelCatalog.some((entry) => entry.id === this.model)
     );
-    if (storedModel === null || (modelCatalog.length > 0 && !selectedModelIsCataloged)) {
-      this.model = this._normalizeModel(model);
-      if (storedModel !== null) {
-        persistRunSettings(localStorage, { model: this.model });
-      }
+    if (modelCatalog.length > 0 && !selectedModelIsCataloged) {
+      this.setModel(WORKSPACE_DEFAULT_RUN_SETTING);
     }
-    if (localStorage.getItem(CORTEX_RUN_SETTINGS_STORAGE_KEYS.effortLevel) === null) {
-      this.effortLevel = this._normalizeEffortLevel(effortLevel);
-    }
-    const catalogEntry = modelCatalog.find((entry) => entry.id === this.model);
+
+    const workspaceModel = this._normalizeModel(model);
+    const catalogEntry = this._selectedCatalogEntry(workspaceModel);
     if (
       catalogEntry &&
+      this.effortLevel !== WORKSPACE_DEFAULT_RUN_SETTING &&
       !catalogEntry.supported_effort_tiers.includes(this.effortLevel)
     ) {
-      this.setEffortLevel(catalogEntry.supported_effort_tiers[0] || 'none');
+      this.setEffortLevel(WORKSPACE_DEFAULT_RUN_SETTING);
     }
   }
 
-  runSettingsOptions(): Pick<AgentRunOptions, 'executionProfile' | 'model' | 'effortLevel'> {
-    return {
-      executionProfile: this.executionProfile,
+  runSettingsOptions(): Pick<AgentRunOptions, 'model' | 'effortLevel'> {
+    return selectedRunSettingsOptions({
       model: this.model,
       effortLevel: this.effortLevel,
-    };
+    });
+  }
+
+  private _selectedCatalogEntry(workspaceModel = ''): RuntimeModelCatalogEntry | undefined {
+    if (this.model !== WORKSPACE_DEFAULT_RUN_SETTING) {
+      return this.modelCatalog.find((entry) => entry.id === this.model);
+    }
+    return this.modelCatalog.find((entry) =>
+      entry.default_provenance.workspace_default || entry.id === workspaceModel);
   }
 
   private _ideaRevision(idea: Pick<Idea, 'updated_at' | 'created_at'> | null | undefined): string {
@@ -828,7 +816,7 @@ class CortexStore {
       this.stream as CortexRunStreamItem[],
       msg,
       this.selectedIdeaId,
-      this.executionProfile,
+      'fast',
     ) as StreamItem[];
   }
 
@@ -1565,9 +1553,7 @@ class CortexStore {
     const projectContextAttachment = attachments.find((att: any) => att?.type === 'project_context' || att?.project_context);
     const projectContext = projectContextAttachment?.project_context;
     const messageMetadata: Record<string, any> = {
-      execution_profile: runOptions.executionProfile,
-      model: runOptions.model,
-      effort: runOptions.effortLevel,
+      ...routingMetadataForRunOptions(runOptions),
       ...(runOptions.metadata || {}),
     };
     if (projectContext) messageMetadata.project_context = projectContext;
@@ -1584,10 +1570,7 @@ class CortexStore {
       this._ensureIdeasSnapshotReconcile();
       const runMetadata: Record<string, any> = {
         ...(decision.isExplicit ? {} : { background_activation: decision.reason }),
-        execution_profile: runOptions.executionProfile,
-        model: runOptions.model,
-        thinking_tier: runOptions.effortLevel,
-        effort: runOptions.effortLevel,
+        ...routingMetadataForRunOptions(runOptions),
         thread_message_id: threadMessage?.id,
         ...(runOptions.metadata || {}),
       };

--- a/frontend/src/lib/types/cortex.ts
+++ b/frontend/src/lib/types/cortex.ts
@@ -231,7 +231,6 @@ export type CortexExecutionProfile = 'fast' | 'deep';
 export type CortexEffortLevel = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface AgentRunOptions {
-  executionProfile?: CortexExecutionProfile;
   model?: string;
   effortLevel?: CortexEffortLevel;
   metadata?: Record<string, any>;

--- a/frontend/src/lib/utils/cortexRunStream.test.js
+++ b/frontend/src/lib/utils/cortexRunStream.test.js
@@ -119,6 +119,17 @@ test('appends, extends, and resets live text deltas', () => {
   assert.deepEqual(reset, []);
 });
 
+test('preserves a historical deep profile when live activity precedes its snapshot', () => {
+  const stream = applyAgentActivityToStream([], {
+    idea_id: 'idea-1',
+    run_id: 13,
+    activity: 'Coordinating workers',
+    profile: 'deep',
+  }, 'idea-1', 'fast');
+
+  assert.equal(stream[0].execution_profile, 'deep');
+});
+
 test('keeps live agent text visible until a settled run reply exists', () => {
   const run = { type: 'run', id: '12', run_id: 12, status: 'running' };
   const live = {

--- a/frontend/src/lib/utils/cortexRunStream.ts
+++ b/frontend/src/lib/utils/cortexRunStream.ts
@@ -404,7 +404,7 @@ export function applyAgentActivityToStream(
   stream: CortexRunStreamItem[],
   msg: any,
   selectedIdeaId: string | null,
-  executionProfile: string,
+  fallbackExecutionProfile: string,
 ): CortexRunStreamItem[] {
   if (!msg || msg.idea_id !== selectedIdeaId) return stream;
   const activity = typeof msg.activity === 'string' ? msg.activity.trim() : '';
@@ -412,6 +412,10 @@ export function applyAgentActivityToStream(
   const runId = msg.run_id ?? msg.id;
   if (runId == null) return stream;
   const now = eventAt(msg);
+  const eventExecutionProfile = String(
+    msg.execution_profile ?? msg.profile ?? msg.strategy ?? '',
+  ).trim().toLowerCase();
+  const executionProfile = eventExecutionProfile || fallbackExecutionProfile;
   let matched = false;
   const activityEntry = {
     at: now,
@@ -459,10 +463,7 @@ export function applyAgentActivityToStream(
     live_lines: [activity],
     activity_trace: [activityEntry],
     work_log: [workEntry],
-    execution_profile:
-      msg.strategy === 'fast' || msg.profile === 'fast' || executionProfile === 'fast'
-        ? 'fast'
-        : undefined,
+    execution_profile: executionProfile || undefined,
   };
   if (msg.type === 'tool_started' || msg.type === 'tool_finished') {
     runItem = appendRunToolCall(runItem, msg, now);

--- a/frontend/src/lib/utils/runSettingsController.test.js
+++ b/frontend/src/lib/utils/runSettingsController.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as controller from '../features/cortex/controllers/runSettingsController.ts';
+
+class MemoryStorage {
+  constructor(entries = {}) {
+    this.entries = new Map(Object.entries(entries));
+  }
+
+  getItem(key) {
+    return this.entries.has(key) ? this.entries.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.entries.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.entries.delete(key);
+  }
+}
+
+test('workspace-default composer state omits model and effort routing metadata', () => {
+  const options = controller.normalizeRunOptions(
+    {},
+    controller.DEFAULT_CORTEX_RUN_SETTINGS,
+  );
+
+  assert.equal(Object.hasOwn(options, 'model'), false);
+  assert.equal(Object.hasOwn(options, 'effortLevel'), false);
+  assert.deepEqual(controller.routingMetadataForRunOptions(options), {});
+});
+
+test('explicit composer picks emit model and effort routing metadata', () => {
+  const options = controller.normalizeRunOptions(
+    {
+      model: 'openai/gpt-5.6-sol',
+      effortLevel: 'xhigh',
+    },
+    controller.DEFAULT_CORTEX_RUN_SETTINGS,
+  );
+
+  assert.deepEqual(controller.routingMetadataForRunOptions(options), {
+    model: 'openai/gpt-5.6-sol',
+    thinking_tier: 'xhigh',
+    effort: 'xhigh',
+  });
+});
+
+test('legacy stored picks migrate once, then new explicit picks persist', () => {
+  const keys = controller.CORTEX_RUN_SETTINGS_STORAGE_KEYS;
+  const storage = new MemoryStorage({
+    'illo:cortex:execution-profile': 'deep',
+    [keys.model]: 'openai/gpt-5.6-sol',
+    [keys.effortLevel]: 'xhigh',
+  });
+
+  assert.deepEqual(
+    controller.loadRunSettings(storage),
+    controller.DEFAULT_CORTEX_RUN_SETTINGS,
+  );
+  assert.equal(storage.getItem('illo:cortex:execution-profile'), null);
+  assert.equal(storage.getItem(keys.model), null);
+  assert.equal(storage.getItem(keys.effortLevel), null);
+
+  assert.equal(
+    controller.persistRunSettings(storage, {
+      model: 'openai/gpt-5.5',
+      effortLevel: 'high',
+    }),
+    true,
+  );
+  assert.deepEqual(controller.loadRunSettings(storage), {
+    model: 'openai/gpt-5.5',
+    effortLevel: 'high',
+  });
+});

--- a/frontend/src/routes/system/+page.svelte
+++ b/frontend/src/routes/system/+page.svelte
@@ -13,6 +13,7 @@
     CONSTELLATION_PAGE_FRAME_MODAL_CONTEXT,
     type ConstellationPageFrameModalContext,
   } from '$lib/components/constellation/constellationPageFrameContext';
+  import { cortex } from '$lib/stores/cortex.svelte';
   import {
     closeOAuthPopup,
     navigateOpenAIOAuthPopup,
@@ -20,7 +21,6 @@
   } from '$lib/utils/oauthPopup';
   import { hasPersonalOpenAIRuntimeConnection } from '$lib/utils/runtimeOnboarding';
   import { auth } from '$lib/stores/auth.svelte';
-  import { cortex } from '$lib/stores/cortex.svelte';
 
   import MemoryCard from './MemoryCard.svelte';
   import ModelsCard from './ModelsCard.svelte';

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -6,17 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
-def test_agent_runtime_root_exports_canonical_run_profile_primitives():
-    from brain.systems import runs as agent_runtime
-
-    assert agent_runtime.run_execution_profile({"execution_profile": "fast"}) == "fast"
-    assert agent_runtime.requested_run_profile({"executionProfile": "deep"}) == "deep"
-    assert agent_runtime.run_profile_policy("fast").stream_live_reply is True
-    assert agent_runtime.select_run_runtime(
-        agent_runtime.run_profile_policy("deep")
-    ).run_graph is True
-
-
 def test_retired_cortex_runtime_modules_stay_out_of_live_paths():
     root = Path(__file__).resolve().parents[1]
     retired_roots = [

--- a/tests/test_cortex_misc_failure_projection.py
+++ b/tests/test_cortex_misc_failure_projection.py
@@ -204,6 +204,12 @@ async def test_audit_analyze_authorizes_and_projects_failed_thread_content():
     assert "temporary upstream problem" in admitted_message
     assert "Total tokens: 12,345" in admitted_message
     assert "Est cost: $0.0679" in admitted_message
+    assert captured["event"].payload["metadata"] == {
+        "run_profile": "fast",
+        "recipe": "fast",
+        "thinking_tier": "xhigh",
+        "source": "audit",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_work_intake.py
+++ b/tests/test_work_intake.py
@@ -45,8 +45,8 @@ async def test_chat_work_intake_builds_agent_run_request_from_normalized_trigger
     assert request.user_id == "user-1"
     assert request.thread_id == "chat:conv-1:22"
     assert request.message == "Summarize this"
-    assert request.profile == RunProfile.DEEP
-    assert request.recipe == RunRecipe.DEEP
+    assert request.profile == RunProfile.FAST
+    assert request.recipe == RunRecipe.FAST
     assert request.target_ref == {
         "conversation_id": "conv-1",
         "kind": "chat_message",
@@ -212,8 +212,8 @@ async def test_cortex_agent_run_request_uses_shared_work_intake_policy(monkeypat
         ),
     )
 
-    assert request.profile == RunProfile.DEEP
-    assert request.recipe == RunRecipe.DEEP
+    assert request.profile == RunProfile.FAST
+    assert request.recipe == RunRecipe.FAST
     assert request.user_id == "user-1"
     assert request.thread_id == "idea-1"
     assert request.target_ref["kind"] == "cortex_idea"
@@ -413,6 +413,49 @@ def test_invalid_high_priority_metadata_warns_before_valid_fallback(caplog):
         "Ignoring invalid metadata value for thinking_tier; "
         "falling through to lower-priority keys"
     ) in caplog.messages
+
+
+def test_deep_profile_metadata_is_coerced_to_fast_with_structured_source_log(caplog):
+    from brain.systems.runs.domain import RunProfile
+    from brain.systems.runs.work_intake import profile_from_metadata
+
+    with caplog.at_level("WARNING", logger="work_intake"):
+        profile = profile_from_metadata(
+            {
+                "execution_profile": "deep",
+                "source": "stale-browser",
+            }
+        )
+
+    assert profile is RunProfile.FAST
+    record = next(record for record in caplog.records if record.event == "deep_run_coerced")
+    assert record.routing_source == "stale-browser"
+    assert record.routing_field == "profile"
+    assert record.requested_value == "deep"
+    assert record.coerced_value == "fast"
+    assert "source=stale-browser" in record.getMessage()
+
+
+def test_deep_recipe_metadata_is_coerced_independently_with_structured_source_log(caplog):
+    from brain.systems.runs.domain import RunProfile, RunRecipe
+    from brain.systems.runs.work_intake import recipe_for_profile
+
+    with caplog.at_level("WARNING", logger="work_intake"):
+        recipe = recipe_for_profile(
+            RunProfile.FAST,
+            {
+                "recipe": "deep",
+                "work_intake": {"source": "notify"},
+            },
+        )
+
+    assert recipe is RunRecipe.FAST
+    record = next(record for record in caplog.records if record.event == "deep_run_coerced")
+    assert record.routing_source == "notify"
+    assert record.routing_field == "recipe"
+    assert record.requested_value == "deep"
+    assert record.coerced_value == "fast"
+    assert "source=notify" in record.getMessage()
 
 
 def test_cortex_thread_binding_compatibility_shell_is_removed():

--- a/tests/test_work_intake_full_architecture.py
+++ b/tests/test_work_intake_full_architecture.py
@@ -178,8 +178,8 @@ async def test_cycle_tool_and_external_agent_events_share_the_same_intake_policy
     assert {request.thread_id for request in requests} == {"idea-1"}
     assert {request.target_ref["kind"] for request in requests} == {"cortex_idea"}
     assert {request.user_id for request in requests} == {"owner-1"}
-    assert requests[0].profile == RunProfile.DEEP
-    assert requests[0].recipe == RunRecipe.DEEP
+    assert requests[0].profile == RunProfile.FAST
+    assert requests[0].recipe == RunRecipe.FAST
     assert requests[0].model_policy["model"] == "openai/gpt-5.4"
     assert requests[1].model_policy["thinking"] == "xhigh"
     assert requests[2].model_policy["provider"] == "anthropic"


### PR DESCRIPTION
Closes #481. Slice 4 of `docs/prd-model-effort-routing.md`.

## Part A — retire fast/deep
1. **Deleted the dead parallel resolver** (`run_profile_policy`, `select_run_runtime`, `RunProfilePolicy`, `RunRuntimeSelection`, `run_execution_profile`, `requested_run_profile`) and **only** the single test that referenced it — the other ~890 lines of live regression guards in that file are untouched.
2. **Central admission coercion is the real off-switch.** Both `profile_from_metadata` *and* `recipe_for_profile` coerce an inbound `deep` to `fast` with a structured warning naming the source. Both are required: `recipe` is independent of `profile` and can override it, and the value rides free-form metadata (e.g. `/notify`), so old clients and stale browser localStorage cannot reintroduce deep. Verified live:
   ```
   Coercing retired deep run profile to fast (source=legacy-client)
   Coercing retired deep run recipe to fast (source=legacy-client)
   profile deep -> fast ; recipe deep -> fast
   ```
3. Removed the composer **Mode** group, its persistence, and the thread-screen display. Model and Effort pickers stay.
4. The idea self-critique **audit endpoint** — the last backend `deep` sender — now admits a fast run with explicit `thinking_tier: xhigh`.

## Part B — composer workspace defaults
The composer defaulted to `gpt-5.6-sol` at `xhigh`, always sent explicitly and sticky in localStorage — so browser runs **never inherited org defaults** and `xhigh` was the ambient interactive tier. Model and effort now default to a **workspace sentinel that omits those metadata keys entirely**, with a versioned one-time migration of previously stored picks. Explicit picks still win and still persist.

## Scope
`DeepRecipe`/`ScoutRecipe`/`phase_barrier` remain in-tree so historical rows stay readable. Deleting them is #482, gated on a quiet coercion window (and on #491, which ships the join primitive that replaces deep's fan-out→join→synthesize).

## Verification
Backend **4174 passed**. Frontend: `npm run check` **0 errors** across 6697 files, **248 tests passed**, build succeeded — I re-ran all three myself rather than trusting the report, since the previous slice shipped a type error that only CI caught.

Implementation by Codex at `xhigh`, reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)