### PR TITLE
feat(release): hourly staging→main promotion PR reconciliation (#475)

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -81,6 +81,33 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "retry_policy": {"max_attempts": 2, "backoff_seconds": 0},
     },
     {
+        "job_key": "uwear_staging_promotion_pr",
+        "family": "uwear_staging_promotion_pr",
+        "program_key": "uwear_staging_promotion_pr",
+        "handler_kind": CATALOG_HANDLER_KIND,
+        "handler_ref": "brain.app.scheduler.programs:uwear_staging_promotion_pr",
+        "cron_expr": "0 * * * *",
+        "timezone": "UTC",
+        "default_payload": {
+            "name": "Uwear Staging Promotion PR",
+            "description": "Hourly staging-to-main promotion pull request reconciliation",
+            "action_manifest": ["create_github_pull_request"],
+        },
+        "task_contract": {
+            "memory_scope": {"visibility": "system"},
+            "allowed_actions": ["scheduler.run", "create_github_pull_request"],
+            "output_channel": "scheduler",
+            "success_criteria": [
+                "Each configured repository with staging ahead has one open promotion pull request"
+            ],
+        },
+        "priority": 90,
+        "max_concurrency": 1,
+        "timeout_seconds": 300,
+        "retry_policy": {"max_attempts": 1, "backoff_seconds": 0},
+        "misfire_policy": "skip",
+    },
+    {
         "job_key": "uwear_aws_health_scan",
         "family": "uwear_aws_health_scan",
         "program_key": "uwear_aws_health_scan",

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -17,6 +17,11 @@ UWEAR_AWS_HEALTH_SCAN_COMMAND = [
     "-m",
     "brain.jobs.pipelines.aws_health_scan",
 ]
+UWEAR_STAGING_PROMOTION_PR_COMMAND = [
+    "python3",
+    "-m",
+    "brain.jobs.pipelines.staging_promotion_pr",
+]
 
 
 def _python_one_liner(code: str) -> list[str]:
@@ -460,6 +465,21 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             }
         ]
 
