### PR TITLE
feat(routing): per-run budget visibility from the real token ledger

### DIFF
--- a/brain/app/api/routers/cortex/_misc.py
+++ b/brain/app/api/routers/cortex/_misc.py
@@ -66,6 +66,7 @@ from brain.systems.cortex.upload_preview import (
 )
 from brain.systems.services.runtime_introspection import async_get_provider_auth_status
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+from brain.systems.runs.token_usage import async_summarize_runs_usage
 
 logger = logging.getLogger(__name__)
 
@@ -774,9 +775,13 @@ async def idea_audit_analyze(
         skills_used = set()
         failed = sum(1 for d in runs if d.status == "failed")
         all_misses = []
+        usage_by_run = {
+            int(usage["id"]): usage
+            for usage in await async_summarize_runs_usage(uow.session, runs)
+        }
         for d in runs:
             metadata = d.metadata_ if isinstance(d.metadata_, dict) else {}
-            usage = metadata.get("usage") if isinstance(metadata.get("usage"), dict) else {}
+            usage = usage_by_run.get(int(d.id), {})
             routing = metadata.get("routing") if isinstance(metadata.get("routing"), dict) else {}
             total_cost += float(usage.get("estimated_cost") or 0)
             total_tokens += int(usage.get("tokens_total") or 0)
@@ -1117,17 +1122,24 @@ async def audit_eval(
                 detail="No completed runs with output artifacts found for evaluation",
             )
 
+        usage_by_run = {
+            int(usage["id"]): usage
+            for usage in await async_summarize_runs_usage(
+                uow.session,
+                [run for run, _artifact in benchmarks],
+            )
+        }
         benchmark_data = []
         for d, artifact in benchmarks:
             metadata = d.metadata_ if isinstance(d.metadata_, dict) else {}
             routing = metadata.get("routing") if isinstance(metadata.get("routing"), dict) else {}
-            usage = metadata.get("usage") if isinstance(metadata.get("usage"), dict) else {}
+            usage = usage_by_run.get(int(d.id), {})
             benchmark_data.append({
                 "run_id": d.id,
                 "task_summary": d.input_message or routing.get("selected_skill") or "unknown",
                 "output_artifact": (artifact.text or "")[:2000],
                 "tokens_total": usage.get("tokens_total") or 0,
-                "attempts": usage.get("attempts") or 1,
+                "api_calls": usage.get("api_calls") or 0,
                 "skill_used": routing.get("selected_skill"),
             })
 
@@ -1143,7 +1155,7 @@ TASK SUMMARY:
 ACTUAL OUTPUT PRODUCED:
 {bm['output_artifact']}
 
-ACTUAL COST: {bm['tokens_total']} tokens · {bm['attempts']} attempts
+ACTUAL COST: {bm['tokens_total']} tokens · {bm['api_calls']} model API calls
 
 PROPOSED CHANGE ({proposal_type}):
 {proposal_desc}
@@ -1188,7 +1200,7 @@ Respond as JSON only: {{"score": N, "task_solved": "yes|partial|no", "output_bet
             "run_id": bm["run_id"],
             "task_summary": bm["task_summary"],
             "tokens": bm["tokens_total"],
-            "attempts": bm["attempts"],
+            "api_calls": bm["api_calls"],
             "score": parsed.get("score", 5),
             "task_solved": parsed.get("task_solved", "partial"),
             "output_better": parsed.get("output_better", "neutral"),

--- a/brain/platform/db/alembic/versions/0041_agent_api_call_effort.py
+++ b/brain/platform/db/alembic/versions/0041_agent_api_call_effort.py
@@ -1,0 +1,42 @@
+"""Record the canonical effort tier on each model API call.
+
+Historical rows remain NULL. New telemetry rows persist the run's canonical
+effort tier so token and cost reporting can be broken down by routing tier.
+
+Revision ID: 0041_agent_api_call_effort
+Revises: 0040_drop_routing_effort
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0041_agent_api_call_effort"
+down_revision = "0040_drop_routing_effort"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    schema = "public" if op.get_bind().dialect.name == "postgresql" else None
+    return column_name in {
+        column["name"]
+        for column in inspector.get_columns(table_name, schema=schema)
+    }
+
+
+def upgrade() -> None:
+    if not _column_exists("agent_api_calls", "effort"):
+        op.add_column(
+            "agent_api_calls",
+            sa.Column("effort", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("agent_api_calls", "effort"):
+        op.drop_column("agent_api_calls", "effort")

--- a/brain/platform/db/models/agent.py
+++ b/brain/platform/db/models/agent.py
@@ -83,6 +83,7 @@ class AgentApiCall(Base, CreatedAtMixin):
     trace_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     turn_number: Mapped[int] = mapped_column(Integer, nullable=False)
     model: Mapped[str] = mapped_column(Text, nullable=False)
+    effort: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     tokens_input: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     tokens_output: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     cache_read: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)

--- a/brain/systems/cycles/memory.py
+++ b/brain/systems/cycles/memory.py
@@ -1,6 +1,9 @@
 """Durable Cycle memory, revisions, snapshots, and evaluations."""
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from sqlalchemy import func, select
 
 from brain.kernel.common.serialization import jsonable
@@ -42,6 +45,12 @@ from brain.systems.cycles.serializers import (
     serialize_cycle_revision,
 )
 from brain.systems.cycles.output_targets import default_output_target_specs
+from brain.systems.runs.token_usage import (
+    async_summarize_run_tree_usage_in_savepoint,
+    usage_totals_payload,
+)
+
+logger = logging.getLogger(__name__)
 
 
 async def async_record_cycle_revision(
@@ -356,10 +365,27 @@ async def record_cycle_run_evaluation(
 ) -> None:
     if run.id is None:
         raise ValueError("CycleRun must be flushed before recording an evaluation")
+    usage = None
+    if run.run_id is not None:
+        try:
+            run_usage = await async_summarize_run_tree_usage_in_savepoint(
+                session,
+                int(run.run_id),
+            )
+        except Exception:
+            logger.warning(
+                "cycle_run_usage_summary_failed",
+                extra={"cycle_run_id": run.id, "agent_run_id": run.run_id},
+                exc_info=True,
+            )
+            run_usage = None
+        if run_usage is not None:
+            usage = usage_totals_payload(run_usage)
     summary = cycle_run_evaluation_summary(
         status=status,
         error=error,
         skip_reason=skip_reason,
+        usage=usage,
     )
     score = 1 if status == "completed" else 0 if status in {"failed", "degraded", "auth_blocked"} else None
     context_snapshot = json_dict(getattr(run, "context_snapshot", None))
@@ -387,6 +413,8 @@ async def record_cycle_run_evaluation(
         "observed_causes": observed_causes,
         "result_state": degradation_state,
     }
+    if usage is not None:
+        context_snapshot["usage"] = usage
     run.context_snapshot = jsonable(context_snapshot)
     run.self_review_summary = summary
     session.add(
@@ -408,6 +436,7 @@ async def record_cycle_run_evaluation(
                 "evidence_health": context_snapshot.get("evidence_health"),
                 "degradation_tracking": context_snapshot.get("degradation_tracking"),
                 "launch_receipts": context_snapshot.get("launch_receipts", []),
+                "usage": usage,
                 MISSION_RESULT_CONTRACT_VERDICT_KEY: context_snapshot.get(
                     MISSION_RESULT_CONTRACT_VERDICT_KEY
                 ),
@@ -469,22 +498,29 @@ def cycle_run_evaluation_summary(
     status: str,
     error: str | None = None,
     skip_reason: str | None = None,
+    usage: dict[str, Any] | None = None,
 ) -> str:
+    burn = ""
+    if usage is not None:
+        burn = (
+            f" Burn: {int(usage.get('tokens_total') or 0):,} tokens; "
+            f"estimated cost ${float(usage.get('estimated_cost') or 0):.6f}."
+        )
     if status == "completed":
-        return "Cycle run completed and was recorded in the Cycle ledger."
+        return "Cycle run completed and was recorded in the Cycle ledger." + burn
     if status == "failed":
         detail = error or "unknown failure"
-        return f"Cycle run failed and was recorded in the Cycle ledger: {detail}"
+        return f"Cycle run failed and was recorded in the Cycle ledger: {detail}" + burn
     if status == "degraded":
         detail = error or "mission result contract degraded"
-        return f"Cycle run degraded and was recorded in the Cycle ledger: {detail}"
+        return f"Cycle run degraded and was recorded in the Cycle ledger: {detail}" + burn
     if status == "auth_blocked":
         detail = error or "external auth preflight blocked the run"
-        return f"Cycle run was auth-blocked and recorded in the Cycle ledger: {detail}"
+        return f"Cycle run was auth-blocked and recorded in the Cycle ledger: {detail}" + burn
     if status == "skipped":
         detail = skip_reason or "unknown skip reason"
-        return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}"
-    return f"Cycle run reached status {status} and was recorded in the Cycle ledger."
+        return f"Cycle run was skipped and recorded in the Cycle ledger: {detail}" + burn
+    return f"Cycle run reached status {status} and was recorded in the Cycle ledger." + burn
 
 
 def _aware_utc(value):

--- a/brain/systems/runs/cortex/analytics.py
+++ b/brain/systems/runs/cortex/analytics.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import select
 
 from brain.platform.db.models.agent_run import AgentRunEventRow, AgentRunRow
+from brain.systems.runs.token_usage import async_summarize_runs_usage
 
 
 class RunAuditNotFound(LookupError):
@@ -69,14 +70,32 @@ async def async_build_idea_audit_summary(session, idea_id: str) -> dict[str, Any
             .order_by(AgentRunEventRow.id.asc())
         )
     ).all()
-    return _idea_audit_summary_payload(idea_id, list(runs), list(events))
+    usage = await async_summarize_runs_usage(session, runs)
+    return _idea_audit_summary_payload(idea_id, list(runs), list(events), usage=usage)
 
 
 def _idea_audit_summary_payload(
     idea_id: str,
     runs: list[AgentRunRow],
     events: list[AgentRunEventRow],
+    *,
+    usage: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    usage_by_run = {
+        int(item["id"]): item
+        for item in usage or []
+        if item.get("id") is not None
+    }
+    token_totals = {
+        "api_calls": sum(int(item.get("api_calls") or 0) for item in usage_by_run.values()),
+        "tokens_input": sum(int(item.get("tokens_input") or 0) for item in usage_by_run.values()),
+        "tokens_output": sum(int(item.get("tokens_output") or 0) for item in usage_by_run.values()),
+        "tokens_total": sum(int(item.get("tokens_total") or 0) for item in usage_by_run.values()),
+        "estimated_cost": round(
+            sum(float(item.get("estimated_cost") or 0) for item in usage_by_run.values()),
+            6,
+        ),
+    }
     return {
         "idea_id": idea_id,
         "run_count": len(runs),
@@ -89,9 +108,23 @@ def _idea_audit_summary_payload(
                 "status": run.status,
                 "created_at": _iso(run.created_at),
                 "completed_at": _iso(run.completed_at),
+                "usage": {
+                    key: usage_by_run[int(run.id)].get(key)
+                    for key in (
+                        "api_calls",
+                        "tokens_input",
+                        "tokens_output",
+                        "tokens_total",
+                        "estimated_cost",
+                        "by_effort",
+                    )
+                }
+                if int(run.id) in usage_by_run
+                else None,
             }
             for run in runs
         ],
+        "usage": token_totals,
         "event_count": len(events),
         "tool_summary": build_tool_summary(events),
     }

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1694,6 +1694,7 @@ async def run_agent_async(
                             run_id=run_id,
                             turn=turn,
                             model=preferred_model,
+                            effort=thinking,
                             context_messages=len(state.messages),
                             system_prompt_chars=len(json.dumps(system)) if system else 0,
                             status="model_unavailable",
@@ -1749,7 +1750,7 @@ async def run_agent_async(
                     )
                     await _async_record_api_call(
                         session_id=session_id, run_id=run_id, turn=turn,
-                        model=model,
+                        model=model, effort=thinking,
                         context_messages=len(state.messages),
                         system_prompt_chars=len(json.dumps(system)) if system else 0,
                         status="context_overflow",
@@ -1815,7 +1816,7 @@ async def run_agent_async(
             # Per-call telemetry (fire-and-forget)
             await _async_record_api_call(
                 session_id=session_id, run_id=run_id, turn=turn,
-                model=model,
+                model=model, effort=thinking,
                 tokens_input=getattr(response.usage, "input_tokens", 0),
                 tokens_output=getattr(response.usage, "output_tokens", 0),
                 cache_read=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
@@ -2053,7 +2054,7 @@ async def run_agent_async(
             )
             await _async_record_api_call(
                 session_id=session_id, run_id=run_id, turn=0,
-                model=model, status="error", error=f"{e} | body={str(_body)[:200]}",
+                model=model, effort=thinking, status="error", error=f"{e} | body={str(_body)[:200]}",
             )
             return _make_result(
                 "",

--- a/brain/systems/runs/direct_loop/telemetry.py
+++ b/brain/systems/runs/direct_loop/telemetry.py
@@ -14,6 +14,7 @@ def _api_call_params(
     run_id: int | None,
     turn: int,
     model: str,
+    effort: str | None,
     tokens_input: int,
     tokens_output: int,
     cache_read: int,
@@ -33,6 +34,7 @@ def _api_call_params(
         "turn": turn,
         "trace_id": trace_id_for_run_id(run_id),
         "model": model,
+        "effort": (str(effort).strip().lower() or None) if effort is not None else None,
         "ti": tokens_input,
         "to": tokens_output,
         "cr": cache_read,
@@ -51,6 +53,7 @@ async def async_record_api_call(
     run_id: int | None = None,
     turn: int = 0,
     model: str = "",
+    effort: str | None = None,
     tokens_input: int = 0,
     tokens_output: int = 0,
     cache_read: int = 0,
@@ -76,6 +79,7 @@ async def async_record_api_call(
             run_id=run_id,
             turn=turn,
             model=model,
+            effort=effort,
             tokens_input=tokens_input,
             tokens_output=tokens_output,
             cache_read=cache_read,
@@ -92,20 +96,20 @@ async def async_record_api_call(
             try:
                 await active_session.execute(sa_text(
                     "INSERT INTO agent_api_calls "
-                    "(session_id, run_id, trace_id, turn_number, model, tokens_input, tokens_output, "
+                    "(session_id, run_id, trace_id, turn_number, model, effort, tokens_input, tokens_output, "
                     "cache_read, cache_write, context_messages, system_prompt_chars, "
                     "status, stop_reason, latency_ms, error) "
-                    "VALUES (:sid, :did, :trace_id, :turn, :model, :ti, :to, :cr, :cw, :ctx, :spc, "
+                    "VALUES (:sid, :did, :trace_id, :turn, :model, :effort, :ti, :to, :cr, :cw, :ctx, :spc, "
                     ":status, :stop, :lat, :err)"
                 ), params)
             except SQLAlchemyError:
                 await active_session.rollback()
                 await active_session.execute(sa_text(
                     "INSERT INTO agent_api_calls "
-                    "(session_id, run_id, turn_number, model, tokens_input, tokens_output, "
+                    "(session_id, run_id, turn_number, model, effort, tokens_input, tokens_output, "
                     "cache_read, cache_write, context_messages, system_prompt_chars, "
                     "status, stop_reason, latency_ms, error) "
-                    "VALUES (:sid, :did, :turn, :model, :ti, :to, :cr, :cw, :ctx, :spc, "
+                    "VALUES (:sid, :did, :turn, :model, :effort, :ti, :to, :cr, :cw, :ctx, :spc, "
                     ":status, :stop, :lat, :err)"
                 ), params)
 

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -24,6 +24,10 @@ from brain.systems.runs.routing_metadata import (
     effective_routing_snapshot,
     routing_metadata_with_effective,
 )
+from brain.systems.runs.token_usage import (
+    async_summarize_run_usage_in_savepoint,
+    usage_totals_payload,
+)
 from brain.systems.runs.tool_surface import build_agent_tools, build_tool_handlers
 from brain.systems.runs.recipes.surface_guidance import response_surface_guidance
 
@@ -80,6 +84,21 @@ def _thread_attachment_context(runtime: RunRuntime) -> dict[str, Any] | None:
         if isinstance(value, dict):
             return value
     return None
+
+
+async def _worker_run_usage(runtime: RunRuntime) -> dict[str, Any] | None:
+    try:
+        return await async_summarize_run_usage_in_savepoint(
+            runtime.store.session,
+            runtime.run.id,
+        )
+    except Exception:
+        logger.warning(
+            "worker_usage_summary_failed",
+            extra={"run_id": runtime.run.id},
+            exc_info=True,
+        )
+        return None
 
 
 class WorkerRecipe(BaseRunRecipe):
@@ -225,6 +244,7 @@ class WorkerRecipe(BaseRunRecipe):
         public_output = output if status == RunStatus.COMPLETED else str((failure or {}).get("message") or "")
         if public_output and not streamed_output:
             await runtime.text_delta(public_output)
+        usage = await _worker_run_usage(runtime)
         worker_result = worker_result_artifact(
             runtime.run.id,
             assignment=assignment,
@@ -234,6 +254,7 @@ class WorkerRecipe(BaseRunRecipe):
             root_run_id=runtime.run.root_run_id,
             failure=failure,
             routing=effective_routing,
+            usage=usage,
         )
         return RunRecipeResult(
             output=output,
@@ -312,6 +333,7 @@ def worker_result_artifact(
     root_run_id: int | None,
     failure: dict[str, str] | None = None,
     routing: dict[str, Any] | None = None,
+    usage: dict[str, Any] | None = None,
 ) -> AgentRunArtifact:
     payload = {
         "status": status.value,
@@ -328,6 +350,8 @@ def worker_result_artifact(
         payload["failure"] = dict(failure)
     if routing:
         payload["routing"] = dict(routing)
+    if usage:
+        payload["usage"] = usage_totals_payload(usage)
     return AgentRunArtifact(
         run_id=run_id,
         root_run_id=root_run_id,

--- a/brain/systems/runs/token_usage.py
+++ b/brain/systems/runs/token_usage.py
@@ -11,12 +11,21 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any, Iterable
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent import AgentApiCall
 from brain.platform.db.models.agent_run import AgentRunRow
-from brain.systems.runs.modeling import calculate_cost
+from brain.platform.providers.model_policy import calculate_model_cost
+
+USAGE_COUNT_FIELDS = (
+    "api_calls",
+    "tokens_input",
+    "tokens_output",
+    "tokens_total",
+    "cache_read",
+    "cache_write",
+)
 
 
 def _coerce_int(value: Any) -> int:
@@ -87,7 +96,69 @@ def _empty_usage() -> dict[str, Any]:
         "cache_write": 0,
         "estimated_cost": 0.0,
         "last_used_at": None,
+        "by_effort": [],
     }
+
+
+def usage_totals_payload(
+    usage: dict[str, Any] | None = None,
+    *,
+    include_runs: bool = False,
+) -> dict[str, Any]:
+    """Return the stable token/cost reporting contract without run metadata."""
+
+    source = usage or {}
+    payload = {
+        key: _coerce_int(source.get(key))
+        for key in USAGE_COUNT_FIELDS
+    }
+    if include_runs:
+        payload = {"runs": _coerce_int(source.get("runs")), **payload}
+    payload["estimated_cost"] = round(float(source.get("estimated_cost") or 0), 6)
+    payload["by_effort"] = [
+        {
+            **{key: _coerce_int(item.get(key)) for key in USAGE_COUNT_FIELDS},
+            "effort": item.get("effort"),
+            "estimated_cost": round(float(item.get("estimated_cost") or 0), 6),
+        }
+        for item in source.get("by_effort") or []
+        if isinstance(item, dict)
+    ]
+    return payload
+
+
+def merge_usage_totals(
+    target: dict[str, Any],
+    usage: dict[str, Any] | None,
+    *,
+    runs: int = 0,
+) -> None:
+    """Merge one stable usage payload into another in place."""
+
+    source = usage_totals_payload(usage)
+    if "runs" in target:
+        target["runs"] += int(runs)
+    for key in USAGE_COUNT_FIELDS:
+        target[key] += source[key]
+    target["estimated_cost"] = round(
+        float(target.get("estimated_cost") or 0) + source["estimated_cost"],
+        6,
+    )
+    by_effort = {
+        item.get("effort"): item
+        for item in target.get("by_effort") or []
+        if isinstance(item, dict)
+    }
+    for item in source["by_effort"]:
+        effort = item.get("effort")
+        effort_usage = by_effort.setdefault(effort, _effort_usage_row(effort))
+        for key in USAGE_COUNT_FIELDS:
+            effort_usage[key] += item[key]
+        effort_usage["estimated_cost"] = round(
+            effort_usage["estimated_cost"] + item["estimated_cost"],
+            6,
+        )
+    target["by_effort"] = _sorted_effort_usage(by_effort)
 
 
 def _add_call_usage(target: dict[str, Any], row: Any) -> None:
@@ -109,12 +180,54 @@ def _add_call_usage(target: dict[str, Any], row: Any) -> None:
 
 
 def _model_cost(row: Any) -> float:
-    return calculate_cost(
+    return calculate_model_cost(
         model=getattr(row, "model", None),
         tokens_input=_coerce_int(row.tokens_input),
         tokens_output=_coerce_int(row.tokens_output),
         cache_read=_coerce_int(row.cache_read),
         cache_write=_coerce_int(row.cache_write),
+    )
+
+
+def _effort_usage_row(effort: str | None) -> dict[str, Any]:
+    return {
+        "effort": effort,
+        "api_calls": 0,
+        "tokens_input": 0,
+        "tokens_output": 0,
+        "tokens_total": 0,
+        "cache_read": 0,
+        "cache_write": 0,
+        "estimated_cost": 0.0,
+    }
+
+
+def _add_effort_usage(
+    usage_by_effort: dict[str | None, dict[str, Any]],
+    row: Any,
+    *,
+    cost: float,
+) -> None:
+    raw_effort = getattr(row, "effort", None)
+    effort = str(raw_effort).strip().lower() if raw_effort else None
+    target = usage_by_effort.setdefault(effort, _effort_usage_row(effort))
+    input_tokens = _coerce_int(row.tokens_input)
+    output_tokens = _coerce_int(row.tokens_output)
+    target["api_calls"] += _coerce_int(row.api_calls)
+    target["tokens_input"] += input_tokens
+    target["tokens_output"] += output_tokens
+    target["tokens_total"] += input_tokens + output_tokens
+    target["cache_read"] += _coerce_int(row.cache_read)
+    target["cache_write"] += _coerce_int(row.cache_write)
+    target["estimated_cost"] = round(target["estimated_cost"] + cost, 6)
+
+
+def _sorted_effort_usage(
+    usage_by_effort: dict[str | None, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(
+        usage_by_effort.values(),
+        key=lambda item: (item["effort"] is None, str(item["effort"] or "")),
     )
 
 
@@ -170,6 +283,78 @@ async def async_summarize_run_usage(session: AsyncSession, run_id: int) -> dict[
     return rows[0] if rows else None
 
 
+async def async_summarize_run_usage_in_savepoint(
+    session: AsyncSession,
+    run_id: int,
+) -> dict[str, Any] | None:
+    """Read one run's usage without letting a failed report abort caller writes."""
+
+    begin_nested = getattr(session, "begin_nested", None)
+    if not callable(begin_nested):
+        return await async_summarize_run_usage(session, run_id)
+    async with begin_nested():
+        return await async_summarize_run_usage(session, run_id)
+
+
+async def async_summarize_run_trees_usage(
+    session: AsyncSession,
+    root_run_ids: Iterable[int],
+) -> dict[int, dict[str, Any]]:
+    """Aggregate each selected root run together with all of its descendants."""
+
+    root_ids = list(dict.fromkeys(int(run_id) for run_id in root_run_ids))
+    usage_by_root = {
+        run_id: usage_totals_payload()
+        for run_id in root_ids
+    }
+    if not root_ids:
+        return usage_by_root
+
+    runs = list(
+        (
+            await session.scalars(
+                select(AgentRunRow).where(
+                    or_(
+                        AgentRunRow.id.in_(root_ids),
+                        AgentRunRow.root_run_id.in_(root_ids),
+                    )
+                )
+            )
+        ).all()
+    )
+    raw_usage_by_run = {
+        int(usage["id"]): usage
+        for usage in await async_summarize_runs_usage(session, runs)
+    }
+    root_id_set = set(root_ids)
+    for run in runs:
+        run_id = int(run.id)
+        tree_root_id = (
+            run_id
+            if run_id in root_id_set
+            else int(run.root_run_id) if run.root_run_id in root_id_set else None
+        )
+        if tree_root_id is not None:
+            merge_usage_totals(
+                usage_by_root[tree_root_id],
+                raw_usage_by_run.get(run_id),
+            )
+    return usage_by_root
+
+
+async def async_summarize_run_tree_usage_in_savepoint(
+    session: AsyncSession,
+    root_run_id: int,
+) -> dict[str, Any]:
+    """Read a run tree's usage while containing reporting-query failures."""
+
+    begin_nested = getattr(session, "begin_nested", None)
+    if not callable(begin_nested):
+        return (await async_summarize_run_trees_usage(session, [root_run_id]))[root_run_id]
+    async with begin_nested():
+        return (await async_summarize_run_trees_usage(session, [root_run_id]))[root_run_id]
+
+
 async def async_summarize_runs_usage(
     session: AsyncSession,
     runs: Iterable[AgentRunRow],
@@ -179,6 +364,7 @@ async def async_summarize_runs_usage(
 
     usage_by_run: dict[int, dict[str, Any]] = {}
     model_rank: dict[int, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    effort_usage_by_run: dict[int, dict[str | None, dict[str, Any]]] = defaultdict(dict)
     for run in runs:
         row = _empty_usage()
         row.update(
@@ -206,7 +392,8 @@ async def async_summarize_runs_usage(
             continue
         _add_call_usage(row, call_row)
         cost = _model_cost(call_row)
-        row["estimated_cost"] += cost
+        row["estimated_cost"] = round(row["estimated_cost"] + cost, 6)
+        _add_effort_usage(effort_usage_by_run[call_row.run_id], call_row, cost=cost)
         model = call_row.model or row.get("model_used")
         if isinstance(model, str) and model:
             model_rank[call_row.run_id][model] += (
@@ -218,6 +405,8 @@ async def async_summarize_runs_usage(
     for run_id, ranks in model_rank.items():
         if ranks:
             usage_by_run[run_id]["model_used"] = max(ranks.items(), key=lambda item: item[1])[0]
+    for run_id, usage_by_effort in effort_usage_by_run.items():
+        usage_by_run[run_id]["by_effort"] = _sorted_effort_usage(usage_by_effort)
 
     return [usage_by_run[run.id] for run in runs]
 
@@ -227,6 +416,7 @@ def _run_usage_call_stmt(run_ids: list[int]):
         select(
             AgentApiCall.run_id.label("run_id"),
             AgentApiCall.model.label("model"),
+            AgentApiCall.effort.label("effort"),
             func.count(AgentApiCall.id).label("api_calls"),
             func.coalesce(func.sum(AgentApiCall.tokens_input), 0).label("tokens_input"),
             func.coalesce(func.sum(AgentApiCall.tokens_output), 0).label("tokens_output"),
@@ -235,7 +425,7 @@ def _run_usage_call_stmt(run_ids: list[int]):
             func.max(AgentApiCall.created_at).label("last_call_at"),
         )
         .where(AgentApiCall.run_id.in_(run_ids))
-        .group_by(AgentApiCall.run_id, AgentApiCall.model)
+        .group_by(AgentApiCall.run_id, AgentApiCall.model, AgentApiCall.effort)
     )
 
 
@@ -255,7 +445,15 @@ async def async_summarize_member_token_usage(
         _add_call_usage(target, row)
 
     for row in (await session.execute(_member_cost_stmt(org_id=org_id, since=since))).all():
-        usage_by_user[row.user_id]["estimated_cost"] += _model_cost(row)
+        target = usage_by_user[row.user_id]
+        cost = _model_cost(row)
+        target["estimated_cost"] = round(target["estimated_cost"] + cost, 6)
+        usage_by_effort = {
+            item["effort"]: item
+            for item in target["by_effort"]
+        }
+        _add_effort_usage(usage_by_effort, row, cost=cost)
+        target["by_effort"] = _sorted_effort_usage(usage_by_effort)
 
     return dict(usage_by_user)
 
@@ -283,6 +481,8 @@ def _member_cost_stmt(*, org_id: str, since: datetime):
         select(
             AgentRunRow.user_id.label("user_id"),
             AgentApiCall.model.label("model"),
+            AgentApiCall.effort.label("effort"),
+            func.count(AgentApiCall.id).label("api_calls"),
             func.coalesce(func.sum(AgentApiCall.tokens_input), 0).label("tokens_input"),
             func.coalesce(func.sum(AgentApiCall.tokens_output), 0).label("tokens_output"),
             func.coalesce(func.sum(AgentApiCall.cache_read), 0).label("cache_read"),
@@ -290,7 +490,7 @@ def _member_cost_stmt(*, org_id: str, since: datetime):
         )
         .join(AgentRunRow, AgentRunRow.id == AgentApiCall.run_id)
         .where(AgentRunRow.org_id == org_id, AgentApiCall.created_at >= since)
-        .group_by(AgentRunRow.user_id, AgentApiCall.model)
+        .group_by(AgentRunRow.user_id, AgentApiCall.model, AgentApiCall.effort)
     )
 
 
@@ -333,6 +533,8 @@ async def async_summarize_token_totals(
     cost_stmt = (
         select(
             AgentApiCall.model.label("model"),
+            AgentApiCall.effort.label("effort"),
+            func.count(AgentApiCall.id).label("api_calls"),
             func.coalesce(func.sum(AgentApiCall.tokens_input), 0).label("tokens_input"),
             func.coalesce(func.sum(AgentApiCall.tokens_output), 0).label("tokens_output"),
             func.coalesce(func.sum(AgentApiCall.cache_read), 0).label("cache_read"),
@@ -340,9 +542,14 @@ async def async_summarize_token_totals(
         )
         .join(AgentRunRow, AgentRunRow.id == AgentApiCall.run_id)
         .where(*filters)
-        .group_by(AgentApiCall.model)
+        .group_by(AgentApiCall.model, AgentApiCall.effort)
     )
     cost_stmt = _apply_status_filter(cost_stmt, statuses)
 
-    result["estimated_cost"] = sum(_model_cost(row) for row in (await session.execute(cost_stmt)).all())
+    usage_by_effort: dict[str | None, dict[str, Any]] = {}
+    for row in (await session.execute(cost_stmt)).all():
+        cost = _model_cost(row)
+        result["estimated_cost"] = round(result["estimated_cost"] + cost, 6)
+        _add_effort_usage(usage_by_effort, row, cost=cost)
+    result["by_effort"] = _sorted_effort_usage(usage_by_effort)
     return result

--- a/brain/systems/runs/tool_catalog/definitions/brain.py
+++ b/brain/systems/runs/tool_catalog/definitions/brain.py
@@ -859,7 +859,9 @@ BRAIN_TOOLS = [
             "Create, update, delete, list, manually run, or orient workspace Cycles, which are recurring "
             "Illo prompts/check-ins/reports or one-time reminders. This is the action tool. For answering questions about "
             "which Cycles exist or what ran recently, prefer read_cycles first. Actions: 'create', "
-            "'list', 'update', 'delete', 'run', 'add_guidance', 'add_output_target', 'remove_output_target'. Use action='help' or action='schema' with operation to inspect "
+            "'list', 'usage_summary', 'update', 'delete', 'run', 'add_guidance', 'add_output_target', "
+            "'remove_output_target'. usage_summary is read-only and reports real token/cost burn from model API calls. "
+            "Use action='help' or action='schema' with operation to inspect "
             "arguments before mutating."
         ),
         "input_schema": {
@@ -872,6 +874,7 @@ BRAIN_TOOLS = [
                         "schema",
                         "create",
                         "list",
+                        "usage_summary",
                         "update",
                         "delete",
                         "run",
@@ -886,6 +889,18 @@ BRAIN_TOOLS = [
                     "description": "Optional operation name to inspect when action is help or schema.",
                 },
                 "id": {"type": "integer", "description": "Cycle id (required for update/delete/run)"},
+                "days": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3650,
+                    "description": "For usage_summary, include Cycle runs scheduled within the last N days. Omit when selecting only by run_limit.",
+                },
+                "run_limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "For usage_summary, cap the window to the most recent N Cycle runs.",
+                },
                 "name": {"type": "string", "description": "Cycle name"},
                 "prompt": {"type": "string", "description": "Prompt Illo should run each cycle"},
                 "schedule_expr": {

--- a/brain/systems/runs/tool_catalog/handlers/common.py
+++ b/brain/systems/runs/tool_catalog/handlers/common.py
@@ -60,6 +60,11 @@ _ACTION_MANIFEST_TOOL_NAMES = action_manifest_tool_names()
 _MANAGE_TOOL_OPERATIONS: dict[str, dict[str, dict[str, object]]] = {
     "manage_cycle": {
         "list": {"required": [], "optional": [], "effect": "read scheduled cycles"},
+        "usage_summary": {
+            "required": [],
+            "optional": ["id", "days", "run_limit"],
+            "effect": "read token and estimated-cost usage by cycle",
+        },
         "create": {
             "required": ["name", "prompt", "timezone", "schedule_expr or run_at"],
             "optional": ["enabled", "target_idea_id", "model_override", "thinking_override", "guidance", "rationale"],

--- a/brain/systems/runs/tool_catalog/handlers/cycles.py
+++ b/brain/systems/runs/tool_catalog/handlers/cycles.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
 
 from sqlalchemy import select
 
-from brain.platform.db.models.cycle import Cycle
+from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cycles.access import (
@@ -37,6 +38,11 @@ from brain.systems.cycles.serializers import (
     serialize_cycle_output_target,
 )
 from brain.systems.cycles.service import async_run_cycle_now
+from brain.systems.runs.token_usage import (
+    async_summarize_run_trees_usage,
+    merge_usage_totals,
+    usage_totals_payload,
+)
 from brain.systems.runs.tool_catalog.handlers.common import *
 
 
@@ -60,6 +66,8 @@ class ManageCycleArgs:
     output_target_id: str | None = None
     output_target_label: str | None = None
     output_target_config: dict | None = None
+    days: int | None = None
+    run_limit: int | None = None
 
 
 @dataclass(frozen=True)
@@ -91,6 +99,8 @@ async def _handle_manage_cycle(
     output_target_id: str | None = None,
     output_target_label: str | None = None,
     output_target_config: dict | None = None,
+    days: int | None = None,
+    run_limit: int | None = None,
 ):
     return await _handle_manage_cycle_async(
         action=action,
@@ -112,6 +122,8 @@ async def _handle_manage_cycle(
         output_target_id=output_target_id,
         output_target_label=output_target_label,
         output_target_config=output_target_config,
+        days=days,
+        run_limit=run_limit,
     )
 
 
@@ -135,6 +147,8 @@ async def _handle_manage_cycle_async(
     output_target_id: str | None = None,
     output_target_label: str | None = None,
     output_target_config: dict | None = None,
+    days: int | None = None,
+    run_limit: int | None = None,
 ) -> str:
     normalized_action = str(action or "").strip().lower()
     if normalized_action in {"help", "schema"}:
@@ -167,6 +181,8 @@ async def _handle_manage_cycle_async(
         output_target_id=output_target_id,
         output_target_label=output_target_label,
         output_target_config=output_target_config,
+        days=days,
+        run_limit=run_limit,
     )
     context = ManageCycleContext(args=args, actor=_tool_actor(str(user_id)))
 
@@ -190,6 +206,79 @@ async def _action_list(ctx: ManageCycleContext) -> dict[str, Any]:
             .order_by(Cycle.created_at.desc())
         )
         return {"cycles": [serialize_cycle(cycle) for cycle in result.all()]}
+
+
+def _window_value(value: int | None, *, field: str, maximum: int) -> int | None:
+    if value is None:
+        return None
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an integer") from exc
+    if normalized < 1 or normalized > maximum:
+        raise ValueError(f"{field} must be between 1 and {maximum}")
+    return normalized
+
+
+async def _action_usage_summary(ctx: ManageCycleContext) -> dict[str, Any]:
+    args = ctx.args
+    days = _window_value(args.days, field="days", maximum=3650)
+    run_limit = _window_value(args.run_limit, field="run_limit", maximum=500)
+    if days is None and run_limit is None:
+        days = 30
+    effective_limit = run_limit or 500
+    since = datetime.now(timezone.utc) - timedelta(days=days) if days is not None else None
+
+    async with UnitOfWork() as uow:
+        stmt = (
+            select(CycleRun, Cycle)
+            .join(Cycle, Cycle.id == CycleRun.cycle_id)
+            .where(
+                *cycle_scope_conditions(ctx.actor),
+                CycleRun.run_id.isnot(None),
+            )
+            .order_by(CycleRun.scheduled_for.desc(), CycleRun.id.desc())
+            .limit(effective_limit)
+        )
+        if args.id is not None:
+            stmt = stmt.where(Cycle.id == args.id)
+        if since is not None:
+            stmt = stmt.where(CycleRun.scheduled_for >= since)
+        selected_rows = list((await uow.session.execute(stmt)).all())
+        run_ids = [int(cycle_run.run_id) for cycle_run, _cycle in selected_rows]
+        usage_by_run = await async_summarize_run_trees_usage(uow.session, run_ids)
+
+    cycles: dict[int, dict[str, Any]] = {}
+    totals = usage_totals_payload(include_runs=True)
+    for cycle_run, cycle in selected_rows:
+        cycle_usage = cycles.setdefault(
+            int(cycle.id),
+            {
+                "cycle_id": int(cycle.id),
+                "name": cycle.name,
+                **usage_totals_payload(include_runs=True),
+            },
+        )
+        usage = usage_by_run.get(int(cycle_run.run_id), {})
+        merge_usage_totals(cycle_usage, usage, runs=1)
+        merge_usage_totals(totals, usage, runs=1)
+
+    return {
+        "usage_summary": {
+            "window": {
+                "days": days,
+                "run_limit": effective_limit,
+                "since": since.isoformat() if since is not None else None,
+                "selected_runs": len(selected_rows),
+                "truncated": len(selected_rows) == effective_limit,
+            },
+            "totals": totals,
+            "cycles": sorted(
+                cycles.values(),
+                key=lambda item: (-item["estimated_cost"], -item["tokens_total"], item["cycle_id"]),
+            ),
+        }
+    }
 
 
 async def _action_create(ctx: ManageCycleContext) -> dict[str, Any]:
@@ -323,6 +412,7 @@ async def _action_remove_output_target(ctx: ManageCycleContext) -> dict[str, Any
 
 CYCLE_ACTIONS: dict[str, CycleAction] = {
     "list": _action_list,
+    "usage_summary": _action_usage_summary,
     "create": _action_create,
     "update": _action_update,
     "delete": _action_delete,

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -980,6 +980,8 @@ def action_policy_for_tool(
     kwargs_dict = dict(kwargs or {})
     if tool_name in {"manage_cycle", "manage_cron_job"} and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list"}:
         return None
+    if tool_name == "manage_cycle" and _arg_at(args_tuple, kwargs_dict, "action", 0) == "usage_summary":
+        return None
     if tool_name == "manage_domain" and _arg_at(args_tuple, kwargs_dict, "action", 0) in {"help", "schema", "list", "query_records", "get_record", "events"}:
         return None
     if tool_name == "manage_slack" and _arg_at(

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -4111,6 +4111,32 @@ async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_
         lambda **kwargs: {"read_file": lambda **tool_args: {"content": "setup steps", "path": tool_args["path"]}},
     )
     monkeypatch.setattr("brain.systems.runs.recipes.workers.invoke_direct_agent_async", fake_invoke)
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.async_summarize_run_usage_in_savepoint",
+        lambda *_args, **_kwargs: _AwaitableValue(
+            {
+                "api_calls": 2,
+                "tokens_input": 1_200,
+                "tokens_output": 300,
+                "tokens_total": 1_500,
+                "cache_read": 800,
+                "cache_write": 0,
+                "estimated_cost": 0.009,
+                "by_effort": [
+                    {
+                        "effort": "high",
+                        "api_calls": 2,
+                        "tokens_input": 1_200,
+                        "tokens_output": 300,
+                        "tokens_total": 1_500,
+                        "cache_read": 800,
+                        "cache_write": 0,
+                        "estimated_cost": 0.009,
+                    }
+                ],
+            }
+        ),
+    )
 
     runtime = _runtime("worker")
     result = await WorkerRecipe().execute(runtime)
@@ -4148,6 +4174,9 @@ async def test_worker_recipe_invokes_direct_agent_with_runtime_tools_and_worker_
         "provider": "anthropic",
         "auth_mode": "api_key",
     }
+    assert worker_result.payload["usage"]["tokens_total"] == 1_500
+    assert worker_result.payload["usage"]["estimated_cost"] == 0.009
+    assert worker_result.payload["usage"]["by_effort"][0]["effort"] == "high"
 
 
 async def test_worker_recipe_keeps_failed_provider_diagnostics_internal(monkeypatch):

--- a/tests/test_async_unit_of_work.py
+++ b/tests/test_async_unit_of_work.py
@@ -307,6 +307,7 @@ async def test_async_record_api_call_uses_supplied_async_session():
         run_id=7,
         turn=2,
         model="test-model",
+        effort="low",
         tokens_input=11,
         tokens_output=13,
         cache_read=3,
@@ -325,6 +326,7 @@ async def test_async_record_api_call_uses_supplied_async_session():
     assert params["sid"] == "session-1"
     assert params["did"] == 7
     assert params["trace_id"] == "run:7"
+    assert params["effort"] == "low"
     assert params["ti"] == 11
     assert params["to"] == 13
 

--- a/tests/test_cortex_misc_failure_projection.py
+++ b/tests/test_cortex_misc_failure_projection.py
@@ -173,6 +173,19 @@ async def test_audit_analyze_authorizes_and_projects_failed_thread_content():
         patch.object(_misc, "UnitOfWork", return_value=_Uow(session)),
         patch.object(_misc, "_a_require_idea_for_user", authorize),
         patch.object(_misc, "admit_work", side_effect=capture_admission),
+        patch.object(
+            _misc,
+            "async_summarize_runs_usage",
+            AsyncMock(
+                return_value=[
+                    {
+                        "id": run.id,
+                        "tokens_total": 12_345,
+                        "estimated_cost": 0.06789,
+                    }
+                ]
+            ),
+        ),
     ):
         result = await _misc.idea_audit_analyze(
             "idea-1",
@@ -189,6 +202,8 @@ async def test_audit_analyze_authorizes_and_projects_failed_thread_content():
     admitted_message = captured["event"].payload["message"]
     assert "raw-secret" not in admitted_message
     assert "temporary upstream problem" in admitted_message
+    assert "Total tokens: 12,345" in admitted_message
+    assert "Est cost: $0.0679" in admitted_message
 
 
 @pytest.mark.asyncio
@@ -301,3 +316,79 @@ async def test_audit_analysis_result_returns_typed_failure_without_diagnostics()
         "category": "upstream",
         "message": result["failure"]["message"],
     }
+
+
+@pytest.mark.asyncio
+async def test_audit_eval_returns_real_api_call_count_without_legacy_attempts_key():
+    from brain.app.api.routers.cortex import _misc
+
+    now = datetime.now(timezone.utc)
+    run = SimpleNamespace(
+        id=73,
+        status="completed",
+        input_message="Inspect the routing audit",
+        metadata_={},
+        completed_at=now,
+        created_at=now,
+    )
+    artifact = SimpleNamespace(
+        text="The routing audit is complete.",
+        created_at=now,
+    )
+
+    class EvalSession:
+        async def execute(self, _statement):
+            return _Rows([(run, artifact)])
+
+    request = SimpleNamespace(
+        json=AsyncMock(
+            return_value={
+                "proposal": {
+                    "type": "skill",
+                    "description": "Improve routing guidance",
+                    "recommendation": "Use the measured burn",
+                }
+            }
+        )
+    )
+
+    with (
+        patch.object(_misc, "UnitOfWork", return_value=_Uow(EvalSession())),
+        patch.object(
+            _misc,
+            "async_summarize_runs_usage",
+            AsyncMock(
+                return_value=[
+                    {
+                        "id": 73,
+                        "tokens_total": 2_500,
+                        "api_calls": 4,
+                    }
+                ]
+            ),
+        ),
+        patch(
+            "brain.platform.integrations.completions.simple_text_completion",
+            return_value=json.dumps(
+                {
+                    "score": 8,
+                    "task_solved": "yes",
+                    "output_better": "yes",
+                    "less_waste": "yes",
+                    "regression_risk": "low",
+                    "reasoning": "Measured routing should improve the proposal.",
+                }
+            ),
+        ),
+        patch(
+            "brain.platform.providers.model_policy.get_default_model",
+            return_value="openai/gpt-5.4",
+        ),
+    ):
+        result = await _misc.audit_eval(
+            request,
+            user={"id": "user-1", "org_id": "org-1"},
+        )
+
+    assert result["benchmarks"][0]["tokens"] == 2_500
+    assert result["benchmarks"][0]["api_calls"] == 4

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -250,9 +250,10 @@ async def test_async_summarize_recent_run_usage_uses_async_session():
         target_ref={},
         model_policy={},
     )
-    call = SimpleNamespace(
+    low_call = SimpleNamespace(
         run_id=7,
         model="openai/gpt-5.4",
+        effort="low",
         api_calls=2,
         tokens_input=10,
         tokens_output=5,
@@ -260,14 +261,111 @@ async def test_async_summarize_recent_run_usage_uses_async_session():
         cache_write=1,
         last_call_at=created_at,
     )
+    high_call = SimpleNamespace(
+        run_id=7,
+        model="openai/gpt-5.4",
+        effort="high",
+        api_calls=1,
+        tokens_input=20,
+        tokens_output=10,
+        cache_read=0,
+        cache_write=0,
+        last_call_at=created_at,
+    )
 
     session = MagicMock()
     session.scalars = AsyncMock(return_value=SimpleNamespace(all=lambda: [run]))
-    session.execute = AsyncMock(return_value=SimpleNamespace(all=lambda: [call]))
+    session.execute = AsyncMock(
+        return_value=SimpleNamespace(all=lambda: [low_call, high_call])
+    )
 
     rows = await async_summarize_recent_run_usage(session, limit=10, org_id="org-1")
 
     assert rows[0]["id"] == 7
-    assert rows[0]["tokens_total"] == 15
-    assert rows[0]["api_calls"] == 2
+    assert rows[0]["tokens_input"] == 30
+    assert rows[0]["tokens_output"] == 15
+    assert rows[0]["tokens_total"] == 45
+    assert rows[0]["api_calls"] == 3
+    assert rows[0]["estimated_cost"] == 0.000296
     assert rows[0]["model_used"] == "openai/gpt-5.4"
+    assert rows[0]["by_effort"] == [
+        {
+            "effort": "high",
+            "api_calls": 1,
+            "tokens_input": 20,
+            "tokens_output": 10,
+            "tokens_total": 30,
+            "cache_read": 0,
+            "cache_write": 0,
+            "estimated_cost": 0.0002,
+        },
+        {
+            "effort": "low",
+            "api_calls": 2,
+            "tokens_input": 10,
+            "tokens_output": 5,
+            "tokens_total": 15,
+            "cache_read": 3,
+            "cache_write": 1,
+            "estimated_cost": 0.000096,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_summarize_run_trees_usage_includes_worker_descendants(monkeypatch):
+    from brain.systems.runs import token_usage
+
+    root = SimpleNamespace(id=70, root_run_id=70)
+    worker = SimpleNamespace(id=71, root_run_id=70)
+    session = MagicMock()
+    session.scalars = AsyncMock(
+        return_value=SimpleNamespace(all=lambda: [root, worker])
+    )
+
+    async def summarize(_session, runs):
+        assert [run.id for run in runs] == [70, 71]
+        return [
+            {
+                "id": 70,
+                "api_calls": 1,
+                "tokens_input": 100,
+                "tokens_output": 20,
+                "tokens_total": 120,
+                "cache_read": 0,
+                "cache_write": 0,
+                "estimated_cost": 0.001,
+                "by_effort": [],
+            },
+            {
+                "id": 71,
+                "api_calls": 2,
+                "tokens_input": 300,
+                "tokens_output": 80,
+                "tokens_total": 380,
+                "cache_read": 50,
+                "cache_write": 0,
+                "estimated_cost": 0.004,
+                "by_effort": [
+                    {
+                        "effort": "low",
+                        "api_calls": 2,
+                        "tokens_input": 300,
+                        "tokens_output": 80,
+                        "tokens_total": 380,
+                        "cache_read": 50,
+                        "cache_write": 0,
+                        "estimated_cost": 0.004,
+                    }
+                ],
+            },
+        ]
+
+    monkeypatch.setattr(token_usage, "async_summarize_runs_usage", summarize)
+
+    usage = await token_usage.async_summarize_run_trees_usage(session, [70])
+
+    assert usage[70]["api_calls"] == 3
+    assert usage[70]["tokens_total"] == 500
+    assert usage[70]["estimated_cost"] == 0.005
+    assert usage[70]["by_effort"][0]["effort"] == "low"

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -1581,6 +1581,83 @@ async def test_manage_cycle_list_uses_native_uow_without_sync_bridges(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_manage_cycle_usage_summary_groups_real_ledger_usage_by_cycle(monkeypatch):
+    from brain.systems.runs.execution_context import bind_agent_context
+    from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
+
+    cycle = _cycle_for_serialization(
+        schedule_expr="0 9 * * *",
+        timezone_name="America/Toronto",
+    )
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = cycle.id
+    cycle_run.run_id = 77
+    cycle_run.scheduled_for = datetime.now(timezone.utc)
+
+    class UsageSession:
+        async def execute(self, _statement):
+            return _AllResult([(cycle_run, cycle)])
+
+    usage = {
+        "api_calls": 2,
+        "tokens_input": 1_000,
+        "tokens_output": 250,
+        "tokens_total": 1_250,
+        "cache_read": 400,
+        "cache_write": 0,
+        "estimated_cost": 0.0125,
+        "by_effort": [
+            {
+                "effort": "low",
+                "api_calls": 2,
+                "tokens_input": 1_000,
+                "tokens_output": 250,
+                "tokens_total": 1_250,
+                "cache_read": 400,
+                "cache_write": 0,
+                "estimated_cost": 0.0125,
+            }
+        ],
+    }
+
+    async def summarize(_session, run_ids):
+        assert list(run_ids) == [77]
+        return {77: usage}
+
+    factory = _AsyncUnitOfWorkFactory([UsageSession()])
+    monkeypatch.setattr(cycle_handlers, "UnitOfWork", factory)
+    monkeypatch.setattr(cycle_handlers, "async_summarize_run_trees_usage", summarize)
+
+    with bind_agent_context({"user_id": "user-1", "org_id": None}):
+        payload = json.loads(
+            await cycle_handlers._handle_manage_cycle_async(
+                action="usage_summary",
+                run_limit=10,
+            )
+        )
+
+    summary = payload["usage_summary"]
+    assert summary["window"]["days"] is None
+    assert summary["window"]["run_limit"] == 10
+    assert summary["totals"]["tokens_total"] == 1_250
+    assert summary["totals"]["estimated_cost"] == 0.0125
+    assert summary["cycles"][0]["cycle_id"] == cycle.id
+    assert summary["cycles"][0]["by_effort"][0]["effort"] == "low"
+
+
+def test_cycle_self_review_summary_includes_run_burn():
+    from brain.systems.cycles.memory import cycle_run_evaluation_summary
+
+    summary = cycle_run_evaluation_summary(
+        status="completed",
+        usage={"tokens_total": 12_345, "estimated_cost": 0.06789},
+    )
+
+    assert summary.endswith("Burn: 12,345 tokens; estimated cost $0.067890.")
+
+
+@pytest.mark.asyncio
 async def test_manage_cycle_run_propagates_agent_trigger_provenance(monkeypatch):
     from brain.systems.runs.tool_catalog.handlers import cycles as cycle_handlers
     from brain.systems.runs.execution_context import bind_agent_context

--- a/tests/test_tool_policy.py
+++ b/tests/test_tool_policy.py
@@ -430,6 +430,25 @@ def test_manage_cycle_list_is_not_audited():
     assert completions == []
 
 
+def test_manage_cycle_usage_summary_is_not_audited():
+    from brain.systems.runs.tool_handlers import _get_tool_handlers
+
+    records, completions, record, complete = _capture_manifests()
+    handlers = _get_tool_handlers()
+
+    with patch("brain.systems.runs.actions.record_action_manifest", side_effect=record), \
+         patch("brain.systems.runs.actions.complete_action_manifest", side_effect=complete), \
+         patch(
+             "brain.systems.runs.tool_handlers._handle_manage_cycle",
+             return_value={"usage_summary": {"cycles": []}},
+         ):
+        result = handlers["manage_cycle"](action="usage_summary", days=7)
+
+    assert result == {"usage_summary": {"cycles": []}}
+    assert records == []
+    assert completions == []
+
+
 def test_tool_registration_normalizes_legacy_policy_strings():
     from brain.systems.runs.tool_catalog.metadata import (
         ToolAvailability,

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -604,6 +604,9 @@ def test_manage_cycle_schema_matches_canonical_runtime_policy():
 
     assert "execution_mode" not in properties
     assert "reopen_archived" not in properties
+    assert "usage_summary" in properties["action"]["enum"]
+    assert properties["days"]["minimum"] == 1
+    assert properties["run_limit"]["maximum"] == 500
     assert "add_guidance" in properties["action"]["enum"]
     assert "add_output_target" in properties["action"]["enum"]
     assert properties["run_kind"]["enum"] == [


### PR DESCRIPTION
Closes #484. Slice 7 of `docs/prd-model-effort-routing.md` — the last slice.

## The correction this builds on
The audit endpoint summed `agent_runs.metadata->>'usage'` — a key **nothing under `brain/` ever writes**, so it always reported zeros. The durable ledger is `agent_api_calls`, aggregated by `token_usage.py`. Everything here builds on that instead, with cost via `calculate_model_cost` so pricing stays in one place.

## Changes
- `spawn_worker` results and the worker artifact carry the child run's **tokens and estimated cost**, alongside the routing snapshot from #489.
- `manage_cycle` gains a **read-only usage summary** so Illo can see which cycles are expensive.
- The cycle **self-review line** includes that run's burn.
- `agent_api_calls` gains an **`effort` column** (migration `0041_agent_api_call_effort`), recorded where the call is logged — enabling per-tier cost breakdown. Effort was the one dimension the ledger couldn't express. Historical rows stay NULL; no backfill.
- The stale `metadata['usage']` read is fixed, so the audit endpoint reports real numbers.

Read-only reporting only: no quotas, no enforcement, no routing changes.

## Rebase notes (worth reading)
Rebased onto merged Slice 2 and Slice 6:
- **Two conflicts resolved by keeping both features** — the worker artifact now carries `routing` *and* `usage`; they're complementary, not competing.
- **Migration renumbered 0040 → 0041**, chained after `0040_drop_routing_effort`. Slice 6 and Slice 7 had each independently claimed `0040` off main; merging both as-is would have left main with **two alembic heads** — the exact failure that has broken this repo's migrations twice before. The repo's own `test_alembic_revision_headers_match_identifiers` guard then caught that I'd updated the identifiers but not the docstring header, which was a nice save.

**4183 passed**, exactly one alembic head.

Implementation by Codex (high effort), reviewed and rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)