### PR TITLE
refactor(scheduler): one exact-keyed registry for scheduler program dispatch (#501)

### DIFF
--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -88,8 +88,7 @@ class SingleCommandProgram:
         ]
 
 
-# Curiosity and heartbeat retain divergent plan/spec shapes. They stay on the
-# isolated legacy path until changing those public representations is intentional.
+# Programs whose plan and StepSpec projections share one representation.
 SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
     "uwear_aws_health_scan": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.aws_health_scan"),
@@ -102,6 +101,17 @@ SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
         description="Ensure Uwear staging promotion pull requests exist",
     ),
 }
+
+
+@dataclass(frozen=True)
+class DivergentSchedulerProgram:
+    """Exact-key builders for programs with distinct plan and StepSpec shapes."""
+
+    plan_builder: Callable[
+        [SchedulerJob, dict[str, object]],
+        list[dict[str, object]],
+    ]
+    step_specs_builder: Callable[[SchedulerJob, SchedulerRun], list[StepSpec]]
 
 
 @dataclass(frozen=True)
@@ -443,82 +453,83 @@ def _legacy_job_identity_contains(job: SchedulerJob, *fragments: str) -> bool:
     return any(fragment in identity for fragment in fragments)
 
 
-def _build_legacy_scheduler_step_plan(
+def _build_nightly_scheduler_step_plan(
     job: SchedulerJob,
     payload: dict[str, object],
 ) -> list[dict[str, object]]:
-    """Build plans for legacy programs whose plan/spec shapes are not shared."""
-    if job.program_key == "nightly_sleep" or _legacy_job_identity_contains(
-        job,
-        "nightly",
-        "sleep",
-    ):
-        if payload.get("scheduler_split_steps"):
-            step_keys = _nightly_planned_step_keys(payload)
-            return [
-                {
-                    "step_key": WRAPPER_STEP_KEY,
-                    "sequence_no": 1,
-                    "kind": "wrapper",
-                    "handler_ref": job.handler_ref,
-                    "payload": {
-                        "mode": "wrapper",
-                        "night_budget": {
-                            "mode": "advisory",
-                            "planner": "brain.systems.learning.night_budget:build_night_budget_plan",
-                        },
-                    },
-                },
-                *[
-                    {
-                        "step_key": step_key,
-                        "sequence_no": index + 2,
-                        "kind": "phase",
-                        "handler_ref": job.handler_ref,
-                        "payload": _nightly_step_payload(step_key),
-                    }
-                    for index, step_key in enumerate(step_keys)
-                ],
-            ]
+    if payload.get("scheduler_split_steps"):
+        step_keys = _nightly_planned_step_keys(payload)
         return [
             {
                 "step_key": WRAPPER_STEP_KEY,
                 "sequence_no": 1,
                 "kind": "wrapper",
                 "handler_ref": job.handler_ref,
-                "payload": {"mode": "wrapper"},
-            }
+                "payload": {
+                    "mode": "wrapper",
+                    "night_budget": {
+                        "mode": "advisory",
+                        "planner": "brain.systems.learning.night_budget:build_night_budget_plan",
+                    },
+                },
+            },
+            *[
+                {
+                    "step_key": step_key,
+                    "sequence_no": index + 2,
+                    "kind": "phase",
+                    "handler_ref": job.handler_ref,
+                    "payload": _nightly_step_payload(step_key),
+                }
+                for index, step_key in enumerate(step_keys)
+            ],
         ]
+    return [
+        {
+            "step_key": WRAPPER_STEP_KEY,
+            "sequence_no": 1,
+            "kind": "wrapper",
+            "handler_ref": job.handler_ref,
+            "payload": {"mode": "wrapper"},
+        }
+    ]
 
-    if job.program_key == "curiosity" or _legacy_job_identity_contains(
-        job,
-        "curiosity",
-    ):
-        return [
-            {
-                "step_key": "curiosity",
-                "sequence_no": 1,
-                "kind": "single",
-                "handler_ref": job.handler_ref,
-                "payload": {"program": "curiosity"},
-            }
-        ]
 
-    if job.program_key == "illo_external_heartbeat" or _legacy_job_identity_contains(
-        job,
-        "illo_external_heartbeat",
-    ):
-        return [
-            {
-                "step_key": "illo_external_heartbeat",
-                "sequence_no": 1,
-                "kind": "single",
-                "handler_ref": job.handler_ref,
-                "payload": {"program": "illo_external_heartbeat"},
-                "command": ILLO_EXTERNAL_HEARTBEAT_COMMAND,
-            }
-        ]
+def _build_curiosity_scheduler_step_plan(
+    job: SchedulerJob,
+    payload: dict[str, object],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "step_key": "curiosity",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": job.handler_ref,
+            "payload": {"program": "curiosity"},
+        }
+    ]
 
