### PR TITLE
feat(runs): stamp the registry side-effect class on tool events (#507)

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -62,6 +62,7 @@ from brain.systems.runs.cortex.read_models import (
     public_run_debug_event_payload,
     run_stream_payload,
 )
+from brain.systems.runs.events import tool_call_write_timing
 from brain.systems.runs.failures import public_run_failure
 
 
@@ -850,12 +851,16 @@ async def _read_run_get(
                 AgentRunEventRow.event_type.like("run.tool_%"),
             )
             .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
-            .limit(limit)
         )
+        tool_events = list((await db.scalars(tool_stmt)).all())
         payload["tool_events"] = [
             _serialize_run_event(event, failure)
-            for event in (await db.scalars(tool_stmt)).all()
+            for event in tool_events[:limit]
         ]
+        payload["tool_call_summary"] = {
+            "run_id": run_id,
+            **tool_call_write_timing(tool_events),
+        }
     if bool(arguments.get("include_artifacts", True)):
         artifact_stmt = (
             select(AgentRunArtifactRow)

--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -62,8 +62,8 @@ from brain.systems.runs.cortex.read_models import (
     public_run_debug_event_payload,
     run_stream_payload,
 )
-from brain.systems.runs.events import tool_call_write_timing
 from brain.systems.runs.failures import public_run_failure
+from brain.systems.runs.tool_event_read_model import tool_call_summary
 
 
 router = APIRouter(tags=["agent-mcp"], dependencies=[Depends(rate_limit)])
@@ -851,16 +851,13 @@ async def _read_run_get(
                 AgentRunEventRow.event_type.like("run.tool_%"),
             )
             .order_by(AgentRunEventRow.sequence_no.asc(), AgentRunEventRow.id.asc())
+            .limit(limit)
         )
-        tool_events = list((await db.scalars(tool_stmt)).all())
         payload["tool_events"] = [
             _serialize_run_event(event, failure)
-            for event in tool_events[:limit]
+            for event in (await db.scalars(tool_stmt)).all()
         ]
