### PR TITLE
feat(promotion): hourly detector wakes the readiness cycle on SHA-pair movement

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -90,7 +90,11 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
         "timezone": "UTC",
         "default_payload": {
             "name": "Uwear Staging Promotion PR",
-            "description": "Hourly staging-to-main promotion pull request reconciliation",
+            "description": (
+                "Hourly staging-to-main promotion pull request reconciliation; "
+                "wakes the promotion-readiness cycle when the promotable SHA "
+                "pair moves past its last completed evaluation"
+            ),
             "action_manifest": ["create_github_pull_request"],
         },
         "task_contract": {
@@ -98,7 +102,8 @@ SCHEDULER_CATALOG: tuple[dict[str, Any], ...] = (
             "allowed_actions": ["scheduler.run", "create_github_pull_request"],
             "output_channel": "scheduler",
             "success_criteria": [
-                "Each configured repository with staging ahead has one open promotion pull request"
+                "Each configured repository with staging ahead has one open promotion pull request",
+                "The readiness cycle is woken when the promotable SHA pair has moved",
             ],
         },
         "priority": 90,

--- a/brain/jobs/pipelines/staging_promotion_pr.py
+++ b/brain/jobs/pipelines/staging_promotion_pr.py
@@ -9,20 +9,32 @@ from typing import Any
 
 from sqlalchemy import select
 
+from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.cortex.project_context.github import async_get_repo_branch_head
 from brain.systems.cortex.project_context.github_promotion import (
     PROMOTION_PULL_REQUEST_POLICY,
     PromotionPullRequestResult,
     async_reconcile_promotion_pull_request,
 )
+from brain.systems.cycles.service import async_wake_cycle_now
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
 
 logger = logging.getLogger("illo.jobs.staging_promotion_pr")
 
 CONFIGURED_REPOS = tuple(sorted(PROMOTION_PULL_REQUEST_POLICY.repositories))
+
+# The repository whose promotion readiness has an agent-run analysis cycle.
+# When this repo's (staging, main) pair moves past the cycle's last completed
+# evaluation, the detector wakes that cycle instead of waiting for its
+# scheduled backstop slot — small deltas per evaluation, no catch-up storms.
+READINESS_WAKE_REPO = "uwear-ai/uwear-backend"
+READINESS_CYCLE_NAME = "Uwear Backend Promotion Readiness"
+READINESS_STATUS_DOMAIN_SLUG = "promotion-readiness"
+READINESS_STATUS_OBJECT_KEY = "status"
 
 
 @dataclass(frozen=True)
@@ -99,10 +111,97 @@ async def _repo_token(repo: str, actor: PromotionActor) -> str:
     return token
 
 
+async def _async_last_evaluated_pair(org_id: str) -> tuple[str | None, str | None]:
+    """Read the readiness cycle's last evaluated (staging, main) SHA pair.
+
+    The status record is runtime-authored by the cycle (its playbook pins the
+    domain slug and object key), so every miss — no domain, no record, empty
+    fields — reads as "no baseline" and the caller wakes the cycle to evaluate.
+    Domain slugs are only unique per org, so the lookup is scoped to the org
+    that owns the repo's GitHub App binding.
+    """
+    async with UnitOfWork() as uow:
+        record = (
+            await uow.session.scalars(
+                select(DomainRecord)
+                .join(Domain, Domain.id == DomainRecord.domain_id)
+                .join(
+                    DomainObjectType,
+                    DomainObjectType.id == DomainRecord.object_type_id,
+                )
+                .where(
+                    Domain.slug == READINESS_STATUS_DOMAIN_SLUG,
+                    Domain.org_id == org_id,
+                    Domain.archived_at.is_(None),
+                    DomainObjectType.key == READINESS_STATUS_OBJECT_KEY,
+                    DomainObjectType.archived_at.is_(None),
+                    DomainRecord.org_id == org_id,
+                    DomainRecord.archived_at.is_(None),
+                )
+                .order_by(DomainRecord.updated_at.desc())
+                .limit(1)
+            )
+        ).first()
+    if record is None or not isinstance(record.data, dict):
+        return None, None
+    staging = str(record.data.get("last_staging_sha") or "").strip() or None
+    main = str(record.data.get("last_main_sha") or "").strip() or None
+    return staging, main
+
+
+# Wake dispositions that leave the scheduler run green. "not_found" and
+# "ambiguous" are deliberately absent: a wake that can never fire again must
+# fail the run loudly instead of presenting as healthy while doing no work.
+READINESS_WAKE_OK_OUTCOMES = frozenset(
+    {"pair_unchanged", "woken", "already_pending", "run_in_flight"}
+)
+
+
+async def _async_wake_readiness_cycle(token: str, org_id: str) -> dict[str, Any]:
+    """Wake the readiness cycle when the promotable SHA pair has moved.
+
+    Comparing against the cycle's own last completed evaluation (not this
+    job's previous observation) makes the wake self-retrying: an evaluation
+    that failed to complete leaves the baseline unchanged, so the next hourly
+    tick wakes the cycle again until an evaluation lands.
+    """
+    staging_sha = await async_get_repo_branch_head(
+        READINESS_WAKE_REPO, PROMOTION_PULL_REQUEST_POLICY.head, token=token
+    )
+    main_sha = await async_get_repo_branch_head(
+        READINESS_WAKE_REPO, PROMOTION_PULL_REQUEST_POLICY.base, token=token
+    )
+    last_staging, last_main = await _async_last_evaluated_pair(org_id)
+    if (staging_sha, main_sha) == (last_staging, last_main):
+        return {
+            "cycle": READINESS_CYCLE_NAME,
+            "outcome": "pair_unchanged",
+            "staging_sha": staging_sha,
+            "main_sha": main_sha,
+        }
+    disposition = await async_wake_cycle_now(name=READINESS_CYCLE_NAME)
+    logger.info(
+        "Readiness wake for %s: %s (staging %s vs evaluated %s)",
+        READINESS_WAKE_REPO,
+        disposition,
+        staging_sha[:7],
+        (last_staging or "none")[:7],
+    )
+    return {
+        "cycle": READINESS_CYCLE_NAME,
+        "outcome": disposition,
+        "staging_sha": staging_sha,
+        "main_sha": main_sha,
+    }
+
+
 async def run_promotion_job() -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     failures = 0
+    wake: dict[str, Any] | None = None
     for repo in CONFIGURED_REPOS:
+        token: str | None = None
+        actor: PromotionActor | None = None
         try:
             target = PROMOTION_PULL_REQUEST_POLICY.target_for(repo)
             actor = await _promotion_actor(repo)
@@ -118,12 +217,36 @@ async def run_promotion_job() -> dict[str, Any]:
             logger.error("Promotion PR reconciliation failed for %s: %s", repo, error)
             result = {"repo": repo, "outcome": "error", "error": error}
         results.append(result)
-    return {
+
+        if (
+            repo == READINESS_WAKE_REPO
+            and token is not None
+            and actor is not None
+            and result["outcome"] in ("created", "already_open")
+        ):
+            try:
+                wake = await _async_wake_readiness_cycle(token, actor.org_id)
+                if wake["outcome"] not in READINESS_WAKE_OK_OUTCOMES:
+                    failures += 1
+                    logger.error(
+                        "Readiness cycle wake settled dead for %s: %s",
+                        repo,
+                        wake["outcome"],
+                    )
+            except Exception as exc:  # noqa: BLE001 - a broken wake path must be visible, not silent
+                failures += 1
+                error = str(getattr(exc, "message", None) or exc)
+                logger.error("Readiness cycle wake failed for %s: %s", repo, error)
+                wake = {"cycle": READINESS_CYCLE_NAME, "outcome": "error", "error": error}
+    payload: dict[str, Any] = {
         "job": "uwear_staging_promotion_pr",
         "ok": failures == 0,
         "failures": failures,
         "results": results,
     }
+    if wake is not None:
+        payload["readiness_wake"] = wake
+    return payload
 
 
 async def async_main() -> int:

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -586,6 +586,19 @@ async def _async_resolve_repo_ref(
     }
 
 
+async def async_get_repo_branch_head(
+    slug: str,
+    branch: str,
+    *,
+    token: str | None = None,
+) -> str:
+    """Resolve a branch name to its current head commit SHA."""
+
+    async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
+        resolved = await _async_resolve_repo_ref(client, slug, branch, token=token)
+    return resolved["resolved_ref"]
+
+
 async def async_get_repo_file(
     slug: str,
     path: str,

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -608,6 +608,57 @@ async def _async_materialize_due_cycle_runs_once(
     return executable_run_ids
 
 
+async def async_wake_cycle_now(*, name: str, org_id: str | None = None) -> str:
+    """Pull an enabled cycle's next run forward to now, without flooding.
+
+    Event sources (e.g. the staging-promotion detector) use this instead of a
+    native event->cycle binding: the cycle scheduler claims the due slot on its
+    next tick, fires exactly one run, and recomputes ``next_run_at`` onto the
+    future cron grid. A wake therefore never duplicates a scheduled slot — the
+    recompute lands on the next genuine cron boundary, which later fires as
+    the normal backstop run (cycles are contracted to exit cheaply when their
+    inputs are unchanged). Returns a disposition string rather than raising so
+    callers can report the outcome without owning cycle semantics: ``woken`` |
+    ``already_pending`` | ``run_in_flight`` | ``not_found`` | ``ambiguous``.
+    Cycle names are not globally unique; pass ``org_id`` to scope the lookup,
+    and an ambiguous match refuses to wake anything rather than guessing.
+    """
+    now = datetime.now(timezone.utc)
+    async with UnitOfWork() as uow:
+        filters = [
+            Cycle.name == name,
+            Cycle.enabled.is_(True),
+            Cycle.deleted_at.is_(None),
+        ]
+        if org_id is not None:
+            filters.append(Cycle.org_id == org_id)
+        matches = (
+            await uow.session.scalars(
+                select(Cycle).where(*filters).order_by(Cycle.id.asc()).limit(2)
+            )
+        ).all()
+        if not matches:
+            return "not_found"
+        if len(matches) > 1:
+            logger.warning("Cycle wake for %r is ambiguous; refusing to wake", name)
+            return "ambiguous"
+        cycle = (
+            await uow.session.scalars(
+                select(Cycle).where(Cycle.id == matches[0].id).with_for_update()
+            )
+        ).first()
+        if cycle is None or not cycle.enabled or cycle.deleted_at is not None:
+            return "not_found"
+        if cycle.next_run_at is not None and cycle.next_run_at <= now:
+            return "already_pending"
+        active_run_count = await _async_active_cycle_run_count(uow.session, cycle.id)
+        if active_run_count > 0:
+            return "run_in_flight"
+        cycle.next_run_at = now
+        logger.info("Cycle %s (%s) woken by event source", cycle.id, cycle.name)
+    return "woken"
+
+
 async def async_schedule_due_cycles_once(*, limit: int = 10) -> list[int]:
     now = datetime.now(timezone.utc)
     await async_recover_stale_cycle_runs_once(limit=limit)

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -3275,3 +3275,130 @@ def test_cycle_run_model_policy_ignores_live_cycle_when_snapshot_pins_a_model():
     }
 
     assert service._cycle_run_model_policy(cycle, run) == {"thinking": "low"}
+
+
+@pytest.mark.asyncio
+async def test_wake_cycle_now_pulls_next_run_forward(
+    monkeypatch,
+    cycle_scheduler_session,
+):
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    cycle = Cycle(
+        id=9,
+        user_id=str(uuid4()),
+        org_id=None,
+        name="Promotion Readiness",
+        prompt="Evaluate promotion readiness.",
+        schedule_expr="0 11 * * 1-5",
+        timezone="America/New_York",
+        enabled=True,
+        next_run_at=now + timedelta(days=1),
+    )
+    cycle_scheduler_session.add(cycle)
+    await cycle_scheduler_session.flush()
+    monkeypatch.setattr(
+        service,
+        "UnitOfWork",
+        lambda: _SharedSessionUnitOfWork(cycle_scheduler_session),
+    )
+
+    disposition = await service.async_wake_cycle_now(name="Promotion Readiness")
+
+    assert disposition == "woken"
+    assert cycle.next_run_at is not None
+    assert cycle.next_run_at <= datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_wake_cycle_now_skips_when_run_in_flight(
+    monkeypatch,
+    cycle_scheduler_session,
+):
+    cycle, _active_run, scheduled_for = await _seed_due_cycle_with_active_run(
+        cycle_scheduler_session
+    )
+    future = datetime.now(timezone.utc) + timedelta(hours=2)
+    cycle.next_run_at = future
+    await cycle_scheduler_session.flush()
+    monkeypatch.setattr(
+        service,
+        "UnitOfWork",
+        lambda: _SharedSessionUnitOfWork(cycle_scheduler_session),
+    )
+
+    disposition = await service.async_wake_cycle_now(name=cycle.name)
+
+    assert disposition == "run_in_flight"
+    assert cycle.next_run_at == future
+
+
+@pytest.mark.asyncio
+async def test_wake_cycle_now_reports_already_pending_and_missing(
+    monkeypatch,
+    cycle_scheduler_session,
+):
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    pending = Cycle(
+        id=21,
+        user_id=str(uuid4()),
+        org_id=None,
+        name="Pending Cycle",
+        prompt="p",
+        schedule_expr="0 11 * * *",
+        timezone="UTC",
+        enabled=True,
+        next_run_at=now - timedelta(minutes=5),
+    )
+    disabled = Cycle(
+        id=22,
+        user_id=str(uuid4()),
+        org_id=None,
+        name="Disabled Cycle",
+        prompt="p",
+        schedule_expr="0 11 * * *",
+        timezone="UTC",
+        enabled=False,
+        next_run_at=now + timedelta(hours=1),
+    )
+    cycle_scheduler_session.add_all([pending, disabled])
+    await cycle_scheduler_session.flush()
+    monkeypatch.setattr(
+        service,
+        "UnitOfWork",
+        lambda: _SharedSessionUnitOfWork(cycle_scheduler_session),
+    )
+
+    assert await service.async_wake_cycle_now(name="Pending Cycle") == "already_pending"
+    assert pending.next_run_at == now - timedelta(minutes=5)
+    assert await service.async_wake_cycle_now(name="Disabled Cycle") == "not_found"
+    assert await service.async_wake_cycle_now(name="No Such Cycle") == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_wake_cycle_now_refuses_ambiguous_names(
+    monkeypatch,
+    cycle_scheduler_session,
+):
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    for cycle_id in (31, 32):
+        cycle_scheduler_session.add(
+            Cycle(
+                id=cycle_id,
+                user_id=str(uuid4()),
+                org_id=None,
+                name="Twin Cycle",
+                prompt="p",
+                schedule_expr="0 11 * * *",
+                timezone="UTC",
+                enabled=True,
+                next_run_at=now + timedelta(hours=1),
+            )
+        )
+    await cycle_scheduler_session.flush()
+    monkeypatch.setattr(
+        service,
+        "UnitOfWork",
+        lambda: _SharedSessionUnitOfWork(cycle_scheduler_session),
+    )
+
+    assert await service.async_wake_cycle_now(name="Twin Cycle") == "ambiguous"

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -419,3 +419,222 @@ async def test_job_minted_token_requests_read_only_contents_permission(
     assert mint.await_args.kwargs["repositories"] == ["uwear-backend"]
     assert mint.await_args.kwargs["permissions"]["contents"] == "read"
     assert mint.await_args.kwargs["permissions"]["contents"] != "write"
+
+
+def _reconcile_pair(backend_outcome: str):
+    """Reconcile results for (backend, app) in CONFIGURED_REPOS order."""
+    return AsyncMock(
+        side_effect=[
+            PromotionPullRequestResult(
+                repo=REPO,
+                outcome=backend_outcome,
+                settled_by="search" if backend_outcome == "already_open" else "comparison",
+                number=900 if backend_outcome == "already_open" else None,
+            ),
+            PromotionPullRequestResult(
+                repo="uwear-ai/uwearaiapp",
+                outcome="no_diff",
+                settled_by="comparison",
+            ),
+        ]
+    )
+
+
+def _patch_reconcile_plumbing(monkeypatch, reconcile):
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_promotion_actor",
+        AsyncMock(
+            return_value=staging_promotion_pr.PromotionActor(
+                user_id="user-1", org_id="org-1"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr, "_repo_token", AsyncMock(return_value="app-token")
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr, "async_reconcile_promotion_pull_request", reconcile
+    )
+
+
+@pytest.mark.asyncio
+async def test_moved_sha_pair_wakes_the_readiness_cycle(monkeypatch):
+    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
+    heads = AsyncMock(side_effect=["staging-new-sha", "main-new-sha"])
+    monkeypatch.setattr(staging_promotion_pr, "async_get_repo_branch_head", heads)
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_async_last_evaluated_pair",
+        AsyncMock(return_value=("staging-old-sha", "main-new-sha")),
+    )
+    wake = AsyncMock(return_value="woken")
+    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is True
+    assert result["readiness_wake"] == {
+        "cycle": staging_promotion_pr.READINESS_CYCLE_NAME,
+        "outcome": "woken",
+        "staging_sha": "staging-new-sha",
+        "main_sha": "main-new-sha",
+    }
+    wake.assert_awaited_once_with(name=staging_promotion_pr.READINESS_CYCLE_NAME)
+    assert heads.await_args_list[0].args == (REPO, "staging")
+    assert heads.await_args_list[1].args == (REPO, "main")
+
+
+@pytest.mark.asyncio
+async def test_unchanged_sha_pair_does_not_wake(monkeypatch):
+    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "async_get_repo_branch_head",
+        AsyncMock(side_effect=["same-staging", "same-main"]),
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_async_last_evaluated_pair",
+        AsyncMock(return_value=("same-staging", "same-main")),
+    )
+    wake = AsyncMock()
+    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is True
+    assert result["readiness_wake"]["outcome"] == "pair_unchanged"
+    wake.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_diff_backend_skips_the_wake_probe_entirely(monkeypatch):
+    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("no_diff"))
+    heads = AsyncMock()
+    monkeypatch.setattr(staging_promotion_pr, "async_get_repo_branch_head", heads)
+    wake = AsyncMock()
+    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is True
+    assert "readiness_wake" not in result
+    heads.assert_not_awaited()
+    wake.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wake_failure_fails_the_job_but_keeps_reconciliation_results(
+    monkeypatch, caplog
+):
+    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("created"))
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_async_wake_readiness_cycle",
+        AsyncMock(side_effect=RuntimeError("status record unreadable")),
+    )
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is False
+    assert result["failures"] == 1
+    assert [r["outcome"] for r in result["results"]] == ["created", "no_diff"]
+    assert result["readiness_wake"]["outcome"] == "error"
+    assert "Readiness cycle wake failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_last_evaluated_pair_reads_the_cycle_status_record(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    from brain.platform.db.models.domain import (
+        Domain,
+        DomainObjectType,
+        DomainRecord,
+    )
+
+    session = await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            Domain.__table__,
+            DomainObjectType.__table__,
+            DomainRecord.__table__,
+        ],
+        connect_listener=_register_sqlite_functions,
+    )
+    org_id = "bbbbbbbb-0000-4000-8000-000000000002"
+    session.add(Org(id=org_id, name="Readiness Org", slug="readiness-org"))
+    domain = Domain(org_id=org_id, slug="promotion-readiness", name="Promotion Readiness")
+    session.add(domain)
+    await session.flush()
+    object_type = DomainObjectType(domain_id=domain.id, key="status", name="Status")
+    session.add(object_type)
+    await session.flush()
+    session.add(
+        DomainRecord(
+            org_id=org_id,
+            domain_id=domain.id,
+            object_type_id=object_type.id,
+            title="status",
+            data={
+                "last_staging_sha": "7bc4dd27c554",
+                "last_main_sha": "762e2b48f7d9",
+            },
+        )
+    )
+    await session.commit()
+
+    class TestUnitOfWork:
+        def __init__(self):
+            self.session = session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(staging_promotion_pr, "UnitOfWork", TestUnitOfWork)
+
+    pair = await staging_promotion_pr._async_last_evaluated_pair(org_id)
+
+    assert pair == ("7bc4dd27c554", "762e2b48f7d9")
+
+    # Another org's identically-slugged domain must not leak in.
+    assert await staging_promotion_pr._async_last_evaluated_pair(
+        "bbbbbbbb-0000-4000-8000-000000000099"
+    ) == (None, None)
+
+    # An archived object type reads as "no baseline", never as evidence.
+    object_type.archived_at = datetime.now(timezone.utc)
+    await session.commit()
+    assert await staging_promotion_pr._async_last_evaluated_pair(org_id) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_dead_wake_disposition_fails_the_job(monkeypatch, caplog):
+    """A wake that can never fire again (cycle gone) must not stay green."""
+    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "async_get_repo_branch_head",
+        AsyncMock(side_effect=["staging-new", "main-new"]),
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr,
+        "_async_last_evaluated_pair",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        staging_promotion_pr, "async_wake_cycle_now", AsyncMock(return_value="not_found")
+    )
+
+    result = await staging_promotion_pr.run_promotion_job()
+
+    assert result["ok"] is False
+    assert result["failures"] == 1
+    assert result["readiness_wake"]["outcome"] == "not_found"
+    assert "settled dead" in caplog.text