+
+def _build_illo_external_heartbeat_scheduler_step_plan(
+    job: SchedulerJob,
+    payload: dict[str, object],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "step_key": "illo_external_heartbeat",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": job.handler_ref,
+            "payload": {"program": "illo_external_heartbeat"},
+            "command": ILLO_EXTERNAL_HEARTBEAT_COMMAND,
+        }
+    ]
+
+
+def _build_fallback_scheduler_step_plan(
+    job: SchedulerJob,
+    payload: dict[str, object],
+) -> list[dict[str, object]]:
     return [
         {
             "step_key": job.program_key or "scheduler_job",
@@ -528,6 +539,20 @@ def _build_legacy_scheduler_step_plan(
             "payload": {},
         }
     ]
+
+
+def _build_legacy_scheduler_step_plan(
+    job: SchedulerJob,
+    payload: dict[str, object],
+) -> list[dict[str, object]]:
+    """Terminal substring compatibility fallback for non-catalog programs."""
+    if _legacy_job_identity_contains(job, "nightly", "sleep"):
+        return _build_nightly_scheduler_step_plan(job, payload)
+    if _legacy_job_identity_contains(job, "curiosity"):
+        return _build_curiosity_scheduler_step_plan(job, payload)
+    if _legacy_job_identity_contains(job, "illo_external_heartbeat"):
+        return _build_illo_external_heartbeat_scheduler_step_plan(job, payload)
+    return _build_fallback_scheduler_step_plan(job, payload)
 
 
 def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
@@ -557,6 +582,10 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
     definition = SINGLE_COMMAND_PROGRAM_REGISTRY.get(job.program_key)
     if definition is not None:
         return definition.build_step_plan(job, program_key=job.program_key)
+
+    divergent_definition = DIVERGENT_PROGRAM_REGISTRY.get(job.program_key)
+    if divergent_definition is not None:
+        return divergent_definition.plan_builder(job, payload)
 
     return _build_legacy_scheduler_step_plan(job, payload)
 
@@ -598,6 +627,19 @@ def _curiosity_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     ]
 
 
+def _illo_external_heartbeat_steps(
+    job: SchedulerJob,
+    run: SchedulerRun,
+) -> list[StepSpec]:
+    return [
+        StepSpec(
+            "program",
+            ["python3", "-m", "illo_external_heartbeat"],
+            "Program fallback",
+        )
+    ]
+
+
 def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     payload = job.default_payload or {}
     command = payload.get("command")
@@ -608,8 +650,24 @@ def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     return [StepSpec("program", ["python3", "-m", job.program_key], "Program fallback")]
 
 
+DIVERGENT_PROGRAM_REGISTRY: dict[str, DivergentSchedulerProgram] = {
+    "nightly_sleep": DivergentSchedulerProgram(
+        plan_builder=_build_nightly_scheduler_step_plan,
+        step_specs_builder=_nightly_steps,
+    ),
+    "curiosity": DivergentSchedulerProgram(
+        plan_builder=_build_curiosity_scheduler_step_plan,
+        step_specs_builder=_curiosity_steps,
+    ),
+    "illo_external_heartbeat": DivergentSchedulerProgram(
+        plan_builder=_build_illo_external_heartbeat_scheduler_step_plan,
+        step_specs_builder=_illo_external_heartbeat_steps,
+    ),
+}
+
+
 def _get_legacy_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
-    """Return legacy specs whose dispatch or shape predates the shared registry."""
+    """Terminal substring compatibility fallback for non-catalog programs."""
     if _legacy_job_identity_contains(job, "curiosity"):
         return _curiosity_steps(job, run)
     if _legacy_job_identity_contains(job, "nightly", "sleep"):
@@ -621,4 +679,9 @@ def get_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     definition = SINGLE_COMMAND_PROGRAM_REGISTRY.get(job.program_key)
     if definition is not None:
         return definition.build_step_specs()
+
+    divergent_definition = DIVERGENT_PROGRAM_REGISTRY.get(job.program_key)
+    if divergent_definition is not None:
+        return divergent_definition.step_specs_builder(job, run)
+
     return _get_legacy_step_specs(job, run)

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -12,16 +12,6 @@ from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 
 DEFAULT_STEP_KIND = "single"
 WRAPPER_STEP_KEY = "nightly_wrapper"
