### PR TITLE
fix(runs): detect semantic tool loops, not just byte-identical ones

### DIFF
--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -66,7 +66,9 @@ from brain.systems.runs.direct_loop.loop_control import (
     LoopTermination,
     _detect_stuck_loop,
     _inject_nudges,
+    exact_tool_call_fingerprint,
     resolve_loop_output,
+    semantic_tool_call_fingerprint,
 )
 from brain.systems.runs.direct_loop.request import (
     apply_anthropic_cache_breakpoint as _runtime_apply_anthropic_cache_breakpoint,
@@ -1917,17 +1919,25 @@ async def run_agent_async(
 
             if response.stop_reason == StopReason.TOOL_USE:
                 # Stuck detection
-                _turn_fingerprints = [
-                    f"{b.name}:{json.dumps(b.input, sort_keys=True)}"
+                _turn_tool_calls = [
+                    (b.name, b.input)
                     for b in response.content
                     if hasattr(b, "type") and b.type == ContentBlockType.TOOL_USE
                 ]
-                state.recent_calls.extend(_turn_fingerprints)
+                state.recent_calls.extend(
+                    exact_tool_call_fingerprint(name, tool_input)
+                    for name, tool_input in _turn_tool_calls
+                )
+                state.recent_semantic_calls.extend(
+                    semantic_tool_call_fingerprint(name, tool_input)
+                    for name, tool_input in _turn_tool_calls
+                )
 
                 termination = state.loop_control.detect_stuck_loop(
                     state.recent_calls,
                     session_id,
                     state.messages,
+                    semantic_calls=state.recent_semantic_calls,
                 )
                 if termination is not None:
                     break
@@ -1973,7 +1983,10 @@ async def run_agent_async(
                         )
 
                 if termination is not None:
-                    termination_message = termination.transcript_message()
+                    termination_message = (
+                        termination.transcript_message()
+                        or termination.control_message()
+                    )
                     if termination_message is not None:
                         _append_message_with_archive(
                             state.messages,

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -62,13 +62,9 @@ from brain.systems.runs.direct_loop.gates import (
     check_gate_violations as _runtime_check_gate_violations,
 )
 from brain.systems.runs.direct_loop.loop_control import (
-    LoopControlPolicy,
     LoopTermination,
-    _detect_stuck_loop,
-    _inject_nudges,
-    exact_tool_call_fingerprint,
+    RunControlPolicy,
     resolve_loop_output,
-    semantic_tool_call_fingerprint,
 )
 from brain.systems.runs.direct_loop.request import (
     apply_anthropic_cache_breakpoint as _runtime_apply_anthropic_cache_breakpoint,
@@ -1239,7 +1235,7 @@ async def _execute_tool_calls_async(
     on_tool_call, run_id, idea_id, tool_call_source: str,
     *,
     max_parallel_tool_calls: int = _MAX_PARALLEL_TOOL_CALLS,
-    loop_control: LoopControlPolicy,
+    loop_control: RunControlPolicy,
 ) -> _ToolExecutionResult:
     """Execute all tool calls from async runtime code."""
     return await _runtime_async_execute_tool_calls(
@@ -1362,6 +1358,7 @@ async def run_agent_async(
             brain=brain_context_preloaded,
             skills=brain_context_preloaded,
         ),
+        loop_control=RunControlPolicy(session_id=session_id),
         operation_type=operation_type,
         metadata=metadata,
     )
@@ -1918,30 +1915,6 @@ async def run_agent_async(
                 break
 
             if response.stop_reason == StopReason.TOOL_USE:
-                # Stuck detection
-                _turn_tool_calls = [
-                    (b.name, b.input)
-                    for b in response.content
-                    if hasattr(b, "type") and b.type == ContentBlockType.TOOL_USE
-                ]
-                state.recent_calls.extend(
-                    exact_tool_call_fingerprint(name, tool_input)
-                    for name, tool_input in _turn_tool_calls
-                )
-                state.recent_semantic_calls.extend(
-                    semantic_tool_call_fingerprint(name, tool_input)
-                    for name, tool_input in _turn_tool_calls
-                )
-
-                termination = state.loop_control.detect_stuck_loop(
-                    state.recent_calls,
-                    session_id,
-                    state.messages,
-                    semantic_calls=state.recent_semantic_calls,
-                )
-                if termination is not None:
-                    break
-
                 # Execute tool calls
                 execution = await _execute_tool_calls_async(
                     response, tool_handlers, state.tool_calls_made, state.gates,
@@ -1997,7 +1970,7 @@ async def run_agent_async(
 
                 # Durable reminder (e.g. `cd` non-persistence), sent as its own
                 # message AFTER tool_results — never spliced into tool output.
-                reminder_message = _inject_nudges(state.recent_calls)
+                reminder_message = state.loop_control.reminder_message()
                 if reminder_message is not None:
                     _append_message_with_archive(
                         state.messages,

--- a/brain/systems/runs/direct_loop/final_reply_evidence.py
+++ b/brain/systems/runs/direct_loop/final_reply_evidence.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
-from brain.systems.runs.direct_loop.loop_control import ToolDisablement
+from brain.systems.runs.direct_loop.tool_failure_policy import ToolDisablement
 from brain.systems.runs.status import RunStatus, coerce_run_status
 
 

--- a/brain/systems/runs/direct_loop/loop_control.py
+++ b/brain/systems/runs/direct_loop/loop_control.py
@@ -1,190 +1,35 @@
-"""Loop-control policy for the agent runtime."""
+"""Run-control façade for tool failures and stuck-loop termination."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-import hashlib
-import json
 import logging
-import os
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
-from brain.systems.runs.tool_outcomes import DEFAULT_TOOL_FAILURE_CATEGORY
+from brain.systems.runs.direct_loop.loop_guard import (
+    LoopGuard,
+    LoopSignal,
+    LoopTrigger,
+)
+from brain.systems.runs.direct_loop.tool_failure_policy import (
+    ToolDisablement,
+    ToolFailurePolicy,
+    tool_failure_threshold,
+    tool_failure_window_calls,
+    tool_zero_success_failure_threshold,
+)
 
 if TYPE_CHECKING:
     from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
 
 logger = logging.getLogger("agent")
 
-_STUCK_WARN_THRESHOLD = 3
-_STUCK_BREAK_THRESHOLD = 5
-_SEMANTIC_STALL_THRESHOLD = 10
-_UNCHANGED_RESULT_THRESHOLD = 4
-SEMANTIC_FREE_TEXT_FIELDS = frozenset(
-    {
-        "cursor",
-        "prompt",
-        "query",
-        "search",
-    }
-)
-TOOL_FAILURE_THRESHOLD_DEFAULT = 3
-TOOL_FAILURE_WINDOW_CALLS_DEFAULT = 10
-TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD_DEFAULT = 2
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.environ.get(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-
-
-def tool_failure_threshold() -> int:
-    """Return failures of one class required inside the rolling call window."""
-
-    return max(
-        1,
-        _env_int("AGENT_TOOL_FAILURE_THRESHOLD", TOOL_FAILURE_THRESHOLD_DEFAULT),
-    )
-
-
-def tool_failure_window_calls() -> int:
-    """Return the number of calls to one tool retained for failure evaluation."""
-
-    return max(
-        1,
-        _env_int(
-            "AGENT_TOOL_FAILURE_WINDOW_CALLS",
-            TOOL_FAILURE_WINDOW_CALLS_DEFAULT,
-        ),
-    )
-
-
-def tool_zero_success_failure_threshold() -> int:
-    """Return failures allowed before disabling a tool that has never succeeded."""
-
-    return max(
-        2,
-        _env_int(
-            "AGENT_TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD",
-            TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD_DEFAULT,
-        ),
-    )
-
 
 class LoopTerminationReason(str, Enum):
-    """Named reasons the canonical loop-control policy can stop a run."""
+    """Named reasons run control can stop an agent."""
 
     STUCK_LOOP = "stuck_loop"
-
-
-class ToolFailureTrigger(str, Enum):
-    """Edges evaluated together when deciding whether to disable one tool."""
-
-    ROLLING_WINDOW = "rolling_window"
-    ZERO_SUCCESS = "zero_success"
-
-
-@dataclass
-class _ToolFailureWindow:
-    """Per-tool outcomes retained only for the current agent invocation."""
-
-    recent_error_classes: list[str | None] = field(default_factory=list)
-    total_failures: int = 0
-    total_successes: int = 0
-
-    def observe(self, error_class: str | None, *, window_calls: int) -> None:
-        self.recent_error_classes.append(error_class)
-        if len(self.recent_error_classes) > window_calls:
-            del self.recent_error_classes[:-window_calls]
-        if error_class is None:
-            self.total_successes += 1
-        else:
-            self.total_failures += 1
-
-    def rolling_failures(self, error_class: str) -> int:
-        return self.recent_error_classes.count(error_class)
-
-    def largest_rolling_failure_count(self) -> int:
-        error_classes = {
-            error_class
-            for error_class in self.recent_error_classes
-            if error_class is not None
-        }
-        return max(
-            (self.rolling_failures(error_class) for error_class in error_classes),
-            default=0,
-        )
-
-
-@dataclass
-class _SemanticResultWindow:
-    """Result progress for one read-only semantic call site."""
-
-    last_result_hash: str | None = None
-    unchanged_count: int = 0
-    last_result_changed: bool = False
-
-    def observe(self, result_hash: str) -> bool:
-        changed = self.last_result_hash != result_hash
-        if changed:
-            self.last_result_hash = result_hash
-            self.unchanged_count = 1
-        else:
-            self.unchanged_count += 1
-        self.last_result_changed = changed
-        return changed
-
-
-@dataclass(frozen=True)
-class ToolDisablement:
-    """One-shot record explaining why a tool left this run's surface."""
-
-    tool_name: str
-    error_class: str
-    triggers: tuple[ToolFailureTrigger, ...]
-    rolling_failures: int
-    total_failures: int
-    total_successes: int
-    window_calls: int
-    last_error_message: str
-
-    def model_note(self) -> str:
-        trigger_details: list[str] = []
-        if ToolFailureTrigger.ROLLING_WINDOW in self.triggers:
-            trigger_details.append(
-                f"{self.rolling_failures} `{self.error_class}` failures in the "
-                f"last {self.window_calls} calls to this tool"
-            )
-        if ToolFailureTrigger.ZERO_SUCCESS in self.triggers:
-            trigger_details.append(
-                f"{self.total_failures} failures with zero successes"
-            )
-        trigger_summary = "; ".join(trigger_details)
-        detail = (
-            self.last_error_message or "No error detail was returned."
-        ).strip()
-        if len(detail) > 500:
-            detail = f"{detail[:497]}..."
-        return (
-            f"[System: Tool `{self.tool_name}` is unavailable for the rest of this run; "
-            "proceed degraded and record the gap. "
-            f"Guard trigger: {trigger_summary}. Observed {self.total_failures} failures "
-            f"and {self.total_successes} successes for this tool. "
-            f"Last error (`{self.error_class}`): {detail}]"
-        )
-
-    def skipped_tool_result(self, block_id: str) -> dict:
-        """Pair an unstarted call to this disabled tool without stopping its batch."""
-
-        return {
-            "type": "tool_result",
-            "tool_use_id": block_id,
-            "content": self.model_note(),
-            "is_error": True,
-        }
 
 
 @dataclass(frozen=True)
@@ -193,6 +38,7 @@ class LoopTermination:
 
     reason: LoopTerminationReason
     message: str
+    trigger: LoopTrigger
     final_output: str | None = None
 
     def transcript_message(self) -> dict | None:
@@ -224,305 +70,125 @@ class LoopTermination:
         }
 
 
-@dataclass
-class LoopControlPolicy:
-    """Single owner for stuck-loop termination and per-tool failure control.
+@dataclass(frozen=True)
+class ControlDecision:
+    """One resolved call's complete run-control outcome."""
 
-    Disabled tools stay latched for this invocation. A newly constructed policy
-    is the explicit reset boundary for a subsequent invocation.
-    """
-
-    failure_threshold: int = field(default_factory=tool_failure_threshold)
-    failure_window_calls: int = field(default_factory=tool_failure_window_calls)
-    zero_success_failure_threshold: int = field(
-        default_factory=tool_zero_success_failure_threshold
-    )
-    semantic_stall_threshold: int = _SEMANTIC_STALL_THRESHOLD
-    unchanged_result_threshold: int = _UNCHANGED_RESULT_THRESHOLD
     termination: LoopTermination | None = None
-    disabled_tools: dict[str, ToolDisablement] = field(default_factory=dict)
-    _tool_failure_windows: dict[str, _ToolFailureWindow] = field(
-        default_factory=dict,
-        repr=False,
-    )
-    _semantic_result_windows: dict[str, _SemanticResultWindow] = field(
-        default_factory=dict,
-        repr=False,
-    )
-    _semantic_stall_streak: int = field(default=0, repr=False)
-    _session_id: str | None = field(default=None, repr=False)
+    disablement: ToolDisablement | None = None
 
-    def __post_init__(self) -> None:
-        self.failure_threshold = max(1, int(self.failure_threshold))
-        self.failure_window_calls = max(
-            self.failure_threshold,
-            int(self.failure_window_calls),
-        )
-        self.zero_success_failure_threshold = max(
-            2,
-            int(self.zero_success_failure_threshold),
-        )
-        self.semantic_stall_threshold = max(
-            1,
-            int(self.semantic_stall_threshold),
-        )
-        self.unchanged_result_threshold = max(
-            2,
-            int(self.unchanged_result_threshold),
-        )
 
-    def detect_stuck_loop(
+@dataclass
+class ControlEvaluator:
+    """Own loop-signal precedence and termination latching."""
+
+    session_id: str = "unknown"
+    termination: LoopTermination | None = None
+
+    _SIGNAL_PRECEDENCE = {
+        LoopTrigger.UNCHANGED_RESULT: 0,
+        LoopTrigger.EXACT_REPEAT: 1,
+        LoopTrigger.SEMANTIC_NO_PROGRESS: 2,
+    }
+
+    def evaluate(
         self,
-        recent_calls: list[str],
-        session_id: str,
-        messages: list,
-        *,
-        semantic_calls: list[str] | None = None,
-    ) -> LoopTermination | None:
-        self._session_id = session_id
-        if self.termination is None:
-            repeated = _repeated_exact_fingerprint(recent_calls)
-            semantic_call = semantic_calls[-1] if semantic_calls else None
-            semantic_state = (
-                self._semantic_result_windows.get(semantic_call)
-                if semantic_call is not None
-                else None
+        loop_signals: tuple[LoopSignal, ...],
+        disablement: ToolDisablement | None,
+    ) -> ControlDecision:
+        if self.termination is not None:
+            return ControlDecision(termination=self.termination)
+        if loop_signals:
+            signal = min(
+                loop_signals,
+                key=lambda item: self._SIGNAL_PRECEDENCE[item.trigger],
             )
-            if (
-                repeated is not None
-                and semantic_state is not None
-                and semantic_state.last_result_changed
-            ):
-                return None
-            self.termination = _detect_stuck_loop(recent_calls, session_id, messages)
-        return self.termination
+            self.termination = LoopTermination(
+                reason=LoopTerminationReason.STUCK_LOOP,
+                message=signal.message,
+                trigger=signal.trigger,
+            )
+            logger.warning(
+                "Agent %s: %s",
+                self.session_id,
+                signal.message.removeprefix("[System: ").removesuffix("]"),
+            )
+            return ControlDecision(termination=self.termination)
+        return ControlDecision(disablement=disablement)
+
+
+class RunControlPolicy:
+    """Compose loop protection and per-tool failure control for one run."""
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int | None = None,
+        failure_window_calls: int | None = None,
+        zero_success_failure_threshold: int | None = None,
+        semantic_stall_threshold: int = 10,
+        unchanged_result_threshold: int = 4,
+        exact_repeat_threshold: int = 5,
+        session_id: str = "unknown",
+    ) -> None:
+        self.tool_failures = ToolFailurePolicy(
+            failure_threshold=(
+                tool_failure_threshold()
+                if failure_threshold is None
+                else failure_threshold
+            ),
+            failure_window_calls=(
+                tool_failure_window_calls()
+                if failure_window_calls is None
+                else failure_window_calls
+            ),
+            zero_success_failure_threshold=(
+                tool_zero_success_failure_threshold()
+                if zero_success_failure_threshold is None
+                else zero_success_failure_threshold
+            ),
+        )
+        self.loop_guard = LoopGuard(
+            semantic_stall_threshold=semantic_stall_threshold,
+            unchanged_result_threshold=unchanged_result_threshold,
+            exact_repeat_threshold=exact_repeat_threshold,
+        )
+        self.evaluator = ControlEvaluator(session_id=session_id)
+
+    @property
+    def failure_threshold(self) -> int:
+        return self.tool_failures.failure_threshold
+
+    @property
+    def failure_window_calls(self) -> int:
+        return self.tool_failures.failure_window_calls
+
+    @property
+    def zero_success_failure_threshold(self) -> int:
+        return self.tool_failures.zero_success_failure_threshold
+
+    @property
+    def termination(self) -> LoopTermination | None:
+        return self.evaluator.termination
+
+    @property
+    def disabled_tools(self) -> dict[str, ToolDisablement]:
+        return self.tool_failures.disabled_tools
 
     def parallel_same_tool_limit(self, tool_name: str) -> int:
-        """Bound speculative duplicates to the nearest failure-control edge."""
+        return self.tool_failures.parallel_same_tool_limit(tool_name)
 
-        state = self._tool_failure_windows.get(tool_name)
-        rolling_failures = (
-            state.largest_rolling_failure_count() if state is not None else 0
-        )
-        remaining = [self.failure_threshold - rolling_failures]
-        if state is None or state.total_successes == 0:
-            remaining.append(
-                self.zero_success_failure_threshold
-                - (state.total_failures if state is not None else 0)
-            )
-        return max(1, min(remaining))
+    def observe_tool_result(self, resolved: ResolvedToolCall) -> ControlDecision:
+        """Evaluate every control policy and return one authoritative decision."""
 
-    def observe_tool_result(self, resolved: ResolvedToolCall) -> ToolDisablement | None:
-        """Observe one resolved call and emit a one-shot tool-disable edge."""
+        loop_signals = self.loop_guard.observe_tool_result(resolved)
+        disablement = self.tool_failures.observe_tool_result(resolved)
+        return self.evaluator.evaluate(loop_signals, disablement)
 
-        if self.termination is not None:
-            return None
-        self._observe_semantic_result(resolved)
-        if self.termination is not None:
-            return None
-        tool_name = resolved.tool_name or "unknown_tool"
-        state = self._tool_failure_windows.setdefault(
-            tool_name,
-            _ToolFailureWindow(),
-        )
-        failure = resolved.outcome.failure
-        if failure is None:
-            state.observe(None, window_calls=self.failure_window_calls)
-            return None
+    def reminder_message(self) -> dict | None:
+        """Return a durable runtime reminder for a repeated exact call."""
 
-        error_class = failure.category or DEFAULT_TOOL_FAILURE_CATEGORY
-        state.observe(error_class, window_calls=self.failure_window_calls)
-        triggers = self._evaluate_failure_triggers(state, error_class)
-        if not triggers or tool_name in self.disabled_tools:
-            return None
-
-        disablement = ToolDisablement(
-            tool_name=tool_name,
-            error_class=error_class,
-            triggers=triggers,
-            rolling_failures=state.rolling_failures(error_class),
-            total_failures=state.total_failures,
-            total_successes=state.total_successes,
-            window_calls=self.failure_window_calls,
-            last_error_message=resolved.result_text or "",
-        )
-        self.disabled_tools[tool_name] = disablement
-        return disablement
-
-    def _observe_semantic_result(self, resolved: ResolvedToolCall) -> None:
-        """Latch loop termination when a read call stops producing progress."""
-
-        tool_name = resolved.tool_name or "unknown_tool"
-        if not _is_semantic_loop_candidate(tool_name):
-            return
-
-        semantic_key = semantic_tool_call_fingerprint(
-            tool_name,
-            resolved.tool_input,
-        )
-        result_hash = tool_result_fingerprint(resolved)
-        state = self._semantic_result_windows.get(semantic_key)
-        new_semantic_key = state is None
-        if state is None:
-            state = _SemanticResultWindow()
-            self._semantic_result_windows[semantic_key] = state
-        result_changed = state.observe(result_hash)
-
-        if new_semantic_key or result_changed:
-            self._semantic_stall_streak = 0
-        else:
-            self._semantic_stall_streak += 1
-
-        if state.unchanged_count >= self.unchanged_result_threshold:
-            self._terminate_stuck_loop(
-                "[System: Agent terminated: stuck in a loop repeating the same "
-                "read-only tool call with an unchanged result]"
-            )
-            return
-        if self._semantic_stall_streak >= self.semantic_stall_threshold:
-            self._terminate_stuck_loop(
-                "[System: Agent terminated: stuck in a semantic tool-call loop "
-                "with no new target or result]"
-            )
-
-    def _terminate_stuck_loop(self, message: str) -> None:
-        if self.termination is not None:
-            return
-        logger.warning(
-            "Agent %s: %s",
-            self._session_id or "unknown",
-            message.removeprefix("[System: ").removesuffix("]"),
-        )
-        self.termination = LoopTermination(
-            reason=LoopTerminationReason.STUCK_LOOP,
-            message=message,
-        )
-
-    def _evaluate_failure_triggers(
-        self,
-        state: _ToolFailureWindow,
-        error_class: str,
-    ) -> tuple[ToolFailureTrigger, ...]:
-        """Evaluate every tool-failure trigger once for the current outcome."""
-
-        triggers: list[ToolFailureTrigger] = []
-        if state.rolling_failures(error_class) >= self.failure_threshold:
-            triggers.append(ToolFailureTrigger.ROLLING_WINDOW)
-        if (
-            state.total_successes == 0
-            and state.total_failures >= self.zero_success_failure_threshold
-        ):
-            triggers.append(ToolFailureTrigger.ZERO_SUCCESS)
-        return tuple(triggers)
-
-
-def exact_tool_call_fingerprint(
-    tool_name: str,
-    tool_input: dict[str, Any],
-) -> str:
-    """Return the legacy byte-exact tool-call fingerprint."""
-
-    return f"{tool_name}:{json.dumps(tool_input, sort_keys=True)}"
-
-
-def semantic_tool_call_fingerprint(
-    tool_name: str,
-    tool_input: dict[str, Any],
-) -> str:
-    """Return a stable target fingerprint with declared prose fields removed."""
-
-    ignored_fields = set(SEMANTIC_FREE_TEXT_FIELDS)
-    from brain.systems.runs.tool_catalog.registry import get_tool_registration
-
-    registration = get_tool_registration(tool_name)
-    if registration is not None:
-        ignored_fields.update(registration.semantic_free_text_fields)
-    semantic_input = {
-        key: value
-        for key, value in tool_input.items()
-        if key not in ignored_fields
-    }
-    return f"{tool_name}:{json.dumps(semantic_input, sort_keys=True)}"
-
-
-def tool_result_fingerprint(resolved: ResolvedToolCall) -> str:
-    """Hash the canonical resolved value used to judge read progress."""
-
-    value = (
-        resolved.result_value
-        if resolved.result_value is not None
-        else resolved.result_text
-    )
-    encoded = json.dumps(
-        value,
-        default=str,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _is_semantic_loop_candidate(tool_name: str) -> bool:
-    """Limit weaker semantic heuristics to registry-declared read-only tools."""
-
-    from brain.systems.runs.tool_catalog.metadata import ToolSideEffectClass
-    from brain.systems.runs.tool_catalog.registry import get_tool_registration
-
-    registration = get_tool_registration(tool_name)
-    return (
-        registration is not None
-        and registration.side_effect_class
-        in {
-            ToolSideEffectClass.READ_ONLY,
-            ToolSideEffectClass.READ_ONLY_EXTERNAL,
-        }
-    )
-
-
-def _repeated_exact_fingerprint(
-    recent_calls: list[str],
-    *,
-    warn_threshold: int = _STUCK_WARN_THRESHOLD,
-    break_threshold: int = _STUCK_BREAK_THRESHOLD,
-) -> tuple[str, int] | None:
-    if len(recent_calls) < warn_threshold:
-        return None
-    tail = recent_calls[-warn_threshold:]
-    if len(set(tail)) != 1:
-        return None
-    repeat_count = sum(1 for fingerprint in recent_calls if fingerprint == tail[0])
-    if repeat_count < break_threshold:
-        return None
-    return tail[0], repeat_count
-
-
-def _detect_stuck_loop(
-    recent_calls: list[str],
-    session_id: str,
-    messages: list,
-    *,
-    warn_threshold: int = _STUCK_WARN_THRESHOLD,
-    break_threshold: int = _STUCK_BREAK_THRESHOLD,
-) -> LoopTermination | None:
-    """Return typed termination when identical tool calls prove the loop is stuck."""
-
-    repeated = _repeated_exact_fingerprint(
-        recent_calls,
-        warn_threshold=warn_threshold,
-        break_threshold=break_threshold,
-    )
-    if repeated is None:
-        return None
-    _, repeat_count = repeated
-    logger.warning("Agent %s: stuck loop (%d identical calls). Breaking.", session_id, repeat_count)
-    message = "[System: Agent terminated: stuck in a loop repeating the same tool call]"
-    messages.append({"role": "user", "content": [
-        {"type": "text", "text": message},
-    ]})
-    return LoopTermination(
-        reason=LoopTerminationReason.STUCK_LOOP,
-        message=message,
-    )
+        return self.loop_guard.reminder_message()
 
 
 def resolve_loop_output(
@@ -537,32 +203,3 @@ def resolve_loop_output(
     if staged_reply_contents:
         return staged_reply_contents[-1]
     return extracted_output
-
-
-def _inject_nudges(
-    recent_calls: list[str],
-    *,
-    warn_threshold: int = _STUCK_WARN_THRESHOLD,
-) -> dict | None:
-    """Return a standalone reminder message, or None if nothing to say.
-
-    Strategy is the model's job — the harness does not second-guess it (no
-    "try a different strategy" / "consolidate into a script" / "is this reply
-    adding new information" nudges). The only thing worth surfacing here is a
-    durable, non-obvious mechanical fact that trips models up repeatedly.
-    The caller appends the returned message AFTER the tool_results message —
-    it must never be spliced into the tool_results content array.
-    """
-
-    if (
-        len(recent_calls) >= warn_threshold
-        and len(set(recent_calls[-warn_threshold:])) == 1
-    ):
-        return {
-            "role": "user",
-            "content": (
-                "[System: NOTE: `cd` does not persist between exec_command calls; "
-                "use `working_dir` or absolute paths.]"
-            ),
-        }
-    return None

--- a/brain/systems/runs/direct_loop/loop_control.py
+++ b/brain/systems/runs/direct_loop/loop_control.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+import hashlib
+import json
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from brain.systems.runs.tool_outcomes import DEFAULT_TOOL_FAILURE_CATEGORY
 
@@ -17,6 +19,16 @@ logger = logging.getLogger("agent")
 
 _STUCK_WARN_THRESHOLD = 3
 _STUCK_BREAK_THRESHOLD = 5
+_SEMANTIC_STALL_THRESHOLD = 10
+_UNCHANGED_RESULT_THRESHOLD = 4
+SEMANTIC_FREE_TEXT_FIELDS = frozenset(
+    {
+        "cursor",
+        "prompt",
+        "query",
+        "search",
+    }
+)
 TOOL_FAILURE_THRESHOLD_DEFAULT = 3
 TOOL_FAILURE_WINDOW_CALLS_DEFAULT = 10
 TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD_DEFAULT = 2
@@ -107,6 +119,25 @@ class _ToolFailureWindow:
         )
 
 
+@dataclass
+class _SemanticResultWindow:
+    """Result progress for one read-only semantic call site."""
+
+    last_result_hash: str | None = None
+    unchanged_count: int = 0
+    last_result_changed: bool = False
+
+    def observe(self, result_hash: str) -> bool:
+        changed = self.last_result_hash != result_hash
+        if changed:
+            self.last_result_hash = result_hash
+            self.unchanged_count = 1
+        else:
+            self.unchanged_count += 1
+        self.last_result_changed = changed
+        return changed
+
+
 @dataclass(frozen=True)
 class ToolDisablement:
     """One-shot record explaining why a tool left this run's surface."""
@@ -184,6 +215,14 @@ class LoopTermination:
             "is_error": True,
         }
 
+    def control_message(self) -> dict:
+        """Return a system-authored transcript notice for policy termination."""
+
+        return {
+            "role": "user",
+            "content": [{"type": "text", "text": self.message}],
+        }
+
 
 @dataclass
 class LoopControlPolicy:
@@ -198,12 +237,20 @@ class LoopControlPolicy:
     zero_success_failure_threshold: int = field(
         default_factory=tool_zero_success_failure_threshold
     )
+    semantic_stall_threshold: int = _SEMANTIC_STALL_THRESHOLD
+    unchanged_result_threshold: int = _UNCHANGED_RESULT_THRESHOLD
     termination: LoopTermination | None = None
     disabled_tools: dict[str, ToolDisablement] = field(default_factory=dict)
     _tool_failure_windows: dict[str, _ToolFailureWindow] = field(
         default_factory=dict,
         repr=False,
     )
+    _semantic_result_windows: dict[str, _SemanticResultWindow] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    _semantic_stall_streak: int = field(default=0, repr=False)
+    _session_id: str | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         self.failure_threshold = max(1, int(self.failure_threshold))
@@ -215,14 +262,38 @@ class LoopControlPolicy:
             2,
             int(self.zero_success_failure_threshold),
         )
+        self.semantic_stall_threshold = max(
+            1,
+            int(self.semantic_stall_threshold),
+        )
+        self.unchanged_result_threshold = max(
+            2,
+            int(self.unchanged_result_threshold),
+        )
 
     def detect_stuck_loop(
         self,
         recent_calls: list[str],
         session_id: str,
         messages: list,
+        *,
+        semantic_calls: list[str] | None = None,
     ) -> LoopTermination | None:
+        self._session_id = session_id
         if self.termination is None:
+            repeated = _repeated_exact_fingerprint(recent_calls)
+            semantic_call = semantic_calls[-1] if semantic_calls else None
+            semantic_state = (
+                self._semantic_result_windows.get(semantic_call)
+                if semantic_call is not None
+                else None
+            )
+            if (
+                repeated is not None
+                and semantic_state is not None
+                and semantic_state.last_result_changed
+            ):
+                return None
             self.termination = _detect_stuck_loop(recent_calls, session_id, messages)
         return self.termination
 
@@ -244,6 +315,9 @@ class LoopControlPolicy:
     def observe_tool_result(self, resolved: ResolvedToolCall) -> ToolDisablement | None:
         """Observe one resolved call and emit a one-shot tool-disable edge."""
 
+        if self.termination is not None:
+            return None
+        self._observe_semantic_result(resolved)
         if self.termination is not None:
             return None
         tool_name = resolved.tool_name or "unknown_tool"
@@ -275,6 +349,55 @@ class LoopControlPolicy:
         self.disabled_tools[tool_name] = disablement
         return disablement
 
+    def _observe_semantic_result(self, resolved: ResolvedToolCall) -> None:
+        """Latch loop termination when a read call stops producing progress."""
+
+        tool_name = resolved.tool_name or "unknown_tool"
+        if not _is_semantic_loop_candidate(tool_name):
+            return
+
+        semantic_key = semantic_tool_call_fingerprint(
+            tool_name,
+            resolved.tool_input,
+        )
+        result_hash = tool_result_fingerprint(resolved)
+        state = self._semantic_result_windows.get(semantic_key)
+        new_semantic_key = state is None
+        if state is None:
+            state = _SemanticResultWindow()
+            self._semantic_result_windows[semantic_key] = state
+        result_changed = state.observe(result_hash)
+
+        if new_semantic_key or result_changed:
+            self._semantic_stall_streak = 0
+        else:
+            self._semantic_stall_streak += 1
+
+        if state.unchanged_count >= self.unchanged_result_threshold:
+            self._terminate_stuck_loop(
+                "[System: Agent terminated: stuck in a loop repeating the same "
+                "read-only tool call with an unchanged result]"
+            )
+            return
+        if self._semantic_stall_streak >= self.semantic_stall_threshold:
+            self._terminate_stuck_loop(
+                "[System: Agent terminated: stuck in a semantic tool-call loop "
+                "with no new target or result]"
+            )
+
+    def _terminate_stuck_loop(self, message: str) -> None:
+        if self.termination is not None:
+            return
+        logger.warning(
+            "Agent %s: %s",
+            self._session_id or "unknown",
+            message.removeprefix("[System: ").removesuffix("]"),
+        )
+        self.termination = LoopTermination(
+            reason=LoopTerminationReason.STUCK_LOOP,
+            message=message,
+        )
+
     def _evaluate_failure_triggers(
         self,
         state: _ToolFailureWindow,
@@ -292,6 +415,87 @@ class LoopControlPolicy:
             triggers.append(ToolFailureTrigger.ZERO_SUCCESS)
         return tuple(triggers)
 
+
+def exact_tool_call_fingerprint(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> str:
+    """Return the legacy byte-exact tool-call fingerprint."""
+
+    return f"{tool_name}:{json.dumps(tool_input, sort_keys=True)}"
+
+
+def semantic_tool_call_fingerprint(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> str:
+    """Return a stable target fingerprint with declared prose fields removed."""
+
+    ignored_fields = set(SEMANTIC_FREE_TEXT_FIELDS)
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    registration = get_tool_registration(tool_name)
+    if registration is not None:
+        ignored_fields.update(registration.semantic_free_text_fields)
+    semantic_input = {
+        key: value
+        for key, value in tool_input.items()
+        if key not in ignored_fields
+    }
+    return f"{tool_name}:{json.dumps(semantic_input, sort_keys=True)}"
+
+
+def tool_result_fingerprint(resolved: ResolvedToolCall) -> str:
+    """Hash the canonical resolved value used to judge read progress."""
+
+    value = (
+        resolved.result_value
+        if resolved.result_value is not None
+        else resolved.result_text
+    )
+    encoded = json.dumps(
+        value,
+        default=str,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _is_semantic_loop_candidate(tool_name: str) -> bool:
+    """Limit weaker semantic heuristics to registry-declared read-only tools."""
+
+    from brain.systems.runs.tool_catalog.metadata import ToolSideEffectClass
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    registration = get_tool_registration(tool_name)
+    return (
+        registration is not None
+        and registration.side_effect_class
+        in {
+            ToolSideEffectClass.READ_ONLY,
+            ToolSideEffectClass.READ_ONLY_EXTERNAL,
+        }
+    )
+
+
+def _repeated_exact_fingerprint(
+    recent_calls: list[str],
+    *,
+    warn_threshold: int = _STUCK_WARN_THRESHOLD,
+    break_threshold: int = _STUCK_BREAK_THRESHOLD,
+) -> tuple[str, int] | None:
+    if len(recent_calls) < warn_threshold:
+        return None
+    tail = recent_calls[-warn_threshold:]
+    if len(set(tail)) != 1:
+        return None
+    repeat_count = sum(1 for fingerprint in recent_calls if fingerprint == tail[0])
+    if repeat_count < break_threshold:
+        return None
+    return tail[0], repeat_count
+
+
 def _detect_stuck_loop(
     recent_calls: list[str],
     session_id: str,
@@ -302,23 +506,23 @@ def _detect_stuck_loop(
 ) -> LoopTermination | None:
     """Return typed termination when identical tool calls prove the loop is stuck."""
 
-    if len(recent_calls) < warn_threshold:
+    repeated = _repeated_exact_fingerprint(
+        recent_calls,
+        warn_threshold=warn_threshold,
+        break_threshold=break_threshold,
+    )
+    if repeated is None:
         return None
-    tail = recent_calls[-warn_threshold:]
-    if len(set(tail)) != 1:
-        return None
-    repeat_count = sum(1 for fp in reversed(recent_calls) if fp == tail[0])
-    if repeat_count >= break_threshold:
-        logger.warning("Agent %s: stuck loop (%d identical calls). Breaking.", session_id, repeat_count)
-        message = "[System: Agent terminated: stuck in a loop repeating the same tool call]"
-        messages.append({"role": "user", "content": [
-            {"type": "text", "text": message},
-        ]})
-        return LoopTermination(
-            reason=LoopTerminationReason.STUCK_LOOP,
-            message=message,
-        )
-    return None
+    _, repeat_count = repeated
+    logger.warning("Agent %s: stuck loop (%d identical calls). Breaking.", session_id, repeat_count)
+    message = "[System: Agent terminated: stuck in a loop repeating the same tool call]"
+    messages.append({"role": "user", "content": [
+        {"type": "text", "text": message},
+    ]})
+    return LoopTermination(
+        reason=LoopTerminationReason.STUCK_LOOP,
+        message=message,
+    )
 
 
 def resolve_loop_output(

--- a/brain/systems/runs/direct_loop/loop_guard.py
+++ b/brain/systems/runs/direct_loop/loop_guard.py
@@ -1,0 +1,306 @@
+"""Progress tracking and named stuck-loop detectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import hashlib
+import json
+from typing import Any, TYPE_CHECKING
+
+from brain.systems.runs.tool_catalog.metadata import ToolSideEffectClass
+
+if TYPE_CHECKING:
+    from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
+
+
+_STUCK_WARN_THRESHOLD = 3
+_STUCK_BREAK_THRESHOLD = 5
+_SEMANTIC_STALL_THRESHOLD = 10
+_UNCHANGED_RESULT_THRESHOLD = 4
+
+
+class Progress(str, Enum):
+    """How one result changed the known state of its declared target."""
+
+    NEW_TARGET = "new_target"
+    CHANGED = "changed"
+    UNCHANGED = "unchanged"
+
+
+class LoopTrigger(str, Enum):
+    """Named detector edges considered by run-control precedence."""
+
+    EXACT_REPEAT = "exact_repeat"
+    SEMANTIC_NO_PROGRESS = "semantic_no_progress"
+    UNCHANGED_RESULT = "unchanged_result"
+
+
+@dataclass(frozen=True)
+class ToolCallIdentity:
+    """Exact invocation identity plus its catalog-declared stable target."""
+
+    exact_key: str
+    target_key: str
+
+
+@dataclass(frozen=True)
+class ProgressObservation:
+    """The sole observation contract consumed by loop detectors."""
+
+    identity: ToolCallIdentity
+    result_key: str
+    progress: Progress
+
+
+@dataclass(frozen=True)
+class LoopSignal:
+    """A detector edge with provider-facing termination context."""
+
+    trigger: LoopTrigger
+    message: str
+
+
+def _canonical_key(tool_name: str, tool_input: dict[str, Any]) -> str:
+    return f"{tool_name}:{json.dumps(tool_input, sort_keys=True)}"
+
+
+def tool_call_target_key(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> str:
+    """Project a call to the stable target declared by its tool registration."""
+
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    registration = get_tool_registration(tool_name)
+    projected_input = (
+        registration.identity_spec.project(tool_input)
+        if registration is not None and registration.identity_spec is not None
+        else dict(tool_input)
+    )
+    return _canonical_key(tool_name, projected_input)
+
+
+def tool_call_identity(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> ToolCallIdentity:
+    """Return both identities needed to evaluate one resolved call."""
+
+    return ToolCallIdentity(
+        exact_key=_canonical_key(tool_name, tool_input),
+        target_key=tool_call_target_key(tool_name, tool_input),
+    )
+
+
+def tool_result_key(resolved: ResolvedToolCall) -> str:
+    """Hash the canonical resolved value used to judge target progress."""
+
+    value = (
+        resolved.result_value
+        if resolved.result_value is not None
+        else resolved.result_text
+    )
+    encoded = json.dumps(
+        value,
+        default=str,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def is_loop_progress_candidate(tool_name: str) -> bool:
+    """Limit progress heuristics to registry-declared read-only tools."""
+
+    from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+    registration = get_tool_registration(tool_name)
+    return (
+        registration is not None
+        and registration.side_effect_class
+        in {
+            ToolSideEffectClass.READ_ONLY,
+            ToolSideEffectClass.READ_ONLY_EXTERNAL,
+        }
+    )
+
+
+@dataclass
+class ProgressTracker:
+    """Own the last result for each declared target."""
+
+    _last_results: dict[str, str] = field(default_factory=dict, repr=False)
+
+    def observe(
+        self,
+        identity: ToolCallIdentity,
+        result_key: str,
+    ) -> ProgressObservation:
+        previous = self._last_results.get(identity.target_key)
+        if previous is None:
+            progress = Progress.NEW_TARGET
+        elif previous != result_key:
+            progress = Progress.CHANGED
+        else:
+            progress = Progress.UNCHANGED
+        self._last_results[identity.target_key] = result_key
+        return ProgressObservation(
+            identity=identity,
+            result_key=result_key,
+            progress=progress,
+        )
+
+
+@dataclass
+class ExactRepeatDetector:
+    """Detect identical calls only while their observed results make no progress."""
+
+    break_threshold: int = _STUCK_BREAK_THRESHOLD
+    warn_threshold: int = _STUCK_WARN_THRESHOLD
+    _last_exact_key: str | None = field(default=None, repr=False)
+    _repeat_count: int = field(default=0, repr=False)
+
+    def __post_init__(self) -> None:
+        self.break_threshold = max(1, int(self.break_threshold))
+        self.warn_threshold = max(1, int(self.warn_threshold))
+
+    def observe(self, observation: ProgressObservation) -> LoopSignal | None:
+        if observation.progress is Progress.CHANGED:
+            self._last_exact_key = None
+            self._repeat_count = 0
+            return None
+        if observation.identity.exact_key == self._last_exact_key:
+            self._repeat_count += 1
+        else:
+            self._last_exact_key = observation.identity.exact_key
+            self._repeat_count = 1
+        if self._repeat_count < self.break_threshold:
+            return None
+        return LoopSignal(
+            trigger=LoopTrigger.EXACT_REPEAT,
+            message=(
+                "[System: Agent terminated: stuck in a loop repeating the same "
+                "tool call]"
+            ),
+        )
+
+    def reminder_message(self) -> dict | None:
+        """Return the one durable reminder attached to exact repetition."""
+
+        if self._repeat_count < self.warn_threshold:
+            return None
+        return {
+            "role": "user",
+            "content": (
+                "[System: NOTE: `cd` does not persist between exec_command calls; "
+                "use `working_dir` or absolute paths.]"
+            ),
+        }
+
+
+@dataclass
+class SemanticNoProgressDetector:
+    """Detect repeated known targets whose results stay unchanged."""
+
+    threshold: int = _SEMANTIC_STALL_THRESHOLD
+    _streak: int = field(default=0, repr=False)
+
+    def __post_init__(self) -> None:
+        self.threshold = max(1, int(self.threshold))
+
+    def observe(self, observation: ProgressObservation) -> LoopSignal | None:
+        if observation.progress is Progress.UNCHANGED:
+            self._streak += 1
+        else:
+            self._streak = 0
+        if self._streak < self.threshold:
+            return None
+        return LoopSignal(
+            trigger=LoopTrigger.SEMANTIC_NO_PROGRESS,
+            message=(
+                "[System: Agent terminated: stuck in a semantic tool-call loop "
+                "with no new target or result]"
+            ),
+        )
+
+
+@dataclass
+class UnchangedResultDetector:
+    """Detect one target returning the same result too many times."""
+
+    threshold: int = _UNCHANGED_RESULT_THRESHOLD
+    _observations_by_target: dict[str, int] = field(
+        default_factory=dict,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self.threshold = max(2, int(self.threshold))
+
+    def observe(self, observation: ProgressObservation) -> LoopSignal | None:
+        target_key = observation.identity.target_key
+        if observation.progress is Progress.UNCHANGED:
+            count = self._observations_by_target.get(target_key, 1) + 1
+        else:
+            count = 1
+        self._observations_by_target[target_key] = count
+        if count < self.threshold:
+            return None
+        return LoopSignal(
+            trigger=LoopTrigger.UNCHANGED_RESULT,
+            message=(
+                "[System: Agent terminated: stuck in a loop repeating the same "
+                "read-only tool call with an unchanged result]"
+            ),
+        )
+
+
+@dataclass
+class LoopGuard:
+    """Compose progress tracking and independent named loop detectors."""
+
+    semantic_stall_threshold: int = _SEMANTIC_STALL_THRESHOLD
+    unchanged_result_threshold: int = _UNCHANGED_RESULT_THRESHOLD
+    exact_repeat_threshold: int = _STUCK_BREAK_THRESHOLD
+    progress_tracker: ProgressTracker = field(default_factory=ProgressTracker)
+    exact_repeats: ExactRepeatDetector = field(init=False)
+    semantic_no_progress: SemanticNoProgressDetector = field(init=False)
+    unchanged_results: UnchangedResultDetector = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.exact_repeats = ExactRepeatDetector(
+            break_threshold=self.exact_repeat_threshold,
+        )
+        self.semantic_no_progress = SemanticNoProgressDetector(
+            threshold=self.semantic_stall_threshold,
+        )
+        self.unchanged_results = UnchangedResultDetector(
+            threshold=self.unchanged_result_threshold,
+        )
+
+    def observe_tool_result(
+        self,
+        resolved: ResolvedToolCall,
+    ) -> tuple[LoopSignal, ...]:
+        identity = tool_call_identity(
+            resolved.tool_name or "unknown_tool",
+            resolved.tool_input,
+        )
+        observation = self.progress_tracker.observe(
+            identity,
+            tool_result_key(resolved),
+        )
+        signals = [self.exact_repeats.observe(observation)]
+        if is_loop_progress_candidate(resolved.tool_name or "unknown_tool"):
+            signals.extend(
+                (
+                    self.semantic_no_progress.observe(observation),
+                    self.unchanged_results.observe(observation),
+                )
+            )
+        return tuple(signal for signal in signals if signal is not None)
+
+    def reminder_message(self) -> dict | None:
+        return self.exact_repeats.reminder_message()

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -18,6 +18,7 @@ class AgentLoopState:
     gates: GateState = field(default_factory=GateState)
     tokens: TokenAccumulator = field(default_factory=TokenAccumulator)
     recent_calls: list[str] = field(default_factory=list)
+    recent_semantic_calls: list[str] = field(default_factory=list)
     tool_calls_made: list[str] = field(default_factory=list)
     loop_control: LoopControlPolicy = field(default_factory=LoopControlPolicy)
     provider: Any | None = None

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from brain.systems.runs.direct_loop.gates import GateState
-from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
 from brain.systems.runs.direct_loop.result import TokenAccumulator
 
 
@@ -17,10 +17,8 @@ class AgentLoopState:
     messages: list[dict[str, Any]] = field(default_factory=list)
     gates: GateState = field(default_factory=GateState)
     tokens: TokenAccumulator = field(default_factory=TokenAccumulator)
-    recent_calls: list[str] = field(default_factory=list)
-    recent_semantic_calls: list[str] = field(default_factory=list)
     tool_calls_made: list[str] = field(default_factory=list)
-    loop_control: LoopControlPolicy = field(default_factory=LoopControlPolicy)
+    loop_control: RunControlPolicy = field(default_factory=RunControlPolicy)
     provider: Any | None = None
     provider_name: str | None = None
     operation_type: str | None = None

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -698,10 +698,12 @@ def execute_tool_calls(
     termination = loop_control.termination
 
     def consume_resolved(resolved: ResolvedToolCall) -> None:
+        nonlocal termination
         if termination is None:
             disablement = loop_control.observe_tool_result(resolved)
             if disablement is not None:
                 tool_disablements.append(disablement)
+            termination = loop_control.termination
         emit_resolved_tool_call(
             resolved,
             tool_results,
@@ -855,10 +857,12 @@ async def async_execute_tool_calls(
     termination = loop_control.termination
 
     async def consume_resolved(resolved: ResolvedToolCall) -> None:
+        nonlocal termination
         if termination is None:
             disablement = loop_control.observe_tool_result(resolved)
             if disablement is not None:
                 tool_disablements.append(disablement)
+            termination = loop_control.termination
         await async_emit_resolved_tool_call(
             resolved,
             tool_results,

--- a/brain/systems/runs/direct_loop/tool_execution.py
+++ b/brain/systems/runs/direct_loop/tool_execution.py
@@ -18,10 +18,10 @@ from brain.platform.async_io import (
 )
 from brain.systems.runs.actions import result_failure_summary
 from brain.systems.runs.direct_loop.loop_control import (
-    LoopControlPolicy,
     LoopTermination,
-    ToolDisablement,
+    RunControlPolicy,
 )
+from brain.systems.runs.direct_loop.tool_failure_policy import ToolDisablement
 from brain.systems.runs.execution_context import bind_agent_context, clone_agent_context_mapping
 from brain.systems.runs.direct_loop.final_reply_evidence import ToolResultEvidence
 from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
@@ -681,7 +681,7 @@ def execute_tool_calls(
     parallel_safe_tool_names: frozenset[str],
     max_parallel_tool_calls: int,
     check_gate_violations: Callable,
-    loop_control: LoopControlPolicy,
+    loop_control: RunControlPolicy,
 ) -> ToolExecutionResult:
     """Execute all tool calls from a provider response."""
     try:
@@ -700,10 +700,10 @@ def execute_tool_calls(
     def consume_resolved(resolved: ResolvedToolCall) -> None:
         nonlocal termination
         if termination is None:
-            disablement = loop_control.observe_tool_result(resolved)
-            if disablement is not None:
-                tool_disablements.append(disablement)
-            termination = loop_control.termination
+            decision = loop_control.observe_tool_result(resolved)
+            if decision.disablement is not None:
+                tool_disablements.append(decision.disablement)
+            termination = decision.termination
         emit_resolved_tool_call(
             resolved,
             tool_results,
@@ -847,7 +847,7 @@ async def async_execute_tool_calls(
     parallel_safe_tool_names: frozenset[str],
     max_parallel_tool_calls: int,
     check_gate_violations: Callable,
-    loop_control: LoopControlPolicy,
+    loop_control: RunControlPolicy,
 ) -> ToolExecutionResult:
     """Execute all tool calls from async runtime code."""
     tool_results: list[dict] = []
@@ -859,10 +859,10 @@ async def async_execute_tool_calls(
     async def consume_resolved(resolved: ResolvedToolCall) -> None:
         nonlocal termination
         if termination is None:
-            disablement = loop_control.observe_tool_result(resolved)
-            if disablement is not None:
-                tool_disablements.append(disablement)
-            termination = loop_control.termination
+            decision = loop_control.observe_tool_result(resolved)
+            if decision.disablement is not None:
+                tool_disablements.append(decision.disablement)
+            termination = decision.termination
         await async_emit_resolved_tool_call(
             resolved,
             tool_results,

--- a/brain/systems/runs/direct_loop/tool_failure_policy.py
+++ b/brain/systems/runs/direct_loop/tool_failure_policy.py
@@ -1,0 +1,235 @@
+"""Per-tool failure control for one agent run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import os
+from typing import TYPE_CHECKING
+
+from brain.systems.runs.tool_outcomes import DEFAULT_TOOL_FAILURE_CATEGORY
+
+if TYPE_CHECKING:
+    from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
+
+
+TOOL_FAILURE_THRESHOLD_DEFAULT = 3
+TOOL_FAILURE_WINDOW_CALLS_DEFAULT = 10
+TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD_DEFAULT = 2
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def tool_failure_threshold() -> int:
+    """Return failures of one class required inside the rolling call window."""
+
+    return max(
+        1,
+        _env_int("AGENT_TOOL_FAILURE_THRESHOLD", TOOL_FAILURE_THRESHOLD_DEFAULT),
+    )
+
+
+def tool_failure_window_calls() -> int:
+    """Return the number of calls to one tool retained for failure evaluation."""
+
+    return max(
+        1,
+        _env_int(
+            "AGENT_TOOL_FAILURE_WINDOW_CALLS",
+            TOOL_FAILURE_WINDOW_CALLS_DEFAULT,
+        ),
+    )
+
+
+def tool_zero_success_failure_threshold() -> int:
+    """Return failures allowed before disabling a tool that has never succeeded."""
+
+    return max(
+        2,
+        _env_int(
+            "AGENT_TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD",
+            TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD_DEFAULT,
+        ),
+    )
+
+
+class ToolFailureTrigger(str, Enum):
+    """Edges evaluated together when deciding whether to disable one tool."""
+
+    ROLLING_WINDOW = "rolling_window"
+    ZERO_SUCCESS = "zero_success"
+
+
+@dataclass
+class _ToolFailureWindow:
+    """Per-tool outcomes retained only for the current agent invocation."""
+
+    recent_error_classes: list[str | None] = field(default_factory=list)
+    total_failures: int = 0
+    total_successes: int = 0
+
+    def observe(self, error_class: str | None, *, window_calls: int) -> None:
+        self.recent_error_classes.append(error_class)
+        if len(self.recent_error_classes) > window_calls:
+            del self.recent_error_classes[:-window_calls]
+        if error_class is None:
+            self.total_successes += 1
+        else:
+            self.total_failures += 1
+
+    def rolling_failures(self, error_class: str) -> int:
+        return self.recent_error_classes.count(error_class)
+
+    def largest_rolling_failure_count(self) -> int:
+        error_classes = {
+            error_class
+            for error_class in self.recent_error_classes
+            if error_class is not None
+        }
+        return max(
+            (self.rolling_failures(error_class) for error_class in error_classes),
+            default=0,
+        )
+
+
+@dataclass(frozen=True)
+class ToolDisablement:
+    """One-shot record explaining why a tool left this run's surface."""
+
+    tool_name: str
+    error_class: str
+    triggers: tuple[ToolFailureTrigger, ...]
+    rolling_failures: int
+    total_failures: int
+    total_successes: int
+    window_calls: int
+    last_error_message: str
+
+    def model_note(self) -> str:
+        trigger_details: list[str] = []
+        if ToolFailureTrigger.ROLLING_WINDOW in self.triggers:
+            trigger_details.append(
+                f"{self.rolling_failures} `{self.error_class}` failures in the "
+                f"last {self.window_calls} calls to this tool"
+            )
+        if ToolFailureTrigger.ZERO_SUCCESS in self.triggers:
+            trigger_details.append(
+                f"{self.total_failures} failures with zero successes"
+            )
+        trigger_summary = "; ".join(trigger_details)
+        detail = (
+            self.last_error_message or "No error detail was returned."
+        ).strip()
+        if len(detail) > 500:
+            detail = f"{detail[:497]}..."
+        return (
+            f"[System: Tool `{self.tool_name}` is unavailable for the rest of this run; "
+            "proceed degraded and record the gap. "
+            f"Guard trigger: {trigger_summary}. Observed {self.total_failures} failures "
+            f"and {self.total_successes} successes for this tool. "
+            f"Last error (`{self.error_class}`): {detail}]"
+        )
+
+    def skipped_tool_result(self, block_id: str) -> dict:
+        """Pair an unstarted call to this disabled tool without stopping its batch."""
+
+        return {
+            "type": "tool_result",
+            "tool_use_id": block_id,
+            "content": self.model_note(),
+            "is_error": True,
+        }
+
+
+@dataclass
+class ToolFailurePolicy:
+    """Own failure windows and tool-disablement latching."""
+
+    failure_threshold: int = field(default_factory=tool_failure_threshold)
+    failure_window_calls: int = field(default_factory=tool_failure_window_calls)
+    zero_success_failure_threshold: int = field(
+        default_factory=tool_zero_success_failure_threshold
+    )
+    disabled_tools: dict[str, ToolDisablement] = field(default_factory=dict)
+    _windows: dict[str, _ToolFailureWindow] = field(
+        default_factory=dict,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self.failure_threshold = max(1, int(self.failure_threshold))
+        self.failure_window_calls = max(
+            self.failure_threshold,
+            int(self.failure_window_calls),
+        )
+        self.zero_success_failure_threshold = max(
+            2,
+            int(self.zero_success_failure_threshold),
+        )
+
+    def parallel_same_tool_limit(self, tool_name: str) -> int:
+        """Bound speculative duplicates to the nearest failure-control edge."""
+
+        state = self._windows.get(tool_name)
+        rolling_failures = (
+            state.largest_rolling_failure_count() if state is not None else 0
+        )
+        remaining = [self.failure_threshold - rolling_failures]
+        if state is None or state.total_successes == 0:
+            remaining.append(
+                self.zero_success_failure_threshold
+                - (state.total_failures if state is not None else 0)
+            )
+        return max(1, min(remaining))
+
+    def observe_tool_result(
+        self,
+        resolved: ResolvedToolCall,
+    ) -> ToolDisablement | None:
+        """Observe one resolved call and emit a one-shot tool-disable edge."""
+
+        tool_name = resolved.tool_name or "unknown_tool"
+        state = self._windows.setdefault(tool_name, _ToolFailureWindow())
+        failure = resolved.outcome.failure
+        if failure is None:
+            state.observe(None, window_calls=self.failure_window_calls)
+            return None
+
+        error_class = failure.category or DEFAULT_TOOL_FAILURE_CATEGORY
+        state.observe(error_class, window_calls=self.failure_window_calls)
+        triggers = self._evaluate_triggers(state, error_class)
+        if not triggers or tool_name in self.disabled_tools:
+            return None
+
+        disablement = ToolDisablement(
+            tool_name=tool_name,
+            error_class=error_class,
+            triggers=triggers,
+            rolling_failures=state.rolling_failures(error_class),
+            total_failures=state.total_failures,
+            total_successes=state.total_successes,
+            window_calls=self.failure_window_calls,
+            last_error_message=resolved.result_text or "",
+        )
+        self.disabled_tools[tool_name] = disablement
+        return disablement
+
+    def _evaluate_triggers(
+        self,
+        state: _ToolFailureWindow,
+        error_class: str,
+    ) -> tuple[ToolFailureTrigger, ...]:
+        triggers: list[ToolFailureTrigger] = []
+        if state.rolling_failures(error_class) >= self.failure_threshold:
+            triggers.append(ToolFailureTrigger.ROLLING_WINDOW)
+        if (
+            state.total_successes == 0
+            and state.total_failures >= self.zero_success_failure_threshold
+        ):
+            triggers.append(ToolFailureTrigger.ZERO_SUCCESS)
+        return tuple(triggers)

--- a/brain/systems/runs/tool_catalog/__init__.py
+++ b/brain/systems/runs/tool_catalog/__init__.py
@@ -1,6 +1,9 @@
 """Tool registry package for AgentRun metadata."""
 
-from brain.systems.runs.tool_catalog.metadata import ToolRegistration
+from brain.systems.runs.tool_catalog.metadata import (
+    ToolCallIdentitySpec,
+    ToolRegistration,
+)
 from brain.systems.runs.tool_catalog.registry import (
     action_manifest_tool_names,
     action_policy_for_tool,
@@ -12,6 +15,7 @@ from brain.systems.runs.tool_catalog.registry import (
 
 __all__ = [
     "ToolRegistration",
+    "ToolCallIdentitySpec",
     "action_manifest_tool_names",
     "action_policy_for_tool",
     "all_tool_registrations",

--- a/brain/systems/runs/tool_catalog/metadata.py
+++ b/brain/systems/runs/tool_catalog/metadata.py
@@ -233,6 +233,47 @@ def _normalize_context_route(value: Any, *, tool_name: str) -> ToolContextRoute 
 
 
 @dataclass(frozen=True)
+class ToolCallIdentitySpec:
+    """Catalog-owned projection from call arguments to a stable target."""
+
+    volatile_fields: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "volatile_fields",
+            _normalize_string_tuple(
+                self.volatile_fields,
+                field_name="identity_spec.volatile_fields",
+                tool_name="identity projection",
+            ),
+        )
+
+    def project(self, tool_input: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in tool_input.items()
+            if key not in self.volatile_fields
+        }
+
+
+def _normalize_identity_spec(
+    value: Any,
+    *,
+    tool_name: str,
+) -> ToolCallIdentitySpec | None:
+    if value is None:
+        return None
+    if isinstance(value, ToolCallIdentitySpec):
+        return value
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Tool {tool_name!r} identity_spec must be a mapping")
+    return ToolCallIdentitySpec(
+        volatile_fields=tuple(value.get("volatile_fields") or ()),
+    )
+
+
+@dataclass(frozen=True)
 class ToolRegistration:
     """Single source of truth for a tool's schema and runtime policy metadata."""
 
@@ -255,7 +296,7 @@ class ToolRegistration:
     action_manifest: bool = False
     expected_effect: str | None = None
     context_route: ToolContextRoute | Mapping[str, Any] | None = None
-    semantic_free_text_fields: tuple[str, ...] = ()
+    identity_spec: ToolCallIdentitySpec | Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -309,14 +350,22 @@ class ToolRegistration:
         if self.expected_effect is not None:
             object.__setattr__(self, "expected_effect", str(self.expected_effect))
         object.__setattr__(self, "context_route", _normalize_context_route(self.context_route, tool_name=self.name))
+        identity_spec = _normalize_identity_spec(
+            self.identity_spec,
+            tool_name=self.name,
+        )
+        schema_fields = set((self.schema.get("properties") or {}).keys())
+        if identity_spec is not None:
+            unknown_fields = set(identity_spec.volatile_fields) - schema_fields
+            if unknown_fields:
+                raise ValueError(
+                    f"Tool {self.name!r} identity_spec names unknown fields: "
+                    f"{', '.join(sorted(unknown_fields))}"
+                )
         object.__setattr__(
             self,
-            "semantic_free_text_fields",
-            _normalize_string_tuple(
-                self.semantic_free_text_fields,
-                field_name="semantic_free_text_fields",
-                tool_name=self.name,
-            ),
+            "identity_spec",
+            identity_spec,
         )
 
     def to_permission_payload(self) -> dict[str, Any]:
@@ -334,7 +383,6 @@ class ToolRegistration:
             "action_manifest": self.action_manifest,
             "expected_effect": self.expected_effect,
             "context_route": self.context_route.to_payload() if self.context_route else None,
-            "semantic_free_text_fields": list(self.semantic_free_text_fields),
         }
 
     def to_action_policy(self) -> dict[str, str] | None:

--- a/brain/systems/runs/tool_catalog/metadata.py
+++ b/brain/systems/runs/tool_catalog/metadata.py
@@ -255,6 +255,7 @@ class ToolRegistration:
     action_manifest: bool = False
     expected_effect: str | None = None
     context_route: ToolContextRoute | Mapping[str, Any] | None = None
+    semantic_free_text_fields: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -308,6 +309,15 @@ class ToolRegistration:
         if self.expected_effect is not None:
             object.__setattr__(self, "expected_effect", str(self.expected_effect))
         object.__setattr__(self, "context_route", _normalize_context_route(self.context_route, tool_name=self.name))
+        object.__setattr__(
+            self,
+            "semantic_free_text_fields",
+            _normalize_string_tuple(
+                self.semantic_free_text_fields,
+                field_name="semantic_free_text_fields",
+                tool_name=self.name,
+            ),
+        )
 
     def to_permission_payload(self) -> dict[str, Any]:
         """Return compact metadata suitable for context packs."""
@@ -324,6 +334,7 @@ class ToolRegistration:
             "action_manifest": self.action_manifest,
             "expected_effect": self.expected_effect,
             "context_route": self.context_route.to_payload() if self.context_route else None,
+            "semantic_free_text_fields": list(self.semantic_free_text_fields),
         }
 
     def to_action_policy(self) -> dict[str, str] | None:

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -33,6 +33,7 @@ from brain.systems.runs.tool_definitions import (
 from brain.systems.runs.tool_catalog.metadata import (
     ActionPolicyResult,
     ToolAvailability,
+    ToolCallIdentitySpec,
     ToolParallelSafety,
     ToolPermission,
     ToolRegistration,
@@ -264,6 +265,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
+        "identity_spec": {"volatile_fields": ("cursor",)},
         "context_route": {
             "description": (
                 "Low-level read-only query over Illospace DB-backed workspace truth: team members, "
@@ -311,6 +313,9 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
+        "identity_spec": {
+            "volatile_fields": ("cursor", "query", "search"),
+        },
         "context_route": {
             "description": "Read recent human and Illo activity across Cortex messages, ideas, runs, tool calls, Domain events, Project Context attachments, apps, and Cycle runs.",
             "domains": ["team activity", "teammate activity", "workspace activity", "recent activity", "what changed", "what Illo did"],
@@ -344,6 +349,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
+        "identity_spec": {"volatile_fields": ("cursor",)},
         "context_route": {
             "description": "Read user-created structured workspace data: Domain schemas, typed records, and Domain audit events.",
             "domains": ["workspace records", "domains", "domain records", "structured data", "trackers", "team database"],
@@ -355,6 +361,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "output_budget_chars": 14_000,
         "evidence_emitter": True,
+        "identity_spec": {"volatile_fields": ("cursor",)},
         "context_route": {
             "description": "Read workspace Cycles and Cycle runs: recurring prompts, schedules, enabled state, last/next run, linked thoughts, and status.",
             "domains": ["cycles", "recurring work", "scheduled work", "check-ins", "automations", "reports"],
@@ -382,6 +389,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         ),
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
+        "identity_spec": {"volatile_fields": ("cursor",)},
     },
     "check_fix_deploy_state": {
         "permission": "read_workspace",
@@ -454,6 +462,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "expected_effect": "list native GitHub sub-issues or look up an issue's parent",
         "output_budget_chars": 18_000,
         "evidence_emitter": True,
+        "identity_spec": {"volatile_fields": ("cursor",)},
     },
     "manage_cycle": {
         "permission": "manage_cycles",
@@ -735,14 +744,16 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
-        "semantic_free_text_fields": ("question", "focus"),
+        "identity_spec": {
+            "volatile_fields": ("question", "focus"),
+        },
     },
     "summarize_files_for_task": {
         "permission": "read_workspace",
         "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
-        "semantic_free_text_fields": ("question",),
+        "identity_spec": {"volatile_fields": ("question",)},
     },
     "trace_symbol": {
         "permission": "read_workspace",
@@ -755,7 +766,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "parallel_safety": "safe",
         "evidence_emitter": True,
-        "semantic_free_text_fields": ("question",),
+        "identity_spec": {"volatile_fields": ("question",)},
     },
     "session_write": {
         "permission": "write_session",
@@ -880,9 +891,7 @@ def _default_registration(
         action_manifest=bool(metadata.get("action_manifest", False)),
         expected_effect=metadata.get("expected_effect"),
         context_route=metadata.get("context_route"),
-        semantic_free_text_fields=tuple(
-            metadata.get("semantic_free_text_fields") or ()
-        ),
+        identity_spec=metadata.get("identity_spec"),
     )
 
 
@@ -923,6 +932,11 @@ def _validate_registry(registrations: Mapping[str, ToolRegistration]) -> None:
             raise ValueError(f"Tool {name!r} has untyped reversibility metadata")
         if not isinstance(registration.parallel_safety, ToolParallelSafety):
             raise ValueError(f"Tool {name!r} has untyped parallel_safety metadata")
+        if (
+            registration.identity_spec is not None
+            and not isinstance(registration.identity_spec, ToolCallIdentitySpec)
+        ):
+            raise ValueError(f"Tool {name!r} has untyped identity_spec metadata")
         if (
             registration.side_effect_class != ToolSideEffectClass.READ_ONLY
             and not registration.expected_effect

--- a/brain/systems/runs/tool_catalog/registry.py
+++ b/brain/systems/runs/tool_catalog/registry.py
@@ -735,12 +735,14 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
+        "semantic_free_text_fields": ("question", "focus"),
     },
     "summarize_files_for_task": {
         "permission": "read_workspace",
         "side_effect_class": "read_only",
         "parallel_safety": "agent_safe",
         "evidence_emitter": True,
+        "semantic_free_text_fields": ("question",),
     },
     "trace_symbol": {
         "permission": "read_workspace",
@@ -753,6 +755,7 @@ _STATIC_METADATA: dict[str, dict[str, Any]] = {
         "side_effect_class": "read_only",
         "parallel_safety": "safe",
         "evidence_emitter": True,
+        "semantic_free_text_fields": ("question",),
     },
     "session_write": {
         "permission": "write_session",
@@ -877,6 +880,9 @@ def _default_registration(
         action_manifest=bool(metadata.get("action_manifest", False)),
         expected_effect=metadata.get("expected_effect"),
         context_route=metadata.get("context_route"),
+        semantic_free_text_fields=tuple(
+            metadata.get("semantic_free_text_fields") or ()
+        ),
     )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -828,7 +828,7 @@ class TestAgentLoop:
 
     async def test_repeated_brain_encode_is_rejected(self):
         from brain.systems.runs.direct_agent import _execute_tool_calls_async, _GateState
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
 
         block = MagicMock()
         block.type = "tool_use"
@@ -851,7 +851,7 @@ class TestAgentLoop:
             None,
             None,
             "runner",
-            loop_control=LoopControlPolicy(),
+            loop_control=RunControlPolicy(),
         )
 
         assert handler.call_count == 0
@@ -861,7 +861,7 @@ class TestAgentLoop:
 
     async def test_failed_brain_encode_is_marked_non_retryable(self):
         from brain.systems.runs.direct_agent import _execute_tool_calls_async, _GateState
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
 
         block = MagicMock()
         block.type = "tool_use"
@@ -883,7 +883,7 @@ class TestAgentLoop:
             None,
             None,
             "runner",
-            loop_control=LoopControlPolicy(),
+            loop_control=RunControlPolicy(),
         )
 
         results = execution.tool_results
@@ -894,7 +894,7 @@ class TestAgentLoop:
     async def test_execute_tool_calls_supports_async_handlers_inside_running_loop(self):
         from brain.systems.runs.direct_agent import _GateState
         from brain.systems.runs.direct_loop.gates import check_gate_violations
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
         from brain.systems.runs.direct_loop.tool_execution import async_execute_tool_calls
 
         block = MagicMock()
@@ -927,7 +927,7 @@ class TestAgentLoop:
             parallel_safe_tool_names=frozenset(),
             max_parallel_tool_calls=1,
             check_gate_violations=check_gate_violations,
-            loop_control=LoopControlPolicy(),
+            loop_control=RunControlPolicy(),
         )
 
         results = execution.tool_results
@@ -937,7 +937,7 @@ class TestAgentLoop:
     async def test_parallel_safe_tool_batch_overlaps_and_preserves_order(self):
         from brain.systems.runs.direct_agent import _GateState
         from brain.systems.runs.direct_loop.gates import check_gate_violations
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
         from brain.systems.runs.direct_loop.tool_execution import async_execute_tool_calls
 
         block_a = MagicMock()
@@ -991,7 +991,7 @@ class TestAgentLoop:
             parallel_safe_tool_names=frozenset({"read_file", "search_files"}),
             max_parallel_tool_calls=2,
             check_gate_violations=check_gate_violations,
-            loop_control=LoopControlPolicy(),
+            loop_control=RunControlPolicy(),
         )
 
         results = execution.tool_results
@@ -1011,7 +1011,7 @@ class TestAgentLoop:
     async def test_parallel_safe_sync_tool_batch_runs_off_loop(self):
         from brain.systems.runs.direct_agent import _GateState
         from brain.systems.runs.direct_loop.gates import check_gate_violations
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
         from brain.systems.runs.direct_loop.tool_execution import async_execute_tool_calls
 
         blocks = []
@@ -1060,7 +1060,7 @@ class TestAgentLoop:
                 parallel_safe_tool_names=frozenset({"read_file", "search_files"}),
                 max_parallel_tool_calls=2,
                 check_gate_violations=check_gate_violations,
-                loop_control=LoopControlPolicy(),
+                loop_control=RunControlPolicy(),
             )
         finally:
             elapsed = time.perf_counter() - started_at
@@ -1074,7 +1074,7 @@ class TestAgentLoop:
 
     async def test_parallel_safe_tool_batch_propagates_agent_context(self):
         from brain.systems.runs.direct_agent import _execute_tool_calls_async, _GateState, _agent_context
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
 
         block = MagicMock()
         block.type = "tool_use"
@@ -1104,7 +1104,7 @@ class TestAgentLoop:
                 None,
                 None,
                 "runner",
-                loop_control=LoopControlPolicy(),
+                loop_control=RunControlPolicy(),
             )
         finally:
             for attr in ("user_id", "worker_name"):
@@ -2238,7 +2238,7 @@ class TestFinalReplyReview:
             ToolFailureStateEvidence,
             ToolResultEvidence,
         )
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
         from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
         from brain.systems.runs.tool_outcomes import ToolOutcome
 
@@ -2251,7 +2251,7 @@ class TestFinalReplyReview:
             )
             for _ in range(2)
         )
-        policy = LoopControlPolicy(
+        policy = RunControlPolicy(
             failure_threshold=3,
             failure_window_calls=10,
             zero_success_failure_threshold=2,
@@ -2269,7 +2269,7 @@ class TestFinalReplyReview:
                         category="ToolValidationError",
                     ),
                 )
-            )
+            ).disablement
         assert disablement is not None
         evidence = FinalReplyEvidence(
             tool_results=failures,

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -542,12 +541,12 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
         FinalReplyEvidence,
         ToolResultEvidence,
     )
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+    from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
     from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
     from brain.systems.runs.status import RunStatus
     from brain.systems.runs.tool_outcomes import ToolOutcome
 
-    loop_control = LoopControlPolicy(
+    loop_control = RunControlPolicy(
         failure_threshold=3,
         zero_success_failure_threshold=2,
     )
@@ -612,241 +611,6 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
     assert evidence.tool_failure_state.threshold_reached is True
     assert evidence.tool_failure_state.tool_name == "manage_idea"
     assert evidence.tool_failure_state.disabled_tools == ("manage_idea",)
-
-
-def _resolved_read_call(
-    tool_name: str,
-    tool_input: dict,
-    result: dict,
-    *,
-    block_id: str = "replay",
-):
-    from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
-
-    return ResolvedToolCall(
-        block_id=block_id,
-        tool_name=tool_name,
-        tool_input=tool_input,
-        result_text=json.dumps(result, sort_keys=True),
-        result_value=result,
-    )
-
-
-def test_cycle_9_query_paraphrases_collapse_to_one_semantic_signature():
-    from brain.systems.runs.direct_loop.loop_control import (
-        exact_tool_call_fingerprint,
-        semantic_tool_call_fingerprint,
-    )
-
-    queries = [
-        "Promotion readiness workspace evidence during the scheduled review window",
-        "Promotion readiness workspace evidence for scheduled window",
-        (
-            "Promotion readiness workspace evidence in the scheduled review window, "
-            "including relevant thread/Cycle activity"
-        ),
-    ]
-    inputs = [
-        {
-            "query": query,
-            "time_window": "custom",
-            "start_at": "2026-07-01T14:00:00Z",
-            "end_at": "2026-07-01T15:00:00Z",
-            "person": "reviewer@example.com",
-        }
-        for query in queries
-    ]
-
-    exact = {
-        exact_tool_call_fingerprint("read_team_activity", tool_input)
-        for tool_input in inputs
-    }
-    semantic = {
-        semantic_tool_call_fingerprint("read_team_activity", tool_input)
-        for tool_input in inputs
-    }
-
-    assert len(exact) == 3
-    assert len(semantic) == 1
-    assert semantic_tool_call_fingerprint(
-        "read_team_activity",
-        {**inputs[0], "person": "different-reviewer@example.com"},
-    ) not in semantic
-    assert semantic_tool_call_fingerprint(
-        "summarize_file_for_task",
-        {
-            "path": "brain/agent.py",
-            "question": "Where does the loop stop?",
-            "focus": "Termination behavior",
-        },
-    ) == semantic_tool_call_fingerprint(
-        "summarize_file_for_task",
-        {
-            "path": "brain/agent.py",
-            "question": "Explain how this loop exits",
-            "focus": "Control-flow edges",
-        },
-    )
-
-
-def test_semantic_stall_trips_after_ten_calls_add_no_new_key_or_result():
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
-
-    policy = LoopControlPolicy()
-    targets = [f"thread-{index}" for index in range(10)]
-
-    for target in targets:
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_team_activity",
-                {"idea_id": target, "query": f"Initial evidence for {target}"},
-                {"items": [{"thread_id": target}]},
-            )
-        )
-    assert policy.termination is None
-
-    for index, target in enumerate(targets, start=1):
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_team_activity",
-                {"idea_id": target, "query": f"Paraphrased evidence request {index}"},
-                {"items": [{"thread_id": target}]},
-            )
-        )
-        if index < 10:
-            assert policy.termination is None
-
-    assert policy.termination is not None
-    assert "semantic" in policy.termination.message
-
-
-def test_paginated_reads_with_new_results_do_not_trip_semantic_stall():
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
-
-    policy = LoopControlPolicy()
-    for page in range(20):
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_team_activity",
-                {
-                    "query": "Promotion readiness evidence",
-                    "time_window": "week",
-                    "cursor": f"opaque-page-{page}",
-                },
-                {
-                    "items": [{"event_id": page}],
-                    "next_cursor": f"opaque-page-{page + 1}",
-                },
-            )
-        )
-
-    assert policy.termination is None
-
-
-def test_changing_poll_results_suppress_exact_and_semantic_loop_triggers():
-    from brain.systems.runs.direct_loop.loop_control import (
-        LoopControlPolicy,
-        exact_tool_call_fingerprint,
-        semantic_tool_call_fingerprint,
-    )
-
-    policy = LoopControlPolicy()
-    messages = []
-    exact_calls = []
-    semantic_calls = []
-    tool_input = {
-        "action": "pull_request_checks",
-        "repo": "Illospace/illospace",
-        "sha": "abc123",
-    }
-
-    for poll in range(20):
-        exact_calls.append(exact_tool_call_fingerprint("read_github_source", tool_input))
-        semantic_calls.append(
-            semantic_tool_call_fingerprint("read_github_source", tool_input)
-        )
-        assert policy.detect_stuck_loop(
-            exact_calls,
-            "session-changing-poll",
-            messages,
-            semantic_calls=semantic_calls,
-        ) is None
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_github_source",
-                tool_input,
-                {"status": "pending", "completed_checks": poll},
-            )
-        )
-
-    assert policy.termination is None
-    assert messages == []
-
-
-def test_unchanged_poll_result_trips_on_fourth_call():
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
-
-    policy = LoopControlPolicy()
-    tool_input = {
-        "action": "pull_request_checks",
-        "repo": "Illospace/illospace",
-        "sha": "abc123",
-    }
-
-    for poll in range(4):
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_github_source",
-                tool_input,
-                {"status": "pending"},
-                block_id=f"poll-{poll}",
-            )
-        )
-        if poll < 3:
-            assert policy.termination is None
-
-    assert policy.termination is not None
-    assert "unchanged result" in policy.termination.message
-
-
-def test_structurally_distinct_read_targets_do_not_trip_semantic_stall():
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
-
-    policy = LoopControlPolicy()
-    for index in range(20):
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "read_team_activity",
-                {
-                    "idea_id": f"thread-{index}",
-                    "query": f"Inspect target {index}",
-                    "search": f"ticket {index}",
-                },
-                {"items": []},
-            )
-        )
-
-    assert policy.termination is None
-
-
-def test_semantic_heuristics_do_not_apply_to_write_capable_tools():
-    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
-
-    policy = LoopControlPolicy()
-    for index in range(20):
-        policy.observe_tool_result(
-            _resolved_read_call(
-                "manage_cycle",
-                {
-                    "action": "create",
-                    "name": "Review reminder",
-                    "prompt": f"Review wording {index}",
-                },
-                {"ok": True},
-            )
-        )
-
-    assert policy.termination is None
 
 
 def test_final_reply_helpers_parse_json_and_cache_review():