-        payload["tool_call_summary"] = {
-            "run_id": run_id,
-            **tool_call_write_timing(tool_events),
-        }
+        payload["tool_call_summary"] = await tool_call_summary(db, run_id)
     if bool(arguments.get("include_artifacts", True)):
         artifact_stmt = (
             select(AgentRunArtifactRow)

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -25,7 +25,6 @@ from brain.systems.runs.tool_catalog.registry import (
     action_policy_for_tool,
     get_tool_registration,
     output_budget_chars_for_tool,
-    side_effect_class_for_tool,
 )
 from brain.systems.runs.tool_outcomes import (
     DEFAULT_TOOL_FAILURE_CATEGORY,
@@ -563,6 +562,7 @@ async def async_emit_resolved_tool_call(
     if run_id and idea_id:
         from brain.systems.runs.events import async_record_tool_call
 
+        registration = get_tool_registration(resolved.tool_name)
         await async_record_tool_call(
             run_id,
             idea_id,
@@ -570,7 +570,11 @@ async def async_emit_resolved_tool_call(
             resolved.tool_input,
             callback_result_text,
             source=tool_call_source,
-            side_effect=side_effect_class_for_tool(resolved.tool_name),
+            side_effect=(
+                registration.side_effect_class
+                if registration is not None
+                else "unknown"
+            ),
         )
 
 

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -20,10 +20,12 @@ from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy, LoopTermination
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
 from brain.systems.runs.direct_loop.final_reply_evidence import ToolResultEvidence
+from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
 from brain.systems.runs.tool_catalog.registry import (
     action_policy_for_tool,
     get_tool_registration,
     output_budget_chars_for_tool,
+    side_effect_class_for_tool,
 )
 from brain.systems.runs.tool_outcomes import (
     DEFAULT_TOOL_FAILURE_CATEGORY,
@@ -165,8 +167,7 @@ def _must_finish_before_reporting(request: PendingToolCall) -> bool:
         return bool(getattr(request.handler, "_action_manifest_audited", False))
     if action_policy_for_tool(request.tool_name, kwargs=request.tool_input) is None:
         return False
-    side_effect = str(getattr(registration.side_effect_class, "value", registration.side_effect_class))
-    return side_effect not in {"read_only", "read_only_external"}
+    return is_write_side_effect_class(registration.side_effect_class)
 
 
 def _truncate_middle_text(text: str, max_chars: int) -> str:
@@ -569,6 +570,7 @@ async def async_emit_resolved_tool_call(
             resolved.tool_input,
             callback_result_text,
             source=tool_call_source,
+            side_effect=side_effect_class_for_tool(resolved.tool_name),
         )
 
 

--- a/brain/systems/runs/events.py
+++ b/brain/systems/runs/events.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from datetime import datetime, timezone
 from typing import Any
 
 from brain.systems.runs.domain import AgentRunEvent, EventVisibility
+from brain.systems.runs.tool_catalog.metadata import (
+    ToolSideEffectClass,
+    coerce_tool_side_effect_class,
+    is_write_side_effect_class,
+)
+from brain.systems.runs.tool_catalog.registry import side_effect_class_for_tool
 
 
 SECRET_TOOL_NAMES = {"brain_vault", "vault", "secrets"}
@@ -64,13 +72,21 @@ def tool_call_completed_payload(
     result: Any,
     *,
     source: str = "runner",
+    side_effect: ToolSideEffectClass | str | None = None,
 ) -> dict[str, Any]:
+    side_effect_class = (
+        side_effect_class_for_tool(tool_name)
+        if side_effect is None
+        else coerce_tool_side_effect_class(side_effect)
+    )
     return {
         "idea_id": idea_id,
         "tool_name": tool_name,
         "args": args or {},
         "result": redact_tool_call_result(tool_name, result),
         "source": source,
+        "side_effect": side_effect_class.value,
+        "is_write": is_write_side_effect_class(side_effect_class),
     }
 
 
@@ -82,6 +98,7 @@ async def async_record_tool_call(
     result: Any,
     *,
     source: str = "runner",
+    side_effect: ToolSideEffectClass | str | None = None,
     **_: Any,
 ) -> None:
     from brain.systems.runs.event_log import async_record_run_event
@@ -89,7 +106,14 @@ async def async_record_tool_call(
     await async_record_run_event(
         int(run_id),
         "run.tool_completed",
-        tool_call_completed_payload(idea_id, tool_name, args, result, source=source),
+        tool_call_completed_payload(
+            idea_id,
+            tool_name,
+            args,
+            result,
+            source=source,
+            side_effect=side_effect,
+        ),
         producer=source or "runner",
     )
 
@@ -103,7 +127,65 @@ async def async_record_tool_activity(
     source: str = "runner",
     **kwargs: Any,
 ) -> None:
-    await async_record_tool_call(run_id, kwargs.get("idea_id"), tool_name, args or {}, result, source=source)
+    await async_record_tool_call(
+        run_id,
+        kwargs.get("idea_id"),
+        tool_name,
+        args or {},
+        result,
+        source=source,
+        side_effect=kwargs.get("side_effect"),
+    )
+
+
+def tool_call_write_timing(
+    events: Iterable[Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Summarize the most recent stored write-class completed tool event."""
+    last_write_at: datetime | None = None
+    for event in events:
+        if str(getattr(event, "event_type", "") or "") not in {
+            "run.tool_completed",
+            "run.tool_failed",
+        }:
+            continue
+        payload = getattr(event, "payload", None)
+        payload = payload if isinstance(payload, dict) else {}
+        stored_is_write = payload.get("is_write")
+        is_write = (
+            stored_is_write
+            if isinstance(stored_is_write, bool)
+            else is_write_side_effect_class(payload.get("side_effect"))
+        )
+        called_at = getattr(event, "created_at", None)
+        if not is_write or not isinstance(called_at, datetime):
+            continue
+        if called_at.tzinfo is None:
+            called_at = called_at.replace(tzinfo=timezone.utc)
+        else:
+            called_at = called_at.astimezone(timezone.utc)
+        if last_write_at is None or called_at > last_write_at:
+            last_write_at = called_at
+
+    if last_write_at is None:
+        return {
+            "last_write_tool_call_at": None,
+            "seconds_since_last_write_tool_call": None,
+        }
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    else:
+        reference = reference.astimezone(timezone.utc)
+    return {
+        "last_write_tool_call_at": last_write_at.isoformat(),
+        "seconds_since_last_write_tool_call": max(
+            0,
+            int((reference - last_write_at).total_seconds()),
+        ),
+    }
 
 
 __all__ = [
@@ -115,4 +197,5 @@ __all__ = [
     "status_changed_event",
     "text_delta_event",
     "tool_call_completed_payload",
+    "tool_call_write_timing",
 ]

--- a/brain/systems/runs/events.py
+++ b/brain/systems/runs/events.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from datetime import datetime, timezone
 from typing import Any
 
 from brain.systems.runs.domain import AgentRunEvent, EventVisibility
 from brain.systems.runs.tool_catalog.metadata import (
     ToolSideEffectClass,
-    coerce_tool_side_effect_class,
     is_write_side_effect_class,
 )
-from brain.systems.runs.tool_catalog.registry import side_effect_class_for_tool
+from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 
 SECRET_TOOL_NAMES = {"brain_vault", "vault", "secrets"}
@@ -65,6 +62,29 @@ def redact_tool_call_result(tool_name: str, result: Any) -> str:
     return str(result or "")
 
 
+def _event_side_effect(
+    tool_name: str,
+    side_effect: ToolSideEffectClass | str | None,
+) -> tuple[str, bool]:
+    if side_effect is None:
+        registration = get_tool_registration(tool_name)
+        if registration is None:
+            return "unknown", True
+        side_effect_class = registration.side_effect_class
+    elif side_effect == "unknown":
+        return "unknown", True
+    else:
+        side_effect_class = (
+            side_effect
+            if isinstance(side_effect, ToolSideEffectClass)
+            else ToolSideEffectClass(str(side_effect))
+        )
+    return (
+        side_effect_class.value,
+        is_write_side_effect_class(side_effect_class),
+    )
+
+
 def tool_call_completed_payload(
     idea_id: str | None,
     tool_name: str,
@@ -74,19 +94,15 @@ def tool_call_completed_payload(
     source: str = "runner",
     side_effect: ToolSideEffectClass | str | None = None,
 ) -> dict[str, Any]:
-    side_effect_class = (
-        side_effect_class_for_tool(tool_name)
-        if side_effect is None
-        else coerce_tool_side_effect_class(side_effect)
-    )
+    side_effect_value, is_write = _event_side_effect(tool_name, side_effect)
     return {
         "idea_id": idea_id,
         "tool_name": tool_name,
         "args": args or {},
         "result": redact_tool_call_result(tool_name, result),
         "source": source,
-        "side_effect": side_effect_class.value,
-        "is_write": is_write_side_effect_class(side_effect_class),
+        "side_effect": side_effect_value,
+        "is_write": is_write,
     }
 
 
@@ -138,56 +154,6 @@ async def async_record_tool_activity(
     )
 
 
-def tool_call_write_timing(
-    events: Iterable[Any],
-    *,
-    now: datetime | None = None,
-) -> dict[str, Any]:
-    """Summarize the most recent stored write-class completed tool event."""
-    last_write_at: datetime | None = None
-    for event in events:
-        if str(getattr(event, "event_type", "") or "") not in {
-            "run.tool_completed",
-            "run.tool_failed",
-        }:
-            continue
-        payload = getattr(event, "payload", None)
-        payload = payload if isinstance(payload, dict) else {}
-        stored_is_write = payload.get("is_write")
-        is_write = (
-            stored_is_write
-            if isinstance(stored_is_write, bool)
-            else is_write_side_effect_class(payload.get("side_effect"))
-        )
-        called_at = getattr(event, "created_at", None)
-        if not is_write or not isinstance(called_at, datetime):
-            continue
-        if called_at.tzinfo is None:
-            called_at = called_at.replace(tzinfo=timezone.utc)
-        else:
-            called_at = called_at.astimezone(timezone.utc)
-        if last_write_at is None or called_at > last_write_at:
-            last_write_at = called_at
-
-    if last_write_at is None:
-        return {
-            "last_write_tool_call_at": None,
-            "seconds_since_last_write_tool_call": None,
-        }
-    reference = now or datetime.now(timezone.utc)
-    if reference.tzinfo is None:
-        reference = reference.replace(tzinfo=timezone.utc)
-    else:
-        reference = reference.astimezone(timezone.utc)
-    return {
-        "last_write_tool_call_at": last_write_at.isoformat(),
-        "seconds_since_last_write_tool_call": max(
-            0,
-            int((reference - last_write_at).total_seconds()),
-        ),
-    }
-
-
 __all__ = [
     "activity_event",
     "async_record_tool_activity",
@@ -197,5 +163,4 @@ __all__ = [
     "status_changed_event",
     "text_delta_event",
     "tool_call_completed_payload",
-    "tool_call_write_timing",
 ]

--- a/brain/systems/runs/presentation.py
+++ b/brain/systems/runs/presentation.py
@@ -14,9 +14,8 @@ from urllib.parse import urlparse
 
 from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.failures import failure_category_for_error, public_run_failure
-from brain.systems.runs.tool_catalog.metadata import (
-    coerce_tool_side_effect_class,
-    is_write_side_effect_class,
+from brain.systems.runs.tool_event_read_model import (
+    parse_persisted_tool_side_effect,
 )
 
 
@@ -74,7 +73,7 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
 
     raw = dict(payload or {})
     tool_name = _text(raw.get("tool_name") or raw.get("tool") or "tool") or "tool"
-    side_effect = coerce_tool_side_effect_class(raw.get("side_effect"))
+    side_effect = parse_persisted_tool_side_effect(raw)
     args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
     failure_summary = (
         _text(raw.get("error"))
@@ -104,8 +103,8 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
     }
     public["tool_name"] = tool_name
     public["tool"] = tool_name
-    public["side_effect"] = side_effect.value
-    public["is_write"] = is_write_side_effect_class(side_effect)
+    public["side_effect"] = side_effect.side_effect
+    public["is_write"] = side_effect.is_write
     public["args"] = public_tool_args(args)
     public["tool_display"] = display
     public["display"] = display

--- a/brain/systems/runs/presentation.py
+++ b/brain/systems/runs/presentation.py
@@ -14,6 +14,10 @@ from urllib.parse import urlparse
 
 from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.failures import failure_category_for_error, public_run_failure
+from brain.systems.runs.tool_catalog.metadata import (
+    coerce_tool_side_effect_class,
+    is_write_side_effect_class,
+)
 
 
 SENSITIVE_ARG_PARTS = {
@@ -70,6 +74,7 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
 
     raw = dict(payload or {})
     tool_name = _text(raw.get("tool_name") or raw.get("tool") or "tool") or "tool"
+    side_effect = coerce_tool_side_effect_class(raw.get("side_effect"))
     args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
     failure_summary = (
         _text(raw.get("error"))
@@ -99,6 +104,8 @@ def public_tool_event_payload(payload: dict[str, Any] | None, event_type: str = 
     }
     public["tool_name"] = tool_name
     public["tool"] = tool_name
+    public["side_effect"] = side_effect.value
+    public["is_write"] = is_write_side_effect_class(side_effect)
     public["args"] = public_tool_args(args)
     public["tool_display"] = display
     public["display"] = display

--- a/brain/systems/runs/tool_catalog/__init__.py
+++ b/brain/systems/runs/tool_catalog/__init__.py
@@ -7,6 +7,7 @@ from brain.systems.runs.tool_catalog.registry import (
     all_tool_registrations,
     get_tool_registration,
     parallel_safe_tool_names,
+    side_effect_class_for_tool,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "all_tool_registrations",
     "get_tool_registration",
     "parallel_safe_tool_names",
+    "side_effect_class_for_tool",
 ]

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -726,8 +726,8 @@ async def _query_tool_calls(
     from brain.platform.db.models.agent_run import AgentRunEventRow
     from brain.platform.db.models.run import AgentRun
     from brain.platform.db.models.idea import Idea
-    from brain.systems.runs.events import tool_call_write_timing
     from brain.systems.runs.presentation import public_tool_event_payload
+    from brain.systems.runs.tool_event_read_model import tool_call_summary
 
     stmt = (
         select(AgentRunEventRow, AgentRun, Idea)
@@ -735,13 +735,12 @@ async def _query_tool_calls(
         .outerjoin(Idea, _uuid_text_equals(Idea.id, AgentRun.thread_id))
         .where(AgentRunEventRow.event_type.in_(("run.tool_completed", "run.tool_failed")))
         .order_by(AgentRunEventRow.created_at.desc().nullslast(), AgentRunEventRow.id.desc())
+        .limit(limit)
     )
     stmt = _scope_run(stmt, AgentRun, org_id=org_id, user_id=user_id)
     stmt = _apply_date_bounds(stmt, AgentRunEventRow.created_at, start, end)
     if idea_id:
         stmt = stmt.where(AgentRun.thread_id == idea_id)
-    if run_id is not None:
-        stmt = stmt.where(AgentRun.id == run_id)
     if person_ids:
         stmt = stmt.where(AgentRun.user_id.in_(person_ids))
     text_match = _text_filter(
@@ -752,20 +751,16 @@ async def _query_tool_calls(
     )
     if text_match is not None:
         stmt = stmt.where(text_match)
-    if run_id is None:
-        stmt = stmt.limit(limit)
 
     rows = await _session_execute_all(session, stmt)
     if run_id is not None:
-        payload["tool_call_summary"] = {
-            "run_id": run_id,
-            **tool_call_write_timing(
-                (event for event, _run, _idea in rows),
-                now=_now_utc(),
-            ),
-        }
+        payload["tool_call_summary"] = await tool_call_summary(
+            session,
+            run_id,
+            now=_now_utc(),
+        )
     tool_calls = []
-    for event, run, idea in rows[:limit]:
+    for event, run, idea in rows:
         public_event = public_tool_event_payload(event.payload, event.event_type)
         failure = public_event.get("failure") if isinstance(public_event.get("failure"), dict) else None
         tool_calls.append({

--- a/brain/systems/runs/tool_catalog/handlers/workspace_data.py
+++ b/brain/systems/runs/tool_catalog/handlers/workspace_data.py
@@ -721,10 +721,12 @@ async def _query_tool_calls(
     idea_id: str | None,
     search: str | None,
     limit: int,
+    run_id: int | None = None,
 ) -> None:
     from brain.platform.db.models.agent_run import AgentRunEventRow
     from brain.platform.db.models.run import AgentRun
     from brain.platform.db.models.idea import Idea
+    from brain.systems.runs.events import tool_call_write_timing
     from brain.systems.runs.presentation import public_tool_event_payload
 
     stmt = (
@@ -733,12 +735,13 @@ async def _query_tool_calls(
         .outerjoin(Idea, _uuid_text_equals(Idea.id, AgentRun.thread_id))
         .where(AgentRunEventRow.event_type.in_(("run.tool_completed", "run.tool_failed")))
         .order_by(AgentRunEventRow.created_at.desc().nullslast(), AgentRunEventRow.id.desc())
-        .limit(limit)
     )
     stmt = _scope_run(stmt, AgentRun, org_id=org_id, user_id=user_id)
     stmt = _apply_date_bounds(stmt, AgentRunEventRow.created_at, start, end)
     if idea_id:
         stmt = stmt.where(AgentRun.thread_id == idea_id)
+    if run_id is not None:
+        stmt = stmt.where(AgentRun.id == run_id)
     if person_ids:
         stmt = stmt.where(AgentRun.user_id.in_(person_ids))
     text_match = _text_filter(
@@ -749,10 +752,20 @@ async def _query_tool_calls(
     )
     if text_match is not None:
         stmt = stmt.where(text_match)
+    if run_id is None:
+        stmt = stmt.limit(limit)
 
     rows = await _session_execute_all(session, stmt)
+    if run_id is not None:
+        payload["tool_call_summary"] = {
+            "run_id": run_id,
+            **tool_call_write_timing(
+                (event for event, _run, _idea in rows),
+                now=_now_utc(),
+            ),
+        }
     tool_calls = []
-    for event, run, idea in rows:
+    for event, run, idea in rows[:limit]:
         public_event = public_tool_event_payload(event.payload, event.event_type)
         failure = public_event.get("failure") if isinstance(public_event.get("failure"), dict) else None
         tool_calls.append({
@@ -766,6 +779,8 @@ async def _query_tool_calls(
             "run_status": run.status if run else None,
             "tool_name": public_event.get("tool_name"),
             "source": public_event.get("source"),
+            "side_effect": public_event.get("side_effect"),
+            "is_write": public_event.get("is_write"),
             "args": _snippet(public_event.get("args"), 420),
             "result": _snippet(
                 failure.get("message") if failure else public_event.get("result") or public_event.get("result_preview"),
@@ -1656,6 +1671,7 @@ async def _run_tool_calls(session: Any, payload: dict[str, Any], ctx: WorkspaceD
         user_id=ctx.user_id,
         person_ids=ctx.person_ids,
         idea_id=ctx.idea_id,
+        run_id=ctx.run_id,
         search=ctx.search,
         limit=ctx.limit,
     )

--- a/brain/systems/runs/tool_catalog/metadata.py
+++ b/brain/systems/runs/tool_catalog/metadata.py
@@ -87,19 +87,14 @@ class ToolSideEffectClass(StrEnum):
     WORKSPACE_APP_MANAGEMENT = "workspace_app_management"
 
 
-def coerce_tool_side_effect_class(value: ToolSideEffectClass | str | None) -> ToolSideEffectClass:
-    """Normalize event metadata, defaulting missing/invalid values to write."""
-    if isinstance(value, ToolSideEffectClass):
-        return value
-    try:
-        return ToolSideEffectClass(str(value))
-    except (TypeError, ValueError):
-        return ToolSideEffectClass.WRITE
-
-
-def is_write_side_effect_class(value: ToolSideEffectClass | str | None) -> bool:
-    """Return whether a side-effect class may change state."""
-    return coerce_tool_side_effect_class(value) not in {
+def is_write_side_effect_class(value: ToolSideEffectClass | str) -> bool:
+    """Return whether an exact registration side-effect class may change state."""
+    side_effect_class = (
+        value
+        if isinstance(value, ToolSideEffectClass)
+        else ToolSideEffectClass(str(value))
+    )
+    return side_effect_class not in {
         ToolSideEffectClass.READ_ONLY,
         ToolSideEffectClass.READ_ONLY_EXTERNAL,
     }
@@ -250,9 +245,6 @@ class ToolRegistration:
     )
     permission: ToolPermission | str = ToolPermission.READ
     risk_class: ToolRiskClass | str = ToolRiskClass.LOW
-    # Missing classification must never make an unclassified tool look like a
-    # read. Registry entries should declare their precise class; this generic
-    # write class is the conservative boundary fallback.
     side_effect_class: ToolSideEffectClass | str = ToolSideEffectClass.WRITE
     reversibility: ToolReversibility | str = ToolReversibility.NONE
     output_budget_chars: int = 10_000

--- a/brain/systems/runs/tool_catalog/metadata.py
+++ b/brain/systems/runs/tool_catalog/metadata.py
@@ -83,7 +83,26 @@ class ToolSideEffectClass(StrEnum):
     SCRATCHPAD_LIFECYCLE = "scratchpad_lifecycle"
     SHELL = "shell"
     SKILL_WRITE = "skill_write"
+    WRITE = "write"
     WORKSPACE_APP_MANAGEMENT = "workspace_app_management"
+
+
+def coerce_tool_side_effect_class(value: ToolSideEffectClass | str | None) -> ToolSideEffectClass:
+    """Normalize event metadata, defaulting missing/invalid values to write."""
+    if isinstance(value, ToolSideEffectClass):
+        return value
+    try:
+        return ToolSideEffectClass(str(value))
+    except (TypeError, ValueError):
+        return ToolSideEffectClass.WRITE
+
+
+def is_write_side_effect_class(value: ToolSideEffectClass | str | None) -> bool:
+    """Return whether a side-effect class may change state."""
+    return coerce_tool_side_effect_class(value) not in {
+        ToolSideEffectClass.READ_ONLY,
+        ToolSideEffectClass.READ_ONLY_EXTERNAL,
+    }
 
 
 class ToolReversibility(StrEnum):
@@ -231,7 +250,10 @@ class ToolRegistration:
     )
     permission: ToolPermission | str = ToolPermission.READ
     risk_class: ToolRiskClass | str = ToolRiskClass.LOW
-    side_effect_class: ToolSideEffectClass | str = ToolSideEffectClass.READ_ONLY
+    # Missing classification must never make an unclassified tool look like a
+    # read. Registry entries should declare their precise class; this generic
+    # write class is the conservative boundary fallback.
+    side_effect_class: ToolSideEffectClass | str = ToolSideEffectClass.WRITE
     reversibility: ToolReversibility | str = ToolReversibility.NONE
     output_budget_chars: int = 10_000
     parallel_safety: ToolParallelSafety | str = ToolParallelSafety.SERIAL

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -49,6 +49,7 @@ _BROWSER_TOOLS = [
 _STATIC_METADATA: dict[str, dict[str, Any]] = {
     "brain_recall": {
         "permission": "read_memory",
+        "side_effect_class": "read_only",
         "output_budget_chars": 8_000,
         "context_route": {
             "description": "Search long-term semantic memories. Use for remembered lessons, facts, patterns, and episodes; use read_workspace_* tools for source-of-truth workspace records and current team activity.",
@@ -57,10 +58,26 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
             "empty_result_policy": "fallback_full_pipeline_when_broad",
         },
     },
-    "brain_guardrails": {"permission": "read_memory", "output_budget_chars": 6_000},
-    "brain_skills": {"permission": "read_skills", "output_budget_chars": 6_000},
-    "skill_view": {"permission": "read_skills", "output_budget_chars": 12_000},
-    "skill_asset": {"permission": "read_skills", "output_budget_chars": 12_000},
+    "brain_guardrails": {
+        "permission": "read_memory",
+        "side_effect_class": "read_only",
+        "output_budget_chars": 6_000,
+    },
+    "brain_skills": {
+        "permission": "read_skills",
+        "side_effect_class": "read_only",
+        "output_budget_chars": 6_000,
+    },
+    "skill_view": {
+        "permission": "read_skills",
+        "side_effect_class": "read_only",
+        "output_budget_chars": 12_000,
+    },
+    "skill_asset": {
+        "permission": "read_skills",
+        "side_effect_class": "read_only",
+        "output_budget_chars": 12_000,
+    },
     "manage_skill": {
         "permission": "write_skill",
         "risk_class": "high",
@@ -174,6 +191,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "runtime_settings": {
         "permission": "read_runtime",
+        "side_effect_class": "read_only",
         "context_route": {
             "description": "Inspect active provider, credentials/auth status, runtime model routing, and provider/model mappings for the current user/workspace.",
             "domains": ["runtime settings", "provider", "auth status", "model routing", "credentials"],
@@ -182,6 +200,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_self_context": {
         "permission": "read_runtime",
+        "side_effect_class": "read_only",
         "output_budget_chars": 12_000,
         "evidence_emitter": True,
         "context_route": {
@@ -192,6 +211,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_capabilities": {
         "permission": "read_runtime",
+        "side_effect_class": "read_only",
         "output_budget_chars": 16_000,
         "evidence_emitter": True,
         "context_route": {
@@ -221,6 +241,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_thread_messages": {
         "permission": "read_session",
+        "side_effect_class": "read_only",
         "parallel_safety": "safe",
         "output_budget_chars": 12_000,
         "context_route": {
@@ -231,6 +252,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "query_workspace_data": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
         "context_route": {
@@ -261,6 +283,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_workspace_overview": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 22_000,
         "evidence_emitter": True,
         "context_route": {
@@ -276,6 +299,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_team_activity": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
         "context_route": {
@@ -286,6 +310,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_project_contexts": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
         "context_route": {
@@ -296,6 +321,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_team_members": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 14_000,
         "evidence_emitter": True,
         "context_route": {
@@ -306,6 +332,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_workspace_records": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
         "context_route": {
@@ -316,6 +343,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_cycles": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 14_000,
         "evidence_emitter": True,
         "context_route": {
@@ -326,6 +354,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "read_workspace_apps": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
         "context_route": {
@@ -592,7 +621,12 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "execute shell command",
     },
-    "read_file": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
+    "read_file": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
     "write_file": {
         "permission": "write_workspace",
         "risk_class": "medium",
@@ -609,8 +643,18 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "edit file contents",
     },
-    "search_files": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
-    "list_files": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
+    "search_files": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
+    "list_files": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
     "run_script": {
         "permission": "execute_python",
         "risk_class": "medium",
@@ -651,8 +695,18 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "fetch external URL",
     },
-    "semantic_search": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
-    "file_summary": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
+    "semantic_search": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
+    "file_summary": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
     "test_runner": {
         "permission": "execute_tests",
         "risk_class": "medium",
@@ -661,19 +715,36 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "execute test command",
     },
-    "project_context": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
+    "project_context": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
     "summarize_file_for_task": {
         "permission": "read_workspace",
+        "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
     },
     "summarize_files_for_task": {
         "permission": "read_workspace",
+        "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
     },
-    "trace_symbol": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
-    "build_implementation_map": {"permission": "read_workspace", "parallel_safety": "safe", "evidence_emitter": True},
+    "trace_symbol": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
+    "build_implementation_map": {
+        "permission": "read_workspace",
+        "side_effect_class": "read_only",
+        "parallel_safety": "safe",
+        "evidence_emitter": True,
+    },
     "session_write": {
         "permission": "write_session",
         "side_effect_class": "scratchpad",
@@ -681,7 +752,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "write session scratchpad entry",
     },
-    "session_read": {"permission": "read_session"},
+    "session_read": {"permission": "read_session", "side_effect_class": "read_only"},
     "session_append": {
         "permission": "write_session",
         "side_effect_class": "scratchpad",
@@ -689,7 +760,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "action_manifest": True,
         "expected_effect": "append session scratchpad entry",
     },
-    "session_list": {"permission": "read_session"},
+    "session_list": {"permission": "read_session", "side_effect_class": "read_only"},
     "session_promote": {
         "permission": "promote_session",
         "side_effect_class": "scratchpad_lifecycle",
@@ -722,6 +793,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
     },
     "my_activity": {
         "permission": "read_activity",
+        "side_effect_class": "read_only",
         "context_route": {
             "description": "Inspect the current agent run's own execution artifacts and provenance when the answer is about this live run/session, not historical workspace activity.",
             "domains": ["current run provenance", "current branch", "current commit", "current PR", "files edited in this run"],
@@ -787,7 +859,7 @@ def _default_registration(
         availability=availability,
         permission=str(metadata.get("permission") or "read"),
         risk_class=str(metadata.get("risk_class") or "low"),
-        side_effect_class=str(metadata.get("side_effect_class") or "read_only"),
+        side_effect_class=str(metadata.get("side_effect_class") or ToolSideEffectClass.WRITE.value),
         reversibility=str(metadata.get("reversibility") or "none"),
         output_budget_chars=int(metadata.get("output_budget_chars") or _DEFAULT_OUTPUT_BUDGET_CHARS),
         parallel_safety=str(metadata.get("parallel_safety") or "serial"),
@@ -874,6 +946,14 @@ def get_tool_registration(name: str) -> ToolRegistration | None:
     """Return a tool registration by name."""
     _ensure_dynamic_registrations()
     return _REGISTRY.get(name)
+
+
+def side_effect_class_for_tool(name: str) -> ToolSideEffectClass:
+    """Return the registry class, conservatively treating unknown tools as writes."""
+    registration = get_tool_registration(name)
+    if registration is None:
+        return ToolSideEffectClass.WRITE
+    return registration.side_effect_class
 
 
 def context_route_registrations() -> dict[str, ToolRegistration]:

--- a/brain/systems/runs/tool_event_read_model.py
+++ b/brain/systems/runs/tool_event_read_model.py
@@ -1,0 +1,163 @@
+"""Read projections over persisted tool events."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import inspect
+from typing import Any
+
+from sqlalchemy import case, func, or_, select
+
+from brain.platform.db.models.agent_run import AgentRunEventRow
+from brain.systems.runs.tool_catalog.metadata import ToolSideEffectClass
+
+
+_TOOL_RESULT_EVENT_TYPES = ("run.tool_completed", "run.tool_failed")
+_LEGACY_SIDE_EFFECT_CLASSES = frozenset(
+    {"read", "write", "command", "chat_message", "external", "unknown"}
+)
+_KNOWN_SIDE_EFFECT_CLASSES = frozenset(
+    side_effect_class.value for side_effect_class in ToolSideEffectClass
+) | _LEGACY_SIDE_EFFECT_CLASSES
+_NON_WRITE_SIDE_EFFECT_CLASSES = frozenset(
+    {
+        "read",
+        ToolSideEffectClass.READ_ONLY.value,
+        ToolSideEffectClass.READ_ONLY_EXTERNAL.value,
+    }
+)
+
+
+@dataclass(frozen=True)
+class PersistedToolSideEffect:
+    """Compatibility projection for current and historical event metadata."""
+
+    side_effect: str
+    is_write: bool
+
+
+def parse_persisted_tool_side_effect(payload: Any) -> PersistedToolSideEffect:
+    """Parse untrusted stored event metadata without inventing a known class."""
+    metadata = payload if isinstance(payload, Mapping) else {}
+    raw_side_effect = metadata.get("side_effect")
+    side_effect = (
+        raw_side_effect
+        if isinstance(raw_side_effect, str)
+        and raw_side_effect in _KNOWN_SIDE_EFFECT_CLASSES
+        else "unknown"
+    )
+    stored_is_write = metadata.get("is_write")
+    is_write = (
+        stored_is_write
+        if isinstance(stored_is_write, bool)
+        else side_effect not in _NON_WRITE_SIDE_EFFECT_CLASSES
+    )
+    return PersistedToolSideEffect(
+        side_effect=side_effect,
+        is_write=is_write,
+    )
+
+
+def _session_dialect_name(session: Any) -> str:
+    try:
+        return str(session.get_bind().dialect.name)
+    except Exception:
+        return "postgresql"
+
+
+def _persisted_is_write_expression(*, dialect_name: str) -> Any:
+    payload = AgentRunEventRow.payload
+    stored_is_write = payload["is_write"].as_boolean()
+    if dialect_name == "sqlite":
+        stored_is_boolean = func.json_type(payload, "$.is_write").in_(
+            ("true", "false")
+        )
+    else:
+        stored_is_boolean = (
+            func.jsonb_typeof(payload["is_write"]) == "boolean"
+        )
+
+    side_effect = payload["side_effect"].as_string()
+    legacy_fallback = or_(
+        side_effect.is_(None),
+        side_effect.not_in(_NON_WRITE_SIDE_EFFECT_CLASSES),
+    )
+    return case(
+        (stored_is_boolean, stored_is_write),
+        else_=legacy_fallback,
+    ).is_(True)
+
+
+def _tool_call_summary_statement(run_id: int, *, dialect_name: str) -> Any:
+    return (
+        select(AgentRunEventRow)
+        .where(
+            AgentRunEventRow.run_id == int(run_id),
+            AgentRunEventRow.event_type.in_(_TOOL_RESULT_EVENT_TYPES),
+            _persisted_is_write_expression(dialect_name=dialect_name),
+        )
+        .order_by(
+            AgentRunEventRow.created_at.desc(),
+            AgentRunEventRow.id.desc(),
+        )
+        .limit(1)
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    return await value if inspect.isawaitable(value) else value
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def tool_call_summary(
+    session: Any,
+    run_id: int,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the latest write-class tool-call timing for one complete run."""
+    statement = _tool_call_summary_statement(
+        run_id,
+        dialect_name=_session_dialect_name(session),
+    )
+    event = await _maybe_await(session.scalar(statement))
+
+    last_write_at: datetime | None = None
+    if event is not None:
+        side_effect = parse_persisted_tool_side_effect(
+            getattr(event, "payload", None)
+        )
+        created_at = getattr(event, "created_at", None)
+        if side_effect.is_write and isinstance(created_at, datetime):
+            last_write_at = _as_utc(created_at)
+
+    if last_write_at is None:
+        return {
+            "run_id": int(run_id),
+            "last_write_tool_call_at": None,
+            "seconds_since_last_write_tool_call": None,
+        }
+
+    reference = _as_utc(now or datetime.now(timezone.utc))
+    return {
+        "run_id": int(run_id),
+        "last_write_tool_call_at": last_write_at.isoformat(),
+        "seconds_since_last_write_tool_call": max(
+            0,
+            int((reference - last_write_at).total_seconds()),
+        ),
+    }
+
+
+__all__ = [
+    "PersistedToolSideEffect",
+    "parse_persisted_tool_side_effect",
+    "tool_call_summary",
+]

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -32,7 +32,8 @@ from brain.systems.runs.secret_mounts import (
     resolve_secret_env_mounts,
 )
 from brain.systems.runs.store import AsyncAgentRunStore
-from brain.systems.runs.tool_catalog.metadata import ActionPolicyResult
+from brain.systems.runs.tool_catalog.metadata import ActionPolicyResult, is_write_side_effect_class
+from brain.systems.runs.tool_catalog.registry import side_effect_class_for_tool
 from brain.systems.runs.workspace_tool_runtime import (
     handler_args_with_resolved_workspace_tool_runtime,
     resolve_workspace_tool_runtime,
@@ -618,16 +619,8 @@ def artifact_type_for_tool(tool_name: str) -> ArtifactType:
 
 
 def classify_side_effect(tool_name: str) -> str:
-    name = str(tool_name or "")
-    if name in FILE_OBSERVATION_TOOLS or name.startswith(("brain_", "query_")):
-        return "read"
-    if name in FILE_EDIT_TOOLS:
-        return "write"
-    if name in COMMAND_OUTPUT_TOOLS:
-        return "command"
-    if name in CHAT_MESSAGE_TOOLS:
-        return "chat_message"
-    return "external" if name == "browser" or name.startswith(("web_", "browser_")) else "unknown"
+    """Return the registry side-effect class for event and artifact metadata."""
+    return side_effect_class_for_tool(str(tool_name or "")).value
 
 
 def tool_activity_label(tool_name: str, args: dict[str, Any] | None = None) -> str:
@@ -649,7 +642,7 @@ def enforce_tool_scope(tool_name: str, args: dict[str, Any] | None, scope: ToolS
         raise ToolScopeViolation(f"{tool_name} target is forbidden by worker scope: {target}")
     if scope.allowed_files and not _matches_any(target, scope.allowed_files):
         side_effect = classify_side_effect(tool_name)
-        if side_effect == "write" and scope.require_approval_for_out_of_scope_mutation:
+        if is_write_side_effect_class(side_effect) and scope.require_approval_for_out_of_scope_mutation:
             raise ToolScopeViolation(f"{tool_name} target needs approval outside worker scope: {target}")
         raise ToolScopeViolation(f"{tool_name} target is outside worker scope: {target}")
 
@@ -667,6 +660,7 @@ def _event_payload(
         "args": args,
         "side_effect": classify_side_effect(tool_name),
     }
+    payload["is_write"] = is_write_side_effect_class(payload["side_effect"])
     if result is not None:
         # The stored result is a bounded PREVIEW; entity refs are extracted
         # from the FULL result first, or a big JSON result truncates into an

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -33,7 +33,7 @@ from brain.systems.runs.secret_mounts import (
 )
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.tool_catalog.metadata import ActionPolicyResult, is_write_side_effect_class
-from brain.systems.runs.tool_catalog.registry import side_effect_class_for_tool
+from brain.systems.runs.tool_catalog.registry import get_tool_registration
 from brain.systems.runs.workspace_tool_runtime import (
     handler_args_with_resolved_workspace_tool_runtime,
     resolve_workspace_tool_runtime,
@@ -620,7 +620,14 @@ def artifact_type_for_tool(tool_name: str) -> ArtifactType:
 
 def classify_side_effect(tool_name: str) -> str:
     """Return the registry side-effect class for event and artifact metadata."""
-    return side_effect_class_for_tool(str(tool_name or "")).value
+    registration = get_tool_registration(str(tool_name or ""))
+    if registration is None:
+        return "unknown"
+    return registration.side_effect_class.value
+
+
+def _classified_side_effect_is_write(side_effect: str) -> bool:
+    return side_effect == "unknown" or is_write_side_effect_class(side_effect)
 
 
 def tool_activity_label(tool_name: str, args: dict[str, Any] | None = None) -> str:
@@ -642,7 +649,7 @@ def enforce_tool_scope(tool_name: str, args: dict[str, Any] | None, scope: ToolS
         raise ToolScopeViolation(f"{tool_name} target is forbidden by worker scope: {target}")
     if scope.allowed_files and not _matches_any(target, scope.allowed_files):
         side_effect = classify_side_effect(tool_name)
-        if is_write_side_effect_class(side_effect) and scope.require_approval_for_out_of_scope_mutation:
+        if _classified_side_effect_is_write(side_effect) and scope.require_approval_for_out_of_scope_mutation:
             raise ToolScopeViolation(f"{tool_name} target needs approval outside worker scope: {target}")
         raise ToolScopeViolation(f"{tool_name} target is outside worker scope: {target}")
 
@@ -660,7 +667,7 @@ def _event_payload(
         "args": args,
         "side_effect": classify_side_effect(tool_name),
     }
-    payload["is_write"] = is_write_side_effect_class(payload["side_effect"])
+    payload["is_write"] = _classified_side_effect_is_write(payload["side_effect"])
     if result is not None:
         # The stored result is a bounded PREVIEW; entity refs are extracted
         # from the FULL result first, or a big JSON result truncates into an

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -706,7 +706,11 @@ async def test_hosted_mcp_run_get_returns_tool_events_and_artifacts():
         root_run_id=None,
         sequence_no=3,
         event_type="run.tool_completed",
-        payload={"tool_name": "domain.inspect"},
+        payload={
+            "tool_name": "domain.inspect",
+            "side_effect": "read_only",
+            "is_write": False,
+        },
         producer="agent_runtime",
         visibility="public",
         created_at=now,
@@ -772,7 +776,14 @@ async def test_hosted_mcp_run_get_returns_tool_events_and_artifacts():
     payload = json.loads(response.json()["result"]["content"][0]["text"])
     assert payload["run"]["run_id"] == 55
     assert payload["tool_events"][0]["payload"]["tool_name"] == "domain.inspect"
+    assert payload["tool_events"][0]["payload"]["side_effect"] == "read_only"
+    assert payload["tool_events"][0]["payload"]["is_write"] is False
     assert payload["tool_events"][0]["payload"]["display"]["status"] == "completed"
+    assert payload["tool_call_summary"] == {
+        "run_id": 55,
+        "last_write_tool_call_at": None,
+        "seconds_since_last_write_tool_call": None,
+    }
     assert payload["artifacts"][0]["text"] == "Finished."
     assert "events" not in payload
     assert session.order == []

--- a/tests/test_external_agent_routes.py
+++ b/tests/test_external_agent_routes.py
@@ -736,17 +736,27 @@ async def test_hosted_mcp_run_get_returns_tool_events_and_artifacts():
             return self.rows
 
     class RunSession(_AsyncSession):
+        def __init__(self):
+            super().__init__()
+            self.scalar_statements = []
+            self.scalars_statements = []
+
         async def get(self, model, row_id):
             assert row_id == 55
             return run
 
         async def scalars(self, stmt):
             text = str(stmt)
+            self.scalars_statements.append(text)
             if "agent_run_events" in text:
                 return ScalarResult([event])
             if "agent_run_artifacts" in text:
                 return ScalarResult([artifact])
             return ScalarResult([])
+
+        async def scalar(self, stmt):
+            self.scalar_statements.append(str(stmt))
+            return event
 
     session = RunSession()
     with patch(
@@ -786,6 +796,12 @@ async def test_hosted_mcp_run_get_returns_tool_events_and_artifacts():
     }
     assert payload["artifacts"][0]["text"] == "Finished."
     assert "events" not in payload
+    assert any(
+        "LIKE" in statement and "LIMIT" in statement
+        for statement in session.scalars_statements
+    )
+    assert len(session.scalar_statements) == 1
+    assert "LIMIT" in session.scalar_statements[0]
     assert session.order == []
 
 

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -19,7 +19,9 @@ from brain.systems.runs.event_log import (
 from brain.systems.runs.events import (
     async_record_tool_call,
     tool_call_completed_payload,
-    tool_call_write_timing,
+)
+from brain.systems.runs.tool_event_read_model import (
+    parse_persisted_tool_side_effect,
 )
 from brain.systems.cortex.events import run_event_scope
 from brain.platform.db.models.run import RunEvent
@@ -141,29 +143,35 @@ def test_tool_call_payload_uses_registry_classes_and_conservative_unknown_fallba
         {},
         "ok",
     )
-    assert unknown_payload["side_effect"] == "write"
+    assert unknown_payload["side_effect"] == "unknown"
     assert unknown_payload["is_write"] is True
 
 
-def test_tool_call_write_timing_uses_stored_typed_metadata():
-    now = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
-    events = [
-        SimpleNamespace(
-            event_type="run.tool_completed",
-            payload={"side_effect": "file_write", "is_write": True},
-            created_at=now - timedelta(seconds=95),
-        ),
-        SimpleNamespace(
-            event_type="run.tool_completed",
-            payload={"side_effect": "read_only", "is_write": False},
-            created_at=now - timedelta(seconds=5),
-        ),
-    ]
+@pytest.mark.parametrize(
+    ("payload", "expected_side_effect", "expected_is_write"),
+    [
+        ({"side_effect": "read_only"}, "read_only", False),
+        ({"side_effect": "file_write"}, "file_write", True),
+        ({"side_effect": "read"}, "read", False),
+        ({"side_effect": "command"}, "command", True),
+        ({"side_effect": "external"}, "external", True),
+        ({"side_effect": "unknown"}, "unknown", True),
+        ({}, "unknown", True),
+        (None, "unknown", True),
+        ({"side_effect": "typo"}, "unknown", True),
+        ({"side_effect": ["read"]}, "unknown", True),
+        ({"side_effect": "read", "is_write": True}, "read", True),
+    ],
+)
+def test_persisted_tool_side_effect_compatibility_parser(
+    payload,
+    expected_side_effect,
+    expected_is_write,
+):
+    parsed = parse_persisted_tool_side_effect(payload)
 
-    assert tool_call_write_timing(events, now=now) == {
-        "last_write_tool_call_at": (now - timedelta(seconds=95)).isoformat(),
-        "seconds_since_last_write_tool_call": 95,
-    }
+    assert parsed.side_effect == expected_side_effect
+    assert parsed.is_write is expected_is_write
 
 
 def test_run_event_to_message_handles_projected_rows_and_replay_flag():
@@ -411,11 +419,26 @@ def test_public_tool_projection_strips_sensitive_url_parts():
     serialized = json.dumps(message)
     assert message["args"]["url"] == "example.com/private/file"
     assert message["tool_display"]["target"] == "example.com/private/file"
-    assert message["side_effect"] == "write"
+    assert message["side_effect"] == "unknown"
     assert message["is_write"] is True
     assert "secret" not in serialized
     assert "abc123" not in serialized
     assert "X-Amz-Signature" not in serialized
+
+
+def test_public_tool_projection_keeps_legacy_read_non_write():
+    from brain.systems.runs.presentation import public_tool_event_payload
+
+    message = public_tool_event_payload(
+        {
+            "tool_name": "read_file",
+            "side_effect": "read",
+        },
+        "run.tool_completed",
+    )
+
+    assert message["side_effect"] == "read"
+    assert message["is_write"] is False
 
 
 def test_publish_live_fans_out_without_durable_storage(monkeypatch):

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -15,7 +16,11 @@ from brain.systems.runs.event_log import (
     list_run_events_after_for_principal_async,
     run_event_to_message,
 )
-from brain.systems.runs.events import async_record_tool_call
+from brain.systems.runs.events import (
+    async_record_tool_call,
+    tool_call_completed_payload,
+    tool_call_write_timing,
+)
 from brain.systems.cortex.events import run_event_scope
 from brain.platform.db.models.run import RunEvent
 
@@ -109,10 +114,56 @@ async def test_async_record_tool_call_persists_redacted_tool_trace(monkeypatch):
                 "args": {"key": "OPENAI_API_KEY"},
                 "result": "[secret redacted]",
                 "source": "runner:test",
+                "side_effect": "read_only",
+                "is_write": False,
             },
             {"producer": "runner:test"},
         )
     ]
+
+
+def test_tool_call_payload_uses_registry_classes_and_conservative_unknown_fallback():
+    assert tool_call_completed_payload(
+        "idea-1",
+        "read_file",
+        {},
+        "ok",
+    )["side_effect"] == "read_only"
+    assert tool_call_completed_payload(
+        "idea-1",
+        "write_file",
+        {},
+        "ok",
+    )["side_effect"] == "file_write"
+    unknown_payload = tool_call_completed_payload(
+        "idea-1",
+        "not_registered",
+        {},
+        "ok",
+    )
+    assert unknown_payload["side_effect"] == "write"
+    assert unknown_payload["is_write"] is True
+
+
+def test_tool_call_write_timing_uses_stored_typed_metadata():
+    now = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+    events = [
+        SimpleNamespace(
+            event_type="run.tool_completed",
+            payload={"side_effect": "file_write", "is_write": True},
+            created_at=now - timedelta(seconds=95),
+        ),
+        SimpleNamespace(
+            event_type="run.tool_completed",
+            payload={"side_effect": "read_only", "is_write": False},
+            created_at=now - timedelta(seconds=5),
+        ),
+    ]
+
+    assert tool_call_write_timing(events, now=now) == {
+        "last_write_tool_call_at": (now - timedelta(seconds=95)).isoformat(),
+        "seconds_since_last_write_tool_call": 95,
+    }
 
 
 def test_run_event_to_message_handles_projected_rows_and_replay_flag():
@@ -360,6 +411,8 @@ def test_public_tool_projection_strips_sensitive_url_parts():
     serialized = json.dumps(message)
     assert message["args"]["url"] == "example.com/private/file"
     assert message["tool_display"]["target"] == "example.com/private/file"
+    assert message["side_effect"] == "write"
+    assert message["is_write"] is True
     assert "secret" not in serialized
     assert "abc123" not in serialized
     assert "X-Amz-Signature" not in serialized

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -20,6 +20,7 @@ from brain.systems.runs.tool_outcomes import (
 from brain.systems.runs.direct_loop.tool_execution import (
     PendingToolCall,
     ResolvedToolCall,
+    async_emit_resolved_tool_call,
     async_execute_parallel_tool_batch,
     async_execute_tool_calls,
     async_resolve_tool_call,
@@ -244,6 +245,31 @@ async def test_batch_helpers_return_resolved_calls_without_observing_policy():
 
     assert all(isinstance(result, ResolvedToolCall) for result in sync_results)
     assert all(isinstance(result, ResolvedToolCall) for result in async_results)
+
+
+async def test_direct_loop_stamps_registry_side_effect_at_emit(monkeypatch):
+    recorded = []
+
+    async def record(*args, **kwargs):
+        recorded.append((args, kwargs))
+
+    monkeypatch.setattr("brain.systems.runs.events.async_record_tool_call", record)
+
+    await async_emit_resolved_tool_call(
+        ResolvedToolCall(
+            block_id="tool-1",
+            tool_name="create_github_pull_request",
+            tool_input={"repo": "Illospace/illospace"},
+            result_text='{"ok": true}',
+        ),
+        [],
+        None,
+        42,
+        "idea-1",
+        "test",
+    )
+
+    assert recorded[0][1]["side_effect"] == "append_only"
 
 
 async def test_failure_policy_stops_parallel_batch_before_fourth_attempt():

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -20,6 +20,23 @@ def test_every_exposed_tool_has_registry_metadata():
     assert exposed <= registered
 
 
+def test_every_registered_tool_declares_an_explicit_side_effect_class():
+    from brain.systems.runs.tool_catalog.registry import _STATIC_METADATA, all_tool_registrations
+
+    assert {
+        name
+        for name in all_tool_registrations()
+        if not _STATIC_METADATA.get(name, {}).get("side_effect_class")
+    } == set()
+
+
+def test_unknown_tool_side_effect_defaults_to_write():
+    from brain.systems.runs.tool_catalog.metadata import ToolSideEffectClass
+    from brain.systems.runs.tool_catalog.registry import side_effect_class_for_tool
+
+    assert side_effect_class_for_tool("not_registered") is ToolSideEffectClass.WRITE
+
+
 def test_registered_tools_have_capability_coverage_or_explicit_exemption():
     from brain.systems.runs.capabilities import (
         CAPABILITY_COVERAGE_EXEMPT_TOOLS,

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -297,50 +297,69 @@ async def test_workspace_tool_calls_project_legacy_structured_failures_safely():
     assert payload["sources"]["tool_calls"][0]["failure"]["status"] == "failed"
 
 
-async def test_workspace_tool_calls_preserve_side_effect_and_report_seconds_since_last_write(monkeypatch):
+async def test_workspace_tool_calls_keep_team_scope_and_report_current_run_summary(monkeypatch):
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 
     now = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
-    events = [
-        SimpleNamespace(
-            id=12,
-            run_id=7,
-            event_type="run.tool_completed",
-            payload={
-                "tool_name": "read_file",
-                "args": {"path": "README.md"},
-                "result": "read",
-                "side_effect": "read_only",
-                "is_write": False,
-            },
-            created_at=now - timedelta(seconds=5),
-        ),
-        SimpleNamespace(
-            id=11,
-            run_id=7,
-            event_type="run.tool_completed",
-            payload={
-                "tool_name": "write_file",
-                "args": {"path": "README.md"},
-                "result": "wrote",
-                "side_effect": "file_write",
-                "is_write": True,
-            },
-            created_at=now - timedelta(seconds=80),
-        ),
-    ]
-    run = SimpleNamespace(id=7, thread_id="idea-1", status="running")
+    teammate_event = SimpleNamespace(
+        id=12,
+        run_id=8,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "read_file",
+            "args": {"path": "README.md"},
+            "result": "read",
+            "side_effect": "read",
+        },
+        created_at=now - timedelta(seconds=5),
+    )
+    current_run_write = SimpleNamespace(
+        id=11,
+        run_id=7,
+        event_type="run.tool_completed",
+        payload={
+            "tool_name": "write_file",
+            "args": {"path": "README.md"},
+            "result": "wrote",
+            "side_effect": "file_write",
+            "is_write": True,
+        },
+        created_at=now - timedelta(seconds=80),
+    )
+    teammate_run = SimpleNamespace(
+        id=8,
+        thread_id="idea-team",
+        status="completed",
+    )
+    current_run = SimpleNamespace(id=7, thread_id="idea-1", status="running")
 
     class Result:
         def all(self):
-            return [(event, run, None) for event in events]
+            return [
+                (teammate_event, teammate_run, None),
+                (current_run_write, current_run, None),
+            ]
 
     captured = {}
 
     class StubSession:
         def execute(self, stmt):
-            captured["sql"] = str(stmt)
+            captured["listing_sql"] = str(
+                stmt.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
             return Result()
+
+        def scalar(self, stmt):
+            captured["summary_sql"] = str(
+                stmt.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+            return current_run_write
 
     monkeypatch.setattr(workspace_data, "_now_utc", lambda: now)
     payload = {"sources": {}}
@@ -358,11 +377,22 @@ async def test_workspace_tool_calls_preserve_side_effect_and_report_seconds_sinc
         run_id=7,
     )
 
-    assert payload["sources"]["tool_calls"][0]["side_effect"] == "read_only"
+    assert [row["run_id"] for row in payload["sources"]["tool_calls"]] == [8, 7]
+    assert payload["sources"]["tool_calls"][0]["side_effect"] == "read"
     assert payload["sources"]["tool_calls"][0]["is_write"] is False
     assert payload["sources"]["tool_calls"][1]["side_effect"] == "file_write"
     assert payload["sources"]["tool_calls"][1]["is_write"] is True
-    assert "agent_runs.id =" in captured["sql"]
+    assert "agent_runs.id = 7" not in captured["listing_sql"]
+    assert "LIMIT 10" in captured["listing_sql"]
+    assert "agent_run_events.run_id = 7" in captured["summary_sql"]
+    assert "run.tool_completed" in captured["summary_sql"]
+    assert "run.tool_failed" in captured["summary_sql"]
+    assert "read" in captured["summary_sql"]
+    assert (
+        "ORDER BY agent_run_events.created_at DESC, "
+        "agent_run_events.id DESC" in captured["summary_sql"]
+    )
+    assert "LIMIT 1" in captured["summary_sql"]
     assert payload["tool_call_summary"] == {
         "run_id": 7,
         "last_write_tool_call_at": (now - timedelta(seconds=80)).isoformat(),
@@ -370,7 +400,7 @@ async def test_workspace_tool_calls_preserve_side_effect_and_report_seconds_sinc
     }
 
 
-async def test_workspace_tool_call_source_forwards_run_filter(monkeypatch):
+async def test_workspace_tool_call_source_forwards_current_run_for_summary(monkeypatch):
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 
     captured = {}

--- a/tests/test_workspace_data_query.py
+++ b/tests/test_workspace_data_query.py
@@ -297,6 +297,111 @@ async def test_workspace_tool_calls_project_legacy_structured_failures_safely():
     assert payload["sources"]["tool_calls"][0]["failure"]["status"] == "failed"
 
 
+async def test_workspace_tool_calls_preserve_side_effect_and_report_seconds_since_last_write(monkeypatch):
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    now = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+    events = [
+        SimpleNamespace(
+            id=12,
+            run_id=7,
+            event_type="run.tool_completed",
+            payload={
+                "tool_name": "read_file",
+                "args": {"path": "README.md"},
+                "result": "read",
+                "side_effect": "read_only",
+                "is_write": False,
+            },
+            created_at=now - timedelta(seconds=5),
+        ),
+        SimpleNamespace(
+            id=11,
+            run_id=7,
+            event_type="run.tool_completed",
+            payload={
+                "tool_name": "write_file",
+                "args": {"path": "README.md"},
+                "result": "wrote",
+                "side_effect": "file_write",
+                "is_write": True,
+            },
+            created_at=now - timedelta(seconds=80),
+        ),
+    ]
+    run = SimpleNamespace(id=7, thread_id="idea-1", status="running")
+
+    class Result:
+        def all(self):
+            return [(event, run, None) for event in events]
+
+    captured = {}
+
+    class StubSession:
+        def execute(self, stmt):
+            captured["sql"] = str(stmt)
+            return Result()
+
+    monkeypatch.setattr(workspace_data, "_now_utc", lambda: now)
+    payload = {"sources": {}}
+    await workspace_data._query_tool_calls(
+        StubSession(),
+        payload,
+        start=None,
+        end=None,
+        org_id=None,
+        user_id=None,
+        person_ids=[],
+        idea_id=None,
+        search=None,
+        limit=10,
+        run_id=7,
+    )
+
+    assert payload["sources"]["tool_calls"][0]["side_effect"] == "read_only"
+    assert payload["sources"]["tool_calls"][0]["is_write"] is False
+    assert payload["sources"]["tool_calls"][1]["side_effect"] == "file_write"
+    assert payload["sources"]["tool_calls"][1]["is_write"] is True
+    assert "agent_runs.id =" in captured["sql"]
+    assert payload["tool_call_summary"] == {
+        "run_id": 7,
+        "last_write_tool_call_at": (now - timedelta(seconds=80)).isoformat(),
+        "seconds_since_last_write_tool_call": 80,
+    }
+
+
+async def test_workspace_tool_call_source_forwards_run_filter(monkeypatch):
+    from brain.systems.runs.tool_catalog.handlers import workspace_data
+
+    captured = {}
+
+    async def query_tool_calls(_session, _payload, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(workspace_data, "_query_tool_calls", query_tool_calls)
+    ctx = workspace_data.WorkspaceDataQueryContext(
+        start=None,
+        end=None,
+        org_id="org-1",
+        user_id="user-1",
+        person_ids=[],
+        idea_id=None,
+        run_id=507,
+        domain_id=None,
+        cycle_id=None,
+        object_key=None,
+        query=None,
+        search=None,
+        include_archived=False,
+        limit=10,
+        offset=0,
+    )
+
+    await workspace_data._run_tool_calls(object(), {"sources": {}}, ctx)
+
+    assert captured["run_id"] == 507
+
+
 async def test_workspace_data_runs_include_latest_final_answer_artifact():
     from brain.systems.runs.tool_catalog.handlers import workspace_data
 


### PR DESCRIPTION
Closes #507

## What this does

Tool events used to persist `side_effect="unknown"` even though the tool registry already knows each tool's class, so nothing downstream could tell a read from a write. This stamps the registry class onto every tool event and exposes a `tool_call_summary` (`last_write_tool_call_at`, `seconds_since_last_write_tool_call`) on `run.get` and `query_workspace_data`.

Two commits: the implementation, then a fix pass answering a code-quality review of it.

## What the review caught (and this branch fixes)

- **The signal was inverted for historical events.** Events stored under the old vocabulary (`side_effect="read"`) coerced to the write default, so "last write tool call" could report a *read* as the most recent write — the exact opposite of what the ticket exists to provide. Stored metadata is now parsed, not coerced.
- **The read path loaded every tool event.** `run.get` and `query_workspace_data` both dropped the SQL `LIMIT` and sliced in Python. Both now push the limit into SQL and get the timing from one aggregate query.
- **`query_workspace_data` had silently narrowed its tool-call listing to the ambient run.** The run filter belongs to the summary; the listing is unscoped again.

## Verification

Full fast suite on this branch, outside any sandbox:

```
cd <worktree> && venv/bin/python -m pytest tests/ -m "not requires_db" -q
# 4231 passed, 14 skipped, 0 failed
```

## Acceptance checks

1. A tool call to a registered write tool persists `side_effect` = its registry class and `is_write: true`; a registered read tool persists its class and `is_write: false`.
2. A run whose only recent activity is reads reports **no** recent write in `tool_call_summary` — including for events written before this change, when the stored class was `"read"`.
3. `run.get` with `limit=N` on a long run issues a bounded query — it does not load the run's whole event history to serve N events.
4. `query_workspace_data` tool-call listings are not narrowed to the current run; only the summary is run-scoped.

## Assumptions / left out

An unregistered tool is treated as **write** (conservative: it can't be silently trusted as a read). Making `ToolRegistration.side_effect_class` a required field is left to a follow-up — an 88-entry restructure, and `test_tool_registry.py` already enforces explicit declarations.
