### PR TITLE
fix(cycles): fail fast when a run's context floor exceeds its budget

### DIFF
--- a/brain/platform/db/repositories/unit_of_work.py
+++ b/brain/platform/db/repositories/unit_of_work.py
@@ -1,8 +1,10 @@
 """Unit of Work — transaction boundary for database-backed code."""
 from __future__ import annotations
 
+from contextlib import suppress
 from functools import cached_property
 import inspect
+import logging
 from typing import Any, Generic, TypeVar
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -71,6 +73,7 @@ from brain.platform.db.repositories.vault import (
 )
 
 RepoT = TypeVar("RepoT")
+logger = logging.getLogger(__name__)
 
 
 def _method_owner(repo_cls: type[Any], name: str) -> type[Any] | None:
@@ -137,13 +140,31 @@ class UnitOfWork:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         assert self._async_session is not None
-        if exc_type:
-            await self._async_session.rollback()
-        else:
-            await self._async_session.commit()
-        await self._async_session.close()
-        self._async_session = None
-        self._clear_cached_repositories()
+        exit_failed = exc_type is not None
+        try:
+            if exc_type:
+                try:
+                    await self._async_session.rollback()
+                except BaseException:
+                    logger.exception("unit_of_work_rollback_failed")
+            else:
+                try:
+                    await self._async_session.commit()
+                except BaseException:
+                    exit_failed = True
+                    with suppress(BaseException):
+                        await self._async_session.rollback()
+                    raise
+        finally:
+            try:
+                await self._async_session.close()
+            except BaseException:
+                if not exit_failed:
+                    raise
+                logger.exception("unit_of_work_close_failed_after_primary_error")
+            finally:
+                self._async_session = None
+                self._clear_cached_repositories()
 
     def __enter__(self) -> UnitOfWork:
         raise RuntimeError("UnitOfWork is async-only; use `async with UnitOfWork()`.")