--- a/tests/test_agent_runtime_modules.py
+++ b/tests/test_agent_runtime_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -611,6 +612,241 @@ def test_final_reply_evidence_reads_status_and_tool_failure_state_from_agent_con
     assert evidence.tool_failure_state.threshold_reached is True
     assert evidence.tool_failure_state.tool_name == "manage_idea"
     assert evidence.tool_failure_state.disabled_tools == ("manage_idea",)
+
+
+def _resolved_read_call(
+    tool_name: str,
+    tool_input: dict,
+    result: dict,
+    *,
+    block_id: str = "replay",
+):
+    from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
+
+    return ResolvedToolCall(
+        block_id=block_id,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        result_text=json.dumps(result, sort_keys=True),
+        result_value=result,
+    )
+
+
+def test_cycle_9_query_paraphrases_collapse_to_one_semantic_signature():
+    from brain.systems.runs.direct_loop.loop_control import (
+        exact_tool_call_fingerprint,
+        semantic_tool_call_fingerprint,
+    )
+
+    queries = [
+        "Promotion readiness workspace evidence during the scheduled review window",
+        "Promotion readiness workspace evidence for scheduled window",
+        (
+            "Promotion readiness workspace evidence in the scheduled review window, "
+            "including relevant thread/Cycle activity"
+        ),
+    ]
+    inputs = [
+        {
+            "query": query,
+            "time_window": "custom",
+            "start_at": "2026-07-01T14:00:00Z",
+            "end_at": "2026-07-01T15:00:00Z",
+            "person": "reviewer@example.com",
+        }
+        for query in queries
+    ]
+
+    exact = {
+        exact_tool_call_fingerprint("read_team_activity", tool_input)
+        for tool_input in inputs
+    }
+    semantic = {
+        semantic_tool_call_fingerprint("read_team_activity", tool_input)
+        for tool_input in inputs
+    }
+
+    assert len(exact) == 3
+    assert len(semantic) == 1
+    assert semantic_tool_call_fingerprint(
+        "read_team_activity",
+        {**inputs[0], "person": "different-reviewer@example.com"},
+    ) not in semantic
+    assert semantic_tool_call_fingerprint(
+        "summarize_file_for_task",
+        {
+            "path": "brain/agent.py",
+            "question": "Where does the loop stop?",
+            "focus": "Termination behavior",
+        },
+    ) == semantic_tool_call_fingerprint(
+        "summarize_file_for_task",
+        {
+            "path": "brain/agent.py",
+            "question": "Explain how this loop exits",
+            "focus": "Control-flow edges",
+        },
+    )
+
+
+def test_semantic_stall_trips_after_ten_calls_add_no_new_key_or_result():
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    policy = LoopControlPolicy()
+    targets = [f"thread-{index}" for index in range(10)]
+
+    for target in targets:
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_team_activity",
+                {"idea_id": target, "query": f"Initial evidence for {target}"},
+                {"items": [{"thread_id": target}]},
+            )
+        )
+    assert policy.termination is None
+
+    for index, target in enumerate(targets, start=1):
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_team_activity",
+                {"idea_id": target, "query": f"Paraphrased evidence request {index}"},
+                {"items": [{"thread_id": target}]},
+            )
+        )
+        if index < 10:
+            assert policy.termination is None
+
+    assert policy.termination is not None
+    assert "semantic" in policy.termination.message
+
+
+def test_paginated_reads_with_new_results_do_not_trip_semantic_stall():
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    policy = LoopControlPolicy()
+    for page in range(20):
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_team_activity",
+                {
+                    "query": "Promotion readiness evidence",
+                    "time_window": "week",
+                    "cursor": f"opaque-page-{page}",
+                },
+                {
+                    "items": [{"event_id": page}],
+                    "next_cursor": f"opaque-page-{page + 1}",
+                },
+            )
+        )
+
+    assert policy.termination is None
+
+
+def test_changing_poll_results_suppress_exact_and_semantic_loop_triggers():
+    from brain.systems.runs.direct_loop.loop_control import (
+        LoopControlPolicy,
+        exact_tool_call_fingerprint,
+        semantic_tool_call_fingerprint,
+    )
+
+    policy = LoopControlPolicy()
+    messages = []
+    exact_calls = []
+    semantic_calls = []
+    tool_input = {
+        "action": "pull_request_checks",
+        "repo": "Illospace/illospace",
+        "sha": "abc123",
+    }
+
+    for poll in range(20):
+        exact_calls.append(exact_tool_call_fingerprint("read_github_source", tool_input))
+        semantic_calls.append(
+            semantic_tool_call_fingerprint("read_github_source", tool_input)
+        )
+        assert policy.detect_stuck_loop(
+            exact_calls,
+            "session-changing-poll",
+            messages,
+            semantic_calls=semantic_calls,
+        ) is None
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_github_source",
+                tool_input,
+                {"status": "pending", "completed_checks": poll},
+            )
+        )
+
+    assert policy.termination is None
+    assert messages == []
+
+
+def test_unchanged_poll_result_trips_on_fourth_call():
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    policy = LoopControlPolicy()
+    tool_input = {
+        "action": "pull_request_checks",
+        "repo": "Illospace/illospace",
+        "sha": "abc123",
+    }
+
+    for poll in range(4):
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_github_source",
+                tool_input,
+                {"status": "pending"},
+                block_id=f"poll-{poll}",
+            )
+        )
+        if poll < 3:
+            assert policy.termination is None
+
+    assert policy.termination is not None
+    assert "unchanged result" in policy.termination.message
+
+
+def test_structurally_distinct_read_targets_do_not_trip_semantic_stall():
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    policy = LoopControlPolicy()
+    for index in range(20):
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "read_team_activity",
+                {
+                    "idea_id": f"thread-{index}",
+                    "query": f"Inspect target {index}",
+                    "search": f"ticket {index}",
+                },
+                {"items": []},
+            )
+        )
+
+    assert policy.termination is None
+
+
+def test_semantic_heuristics_do_not_apply_to_write_capable_tools():
+    from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+
+    policy = LoopControlPolicy()
+    for index in range(20):
+        policy.observe_tool_result(
+            _resolved_read_call(
+                "manage_cycle",
+                {
+                    "action": "create",
+                    "name": "Review reminder",
+                    "prompt": f"Review wording {index}",
+                },
+                {"ok": True},
+            )
+        )
+
+    assert policy.termination is None
 
 
 def test_final_reply_helpers_parse_json_and_cache_review():

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -337,6 +337,7 @@ class TestRuntimeExtractionContracts:
         assert isinstance(state.loop_control, LoopControlPolicy)
         assert state.loop_control.termination is None
         assert state.recent_calls == ["read_file:{}"]
