### PR TITLE
chore(deploy-state): normalize fix_pr + backfill fix_merge_sha, with owned tracker/fix-ref modules (#474)

### DIFF
--- a/brain/systems/deploy_fix_refs.py
+++ b/brain/systems/deploy_fix_refs.py
@@ -1,0 +1,58 @@
+"""Pure normalization of GitHub PR references used by deploy tracking."""
+
+from __future__ import annotations
+
+import re
+
+
+_REPO_PR_RE = re.compile(
+    r"\b(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<number>[1-9][0-9]*)\b"
+)
+_GITHUB_PR_URL_RE = re.compile(
+    r"https?://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/(?P<number>[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+_GITHUB_PR_KEY_RE = re.compile(
+    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):pr:(?P<number>[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_KEY_RE = re.compile(
+    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):issue:[1-9][0-9]*\b",
+    re.IGNORECASE,
+)
+_SHORT_PR_RE = re.compile(
+    r"\b(?:pr|pull request)\s*#?(?P<number>[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+_BARE_PR_RE = re.compile(r"^(?P<number>[1-9][0-9]*)$")
+
+
+def github_repo_from_issue_text(text: str) -> str | None:
+    """Extract ``owner/repo`` from a tracker GitHub issue key."""
+    match = _GITHUB_ISSUE_KEY_RE.search(str(text or "").strip())
+    return match.group("repo") if match else None
+
+
+def normalize_fix_pr_reference(
+    text: str,
+    *,
+    default_repo: str | None,
+) -> str | None:
+    """Normalize a supported PR reference to ``owner/repo#N``."""
+    url_match = _GITHUB_PR_URL_RE.search(text)
+    if url_match:
+        return f"{url_match.group('repo')}#{url_match.group('number')}"
+    key_match = _GITHUB_PR_KEY_RE.search(text)
+    if key_match:
+        return f"{key_match.group('repo')}#{key_match.group('number')}"
+    repo_match = _REPO_PR_RE.search(text)
+    if repo_match:
+        return f"{repo_match.group('repo')}#{repo_match.group('number')}"
+    short_match = _SHORT_PR_RE.search(text)
+    clean_repo = str(default_repo or "").strip()
+    if short_match and clean_repo:
+        return f"{clean_repo}#{short_match.group('number')}"
+    bare_match = _BARE_PR_RE.fullmatch(str(text or "").strip())
+    if bare_match and clean_repo:
+        return f"{clean_repo}#{bare_match.group('number')}"
+    return None

--- a/brain/systems/deploy_state_sweep.py
+++ b/brain/systems/deploy_state_sweep.py
@@ -129,7 +129,16 @@ _GITHUB_PR_URL_RE = re.compile(
     r"https?://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/(?P<number>[1-9][0-9]*)\b",
     re.IGNORECASE,
 )
+_GITHUB_PR_KEY_RE = re.compile(
+    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):pr:(?P<number>[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_KEY_RE = re.compile(
+    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):issue:[1-9][0-9]*\b",
+    re.IGNORECASE,
+)
 _SHORT_PR_RE = re.compile(r"\b(?:pr|pull request)\s*#?(?P<number>[1-9][0-9]*)\b", re.IGNORECASE)
+_BARE_PR_RE = re.compile(r"^(?P<number>[1-9][0-9]*)$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,7 +184,8 @@ def _iso(value: datetime | str | object) -> str | None:
     return parsed.isoformat() if parsed else None
 
 
-def _append_progress_note(data: Mapping[str, object], line: str) -> str | None:
+def append_progress_note(data: Mapping[str, object], line: str) -> str | None:
+    """Append one line using the tracker progress-note convention."""
     if "progress_note" not in data:
         return None
     current = str(data.get("progress_note") or "").rstrip()
@@ -218,10 +228,20 @@ def _human_reply(message: Mapping[str, object], *, bot_user_id: str | None) -> b
     return not bot_user_id or user_id != bot_user_id
 
 
-def _fix_pr_from_text(text: str, *, repo: str | None) -> str | None:
+def github_repo_from_issue_text(text: str) -> str | None:
+    """Extract ``owner/repo`` from a tracker GitHub issue key."""
+    match = _GITHUB_ISSUE_KEY_RE.search(_text(text))
+    return match.group("repo") if match else None
+
+
+def fix_pr_from_text(text: str, *, repo: str | None) -> str | None:
+    """Normalize a supported PR reference to ``owner/repo#N``."""
     url_match = _GITHUB_PR_URL_RE.search(text)
     if url_match:
         return f"{url_match.group('repo')}#{url_match.group('number')}"
+    key_match = _GITHUB_PR_KEY_RE.search(text)
+    if key_match:
+        return f"{key_match.group('repo')}#{key_match.group('number')}"
     repo_match = _REPO_PR_RE.search(text)
     if repo_match:
         return f"{repo_match.group('repo')}#{repo_match.group('number')}"
@@ -229,6 +249,9 @@ def _fix_pr_from_text(text: str, *, repo: str | None) -> str | None:
     clean_repo = _text(repo)
     if short_match and clean_repo:
         return f"{clean_repo}#{short_match.group('number')}"
+    bare_match = _BARE_PR_RE.fullmatch(_text(text))
+    if bare_match and clean_repo:
+        return f"{clean_repo}#{bare_match.group('number')}"
     return None
 
 
@@ -271,7 +294,7 @@ def _resolution_signals(
                 text=text,
                 source=source,
                 fix_pr=(
-                    _fix_pr_from_text(text, repo=repo)
+                    fix_pr_from_text(text, repo=repo)
                     if kind in {"deployed", "verified"}
                     else None
                 ),
@@ -314,7 +337,7 @@ def alert_thread_source_from_run(
 
 
 async def _alert_thread_sources(session, *, org_id: str) -> list[AlertThreadSource]:
-    records = await _ticket_records(session, org_id=org_id)
+    records = await ticket_records(session, org_id=org_id)
     if not records:
         return []
     records_by_id = {record.id: record for record in records}
@@ -468,7 +491,7 @@ async def _resolution_patch(
         status = _matching_enum_option(fields.get("status"), "Todo", "In Progress", "Blocked")
     if status is not None:
         patch["status"] = status
-    note = _append_progress_note(data, _resolution_note(signal))
+    note = append_progress_note(data, _resolution_note(signal))
     if note is not None:
         patch["progress_note"] = note
     return {key: value for key, value in patch.items() if key in fields}
@@ -583,7 +606,7 @@ async def run_alert_resolution_harvest(
             summary["skipped"] += 1
             continue
         try:
-            await _update_record(
+            await update_record(
                 session,
                 record,
                 patch,
@@ -643,7 +666,7 @@ def _json_text(session, key: str):
     return DomainRecord.data[key].as_string()
 
 
-async def _ticket_records(
+async def ticket_records(
     session,
     *,
     org_id: str,
@@ -685,7 +708,7 @@ async def _ticket_records(
     return list((await session.scalars(stmt.order_by(DomainRecord.id))).all())
 
 
-async def _update_record(
+async def update_record(
     session,
     record: DomainRecord,
     patch: dict,
@@ -746,7 +769,7 @@ async def _sweep_main_merge(
 ) -> None:
     kind = classify_merge_event(event)
     fix_pr = f"{repo}#{event.get('number')}" if kind is MergeKind.HOTFIX and event.get("number") else None
-    records = await _ticket_records(
+    records = await ticket_records(
         session,
         org_id=org_id,
         states={DeployState.STAGING.value, DeployState.PROD_PENDING.value},
@@ -775,7 +798,7 @@ async def _sweep_main_merge(
             patch.update({"deploy_state": DeployState.DEPLOYED.value, "deployed_at": deployed_at})
             if fix_pr and data.get("fix_pr") == fix_pr:
                 patch.update({"fix_merge_sha": sha, "fix_merged_at": deployed_at})
-            note = _append_progress_note(data, f"deployed to main at {deployed_at}")
+            note = append_progress_note(data, f"deployed to main at {deployed_at}")
             if note is not None:
                 patch["progress_note"] = note
             bucket = "deployed"
@@ -788,7 +811,7 @@ async def _sweep_main_merge(
                 summary["skipped"] += 1
                 continue
             patch["deploy_state"] = DeployState.PROD_PENDING.value
-            note = _append_progress_note(data, "fix confirmed on staging; awaiting promotion")
+            note = append_progress_note(data, "fix confirmed on staging; awaiting promotion")
             if note is not None:
                 patch["progress_note"] = note
             bucket = "prod_pending"
@@ -796,7 +819,7 @@ async def _sweep_main_merge(
             summary["skipped"] += 1
             continue
         try:
-            await _update_record(session, record, patch, reason=f"deploy_sweep:{kind.value}")
+            await update_record(session, record, patch, reason=f"deploy_sweep:{kind.value}")
         except Exception as exc:
             logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)
@@ -821,7 +844,7 @@ async def _sweep_staging_merge(
         summary["skipped"] += 1
         return
     fix_pr = f"{repo}#{number}"
-    records = await _ticket_records(session, org_id=org_id, fix_pr=fix_pr)
+    records = await ticket_records(session, org_id=org_id, fix_pr=fix_pr)
     for record in records:
         summary["examined"] += 1
         data = record.data or {}
@@ -841,11 +864,11 @@ async def _sweep_staging_merge(
         }
         if state is DeployState.DEPLOYED:
             patch["deployed_at"] = merged_at
-        note = _append_progress_note(data, f"fix {fix_pr} merged to staging at {merged_at}")
+        note = append_progress_note(data, f"fix {fix_pr} merged to staging at {merged_at}")
         if note is not None:
             patch["progress_note"] = note
         try:
-            await _update_record(session, record, patch, reason="deploy_sweep:fix_to_staging")
+            await update_record(session, record, patch, reason="deploy_sweep:fix_to_staging")
         except Exception as exc:
             logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)
@@ -943,7 +966,7 @@ async def run_deploy_verification(
         return summary
     try:
         summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
-        records = await _ticket_records(
+        records = await ticket_records(
             session,
             org_id=org_id,
             states={DeployState.DEPLOYED.value},
@@ -995,14 +1018,14 @@ async def run_deploy_verification(
             "verified_at": current.isoformat(),
             "status": "Done",
         }
-        note = _append_progress_note(
+        note = append_progress_note(
             data,
             f"verified quiet since deploy at {deployed_iso}",
         )
         if note is not None:
             patch["progress_note"] = note
         try:
-            await _update_record(session, record, patch, reason="deploy_verification")
+            await update_record(session, record, patch, reason="deploy_verification")
         except Exception as exc:
             logger.warning("deploy verification skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)

--- a/brain/systems/deploy_state_sweep.py
+++ b/brain/systems/deploy_state_sweep.py
@@ -1,10 +1,9 @@
-"""Deterministic persistence wiring for the deploy-state lifecycle.
+"""Deterministic coordination for the deploy-state lifecycle.
 
 The pure axis and ladder live in :mod:`brain.systems.deploy_state`.  This module
-owns best-effort reads of GitHub-ticket records and monitored-alert threads,
-plus optimistic writes through ``AsyncDomainService``. It never posts to Slack
-and never lets GitHub, Slack, or record conflicts fail a coordinator sweep,
-webhook ingestion, or notification tick.
+combines deploy-tracker persistence with monitored-alert reads. It never posts
+to Slack and never lets GitHub, Slack, or record conflicts fail a coordinator
+sweep, webhook ingestion, or notification tick.
 """
 
 from __future__ import annotations
@@ -18,16 +17,15 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, Awaitable, Mapping, Protocol, Sequence
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import select
 
 from brain.platform.db.models.domain import (
-    Domain,
     DomainEvent,
     DomainFieldDefinition,
-    DomainObjectType,
     DomainRecord,
 )
 from brain.platform.db.models.run import AgentRun
+from brain.systems import deploy_fix_refs, deploy_tracker
 from brain.systems.deploy_state import (
     DeployState,
     MergeKind,
@@ -39,60 +37,12 @@ from brain.systems.deploy_state_config import (
     deploy_feature_enabled,
     deploy_quiet_window,
     deploy_settle_window,
-    deploy_ticket_object_keys,
 )
 from brain.systems.deploy_state_github import is_ancestor_of
 from brain.systems.user_domains.service import AsyncDomainService
 
 
 logger = logging.getLogger("illo.deploy_state")
-
-DEPLOY_STATE_FIELD_DEFINITIONS: tuple[dict, ...] = (
-    {"key": "rollbar_item", "name": "Rollbar Item", "field_type": "text"},
-    {"key": "alert_last_seen_at", "name": "Alert Last Seen At", "field_type": "datetime"},
-    {"key": "alert_occurrences", "name": "Alert Occurrences", "field_type": "number"},
-    {"key": "fix_pr", "name": "Fix PR", "field_type": "text"},
-    {"key": "fix_merge_sha", "name": "Fix Merge SHA", "field_type": "text"},
-    {"key": "fix_merged_at", "name": "Fix Merged At", "field_type": "datetime"},
-    {
-        "key": "deploy_state",
-        "name": "Deploy State",
-        "field_type": "enum",
-        "options": [state.value for state in DeployState],
-    },
-    {"key": "deployed_at", "name": "Deployed At", "field_type": "datetime"},
-    {"key": "verified_at", "name": "Verified At", "field_type": "datetime"},
-    {
-        "key": "alert_slack_channel",
-        "name": "Alert Slack Channel",
-        "field_type": "text",
-    },
-    {
-        "key": "alert_slack_thread_ts",
-        "name": "Alert Slack Thread Timestamp",
-        "field_type": "text",
-    },
-    {
-        "key": "alert_slack_bot_user_id",
-        "name": "Alert Slack Bot User Id",
-        "field_type": "text",
-    },
-    {
-        "key": "resolution_confirmed_ts",
-        "name": "Resolution Confirming Slack Timestamp",
-        "field_type": "text",
-    },
-    {
-        "key": "resolution_reproduced_ts",
-        "name": "Resolution Reproduced Slack Timestamp",
-        "field_type": "text",
-    },
-    {
-        "key": "promotion_recommended_at",
-        "name": "Promotion Recommended At",
-        "field_type": "datetime",
-    },
-)
 
 _SLACK_THREAD_PAGE_LIMIT = 200
 _SLACK_THREAD_MAX_PAGES = 3
@@ -122,23 +72,6 @@ _VERIFICATION_PATTERNS = (
 _DEPLOYMENT_RE = re.compile(r"\bdeploy(?:e|ed|ment)?\b")
 _MERGE_OR_PROMOTION_RE = re.compile(r"\b(?:merge(?:d|e|ee)?|promot(?:ed|e|ee|ion))\b")
 _PR_REFERENCE_RE = re.compile(r"\b(?:pr|pull request)\b|#[1-9][0-9]*\b")
-_REPO_PR_RE = re.compile(
-    r"\b(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<number>[1-9][0-9]*)\b"
-)
-_GITHUB_PR_URL_RE = re.compile(
-    r"https?://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/(?P<number>[1-9][0-9]*)\b",
-    re.IGNORECASE,
-)
-_GITHUB_PR_KEY_RE = re.compile(
-    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):pr:(?P<number>[1-9][0-9]*)\b",
-    re.IGNORECASE,
-)
-_GITHUB_ISSUE_KEY_RE = re.compile(
-    r"\bgithub:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):issue:[1-9][0-9]*\b",
-    re.IGNORECASE,
-)
-_SHORT_PR_RE = re.compile(r"\b(?:pr|pull request)\s*#?(?P<number>[1-9][0-9]*)\b", re.IGNORECASE)
-_BARE_PR_RE = re.compile(r"^(?P<number>[1-9][0-9]*)$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,14 +117,6 @@ def _iso(value: datetime | str | object) -> str | None:
     return parsed.isoformat() if parsed else None
 
 
-def append_progress_note(data: Mapping[str, object], line: str) -> str | None:
-    """Append one line using the tracker progress-note convention."""
-    if "progress_note" not in data:
-        return None
-    current = str(data.get("progress_note") or "").rstrip()
-    return f"{current}\n{line}".lstrip()
-
-
 def _text(value: object) -> str:
     return str(value or "").strip()
 
@@ -226,33 +151,6 @@ def _human_reply(message: Mapping[str, object], *, bot_user_id: str | None) -> b
     if _text(message.get("subtype")).casefold() == "bot_message":
         return False
     return not bot_user_id or user_id != bot_user_id
-
-
-def github_repo_from_issue_text(text: str) -> str | None:
-    """Extract ``owner/repo`` from a tracker GitHub issue key."""
-    match = _GITHUB_ISSUE_KEY_RE.search(_text(text))
-    return match.group("repo") if match else None
-
-
-def fix_pr_from_text(text: str, *, repo: str | None) -> str | None:
-    """Normalize a supported PR reference to ``owner/repo#N``."""
-    url_match = _GITHUB_PR_URL_RE.search(text)
-    if url_match:
-        return f"{url_match.group('repo')}#{url_match.group('number')}"
-    key_match = _GITHUB_PR_KEY_RE.search(text)
-    if key_match:
-        return f"{key_match.group('repo')}#{key_match.group('number')}"
-    repo_match = _REPO_PR_RE.search(text)
-    if repo_match:
-        return f"{repo_match.group('repo')}#{repo_match.group('number')}"
-    short_match = _SHORT_PR_RE.search(text)
-    clean_repo = _text(repo)
-    if short_match and clean_repo:
-        return f"{clean_repo}#{short_match.group('number')}"
-    bare_match = _BARE_PR_RE.fullmatch(_text(text))
-    if bare_match and clean_repo:
-        return f"{clean_repo}#{bare_match.group('number')}"
-    return None
 
 
 def _resolution_kind(text: str) -> str | None:
@@ -294,7 +192,10 @@ def _resolution_signals(
                 text=text,
                 source=source,
                 fix_pr=(
-                    fix_pr_from_text(text, repo=repo)
+                    deploy_fix_refs.normalize_fix_pr_reference(
+                        text,
+                        default_repo=repo,
+                    )
                     if kind in {"deployed", "verified"}
                     else None
                 ),
@@ -337,7 +238,10 @@ def alert_thread_source_from_run(
 
 
 async def _alert_thread_sources(session, *, org_id: str) -> list[AlertThreadSource]:
-    records = await ticket_records(session, org_id=org_id)
+    records = await deploy_tracker.list_deploy_ticket_records(
+        session,
+        org_id=org_id,
+    )
     if not records:
         return []
     records_by_id = {record.id: record for record in records}
@@ -491,7 +395,7 @@ async def _resolution_patch(
         status = _matching_enum_option(fields.get("status"), "Todo", "In Progress", "Blocked")
     if status is not None:
         patch["status"] = status
-    note = append_progress_note(data, _resolution_note(signal))
+    note = deploy_tracker.append_progress_note(data, _resolution_note(signal))
     if note is not None:
         patch["progress_note"] = note
     return {key: value for key, value in patch.items() if key in fields}
@@ -528,7 +432,10 @@ async def run_alert_resolution_harvest(
         summary["disabled"] = True
         return summary
     try:
-        summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
+        summary["fields"] = await deploy_tracker.ensure_deploy_state_fields(
+            session,
+            org_id=org_id,
+        )
         resolved_sources = list(sources) if sources is not None else await _alert_thread_sources(
             session, org_id=org_id
         )
@@ -606,7 +513,7 @@ async def run_alert_resolution_harvest(
             summary["skipped"] += 1
             continue
         try:
-            await update_record(
+            await deploy_tracker.update_deploy_ticket_record(
                 session,
                 record,
                 patch,
@@ -626,105 +533,6 @@ async def run_alert_resolution_harvest(
             }
         )
     return summary
-
-
-async def ensure_deploy_state_fields(session, *, org_id: str) -> dict:
-    """Idempotently add optional deploy fields to every active ticket type."""
-    object_types = (
-        await session.scalars(
-            select(DomainObjectType)
-            .join(Domain, Domain.id == DomainObjectType.domain_id)
-            .where(
-                Domain.org_id == str(org_id),
-                Domain.archived_at.is_(None),
-                DomainObjectType.key.in_(deploy_ticket_object_keys()),
-                DomainObjectType.archived_at.is_(None),
-            )
-            .order_by(DomainObjectType.id)
-        )
-    ).all()
-    service = AsyncDomainService(session)
-    added = 0
-    for object_type in object_types:
-        existing = {
-            field.key
-            for field in await service.list_fields(object_type.id)
-        }
-        for payload in DEPLOY_STATE_FIELD_DEFINITIONS:
-            if payload["key"] in existing:
-                continue
-            await service.add_field_definition(object_type, dict(payload), emit_event=False)
-            existing.add(str(payload["key"]))
-            added += 1
-    return {"object_types": len(object_types), "fields_added": added}
-
-
-def _json_text(session, key: str):
-    bind = session.get_bind()
-    if bind is not None and bind.dialect.name == "sqlite":
-        return func.json_extract(DomainRecord.data, f"$.{key}")
-    return DomainRecord.data[key].as_string()
-
-
-async def ticket_records(
-    session,
-    *,
-    org_id: str,
-    states: set[str] | None = None,
-    fix_pr_prefix: str | None = None,
-    fix_pr: str | None = None,
-) -> list[DomainRecord]:
-    """Select ticket records by deploy-state and/or fix-PR identity.
-
-    Selection keys on where the FIX lives (``fix_pr`` is repo-qualified), not
-    on the ticket's own ``repo`` field — an app ticket fixed by a backend PR
-    must be swept by the backend promotion, not the app one.
-    """
-    stmt = (
-        select(DomainRecord)
-        .join(DomainObjectType, DomainObjectType.id == DomainRecord.object_type_id)
-        .join(Domain, Domain.id == DomainRecord.domain_id)
-        .where(
-            DomainRecord.org_id == str(org_id),
-            DomainRecord.archived_at.is_(None),
-            Domain.archived_at.is_(None),
-            DomainObjectType.key.in_(deploy_ticket_object_keys()),
-            DomainObjectType.archived_at.is_(None),
-        )
-    )
-    conditions = []
-    if states:
-        state_arm = _json_text(session, "deploy_state").in_(states)
-        if fix_pr_prefix:
-            state_arm = and_(
-                state_arm,
-                _json_text(session, "fix_pr").like(f"{fix_pr_prefix}%"),
-            )
-        conditions.append(state_arm)
-    if fix_pr:
-        conditions.append(_json_text(session, "fix_pr") == fix_pr)
-    if conditions:
-        stmt = stmt.where(or_(*conditions))
-    return list((await session.scalars(stmt.order_by(DomainRecord.id))).all())
-
-
-async def update_record(
-    session,
-    record: DomainRecord,
-    patch: dict,
-    *,
-    reason: str,
-) -> None:
-    async with session.begin_nested():
-        await AsyncDomainService(session).update_record(
-            str(record.org_id),
-            record.domain_id,
-            record.id,
-            data_patch=patch,
-            expected_version=record.version,
-            actor_kind="system",
-            reason=reason,
-        )
 
 
 async def _check_ancestry(
@@ -769,7 +577,7 @@ async def _sweep_main_merge(
 ) -> None:
     kind = classify_merge_event(event)
     fix_pr = f"{repo}#{event.get('number')}" if kind is MergeKind.HOTFIX and event.get("number") else None
-    records = await ticket_records(
+    records = await deploy_tracker.list_deploy_ticket_records(
         session,
         org_id=org_id,
         states={DeployState.STAGING.value, DeployState.PROD_PENDING.value},
@@ -798,7 +606,10 @@ async def _sweep_main_merge(
             patch.update({"deploy_state": DeployState.DEPLOYED.value, "deployed_at": deployed_at})
             if fix_pr and data.get("fix_pr") == fix_pr:
                 patch.update({"fix_merge_sha": sha, "fix_merged_at": deployed_at})
-            note = append_progress_note(data, f"deployed to main at {deployed_at}")
+            note = deploy_tracker.append_progress_note(
+                data,
+                f"deployed to main at {deployed_at}",
+            )
             if note is not None:
                 patch["progress_note"] = note
             bucket = "deployed"
@@ -811,7 +622,10 @@ async def _sweep_main_merge(
                 summary["skipped"] += 1
                 continue
             patch["deploy_state"] = DeployState.PROD_PENDING.value
-            note = append_progress_note(data, "fix confirmed on staging; awaiting promotion")
+            note = deploy_tracker.append_progress_note(
+                data,
+                "fix confirmed on staging; awaiting promotion",
+            )
             if note is not None:
                 patch["progress_note"] = note
             bucket = "prod_pending"
@@ -819,7 +633,12 @@ async def _sweep_main_merge(
             summary["skipped"] += 1
             continue
         try:
-            await update_record(session, record, patch, reason=f"deploy_sweep:{kind.value}")
+            await deploy_tracker.update_deploy_ticket_record(
+                session,
+                record,
+                patch,
+                reason=f"deploy_sweep:{kind.value}",
+            )
         except Exception as exc:
             logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)
@@ -844,7 +663,11 @@ async def _sweep_staging_merge(
         summary["skipped"] += 1
         return
     fix_pr = f"{repo}#{number}"
-    records = await ticket_records(session, org_id=org_id, fix_pr=fix_pr)
+    records = await deploy_tracker.list_deploy_ticket_records(
+        session,
+        org_id=org_id,
+        fix_pr=fix_pr,
+    )
     for record in records:
         summary["examined"] += 1
         data = record.data or {}
@@ -864,11 +687,19 @@ async def _sweep_staging_merge(
         }
         if state is DeployState.DEPLOYED:
             patch["deployed_at"] = merged_at
-        note = append_progress_note(data, f"fix {fix_pr} merged to staging at {merged_at}")
+        note = deploy_tracker.append_progress_note(
+            data,
+            f"fix {fix_pr} merged to staging at {merged_at}",
+        )
         if note is not None:
             patch["progress_note"] = note
         try:
-            await update_record(session, record, patch, reason="deploy_sweep:fix_to_staging")
+            await deploy_tracker.update_deploy_ticket_record(
+                session,
+                record,
+                patch,
+                reason="deploy_sweep:fix_to_staging",
+            )
         except Exception as exc:
             logger.warning("deploy sweep skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)
@@ -895,7 +726,10 @@ async def run_deploy_sweep(
         return summary
     try:
         tokens = tuple(ancestry_tokens or (None,))
-        summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
+        summary["fields"] = await deploy_tracker.ensure_deploy_state_fields(
+            session,
+            org_id=org_id,
+        )
         if kind in {MergeKind.PROMOTION, MergeKind.HOTFIX}:
             await _sweep_main_merge(
                 session,
@@ -965,8 +799,11 @@ async def run_deploy_verification(
         summary["disabled"] = True
         return summary
     try:
-        summary["fields"] = await ensure_deploy_state_fields(session, org_id=org_id)
-        records = await ticket_records(
+        summary["fields"] = await deploy_tracker.ensure_deploy_state_fields(
+            session,
+            org_id=org_id,
+        )
+        records = await deploy_tracker.list_deploy_ticket_records(
             session,
             org_id=org_id,
             states={DeployState.DEPLOYED.value},
@@ -1018,14 +855,19 @@ async def run_deploy_verification(
             "verified_at": current.isoformat(),
             "status": "Done",
         }
-        note = append_progress_note(
+        note = deploy_tracker.append_progress_note(
             data,
             f"verified quiet since deploy at {deployed_iso}",
         )
         if note is not None:
             patch["progress_note"] = note
         try:
-            await update_record(session, record, patch, reason="deploy_verification")
+            await deploy_tracker.update_deploy_ticket_record(
+                session,
+                record,
+                patch,
+                reason="deploy_verification",
+            )
         except Exception as exc:
             logger.warning("deploy verification skipped record %s: %s", record.id, exc)
             summary["errors"].append(record.id)

--- a/brain/systems/deploy_tracker.py
+++ b/brain/systems/deploy_tracker.py
@@ -1,0 +1,172 @@
+"""Schema and persistence operations for deploy-tracker records."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from sqlalchemy import and_, func, or_, select
+
+from brain.platform.db.models.domain import (
+    Domain,
+    DomainObjectType,
+    DomainRecord,
+)
+from brain.systems.deploy_state import DeployState
+from brain.systems.deploy_state_config import deploy_ticket_object_keys
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+DEPLOY_STATE_FIELD_DEFINITIONS: tuple[dict, ...] = (
+    {"key": "rollbar_item", "name": "Rollbar Item", "field_type": "text"},
+    {"key": "alert_last_seen_at", "name": "Alert Last Seen At", "field_type": "datetime"},
+    {"key": "alert_occurrences", "name": "Alert Occurrences", "field_type": "number"},
+    {"key": "fix_pr", "name": "Fix PR", "field_type": "text"},
+    {"key": "fix_merge_sha", "name": "Fix Merge SHA", "field_type": "text"},
+    {"key": "fix_merged_at", "name": "Fix Merged At", "field_type": "datetime"},
+    {
+        "key": "deploy_state",
+        "name": "Deploy State",
+        "field_type": "enum",
+        "options": [state.value for state in DeployState],
+    },
+    {"key": "deployed_at", "name": "Deployed At", "field_type": "datetime"},
+    {"key": "verified_at", "name": "Verified At", "field_type": "datetime"},
+    {
+        "key": "alert_slack_channel",
+        "name": "Alert Slack Channel",
+        "field_type": "text",
+    },
+    {
+        "key": "alert_slack_thread_ts",
+        "name": "Alert Slack Thread Timestamp",
+        "field_type": "text",
+    },
+    {
+        "key": "alert_slack_bot_user_id",
+        "name": "Alert Slack Bot User Id",
+        "field_type": "text",
+    },
+    {
+        "key": "resolution_confirmed_ts",
+        "name": "Resolution Confirming Slack Timestamp",
+        "field_type": "text",
+    },
+    {
+        "key": "resolution_reproduced_ts",
+        "name": "Resolution Reproduced Slack Timestamp",
+        "field_type": "text",
+    },
+    {
+        "key": "promotion_recommended_at",
+        "name": "Promotion Recommended At",
+        "field_type": "datetime",
+    },
+)
+
+
+def append_progress_note(data: Mapping[str, object], line: str) -> str | None:
+    """Append one line using the tracker progress-note convention."""
+    if "progress_note" not in data:
+        return None
+    current = str(data.get("progress_note") or "").rstrip()
+    return f"{current}\n{line}".lstrip()
+
+
+async def ensure_deploy_state_fields(session, *, org_id: str) -> dict:
+    """Idempotently add optional deploy fields to every active ticket type."""
+    object_types = (
+        await session.scalars(
+            select(DomainObjectType)
+            .join(Domain, Domain.id == DomainObjectType.domain_id)
+            .where(
+                Domain.org_id == str(org_id),
+                Domain.archived_at.is_(None),
+                DomainObjectType.key.in_(deploy_ticket_object_keys()),
+                DomainObjectType.archived_at.is_(None),
+            )
+            .order_by(DomainObjectType.id)
+        )
+    ).all()
+    service = AsyncDomainService(session)
+    added = 0
+    for object_type in object_types:
+        existing = {
+            field.key
+            for field in await service.list_fields(object_type.id)
+        }
+        for payload in DEPLOY_STATE_FIELD_DEFINITIONS:
+            if payload["key"] in existing:
+                continue
+            await service.add_field_definition(object_type, dict(payload), emit_event=False)
+            existing.add(str(payload["key"]))
+            added += 1
+    return {"object_types": len(object_types), "fields_added": added}
+
+
+def _json_text(session, key: str):
+    bind = session.get_bind()
+    if bind is not None and bind.dialect.name == "sqlite":
+        return func.json_extract(DomainRecord.data, f"$.{key}")
+    return DomainRecord.data[key].as_string()
+
+
+async def list_deploy_ticket_records(
+    session,
+    *,
+    org_id: str,
+    states: set[str] | None = None,
+    fix_pr_prefix: str | None = None,
+    fix_pr: str | None = None,
+) -> list[DomainRecord]:
+    """Select ticket records by deploy-state and/or fix-PR identity.
+
+    Selection keys on where the FIX lives (``fix_pr`` is repo-qualified), not
+    on the ticket's own ``repo`` field — an app ticket fixed by a backend PR
+    must be swept by the backend promotion, not the app one.
+    """
+    stmt = (
+        select(DomainRecord)
+        .join(DomainObjectType, DomainObjectType.id == DomainRecord.object_type_id)
+        .join(Domain, Domain.id == DomainRecord.domain_id)
+        .where(
+            DomainRecord.org_id == str(org_id),
+            DomainRecord.archived_at.is_(None),
+            Domain.archived_at.is_(None),
+            DomainObjectType.key.in_(deploy_ticket_object_keys()),
+            DomainObjectType.archived_at.is_(None),
+        )
+    )
+    conditions = []
+    if states:
+        state_arm = _json_text(session, "deploy_state").in_(states)
+        if fix_pr_prefix:
+            state_arm = and_(
+                state_arm,
+                _json_text(session, "fix_pr").like(f"{fix_pr_prefix}%"),
+            )
+        conditions.append(state_arm)
+    if fix_pr:
+        conditions.append(_json_text(session, "fix_pr") == fix_pr)
+    if conditions:
+        stmt = stmt.where(or_(*conditions))
+    return list((await session.scalars(stmt.order_by(DomainRecord.id))).all())
+
+
+async def update_deploy_ticket_record(
+    session,
+    record: DomainRecord,
+    patch: dict,
+    *,
+    reason: str,
+) -> None:
+    """Apply an optimistic system-authored patch to a deploy ticket."""
+    async with session.begin_nested():
+        await AsyncDomainService(session).update_record(
+            str(record.org_id),
+            record.domain_id,
+            record.id,
+            data_patch=patch,
+            expected_version=record.version,
+            actor_kind="system",
+            reason=reason,
+        )

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -1402,7 +1402,7 @@ async def _handle_list_github_sub_issues(
 
 async def _maybe_ensure_deploy_fields(repo_slug: str) -> None:
     """Lazily provision runtime fields when this env-gated feature is armed."""
-    from brain.systems.deploy_state_sweep import ensure_deploy_state_fields
+    from brain.systems.deploy_tracker import ensure_deploy_state_fields
 
     if not deploy_feature_enabled(repo_slug):
         return

--- a/brain/systems/vault/__init__.py
+++ b/brain/systems/vault/__init__.py
@@ -661,6 +661,7 @@ async def async_resolve_project_bound_env_tokens(
     project_slugs: list[str] | tuple[str, ...] | set[str] | None = None,
     target_registry_id: int | None = None,
     github_app_only: bool = False,
+    github_app_permissions: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Return env-name/token pairs for matching org project bindings.
 
@@ -668,6 +669,8 @@ async def async_resolve_project_bound_env_tokens(
     down-scoped to their combined repository names. Cross-repository GitHub
     operations can therefore use one installation identity without widening
     its permissions or repository access beyond the supplied bindings.
+    ``github_app_permissions`` lets read-only maintenance callers narrow the
+    minted token below the runtime default.
     """
     if not project_slug and not project_slugs and target_registry_id is None:
         return {}
@@ -757,7 +760,11 @@ async def async_resolve_project_bound_env_tokens(
             env[env_name] = await async_mint_installation_token(
                 decrypted_blob,
                 repositories=repo_names,
-                permissions=DEFAULT_INSTALLATION_PERMISSIONS,
+                permissions=(
+                    github_app_permissions
+                    if github_app_permissions is not None
+                    else DEFAULT_INSTALLATION_PERMISSIONS
+                ),
             )
         finally:
             decrypted_blob = None

--- a/scripts/backfill_deploy_fix_refs.py
+++ b/scripts/backfill_deploy_fix_refs.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Normalize deploy-tracker fix PRs and backfill merged commit SHAs.
+
+The default mode is a dry run. Pass ``--apply`` to write the proposed record
+patches through the domain-record service. GitHub access is read-only and uses
+the org's project-bound GitHub App credential.
+
+Usage:
+    venv/bin/python scripts/backfill_deploy_fix_refs.py \
+        --org-id <org-uuid> --actor-user-id <user-uuid>
+    venv/bin/python scripts/backfill_deploy_fix_refs.py \
+        --org-id <org-uuid> --actor-user-id <user-uuid> --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.project_context.github import (
+    async_get_pull_request_deploy_info,
+)
+from brain.systems.deploy_state import DeployState
+from brain.systems.deploy_state_sweep import (
+    append_progress_note,
+    ensure_deploy_state_fields,
+    fix_pr_from_text,
+    github_repo_from_issue_text,
+    ticket_records,
+    update_record,
+)
+from brain.systems.vault import async_resolve_project_bound_env_tokens
+
+
+PullRequestLookup = Callable[[str, int], Awaitable[Mapping[str, Any]]]
+
+_ENUMERATED_STATES = {
+    DeployState.STAGING.value,
+    DeployState.PROD_PENDING.value,
+    DeployState.DEPLOYED.value,
+}
+_SHA_BACKFILL_STATES = {
+    DeployState.STAGING.value,
+    DeployState.PROD_PENDING.value,
+}
+_MERGE_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_NEEDS_HUMAN_NOTE = "needs-human: no fix PR reference"
+_READ_ONLY_GITHUB_APP_PERMISSIONS = {"pull_requests": "read"}
+_ALLOWED_PATCH_FIELDS = {"fix_pr", "fix_merge_sha", "progress_note"}
+
+
+def github_app_pull_request_lookup(
+    *,
+    org_id: str,
+    actor_user_id: str,
+) -> PullRequestLookup:
+    """Build a cached, read-only GitHub App PR lookup for one org."""
+
+    tokens_by_repo: dict[str, str] = {}
+
+    async def lookup(repo: str, number: int) -> Mapping[str, Any]:
+        token = tokens_by_repo.get(repo)
+        if token is None:
+            bound_tokens = await async_resolve_project_bound_env_tokens(
+                actor_user_id=actor_user_id,
+                org_id=org_id,
+                project_slug=repo,
+                github_app_only=True,
+                github_app_permissions=_READ_ONLY_GITHUB_APP_PERMISSIONS,
+            )
+            token = next((value for value in bound_tokens.values() if value), None)
+            if token is None:
+                raise RuntimeError(f"No project-bound GitHub App token for {repo}")
+            tokens_by_repo[repo] = token
+        return await async_get_pull_request_deploy_info(repo, number, token=token)
+
+    return lookup
+
+
+def _pull_request_detail(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    detail = payload.get("pull_request")
+    return detail if isinstance(detail, Mapping) else payload
+
+
+def _progress_note_patch(data: Mapping[str, object]) -> dict[str, object]:
+    current_lines = {
+        line.strip()
+        for line in str(data.get("progress_note") or "").splitlines()
+        if line.strip()
+    }
+    if _NEEDS_HUMAN_NOTE in current_lines:
+        return {}
+    note = append_progress_note(data, _NEEDS_HUMAN_NOTE)
+    return {"progress_note": note} if note is not None else {}
+
+
+async def backfill_deploy_fix_refs(
+    session,
+    *,
+    org_id: str,
+    apply: bool = False,
+    pull_request_lookup: PullRequestLookup | None = None,
+    actor_user_id: str | None = None,
+) -> dict[str, object]:
+    """Build and optionally apply the deploy fix-reference backfill."""
+
+    if apply:
+        await ensure_deploy_state_fields(session, org_id=org_id)
+    records = await ticket_records(
+        session,
+        org_id=org_id,
+        states=_ENUMERATED_STATES,
+    )
+    lookup = pull_request_lookup
+    rows: list[dict[str, object]] = []
+
+    for record in records:
+        data = record.data or {}
+        state = str(data.get("deploy_state") or "").strip()
+        old_fix_pr = (
+            None
+            if data.get("fix_pr") is None
+            else str(data.get("fix_pr"))
+        )
+        title_repo = github_repo_from_issue_text(record.title)
+        canonical_fix_pr = fix_pr_from_text(
+            str(data.get("fix_pr") or ""),
+            repo=title_repo,
+        )
+        patch: dict[str, object] = {}
+        sha_found = False
+        unresolvable_reason: str | None = None
+
+        if canonical_fix_pr is None:
+            unresolvable_reason = "no fix PR reference"
+            if state in _SHA_BACKFILL_STATES:
+                patch.update(_progress_note_patch(data))
+        else:
+            if old_fix_pr != canonical_fix_pr:
+                patch["fix_pr"] = canonical_fix_pr
+            if state in _SHA_BACKFILL_STATES:
+                if lookup is None:
+                    if not actor_user_id:
+                        raise ValueError(
+                            "actor_user_id is required when pull_request_lookup is not supplied"
+                        )
+                    lookup = github_app_pull_request_lookup(
+                        org_id=org_id,
+                        actor_user_id=actor_user_id,
+                    )
+                repo, number_text = canonical_fix_pr.rsplit("#", 1)
+                try:
+                    payload = await lookup(repo, int(number_text))
+                except Exception as exc:
+                    unresolvable_reason = f"github lookup failed: {exc}"
+                else:
+                    detail = _pull_request_detail(payload)
+                    if detail.get("merged_at"):
+                        merge_sha = str(detail.get("merge_commit_sha") or "").strip()
+                        if _MERGE_SHA_RE.fullmatch(merge_sha):
+                            sha_found = True
+                            if data.get("fix_merge_sha") != merge_sha:
+                                patch["fix_merge_sha"] = merge_sha
+                        else:
+                            unresolvable_reason = (
+                                "merged PR has no valid merge_commit_sha"
+                            )
+
+        rows.append(
+            {
+                "record_id": record.id,
+                "old_fix_pr": old_fix_pr,
+                "new_fix_pr": canonical_fix_pr or old_fix_pr,
+                "sha_found": sha_found,
+                "unresolvable_reason": unresolvable_reason,
+            }
+        )
+        unexpected_fields = set(patch) - _ALLOWED_PATCH_FIELDS
+        if unexpected_fields:
+            raise AssertionError(
+                f"Backfill patch escaped scope: {sorted(unexpected_fields)}"
+            )
+        if apply and patch:
+            await update_record(
+                session,
+                record,
+                patch,
+                reason="deploy_backfill",
+            )
+
+    return {"applied": apply, "records": rows}
+
+
+async def _run(
+    *,
+    org_id: str,
+    actor_user_id: str,
+    apply: bool,
+) -> dict[str, object]:
+    async with UnitOfWork() as uow:
+        return await backfill_deploy_fix_refs(
+            uow.session,
+            org_id=org_id,
+            actor_user_id=actor_user_id,
+            apply=apply,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--org-id",
+        required=True,
+        help="Organization UUID that owns the deploy tracker",
+    )
+    parser.add_argument(
+        "--actor-user-id",
+        required=True,
+        help="User UUID used to audit access to the org's GitHub App credential",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write proposed record patches (default: dry run)",
+    )
+    args = parser.parse_args()
+    report = asyncio.run(
+        _run(
+            org_id=args.org_id,
+            actor_user_id=args.actor_user_id,
+            apply=args.apply,
+        )
+    )
+    print(json.dumps(report, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_deploy_fix_refs.py
+++ b/scripts/backfill_deploy_fix_refs.py
@@ -20,24 +20,28 @@ import json
 import re
 import sys
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from brain.platform.db.models.domain import DomainRecord
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.cortex.project_context.github import (
     async_get_pull_request_deploy_info,
 )
 from brain.systems.deploy_state import DeployState
-from brain.systems.deploy_state_sweep import (
+from brain.systems.deploy_fix_refs import (
+    github_repo_from_issue_text,
+    normalize_fix_pr_reference,
+)
+from brain.systems.deploy_tracker import (
     append_progress_note,
     ensure_deploy_state_fields,
-    fix_pr_from_text,
-    github_repo_from_issue_text,
-    ticket_records,
-    update_record,
+    list_deploy_ticket_records,
+    update_deploy_ticket_record,
 )
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
@@ -57,6 +61,31 @@ _MERGE_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _NEEDS_HUMAN_NOTE = "needs-human: no fix PR reference"
 _READ_ONLY_GITHUB_APP_PERMISSIONS = {"pull_requests": "read"}
 _ALLOWED_PATCH_FIELDS = {"fix_pr", "fix_merge_sha", "progress_note"}
+
+
+class BackfillPatch(TypedDict, total=False):
+    fix_pr: str
+    fix_merge_sha: str
+    progress_note: str
+
+
+class BackfillReportRow(TypedDict):
+    record_id: int
+    old_fix_pr: str | None
+    new_fix_pr: str | None
+    sha_found: bool
+    unresolvable_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillPlan:
+    record: DomainRecord
+    patch: BackfillPatch
+    report_row: BackfillReportRow
+
+
+class BackfillScopeError(RuntimeError):
+    """Raised when a planned patch escapes the backfill's allowed fields."""
 
 
 def github_app_pull_request_lookup(
@@ -92,7 +121,7 @@ def _pull_request_detail(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return detail if isinstance(detail, Mapping) else payload
 
 
-def _progress_note_patch(data: Mapping[str, object]) -> dict[str, object]:
+def _progress_note_patch(data: Mapping[str, object]) -> BackfillPatch:
     current_lines = {
         line.strip()
         for line in str(data.get("progress_note") or "").splitlines()
@@ -102,6 +131,65 @@ def _progress_note_patch(data: Mapping[str, object]) -> dict[str, object]:
         return {}
     note = append_progress_note(data, _NEEDS_HUMAN_NOTE)
     return {"progress_note": note} if note is not None else {}
+
+
+async def _plan_backfill_record(
+    record: DomainRecord,
+    *,
+    pull_request_lookup: PullRequestLookup | None,
+) -> BackfillPlan:
+    """Interpret one record, enrich it when needed, and build its plan."""
+    data = record.data or {}
+    state = str(data.get("deploy_state") or "").strip()
+    old_fix_pr = None if data.get("fix_pr") is None else str(data.get("fix_pr"))
+    title_repo = github_repo_from_issue_text(record.title)
+    canonical_fix_pr = normalize_fix_pr_reference(
+        str(data.get("fix_pr") or ""),
+        default_repo=title_repo,
+    )
+    patch: BackfillPatch = {}
+    sha_found = False
+    unresolvable_reason: str | None = None
+
+    if canonical_fix_pr is None:
+        unresolvable_reason = "no fix PR reference"
+        if state in _SHA_BACKFILL_STATES:
+            patch.update(_progress_note_patch(data))
+    else:
+        if old_fix_pr != canonical_fix_pr:
+            patch["fix_pr"] = canonical_fix_pr
+        if state in _SHA_BACKFILL_STATES:
+            if pull_request_lookup is None:
+                raise ValueError(
+                    "actor_user_id is required when pull_request_lookup is not supplied"
+                )
+            repo, number_text = canonical_fix_pr.rsplit("#", 1)
+            try:
+                payload = await pull_request_lookup(repo, int(number_text))
+            except Exception as exc:
+                unresolvable_reason = f"github lookup failed: {exc}"
+            else:
+                detail = _pull_request_detail(payload)
+                if detail.get("merged_at"):
+                    merge_sha = str(detail.get("merge_commit_sha") or "").strip()
+                    if _MERGE_SHA_RE.fullmatch(merge_sha):
+                        sha_found = True
+                        if data.get("fix_merge_sha") != merge_sha:
+                            patch["fix_merge_sha"] = merge_sha
+                    else:
+                        unresolvable_reason = "merged PR has no valid merge_commit_sha"
+
+    return BackfillPlan(
+        record=record,
+        patch=patch,
+        report_row={
+            "record_id": record.id,
+            "old_fix_pr": old_fix_pr,
+            "new_fix_pr": canonical_fix_pr or old_fix_pr,
+            "sha_found": sha_found,
+            "unresolvable_reason": unresolvable_reason,
+        },
+    )
 
 
 async def backfill_deploy_fix_refs(
@@ -114,91 +202,47 @@ async def backfill_deploy_fix_refs(
 ) -> dict[str, object]:
     """Build and optionally apply the deploy fix-reference backfill."""
 
-    if apply:
-        await ensure_deploy_state_fields(session, org_id=org_id)
-    records = await ticket_records(
+    records = await list_deploy_ticket_records(
         session,
         org_id=org_id,
         states=_ENUMERATED_STATES,
     )
     lookup = pull_request_lookup
-    rows: list[dict[str, object]] = []
-
-    for record in records:
-        data = record.data or {}
-        state = str(data.get("deploy_state") or "").strip()
-        old_fix_pr = (
-            None
-            if data.get("fix_pr") is None
-            else str(data.get("fix_pr"))
+    if lookup is None and actor_user_id:
+        lookup = github_app_pull_request_lookup(
+            org_id=org_id,
+            actor_user_id=actor_user_id,
         )
-        title_repo = github_repo_from_issue_text(record.title)
-        canonical_fix_pr = fix_pr_from_text(
-            str(data.get("fix_pr") or ""),
-            repo=title_repo,
+    plans = [
+        await _plan_backfill_record(
+            record,
+            pull_request_lookup=lookup,
         )
-        patch: dict[str, object] = {}
-        sha_found = False
-        unresolvable_reason: str | None = None
+        for record in records
+    ]
 
-        if canonical_fix_pr is None:
-            unresolvable_reason = "no fix PR reference"
-            if state in _SHA_BACKFILL_STATES:
-                patch.update(_progress_note_patch(data))
-        else:
-            if old_fix_pr != canonical_fix_pr:
-                patch["fix_pr"] = canonical_fix_pr
-            if state in _SHA_BACKFILL_STATES:
-                if lookup is None:
-                    if not actor_user_id:
-                        raise ValueError(
-                            "actor_user_id is required when pull_request_lookup is not supplied"
-                        )
-                    lookup = github_app_pull_request_lookup(
-                        org_id=org_id,
-                        actor_user_id=actor_user_id,
-                    )
-                repo, number_text = canonical_fix_pr.rsplit("#", 1)
-                try:
-                    payload = await lookup(repo, int(number_text))
-                except Exception as exc:
-                    unresolvable_reason = f"github lookup failed: {exc}"
-                else:
-                    detail = _pull_request_detail(payload)
-                    if detail.get("merged_at"):
-                        merge_sha = str(detail.get("merge_commit_sha") or "").strip()
-                        if _MERGE_SHA_RE.fullmatch(merge_sha):
-                            sha_found = True
-                            if data.get("fix_merge_sha") != merge_sha:
-                                patch["fix_merge_sha"] = merge_sha
-                        else:
-                            unresolvable_reason = (
-                                "merged PR has no valid merge_commit_sha"
-                            )
-
-        rows.append(
-            {
-                "record_id": record.id,
-                "old_fix_pr": old_fix_pr,
-                "new_fix_pr": canonical_fix_pr or old_fix_pr,
-                "sha_found": sha_found,
-                "unresolvable_reason": unresolvable_reason,
-            }
-        )
-        unexpected_fields = set(patch) - _ALLOWED_PATCH_FIELDS
+    for plan in plans:
+        unexpected_fields = set(plan.patch) - _ALLOWED_PATCH_FIELDS
         if unexpected_fields:
-            raise AssertionError(
+            raise BackfillScopeError(
                 f"Backfill patch escaped scope: {sorted(unexpected_fields)}"
             )
-        if apply and patch:
-            await update_record(
+    if apply:
+        await ensure_deploy_state_fields(session, org_id=org_id)
+        for plan in plans:
+            if not plan.patch:
+                continue
+            await update_deploy_ticket_record(
                 session,
-                record,
-                patch,
+                plan.record,
+                plan.patch,
                 reason="deploy_backfill",
             )
 
-    return {"applied": apply, "records": rows}
+    return {
+        "applied": apply,
+        "records": [plan.report_row for plan in plans],
+    }
 
 
 async def _run(

--- a/tests/test_backfill_deploy_fix_refs.py
+++ b/tests/test_backfill_deploy_fix_refs.py
@@ -1,0 +1,466 @@
+"""Deploy fix-reference normalization and backfill tests."""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
+
+import scripts.backfill_deploy_fix_refs as backfill
+from brain.platform.db.models.domain import (
+    Domain,
+    DomainEvent,
+    DomainFieldDefinition,
+    DomainObjectType,
+    DomainRecord,
+    DomainRelation,
+    DomainRelationType,
+)
+from brain.systems.deploy_fix_refs import (
+    github_repo_from_issue_text,
+    normalize_fix_pr_reference,
+)
+from brain.systems.deploy_tracker import ensure_deploy_state_fields
+from brain.systems.user_domains.service import AsyncDomainService
+
+
+pytestmark = pytest.mark.asyncio
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+REPO = "uwear-ai/uwear-backend"
+NOW = datetime(2026, 7, 10, 12, tzinfo=timezone.utc)
+ALLOWED_PATCH_FIELDS = {"fix_pr", "fix_merge_sha", "progress_note"}
+
+
+def _patch_sqlite_for_pg_types():
+    if not hasattr(SQLiteTypeCompiler, "visit_JSONB"):
+        SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
+    original = SQLiteDDLCompiler.get_column_default_string
+    if getattr(original, "_deploy_state_patch", False):
+        return
+
+    def patched(self, column, **kw):
+        result = original(self, column, **kw)
+        if result:
+            result = re.sub(r"::jsonb", "", result)
+            result = result.replace("NOW()", "CURRENT_TIMESTAMP")
+            result = result.replace("TRUE", "1").replace("FALSE", "0")
+        return result
+
+    patched._deploy_state_patch = True
+    SQLiteDDLCompiler.get_column_default_string = patched
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    _patch_sqlite_for_pg_types()
+    return await async_sqlite_session_factory(
+        [
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainFieldDefinition.__table__,
+            DomainRelationType.__table__,
+            DomainRecord.__table__,
+            DomainRelation.__table__,
+            DomainEvent.__table__,
+        ]
+    )
+
+
+async def _domain(session):
+    return await AsyncDomainService(session).create_domain(
+        ORG_ID,
+        name="Engineering",
+        objects=[
+            {
+                "key": "github_ticket",
+                "name": "GitHub Ticket",
+                "title_field": "title",
+                "fields": [
+                    {"key": "title", "field_type": "text", "required": True},
+                    {"key": "repo", "field_type": "text"},
+                    {
+                        "key": "status",
+                        "field_type": "enum",
+                        "options": ["Todo", "In Progress", "In Review", "Done"],
+                    },
+                    {"key": "progress_note", "field_type": "long_text"},
+                ],
+            }
+        ],
+    )
+
+
+async def _record(session, domain, *, title, **data):
+    return await AsyncDomainService(session).create_record(
+        ORG_ID,
+        domain.id,
+        "github_ticket",
+        title=title,
+        data={
+            "title": title,
+            "repo": REPO,
+            "status": "Todo",
+            "progress_note": "investigating",
+            **data,
+        },
+    )
+
+
+async def _seed_backfill_records(session) -> dict[str, DomainRecord]:
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    records = {
+        "canonical": await _record(
+            session,
+            domain,
+            title="Canonical",
+            deploy_state="staging",
+            fix_pr=f"{REPO}#1264",
+        ),
+        "full_url": await _record(
+            session,
+            domain,
+            title="Full URL",
+            deploy_state="prod_pending",
+            fix_pr=f"https://github.com/{REPO}/pull/1237",
+        ),
+        "internal_key": await _record(
+            session,
+            domain,
+            title="Internal key",
+            deploy_state="staging",
+            fix_pr=f"github:{REPO}:pr:1178",
+        ),
+        "invalid_merge_sha": await _record(
+            session,
+            domain,
+            title="Invalid merge SHA",
+            deploy_state="staging",
+            fix_pr=f"{REPO}#555",
+        ),
+        "bare_number": await _record(
+            session,
+            domain,
+            title="github:uwear-ai/uwearaiapp:issue:389",
+            deploy_state="prod_pending",
+            fix_pr="591",
+        ),
+        "no_reference": await _record(
+            session,
+            domain,
+            title="No reference",
+            deploy_state="prod_pending",
+            fix_pr="",
+        ),
+        "deployed": await _record(
+            session,
+            domain,
+            title="Already deployed",
+            deploy_state="deployed",
+            fix_pr=f"https://github.com/{REPO}/pull/999",
+        ),
+        "archived": await _record(
+            session,
+            domain,
+            title="Archived",
+            deploy_state="staging",
+            fix_pr=f"https://github.com/{REPO}/pull/777",
+        ),
+    }
+    records["archived"].archived_at = NOW
+    await session.flush()
+    return records
+
+
+def _github_lookup() -> AsyncMock:
+    merge_shas = {
+        (REPO, 1264): "a" * 40,
+        (REPO, 1178): "c" * 40,
+        ("uwear-ai/uwearaiapp", 591): "d" * 40,
+    }
+
+    async def github_response(repo, number):
+        merge_sha = merge_shas.get((repo, number))
+        if number == 555:
+            return {
+                "pull_request": {
+                    "merged_at": NOW.isoformat(),
+                    "merge_commit_sha": "not-a-merge-sha",
+                }
+            }
+        return {
+            "pull_request": {
+                "merged_at": NOW.isoformat() if merge_sha else None,
+                # Open PRs can expose a temporary merge SHA; never persist it.
+                "merge_commit_sha": merge_sha or ("b" * 40),
+            }
+        }
+
+    return AsyncMock(side_effect=github_response)
+
+
+@pytest.mark.parametrize(
+    ("value", "title", "expected"),
+    [
+        (f"{REPO}#1264", "Canonical", f"{REPO}#1264"),
+        (f"https://github.com/{REPO}/pull/1237", "URL", f"{REPO}#1237"),
+        (f"github:{REPO}:pr:1178", "Internal key", f"{REPO}#1178"),
+        ("PR 1142", f"github:{REPO}:issue:474", f"{REPO}#1142"),
+        (
+            "591",
+            "github:uwear-ai/uwearaiapp:issue:389",
+            "uwear-ai/uwearaiapp#591",
+        ),
+    ],
+)
+async def test_normalize_fix_pr_reference_formats(value, title, expected):
+    default_repo = github_repo_from_issue_text(title)
+    assert (
+        normalize_fix_pr_reference(value, default_repo=default_repo)
+        == expected
+    )
+
+
+async def test_backfill_dry_run_writes_nothing(session):
+    records = await _seed_backfill_records(session)
+    before_data = {
+        name: deepcopy(record.data)
+        for name, record in records.items()
+    }
+    before_versions = {
+        name: record.version
+        for name, record in records.items()
+    }
+
+    report = await backfill.backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        pull_request_lookup=_github_lookup(),
+    )
+
+    assert report["applied"] is False
+    assert len(report["records"]) == 7
+    assert records["archived"].id not in {
+        row["record_id"] for row in report["records"]
+    }
+    for name, record in records.items():
+        await session.refresh(record)
+        assert record.data == before_data[name]
+        assert record.version == before_versions[name]
+
+
+async def test_backfill_apply_normalizes_enriches_and_stays_in_scope(session):
+    records = await _seed_backfill_records(session)
+    before_data = {
+        name: deepcopy(record.data)
+        for name, record in records.items()
+    }
+    github_lookup = _github_lookup()
+
+    report = await backfill.backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        apply=True,
+        pull_request_lookup=github_lookup,
+    )
+
+    assert report["applied"] is True
+    assert {
+        row["record_id"]: row["new_fix_pr"] for row in report["records"]
+    } == {
+        records["canonical"].id: f"{REPO}#1264",
+        records["full_url"].id: f"{REPO}#1237",
+        records["internal_key"].id: f"{REPO}#1178",
+        records["invalid_merge_sha"].id: f"{REPO}#555",
+        records["bare_number"].id: "uwear-ai/uwearaiapp#591",
+        records["no_reference"].id: None,
+        records["deployed"].id: f"{REPO}#999",
+    }
+    rows_by_id = {
+        row["record_id"]: row
+        for row in report["records"]
+    }
+    assert rows_by_id[records["canonical"].id]["sha_found"] is True
+    assert rows_by_id[records["full_url"].id]["sha_found"] is False
+    assert rows_by_id[records["full_url"].id]["unresolvable_reason"] is None
+    assert rows_by_id[records["invalid_merge_sha"].id]["sha_found"] is False
+    assert rows_by_id[records["invalid_merge_sha"].id]["unresolvable_reason"] == (
+        "merged PR has no valid merge_commit_sha"
+    )
+    assert rows_by_id[records["no_reference"].id]["unresolvable_reason"] == (
+        "no fix PR reference"
+    )
+    assert rows_by_id[records["deployed"].id]["sha_found"] is False
+    assert all(
+        call.args != (REPO, 999)
+        for call in github_lookup.await_args_list
+    )
+
+    for name, record in records.items():
+        await session.refresh(record)
+        changed_keys = {
+            key
+            for key in set(before_data[name]) | set(record.data)
+            if before_data[name].get(key) != record.data.get(key)
+        }
+        assert changed_keys <= ALLOWED_PATCH_FIELDS
+        assert record.data.get("deploy_state") == before_data[name].get(
+            "deploy_state"
+        )
+    assert records["canonical"].data["fix_merge_sha"] == "a" * 40
+    assert records["full_url"].data.get("fix_merge_sha") is None
+    assert records["internal_key"].data["fix_merge_sha"] == "c" * 40
+    assert records["invalid_merge_sha"].data.get("fix_merge_sha") is None
+    assert records["bare_number"].data["fix_merge_sha"] == "d" * 40
+    assert records["no_reference"].data["progress_note"].splitlines().count(
+        "needs-human: no fix PR reference"
+    ) == 1
+    assert records["archived"].data == before_data["archived"]
+
+    events = (
+        await session.scalars(
+            select(DomainEvent).where(DomainEvent.reason == "deploy_backfill")
+        )
+    ).all()
+    assert len(events) == 6
+    assert all(event.actor_kind == "system" for event in events)
+    assert all(set(event.patch) <= ALLOWED_PATCH_FIELDS for event in events)
+
+
+async def test_backfill_apply_is_idempotent(session):
+    records = await _seed_backfill_records(session)
+    github_lookup = _github_lookup()
+    await backfill.backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        apply=True,
+        pull_request_lookup=github_lookup,
+    )
+    after_first_data = {
+        name: deepcopy(record.data)
+        for name, record in records.items()
+    }
+    after_first_versions = {
+        name: record.version
+        for name, record in records.items()
+    }
+
+    second_report = await backfill.backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        apply=True,
+        pull_request_lookup=github_lookup,
+    )
+
+    assert second_report["applied"] is True
+    for name, record in records.items():
+        await session.refresh(record)
+        assert record.data == after_first_data[name]
+        assert record.version == after_first_versions[name]
+    assert records["no_reference"].data["progress_note"].splitlines().count(
+        "needs-human: no fix PR reference"
+    ) == 1
+    events = (
+        await session.scalars(
+            select(DomainEvent).where(DomainEvent.reason == "deploy_backfill")
+        )
+    ).all()
+    assert len(events) == 6
+
+
+async def test_backfill_validates_every_plan_before_first_write(session, monkeypatch):
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    first = await _record(
+        session,
+        domain,
+        title="First",
+        deploy_state="deployed",
+        fix_pr=f"https://github.com/{REPO}/pull/1",
+    )
+    second = await _record(
+        session,
+        domain,
+        title="Second",
+        deploy_state="deployed",
+        fix_pr=f"https://github.com/{REPO}/pull/2",
+    )
+    before = {
+        first.id: (deepcopy(first.data), first.version),
+        second.id: (deepcopy(second.data), second.version),
+    }
+    original_planner = backfill._plan_backfill_record
+
+    async def out_of_scope_second_plan(record, *, pull_request_lookup):
+        plan = await original_planner(
+            record,
+            pull_request_lookup=pull_request_lookup,
+        )
+        if record.id == second.id:
+            return replace(plan, patch={"deploy_state": "verified"})
+        return plan
+
+    monkeypatch.setattr(
+        backfill,
+        "_plan_backfill_record",
+        out_of_scope_second_plan,
+    )
+
+    with pytest.raises(backfill.BackfillScopeError, match="escaped scope"):
+        await backfill.backfill_deploy_fix_refs(
+            session,
+            org_id=ORG_ID,
+            apply=True,
+            pull_request_lookup=AsyncMock(),
+        )
+
+    for record in (first, second):
+        await session.refresh(record)
+        assert (record.data, record.version) == before[record.id]
+    events = (
+        await session.scalars(
+            select(DomainEvent).where(DomainEvent.reason == "deploy_backfill")
+        )
+    ).all()
+    assert events == []
+
+
+async def test_github_lookup_uses_read_only_app_token(monkeypatch):
+    resolve = AsyncMock(return_value={"GITHUB_TOKEN": "app-token"})
+    get_pr = AsyncMock(return_value={"pull_request": {"merged_at": None}})
+    monkeypatch.setattr(
+        backfill,
+        "async_resolve_project_bound_env_tokens",
+        resolve,
+    )
+    monkeypatch.setattr(
+        backfill,
+        "async_get_pull_request_deploy_info",
+        get_pr,
+    )
+
+    lookup = backfill.github_app_pull_request_lookup(
+        org_id=ORG_ID,
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+    )
+    await lookup(REPO, 1264)
+    await lookup(REPO, 1265)
+
+    resolve.assert_awaited_once_with(
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+        org_id=ORG_ID,
+        project_slug=REPO,
+        github_app_only=True,
+        github_app_permissions={"pull_requests": "read"},
+    )
+    assert get_pr.await_args_list[0].args == (REPO, 1264)
+    assert get_pr.await_args_list[0].kwargs == {"token": "app-token"}
+    assert get_pr.await_args_list[1].args == (REPO, 1265)

--- a/tests/test_deploy_state_sweep.py
+++ b/tests/test_deploy_state_sweep.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
@@ -22,14 +21,14 @@ from brain.platform.db.models.domain import (
 )
 from brain.systems.deploy_state_sweep import (
     AlertThreadSource,
-    DEPLOY_STATE_FIELD_DEFINITIONS,
     alert_thread_source_from_run,
-    ensure_deploy_state_fields,
-    fix_pr_from_text,
-    github_repo_from_issue_text,
     run_alert_resolution_harvest,
     run_deploy_sweep,
     run_deploy_verification,
+)
+from brain.systems.deploy_tracker import (
+    DEPLOY_STATE_FIELD_DEFINITIONS,
+    ensure_deploy_state_fields,
 )
 from brain.systems.user_domains.service import AsyncDomainService
 
@@ -115,37 +114,6 @@ async def _record(session, domain, *, title, **data):
             **data,
         },
     )
-
-
-@pytest.mark.parametrize(
-    ("value", "title", "expected"),
-    [
-        (
-            "uwear-ai/uwear-backend#1264",
-            "Canonical",
-            "uwear-ai/uwear-backend#1264",
-        ),
-        (
-            "https://github.com/uwear-ai/uwear-backend/pull/1237",
-            "URL",
-            "uwear-ai/uwear-backend#1237",
-        ),
-        (
-            "github:uwear-ai/uwear-backend:pr:1178",
-            "Internal key",
-            "uwear-ai/uwear-backend#1178",
-        ),
-        (
-            "591",
-            "github:uwear-ai/uwearaiapp:issue:389",
-            "uwear-ai/uwearaiapp#591",
-        ),
-        ("", "Nothing", None),
-    ],
-)
-async def test_fix_pr_formats_share_one_normalizer(value, title, expected):
-    repo = github_repo_from_issue_text(title)
-    assert fix_pr_from_text(value, repo=repo) == expected
 
 
 async def test_ensure_fields_is_runtime_id_agnostic_and_idempotent(session):
@@ -682,242 +650,6 @@ def test_alert_resolution_phrase_classifier_handles_en_fr_and_unshipped_negation
     from brain.systems.deploy_state_sweep import _resolution_kind
 
     assert _resolution_kind(text) == expected
-
-
-async def test_deploy_fix_ref_backfill_is_dry_run_safe_scoped_and_idempotent(session):
-    from scripts.backfill_deploy_fix_refs import backfill_deploy_fix_refs
-
-    domain = await _domain(session)
-    await ensure_deploy_state_fields(session, org_id=ORG_ID)
-    canonical = await _record(
-        session,
-        domain,
-        title="Canonical",
-        deploy_state="staging",
-        fix_pr="uwear-ai/uwear-backend#1264",
-    )
-    full_url = await _record(
-        session,
-        domain,
-        title="Full URL",
-        deploy_state="prod_pending",
-        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/1237",
-    )
-    internal_key = await _record(
-        session,
-        domain,
-        title="Internal key",
-        deploy_state="staging",
-        fix_pr="github:uwear-ai/uwear-backend:pr:1178",
-    )
-    invalid_merge_sha = await _record(
-        session,
-        domain,
-        title="Invalid merge SHA",
-        deploy_state="staging",
-        fix_pr="uwear-ai/uwear-backend#555",
-    )
-    bare_number = await _record(
-        session,
-        domain,
-        title="github:uwear-ai/uwearaiapp:issue:389",
-        deploy_state="prod_pending",
-        fix_pr="591",
-    )
-    no_reference = await _record(
-        session,
-        domain,
-        title="No reference",
-        deploy_state="prod_pending",
-        fix_pr="",
-    )
-    deployed = await _record(
-        session,
-        domain,
-        title="Already deployed",
-        deploy_state="deployed",
-        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/999",
-    )
-    archived = await _record(
-        session,
-        domain,
-        title="Archived",
-        deploy_state="staging",
-        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/777",
-    )
-    archived.archived_at = NOW
-    await session.flush()
-
-    records = [
-        canonical,
-        full_url,
-        internal_key,
-        invalid_merge_sha,
-        bare_number,
-        no_reference,
-        deployed,
-        archived,
-    ]
-    before_data = {record.id: deepcopy(record.data) for record in records}
-    before_versions = {record.id: record.version for record in records}
-    merge_shas = {
-        ("uwear-ai/uwear-backend", 1264): "a" * 40,
-        ("uwear-ai/uwear-backend", 1178): "c" * 40,
-        ("uwear-ai/uwearaiapp", 591): "d" * 40,
-    }
-
-    async def github_response(repo, number):
-        merge_sha = merge_shas.get((repo, number))
-        if number == 555:
-            return {
-                "pull_request": {
-                    "merged_at": NOW.isoformat(),
-                    "merge_commit_sha": "not-a-merge-sha",
-                }
-            }
-        return {
-            "pull_request": {
-                "merged_at": NOW.isoformat() if merge_sha else None,
-                # Open PRs can expose a temporary merge SHA; never persist it.
-                "merge_commit_sha": merge_sha or ("b" * 40),
-            }
-        }
-
-    github_lookup = AsyncMock(side_effect=github_response)
-    dry_report = await backfill_deploy_fix_refs(
-        session,
-        org_id=ORG_ID,
-        pull_request_lookup=github_lookup,
-    )
-
-    assert dry_report["applied"] is False
-    assert len(dry_report["records"]) == 7
-    assert archived.id not in {
-        row["record_id"] for row in dry_report["records"]
-    }
-    for record in records:
-        await session.refresh(record)
-        assert record.data == before_data[record.id]
-        assert record.version == before_versions[record.id]
-
-    first_report = await backfill_deploy_fix_refs(
-        session,
-        org_id=ORG_ID,
-        apply=True,
-        pull_request_lookup=github_lookup,
-    )
-    assert first_report["applied"] is True
-    assert {
-        row["record_id"]: row["new_fix_pr"] for row in first_report["records"]
-    } == {
-        canonical.id: "uwear-ai/uwear-backend#1264",
-        full_url.id: "uwear-ai/uwear-backend#1237",
-        internal_key.id: "uwear-ai/uwear-backend#1178",
-        invalid_merge_sha.id: "uwear-ai/uwear-backend#555",
-        bare_number.id: "uwear-ai/uwearaiapp#591",
-        no_reference.id: None,
-        deployed.id: "uwear-ai/uwear-backend#999",
-    }
-    rows_by_id = {
-        row["record_id"]: row for row in first_report["records"]
-    }
-    assert rows_by_id[canonical.id]["sha_found"] is True
-    assert rows_by_id[full_url.id]["sha_found"] is False
-    assert rows_by_id[full_url.id]["unresolvable_reason"] is None
-    assert rows_by_id[invalid_merge_sha.id]["sha_found"] is False
-    assert rows_by_id[invalid_merge_sha.id]["unresolvable_reason"] == (
-        "merged PR has no valid merge_commit_sha"
-    )
-    assert rows_by_id[no_reference.id]["unresolvable_reason"] == (
-        "no fix PR reference"
-    )
-    assert rows_by_id[deployed.id]["sha_found"] is False
-    assert all(
-        call.args != ("uwear-ai/uwear-backend", 999)
-        for call in github_lookup.await_args_list
-    )
-
-    allowed_keys = {"fix_pr", "fix_merge_sha", "progress_note"}
-    for record in records:
-        await session.refresh(record)
-        changed_keys = {
-            key
-            for key in set(before_data[record.id]) | set(record.data)
-            if before_data[record.id].get(key) != record.data.get(key)
-        }
-        assert changed_keys <= allowed_keys
-        assert record.data.get("deploy_state") == before_data[record.id].get(
-            "deploy_state"
-        )
-    assert canonical.data["fix_merge_sha"] == "a" * 40
-    assert full_url.data.get("fix_merge_sha") is None
-    assert internal_key.data["fix_merge_sha"] == "c" * 40
-    assert invalid_merge_sha.data.get("fix_merge_sha") is None
-    assert bare_number.data["fix_merge_sha"] == "d" * 40
-    assert no_reference.data["progress_note"].splitlines().count(
-        "needs-human: no fix PR reference"
-    ) == 1
-    assert archived.data == before_data[archived.id]
-
-    after_first_data = {record.id: deepcopy(record.data) for record in records}
-    after_first_versions = {record.id: record.version for record in records}
-    second_report = await backfill_deploy_fix_refs(
-        session,
-        org_id=ORG_ID,
-        apply=True,
-        pull_request_lookup=github_lookup,
-    )
-    assert second_report["applied"] is True
-    for record in records:
-        await session.refresh(record)
-        assert record.data == after_first_data[record.id]
-        assert record.version == after_first_versions[record.id]
-
-    backfill_events = (
-        await session.scalars(
-            select(DomainEvent).where(DomainEvent.reason == "deploy_backfill")
-        )
-    ).all()
-    assert len(backfill_events) == 6
-    assert all(event.actor_kind == "system" for event in backfill_events)
-    assert all(set(event.patch) <= allowed_keys for event in backfill_events)
-
-
-async def test_deploy_fix_ref_backfill_github_lookup_uses_read_only_app_token(
-    monkeypatch,
-):
-    import scripts.backfill_deploy_fix_refs as backfill
-
-    resolve = AsyncMock(return_value={"GITHUB_TOKEN": "app-token"})
-    get_pr = AsyncMock(return_value={"pull_request": {"merged_at": None}})
-    monkeypatch.setattr(
-        backfill,
-        "async_resolve_project_bound_env_tokens",
-        resolve,
-    )
-    monkeypatch.setattr(
-        backfill,
-        "async_get_pull_request_deploy_info",
-        get_pr,
-    )
-
-    lookup = backfill.github_app_pull_request_lookup(
-        org_id=ORG_ID,
-        actor_user_id="22222222-2222-4222-8222-222222222222",
-    )
-    await lookup(REPO, 1264)
-    await lookup(REPO, 1265)
-
-    resolve.assert_awaited_once_with(
-        actor_user_id="22222222-2222-4222-8222-222222222222",
-        org_id=ORG_ID,
-        project_slug=REPO,
-        github_app_only=True,
-        github_app_permissions={"pull_requests": "read"},
-    )
-    assert get_pr.await_args_list[0].args == (REPO, 1264)
-    assert get_pr.await_args_list[0].kwargs == {"token": "app-token"}
-    assert get_pr.await_args_list[1].args == (REPO, 1265)
 
 
 async def test_sweep_exception_does_not_propagate_from_inbound_hook(session, monkeypatch):

--- a/tests/test_deploy_state_sweep.py
+++ b/tests/test_deploy_state_sweep.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
@@ -24,6 +25,8 @@ from brain.systems.deploy_state_sweep import (
     DEPLOY_STATE_FIELD_DEFINITIONS,
     alert_thread_source_from_run,
     ensure_deploy_state_fields,
+    fix_pr_from_text,
+    github_repo_from_issue_text,
     run_alert_resolution_harvest,
     run_deploy_sweep,
     run_deploy_verification,
@@ -112,6 +115,37 @@ async def _record(session, domain, *, title, **data):
             **data,
         },
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "title", "expected"),
+    [
+        (
+            "uwear-ai/uwear-backend#1264",
+            "Canonical",
+            "uwear-ai/uwear-backend#1264",
+        ),
+        (
+            "https://github.com/uwear-ai/uwear-backend/pull/1237",
+            "URL",
+            "uwear-ai/uwear-backend#1237",
+        ),
+        (
+            "github:uwear-ai/uwear-backend:pr:1178",
+            "Internal key",
+            "uwear-ai/uwear-backend#1178",
+        ),
+        (
+            "591",
+            "github:uwear-ai/uwearaiapp:issue:389",
+            "uwear-ai/uwearaiapp#591",
+        ),
+        ("", "Nothing", None),
+    ],
+)
+async def test_fix_pr_formats_share_one_normalizer(value, title, expected):
+    repo = github_repo_from_issue_text(title)
+    assert fix_pr_from_text(value, repo=repo) == expected
 
 
 async def test_ensure_fields_is_runtime_id_agnostic_and_idempotent(session):
@@ -648,6 +682,242 @@ def test_alert_resolution_phrase_classifier_handles_en_fr_and_unshipped_negation
     from brain.systems.deploy_state_sweep import _resolution_kind
 
     assert _resolution_kind(text) == expected
+
+
+async def test_deploy_fix_ref_backfill_is_dry_run_safe_scoped_and_idempotent(session):
+    from scripts.backfill_deploy_fix_refs import backfill_deploy_fix_refs
+
+    domain = await _domain(session)
+    await ensure_deploy_state_fields(session, org_id=ORG_ID)
+    canonical = await _record(
+        session,
+        domain,
+        title="Canonical",
+        deploy_state="staging",
+        fix_pr="uwear-ai/uwear-backend#1264",
+    )
+    full_url = await _record(
+        session,
+        domain,
+        title="Full URL",
+        deploy_state="prod_pending",
+        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/1237",
+    )
+    internal_key = await _record(
+        session,
+        domain,
+        title="Internal key",
+        deploy_state="staging",
+        fix_pr="github:uwear-ai/uwear-backend:pr:1178",
+    )
+    invalid_merge_sha = await _record(
+        session,
+        domain,
+        title="Invalid merge SHA",
+        deploy_state="staging",
+        fix_pr="uwear-ai/uwear-backend#555",
+    )
+    bare_number = await _record(
+        session,
+        domain,
+        title="github:uwear-ai/uwearaiapp:issue:389",
+        deploy_state="prod_pending",
+        fix_pr="591",
+    )
+    no_reference = await _record(
+        session,
+        domain,
+        title="No reference",
+        deploy_state="prod_pending",
+        fix_pr="",
+    )
+    deployed = await _record(
+        session,
+        domain,
+        title="Already deployed",
+        deploy_state="deployed",
+        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/999",
+    )
+    archived = await _record(
+        session,
+        domain,
+        title="Archived",
+        deploy_state="staging",
+        fix_pr="https://github.com/uwear-ai/uwear-backend/pull/777",
+    )
+    archived.archived_at = NOW
+    await session.flush()
+
+    records = [
+        canonical,
+        full_url,
+        internal_key,
+        invalid_merge_sha,
+        bare_number,
+        no_reference,
+        deployed,
+        archived,
+    ]
+    before_data = {record.id: deepcopy(record.data) for record in records}
+    before_versions = {record.id: record.version for record in records}
+    merge_shas = {
+        ("uwear-ai/uwear-backend", 1264): "a" * 40,
+        ("uwear-ai/uwear-backend", 1178): "c" * 40,
+        ("uwear-ai/uwearaiapp", 591): "d" * 40,
+    }
+
+    async def github_response(repo, number):
+        merge_sha = merge_shas.get((repo, number))
+        if number == 555:
+            return {
+                "pull_request": {
+                    "merged_at": NOW.isoformat(),
+                    "merge_commit_sha": "not-a-merge-sha",
+                }
+            }
+        return {
+            "pull_request": {
+                "merged_at": NOW.isoformat() if merge_sha else None,
+                # Open PRs can expose a temporary merge SHA; never persist it.
+                "merge_commit_sha": merge_sha or ("b" * 40),
+            }
+        }
+
+    github_lookup = AsyncMock(side_effect=github_response)
+    dry_report = await backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        pull_request_lookup=github_lookup,
+    )
+
+    assert dry_report["applied"] is False
+    assert len(dry_report["records"]) == 7
+    assert archived.id not in {
+        row["record_id"] for row in dry_report["records"]
+    }
+    for record in records:
+        await session.refresh(record)
+        assert record.data == before_data[record.id]
+        assert record.version == before_versions[record.id]
+
+    first_report = await backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        apply=True,
+        pull_request_lookup=github_lookup,
+    )
+    assert first_report["applied"] is True
+    assert {
+        row["record_id"]: row["new_fix_pr"] for row in first_report["records"]
+    } == {
+        canonical.id: "uwear-ai/uwear-backend#1264",
+        full_url.id: "uwear-ai/uwear-backend#1237",
+        internal_key.id: "uwear-ai/uwear-backend#1178",
+        invalid_merge_sha.id: "uwear-ai/uwear-backend#555",
+        bare_number.id: "uwear-ai/uwearaiapp#591",
+        no_reference.id: None,
+        deployed.id: "uwear-ai/uwear-backend#999",
+    }
+    rows_by_id = {
+        row["record_id"]: row for row in first_report["records"]
+    }
+    assert rows_by_id[canonical.id]["sha_found"] is True
+    assert rows_by_id[full_url.id]["sha_found"] is False
+    assert rows_by_id[full_url.id]["unresolvable_reason"] is None
+    assert rows_by_id[invalid_merge_sha.id]["sha_found"] is False
+    assert rows_by_id[invalid_merge_sha.id]["unresolvable_reason"] == (
+        "merged PR has no valid merge_commit_sha"
+    )
+    assert rows_by_id[no_reference.id]["unresolvable_reason"] == (
+        "no fix PR reference"
+    )
+    assert rows_by_id[deployed.id]["sha_found"] is False
+    assert all(
+        call.args != ("uwear-ai/uwear-backend", 999)
+        for call in github_lookup.await_args_list
+    )
+
+    allowed_keys = {"fix_pr", "fix_merge_sha", "progress_note"}
+    for record in records:
+        await session.refresh(record)
+        changed_keys = {
+            key
+            for key in set(before_data[record.id]) | set(record.data)
+            if before_data[record.id].get(key) != record.data.get(key)
+        }
+        assert changed_keys <= allowed_keys
+        assert record.data.get("deploy_state") == before_data[record.id].get(
+            "deploy_state"
+        )
+    assert canonical.data["fix_merge_sha"] == "a" * 40
+    assert full_url.data.get("fix_merge_sha") is None
+    assert internal_key.data["fix_merge_sha"] == "c" * 40
+    assert invalid_merge_sha.data.get("fix_merge_sha") is None
+    assert bare_number.data["fix_merge_sha"] == "d" * 40
+    assert no_reference.data["progress_note"].splitlines().count(
+        "needs-human: no fix PR reference"
+    ) == 1
+    assert archived.data == before_data[archived.id]
+
+    after_first_data = {record.id: deepcopy(record.data) for record in records}
+    after_first_versions = {record.id: record.version for record in records}
+    second_report = await backfill_deploy_fix_refs(
+        session,
+        org_id=ORG_ID,
+        apply=True,
+        pull_request_lookup=github_lookup,
+    )
+    assert second_report["applied"] is True
+    for record in records:
+        await session.refresh(record)
+        assert record.data == after_first_data[record.id]
+        assert record.version == after_first_versions[record.id]
+
+    backfill_events = (
+        await session.scalars(
+            select(DomainEvent).where(DomainEvent.reason == "deploy_backfill")
+        )
+    ).all()
+    assert len(backfill_events) == 6
+    assert all(event.actor_kind == "system" for event in backfill_events)
+    assert all(set(event.patch) <= allowed_keys for event in backfill_events)
+
+
+async def test_deploy_fix_ref_backfill_github_lookup_uses_read_only_app_token(
+    monkeypatch,
+):
+    import scripts.backfill_deploy_fix_refs as backfill
+
+    resolve = AsyncMock(return_value={"GITHUB_TOKEN": "app-token"})
+    get_pr = AsyncMock(return_value={"pull_request": {"merged_at": None}})
+    monkeypatch.setattr(
+        backfill,
+        "async_resolve_project_bound_env_tokens",
+        resolve,
+    )
+    monkeypatch.setattr(
+        backfill,
+        "async_get_pull_request_deploy_info",
+        get_pr,
+    )
+
+    lookup = backfill.github_app_pull_request_lookup(
+        org_id=ORG_ID,
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+    )
+    await lookup(REPO, 1264)
+    await lookup(REPO, 1265)
+
+    resolve.assert_awaited_once_with(
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+        org_id=ORG_ID,
+        project_slug=REPO,
+        github_app_only=True,
+        github_app_permissions={"pull_requests": "read"},
+    )
+    assert get_pr.await_args_list[0].args == (REPO, 1264)
+    assert get_pr.await_args_list[0].kwargs == {"token": "app-token"}
+    assert get_pr.await_args_list[1].args == (REPO, 1265)
 
 
 async def test_sweep_exception_does_not_propagate_from_inbound_hook(session, monkeypatch):

--- a/tests/test_inbound_webhooks.py
+++ b/tests/test_inbound_webhooks.py
@@ -1296,7 +1296,7 @@ async def test_postgres_merged_main_envelope_flips_record_and_emits_domain_event
             }
         ],
     )
-    from brain.systems.deploy_state_sweep import (
+    from brain.systems.deploy_tracker import (
         DEPLOY_STATE_FIELD_DEFINITIONS,
         ensure_deploy_state_fields,
     )

--- a/tests/test_vault_project_tokens.py
+++ b/tests/test_vault_project_tokens.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -480,6 +480,48 @@ async def test_resolve_project_bound_env_tokens_can_filter_to_github_app_only(pa
         "GITHUB_TOKEN": "minted-installation-token",
         "GH_TOKEN": "personal-token",
     }
+
+
+async def test_backfill_can_narrow_github_app_token_to_read_only_pr_access(
+    patch_uow,
+    session,
+    monkeypatch,
+):
+    from brain.systems.vault import async_resolve_project_bound_env_tokens
+
+    github_app = await _secret(
+        session,
+        "GITHUB_APP__ILLO",
+        "github-app-blob",
+        access_level="manual",
+        category="github_app",
+    )
+    await _binding(
+        session,
+        github_app,
+        project_slug="uwear-ai/uwear-backend",
+        env_name="GITHUB_TOKEN",
+    )
+    mint = AsyncMock(return_value="read-only-installation-token")
+    monkeypatch.setattr(
+        "brain.systems.vault.github_app_mint.async_mint_installation_token",
+        mint,
+    )
+
+    env = await async_resolve_project_bound_env_tokens(
+        actor_user_id=OTHER_USER_ID,
+        org_id=ORG_ID,
+        project_slug="uwear-ai/uwear-backend",
+        github_app_only=True,
+        github_app_permissions={"pull_requests": "read"},
+    )
+
+    assert env == {"GITHUB_TOKEN": "read-only-installation-token"}
+    mint.assert_awaited_once_with(
+        "github-app-blob",
+        repositories=["uwear-backend"],
+        permissions={"pull_requests": "read"},
+    )
 
 
 async def test_github_app_binding_mints_one_token_for_cross_repo_operation(


### PR DESCRIPTION
## What this does

Closes the data half of the deploy-state work: `fix_pr` becomes one format, and
`fix_merge_sha` gets backfilled so records can actually transition.

Today the tracker stores `fix_pr` in **five** different shapes, and **14 of 20**
active records carry no `fix_merge_sha` at all — and `_sweep_main_merge` reads
`fix_merge_sha` and `continue`s unconditionally when it is empty
(`deploy_state_sweep.py:759-764`, confirmed at line level), so those records can
never transition under the current design *or* under #473's derive-on-read design.

Adds **`scripts/backfill_deploy_fix_refs.py`**, built on the existing
`scripts/archive_auto_encoded_memories.py` pattern rather than a new one:

- **dry run is the default**; `--apply` is required to write anything,
- `UnitOfWork` session, JSON before/after report on stdout (record id, old
  `fix_pr`, new `fix_pr`, `sha_found`, `unresolvable_reason`),
- writes go through the domain-record service — `actor_kind="system"`,
  `reason="deploy_backfill"`, `expected_version` optimistic lock — **never raw SQL**,
- patches are scope-asserted to `fix_pr` / `fix_merge_sha` / `progress_note`; a
  patch containing anything else raises instead of writing,
- `deploy_state` values are never touched (that is #473's job),
- archived records are excluded (`ticket_records` filters `archived_at IS NULL`),
- records with no resolvable PR get a `needs-human: no fix PR reference` note and
  are listed in the report — never a guessed PR,
- GitHub access is read-only, and mints a **narrower** token than the runtime
  default (`pull_requests: read`) via a new optional `github_app_permissions`
  parameter on `async_resolve_project_bound_env_tokens`.

**One parser, not two — and a stable owner for it.** Rather than reimplementing
reference-parsing in the script, the shared parser grew the two missing formats
(`github:owner/repo:pr:N` and a bare PR number). But those helpers lived in
`deploy_state_sweep.py`, which **#473 deletes** — so publishing them from there
would have made #473 harder. They now have their own owners instead:

- **`brain/systems/deploy_fix_refs.py`** (58 lines) — pure reference
  normalization, no I/O: `normalize_fix_pr_reference(text, *, default_repo)` and
  `github_repo_from_issue_text` (infers the repo from a record title
  `github:<owner>/<repo>:issue:<n>` when the value is a bare number).
- **`brain/systems/deploy_tracker.py`** (172 lines) — tracker schema and
  persistence: `list_deploy_ticket_records`, `update_deploy_ticket_record`,
  `append_progress_note`, `ensure_deploy_state_fields`. The generic-sounding old
  names (`ticket_records`, `update_record`) are gone; these say what they do.

`deploy_state_sweep.py` becomes a consumer of both (1034 → 876 lines) with no
compatibility aliases, and the backfill script imports **nothing** from it. So
**#473 can delete the sweep without touching this script or its tests.**

## ⚠️ The live backfill has NOT been run

This PR contains the tool and its proof; it does not contain the data change.
Runbook step 6 (the before/after table from live `illo-dev` data) needs the branch
code inside `illospace-worker-1`, whose deployed image does not have the promoted
public helpers yet. Staging branch code on the production host is not something
this routine has a grant to do, so the `--apply` run stays yours.

After this merges and deploys:

```
docker compose exec illospace-worker-1 python scripts/backfill_deploy_fix_refs.py \
  --org-id <org-uuid> --actor-user-id <user-uuid>          # dry run, writes nothing
docker compose exec illospace-worker-1 python scripts/backfill_deploy_fix_refs.py \
  --org-id <org-uuid> --actor-user-id <user-uuid> --apply  # then, once the table looks right
```

The dry-run JSON *is* the before/after table the ticket asks to be posted on #474.

## Review passes already run

A thermo-nuclear maintainability review (Codex, cross-family) ran against the first
implementation and returned **two blocking findings**, both folded in here:

1. the helpers were made public inside the module #473 deletes → fixed by the
   `deploy_tracker` / `deploy_fix_refs` extraction above;
2. the driver mixed enumeration, GitHub I/O, patch-building, scope validation and
   mutation in one ~95-line function → fixed by **plan-then-apply**: a frozen
   `BackfillPlan` (record + `TypedDict` patch + report row), one per-record planner,
   and a driver that only enumerates → plans → validates **every** plan → applies
   under `--apply` → reports. Scope violations now raise a named
   `BackfillScopeError` before the first write instead of an `AssertionError`
   mid-loop, so a bad patch can no longer be discovered after other records have
   already been written.

Two should-fixes from the same review were also folded: the backfill tests moved to
their own `tests/test_backfill_deploy_fix_refs.py` (parameterized shape cases +
separate dry-run/apply/idempotency tests), and the parser's `repo` parameter became
`default_repo` since a bare `123` is a *relative* reference. The review explicitly
approved keeping the five-shape parser as one function and the vault permission
override where it is.

## Verification

- Full suite on this branch, run by the orchestrator outside the worker sandbox:
  **4140 passed, 76 skipped, 0 failed** (63.6s) — the pre-change baseline was 4137
  passed, +3 from the newly split test cases,
  excluding `tests/test_gpu_server.py` + `tests/test_llm_worker.py`, which fail on
  the local Mac only because that venv has a half-installed torch
  (`libtorch_cpu.dylib` missing). CI is unaffected.
- New tests cover: all five `fix_pr` formats normalizing to `owner/repo#N`
  including bare-number repo inference; an unmerged PR yielding **no**
  `fix_merge_sha`; the unresolvable path getting the `needs-human` note;
  **dry run writing nothing**; `--apply` being **idempotent** on a second run; and
  the patch never touching keys outside the three allowed ones.
- Checked separately by the orchestrator: no leftover references to the four
  renamed private helpers anywhere in the tree; `project_slug=<owner/repo>` for the
  token lookup follows the live precedent at
  `runs/tool_catalog/handlers/github.py:246`.

## Acceptance checks for review

1. Dry run against illo-dev prints a table where every record with a resolvable
   merged PR shows canonical `owner/repo#N` + a 40-hex sha, and record 2311 (no
   reference) shows as unresolvable rather than guessed.
2. Record 2474 keeps `uwear-ai/uwear-backend#1264` and gains #1264's merge sha;
   ancestry on that sha vs `main` returns contained (it shipped via
   uwear-ai/uwear-backend#1289).
3. Re-running `--apply` immediately after a first `--apply` reports no further
   changes (no version churn on the records).
4. No record's `deploy_state`, and no data key beyond the three allowed, changes.

## Sequencing

Independent of PR #468. This is the data precondition #473 lists first; #473 itself
stays blocked on #468's `inbound/service.py` hunk. Note for whoever picks up #473:
its plan says "add `derive_deploy_state(repo, sha, *, tokens)`", but that name
already exists as a pure classifier at `brain/systems/deploy_state.py:145` with two
live callers — see my comment on #473.

Refs #474
