### PR TITLE
fix(knowledge): index whole GitHub bodies, not the 1000-char LLM excerpt

### DIFF
--- a/brain/systems/cortex/project_context/github.py
+++ b/brain/systems/cortex/project_context/github.py
@@ -354,9 +354,9 @@ def _label_payloads(labels: Any) -> list[dict[str, Any]]:
     ]
 
 
-def _issue_payload(issue: dict[str, Any]) -> dict[str, Any]:
+def _issue_payload(issue: dict[str, Any], *, body_limit: int = 1000) -> dict[str, Any]:
     raw_body = str(issue.get("body") or "")
-    compact_body = _compact_body(raw_body)
+    compact_body = _compact_body(raw_body, limit=body_limit)
     normalized_body_chars = len(" ".join(raw_body.split()))
     pull_request = issue.get("pull_request") if isinstance(issue.get("pull_request"), dict) else {}
     return {
@@ -1240,6 +1240,7 @@ async def async_list_repo_issues(
     include_pull_requests: bool = False,
     limit: int = 30,
     cursor: str | None = None,
+    body_limit: int = 1000,
 ) -> dict[str, Any]:
     owner, repo = slug.split("/", 1)
     max_items = max(1, min(int(limit or 30), GITHUB_ITEM_LIMIT))
@@ -1290,7 +1291,11 @@ async def async_list_repo_issues(
     return {
         "repo": slug,
         "state": params["state"],
-        "issues": [_issue_payload(item) for item in selected if isinstance(item, dict)],
+        "issues": [
+            _issue_payload(item, body_limit=body_limit)
+            for item in selected
+            if isinstance(item, dict)
+        ],
         "included_pull_requests": include_pull_requests,
         "truncated": next_position is not None,
         "next_page": encode_page_token(page_kind, next_position) if next_position else None,

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -22,6 +22,7 @@ from brain.systems.cortex.project_context.github import (
     parse_github_repo_slug,
 )
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
 
@@ -253,6 +254,10 @@ class GitHubConnector:
                 include_pull_requests=True,
                 limit=remaining,
                 cursor=state.get("next_page"),
+                # Project-context reads compact bodies to 1000 chars for LLM
+                # budgets; an index wants the whole body and bounds it once,
+                # in the pipeline, at RAW_TEXT_MAX_CHARS.
+                body_limit=RAW_TEXT_MAX_CHARS,
             )
             issues = [item for item in payload.get("issues") or [] if isinstance(item, Mapping)]
             for issue in issues:


### PR DESCRIPTION
Follow-up to #560, found by verifying the first live sync on illo-dev rather than trusting it.

## The defect

The knowledge GitHub connector reuses `async_list_repo_issues` from `project_context/github.py`, whose `_issue_payload` runs bodies through `_compact_body` — a **1000-char cap that exists for LLM prompt budgets**. Every indexed issue and PR therefore landed truncated to exactly 1000 chars.

Measured on illo-dev after the first sync, across all 100 GitHub rows:

```
min=999  avg=1000  max=1000
```

The stats caught it honestly (`"truncated": 100`), which is what that accounting is for — but a knowledge index that stores the first 1000 characters of every issue is searching a fraction of its corpus. This directly undercuts the point of the index.

## The fix

Thread a `body_limit` through `async_list_repo_issues` → `_issue_payload` → `_compact_body`, **defaulting to the existing 1000** so all ~14 project-context call sites are byte-for-byte unchanged. The knowledge connector asks for `RAW_TEXT_MAX_CHARS` instead: the index bounds `raw_text` once, in the pipeline, where truncation is already recorded.

Extending the shared module rather than forking it, per the slice-1 PRD.

## Testing

`4365 passed, 81 skipped` (full suite). GitHub tool tests (87) pass unchanged, confirming the default preserves existing behavior.

## Follow-up after merge

The 100 already-indexed rows keep their truncated bodies, since the connector resumes from a watermark. Clearing the `github` row in `knowledge_sync_state` re-ingests them; they upsert in place on `(source, source_ref)` and re-embed because the digest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)