+        assert state.recent_semantic_calls == []
         assert state.tool_calls_made == ["read_file"]
         assert state.operation_type == "worker"
         assert state.metadata == {"role": "worker"}
@@ -350,7 +351,17 @@ class TestRuntimeExtractionContracts:
         assert agent_inject_nudges is _inject_nudges
 
         messages = []
-        assert _detect_stuck_loop(["read_file:{}"] * 5, "session-1", messages)
+        exact_return = "read_team_activity:{\"query\": \"original\"}"
+        trace = [
+            exact_return,
+            "read_team_activity:{\"query\": \"paraphrase one\"}",
+            "read_team_activity:{\"query\": \"paraphrase two\"}",
+            exact_return,
+            exact_return,
+            exact_return,
+            exact_return,
+        ]
+        assert _detect_stuck_loop(trace, "session-1", messages)
         # The fabricated stuck message must not masquerade as model output.
         assert messages[-1]["role"] == "user"
         assert "stuck in a loop" in messages[-1]["content"][0]["text"]

--- a/tests/test_agent_split.py
+++ b/tests/test_agent_split.py
@@ -320,69 +320,36 @@ class TestRunAgentSignature:
 class TestRuntimeExtractionContracts:
     """New runtime collaborators stay importable and behavior-preserving."""
 