--- a/brain/systems/context/__init__.py
+++ b/brain/systems/context/__init__.py
@@ -17,8 +17,18 @@ from brain.systems.context.compaction import (
     split_session_messages_for_compaction,
 )
 from brain.systems.context.semantic_compaction import (
+    CompactionPlan,
     CompactionCheckpoint,
-    compact_session_messages_with_checkpoint,
+    plan_session_compaction,
+)
+from brain.systems.context.errors import (
+    ContextCompactionStalledError,
+    ContextFloorExceedsBudgetError,
+)
+from brain.systems.context.window_policy import (
+    ContextAdmission,
+    ContextCompactionOutcome,
+    ContextWindowPolicy,
 )
 from brain.systems.context.thread_handoff import (
     ThreadHandoff,
@@ -60,7 +70,13 @@ __all__ = [
     "CONTEXT_POLICY_VERSION",
     "CompactionReport",
     "CompactionWindow",
+    "CompactionPlan",
     "CompactionCheckpoint",
+    "ContextAdmission",
+    "ContextCompactionOutcome",
+    "ContextCompactionStalledError",
+    "ContextFloorExceedsBudgetError",
+    "ContextWindowPolicy",
     "ContextRender",
     "ContextRuntime",
     "ContextPack",
@@ -80,12 +96,12 @@ __all__ = [
     "WORKER_SECTION_ORDER",
     "apply_active_context_policy",
     "compact_session_messages",
-    "compact_session_messages_with_checkpoint",
     "context_policy_active_enabled",
     "filter_context_pack_sections",
     "build_thread_handoff",
     "build_thread_handoff_context_messages",
     "normalize_task_class",
+    "plan_session_compaction",
     "recent_raw_messages_for_handoff",
     "resolve_model_context_budget",
     "split_session_messages_for_compaction",

--- a/brain/systems/context/errors.py
+++ b/brain/systems/context/errors.py
@@ -1,0 +1,48 @@
+"""Typed failures raised by model-context admission and compaction."""
+
+from __future__ import annotations
+
+
+class ContextFloorExceedsBudgetError(RuntimeError):
+    """The smallest prompt produced by canonical compaction cannot be admitted."""
+
+    def __init__(self, *, floor: int, ceiling: int, tools: int, min_messages: int):
+        self.floor = int(floor)
+        self.ceiling = int(ceiling)
+        self.tools = int(tools)
+        self.min_messages = int(min_messages)
+        super().__init__(
+            "context_floor_exceeds_budget: "
+            f"floor={self.floor} ceiling={self.ceiling} tools={self.tools} "
+            f"min_messages={self.min_messages}"
+        )
+
+
+class ContextCompactionStalledError(RuntimeError):
+    """Repeated compaction attempts cannot produce an admissible prompt."""
+
+    def __init__(
+        self,
+        *,
+        estimated: int,
+        ceiling: int,
+        tools: int,
+        attempts: int,
+        phase: str,
+    ):
+        self.estimated = int(estimated)
+        self.ceiling = int(ceiling)
+        self.tools = int(tools)
+        self.attempts = int(attempts)
+        self.phase = str(phase)
+        super().__init__(
+            "context_compaction_stalled: "
+            f"estimated={self.estimated} ceiling={self.ceiling} tools={self.tools} "
+            f"attempts={self.attempts} phase={self.phase}"
+        )
+
+
+__all__ = [
+    "ContextCompactionStalledError",
+    "ContextFloorExceedsBudgetError",
+]

--- a/brain/systems/context/semantic_compaction.py
+++ b/brain/systems/context/semantic_compaction.py
@@ -343,7 +343,16 @@ def checkpoint_message(checkpoint: CompactionCheckpoint, *, omitted_count: int) 
     }
 
 
-def compact_session_messages_with_checkpoint(
+@dataclass(frozen=True)
+class CompactionPlan:
+    """Canonical prompt and token estimate produced by checkpoint compaction."""
+
+    messages: list[dict]
+    report: CompactionReport
+    estimated_tokens: int
+
+
+def plan_session_compaction(
     messages: list[dict],
     *,
     token_limit: int,
@@ -358,25 +367,29 @@ def compact_session_messages_with_checkpoint(
     force: bool = False,
     emergency: bool = False,
     semantic_compactor: SemanticCompactor | None = None,
-) -> tuple[list[dict], CompactionReport]:
-    """Compact a transcript using a structured state checkpoint."""
+) -> CompactionPlan:
+    """Build the canonical checkpointed prompt used by admission and execution."""
     original_tokens = estimate_session_tokens(messages, system=system, tools=tools)
     if not force and (token_limit <= 0 or original_tokens <= token_limit):
-        return list(messages), CompactionReport(
-            original_count=len(messages),
-            kept_count=len(messages),
-            omitted_count=0,
-            summary="No compaction required.",
-            strategy="semantic_checkpoint",
-            provenance={
-                "session_id": session_id,
-                "phase": phase,
-                "token_limit": token_limit,
-                "target_tokens": target_tokens,
-                "original_estimated_tokens": original_tokens,
-                "final_estimated_tokens": original_tokens,
-                "summary_source": "none",
-            },
+        return CompactionPlan(
+            messages=list(messages),
+            estimated_tokens=original_tokens,
+            report=CompactionReport(
+                original_count=len(messages),
+                kept_count=len(messages),
+                omitted_count=0,
+                summary="No compaction required.",
+                strategy="semantic_checkpoint",
+                provenance={
+                    "session_id": session_id,
+                    "phase": phase,
+                    "token_limit": token_limit,
+                    "target_tokens": target_tokens,
+                    "original_estimated_tokens": original_tokens,
+                    "final_estimated_tokens": original_tokens,
+                    "summary_source": "none",
+                },
+            ),
         )
 
     target = int(target_tokens or max(1, token_limit * 7 // 10))
@@ -443,32 +456,40 @@ def compact_session_messages_with_checkpoint(
             break
 
     if best_report is None:
-        return list(messages), CompactionReport(
-            original_count=len(messages),
-            kept_count=len(messages),
-            omitted_count=0,
-            summary="No safe transcript messages were eligible for checkpoint compaction.",
-            strategy="emergency_checkpoint_unavailable" if emergency else "checkpoint_unavailable",
-            provenance={
-                "session_id": session_id,
-                "phase": phase,
-                "token_limit": token_limit,
-                "target_tokens": target,
-                "original_estimated_tokens": original_tokens,
-                "final_estimated_tokens": original_tokens,
-                "force": force,
-                "emergency": emergency,
-            },
+        return CompactionPlan(
+            messages=list(messages),
+            estimated_tokens=original_tokens,
+            report=CompactionReport(
+                original_count=len(messages),
+                kept_count=len(messages),
+                omitted_count=0,
+                summary="No safe transcript messages were eligible for checkpoint compaction.",
+                strategy="emergency_checkpoint_unavailable" if emergency else "checkpoint_unavailable",
+                provenance={
+                    "session_id": session_id,
+                    "phase": phase,
+                    "token_limit": token_limit,
+                    "target_tokens": target,
+                    "original_estimated_tokens": original_tokens,
+                    "final_estimated_tokens": original_tokens,
+                    "force": force,
+                    "emergency": emergency,
+                },
+            ),
         )
 
-    return best_messages, CompactionReport(
-        original_count=best_report.original_count,
-        kept_count=best_report.kept_count,
-        omitted_count=best_report.omitted_count,
-        summary=best_report.summary,
-        strategy=best_report.strategy,
-        provenance={
-            **dict(best_report.provenance or {}),
-            "final_estimated_tokens": best_tokens,
-        },
+    return CompactionPlan(
+        messages=best_messages,
+        estimated_tokens=best_tokens,
+        report=CompactionReport(
+            original_count=best_report.original_count,
+            kept_count=best_report.kept_count,
+            omitted_count=best_report.omitted_count,
+            summary=best_report.summary,
+            strategy=best_report.strategy,
+            provenance={
+                **dict(best_report.provenance or {}),
+                "final_estimated_tokens": best_tokens,
+            },
+        ),
     )

--- a/brain/systems/context/window_policy.py
+++ b/brain/systems/context/window_policy.py
@@ -1,0 +1,216 @@
+"""Run-scoped policy for model-context admission and compaction progress."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from brain.systems.context.budget import ModelContextBudget, resolve_model_context_budget
+from brain.systems.context.compaction import CompactionReport, estimate_session_tokens
+from brain.systems.context.errors import (
+    ContextCompactionStalledError,
+    ContextFloorExceedsBudgetError,
+)
+from brain.systems.context.semantic_compaction import (
+    SemanticCompactor,
+    plan_session_compaction,
+)
+
+DEFAULT_MIN_COMPACTION_MESSAGES = 4
+DEFAULT_MAX_COMPACTION_NO_PROGRESS = 3
+
+
+@dataclass(frozen=True)
+class ContextAdmission:
+    """The canonical minimum prompt measured for one run configuration."""
+
+    budget: ModelContextBudget
+    floor_tokens: int
+    tool_count: int
+    min_messages: int
+
+
+@dataclass(frozen=True)
+class ContextCompactionOutcome:
+    """One policy-evaluated compaction result for the run loop to orchestrate."""
+
+    messages: list[dict]
+    report: CompactionReport | None
+    estimated_tokens: int
+    final_tokens: int
+    warning_required: bool = False
+
+
+@dataclass
+class ContextWindowPolicy:
+    """Own context boundaries and mutable compaction progress for one run."""
+
+    budget: ModelContextBudget
+    min_messages: int = DEFAULT_MIN_COMPACTION_MESSAGES
+    max_consecutive_no_progress: int = DEFAULT_MAX_COMPACTION_NO_PROGRESS
+    consecutive_no_progress: int = 0
+    warning_emitted: bool = False
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        model: str,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
+        max_output_tokens: int | None = None,
+        tools: list[dict] | None = None,
+    ) -> "ContextWindowPolicy":
+        """Build the run-scoped policy from one resolved model budget."""
+
+        return cls(
+            budget=resolve_model_context_budget(
+                model=model,
+                provider=provider,
+                reasoning_effort=reasoning_effort,
+                max_output_tokens=max_output_tokens,
+                tools=tools,
+            )
+        )
+
+    @property
+    def threshold_tokens(self) -> int:
+        return self.budget.auto_compact_threshold_tokens
+
+    def admits(self, tokens: int) -> bool:
+        """Equality is admitted: the threshold is the inclusive prompt ceiling."""
+
+        return int(tokens) <= self.threshold_tokens
+
+    def requires_compaction(self, tokens: int) -> bool:
+        """Compaction starts only after crossing the inclusive prompt ceiling."""
+
+        return int(tokens) > self.threshold_tokens
+
+    def admit(
+        self,
+        messages: list[dict],
+        *,
+        system: Any = None,
+        tools: list[dict] | None = None,
+        session_id: str = "",
+        phase: str = "admission",
+    ) -> ContextAdmission:
+        """Measure and admit the canonical minimum checkpointed prompt."""
+
+        minimum_plan = plan_session_compaction(
+            messages,
+            token_limit=self.threshold_tokens,
+            target_tokens=1,
+            session_id=session_id,
+            phase=phase,
+            system=system,
+            tools=tools,
+            max_messages=self.min_messages,
+            min_messages=self.min_messages,
+            force=True,
+        )
+        admission = ContextAdmission(
+            budget=self.budget,
+            floor_tokens=minimum_plan.estimated_tokens,
+            tool_count=len(tools or []),
+            min_messages=self.min_messages,
+        )
+        if not self.admits(admission.floor_tokens):
+            raise ContextFloorExceedsBudgetError(
+                floor=admission.floor_tokens,
+                ceiling=self.threshold_tokens,
+                tools=admission.tool_count,
+                min_messages=admission.min_messages,
+            )
+        return admission
+
+    def compact(
+        self,
+        messages: list[dict],
+        *,
+        session_id: str,
+        phase: str,
+        system: Any = None,
+        tools: list[dict] | None = None,
+        max_messages: int,
+        semantic_compactor: SemanticCompactor | None = None,
+        force: bool = False,
+        emergency: bool = False,
+    ) -> ContextCompactionOutcome:
+        """Plan compaction and own all no-progress/warning state transitions."""
+
+        estimated_tokens = estimate_session_tokens(messages, system=system, tools=tools)
+        if not force and not self.requires_compaction(estimated_tokens):
+            self._reset_progress()
+            return ContextCompactionOutcome(
+                messages=messages,
+                report=None,
+                estimated_tokens=estimated_tokens,
+                final_tokens=estimated_tokens,
+            )
+
+        plan = plan_session_compaction(
+            messages,
+            token_limit=self.threshold_tokens,
+            target_tokens=(
+                self.budget.emergency_target_tokens
+                if emergency
+                else self.budget.target_tokens
+            ),
+            session_id=session_id,
+            phase=phase,
+            system=system,
+            tools=tools,
+            max_messages=max_messages,
+            min_messages=self.min_messages,
+            force=force,
+            emergency=emergency,
+            semantic_compactor=semantic_compactor,
+        )
+        made_sufficient_progress = (
+            plan.report.omitted_count > 0
+            and self.admits(plan.estimated_tokens)
+        )
+        if made_sufficient_progress:
+            self._reset_progress()
+        else:
+            self.consecutive_no_progress += 1
+
+        warning_required = False
+        if plan.report.omitted_count <= 0 and not self.warning_emitted:
+            self.warning_emitted = True
+            warning_required = True
+
+        if (
+            not made_sufficient_progress
+            and self.consecutive_no_progress >= self.max_consecutive_no_progress
+        ):
+            raise ContextCompactionStalledError(
+                estimated=plan.estimated_tokens,
+                ceiling=self.threshold_tokens,
+                tools=len(tools or []),
+                attempts=self.consecutive_no_progress,
+                phase=phase,
+            )
+
+        return ContextCompactionOutcome(
+            messages=plan.messages if plan.report.omitted_count > 0 else messages,
+            report=plan.report if plan.report.omitted_count > 0 else None,
+            estimated_tokens=estimated_tokens,
+            final_tokens=plan.estimated_tokens,
+            warning_required=warning_required,
+        )
+
+    def _reset_progress(self) -> None:
+        self.consecutive_no_progress = 0
+        self.warning_emitted = False
+
+
+__all__ = [
+    "ContextAdmission",
+    "ContextCompactionOutcome",
+    "ContextWindowPolicy",
+    "DEFAULT_MAX_COMPACTION_NO_PROGRESS",
+    "DEFAULT_MIN_COMPACTION_MESSAGES",
+]

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -22,8 +22,9 @@ from sqlalchemy import func, select
 from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
-from brain.systems.runs.engine import AgentRunDatabaseFlushError, AsyncAgentRunEngine
+from brain.systems.runs.engine import AsyncAgentRunEngine
 from brain.systems.runs.events import activity_event, run_event
+from brain.systems.runs.execution_failure import RunExecutionFailure
 from brain.systems.runs.failures import (
     coerce_failure_category,
     failure_category_for_error,
@@ -258,7 +259,7 @@ def _engine_for_session(session) -> AsyncAgentRunEngine:
         session,
         recipes=default_recipes(),
         stream=RunStream(_live_stream_sink(session)),
-        auto_commit_events=True,
+        auto_commit_events=False,
         cancel_event_factory=_run_cancel_token,
         durable_steering_drain=_drain_steering_in_isolated_uow,
     )
@@ -1476,11 +1477,24 @@ async def _process_claimed_run_async(run_id: int) -> bool:
             publish_safe("status_change", status_payload)
         return True
     except Exception as exc:
-        logger.exception("agent_run_failed", extra={"run_id": run_id})
-        error = str(exc) if isinstance(exc, AgentRunDatabaseFlushError) else "runner_failed"
+        failure = RunExecutionFailure.capture(int(run_id), exc)
+        logger.exception(
+            "agent_run_failed",
+            extra={
+                "run_id": run_id,
+                "primary_error": str(failure),
+            },
+        )
         try:
-            status_payload = await _mark_run_failed_after_runner_error_async(int(run_id), error)
-            await _finalize_cycle_run_if_needed_async(int(run_id), status="failed", error=error)
+            status_payload = await _mark_run_failed_after_runner_error_async(
+                int(run_id),
+                str(failure),
+            )
+            await _finalize_cycle_run_if_needed_async(
+                int(run_id),
+                status="failed",
+                error=str(failure),
+            )
             if status_payload:
                 publish_safe("status_change", status_payload)
         except Exception:

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -22,7 +22,7 @@ from sqlalchemy import func, select
 from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
-from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.engine import AgentRunDatabaseFlushError, AsyncAgentRunEngine
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.failures import (
     coerce_failure_category,
@@ -1475,11 +1475,12 @@ async def _process_claimed_run_async(run_id: int) -> bool:
         if status_payload:
             publish_safe("status_change", status_payload)
         return True
-    except Exception:
+    except Exception as exc:
         logger.exception("agent_run_failed", extra={"run_id": run_id})
+        error = str(exc) if isinstance(exc, AgentRunDatabaseFlushError) else "runner_failed"
         try:
-            status_payload = await _mark_run_failed_after_runner_error_async(int(run_id), "runner_failed")
-            await _finalize_cycle_run_if_needed_async(int(run_id), status="failed", error="runner_failed")
+            status_payload = await _mark_run_failed_after_runner_error_async(int(run_id), error)
+            await _finalize_cycle_run_if_needed_async(int(run_id), status="failed", error=error)
             if status_payload:
                 publish_safe("status_change", status_payload)
         except Exception:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -33,6 +33,7 @@ import time
 import uuid
 from collections.abc import Awaitable
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from brain.platform.integrations.llm import (
@@ -223,6 +224,8 @@ _RESEARCH_BUDGET = 6
 _MAX_PARALLEL_TOOL_CALLS = int(os.environ.get("AGENT_MAX_PARALLEL_TOOL_CALLS", "10"))
 _PARALLEL_SAFE_TOOL_NAMES = parallel_safe_tool_names(scope="agent")
 _AGENT_CACHE_DEBUG = os.environ.get("AGENT_CACHE_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+_CONTEXT_COMPACTION_MIN_MESSAGES = 4
+_MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS = 3
 
 
 # ── Extracted Helpers ──────────────────────────────────────────
@@ -970,6 +973,115 @@ def _record_context_compaction_event(
     )
 
 
+@dataclass(frozen=True)
+class ContextAdmission:
+    budget: Any
+    floor_tokens: int
+    tool_count: int
+    min_messages: int
+
+
+class ContextFloorExceedsBudgetError(RuntimeError):
+    def __init__(self, *, floor: int, ceiling: int, tools: int, min_messages: int):
+        self.floor = int(floor)
+        self.ceiling = int(ceiling)
+        self.tools = int(tools)
+        self.min_messages = int(min_messages)
+        super().__init__(
+            "context_floor_exceeds_budget: "
+            f"floor={self.floor} ceiling={self.ceiling} tools={self.tools} "
+            f"min_messages={self.min_messages}"
+        )
+
+
+class ContextCompactionStalledError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        estimated: int,
+        ceiling: int,
+        tools: int,
+        attempts: int,
+        phase: str,
+    ):
+        self.estimated = int(estimated)
+        self.ceiling = int(ceiling)
+        self.tools = int(tools)
+        self.attempts = int(attempts)
+        self.phase = str(phase)
+        super().__init__(
+            "context_compaction_stalled: "
+            f"estimated={self.estimated} ceiling={self.ceiling} tools={self.tools} "
+            f"attempts={self.attempts} phase={self.phase}"
+        )
+
+
+def _irreducible_context_messages(
+    messages: list[dict],
+    *,
+    min_messages: int = _CONTEXT_COMPACTION_MIN_MESSAGES,
+) -> list[dict]:
+    """Return the raw messages the compactor's smallest safe window must retain."""
+    from brain.systems.context.compaction import split_session_messages_for_compaction
+
+    window = split_session_messages_for_compaction(
+        messages,
+        max_messages=max(1, int(min_messages)),
+    )
+    if window is None or not window.omitted_messages:
+        return list(messages)
+    return list(window.kept_early) + list(window.kept_recent)
+
+
+def _admit_active_context(
+    messages: list[dict],
+    *,
+    model: str,
+    system: list[dict] | str | None = None,
+    tools: list[dict] | None = None,
+    provider_name: str | None = None,
+    reasoning_effort: str | None = None,
+    max_output_tokens: int | None = None,
+    min_messages: int = _CONTEXT_COMPACTION_MIN_MESSAGES,
+) -> ContextAdmission:
+    """Reject a prompt scaffold that no transcript compaction can fit."""
+    from brain.systems.context.budget import resolve_model_context_budget
+    from brain.systems.context.compaction import estimate_session_tokens
+
+    budget = resolve_model_context_budget(
+        model=model,
+        provider=provider_name,
+        reasoning_effort=reasoning_effort,
+        max_output_tokens=max_output_tokens,
+        tools=tools,
+    )
+    floor_messages = _irreducible_context_messages(
+        messages,
+        min_messages=min_messages,
+    )
+    floor_tokens = estimate_session_tokens(
+        floor_messages,
+        system=system,
+        tools=tools,
+    )
+    admission = ContextAdmission(
+        budget=budget,
+        floor_tokens=floor_tokens,
+        tool_count=len(tools or []),
+        min_messages=int(min_messages),
+    )
+    if floor_tokens >= budget.auto_compact_threshold_tokens:
+        error = ContextFloorExceedsBudgetError(
+            floor=floor_tokens,
+            ceiling=budget.auto_compact_threshold_tokens,
+            tools=admission.tool_count,
+            min_messages=admission.min_messages,
+        )
+        logger.error("%s", error)
+        raise error
+    return admission
+
+
 def _maybe_compact_active_context(
     messages: list[dict],
     *,
@@ -985,6 +1097,7 @@ def _maybe_compact_active_context(
     semantic_compactor=None,
     force: bool = False,
     emergency: bool = False,
+    tracker=None,
 ) -> tuple[list[dict], object | None]:
     """Compact active history when the estimated prompt crosses the runtime limit."""
     from brain.systems.context.budget import resolve_model_context_budget
@@ -1002,6 +1115,8 @@ def _maybe_compact_active_context(
     )
     estimated_tokens = estimate_session_tokens(messages, system=system, tools=tools)
     if not force and estimated_tokens < budget.auto_compact_threshold_tokens:
+        if tracker is not None:
+            tracker.reset()
         return messages, None
 
     compacted, report = compact_session_messages_with_checkpoint(
@@ -1013,21 +1128,48 @@ def _maybe_compact_active_context(
         system=system,
         tools=tools,
         max_messages=_MAX_PERSISTED_MESSAGES,
-        min_messages=4,
+        min_messages=_CONTEXT_COMPACTION_MIN_MESSAGES,
         force=force,
         emergency=emergency,
         semantic_compactor=semantic_compactor,
     )
     final_tokens = report.provenance.get("final_estimated_tokens")
+    if not isinstance(final_tokens, int):
+        final_tokens = estimate_session_tokens(compacted, system=system, tools=tools)
+    below_threshold = final_tokens < budget.auto_compact_threshold_tokens
+    made_sufficient_progress = report.omitted_count > 0 and below_threshold
+    if made_sufficient_progress:
+        if tracker is not None:
+            tracker.reset()
+    elif tracker is not None:
+        tracker.consecutive_no_progress += 1
     if report.omitted_count <= 0:
-        logger.warning(
-            "Agent %s: %s context exceeded token limit (~%d >= %d) but no safe transcript "
-            "messages were eligible for compaction",
-            session_id,
-            phase,
-            estimated_tokens,
-            budget.auto_compact_threshold_tokens,
+        if tracker is None or not tracker.warned_no_safe_messages:
+            logger.warning(
+                "Agent %s: %s context exceeded token limit (~%d >= %d) but no safe transcript "
+                "messages were eligible for compaction",
+                session_id,
+                phase,
+                estimated_tokens,
+                budget.auto_compact_threshold_tokens,
+            )
+            if tracker is not None:
+                tracker.warned_no_safe_messages = True
+    if (
+        not made_sufficient_progress
+        and tracker is not None
+        and tracker.consecutive_no_progress >= _MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS
+    ):
+        error = ContextCompactionStalledError(
+            estimated=final_tokens,
+            ceiling=budget.auto_compact_threshold_tokens,
+            tools=len(tools or []),
+            attempts=tracker.consecutive_no_progress,
+            phase=phase,
         )
+        logger.error("Agent %s: %s", session_id, error)
+        raise error
+    if report.omitted_count <= 0:
         return messages, None
     logger.info(
         "Agent %s: %s auto-compacted active context from ~%d to ~%s tokens "
@@ -1544,6 +1686,19 @@ async def run_agent_async(
         system = _build_system_blocks(llm, system_prompt, cache_system_prompt)
         system = _apply_provider_system_cache_policy(state.provider_name, system, cache_system_prompt)
         reasoning_effort, max_tokens = _build_reasoning_effort(thinking)
+        current_user_message = {"role": "user", "content": _initial_user_content(message, metadata)}
+
+        # The current request plus the static prompt/tool scaffold is unavoidable.
+        # Admit it before startup handoff compaction can make its own model call.
+        _admit_active_context(
+            [current_user_message],
+            model=model,
+            system=system,
+            tools=tools,
+            provider_name=state.provider_name,
+            reasoning_effort=reasoning_effort,
+            max_output_tokens=max_tokens,
+        )
 
         if persist_session:
             state.messages, thread_handoff = _prepare_thread_startup_context(
@@ -1557,11 +1712,19 @@ async def run_agent_async(
         else:
             state.messages = loaded_messages
 
-        current_user_message = {"role": "user", "content": _initial_user_content(message, metadata)}
         _append_message_with_archive(
             state.messages,
             current_user_message,
             raw_archive_messages,
+        )
+        _admit_active_context(
+            state.messages,
+            model=model,
+            system=system,
+            tools=tools,
+            provider_name=state.provider_name,
+            reasoning_effort=reasoning_effort,
+            max_output_tokens=max_tokens,
         )
 
         # Agent loop
@@ -1603,6 +1766,7 @@ async def run_agent_async(
                 max_output_tokens=max_tokens,
                 run_id=run_id,
                 semantic_compactor=semantic_compactor,
+                tracker=state.context_compaction,
             )
             if scheduled_result_contract and turn == 0:
                 _ensure_current_message_last(state.messages, current_user_message)
@@ -1790,6 +1954,7 @@ async def run_agent_async(
                         semantic_compactor=semantic_compactor,
                         force=True,
                         emergency=True,
+                        tracker=state.context_compaction,
                     )
                     if recovery_report is None:
                         logger.warning(
@@ -1989,6 +2154,7 @@ async def run_agent_async(
                     max_output_tokens=max_tokens,
                     run_id=run_id,
                     semantic_compactor=semantic_compactor,
+                    tracker=state.context_compaction,
                 )
             else:
                 logger.warning("Unknown stop_reason: %s", response.stop_reason)

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -33,7 +33,6 @@ import time
 import uuid
 from collections.abc import Awaitable
 from contextlib import suppress
-from dataclasses import dataclass
 from typing import Any, Callable
 
 from brain.platform.integrations.llm import (
@@ -126,6 +125,10 @@ from brain.systems.runs.routing_metadata import (
 from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems import sessions as _session_store
+from brain.systems.context.window_policy import (
+    ContextCompactionOutcome,
+    ContextWindowPolicy,
+)
 
 logger = logging.getLogger("agent")
 
@@ -224,8 +227,6 @@ _RESEARCH_BUDGET = 6
 _MAX_PARALLEL_TOOL_CALLS = int(os.environ.get("AGENT_MAX_PARALLEL_TOOL_CALLS", "10"))
 _PARALLEL_SAFE_TOOL_NAMES = parallel_safe_tool_names(scope="agent")
 _AGENT_CACHE_DEBUG = os.environ.get("AGENT_CACHE_DEBUG", "").lower() in {"1", "true", "yes", "on"}
-_CONTEXT_COMPACTION_MIN_MESSAGES = 4
-_MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS = 3
 
 
 # ── Extracted Helpers ──────────────────────────────────────────
@@ -973,215 +974,55 @@ def _record_context_compaction_event(
     )
 
 
-@dataclass(frozen=True)
-class ContextAdmission:
-    budget: Any
-    floor_tokens: int
-    tool_count: int
-    min_messages: int
-
-
-class ContextFloorExceedsBudgetError(RuntimeError):
-    def __init__(self, *, floor: int, ceiling: int, tools: int, min_messages: int):
-        self.floor = int(floor)
-        self.ceiling = int(ceiling)
-        self.tools = int(tools)
-        self.min_messages = int(min_messages)
-        super().__init__(
-            "context_floor_exceeds_budget: "
-            f"floor={self.floor} ceiling={self.ceiling} tools={self.tools} "
-            f"min_messages={self.min_messages}"
-        )
-
-
-class ContextCompactionStalledError(RuntimeError):
-    def __init__(
-        self,
-        *,
-        estimated: int,
-        ceiling: int,
-        tools: int,
-        attempts: int,
-        phase: str,
-    ):
-        self.estimated = int(estimated)
-        self.ceiling = int(ceiling)
-        self.tools = int(tools)
-        self.attempts = int(attempts)
-        self.phase = str(phase)
-        super().__init__(
-            "context_compaction_stalled: "
-            f"estimated={self.estimated} ceiling={self.ceiling} tools={self.tools} "
-            f"attempts={self.attempts} phase={self.phase}"
-        )
-
-
-def _irreducible_context_messages(
+def _compact_active_context(
     messages: list[dict],
     *,
-    min_messages: int = _CONTEXT_COMPACTION_MIN_MESSAGES,
-) -> list[dict]:
-    """Return the raw messages the compactor's smallest safe window must retain."""
-    from brain.systems.context.compaction import split_session_messages_for_compaction
-
-    window = split_session_messages_for_compaction(
-        messages,
-        max_messages=max(1, int(min_messages)),
-    )
-    if window is None or not window.omitted_messages:
-        return list(messages)
-    return list(window.kept_early) + list(window.kept_recent)
-
-
-def _admit_active_context(
-    messages: list[dict],
-    *,
-    model: str,
-    system: list[dict] | str | None = None,
-    tools: list[dict] | None = None,
-    provider_name: str | None = None,
-    reasoning_effort: str | None = None,
-    max_output_tokens: int | None = None,
-    min_messages: int = _CONTEXT_COMPACTION_MIN_MESSAGES,
-) -> ContextAdmission:
-    """Reject a prompt scaffold that no transcript compaction can fit."""
-    from brain.systems.context.budget import resolve_model_context_budget
-    from brain.systems.context.compaction import estimate_session_tokens
-
-    budget = resolve_model_context_budget(
-        model=model,
-        provider=provider_name,
-        reasoning_effort=reasoning_effort,
-        max_output_tokens=max_output_tokens,
-        tools=tools,
-    )
-    floor_messages = _irreducible_context_messages(
-        messages,
-        min_messages=min_messages,
-    )
-    floor_tokens = estimate_session_tokens(
-        floor_messages,
-        system=system,
-        tools=tools,
-    )
-    admission = ContextAdmission(
-        budget=budget,
-        floor_tokens=floor_tokens,
-        tool_count=len(tools or []),
-        min_messages=int(min_messages),
-    )
-    if floor_tokens >= budget.auto_compact_threshold_tokens:
-        error = ContextFloorExceedsBudgetError(
-            floor=floor_tokens,
-            ceiling=budget.auto_compact_threshold_tokens,
-            tools=admission.tool_count,
-            min_messages=admission.min_messages,
-        )
-        logger.error("%s", error)
-        raise error
-    return admission
-
-
-def _maybe_compact_active_context(
-    messages: list[dict],
-    *,
+    policy: ContextWindowPolicy,
     session_id: str,
     model: str,
     phase: str,
     system: list[dict] | str | None = None,
     tools: list[dict] | None = None,
     provider_name: str | None = None,
-    reasoning_effort: str | None = None,
-    max_output_tokens: int | None = None,
     run_id: int | None = None,
     semantic_compactor=None,
     force: bool = False,
     emergency: bool = False,
-    tracker=None,
-) -> tuple[list[dict], object | None]:
-    """Compact active history when the estimated prompt crosses the runtime limit."""
-    from brain.systems.context.budget import resolve_model_context_budget
-    from brain.systems.context.compaction import (
-        estimate_session_tokens,
-    )
-    from brain.systems.context.semantic_compaction import compact_session_messages_with_checkpoint
-
-    budget = resolve_model_context_budget(
-        model=model,
-        provider=provider_name,
-        reasoning_effort=reasoning_effort,
-        max_output_tokens=max_output_tokens,
-        tools=tools,
-    )
-    estimated_tokens = estimate_session_tokens(messages, system=system, tools=tools)
-    if not force and estimated_tokens < budget.auto_compact_threshold_tokens:
-        if tracker is not None:
-            tracker.reset()
-        return messages, None
-
-    compacted, report = compact_session_messages_with_checkpoint(
+) -> ContextCompactionOutcome:
+    """Orchestrate the run-scoped context policy and its canonical plan."""
+    outcome = policy.compact(
         messages,
-        token_limit=budget.auto_compact_threshold_tokens,
-        target_tokens=budget.emergency_target_tokens if emergency else budget.target_tokens,
         session_id=session_id,
         phase=phase,
         system=system,
         tools=tools,
         max_messages=_MAX_PERSISTED_MESSAGES,
-        min_messages=_CONTEXT_COMPACTION_MIN_MESSAGES,
         force=force,
         emergency=emergency,
         semantic_compactor=semantic_compactor,
     )
-    final_tokens = report.provenance.get("final_estimated_tokens")
-    if not isinstance(final_tokens, int):
-        final_tokens = estimate_session_tokens(compacted, system=system, tools=tools)
-    below_threshold = final_tokens < budget.auto_compact_threshold_tokens
-    made_sufficient_progress = report.omitted_count > 0 and below_threshold
-    if made_sufficient_progress:
-        if tracker is not None:
-            tracker.reset()
-    elif tracker is not None:
-        tracker.consecutive_no_progress += 1
-    if report.omitted_count <= 0:
-        if tracker is None or not tracker.warned_no_safe_messages:
-            logger.warning(
-                "Agent %s: %s context exceeded token limit (~%d >= %d) but no safe transcript "
-                "messages were eligible for compaction",
-                session_id,
-                phase,
-                estimated_tokens,
-                budget.auto_compact_threshold_tokens,
-            )
-            if tracker is not None:
-                tracker.warned_no_safe_messages = True
-    if (
-        not made_sufficient_progress
-        and tracker is not None
-        and tracker.consecutive_no_progress >= _MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS
-    ):
-        error = ContextCompactionStalledError(
-            estimated=final_tokens,
-            ceiling=budget.auto_compact_threshold_tokens,
-            tools=len(tools or []),
-            attempts=tracker.consecutive_no_progress,
-            phase=phase,
+    if outcome.warning_required:
+        logger.warning(
+            "Agent %s: %s context exceeded token limit (~%d > %d) but no safe transcript "
+            "messages were eligible for compaction",
+            session_id,
+            phase,
+            outcome.estimated_tokens,
+            policy.threshold_tokens,
         )
-        logger.error("Agent %s: %s", session_id, error)
-        raise error
-    if report.omitted_count <= 0:
-        return messages, None
+    if outcome.report is None:
+        return outcome
     logger.info(
         "Agent %s: %s auto-compacted active context from ~%d to ~%s tokens "
         "(limit=%d, omitted=%d, kept=%d, strategy=%s)",
         session_id,
         phase,
-        estimated_tokens,
-        final_tokens if final_tokens is not None else "?",
-        budget.auto_compact_threshold_tokens,
-        report.omitted_count,
-        len(compacted),
-        report.strategy,
+        outcome.estimated_tokens,
+        outcome.final_tokens,
+        policy.threshold_tokens,
+        outcome.report.omitted_count,
+        len(outcome.messages),
+        outcome.report.strategy,
     )
     _record_context_compaction_event(
         run_id=run_id,
@@ -1189,10 +1030,10 @@ def _maybe_compact_active_context(
         model=model,
         provider_name=provider_name,
         phase=phase,
-        budget=budget.to_payload(),
-        report=report,
+        budget=policy.budget.to_payload(),
+        report=outcome.report,
     )
-    return compacted, report
+    return outcome
 
 
 def _mark_tools_cacheable(tools: list[dict]) -> list[dict]:
@@ -1687,17 +1528,22 @@ async def run_agent_async(
         system = _apply_provider_system_cache_policy(state.provider_name, system, cache_system_prompt)
         reasoning_effort, max_tokens = _build_reasoning_effort(thinking)
         current_user_message = {"role": "user", "content": _initial_user_content(message, metadata)}
+        context_policy = ContextWindowPolicy.resolve(
+            model=model,
+            provider=state.provider_name,
+            reasoning_effort=reasoning_effort,
+            max_output_tokens=max_tokens,
+            tools=tools,
+        )
 
         # The current request plus the static prompt/tool scaffold is unavoidable.
         # Admit it before startup handoff compaction can make its own model call.
-        _admit_active_context(
+        context_policy.admit(
             [current_user_message],
-            model=model,
             system=system,
             tools=tools,
-            provider_name=state.provider_name,
-            reasoning_effort=reasoning_effort,
-            max_output_tokens=max_tokens,
+            session_id=session_id,
+            phase="startup_admission",
         )
 
         if persist_session:
@@ -1717,14 +1563,12 @@ async def run_agent_async(
             current_user_message,
             raw_archive_messages,
         )
-        _admit_active_context(
+        context_policy.admit(
             state.messages,
-            model=model,
             system=system,
             tools=tools,
-            provider_name=state.provider_name,
-            reasoning_effort=reasoning_effort,
-            max_output_tokens=max_tokens,
+            session_id=session_id,
+            phase="active_context_admission",
         )
 
         # Agent loop
@@ -1754,20 +1598,19 @@ async def run_agent_async(
             if guidance_count and raw_archive_messages is not None and len(state.messages) > before_guidance_len:
                 raw_archive_messages.append(copy.deepcopy(state.messages[-1]))
             state.messages = _sanitize_tool_pairs(state.messages, session_id)
-            state.messages, _ = _maybe_compact_active_context(
+            compaction = _compact_active_context(
                 state.messages,
+                policy=context_policy,
                 session_id=session_id,
                 model=model,
                 phase="pre_sampling",
                 system=system,
                 tools=tools,
                 provider_name=state.provider_name,
-                reasoning_effort=reasoning_effort,
-                max_output_tokens=max_tokens,
                 run_id=run_id,
                 semantic_compactor=semantic_compactor,
-                tracker=state.context_compaction,
             )
+            state.messages = compaction.messages
             if scheduled_result_contract and turn == 0:
                 _ensure_current_message_last(state.messages, current_user_message)
             if state.provider_name == "anthropic" and cache_system_prompt and len(state.messages) >= 2:
@@ -1905,6 +1748,20 @@ async def run_agent_async(
                                 provider_name=state.provider_name,
                                 session_id=session_id,
                             )
+                        context_policy = ContextWindowPolicy.resolve(
+                            model=model,
+                            provider=state.provider_name,
+                            reasoning_effort=reasoning_effort,
+                            max_output_tokens=max_tokens,
+                            tools=tools,
+                        )
+                        context_policy.admit(
+                            state.messages,
+                            system=system,
+                            tools=tools,
+                            session_id=session_id,
+                            phase="model_fallback_admission",
+                        )
                         request = _build_api_request(
                             model,
                             state.messages,
@@ -1940,23 +1797,22 @@ async def run_agent_async(
                         error=overflow_payload.get("message"),
                         latency_ms=int((time.time() - _call_start) * 1000),
                     )
-                    state.messages, recovery_report = _maybe_compact_active_context(
+                    compaction = _compact_active_context(
                         state.messages,
+                        policy=context_policy,
                         session_id=session_id,
                         model=model,
                         phase="context_overflow_retry",
                         system=system,
                         tools=tools,
                         provider_name=state.provider_name,
-                        reasoning_effort=reasoning_effort,
-                        max_output_tokens=max_tokens,
                         run_id=run_id,
                         semantic_compactor=semantic_compactor,
                         force=True,
                         emergency=True,
-                        tracker=state.context_compaction,
                     )
-                    if recovery_report is None:
+                    state.messages = compaction.messages
+                    if compaction.report is None:
                         logger.warning(
                             "Agent %s turn %d: context overflow recovery had no eligible messages to compact",
                             session_id,
@@ -2106,6 +1962,20 @@ async def run_agent_async(
                         tool_handlers,
                         disabled_names,
                     )
+                    context_policy = ContextWindowPolicy.resolve(
+                        model=model,
+                        provider=state.provider_name,
+                        reasoning_effort=reasoning_effort,
+                        max_output_tokens=max_tokens,
+                        tools=tools,
+                    )
+                    context_policy.admit(
+                        state.messages,
+                        system=system,
+                        tools=tools,
+                        session_id=session_id,
+                        phase="tool_surface_admission",
+                    )
                     for disablement in execution.tool_disablements:
                         _append_message_with_archive(
                             state.messages,
@@ -2142,20 +2012,19 @@ async def run_agent_async(
                         reminder_message,
                         raw_archive_messages,
                     )
-                state.messages, _ = _maybe_compact_active_context(
+                compaction = _compact_active_context(
                     state.messages,
+                    policy=context_policy,
                     session_id=session_id,
                     model=model,
                     phase="mid_turn",
                     system=system,
                     tools=tools,
                     provider_name=state.provider_name,
-                    reasoning_effort=reasoning_effort,
-                    max_output_tokens=max_tokens,
                     run_id=run_id,
                     semantic_compactor=semantic_compactor,
-                    tracker=state.context_compaction,
                 )
+                state.messages = compaction.messages
             else:
                 logger.warning("Unknown stop_reason: %s", response.stop_reason)
                 break

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -11,18 +11,6 @@ from brain.systems.runs.direct_loop.result import TokenAccumulator
 
 
 @dataclass
-class ContextCompactionTracker:
-    """Track consecutive compactions that cannot get below the context ceiling."""
-
-    consecutive_no_progress: int = 0
-    warned_no_safe_messages: bool = False
-
-    def reset(self) -> None:
-        self.consecutive_no_progress = 0
-        self.warned_no_safe_messages = False
-
-
-@dataclass
 class AgentLoopState:
     """State that evolves across provider turns in the agent loop."""
 
@@ -35,4 +23,3 @@ class AgentLoopState:
     provider_name: str | None = None
     operation_type: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
-    context_compaction: ContextCompactionTracker = field(default_factory=ContextCompactionTracker)

--- a/brain/systems/runs/direct_loop/state.py
+++ b/brain/systems/runs/direct_loop/state.py
@@ -11,6 +11,18 @@ from brain.systems.runs.direct_loop.result import TokenAccumulator
 
 
 @dataclass
+class ContextCompactionTracker:
+    """Track consecutive compactions that cannot get below the context ceiling."""
+
+    consecutive_no_progress: int = 0
+    warned_no_safe_messages: bool = False
+
+    def reset(self) -> None:
+        self.consecutive_no_progress = 0
+        self.warned_no_safe_messages = False
+
+
+@dataclass
 class AgentLoopState:
     """State that evolves across provider turns in the agent loop."""
 
@@ -23,3 +35,4 @@ class AgentLoopState:
     provider_name: str | None = None
     operation_type: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    context_compaction: ContextCompactionTracker = field(default_factory=ContextCompactionTracker)

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -34,6 +34,61 @@ from brain.systems.runs.tools import AsyncRunToolExecutor
 
 logger = logging.getLogger(__name__)
 _post_completion_tasks: set[asyncio.Task[None]] = set()
+_FIRST_FLUSH_ERROR_KEY = "agent_run_first_flush_error"
+
+
+class AgentRunDatabaseFlushError(RuntimeError):
+    """Preserve the first flush exception when a later DB error masks it."""
+
+    def __init__(self, run_id: int, original: BaseException):
+        self.run_id = int(run_id)
+        self.original = original
+        super().__init__(
+            "database_flush_failed: "
+            f"{type(original).__name__}: {str(original).strip() or repr(original)}"
+        )
+
+
+def _first_flush_error(session: AsyncSession) -> BaseException | None:
+    value = session.info.get(_FIRST_FLUSH_ERROR_KEY)
+    if isinstance(value, BaseException):
+        return value
+    transaction = session.sync_session.get_transaction()
+    rollback_error = getattr(transaction, "_rollback_exception", None)
+    return rollback_error if isinstance(rollback_error, BaseException) else None
+
+
+@asynccontextmanager
+async def _capture_first_flush_error(session: AsyncSession, *, run_id: int):
+    """Instrument one run-owned session without changing unrelated sessions."""
+    original_flush = session.flush
+    session.info.pop(_FIRST_FLUSH_ERROR_KEY, None)
+
+    async def capturing_flush(*args, **kwargs):
+        try:
+            return await original_flush(*args, **kwargs)
+        except BaseException as exc:
+            if _first_flush_error(session) is None:
+                session.info[_FIRST_FLUSH_ERROR_KEY] = exc
+                logger.exception(
+                    "agent_run_database_flush_failed run_id=%s original=%s: %s",
+                    run_id,
+                    type(exc).__name__,
+                    exc,
+                )
+            raise
+
+    session.flush = capturing_flush
+    try:
+        yield
+    except BaseException as exc:
+        first = _first_flush_error(session)
+        if first is not None and not isinstance(exc, AgentRunDatabaseFlushError):
+            raise AgentRunDatabaseFlushError(run_id, first) from first
+        raise
+    finally:
+        session.flush = original_flush
+        session.info.pop(_FIRST_FLUSH_ERROR_KEY, None)
 
 
 class AsyncRunRecipeHandler(Protocol):
@@ -191,6 +246,10 @@ class AsyncAgentRunEngine:
         return await self.store.set_status(run_id, RunStatus.PAUSED, reason=reason)
 
     async def run_existing(self, run_id: int) -> AgentRun:
+        async with _capture_first_flush_error(self.store.session, run_id=run_id):
+            return await self._run_existing_with_flush_capture(run_id)
+
+    async def _run_existing_with_flush_capture(self, run_id: int) -> AgentRun:
         execution_lease = getattr(self.store, "execution_lease", None)
         if callable(execution_lease):
             post_completion_tasks: list[Callable[[], Awaitable[Any]]] = []
@@ -276,10 +335,15 @@ class AsyncAgentRunEngine:
             if inspect.isawaitable(result):
                 result = await result
         except Exception as exc:
+            error, flush_failed = await self._prepare_failure_diagnostic(run.id, exc)
             return await self.fail(
                 run.id,
-                str(exc),
-                failure_category=failure_category_for_error(exc),
+                error,
+                failure_category=(
+                    RunFailureCategory.INTERNAL
+                    if flush_failed
+                    else failure_category_for_error(exc)
+                ),
                 execution_claim=execution_claim,
             )
         for artifact in result.artifacts:
@@ -299,11 +363,16 @@ class AsyncAgentRunEngine:
             )
         if result_status == RunStatus.FAILED:
             error = str(result.error or result.output or "recipe_failed")
+            error, flush_failed = await self._prepare_failure_diagnostic(run.id, error)
             return await self.fail(
                 run.id,
                 error,
                 final_output=result.final_output,
-                failure_category=result.failure_category or failure_category_for_error(error),
+                failure_category=(
+                    RunFailureCategory.INTERNAL
+                    if flush_failed
+                    else result.failure_category or failure_category_for_error(error)
+                ),
                 execution_claim=execution_claim,
             )
         if result_status == RunStatus.CANCELED:
@@ -324,6 +393,26 @@ class AsyncAgentRunEngine:
         else:
             deferred_post_completion_tasks.extend(result.post_completion_tasks)
         return completed
+
+    async def _prepare_failure_diagnostic(
+        self,
+        run_id: int,
+        error: BaseException | str,
+    ) -> tuple[str, bool]:
+        first = _first_flush_error(self.store.session)
+        if first is None:
+            return str(error), False
+        if self.store.session.info.get(_FIRST_FLUSH_ERROR_KEY) is not first:
+            self.store.session.info[_FIRST_FLUSH_ERROR_KEY] = first
+            logger.error(
+                "agent_run_database_flush_failed run_id=%s original=%s: %s",
+                run_id,
+                type(first).__name__,
+                first,
+            )
+        diagnostic = str(AgentRunDatabaseFlushError(run_id, first))
+        await self.store.session.rollback()
+        return diagnostic, True
 
     async def complete(
         self,

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.systems.runs.context import RunContextLoader
 from brain.systems.runs.domain import AgentRun, AgentRunRequest
 from brain.systems.runs.events import activity_event, run_event, text_delta_event
+from brain.systems.runs.execution_failure import RunExecutionFailure
 from brain.systems.runs.failures import (
     RunFailureCategory,
     coerce_failure_category,
@@ -34,61 +35,6 @@ from brain.systems.runs.tools import AsyncRunToolExecutor
 
 logger = logging.getLogger(__name__)
 _post_completion_tasks: set[asyncio.Task[None]] = set()
-_FIRST_FLUSH_ERROR_KEY = "agent_run_first_flush_error"
-
-
-class AgentRunDatabaseFlushError(RuntimeError):
-    """Preserve the first flush exception when a later DB error masks it."""
-
-    def __init__(self, run_id: int, original: BaseException):
-        self.run_id = int(run_id)
-        self.original = original
-        super().__init__(
-            "database_flush_failed: "
-            f"{type(original).__name__}: {str(original).strip() or repr(original)}"
-        )
-
-
-def _first_flush_error(session: AsyncSession) -> BaseException | None:
-    value = session.info.get(_FIRST_FLUSH_ERROR_KEY)
-    if isinstance(value, BaseException):
-        return value
-    transaction = session.sync_session.get_transaction()
-    rollback_error = getattr(transaction, "_rollback_exception", None)
-    return rollback_error if isinstance(rollback_error, BaseException) else None
-
-
-@asynccontextmanager
-async def _capture_first_flush_error(session: AsyncSession, *, run_id: int):
-    """Instrument one run-owned session without changing unrelated sessions."""
-    original_flush = session.flush
-    session.info.pop(_FIRST_FLUSH_ERROR_KEY, None)
-
-    async def capturing_flush(*args, **kwargs):
-        try:
-            return await original_flush(*args, **kwargs)
-        except BaseException as exc:
-            if _first_flush_error(session) is None:
-                session.info[_FIRST_FLUSH_ERROR_KEY] = exc
-                logger.exception(
-                    "agent_run_database_flush_failed run_id=%s original=%s: %s",
-                    run_id,
-                    type(exc).__name__,
-                    exc,
-                )
-            raise
-
-    session.flush = capturing_flush
-    try:
-        yield
-    except BaseException as exc:
-        first = _first_flush_error(session)
-        if first is not None and not isinstance(exc, AgentRunDatabaseFlushError):
-            raise AgentRunDatabaseFlushError(run_id, first) from first
-        raise
-    finally:
-        session.flush = original_flush
-        session.info.pop(_FIRST_FLUSH_ERROR_KEY, None)
 
 
 class AsyncRunRecipeHandler(Protocol):
@@ -246,10 +192,6 @@ class AsyncAgentRunEngine:
         return await self.store.set_status(run_id, RunStatus.PAUSED, reason=reason)
 
     async def run_existing(self, run_id: int) -> AgentRun:
-        async with _capture_first_flush_error(self.store.session, run_id=run_id):
-            return await self._run_existing_with_flush_capture(run_id)
-
-    async def _run_existing_with_flush_capture(self, run_id: int) -> AgentRun:
         execution_lease = getattr(self.store, "execution_lease", None)
         if callable(execution_lease):
             post_completion_tasks: list[Callable[[], Awaitable[Any]]] = []
@@ -335,17 +277,7 @@ class AsyncAgentRunEngine:
             if inspect.isawaitable(result):
                 result = await result
         except Exception as exc:
-            error, flush_failed = await self._prepare_failure_diagnostic(run.id, exc)
-            return await self.fail(
-                run.id,
-                error,
-                failure_category=(
-                    RunFailureCategory.INTERNAL
-                    if flush_failed
-                    else failure_category_for_error(exc)
-                ),
-                execution_claim=execution_claim,
-            )
+            raise RunExecutionFailure.capture(run.id, exc) from exc
         for artifact in result.artifacts:
             await self.store.append_artifact(artifact)
         if await cancel_event_is_set(cancel_event):
@@ -363,16 +295,11 @@ class AsyncAgentRunEngine:
             )
         if result_status == RunStatus.FAILED:
             error = str(result.error or result.output or "recipe_failed")
-            error, flush_failed = await self._prepare_failure_diagnostic(run.id, error)
             return await self.fail(
                 run.id,
                 error,
                 final_output=result.final_output,
-                failure_category=(
-                    RunFailureCategory.INTERNAL
-                    if flush_failed
-                    else result.failure_category or failure_category_for_error(error)
-                ),
+                failure_category=result.failure_category or failure_category_for_error(error),
                 execution_claim=execution_claim,
             )
         if result_status == RunStatus.CANCELED:
@@ -393,26 +320,6 @@ class AsyncAgentRunEngine:
         else:
             deferred_post_completion_tasks.extend(result.post_completion_tasks)
         return completed
-
-    async def _prepare_failure_diagnostic(
-        self,
-        run_id: int,
-        error: BaseException | str,
-    ) -> tuple[str, bool]:
-        first = _first_flush_error(self.store.session)
-        if first is None:
-            return str(error), False
-        if self.store.session.info.get(_FIRST_FLUSH_ERROR_KEY) is not first:
-            self.store.session.info[_FIRST_FLUSH_ERROR_KEY] = first
-            logger.error(
-                "agent_run_database_flush_failed run_id=%s original=%s: %s",
-                run_id,
-                type(first).__name__,
-                first,
-            )
-        diagnostic = str(AgentRunDatabaseFlushError(run_id, first))
-        await self.store.session.rollback()
-        return diagnostic, True
 
     async def complete(
         self,

--- a/brain/systems/runs/execution_failure.py
+++ b/brain/systems/runs/execution_failure.py
@@ -1,0 +1,30 @@
+"""Primary failure captured across a complete run-scoped unit of work."""
+
+from __future__ import annotations
+
+
+class RunExecutionFailure(RuntimeError):
+    """Keep the first run exception stable across rollback and settlement."""
+
+    def __init__(self, run_id: int, original: BaseException):
+        self.run_id = int(run_id)
+        self.original = original
+        detail = str(original).strip() or repr(original)
+        super().__init__(
+            f"run_execution_failed: {type(original).__name__}: {detail}"
+        )
+
+    @classmethod
+    def capture(
+        cls,
+        run_id: int,
+        error: BaseException,
+    ) -> "RunExecutionFailure":
+        if isinstance(error, cls):
+            return error
+        if isinstance(error.__context__, cls):
+            return error.__context__
+        return cls(run_id, error)
+
+
+__all__ = ["RunExecutionFailure"]

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1091,6 +1091,254 @@ async def test_scheduled_cycle_handoff_identity_summary_does_not_override_missio
     assert first_request.messages[-1]["content"] == message
 
 
+async def test_oversized_system_prompt_fails_admission_before_sampling_and_names_budget(
+    monkeypatch,
+    caplog,
+):
+    from brain.systems.runs import direct_agent
+
+    class FakeProvider:
+        def __init__(self):
+            self.requests = []
+
+        def is_api_error(self, exc):
+            return False
+
+        def is_retryable_error(self, exc):
+            return False
+
+        def create(self, request):
+            self.requests.append(request)
+            raise AssertionError("admission failure must happen before provider sampling")
+
+    provider = FakeProvider()
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    monkeypatch.setattr(direct_agent, "get_provider", lambda _provider_name, _client: provider)
+    resolved_llm = SimpleNamespace(
+        provider="openai",
+        client=object(),
+        source="test",
+        auth_mode="api_key",
+        is_oauth=False,
+        token_prefix="test-token",
+        build_request_headers=lambda **_kwargs: {},
+    )
+
+    with caplog.at_level("ERROR", logger="agent"):
+        result = await direct_agent.run_agent_async(
+            "start",
+            system_prompt="oversized " + ("x" * 4000),
+            session_id="oversized-admission",
+            model="openai/gpt-5.5",
+            thinking="low",
+            tools=[{"name": "read_file"}, {"name": "search_files"}],
+            tool_handlers={},
+            max_turns=20,
+            persist_session=False,
+            cache_system_prompt=False,
+            resolved_llm=resolved_llm,
+        )
+
+    assert result.success is False
+    assert result.tokens_input == 0
+    assert result.error is not None
+    assert result.error.startswith("context_floor_exceeds_budget:")
+    assert "floor=" in result.error
+    assert "ceiling=500" in result.error
+    assert "tools=2" in result.error
+    assert provider.requests == []
+    assert result.error in caplog.text
+
+
+async def test_context_admission_healthy_path_still_samples_once(monkeypatch):
+    from brain.platform.integrations.providers import (
+        LLMResponse,
+        StopReason,
+        TextContentBlock,
+        Usage,
+    )
+    from brain.systems.runs import direct_agent
+
+    class FakeProvider:
+        def __init__(self):
+            self.requests = []
+
+        def is_api_error(self, exc):
+            return False
+
+        def is_retryable_error(self, exc):
+            return False
+
+        def create(self, request):
+            self.requests.append(request)
+            return LLMResponse(
+                content=[TextContentBlock("healthy response")],
+                stop_reason=StopReason.END_TURN,
+                usage=Usage(input_tokens=12, output_tokens=3),
+            )
+
+    provider = FakeProvider()
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "10000")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "7000")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    monkeypatch.setattr(direct_agent, "get_provider", lambda _provider_name, _client: provider)
+    resolved_llm = SimpleNamespace(
+        provider="openai",
+        client=object(),
+        source="test",
+        auth_mode="api_key",
+        is_oauth=False,
+        token_prefix="test-token",
+        build_request_headers=lambda **_kwargs: {},
+    )
+
+    result = await direct_agent.run_agent_async(
+        "start",
+        system_prompt="small healthy system prompt",
+        session_id="healthy-admission",
+        model="openai/gpt-5.5",
+        thinking="low",
+        tools=[{"name": "read_file"}],
+        tool_handlers={},
+        max_turns=1,
+        persist_session=False,
+        cache_system_prompt=False,
+        resolved_llm=resolved_llm,
+    )
+
+    assert result.success is True
+    assert result.output == "healthy response"
+    assert result.error is None
+    assert len(provider.requests) == 1
+
+
+def test_repeated_unwinnable_compaction_stops_and_rate_limits_warning(
+    monkeypatch,
+    caplog,
+):
+    from brain.systems.runs import direct_agent
+    from brain.systems.runs.direct_loop.state import ContextCompactionTracker
+
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    messages = [
+        {"role": "user", "content": "x" * 1200},
+        {"role": "assistant", "content": "y" * 1200},
+        {"role": "user", "content": "z" * 1200},
+        {"role": "assistant", "content": "w" * 1200},
+    ]
+    tracker = ContextCompactionTracker()
+
+    with caplog.at_level("WARNING", logger="agent"):
+        for _ in range(direct_agent._MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS - 1):
+            compacted, report = direct_agent._maybe_compact_active_context(
+                messages,
+                session_id="stalled-compaction",
+                model="gpt-5.5",
+                phase="mid_turn",
+                provider_name="openai",
+                reasoning_effort="low",
+                max_output_tokens=0,
+                tracker=tracker,
+            )
+            assert compacted == messages
+            assert report is None
+
+        with pytest.raises(
+            direct_agent.ContextCompactionStalledError,
+            match=r"context_compaction_stalled: .*ceiling=500.*tools=0.*attempts=3",
+        ):
+            direct_agent._maybe_compact_active_context(
+                messages,
+                session_id="stalled-compaction",
+                model="gpt-5.5",
+                phase="mid_turn",
+                provider_name="openai",
+                reasoning_effort="low",
+                max_output_tokens=0,
+                tracker=tracker,
+            )
+
+    assert caplog.text.count("no safe transcript messages were eligible for compaction") == 1
+
+
+def test_repeated_compaction_that_stays_over_ceiling_also_stops(monkeypatch):
+    from brain.systems.context.compaction import CompactionReport
+    from brain.systems.runs import direct_agent
+    from brain.systems.runs.direct_loop.state import ContextCompactionTracker
+
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    messages = [
+        {"role": "user", "content": "x" * 1600},
+        {"role": "assistant", "content": "y" * 1600},
+        {"role": "user", "content": "z" * 1600},
+        {"role": "assistant", "content": "w" * 1600},
+        {"role": "user", "content": "latest"},
+    ]
+
+    def still_too_large(candidate_messages, **_kwargs):
+        compacted = candidate_messages[1:]
+        return compacted, CompactionReport(
+            original_count=len(candidate_messages),
+            kept_count=len(compacted),
+            omitted_count=1,
+            summary="Reduced, but not enough.",
+            strategy="semantic_checkpoint",
+            provenance={"final_estimated_tokens": 600},
+        )
+
+    monkeypatch.setattr(
+        "brain.systems.context.semantic_compaction.compact_session_messages_with_checkpoint",
+        still_too_large,
+    )
+    tracker = ContextCompactionTracker()
+
+    for _ in range(direct_agent._MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS - 1):
+        _, report = direct_agent._maybe_compact_active_context(
+            messages,
+            session_id="insufficient-compaction",
+            model="gpt-5.5",
+            phase="mid_turn",
+            provider_name="openai",
+            reasoning_effort="low",
+            max_output_tokens=0,
+            tracker=tracker,
+        )
+        assert report is not None
+
+    with pytest.raises(
+        direct_agent.ContextCompactionStalledError,
+        match=r"context_compaction_stalled: estimated=600 ceiling=500",
+    ):
+        direct_agent._maybe_compact_active_context(
+            messages,
+            session_id="insufficient-compaction",
+            model="gpt-5.5",
+            phase="mid_turn",
+            provider_name="openai",
+            reasoning_effort="low",
+            max_output_tokens=0,
+            tracker=tracker,
+        )
+
+
 def test_fast_onboarding_tool_surface_uses_standard_fast_surface(monkeypatch):
     from brain.systems.runs.recipes.fast import _agent_tools_for_runtime
 

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1224,8 +1224,9 @@ def test_repeated_unwinnable_compaction_stops_and_rate_limits_warning(
     monkeypatch,
     caplog,
 ):
+    from brain.systems.context.errors import ContextCompactionStalledError
+    from brain.systems.context.window_policy import ContextWindowPolicy
     from brain.systems.runs import direct_agent
-    from brain.systems.runs.direct_loop.state import ContextCompactionTracker
 
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
@@ -1239,45 +1240,47 @@ def test_repeated_unwinnable_compaction_stops_and_rate_limits_warning(
         {"role": "user", "content": "z" * 1200},
         {"role": "assistant", "content": "w" * 1200},
     ]
-    tracker = ContextCompactionTracker()
+    policy = ContextWindowPolicy.resolve(
+        model="gpt-5.5",
+        provider="openai",
+        reasoning_effort="low",
+        max_output_tokens=0,
+        tools=[],
+    )
 
     with caplog.at_level("WARNING", logger="agent"):
-        for _ in range(direct_agent._MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS - 1):
-            compacted, report = direct_agent._maybe_compact_active_context(
+        for _ in range(policy.max_consecutive_no_progress - 1):
+            outcome = direct_agent._compact_active_context(
                 messages,
+                policy=policy,
                 session_id="stalled-compaction",
                 model="gpt-5.5",
                 phase="mid_turn",
                 provider_name="openai",
-                reasoning_effort="low",
-                max_output_tokens=0,
-                tracker=tracker,
             )
-            assert compacted == messages
-            assert report is None
+            assert outcome.messages == messages
+            assert outcome.report is None
 
         with pytest.raises(
-            direct_agent.ContextCompactionStalledError,
+            ContextCompactionStalledError,
             match=r"context_compaction_stalled: .*ceiling=500.*tools=0.*attempts=3",
         ):
-            direct_agent._maybe_compact_active_context(
+            direct_agent._compact_active_context(
                 messages,
+                policy=policy,
                 session_id="stalled-compaction",
                 model="gpt-5.5",
                 phase="mid_turn",
                 provider_name="openai",
-                reasoning_effort="low",
-                max_output_tokens=0,
-                tracker=tracker,
             )
 
     assert caplog.text.count("no safe transcript messages were eligible for compaction") == 1
 
 
 def test_repeated_compaction_that_stays_over_ceiling_also_stops(monkeypatch):
-    from brain.systems.context.compaction import CompactionReport
+    from brain.systems.context.errors import ContextCompactionStalledError
+    from brain.systems.context.window_policy import ContextWindowPolicy
     from brain.systems.runs import direct_agent
-    from brain.systems.runs.direct_loop.state import ContextCompactionTracker
 
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
@@ -1293,49 +1296,40 @@ def test_repeated_compaction_that_stays_over_ceiling_also_stops(monkeypatch):
         {"role": "user", "content": "latest"},
     ]
 
-    def still_too_large(candidate_messages, **_kwargs):
-        compacted = candidate_messages[1:]
-        return compacted, CompactionReport(
-            original_count=len(candidate_messages),
-            kept_count=len(compacted),
-            omitted_count=1,
-            summary="Reduced, but not enough.",
-            strategy="semantic_checkpoint",
-            provenance={"final_estimated_tokens": 600},
-        )
+    def oversized_checkpoint(_omitted, _context):
+        return {"active_objective": "still too large " + ("q" * 2400)}
 
-    monkeypatch.setattr(
-        "brain.systems.context.semantic_compaction.compact_session_messages_with_checkpoint",
-        still_too_large,
+    policy = ContextWindowPolicy.resolve(
+        model="gpt-5.5",
+        provider="openai",
+        reasoning_effort="low",
+        max_output_tokens=0,
+        tools=[],
     )
-    tracker = ContextCompactionTracker()
-
-    for _ in range(direct_agent._MAX_CONSECUTIVE_CONTEXT_COMPACTION_NO_PROGRESS - 1):
-        _, report = direct_agent._maybe_compact_active_context(
+    for _ in range(policy.max_consecutive_no_progress - 1):
+        outcome = direct_agent._compact_active_context(
             messages,
+            policy=policy,
             session_id="insufficient-compaction",
             model="gpt-5.5",
             phase="mid_turn",
             provider_name="openai",
-            reasoning_effort="low",
-            max_output_tokens=0,
-            tracker=tracker,
+            semantic_compactor=oversized_checkpoint,
         )
-        assert report is not None
+        assert outcome.report is not None
 
     with pytest.raises(
-        direct_agent.ContextCompactionStalledError,
-        match=r"context_compaction_stalled: estimated=600 ceiling=500",
+        ContextCompactionStalledError,
+        match=r"context_compaction_stalled: estimated=\d+ ceiling=500",
     ):
-        direct_agent._maybe_compact_active_context(
+        direct_agent._compact_active_context(
             messages,
+            policy=policy,
             session_id="insufficient-compaction",
             model="gpt-5.5",
             phase="mid_turn",
             provider_name="openai",
-            reasoning_effort="low",
-            max_output_tokens=0,
-            tracker=tracker,
+            semantic_compactor=oversized_checkpoint,
         )
 
 

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -932,6 +932,143 @@ async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
     assert [artifact.text for artifact in artifacts] == [UPSTREAM_FAILED_RUN_MESSAGE]
     assert [event.payload for event in text_events] == [{"text": UPSTREAM_FAILED_RUN_MESSAGE}]
     assert all(raw_diagnostic not in str(value) for value in (artifacts, text_events))
+
+
+async def test_original_flush_exception_is_logged_and_persisted_on_run_failed(
+    caplog,
+    session_factory,
+):
+    session = session_factory()
+    armed = {"value": False}
+    raised = {"value": False}
+
+    def fail_first_armed_flush(_session, _flush_context, _instances):
+        if armed["value"] and not raised["value"]:
+            raised["value"] = True
+            raise RuntimeError("original flush exploded")
+
+    event.listen(session.sync_session, "before_flush", fail_first_armed_flush)
+
+    class FlushFailureRecipe:
+        async def execute(self, runtime: RunRuntime) -> RunRecipeResult:
+            armed["value"] = True
+            await runtime.activity("Trigger the failing flush")
+            raise AssertionError("the injected flush must fail")
+
+    try:
+        with caplog.at_level("ERROR", logger="brain.systems.runs.engine"):
+            result = await AsyncAgentRunEngine(
+                session,
+                recipes={"fast": FlushFailureRecipe()},
+            ).run(_run_request(thread_id="thread-1", message="flush failure"))
+    finally:
+        event.remove(session.sync_session, "before_flush", fail_first_armed_flush)
+
+    events = list(
+        (
+            await session.scalars(
+                select(AgentRunEventRow)
+                .where(
+                    AgentRunEventRow.run_id == result.id,
+                    AgentRunEventRow.event_type == "run.failed",
+                )
+                .order_by(AgentRunEventRow.sequence_no.asc())
+            )
+        ).all()
+    )
+
+    assert result.status == RunStatus.FAILED
+    assert len(events) == 1
+    assert events[0].payload["error"] == (
+        "database_flush_failed: RuntimeError: original flush exploded"
+    )
+    assert "PendingRollbackError" not in events[0].payload["error"]
+    assert "original flush exploded" in caplog.text
+
+
+async def test_oversized_system_admission_error_reaches_run_failed_event(
+    monkeypatch,
+    caplog,
+    session_factory,
+):
+    from brain.systems.runs import direct_agent
+
+    class FakeProvider:
+        def __init__(self):
+            self.requests = []
+
+        def is_api_error(self, exc):
+            return False
+
+        def is_retryable_error(self, exc):
+            return False
+
+        def create(self, request):
+            self.requests.append(request)
+            raise AssertionError("admission failure must happen before provider sampling")
+
+    provider = FakeProvider()
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "4096")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    monkeypatch.setattr(direct_agent, "get_provider", lambda _provider_name, _client: provider)
+    resolved_llm = SimpleNamespace(
+        provider="openai",
+        client=object(),
+        source="test",
+        auth_mode="api_key",
+        is_oauth=False,
+        token_prefix="test-token",
+        build_request_headers=lambda **_kwargs: {},
+    )
+
+    class OversizedSystemRecipe:
+        async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:
+            agent_result = await direct_agent.run_agent_async(
+                "start",
+                system_prompt="oversized " + ("x" * 4000),
+                session_id="oversized-event",
+                model="openai/gpt-5.5",
+                thinking="low",
+                tools=[{"name": "read_file"}, {"name": "search_files"}],
+                tool_handlers={},
+                max_turns=20,
+                persist_session=False,
+                cache_system_prompt=False,
+                resolved_llm=resolved_llm,
+            )
+            return RunRecipeResult(
+                error=agent_result.error,
+                status=RunStatus.FAILED,
+            )
+
+    session = session_factory()
+    with caplog.at_level("ERROR", logger="agent"):
+        result = await AsyncAgentRunEngine(
+            session,
+            recipes={"fast": OversizedSystemRecipe()},
+        ).run(_run_request(thread_id="thread-1", message="oversized system"))
+
+    failed_event = (
+        await session.scalars(
+            select(AgentRunEventRow).where(
+                AgentRunEventRow.run_id == result.id,
+                AgentRunEventRow.event_type == "run.failed",
+            )
+        )
+    ).one()
+    error = failed_event.payload["error"]
+
+    assert result.status == RunStatus.FAILED
+    assert error.startswith("context_floor_exceeds_budget:")
+    assert "floor=" in error
+    assert "ceiling=500" in error
+    assert "tools=2" in error
+    assert error in caplog.text
+    assert provider.requests == []
 
 
 async def test_interactive_slack_transport_failure_never_persists_raw_error_as_final_answer(

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -934,10 +934,11 @@ async def test_runner_setup_failure_never_persists_diagnostic_as_public_output(
     assert all(raw_diagnostic not in str(value) for value in (artifacts, text_events))
 
 
-async def test_original_flush_exception_is_logged_and_persisted_on_run_failed(
-    caplog,
+async def test_engine_preserves_original_flush_exception_for_uow_owner(
     session_factory,
 ):
+    from brain.systems.runs.execution_failure import RunExecutionFailure
+
     session = session_factory()
     armed = {"value": False}
     raised = {"value": False}
@@ -956,34 +957,139 @@ async def test_original_flush_exception_is_logged_and_persisted_on_run_failed(
             raise AssertionError("the injected flush must fail")
 
     try:
-        with caplog.at_level("ERROR", logger="brain.systems.runs.engine"):
-            result = await AsyncAgentRunEngine(
+        with pytest.raises(RunExecutionFailure) as captured:
+            await AsyncAgentRunEngine(
                 session,
                 recipes={"fast": FlushFailureRecipe()},
             ).run(_run_request(thread_id="thread-1", message="flush failure"))
     finally:
         event.remove(session.sync_session, "before_flush", fail_first_armed_flush)
 
-    events = list(
-        (
-            await session.scalars(
-                select(AgentRunEventRow)
-                .where(
-                    AgentRunEventRow.run_id == result.id,
-                    AgentRunEventRow.event_type == "run.failed",
-                )
-                .order_by(AgentRunEventRow.sequence_no.asc())
-            )
-        ).all()
+    failure = captured.value
+
+    assert isinstance(failure.original, RuntimeError)
+    assert str(failure.original) == "original flush exploded"
+    assert str(failure) == (
+        "run_execution_failed: RuntimeError: original flush exploded"
+    )
+    assert "PendingRollbackError" not in str(failure)
+
+
+def test_run_execution_failure_survives_a_cleanup_exception():
+    from brain.systems.runs.execution_failure import RunExecutionFailure
+
+    primary = RunExecutionFailure(42, RuntimeError("primary exploded"))
+    try:
+        raise primary
+    except RunExecutionFailure:
+        try:
+            raise RuntimeError("cleanup exploded")
+        except RuntimeError as cleanup:
+            captured = RunExecutionFailure.capture(42, cleanup)
+
+    assert captured is primary
+
+
+async def test_runner_commit_failure_rolls_back_then_settles_in_fresh_uow(
+    monkeypatch,
+    session_factory,
+):
+    from contextlib import asynccontextmanager
+
+    from brain.systems.runs.cortex import runner
+
+    setup_session = session_factory()
+    store = AsyncAgentRunStore(setup_session)
+    run = await store.create_run(
+        _run_request(thread_id="thread-commit-failure", message="commit failure")
+    )
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+    await setup_session.commit()
+    await setup_session.close()
+
+    opened_uows = 0
+
+    class CommitAwareUoW:
+        def __init__(self):
+            nonlocal opened_uows
+            self.index = opened_uows
+            opened_uows += 1
+            self.session = session_factory()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, _exc, _tb):
+            try:
+                if exc_type is not None:
+                    await self.session.rollback()
+                elif self.index == 0:
+                    await self.session.rollback()
+                    raise RuntimeError("commit exploded")
+                else:
+                    await self.session.commit()
+            finally:
+                await self.session.close()
+
+    class CompletingEngine:
+        def __init__(self, session):
+            self.session = session
+
+        async def run_existing(self, run_id):
+            row = await self.session.get(AgentRunRow, int(run_id))
+            assert row is not None
+            row.status = RunStatus.COMPLETED.value
+            return SimpleNamespace(status=RunStatus.COMPLETED)
+
+    @asynccontextmanager
+    async def heartbeat(_run_id):
+        yield
+
+    async def materialize(_run_id):
+        return True, None
+
+    async def no_settlement(_session, _run_id):
+        return None
+
+    async def no_cycle_finalization(*_args, **_kwargs):
+        return None
+
+    async def no_contract_gate(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(runner, "_unit_of_work_factory", lambda: CommitAwareUoW)
+    monkeypatch.setattr(runner, "_engine_for_session", lambda session: CompletingEngine(session))
+    monkeypatch.setattr(runner, "_run_heartbeat_async", heartbeat)
+    monkeypatch.setattr(runner, "_async_materialize_project_context", materialize)
+    monkeypatch.setattr(runner, "_settle_terminal_root_run_async", no_settlement)
+    monkeypatch.setattr(runner, "_finalize_cycle_run_if_needed_async", no_cycle_finalization)
+    monkeypatch.setattr(
+        "brain.systems.cycles.contract_gate.async_prepare_cycle_run_visible_finalization",
+        no_contract_gate,
     )
 
-    assert result.status == RunStatus.FAILED
-    assert len(events) == 1
-    assert events[0].payload["error"] == (
-        "database_flush_failed: RuntimeError: original flush exploded"
+    processed = await runner._process_claimed_run_async(run.id)
+
+    inspection_session = session_factory()
+    row = await inspection_session.get(AgentRunRow, run.id)
+    failed_event = (
+        await inspection_session.scalars(
+            select(AgentRunEventRow).where(
+                AgentRunEventRow.run_id == run.id,
+                AgentRunEventRow.event_type == "run.failed",
+            )
+        )
+    ).one()
+    await inspection_session.close()
+
+    assert processed is False
+    assert opened_uows == 2
+    assert row is not None
+    assert row.status == RunStatus.FAILED.value
+    assert failed_event.payload["error"] == (
+        "run_execution_failed: RuntimeError: commit exploded"
     )
-    assert "PendingRollbackError" not in events[0].payload["error"]
-    assert "original flush exploded" in caplog.text
 
 
 async def test_oversized_system_admission_error_reaches_run_failed_event(

--- a/tests/test_async_unit_of_work.py
+++ b/tests/test_async_unit_of_work.py
@@ -192,6 +192,25 @@ async def test_unit_of_work_async_lifecycle_rolls_back_on_error(monkeypatch):
     assert session.closed is True
 
 
+@pytest.mark.asyncio
+async def test_unit_of_work_commit_failure_rolls_back_closes_and_preserves_error(monkeypatch):
+    class CommitFailureSession(_AsyncSession):
+        async def commit(self) -> None:
+            self.commits += 1
+            raise RuntimeError("commit exploded")
+
+    session = CommitFailureSession()
+    monkeypatch.setattr(uow_module, "SessionFactory", lambda: session)
+
+    with pytest.raises(RuntimeError, match="commit exploded"):
+        async with UnitOfWork():
+            pass
+
+    assert session.commits == 1
+    assert session.rollbacks == 1
+    assert session.closed is True
+
+
 def test_cortex_runner_exposes_async_db_boundaries_without_sync_bridge():
     source = inspect.getsource(cortex_runner)
 

--- a/tests/test_context_runtime.py
+++ b/tests/test_context_runtime.py
@@ -179,13 +179,9 @@ def test_model_context_budget_is_model_and_provider_aware(monkeypatch):
     assert openai_budget.reserved_tool_tokens > 0
 
 
-def test_context_admission_floor_includes_irreducible_messages_and_healthy_path(monkeypatch):
+def test_context_admission_floor_includes_canonical_checkpoint_and_healthy_path(monkeypatch):
     from brain.systems.context.compaction import estimate_session_tokens
-    from brain.systems.runs.direct_agent import (
-        _CONTEXT_COMPACTION_MIN_MESSAGES,
-        _admit_active_context,
-        _irreducible_context_messages,
-    )
+    from brain.systems.context.window_policy import ContextWindowPolicy
 
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "10000")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "7000")
@@ -200,31 +196,58 @@ def test_context_admission_floor_includes_irreducible_messages_and_healthy_path(
     system = "healthy system prompt"
     tools = [{"name": "read_file"}]
 
-    admission = _admit_active_context(
-        messages,
+    policy = ContextWindowPolicy.resolve(
         model="gpt-5.5",
-        provider_name="openai",
+        provider="openai",
         reasoning_effort="low",
         max_output_tokens=0,
+        tools=tools,
+    )
+    admission = policy.admit(
+        messages,
         system=system,
         tools=tools,
+        session_id="admission-test",
     )
 
-    floor_messages = _irreducible_context_messages(
-        messages,
-        min_messages=_CONTEXT_COMPACTION_MIN_MESSAGES,
-    )
-    assert admission.floor_tokens == estimate_session_tokens(
-        floor_messages,
+    retained_raw_edges = messages[:2] + messages[-1:]
+    assert admission.floor_tokens > estimate_session_tokens(
+        retained_raw_edges,
         system=system,
         tools=tools,
     )
-    assert admission.floor_tokens < admission.budget.auto_compact_threshold_tokens
+    assert policy.admits(admission.floor_tokens)
     assert admission.tool_count == 1
+    assert admission.min_messages == policy.min_messages
+
+
+def test_context_window_threshold_is_an_inclusive_admission_boundary():
+    from brain.systems.context.budget import ModelContextBudget
+    from brain.systems.context.window_policy import ContextWindowPolicy
+
+    budget = ModelContextBudget(
+        provider="openai",
+        model="gpt-5.5",
+        context_window_tokens=1_000,
+        reserved_output_tokens=0,
+        reserved_reasoning_tokens=0,
+        reserved_tool_tokens=0,
+        safety_margin_tokens=0,
+        effective_input_limit_tokens=500,
+        auto_compact_threshold_tokens=500,
+        target_tokens=350,
+        emergency_target_tokens=250,
+    )
+    policy = ContextWindowPolicy(budget)
+
+    assert policy.admits(500) is True
+    assert policy.requires_compaction(500) is False
+    assert policy.admits(501) is False
+    assert policy.requires_compaction(501) is True
 
 
 def test_structured_checkpoint_compaction_uses_injected_semantic_compactor():
-    from brain.systems.context.semantic_compaction import compact_session_messages_with_checkpoint
+    from brain.systems.context.semantic_compaction import plan_session_compaction
 
     messages = [{"role": "user", "content": "Build the compaction harness cleanly."}]
     for index in range(16):
@@ -243,7 +266,7 @@ def test_structured_checkpoint_compaction_uses_injected_semantic_compactor():
             "verification_status": "not run",
         }
 
-    compacted, report = compact_session_messages_with_checkpoint(
+    plan = plan_session_compaction(
         messages,
         token_limit=10,
         target_tokens=10,
@@ -254,6 +277,7 @@ def test_structured_checkpoint_compaction_uses_injected_semantic_compactor():
         force=True,
         semantic_compactor=semantic_compactor,
     )
+    compacted, report = plan.messages, plan.report
 
     checkpoint_text = "\n".join(
         msg.get("content", "")
@@ -267,7 +291,7 @@ def test_structured_checkpoint_compaction_uses_injected_semantic_compactor():
 
 
 def test_structured_checkpoint_falls_back_and_retains_constraints():
-    from brain.systems.context.semantic_compaction import compact_session_messages_with_checkpoint
+    from brain.systems.context.semantic_compaction import plan_session_compaction
 
     messages = [
         {"role": "user", "content": "Never edit billing.py. Must preserve tool-call boundaries."},
@@ -280,7 +304,7 @@ def test_structured_checkpoint_falls_back_and_retains_constraints():
     def broken_compactor(_omitted, _context):
         raise RuntimeError("summary model unavailable")
 
-    compacted, report = compact_session_messages_with_checkpoint(
+    plan = plan_session_compaction(
         messages,
         token_limit=10,
         target_tokens=10,
@@ -291,6 +315,7 @@ def test_structured_checkpoint_falls_back_and_retains_constraints():
         force=True,
         semantic_compactor=broken_compactor,
     )
+    compacted, report = plan.messages, plan.report
 
     checkpoint_text = "\n".join(
         msg.get("content", "")
@@ -306,7 +331,7 @@ def test_structured_checkpoint_falls_back_and_retains_constraints():
 def test_structured_checkpoint_fallback_uses_latest_user_intent_as_objective():
     import json
 
-    from brain.systems.context.semantic_compaction import compact_session_messages_with_checkpoint
+    from brain.systems.context.semantic_compaction import plan_session_compaction
 
     messages = [{"role": "user", "content": "First stale question: which project is attached?"}]
     for index in range(12):
@@ -317,7 +342,7 @@ def test_structured_checkpoint_fallback_uses_latest_user_intent_as_objective():
     def broken_compactor(_omitted, _context):
         raise RuntimeError("summary model unavailable")
 
-    compacted, report = compact_session_messages_with_checkpoint(
+    plan = plan_session_compaction(
         messages,
         token_limit=10,
         target_tokens=10,
@@ -328,6 +353,7 @@ def test_structured_checkpoint_fallback_uses_latest_user_intent_as_objective():
         force=True,
         semantic_compactor=broken_compactor,
     )
+    compacted, report = plan.messages, plan.report
 
     checkpoint_text = next(
         msg["content"]

--- a/tests/test_context_runtime.py
+++ b/tests/test_context_runtime.py
@@ -179,6 +179,50 @@ def test_model_context_budget_is_model_and_provider_aware(monkeypatch):
     assert openai_budget.reserved_tool_tokens > 0
 
 
+def test_context_admission_floor_includes_irreducible_messages_and_healthy_path(monkeypatch):
+    from brain.systems.context.compaction import estimate_session_tokens
+    from brain.systems.runs.direct_agent import (
+        _CONTEXT_COMPACTION_MIN_MESSAGES,
+        _admit_active_context,
+        _irreducible_context_messages,
+    )
+
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "10000")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "7000")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+    messages = [
+        {"role": "user", "content": f"message {index} " + ("x" * 80)}
+        for index in range(8)
+    ]
+    system = "healthy system prompt"
+    tools = [{"name": "read_file"}]
+
+    admission = _admit_active_context(
+        messages,
+        model="gpt-5.5",
+        provider_name="openai",
+        reasoning_effort="low",
+        max_output_tokens=0,
+        system=system,
+        tools=tools,
+    )
+
+    floor_messages = _irreducible_context_messages(
+        messages,
+        min_messages=_CONTEXT_COMPACTION_MIN_MESSAGES,
+    )
+    assert admission.floor_tokens == estimate_session_tokens(
+        floor_messages,
+        system=system,
+        tools=tools,
+    )
+    assert admission.floor_tokens < admission.budget.auto_compact_threshold_tokens
+    assert admission.tool_count == 1
+
+
 def test_structured_checkpoint_compaction_uses_injected_semantic_compactor():
     from brain.systems.context.semantic_compaction import compact_session_messages_with_checkpoint
 


### PR DESCRIPTION
Closes #545

## What this does

Cycle 2 (Uwear Ticket Coordinator) is permanently wedged: its irreducible context floor (~51.7k) exceeds its own ceiling (50,486), so compaction can never win and the run thrashes for 20+ minutes before dying as an uninformative `runner_failed`. This makes that state **detectable at turn 0** and **terminal with a named error**, instead of an unwinnable loop.

Four changes:

1. **Admission-time floor check.** Before the agent loop runs, the run's floor is compared to its ceiling. If the floor cannot fit, the run fails immediately with `context_floor_exceeds_budget: floor=… ceiling=… tools=…` — naming the floor, the ceiling and the tool count.
2. **No-progress compaction terminates.** After N consecutive compactions that reduce nothing, the run settles with `context_compaction_stalled:` rather than emitting the same warning every turn forever.
3. **The original flush exception survives.** Failures are captured across the complete unit of work *including commit*, then settled through a fresh unit of work — so the first flush error reaches `run.failed` instead of only the derived `PendingRollbackError`.
4. **One owner for context-window policy.** New `brain/systems/context/window_policy.py` owns admission, thresholds, minimum messages and stall state; `semantic_compaction.py` exposes a single typed `CompactionPlan` consumed by both admission and execution.

## Review surface — how to judge this without reading the diff

This is backend-only (no UI). Run the tests:

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-545-context-floor
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_context_runtime.py tests/test_agent_run_runtime.py \
  tests/test_agent_run_state_machine.py tests/test_cycles_service.py \
  tests/test_async_unit_of_work.py tests/test_agent_run_runner.py \
  tests/test_architecture_boundaries.py -q
```

**Result: 303 passed, 1 skipped** — run by the orchestrator on `41d9f1c`, not just reported by the worker.

## Acceptance checks

| # | Issue acceptance check | Status |
|---|---|---|
| 1 | Over-budget cycle fails within one turn with an error naming floor/ceiling/tool count, not `runner_failed` | ✅ covered by tests |
| 2 | Cycle 2 completes a scheduled run with `status='completed'` | ⏳ **only observable after deploy** — this PR removes the wedge; it cannot prove the run then succeeds |
| 3 | Each of the four active chantiers refreshed after that run | ⏳ **only observable after deploy**, follows from check 2 |
| 4 | Synthetic oversized-prompt run produces the named error, and `run.failed` carries the *original* exception on a flush error | ✅ covered by tests |

Checks 2 and 3 are downstream of a real scheduled run and are deliberately **not** claimed here.

## Assumptions

- `_admit_active_context` is called once at turn 0 before the agent loop, so a long-but-compactable transcript cannot be misclassified as an unrunnable scaffold. Verified against `direct_agent.py`.
- The threshold is an **inclusive ceiling**: at exactly the threshold the run is admitted and compaction is not required. This is a deliberate boundary change, pinned by an exact-equality test.
- Named error strings are preserved verbatim so existing log greps keep working.

## Code-quality review

A thermo-nuclear maintainability review ran on the implementation (4 blocking findings → fix pass), then a **second review scoped to the fix delta returned `VERDICT: SHIP` with zero blocking findings**: findings 2, 3 and 4 fully **RESOLVED**, finding 1 **PARTIALLY RESOLVED**.

Two non-blocking items left deliberately for follow-up rather than a second fix pass:

- `ContextWindowPolicy` still carries mutable compaction-episode state alongside immutable budget policy; re-resolving after model fallback replaces the object and implicitly resets stall/warning progress. All current mutation sites are covered — it is not stale today — but invalidation is manual.
- `brain/systems/context/__init__.py` re-exports every new layer; no caller consumes them through the facade, so it reads as a barrel rather than a curated surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