-UWEAR_AWS_HEALTH_SCAN_COMMAND = [
-    "python3",
-    "-m",
-    "brain.jobs.pipelines.aws_health_scan",
-]
-UWEAR_STAGING_PROMOTION_PR_COMMAND = [
-    "python3",
-    "-m",
-    "brain.jobs.pipelines.staging_promotion_pr",
-]
 ILLO_EXTERNAL_HEARTBEAT_COMMAND = [
     "python3",
     "-m",
@@ -61,6 +51,57 @@ class StepSpec:
     step_key: str
     command: list[str]
     description: str = ""
+
+
+@dataclass(frozen=True)
+class SingleCommandProgram:
+    """Canonical metadata shared by both scheduler step representations."""
+
+    command: tuple[str, ...]
+    step_key: str
+    description: str
+
+    def build_step_plan(
+        self,
+        job: SchedulerJob,
+        *,
+        program_key: str,
+    ) -> list[dict[str, object]]:
+        return [
+            {
+                "step_key": self.step_key,
+                "sequence_no": 1,
+                "kind": DEFAULT_STEP_KIND,
+                "handler_ref": job.handler_ref,
+                "payload": {"program": program_key},
+                "command": list(self.command),
+            }
+        ]
+
+    def build_step_specs(self) -> list[StepSpec]:
+        return [
+            StepSpec(
+                self.step_key,
+                list(self.command),
+                self.description,
+            )
+        ]
+
+
+# Curiosity and heartbeat retain divergent plan/spec shapes. They stay on the
+# isolated legacy path until changing those public representations is intentional.
+SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
+    "uwear_aws_health_scan": SingleCommandProgram(
+        command=("python3", "-m", "brain.jobs.pipelines.aws_health_scan"),
+        step_key="uwear_aws_health_scan",
+        description="Uwear AWS production health scan",
+    ),
+    "uwear_staging_promotion_pr": SingleCommandProgram(
+        command=("python3", "-m", "brain.jobs.pipelines.staging_promotion_pr"),
+        step_key="uwear_staging_promotion_pr",
+        description="Ensure Uwear staging promotion pull requests exist",
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -396,32 +437,22 @@ def _job_identity(job: SchedulerJob) -> str:
     )
 
 
-def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
-    """Return persisted step metadata for a scheduler run."""
-    payload = job.default_payload or {}
-    custom_plan = payload.get("step_plan")
-    if isinstance(custom_plan, list) and custom_plan:
-        plan: list[dict[str, object]] = []
-        for index, step in enumerate(custom_plan, start=1):
-            if not isinstance(step, dict):
-                continue
-            step_key = str(step.get("step_key") or step.get("key") or f"step_{index}")
-            plan.append(
-                {
-                    "step_key": step_key,
-                    "sequence_no": int(step.get("sequence_no") or index),
-                    "kind": str(step.get("kind") or DEFAULT_STEP_KIND),
-                    "handler_ref": step.get("handler_ref") or job.handler_ref,
-                    "payload": step.get("payload") or {},
-                    "command": step.get("command"),
-                    "commands": step.get("commands"),
-                }
-            )
-        if plan:
-            return plan
-
+def _legacy_job_identity_contains(job: SchedulerJob, *fragments: str) -> bool:
+    """Quarantine substring dispatch retained for non-canonical legacy programs."""
     identity = _job_identity(job)
-    if job.program_key == "nightly_sleep" or "nightly" in identity or "sleep" in identity:
+    return any(fragment in identity for fragment in fragments)
+
+
+def _build_legacy_scheduler_step_plan(
+    job: SchedulerJob,
+    payload: dict[str, object],
+) -> list[dict[str, object]]:
+    """Build plans for legacy programs whose plan/spec shapes are not shared."""
+    if job.program_key == "nightly_sleep" or _legacy_job_identity_contains(
+        job,
+        "nightly",
+        "sleep",
+    ):
         if payload.get("scheduler_split_steps"):
             step_keys = _nightly_planned_step_keys(payload)
             return [
@@ -459,7 +490,10 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             }
         ]
 
-    if job.program_key == "curiosity" or "curiosity" in identity:
+    if job.program_key == "curiosity" or _legacy_job_identity_contains(
+        job,
+        "curiosity",
+    ):
         return [
             {
                 "step_key": "curiosity",
@@ -470,34 +504,10 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             }
         ]
 