-    def test_agent_loop_state_tracks_loop_mutables(self):
+    def test_agent_loop_state_tracks_run_control(self):
         from brain.systems.runs.direct_loop.gates import GateState
-        from brain.systems.runs.direct_loop.loop_control import LoopControlPolicy
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
         from brain.systems.runs.direct_loop.result import TokenAccumulator
         from brain.systems.runs.direct_loop.state import AgentLoopState
 
         state = AgentLoopState(operation_type="worker", metadata={"role": "worker"})
         state.messages.append({"role": "user", "content": "hi"})
-        state.recent_calls.append("read_file:{}")
         state.tool_calls_made.append("read_file")
 
         assert state.messages == [{"role": "user", "content": "hi"}]
         assert isinstance(state.gates, GateState)
         assert isinstance(state.tokens, TokenAccumulator)
-        assert isinstance(state.loop_control, LoopControlPolicy)
+        assert isinstance(state.loop_control, RunControlPolicy)
         assert state.loop_control.termination is None
-        assert state.recent_calls == ["read_file:{}"]
-        assert state.recent_semantic_calls == []
         assert state.tool_calls_made == ["read_file"]
         assert state.operation_type == "worker"
         assert state.metadata == {"role": "worker"}
 
-    def test_loop_control_helpers_are_runtime_owned_and_reexported(self):
-        from brain.systems.runs.direct_agent import _detect_stuck_loop as agent_detect_stuck_loop
-        from brain.systems.runs.direct_agent import _inject_nudges as agent_inject_nudges
-        from brain.systems.runs.direct_loop.loop_control import _detect_stuck_loop, _inject_nudges
+    def test_run_control_composes_loop_and_failure_policies(self):
+        from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
+        from brain.systems.runs.direct_loop.loop_guard import LoopGuard
+        from brain.systems.runs.direct_loop.tool_failure_policy import (
+            ToolFailurePolicy,
+        )
 