### PR DESCRIPTION
## One owner for one concern

The hourly `uwear_staging_promotion_pr` job and the Promotion Readiness cycle both owned promotion-PR existence (with two different PR titles), and the analysis ran on an arbitrary weekday slot — swallowing days of delta per evaluation. Both real evaluations to date went DEGRADED on evidence budget.

This PR makes the deterministic hourly job the single owner of **detect + ensure PR + trigger analysis**:

- After reconciling the PR, it resolves live `(staging, main)` head SHAs and compares them to the cycle's **last completed evaluation** (its runtime-authored status record, org-scoped, read tolerantly — no baseline = wake).
- On movement it wakes the cycle via a new generic `async_wake_cycle_now` primitive: `next_run_at=now`, one run, schedule recomputes onto the future cron grid (semantics verified live on illo-dev during the 2026-07-27 recovery). Wakes cannot flood; the weekday 11:00 slot survives as a cheap SKIP backstop.
- Baseline-on-completed-evaluation makes the wake **self-retrying hourly** until an evaluation actually lands — a free retry policy for a cycle that has none.
- **Failure visibility:** a dead wake disposition (`not_found`/`ambiguous`) fails the scheduler run; ambiguous cycle names refuse to wake rather than guessing.

## Review

Codex adversarial pass: 4 majors raised → 3 fixed in this diff (org/archived scoping of the baseline read, name-ambiguity guard, dead-disposition failure). The cron-boundary double-run observation is rejected as designed-in and documented on the primitive: the recompute lands on a genuine future boundary whose run hits the cycle's mandatory unchanged-exit.

Follow-ups deliberately out of scope: Postgres two-session concurrency tests for the wake/claim lock ordering; the cycle-9 prompt edit removing its own PR-creation step (staged, applied only after this job proves one successful live reconcile — currently gated on the server clock fix).

Tests: 98 in the two touched suites; full fast suite 4322 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)