-    if (
-        job.program_key == "uwear_staging_promotion_pr"
-        or "uwear_staging_promotion_pr" in identity
+    if job.program_key == "illo_external_heartbeat" or _legacy_job_identity_contains(
+        job,
+        "illo_external_heartbeat",
     ):
-        return [
-            {
-                "step_key": "uwear_staging_promotion_pr",
-                "sequence_no": 1,
-                "kind": "single",
-                "handler_ref": job.handler_ref,
-                "payload": {"program": "uwear_staging_promotion_pr"},
-                "command": UWEAR_STAGING_PROMOTION_PR_COMMAND,
-            }
-        ]
-
-    if job.program_key == "uwear_aws_health_scan" or "uwear_aws_health_scan" in identity:
-        return [
-            {
-                "step_key": "uwear_aws_health_scan",
-                "sequence_no": 1,
-                "kind": "single",
-                "handler_ref": job.handler_ref,
-                "payload": {"program": "uwear_aws_health_scan"},
-                "command": UWEAR_AWS_HEALTH_SCAN_COMMAND,
-            }
-        ]
-
-    if job.program_key == "illo_external_heartbeat" or "illo_external_heartbeat" in identity:
         return [
             {
                 "step_key": "illo_external_heartbeat",
@@ -518,6 +528,37 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             "payload": {},
         }
     ]
+
+
+def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
+    """Return persisted step metadata for a scheduler run."""
+    payload = job.default_payload or {}
+    custom_plan = payload.get("step_plan")
+    if isinstance(custom_plan, list) and custom_plan:
+        plan: list[dict[str, object]] = []
+        for index, step in enumerate(custom_plan, start=1):
+            if not isinstance(step, dict):
+                continue
+            step_key = str(step.get("step_key") or step.get("key") or f"step_{index}")
+            plan.append(
+                {
+                    "step_key": step_key,
+                    "sequence_no": int(step.get("sequence_no") or index),
+                    "kind": str(step.get("kind") or DEFAULT_STEP_KIND),
+                    "handler_ref": step.get("handler_ref") or job.handler_ref,
+                    "payload": step.get("payload") or {},
+                    "command": step.get("command"),
+                    "commands": step.get("commands"),
+                }
+            )
+        if plan:
+            return plan
+
+    definition = SINGLE_COMMAND_PROGRAM_REGISTRY.get(job.program_key)
+    if definition is not None:
+        return definition.build_step_plan(job, program_key=job.program_key)
+
+    return _build_legacy_scheduler_step_plan(job, payload)
 
 
 def _timezone(job: SchedulerJob) -> ZoneInfo:
@@ -557,29 +598,6 @@ def _curiosity_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     ]
 
 
-def _uwear_aws_health_scan_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
-    return [
-        StepSpec(
-            "uwear_aws_health_scan",
-            UWEAR_AWS_HEALTH_SCAN_COMMAND,
-            "Uwear AWS production health scan",
-        ),
-    ]
-
-
-def _uwear_staging_promotion_pr_steps(
-    job: SchedulerJob,
-    run: SchedulerRun,
-) -> list[StepSpec]:
-    return [
-        StepSpec(
-            "uwear_staging_promotion_pr",
-            UWEAR_STAGING_PROMOTION_PR_COMMAND,
-            "Ensure Uwear staging promotion pull requests exist",
-        ),
-    ]
-
-
 def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     payload = job.default_payload or {}
     command = payload.get("command")
