### PR TITLE
feat(runs): push token budget notices into context so a looping run is told to stop (part of #510)

### DIFF
--- a/brain/kernel/config.py
+++ b/brain/kernel/config.py
@@ -62,6 +62,22 @@ AGENT_SOUL_PATH = Path(os.getenv("AGENT_SOUL_PATH", AGENT_CONTEXT_DIR / "SOUL.md
 BRAIN_LOG_DIR = Path(os.getenv("BRAIN_LOG_DIR", PRIVATE_HOME / "logs"))
 
 # ---------------------------------------------------------------------------
+# Agent runtime
+# ---------------------------------------------------------------------------
+_DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION = 2 / 3
+try:
+    AGENT_RUN_BUDGET_NOTICE_FRACTION = float(
+        os.getenv(
+            "AGENT_RUN_BUDGET_NOTICE_FRACTION",
+            str(_DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION),
+        )
+    )
+except (TypeError, ValueError):
+    AGENT_RUN_BUDGET_NOTICE_FRACTION = _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION
+if not 0 < AGENT_RUN_BUDGET_NOTICE_FRACTION < 1:
+    AGENT_RUN_BUDGET_NOTICE_FRACTION = _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION
+
+# ---------------------------------------------------------------------------
 # Database
 # ---------------------------------------------------------------------------
 DB_HOST = os.getenv("DB_HOST", "127.0.0.1")

--- a/brain/kernel/config.py
+++ b/brain/kernel/config.py
@@ -9,6 +9,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from brain.kernel.common.env import env_float, env_int
+
 # ---------------------------------------------------------------------------
 # Resolve .env (if python-dotenv available)
 # ---------------------------------------------------------------------------
@@ -64,34 +66,21 @@ BRAIN_LOG_DIR = Path(os.getenv("BRAIN_LOG_DIR", PRIVATE_HOME / "logs"))
 # ---------------------------------------------------------------------------
 # Agent runtime
 # ---------------------------------------------------------------------------
-# About 33 near-limit 150K-token requests: well beyond an ordinary run, while
-# still catching a sustained large-context loop before it can consume 45 minutes.
+# Unvalidated estimate: 33 near-limit requests * 150K budget tokens = 4.95M,
+# rounded to 5M. The budget metric includes uncached input/output plus cache
+# reads/writes; see cumulative_run_budget_tokens() in runtime_activity.py.
 _DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = 5_000_000
-try:
-    AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = max(
-        0,
-        int(
-            os.getenv(
-                "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET",
-                str(_DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET),
-            )
-        ),
-    )
-except (TypeError, ValueError):
-    AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = (
-        _DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET
-    )
+AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = env_int(
+    "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET",
+    _DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET,
+    minimum=0,
+)
 
 _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION = 2 / 3
-try:
-    AGENT_RUN_BUDGET_NOTICE_FRACTION = float(
-        os.getenv(
-            "AGENT_RUN_BUDGET_NOTICE_FRACTION",
-            str(_DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION),
-        )
-    )
-except (TypeError, ValueError):
-    AGENT_RUN_BUDGET_NOTICE_FRACTION = _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION
+AGENT_RUN_BUDGET_NOTICE_FRACTION = env_float(
+    "AGENT_RUN_BUDGET_NOTICE_FRACTION",
+    _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION,
+)
 if not 0 < AGENT_RUN_BUDGET_NOTICE_FRACTION < 1:
     AGENT_RUN_BUDGET_NOTICE_FRACTION = _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION
 

--- a/brain/kernel/config.py
+++ b/brain/kernel/config.py
@@ -64,6 +64,24 @@ BRAIN_LOG_DIR = Path(os.getenv("BRAIN_LOG_DIR", PRIVATE_HOME / "logs"))
 # ---------------------------------------------------------------------------
 # Agent runtime
 # ---------------------------------------------------------------------------
+# About 33 near-limit 150K-token requests: well beyond an ordinary run, while
+# still catching a sustained large-context loop before it can consume 45 minutes.
+_DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = 5_000_000
+try:
+    AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = max(
+        0,
+        int(
+            os.getenv(
+                "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET",
+                str(_DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET),
+            )
+        ),
+    )
+except (TypeError, ValueError):
+    AGENT_RUN_CUMULATIVE_TOKEN_BUDGET = (
+        _DEFAULT_AGENT_RUN_CUMULATIVE_TOKEN_BUDGET
+    )
+
 _DEFAULT_AGENT_RUN_BUDGET_NOTICE_FRACTION = 2 / 3
 try:
     AGENT_RUN_BUDGET_NOTICE_FRACTION = float(

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -122,6 +122,10 @@ from brain.systems.runs.routing_metadata import (
     effective_routing_snapshot,
     routing_metadata_with_effective,
 )
+from brain.systems.runs.direct_loop.run_budget_notice import (
+    budget_notices_seen,
+    load_due_budget_notices,
+)
 from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
 from brain.systems import sessions as _session_store
@@ -1518,6 +1522,10 @@ async def run_agent_async(
         loaded_messages, stored_system = (
             await _maybe_await(load_session(session_id)) if persist_session else ([], None)
         )
+        run_budget_notices_sent = budget_notices_seen(
+            loaded_messages,
+            run_id=run_id,
+        )
         if stored_system and not system_prompt:
             system_prompt = stored_system
         raw_archive_messages = copy.deepcopy(loaded_messages) if persist_session else None
@@ -1597,6 +1605,18 @@ async def run_agent_async(
             )
             if guidance_count and raw_archive_messages is not None and len(state.messages) > before_guidance_len:
                 raw_archive_messages.append(copy.deepcopy(state.messages[-1]))
+            for notice in await load_due_budget_notices(
+                run_id=run_id,
+                budget=context_policy.budget.to_payload(),
+                tool_calls_log=getattr(_agent_context, "tool_calls_log", []),
+                sent=run_budget_notices_sent,
+            ):
+                _append_message_with_archive(
+                    state.messages,
+                    notice.message,
+                    raw_archive_messages,
+                )
+                run_budget_notices_sent.add(notice.key)
             state.messages = _sanitize_tool_pairs(state.messages, session_id)
             compaction = _compact_active_context(
                 state.messages,

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -1607,7 +1607,6 @@ async def run_agent_async(
                 raw_archive_messages.append(copy.deepcopy(state.messages[-1]))
             for notice in await load_due_budget_notices(
                 run_id=run_id,
-                budget=context_policy.budget.to_payload(),
                 tool_calls_log=getattr(_agent_context, "tool_calls_log", []),
                 sent=run_budget_notices_sent,
             ):

--- a/brain/systems/runs/direct_agent.py
+++ b/brain/systems/runs/direct_agent.py
@@ -123,8 +123,9 @@ from brain.systems.runs.routing_metadata import (
     routing_metadata_with_effective,
 )
 from brain.systems.runs.direct_loop.run_budget_notice import (
-    budget_notices_seen,
+    load_budget_notices_sent,
     load_due_budget_notices,
+    record_budget_notice_sent,
 )
 from brain.systems.runs.tool_catalog.registry import parallel_safe_tool_names
 from brain.systems.runs.tool_policy import disabled_tool_names_from_metadata
@@ -1522,10 +1523,7 @@ async def run_agent_async(
         loaded_messages, stored_system = (
             await _maybe_await(load_session(session_id)) if persist_session else ([], None)
         )
-        run_budget_notices_sent = budget_notices_seen(
-            loaded_messages,
-            run_id=run_id,
-        )
+        run_budget_notices_sent = await load_budget_notices_sent(run_id)
         if stored_system and not system_prompt:
             system_prompt = stored_system
         raw_archive_messages = copy.deepcopy(loaded_messages) if persist_session else None
@@ -1607,14 +1605,14 @@ async def run_agent_async(
                 raw_archive_messages.append(copy.deepcopy(state.messages[-1]))
             for notice in await load_due_budget_notices(
                 run_id=run_id,
-                tool_calls_log=getattr(_agent_context, "tool_calls_log", []),
                 sent=run_budget_notices_sent,
             ):
-                _append_message_with_archive(
-                    state.messages,
-                    notice.message,
-                    raw_archive_messages,
-                )
+                if await record_budget_notice_sent(run_id=int(run_id), notice=notice):
+                    _append_message_with_archive(
+                        state.messages,
+                        notice.message,
+                        raw_archive_messages,
+                    )
                 run_budget_notices_sent.add(notice.key)
             state.messages = _sanitize_tool_pairs(state.messages, session_id)
             compaction = _compact_active_context(

--- a/brain/systems/runs/direct_loop/run_budget_notice.py
+++ b/brain/systems/runs/direct_loop/run_budget_notice.py
@@ -1,0 +1,168 @@
+"""One-shot model-context notices for cumulative AgentRun token usage."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+import logging
+import math
+from typing import Any
+
+from brain.kernel import config
+from brain.systems.runs.runtime_activity import load_run_activity
+
+logger = logging.getLogger("agent")
+
+SOFT_NOTICE_KEY = "soft"
+CEILING_NOTICE_KEY = "ceiling"
+_MARKER_PREFIX = "[System run budget notice:"
+
+
+@dataclass(frozen=True)
+class RunBudgetNotice:
+    """A newly due notice and its once-per-run identity."""
+
+    key: str
+    message: dict[str, str]
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, Sequence):
+        return ""
+    return "\n".join(
+        str(block.get("text") or block.get("content") or "")
+        for block in content
+        if isinstance(block, Mapping)
+    )
+
+
+def _marker(key: str, run_id: int) -> str:
+    return f"{_MARKER_PREFIX} {key}; run_id={run_id}]"
+
+
+def budget_notices_seen(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    run_id: int | None,
+) -> set[str]:
+    """Recover notice state for this run from its persisted transcript."""
+
+    if run_id is None:
+        return set()
+    resolved_run_id = int(run_id)
+    seen: set[str] = set()
+    for message in messages:
+        text = _message_text(message)
+        for key in (SOFT_NOTICE_KEY, CEILING_NOTICE_KEY):
+            if _marker(key, resolved_run_id) in text:
+                seen.add(key)
+    return seen
+
+
+def _budget_ceiling(budget: Mapping[str, Any]) -> int:
+    try:
+        return max(0, int(budget.get("auto_compact_threshold_tokens") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _tool_call_phrase(count: int) -> str:
+    return f"{count} tool call" if count == 1 else f"{count} tool calls"
+
+
+def _notice(
+    *,
+    key: str,
+    run_id: int,
+    tokens_used: int,
+    ceiling_tokens: int,
+    tool_call_count: int,
+) -> RunBudgetNotice:
+    position = (
+        f"Run {run_id} has used {tokens_used} of {ceiling_tokens} tokens "
+        f"and made {_tool_call_phrase(tool_call_count)}."
+    )
+    if key == SOFT_NOTICE_KEY:
+        instruction = (
+            "You are nearing this run's token budget. "
+            "Wrap up now and persist durable progress before closing."
+        )
+    else:
+        instruction = (
+            "This run has reached its token budget ceiling. Stop new work: "
+            "persist what you have and emit the closing output now."
+        )
+    return RunBudgetNotice(
+        key=key,
+        message={
+            "role": "user",
+            "content": f"{_marker(key, run_id)} {position} {instruction}",
+        },
+    )
+
+
+async def load_due_budget_notices(
+    *,
+    run_id: int | None,
+    budget: Mapping[str, Any],
+    tool_calls_log: Sequence[str],
+    sent: Collection[str],
+) -> tuple[RunBudgetNotice, ...]:
+    """Load ledger-backed usage and return each newly crossed notice once."""
+
+    if run_id is None:
+        return ()
+    ceiling_tokens = _budget_ceiling(budget)
+    if ceiling_tokens <= 0:
+        return ()
+
+    resolved_run_id = int(run_id)
+    try:
+        activity = await load_run_activity(resolved_run_id)
+    except Exception:
+        logger.warning(
+            "Failed to load durable run activity for budget notice",
+            extra={"run_id": resolved_run_id},
+            exc_info=True,
+        )
+        return ()
+
+    tokens_used = max(0, int(activity.get("tokens_used") or 0))
+    tool_call_count = len(tool_calls_log)
+    soft_threshold = math.ceil(
+        ceiling_tokens * config.AGENT_RUN_BUDGET_NOTICE_FRACTION
+    )
+    notices: list[RunBudgetNotice] = []
+    if tokens_used >= soft_threshold and SOFT_NOTICE_KEY not in sent:
+        notices.append(
+            _notice(
+                key=SOFT_NOTICE_KEY,
+                run_id=resolved_run_id,
+                tokens_used=tokens_used,
+                ceiling_tokens=ceiling_tokens,
+                tool_call_count=tool_call_count,
+            )
+        )
+    if tokens_used >= ceiling_tokens and CEILING_NOTICE_KEY not in sent:
+        notices.append(
+            _notice(
+                key=CEILING_NOTICE_KEY,
+                run_id=resolved_run_id,
+                tokens_used=tokens_used,
+                ceiling_tokens=ceiling_tokens,
+                tool_call_count=tool_call_count,
+            )
+        )
+    return tuple(notices)
+
+
+__all__ = [
+    "CEILING_NOTICE_KEY",
+    "RunBudgetNotice",
+    "SOFT_NOTICE_KEY",
+    "budget_notices_seen",
+    "load_due_budget_notices",
+]

--- a/brain/systems/runs/direct_loop/run_budget_notice.py
+++ b/brain/systems/runs/direct_loop/run_budget_notice.py
@@ -2,20 +2,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Collection
 from dataclasses import dataclass
 import logging
 import math
 from typing import Any
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from brain.kernel import config
+from brain.platform.db.models.agent_run import AgentRunEventRow
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.systems.runs.domain import EventVisibility
+from brain.systems.runs.events import run_event
 from brain.systems.runs.runtime_activity import load_run_activity
+from brain.systems.runs.store import AsyncAgentRunStore
 
 logger = logging.getLogger("agent")
 
 SOFT_NOTICE_KEY = "soft"
 CEILING_NOTICE_KEY = "ceiling"
-_MARKER_PREFIX = "[System run budget notice:"
+BUDGET_NOTICE_SENT_EVENT = "run.budget_notice_sent"
+_NOTICE_KEYS = frozenset({SOFT_NOTICE_KEY, CEILING_NOTICE_KEY})
 
 
 @dataclass(frozen=True)
@@ -26,74 +35,96 @@ class RunBudgetNotice:
     message: dict[str, str]
 
 
-def _message_text(message: Mapping[str, Any]) -> str:
-    content = message.get("content")
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, Sequence):
-        return ""
-    return "\n".join(
-        str(block.get("text") or block.get("content") or "")
-        for block in content
-        if isinstance(block, Mapping)
-    )
+def _notice_kind(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    kind = str(payload.get("kind") or "")
+    return kind if kind in _NOTICE_KEYS else None
 
 
-def _marker(key: str, run_id: int) -> str:
-    return f"{_MARKER_PREFIX} {key}; run_id={run_id}]"
+async def _recorded_notice_keys(session: AsyncSession, run_id: int) -> set[str]:
+    payloads = (
+        await session.scalars(
+            select(AgentRunEventRow.payload).where(
+                AgentRunEventRow.run_id == run_id,
+                AgentRunEventRow.event_type == BUDGET_NOTICE_SENT_EVENT,
+            )
+        )
+    ).all()
+    return {
+        kind
+        for payload in payloads
+        if (kind := _notice_kind(payload)) is not None
+    }
 
 
-def budget_notices_seen(
-    messages: Sequence[Mapping[str, Any]],
-    *,
-    run_id: int | None,
-) -> set[str]:
-    """Recover notice state for this run from its persisted transcript."""
+async def load_budget_notices_sent(run_id: int | None) -> set[str]:
+    """Recover once-per-run notice state from the internal event ledger."""
 
-    if run_id is None:
+    if run_id is None or config.AGENT_RUN_CUMULATIVE_TOKEN_BUDGET == 0:
         return set()
     resolved_run_id = int(run_id)
-    seen: set[str] = set()
-    for message in messages:
-        text = _message_text(message)
-        for key in (SOFT_NOTICE_KEY, CEILING_NOTICE_KEY):
-            if _marker(key, resolved_run_id) in text:
-                seen.add(key)
-    return seen
-
-
-def _cumulative_run_token_budget() -> int:
     try:
-        return max(
-            0,
-            int(
-                getattr(
-                    config,
-                    "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET",
-                    0,
-                )
-                or 0
-            ),
+        async with UnitOfWork() as uow:
+            return await _recorded_notice_keys(uow.session, resolved_run_id)
+    except Exception:
+        logger.warning(
+            "Failed to load durable run budget notice state",
+            extra={"run_id": resolved_run_id},
+            exc_info=True,
         )
-    except (TypeError, ValueError):
-        return 0
+        # Fail closed: an unavailable ledger must never cause a duplicate or
+        # potentially misleading safety notice.
+        return set(_NOTICE_KEYS)
 
 
-def _tool_call_phrase(count: int) -> str:
-    return f"{count} tool call" if count == 1 else f"{count} tool calls"
+async def record_budget_notice_sent(
+    *,
+    run_id: int,
+    notice: RunBudgetNotice,
+) -> bool:
+    """Persist a notice marker, returning true only for a newly recorded notice."""
+
+    resolved_run_id = int(run_id)
+    try:
+        async with UnitOfWork() as uow:
+            store = AsyncAgentRunStore(uow.session)
+            run = await store.require_run(resolved_run_id)
+            await store.lock_event_stream(resolved_run_id)
+            if notice.key in await _recorded_notice_keys(
+                uow.session,
+                resolved_run_id,
+            ):
+                return False
+            await store.append_event(
+                run_event(
+                    resolved_run_id,
+                    BUDGET_NOTICE_SENT_EVENT,
+                    {"kind": notice.key},
+                    root_run_id=run.root_run_id or resolved_run_id,
+                    visibility=EventVisibility.INTERNAL,
+                )
+            )
+        return True
+    except Exception:
+        logger.warning(
+            "Failed to persist durable run budget notice state",
+            extra={"run_id": resolved_run_id, "notice_kind": notice.key},
+            exc_info=True,
+        )
+        return False
 
 
 def _notice(
     *,
     key: str,
     run_id: int,
-    tokens_used: int,
+    budget_tokens_used: int,
     ceiling_tokens: int,
-    tool_call_count: int,
 ) -> RunBudgetNotice:
     position = (
-        f"Run {run_id} has used {tokens_used} of {ceiling_tokens} tokens "
-        f"and made {_tool_call_phrase(tool_call_count)}."
+        f"Run {run_id} has used {budget_tokens_used} of {ceiling_tokens} cumulative "
+        "budget tokens."
     )
     if key == SOFT_NOTICE_KEY:
         instruction = (
@@ -109,7 +140,7 @@ def _notice(
         key=key,
         message={
             "role": "user",
-            "content": f"{_marker(key, run_id)} {position} {instruction}",
+            "content": f"{position} {instruction}",
         },
     )
 
@@ -117,17 +148,14 @@ def _notice(
 async def load_due_budget_notices(
     *,
     run_id: int | None,
-    tool_calls_log: Sequence[str],
     sent: Collection[str],
 ) -> tuple[RunBudgetNotice, ...]:
     """Load ledger-backed usage and return each newly crossed notice once."""
 
-    if run_id is None:
+    if run_id is None or _NOTICE_KEYS.issubset(sent):
         return ()
-    if {SOFT_NOTICE_KEY, CEILING_NOTICE_KEY}.issubset(sent):
-        return ()
-    ceiling_tokens = _cumulative_run_token_budget()
-    if ceiling_tokens <= 0:
+    ceiling_tokens = config.AGENT_RUN_CUMULATIVE_TOKEN_BUDGET
+    if ceiling_tokens == 0:
         return ()
 
     resolved_run_id = int(run_id)
@@ -141,39 +169,41 @@ async def load_due_budget_notices(
         )
         return ()
 
-    tokens_used = max(0, int(activity.get("tokens_used") or 0))
-    tool_call_count = len(tool_calls_log)
+    budget_tokens_used = max(
+        0,
+        int(activity.get("run_budget_tokens_used") or 0),
+    )
     soft_threshold = math.ceil(
         ceiling_tokens * config.AGENT_RUN_BUDGET_NOTICE_FRACTION
     )
     notices: list[RunBudgetNotice] = []
-    if tokens_used >= soft_threshold and SOFT_NOTICE_KEY not in sent:
+    if budget_tokens_used >= soft_threshold and SOFT_NOTICE_KEY not in sent:
         notices.append(
             _notice(
                 key=SOFT_NOTICE_KEY,
                 run_id=resolved_run_id,
-                tokens_used=tokens_used,
+                budget_tokens_used=budget_tokens_used,
                 ceiling_tokens=ceiling_tokens,
-                tool_call_count=tool_call_count,
             )
         )
-    if tokens_used >= ceiling_tokens and CEILING_NOTICE_KEY not in sent:
+    if budget_tokens_used >= ceiling_tokens and CEILING_NOTICE_KEY not in sent:
         notices.append(
             _notice(
                 key=CEILING_NOTICE_KEY,
                 run_id=resolved_run_id,
-                tokens_used=tokens_used,
+                budget_tokens_used=budget_tokens_used,
                 ceiling_tokens=ceiling_tokens,
-                tool_call_count=tool_call_count,
             )
         )
     return tuple(notices)
 
 
 __all__ = [
+    "BUDGET_NOTICE_SENT_EVENT",
     "CEILING_NOTICE_KEY",
     "RunBudgetNotice",
     "SOFT_NOTICE_KEY",
-    "budget_notices_seen",
+    "load_budget_notices_sent",
     "load_due_budget_notices",
+    "record_budget_notice_sent",
 ]

--- a/brain/systems/runs/direct_loop/run_budget_notice.py
+++ b/brain/systems/runs/direct_loop/run_budget_notice.py
@@ -62,9 +62,19 @@ def budget_notices_seen(
     return seen
 
 
-def _budget_ceiling(budget: Mapping[str, Any]) -> int:
+def _cumulative_run_token_budget() -> int:
     try:
-        return max(0, int(budget.get("auto_compact_threshold_tokens") or 0))
+        return max(
+            0,
+            int(
+                getattr(
+                    config,
+                    "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET",
+                    0,
+                )
+                or 0
+            ),
+        )
     except (TypeError, ValueError):
         return 0
 
@@ -107,7 +117,6 @@ def _notice(
 async def load_due_budget_notices(
     *,
     run_id: int | None,
-    budget: Mapping[str, Any],
     tool_calls_log: Sequence[str],
     sent: Collection[str],
 ) -> tuple[RunBudgetNotice, ...]:
@@ -115,7 +124,9 @@ async def load_due_budget_notices(
 
     if run_id is None:
         return ()
-    ceiling_tokens = _budget_ceiling(budget)
+    if {SOFT_NOTICE_KEY, CEILING_NOTICE_KEY}.issubset(sent):
+        return ()
+    ceiling_tokens = _cumulative_run_token_budget()
     if ceiling_tokens <= 0:
         return ()
 

--- a/brain/systems/runs/runtime_activity.py
+++ b/brain/systems/runs/runtime_activity.py
@@ -9,8 +9,23 @@ from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.runs.token_usage import async_summarize_run_usage
 
 
+def cumulative_run_budget_tokens(usage: dict | None) -> int:
+    """Return the cache-aware token volume used by the cumulative run budget.
+
+    Cached reads count because repeatedly sending a large cached context is the
+    failure mode this budget detects. Cache writes count too: the usage ledger
+    reports those processed prompt tokens separately from ``tokens_total``.
+    """
+
+    usage = usage or {}
+    return sum(
+        max(0, int(usage.get(field) or 0))
+        for field in ("tokens_total", "cache_read", "cache_write")
+    )
+
+
 async def load_run_activity(run_id: int) -> dict[str, int]:
-    """Read current-run tokens and spawned-worker count from durable ledgers."""
+    """Read current-run token metrics and spawned workers from durable ledgers."""
 
     async with UnitOfWork() as uow:
         usage = await async_summarize_run_usage(uow.session, run_id)
@@ -22,8 +37,9 @@ async def load_run_activity(run_id: int) -> dict[str, int]:
         )
     return {
         "tokens_used": int((usage or {}).get("tokens_total") or 0),
+        "run_budget_tokens_used": cumulative_run_budget_tokens(usage),
         "workers_spawned": int(workers_spawned or 0),
     }
 
 
-__all__ = ["load_run_activity"]
+__all__ = ["cumulative_run_budget_tokens", "load_run_activity"]

--- a/brain/systems/runs/tool_catalog/handlers/activity.py
+++ b/brain/systems/runs/tool_catalog/handlers/activity.py
@@ -49,7 +49,11 @@ async def _handle_my_activity() -> dict:
                 extra={"run_id": run_id},
                 exc_info=True,
             )
-            result.update(tokens_used=0, workers_spawned=0)
+            result.update(
+                tokens_used=0,
+                run_budget_tokens_used=0,
+                workers_spawned=0,
+            )
     if not result.get("execution_artifacts"):
         try:
             execution_metadata = getattr(_agent_context, "execution_metadata", {}) or {}

--- a/tests/test_runtime_activity.py
+++ b/tests/test_runtime_activity.py
@@ -2,9 +2,8 @@
 
 import copy
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 
 def _mock_llm_client(mock_anthropic_client):
@@ -61,7 +60,11 @@ async def test_run_activity_uses_token_ledger_and_worker_spawn_events():
     uow.session = session
     uow.__aenter__ = AsyncMock(return_value=uow)
     uow.__aexit__ = AsyncMock(return_value=False)
-    summarize = AsyncMock(return_value={"tokens_total": 987})
+    summarize = AsyncMock(return_value={
+        "tokens_total": 1_200,
+        "cache_read": 148_000,
+        "cache_write": 800,
+    })
 
     with patch(
         "brain.systems.runs.runtime_activity.UnitOfWork",
@@ -72,7 +75,11 @@ async def test_run_activity_uses_token_ledger_and_worker_spawn_events():
     ):
         result = await load_run_activity(42)
 
-    assert result == {"tokens_used": 987, "workers_spawned": 2}
+    assert result == {
+        "tokens_used": 1_200,
+        "run_budget_tokens_used": 150_000,
+        "workers_spawned": 2,
+    }
     summarize.assert_awaited_once_with(session, 42)
     worker_count_query = session.scalar.await_args.args[0]
     compiled = worker_count_query.compile()
@@ -155,13 +162,18 @@ async def test_my_activity_includes_live_execution_artifacts():
         ],
     }), patch(
         "brain.systems.runs.tool_catalog.handlers.activity.load_run_activity",
-        new=AsyncMock(return_value={"tokens_used": 1234, "workers_spawned": 2}),
+        new=AsyncMock(return_value={
+            "tokens_used": 1234,
+            "run_budget_tokens_used": 1734,
+            "workers_spawned": 2,
+        }),
     ):
         result = await _handle_my_activity()
 
     assert result["execution_artifacts"][0]["type"] == "pr"
     assert result["execution_artifacts"][0]["number"] == 123
     assert result["tokens_used"] == 1234
+    assert result["run_budget_tokens_used"] == 1734
     assert result["workers_spawned"] == 2
 
 
@@ -259,10 +271,11 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
 
     client.messages.create.side_effect = create
     load_activity = AsyncMock(side_effect=[
-        {"tokens_used": 0, "workers_spawned": 0},
-        {"tokens_used": 750, "workers_spawned": 0},
-        {"tokens_used": 1500, "workers_spawned": 0},
+        {"tokens_used": 0, "run_budget_tokens_used": 0, "workers_spawned": 0},
+        {"tokens_used": 50, "run_budget_tokens_used": 750, "workers_spawned": 0},
+        {"tokens_used": 100, "run_budget_tokens_used": 1500, "workers_spawned": 0},
     ])
+    record_notice = AsyncMock(return_value=True)
 
     with patch.object(
         direct_agent,
@@ -272,6 +285,14 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
         direct_agent,
         "_async_record_api_call",
         new=AsyncMock(),
+    ), patch.object(
+        direct_agent,
+        "load_budget_notices_sent",
+        new=AsyncMock(return_value=set()),
+    ), patch.object(
+        direct_agent,
+        "record_budget_notice_sent",
+        new=record_notice,
     ), patch(
         "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
         new=load_activity,
@@ -298,14 +319,16 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
     assert result.success
     assert load_activity.await_count == 3
     assert all(call.args == (42,) for call in load_activity.await_args_list)
+    assert [call.kwargs["notice"].key for call in record_notice.await_args_list] == [
+        "soft",
+        "ceiling",
+    ]
     final_context = json.dumps(request_messages[-1])
-    assert final_context.count("[System run budget notice: soft; run_id=42]") == 1
-    assert final_context.count("[System run budget notice: ceiling; run_id=42]") == 1
-    assert "750 of 1500 tokens" in final_context
-    assert "1 tool call" in final_context
+    assert "[System run budget notice:" not in final_context
+    assert "750 of 1500 cumulative budget tokens" in final_context
     assert "Wrap up now and persist durable progress" in final_context
-    assert "1500 of 1500 tokens" in final_context
-    assert "2 tool calls" in final_context
+    assert "1500 of 1500 cumulative budget tokens" in final_context
+    assert "tool call" not in final_context
     assert "persist what you have and emit the closing output" in final_context
     assert "my_activity" not in final_context
 
@@ -317,7 +340,7 @@ def test_cumulative_usage_above_context_compaction_but_below_run_budget_gets_no_
     from brain.systems.runs import direct_agent
 
     monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 10_000)
-    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
+    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.75)
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "2000")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "1500")
     monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
@@ -334,8 +357,13 @@ def test_cumulative_usage_above_context_compaction_but_below_run_budget_gets_no_
 
     client.messages.create.side_effect = create
     load_activity = AsyncMock(
-        return_value={"tokens_used": 1600, "workers_spawned": 0},
+        return_value={
+            "tokens_used": 600,
+            "run_budget_tokens_used": 6_400,
+            "workers_spawned": 0,
+        },
     )
+    record_notice = AsyncMock()
 
     with patch.object(
         direct_agent,
@@ -345,6 +373,14 @@ def test_cumulative_usage_above_context_compaction_but_below_run_budget_gets_no_
         direct_agent,
         "_async_record_api_call",
         new=AsyncMock(),
+    ), patch.object(
+        direct_agent,
+        "load_budget_notices_sent",
+        new=AsyncMock(return_value=set()),
+    ), patch.object(
+        direct_agent,
+        "record_budget_notice_sent",
+        new=record_notice,
     ), patch(
         "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
         new=load_activity,
@@ -362,97 +398,251 @@ def test_cumulative_usage_above_context_compaction_but_below_run_budget_gets_no_
     assert result.success
     assert request_messages == [[{"role": "user", "content": "Do a short task"}]]
     load_activity.assert_awaited_once_with(42)
+    record_notice.assert_not_awaited()
 
 
-@pytest.mark.parametrize("run_budget", [None, 0, -1])
-async def test_unconfigured_run_budget_skips_notices_and_ledger_read(
-    monkeypatch,
-    run_budget,
-):
+async def test_zero_run_budget_skips_notices_and_ledger_read(monkeypatch):
     from brain.kernel import config
     from brain.systems.runs.direct_loop.run_budget_notice import (
+        load_budget_notices_sent,
         load_due_budget_notices,
     )
 
-    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", run_budget)
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 0)
     load_activity = AsyncMock()
+    uow = MagicMock()
 
     with patch(
         "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
         new=load_activity,
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.UnitOfWork",
+        new=uow,
     ):
         notices = await load_due_budget_notices(
             run_id=42,
-            tool_calls_log=[],
             sent=set(),
         )
+        sent = await load_budget_notices_sent(42)
 
     assert notices == ()
+    assert sent == set()
     load_activity.assert_not_awaited()
+    uow.assert_not_called()
 
 
-async def test_reloaded_run_with_both_budget_notices_skips_ledger_read(monkeypatch):
+async def test_budget_notice_state_is_loaded_from_internal_run_events(monkeypatch):
     from brain.kernel import config
     from brain.systems.runs.direct_loop.run_budget_notice import (
-        budget_notices_seen,
-        load_due_budget_notices,
+        BUDGET_NOTICE_SENT_EVENT,
+        load_budget_notices_sent,
     )
 
     monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 1500)
-    loaded_messages = [
-        {
-            "role": "user",
-            "content": "[System run budget notice: soft; run_id=42] prior notice",
-        },
-        {
-            "role": "user",
-            "content": "[System run budget notice: ceiling; run_id=42] prior notice",
-        },
+    payload_result = MagicMock()
+    payload_result.all.return_value = [
+        {"kind": "soft"},
+        {"kind": "ceiling"},
+        {"kind": "not-a-notice"},
     ]
-    sent = budget_notices_seen(loaded_messages, run_id=42)
-    load_activity = AsyncMock()
+    session = MagicMock()
+    session.scalars = AsyncMock(return_value=payload_result)
+    uow = MagicMock()
+    uow.session = session
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
 
     with patch(
-        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
-        new=load_activity,
+        "brain.systems.runs.direct_loop.run_budget_notice.UnitOfWork",
+        return_value=uow,
     ):
-        notices = await load_due_budget_notices(
-            run_id=42,
-            tool_calls_log=[],
-            sent=sent,
-        )
+        sent = await load_budget_notices_sent(42)
 
     assert sent == {"soft", "ceiling"}
-    assert notices == ()
-    load_activity.assert_not_awaited()
+    query = session.scalars.await_args.args[0]
+    compiled = query.compile()
+    assert 42 in compiled.params.values()
+    assert BUDGET_NOTICE_SENT_EVENT in compiled.params.values()
 
 
-@pytest.mark.parametrize(
-    ("loaded_messages", "run_id", "expected"),
-    [
-        (
-            [{
-                "role": "user",
-                "content": "[System run budget notice: soft; run_id=42] prior notice",
-            }],
-            42,
-            {"soft"},
-        ),
-        (
-            [{
-                "role": "user",
-                "content": "[System run budget notice: ceiling; run_id=41] another run",
-            }],
-            42,
-            set(),
-        ),
-    ],
-)
-def test_budget_notice_markers_are_scoped_to_the_run(
-    loaded_messages,
-    run_id,
-    expected,
-):
-    from brain.systems.runs.direct_loop.run_budget_notice import budget_notices_seen
+async def test_budget_notice_event_is_internal_and_records_kind():
+    from brain.systems.runs.direct_loop.run_budget_notice import (
+        BUDGET_NOTICE_SENT_EVENT,
+        RunBudgetNotice,
+        record_budget_notice_sent,
+    )
 
-    assert budget_notices_seen(loaded_messages, run_id=run_id) == expected
+    payload_result = MagicMock()
+    payload_result.all.return_value = []
+    session = MagicMock()
+    session.scalars = AsyncMock(return_value=payload_result)
+    uow = MagicMock()
+    uow.session = session
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    store = MagicMock()
+    store.require_run = AsyncMock(return_value=SimpleNamespace(root_run_id=7))
+    store.lock_event_stream = AsyncMock()
+    store.append_event = AsyncMock()
+    notice = RunBudgetNotice(
+        key="soft",
+        message={"role": "user", "content": "clean prose"},
+    )
+
+    with patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.UnitOfWork",
+        return_value=uow,
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.AsyncAgentRunStore",
+        return_value=store,
+    ):
+        recorded = await record_budget_notice_sent(run_id=42, notice=notice)
+
+    assert recorded is True
+    event = store.append_event.await_args.args[0]
+    assert event.run_id == 42
+    assert event.root_run_id == 7
+    assert event.event_type == BUDGET_NOTICE_SENT_EVENT
+    assert event.payload == {"kind": "soft"}
+    assert event.visibility.value == "internal"
+
+
+async def test_budget_notice_does_not_refire_after_same_run_save_reload(monkeypatch):
+    from brain.kernel import config
+    from brain.systems.runs import direct_agent
+
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 1500)
+    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
+    ledger: set[str] = set()
+    saved_messages: list[dict] = []
+    request_messages: list[list[dict]] = []
+
+    async def load_sent(_run_id):
+        return set(ledger)
+
+    async def record_sent(*, run_id, notice):
+        assert run_id == 42
+        if notice.key in ledger:
+            return False
+        ledger.add(notice.key)
+        return True
+
+    async def load_session(_session_id):
+        return copy.deepcopy(saved_messages), None
+
+    async def save_session(_session_id, messages, *_usage):
+        saved_messages[:] = copy.deepcopy(messages)
+
+    async def run_once():
+        client = MagicMock()
+
+        def create(**kwargs):
+            request_messages.append(copy.deepcopy(kwargs["messages"]))
+            return _response("Done.")
+
+        client.messages.create.side_effect = create
+        return await direct_agent.run_agent_async(
+            message="Resume the same run",
+            session_id="same-session",
+            model="claude-sonnet-4-6",
+            tools=[],
+            tool_handlers={},
+            persist_session=True,
+            max_turns=1,
+            run_id=42,
+            resolved_llm=_mock_llm_client(client),
+            load_session=load_session,
+            load_session_handoff=AsyncMock(return_value=None),
+            save_session=save_session,
+            save_session_handoff=AsyncMock(),
+            defer_thread_handoff=True,
+        )
+
+    with patch.object(
+        direct_agent,
+        "_async_record_api_call",
+        new=AsyncMock(),
+    ), patch.object(
+        direct_agent,
+        "load_budget_notices_sent",
+        new=AsyncMock(side_effect=load_sent),
+    ), patch.object(
+        direct_agent,
+        "record_budget_notice_sent",
+        new=AsyncMock(side_effect=record_sent),
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=AsyncMock(return_value={
+            "tokens_used": 100,
+            "run_budget_tokens_used": 750,
+            "workers_spawned": 0,
+        }),
+    ):
+        first = await run_once()
+        second = await run_once()
+
+    assert first.success and second.success
+    assert ledger == {"soft"}
+    assert json.dumps(request_messages[0]).count("nearing this run's token budget") == 1
+    # The saved notice remains in history, but reload must not inject a duplicate.
+    assert json.dumps(request_messages[1]).count("nearing this run's token budget") == 1
+
+
+def test_old_style_marker_prose_does_not_suppress_notice(monkeypatch):
+    from brain.kernel import config
+    from brain.systems.runs import direct_agent
+
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 1500)
+    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
+    client = MagicMock()
+    request_messages = []
+
+    def create(**kwargs):
+        request_messages.append(copy.deepcopy(kwargs["messages"]))
+        return _response("Done.")
+
+    client.messages.create.side_effect = create
+    old_marker = "[System run budget notice: soft; run_id=42] pasted prose"
+
+    with patch.object(
+        direct_agent,
+        "_async_record_api_call",
+        new=AsyncMock(),
+    ), patch.object(
+        direct_agent,
+        "load_budget_notices_sent",
+        new=AsyncMock(return_value=set()),
+    ), patch.object(
+        direct_agent,
+        "record_budget_notice_sent",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=AsyncMock(return_value={
+            "tokens_used": 100,
+            "run_budget_tokens_used": 750,
+            "workers_spawned": 0,
+        }),
+    ):
+        result = direct_agent.run_agent(
+            message="Continue",
+            model="claude-sonnet-4-6",
+            tools=[],
+            tool_handlers={},
+            persist_session=True,
+            max_turns=1,
+            run_id=42,
+            resolved_llm=_mock_llm_client(client),
+            load_session=AsyncMock(return_value=(
+                [{"role": "user", "content": old_marker}],
+                None,
+            )),
+            load_session_handoff=AsyncMock(return_value=None),
+            save_session=AsyncMock(),
+            save_session_handoff=AsyncMock(),
+        )
+
+    assert result.success
+    final_context = json.dumps(request_messages[-1])
+    assert old_marker in final_context
+    assert "nearing this run's token budget" in final_context

--- a/tests/test_runtime_activity.py
+++ b/tests/test_runtime_activity.py
@@ -1,6 +1,10 @@
 """Focused tests for live-run activity introspection."""
 
+import copy
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _mock_llm_client(mock_anthropic_client):
@@ -221,3 +225,169 @@ async def test_my_activity_skips_persisted_artifacts_without_execution_id():
     assert result["tokens_used"] == 50
     assert result["workers_spawned"] == 0
     load_artifacts.assert_not_called()
+
+
+def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool(
+    monkeypatch,
+):
+    from brain.kernel import config
+    from brain.systems.runs import direct_agent
+
+    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "2000")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "1500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+
+    client = MagicMock()
+    responses = [
+        _response(
+            stop_reason="tool_use",
+            tool_use={"name": "read_file", "input": {"path": f"step-{index}.txt"}},
+        )
+        for index in range(3)
+    ]
+    responses.append(_response("Persisted and closing."))
+    request_messages = []
+
+    def create(**kwargs):
+        request_messages.append(copy.deepcopy(kwargs["messages"]))
+        return responses.pop(0)
+
+    client.messages.create.side_effect = create
+    load_activity = AsyncMock(side_effect=[
+        {"tokens_used": 0, "workers_spawned": 0},
+        {"tokens_used": 750, "workers_spawned": 0},
+        {"tokens_used": 1500, "workers_spawned": 0},
+        {"tokens_used": 1700, "workers_spawned": 0},
+    ])
+
+    with patch.object(
+        direct_agent,
+        "async_resolve_llm_client",
+        new=AsyncMock(return_value=_mock_llm_client(client)),
+    ), patch.object(
+        direct_agent,
+        "_async_record_api_call",
+        new=AsyncMock(),
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=load_activity,
+    ):
+        result = direct_agent.run_agent(
+            message="Do a long task",
+            model="claude-sonnet-4-6",
+            tools=[{
+                "name": "read_file",
+                "description": "Read a file.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }],
+            tool_handlers={"read_file": MagicMock(return_value={"content": "ok"})},
+            brain_context_preloaded=True,
+            persist_session=False,
+            max_turns=4,
+            run_id=42,
+        )
+
+    assert result.success
+    assert load_activity.await_count == 4
+    assert all(call.args == (42,) for call in load_activity.await_args_list)
+    final_context = json.dumps(request_messages[-1])
+    assert final_context.count("[System run budget notice: soft; run_id=42]") == 1
+    assert final_context.count("[System run budget notice: ceiling; run_id=42]") == 1
+    assert "750 of 1500 tokens" in final_context
+    assert "1 tool call" in final_context
+    assert "Wrap up now and persist durable progress" in final_context
+    assert "1500 of 1500 tokens" in final_context
+    assert "2 tool calls" in final_context
+    assert "persist what you have and emit the closing output" in final_context
+    assert "my_activity" not in final_context
+
+
+def test_agent_below_budget_leaves_model_context_byte_for_byte_unchanged(
+    monkeypatch,
+):
+    from brain.kernel import config
+    from brain.systems.runs import direct_agent
+
+    monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "2000")
+    monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "1500")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_REASONING_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_RESERVED_TOOL_TOKENS", "0")
+    monkeypatch.setenv("AGENT_CONTEXT_SAFETY_MARGIN_TOKENS", "0")
+
+    client = MagicMock()
+    request_messages = []
+
+    def create(**kwargs):
+        request_messages.append(copy.deepcopy(kwargs["messages"]))
+        return _response("Done.")
+
+    client.messages.create.side_effect = create
+    load_activity = AsyncMock(
+        return_value={"tokens_used": 749, "workers_spawned": 0},
+    )
+
+    with patch.object(
+        direct_agent,
+        "async_resolve_llm_client",
+        new=AsyncMock(return_value=_mock_llm_client(client)),
+    ), patch.object(
+        direct_agent,
+        "_async_record_api_call",
+        new=AsyncMock(),
+    ), patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=load_activity,
+    ):
+        result = direct_agent.run_agent(
+            message="Do a short task",
+            model="claude-sonnet-4-6",
+            tools=[],
+            tool_handlers={},
+            persist_session=False,
+            max_turns=1,
+            run_id=42,
+        )
+
+    assert result.success
+    assert request_messages == [[{"role": "user", "content": "Do a short task"}]]
+
+
+@pytest.mark.parametrize(
+    ("loaded_messages", "run_id", "expected"),
+    [
+        (
+            [{
+                "role": "user",
+                "content": "[System run budget notice: soft; run_id=42] prior notice",
+            }],
+            42,
+            {"soft"},
+        ),
+        (
+            [{
+                "role": "user",
+                "content": "[System run budget notice: ceiling; run_id=41] another run",
+            }],
+            42,
+            set(),
+        ),
+    ],
+)
+def test_budget_notice_markers_are_scoped_to_the_run(
+    loaded_messages,
+    run_id,
+    expected,
+):
+    from brain.systems.runs.direct_loop.run_budget_notice import budget_notices_seen
+
+    assert budget_notices_seen(loaded_messages, run_id=run_id) == expected

--- a/tests/test_runtime_activity.py
+++ b/tests/test_runtime_activity.py
@@ -233,6 +233,7 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
     from brain.kernel import config
     from brain.systems.runs import direct_agent
 
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 1500)
     monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "2000")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "1500")
@@ -261,7 +262,6 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
         {"tokens_used": 0, "workers_spawned": 0},
         {"tokens_used": 750, "workers_spawned": 0},
         {"tokens_used": 1500, "workers_spawned": 0},
-        {"tokens_used": 1700, "workers_spawned": 0},
     ])
 
     with patch.object(
@@ -296,7 +296,7 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
         )
 
     assert result.success
-    assert load_activity.await_count == 4
+    assert load_activity.await_count == 3
     assert all(call.args == (42,) for call in load_activity.await_args_list)
     final_context = json.dumps(request_messages[-1])
     assert final_context.count("[System run budget notice: soft; run_id=42]") == 1
@@ -310,12 +310,13 @@ def test_agent_pushes_soft_and_ceiling_budget_notices_once_without_activity_tool
     assert "my_activity" not in final_context
 
 
-def test_agent_below_budget_leaves_model_context_byte_for_byte_unchanged(
+def test_cumulative_usage_above_context_compaction_but_below_run_budget_gets_no_notice(
     monkeypatch,
 ):
     from brain.kernel import config
     from brain.systems.runs import direct_agent
 
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 10_000)
     monkeypatch.setattr(config, "AGENT_RUN_BUDGET_NOTICE_FRACTION", 0.5)
     monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "2000")
     monkeypatch.setenv("AGENT_AUTO_COMPACT_TOKEN_LIMIT", "1500")
@@ -333,7 +334,7 @@ def test_agent_below_budget_leaves_model_context_byte_for_byte_unchanged(
 
     client.messages.create.side_effect = create
     load_activity = AsyncMock(
-        return_value={"tokens_used": 749, "workers_spawned": 0},
+        return_value={"tokens_used": 1600, "workers_spawned": 0},
     )
 
     with patch.object(
@@ -360,6 +361,70 @@ def test_agent_below_budget_leaves_model_context_byte_for_byte_unchanged(
 
     assert result.success
     assert request_messages == [[{"role": "user", "content": "Do a short task"}]]
+    load_activity.assert_awaited_once_with(42)
+
+
+@pytest.mark.parametrize("run_budget", [None, 0, -1])
+async def test_unconfigured_run_budget_skips_notices_and_ledger_read(
+    monkeypatch,
+    run_budget,
+):
+    from brain.kernel import config
+    from brain.systems.runs.direct_loop.run_budget_notice import (
+        load_due_budget_notices,
+    )
+
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", run_budget)
+    load_activity = AsyncMock()
+
+    with patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=load_activity,
+    ):
+        notices = await load_due_budget_notices(
+            run_id=42,
+            tool_calls_log=[],
+            sent=set(),
+        )
+
+    assert notices == ()
+    load_activity.assert_not_awaited()
+
+
+async def test_reloaded_run_with_both_budget_notices_skips_ledger_read(monkeypatch):
+    from brain.kernel import config
+    from brain.systems.runs.direct_loop.run_budget_notice import (
+        budget_notices_seen,
+        load_due_budget_notices,
+    )
+
+    monkeypatch.setattr(config, "AGENT_RUN_CUMULATIVE_TOKEN_BUDGET", 1500)
+    loaded_messages = [
+        {
+            "role": "user",
+            "content": "[System run budget notice: soft; run_id=42] prior notice",
+        },
+        {
+            "role": "user",
+            "content": "[System run budget notice: ceiling; run_id=42] prior notice",
+        },
+    ]
+    sent = budget_notices_seen(loaded_messages, run_id=42)
+    load_activity = AsyncMock()
+
+    with patch(
+        "brain.systems.runs.direct_loop.run_budget_notice.load_run_activity",
+        new=load_activity,
+    ):
+        notices = await load_due_budget_notices(
+            run_id=42,
+            tool_calls_log=[],
+            sent=sent,
+        )
+
+    assert sent == {"soft", "ceiling"}
+    assert notices == ()
+    load_activity.assert_not_awaited()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Part of #510** — deliberately not `Closes`. One acceptance criterion is explicitly deferred; see "What is NOT here".

## What was wrong

Agents do not reliably self-monitor. On cycle 9 run 2718 — 45 minutes, 40 of them looping — the agent called its own `my_activity` tool **exactly once, at +179s**, while it was still doing productive work, and never again. The tool's description literally says *"use this to assess whether you are repeating yourself"*, and the mission text said *"stop at roughly two thirds of the budget."* Neither produced the behaviour. Parts A and B (#525) made `my_activity` honest and gave it to workers, but a tool nobody calls cannot help.

So the runtime now **pushes** instead of waiting for a pull.

## What changed

- A **soft notice** at a configurable fraction of a cumulative run-token budget (default two-thirds), and a firmer **ceiling notice** naming the close-out path. Each fires **at most once per run**, including across a session reload.
- Once-per-run state lives in **internal `run.budget_notice_sent` events** on the existing `agent_run_events` ledger — structured, durable, and invisible to the model. No migration.
- The budget metric is **cache-aware and defined in one place** (`cumulative_run_budget_tokens`): `tokens_total + cache_read + cache_write`. This matters — Illo uses prompt caching, so in a long-context loop most of each resent context bills as `cache_read`, *not* as input tokens. Counting only `tokens_total` would have undercounted precisely the run shape this feature exists to catch.
- `my_activity` gains the same `run_budget_tokens_used` field from the same function, so the pushed notice and the pulled tool can never disagree. Its existing `tokens_used` contract from #525 is unchanged.
- No ledger read at all when the budget is disabled or both notices have already fired.

## How to judge it without reading the diff

Two review passes ran before this opened. The first caught a **units mismatch**: the notice compared cumulative run tokens against `auto_compact_threshold_tokens`, which is a *per-request* context-window size. Cumulative usage crosses that after two or three turns, so both notices would have fired in the first minute of any substantial run — run 2718 would have been told to close out while it was still working. The second pass caught notice state being kept as a **marker string inside model-visible prose**, which the model could echo and thereby silence its own safety notice. Both are fixed here.

**Acceptance checks:**
1. A long run gets an unsolicited notice at the threshold **without calling any tool to request it**.
2. A run past the per-request *context compaction threshold* but under the *cumulative run budget* gets **no** notice — the two quantities are pinned apart by a named test.
3. A cache-heavy run (large `cache_read`, small input/output) counts toward the budget — the run-2718 shape.
4. A notice sent in one invocation does not re-fire after a session reload; transcript prose that looks like a marker cannot suppress a real notice.

**Verification:** CI-equivalent suite (`-m "not requires_db and not requires_browser and not live_provider"`, provider credentials stripped from the env so the no-credential CI branch is actually exercised) — **4374 passed, 11 skipped, 75 deselected**. Merges clean onto `main@e5399000`; adds no migration.

## Two things to know before merging

- **The default budget of 5,000,000 tokens is an unvalidated estimate**, not a measurement — arithmetic is 33 × 150k-token requests. I tried to place it against the real per-run distribution on illo-dev and the DB access I needed was denied, so I stopped rather than route around it. The failure direction is safe (too high ⇒ the notice never fires, never a false "stop work" to a healthy run) but too high also means the looping problem is not actually solved. To calibrate, compare against real runs and set `AGENT_RUN_CUMULATIVE_TOKEN_BUDGET`:
  ```sql
  SELECT round(percentile_cont(0.5) within group (order by t)) AS p50,
         round(percentile_cont(0.95) within group (order by t)) AS p95, max(t)
  FROM (SELECT run_id, sum(COALESCE(input_tokens,0)+COALESCE(output_tokens,0)
                          +COALESCE(cache_read,0)+COALESCE(cache_write,0)) AS t
        FROM agent_api_calls GROUP BY run_id) s;
  ```
- **If the event-ledger read fails, no notice is emitted** (fail-closed, to avoid duplicate or misleading notices). That means a telemetry outage silently disables this safety feature. Deliberate for v1; worth revisiting if it ever bites.

## What is NOT here

- The deadline / `RunStatus.EXPIRED` / sweeper work — that is **#505**, and this composes with it rather than pre-empting it.
- The acceptance criterion *"the injected notice includes time since the last state-changing call"* stays deferred to that ticket, as #510's own body specifies.
- The tool-call count was **removed** from the notice text: `tool_calls_log` re-initialises on every invocation, so after a reload it would have reported post-reload activity next to cumulative token figures. A durable run-level counter is a separate concern.
- A code-quality review also proposed a `RunBudgetTracker` fed from live per-response usage, with the ledger used only for reload recovery. Declined as out of scope: it is a larger rearchitecture, and keeping the ledger as the single source is what guarantees the notice and `my_activity` agree.

🤖 Implemented by a Codex worker, reviewed and corrected across two fix passes by Claude Code (R3).
