### PR TITLE
fix(runs): make spawn_worker fan-out failures visible, retryable, and refused at admission

### DIFF
--- a/brain/app/ops/health.py
+++ b/brain/app/ops/health.py
@@ -25,6 +25,7 @@ DEFAULT_GPU_HEALTH_TIMEOUT_SECONDS = 1.0
 DEFAULT_STUCK_RUN_SECONDS = 15 * 60
 DEFAULT_RECENT_FAILURE_WINDOW_MINUTES = 60
 DEFAULT_RECENT_FAILURE_LIMIT = 10
+DEFAULT_SPAWN_WORKER_RATE_WINDOW_MINUTES = 24 * 60
 DEFAULT_STALE_CYCLE_BACKLOG_MINUTES = 15
 DEFAULT_STALE_CYCLE_BACKLOG_LIMIT = 10
 
@@ -593,10 +594,18 @@ async def _run_health_check(session: AsyncSession | None = None) -> HealthCheck:
         DEFAULT_RECENT_FAILURE_WINDOW_MINUTES,
         minimum=1,
     )
+    spawn_worker_rate_window_minutes = _int_env(
+        "HEALTH_SPAWN_WORKER_RATE_WINDOW_MINUTES",
+        DEFAULT_SPAWN_WORKER_RATE_WINDOW_MINUTES,
+        minimum=1,
+    )
     recent_limit = _int_env("HEALTH_RECENT_FAILURE_LIMIT", DEFAULT_RECENT_FAILURE_LIMIT, minimum=1)
     now = _utc_now()
     stuck_cutoff = now - timedelta(seconds=stuck_after_seconds)
     failure_cutoff = now - timedelta(minutes=failure_window_minutes)
+    spawn_worker_rate_cutoff = now - timedelta(
+        minutes=spawn_worker_rate_window_minutes
+    )
     try:
         if session is None:
             raise RuntimeError("health checks require an explicit database session")
@@ -626,6 +635,31 @@ async def _run_health_check(session: AsyncSession | None = None) -> HealthCheck:
         recent_failure_count = await session.scalar(
             select(func.count()).select_from(AgentRun).where(recent_failure_clause)
         ) or 0
+        spawn_worker_counts_result = await session.execute(
+            select(AgentRun.status, func.count())
+            .where(
+                AgentRun.metadata_["origin"].as_string() == "spawn_worker",
+                AgentRun.status.in_(("completed", RUN_FAILED_STATUS_VALUE)),
+                func.coalesce(AgentRun.completed_at, AgentRun.created_at)
+                >= spawn_worker_rate_cutoff,
+            )
+            .group_by(AgentRun.status)
+        )
+        spawn_worker_counts = {
+            str(status): int(count)
+            for status, count in spawn_worker_counts_result
+        }
+        spawn_worker_completed = spawn_worker_counts.get("completed", 0)
+        spawn_worker_failed = spawn_worker_counts.get(
+            RUN_FAILED_STATUS_VALUE,
+            0,
+        )
+        spawn_worker_terminal = spawn_worker_completed + spawn_worker_failed
+        spawn_worker_success_rate = (
+            spawn_worker_completed / spawn_worker_terminal
+            if spawn_worker_terminal
+            else None
+        )
 
         status = "ok"
         reasons: list[str] = []
@@ -635,6 +669,15 @@ async def _run_health_check(session: AsyncSession | None = None) -> HealthCheck:
         if recent_failure_count:
             status = "degraded"
             reasons.append(f"{int(recent_failure_count)} recent failed run(es)")
+        if (
+            spawn_worker_success_rate is not None
+            and spawn_worker_success_rate < 0.9
+        ):
+            status = "degraded"
+            reasons.append(
+                "spawn_worker success "
+                f"{spawn_worker_success_rate * 100:.1f}%"
+            )
 
         return HealthCheck(
             name="run",
@@ -647,6 +690,18 @@ async def _run_health_check(session: AsyncSession | None = None) -> HealthCheck:
                 "stuck_runs": [_run_row_payload(row, now=now) for row in stuck_runs],
                 "recent_failures_count": int(recent_failure_count),
                 "recent_failures": [_run_row_payload(row, now=now) for row in recent_failures],
+                "spawn_worker_success_rate": {
+                    "window_minutes": spawn_worker_rate_window_minutes,
+                    "completed": spawn_worker_completed,
+                    "failed": spawn_worker_failed,
+                    "terminal": spawn_worker_terminal,
+                    "rate": spawn_worker_success_rate,
+                    "percent": (
+                        round(spawn_worker_success_rate * 100, 1)
+                        if spawn_worker_success_rate is not None
+                        else None
+                    ),
+                },
             },
             remediation="Inspect stuck run leases and recent failure errors." if status != "ok" else None,
         )

--- a/brain/platform/integrations/provider_auth_preflight.py
+++ b/brain/platform/integrations/provider_auth_preflight.py
@@ -1,0 +1,139 @@
+"""Neutral provider credential probing for admission boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.integrations.llm import async_resolve_llm_client
+from brain.platform.providers.model_policy import required_openai_auth_mode
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAuthPreflightResult:
+    status: str
+    provider: str
+    model: str
+    credential: str | None = None
+    error_code: str | None = None
+    repair_action: str | None = None
+    visible_message: str | None = None
+
+    @property
+    def blocked(self) -> bool:
+        return self.status == "auth_blocked"
+
+    def with_presentation(
+        self,
+        *,
+        repair_action: str,
+        visible_message: str,
+    ) -> ProviderAuthPreflightResult:
+        return replace(
+            self,
+            repair_action=repair_action,
+            visible_message=visible_message,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "provider": self.provider,
+            "model": self.model,
+            "credential": self.credential,
+            "error_code": self.error_code,
+            "repair_action": self.repair_action,
+            "visible_message": self.visible_message,
+        }
+
+
+def skipped_provider_auth_preflight(
+    *,
+    provider: str,
+    model: str,
+) -> ProviderAuthPreflightResult:
+    return ProviderAuthPreflightResult(
+        status="skipped",
+        provider=provider,
+        model=model,
+    )
+
+
+def _normalize_model(model: str) -> str:
+    value = str(model or "").strip()
+    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
+        if value.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+def _credential_label(
+    *,
+    provider: str,
+    model: str,
+    auth_mode: str | None,
+    error_text: str,
+) -> str:
+    normalized_model = _normalize_model(model).lower()
+    normalized_error = error_text.lower()
+    if provider == "anthropic":
+        return "Anthropic API key"
+    if (
+        auth_mode == "chatgpt"
+        or "codex" in normalized_model
+        or "codex" in normalized_error
+    ):
+        return "OpenAI Codex / ChatGPT"
+    return "OpenAI runtime"
+
+
+async def async_probe_provider_auth(
+    session: AsyncSession,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+    provider: str,
+    model: str,
+) -> ProviderAuthPreflightResult:
+    """Probe one caller-approved provider route without presentation policy."""
+
+    if provider not in {"anthropic", "openai"}:
+        raise ValueError(f"Unsupported provider auth probe: {provider}")
+
+    auth_mode = required_openai_auth_mode(model) if provider == "openai" else None
+    try:
+        await async_resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=provider,
+            auth_mode=auth_mode,
+            session=session,
+        )
+    except Exception as exc:
+        return ProviderAuthPreflightResult(
+            status="auth_blocked",
+            provider=provider,
+            model=model,
+            credential=_credential_label(
+                provider=provider,
+                model=model,
+                auth_mode=auth_mode,
+                error_text=str(exc),
+            ),
+            error_code="provider_credential_unavailable",
+        )
+
+    return ProviderAuthPreflightResult(
+        status="passed",
+        provider=provider,
+        model=model,
+    )
+
+
+__all__ = [
+    "ProviderAuthPreflightResult",
+    "async_probe_provider_auth",
+    "skipped_provider_auth_preflight",
+]

--- a/brain/platform/integrations/provider_error_sentinel.py
+++ b/brain/platform/integrations/provider_error_sentinel.py
@@ -28,6 +28,21 @@ _PROVIDER_ERROR_CONTEXT_RE = re.compile(
 )
 
 
+def _classify_normalized_provider_error(normalized: str) -> str | None:
+    for alias, kind in _PROVIDER_ERROR_ALIASES.items():
+        if re.search(rf"\b{re.escape(alias)}\b", normalized):
+            return kind
+    for kind in _PROVIDER_ERROR_KINDS:
+        if re.search(rf"\b{re.escape(kind)}\b", normalized):
+            return kind
+    if (
+        _TRANSIENT_PROVIDER_STATUS_RE.search(normalized)
+        and _PROVIDER_ERROR_CONTEXT_RE.search(normalized)
+    ):
+        return "server_error"
+    return None
+
+
 def provider_error_kind(
     candidate: Any,
     *,
@@ -45,17 +60,8 @@ def provider_error_kind(
     if normalized.startswith(PROVIDER_ERROR_SENTINEL_PREFIX):
         sentinel_kind = normalized.removeprefix(PROVIDER_ERROR_SENTINEL_PREFIX).strip()
         return sentinel_kind if sentinel_kind in _PROVIDER_ERROR_KIND_VALUES else "provider_error"
-    for alias, kind in _PROVIDER_ERROR_ALIASES.items():
-        if re.search(rf"\b{re.escape(alias)}\b", normalized):
-            return kind
-    for kind in _PROVIDER_ERROR_KINDS:
-        if re.search(rf"\b{re.escape(kind)}\b", normalized):
-            return kind
-    if (
-        _TRANSIENT_PROVIDER_STATUS_RE.search(normalized)
-        and _PROVIDER_ERROR_CONTEXT_RE.search(normalized)
-    ):
-        return "server_error"
+    if classified := _classify_normalized_provider_error(normalized):
+        return classified
     if "help.openai.com" in normalized:
         return "provider_error"
     if text:
@@ -66,18 +72,7 @@ def provider_error_kind(
     exception_text = str(provider_exception or "").strip().lower()
     if not exception_text:
         return None
-    for alias, kind in _PROVIDER_ERROR_ALIASES.items():
-        if re.search(rf"\b{re.escape(alias)}\b", exception_text):
-            return kind
-    for kind in _PROVIDER_ERROR_KINDS:
-        if re.search(rf"\b{re.escape(kind)}\b", exception_text):
-            return kind
-    if (
-        _TRANSIENT_PROVIDER_STATUS_RE.search(exception_text)
-        and _PROVIDER_ERROR_CONTEXT_RE.search(exception_text)
-    ):
-        return "server_error"
-    return "provider_error"
+    return _classify_normalized_provider_error(exception_text) or "provider_error"
 
 
 def safe_provider_error_sentinel(kind: str | None) -> str:

--- a/brain/platform/integrations/provider_error_sentinel.py
+++ b/brain/platform/integrations/provider_error_sentinel.py
@@ -13,6 +13,19 @@ _PROVIDER_ERROR_KINDS = (
     "rate_limit_error",
 )
 _PROVIDER_ERROR_KIND_VALUES = frozenset((*_PROVIDER_ERROR_KINDS, "provider_error"))
+_PROVIDER_ERROR_ALIASES = {
+    "server_is_overloaded": "overloaded_error",
+    "service_unavailable_error": "server_error",
+}
+_TRANSIENT_PROVIDER_STATUS_RE = re.compile(
+    r"\b(?:(?:http(?:\s+status)?|status(?:\s+code)?)\s*)?"
+    r"(?:500|502|503|504|529)\b",
+    re.IGNORECASE,
+)
+_PROVIDER_ERROR_CONTEXT_RE = re.compile(
+    r"\b(?:api|error|failed|http|provider|server|service|unavailable|upstream)\b",
+    re.IGNORECASE,
+)
 
 
 def provider_error_kind(
@@ -32,9 +45,17 @@ def provider_error_kind(
     if normalized.startswith(PROVIDER_ERROR_SENTINEL_PREFIX):
         sentinel_kind = normalized.removeprefix(PROVIDER_ERROR_SENTINEL_PREFIX).strip()
         return sentinel_kind if sentinel_kind in _PROVIDER_ERROR_KIND_VALUES else "provider_error"
+    for alias, kind in _PROVIDER_ERROR_ALIASES.items():
+        if re.search(rf"\b{re.escape(alias)}\b", normalized):
+            return kind
     for kind in _PROVIDER_ERROR_KINDS:
         if re.search(rf"\b{re.escape(kind)}\b", normalized):
             return kind
+    if (
+        _TRANSIENT_PROVIDER_STATUS_RE.search(normalized)
+        and _PROVIDER_ERROR_CONTEXT_RE.search(normalized)
+    ):
+        return "server_error"
     if "help.openai.com" in normalized:
         return "provider_error"
     if text:
@@ -45,9 +66,17 @@ def provider_error_kind(
     exception_text = str(provider_exception or "").strip().lower()
     if not exception_text:
         return None
+    for alias, kind in _PROVIDER_ERROR_ALIASES.items():
+        if re.search(rf"\b{re.escape(alias)}\b", exception_text):
+            return kind
     for kind in _PROVIDER_ERROR_KINDS:
         if re.search(rf"\b{re.escape(kind)}\b", exception_text):
             return kind
+    if (
+        _TRANSIENT_PROVIDER_STATUS_RE.search(exception_text)
+        and _PROVIDER_ERROR_CONTEXT_RE.search(exception_text)
+    ):
+        return "server_error"
     return "provider_error"
 
 

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -1,4 +1,4 @@
-"""Cheap auth checks for scheduled Cycle launches."""
+"""Cheap provider-auth checks shared by Cycle and worker admission."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -20,6 +20,7 @@ class CycleAuthPreflightResult:
     provider: str | None = None
     model: str | None = None
     credential: str | None = None
+    error_code: str | None = None
     repair_action: str | None = None
     visible_message: str | None = None
 
@@ -33,6 +34,7 @@ class CycleAuthPreflightResult:
             "provider": self.provider,
             "model": self.model,
             "credential": self.credential,
+            "error_code": self.error_code,
             "repair_action": self.repair_action,
             "visible_message": self.visible_message,
         }
@@ -49,44 +51,63 @@ def _normalize_model(model: str) -> str:
 def _credential_label(model: str, auth_mode: str | None, error_text: str = "") -> str:
     normalized_model = _normalize_model(model).lower()
     normalized_error = error_text.lower()
+    if model.startswith(("anthropic/", "anthropic:")):
+        return "Anthropic API key"
     if auth_mode == "chatgpt" or "codex" in normalized_model or "codex" in normalized_error:
         return "OpenAI Codex / ChatGPT"
     return "OpenAI runtime"
 
 
-def _blocked_message(credential: str) -> tuple[str, str]:
+def _blocked_message(credential: str, *, subject: str) -> tuple[str, str]:
+    if subject == "Scheduled Cycle":
+        repair_action = (
+            "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
+            "then rerun the Cycle or wait for its next scheduled run."
+        )
+        return (
+            repair_action,
+            f"Scheduled Cycle auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
+        )
+    if credential == "Anthropic API key":
+        repair_action = (
+            "Add an Anthropic API key in Settings > Access, then retry the run."
+        )
+        return (
+            repair_action,
+            f"{subject} auth blocked: the {credential} is not configured. {repair_action}",
+        )
+    if credential == "OpenAI runtime":
+        repair_action = (
+            "Add an OpenAI API key in Settings > Access, then retry the run."
+        )
+        return (
+            repair_action,
+            f"{subject} auth blocked: the {credential} credential is unavailable. {repair_action}",
+        )
     repair_action = (
         "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
-        "then rerun the Cycle or wait for its next scheduled run."
+        "then retry the run."
     )
     return (
         repair_action,
-        f"Scheduled Cycle auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
+        f"{subject} auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
     )
 
 
