### PR TITLE
fix(db): linearize the 0043/0044 migration heads that broke main

### DIFF
--- a/brain/platform/db/alembic/versions/0044_open_ask_deferral_obligations.py
+++ b/brain/platform/db/alembic/versions/0044_open_ask_deferral_obligations.py
@@ -1,7 +1,7 @@
 """Extend the open-ask ledger to carry run deferral obligations.
 
 Revision ID: 0044_open_ask_deferral_obligations
-Revises: 0042_scheduler_failure_rate_guard
+Revises: 0043_cycle_liveness_controls
 Create Date: 2026-07-27
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 revision = "0044_open_ask_deferral_obligations"
-down_revision = "0042_scheduler_failure_rate_guard"
+down_revision = "0043_cycle_liveness_controls"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
**main is currently undeployable.** PRs #521 and #523 merged within minutes of each other, each adding a migration branched from `0042_scheduler_failure_rate_guard`:

```
0043_cycle_liveness_controls (head)
0044_open_ask_deferral_obligations (head)
```

`alembic upgrade head` fails with *"Multiple head revisions are present"*, so:

- every open PR's CI fails on a fault it did not cause (that is how I found this — #530's suites all went red)
- `upgrade.sh` on illo-dev would fail at `compose run --rm migrate`
- illo-dev's `alembic_version` is still `0042` — it has applied **neither** migration

## Fix

Re-point `0044.down_revision` to `0043_cycle_liveness_controls`. The two migrations are independent — `0043` drops columns on `cycles`, `0044` extends `open_asks` / `obligation_notices` — so linearizing in revision-number order is safe and changes no behaviour. Two lines: the `Revises:` docstring and `down_revision`.

Verified: `alembic heads` now reports a single head, and `tests/test_alembic_config.py` passes (14 tests).

Same failure mode as #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)