+    if (
+        job.program_key == "uwear_staging_promotion_pr"
+        or "uwear_staging_promotion_pr" in identity
+    ):
+        return [
+            {
+                "step_key": "uwear_staging_promotion_pr",
+                "sequence_no": 1,
+                "kind": "single",
+                "handler_ref": job.handler_ref,
+                "payload": {"program": "uwear_staging_promotion_pr"},
+                "command": UWEAR_STAGING_PROMOTION_PR_COMMAND,
+            }
+        ]
+
     if job.program_key == "uwear_aws_health_scan" or "uwear_aws_health_scan" in identity:
         return [
             {
@@ -530,6 +550,19 @@ def _uwear_aws_health_scan_steps(job: SchedulerJob, run: SchedulerRun) -> list[S
     ]
 
 
+def _uwear_staging_promotion_pr_steps(
+    job: SchedulerJob,
+    run: SchedulerRun,
+) -> list[StepSpec]:
+    return [
+        StepSpec(
+            "uwear_staging_promotion_pr",
+            UWEAR_STAGING_PROMOTION_PR_COMMAND,
+            "Ensure Uwear staging promotion pull requests exist",
+        ),
+    ]
+
+
 def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     payload = job.default_payload or {}
     command = payload.get("command")
@@ -542,6 +575,8 @@ def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
 
 def get_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     key = _job_identity(job)
+    if "uwear_staging_promotion_pr" in key:
+        return _uwear_staging_promotion_pr_steps(job, run)
     if "uwear_aws_health_scan" in key:
         return _uwear_aws_health_scan_steps(job, run)
     if "curiosity" in key:

--- a/brain/jobs/pipelines/staging_promotion_pr.py
+++ b/brain/jobs/pipelines/staging_promotion_pr.py
@@ -5,7 +5,6 @@ import asyncio
 from dataclasses import dataclass
 import json
 import logging
-import re
 from typing import Any
 
 from sqlalchemy import select
@@ -13,25 +12,17 @@ from sqlalchemy import select
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.cortex.project_context.github import (
-    async_compare_repo_branches,
-    async_list_repo_pull_requests,
-)
-from brain.systems.runs.execution_context import bind_agent_context
-from brain.systems.runs.tool_catalog.handlers.github import (
-    PROMOTION_PULL_REQUEST_BASE,
-    PROMOTION_PULL_REQUEST_HEAD,
-    PROMOTION_PULL_REQUEST_REPOS,
-    PROMOTION_PULL_REQUEST_TITLE,
-    _handle_create_github_pull_request,
+from brain.systems.cortex.project_context.github_promotion import (
+    PROMOTION_PULL_REQUEST_POLICY,
+    PromotionPullRequestResult,
+    async_reconcile_promotion_pull_request,
 )
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
 
 logger = logging.getLogger("illo.jobs.staging_promotion_pr")
 
-CONFIGURED_REPOS = tuple(sorted(PROMOTION_PULL_REQUEST_REPOS))
-ISSUE_NUMBER_PATTERN = re.compile(r"(?<![A-Za-z0-9_])#([1-9][0-9]*)\b")
+CONFIGURED_REPOS = tuple(sorted(PROMOTION_PULL_REQUEST_POLICY.repositories))
 
 
 @dataclass(frozen=True)
@@ -44,100 +35,16 @@ class PromotionPullRequestError(RuntimeError):
     """A settled per-repository failure that should fail the scheduler run."""
 
 
-def build_promotion_body(repo: str, commits: list[dict[str, Any]]) -> str:
-    """Render compare commits and their issue references as Markdown."""
-
-    lines = ["## Commits being promoted", ""]
-    linked_issues: set[int] = set()
-    for commit in commits:
-        subject = str(commit.get("subject") or "(no commit subject)").strip()
-        sha = str(commit.get("sha") or "").strip()
-        url = str(commit.get("html_url") or "").strip()
-        commit_label = sha[:7] if sha else "commit"
-        commit_ref = f"[`{commit_label}`]({url})" if url else f"`{commit_label}`"
-        issue_numbers = {
-            int(match.group(1))
-            for match in ISSUE_NUMBER_PATTERN.finditer(subject)
-        }
-        linked_issues.update(issue_numbers)
-        lines.append(f"- {commit_ref} {subject}")
-
-    lines.extend(["", "## Linked issues", ""])
-    if linked_issues:
-        lines.extend(
-            f"- [#{number}](https://github.com/{repo}/issues/{number})"
-            for number in sorted(linked_issues)
-        )
-    else:
-        lines.append("- None referenced in the commit subjects.")
-    return "\n".join(lines)
-
-
-async def reconcile_repository(repo: str, *, token: str) -> dict[str, Any]:
-    """Create the missing promotion PR for one repository, if staging is ahead."""
-
-    comparison = await async_compare_repo_branches(
-        repo,
-        PROMOTION_PULL_REQUEST_BASE,
-        PROMOTION_PULL_REQUEST_HEAD,
-        token=token,
-    )
-    if comparison["ahead_by"] == 0:
-        return {"repo": repo, "outcome": "no_diff"}
-
-    open_pulls = await async_list_repo_pull_requests(
-        repo,
-        token=token,
-        state="open",
-        base=PROMOTION_PULL_REQUEST_BASE,
-        head=PROMOTION_PULL_REQUEST_HEAD,
-        limit=100,
-    )
-    matching_pull = next(
-        (
-            pull
-            for pull in open_pulls.get("pull_requests", [])
-            if (pull.get("base") or {}).get("ref") == PROMOTION_PULL_REQUEST_BASE
-            and (pull.get("head") or {}).get("ref") == PROMOTION_PULL_REQUEST_HEAD
-        ),
-        None,
-    )
-    if matching_pull is not None:
-        return {
-            "repo": repo,
-            "outcome": "already_open",
-            "number": matching_pull.get("number"),
-        }
-
-    body = build_promotion_body(repo, comparison["commits"])
-    raw_result = await _handle_create_github_pull_request(
-        repo=repo,
-        base=PROMOTION_PULL_REQUEST_BASE,
-        head=PROMOTION_PULL_REQUEST_HEAD,
-        title=PROMOTION_PULL_REQUEST_TITLE,
-        body=body,
-        draft=False,
-    )
-    try:
-        result = json.loads(raw_result)
-    except (TypeError, json.JSONDecodeError) as exc:
-        raise PromotionPullRequestError(
-            f"create_github_pull_request returned invalid JSON for {repo}"
-        ) from exc
-    if result.get("error") == "pull_request_exists":
-        return {
-            "repo": repo,
-            "outcome": "already_open",
-            "number": result.get("existing"),
-        }
-    if result.get("error"):
-        raise PromotionPullRequestError(str(result["error"]))
-    return {
-        "repo": repo,
-        "outcome": "created",
-        "number": result.get("number"),
-        "html_url": result.get("html_url"),
+def _job_result(result: PromotionPullRequestResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "repo": result.repo,
+        "outcome": result.outcome,
     }
+    if result.number is not None:
+        payload["number"] = result.number
+    if result.html_url is not None:
+        payload["html_url"] = result.html_url
+    return payload
 
 
 async def _promotion_actor(repo: str) -> PromotionActor:
@@ -197,13 +104,14 @@ async def run_promotion_job() -> dict[str, Any]:
     failures = 0
     for repo in CONFIGURED_REPOS:
         try:
+            target = PROMOTION_PULL_REQUEST_POLICY.target_for(repo)
             actor = await _promotion_actor(repo)
             token = await _repo_token(repo, actor)
-            with bind_agent_context({
-                "user_id": actor.user_id,
-                "org_id": actor.org_id,
-            }):
-                result = await reconcile_repository(repo, token=token)
+            promotion = await async_reconcile_promotion_pull_request(
+                target,
+                token=token,
+            )
+            result = _job_result(promotion)
         except Exception as exc:  # noqa: BLE001 - each repository must settle independently
             failures += 1
             error = str(getattr(exc, "message", None) or exc)

--- a/brain/jobs/pipelines/staging_promotion_pr.py
+++ b/brain/jobs/pipelines/staging_promotion_pr.py
@@ -1,0 +1,232 @@
+"""Ensure each configured Uwear repository has a staging-to-main promotion PR."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import json
+import logging
+import re
+from typing import Any
+
+from sqlalchemy import select
+
+from brain.platform.db.models.org import User
+from brain.platform.db.models.vault import Secret, VaultProjectBinding
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.project_context.github import (
+    async_compare_repo_branches,
+    async_list_repo_pull_requests,
+)
+from brain.systems.runs.execution_context import bind_agent_context
+from brain.systems.runs.tool_catalog.handlers.github import (
+    PROMOTION_PULL_REQUEST_BASE,
+    PROMOTION_PULL_REQUEST_HEAD,
+    PROMOTION_PULL_REQUEST_REPOS,
+    PROMOTION_PULL_REQUEST_TITLE,
+    _handle_create_github_pull_request,
+)
+from brain.systems.vault import async_resolve_project_bound_env_tokens
+
+
+logger = logging.getLogger("illo.jobs.staging_promotion_pr")
+
+CONFIGURED_REPOS = tuple(sorted(PROMOTION_PULL_REQUEST_REPOS))
+ISSUE_NUMBER_PATTERN = re.compile(r"(?<![A-Za-z0-9_])#([1-9][0-9]*)\b")
+
+
+@dataclass(frozen=True)
+class PromotionActor:
+    user_id: str
+    org_id: str
+
+
+class PromotionPullRequestError(RuntimeError):
+    """A settled per-repository failure that should fail the scheduler run."""
+
+
+def build_promotion_body(repo: str, commits: list[dict[str, Any]]) -> str:
+    """Render compare commits and their issue references as Markdown."""
+
+    lines = ["## Commits being promoted", ""]
+    linked_issues: set[int] = set()
+    for commit in commits:
+        subject = str(commit.get("subject") or "(no commit subject)").strip()
+        sha = str(commit.get("sha") or "").strip()
+        url = str(commit.get("html_url") or "").strip()
+        commit_label = sha[:7] if sha else "commit"
+        commit_ref = f"[`{commit_label}`]({url})" if url else f"`{commit_label}`"
+        issue_numbers = {
+            int(match.group(1))
+            for match in ISSUE_NUMBER_PATTERN.finditer(subject)
+        }
+        linked_issues.update(issue_numbers)
+        lines.append(f"- {commit_ref} {subject}")
+
+    lines.extend(["", "## Linked issues", ""])
+    if linked_issues:
+        lines.extend(
+            f"- [#{number}](https://github.com/{repo}/issues/{number})"
+            for number in sorted(linked_issues)
+        )
+    else:
+        lines.append("- None referenced in the commit subjects.")
+    return "\n".join(lines)
+
+
+async def reconcile_repository(repo: str, *, token: str) -> dict[str, Any]:
+    """Create the missing promotion PR for one repository, if staging is ahead."""
+
+    comparison = await async_compare_repo_branches(
+        repo,
+        PROMOTION_PULL_REQUEST_BASE,
+        PROMOTION_PULL_REQUEST_HEAD,
+        token=token,
+    )
+    if comparison["ahead_by"] == 0:
+        return {"repo": repo, "outcome": "no_diff"}
+
+    open_pulls = await async_list_repo_pull_requests(
+        repo,
+        token=token,
+        state="open",
+        base=PROMOTION_PULL_REQUEST_BASE,
+        head=PROMOTION_PULL_REQUEST_HEAD,
+        limit=100,
+    )
+    matching_pull = next(
+        (
+            pull
+            for pull in open_pulls.get("pull_requests", [])
+            if (pull.get("base") or {}).get("ref") == PROMOTION_PULL_REQUEST_BASE
+            and (pull.get("head") or {}).get("ref") == PROMOTION_PULL_REQUEST_HEAD
+        ),
+        None,
+    )
+    if matching_pull is not None:
+        return {
+            "repo": repo,
+            "outcome": "already_open",
+            "number": matching_pull.get("number"),
+        }
+
+    body = build_promotion_body(repo, comparison["commits"])
+    raw_result = await _handle_create_github_pull_request(
+        repo=repo,
+        base=PROMOTION_PULL_REQUEST_BASE,
+        head=PROMOTION_PULL_REQUEST_HEAD,
+        title=PROMOTION_PULL_REQUEST_TITLE,
+        body=body,
+        draft=False,
+    )
+    try:
+        result = json.loads(raw_result)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise PromotionPullRequestError(
+            f"create_github_pull_request returned invalid JSON for {repo}"
+        ) from exc
+    if result.get("error") == "pull_request_exists":
+        return {
+            "repo": repo,
+            "outcome": "already_open",
+            "number": result.get("existing"),
+        }
+    if result.get("error"):
+        raise PromotionPullRequestError(str(result["error"]))
+    return {
+        "repo": repo,
+        "outcome": "created",
+        "number": result.get("number"),
+        "html_url": result.get("html_url"),
+    }
+
+
+async def _promotion_actor(repo: str) -> PromotionActor:
+    async with UnitOfWork() as uow:
+        binding = await uow.session.scalar(
+            select(VaultProjectBinding)
+            .join(Secret, Secret.id == VaultProjectBinding.secret_id)
+            .where(
+                VaultProjectBinding.project_slug == repo,
+                VaultProjectBinding.active.is_(True),
+                Secret.category == "github_app",
+            )
+            .order_by(VaultProjectBinding.id.asc())
+            .limit(1)
+        )
+        if binding is None:
+            raise PromotionPullRequestError(
+                f"No GitHub App project binding is configured for {repo}"
+            )
+
+        actor = None
+        if binding.created_by_user_id:
+            actor = await uow.session.get(User, str(binding.created_by_user_id))
+        if actor is None:
+            actor = (
+                await uow.session.scalars(
+                    select(User)
+                    .where(User.org_id == str(binding.org_id))
+                    .order_by(User.created_at.asc(), User.id.asc())
+                    .limit(1)
+                )
+            ).first()
+        if actor is None:
+            raise PromotionPullRequestError(
+                f"No Illospace user is available for {repo}'s GitHub App binding"
+            )
+        return PromotionActor(user_id=str(actor.id), org_id=str(actor.org_id))
+
+
+async def _repo_token(repo: str, actor: PromotionActor) -> str:
+    env = await async_resolve_project_bound_env_tokens(
+        actor_user_id=actor.user_id,
+        org_id=actor.org_id,
+        project_slug=repo,
+        github_app_only=True,
+    )
+    token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
+    if not token:
+        raise PromotionPullRequestError(
+            f"No project-bound GitHub App token is available for {repo}"
+        )
+    return token
+
+
+async def run_promotion_job() -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    failures = 0
+    for repo in CONFIGURED_REPOS:
+        try:
+            actor = await _promotion_actor(repo)
+            token = await _repo_token(repo, actor)
+            with bind_agent_context({
+                "user_id": actor.user_id,
+                "org_id": actor.org_id,
+            }):
+                result = await reconcile_repository(repo, token=token)
+        except Exception as exc:  # noqa: BLE001 - each repository must settle independently
+            failures += 1
+            error = str(getattr(exc, "message", None) or exc)
+            logger.error("Promotion PR reconciliation failed for %s: %s", repo, error)
+            result = {"repo": repo, "outcome": "error", "error": error}
+        results.append(result)
+    return {
+        "job": "uwear_staging_promotion_pr",
+        "ok": failures == 0,
+        "failures": failures,
+        "results": results,
+    }
+
+
+async def async_main() -> int:
+    result = await run_promotion_job()
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+def main() -> int:
+    return asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -1863,14 +1863,13 @@ async def async_get_pull_request_deploy_info(
     }
 
 
-async def async_compare_commits(
+async def _async_compare_payload(
     slug: str,
     base: str,
     head: str,
     *,
     token: str | None = None,
-) -> str:
-    """Return GitHub's compare status for ``base...head``."""
+) -> dict[str, Any]:
     owner, repo = slug.split("/", 1)
     async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
         payload = await _async_request(
@@ -1879,7 +1878,70 @@ async def async_compare_commits(
             f"/repos/{owner}/{repo}/compare/{base}...{head}",
             token=token,
         )
-    status = payload.get("status") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub compare response was not an object.",
+        )
+    return payload
+
+
+async def async_compare_repo_branches(
+    slug: str,
+    base: str,
+    head: str,
+    *,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Return the ahead count and commit subjects for a branch comparison."""
+
+    payload = await _async_compare_payload(slug, base, head, token=token)
+    ahead_by = payload.get("ahead_by")
+    if not isinstance(ahead_by, int) or isinstance(ahead_by, bool) or ahead_by < 0:
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub compare response omitted a valid ahead_by count.",
+        )
+
+    raw_commits = payload.get("commits")
+    if not isinstance(raw_commits, list):
+        raise GitHubConnectorError(
+            status_code=502,
+            message="GitHub compare response omitted its commits.",
+        )
+    commits = []
+    for item in raw_commits:
+        if not isinstance(item, dict):
+            continue
+        details = item.get("commit")
+        message = details.get("message") if isinstance(details, dict) else None
+        subject = str(message or "").splitlines()[0].strip()
+        commits.append({
+            "sha": item.get("sha"),
+            "html_url": item.get("html_url"),
+            "subject": subject or "(no commit subject)",
+        })
+
+    return {
+        "repo": slug,
+        "base": base,
+        "head": head,
+        "status": payload.get("status"),
+        "ahead_by": ahead_by,
+        "commits": commits,
+    }
+
+
+async def async_compare_commits(
+    slug: str,
+    base: str,
+    head: str,
+    *,
+    token: str | None = None,
+) -> str:
+    """Return GitHub's compare status for ``base...head``."""
+    payload = await _async_compare_payload(slug, base, head, token=token)
+    status = payload.get("status")
     if status not in {"identical", "behind", "ahead", "diverged"}:
         raise GitHubConnectorError(
             status_code=502,

--- a/brain/systems/cortex/project_context/github_promotion.py
+++ b/brain/systems/cortex/project_context/github_promotion.py
@@ -1,0 +1,256 @@
+"""Policy and reconciliation service for GitHub staging promotion pull requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Literal
+
+from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
+    async_compare_repo_branches,
+    async_create_repo_pull_request,
+    async_list_repo_pull_requests,
+)
+
+
+_ISSUE_NUMBER_PATTERN = re.compile(r"(?<![A-Za-z0-9_])#([1-9][0-9]*)\b")
+
+
+@dataclass(frozen=True)
+class PromotionPullRequestTarget:
+    """A requested promotion pull request target."""
+
+    repo: str
+    base: str
+    head: str
+    title: str
+    draft: bool
+
+
+class PromotionPullRequestPolicyViolation(ValueError):
+    """The requested pull request falls outside the promotion policy."""
+
+
+@dataclass(frozen=True)
+class PromotionPullRequestPolicy:
+    """Immutable allowlist for the scheduler's sole GitHub write."""
+
+    repositories: frozenset[str]
+    base: str
+    head: str
+    title: str
+    require_non_draft: bool = True
+
+    def target_for(self, repo: str) -> PromotionPullRequestTarget:
+        target = PromotionPullRequestTarget(
+            repo=repo,
+            base=self.base,
+            head=self.head,
+            title=self.title,
+            draft=False,
+        )
+        self.validate(target)
+        return target
+
+    def validate(self, target: PromotionPullRequestTarget) -> None:
+        error = self.validation_error(target)
+        if error:
+            raise PromotionPullRequestPolicyViolation(error)
+
+    def validation_error(self, target: PromotionPullRequestTarget) -> str | None:
+        if target.repo not in self.repositories:
+            return f"repository must be one of {sorted(self.repositories)}"
+        if target.base != self.base:
+            return f"base must be {self.base!r}"
+        if target.head != self.head:
+            return f"head must be {self.head!r}"
+        if target.title != self.title:
+            return f"title must be {self.title!r}"
+        if self.require_non_draft and target.draft:
+            return "draft must be false"
+        return None
+
+
+PROMOTION_PULL_REQUEST_POLICY = PromotionPullRequestPolicy(
+    repositories=frozenset(
+        {
+            "uwear-ai/uwear-backend",
+            "uwear-ai/uwearaiapp",
+        }
+    ),
+    base="main",
+    head="staging",
+    title="Staging → main promotion",
+)
+
+
+PromotionPullRequestOutcome = Literal["no_diff", "already_open", "created"]
+PromotionPullRequestSettlement = Literal[
+    "comparison",
+    "search",
+    "create",
+    "create_conflict",
+]
+
+
+@dataclass(frozen=True)
+class PromotionPullRequestResult:
+    """Typed result from reconciling one repository."""
+
+    repo: str
+    outcome: PromotionPullRequestOutcome
+    settled_by: PromotionPullRequestSettlement
+    number: int | None = None
+    html_url: str | None = None
+    state: str | None = None
+    draft: bool = False
+    conflict_message: str | None = None
+
+
+class PromotionPullRequestOperationError(RuntimeError):
+    """A recognized GitHub response that remains an operation failure."""
+
+    def __init__(self, code: str, *, detail: str, status_code: int) -> None:
+        super().__init__(code)
+        self.code = code
+        self.detail = detail
+        self.status_code = status_code
+
+
+def build_promotion_body(repo: str, commits: list[dict[str, Any]]) -> str:
+    """Render compare commits and their issue references as Markdown."""
+
+    lines = ["## Commits being promoted", ""]
+    linked_issues: set[int] = set()
+    for commit in commits:
+        subject = str(commit.get("subject") or "(no commit subject)").strip()
+        sha = str(commit.get("sha") or "").strip()
+        url = str(commit.get("html_url") or "").strip()
+        commit_label = sha[:7] if sha else "commit"
+        commit_ref = f"[`{commit_label}`]({url})" if url else f"`{commit_label}`"
+        issue_numbers = {
+            int(match.group(1))
+            for match in _ISSUE_NUMBER_PATTERN.finditer(subject)
+        }
+        linked_issues.update(issue_numbers)
+        lines.append(f"- {commit_ref} {subject}")
+
+    lines.extend(["", "## Linked issues", ""])
+    if linked_issues:
+        lines.extend(
+            f"- [#{number}](https://github.com/{repo}/issues/{number})"
+            for number in sorted(linked_issues)
+        )
+    else:
+        lines.append("- None referenced in the commit subjects.")
+    return "\n".join(lines)
+
+
+async def async_reconcile_promotion_pull_request(
+    target: PromotionPullRequestTarget,
+    *,
+    token: str,
+    body: str | None = None,
+) -> PromotionPullRequestResult:
+    """Compare, search, and create a promotion pull request when needed."""
+
+    PROMOTION_PULL_REQUEST_POLICY.validate(target)
+    comparison = await async_compare_repo_branches(
+        target.repo,
+        target.base,
+        target.head,
+        token=token,
+    )
+    if comparison["ahead_by"] == 0:
+        return PromotionPullRequestResult(
+            repo=target.repo,
+            outcome="no_diff",
+            settled_by="comparison",
+        )
+
+    open_pulls = await async_list_repo_pull_requests(
+        target.repo,
+        token=token,
+        state="open",
+        base=target.base,
+        head=target.head,
+        limit=100,
+    )
+    matching_pull = next(
+        (
+            pull
+            for pull in open_pulls.get("pull_requests", [])
+            if (pull.get("base") or {}).get("ref") == target.base
+            and (pull.get("head") or {}).get("ref") == target.head
+        ),
+        None,
+    )
+    if matching_pull is not None:
+        return PromotionPullRequestResult(
+            repo=target.repo,
+            outcome="already_open",
+            settled_by="search",
+            number=_optional_int(matching_pull.get("number")),
+        )
+
+    pull_request_body = (
+        body
+        if body is not None
+        else build_promotion_body(target.repo, comparison["commits"])
+    )
+    try:
+        payload = await async_create_repo_pull_request(
+            target.repo,
+            base=target.base,
+            head=target.head,
+            title=target.title,
+            body=pull_request_body,
+            draft=target.draft,
+            token=token,
+        )
+    except GitHubConnectorError as exc:
+        lowered = exc.message.lower()
+        if exc.status_code == 422 and "pull request already exists" in lowered:
+            return PromotionPullRequestResult(
+                repo=target.repo,
+                outcome="already_open",
+                settled_by="create_conflict",
+                number=_existing_pull_request_number(exc.message),
+                conflict_message=exc.message,
+            )
+        if exc.status_code == 422 and "no commits between" in lowered:
+            raise PromotionPullRequestOperationError(
+                "no_commits_between",
+                detail=exc.message,
+                status_code=exc.status_code,
+            ) from exc
+        raise
+
+    pull_request = payload.get("pull_request")
+    pull_request = pull_request if isinstance(pull_request, dict) else {}
+    return PromotionPullRequestResult(
+        repo=target.repo,
+        outcome="created",
+        settled_by="create",
+        number=_optional_int(pull_request.get("number")),
+        html_url=_optional_string(pull_request.get("html_url")),
+        state=_optional_string(pull_request.get("state")),
+        draft=bool(pull_request.get("draft")),
+    )
+
+
+def _existing_pull_request_number(message: str) -> int | None:
+    for pattern in (r"/pull/(\d+)", r"pull request\s+#?(\d+)"):
+        match = re.search(pattern, message, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) else None

--- a/brain/systems/runs/tool_catalog/definitions/github.py
+++ b/brain/systems/runs/tool_catalog/definitions/github.py
@@ -192,41 +192,40 @@ GITHUB_TOOLS = [
     {
         "name": "create_github_pull_request",
         "description": (
-            "Open a REAL GitHub pull request via the GitHub API. This performs a public write to "
-            "the target repository; it never merges the pull request. Missions must restrict this "
-            "tool to a specific, single-purpose policy describing exactly when a pull request may "
-            "be opened. The shipped Uwear use case is recreating the evergreen staging→main "
-            "promotion pull request when it is missing. The repo may be supplied as owner/name, "
-            "a GitHub URL, or a git remote URL. If no write-capable token can reach the repository, "
-            "the error carries no_write_token=true; GitHub API failures include their status code."
+            "Open a REAL GitHub pull request for the evergreen staging→main promotion via the "
+            "GitHub API when it is missing. This public write is restricted to the configured "
+            "Uwear repositories, the exact promotion branches and title, and a non-draft pull "
+            "request; the tool never merges, approves, reviews, or updates a pull request. If no "
+            "write-capable token can reach the repository, the error carries no_write_token=true; "
+            "GitHub API failures include their status code."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "repo": {
                     "type": "string",
-                    "description": "Target repository as owner/name, GitHub URL, or git remote URL.",
+                    "description": "Configured Uwear repository as owner/name, GitHub URL, or git remote URL.",
                 },
                 "base": {
                     "type": "string",
-                    "description": "Target branch the pull request proposes to merge into.",
+                    "description": "Target branch. Must be main.",
                 },
                 "head": {
                     "type": "string",
-                    "description": "Source branch containing the proposed changes.",
+                    "description": "Source branch. Must be staging.",
                 },
                 "title": {
                     "type": "string",
-                    "description": "Pull request title. Required.",
+                    "description": "Pull request title. Must be 'Staging → main promotion'.",
                 },
                 "body": {
                     "type": "string",
-                    "description": "Markdown pull request body. Required.",
+                    "description": "Markdown summary of the commits and linked issues being promoted.",
                 },
                 "draft": {
                     "type": "boolean",
                     "default": False,
-                    "description": "Whether to open the pull request as a draft.",
+                    "description": "Must be false; promotion pull requests are never opened as drafts.",
                 },
                 "token_secret_key": {
                     "type": "string",

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -14,7 +14,6 @@ from brain.systems.cortex.project_context.github import (
     async_add_repo_issue_comment,
     async_add_repo_sub_issue,
     async_create_repo_issue,
-    async_create_repo_pull_request,
     async_grep_repo,
     async_get_repo_issue_parent,
     async_get_pull_request_deploy_info,
@@ -30,6 +29,13 @@ from brain.systems.cortex.project_context.github import (
     async_remove_repo_sub_issue,
     async_update_repo_issue,
     parse_github_repo_slug,
+)
+from brain.systems.cortex.project_context.github_promotion import (
+    PROMOTION_PULL_REQUEST_POLICY,
+    PromotionPullRequestOperationError,
+    PromotionPullRequestPolicyViolation,
+    PromotionPullRequestTarget,
+    async_reconcile_promotion_pull_request,
 )
 from brain.systems.deploy_state import (
     DeployState,
@@ -61,14 +67,6 @@ def _clean(value: Any) -> str | None:
 _SLACK_ORIGIN_REF_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_-])(slack:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+:[0-9.]+)"
 )
-
-PROMOTION_PULL_REQUEST_REPOS = frozenset({
-    "uwear-ai/uwear-backend",
-    "uwear-ai/uwearaiapp",
-})
-PROMOTION_PULL_REQUEST_BASE = "main"
-PROMOTION_PULL_REQUEST_HEAD = "staging"
-PROMOTION_PULL_REQUEST_TITLE = "Staging → main promotion"
 
 
 def _origin_ref_from_body(body: str | None) -> str | None:
@@ -737,35 +735,6 @@ async def _handle_create_github_issue(
     return json.dumps({"error": "No GitHub token candidates were available", "no_write_token": True})
 
 
-def _existing_pull_request_number(message: str) -> int | None:
-    for pattern in (r"/pull/(\d+)", r"pull request\s+#?(\d+)"):
-        match = re.search(pattern, message, flags=re.IGNORECASE)
-        if match:
-            return int(match.group(1))
-    return None
-
-
-def _promotion_pull_request_policy_error(
-    *,
-    repo: str,
-    base: str,
-    head: str,
-    title: str,
-    draft: bool,
-) -> str | None:
-    if repo not in PROMOTION_PULL_REQUEST_REPOS:
-        return f"repository must be one of {sorted(PROMOTION_PULL_REQUEST_REPOS)}"
-    if base != PROMOTION_PULL_REQUEST_BASE:
-        return f"base must be {PROMOTION_PULL_REQUEST_BASE!r}"
-    if head != PROMOTION_PULL_REQUEST_HEAD:
-        return f"head must be {PROMOTION_PULL_REQUEST_HEAD!r}"
-    if title != PROMOTION_PULL_REQUEST_TITLE:
-        return f"title must be {PROMOTION_PULL_REQUEST_TITLE!r}"
-    if draft:
-        return "draft must be false"
-    return None
-
-
 async def _handle_create_github_pull_request(
     repo: str | None = None,
     base: str | None = None,
@@ -794,17 +763,19 @@ async def _handle_create_github_pull_request(
     clean_body = _clean(body)
     if not clean_body:
         return json.dumps({"error": "create_github_pull_request requires a non-empty body"})
-    policy_error = _promotion_pull_request_policy_error(
+    target = PromotionPullRequestTarget(
         repo=repo_slug,
         base=clean_base,
         head=clean_head,
         title=clean_title,
         draft=bool(draft),
     )
-    if policy_error:
+    try:
+        PROMOTION_PULL_REQUEST_POLICY.validate(target)
+    except PromotionPullRequestPolicyViolation as exc:
         return json.dumps({
             "error": "promotion_pull_request_policy_violation",
-            "message": policy_error,
+            "message": str(exc),
             "repo": repo_slug,
         })
 
@@ -829,39 +800,24 @@ async def _handle_create_github_pull_request(
     auth_statuses = {401, 403, 404}
     for index, candidate in enumerate(write_candidates):
         try:
-            payload = await async_create_repo_pull_request(
-                repo_slug,
-                base=clean_base,
-                head=clean_head,
-                title=clean_title,
+            result = await async_reconcile_promotion_pull_request(
+                target,
                 body=clean_body,
-                draft=bool(draft),
                 token=candidate["token"],
             )
+        except PromotionPullRequestOperationError as exc:
+            return json.dumps({
+                "error": exc.code,
+                "message": exc.detail,
+                "status_code": exc.status_code,
+                "repo": repo_slug,
+                "base": clean_base,
+                "head": clean_head,
+            })
         except GitHubConnectorError as exc:
             last_error = exc
             if exc.status_code in auth_statuses and index < len(write_candidates) - 1:
                 continue
-            lowered = exc.message.lower()
-            if exc.status_code == 422 and "no commits between" in lowered:
-                return json.dumps({
-                    "error": "no_commits_between",
-                    "message": exc.message,
-                    "status_code": 422,
-                    "repo": repo_slug,
-                    "base": clean_base,
-                    "head": clean_head,
-                })
-            if exc.status_code == 422 and "pull request already exists" in lowered:
-                return json.dumps({
-                    "error": "pull_request_exists",
-                    "existing": _existing_pull_request_number(exc.message),
-                    "message": exc.message,
-                    "status_code": 422,
-                    "repo": repo_slug,
-                    "base": clean_base,
-                    "head": clean_head,
-                })
             error_payload = {
                 "error": exc.message,
                 "status_code": exc.status_code,
@@ -873,21 +829,37 @@ async def _handle_create_github_pull_request(
                 error_payload["required_permission"] = "pull_requests:write"
             return json.dumps(error_payload)
 
-        pull_request = payload.get("pull_request")
-        pull_request = pull_request if isinstance(pull_request, dict) else {}
-        result = {
+        if result.settled_by == "create_conflict":
+            return json.dumps({
+                "error": "pull_request_exists",
+                "existing": result.number,
+                "message": result.conflict_message,
+                "status_code": 422,
+                "repo": repo_slug,
+                "base": clean_base,
+                "head": clean_head,
+            })
+
+        payload = {
             "repo": repo_slug,
-            "number": pull_request.get("number"),
-            "html_url": pull_request.get("html_url"),
-            "state": pull_request.get("state"),
-            "draft": bool(pull_request.get("draft")),
+            "number": result.number,
             "token_secret_key_used": bool(candidate.get("key_name")),
             "token_source": candidate["source"],
             "token_key_name": candidate.get("key_name"),
         }
+        if result.outcome == "created":
+            payload.update(
+                {
+                    "html_url": result.html_url,
+                    "state": result.state,
+                    "draft": result.draft,
+                }
+            )
+        else:
+            payload["outcome"] = result.outcome
         if last_error is not None:
-            result["fallback_from_status_code"] = last_error.status_code
-        return json.dumps(result, default=str)
+            payload["fallback_from_status_code"] = last_error.status_code
+        return json.dumps(payload, default=str)
 
     return json.dumps({"error": "No GitHub token candidates were available", "no_write_token": True})
 

--- a/brain/systems/runs/tool_catalog/handlers/github.py
+++ b/brain/systems/runs/tool_catalog/handlers/github.py
@@ -62,6 +62,14 @@ _SLACK_ORIGIN_REF_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_-])(slack:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+:[0-9.]+)"
 )
 
+PROMOTION_PULL_REQUEST_REPOS = frozenset({
+    "uwear-ai/uwear-backend",
+    "uwear-ai/uwearaiapp",
+})
+PROMOTION_PULL_REQUEST_BASE = "main"
+PROMOTION_PULL_REQUEST_HEAD = "staging"
+PROMOTION_PULL_REQUEST_TITLE = "Staging → main promotion"
+
 
 def _origin_ref_from_body(body: str | None) -> str | None:
     match = _SLACK_ORIGIN_REF_PATTERN.search(str(body or ""))
@@ -737,6 +745,27 @@ def _existing_pull_request_number(message: str) -> int | None:
     return None
 
 
+def _promotion_pull_request_policy_error(
+    *,
+    repo: str,
+    base: str,
+    head: str,
+    title: str,
+    draft: bool,
+) -> str | None:
+    if repo not in PROMOTION_PULL_REQUEST_REPOS:
+        return f"repository must be one of {sorted(PROMOTION_PULL_REQUEST_REPOS)}"
+    if base != PROMOTION_PULL_REQUEST_BASE:
+        return f"base must be {PROMOTION_PULL_REQUEST_BASE!r}"
+    if head != PROMOTION_PULL_REQUEST_HEAD:
+        return f"head must be {PROMOTION_PULL_REQUEST_HEAD!r}"
+    if title != PROMOTION_PULL_REQUEST_TITLE:
+        return f"title must be {PROMOTION_PULL_REQUEST_TITLE!r}"
+    if draft:
+        return "draft must be false"
+    return None
+
+
 async def _handle_create_github_pull_request(
     repo: str | None = None,
     base: str | None = None,
@@ -765,6 +794,19 @@ async def _handle_create_github_pull_request(
     clean_body = _clean(body)
     if not clean_body:
         return json.dumps({"error": "create_github_pull_request requires a non-empty body"})
+    policy_error = _promotion_pull_request_policy_error(
+        repo=repo_slug,
+        base=clean_base,
+        head=clean_head,
+        title=clean_title,
+        draft=bool(draft),
+    )
+    if policy_error:
+        return json.dumps({
+            "error": "promotion_pull_request_policy_violation",
+            "message": policy_error,
+            "repo": repo_slug,
+        })
 
     candidates = await _github_token_candidates(
         repo_slug=repo_slug,

--- a/tests/test_create_github_pull_request_tool.py
+++ b/tests/test_create_github_pull_request_tool.py
@@ -18,6 +18,20 @@ from brain.systems.runs.tool_catalog.handlers.github import (
 
 
 _H = "brain.systems.runs.tool_catalog.handlers.github"
+_P = "brain.systems.cortex.project_context.github_promotion"
+
+
+def _promotion_read_patches():
+    return (
+        patch(
+            f"{_P}.async_compare_repo_branches",
+            new=AsyncMock(return_value={"ahead_by": 1, "commits": []}),
+        ),
+        patch(
+            f"{_P}.async_list_repo_pull_requests",
+            new=AsyncMock(return_value={"pull_requests": []}),
+        ),
+    )
 
 
 def _vault_patches(*, bound_env: dict, secrets: list, get_secret=None):
@@ -84,10 +98,19 @@ async def test_create_github_pull_request_happy_path_opens_real_pull_request():
         bound_env={"GITHUB_TOKEN": "write-token"},
         secrets=[],
     )
-    with bind_agent_context({"user_id": "u", "org_id": "o"}), p1, p2, p3, patch(
-        f"{_H}.async_create_repo_pull_request",
-        new=AsyncMock(return_value=created),
-    ) as create:
+    compare, search = _promotion_read_patches()
+    with (
+        bind_agent_context({"user_id": "u", "org_id": "o"}),
+        p1,
+        p2,
+        p3,
+        compare,
+        search,
+        patch(
+            f"{_P}.async_create_repo_pull_request",
+            new=AsyncMock(return_value=created),
+        ) as create,
+    ):
         result = await _handle_create_github_pull_request(
             repo="https://github.com/uwear-ai/uwear-backend.git",
             base="main",
@@ -121,9 +144,9 @@ async def test_create_github_pull_request_happy_path_opens_real_pull_request():
 @pytest.mark.asyncio
 async def test_create_github_pull_request_returns_no_write_token():
     with patch(
-        f"{_H}.async_create_repo_pull_request",
+        f"{_H}.async_reconcile_promotion_pull_request",
         new=AsyncMock(),
-    ) as create:
+    ) as reconcile:
         result = await _handle_create_github_pull_request(
             repo="uwear-ai/uwear-backend",
             base="main",
@@ -136,7 +159,7 @@ async def test_create_github_pull_request_returns_no_write_token():
     assert payload["no_write_token"] is True
     assert payload["status_code"] == 401
     assert payload["repo"] == "uwear-ai/uwear-backend"
-    create.assert_not_awaited()
+    reconcile.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -145,13 +168,22 @@ async def test_create_github_pull_request_maps_no_commits_422():
         bound_env={"GITHUB_TOKEN": "write-token"},
         secrets=[],
     )
-    with bind_agent_context({"user_id": "u", "org_id": "o"}), p1, p2, p3, patch(
-        f"{_H}.async_create_repo_pull_request",
-        new=AsyncMock(
-            side_effect=GitHubConnectorError(
-                status_code=422,
-                message="Validation Failed: No commits between main and staging",
-            )
+    compare, search = _promotion_read_patches()
+    with (
+        bind_agent_context({"user_id": "u", "org_id": "o"}),
+        p1,
+        p2,
+        p3,
+        compare,
+        search,
+        patch(
+            f"{_P}.async_create_repo_pull_request",
+            new=AsyncMock(
+                side_effect=GitHubConnectorError(
+                    status_code=422,
+                    message="Validation Failed: No commits between main and staging",
+                )
+            ),
         ),
     ):
         result = await _handle_create_github_pull_request(
@@ -175,16 +207,26 @@ async def test_create_github_pull_request_maps_already_exists_422():
         bound_env={"GITHUB_TOKEN": "write-token"},
         secrets=[],
     )
-    with bind_agent_context({"user_id": "u", "org_id": "o"}), p1, p2, p3, patch(
-        f"{_H}.async_create_repo_pull_request",
-        new=AsyncMock(
-            side_effect=GitHubConnectorError(
-                status_code=422,
-                message=(
-                    "Validation Failed: A pull request already exists for "
-                    "uwear-ai:staging: https://github.com/uwear-ai/uwear-backend/pull/841"
-                ),
-            )
+    compare, search = _promotion_read_patches()
+    with (
+        bind_agent_context({"user_id": "u", "org_id": "o"}),
+        p1,
+        p2,
+        p3,
+        compare,
+        search,
+        patch(
+            f"{_P}.async_create_repo_pull_request",
+            new=AsyncMock(
+                side_effect=GitHubConnectorError(
+                    status_code=422,
+                    message=(
+                        "Validation Failed: A pull request already exists for "
+                        "uwear-ai:staging: "
+                        "https://github.com/uwear-ai/uwear-backend/pull/841"
+                    ),
+                )
+            ),
         ),
     ):
         result = await _handle_create_github_pull_request(
@@ -222,16 +264,20 @@ async def test_create_github_pull_request_rejects_non_promotion_writes(overrides
         "draft": False,
         **overrides,
     }
-    with patch(
-        f"{_H}.async_create_repo_pull_request",
-        new=AsyncMock(),
-    ) as create:
+    with (
+        patch(f"{_H}._github_token_candidates", new=AsyncMock()) as candidates,
+        patch(
+            f"{_H}.async_reconcile_promotion_pull_request",
+            new=AsyncMock(),
+        ) as reconcile,
+    ):
         result = await _handle_create_github_pull_request(**arguments)
 
     payload = json.loads(result)
     assert payload["error"] == "promotion_pull_request_policy_violation"
     assert message in payload["message"]
-    create.assert_not_awaited()
+    candidates.assert_not_awaited()
+    reconcile.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_create_github_pull_request_tool.py
+++ b/tests/test_create_github_pull_request_tool.py
@@ -48,8 +48,9 @@ def test_create_github_pull_request_definition_and_registry_wiring():
     assert "REAL GitHub pull request" in description
     assert "public write" in description
     assert "never merges" in description
-    assert "Missions must restrict" in description
     assert "staging→main" in description
+    assert "configured Uwear repositories" in description
+    assert "non-draft" in description
     assert schema["required"] == ["repo", "base", "head", "title", "body"]
     assert schema["properties"]["draft"]["default"] is False
     assert name in {tool["name"] for tool in COORDINATOR_TOOLS}
@@ -91,7 +92,7 @@ async def test_create_github_pull_request_happy_path_opens_real_pull_request():
             repo="https://github.com/uwear-ai/uwear-backend.git",
             base="main",
             head="staging",
-            title="Promote staging to main",
+            title="Staging → main promotion",
             body="Evergreen promotion pull request.",
         )
 
@@ -110,7 +111,7 @@ async def test_create_github_pull_request_happy_path_opens_real_pull_request():
         "uwear-ai/uwear-backend",
         base="main",
         head="staging",
-        title="Promote staging to main",
+        title="Staging → main promotion",
         body="Evergreen promotion pull request.",
         draft=False,
         token="write-token",
@@ -127,7 +128,7 @@ async def test_create_github_pull_request_returns_no_write_token():
             repo="uwear-ai/uwear-backend",
             base="main",
             head="staging",
-            title="Promote staging to main",
+            title="Staging → main promotion",
             body="Evergreen promotion pull request.",
         )
 
@@ -157,7 +158,7 @@ async def test_create_github_pull_request_maps_no_commits_422():
             repo="uwear-ai/uwear-backend",
             base="main",
             head="staging",
-            title="Promote staging to main",
+            title="Staging → main promotion",
             body="Evergreen promotion pull request.",
         )
 
@@ -190,7 +191,7 @@ async def test_create_github_pull_request_maps_already_exists_422():
             repo="uwear-ai/uwear-backend",
             base="main",
             head="staging",
-            title="Promote staging to main",
+            title="Staging → main promotion",
             body="Evergreen promotion pull request.",
         )
 
@@ -198,6 +199,39 @@ async def test_create_github_pull_request_maps_already_exists_422():
     assert payload["error"] == "pull_request_exists"
     assert payload["existing"] == 841
     assert payload["status_code"] == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"repo": "acme/widgets"}, "repository must be one of"),
+        ({"base": "release"}, "base must be 'main'"),
+        ({"head": "feature"}, "head must be 'staging'"),
+        ({"title": "Open my feature PR"}, "title must be 'Staging → main promotion'"),
+        ({"draft": True}, "draft must be false"),
+    ],
+)
+async def test_create_github_pull_request_rejects_non_promotion_writes(overrides, message):
+    arguments = {
+        "repo": "uwear-ai/uwear-backend",
+        "base": "main",
+        "head": "staging",
+        "title": "Staging → main promotion",
+        "body": "## Commits being promoted\n\n- Fix release issue (#475)",
+        "draft": False,
+        **overrides,
+    }
+    with patch(
+        f"{_H}.async_create_repo_pull_request",
+        new=AsyncMock(),
+    ) as create:
+        result = await _handle_create_github_pull_request(**arguments)
+
+    payload = json.loads(result)
+    assert payload["error"] == "promotion_pull_request_policy_violation"
+    assert message in payload["message"]
+    create.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -139,9 +139,14 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     await session.flush()
 
-    assert result == {"upserted": 3, "retired": 0}
+    assert result == {"upserted": 4, "retired": 0}
     jobs = {job["job_key"]: job for job in await async_list_scheduler_jobs(session)}
-    assert set(jobs) == {"curiosity_cron", "nightly_sleep", "uwear_aws_health_scan"}
+    assert set(jobs) == {
+        "curiosity_cron",
+        "nightly_sleep",
+        "uwear_aws_health_scan",
+        "uwear_staging_promotion_pr",
+    }
     assert jobs["nightly_sleep"]["owner_mode"] == "scheduler"
     assert jobs["nightly_sleep"]["handler_kind"] == "scheduler_builtin"
     assert jobs["nightly_sleep"]["default_payload"]["scheduler_split_steps"] is True
@@ -177,6 +182,43 @@ async def test_uwear_aws_health_scan_catalog_config(session):
     ]
 
 
+async def test_uwear_staging_promotion_pr_catalog_config(session):
+    now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
+
+    await async_sync_scheduler_catalog(session, timezone_name="America/Toronto", now=now)
+    jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
+    job = jobs["uwear_staging_promotion_pr"]
+
+    catalog_keys = [definition["job_key"] for definition in scheduler_catalog.SCHEDULER_CATALOG]
+    assert catalog_keys.index("uwear_staging_promotion_pr") + 1 == catalog_keys.index(
+        "uwear_aws_health_scan"
+    )
+    assert job.cron_expr == "0 * * * *"
+    assert job.timezone == "UTC"
+    assert job.misfire_policy == "skip"
+    assert job.timeout_seconds == 300
+    assert job.max_concurrency == 1
+    assert job.retry_policy == {"max_attempts": 1, "backoff_seconds": 0}
+    assert job.task_contract["allowed_actions"] == [
+        "scheduler.run",
+        "create_github_pull_request",
+    ]
+    assert build_scheduler_step_plan(job) == [
+        {
+            "step_key": "uwear_staging_promotion_pr",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": "brain.app.scheduler.programs:uwear_staging_promotion_pr",
+            "payload": {"program": "uwear_staging_promotion_pr"},
+            "command": [
+                "python3",
+                "-m",
+                "brain.jobs.pipelines.staging_promotion_pr",
+            ],
+        }
+    ]
+
+
 async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_restart(session):
     first_boot = datetime(2026, 4, 20, 0, 0, tzinfo=timezone.utc)
     await async_sync_scheduler_catalog(session, timezone_name="UTC", now=first_boot)
@@ -187,8 +229,8 @@ async def test_sync_scheduler_catalog_is_idempotent_and_reseeds_forward_on_resta
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=restart)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 3, "retired": 0}
-    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 3
+    assert result == {"upserted": 4, "retired": 0}
+    assert await session.scalar(select(func.count()).select_from(SchedulerJob)) == 4
     assert {key: job.id for key, job in jobs.items()} == first_ids
     assert all(job.next_run_at > restart for job in jobs.values())
     assert await async_materialize_due_runs(session, now=restart) == []
@@ -220,12 +262,17 @@ async def test_sync_scheduler_catalog_retires_jobs_dropped_from_full_catalog(ses
     result = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     jobs = {job.job_key: job for job in (await session.scalars(select(SchedulerJob))).all()}
 
-    assert result == {"upserted": 1, "retired": 2}
+    assert result == {"upserted": 1, "retired": 3}
     assert jobs["nightly_sleep"].enabled is True
     assert jobs["curiosity_cron"].enabled is False
     assert jobs["curiosity_cron"].pause_reason == "removed from scheduler catalog"
     assert jobs["uwear_aws_health_scan"].enabled is False
     assert jobs["uwear_aws_health_scan"].pause_reason == "removed from scheduler catalog"
+    assert jobs["uwear_staging_promotion_pr"].enabled is False
+    assert (
+        jobs["uwear_staging_promotion_pr"].pause_reason
+        == "removed from scheduler catalog"
+    )
 
     repeated = await async_sync_scheduler_catalog(session, timezone_name="UTC", now=now)
     assert repeated == {"upserted": 1, "retired": 0}
@@ -237,9 +284,9 @@ async def test_scheduler_daemon_startup_syncs_catalog_before_snapshot(session):
     result = await async_scheduler_daemon_startup(session, now=now, timezone_name="UTC")
 
     assert result["ok"] is True
-    assert result["catalog"] == {"upserted": 3, "retired": 0}
-    assert result["snapshot"]["summary"]["jobs_total"] == 3
-    assert result["snapshot"]["summary"]["jobs_enabled"] == 3
+    assert result["catalog"] == {"upserted": 4, "retired": 0}
+    assert result["snapshot"]["summary"]["jobs_total"] == 4
+    assert result["snapshot"]["summary"]["jobs_enabled"] == 4
     assert all(job["next_run_at"] > now.isoformat() for job in result["snapshot"]["jobs"])
 
 

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -1,0 +1,259 @@
+"""Tests for the scheduled staging-to-main promotion PR reconciler."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from brain.jobs.pipelines import staging_promotion_pr
+from brain.systems.cortex.project_context.github import (
+    GitHubConnectorError,
+    async_compare_repo_branches,
+)
+from brain.systems.runs.tool_catalog.handlers.github import (
+    PROMOTION_PULL_REQUEST_TITLE,
+)
+from brain.systems.vault.github_app_mint import DEFAULT_INSTALLATION_PERMISSIONS
+
+
+REPO = "uwear-ai/uwear-backend"
+COMPARE_PAYLOAD = {
+    "repo": REPO,
+    "base": "main",
+    "head": "staging",
+    "status": "ahead",
+    "ahead_by": 2,
+    "commits": [
+        {
+            "sha": "abc123456789",
+            "html_url": f"https://github.com/{REPO}/commit/abc123456789",
+            "subject": "Fix generation status (#475)",
+        },
+        {
+            "sha": "def987654321",
+            "html_url": f"https://github.com/{REPO}/commit/def987654321",
+            "subject": "Harden scheduler guard (#441) (#445)",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_ahead_repository_is_idempotent_across_repeated_runs(monkeypatch):
+    open_pulls: list[dict] = []
+    compare = AsyncMock(return_value=COMPARE_PAYLOAD)
+    list_pulls = AsyncMock(
+        side_effect=lambda *args, **kwargs: {"pull_requests": list(open_pulls)}
+    )
+
+    async def create_pull(**arguments):
+        open_pulls.append({
+            "number": 901,
+            "base": {"ref": "main"},
+            "head": {"ref": "staging"},
+        })
+        return json.dumps({
+            "repo": REPO,
+            "number": 901,
+            "html_url": f"https://github.com/{REPO}/pull/901",
+        })
+
+    create = AsyncMock(side_effect=create_pull)
+    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_handle_create_github_pull_request",
+        create,
+    )
+
+    first = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
+    second = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
+
+    assert first["outcome"] == "created"
+    assert second == {"repo": REPO, "outcome": "already_open", "number": 901}
+    assert compare.await_count == 2
+    assert list_pulls.await_count == 2
+    create.assert_awaited_once()
+    assert create.await_args.kwargs["title"] == PROMOTION_PULL_REQUEST_TITLE
+    assert create.await_args.kwargs["draft"] is False
+    body = create.await_args.kwargs["body"]
+    assert "Fix generation status (#475)" in body
+    assert "Harden scheduler guard (#441) (#445)" in body
+    assert f"[#441](https://github.com/{REPO}/issues/441)" in body
+    assert f"[#445](https://github.com/{REPO}/issues/445)" in body
+    assert f"[#475](https://github.com/{REPO}/issues/475)" in body
+    assert list_pulls.await_args.kwargs == {
+        "token": "app-token",
+        "state": "open",
+        "base": "main",
+        "head": "staging",
+        "limit": 100,
+    }
+
+
+@pytest.mark.asyncio
+async def test_identical_repository_settles_without_search_or_create(monkeypatch):
+    compare = AsyncMock(return_value={**COMPARE_PAYLOAD, "status": "identical", "ahead_by": 0})
+    list_pulls = AsyncMock()
+    create = AsyncMock()
+    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_handle_create_github_pull_request",
+        create,
+    )
+
+    result = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
+
+    assert result == {"repo": REPO, "outcome": "no_diff"}
+    list_pulls.assert_not_awaited()
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_existing_open_promotion_pr_is_not_duplicated(monkeypatch):
+    compare = AsyncMock(return_value=COMPARE_PAYLOAD)
+    list_pulls = AsyncMock(return_value={
+        "pull_requests": [
+            {
+                "number": 900,
+                "base": {"ref": "main"},
+                "head": {"ref": "staging"},
+            }
+        ]
+    })
+    create = AsyncMock()
+    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_handle_create_github_pull_request",
+        create,
+    )
+
+    result = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
+
+    assert result == {"repo": REPO, "outcome": "already_open", "number": 900}
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_api_error_is_logged_and_other_repository_still_settles(monkeypatch, caplog):
+    actor = staging_promotion_pr.PromotionActor(user_id="user-1", org_id="org-1")
+    reconcile = AsyncMock(
+        side_effect=[
+            GitHubConnectorError(status_code=502, message="GitHub unavailable"),
+            {"repo": "uwear-ai/uwearaiapp", "outcome": "no_diff"},
+        ]
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_promotion_actor",
+        AsyncMock(return_value=actor),
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_repo_token",
+        AsyncMock(return_value="app-token"),
+    )
+    monkeypatch.setattr(staging_promotion_pr, "reconcile_repository", reconcile)
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is False
+    assert result["failures"] == 1
+    assert reconcile.await_count == 2
+    assert "Promotion PR reconciliation failed" in caplog.text
+    assert "GitHub unavailable" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_repo_token_uses_only_the_project_bound_github_app(monkeypatch):
+    actor = staging_promotion_pr.PromotionActor(user_id="user-1", org_id="org-1")
+    resolve = AsyncMock(return_value={"GITHUB_TOKEN": "minted-app-token"})
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "async_resolve_project_bound_env_tokens",
+        resolve,
+    )
+
+    token = await staging_promotion_pr._repo_token(REPO, actor)
+
+    assert token == "minted-app-token"
+    resolve.assert_awaited_once_with(
+        actor_user_id="user-1",
+        org_id="org-1",
+        project_slug=REPO,
+        github_app_only=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_reconciliation_exits_nonzero_for_scheduler_failure_guard(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "run_promotion_job",
+        AsyncMock(return_value={
+            "job": "uwear_staging_promotion_pr",
+            "ok": False,
+            "failures": 1,
+            "results": [],
+        }),
+    )
+
+    assert await staging_promotion_pr.async_main() == 1
+
+
+@pytest.mark.asyncio
+async def test_compare_connector_reads_ahead_count_and_commit_subjects():
+    response = {
+        "status": "ahead",
+        "ahead_by": 1,
+        "commits": [
+            {
+                "sha": "abc123",
+                "html_url": f"https://github.com/{REPO}/commit/abc123",
+                "commit": {"message": "Fix promotion flow (#475)\n\nLong explanation"},
+            }
+        ],
+    }
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(return_value=response),
+    ) as request:
+        result = await async_compare_repo_branches(
+            REPO,
+            "main",
+            "staging",
+            token="app-token",
+        )
+
+    assert result["ahead_by"] == 1
+    assert result["commits"] == [
+        {
+            "sha": "abc123",
+            "html_url": f"https://github.com/{REPO}/commit/abc123",
+            "subject": "Fix promotion flow (#475)",
+        }
+    ]
+    request.assert_awaited_once()
+    assert request.await_args.args[1:] == (
+        "GET",
+        f"/repos/{REPO}/compare/main...staging",
+    )
+    assert request.await_args.kwargs["token"] == "app-token"
+
+
+def test_promotion_run_mints_a_token_that_cannot_merge():
+    assert DEFAULT_INSTALLATION_PERMISSIONS == {
+        "issues": "write",
+        "contents": "read",
+        "pull_requests": "write",
+        "checks": "read",
+    }
+    assert DEFAULT_INSTALLATION_PERMISSIONS["contents"] != "write"

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -1,20 +1,31 @@
 """Tests for the scheduled staging-to-main promotion PR reconciler."""
 from __future__ import annotations
 
-import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
+import uuid
 
+from cryptography.fernet import Fernet
 import pytest
 
 from brain.jobs.pipelines import staging_promotion_pr
+from brain.platform.db.models.environment import TargetRegistry  # noqa: F401
+from brain.platform.db.models.org import Org, User
+from brain.platform.db.models.run import AgentRun  # noqa: F401
+from brain.platform.db.models.vault import (
+    Secret,
+    VaultAccessLog,
+    VaultProjectBinding,
+)
+from brain.systems.cortex.project_context import github_promotion
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
     async_compare_repo_branches,
 )
-from brain.systems.runs.tool_catalog.handlers.github import (
-    PROMOTION_PULL_REQUEST_TITLE,
+from brain.systems.cortex.project_context.github_promotion import (
+    PROMOTION_PULL_REQUEST_POLICY,
+    PromotionPullRequestResult,
 )
-from brain.systems.vault.github_app_mint import DEFAULT_INSTALLATION_PERMISSIONS
 
 
 REPO = "uwear-ai/uwear-backend"
@@ -39,6 +50,15 @@ COMPARE_PAYLOAD = {
 }
 
 
+def _register_sqlite_functions(dbapi_conn, connection_record):
+    dbapi_conn.create_function(
+        "NOW",
+        0,
+        lambda: datetime.now(timezone.utc).isoformat(),
+    )
+    dbapi_conn.create_function("gen_random_uuid", 0, lambda: str(uuid.uuid4()))
+
+
 @pytest.mark.asyncio
 async def test_ahead_repository_is_idempotent_across_repeated_runs(monkeypatch):
     open_pulls: list[dict] = []
@@ -47,36 +67,49 @@ async def test_ahead_repository_is_idempotent_across_repeated_runs(monkeypatch):
         side_effect=lambda *args, **kwargs: {"pull_requests": list(open_pulls)}
     )
 
-    async def create_pull(**arguments):
+    async def create_pull(*args, **arguments):
+        assert args == (REPO,)
         open_pulls.append({
             "number": 901,
             "base": {"ref": "main"},
             "head": {"ref": "staging"},
         })
-        return json.dumps({
+        return {
             "repo": REPO,
-            "number": 901,
-            "html_url": f"https://github.com/{REPO}/pull/901",
-        })
+            "pull_request": {
+                "number": 901,
+                "html_url": f"https://github.com/{REPO}/pull/901",
+                "state": "open",
+                "draft": False,
+            },
+        }
 
     create = AsyncMock(side_effect=create_pull)
-    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
-    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_handle_create_github_pull_request",
-        create,
+    monkeypatch.setattr(github_promotion, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(github_promotion, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(github_promotion, "async_create_repo_pull_request", create)
+
+    target = PROMOTION_PULL_REQUEST_POLICY.target_for(REPO)
+    first = await github_promotion.async_reconcile_promotion_pull_request(
+        target,
+        token="app-token",
+    )
+    second = await github_promotion.async_reconcile_promotion_pull_request(
+        target,
+        token="app-token",
     )
 
-    first = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
-    second = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
-
-    assert first["outcome"] == "created"
-    assert second == {"repo": REPO, "outcome": "already_open", "number": 901}
+    assert first.outcome == "created"
+    assert second == PromotionPullRequestResult(
+        repo=REPO,
+        outcome="already_open",
+        settled_by="search",
+        number=901,
+    )
     assert compare.await_count == 2
     assert list_pulls.await_count == 2
     create.assert_awaited_once()
-    assert create.await_args.kwargs["title"] == PROMOTION_PULL_REQUEST_TITLE
+    assert create.await_args.kwargs["title"] == PROMOTION_PULL_REQUEST_POLICY.title
     assert create.await_args.kwargs["draft"] is False
     body = create.await_args.kwargs["body"]
     assert "Fix generation status (#475)" in body
@@ -98,17 +131,20 @@ async def test_identical_repository_settles_without_search_or_create(monkeypatch
     compare = AsyncMock(return_value={**COMPARE_PAYLOAD, "status": "identical", "ahead_by": 0})
     list_pulls = AsyncMock()
     create = AsyncMock()
-    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
-    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_handle_create_github_pull_request",
-        create,
+    monkeypatch.setattr(github_promotion, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(github_promotion, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(github_promotion, "async_create_repo_pull_request", create)
+
+    result = await github_promotion.async_reconcile_promotion_pull_request(
+        PROMOTION_PULL_REQUEST_POLICY.target_for(REPO),
+        token="app-token",
     )
 
-    result = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
-
-    assert result == {"repo": REPO, "outcome": "no_diff"}
+    assert result == PromotionPullRequestResult(
+        repo=REPO,
+        outcome="no_diff",
+        settled_by="comparison",
+    )
     list_pulls.assert_not_awaited()
     create.assert_not_awaited()
 
@@ -126,18 +162,54 @@ async def test_existing_open_promotion_pr_is_not_duplicated(monkeypatch):
         ]
     })
     create = AsyncMock()
-    monkeypatch.setattr(staging_promotion_pr, "async_compare_repo_branches", compare)
-    monkeypatch.setattr(staging_promotion_pr, "async_list_repo_pull_requests", list_pulls)
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_handle_create_github_pull_request",
-        create,
+    monkeypatch.setattr(github_promotion, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(github_promotion, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(github_promotion, "async_create_repo_pull_request", create)
+
+    result = await github_promotion.async_reconcile_promotion_pull_request(
+        PROMOTION_PULL_REQUEST_POLICY.target_for(REPO),
+        token="app-token",
     )
 
-    result = await staging_promotion_pr.reconcile_repository(REPO, token="app-token")
-
-    assert result == {"repo": REPO, "outcome": "already_open", "number": 900}
+    assert result == PromotionPullRequestResult(
+        repo=REPO,
+        outcome="already_open",
+        settled_by="search",
+        number=900,
+    )
     create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_race_422_already_exists_settles_as_already_open(monkeypatch):
+    compare = AsyncMock(return_value=COMPARE_PAYLOAD)
+    list_pulls = AsyncMock(return_value={"pull_requests": []})
+    create = AsyncMock(
+        side_effect=GitHubConnectorError(
+            status_code=422,
+            message=(
+                "Validation Failed: A pull request already exists for "
+                "uwear-ai:staging: "
+                f"https://github.com/{REPO}/pull/901"
+            ),
+        )
+    )
+    monkeypatch.setattr(github_promotion, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(github_promotion, "async_list_repo_pull_requests", list_pulls)
+    monkeypatch.setattr(github_promotion, "async_create_repo_pull_request", create)
+
+    result = await github_promotion.async_reconcile_promotion_pull_request(
+        PROMOTION_PULL_REQUEST_POLICY.target_for(REPO),
+        token="app-token",
+    )
+
+    assert result == PromotionPullRequestResult(
+        repo=REPO,
+        outcome="already_open",
+        settled_by="create_conflict",
+        number=901,
+        conflict_message=create.side_effect.message,
+    )
 
 
 @pytest.mark.asyncio
@@ -146,7 +218,11 @@ async def test_api_error_is_logged_and_other_repository_still_settles(monkeypatc
     reconcile = AsyncMock(
         side_effect=[
             GitHubConnectorError(status_code=502, message="GitHub unavailable"),
-            {"repo": "uwear-ai/uwearaiapp", "outcome": "no_diff"},
+            PromotionPullRequestResult(
+                repo="uwear-ai/uwearaiapp",
+                outcome="no_diff",
+                settled_by="comparison",
+            ),
         ]
     )
     monkeypatch.setattr(
@@ -154,18 +230,27 @@ async def test_api_error_is_logged_and_other_repository_still_settles(monkeypatc
         "_promotion_actor",
         AsyncMock(return_value=actor),
     )
+    repo_token = AsyncMock(return_value="app-token")
+    monkeypatch.setattr(staging_promotion_pr, "_repo_token", repo_token)
     monkeypatch.setattr(
         staging_promotion_pr,
-        "_repo_token",
-        AsyncMock(return_value="app-token"),
+        "async_reconcile_promotion_pull_request",
+        reconcile,
     )
-    monkeypatch.setattr(staging_promotion_pr, "reconcile_repository", reconcile)
 
     result = await staging_promotion_pr.run_promotion_job()
 
     assert result["ok"] is False
     assert result["failures"] == 1
+    assert repo_token.await_count == len(staging_promotion_pr.CONFIGURED_REPOS)
     assert reconcile.await_count == 2
+    assert [call.args[0].repo for call in reconcile.await_args_list] == list(
+        staging_promotion_pr.CONFIGURED_REPOS
+    )
+    assert all(
+        call.kwargs == {"token": "app-token"}
+        for call in reconcile.await_args_list
+    )
     assert "Promotion PR reconciliation failed" in caplog.text
     assert "GitHub unavailable" in caplog.text
 
@@ -249,11 +334,88 @@ async def test_compare_connector_reads_ahead_count_and_commit_subjects():
     assert request.await_args.kwargs["token"] == "app-token"
 
 
-def test_promotion_run_mints_a_token_that_cannot_merge():
-    assert DEFAULT_INSTALLATION_PERMISSIONS == {
-        "issues": "write",
-        "contents": "read",
-        "pull_requests": "write",
-        "checks": "read",
-    }
-    assert DEFAULT_INSTALLATION_PERMISSIONS["contents"] != "write"
+@pytest.mark.asyncio
+async def test_job_minted_token_requests_read_only_contents_permission(
+    async_sqlite_session_factory,
+    monkeypatch,
+):
+    """Prove the job's minted App token is read-only for repository contents."""
+
+    from brain.systems.vault import _encrypt
+
+    monkeypatch.setenv("VAULT_MASTER_KEY", Fernet.generate_key().decode())
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            Secret.__table__,
+            VaultAccessLog.__table__,
+            VaultProjectBinding.__table__,
+        ],
+        connect_listener=_register_sqlite_functions,
+    )
+    org_id = "bbbbbbbb-0000-4000-8000-000000000001"
+    user_id = "aaaaaaaa-0000-4000-8000-000000000001"
+    session.add(Org(id=org_id, name="Promotion Org", slug="promotion-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=org_id,
+            name="Promotion Actor",
+            email="promotion@test.com",
+        )
+    )
+    secret = Secret(
+        key_name="GITHUB_APP__ILLO",
+        encrypted_value=_encrypt("github-app-blob"),
+        category="github_app",
+        org_id=org_id,
+        created_by_user_id=user_id,
+        updated_by_user_id=user_id,
+        agent_access_level="manual",
+    )
+    session.add(secret)
+    await session.flush()
+    session.add(
+        VaultProjectBinding(
+            secret_id=secret.id,
+            org_id=org_id,
+            created_by_user_id=user_id,
+            project_slug=REPO,
+            env_name="GITHUB_TOKEN",
+            active=True,
+        )
+    )
+    await session.commit()
+
+    class TestUnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            if exc_type:
+                await self.session.rollback()
+            else:
+                await self.session.commit()
+            return False
+
+    mint = AsyncMock(return_value="minted-app-token")
+    monkeypatch.setattr("brain.systems.vault.UnitOfWork", TestUnitOfWork)
+    monkeypatch.setattr(
+        "brain.systems.vault.github_app_mint.async_mint_installation_token",
+        mint,
+    )
+
+    token = await staging_promotion_pr._repo_token(
+        REPO,
+        staging_promotion_pr.PromotionActor(user_id=user_id, org_id=org_id),
+    )
+
+    assert token == "minted-app-token"
+    mint.assert_awaited_once()
+    assert mint.await_args.kwargs["repositories"] == ["uwear-backend"]
+    assert mint.await_args.kwargs["permissions"]["contents"] == "read"
+    assert mint.await_args.kwargs["permissions"]["contents"] != "write"


### PR DESCRIPTION
Closes #475

## What this does

GitHub won't re-open a staging→main PR once it has merged with no diff, so after every promotion the next one has to be recreated **by hand** — and humans forget, leaving fixes sitting on staging with no visible promotion vehicle. This adds the hourly job that recreates it.

Workflow convenience only: deploy-state truth is derived from git ancestry and is indifferent to whether the PR exists.

**Authorization:** built on your decision of 2026-07-25 (`decisions/illo-475.md`), at the rescoped size. Note the issue **body** still opens with "BLOCKED ON A HUMAN DECISION — do not pick up" — that line is stale, superseded by your own 2026-07-24 comment on the ticket and the decision file. Worth deleting, along with the `ready-for-agent` label the body says it doesn't have.

## Everything except the trigger already existed

#462 shipped `create_github_pull_request` and the `pull_requests:write` mint, and the installation already holds the grant. This PR adds the automation and the fence around it.

- **Catalog + program** — `uwear_staging_promotion_pr`, hourly, `misfire_policy=skip`, `max_concurrency=1`, 300s timeout.
- **The job** — per configured repo: compare `main...staging`; `ahead_by == 0` settles quietly with no PR; otherwise search for an open `base=main head=staging` PR and create one only if none exists.
- **Policy fence** — the shared policy rejects, *before* token resolution and before any API call, anything that is not one of the two configured repos, `staging`→`main`, the exact promotion title, and non-draft. The tool description was narrowed to match, so this can't become a general "agents may open PRs" capability by the back door.
- **Connector** — extracted the shared compare request; the new reader returns `ahead_by` plus commit subjects for the PR body. `async_compare_commits` keeps its signature and behavior for existing callers.

## How to check it (no code reading required)

```bash
cd <checkout> && git checkout illo-qa/475-fix1
venv/bin/python -m pytest tests/test_staging_promotion_pr.py tests/test_create_github_pull_request_tool.py tests/test_scheduler.py tests/test_architecture_boundaries.py -q
```

Result on this branch: **65 passed**.

**The live check is the interesting one, and it is a first:** `pull_requests:write` has never actually been exercised against GitHub — every recent PR in this repo is authored by `redawear`. The first run of this job with staging ahead is that proof. If the installation grant were somehow missing, it fails loudly with `required_permission: pull_requests:write` rather than silently.

## Acceptance checks

1. Staging ahead + no open promotion PR ⇒ exactly one PR within the hour, titled for promotion, body listing the commits and linked issues being promoted.
2. Promotion PR already open ⇒ zero duplicates across repeated runs.
3. `main...staging` identical ⇒ no PR, no error, quiet settle — the no-diff case that motivated the ticket.
4. The token the job mints still carries `contents: read`, so it structurally cannot merge.

## Reviewer notes — what the maintainability review found

A Codex thermo-nuclear review ran against the first commit and returned **two blocking findings**. One was in scope and is fixed in the second commit; one is filed.

**Fixed — the pipeline was calling an agent-tool handler.** It imported the *private* `_handle_create_github_pull_request`, bound synthetic agent context, and JSON round-tripped the result, while resolving a second token. The policy and the typed compare→search→create operation now live in `brain/systems/cortex/project_context/github_promotion.py`, below both callers; the job calls it directly (‑132 lines) and the tool handler is a thin adapter that validates the same policy and serializes only at the agent boundary. The architecture-boundary test enforces that the new module sits where `brain.jobs` may import it.

**Filed as #501 — dual dispatch** across `build_scheduler_step_plan` and `get_step_specs` in `programs.py`. Real finding, but it refactors pre-existing shared machinery that every scheduler program rides on; doing it inside a feature PR would mix a behavior change with a cross-cutting refactor. #501 also carries two smaller follow-ups (a true concurrent-race test, and a changed malformed-response diagnostic string in `async_compare_commits`).

Two things the review **verified with code evidence**, which matter more than the diff here:

- **Merge impossibility — confirmed, with a caveat now stated honestly.** The job's resolver requests App-only tokens and mints with `contents: read`; neither job nor resolver exposes a permissions override, and the handler has no merge operation. The caveat: the tool schema still accepts `token_secret_key`, which could select a broader non-minted PAT — so the structural guarantee holds for **tokens this job mints**, not for every token the general handler could ever be handed. The test used to assert only a global constant; it now drives the real resolver path and claims only what it proves.
- **Idempotency — two overlapping runs can both reach create.** `max_concurrency=1` is not a lock. The real backstop is GitHub's one-open-PR invariant: a 422 "pull request already exists" is normalized and treated as settled. Two open PRs are therefore impossible; if GitHub ever changed that wording, the result would be a *failed run*, not a duplicate PR. Worth knowing, since the whole point of the job is to not spam promotion PRs.
- **Failure isolation — confirmed.** Repo A failing does not stop repo B, and the run still exits nonzero so the scheduler failure guard sees it.

## Related

- #499, #501 — deferred structural findings from this run's two reviews.
- #496 / #498 and #497 / #500 — the AWS-monitor incident work from the same run; all three branches merge clean onto `main` in any order.

<sub>Opened by Routine R3 (Illospace ticket worker). Implemented and fix-passed by Codex (gpt-5.6-sol) workers, reviewed by a Codex maintainability pass, judged and landed by the orchestrator. Draft — Reda merges.</sub>
