### PR TITLE
fix(deploy): install the boot unit without root via a user systemd unit (#527)

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -138,6 +138,14 @@ The unit is generated per host rather than committed, because the Docker unit
 name and binary path differ (a Docker snap install has no `docker.service` at
 all). Inspect it before installing with `./illo deploy boot-unit --print`.
 
+It installs a **user** unit by default when you are not root, so it needs no
+`sudo` — user units start at boot on their own provided the account has
+lingering enabled (the installer turns it on when it can). A user unit cannot
+order itself after a system Docker unit, so it waits for the daemon to accept
+connections instead, bounded by `TimeoutStartSec`. Pass `--system` to install
+into `/etc/systemd/system` and order directly after the Docker unit; that path
+needs root.
+
 Two worker settings interact with shutdown and must stay consistent:
 
 - `stop_grace_period` (default `10s`, override with `ILLO_WORKER_STOP_GRACE_PERIOD`)

--- a/deploy/scripts/install-boot-unit.sh
+++ b/deploy/scripts/install-boot-unit.sh
@@ -21,19 +21,30 @@ COMPOSE_DIR="$ROOT/deploy/compose"
 COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
 ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$COMPOSE_DIR/.env}"
 UNIT_NAME="${ILLO_BOOT_UNIT_NAME:-illospace-compose.service}"
-UNIT_DIR="${ILLO_BOOT_UNIT_DIR:-/etc/systemd/system}"
 
 PRINT_ONLY=0
+# Installing a system unit needs root. Default to a user unit when we do not
+# have it, rather than dead-ending on an interactive sudo password: user units
+# start at boot on their own as long as lingering is enabled for the account.
+SCOPE=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --print)
       PRINT_ONLY=1
       shift
       ;;
+    --system)
+      SCOPE=system
+      shift
+      ;;
+    --user)
+      SCOPE=user
+      shift
+      ;;
     -h|--help)
       cat <<'EOF'
-Usage: ./illo deploy boot-unit [--print]
-       deploy/scripts/install-boot-unit.sh [--print]
+Usage: ./illo deploy boot-unit [--user|--system] [--print]
+       deploy/scripts/install-boot-unit.sh [--user|--system] [--print]
 
 Generates and installs a systemd unit that runs `docker compose up -d` once at
 boot, so the whole stack -- including the worker -- comes back after an
@@ -44,7 +55,13 @@ binary path differ per host (a Docker snap install exposes
 snap.docker.dockerd.service and /snap/bin/docker, and has no docker.service at
 all, so a hardcoded Requires=docker.service fails silently).
 
+  --system  install to /etc/systemd/system (needs root; orders after the Docker
+            unit directly)
+  --user    install to ~/.config/systemd/user (no root; waits for the Docker
+            daemon instead, and needs lingering enabled for the account)
   --print   write the generated unit to stdout without installing it
+
+Defaults to --system when running as root, otherwise --user.
 EOF
       exit 0
       ;;
@@ -54,6 +71,22 @@ EOF
       ;;
   esac
 done
+
+if [ -z "$SCOPE" ]; then
+  if [ "$(id -u)" = "0" ]; then
+    SCOPE=system
+  else
+    SCOPE=user
+  fi
+fi
+
+if [ "$SCOPE" = "system" ]; then
+  UNIT_DIR="${ILLO_BOOT_UNIT_DIR:-/etc/systemd/system}"
+  systemctl_scope=""
+else
+  UNIT_DIR="${ILLO_BOOT_UNIT_DIR:-$HOME/.config/systemd/user}"
+  systemctl_scope="--user"
+fi
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Missing $ENV_FILE; run ./illo deploy init first." >&2
@@ -78,12 +111,12 @@ for candidate in snap.docker.dockerd.service docker.service; do
     break
   fi
 done
-if [ -z "$docker_unit" ]; then
+docker_unit="${ILLO_BOOT_DOCKER_UNIT:-$docker_unit}"
+if [ -z "$docker_unit" ] && [ "$SCOPE" = "system" ]; then
   echo "Could not find a Docker systemd unit (looked for snap.docker.dockerd.service and docker.service)." >&2
-  echo "Set ILLO_BOOT_DOCKER_UNIT=<unit> to name it explicitly." >&2
+  echo "Set ILLO_BOOT_DOCKER_UNIT=<unit> to name it explicitly, or install a user unit with --user." >&2
   exit 1
 fi