-async def async_preflight_cycle_external_auth(
+async def async_preflight_run_external_auth(
     session: AsyncSession,
     *,
-    cycle: Any,
+    user_id: str | None,
+    org_id: str | None,
+    model: str,
+    subject: str,
 ) -> CycleAuthPreflightResult:
-    """Validate required external auth before admitting the full agent."""
-    user_id = str(getattr(cycle, "user_id", "") or "") or None
-    org_id = str(getattr(cycle, "org_id", "") or "") or None
-    model = str(getattr(cycle, "model_override", None) or "").strip()
-    if not model:
-        model = await async_get_default_model(
-            session,
-            include_provider_prefix=True,
-            user_id=user_id,
-            org_id=org_id,
-        )
-
+    """Validate a resolved run route before it consumes an agent slot."""
     provider = infer_provider_from_model(model)
-    if provider != "openai":
+    if provider not in {"anthropic", "openai"}:
         return CycleAuthPreflightResult(status="skipped", provider=provider, model=model)
 
-    auth_mode = required_openai_auth_mode(model)
+    auth_mode = required_openai_auth_mode(model) if provider == "openai" else None
     try:
         await async_resolve_llm_client(
             user_id=user_id,
@@ -97,14 +118,61 @@ async def async_preflight_cycle_external_auth(
         )
     except Exception as exc:
         credential = _credential_label(model, auth_mode, str(exc))
-        repair_action, visible_message = _blocked_message(credential)
+        repair_action, visible_message = _blocked_message(
+            credential,
+            subject=subject,
+        )
         return CycleAuthPreflightResult(
             status="auth_blocked",
             provider=provider,
             model=model,
             credential=credential,
+            error_code="provider_credential_unavailable",
             repair_action=repair_action,
             visible_message=visible_message,
         )
 
     return CycleAuthPreflightResult(status="passed", provider=provider, model=model)
+
+
+async def async_preflight_cycle_external_auth(
+    session: AsyncSession,
+    *,
+    cycle: Any,
+) -> CycleAuthPreflightResult:
+    """Validate required external auth before admitting the full Cycle agent."""
+
+    user_id = str(getattr(cycle, "user_id", "") or "") or None
+    org_id = str(getattr(cycle, "org_id", "") or "") or None
+    model = str(getattr(cycle, "model_override", None) or "").strip()
+    if not model:
+        model = await async_get_default_model(
+            session,
+            include_provider_prefix=True,
+            user_id=user_id,
+            org_id=org_id,
+        )
+    # Preserve the scheduled-Cycle policy added in #274: it preflights OpenAI
+    # refreshable auth only. Provider-neutral admission callers such as
+    # spawn_worker use async_preflight_run_external_auth directly.
+    provider = infer_provider_from_model(model)
+    if provider != "openai":
+        return CycleAuthPreflightResult(
+            status="skipped",
+            provider=provider,
+            model=model,
+        )
+    return await async_preflight_run_external_auth(
+        session,
+        user_id=user_id,
+        org_id=org_id,
+        model=model,
+        subject="Scheduled Cycle",
+    )
+
+
+__all__ = [
+    "CycleAuthPreflightResult",
+    "async_preflight_cycle_external_auth",
+    "async_preflight_run_external_auth",
+]

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -1,146 +1,48 @@
-"""Cheap provider-auth checks shared by Cycle and worker admission."""
+"""Scheduled-Cycle adapter for neutral provider credential probing."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.integrations.llm import async_resolve_llm_client
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPreflightResult,
+    async_probe_provider_auth,
+    skipped_provider_auth_preflight,
+)
 from brain.platform.providers.model_policy import (
     async_get_default_model,
     infer_provider_from_model,
-    required_openai_auth_mode,
 )
 
 
-@dataclass(frozen=True)
-class CycleAuthPreflightResult:
-    status: str
-    provider: str | None = None
-    model: str | None = None
-    credential: str | None = None
-    error_code: str | None = None
-    repair_action: str | None = None
-    visible_message: str | None = None
-
-    @property
-    def blocked(self) -> bool:
-        return self.status == "auth_blocked"
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "status": self.status,
-            "provider": self.provider,
-            "model": self.model,
-            "credential": self.credential,
-            "error_code": self.error_code,
-            "repair_action": self.repair_action,
-            "visible_message": self.visible_message,
-        }
-
-
-def _normalize_model(model: str) -> str:
-    value = str(model or "").strip()
-    for prefix in ("anthropic/", "openai/", "anthropic:", "openai:"):
-        if value.startswith(prefix):
-            return value[len(prefix):]
-    return value
-
-
-def _credential_label(model: str, auth_mode: str | None, error_text: str = "") -> str:
-    normalized_model = _normalize_model(model).lower()
-    normalized_error = error_text.lower()
-    if model.startswith(("anthropic/", "anthropic:")):
-        return "Anthropic API key"
-    if auth_mode == "chatgpt" or "codex" in normalized_model or "codex" in normalized_error:
-        return "OpenAI Codex / ChatGPT"
-    return "OpenAI runtime"
-
-
-def _blocked_message(credential: str, *, subject: str) -> tuple[str, str]:
-    if subject == "Scheduled Cycle":
-        repair_action = (
-            "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
-            "then rerun the Cycle or wait for its next scheduled run."
-        )
-        return (
-            repair_action,
-            f"Scheduled Cycle auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
-        )
-    if credential == "Anthropic API key":
-        repair_action = (
-            "Add an Anthropic API key in Settings > Access, then retry the run."
-        )
-        return (
-            repair_action,
-            f"{subject} auth blocked: the {credential} is not configured. {repair_action}",
-        )
-    if credential == "OpenAI runtime":
-        repair_action = (
-            "Add an OpenAI API key in Settings > Access, then retry the run."
-        )
-        return (
-            repair_action,
-            f"{subject} auth blocked: the {credential} credential is unavailable. {repair_action}",
-        )
+def _with_cycle_presentation(
+    result: ProviderAuthPreflightResult,
+) -> ProviderAuthPreflightResult:
+    if not result.blocked:
+        return result
     repair_action = (
         "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
-        "then retry the run."
+        "then rerun the Cycle or wait for its next scheduled run."
     )
-    return (
-        repair_action,
-        f"{subject} auth blocked: the {credential} credential is unavailable or could not be refreshed. {repair_action}",
+    credential = result.credential or "OpenAI"
+    return result.with_presentation(
+        repair_action=repair_action,
+        visible_message=(
+            "Scheduled Cycle auth blocked: the "
+            f"{credential} credential is unavailable or could not be refreshed. "
+            f"{repair_action}"
+        ),
     )
-
-
-async def async_preflight_run_external_auth(
-    session: AsyncSession,
-    *,
-    user_id: str | None,
-    org_id: str | None,
-    model: str,
-    subject: str,
-) -> CycleAuthPreflightResult:
-    """Validate a resolved run route before it consumes an agent slot."""
-    provider = infer_provider_from_model(model)
-    if provider not in {"anthropic", "openai"}:
-        return CycleAuthPreflightResult(status="skipped", provider=provider, model=model)
-
-    auth_mode = required_openai_auth_mode(model) if provider == "openai" else None
-    try:
-        await async_resolve_llm_client(
-            user_id=user_id,
-            org_id=org_id,
-            provider=provider,
-            auth_mode=auth_mode,
-            session=session,
-        )
-    except Exception as exc:
-        credential = _credential_label(model, auth_mode, str(exc))
-        repair_action, visible_message = _blocked_message(
-            credential,
-            subject=subject,
-        )
-        return CycleAuthPreflightResult(
-            status="auth_blocked",
-            provider=provider,
-            model=model,
-            credential=credential,
-            error_code="provider_credential_unavailable",
-            repair_action=repair_action,
-            visible_message=visible_message,
-        )
-
-    return CycleAuthPreflightResult(status="passed", provider=provider, model=model)
 
 
 async def async_preflight_cycle_external_auth(
     session: AsyncSession,
     *,
     cycle: Any,
-) -> CycleAuthPreflightResult:
-    """Validate required external auth before admitting the full Cycle agent."""
+) -> ProviderAuthPreflightResult:
+    """Apply the Cycle's OpenAI-only probe and scheduled-run wording."""
 
     user_id = str(getattr(cycle, "user_id", "") or "") or None
     org_id = str(getattr(cycle, "org_id", "") or "") or None
@@ -152,27 +54,21 @@ async def async_preflight_cycle_external_auth(
             user_id=user_id,
             org_id=org_id,
         )
-    # Preserve the scheduled-Cycle policy added in #274: it preflights OpenAI
-    # refreshable auth only. Provider-neutral admission callers such as
-    # spawn_worker use async_preflight_run_external_auth directly.
+
     provider = infer_provider_from_model(model)
     if provider != "openai":
-        return CycleAuthPreflightResult(
-            status="skipped",
+        return skipped_provider_auth_preflight(
             provider=provider,
             model=model,
         )
-    return await async_preflight_run_external_auth(
+    result = await async_probe_provider_auth(
         session,
         user_id=user_id,
         org_id=org_id,
+        provider=provider,
         model=model,
-        subject="Scheduled Cycle",
     )
+    return _with_cycle_presentation(result)
 
 
-__all__ = [
-    "CycleAuthPreflightResult",
-    "async_preflight_cycle_external_auth",
-    "async_preflight_run_external_auth",
-]
+__all__ = ["async_preflight_cycle_external_auth"]

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -8,12 +8,14 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPreflightResult,
+)
 from brain.platform.providers.model_policy import EFFORT_TIER_SET, normalize_model_name
 from brain.systems.cortex.events import publish
 from brain.systems.cortex.thought_lifecycle import ThreadMessageCommand, post_thread_message
 from brain.systems.cycles.status import CYCLE_RUN_ACTIVE_STATUSES, CYCLE_RUN_TERMINAL_STATUSES
 from brain.systems.cycles.auth_preflight import (
-    CycleAuthPreflightResult,
     async_preflight_cycle_external_auth,
 )
 from brain.systems.cycles.common import (
@@ -256,7 +258,7 @@ async def _async_append_cycle_auth_blocked_thread_message(
     idea: Idea,
     cycle: Cycle,
     cycle_run: CycleRun,
-    preflight: CycleAuthPreflightResult,
+    preflight: ProviderAuthPreflightResult,
 ) -> tuple[dict, dict | None]:
     metadata = {
         "source": "cycle",

--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -17,7 +17,12 @@ from brain.platform.db.models.agent_run import (
     AgentRunRow,
 )
 from brain.systems.runs.domain import ArtifactType
+from brain.systems.runs.evidence_health import (
+    evidence_health_for_completed_fanout,
+    record_parent_evidence_failures,
+)
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failures import safe_terminal_run_message
 from brain.systems.runs.status import TERMINAL_RUN_STATUSES, RunStatus, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.work_intake import (
@@ -64,14 +69,27 @@ async def queue_chantier_continuation_for_terminal_run(
     if anchor_id is None:
         return None
     anchor = await _lock_run(session, anchor_id)
-    if anchor is None or coerce_run_status(anchor.status) not in TERMINAL_RUN_STATUSES:
+    if anchor is None:
         return None
 
     workers = await _spawned_workers(session, anchor.id)
-    if not workers or any(
+    if not workers:
+        return None
+    anchor_terminal = (
+        coerce_run_status(anchor.status) in TERMINAL_RUN_STATUSES
+    )
+    all_workers_terminal = not any(
         coerce_run_status(worker.status) not in TERMINAL_RUN_STATUSES
         for worker in workers
-    ):
+    )
+    await _record_fanout_evidence_health(
+        session,
+        anchor=anchor,
+        workers=workers,
+        anchor_terminal=anchor_terminal,
+        all_workers_terminal=all_workers_terminal,
+    )
+    if not anchor_terminal or not all_workers_terminal:
         return None
 
     store = AsyncAgentRunStore(session)
@@ -88,6 +106,7 @@ async def queue_chantier_continuation_for_terminal_run(
         )
 
     child_results = await _child_results(session, workers)
+    evidence_health = _anchor_evidence_health(anchor)
     idempotency_key = f"chantier:continuation:{anchor.id}"
     target = _continuation_target(scope.source_run, scope=scope, fanout_run_id=anchor.id)
     admission = await admit_work(
@@ -108,6 +127,7 @@ async def queue_chantier_continuation_for_terminal_run(
                     scope=scope,
                     fanout_run_id=anchor.id,
                     child_results=child_results,
+                    evidence_health=evidence_health,
                 ),
                 "workspace_ref": dict(scope.source_run.workspace_ref or {}),
                 "metadata": _continuation_metadata(
@@ -115,6 +135,7 @@ async def queue_chantier_continuation_for_terminal_run(
                     scope=scope,
                     fanout_run_id=anchor.id,
                     worker_ids=[int(worker.id) for worker in workers],
+                    evidence_health=evidence_health,
                 ),
             },
             policy={
@@ -161,6 +182,7 @@ async def _queue_generic_continuation(
         return await _existing_generic_continuation_run_id(session, anchor.id)
 
     child_results = await _child_results(session, workers)
+    evidence_health = _anchor_evidence_health(anchor)
     idempotency_key = f"worker:continuation:{anchor.id}"
     admission = await admit_work(
         session,
@@ -179,12 +201,14 @@ async def _queue_generic_continuation(
                 "message": _generic_continuation_message(
                     anchor=anchor,
                     child_results=child_results,
+                    evidence_health=evidence_health,
                 ),
                 "workspace_ref": dict(anchor.workspace_ref or {}),
                 "model_policy": dict(anchor.model_policy or {}),
                 "metadata": _generic_continuation_metadata(
                     anchor,
                     worker_ids=[int(worker.id) for worker in workers],
+                    evidence_health=evidence_health,
                 ),
             },
             policy={
@@ -270,6 +294,113 @@ def _wants_generic_continuation(workers: list[AgentRunRow]) -> bool:
         is True
         for worker in workers
     )
+
+
+def _anchor_evidence_health(anchor: AgentRunRow) -> dict[str, Any]:
+    metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
+    health = metadata.get("evidence_health")
+    return dict(health) if isinstance(health, dict) else {}
+
+
+def _worker_shard(worker: AgentRunRow) -> str:
+    metadata = worker.metadata_ if isinstance(worker.metadata_, dict) else {}
+    assignment = (
+        metadata.get("worker_assignment")
+        if isinstance(metadata.get("worker_assignment"), dict)
+        else {}
+    )
+    assignment_metadata = (
+        assignment.get("metadata")
+        if isinstance(assignment.get("metadata"), dict)
+        else {}
+    )
+    for source in (metadata, assignment_metadata, assignment):
+        for key in (
+            "worker_shard",
+            "shard",
+            "repo",
+            "source",
+            "resource_id",
+        ):
+            value = str(source.get(key) or "").strip()
+            if value:
+                return value
+    allowed_resources = assignment.get("allowed_resources")
+    if isinstance(allowed_resources, list) and len(allowed_resources) == 1:
+        value = str(allowed_resources[0] or "").strip()
+        if value:
+            return value
+    return (
+        str(assignment.get("id") or metadata.get("parent_node_id") or "").strip()
+        or str(metadata.get("worker_role") or f"worker-{worker.id}").strip()
+    )
+
+
+def _terminal_worker_failure(worker: AgentRunRow) -> dict[str, Any] | None:
+    status = coerce_run_status(worker.status)
+    if status == RunStatus.COMPLETED or status not in TERMINAL_RUN_STATUSES:
+        return None
+    metadata = worker.metadata_ if isinstance(worker.metadata_, dict) else {}
+    failure_metadata = (
+        metadata.get("failure")
+        if isinstance(metadata.get("failure"), dict)
+        else {}
+    )
+    category = str(failure_metadata.get("category") or "").strip() or None
+    shard = _worker_shard(worker)
+    failure: dict[str, Any] = {
+        "kind": "worker_tool_failure",
+        "tool": "spawn_worker",
+        "child_run_id": int(worker.id),
+        "worker_run_id": int(worker.id),
+        "worker_role": str(metadata.get("worker_role") or "worker"),
+        "shard": shard,
+        "stage": "worker_execution",
+        "status": status.value,
+        "error": safe_terminal_run_message(status, category),
+    }
+    if category:
+        failure["failure_category"] = category
+    return failure
+
+
+async def _record_fanout_evidence_health(
+    session: AsyncSession,
+    *,
+    anchor: AgentRunRow,
+    workers: list[AgentRunRow],
+    anchor_terminal: bool,
+    all_workers_terminal: bool,
+) -> None:
+    existing_health = _anchor_evidence_health(anchor)
+    already_recorded_worker_ids = {
+        int(item.get("worker_run_id") or item.get("child_run_id"))
+        for item in existing_health.get("failures") or []
+        if isinstance(item, dict)
+        and str(item.get("worker_run_id") or item.get("child_run_id") or "").isdigit()
+    }
+    failures = [
+        failure
+        for worker in workers
+        if int(worker.id) not in already_recorded_worker_ids
+        and (failure := _terminal_worker_failure(worker)) is not None
+    ]
+    if failures:
+        await record_parent_evidence_failures(
+            session,
+            parent=anchor,
+            failures=failures,
+        )
+        return
+    if not anchor_terminal or not all_workers_terminal:
+        return
+    metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
+    next_metadata = dict(metadata)
+    next_metadata["evidence_health"] = evidence_health_for_completed_fanout(
+        metadata.get("evidence_health"),
+        worker_shards=[_worker_shard(worker) for worker in workers],
+    )
+    anchor.metadata_ = next_metadata
 
 
 async def _resolve_chantier_scope(
@@ -365,10 +496,12 @@ def _continuation_metadata(
     scope: ChantierScope,
     fanout_run_id: int,
     worker_ids: list[int],
+    evidence_health: dict[str, Any],
 ) -> dict[str, Any]:
     source_metadata = source_run.metadata_ if isinstance(source_run.metadata_, dict) else {}
     metadata: dict[str, Any] = {
         "execution_profile": source_run.profile,
+        "evidence_health": dict(evidence_health),
         "chantier_continuation": {
             "record_id": scope.record_id,
             "domain_id": scope.domain_id,
@@ -408,10 +541,12 @@ def _generic_continuation_metadata(
     anchor: AgentRunRow,
     *,
     worker_ids: list[int],
+    evidence_health: dict[str, Any],
 ) -> dict[str, Any]:
     source_metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
     metadata: dict[str, Any] = {
         "execution_profile": anchor.profile,
+        "evidence_health": dict(evidence_health),
         "worker_continuation": {
             "anchor_run_id": int(anchor.id),
             "anchor_thread_id": anchor.thread_id,
@@ -504,6 +639,7 @@ def _continuation_message(
     scope: ChantierScope,
     fanout_run_id: int,
     child_results: list[dict[str, Any]],
+    evidence_health: dict[str, Any],
 ) -> str:
     lines = [
         "Automated chantier continuation: the worker fan-out has reached its terminal barrier.",
@@ -513,6 +649,7 @@ def _continuation_message(
         f"Anchor thread: {scope.source_run.thread_id}",
         f"Completed fan-out run: {fanout_run_id}",
         "",
+        *_evidence_health_message_lines(evidence_health),
         "Consume every durable worker result below. Fold the evidence into the chantier record "
         "and continue the loop: decide the next step, ask any genuinely blocking questions on "
         "the anchor surface, and delegate distinct follow-up work when warranted. Do not wait "
@@ -533,6 +670,7 @@ def _generic_continuation_message(
     *,
     anchor: AgentRunRow,
     child_results: list[dict[str, Any]],
+    evidence_health: dict[str, Any],
 ) -> str:
     lines = [
         "Automated worker continuation: the worker fan-out has reached its terminal barrier.",
@@ -541,6 +679,7 @@ def _generic_continuation_message(
         f"Anchor thread: {anchor.thread_id}",
         f"Completed fan-out run: {anchor.id}",
         "",
+        *_evidence_health_message_lines(evidence_health),
         "Consume every durable worker result below. Synthesize their evidence, continue the "
         "parent thread's work, and decide the next step. Ask genuinely blocking questions on "
         "the parent surface when needed. Do not wait for a human nudge merely because the "
@@ -555,6 +694,24 @@ def _generic_continuation_message(
             ]
         )
     return "\n".join(lines)
+
+
+def _evidence_health_message_lines(
+    evidence_health: Mapping[str, Any],
+) -> list[str]:
+    if evidence_health.get("status") != "degraded":
+        return ["Evidence health: ok; every spawned worker shard completed.", ""]
+    missing_shards = [
+        str(shard).strip()
+        for shard in evidence_health.get("missing_shards") or []
+        if str(shard).strip()
+    ]
+    named = ", ".join(missing_shards) or "unknown worker shard"
+    return [
+        f"Evidence health: degraded; missing worker shard(s): {named}.",
+        "Do not report a normal sweep or infer absence from those missing shards.",
+        "",
+    ]
 
 
 async def _existing_continuation_run_id(

--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -18,12 +18,12 @@ from brain.platform.db.models.agent_run import (
 )
 from brain.systems.runs.domain import ArtifactType
 from brain.systems.runs.evidence_health import (
-    evidence_health_for_completed_fanout,
-    record_parent_evidence_failures,
+    WorkerEvidenceReceipt,
+    record_terminal_worker_evidence,
+    worker_evidence_receipt_for_run,
 )
 from brain.systems.runs.events import run_event
-from brain.systems.runs.failures import safe_terminal_run_message
-from brain.systems.runs.status import TERMINAL_RUN_STATUSES, RunStatus, coerce_run_status
+from brain.systems.runs.status import TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.work_intake import (
     AGENT_RUN_CONTINUATION_TARGET,
@@ -106,7 +106,8 @@ async def queue_chantier_continuation_for_terminal_run(
         )
 
     child_results = await _child_results(session, workers)
-    evidence_health = _anchor_evidence_health(anchor)
+    evidence_receipt = worker_evidence_receipt_for_run(anchor)
+    evidence_health = evidence_receipt.to_payload()
     idempotency_key = f"chantier:continuation:{anchor.id}"
     target = _continuation_target(scope.source_run, scope=scope, fanout_run_id=anchor.id)
     admission = await admit_work(
@@ -127,7 +128,7 @@ async def queue_chantier_continuation_for_terminal_run(
                     scope=scope,
                     fanout_run_id=anchor.id,
                     child_results=child_results,
-                    evidence_health=evidence_health,
+                    evidence_receipt=evidence_receipt,
                 ),
                 "workspace_ref": dict(scope.source_run.workspace_ref or {}),
                 "metadata": _continuation_metadata(
@@ -182,7 +183,8 @@ async def _queue_generic_continuation(
         return await _existing_generic_continuation_run_id(session, anchor.id)
 
     child_results = await _child_results(session, workers)
-    evidence_health = _anchor_evidence_health(anchor)
+    evidence_receipt = worker_evidence_receipt_for_run(anchor)
+    evidence_health = evidence_receipt.to_payload()
     idempotency_key = f"worker:continuation:{anchor.id}"
     admission = await admit_work(
         session,
@@ -201,7 +203,7 @@ async def _queue_generic_continuation(
                 "message": _generic_continuation_message(
                     anchor=anchor,
                     child_results=child_results,
-                    evidence_health=evidence_health,
+                    evidence_receipt=evidence_receipt,
                 ),
                 "workspace_ref": dict(anchor.workspace_ref or {}),
                 "model_policy": dict(anchor.model_policy or {}),
@@ -296,74 +298,6 @@ def _wants_generic_continuation(workers: list[AgentRunRow]) -> bool:
     )
 
 
-def _anchor_evidence_health(anchor: AgentRunRow) -> dict[str, Any]:
-    metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
-    health = metadata.get("evidence_health")
-    return dict(health) if isinstance(health, dict) else {}
-
-
-def _worker_shard(worker: AgentRunRow) -> str:
-    metadata = worker.metadata_ if isinstance(worker.metadata_, dict) else {}
-    assignment = (
-        metadata.get("worker_assignment")
-        if isinstance(metadata.get("worker_assignment"), dict)
-        else {}
-    )
-    assignment_metadata = (
-        assignment.get("metadata")
-        if isinstance(assignment.get("metadata"), dict)
-        else {}
-    )
-    for source in (metadata, assignment_metadata, assignment):
-        for key in (
-            "worker_shard",
-            "shard",
-            "repo",
-            "source",
-            "resource_id",
-        ):
-            value = str(source.get(key) or "").strip()
-            if value:
-                return value
-    allowed_resources = assignment.get("allowed_resources")
-    if isinstance(allowed_resources, list) and len(allowed_resources) == 1:
-        value = str(allowed_resources[0] or "").strip()
-        if value:
-            return value
-    return (
-        str(assignment.get("id") or metadata.get("parent_node_id") or "").strip()
-        or str(metadata.get("worker_role") or f"worker-{worker.id}").strip()
-    )
-
-
-def _terminal_worker_failure(worker: AgentRunRow) -> dict[str, Any] | None:
-    status = coerce_run_status(worker.status)
-    if status == RunStatus.COMPLETED or status not in TERMINAL_RUN_STATUSES:
-        return None
-    metadata = worker.metadata_ if isinstance(worker.metadata_, dict) else {}
-    failure_metadata = (
-        metadata.get("failure")
-        if isinstance(metadata.get("failure"), dict)
-        else {}
-    )
-    category = str(failure_metadata.get("category") or "").strip() or None
-    shard = _worker_shard(worker)
-    failure: dict[str, Any] = {
-        "kind": "worker_tool_failure",
-        "tool": "spawn_worker",
-        "child_run_id": int(worker.id),
-        "worker_run_id": int(worker.id),
-        "worker_role": str(metadata.get("worker_role") or "worker"),
-        "shard": shard,
-        "stage": "worker_execution",
-        "status": status.value,
-        "error": safe_terminal_run_message(status, category),
-    }
-    if category:
-        failure["failure_category"] = category
-    return failure
-
-
 async def _record_fanout_evidence_health(
     session: AsyncSession,
     *,
@@ -372,35 +306,12 @@ async def _record_fanout_evidence_health(
     anchor_terminal: bool,
     all_workers_terminal: bool,
 ) -> None:
-    existing_health = _anchor_evidence_health(anchor)
-    already_recorded_worker_ids = {
-        int(item.get("worker_run_id") or item.get("child_run_id"))
-        for item in existing_health.get("failures") or []
-        if isinstance(item, dict)
-        and str(item.get("worker_run_id") or item.get("child_run_id") or "").isdigit()
-    }
-    failures = [
-        failure
-        for worker in workers
-        if int(worker.id) not in already_recorded_worker_ids
-        and (failure := _terminal_worker_failure(worker)) is not None
-    ]
-    if failures:
-        await record_parent_evidence_failures(
-            session,
-            parent=anchor,
-            failures=failures,
-        )
-        return
-    if not anchor_terminal or not all_workers_terminal:
-        return
-    metadata = anchor.metadata_ if isinstance(anchor.metadata_, dict) else {}
-    next_metadata = dict(metadata)
-    next_metadata["evidence_health"] = evidence_health_for_completed_fanout(
-        metadata.get("evidence_health"),
-        worker_shards=[_worker_shard(worker) for worker in workers],
+    await record_terminal_worker_evidence(
+        session,
+        parent_run_id=int(anchor.id),
+        workers=workers,
+        fanout_complete=anchor_terminal and all_workers_terminal,
     )
-    anchor.metadata_ = next_metadata
 
 
 async def _resolve_chantier_scope(
@@ -639,7 +550,7 @@ def _continuation_message(
     scope: ChantierScope,
     fanout_run_id: int,
     child_results: list[dict[str, Any]],
-    evidence_health: dict[str, Any],
+    evidence_receipt: WorkerEvidenceReceipt,
 ) -> str:
     lines = [
         "Automated chantier continuation: the worker fan-out has reached its terminal barrier.",
@@ -649,7 +560,7 @@ def _continuation_message(
         f"Anchor thread: {scope.source_run.thread_id}",
         f"Completed fan-out run: {fanout_run_id}",
         "",
-        *_evidence_health_message_lines(evidence_health),
+        *_evidence_health_message_lines(evidence_receipt),
         "Consume every durable worker result below. Fold the evidence into the chantier record "
         "and continue the loop: decide the next step, ask any genuinely blocking questions on "
         "the anchor surface, and delegate distinct follow-up work when warranted. Do not wait "
@@ -670,7 +581,7 @@ def _generic_continuation_message(
     *,
     anchor: AgentRunRow,
     child_results: list[dict[str, Any]],
-    evidence_health: dict[str, Any],
+    evidence_receipt: WorkerEvidenceReceipt,
 ) -> str:
     lines = [
         "Automated worker continuation: the worker fan-out has reached its terminal barrier.",
@@ -679,7 +590,7 @@ def _generic_continuation_message(
         f"Anchor thread: {anchor.thread_id}",
         f"Completed fan-out run: {anchor.id}",
         "",
-        *_evidence_health_message_lines(evidence_health),
+        *_evidence_health_message_lines(evidence_receipt),
         "Consume every durable worker result below. Synthesize their evidence, continue the "
         "parent thread's work, and decide the next step. Ask genuinely blocking questions on "
         "the parent surface when needed. Do not wait for a human nudge merely because the "
@@ -697,16 +608,11 @@ def _generic_continuation_message(
 
 
 def _evidence_health_message_lines(
-    evidence_health: Mapping[str, Any],
+    evidence_receipt: WorkerEvidenceReceipt,
 ) -> list[str]:
-    if evidence_health.get("status") != "degraded":
+    if not evidence_receipt.degraded:
         return ["Evidence health: ok; every spawned worker shard completed.", ""]
-    missing_shards = [
-        str(shard).strip()
-        for shard in evidence_health.get("missing_shards") or []
-        if str(shard).strip()
-    ]
-    named = ", ".join(missing_shards) or "unknown worker shard"
+    named = ", ".join(evidence_receipt.missing_shards) or "unknown worker shard"
     return [
         f"Evidence health: degraded; missing worker shard(s): {named}.",
         "Do not report a normal sweep or infer absence from those missing shards.",

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -23,6 +23,7 @@ from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
 from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.evidence_health import record_parent_evidence_failures
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
 from brain.systems.runs.failures import (
@@ -797,29 +798,6 @@ def _run_has_project_context(run: AgentRunRow | None) -> bool:
     return False
 
 
-def _evidence_health_with_failure(
-    evidence_health: Any,
-    failure: dict[str, Any],
-) -> tuple[dict[str, Any], bool]:
-    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
-    failures = [dict(item) for item in health.get("failures") or [] if isinstance(item, dict)]
-    identity = (
-        failure.get("worker_run_id"),
-        failure.get("repo"),
-        failure.get("stage"),
-    )
-    added = not any(
-        (item.get("worker_run_id"), item.get("repo"), item.get("stage")) == identity
-        for item in failures
-    )
-    if added:
-        failures.append(dict(failure))
-    health["status"] = "degraded"
-    health["failures"] = failures[:20]
-    health["failure_count"] = len(failures)
-    return health, added
-
-
 def _spawned_worker_materialization_failures(
     run: AgentRunRow,
     result: Any,
@@ -901,52 +879,11 @@ async def _record_spawned_worker_materialization_failure(
     )
     if parent is None:
         return
-    parent_metadata = (
-        dict(parent.metadata_ or {}) if isinstance(parent.metadata_, dict) else {}
+    await record_parent_evidence_failures(
+        session,
+        parent=parent,
+        failures=failures,
     )
-    added_failures: list[dict[str, Any]] = []
-    for failure in failures:
-        health, added = _evidence_health_with_failure(parent_metadata.get("evidence_health"), failure)
-        parent_metadata["evidence_health"] = health
-        if added:
-            added_failures.append(failure)
-    parent.metadata_ = parent_metadata
-
-    cycle_run_id = (
-        parent_metadata.get("cycle_run_id")
-        if parent_metadata.get("source") == "cycle"
-        else None
-    )
-    if cycle_run_id:
-        try:
-            from brain.platform.db.models.cycle import CycleRun
-
-            cycle_run = await session.get(
-                CycleRun,
-                int(cycle_run_id),
-                with_for_update=True,
-            )
-        except (TypeError, ValueError):
-            cycle_run = None
-        if cycle_run is not None:
-            context_snapshot = dict(cycle_run.context_snapshot or {})
-            cycle_health = context_snapshot.get("evidence_health")
-            for failure in failures:
-                cycle_health, _ = _evidence_health_with_failure(cycle_health, failure)
-            context_snapshot["evidence_health"] = cycle_health
-            cycle_run.context_snapshot = context_snapshot
-
-    store = AsyncAgentRunStore(session, auto_commit=True)
-    for failure in added_failures:
-        await store.append_event(
-            run_event(
-                int(parent.id),
-                "run.worker_failed",
-                failure,
-                root_run_id=parent.root_run_id or parent.id,
-                producer="spawn_worker",
-            )
-        )
 
 
 def _project_context_root(run_id: int, *, thread_id: str | None = None) -> str:
@@ -1426,6 +1363,14 @@ async def _mark_run_failed_after_runner_error_async(
                 )
             )
             await store.set_status(int(run_id), RunStatus.FAILED, reason=error[:500])
+            from brain.systems.runs.chantier_continuation import (
+                queue_worker_continuation_for_terminal_run,
+            )
+
+            await queue_worker_continuation_for_terminal_run(
+                uow.session,
+                terminal_run_id=int(run_id),
+            )
         return await _settle_terminal_root_run_async(uow.session, int(run_id))
 
 

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -23,7 +23,10 @@ from brain.kernel import config as brain_config
 from brain.contracts.statuses import ACTIVE_RUN_STATUS_VALUES, PROCESSING_RUN_STATUS_VALUES
 from brain.systems.cortex.status import PROTECTED_IDEA_STATUSES
 from brain.systems.runs.engine import AsyncAgentRunEngine
-from brain.systems.runs.evidence_health import record_parent_evidence_failures
+from brain.systems.runs.evidence_health import (
+    materialization_failures_for_worker,
+    record_parent_evidence_failures,
+)
 from brain.systems.runs.events import activity_event, run_event
 from brain.systems.runs.execution_failure import RunExecutionFailure
 from brain.systems.runs.failures import (
@@ -798,90 +801,18 @@ def _run_has_project_context(run: AgentRunRow | None) -> bool:
     return False
 
 
-def _spawned_worker_materialization_failures(
-    run: AgentRunRow,
-    result: Any,
-) -> list[dict[str, Any]]:
-    raw_metadata = getattr(run, "metadata_", None)
-    metadata = dict(raw_metadata or {}) if isinstance(raw_metadata, dict) else {}
-    parent_run_id = getattr(run, "parent_run_id", None)
-    if parent_run_id is None or not (
-        metadata.get("spawned_by_tool") is True or metadata.get("origin") == "spawn_worker"
-    ):
-        return []
-
-    errors = [
-        str(item)
-        for item in [
-            *(getattr(result, "errors", []) or []),
-            *(getattr(result, "warnings", []) or []),
-        ]
-        if str(item).strip()
-    ]
-    failed_resources = [
-        dict(item)
-        for item in [
-            *(getattr(result, "failed_resources", []) or []),
-            *(getattr(result, "degraded_resources", []) or []),
-        ]
-        if isinstance(item, dict)
-    ]
-    if not failed_resources:
-        raw_target_ref = getattr(run, "target_ref", None)
-        target_ref = raw_target_ref if isinstance(raw_target_ref, dict) else {}
-        snapshot = target_ref.get("project_context_snapshot")
-        resources = snapshot.get("resources") if isinstance(snapshot, dict) else []
-        failed_resources = [dict(item) for item in resources or [] if isinstance(item, dict)][:1]
-    if not failed_resources:
-        failed_resources = [{}]
-
-    failures: list[dict[str, Any]] = []
-    for index, resource in enumerate(failed_resources):
-        repo = (
-            str(resource.get("repo") or resource.get("name") or "unknown").strip()
-            or "unknown"
-        )
-        if index < len(errors):
-            fallback_error = errors[index]
-        elif errors:
-            fallback_error = errors[0]
-        else:
-            fallback_error = "Project Context materialization failed."
-        error = str(resource.get("error") or fallback_error)
-        failures.append(
-            {
-                "kind": "worker_tool_failure",
-                "tool": "spawn_worker",
-                "child_run_id": int(run.id),
-                "worker_run_id": int(run.id),
-                "worker_role": str(metadata.get("worker_role") or "worker"),
-                "repo": repo,
-                "stage": "project_context_materialization",
-                "error": error,
-            }
-        )
-    return failures
-
-
 async def _record_spawned_worker_materialization_failure(
     session: Any,
     run: AgentRunRow,
     result: Any,
 ) -> None:
-    failures = _spawned_worker_materialization_failures(run, result)
+    failures = materialization_failures_for_worker(run, result)
     if not failures or run.parent_run_id is None:
         return
 
-    parent = await session.get(
-        AgentRunRow,
-        int(run.parent_run_id),
-        with_for_update=True,
-    )
-    if parent is None:
-        return
     await record_parent_evidence_failures(
         session,
-        parent=parent,
+        parent_run_id=int(run.parent_run_id),
         failures=failures,
     )
 

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -43,7 +43,6 @@ from brain.platform.async_io import run_blocking
 from brain.platform.integrations.providers import get_provider
 from brain.platform.integrations.providers import ContentBlockType, LLMRequest, MessageRole, StopReason
 from brain.platform.integrations.provider_error_sentinel import (
-    provider_error_kind,
     safe_provider_error_sentinel,
 )
 from brain.platform.providers.model_policy import (
@@ -90,6 +89,7 @@ from brain.systems.runs.direct_loop.context_recovery import (
 )
 from brain.systems.runs.direct_loop.retry import (
     async_api_call_with_retry as _runtime_async_api_call_with_retry,
+    response_text_retry_decision,
 )
 from brain.systems.runs.direct_loop.model_fallback import (
     fallback_model_for,
@@ -122,11 +122,7 @@ from brain.systems.runs.routing_metadata import (
     effective_routing_snapshot,
     routing_metadata_with_effective,
 )
-from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
-from brain.systems.runs.tool_catalog.registry import (
-    get_tool_registration,
-    parallel_safe_tool_names,
-)
+from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems import sessions as _session_store
 from brain.systems.context.window_policy import (
@@ -1176,35 +1172,6 @@ _API_RETRY_DELAYS = (2, 5, 10)
 _PROVIDER_ERROR_TEXT_RETRY_DELAYS = (1,)
 
 
-def _spawn_worker_provider_text_retry_allowed(
-    metadata: dict[str, Any],
-    *,
-    tool_call_source: str,
-    tool_calls_made: list[str],
-) -> bool:
-    """Retry only spawned workers whose completed tool calls are read-only."""
-
-    provenance = metadata.get("execution_provenance")
-    if not isinstance(provenance, dict):
-        provenance = {}
-    is_spawned_worker = (
-        tool_call_source == "worker"
-        and (
-            provenance.get("spawned_by_tool") is True
-            or str(provenance.get("origin") or "") == "spawn_worker"
-        )
-    )
-    if not is_spawned_worker:
-        return False
-    for tool_name in tool_calls_made:
-        registration = get_tool_registration(tool_name)
-        if registration is None or is_write_side_effect_class(
-            registration.side_effect_class
-        ):
-            return False
-    return True
-
-
 async def _api_call_with_retry_async(
     provider, request: LLMRequest, llm, cancel_event, on_stream_activity, on_stream_delta,
     session_id: str, turn: int, tokens: _TokenAccumulator,
@@ -1683,13 +1650,12 @@ async def run_agent_async(
             overflow_retry_used = False
             provider_error_text_attempt = 0
             detected_provider_error = None
-            retry_provider_error_text = (
-                scheduled_result_contract
-                or _spawn_worker_provider_text_retry_allowed(
-                    metadata,
-                    tool_call_source=tool_call_source,
-                    tool_calls_made=state.tool_calls_made,
-                )
+            response_text_policy = response_text_retry_decision(
+                "",
+                scheduled_result_contract=scheduled_result_contract,
+                metadata=metadata,
+                tool_call_source=tool_call_source,
+                tool_calls_made=state.tool_calls_made,
             )
             while True:
                 try:
@@ -1699,7 +1665,7 @@ async def run_agent_async(
                     visible_stream_delta = on_stream_delta
                     if scheduled_result_contract:
                         visible_stream_delta = None
-                    elif retry_provider_error_text and on_stream_delta:
+                    elif response_text_policy.withhold_stream and on_stream_delta:
                         visible_stream_delta = attempt_deltas.append
                     response = await _api_call_with_retry_async(
                         state.provider, request, llm, cancel_event, on_stream_activity, visible_stream_delta,
@@ -1708,10 +1674,15 @@ async def run_agent_async(
                     response_text = _extract_text(
                         [{"role": "assistant", "content": _content_to_dicts(response.content)}]
                     ).strip()
+                    response_text_decision = response_text_retry_decision(
+                        response_text,
+                        scheduled_result_contract=scheduled_result_contract,
+                        metadata=metadata,
+                        tool_call_source=tool_call_source,
+                        tool_calls_made=state.tool_calls_made,
+                    )
                     detected_provider_error = (
-                        provider_error_kind(response_text)
-                        if retry_provider_error_text
-                        else None
+                        response_text_decision.provider_error_kind
                     )
                     if detected_provider_error:
                         logger.error(
@@ -1724,7 +1695,11 @@ async def run_agent_async(
                             len(_PROVIDER_ERROR_TEXT_RETRY_DELAYS) + 1,
                             response_text,
                         )
-                        if provider_error_text_attempt < len(_PROVIDER_ERROR_TEXT_RETRY_DELAYS):
+                        if (
+                            response_text_decision.should_retry
+                            and provider_error_text_attempt
+                            < len(_PROVIDER_ERROR_TEXT_RETRY_DELAYS)
+                        ):
                             delay = _PROVIDER_ERROR_TEXT_RETRY_DELAYS[provider_error_text_attempt]
                             provider_error_text_attempt += 1
                             if on_stream_activity:

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -122,7 +122,11 @@ from brain.systems.runs.routing_metadata import (
     effective_routing_snapshot,
     routing_metadata_with_effective,
 )
-from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
+from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
+from brain.systems.runs.tool_catalog.registry import (
+    get_tool_registration,
+    parallel_safe_tool_names,
+)
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems import sessions as _session_store
 from brain.systems.context.window_policy import (
@@ -1172,6 +1176,35 @@ _API_RETRY_DELAYS = (2, 5, 10)
 _PROVIDER_ERROR_TEXT_RETRY_DELAYS = (1,)
 
 
+def _spawn_worker_provider_text_retry_allowed(
+    metadata: dict[str, Any],
+    *,
+    tool_call_source: str,
+    tool_calls_made: list[str],
+) -> bool:
+    """Retry only spawned workers whose completed tool calls are read-only."""
+
+    provenance = metadata.get("execution_provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    is_spawned_worker = (
+        tool_call_source == "worker"
+        and (
+            provenance.get("spawned_by_tool") is True
+            or str(provenance.get("origin") or "") == "spawn_worker"
+        )
+    )
+    if not is_spawned_worker:
+        return False
+    for tool_name in tool_calls_made:
+        registration = get_tool_registration(tool_name)
+        if registration is None or is_write_side_effect_class(
+            registration.side_effect_class
+        ):
+            return False
+    return True
+
+
 async def _api_call_with_retry_async(
     provider, request: LLMRequest, llm, cancel_event, on_stream_activity, on_stream_delta,
     session_id: str, turn: int, tokens: _TokenAccumulator,
@@ -1650,11 +1683,24 @@ async def run_agent_async(
             overflow_retry_used = False
             provider_error_text_attempt = 0
             detected_provider_error = None
+            retry_provider_error_text = (
+                scheduled_result_contract
+                or _spawn_worker_provider_text_retry_allowed(
+                    metadata,
+                    tool_call_source=tool_call_source,
+                    tool_calls_made=state.tool_calls_made,
+                )
+            )
             while True:
                 try:
-                    # Scheduled Cycles settle through the contract gate; withholding live text
-                    # deltas keeps an upstream error body from becoming a public interim answer.
-                    visible_stream_delta = None if scheduled_result_contract else on_stream_delta
+                    # Withhold retry-eligible text until the response is classified so
+                    # an upstream error body cannot become a public interim answer.
+                    attempt_deltas: list[str] = []
+                    visible_stream_delta = on_stream_delta
+                    if scheduled_result_contract:
+                        visible_stream_delta = None
+                    elif retry_provider_error_text and on_stream_delta:
+                        visible_stream_delta = attempt_deltas.append
                     response = await _api_call_with_retry_async(
                         state.provider, request, llm, cancel_event, on_stream_activity, visible_stream_delta,
                         session_id, turn, state.tokens, start_time, state.tool_calls_made, _call_start,
@@ -1663,11 +1709,13 @@ async def run_agent_async(
                         [{"role": "assistant", "content": _content_to_dicts(response.content)}]
                     ).strip()
                     detected_provider_error = (
-                        provider_error_kind(response_text) if scheduled_result_contract else None
+                        provider_error_kind(response_text)
+                        if retry_provider_error_text
+                        else None
                     )
                     if detected_provider_error:
                         logger.error(
-                            "Agent %s turn %d: Cycle provider error text blocked "
+                            "Agent %s turn %d: provider error text blocked "
                             "(kind=%s, attempt=%d/%d): %s",
                             session_id,
                             turn,
@@ -1687,6 +1735,9 @@ async def run_agent_async(
                             await asyncio.sleep(max(0.0, float(delay)))
                             _call_start = time.time()
                             continue
+                    elif attempt_deltas and on_stream_delta:
+                        for delta in attempt_deltas:
+                            await _call_optional_async(on_stream_delta, delta)
                     break
                 except Exception as exc:
                     fallback = fallback_model_for(model)

--- a/brain/systems/runs/direct_loop/retry.py
+++ b/brain/systems/runs/direct_loop/retry.py
@@ -6,15 +6,99 @@ import logging
 import threading
 import time
 import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Callable
 
 from brain.platform.integrations.providers import LLMRequest
+from brain.platform.integrations.provider_error_sentinel import provider_error_kind
 from brain.platform.async_io import run_blocking
+from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
+from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 logger = logging.getLogger("agent")
 _MAX_RETRY_AFTER_SECONDS = 60.0
+_RETRYABLE_PROVIDER_ERROR_KINDS = frozenset(
+    {"server_error", "overloaded_error", "rate_limit_error"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ResponseTextRetryDecision:
+    """Classification plus the replay-safety policy for one model response."""
+
+    provider_error_kind: str | None
+    should_retry: bool
+    inspect_response: bool
+    withhold_stream: bool
+    spawned_worker: bool
+    tool_history_safety: str
+
+
+def _spawned_worker_invocation(
+    metadata: Mapping[str, object],
+    *,
+    tool_call_source: str,
+) -> bool:
+    provenance = metadata.get("execution_provenance")
+    if not isinstance(provenance, Mapping):
+        provenance = {}
+    return bool(
+        tool_call_source == "worker"
+        and (
+            provenance.get("spawned_by_tool") is True
+            or str(provenance.get("origin") or "") == "spawn_worker"
+        )
+    )
+
+
+def _tool_history_safety(tool_calls_made: Sequence[str]) -> str:
+    for tool_name in tool_calls_made:
+        registration = get_tool_registration(tool_name)
+        if registration is None:
+            return "unknown"
+        if is_write_side_effect_class(registration.side_effect_class):
+            return "write"
+    return "read_only"
+
+
+def response_text_retry_decision(
+    response_text: str,
+    *,
+    scheduled_result_contract: bool,
+    metadata: Mapping[str, object],
+    tool_call_source: str,
+    tool_calls_made: Sequence[str],
+) -> ResponseTextRetryDecision:
+    """Decide provider-text handling from provenance, history, and text."""
+
+    spawned_worker = _spawned_worker_invocation(
+        metadata,
+        tool_call_source=tool_call_source,
+    )
+    history_safety = _tool_history_safety(tool_calls_made)
+    inspect_response = bool(scheduled_result_contract or spawned_worker)
+    detected_kind = (
+        provider_error_kind(response_text)
+        if inspect_response and str(response_text or "").strip()
+        else None
+    )
+    retry_safe = bool(
+        scheduled_result_contract
+        or (spawned_worker and history_safety == "read_only")
+    )
+    return ResponseTextRetryDecision(
+        provider_error_kind=detected_kind,
+        should_retry=bool(
+            retry_safe and detected_kind in _RETRYABLE_PROVIDER_ERROR_KINDS
+        ),
+        inspect_response=inspect_response,
+        withhold_stream=inspect_response,
+        spawned_worker=spawned_worker,
+        tool_history_safety=history_safety,
+    )
 
 
 class _NeverCancelled:

--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from sqlalchemy import select
+
 from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.cycle import CycleRun
 from brain.systems.runs.events import run_event
@@ -41,11 +43,13 @@ _RECEIPT_PAYLOAD_KEYS = frozenset(
         "status",
         "completeness",
         "failures",
+        "failure_identities",
         "failure_count",
         "missing_shards",
         "worker_shards",
     }
 )
+FailureIdentity = tuple[int | None, str, str, str | None]
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -71,6 +75,21 @@ def _unique_text(values: Sequence[Any]) -> tuple[str, ...]:
             for value in values
             if (normalized := _text(value)) is not None
         )
+    )
+
+
+def _failure_identity(value: Any) -> FailureIdentity | None:
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        return None
+    shard = _text(value[1])
+    stage = _text(value[2])
+    if shard is None or stage is None:
+        return None
+    return (
+        _run_id(value[0]),
+        shard,
+        stage,
+        _text(value[3]),
     )
 
 
@@ -132,7 +151,7 @@ class WorkerEvidenceFailure:
     details: Mapping[str, Any] = field(default_factory=dict)
 
     @property
-    def identity(self) -> tuple[Any, ...]:
+    def identity(self) -> FailureIdentity:
         return (
             self.worker_run_id,
             self.shard,
@@ -244,6 +263,7 @@ class WorkerEvidenceReceipt:
     status: str | None = None
     completeness: str | None = None
     failures: tuple[WorkerEvidenceFailure, ...] = ()
+    failure_identities: tuple[FailureIdentity, ...] = ()
     worker_shards: tuple[str, ...] = ()
     details: Mapping[str, Any] = field(default_factory=dict)
 
@@ -255,10 +275,23 @@ class WorkerEvidenceReceipt:
             for item in source.get("failures") or []
             if isinstance(item, Mapping)
         )
+        stored_identities = tuple(
+            identity
+            for item in source.get("failure_identities") or []
+            if (identity := _failure_identity(item)) is not None
+        )
         return cls(
             status=_text(source.get("status")),
             completeness=_text(source.get("completeness")),
             failures=failures,
+            failure_identities=tuple(
+                dict.fromkeys(
+                    (
+                        *(failure.identity for failure in failures),
+                        *stored_identities,
+                    )
+                )
+            ),
             worker_shards=_unique_text(source.get("worker_shards") or []),
             details={
                 str(key): value
@@ -280,19 +313,29 @@ class WorkerEvidenceReceipt:
         failures: Sequence[WorkerEvidenceFailure],
     ) -> tuple[WorkerEvidenceReceipt, tuple[WorkerEvidenceFailure, ...]]:
         current = list(self.failures)
-        identities = {failure.identity for failure in current}
+        canonical_identities = list(
+            dict.fromkeys(
+                (
+                    *(failure.identity for failure in current),
+                    *self.failure_identities,
+                )
+            )
+        )
+        identities = set(canonical_identities)
         added: list[WorkerEvidenceFailure] = []
         for failure in failures:
             if failure.identity in identities:
                 continue
             identities.add(failure.identity)
+            canonical_identities.append(failure.identity)
             current.append(failure)
             added.append(failure)
         return (
             WorkerEvidenceReceipt(
                 status="degraded",
                 completeness="unavailable",
-                failures=tuple(current[:20]),
+                failures=tuple(current),
+                failure_identities=tuple(canonical_identities),
                 worker_shards=self.worker_shards,
                 details=self.details,
             ),
@@ -306,22 +349,35 @@ class WorkerEvidenceReceipt:
             status="ok",
             completeness="complete",
             failures=self.failures,
+            failure_identities=self.failure_identities,
             worker_shards=_unique_text(worker_shards)[:20],
             details=self.details,
         )
 
     def to_payload(self) -> dict[str, Any]:
         payload = dict(self.details)
+        identities = tuple(
+            dict.fromkeys(
+                (
+                    *(failure.identity for failure in self.failures),
+                    *self.failure_identities,
+                )
+            )
+        )
         if self.status is not None:
             payload["status"] = self.status
         if self.completeness is not None:
             payload["completeness"] = self.completeness
         if self.failures:
             payload["failures"] = [
-                failure.to_payload() for failure in self.failures
+                failure.to_payload() for failure in self.failures[:20]
             ]
-            payload["failure_count"] = len(self.failures)
+            payload["failure_count"] = len(identities)
             payload["missing_shards"] = list(self.missing_shards)
+        if len(identities) > min(len(self.failures), 20):
+            payload["failure_identities"] = [
+                list(identity) for identity in identities
+            ]
         if self.worker_shards:
             payload["worker_shards"] = list(self.worker_shards)
         return payload
@@ -395,11 +451,13 @@ def materialization_failures_for_worker(
 
 
 async def _lock_parent_run(session: Any, parent_run_id: int) -> AgentRunRow | None:
-    return await session.get(
-        AgentRunRow,
-        int(parent_run_id),
-        with_for_update=True,
+    rows = await session.scalars(
+        select(AgentRunRow)
+        .where(AgentRunRow.id == int(parent_run_id))
+        .with_for_update()
+        .execution_options(populate_existing=True)
     )
+    return rows.one_or_none()
 
 
 async def _lock_cycle_run(
@@ -415,11 +473,13 @@ async def _lock_cycle_run(
         normalized_id = int(cycle_run_id)
     except (TypeError, ValueError):
         return None
-    return await session.get(
-        CycleRun,
-        normalized_id,
-        with_for_update=True,
+    rows = await session.scalars(
+        select(CycleRun)
+        .where(CycleRun.id == normalized_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
     )
+    return rows.one_or_none()
 
 
 async def _persist_parent_evidence_receipt(

--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -1,0 +1,139 @@
+"""Shared evidence-health markers for incomplete worker fan-outs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from brain.systems.runs.events import run_event
+from brain.systems.runs.store import AsyncAgentRunStore
+
+
+def evidence_health_with_failure(
+    evidence_health: Any,
+    failure: Mapping[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    """Add one stable missing-evidence marker without duplicating replays."""
+
+    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
+    failures = [
+        dict(item)
+        for item in health.get("failures") or []
+        if isinstance(item, dict)
+    ]
+    identity = _failure_identity(failure)
+    added = not any(_failure_identity(item) == identity for item in failures)
+    if added:
+        failures.append(dict(failure))
+
+    missing_shards = [
+        str(item.get("shard") or item.get("repo") or "").strip()
+        for item in failures
+    ]
+    health["status"] = "degraded"
+    health["completeness"] = "unavailable"
+    health["failures"] = failures[:20]
+    health["failure_count"] = len(failures)
+    health["missing_shards"] = list(dict.fromkeys(filter(None, missing_shards)))[:20]
+    return health, added
+
+
+def evidence_health_for_completed_fanout(
+    evidence_health: Any,
+    *,
+    worker_shards: list[str],
+) -> dict[str, Any]:
+    """Mark a standalone fan-out complete without erasing broader degradation."""
+
+    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
+    if health.get("failures") or health.get("status") == "degraded":
+        return health
+    # A scheduled Cycle owns a broader pending receipt. Worker completion alone
+    # must not claim those other expected checks have completed.
+    if health.get("status") == "pending":
+        return health
+    health["status"] = "ok"
+    health["completeness"] = "complete"
+    health["worker_shards"] = list(dict.fromkeys(filter(None, worker_shards)))[:20]
+    return health
+
+
+async def record_parent_evidence_failures(
+    session: Any,
+    *,
+    parent: Any,
+    failures: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Persist fan-out degradation on the parent and its Cycle receipt."""
+
+    if not failures:
+        return []
+    parent_metadata = (
+        dict(parent.metadata_ or {})
+        if isinstance(getattr(parent, "metadata_", None), dict)
+        else {}
+    )
+    added_failures: list[dict[str, Any]] = []
+    health = parent_metadata.get("evidence_health")
+    for failure in failures:
+        health, added = evidence_health_with_failure(health, failure)
+        if added:
+            added_failures.append(failure)
+    parent_metadata["evidence_health"] = health
+    parent.metadata_ = parent_metadata
+
+    cycle_run_id = (
+        parent_metadata.get("cycle_run_id")
+        if parent_metadata.get("source") == "cycle"
+        else None
+    )
+    if cycle_run_id:
+        try:
+            from brain.platform.db.models.cycle import CycleRun
+
+            cycle_run = await session.get(
+                CycleRun,
+                int(cycle_run_id),
+                with_for_update=True,
+            )
+        except (TypeError, ValueError):
+            cycle_run = None
+        if cycle_run is not None:
+            context_snapshot = dict(cycle_run.context_snapshot or {})
+            cycle_health = context_snapshot.get("evidence_health")
+            for failure in failures:
+                cycle_health, _ = evidence_health_with_failure(
+                    cycle_health,
+                    failure,
+                )
+            context_snapshot["evidence_health"] = cycle_health
+            cycle_run.context_snapshot = context_snapshot
+
+    store = AsyncAgentRunStore(session)
+    for failure in added_failures:
+        await store.append_event(
+            run_event(
+                int(parent.id),
+                "run.worker_failed",
+                failure,
+                root_run_id=parent.root_run_id or parent.id,
+                producer="spawn_worker",
+            )
+        )
+    return added_failures
+
+
+def _failure_identity(failure: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        failure.get("worker_run_id") or failure.get("child_run_id"),
+        failure.get("shard") or failure.get("repo"),
+        failure.get("stage"),
+        failure.get("configuration_error"),
+    )
+
+
+__all__ = [
+    "evidence_health_for_completed_fanout",
+    "evidence_health_with_failure",
+    "record_parent_evidence_failures",
+]

--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -1,139 +1,530 @@
-"""Shared evidence-health markers for incomplete worker fan-outs."""
+"""Worker fan-out evidence receipts and their atomic persistence."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.cycle import CycleRun
 from brain.systems.runs.events import run_event
+from brain.systems.runs.failures import safe_terminal_run_message
+from brain.systems.runs.status import (
+    TERMINAL_RUN_STATUSES,
+    RunStatus,
+    coerce_run_status,
+)
 from brain.systems.runs.store import AsyncAgentRunStore
 
 
-def evidence_health_with_failure(
-    evidence_health: Any,
-    failure: Mapping[str, Any],
-) -> tuple[dict[str, Any], bool]:
-    """Add one stable missing-evidence marker without duplicating replays."""
-
-    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
-    failures = [
-        dict(item)
-        for item in health.get("failures") or []
-        if isinstance(item, dict)
-    ]
-    identity = _failure_identity(failure)
-    added = not any(_failure_identity(item) == identity for item in failures)
-    if added:
-        failures.append(dict(failure))
-
-    missing_shards = [
-        str(item.get("shard") or item.get("repo") or "").strip()
-        for item in failures
-    ]
-    health["status"] = "degraded"
-    health["completeness"] = "unavailable"
-    health["failures"] = failures[:20]
-    health["failure_count"] = len(failures)
-    health["missing_shards"] = list(dict.fromkeys(filter(None, missing_shards)))[:20]
-    return health, added
-
-
-def evidence_health_for_completed_fanout(
-    evidence_health: Any,
-    *,
-    worker_shards: list[str],
-) -> dict[str, Any]:
-    """Mark a standalone fan-out complete without erasing broader degradation."""
-
-    health = dict(evidence_health or {}) if isinstance(evidence_health, dict) else {}
-    if health.get("failures") or health.get("status") == "degraded":
-        return health
-    # A scheduled Cycle owns a broader pending receipt. Worker completion alone
-    # must not claim those other expected checks have completed.
-    if health.get("status") == "pending":
-        return health
-    health["status"] = "ok"
-    health["completeness"] = "complete"
-    health["worker_shards"] = list(dict.fromkeys(filter(None, worker_shards)))[:20]
-    return health
+_FAILURE_PAYLOAD_KEYS = frozenset(
+    {
+        "kind",
+        "tool",
+        "child_run_id",
+        "worker_run_id",
+        "worker_role",
+        "shard",
+        "repo",
+        "stage",
+        "status",
+        "error",
+        "configuration_error",
+        "provider",
+        "credential",
+        "failure_category",
+    }
+)
+_RECEIPT_PAYLOAD_KEYS = frozenset(
+    {
+        "status",
+        "completeness",
+        "failures",
+        "failure_count",
+        "missing_shards",
+        "worker_shards",
+    }
+)
 
 
-async def record_parent_evidence_failures(
-    session: Any,
-    *,
-    parent: Any,
-    failures: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Persist fan-out degradation on the parent and its Cycle receipt."""
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
 
-    if not failures:
-        return []
-    parent_metadata = (
-        dict(parent.metadata_ or {})
-        if isinstance(getattr(parent, "metadata_", None), dict)
-        else {}
+
+def _text(value: Any) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _run_id(value: Any) -> int | None:
+    try:
+        return int(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _unique_text(values: Sequence[Any]) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for value in values
+            if (normalized := _text(value)) is not None
+        )
     )
-    added_failures: list[dict[str, Any]] = []
-    health = parent_metadata.get("evidence_health")
-    for failure in failures:
-        health, added = evidence_health_with_failure(health, failure)
-        if added:
-            added_failures.append(failure)
-    parent_metadata["evidence_health"] = health
-    parent.metadata_ = parent_metadata
 
+
+def worker_evidence_shard(
+    worker: Any,
+    *,
+    resource: Mapping[str, Any] | None = None,
+) -> str:
+    """Return the canonical shard label for a worker or one of its resources."""
+
+    metadata = _mapping(getattr(worker, "metadata_", None))
+    assignment = _mapping(metadata.get("worker_assignment"))
+    assignment_metadata = _mapping(assignment.get("metadata"))
+    for source in (
+        _mapping(resource),
+        metadata,
+        assignment_metadata,
+        assignment,
+    ):
+        for key in (
+            "worker_shard",
+            "shard",
+            "repo",
+            "name",
+            "source",
+            "resource_id",
+        ):
+            if value := _text(source.get(key)):
+                return value
+
+    allowed_resources = assignment.get("allowed_resources")
+    if isinstance(allowed_resources, list) and len(allowed_resources) == 1:
+        if value := _text(allowed_resources[0]):
+            return value
+
+    worker_id = _run_id(getattr(worker, "id", None))
+    return (
+        _text(assignment.get("id"))
+        or _text(metadata.get("parent_node_id"))
+        or _text(metadata.get("worker_role"))
+        or f"worker-{worker_id or 'unknown'}"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerEvidenceFailure:
+    """One canonical missing-worker-evidence marker."""
+
+    shard: str
+    stage: str
+    error: str
+    worker_run_id: int | None = None
+    worker_role: str = "worker"
+    status: str | None = None
+    configuration_error: str | None = None
+    provider: str | None = None
+    credential: str | None = None
+    failure_category: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def identity(self) -> tuple[Any, ...]:
+        return (
+            self.worker_run_id,
+            self.shard,
+            self.stage,
+            self.configuration_error,
+        )
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> WorkerEvidenceFailure:
+        worker_run_id = _run_id(
+            payload.get("worker_run_id") or payload.get("child_run_id")
+        )
+        return cls(
+            worker_run_id=worker_run_id,
+            worker_role=_text(payload.get("worker_role")) or "worker",
+            shard=(
+                _text(payload.get("shard") or payload.get("repo"))
+                or f"worker-{worker_run_id or 'unknown'}"
+            ),
+            stage=_text(payload.get("stage")) or "worker_execution",
+            status=_text(payload.get("status")),
+            configuration_error=_text(payload.get("configuration_error")),
+            provider=_text(payload.get("provider")),
+            credential=_text(payload.get("credential")),
+            error=_text(payload.get("error")) or "Worker evidence is unavailable.",
+            failure_category=_text(payload.get("failure_category")),
+            details={
+                str(key): value
+                for key, value in payload.items()
+                if key not in _FAILURE_PAYLOAD_KEYS
+            },
+        )
+
+    @classmethod
+    def for_admission(
+        cls,
+        *,
+        worker_role: str,
+        shard: str,
+        configuration_error: str | None,
+        provider: str | None,
+        credential: str | None,
+        error: str,
+    ) -> WorkerEvidenceFailure:
+        return cls(
+            worker_role=worker_role,
+            shard=shard,
+            stage="worker_admission",
+            status="auth_blocked",
+            configuration_error=configuration_error,
+            provider=provider,
+            credential=credential,
+            error=error,
+        )
+
+    @classmethod
+    def from_terminal_worker(cls, worker: Any) -> WorkerEvidenceFailure | None:
+        status = coerce_run_status(getattr(worker, "status", None))
+        if status == RunStatus.COMPLETED or status not in TERMINAL_RUN_STATUSES:
+            return None
+
+        metadata = _mapping(getattr(worker, "metadata_", None))
+        failure_metadata = _mapping(metadata.get("failure"))
+        category = _text(failure_metadata.get("category"))
+        return cls(
+            worker_run_id=int(worker.id),
+            worker_role=_text(metadata.get("worker_role")) or "worker",
+            shard=worker_evidence_shard(worker),
+            stage="worker_execution",
+            status=status.value,
+            error=safe_terminal_run_message(status, category),
+            failure_category=category,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = {
+            **dict(self.details),
+            "kind": "worker_tool_failure",
+            "tool": "spawn_worker",
+        }
+        if self.worker_run_id is not None:
+            payload["child_run_id"] = self.worker_run_id
+            payload["worker_run_id"] = self.worker_run_id
+        payload.update(
+            {
+                "worker_role": self.worker_role,
+                "shard": self.shard,
+                "stage": self.stage,
+            }
+        )
+        for key, value in (
+            ("status", self.status),
+            ("configuration_error", self.configuration_error),
+            ("provider", self.provider),
+            ("credential", self.credential),
+        ):
+            if value is not None:
+                payload[key] = value
+        payload["error"] = self.error
+        if self.failure_category is not None:
+            payload["failure_category"] = self.failure_category
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerEvidenceReceipt:
+    """The typed evidence-health receipt stored on a parent fan-out."""
+
+    status: str | None = None
+    completeness: str | None = None
+    failures: tuple[WorkerEvidenceFailure, ...] = ()
+    worker_shards: tuple[str, ...] = ()
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> WorkerEvidenceReceipt:
+        source = _mapping(payload)
+        failures = tuple(
+            WorkerEvidenceFailure.from_payload(item)
+            for item in source.get("failures") or []
+            if isinstance(item, Mapping)
+        )
+        return cls(
+            status=_text(source.get("status")),
+            completeness=_text(source.get("completeness")),
+            failures=failures,
+            worker_shards=_unique_text(source.get("worker_shards") or []),
+            details={
+                str(key): value
+                for key, value in source.items()
+                if key not in _RECEIPT_PAYLOAD_KEYS
+            },
+        )
+
+    @property
+    def missing_shards(self) -> tuple[str, ...]:
+        return _unique_text([failure.shard for failure in self.failures])[:20]
+
+    @property
+    def degraded(self) -> bool:
+        return self.status == "degraded" or bool(self.failures)
+
+    def with_failures(
+        self,
+        failures: Sequence[WorkerEvidenceFailure],
+    ) -> tuple[WorkerEvidenceReceipt, tuple[WorkerEvidenceFailure, ...]]:
+        current = list(self.failures)
+        identities = {failure.identity for failure in current}
+        added: list[WorkerEvidenceFailure] = []
+        for failure in failures:
+            if failure.identity in identities:
+                continue
+            identities.add(failure.identity)
+            current.append(failure)
+            added.append(failure)
+        return (
+            WorkerEvidenceReceipt(
+                status="degraded",
+                completeness="unavailable",
+                failures=tuple(current[:20]),
+                worker_shards=self.worker_shards,
+                details=self.details,
+            ),
+            tuple(added),
+        )
+
+    def completed(self, worker_shards: Sequence[str]) -> WorkerEvidenceReceipt:
+        if self.degraded or self.status == "pending":
+            return self
+        return WorkerEvidenceReceipt(
+            status="ok",
+            completeness="complete",
+            failures=self.failures,
+            worker_shards=_unique_text(worker_shards)[:20],
+            details=self.details,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = dict(self.details)
+        if self.status is not None:
+            payload["status"] = self.status
+        if self.completeness is not None:
+            payload["completeness"] = self.completeness
+        if self.failures:
+            payload["failures"] = [
+                failure.to_payload() for failure in self.failures
+            ]
+            payload["failure_count"] = len(self.failures)
+            payload["missing_shards"] = list(self.missing_shards)
+        if self.worker_shards:
+            payload["worker_shards"] = list(self.worker_shards)
+        return payload
+
+
+def worker_evidence_receipt_for_run(run: Any) -> WorkerEvidenceReceipt:
+    metadata = _mapping(getattr(run, "metadata_", None))
+    return WorkerEvidenceReceipt.from_payload(metadata.get("evidence_health"))
+
+
+def materialization_failures_for_worker(
+    worker: Any,
+    result: Any,
+) -> tuple[WorkerEvidenceFailure, ...]:
+    """Convert one worker materialization result to canonical evidence failures."""
+
+    metadata = _mapping(getattr(worker, "metadata_", None))
+    if getattr(worker, "parent_run_id", None) is None or not (
+        metadata.get("spawned_by_tool") is True
+        or metadata.get("origin") == "spawn_worker"
+    ):
+        return ()
+
+    errors = [
+        str(item)
+        for item in [
+            *(getattr(result, "errors", []) or []),
+            *(getattr(result, "warnings", []) or []),
+        ]
+        if _text(item) is not None
+    ]
+    failed_resources = [
+        dict(item)
+        for item in [
+            *(getattr(result, "failed_resources", []) or []),
+            *(getattr(result, "degraded_resources", []) or []),
+        ]
+        if isinstance(item, Mapping)
+    ]
+    if not failed_resources:
+        target_ref = _mapping(getattr(worker, "target_ref", None))
+        snapshot = _mapping(target_ref.get("project_context_snapshot"))
+        resources = snapshot.get("resources")
+        failed_resources = [
+            dict(item)
+            for item in resources or []
+            if isinstance(item, Mapping)
+        ][:1]
+    if not failed_resources:
+        failed_resources = [{}]
+
+    failures: list[WorkerEvidenceFailure] = []
+    for index, resource in enumerate(failed_resources):
+        fallback_error = (
+            errors[index]
+            if index < len(errors)
+            else errors[0]
+            if errors
+            else "Project Context materialization failed."
+        )
+        failures.append(
+            WorkerEvidenceFailure(
+                worker_run_id=int(worker.id),
+                worker_role=_text(metadata.get("worker_role")) or "worker",
+                shard=worker_evidence_shard(worker, resource=resource),
+                stage="project_context_materialization",
+                error=_text(resource.get("error")) or fallback_error,
+            )
+        )
+    return tuple(failures)
+
+
+async def _lock_parent_run(session: Any, parent_run_id: int) -> AgentRunRow | None:
+    return await session.get(
+        AgentRunRow,
+        int(parent_run_id),
+        with_for_update=True,
+    )
+
+
+async def _lock_cycle_run(
+    session: Any,
+    parent_metadata: Mapping[str, Any],
+) -> CycleRun | None:
     cycle_run_id = (
         parent_metadata.get("cycle_run_id")
         if parent_metadata.get("source") == "cycle"
         else None
     )
-    if cycle_run_id:
-        try:
-            from brain.platform.db.models.cycle import CycleRun
+    try:
+        normalized_id = int(cycle_run_id)
+    except (TypeError, ValueError):
+        return None
+    return await session.get(
+        CycleRun,
+        normalized_id,
+        with_for_update=True,
+    )
 
-            cycle_run = await session.get(
-                CycleRun,
-                int(cycle_run_id),
-                with_for_update=True,
-            )
-        except (TypeError, ValueError):
-            cycle_run = None
-        if cycle_run is not None:
-            context_snapshot = dict(cycle_run.context_snapshot or {})
-            cycle_health = context_snapshot.get("evidence_health")
-            for failure in failures:
-                cycle_health, _ = evidence_health_with_failure(
-                    cycle_health,
-                    failure,
-                )
-            context_snapshot["evidence_health"] = cycle_health
-            cycle_run.context_snapshot = context_snapshot
+
+async def _persist_parent_evidence_receipt(
+    session: Any,
+    *,
+    parent_run_id: int,
+    failures: Sequence[WorkerEvidenceFailure] = (),
+    completed_worker_shards: Sequence[str] | None = None,
+) -> tuple[WorkerEvidenceReceipt | None, tuple[WorkerEvidenceFailure, ...]]:
+    """Lock parent then Cycle, mutate both receipts, and append events."""
+
+    if not failures and completed_worker_shards is None:
+        return None, ()
+
+    parent = await _lock_parent_run(session, parent_run_id)
+    if parent is None:
+        return None, ()
+
+    parent_metadata = dict(_mapping(parent.metadata_))
+    receipt = WorkerEvidenceReceipt.from_payload(
+        parent_metadata.get("evidence_health")
+    )
+    added: tuple[WorkerEvidenceFailure, ...] = ()
+    if failures:
+        receipt, added = receipt.with_failures(failures)
+    if completed_worker_shards is not None:
+        receipt = receipt.completed(completed_worker_shards)
+    parent_metadata["evidence_health"] = receipt.to_payload()
+    parent.metadata_ = parent_metadata
+
+    cycle_run = await _lock_cycle_run(session, parent_metadata)
+    if cycle_run is not None and failures:
+        context_snapshot = dict(_mapping(cycle_run.context_snapshot))
+        cycle_receipt = WorkerEvidenceReceipt.from_payload(
+            context_snapshot.get("evidence_health")
+        )
+        cycle_receipt, _ = cycle_receipt.with_failures(failures)
+        context_snapshot["evidence_health"] = cycle_receipt.to_payload()
+        cycle_run.context_snapshot = context_snapshot
 
     store = AsyncAgentRunStore(session)
-    for failure in added_failures:
+    for failure in added:
         await store.append_event(
             run_event(
                 int(parent.id),
                 "run.worker_failed",
-                failure,
+                failure.to_payload(),
                 root_run_id=parent.root_run_id or parent.id,
                 producer="spawn_worker",
             )
         )
-    return added_failures
+    return receipt, added
 
 
-def _failure_identity(failure: Mapping[str, Any]) -> tuple[Any, ...]:
-    return (
-        failure.get("worker_run_id") or failure.get("child_run_id"),
-        failure.get("shard") or failure.get("repo"),
-        failure.get("stage"),
-        failure.get("configuration_error"),
+async def record_parent_evidence_failures(
+    session: Any,
+    *,
+    parent_run_id: int,
+    failures: Sequence[WorkerEvidenceFailure],
+) -> tuple[WorkerEvidenceFailure, ...]:
+    """Persist typed failures behind the owner's parent/Cycle lock boundary."""
+
+    _, added = await _persist_parent_evidence_receipt(
+        session,
+        parent_run_id=parent_run_id,
+        failures=failures,
     )
+    return added
+
+
+async def record_terminal_worker_evidence(
+    session: Any,
+    *,
+    parent_run_id: int,
+    workers: Sequence[Any],
+    fanout_complete: bool,
+) -> WorkerEvidenceReceipt | None:
+    """Convert terminal workers and complete the parent receipt in one owner."""
+
+    failures = tuple(
+        failure
+        for worker in workers
+        if (failure := WorkerEvidenceFailure.from_terminal_worker(worker))
+        is not None
+    )
+    worker_shards = (
+        tuple(worker_evidence_shard(worker) for worker in workers)
+        if fanout_complete
+        else None
+    )
+    receipt, _ = await _persist_parent_evidence_receipt(
+        session,
+        parent_run_id=parent_run_id,
+        failures=failures,
+        completed_worker_shards=worker_shards,
+    )
+    return receipt
 
 
 __all__ = [
-    "evidence_health_for_completed_fanout",
-    "evidence_health_with_failure",
+    "WorkerEvidenceFailure",
+    "WorkerEvidenceReceipt",
+    "materialization_failures_for_worker",
     "record_parent_evidence_failures",
+    "record_terminal_worker_evidence",
+    "worker_evidence_receipt_for_run",
+    "worker_evidence_shard",
 ]

--- a/brain/systems/runs/recipes/workers.py
+++ b/brain/systems/runs/recipes/workers.py
@@ -6,6 +6,10 @@ import json
 import logging
 from typing import Any
 
+from brain.platform.integrations.provider_error_sentinel import (
+    provider_error_kind,
+    safe_provider_error_sentinel,
+)
 from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.context import compact_project_reference
 from brain.systems.runs.domain import AgentRunArtifact, ArtifactType
@@ -225,12 +229,29 @@ class WorkerRecipe(BaseRunRecipe):
                 effort=str(thinking),
             )
             output = str(getattr(result, "output", "") or "").strip()
-            status = RunStatus.COMPLETED if getattr(result, "success", False) else RunStatus.FAILED
+            detected_provider_error = (
+                provider_error_kind(output)
+                if getattr(result, "success", False)
+                else None
+            )
+            status = (
+                RunStatus.COMPLETED
+                if getattr(result, "success", False) and not detected_provider_error
+                else RunStatus.FAILED
+            )
             error = None
             failure_category = None
             failure = None
             if status == RunStatus.FAILED:
-                error = str(getattr(result, "error", None) or output or "worker_recipe_failed")
+                error = (
+                    safe_provider_error_sentinel(detected_provider_error)
+                    if detected_provider_error
+                    else str(
+                        getattr(result, "error", None)
+                        or output
+                        or "worker_recipe_failed"
+                    )
+                )
                 failure_category = failure_category_for_error(error)
                 failure = public_run_failure(status, failure_category)
                 output = ""

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -17,8 +17,12 @@ from brain.platform.providers.model_policy import (
     async_get_default_model,
     async_get_default_thinking,
 )
+from brain.systems.cycles.auth_preflight import (
+    async_preflight_run_external_auth,
+)
 from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.domain import RunRecipe
+from brain.systems.runs.evidence_health import record_parent_evidence_failures
 from brain.systems.runs.events import run_event
 from brain.systems.runs.execution_context import _agent_context
 from brain.systems.runs.routing_metadata import effective_routing_snapshot
@@ -346,6 +350,24 @@ def _assignment_payload(
     }
 
 
+def _assignment_shard(
+    assignment: WorkerAssignment,
+    *,
+    idempotency_key: str | None,
+) -> str:
+    metadata = assignment.metadata if isinstance(assignment.metadata, Mapping) else {}
+    for source in (metadata, assignment.to_payload()):
+        for key in ("shard", "repo", "source", "resource_id"):
+            value = str(source.get(key) or "").strip()
+            if value:
+                return value
+    if len(assignment.allowed_resources) == 1:
+        return str(assignment.allowed_resources[0])
+    if idempotency_key:
+        return assignment.id
+    return assignment.role
+
+
 async def _handle_spawn_worker(
     objective: str,
     role: str = "worker",
@@ -416,6 +438,10 @@ async def _handle_spawn_worker(
         "spawned_by_run_id": parent_run_id,
         "headless": bool(headless),
         "worker_role": assignment.role,
+        "worker_shard": _assignment_shard(
+            assignment,
+            idempotency_key=idempotency_key,
+        ),
         "worker_assignment": assignment.to_payload(),
         "parent_node_id": assignment.id,
         "tool_policy": merged_tool_policy,
@@ -449,6 +475,54 @@ async def _handle_spawn_worker(
             effort_overridden=effort_override is not None,
         )
         worker_metadata["routing"] = inherited_routing
+        existing_child_lookup = getattr(store, "child_run_for_step", None)
+        existing_child = (
+            await existing_child_lookup(parent.id, step_key)
+            if callable(existing_child_lookup)
+            else None
+        )
+        if existing_child is None:
+            preflight = await async_preflight_run_external_auth(
+                uow.session,
+                user_id=parent.user_id,
+                org_id=parent.org_id,
+                model=str(child_policy["model"]),
+                subject="spawn_worker",
+            )
+            if preflight.blocked:
+                shard = str(worker_metadata["worker_shard"])
+                failure = {
+                    "kind": "worker_tool_failure",
+                    "tool": "spawn_worker",
+                    "worker_role": assignment.role,
+                    "shard": shard,
+                    "stage": "worker_admission",
+                    "status": "auth_blocked",
+                    "configuration_error": preflight.error_code,
+                    "provider": preflight.provider,
+                    "credential": preflight.credential,
+                    "error": preflight.visible_message,
+                }
+                await record_parent_evidence_failures(
+                    uow.session,
+                    parent=parent,
+                    failures=[failure],
+                )
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "status": "auth_blocked",
+                        "error": preflight.visible_message,
+                        "error_code": preflight.error_code,
+                        "configuration_error": preflight.error_code,
+                        "provider": preflight.provider,
+                        "credential": preflight.credential,
+                        "parent_run_id": parent_run_id,
+                        "shard": shard,
+                        "worker_slot_consumed": False,
+                    },
+                    default=str,
+                )
         child, created = await store.create_child_run_with_result(
             parent,
             recipe=RunRecipe.WORKER,

--- a/brain/systems/runs/tool_catalog/handlers/workers.py
+++ b/brain/systems/runs/tool_catalog/handlers/workers.py
@@ -11,18 +11,24 @@ from typing import Any
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.platform.effort import EFFORT_TIERS, EFFORT_TIER_SET
+from brain.platform.integrations.provider_auth_preflight import (
+    ProviderAuthPreflightResult,
+    async_probe_provider_auth,
+    skipped_provider_auth_preflight,
+)
 from brain.platform.providers.model_policy import (
     DEFAULT_PROVIDER_MODELS,
     PROVIDER_MODEL_OPTIONS,
     async_get_default_model,
     async_get_default_thinking,
-)
-from brain.systems.cycles.auth_preflight import (
-    async_preflight_run_external_auth,
+    infer_provider_from_model,
 )
 from brain.systems.runs.assignments import WorkerAssignment
 from brain.systems.runs.domain import RunRecipe
-from brain.systems.runs.evidence_health import record_parent_evidence_failures
+from brain.systems.runs.evidence_health import (
+    WorkerEvidenceFailure,
+    record_parent_evidence_failures,
+)
 from brain.systems.runs.events import run_event
 from brain.systems.runs.execution_context import _agent_context
 from brain.systems.runs.routing_metadata import effective_routing_snapshot
@@ -50,6 +56,61 @@ _MATERIALIZED_PROJECT_CONTEXT_KEYS = frozenset({
     "workspace_root",
     "workspaces",
 })
+_SPAWN_WORKER_AUTH_PROVIDERS = frozenset({"anthropic", "openai"})
+
+
+def _with_spawn_worker_auth_presentation(
+    result: ProviderAuthPreflightResult,
+) -> ProviderAuthPreflightResult:
+    if not result.blocked:
+        return result
+
+    credential = result.credential or "provider"
+    if credential == "Anthropic API key":
+        repair_action = (
+            "Add an Anthropic API key in Settings > Access, then retry the run."
+        )
+        detail = f"the {credential} is not configured"
+    elif credential == "OpenAI runtime":
+        repair_action = (
+            "Add an OpenAI API key in Settings > Access, then retry the run."
+        )
+        detail = f"the {credential} credential is unavailable"
+    else:
+        repair_action = (
+            "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
+            "then retry the run."
+        )
+        detail = (
+            f"the {credential} credential is unavailable or could not be refreshed"
+        )
+    return result.with_presentation(
+        repair_action=repair_action,
+        visible_message=f"spawn_worker auth blocked: {detail}. {repair_action}",
+    )
+
+
+async def _preflight_spawn_worker_auth(
+    session: Any,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+    model: str,
+) -> ProviderAuthPreflightResult:
+    provider = infer_provider_from_model(model)
+    if provider not in _SPAWN_WORKER_AUTH_PROVIDERS:
+        return skipped_provider_auth_preflight(
+            provider=provider,
+            model=model,
+        )
+    result = await async_probe_provider_auth(
+        session,
+        user_id=user_id,
+        org_id=org_id,
+        provider=provider,
+        model=model,
+    )
+    return _with_spawn_worker_auth_presentation(result)
 
 
 def _current_agent_value(name: str) -> Any:
@@ -482,30 +543,28 @@ async def _handle_spawn_worker(
             else None
         )
         if existing_child is None:
-            preflight = await async_preflight_run_external_auth(
+            preflight = await _preflight_spawn_worker_auth(
                 uow.session,
                 user_id=parent.user_id,
                 org_id=parent.org_id,
                 model=str(child_policy["model"]),
-                subject="spawn_worker",
             )
             if preflight.blocked:
                 shard = str(worker_metadata["worker_shard"])
-                failure = {
-                    "kind": "worker_tool_failure",
-                    "tool": "spawn_worker",
-                    "worker_role": assignment.role,
-                    "shard": shard,
-                    "stage": "worker_admission",
-                    "status": "auth_blocked",
-                    "configuration_error": preflight.error_code,
-                    "provider": preflight.provider,
-                    "credential": preflight.credential,
-                    "error": preflight.visible_message,
-                }
+                failure = WorkerEvidenceFailure.for_admission(
+                    worker_role=assignment.role,
+                    shard=shard,
+                    configuration_error=preflight.error_code,
+                    provider=preflight.provider,
+                    credential=preflight.credential,
+                    error=(
+                        preflight.visible_message
+                        or "spawn_worker provider authentication is unavailable."
+                    ),
+                )
                 await record_parent_evidence_failures(
                     uow.session,
-                    parent=parent,
+                    parent_run_id=int(parent.id),
                     failures=[failure],
                 )
                 return json.dumps(

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1675,9 +1675,12 @@ async def _captured_spawn_worker(
     child_model_policy=None,
     execution_metadata=None,
     created_here=True,
+    preflight_result=None,
     **spawn_kwargs,
 ):
+    from brain.systems.cycles.auth_preflight import CycleAuthPreflightResult
     from brain.systems.runs.domain import RunProfile, RunRecipe
+    from brain.systems.runs.evidence_health import evidence_health_with_failure
     from brain.systems.runs.execution_context import bind_agent_context
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
@@ -1690,6 +1693,7 @@ async def _captured_spawn_worker(
         target_ref={"kind": "cortex_idea", "idea_id": "idea-1"},
         workspace_ref={"workspace_root": "/tmp/work"},
         model_policy=dict(parent_model_policy),
+        metadata_={},
     )
     captured = {}
     events = []
@@ -1735,6 +1739,33 @@ async def _captured_spawn_worker(
 
     monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
     monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
+
+    async def fake_preflight(*_args, **_kwargs):
+        return preflight_result or CycleAuthPreflightResult(
+            status="passed",
+            provider="openai",
+            model="openai/gpt-5.6-sol",
+        )
+
+    async def fake_record_parent_failures(_session, *, parent, failures):
+        health = parent.metadata_.get("evidence_health")
+        for failure in failures:
+            health, _ = evidence_health_with_failure(health, failure)
+        parent.metadata_["evidence_health"] = health
+        captured["admission_failures"] = list(failures)
+        captured["parent_evidence_health"] = dict(health)
+        return list(failures)
+
+    monkeypatch.setattr(
+        worker_handlers,
+        "async_preflight_run_external_auth",
+        fake_preflight,
+    )
+    monkeypatch.setattr(
+        worker_handlers,
+        "record_parent_evidence_failures",
+        fake_record_parent_failures,
+    )
 
     with bind_agent_context(
         run=SimpleNamespace(id=parent.id),
@@ -1910,6 +1941,86 @@ async def test_spawn_worker_bare_provider_resolves_provider_default_and_transpor
         "provider": "anthropic",
         "auth_mode": None,
     }
+
+
+async def test_spawn_worker_auth_preflight_rejects_missing_provider_credential_before_child_creation(
+    monkeypatch,
+):
+    from brain.systems.cycles.auth_preflight import CycleAuthPreflightResult
+
+    blocked = CycleAuthPreflightResult(
+        status="auth_blocked",
+        provider="anthropic",
+        model="anthropic/claude-sonnet-4-6",
+        credential="Anthropic API key",
+        error_code="provider_credential_unavailable",
+        repair_action="Add an Anthropic API key in Settings > Access.",
+        visible_message=(
+            "spawn_worker auth blocked: the Anthropic API key is not configured."
+        ),
+    )
+
+    payload, captured, events = await _captured_spawn_worker(
+        monkeypatch,
+        parent_model_policy={
+            "model": "openai/gpt-5.6-sol",
+            "thinking": "high",
+        },
+        preflight_result=blocked,
+        model="anthropic",
+        metadata={"shard": "github:Illospace/illospace"},
+    )
+
+    assert payload == {
+        "ok": False,
+        "status": "auth_blocked",
+        "error": blocked.visible_message,
+        "error_code": "provider_credential_unavailable",
+        "configuration_error": "provider_credential_unavailable",
+        "provider": "anthropic",
+        "credential": "Anthropic API key",
+        "parent_run_id": 42,
+        "shard": "github:Illospace/illospace",
+        "worker_slot_consumed": False,
+    }
+    assert "model_policy" not in captured
+    assert captured["parent_evidence_health"]["status"] == "degraded"
+    assert captured["parent_evidence_health"]["missing_shards"] == [
+        "github:Illospace/illospace"
+    ]
+    assert captured["admission_failures"][0]["stage"] == "worker_admission"
+    assert events == []
+
+
+async def test_shared_auth_preflight_names_missing_anthropic_configuration(
+    monkeypatch,
+):
+    from brain.systems.cycles import auth_preflight
+
+    async def missing_credential(**_kwargs):
+        raise RuntimeError(
+            "No API key found for anthropic. Add one in Settings."
+        )
+
+    monkeypatch.setattr(
+        auth_preflight,
+        "async_resolve_llm_client",
+        missing_credential,
+    )
+
+    result = await auth_preflight.async_preflight_run_external_auth(
+        object(),
+        user_id="user-1",
+        org_id="org-1",
+        model="anthropic/claude-sonnet-4-6",
+        subject="spawn_worker",
+    )
+
+    assert result.status == "auth_blocked"
+    assert result.error_code == "provider_credential_unavailable"
+    assert result.credential == "Anthropic API key"
+    assert "Anthropic API key" in result.visible_message
+    assert "Settings > Access" in result.visible_message
 
 
 @pytest.mark.parametrize(
@@ -3632,6 +3743,40 @@ async def test_worker_recipe_keeps_failed_provider_diagnostics_internal(monkeypa
     assert raw_error not in json.dumps(result.artifacts[0].payload)
 
 
+async def test_worker_recipe_treats_exhausted_provider_text_retry_as_upstream_failure(
+    monkeypatch,
+):
+    from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
+    from brain.systems.runs.recipes.workers import WorkerRecipe
+
+    async def fake_invoke(_spec):
+        return SimpleNamespace(
+            output="upstream_provider_error: overloaded_error",
+            success=True,
+            error=None,
+        )
+
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.build_agent_tools",
+        lambda _role: [],
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.build_tool_handlers",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "brain.systems.runs.recipes.workers.invoke_direct_agent_async",
+        fake_invoke,
+    )
+
+    result = await WorkerRecipe().execute(_runtime("worker"))
+
+    assert result.status.value == "failed"
+    assert result.error == "upstream_provider_error: overloaded_error"
+    assert result.final_output == UPSTREAM_FAILED_RUN_MESSAGE
+    assert result.artifacts[0].payload["failure"]["category"] == "upstream"
+
+
 async def test_worker_recipe_buffers_partial_deltas_until_success_is_known(monkeypatch):
     from brain.systems.runs.failures import UPSTREAM_FAILED_RUN_MESSAGE
     from brain.systems.runs.recipes.workers import WorkerRecipe
@@ -3669,7 +3814,11 @@ async def test_worker_recipe_keeps_unexpected_exception_internal(monkeypatch):
 
     raw_error = "provider exploded with private diagnostic"
 
+    calls = 0
+
     async def fake_invoke(_spec):
+        nonlocal calls
+        calls += 1
         raise RuntimeError(raw_error)
 
     monkeypatch.setattr("brain.systems.runs.recipes.workers.build_agent_tools", lambda _role: [])
@@ -3684,6 +3833,7 @@ async def test_worker_recipe_keeps_unexpected_exception_internal(monkeypatch):
     assert result.artifacts[0].text == DEFAULT_FAILED_RUN_MESSAGE
     assert raw_error not in json.dumps(runtime.stream.messages)
     assert raw_error not in json.dumps(result.artifacts[0].payload)
+    assert calls == 1
 
 
 async def test_worker_recipe_propagates_headless_tool_policy(monkeypatch):

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -1678,9 +1678,11 @@ async def _captured_spawn_worker(
     preflight_result=None,
     **spawn_kwargs,
 ):
-    from brain.systems.cycles.auth_preflight import CycleAuthPreflightResult
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
     from brain.systems.runs.domain import RunProfile, RunRecipe
-    from brain.systems.runs.evidence_health import evidence_health_with_failure
+    from brain.systems.runs.evidence_health import WorkerEvidenceReceipt
     from brain.systems.runs.execution_context import bind_agent_context
     import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
 
@@ -1741,24 +1743,35 @@ async def _captured_spawn_worker(
     monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
 
     async def fake_preflight(*_args, **_kwargs):
-        return preflight_result or CycleAuthPreflightResult(
+        return preflight_result or ProviderAuthPreflightResult(
             status="passed",
             provider="openai",
             model="openai/gpt-5.6-sol",
         )
 
-    async def fake_record_parent_failures(_session, *, parent, failures):
-        health = parent.metadata_.get("evidence_health")
-        for failure in failures:
-            health, _ = evidence_health_with_failure(health, failure)
+    async def fake_record_parent_failures(
+        _session,
+        *,
+        parent_run_id,
+        failures,
+    ):
+        assert parent_run_id == parent.id
+        receipt = WorkerEvidenceReceipt.from_payload(
+            parent.metadata_.get("evidence_health")
+        )
+        receipt, added = receipt.with_failures(failures)
+        health = receipt.to_payload()
         parent.metadata_["evidence_health"] = health
-        captured["admission_failures"] = list(failures)
-        captured["parent_evidence_health"] = dict(health)
+        captured["admission_failures"] = [
+            failure.to_payload() for failure in failures
+        ]
+        captured["parent_evidence_health"] = health
+        return added
         return list(failures)
 
     monkeypatch.setattr(
         worker_handlers,
-        "async_preflight_run_external_auth",
+        "_preflight_spawn_worker_auth",
         fake_preflight,
     )
     monkeypatch.setattr(
@@ -1946,9 +1959,11 @@ async def test_spawn_worker_bare_provider_resolves_provider_default_and_transpor
 async def test_spawn_worker_auth_preflight_rejects_missing_provider_credential_before_child_creation(
     monkeypatch,
 ):
-    from brain.systems.cycles.auth_preflight import CycleAuthPreflightResult
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
 
-    blocked = CycleAuthPreflightResult(
+    blocked = ProviderAuthPreflightResult(
         status="auth_blocked",
         provider="anthropic",
         model="anthropic/claude-sonnet-4-6",
@@ -1992,10 +2007,10 @@ async def test_spawn_worker_auth_preflight_rejects_missing_provider_credential_b
     assert events == []
 
 
-async def test_shared_auth_preflight_names_missing_anthropic_configuration(
+async def test_neutral_auth_probe_names_missing_anthropic_configuration(
     monkeypatch,
 ):
-    from brain.systems.cycles import auth_preflight
+    from brain.platform.integrations import provider_auth_preflight
 
     async def missing_credential(**_kwargs):
         raise RuntimeError(
@@ -2003,24 +2018,97 @@ async def test_shared_auth_preflight_names_missing_anthropic_configuration(
         )
 
     monkeypatch.setattr(
-        auth_preflight,
+        provider_auth_preflight,
         "async_resolve_llm_client",
         missing_credential,
     )
 
-    result = await auth_preflight.async_preflight_run_external_auth(
+    result = await provider_auth_preflight.async_probe_provider_auth(
         object(),
         user_id="user-1",
         org_id="org-1",
+        provider="anthropic",
         model="anthropic/claude-sonnet-4-6",
-        subject="spawn_worker",
     )
 
     assert result.status == "auth_blocked"
     assert result.error_code == "provider_credential_unavailable"
     assert result.credential == "Anthropic API key"
-    assert "Anthropic API key" in result.visible_message
-    assert "Settings > Access" in result.visible_message
+    assert result.visible_message is None
+    assert result.repair_action is None
+
+
+async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
+    monkeypatch,
+):
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
+    import brain.systems.runs.tool_catalog.handlers.workers as worker_handlers
+
+    captured = {}
+
+    async def blocked_probe(_session, **kwargs):
+        captured.update(kwargs)
+        return ProviderAuthPreflightResult(
+            status="auth_blocked",
+            provider="anthropic",
+            model=kwargs["model"],
+            credential="Anthropic API key",
+            error_code="provider_credential_unavailable",
+        )
+
+    monkeypatch.setattr(
+        worker_handlers,
+        "async_probe_provider_auth",
+        blocked_probe,
+    )
+
+    result = await worker_handlers._preflight_spawn_worker_auth(
+        object(),
+        user_id="user-1",
+        org_id="org-1",
+        model="anthropic/claude-sonnet-4-6",
+    )
+
+    assert captured == {
+        "user_id": "user-1",
+        "org_id": "org-1",
+        "provider": "anthropic",
+        "model": "anthropic/claude-sonnet-4-6",
+    }
+    assert result.blocked is True
+    assert result.repair_action == (
+        "Add an Anthropic API key in Settings > Access, then retry the run."
+    )
+    assert result.visible_message.startswith(
+        "spawn_worker auth blocked: the Anthropic API key is not configured."
+    )
+
+
+async def test_cycle_auth_policy_skips_anthropic_without_probing(monkeypatch):
+    from brain.systems.cycles import auth_preflight
+
+    async def unexpected_probe(*_args, **_kwargs):
+        raise AssertionError("Cycle policy must remain OpenAI-only")
+
+    monkeypatch.setattr(
+        auth_preflight,
+        "async_probe_provider_auth",
+        unexpected_probe,
+    )
+
+    result = await auth_preflight.async_preflight_cycle_external_auth(
+        object(),
+        cycle=SimpleNamespace(
+            user_id="user-1",
+            org_id="org-1",
+            model_override="anthropic/claude-sonnet-4-6",
+        ),
+    )
+
+    assert result.status == "skipped"
+    assert result.provider == "anthropic"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -41,6 +41,32 @@ class _ScalarRows:
         return list(self.rows)
 
 
+def _stub_spawn_worker_auth_preflight(monkeypatch, worker_handlers):
+    """Pin the spawn admission preflight to `passed`.
+
+    Tests that exercise the store path must not depend on whether the machine
+    running them happens to have a provider credential: without this, the probe
+    falls back to ambient env keys, so the handler takes the happy path on a
+    developer laptop and the auth_blocked path on credential-free CI.
+    """
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
+
+    async def passed_preflight(_session, *, model, **_kwargs):
+        return ProviderAuthPreflightResult(
+            status="passed",
+            provider="openai",
+            model=model,
+        )
+
+    monkeypatch.setattr(
+        worker_handlers,
+        "_preflight_spawn_worker_auth",
+        passed_preflight,
+    )
+
+
 class _Store:
     def __init__(self):
         self.events = []
@@ -2236,6 +2262,7 @@ async def test_spawn_worker_handler_uses_child_run_store_path_for_headless(monke
 
     monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
     monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
+    _stub_spawn_worker_auth_preflight(monkeypatch, worker_handlers)
 
     with bind_agent_context(
         run=SimpleNamespace(id=parent.id),
@@ -2332,6 +2359,7 @@ async def test_spawn_worker_handler_prefers_runtime_run_id_over_stale_context(mo
 
     monkeypatch.setattr(worker_handlers, "UnitOfWork", _Uow)
     monkeypatch.setattr(worker_handlers, "AsyncAgentRunStore", _Store)
+    _stub_spawn_worker_auth_preflight(monkeypatch, worker_handlers)
 
     with bind_agent_context(run=stale_parent):
         payload = json.loads(

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 
 class _FakeLLM:
     provider = "anthropic"
@@ -40,6 +42,77 @@ def test_provider_error_classifier_recognizes_transient_aliases_and_contextual_5
     assert provider_error_kind("service_unavailable_error") == "server_error"
     assert provider_error_kind("provider HTTP 503 unavailable") == "server_error"
     assert provider_error_kind("Reader counted 500 matching files.") is None
+    assert (
+        provider_error_kind("", provider_exception="server_is_overloaded")
+        == "overloaded_error"
+    )
+    assert (
+        provider_error_kind("", provider_exception="provider HTTP 503 unavailable")
+        == "server_error"
+    )
+
+
+@pytest.mark.parametrize("spawned", [False, True], ids=["non_spawned", "spawned"])
+@pytest.mark.parametrize(
+    ("tools", "history_safety"),
+    [
+        (["read_file"], "read_only"),
+        (["write_file"], "write"),
+        (["unregistered_test_tool"], "unknown"),
+    ],
+    ids=["read_only_history", "write_history", "unknown_history"],
+)
+@pytest.mark.parametrize(
+    ("response_text", "expected_kind", "transient"),
+    [
+        ("provider HTTP 503 unavailable", "server_error", True),
+        (
+            "Contact help.openai.com with request ID req-non-retryable.",
+            "provider_error",
+            False,
+        ),
+        ("Cycle run degraded: mission_contract_failed.", None, False),
+    ],
+    ids=["retryable_text", "non_retryable_text", "internal_failure"],
+)
+def test_response_text_retry_decision_matrix(
+    *,
+    spawned,
+    tools,
+    history_safety,
+    response_text,
+    expected_kind,
+    transient,
+):
+    from brain.systems.runs.direct_loop.retry import (
+        response_text_retry_decision,
+    )
+
+    decision = response_text_retry_decision(
+        response_text,
+        scheduled_result_contract=False,
+        metadata={
+            "execution_provenance": (
+                {"origin": "spawn_worker", "spawned_by_tool": True}
+                if spawned
+                else {"origin": "slack_teammate"}
+            )
+        },
+        tool_call_source="worker" if spawned else "coordinator",
+        tool_calls_made=tools,
+    )
+
+    assert tools
+    assert decision.spawned_worker is spawned
+    assert decision.tool_history_safety == history_safety
+    assert decision.inspect_response is spawned
+    assert decision.withhold_stream is spawned
+    assert decision.provider_error_kind == (
+        expected_kind if spawned else None
+    )
+    assert decision.should_retry is (
+        spawned and history_safety == "read_only" and transient
+    )
 
 
 async def test_scheduled_cycle_retries_provider_error_text_before_returning_safe_sentinel(

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -31,6 +31,17 @@ def _response(text: str):
     return SimpleNamespace(stop_reason="end_turn", content=[block], usage=usage)
 
 
+def test_provider_error_classifier_recognizes_transient_aliases_and_contextual_5xx():
+    from brain.platform.integrations.provider_error_sentinel import (
+        provider_error_kind,
+    )
+
+    assert provider_error_kind("server_is_overloaded") == "overloaded_error"
+    assert provider_error_kind("service_unavailable_error") == "server_error"
+    assert provider_error_kind("provider HTTP 503 unavailable") == "server_error"
+    assert provider_error_kind("Reader counted 500 matching files.") is None
+
+
 async def test_scheduled_cycle_retries_provider_error_text_before_returning_safe_sentinel(
     monkeypatch,
 ):
@@ -98,6 +109,89 @@ async def test_scheduled_cycle_retries_provider_error_text_before_returning_safe
     assert result.output == "upstream_provider_error: server_error"
     assert "help.openai.com" not in result.output
     assert streamed_deltas == []
+
+
+async def test_spawned_read_only_worker_retries_overload_text_and_recovers(
+    monkeypatch,
+):
+    from brain.systems.runs import direct_agent
+
+    raw_provider_error = (
+        "API error: Our servers are currently overloaded | "
+        "server_is_overloaded | service_unavailable_error"
+    )
+    provider_calls = []
+    streamed_deltas = []
+
+    class FakeStream:
+        def __init__(self, text):
+            self.text = text
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def __iter__(self):
+            yield SimpleNamespace(type="text", text=self.text)
+
+        def get_final_message(self):
+            return _response(self.text)
+
+    class FakeProvider:
+        def stream(self, request):
+            provider_calls.append(request)
+            text = (
+                raw_provider_error
+                if len(provider_calls) == 1
+                else "Recovered repository evidence."
+            )
+            return FakeStream(text)
+
+        def create(self, _request):
+            raise AssertionError("Worker calls with activity hooks should stream")
+
+        def is_api_error(self, _exc):
+            return False
+
+        def is_retryable_error(self, _exc):
+            return False
+
+    monkeypatch.setattr(
+        direct_agent,
+        "get_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
+    monkeypatch.setattr(
+        direct_agent,
+        "_PROVIDER_ERROR_TEXT_RETRY_DELAYS",
+        (0,),
+    )
+
+    result = await direct_agent.run_agent_async(
+        message="Read the repository shard",
+        model="claude-sonnet-4-6",
+        tools=[],
+        persist_session=False,
+        session_id="spawn-worker-overload-retry",
+        resolved_llm=_FakeLLM(),
+        tool_call_source="worker",
+        on_stream_activity=lambda _label: None,
+        on_stream_delta=streamed_deltas.append,
+        metadata={
+            "execution_provenance": {
+                "origin": "spawn_worker",
+                "spawned_by_tool": True,
+            }
+        },
+    )
+
+    assert len(provider_calls) == 2
+    assert result.success is True
+    assert result.output == "Recovered repository evidence."
+    assert raw_provider_error not in streamed_deltas
+    assert streamed_deltas == ["Recovered repository evidence."]
 
 
 async def test_interactive_slack_transport_disconnect_retries_stream_and_completes(monkeypatch):

--- a/tests/test_health_tiers.py
+++ b/tests/test_health_tiers.py
@@ -306,6 +306,64 @@ async def test_deep_health_exposes_legacy_cycle_backlog(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_health_exposes_spawn_worker_success_rate_over_rolling_window(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+    monkeypatch,
+):
+    from brain.platform.db.models.agent_run import AgentRunRow
+
+    session = await async_sqlite_session_factory([AgentRunRow.__table__])
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+
+    def run_row(run_id, *, status, origin, age_hours):
+        created_at = now - timedelta(hours=age_hours)
+        return AgentRunRow(
+            id=run_id,
+            org_id=None,
+            user_id=None,
+            thread_id=f"health-thread-{run_id}",
+            profile="worker" if origin == "spawn_worker" else "fast",
+            recipe="worker" if origin == "spawn_worker" else "fast",
+            status=status,
+            input_message="health rate fixture",
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={"origin": origin},
+            created_at=created_at,
+            updated_at=created_at,
+            completed_at=created_at,
+        )
+
+    session.add_all(
+        [
+            run_row(1, status="completed", origin="spawn_worker", age_hours=1),
+            run_row(2, status="completed", origin="spawn_worker", age_hours=2),
+            run_row(3, status="failed", origin="spawn_worker", age_hours=3),
+            run_row(4, status="failed", origin="scheduler", age_hours=1),
+            run_row(5, status="failed", origin="spawn_worker", age_hours=30),
+        ]
+    )
+    await session.flush()
+    monkeypatch.setattr(health, "_apply_statement_timeout", AsyncMock())
+    monkeypatch.setattr(health, "_utc_now", lambda: now)
+
+    check = await health._run_health_check(session)
+
+    rate = check.details["spawn_worker_success_rate"]
+    assert rate == {
+        "window_minutes": 1440,
+        "completed": 2,
+        "failed": 1,
+        "terminal": 3,
+        "rate": 2 / 3,
+        "percent": 66.7,
+    }
+    assert "spawn_worker success 66.7%" in check.summary
+
+
+@pytest.mark.asyncio
 async def test_legacy_cycle_backlog_health_reports_stale_due_cycles(monkeypatch):
     now = datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc)
     cycle = SimpleNamespace(

--- a/tests/test_openai_auth_mode.py
+++ b/tests/test_openai_auth_mode.py
@@ -28,21 +28,24 @@ def test_other_models_do_not_pin_an_auth_mode(model):
 
 
 def test_cycle_preflight_and_run_agree_on_required_auth_mode():
-    """The preflight must validate the credential the run will actually use.
+    """The shared probe must validate the credential the run will actually use.
 
-    A divergent copy in the cycle preflight recognized only gpt-5.5, so a
+    A divergent preflight copy recognized only gpt-5.5, so a
     GPT-5.6 cycle validated an interchangeable credential and lost the
     actionable auth-blocked message when the ChatGPT credential was dead.
     """
-    from brain.systems.cycles import auth_preflight
+    from brain.platform.integrations import provider_auth_preflight
     from brain.systems.runs import direct_agent
     from brain.systems.runs.direct_loop import final_reply_checker
 
-    for module in (auth_preflight, direct_agent, final_reply_checker):
+    for module in (provider_auth_preflight, direct_agent, final_reply_checker):
         assert not hasattr(module, "_required_openai_auth_mode"), (
             f"{module.__name__} redeclares the auth-mode rule; import the shared helper"
         )
 
-    assert auth_preflight.required_openai_auth_mode is required_openai_auth_mode
+    assert (
+        provider_auth_preflight.required_openai_auth_mode
+        is required_openai_auth_mode
+    )
     assert direct_agent.required_openai_auth_mode is required_openai_auth_mode
     assert final_reply_checker.required_openai_auth_mode is required_openai_auth_mode

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -5,6 +5,14 @@ from unittest.mock import AsyncMock
 import pytest
 
 
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
 def test_project_context_materialization_result_is_ready_when_evidence_is_degraded():
     from brain.systems.cortex.project_context.materializer import ProjectContextMaterializationResult
 
@@ -1487,11 +1495,24 @@ async def test_spawned_reader_materialization_issue_degrades_parent_cycle_eviden
 
     lock_order = []
 
+    rows_by_id = {49: child, 42: parent, 12: cycle_run}
+
     class FakeSession:
         async def get(self, _model, object_id, **_kwargs):
             if _kwargs.get("with_for_update"):
                 lock_order.append((_model.__name__, object_id))
-            return {49: child, 42: parent, 12: cycle_run}.get(object_id)
+            return rows_by_id.get(object_id)
+
+        async def scalars(self, stmt):
+            entity = stmt.column_descriptions[0]["entity"]
+            object_id = int(stmt.whereclause.right.value)
+            if stmt.get_execution_options().get("populate_existing") is not True:
+                raise AssertionError(
+                    f"locked read of {entity.__name__} must refresh the identity map"
+                )
+            if stmt._for_update_arg is not None:
+                lock_order.append((entity.__name__, object_id))
+            return _ScalarRows([rows_by_id[object_id]] if object_id in rows_by_id else [])
 
     class FakeUow:
         session = FakeSession()

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1485,8 +1485,12 @@ async def test_spawned_reader_materialization_issue_degrades_parent_cycle_eviden
         context_snapshot={"evidence_health": {"status": "pending", "expected_checks": ["github"]}},
     )
 
+    lock_order = []
+
     class FakeSession:
         async def get(self, _model, object_id, **_kwargs):
+            if _kwargs.get("with_for_update"):
+                lock_order.append((_model.__name__, object_id))
             return {49: child, 42: parent, 12: cycle_run}.get(object_id)
 
     class FakeUow:
@@ -1547,10 +1551,11 @@ async def test_spawned_reader_materialization_issue_degrades_parent_cycle_eviden
         "child_run_id": 49,
         "worker_run_id": 49,
         "worker_role": "repo_reader",
-        "repo": "example-org/missing-repo",
+        "shard": "example-org/missing-repo",
         "stage": "project_context_materialization",
         "error": error,
     }
+    assert lock_order == [("AgentRunRow", 42), ("CycleRun", 12)]
     assert [(event.run_id, event.event_type, event.payload) for event in events] == [
         (42, "run.worker_failed", failure)
     ]

--- a/tests/test_project_context_materializer.py
+++ b/tests/test_project_context_materializer.py
@@ -1524,7 +1524,10 @@ async def test_spawned_reader_materialization_issue_degrades_parent_cycle_eviden
     )
     mark_failed = AsyncMock(return_value=None)
     monkeypatch.setattr(runner, "UnitOfWork", lambda: FakeUow())
-    monkeypatch.setattr(runner, "AsyncAgentRunStore", FakeStore)
+    monkeypatch.setattr(
+        "brain.systems.runs.evidence_health.AsyncAgentRunStore",
+        FakeStore,
+    )
     monkeypatch.setattr(runner, "_async_record_project_activity", AsyncMock())
     monkeypatch.setattr(runner, "materialize_project_context_workspaces", AsyncMock(return_value=result))
     monkeypatch.setattr(runner, "_mark_run_failed_after_runner_error_async", mark_failed)

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -95,6 +95,7 @@ async def _worker(
     step: str,
     role: str,
     join_parent: bool | None,
+    shard: str | None = None,
 ):
     metadata = {
         "origin": "spawn_worker",
@@ -103,6 +104,8 @@ async def _worker(
     }
     if join_parent is not None:
         metadata["join_parent"] = join_parent
+    if shard:
+        metadata["shard"] = shard
     child = await store.create_child_run(
         anchor,
         recipe=RunRecipe.WORKER,
@@ -173,6 +176,12 @@ async def test_all_children_terminal_queues_one_generic_continuation_on_parent_t
         "completed_fanout_run_id": anchor.id,
         "worker_run_ids": [reader.id, verifier.id],
     }
+    assert continuation.metadata_["evidence_health"] == {
+        "status": "ok",
+        "completeness": "complete",
+        "worker_shards": ["repository reader", "independent verifier"],
+    }
+    assert "Evidence health: ok" in continuation.input_message
     assert "Reader found the relevant contract." in continuation.input_message
     assert "Verifier confirmed the contract." in continuation.input_message
 
@@ -196,6 +205,99 @@ async def test_all_children_terminal_queues_one_generic_continuation_on_parent_t
     assert events[0].payload["continuation_run_id"] == continuation.id
 
 
+async def test_failed_spawned_reader_marks_parent_and_continuation_evidence_degraded(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    anchor = await _anchor(store)
+    failed_reader = await _worker(
+        store,
+        anchor,
+        step="github-reader",
+        role="GitHub reader",
+        join_parent=True,
+        shard="github:Illospace/illospace",
+    )
+    healthy_reader = await _worker(
+        store,
+        anchor,
+        step="domain-reader",
+        role="Domain reader",
+        join_parent=True,
+        shard="domain:engineering-tickets",
+    )
+    engine = AsyncAgentRunEngine(session, recipes={})
+
+    await engine.fail(
+        failed_reader.id,
+        "upstream_provider_error: overloaded_error",
+        failure_category="upstream",
+    )
+    await engine.complete(
+        healthy_reader.id,
+        output="Domain evidence completed.",
+    )
+
+    refreshed_anchor = await session.get(AgentRunRow, anchor.id)
+    health = refreshed_anchor.metadata_["evidence_health"]
+    assert health["status"] == "degraded"
+    assert health["completeness"] == "unavailable"
+    assert health["missing_shards"] == ["github:Illospace/illospace"]
+    assert health["failures"] == [
+        {
+            "kind": "worker_tool_failure",
+            "tool": "spawn_worker",
+            "child_run_id": failed_reader.id,
+            "worker_run_id": failed_reader.id,
+            "worker_role": "GitHub reader",
+            "shard": "github:Illospace/illospace",
+            "stage": "worker_execution",
+            "status": "failed",
+            "error": (
+                "I hit a temporary upstream problem on this and it is still open "
+                "— I will come back."
+            ),
+            "failure_category": "upstream",
+        }
+    ]
+
+    continuation = (await _generic_continuations(session))[0]
+    assert continuation.metadata_["evidence_health"] == health
+    assert "Evidence health: degraded" in continuation.input_message
+    assert "github:Illospace/illospace" in continuation.input_message
+    assert "Do not report a normal sweep" in continuation.input_message
+
+
+async def test_non_spawn_worker_child_failure_does_not_change_parent_evidence_health(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    session = await _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch)
+    store = AsyncAgentRunStore(session)
+    anchor = await _anchor(store)
+    ordinary_child = await store.create_child_run(
+        anchor,
+        recipe=RunRecipe.FAST,
+        message="Run an ordinary child task.",
+        step_key="ordinary-child",
+        metadata={"origin": "scheduler"},
+        initial_status=RunStatus.STARTING,
+    )
+    await store.set_status(ordinary_child.id, RunStatus.RUNNING)
+
+    await AsyncAgentRunEngine(session, recipes={}).fail(
+        ordinary_child.id,
+        "ordinary internal failure",
+        failure_category="internal",
+    )
+
+    refreshed_anchor = await session.get(AgentRunRow, anchor.id)
+    assert "evidence_health" not in refreshed_anchor.metadata_
+    assert await _generic_continuations(session) == []
+
+
 async def test_generic_continuation_waits_for_terminal_parent(
     async_sqlite_session_factory,
     sqlite_postgres_ddl_patch,
@@ -214,11 +316,15 @@ async def test_generic_continuation_waits_for_terminal_parent(
 
     await engine.complete(worker.id, output="Worker finished before its parent.")
     assert await _generic_continuations(session) == []
+    assert "evidence_health" not in (
+        (await session.get(AgentRunRow, anchor.id)).metadata_
+    )
 
     await engine.complete(anchor.id, output="Parent has now reached terminal state.")
     continuations = await _generic_continuations(session)
     assert len(continuations) == 1
     assert "Worker finished before its parent." in continuations[0].input_message
+    assert continuations[0].metadata_["evidence_health"]["status"] == "ok"
 
 
 async def test_spawn_worker_without_join_flag_remains_fire_and_forget(

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -23,9 +23,45 @@ from brain.systems.runs.chantier_continuation import (
 )
 from brain.systems.runs.domain import AgentRunRequest, RunRecipe
 from brain.systems.runs.engine import AsyncAgentRunEngine
+from brain.systems.runs.evidence_health import (
+    WorkerEvidenceFailure,
+    WorkerEvidenceReceipt,
+)
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.tool_catalog.definitions.workers import WORKER_SPAWN_TOOLS
+
+
+def test_worker_evidence_receipt_deduplicates_by_full_canonical_identity():
+    execution_failure = WorkerEvidenceFailure(
+        worker_run_id=49,
+        worker_role="GitHub reader",
+        shard="github:Illospace/illospace",
+        stage="worker_execution",
+        status="failed",
+        error="The worker failed.",
+    )
+    distinct_failure_for_same_worker = WorkerEvidenceFailure(
+        worker_run_id=49,
+        worker_role="GitHub reader",
+        shard="github:Illospace/illospace",
+        stage="project_context_materialization",
+        error="The repository could not be materialized.",
+    )
+
+    receipt, first_added = WorkerEvidenceReceipt().with_failures(
+        [execution_failure]
+    )
+    receipt, replay_added = receipt.with_failures(
+        [execution_failure, distinct_failure_for_same_worker]
+    )
+
+    assert first_added == (execution_failure,)
+    assert replay_added == (distinct_failure_for_same_worker,)
+    assert receipt.failures == (
+        execution_failure,
+        distinct_failure_for_same_worker,
+    )
 
 
 async def _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
@@ -14,6 +15,7 @@ from brain.platform.db.models.agent_run import (
     AgentRunEventRow,
     AgentRunRow,
 )
+from brain.platform.db.models.cycle import CycleRun
 from brain.systems.runs.chantier_continuation import (
     CONTINUATION_QUEUED_EVENT,
     GENERIC_CONTINUATION_QUEUED_EVENT,
@@ -26,6 +28,7 @@ from brain.systems.runs.engine import AsyncAgentRunEngine
 from brain.systems.runs.evidence_health import (
     WorkerEvidenceFailure,
     WorkerEvidenceReceipt,
+    record_parent_evidence_failures,
 )
 from brain.systems.runs.status import RunStatus
 from brain.systems.runs.store import AsyncAgentRunStore
@@ -62,6 +65,31 @@ def test_worker_evidence_receipt_deduplicates_by_full_canonical_identity():
         execution_failure,
         distinct_failure_for_same_worker,
     )
+
+
+def test_worker_evidence_receipt_keeps_identity_past_presentation_limit():
+    failures = tuple(
+        WorkerEvidenceFailure(
+            worker_run_id=worker_id,
+            worker_role="repository reader",
+            shard=f"github:example/repo-{worker_id}",
+            stage="worker_execution",
+            status="failed",
+            error="The worker failed.",
+        )
+        for worker_id in range(1, 22)
+    )
+
+    receipt, added = WorkerEvidenceReceipt().with_failures(failures)
+    payload = receipt.to_payload()
+    replayed = WorkerEvidenceReceipt.from_payload(payload)
+    replayed, replay_added = replayed.with_failures([failures[20]])
+
+    assert added == failures
+    assert len(payload["failures"]) == 20
+    assert payload["failure_count"] == 21
+    assert replay_added == ()
+    assert replayed.to_payload()["failure_count"] == 21
 
 
 async def _session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
@@ -560,3 +588,107 @@ async def test_fanout_anchor_lock_uses_select_for_update():
     )
     assert "WHERE agent_runs.id = 482" in sql
     assert sql.rstrip().endswith("FOR UPDATE")
+
+
+async def test_evidence_locks_refresh_preloaded_parent_and_cycle_after_concurrent_commit(
+    tmp_path,
+    sqlite_postgres_ddl_patch,
+):
+    database = tmp_path / "evidence-lock-freshness.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        for table in (
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            CycleRun.__table__,
+        ):
+            await connection.execute(CreateTable(table, if_not_exists=True))
+
+    try:
+        async with factory() as setup_session:
+            cycle_run = CycleRun(
+                cycle_id=7,
+                scheduled_for=datetime.now(UTC),
+                status="running",
+                prompt_snapshot="Inspect the repository.",
+                context_snapshot={
+                    "evidence_health": {"status": "pending"},
+                    "setup_cycle_marker": True,
+                },
+            )
+            setup_session.add(cycle_run)
+            await setup_session.flush()
+            anchor = await _anchor(
+                AsyncAgentRunStore(setup_session),
+                metadata={
+                    "source": "cycle",
+                    "cycle_run_id": cycle_run.id,
+                    "evidence_health": {"status": "pending"},
+                    "setup_parent_marker": True,
+                },
+            )
+            await setup_session.commit()
+            parent_run_id = anchor.id
+            cycle_run_id = cycle_run.id
+
+        async with factory() as stale_session:
+            stale_parent = await stale_session.get(AgentRunRow, parent_run_id)
+            stale_cycle = await stale_session.get(CycleRun, cycle_run_id)
+            assert "concurrent_parent_marker" not in stale_parent.metadata_
+            assert "concurrent_cycle_marker" not in stale_cycle.context_snapshot
+
+            async with factory() as writer_session:
+                writer_parent = await writer_session.get(
+                    AgentRunRow,
+                    parent_run_id,
+                )
+                writer_parent.metadata_ = {
+                    **writer_parent.metadata_,
+                    "concurrent_parent_marker": "committed while lock waited",
+                }
+                writer_cycle = await writer_session.get(CycleRun, cycle_run_id)
+                writer_cycle.context_snapshot = {
+                    **writer_cycle.context_snapshot,
+                    "concurrent_cycle_marker": "committed while lock waited",
+                }
+                await writer_session.commit()
+
+            failure = WorkerEvidenceFailure(
+                worker_run_id=49,
+                worker_role="repository reader",
+                shard="github:example/repository",
+                stage="worker_execution",
+                status="failed",
+                error="The worker failed.",
+            )
+            await record_parent_evidence_failures(
+                stale_session,
+                parent_run_id=parent_run_id,
+                failures=[failure],
+            )
+            await stale_session.commit()
+
+        async with factory() as inspection_session:
+            persisted_parent = await inspection_session.get(
+                AgentRunRow,
+                parent_run_id,
+            )
+            persisted_cycle = await inspection_session.get(
+                CycleRun,
+                cycle_run_id,
+            )
+            assert persisted_parent.metadata_["concurrent_parent_marker"] == (
+                "committed while lock waited"
+            )
+            assert persisted_cycle.context_snapshot[
+                "concurrent_cycle_marker"
+            ] == "committed while lock waited"
+            assert persisted_parent.metadata_["evidence_health"][
+                "failure_count"
+            ] == 1
+            assert persisted_cycle.context_snapshot["evidence_health"][
+                "failure_count"
+            ] == 1
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
Closes #547

83% of `spawn_worker` children were dying, and their parents could not see it: a dead reader
returns no rows and no error, so the parent swept near-empty evidence and reported **normal**
evidence health. This makes that failure visible, retries only what is genuinely retryable, and
refuses at admission the runs that can never succeed.

## What changed

- **One owner for degraded-evidence receipts** — new `brain/systems/runs/evidence_health.py`.
  A `spawn_worker` child that terminates non-`completed` now writes an explicit degraded marker
  naming its shard onto the parent (and, for cycle-backed parents, the CycleRun), in the same
  class as a truncation marker. Both rows are taken under `FOR UPDATE` with a fresh read, in a
  fixed parent → cycle order.
- **Retry only the retryable** — extended the existing `provider_error_sentinel.py` (shipped by
  #289) with `server_is_overloaded` / `service_unavailable_error` rather than forking a second
  classifier. `internal` failures are never blind-retried. The retry decision moved into
  `direct_loop/retry.py` so `direct_agent.py` keeps orchestration only.
- **Fail configuration errors at admission** — generalized the existing auth preflight from
  #274 (`brain/platform/integrations/provider_auth_preflight.py`) to cover every resolved run
  route including Anthropic, so `"No API key found for anthropic"` is rejected before a worker
  slot is spent. The Cycle adapter stays a thin caller and keeps its OpenAI-only policy.
- **Report the rate** — `spawn_worker` success rate over a rolling window is exposed through
  `brain/app/ops/health.py`, so an 83% failure rate no longer requires a SQL query to notice.

## How to check it (no diff reading required)

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-547-fix2
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/ -m "not requires_db" -q
```

**4389 passed, 14 skipped** — full fast suite, run by the orchestrator outside the Codex
sandbox, on this exact commit.

Acceptance checks from the ticket, and the test that proves each:

1. Parent whose spawned reader fails reports **degraded** evidence health and names the missing
   shard — `tests/test_project_context_materializer.py::test_spawned_reader_materialization_issue_degrades_parent_cycle_evidence_health`
2. `server_is_overloaded` is retried with backoff; `failure_category: internal` is not
   blind-retried — the 18-case matrix in `tests/test_direct_agent_async_contract.py`
3. A run whose resolved provider has no credential is rejected **at admission**, no worker slot
   consumed — `tests/test_openai_auth_mode.py` + `tests/test_agent_run_runtime.py`
4. Rate is visible to an operator — `tests/test_health_tiers.py`

Check 4 of the ticket ("over a 24h window, completion rate > 90%") is only observable after
deploy — the rolling-window figure on the ops health surface is where to read it.

## Review history and what is NOT closed

Two Codex code-quality review passes, each followed by a fix pass:

- **Review 1 → RESHAPE** (4 blocking): fix pass 1 closed all four — one evidence owner instead
  of three, a real lock on the persistence path, an auth probe that owns no caller's wording,
  and a single retry decision.
- **Review 2 → RESHAPE** (2 blocking): fix pass 2 closed both — (a) the `FOR UPDATE` reads
  went through `session.get()` without `populate_existing`, so a lock acquired behind a
  concurrent writer read the *stale* identity-map copy and overwrote the writer's commit — a
  lost update the lock did not prevent; (b) `WorkerEvidenceReceipt` built its dedup identity
  set only from the retained twenty failures, so failure 21 was emitted, forgotten, then
  re-emitted forever on exactly the busy fan-outs this ticket exists to make legible.

**Not closed, carried here deliberately** (fix-pass budget reached, both non-blocking sediment
from review 2):

- `tests/test_agent_run_runtime.py:1770` — an unreachable `return`.
- `brain/systems/runs/chantier_continuation.py:301` `_record_fanout_evidence_health()` is now a
  pass-through wrapper; inline it or justify keeping it.

**Provenance note:** fix pass 2's worker was killed by a host-level restart before it finished.
Its work was salvaged from the worktree and verified by the orchestrator; the one thing it had
not reached — the lock-order test double in `test_project_context_materializer.py`, which still
faked `session.get()` — was completed by the orchestrator and now asserts the locking select
carries `populate_existing`. The fix-pass 2 delta itself was reviewed by the orchestrator, not
by a third Codex review pass.
