### PR TITLE
fix(deploy): the drain wait must watch the cover, not just the clock (#556)

### DIFF
--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -111,6 +111,23 @@ container_running() {
   [ "$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null || echo false)" = "true" ]
 }
 
+# `container_running` folds "docker says no" and "docker did not answer" into the
+# same false. That is safe where a missing answer should stop the deploy, but not
+# where it force-replaces a worker: dockerd here is a snap that restarts itself
+# without warning, and during that window every inspect fails for ~60s. So this
+# reports the three states separately -- 0 running, 1 definitively not running,
+# 2 unknown -- and callers that destroy things must treat 2 as "keep waiting".
+container_running_known() {
+  local id="$1" state
+  [ -n "$id" ] || return 2
+  state="$(docker inspect --format '{{.State.Running}}' "$id" 2>/dev/null)" || return 2
+  case "$state" in
+    true) return 0 ;;
+    false) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
 container_restart_policy() {
   local id="$1"
   [ -n "$id" ] || return 1
@@ -258,7 +275,25 @@ assert_stack_not_inert() {
   return "$STACK_INERT_EXIT_CODE"
 }
 
+# A deploy that dies mid-swap leaves its `compose run` handoff container behind.
+# #544 already had to teach `worker_container_id` to ignore them, because two ids
+# on one line made every downstream `docker kill "$worker_id"` address neither --
+# but nothing ever removed them, so they accumulate. A stopped one is pure
+# debris. A RUNNING one is left alone on purpose: it is another claimer, and
+# deleting a claimer is the #486 outage.
+reap_stopped_worker_handoffs() {
+  local id
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    container_is_oneoff "$id" || continue
+    container_running "$id" && continue
+    echo "Worker: removing stopped handoff container $id left behind by an earlier deploy." >&2
+    docker rm -f "$id" >/dev/null 2>&1 || true
+  done < <(compose ps --all -q worker 2>/dev/null || true)
+}
+
 start_worker_handoff() {
+  reap_stopped_worker_handoffs
   compose run \
     -d \
     --no-deps \
@@ -267,27 +302,48 @@ start_worker_handoff() {
     worker
 }
 
+# The status distinguishes the escalations for whoever reads the file later.
+# Both existing callers already passed one; the parameter was simply dropped on
+# the floor, so every record claimed "worker_draining" even after a forced swap.
 record_worker_drain_timeout() {
   local snapshot="$1"
+  local status="${2:-worker_draining}"
   local details ids
   [ -n "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE:-}" ] || return 0
   details="$(worker_swap_snapshot_details "$snapshot")"
   ids="$(worker_swap_snapshot_run_ids "$snapshot")"
   mkdir -p "$(dirname "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE")" 2>/dev/null || true
-  printf '{"status":"worker_draining","updated_at":"%s","affected_run_ids":"%s","affected_runs":"%s"}\n' \
-    "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$ids" "$details" \
+  printf '{"status":"%s","updated_at":"%s","affected_run_ids":"%s","affected_runs":"%s"}\n' \
+    "$status" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$ids" "$details" \
     > "$COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_FILE" 2>/dev/null || true
 }
 
+# Waits for the outgoing worker to drain, and -- when a handoff worker is
+# covering for it -- for that cover to still exist.
+#
+# Watching only the clock is what turned the 2026-07-28 illo-dev deploy into a
+# 2h16m outage. The handoff came up, passed the one-shot liveness check, claimed
+# runs for 14 minutes, then exited 1 on its own `queue stalled; exiting for
+# restart` supervisor. That contract is honoured for `illospace-worker-1`
+# (`restart: unless-stopped`) and structurally cannot be for a handoff:
+# `compose run` containers are always created with `restart=no`, so "exiting for
+# restart" means exiting for good. From that moment nothing claimed -- and this
+# loop happily kept waiting, because the only thing it looked at was whether the
+# drained worker had exited, against a deadline 24h away by default.
+#
+# So the wait now ends on either condition, and the caller escalates for both:
+#   1 = the drain deadline passed          2 = the cover is gone
 wait_for_worker_exit() {
   local id="$1"
+  local handoff_id="${2:-}"
   local wait_seconds="${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}"
   local started_at="$SECONDS"
   local deadline=$((started_at + wait_seconds))
   local wait_iterations=0
   local consecutive_zero_checks=0
+  local handoff_missing_checks=0
   local hint_printed=0
-  local active_runs affected_runs affected_ids elapsed snapshot
+  local active_runs affected_runs affected_ids elapsed snapshot handoff_state
   while container_running "$id"; do
     if [ "$SECONDS" -ge "$deadline" ]; then
       snapshot="$(worker_swap_snapshot)"
@@ -296,6 +352,27 @@ wait_for_worker_exit() {
       echo "Worker did not drain within ${wait_seconds}s. Affected run ids: ${affected_ids:-unknown} (id/status: $affected_runs)." >&2
       record_worker_drain_timeout "$snapshot"
       return 1
+    fi
+    if [ -n "$handoff_id" ]; then
+      handoff_state=0
+      container_running_known "$handoff_id" || handoff_state=$?
+      case "$handoff_state" in
+        0) handoff_missing_checks=0 ;;
+        1)
+          # Two consecutive definite answers, because a handoff that Docker is
+          # restarting reads as stopped for an instant and is not lost.
+          handoff_missing_checks=$((handoff_missing_checks + 1))
+          if [ "$handoff_missing_checks" -ge 2 ]; then
+            elapsed=$((SECONDS - started_at))
+            echo "Worker: handoff worker $handoff_id stopped after ${elapsed}s while worker $id was still draining, so NOTHING is claiming AgentRuns." >&2
+            echo "Worker: a handoff is a \`compose run\` container and therefore has restart=no, so it does not come back on its own -- not even from the worker's own 'exiting for restart' supervisor. Ending the drain wait now instead of holding zero capacity until the ${wait_seconds}s deadline." >&2
+            return 2
+          fi
+          ;;
+        # Unknown: dockerd is a snap here and restarts itself without warning, so
+        # an unanswered inspect must never authorise force-replacing a worker.
+        *) ;;
+      esac
     fi
     sleep 5
     wait_iterations=$((wait_iterations + 1))
@@ -332,19 +409,31 @@ wait_for_worker_exit() {
 # stack lands back on the single Compose-managed worker that owns the cycle
 # scheduler and the restart policy. Runs the killed worker was holding are
 # recovered by the stale-run reaper.
+#
+# The same escalation covers the other way the wait can end -- the handoff dying
+# first -- but the two must not print the same thing. Announcing that the handoff
+# "keeps claiming" when the handoff is precisely what died is how an operator
+# reads a total outage as a routine slow drain.
 escalate_worker_swap_after_drain_timeout() {
   local worker_id="$1"
   local handoff_id="$2"
   local wait_seconds="$3"
+  local drain_status="${4:-1}"
   local snapshot affected_ids run_details
 
   snapshot="$(worker_swap_snapshot)"
   affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
   run_details="$(worker_swap_snapshot_details "$snapshot")"
 
-  echo "FORCED WORKER SWAP: worker $worker_id did not drain within ${wait_seconds}s and will never claim another AgentRun; replacing it rather than keeping a worker that cannot work. Open run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
-  echo "Worker: handoff worker ${handoff_id:-none} keeps claiming new AgentRuns until the replacement is up. Runs interrupted here are requeued by the stale-run reaper." >&2
-  record_worker_drain_timeout "$snapshot" "worker_swap_forced"
+  if [ "$drain_status" = "2" ]; then
+    echo "FORCED WORKER SWAP: handoff worker ${handoff_id:-none} stopped while worker $worker_id was still draining, so nothing is claiming AgentRuns right now; replacing the drained worker immediately rather than waiting out the remaining ${wait_seconds}s deadline. Open run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
+    echo "Worker: capacity is already zero, so this escalation IS the recovery -- it is not a precaution. Runs interrupted here are requeued by the stale-run reaper." >&2
+    record_worker_drain_timeout "$snapshot" "worker_handoff_lost"
+  else
+    echo "FORCED WORKER SWAP: worker $worker_id did not drain within ${wait_seconds}s and will never claim another AgentRun; replacing it rather than keeping a worker that cannot work. Open run ids: ${affected_ids:-unknown} (id/status: $run_details)." >&2
+    echo "Worker: handoff worker ${handoff_id:-none} keeps claiming new AgentRuns until the replacement is up. Runs interrupted here are requeued by the stale-run reaper." >&2
+    record_worker_drain_timeout "$snapshot" "worker_swap_forced"
+  fi
 
   suspend_worker_restart_policy "$worker_id"
   docker kill "$worker_id" >/dev/null 2>&1 || true
@@ -359,7 +448,7 @@ escalate_worker_swap_after_drain_timeout() {
 update_worker_after_drain() {
   local snapshot="$1"
   local already_reported="${2:-}"
-  local active_runs affected_ids worker_id handoff_id run_details replacement_id
+  local active_runs affected_ids worker_id handoff_id run_details replacement_id drain_status
   active_runs="$(worker_swap_snapshot_count "$snapshot")"
   affected_ids="$(worker_swap_snapshot_run_ids "$snapshot")"
   run_details="$(worker_swap_snapshot_details "$snapshot")"
@@ -389,9 +478,11 @@ update_worker_after_drain() {
   echo "Worker: ${active_runs} interactive AgentRun(s); signaling existing worker to drain. Affected run ids: $affected_ids."
   suspend_worker_restart_policy "$worker_id"
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  if ! wait_for_worker_exit "$worker_id"; then
+  drain_status=0
+  wait_for_worker_exit "$worker_id" "$handoff_id" || drain_status=$?
+  if [ "$drain_status" -ne 0 ]; then
     escalate_worker_swap_after_drain_timeout \
-      "$worker_id" "$handoff_id" "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}" || return 1
+      "$worker_id" "$handoff_id" "${COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS:-86400}" "$drain_status" || return 1
   fi
   # Only drop the suspension once a replacement actually exists. If the recreate
   # failed there is no new worker, so the outgoing container is still the only
@@ -465,7 +556,9 @@ replace_idle_worker() {
   echo "Worker: no interactive AgentRuns; signaling a graceful replacement."
   suspend_worker_restart_policy "$worker_id"
   docker kill -s TERM "$worker_id" >/dev/null 2>&1 || true
-  if ! wait_for_worker_exit "$worker_id"; then
+  # No handoff exists on this path, so there is no cover to watch: only the clock
+  # can end this wait.
+  if ! wait_for_worker_exit "$worker_id" ""; then
     # Returning here would leave a container that is running, healthy-looking and
     # permanently unable to claim -- and this path has no handoff worker to cover
     # for it. There are no interactive runs to protect, so nothing weighs against

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -23,12 +23,21 @@ def _simulator(
     handoff_starts: bool = True,
     recreate_succeeds: bool = True,
     survives_kill: bool = False,
+    stub_drain_wait: bool = True,
+    handoff_dies_after_ticks: int | None = None,
+    handoff_state_unknown: bool = False,
+    drain_timeout_seconds: int = 1,
 ) -> str:
     """Build a bash script whose `docker`/`compose` mutate simulated containers.
 
     A container is running while `$state/<id>.running` exists. A hard kill stops
     it, `docker rm` removes it, and `compose up --force-recreate` swaps the
     service container for a new id. Handoff ids carry Compose's one-off label.
+
+    With `stub_drain_wait=False` the real `wait_for_worker_exit` runs, with
+    `sleep` replaced by a tick counter so the loop is instantaneous. The worker
+    it waits on never drains, so the only way the wait can end is the condition
+    under test.
     """
 
     state.mkdir(parents=True, exist_ok=True)
@@ -37,9 +46,25 @@ def _simulator(
     return f'''
 export STATE="{state}"
 export SURVIVES_KILL={"1" if survives_kill else "0"}
+export HANDOFF_DIES_AFTER_TICKS={-1 if handoff_dies_after_ticks is None else handoff_dies_after_ticks}
+export HANDOFF_STATE_UNKNOWN={"1" if handoff_state_unknown else "0"}
 COMPOSE_RUNTIME_HANDOFF_REAP_TIMEOUT_SECONDS=0
-COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS=1
+COMPOSE_RUNTIME_WORKER_DRAIN_TIMEOUT_SECONDS={drain_timeout_seconds}
 source "{RUNTIME_LIB}"
+
+ticks() {{ cat "$STATE/ticks" 2>/dev/null || printf '0\\n'; }}
+
+{'' if stub_drain_wait else '''
+sleep() {
+  local n
+  n=$(( $(ticks) + 1 ))
+  printf '%s\\n' "$n" > "$STATE/ticks"
+  if [ "$HANDOFF_DIES_AFTER_TICKS" -ge 0 ] && [ "$n" -ge "$HANDOFF_DIES_AFTER_TICKS" ]; then
+    rm -f "$STATE/handoff-1.running"
+  fi
+  return 0
+}
+'''}
 
 log() {{ printf '%s\\n' "$*" >> "$STATE/calls.log"; }}
 
@@ -55,6 +80,11 @@ docker() {{
     inspect)
       case "$*" in
         *State.Running*)
+          # A snap dockerd restart answers nothing at all, which is not the same
+          # answer as "not running".
+          case "${{!#}}" in
+            handoff-*) [ "$HANDOFF_STATE_UNKNOWN" = "1" ] && return 1 ;;
+          esac
           [ -f "$STATE/${{!#}}.running" ] && printf 'true\\n' || printf 'false\\n'
           ;;
         *oneoff*)
@@ -75,7 +105,7 @@ docker() {{
         rm -f "$STATE/$id.running"
       fi
       ;;
-    rm) rm -f "$STATE/${{!#}}.running" ;;
+    rm) rm -f "$STATE/${{!#}}.running" "$STATE/${{!#}}.stopped" ;;
     update) : ;;
   esac
   return 0
@@ -84,10 +114,19 @@ docker() {{
 compose() {{
   log "compose $*"
   case "$*" in
-    "ps -q worker"|"ps --all -q worker"|"ps --status running -q worker")
+    "ps -q worker"|"ps --status running -q worker")
       for f in "$STATE"/*.running; do
         [ -e "$f" ] || continue
         basename "$f" .running
+      done
+      ;;
+    # `--all` also lists the exited handoff containers an interrupted deploy left
+    # behind -- the whole reason `worker_container_id` has to filter one-offs.
+    "ps --all -q worker")
+      for f in "$STATE"/*.running "$STATE"/*.stopped; do
+        [ -e "$f" ] || continue
+        name="$(basename "$f")"
+        printf '%s\\n' "${{name%.*}}"
       done
       ;;
     "up -d --force-recreate --no-deps worker")
@@ -108,7 +147,7 @@ start_worker_handoff() {{
 
 # The drain never completes: the worker is wedged on an in-flight run, which is
 # what run 2896 did on illo-dev for 65 minutes.
-wait_for_worker_exit() {{ [ ! -f "$STATE/$1.running" ]; }}
+{'wait_for_worker_exit() { [ ! -f "$STATE/$1.running" ]; }' if stub_drain_wait else ''}
 
 {body}
 echo "STATUS=$?"
@@ -202,6 +241,129 @@ def test_worker_container_id_ignores_leftover_handoff_containers(tmp_path):
     result = _run(script)
 
     assert "SERVICE=worker-1" in result.stdout
+
+
+def test_the_drain_wait_ends_when_the_handoff_worker_dies(tmp_path):
+    """Regression for the illo-dev outage of 2026-07-28 (6caa36d, i.e. #544 itself).
+
+    The handoff came up, passed the one-shot liveness check, claimed runs for 14
+    minutes, then exited 1 on its own `queue stalled; exiting for restart`
+    supervisor -- a contract a `compose run` container (restart=no) can never
+    honour. The drain wait watched only the clock, whose deadline was 24h away,
+    so nothing claimed an AgentRun for 2h16m.
+    """
+
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=': > "$STATE/handoff-1.running"\nwait_for_worker_exit worker-1 handoff-1',
+        stub_drain_wait=False,
+        handoff_dies_after_ticks=1,
+        # A deadline far beyond any tick this test performs: the wait must end on
+        # the lost cover, never because the clock happened to run out.
+        drain_timeout_seconds=86400,
+    )
+    result = _run(script)
+
+    assert "STATUS=2" in result.stdout
+    assert "stopped after" in result.stderr
+    assert "NOTHING is claiming AgentRuns" in result.stderr
+    assert "restart=no" in result.stderr
+    # The worker it was draining is untouched by the wait itself.
+    assert (state / "worker-1.running").exists()
+
+
+def test_an_unanswered_handoff_inspect_does_not_end_the_drain_wait(tmp_path):
+    """dockerd here is a snap that restarts itself, taking every inspect with it.
+
+    "docker did not answer" must never be read as "the handoff is gone", or a
+    60-second daemon refresh force-replaces a perfectly healthy worker.
+    """
+
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        # The handoff stays up; only the answers stop coming. The worker drains
+        # normally after a few ticks, which is the only way out of this wait.
+        body=(
+            ': > "$STATE/handoff-1.running"\n'
+            'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
+            '[ "$n" -ge 4 ] && rm -f "$STATE/worker-1.running"; return 0; }\n'
+            "wait_for_worker_exit worker-1 handoff-1"
+        ),
+        stub_drain_wait=False,
+        handoff_state_unknown=True,
+        drain_timeout_seconds=86400,
+    )
+    result = _run(script)
+
+    assert "STATUS=0" in result.stdout
+    assert "NOTHING is claiming AgentRuns" not in result.stderr
+
+
+def test_a_single_missed_handoff_observation_does_not_end_the_drain_wait(tmp_path):
+    """A handoff Docker is restarting reads as stopped for an instant."""
+
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            ': > "$STATE/handoff-1.running"\n'
+            'sleep() { local n; n=$(( $(ticks) + 1 )); printf "%s\\n" "$n" > "$STATE/ticks"; '
+            'case "$n" in 1) rm -f "$STATE/handoff-1.running" ;; '
+            '2) : > "$STATE/handoff-1.running" ;; '
+            '4) rm -f "$STATE/worker-1.running" ;; esac; return 0; }\n'
+            "wait_for_worker_exit worker-1 handoff-1"
+        ),
+        stub_drain_wait=False,
+        drain_timeout_seconds=86400,
+    )
+    result = _run(script)
+
+    assert "STATUS=0" in result.stdout
+    assert "NOTHING is claiming AgentRuns" not in result.stderr
+
+
+def test_a_lost_handoff_force_replaces_the_drained_worker(tmp_path):
+    """End to end: losing the cover escalates instead of waiting out the deadline."""
+
+    state = tmp_path / "s"
+    result = _run(
+        _simulator(
+            state,
+            body="update_worker_after_drain 2896:running",
+            stub_drain_wait=False,
+            handoff_dies_after_ticks=1,
+            drain_timeout_seconds=86400,
+        )
+    )
+
+    assert "STATUS=0" in result.stdout
+    assert result.stdout.split("RUNNING=")[1].strip() == "worker-2"
+    assert "FORCED WORKER SWAP" in result.stderr
+    assert "handoff worker handoff-1 stopped" in result.stderr
+    # The banner must not promise cover that is exactly what died.
+    assert "keeps claiming new AgentRuns" not in result.stderr
+
+
+def test_stopped_handoff_containers_are_removed_before_a_new_one_starts(tmp_path):
+    """illo-dev still carried the Exited(1) handoff from the outage.
+
+    A running handoff is another claimer and is deliberately left alone --
+    deleting a claimer is the #486 outage.
+    """
+
+    state = tmp_path / "s"
+    state.mkdir(parents=True)
+    (state / "handoff-old.stopped").write_text("1")
+    (state / "handoff-live.running").write_text("1")
+    result = _run(_simulator(state, body="reap_stopped_worker_handoffs"))
+
+    calls = _calls(state)
+    assert "rm -f handoff-old" in calls
+    assert "rm -f handoff-live" not in calls
+    # The real service container is never a reaping candidate.
+    assert "rm -f worker-1" not in calls
 
 
 def test_the_idle_path_fails_loudly_when_the_replacement_cannot_start(tmp_path):


### PR DESCRIPTION
Closes #556.

## The finding

illo-dev lost all AgentRun capacity for 2h16m on 2026-07-28, **on the deploy of 6caa36d — the #544 merge itself**. The deploy took the #544 path and #544's own guards passed.

`git reflog` on the host puts `1548c60..6caa36d` at 14:18:56, four seconds before `api`/`scheduler`/`web`/`updater` were recreated together at 14:19:00 (the `drain` branch of `upgrade.sh`). The handoff container `illospace-worker-run-e1a55f7235cc` was created at 14:19:17 carrying `ILLO_WORKER_DISABLE_CYCLE_SCHEDULER=1` + `ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS=infinity` — the pair only `start_worker_handoff` sets — and `illospace-worker-1` logged `received SIGTERM, draining` at the same second. So: not `runtime-services.sh`, not a manual kill, not a snap dockerd refresh, not a stale in-memory script.

The handoff then worked fine for fourteen minutes, claiming runs 3002–3007. At 14:31:04 it logged `agent-run worker queue stalled; exiting for restart` and at 14:33:33 it exited 1.

Nothing claimed anything for the next 2h16m.

## Why #544 doesn't cover it

#544 promoted the handoff from "a temporary extra claimer during a short drain" to **the sole claiming capacity for the whole escalation window**, and then verifies it exactly once, instantaneously, right after `compose run -d`. For the rest of the wait, `wait_for_worker_exit` watches one thing: whether the *drained* worker has exited — against a deadline that is `86400` by default on the `upgrade.sh` path.

That leaves a window up to 24h wide where the only claimer can die unobserved. And it will, because of a contract mismatch nothing reconciled:

- `brain/systems/cortex/worker.py` self-exits on three health conditions ([L178](https://github.com/Illospace/illospace/blob/6caa36d/brain/systems/cortex/worker.py#L178), [L192](https://github.com/Illospace/illospace/blob/6caa36d/brain/systems/cortex/worker.py#L192), [L207](https://github.com/Illospace/illospace/blob/6caa36d/brain/systems/cortex/worker.py#L207)), each logging **"exiting for restart"**.
- Honoured for `illospace-worker-1` (`restart: unless-stopped`).
- Structurally *un*honourable for a handoff: `compose run` containers are always `restart=no` — `docker inspect` on the dead one confirms it. For the handoff, "exiting for restart" means exiting for good.

None of #548–#552 catches this. #548 gates the SIGTERM on the handoff reaching `claiming` — a one-shot check *before* the destructive step, which this handoff would have passed. #549's continuous checks are the right backstop but never ran: the deploy was still blocked inside `wait_for_worker_exit`, and `doctor.sh` comes after.

## The change

The drain wait now watches capacity, not only the clock. Losing the cover ends the wait immediately and the existing #544 escalation force-replaces the drained worker — the same recovery that took 2h16m by hand, in ~20s.

Two ways to get this wrong, both avoided on purpose:

- **"docker did not answer" is not "the handoff is gone."** dockerd here is a snap that restarts itself without warning, taking every `inspect` with it for ~60s, and `container_running` folds an inspect failure into `false`. Reusing it would force-replace a *healthy* worker during a daemon refresh. New `container_running_known` reports running / not-running / unknown separately; unknown keeps waiting.
- **A single missed observation is not death.** A container Docker is restarting reads as stopped for an instant, so two consecutive definite negatives are required.

The escalation banner branches as well — announcing that the handoff "keeps claiming new AgentRuns until the replacement is up" when the handoff is exactly what died is how an operator reads a total outage as a routine slow drain.

Two smaller fixes in the same functions:

- Stopped handoff containers are reaped before a new one starts. #544 had to teach `worker_container_id` to ignore them; nothing ever removed them, and illo-dev still carries the `Exited (1)` handoff from this outage. A **running** one is still left alone — deleting a claimer is the #486 outage.
- `record_worker_drain_timeout` took one parameter while both call sites passed two, so every record claimed `"status":"worker_draining"` even after a forced swap.

## Testing

`tests/test_worker_swap_deploy.py` now drives the **real** `wait_for_worker_exit` against #544's container simulator, with `sleep` replaced by a tick counter and the worker it waits on never draining — so the only way the wait can end is the condition under test.

- lost handoff → wait returns "cover gone", worker untouched by the wait itself
- unanswered `inspect` → wait does **not** end (the snap-refresh false positive)
- one missed observation then recovery → wait does **not** end (the debounce)
- end to end → drained worker force-replaced, correct banner, no "keeps claiming" promise
- stopped handoffs reaped, running handoff and the service container untouched

Against the pre-fix library the new regression test does not fail — **it hangs**, which is exactly what the deploy did. 614 tests pass (`-k "deploy or worker or compose or runtime"`).

## Not fixed here, deliberately

- `ILLO_COMPOSE_WORKER_DRAIN_TIMEOUT_SECONDS` defaults to **86400** in `upgrade.sh` but **120** in `runtime-services.sh` and the self-update daemon. Since #544 that default decides when in-flight runs get killed, so it is a behaviour call for you, not a cleanup.
- The deploy process is still a single point of failure. It died sometime after the SIGTERM — no `upgrade.sh` process remained, the handoff was never `docker rm`'d, the worker was never recreated. That is #552 (traps should terminate the deploy) plus #549 (checks that run continuously rather than after the swap).
- The second line of defence that also failed — the stale-run reaper stops the instant the worker is told to drain — is #550, unchanged here. Confirmed against the code: `request_runner_stop()` sets `_stop_event`, and `_supervisor_async_loop` (the reaper's only caller) is `while not _stop_event.is_set()`.

## Deploy note

illo-dev recovered manually at 16:35 and is healthy. It still carries the `Exited (1)` handoff container from the incident; this branch removes it automatically on the next deploy that starts a handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