-        assert agent_detect_stuck_loop is _detect_stuck_loop
-        assert agent_inject_nudges is _inject_nudges
+        policy = RunControlPolicy()
 
-        messages = []
-        exact_return = "read_team_activity:{\"query\": \"original\"}"
-        trace = [
-            exact_return,
-            "read_team_activity:{\"query\": \"paraphrase one\"}",
-            "read_team_activity:{\"query\": \"paraphrase two\"}",
-            exact_return,
-            exact_return,
-            exact_return,
-            exact_return,
-        ]
-        assert _detect_stuck_loop(trace, "session-1", messages)
-        # The fabricated stuck message must not masquerade as model output.
-        assert messages[-1]["role"] == "user"
-        assert "stuck in a loop" in messages[-1]["content"][0]["text"]
-
-    def test_inject_nudges_returns_only_durable_reminder(self):
-        from brain.systems.runs.direct_loop.loop_control import _inject_nudges
-
-        # Below the warn threshold: nothing to say.
-        assert _inject_nudges(["read_file:{}"]) is None
-
-        # 3 identical calls: durable `cd` reminder, no strategy second-guessing.
-        message = _inject_nudges(["read_file:{}"] * 3)
-        assert message is not None
-        assert message["role"] == "user"
-        assert "cd` does not persist" in message["content"]
-        assert "different strategy" not in message["content"]
-        assert "run_script" not in message["content"]
-        assert "adding NEW information" not in message["content"]
-
-        # Non-repeating calls: no reminder.
-        assert _inject_nudges(["read_file:{}", "write_file:{}", "list_files:{}"]) is None
+        assert isinstance(policy.loop_guard, LoopGuard)
+        assert isinstance(policy.tool_failures, ToolFailurePolicy)
 
     def test_session_effects_apply_harvest_and_save(self):
         from brain.systems.runs.direct_loop.session_effects import apply_agent_session_side_effects