-docker_unit="${ILLO_BOOT_DOCKER_UNIT:-$docker_unit}"
 
 # Compose profiles are opt-in, so a profile-gated service (slack-connector)
 # would otherwise be left out of the boot reconcile. Read the project's own
@@ -98,28 +131,45 @@ if [ -n "$profiles" ]; then
   done
 fi
 
+if [ "$SCOPE" = "system" ]; then
+  ordering="Requires=$docker_unit
+After=$docker_unit network-online.target
+Wants=network-online.target"
+  readiness="# Ordered after the Docker unit, so the daemon is already up."
+  # Boot-time image pulls can be slow on a cold cache; let it finish.
+  start_timeout="TimeoutStartSec=0"
+  wanted_by="multi-user.target"
+else
+  # A user unit cannot Requires= or After= a system unit, so it can start before
+  # dockerd is accepting connections. Wait for the daemon instead of failing.
+  ordering="ConditionUser=!root"
+  readiness="ExecStartPre=/bin/sh -c 'until $docker_bin info >/dev/null 2>&1; do sleep 2; done'"
+  # Bounded, unlike the system unit: the readiness loop above would otherwise
+  # spin forever on a host where Docker never comes up.
+  start_timeout="TimeoutStartSec=900"
+  wanted_by="default.target"
+fi
+
 unit_text="$(cat <<EOF
 [Unit]
 Description=Illospace Compose stack
 Documentation=https://github.com/Illospace/illospace/blob/main/deploy/compose/README.md
-Requires=$docker_unit
-After=$docker_unit network-online.target
-Wants=network-online.target
+$ordering
 ConditionPathExists=$ENV_FILE
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=$COMPOSE_DIR
+$readiness
 # No --force-recreate: this is a reconcile, not a deploy. Services that are
 # already running are left untouched.
 ExecStart=$docker_bin compose --env-file $ENV_FILE -f $COMPOSE_FILE$profile_args up -d
-# Boot-time image pulls can be slow on a cold cache; let it finish.
-TimeoutStartSec=0
+$start_timeout
 # Deliberately no ExecStop -- stopping this unit must not tear down the stack.
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=$wanted_by
 EOF
 )"
 
@@ -129,20 +179,34 @@ if [ "$PRINT_ONLY" = "1" ]; then
 fi
 
 sudo_prefix=""
-if [ "$(id -u)" != "0" ]; then
+if [ "$SCOPE" = "system" ] && [ "$(id -u)" != "0" ]; then
   if command -v sudo >/dev/null 2>&1; then
     sudo_prefix="sudo"
   else
     echo "Installing to $UNIT_DIR needs root and sudo is unavailable." >&2
-    echo "Re-run as root, or write the unit yourself with: $0 --print" >&2
+    echo "Re-run with --user, or write the unit yourself with: $0 --system --print" >&2
     exit 1
   fi
 fi
 
+mkdir -p "$UNIT_DIR" 2>/dev/null || $sudo_prefix mkdir -p "$UNIT_DIR"
 printf '%s\n' "$unit_text" | $sudo_prefix tee "$UNIT_DIR/$UNIT_NAME" >/dev/null
-$sudo_prefix systemctl daemon-reload
-$sudo_prefix systemctl enable "$UNIT_NAME"
+$sudo_prefix systemctl $systemctl_scope daemon-reload
+$sudo_prefix systemctl $systemctl_scope enable "$UNIT_NAME"
 
