### PR TITLE
fix(scheduler): reap stale agent runs from the daemon, not only from inside the dead worker

### DIFF
--- a/brain/app/cli/scheduler.py
+++ b/brain/app/cli/scheduler.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import time
 from datetime import datetime
 
-from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.app.scheduler.catalog import (
     async_list_scheduler_jobs,
     async_list_scheduler_runs,
@@ -30,6 +30,12 @@ from brain.app.scheduler.executor import (
 )
 from brain.app.scheduler.planner import async_materialize_due_runs
 from brain.app.scheduler.runtime import make_lease_owner
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.cortex.runner import reap_stale_active_runs
+
+_STALE_RUN_REAP_INTERVAL_SECONDS = 60.0
+_STALE_RUN_REAP_LIMIT = 25
+_monotonic = time.monotonic
 
 
 def _emit(payload: dict, *, compact: bool = False) -> None:
@@ -44,6 +50,34 @@ def _now_from_args(args: argparse.Namespace) -> datetime | None:
     if not raw:
         return None
     return datetime.fromisoformat(raw)
+
+
+async def _reap_stale_active_runs_if_due(*, next_reap_at: float) -> float:
+    now = _monotonic()
+    if now < next_reap_at:
+        return next_reap_at
+
+    try:
+        reaped = await reap_stale_active_runs(limit=_STALE_RUN_REAP_LIMIT)
+    except Exception as exc:
+        _emit(
+            {
+                "event": "agent_run_stale_reap_failed",
+                "ok": False,
+                "error": str(exc),
+            },
+            compact=True,
+        )
+    else:
+        _emit(
+            {
+                "event": "agent_run_stale_reap",
+                "ok": True,
+                "reaped": reaped,
+            },
+            compact=True,
+        )
+    return now + _STALE_RUN_REAP_INTERVAL_SECONDS
 
 
 async def cmd_status(args: argparse.Namespace) -> int:
@@ -205,6 +239,7 @@ async def cmd_retry_run(args: argparse.Namespace) -> int:
 
 async def cmd_daemon(args: argparse.Namespace) -> int:
     tick = 0
+    next_stale_reap_at = 0.0
     try:
         async with UnitOfWork() as uow:
             startup = await async_scheduler_daemon_startup(
@@ -214,6 +249,9 @@ async def cmd_daemon(args: argparse.Namespace) -> int:
             )
         _emit({"event": "scheduler_startup", **startup})
         while True:
+            next_stale_reap_at = await _reap_stale_active_runs_if_due(
+                next_reap_at=next_stale_reap_at,
+            )
             async with UnitOfWork() as uow:
                 result = await async_scheduler_daemon_tick(
                     uow.session,

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 from collections.abc import Callable, AsyncIterator
 from datetime import datetime, timedelta, timezone
@@ -1629,6 +1630,44 @@ async def test_stale_active_run_reaper_interrupts_requeues_and_retries_abandoned
     assert retried is not None
     assert retried.id == run.id
     assert retried.status == RunStatus.STARTING
+
+
+async def test_scheduler_reaps_abandoned_run_without_a_worker(session_factory, monkeypatch, capsys):
+    from brain.app.cli import scheduler
+    from brain.systems.runs.cortex import runner
+
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(_run_request(thread_id="idea-1", message="scheduler recovery"))
+    await store.set_status(run.id, RunStatus.STARTING)
+    await store.set_status(run.id, RunStatus.RUNNING)
+    old = datetime.now(timezone.utc) - timedelta(seconds=600)
+    row = await session.get(AgentRunRow, run.id)
+    assert row is not None
+    row.created_at = old
+    row.started_at = old
+    row.updated_at = old
+    row.execution_token = "dead-worker"
+    row.metadata_ = {"runner_heartbeat": {"at": old.isoformat(), "reason": "runner_running"}}
+    for event in (await session.scalars(select(AgentRunEventRow).where(AgentRunEventRow.run_id == run.id))).all():
+        event.created_at = old
+    await session.commit()
+
+    monkeypatch.setattr(scheduler, "_monotonic", lambda: 100.0)
+    with (
+        patch("brain.systems.runs.cortex.runner.UnitOfWork", return_value=_SessionUoW(session)),
+        patch("brain.systems.runs.cortex.runner.publish_safe"),
+        patch("brain.systems.runs.cortex.runner._settle_idea_for_terminal_root_run_async", return_value=None),
+        patch("brain.systems.runs.cortex.runner.notify_run_interruption", return_value=None),
+    ):
+        next_reap_at = await scheduler._reap_stale_active_runs_if_due(next_reap_at=0.0)
+
+    row = await session.get(AgentRunRow, run.id)
+    assert next_reap_at == 160.0
+    assert row is not None
+    assert row.status == RunStatus.QUEUED.value
+    event = json.loads(capsys.readouterr().out)
+    assert event == {"event": "agent_run_stale_reap", "ok": True, "reaped": 1}
 
 
 async def test_stale_active_run_reaper_uses_recent_events_as_liveness(session_factory):

--- a/tests/test_scheduler_cli.py
+++ b/tests/test_scheduler_cli.py
@@ -1,7 +1,35 @@
 """Scheduler CLI output tests."""
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
+import brain.app.cli.scheduler as scheduler_cli
 from brain.app.cli.scheduler import _emit
+
+
+class _FakeUnitOfWork:
+    session = object()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        return False
+
+
+def _daemon_args(**overrides):
+    values = {
+        "owner_mode": "scheduler",
+        "job_key": None,
+        "max_runs": 10,
+        "resume": True,
+        "once": False,
+        "poll_interval_seconds": 15,
+        "now": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 def test_compact_tick_emission_is_one_bounded_line(capsys):
@@ -21,3 +49,74 @@ def test_compact_tick_emission_is_one_bounded_line(capsys):
     assert output.count("\n") == 1
     assert len(output) < 250
     assert '"snapshot"' not in output
+
+
+async def test_stale_run_reaper_uses_independent_cadence_and_emits_count(monkeypatch, capsys):
+    monotonic_times = iter((100.0, 159.9, 160.0))
+    calls: list[int] = []
+
+    async def fake_reap_stale_active_runs(*, limit):
+        calls.append(limit)
+        return len(calls)
+
+    monkeypatch.setattr(scheduler_cli, "_monotonic", lambda: next(monotonic_times))
+    monkeypatch.setattr(scheduler_cli, "reap_stale_active_runs", fake_reap_stale_active_runs)
+
+    next_reap_at = 0.0
+    next_reap_at = await scheduler_cli._reap_stale_active_runs_if_due(next_reap_at=next_reap_at)
+    assert next_reap_at == 160.0
+
+    next_reap_at = await scheduler_cli._reap_stale_active_runs_if_due(next_reap_at=next_reap_at)
+    assert next_reap_at == 160.0
+
+    next_reap_at = await scheduler_cli._reap_stale_active_runs_if_due(next_reap_at=next_reap_at)
+    assert next_reap_at == 220.0
+    assert calls == [25, 25]
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert events == [
+        {"event": "agent_run_stale_reap", "ok": True, "reaped": 1},
+        {"event": "agent_run_stale_reap", "ok": True, "reaped": 2},
+    ]
+
+
+async def test_stale_run_reaper_failure_emits_and_daemon_keeps_ticking(monkeypatch, capsys):
+    tick_calls = 0
+    sleep_calls = 0
+
+    async def fake_startup(*_args, **_kwargs):
+        return {"ok": True}
+
+    async def fake_tick(*_args, **_kwargs):
+        nonlocal tick_calls
+        tick_calls += 1
+        return {"ok": True}
+
+    async def fail_reap_stale_active_runs(*, limit):
+        assert limit == 25
+        raise RuntimeError("reaper unavailable")
+
+    async def stop_after_second_tick(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 2:
+            raise KeyboardInterrupt
+
+    monotonic_times = iter((100.0, 101.0))
+    monkeypatch.setattr(scheduler_cli, "UnitOfWork", _FakeUnitOfWork)
+    monkeypatch.setattr(scheduler_cli, "async_scheduler_daemon_startup", fake_startup)
+    monkeypatch.setattr(scheduler_cli, "async_scheduler_daemon_tick", fake_tick)
+    monkeypatch.setattr(scheduler_cli, "reap_stale_active_runs", fail_reap_stale_active_runs)
+    monkeypatch.setattr(scheduler_cli, "_monotonic", lambda: next(monotonic_times))
+    monkeypatch.setattr(scheduler_cli.asyncio, "sleep", stop_after_second_tick)
+
+    assert await scheduler_cli.cmd_daemon(_daemon_args()) == 0
+    assert tick_calls == 2
+
+    output = capsys.readouterr().out
+    assert (
+        '{"event":"agent_run_stale_reap_failed","ok":false,"error":"reaper unavailable"}'
+        in output
+    )
+    assert '"stopped": "keyboard_interrupt"' in output
+    assert '"ticks": 2' in output


### PR DESCRIPTION
Closes #550

`reap_stale_active_runs` is the only thing that recovers an AgentRun whose worker died holding
it — and it had exactly one caller: the worker's own supervisor loop. That supervisor stops the
moment the worker is told to drain, and never exists at all for a worker that was killed. So the
recovery path was absent precisely in the cases that need it. Run 2896 on illo-dev sat `running`
and idle for 65 minutes for this reason: nothing outside the worker was looking.

## What changed

The scheduler daemon now runs the same reaper. It is always on and never claims runs, so it
cannot race a claimer.

- One sweep on its own **~60s monotonic cadence**, independent of the 15s scheduler tick, with
  `limit=25`. An overrun produces one sweep on the next loop, never a catch-up burst.
- Emits `agent_run_stale_reap` with the reaped count, so a recovery nobody can see (which is how
  run 2896 stayed invisible) becomes observable.
- A raised exception emits `agent_run_stale_reap_failed` and the daemon **keeps ticking** — the
  reaper cannot take the scheduler down.

Deliberately unchanged: `runner.py`, the reaper's liveness rule, and the worker call site. The
liveness rule already covers "running but idle" and will not fire while the owning process
heartbeats — a fresh heartbeat is the only evidence separating a slow run from a dead one.
"Idle despite heartbeat" is a different ticket. The worker call site stays because it covers the
case where the scheduler itself is down; the reaper's row-lock recheck makes two callers safe.

## How to check it (no diff reading required)

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-550-scheduler-reaping
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest tests/ -m "not requires_db and not requires_browser and not live_provider" -q
```

**4360 passed, 11 skipped** — the exact CI marker expression, run by the orchestrator outside the
Codex sandbox on this commit. The review pass independently ran the three new tests plus the
scheduler-CLI and architecture-boundary suites green.

Acceptance checks and the test that proves each:

1. A run abandoned by a dead worker is reaped by the **scheduler**, no worker process alive —
   `tests/test_agent_run_state_machine.py` (runs against the real database reaper)
2. Cadence is ~60s and independent of the tick, at `limit=25`, with the count emitted —
   `tests/test_scheduler_cli.py`
3. A reaper exception emits and the daemon keeps ticking — `tests/test_scheduler_cli.py`
4. A run whose worker is heart-beating is still NOT reaped — the pre-existing liveness assertions
   pass untouched

## Review

One Codex code-quality pass, **VERDICT: SHIP**, no blocking findings. It specifically confirmed
the two-caller safety argument against the code (the second transaction observes a non-active
status and exits at `runner.py:1134`), that the overrun claim is true, and that the three tests
fail against the old code for the stated reason rather than incidentally.

Non-blocking, carried here rather than fixed:

- The candidate query has no `SKIP LOCKED`, so two concurrent sweeps can select the same 25 rows
  — one wasted sweep and a brief block, not a correctness problem.
- `reap_stale_active_runs` now has a caller outside the worker subsystem; extracting the
  reaper/liveness block out of the already-large `runner.py` into a run-recovery module is a
  sensible future cleanup. This PR reuses the canonical implementation rather than duplicating
  policy, which is why it is not done here.