--- a/tests/test_loop_control.py
+++ b/tests/test_loop_control.py
@@ -1,0 +1,329 @@
+"""Focused tests for call identity, progress tracking, and loop detectors."""
+
+from __future__ import annotations
+
+import json
+
+from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
+from brain.systems.runs.direct_loop.loop_guard import (
+    ExactRepeatDetector,
+    LoopTrigger,
+    Progress,
+    ProgressObservation,
+    ProgressTracker,
+    ToolCallIdentity,
+    tool_call_identity,
+    tool_call_target_key,
+)
+from brain.systems.runs.direct_loop.tool_execution import ResolvedToolCall
+from brain.systems.runs.tool_catalog.metadata import ToolCallIdentitySpec
+from brain.systems.runs.tool_catalog.registry import get_tool_registration
+
+
+def _resolved_read_call(
+    tool_name: str,
+    tool_input: dict,
+    result: dict,
+    *,
+    block_id: str = "replay",
+) -> ResolvedToolCall:
+    return ResolvedToolCall(
+        block_id=block_id,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        result_text=json.dumps(result, sort_keys=True),
+        result_value=result,
+    )
+
+
+class TestIdentityProjection:
+    def test_cycle_9_query_paraphrases_share_the_declared_target(self):
+        queries = [
+            "Promotion readiness workspace evidence during the scheduled review window",
+            "Promotion readiness workspace evidence for scheduled window",
+            (
+                "Promotion readiness workspace evidence in the scheduled review "
+                "window, including relevant thread/Cycle activity"
+            ),
+        ]
+        inputs = [
+            {
+                "query": query,
+                "time_window": "custom",
+                "start_at": "2026-07-01T14:00:00Z",
+                "end_at": "2026-07-01T15:00:00Z",
+                "person": "reviewer@example.com",
+            }
+            for query in queries
+        ]
+
+        identities = [
+            tool_call_identity("read_team_activity", tool_input)
+            for tool_input in inputs
+        ]
+
+        assert len({identity.exact_key for identity in identities}) == 3
+        assert len({identity.target_key for identity in identities}) == 1
+        assert tool_call_target_key(
+            "read_team_activity",
+            {**inputs[0], "person": "different-reviewer@example.com"},
+        ) != identities[0].target_key
+
+    def test_catalog_projection_omits_only_tool_declared_volatile_fields(self):
+        first_summary = tool_call_target_key(
+            "summarize_file_for_task",
+            {
+                "path": "brain/agent.py",
+                "question": "Where does the loop stop?",
+                "focus": "Termination behavior",
+            },
+        )
+        second_summary = tool_call_target_key(
+            "summarize_file_for_task",
+            {
+                "path": "brain/agent.py",
+                "question": "Explain how this loop exits",
+                "focus": "Control-flow edges",
+            },
+        )
+
+        assert first_summary == second_summary
+        assert tool_call_target_key(
+            "web_search",
+            {"query": "first independently meaningful search"},
+        ) != tool_call_target_key(
+            "web_search",
+            {"query": "second independently meaningful search"},
+        )
+
+    def test_identity_spec_is_typed_and_absent_from_permission_payload(self):
+        registration = get_tool_registration("read_team_activity")
+
+        assert registration is not None
+        assert isinstance(registration.identity_spec, ToolCallIdentitySpec)
+        assert registration.identity_spec.volatile_fields == (
+            "cursor",
+            "query",
+            "search",
+        )
+        assert "identity_spec" not in registration.to_permission_payload()
+
+
+class TestProgressTracking:
+    def test_tracker_emits_new_changed_and_unchanged_observations(self):
+        tracker = ProgressTracker()
+        identity = ToolCallIdentity(exact_key="exact", target_key="target")
+
+        new_target = tracker.observe(identity, "result-a")
+        changed = tracker.observe(identity, "result-b")
+        unchanged = tracker.observe(identity, "result-b")
+
+        assert new_target.progress is Progress.NEW_TARGET
+        assert changed.progress is Progress.CHANGED
+        assert unchanged.progress is Progress.UNCHANGED
+        assert all(
+            observation.identity is identity
+            for observation in (new_target, changed, unchanged)
+        )
+
+
+class TestExactRepeatDetector:
+    def test_changing_progress_resets_exact_repetition(self):
+        detector = ExactRepeatDetector(break_threshold=3)
+        identity = ToolCallIdentity(exact_key="exact", target_key="target")
+
+        assert detector.observe(
+            ProgressObservation(identity, "a", Progress.NEW_TARGET)
+        ) is None
+        assert detector.observe(
+            ProgressObservation(identity, "a", Progress.UNCHANGED)
+        ) is None
+        assert detector.observe(
+            ProgressObservation(identity, "b", Progress.CHANGED)
+        ) is None
+        assert detector.observe(
+            ProgressObservation(identity, "b", Progress.UNCHANGED)
+        ) is None
+
+    def test_byte_identical_repeats_still_trip_the_exact_detector(self):
+        policy = RunControlPolicy(
+            exact_repeat_threshold=5,
+            semantic_stall_threshold=100,
+            unchanged_result_threshold=100,
+        )
+        tool_input = {
+            "action": "pull_request_checks",
+            "repo": "Illospace/illospace",
+            "sha": "abc123",
+        }
+
+        for poll in range(5):
+            decision = policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_github_source",
+                    tool_input,
+                    {"status": "pending"},
+                    block_id=f"poll-{poll}",
+                )
+            )
+            if poll < 4:
+                assert decision.termination is None
+
+        assert policy.termination is not None
+        assert policy.termination.trigger is LoopTrigger.EXACT_REPEAT
+
+    def test_reminder_comes_from_detector_state(self):
+        detector = ExactRepeatDetector(break_threshold=5, warn_threshold=3)
+        identity = ToolCallIdentity(exact_key="exact", target_key="target")
+
+        for count in range(3):
+            detector.observe(
+                ProgressObservation(
+                    identity,
+                    "same",
+                    Progress.NEW_TARGET if count == 0 else Progress.UNCHANGED,
+                )
+            )
+
+        message = detector.reminder_message()
+        assert message is not None
+        assert message["role"] == "user"
+        assert "cd` does not persist" in message["content"]
+
+
+class TestSemanticNoProgressDetector:
+    def test_paraphrased_team_activity_calls_trip_after_ten_stalled_targets(self):
+        policy = RunControlPolicy(unchanged_result_threshold=100)
+        targets = [f"thread-{index}" for index in range(10)]
+
+        for target in targets:
+            policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_team_activity",
+                    {"idea_id": target, "query": f"Initial evidence for {target}"},
+                    {"items": [{"thread_id": target}]},
+                )
+            )
+        assert policy.termination is None
+
+        for index, target in enumerate(targets, start=1):
+            decision = policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_team_activity",
+                    {
+                        "idea_id": target,
+                        "query": f"Paraphrased evidence request {index}",
+                    },
+                    {"items": [{"thread_id": target}]},
+                )
+            )
+            if index < 10:
+                assert decision.termination is None
+
+        assert policy.termination is not None
+        assert policy.termination.trigger is LoopTrigger.SEMANTIC_NO_PROGRESS
+
+    def test_structurally_distinct_targets_do_not_trip(self):
+        policy = RunControlPolicy()
+
+        for index in range(20):
+            policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_team_activity",
+                    {
+                        "idea_id": f"thread-{index}",
+                        "query": f"Inspect target {index}",
+                        "search": f"ticket {index}",
+                    },
+                    {"items": []},
+                )
+            )
+
+        assert policy.termination is None
+
+
+class TestUnchangedResultDetector:
+    def test_unchanged_poll_result_trips_on_fourth_call(self):
+        policy = RunControlPolicy()
+        tool_input = {
+            "action": "pull_request_checks",
+            "repo": "Illospace/illospace",
+            "sha": "abc123",
+        }
+
+        for poll in range(4):
+            decision = policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_github_source",
+                    tool_input,
+                    {"status": "pending"},
+                    block_id=f"poll-{poll}",
+                )
+            )
+            if poll < 3:
+                assert decision.termination is None
+
+        assert policy.termination is not None
+        assert policy.termination.trigger is LoopTrigger.UNCHANGED_RESULT
+
+
+class TestLegitimateProgress:
+    def test_changing_poll_results_suppress_every_loop_detector(self):
+        policy = RunControlPolicy()
+        tool_input = {
+            "action": "pull_request_checks",
+            "repo": "Illospace/illospace",
+            "sha": "abc123",
+        }
+
+        for poll in range(20):
+            decision = policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_github_source",
+                    tool_input,
+                    {"status": "pending", "completed_checks": poll},
+                )
+            )
+            assert decision.termination is None
+
+        assert policy.termination is None
+
+    def test_paginated_reads_with_new_results_do_not_trip(self):
+        policy = RunControlPolicy()
+
+        for page in range(20):
+            decision = policy.observe_tool_result(
+                _resolved_read_call(
+                    "read_team_activity",
+                    {
+                        "query": "Promotion readiness evidence",
+                        "time_window": "week",
+                        "cursor": f"opaque-page-{page}",
+                    },
+                    {
+                        "items": [{"event_id": page}],
+                        "next_cursor": f"opaque-page-{page + 1}",
+                    },
+                )
+            )
+            assert decision.termination is None
+
+        assert policy.termination is None
+
+    def test_progress_heuristics_do_not_apply_to_write_capable_tools(self):
+        policy = RunControlPolicy()
+
+        for index in range(20):
+            policy.observe_tool_result(
+                _resolved_read_call(
+                    "manage_cycle",
+                    {
+                        "action": "create",
+                        "name": "Review reminder",
+                        "prompt": f"Review wording {index}",
+                    },
+                    {"ok": True},
+                )
+            )
+
+        assert policy.termination is None

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -490,6 +490,50 @@ async def test_disablement_skips_only_failed_tool_and_runs_healthy_call_in_same_
     assert json.loads(execution.tool_results[2]["content"]) == {"ok": True}
 
 