@@ -590,14 +608,17 @@ def _fallback_steps(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
     return [StepSpec("program", ["python3", "-m", job.program_key], "Program fallback")]
 
 
-def get_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
-    key = _job_identity(job)
-    if "uwear_staging_promotion_pr" in key:
-        return _uwear_staging_promotion_pr_steps(job, run)
-    if "uwear_aws_health_scan" in key:
-        return _uwear_aws_health_scan_steps(job, run)
-    if "curiosity" in key:
+def _get_legacy_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
+    """Return legacy specs whose dispatch or shape predates the shared registry."""
+    if _legacy_job_identity_contains(job, "curiosity"):
         return _curiosity_steps(job, run)
-    if "nightly" in key or "sleep" in key:
+    if _legacy_job_identity_contains(job, "nightly", "sleep"):
         return _nightly_steps(job, run)
     return _fallback_steps(job, run)
+
+
+def get_step_specs(job: SchedulerJob, run: SchedulerRun) -> list[StepSpec]:
+    definition = SINGLE_COMMAND_PROGRAM_REGISTRY.get(job.program_key)
+    if definition is not None:
+        return definition.build_step_specs()
+    return _get_legacy_step_specs(job, run)

--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -1869,6 +1869,7 @@ async def _async_compare_payload(
     head: str,
     *,
     token: str | None = None,
+    non_object_message: str = "GitHub compare response was not an object.",
 ) -> dict[str, Any]:
     owner, repo = slug.split("/", 1)
     async with async_http_client(timeout=httpx.Timeout(12.0, connect=5.0)) as client:
@@ -1881,7 +1882,7 @@ async def _async_compare_payload(
     if not isinstance(payload, dict):
         raise GitHubConnectorError(
             status_code=502,
-            message="GitHub compare response was not an object.",
+            message=non_object_message,
         )
     return payload
 
@@ -1940,7 +1941,13 @@ async def async_compare_commits(
     token: str | None = None,
 ) -> str:
     """Return GitHub's compare status for ``base...head``."""
-    payload = await _async_compare_payload(slug, base, head, token=token)
+    payload = await _async_compare_payload(
+        slug,
+        base,
+        head,
+        token=token,
+        non_object_message="GitHub compare response omitted a recognized status.",
+    )
     status = payload.get("status")
     if status not in {"identical", "behind", "ahead", "diverged"}:
         raise GitHubConnectorError(

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -1,0 +1,174 @@
+"""Focused contract tests for scheduler program dispatch."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+from types import SimpleNamespace
+
+from brain.app.scheduler.programs import (
+    SINGLE_COMMAND_PROGRAM_REGISTRY,
+    SingleCommandProgram,
+    StepSpec,
+    build_scheduler_step_plan,
+    get_step_specs,
+)
+
+
+_SCHEDULED_FOR = datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc)
+_PINNED_PROJECTION_HASHES = {
+    "nightly_sleep": "0cb9173b9e0b71a094063bb867d644304f4c8b996fec6c9d1656b31dde060ee0",
+    "curiosity_cron": "326e1c241800e49721978238c967c423e1ce1133030ca1223c77bb3f44a8519d",
+    "uwear_aws_health_scan": (
+        "10d9a7cb36fa4e7b93d7bb2a76b73228d893420220f13e93a17a85f2f23d87ee"
+    ),
+    "uwear_staging_promotion_pr": (
+        "073a6f20f32cf4d6e4db66f7f3e4a151c095728ee199ce29a0e2dcfe12d71e6b"
+    ),
+    "illo_external_heartbeat": (
+        "5c2f2eede89b1fd4cc5cd067116eb62a02444e0152106325ee133fad9f2bee3b"
+    ),
+}
+
+
+def _job(program_name: str) -> SimpleNamespace:
+    definitions = {
+        "nightly_sleep": {
+            "job_key": "nightly_sleep",
+            "family": "nightly_sleep",
+            "program_key": "nightly_sleep",
+            "handler_ref": "brain.app.scheduler.programs:nightly_sleep",
+            "default_payload": {
+                "name": "Nightly Sleep",
+                "scheduler_split_steps": True,
+            },
+        },
+        "curiosity_cron": {
+            "job_key": "curiosity_cron",
+            "family": "curiosity_cron",
+            "program_key": "curiosity",
+            "handler_ref": "brain.app.scheduler.programs:curiosity",
+            "default_payload": {"name": "Curiosity Engine"},
+        },
+        "uwear_aws_health_scan": {
+            "job_key": "uwear_aws_health_scan",
+            "family": "uwear_aws_health_scan",
+            "program_key": "uwear_aws_health_scan",
+            "handler_ref": "brain.app.scheduler.programs:uwear_aws_health_scan",
+            "default_payload": {"name": "Uwear AWS Health Scan"},
+        },
+        "uwear_staging_promotion_pr": {
+            "job_key": "uwear_staging_promotion_pr",
+            "family": "uwear_staging_promotion_pr",
+            "program_key": "uwear_staging_promotion_pr",
+            "handler_ref": "brain.app.scheduler.programs:uwear_staging_promotion_pr",
+            "default_payload": {"name": "Uwear Staging Promotion PR"},
+        },
+        "illo_external_heartbeat": {
+            "job_key": "illo_external_heartbeat",
+            "family": "illo_external_heartbeat",
+            "program_key": "illo_external_heartbeat",
+            "handler_ref": "brain.app.scheduler.programs:illo_external_heartbeat",
+            "default_payload": {"name": "Illo External Heartbeat"},
+        },
+    }
+    return SimpleNamespace(
+        **definitions[program_name],
+        handler_kind="scheduler_builtin",
+        timezone="UTC",
+    )
+
+
+def _projection_bytes(program_name: str) -> bytes:
+    job = _job(program_name)
+    run = SimpleNamespace(scheduled_for=_SCHEDULED_FOR)
+    projection = {
+        "plan": build_scheduler_step_plan(job),
+        "specs": [asdict(step) for step in get_step_specs(job, run)],
+    }
+    return json.dumps(
+        projection,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def test_existing_scheduler_program_plan_and_specs_match_pinned_projections():
+    actual = {
+        program_name: sha256(_projection_bytes(program_name)).hexdigest()
+        for program_name in _PINNED_PROJECTION_HASHES
+    }
+
+    assert actual == _PINNED_PROJECTION_HASHES
+
+
+def test_registry_only_registration_drives_plan_and_specs(monkeypatch):
+    monkeypatch.setitem(
+        SINGLE_COMMAND_PROGRAM_REGISTRY,
+        "registry_only_program",
+        SingleCommandProgram(
+            command=("python3", "-m", "example.registry_only"),
+            step_key="registry_only_step",
+            description="Registry-only scheduler program",
+        ),
+    )
+    job = SimpleNamespace(
+        job_key="unrelated_job_key",
+        family="unrelated_family",
+        program_key="registry_only_program",
+        handler_kind="scheduler_builtin",
+        handler_ref="example:handler",
+        default_payload={},
+        timezone="UTC",
+    )
+    run = SimpleNamespace(scheduled_for=_SCHEDULED_FOR)
+
+    assert build_scheduler_step_plan(job) == [
+        {
+            "step_key": "registry_only_step",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": "example:handler",
+            "payload": {"program": "registry_only_program"},
+            "command": ["python3", "-m", "example.registry_only"],
+        }
+    ]
+    assert get_step_specs(job, run) == [
+        StepSpec(
+            "registry_only_step",
+            ["python3", "-m", "example.registry_only"],
+            "Registry-only scheduler program",
+        )
+    ]
+
+
+def test_single_command_registry_dispatches_only_by_exact_program_key():
+    job = SimpleNamespace(
+        job_key="uwear_aws_health_scan_shadow",
+        family="uwear_aws_health_scan_shadow",
+        program_key="unregistered_program",
+        handler_kind="scheduler_builtin",
+        handler_ref="example:uwear_aws_health_scan_shadow",
+        default_payload={"name": "Uwear AWS Health Scan Shadow"},
+        timezone="UTC",
+    )
+    run = SimpleNamespace(scheduled_for=_SCHEDULED_FOR)
+
+    assert build_scheduler_step_plan(job) == [
+        {
+            "step_key": "unregistered_program",
+            "sequence_no": 1,
+            "kind": "single",
+            "handler_ref": "example:uwear_aws_health_scan_shadow",
+            "payload": {},
+        }
+    ]
+    assert get_step_specs(job, run) == [
+        StepSpec(
+            "program",
+            ["python3", "-m", "unregistered_program"],
+            "Program fallback",
+        )
+    ]

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -7,6 +7,8 @@ from hashlib import sha256
 import json
 from types import SimpleNamespace
 
+from brain.app.scheduler import programs as scheduler_programs
+from brain.app.scheduler.catalog import SCHEDULER_CATALOG
 from brain.app.scheduler.programs import (
     SINGLE_COMMAND_PROGRAM_REGISTRY,
     SingleCommandProgram,
@@ -30,54 +32,14 @@ _PINNED_PROJECTION_HASHES = {
         "5c2f2eede89b1fd4cc5cd067116eb62a02444e0152106325ee133fad9f2bee3b"
     ),
 }
+_CATALOG_BY_JOB_KEY = {
+    str(definition["job_key"]): definition for definition in SCHEDULER_CATALOG
+}
 
 
 def _job(program_name: str) -> SimpleNamespace:
-    definitions = {
-        "nightly_sleep": {
-            "job_key": "nightly_sleep",
-            "family": "nightly_sleep",
-            "program_key": "nightly_sleep",
-            "handler_ref": "brain.app.scheduler.programs:nightly_sleep",
-            "default_payload": {
-                "name": "Nightly Sleep",
-                "scheduler_split_steps": True,
-            },
-        },
-        "curiosity_cron": {
-            "job_key": "curiosity_cron",
-            "family": "curiosity_cron",
-            "program_key": "curiosity",
-            "handler_ref": "brain.app.scheduler.programs:curiosity",
-            "default_payload": {"name": "Curiosity Engine"},
-        },
-        "uwear_aws_health_scan": {
-            "job_key": "uwear_aws_health_scan",
-            "family": "uwear_aws_health_scan",
-            "program_key": "uwear_aws_health_scan",
-            "handler_ref": "brain.app.scheduler.programs:uwear_aws_health_scan",
-            "default_payload": {"name": "Uwear AWS Health Scan"},
-        },
-        "uwear_staging_promotion_pr": {
-            "job_key": "uwear_staging_promotion_pr",
-            "family": "uwear_staging_promotion_pr",
-            "program_key": "uwear_staging_promotion_pr",
-            "handler_ref": "brain.app.scheduler.programs:uwear_staging_promotion_pr",
-            "default_payload": {"name": "Uwear Staging Promotion PR"},
-        },
-        "illo_external_heartbeat": {
-            "job_key": "illo_external_heartbeat",
-            "family": "illo_external_heartbeat",
-            "program_key": "illo_external_heartbeat",
-            "handler_ref": "brain.app.scheduler.programs:illo_external_heartbeat",
-            "default_payload": {"name": "Illo External Heartbeat"},
-        },
-    }
-    return SimpleNamespace(
-        **definitions[program_name],
-        handler_kind="scheduler_builtin",
-        timezone="UTC",
-    )
+    definition = _CATALOG_BY_JOB_KEY[program_name]
+    return SimpleNamespace(**{**definition, "timezone": definition.get("timezone", "UTC")})
 
 
 def _projection_bytes(program_name: str) -> bytes:
@@ -102,6 +64,32 @@ def test_existing_scheduler_program_plan_and_specs_match_pinned_projections():
     }
 
     assert actual == _PINNED_PROJECTION_HASHES
+
+
+def test_pinned_program_set_equals_scheduler_catalog():
+    assert set(_PINNED_PROJECTION_HASHES) == set(_CATALOG_BY_JOB_KEY)
+
+
+def test_catalog_programs_do_not_reach_legacy_substring_fallback(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("catalog program reached legacy substring fallback")
+
+    monkeypatch.setattr(
+        scheduler_programs,
+        "_build_legacy_scheduler_step_plan",
+        fail_if_called,
+    )
+    monkeypatch.setattr(
+        scheduler_programs,
+        "_get_legacy_step_specs",
+        fail_if_called,
+    )
+
+    run = SimpleNamespace(scheduled_for=_SCHEDULED_FOR)
+    for program_name in _CATALOG_BY_JOB_KEY:
+        job = _job(program_name)
+        build_scheduler_step_plan(job)
+        get_step_specs(job, run)
 
 
 def test_registry_only_registration_drives_plan_and_specs(monkeypatch):

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -1,6 +1,7 @@
 """Tests for the scheduled staging-to-main promotion PR reconciler."""
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 import uuid
@@ -20,6 +21,7 @@ from brain.platform.db.models.vault import (
 from brain.systems.cortex.project_context import github_promotion
 from brain.systems.cortex.project_context.github import (
     GitHubConnectorError,
+    async_compare_commits,
     async_compare_repo_branches,
 )
 from brain.systems.cortex.project_context.github_promotion import (
@@ -213,6 +215,77 @@ async def test_create_race_422_already_exists_settles_as_already_open(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_concurrent_reconciliations_settle_one_create_and_one_422_conflict(
+    monkeypatch,
+):
+    search_barrier = asyncio.Barrier(2)
+    create_lock = asyncio.Lock()
+    open_pull_numbers: list[int] = []
+    search_count = 0
+    compare = AsyncMock(return_value=COMPARE_PAYLOAD)
+
+    async def list_pulls(*args, **kwargs):
+        nonlocal search_count
+        search_count += 1
+        await search_barrier.wait()
+        return {"pull_requests": []}
+
+    async def create_pull(*args, **kwargs):
+        assert search_count == 2
+        async with create_lock:
+            if not open_pull_numbers:
+                open_pull_numbers.append(901)
+                return {
+                    "repo": REPO,
+                    "pull_request": {
+                        "number": 901,
+                        "html_url": f"https://github.com/{REPO}/pull/901",
+                        "state": "open",
+                        "draft": False,
+                    },
+                }
+            raise GitHubConnectorError(
+                status_code=422,
+                message=(
+                    "Validation Failed: A pull request already exists for "
+                    "uwear-ai:staging: "
+                    f"https://github.com/{REPO}/pull/901"
+                ),
+            )
+
+    list_open_pulls = AsyncMock(side_effect=list_pulls)
+    create = AsyncMock(side_effect=create_pull)
+    monkeypatch.setattr(github_promotion, "async_compare_repo_branches", compare)
+    monkeypatch.setattr(
+        github_promotion,
+        "async_list_repo_pull_requests",
+        list_open_pulls,
+    )
+    monkeypatch.setattr(github_promotion, "async_create_repo_pull_request", create)
+
+    target = PROMOTION_PULL_REQUEST_POLICY.target_for(REPO)
+    results = await asyncio.gather(
+        github_promotion.async_reconcile_promotion_pull_request(
+            target,
+            token="app-token",
+        ),
+        github_promotion.async_reconcile_promotion_pull_request(
+            target,
+            token="app-token",
+        ),
+    )
+
+    assert {(result.outcome, result.settled_by) for result in results} == {
+        ("created", "create"),
+        ("already_open", "create_conflict"),
+    }
+    assert open_pull_numbers == [901]
+    assert compare.await_count == 2
+    assert list_open_pulls.await_count == 2
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_api_error_is_logged_and_other_repository_still_settles(monkeypatch, caplog):
     actor = staging_promotion_pr.PromotionActor(user_id="user-1", org_id="org-1")
     reconcile = AsyncMock(
@@ -332,6 +405,27 @@ async def test_compare_connector_reads_ahead_count_and_commit_subjects():
         f"/repos/{REPO}/compare/main...staging",
     )
     assert request.await_args.kwargs["token"] == "app-token"
+
+
+@pytest.mark.asyncio
+async def test_async_compare_commits_preserves_legacy_non_object_diagnostic():
+    with patch(
+        "brain.systems.cortex.project_context.github._async_request",
+        new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(GitHubConnectorError) as exc_info:
+            await async_compare_commits(
+                REPO,
+                "main",
+                "staging",
+                token="app-token",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert (
+        exc_info.value.message
+        == "GitHub compare response omitted a recognized status."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #501

## What this does

A single-command scheduler program used to be bolted into **two parallel dispatch mechanisms** —
one branch in `build_scheduler_step_plan`, a separate helper plus branch in `get_step_specs` —
matched by **substring**. Adding one meant keeping command / step-key / name / description
declarations in sync across several places.

Now there is one **exact-keyed registry** that both consume. Adding a single-command program is
one registry entry.

This is a **pure restructure**. No scheduler program changes behavior — see the proof below.

## The proof this changes nothing

`test_existing_scheduler_program_plan_and_specs_match_pinned_projections` serializes each
program's plan plus `StepSpec` projection into deterministic sorted JSON and pins its SHA-256.

**These pins were verified independently, against pre-refactor `origin/main`.** The projection
helper was extracted and run in a scratch worktree checked out at `origin/main`, and all five
hashes reproduce exactly — so they are genuine pre-change values, not post-change recordings
asserted against themselves:

| program | pinned projection |
|---|---|
| `nightly_sleep` | `0cb9173b…060ee0` |
| `curiosity_cron` | `326e1c24…a8519d` |
| `uwear_aws_health_scan` | `10d9a7cb…3d87ee` |
| `uwear_staging_promotion_pr` | `073a6f20…d71e6b` |
| `illo_external_heartbeat` | `5c2f2eed…f2bee3b` |

`test_pinned_program_set_equals_scheduler_catalog` asserts the pinned set **equals** the
canonical catalog set, so adding a scheduler program without pinning it fails the suite instead
of silently escaping equivalence coverage.

## Dispatch after this change

Every production program resolves by **exact key**; none reaches the substring fallback:

- `nightly_sleep` → `DIVERGENT_PROGRAM_REGISTRY["nightly_sleep"]`
- `curiosity_cron` (`program_key="curiosity"`) → `DIVERGENT_PROGRAM_REGISTRY["curiosity"]`
- `illo_external_heartbeat` → `DIVERGENT_PROGRAM_REGISTRY["illo_external_heartbeat"]`
- `uwear_aws_health_scan` → `SINGLE_COMMAND_PROGRAM_REGISTRY[…]`
- `uwear_staging_promotion_pr` → `SINGLE_COMMAND_PROGRAM_REGISTRY[…]`

Substring matching survives only as a **terminal fallback nothing in production reaches**, so
deleting it later is a change nobody has to reason about. The first pass left it load-bearing
for three programs; the code-quality review caught that, and the fix pass closed it.

## The two smaller follow-ups from the same original review

- **A real race test.** `test_concurrent_reconciliations_settle_one_create_and_one_422_conflict`
  synchronizes two reconciliations *after both searches*, then proves one create wins and the
  other settles through GitHub's 422 already-exists path. (The 422 backstop was already correct;
  this covers the path, it does not fix a bug.)
- **The `async_compare_commits` diagnostic is restored verbatim** — a malformed non-object
  response says *"omitted a recognized status"* again, not *"was not an object"*. Covered by
  `test_async_compare_commits_preserves_legacy_non_object_diagnostic`.

## Verification

```
cd <worktree> && venv/bin/python -m pytest -q
venv/bin/python -m pytest tests/test_architecture_boundaries.py -q
```

- Full suite: **4318 passed, 76 skipped, 0 failed**
- Architecture check: **2 passed**
- All five pinned projections unchanged and passing after the fix pass

## Deliberately not done

- **The legacy `StepSpec` / `get_step_specs` subtree is untouched.** Deleting it is #432, gated
  on a product decision that has not been made. This restructure was scoped to make that
  deletion *easier*, not to perform it.
- The equivalence projection hashes JSON, which erases mapping order, list-vs-tuple and concrete
  `StepSpec` identity. Tightening it to raw typed projections would mean re-pinning — and
  re-pinning would discard the independently verified hashes above. Left alone on purpose.

<sub>Implemented by a Codex worker under Routine R3; reviewed, verified and opened by the R3 orchestrator. Draft — R3 never marks a PR ready.</sub>
