### PR TITLE
fix(cycles): normalize next_run_at before comparing in the wake path

### DIFF
--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -649,7 +649,8 @@ async def async_wake_cycle_now(*, name: str, org_id: str | None = None) -> str:
         ).first()
         if cycle is None or not cycle.enabled or cycle.deleted_at is not None:
             return "not_found"
-        if cycle.next_run_at is not None and cycle.next_run_at <= now:
+        pending_at = _aware_utc(cycle.next_run_at)
+        if pending_at is not None and pending_at <= now:
             return "already_pending"
         active_run_count = await _async_active_cycle_run_count(uow.session, cycle.id)
         if active_run_count > 0:

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -3375,6 +3375,56 @@ async def test_wake_cycle_now_reports_already_pending_and_missing(
 
 
 @pytest.mark.asyncio
+async def test_wake_cycle_now_handles_naive_next_run_at_from_the_driver(
+    monkeypatch,
+    cycle_scheduler_session,
+):
+    """Regression: the DB hands back naive datetimes for cycles.next_run_at.
+
+    Assigning an aware value and reading it back through the identity map hides
+    this — the object never round-trips. Expiring forces a real driver load, so
+    the comparison sees what production sees (verified live: repr was
+    `datetime.datetime(2026, 7, 28, 15, 0)`, tzinfo None).
+    """
+    future = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(hours=6)
+    cycle = Cycle(
+        id=41,
+        user_id=str(uuid4()),
+        org_id=None,
+        name="Naive Clock Cycle",
+        prompt="p",
+        schedule_expr="0 11 * * *",
+        timezone="UTC",
+        enabled=True,
+        next_run_at=future,
+    )
+    cycle_scheduler_session.add(cycle)
+    await cycle_scheduler_session.commit()
+    cycle_scheduler_session.expire_all()
+    reloaded = (
+        await cycle_scheduler_session.scalars(select(Cycle).where(Cycle.id == 41))
+    ).one()
+    assert reloaded.next_run_at.tzinfo is None, "fixture must reproduce the naive load"
+    monkeypatch.setattr(
+        service,
+        "UnitOfWork",
+        lambda: _SharedSessionUnitOfWork(cycle_scheduler_session),
+    )
+
+    assert await service.async_wake_cycle_now(name="Naive Clock Cycle") == "woken"
+
+    cycle_scheduler_session.expire_all()
+    woken = (
+        await cycle_scheduler_session.scalars(select(Cycle).where(Cycle.id == 41))
+    ).one()
+    assert _aware_utc_for_test(woken.next_run_at) <= datetime.now(timezone.utc)
+
+
+def _aware_utc_for_test(value):
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
+@pytest.mark.asyncio
 async def test_wake_cycle_now_refuses_ambiguous_names(
     monkeypatch,
     cycle_scheduler_session,


### PR DESCRIPTION
## What broke

The first live run of the promotion detector (merged in #536, deployed as `e14dc9cc`) failed its wake step:

```
Readiness cycle wake failed for uwear-ai/uwear-backend:
can't compare offset-naive and offset-aware datetimes
```

`cycles.next_run_at` comes back **naive** from this database despite the `DateTime(timezone=True)` column — verified live: `repr` is `datetime.datetime(2026, 7, 28, 15, 0)`, `tzinfo=None`. The already-pending guard compared it to an aware `now()`.

`brain/systems/cycles/service.py` already defines `_aware_utc` for precisely this, and the surrounding code uses it (line 494). The wake path should have too.

## Why the tests missed it

They asserted against the SQLAlchemy identity map: the test assigned an aware datetime and read back the same Python object, so the value never round-tripped through the driver. The regression test here commits, calls `expire_all()`, and reloads — asserting the fixture actually reproduces the naive load before exercising the wake. **It fails with the production `TypeError` when the fix is reverted.**

## Not broken

PR reconciliation worked on that same run — the clock fix restored GitHub App JWT minting: backend `already_open` #1296, uwearaiapp **`created`** [#759](https://github.com/uwear-ai/uwearaiapp/pull/759). The failure-visibility design also behaved correctly: the wake error failed the scheduler run loudly instead of reporting green.

Tests: full fast suite 4323 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)