+async def test_unchanged_result_termination_skips_later_serial_calls():
+    attempts = []
+
+    async def pending_handler(**tool_input):
+        attempts.append(tool_input["query"])
+        return {"status": "pending"}
+
+    policy = LoopControlPolicy()
+    for index in range(3):
+        policy.observe_tool_result(
+            ResolvedToolCall(
+                block_id=f"prior-{index}",
+                tool_name="read_team_activity",
+                tool_input={"time_window": "week", "query": f"prior wording {index}"},
+                result_text='{"status": "pending"}',
+                result_value={"status": "pending"},
+            )
+        )
+    assert policy.termination is None
+
+    execution = await _execute_async(
+        _response(
+            (
+                "trips-loop",
+                "read_team_activity",
+                {"time_window": "week", "query": "another paraphrase"},
+            ),
+            (
+                "skipped-after-loop",
+                "read_team_activity",
+                {"time_window": "week", "query": "one more paraphrase"},
+            ),
+        ),
+        {"read_team_activity": pending_handler},
+        loop_control=policy,
+    )
+
+    assert attempts == ["another paraphrase"]
+    assert execution.termination is policy.termination
+    assert execution.termination is not None
+    assert execution.tool_results[1]["is_error"] is True
+    assert "unchanged result" in execution.tool_results[1]["content"]
+
+
 def test_classifier_ignores_legacy_payload_category():
     outcome = classify_tool_result({
         "error": "invalid tool input",

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -7,8 +7,8 @@ from dataclasses import asdict
 from types import SimpleNamespace
 
 from brain.systems.runs.direct_loop.gates import GateState, check_gate_violations
-from brain.systems.runs.direct_loop.loop_control import (
-    LoopControlPolicy,
+from brain.systems.runs.direct_loop.loop_control import RunControlPolicy
+from brain.systems.runs.direct_loop.tool_failure_policy import (
     ToolFailureTrigger,
 )
 from brain.systems.runs.tool_outcomes import (
@@ -68,7 +68,7 @@ def _execute_sync(
         parallel_safe_tool_names=parallel_safe_tool_names,
         max_parallel_tool_calls=max_parallel_tool_calls,
         check_gate_violations=check_gate_violations,
-        loop_control=loop_control or LoopControlPolicy(),
+        loop_control=loop_control or RunControlPolicy(),
     )
 
 
@@ -100,7 +100,7 @@ async def _execute_async(
         parallel_safe_tool_names=parallel_safe_tool_names,
         max_parallel_tool_calls=max_parallel_tool_calls,
         check_gate_violations=check_gate_violations,
-        loop_control=loop_control or LoopControlPolicy(),
+        loop_control=loop_control or RunControlPolicy(),
     )
 
 
@@ -265,7 +265,7 @@ def _observed_result(*, failed: bool) -> ResolvedToolCall:
 
 
 def test_failure_policy_replay_trips_on_fourth_call_of_interleaved_trace():
-    policy = LoopControlPolicy(
+    policy = RunControlPolicy(
         failure_threshold=3,
         failure_window_calls=10,
         zero_success_failure_threshold=2,
@@ -281,10 +281,10 @@ def test_failure_policy_replay_trips_on_fourth_call_of_interleaved_trace():
     trip_call_index = None
     trip = None
     for call_index, failed in enumerate(trace, start=1):
-        edge = policy.observe_tool_result(_observed_result(failed=failed))
-        if edge is not None:
+        decision = policy.observe_tool_result(_observed_result(failed=failed))
+        if decision.disablement is not None:
             trip_call_index = call_index
-            trip = edge
+            trip = decision.disablement
             break
 
     assert trip_call_index == 4
@@ -298,7 +298,7 @@ def test_failure_policy_replay_trips_on_fourth_call_of_interleaved_trace():
 
 
 def test_failure_policy_disables_after_two_failures_with_zero_successes():
-    policy = LoopControlPolicy(
+    policy = RunControlPolicy(
         failure_threshold=3,
         failure_window_calls=10,
         zero_success_failure_threshold=2,
@@ -307,35 +307,49 @@ def test_failure_policy_disables_after_two_failures_with_zero_successes():
     first = policy.observe_tool_result(_observed_result(failed=True))
     second = policy.observe_tool_result(_observed_result(failed=True))
 
-    assert first is None
-    assert second is not None
+    assert first.disablement is None
+    assert second.disablement is not None
     assert policy.termination is None
     disablement = policy.disabled_tools["check_fix_deploy_state"]
-    assert second is disablement
+    assert second.disablement is disablement
     assert disablement.triggers == (ToolFailureTrigger.ZERO_SUCCESS,)
     assert disablement.total_failures == 2
     assert disablement.total_successes == 0
-    assert policy.observe_tool_result(_observed_result(failed=True)) is None
+    assert (
+        policy.observe_tool_result(_observed_result(failed=True)).disablement
+        is None
+    )
     assert list(policy.disabled_tools) == ["check_fix_deploy_state"]
 
-    rearmed_policy = LoopControlPolicy(
+    rearmed_policy = RunControlPolicy(
         failure_threshold=3,
         failure_window_calls=10,
         zero_success_failure_threshold=2,
     )
     assert rearmed_policy.disabled_tools == {}
-    assert rearmed_policy.observe_tool_result(_observed_result(failed=True)) is None
+    assert (
+        rearmed_policy.observe_tool_result(
+            _observed_result(failed=True)
+        ).disablement
+        is None
+    )
 
 
 def test_failure_policy_does_not_disable_after_one_failure_then_success():
-    policy = LoopControlPolicy(
+    policy = RunControlPolicy(
         failure_threshold=3,
         failure_window_calls=10,
         zero_success_failure_threshold=2,
     )
 
-    assert policy.observe_tool_result(_observed_result(failed=True)) is None
-    assert policy.observe_tool_result(_observed_result(failed=False)) is None
+    assert (
+        policy.observe_tool_result(_observed_result(failed=True)).disablement
+        is None
+    )
+    assert (
+        policy.observe_tool_result(_observed_result(failed=False)).disablement
+        is None
+    )
     assert policy.disabled_tools == {}
 
 
@@ -344,7 +358,7 @@ def test_failure_policy_reads_thresholds_from_environment(monkeypatch):
     monkeypatch.setenv("AGENT_TOOL_FAILURE_WINDOW_CALLS", "12")
     monkeypatch.setenv("AGENT_TOOL_ZERO_SUCCESS_FAILURE_THRESHOLD", "4")
 
-    policy = LoopControlPolicy()
+    policy = RunControlPolicy()
 
     assert policy.failure_threshold == 5
     assert policy.failure_window_calls == 12
@@ -446,7 +460,7 @@ async def test_disablement_skips_only_failed_tool_and_runs_healthy_call_in_same_
         attempts.append("healthy")
         return {"ok": True}
 
-    policy = LoopControlPolicy(
+    policy = RunControlPolicy(
         failure_threshold=3,
         failure_window_calls=10,
         zero_success_failure_threshold=2,
@@ -462,7 +476,7 @@ async def test_disablement_skips_only_failed_tool_and_runs_healthy_call_in_same_
                 category="RuntimeError",
             ),
         )
-    ) is None
+    ).disablement is None
 
     execution = await _execute_async(
         _response(
@@ -497,7 +511,7 @@ async def test_unchanged_result_termination_skips_later_serial_calls():
         attempts.append(tool_input["query"])
         return {"status": "pending"}
 
-    policy = LoopControlPolicy()
+    policy = RunControlPolicy()
     for index in range(3):
         policy.observe_tool_result(
             ResolvedToolCall(


### PR DESCRIPTION
Closes #506

## What was wrong

Loop detection required the last three tool calls to be **byte-identical**. Models paraphrase free-text arguments, so a genuine attractor loop never tripped it — cycle 9 run 2718 looped for 40 minutes undetected. Over its 200 captured calls, 97 signatures looked "novel" by exact match; only 62 were semantically distinct, and the longest stretch adding no new semantic target ran 43 calls.

## What this does

Three detectors behind one evaluator, all fed by a single `ProgressObservation`:

- **exact repeat** — the original trigger, unchanged in intent
- **semantic no-progress** — fires when a window of calls adds no new *target*, where "target" is the call's arguments minus the fields a tool declares volatile
- **unchanged result** — fires when the same target keeps returning the same bytes

"A changing result suppresses exact repetition" is a property of the observation each detector sees, not one detector reaching into another's state.

Which argument fields are volatile is now declared **per tool in the catalog** (`ToolCallIdentitySpec`). The first pass guessed globally from field names, which silently gave loop-control meaning to any argument called `query`, `search`, `prompt` or `cursor` — a tool owner could acquire detection semantics by naming a field.

## Verification (executed on this branch)

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-506-fix1
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest -q
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/test_loop_control.py -q
```

**Full suite: 4326 passed, 76 skipped, 0 failed.** (Run outside the worker sandbox — inside it, five GPU tests and one OAuth test fail on `PermissionError` binding `127.0.0.1`. Environmental; they pass here.)

## Acceptance checks

Each is a named test, run individually and passing:

1. Paraphrased `read_team_activity` calls trip the no-progress detector — `TestSemanticNoProgressDetector::test_paraphrased_team_activity_calls_trip_after_ten_stalled_targets`
2. Byte-identical repeats still trip the original detector — `TestExactRepeatDetector::test_byte_identical_repeats_still_trip_the_exact_detector`
3. Legitimate polling whose results change does **not** trip anything — `TestLegitimateProgress::test_changing_poll_results_suppress_every_loop_detector`
4. Pagination through genuinely new results does **not** trip — `TestLegitimateProgress::test_paginated_reads_with_new_results_do_not_trip`

## Review history

Built, then put through a cross-family code-quality review, which returned three blocking findings: the policy class had become a grab-bag owning every trigger and their interactions; tool-call identity had two owners with detector vocabulary leaking into the catalog; and the new tests pushed a broad module past 1,000 lines. All three are fixed in the second commit — `loop_control.py` is 597 lines lighter, with `loop_guard.py` and `tool_failure_policy.py` split out and the tests moved to `tests/test_loop_control.py`.

## Judgement call worth your eye

The detectors are heuristics with a false-positive cost: tripping one interrupts a run. The guard is that structural arguments (person, time window, ids, refs, paths, shas) stay in the target, and any progress resets the window — that is what checks 3 and 4 above pin down. If you think the windows (10 stalled targets, 4 unchanged results) are tuned wrong, those are the numbers to argue about.