-echo "Installed $UNIT_DIR/$UNIT_NAME (bound to $docker_unit) and enabled it at boot."
-echo "Verify with: systemctl is-enabled $UNIT_NAME"
-echo "Dry-run the reconcile now with: $sudo_prefix systemctl start $UNIT_NAME"
+if [ "$SCOPE" = "user" ]; then
+  # Without lingering the user manager only exists while someone is logged in,
+  # so the unit would never run at boot -- which is the whole point of it.
+  if [ "$(loginctl show-user "$(id -un)" --property=Linger --value 2>/dev/null)" != "yes" ]; then
+    if loginctl enable-linger "$(id -un)" >/dev/null 2>&1; then
+      echo "Enabled lingering for $(id -un) so the unit runs at boot without a login."
+    else
+      echo "WARNING: lingering is not enabled for $(id -un), so this unit will NOT run at boot." >&2
+      echo "Enable it with: sudo loginctl enable-linger $(id -un)" >&2
+    fi
+  fi
+fi
+
+echo "Installed $UNIT_DIR/$UNIT_NAME (${SCOPE} scope${docker_unit:+, Docker unit $docker_unit}) and enabled it at boot."
+echo "Verify with: systemctl $systemctl_scope is-enabled $UNIT_NAME"
+echo "Dry-run the reconcile now with: $sudo_prefix systemctl $systemctl_scope start $UNIT_NAME"

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -755,7 +755,7 @@ def test_boot_unit_binds_to_the_docker_unit_that_actually_exists(tmp_path):
     env["ILLO_COMPOSE_ENV_FILE"] = str(env_file)
 
     result = subprocess.run(
-        [str(root / "deploy" / "scripts" / "install-boot-unit.sh"), "--print"],
+        [str(root / "deploy" / "scripts" / "install-boot-unit.sh"), "--system", "--print"],
         capture_output=True,
         text=True,
         env=env,
@@ -824,3 +824,74 @@ replace_idle_worker
     docker_calls = docker_log.read_text()
     assert "update --restart=no old-worker" in docker_calls
     assert "update --restart=unless-stopped old-worker" in docker_calls
+
+
+def test_boot_unit_falls_back_to_a_user_unit_when_root_is_unavailable(tmp_path):
+    """Installing a system unit needs an interactive sudo password on illo-dev.
+
+    A user unit needs no root and still starts at boot as long as lingering is
+    enabled, so it must not dead-end there (#527).
+    """
+    root = Path(__file__).resolve().parents[1]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text("#!/usr/bin/env bash\nexit 0\n")
+    docker.chmod(0o755)
+    # No Docker system unit at all: a user unit must still be generated.
+    systemctl = bin_dir / "systemctl"
+    systemctl.write_text("#!/usr/bin/env bash\nexit 1\n")
+    systemctl.chmod(0o755)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["ILLO_COMPOSE_ENV_FILE"] = str(env_file)
+
+    result = subprocess.run(
+        [str(root / "deploy" / "scripts" / "install-boot-unit.sh"), "--print"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    unit = result.stdout
+    # A user unit cannot order against a system unit, so it waits for the daemon.
+    assert "Requires=" not in unit
+    assert "ExecStartPre=" in unit
+    assert "docker info" in unit
+    assert "WantedBy=default.target" in unit
+    # The readiness loop must be bounded, unlike the system unit's TimeoutStartSec=0.
+    assert "TimeoutStartSec=900" in unit
+    assert "ExecStop=" not in unit
+
+
+def test_boot_unit_system_scope_still_requires_root_and_orders_after_docker(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in ("docker", "systemctl"):
+        p = bin_dir / name
+        p.write_text("#!/usr/bin/env bash\nexit 1\n")
+        p.chmod(0o755)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["ILLO_COMPOSE_ENV_FILE"] = str(env_file)
+
+    result = subprocess.run(
+        [str(root / "deploy" / "scripts" / "install-boot-unit.sh"), "--system", "--print"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # System scope has no Docker unit to bind to here, so it must refuse rather
+    # than emit a unit with an empty Requires=.
+    assert result.returncode == 1
+    assert "--user" in result.stderr


### PR DESCRIPTION
Follow-up to #529.

`./illo deploy boot-unit` dead-ended on illo-dev: installing into `/etc/systemd/system` needs an interactive sudo password, so the boot reconciler never got installed at all.

It doesn't need root. `loginctl show-user uwear --property=Linger` is already **`yes`** on that host, and `systemctl --user` is live over SSH — so a user unit starts at boot with no root anywhere in the path. This is also already how `ops/` installs the native services (`systemctl --user enable illo-api`), so it's in-pattern rather than a new mechanism.

## Changes

- `--user` / `--system` flags; defaults to `--user` when not running as root.
- A user unit cannot `Requires=`/`After=` a system unit, so instead of ordering against the Docker unit it waits for the daemon to accept connections via `ExecStartPre`.
- That readiness loop is bounded by `TimeoutStartSec=900`, unlike the system unit's `TimeoutStartSec=0` — an unbounded loop on a host where Docker never comes up would hang the unit forever.
- `WantedBy=default.target` for user scope.
- Enables lingering when it can, and warns loudly when it cannot: without lingering the unit silently never runs at boot, which is the entire point of it.
- `--system` still refuses when no Docker system unit exists, rather than emitting a unit with an empty `Requires=`.

## Verification

45 deploy tests pass, including two new ones covering the user-scope fallback and the system-scope refusal. Both unit variants rendered and inspected against the real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)