### PR TITLE
fix(scheduler): a blocking job must not freeze the tick loop — dispatch the health scan, bound drain admission

### DIFF
--- a/brain/app/scheduler/detached_agent_runs.py
+++ b/brain/app/scheduler/detached_agent_runs.py
@@ -1,0 +1,236 @@
+"""Detached AgentRun scheduler state transitions and reconciliation."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.contracts.scheduler_handoff import (
+    HANDOFF_STATUS_DISPATCHED,
+    DetachedAgentRunHandoff,
+)
+from brain.kernel.common.time import ensure_utc
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.scheduler import (
+    SchedulerJob,
+    SchedulerRun,
+    SchedulerRunStep,
+)
+from brain.app.scheduler.runtime import (
+    RUN_STATUS_EXECUTING,
+    RUN_STATUS_SETTLED_FAILURE,
+    RUN_STATUS_SETTLED_SUCCESS,
+    async_finish_run,
+    async_release_lease,
+    trace_id_for_run_id,
+)
+from brain.app.scheduler.scheduler_failure_guard import (
+    async_reset_scheduler_job_failure_guard,
+)
+from brain.systems.runs.status import (
+    TERMINAL_RUN_STATUSES as TERMINAL_AGENT_RUN_STATUSES,
+    RunStatus as AgentRunStatus,
+    coerce_run_status as coerce_agent_run_status,
+)
+
+RetryableFailureSummary = Callable[
+    ...,
+    tuple[str, dict[str, Any]],
+]
+ApplyFailureGuard = Callable[..., Awaitable[None]]
+
+
+def _agent_run_summary(
+    agent_run_id: int,
+    *,
+    status: str,
+    reconciled_at: datetime | None = None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "run_id": agent_run_id,
+        "status": status,
+    }
+    if reconciled_at is not None:
+        summary["reconciled_at"] = reconciled_at.isoformat()
+    return summary
+
+
+async def async_mark_detached_run_dispatched(
+    session: AsyncSession,
+    run: SchedulerRun,
+    step: SchedulerRunStep,
+    *,
+    handoff: DetachedAgentRunHandoff,
+    step_result: dict[str, Any],
+    step_results: list[dict[str, Any]],
+    now: datetime,
+) -> SchedulerRun:
+    """Persist the non-terminal scheduler state after AgentRun dispatch."""
+    agent_run_id = handoff.agent_run_id
+    agent_summary = _agent_run_summary(
+        agent_run_id,
+        status=HANDOFF_STATUS_DISPATCHED,
+    )
+
+    step.status = RUN_STATUS_EXECUTING
+    step.finished_at = None
+    step.result_summary = {
+        "results": list(step_result.get("results") or []),
+        "agent_run": agent_summary,
+    }
+    step.error_text = None
+    step.agent_run_id = agent_run_id
+    step.trace_id = trace_id_for_run_id(agent_run_id)
+
+    run.agent_run_id = agent_run_id
+    run.trace_id = trace_id_for_run_id(agent_run_id)
+    run.status = RUN_STATUS_EXECUTING
+    run.result_summary = {
+        "steps": step_results,
+        "agent_run": agent_summary,
+    }
+    run.error_text = None
+    run.finished_at = None
+    if run.lease_id:
+        await async_release_lease(
+            session,
+            run.lease_id,
+            reason="agent_run_dispatched",
+            now=now,
+        )
+    await session.flush()
+    return run
+
+
+def _agent_run_finished_at(agent_run: AgentRunRow, *, now: datetime) -> datetime:
+    for attr_name in ("completed_at", "failed_at", "canceled_at"):
+        value = getattr(agent_run, attr_name, None)
+        if value is not None:
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return ensure_utc(value)
+    return now
+
+
+def _terminal_scheduler_status(agent_status: AgentRunStatus) -> str:
+    if agent_status == AgentRunStatus.COMPLETED:
+        return RUN_STATUS_SETTLED_SUCCESS
+    return RUN_STATUS_SETTLED_FAILURE
+
+
+async def async_reconcile_detached_runs(
+    session: AsyncSession,
+    *,
+    retryable_failure_summary: RetryableFailureSummary,
+    apply_failure_guard: ApplyFailureGuard,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Settle detached scheduler runs from their linked AgentRun outcomes."""
+    clock = ensure_utc(now)
+    runs = (
+        await session.scalars(
+            select(SchedulerRun)
+            .where(
+                SchedulerRun.status == RUN_STATUS_EXECUTING,
+                SchedulerRun.agent_run_id.is_not(None),
+            )
+            .order_by(SchedulerRun.id.asc())
+        )
+    ).all()
+    reconciled: list[dict[str, Any]] = []
+    for run in runs:
+        agent_run_id = int(run.agent_run_id)
+        agent_run = await session.get(AgentRunRow, agent_run_id)
+        if agent_run is None:
+            continue
+        agent_status = coerce_agent_run_status(agent_run.status)
+        if agent_status not in TERMINAL_AGENT_RUN_STATUSES:
+            continue
+
+        terminal_status = _terminal_scheduler_status(agent_status)
+        job = await session.get(SchedulerJob, run.job_id)
+        error_text = None
+        if terminal_status == RUN_STATUS_SETTLED_FAILURE:
+            error_text = (
+                f"Agent run {agent_run_id} ended with status {agent_status.value}"
+            )
+        agent_summary = _agent_run_summary(
+            agent_run_id,
+            status=agent_status.value,
+            reconciled_at=clock,
+        )
+        summary = {
+            **(run.result_summary or {}),
+            "agent_run": agent_summary,
+        }
+        scheduler_status = terminal_status
+        if terminal_status == RUN_STATUS_SETTLED_FAILURE and job is not None:
+            scheduler_status, summary = retryable_failure_summary(
+                job,
+                run,
+                base_summary=summary,
+                now=clock,
+            )
+
+        finished_at = _agent_run_finished_at(agent_run, now=clock)
+        step = await session.scalar(
+            select(SchedulerRunStep)
+            .where(
+                SchedulerRunStep.run_id == run.id,
+                SchedulerRunStep.agent_run_id == agent_run_id,
+            )
+            .order_by(SchedulerRunStep.sequence_no.desc())
+            .limit(1)
+        )
+        if step is not None:
+            step.status = (
+                RUN_STATUS_SETTLED_SUCCESS
+                if terminal_status == RUN_STATUS_SETTLED_SUCCESS
+                else scheduler_status
+            )
+            step.finished_at = finished_at
+            step.result_summary = {
+                **(step.result_summary or {}),
+                "agent_run": agent_summary,
+            }
+            step.error_text = error_text
+            step.agent_run_id = agent_run_id
+            step.trace_id = trace_id_for_run_id(agent_run_id)
+            await session.flush()
+
+        await async_finish_run(
+            session,
+            run,
+            status=scheduler_status,
+            result_summary=summary,
+            error_text=error_text,
+            now=finished_at,
+        )
+        if job is not None:
+            if scheduler_status == RUN_STATUS_SETTLED_SUCCESS:
+                await async_reset_scheduler_job_failure_guard(
+                    session,
+                    job,
+                    now=clock,
+                )
+            else:
+                await apply_failure_guard(
+                    session,
+                    job,
+                    run,
+                    failure_key="detached_agent_run",
+                    error_text=error_text or "Detached agent run failed",
+                    now=clock,
+                )
+        reconciled.append(
+            {
+                "run_id": run.id,
+                "agent_run_id": agent_run_id,
+                "agent_run_status": agent_status.value,
+                "status": scheduler_status,
+            }
+        )
+    return reconciled

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -121,10 +121,6 @@ _SUCCESS_HANDLER_STATUSES = {"ok", "recorded", "skipped", "success", "succeeded"
 _BLOCKED_HANDLER_STATUSES = {"blocked"}
 
 
-class SchedulerDrainBudgetExceeded(TimeoutError):
-    """Raised after an in-flight scheduler command exhausts its drain budget."""
-
-
 def _utcnow(now: datetime | None = None) -> datetime:
     return ensure_utc(now)
 
@@ -601,7 +597,6 @@ async def _async_run_step(
     runner: Runner,
     now: datetime,
     resume: bool,
-    execution_deadline: float | None = None,
 ) -> dict[str, Any]:
     if step.status == RUN_STATUS_SETTLED_SUCCESS and resume:
         return {"ok": True, "step_key": step.step_key, "skipped": True, "results": []}
@@ -638,34 +633,12 @@ async def _async_run_step(
     dispatched_agent_run_id: int | None = None
     for command in commands:
         try:
-            runner_call = _call_runner(
+            proc = await _call_runner(
                 runner,
                 command,
                 env=env,
                 timeout_seconds=job.timeout_seconds,
             )
-            if execution_deadline is None:
-                proc = await runner_call
-            else:
-                remaining = execution_deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    runner_call.close()
-                    raise SchedulerDrainBudgetExceeded
-                runner_task = asyncio.create_task(runner_call)
-                done, _pending = await asyncio.wait(
-                    (runner_task,),
-                    timeout=remaining,
-                )
-                if not done:
-                    runner_task.cancel()
-                    try:
-                        await runner_task
-                    except asyncio.CancelledError:
-                        pass
-                    raise SchedulerDrainBudgetExceeded
-                proc = runner_task.result()
-        except SchedulerDrainBudgetExceeded:
-            raise
         except Exception as exc:
             error_text = f"{type(exc).__name__}: {exc}"
             results.append(
@@ -732,7 +705,6 @@ async def async_run_scheduler_run(
     runner: Runner = _async_run_command,
     resume: bool = True,
     now: datetime | None = None,
-    execution_deadline: float | None = None,
 ) -> SchedulerRun:
     now = _utcnow(now)
     run = await session.get(SchedulerRun, run_id)
@@ -806,7 +778,6 @@ async def async_run_scheduler_run(
             runner=runner,
             now=now,
             resume=resume,
-            execution_deadline=execution_deadline,
         )
         step_results.append(result)
         if not result["ok"]:
@@ -1344,60 +1315,6 @@ async def async_reconcile_scheduler_agent_runs(
     return reconciled
 
 
-async def _async_finish_drain_budget_overrun(
-    session: AsyncSession,
-    run: SchedulerRun,
-    *,
-    budget_seconds: float,
-    now: datetime,
-) -> str:
-    error_text = (
-        f"Scheduler drain execution budget of {budget_seconds:g}s exceeded"
-    )
-    step = await session.scalar(
-        select(SchedulerRunStep)
-        .where(
-            SchedulerRunStep.run_id == run.id,
-            SchedulerRunStep.status == RUN_STATUS_RUNNING,
-        )
-        .order_by(SchedulerRunStep.sequence_no.desc())
-        .limit(1)
-    )
-    if step is not None:
-        await async_update_run_step(
-            session,
-            step,
-            status=RUN_STATUS_SETTLED_FAILURE,
-            finished_at=now,
-            result_summary={
-                **(step.result_summary or {}),
-                "drain_budget_exceeded": True,
-                "budget_seconds": budget_seconds,
-            },
-            error_text=error_text,
-        )
-    await async_finish_run(
-        session,
-        run,
-        status=RUN_STATUS_SETTLED_FAILURE,
-        result_summary={
-            **(run.result_summary or {}),
-            "drain_budget_exceeded": True,
-            "budget_seconds": budget_seconds,
-        },
-        error_text=error_text,
-        now=now,
-    )
-    logger.error(
-        "Scheduler drain execution budget exceeded: run_id=%s job_id=%s "
-        "budget_seconds=%s",
-        run.id,
-        run.job_id,
-        budget_seconds,
-    )
-    return error_text
-
-
 async def async_drain_scheduler(
     session: AsyncSession,
     *,
@@ -1411,7 +1328,7 @@ async def async_drain_scheduler(
     allowed_owner_modes: tuple[str, ...] | None = None,
     execution_budget_seconds: float | None = None,
 ) -> dict[str, Any]:
-    """Execute due runs within one bounded scheduler-tick budget."""
+    """Start due runs within one bounded scheduler-tick admission budget."""
     now = _utcnow(now)
     modes = allowed_owner_modes or (normalize_owner_mode(owner_mode),)
     budget_seconds = (
@@ -1422,8 +1339,7 @@ async def async_drain_scheduler(
     if budget_seconds <= 0:
         raise ValueError("execution_budget_seconds must be greater than zero")
     loop = asyncio.get_running_loop()
-    started_at = loop.time()
-    execution_deadline = started_at + budget_seconds
+    admission_deadline = loop.time() + budget_seconds
 
     await async_reconcile_scheduler_agent_runs(session, now=now)
 
@@ -1437,9 +1353,8 @@ async def async_drain_scheduler(
     results: list[dict[str, Any]] = []
     executed = 0
     budget_exhausted = False
-    budget_overrun: dict[str, Any] | None = None
     while executed < max_runs:
-        if loop.time() >= execution_deadline:
+        if loop.time() >= admission_deadline:
             budget_exhausted = True
             break
         candidate = await async_claim_next_due_run(
@@ -1453,40 +1368,14 @@ async def async_drain_scheduler(
         if candidate is None:
             break
         run, _lease = candidate
-        try:
-            await async_run_scheduler_run(
-                session,
-                run.id,
-                owner_id=owner_id,
-                runner=runner,
-                resume=resume,
-                now=now,
-                execution_deadline=execution_deadline,
-            )
-        except SchedulerDrainBudgetExceeded:
-            error_text = await _async_finish_drain_budget_overrun(
-                session,
-                run,
-                budget_seconds=budget_seconds,
-                now=now,
-            )
-            budget_exhausted = True
-            budget_overrun = {
-                "run_id": run.id,
-                "job_id": run.job_id,
-                "budget_seconds": budget_seconds,
-                "elapsed_seconds": round(loop.time() - started_at, 3),
-            }
-            results.append(
-                {
-                    "run_id": run.id,
-                    "job_id": run.job_id,
-                    "status": run.status,
-                    "error_text": error_text,
-                }
-            )
-            executed += 1
-            break
+        await async_run_scheduler_run(
+            session,
+            run.id,
+            owner_id=owner_id,
+            runner=runner,
+            resume=resume,
+            now=now,
+        )
         results.append(
             {
                 "run_id": run.id,
@@ -1500,6 +1389,4 @@ async def async_drain_scheduler(
     result = {"ok": True, "executed": executed, "results": results}
     if budget_exhausted:
         result["budget_exhausted"] = True
-        if budget_overrun is not None:
-            result["budget_overrun"] = budget_overrun
     return result

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import logging
 import os
 import shlex
@@ -21,8 +20,13 @@ from brain.kernel.common.time import ensure_utc
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.async_io import run_blocking
-from brain.platform.db.models.agent_run import AgentRunRow
+from brain.contracts.scheduler_handoff import (
+    AGENT_RUN_COMPLETION_MODE,
+    DetachedAgentRunHandoff,
+    DetachedAgentRunHandoffError,
+    parse_detached_agent_run_handoff,
+)
+from brain.platform.async_io import run_blocking, run_subprocess
 from brain.platform.db.models.scheduler import (
     OWNER_MODE_SCHEDULER,
     SchedulerJob,
@@ -34,6 +38,10 @@ from brain.systems.cortex.thread_links import public_app_base_url
 from brain.systems.slack.client import slack_web_client_from_runtime
 from brain.app.scheduler.catalog import normalize_owner_mode
 from brain.app.scheduler.contracts import validate_scheduler_run_contract
+from brain.app.scheduler.detached_agent_runs import (
+    async_mark_detached_run_dispatched,
+    async_reconcile_detached_runs,
+)
 from brain.app.scheduler.scheduler_failure_guard import (
     async_record_scheduler_job_failure,
     async_reset_scheduler_job_failure_guard,
@@ -55,11 +63,11 @@ from brain.app.scheduler.programs import (
     build_scheduler_step_plan,
     nightly_commands,
     nightly_commands_for_step,
+    scheduler_program_completion_mode,
 )
 from brain.app.scheduler.runtime import (
     LEASE_TTL_SECONDS,
     RUN_STATUS_CLAIMED,
-    RUN_STATUS_EXECUTING,
     RUN_STATUS_PAUSED,
     RUN_STATUS_RECORDED,
     RUN_STATUS_RETRYABLE,
@@ -72,7 +80,6 @@ from brain.app.scheduler.runtime import (
     async_finish_run,
     async_find_scheduler_job,
     async_heartbeat_lease,
-    async_release_lease,
     async_retry_run,
     async_set_scheduler_job_load_shed as async_set_scheduler_job_load_shed_state,
     async_set_scheduler_job_owner_mode as async_set_scheduler_job_owner_mode_state,
@@ -83,11 +90,6 @@ from brain.app.scheduler.runtime import (
     retry_available_at,
     trace_id_for_run_id,
     trace_id_for_scheduler_run_id,
-)
-from brain.systems.runs.status import (
-    TERMINAL_RUN_STATUSES as TERMINAL_AGENT_RUN_STATUSES,
-    RunStatus as AgentRunStatus,
-    coerce_run_status as coerce_agent_run_status,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -103,9 +105,10 @@ def _positive_float_env(name: str, default: float) -> float:
     return value if value > 0 else default
 
 
-DEFAULT_DRAIN_EXECUTION_BUDGET_SECONDS = _positive_float_env(
-    "SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS",
-    30.0,
+DEFAULT_DRAIN_ADMISSION_BUDGET_SECONDS = _positive_float_env(
+    "SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS",
+    # Deprecated fallback; remove after deploy configuration uses the admission name.
+    _positive_float_env("SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS", 30.0),
 )
 
 _FINAL_RUN_STATUSES = {
@@ -132,50 +135,14 @@ async def _async_run_command(
     env: dict[str, str] | None = None,
     timeout_seconds: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    argv = list(command)
-    process = await asyncio.create_subprocess_exec(
-        *argv,
+    return await run_subprocess(
+        list(command),
         cwd=str(cwd or REPO_ROOT),
         env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    communicate = asyncio.create_task(process.communicate())
-    try:
-        if timeout_seconds is None:
-            stdout_bytes, stderr_bytes = await asyncio.shield(communicate)
-        else:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                asyncio.shield(communicate),
-                timeout=max(0.0, float(timeout_seconds)),
-            )
-    except asyncio.TimeoutError:
-        if process.returncode is None:
-            try:
-                process.kill()
-            except ProcessLookupError:
-                pass
-        stdout_bytes, stderr_bytes = await communicate
-        raise subprocess.TimeoutExpired(
-            argv,
-            timeout_seconds,
-            output=stdout_bytes.decode(errors="replace"),
-            stderr=stderr_bytes.decode(errors="replace"),
-        ) from None
-    except asyncio.CancelledError:
-        if process.returncode is None:
-            try:
-                process.kill()
-            except ProcessLookupError:
-                pass
-        await communicate
-        raise
-
-    return subprocess.CompletedProcess(
-        argv,
-        int(process.returncode or 0),
-        stdout_bytes.decode(errors="replace"),
-        stderr_bytes.decode(errors="replace"),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout_seconds,
     )
 
 
@@ -239,26 +206,6 @@ def _command_summary(proc: Any) -> dict[str, Any]:
         "stdout_tail": _tail(getattr(proc, "stdout", None)),
         "stderr_tail": _tail(getattr(proc, "stderr", None)),
     }
-
-
-def _scheduler_agent_run_id(proc: Any) -> int | None:
-    """Read the explicit detached-run handoff emitted by a scheduler command."""
-    stdout = str(getattr(proc, "stdout", "") or "")
-    for line in reversed(stdout.splitlines()):
-        try:
-            payload = json.loads(line)
-        except (json.JSONDecodeError, TypeError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        value = payload.get("scheduler_agent_run_id")
-        if value is None:
-            continue
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-    return None
 
 
 def _python_one_liner(code: str) -> list[str]:
@@ -630,7 +577,10 @@ async def _async_run_step(
 
     env = _shell_env(job, run, step.step_key)
     results: list[dict[str, Any]] = []
-    dispatched_agent_run_id: int | None = None
+    completion_mode = str(
+        step_spec.get("completion_mode") or scheduler_program_completion_mode(job)
+    ).strip().lower()
+    detached_handoff: DetachedAgentRunHandoff | None = None
     for command in commands:
         try:
             proc = await _call_runner(
@@ -663,12 +613,6 @@ async def _async_run_step(
                 "error": error_text,
             }
         summary = {"command": list(command), **_command_summary(proc)}
-        agent_run_id = _scheduler_agent_run_id(proc)
-        if agent_run_id is not None:
-            dispatched_agent_run_id = agent_run_id
-            run.agent_run_id = agent_run_id
-            run.trace_id = trace_id_for_run_id(agent_run_id)
-            summary["scheduler_agent_run_id"] = agent_run_id
         results.append(summary)
         if int(getattr(proc, "returncode", 1)) != 0:
             error_text = summary["stderr_tail"] or summary["stdout_tail"] or "step failed"
@@ -681,7 +625,37 @@ async def _async_run_step(
                 error_text=error_text,
             )
             return {"ok": False, "step_key": step.step_key, "results": results, "error": error_text}
+        if completion_mode == AGENT_RUN_COMPLETION_MODE:
+            try:
+                detached_handoff = parse_detached_agent_run_handoff(
+                    getattr(proc, "stdout", None)
+                )
+            except DetachedAgentRunHandoffError as exc:
+                error_text = f"{type(exc).__name__}: {exc}"
+                await async_update_run_step(
+                    session,
+                    step,
+                    status=RUN_STATUS_RETRYABLE,
+                    finished_at=now,
+                    result_summary={"results": results},
+                    error_text=error_text,
+                )
+                return {
+                    "ok": False,
+                    "step_key": step.step_key,
+                    "results": results,
+                    "error": error_text,
+                }
+            summary["scheduler_agent_run_id"] = detached_handoff.agent_run_id
 
+    if detached_handoff is not None:
+        return {
+            "ok": True,
+            "step_key": step.step_key,
+            "results": results,
+            "agent_run_id": detached_handoff.agent_run_id,
+            "_detached_handoff": detached_handoff,
+        }
     await async_update_run_step(
         session,
         step,
@@ -689,12 +663,8 @@ async def _async_run_step(
         finished_at=now,
         result_summary={"results": results},
         error_text=None,
-        agent_run_id=dispatched_agent_run_id,
     )
-    result = {"ok": True, "step_key": step.step_key, "results": results}
-    if dispatched_agent_run_id is not None:
-        result["agent_run_id"] = dispatched_agent_run_id
-    return result
+    return {"ok": True, "step_key": step.step_key, "results": results}
 
 
 async def async_run_scheduler_run(
@@ -766,6 +736,11 @@ async def async_run_scheduler_run(
     await session.flush()
 
     step_results: list[dict[str, Any]] = []
+    detached_dispatch: tuple[
+        SchedulerRunStep,
+        DetachedAgentRunHandoff,
+        dict[str, Any],
+    ] | None = None
     for step_spec in sorted(step_plan, key=lambda item: int(item.get("sequence_no", 0))):
         step_key = str(step_spec["step_key"])
         step = step_by_key[step_key]
@@ -779,6 +754,7 @@ async def async_run_scheduler_run(
             now=now,
             resume=resume,
         )
+        handoff = result.pop("_detached_handoff", None)
         step_results.append(result)
         if not result["ok"]:
             failure_status, failure_summary = _retryable_failure_summary(
@@ -808,35 +784,20 @@ async def async_run_scheduler_run(
                 now=now,
             )
             return run
+        if handoff is not None:
+            detached_dispatch = (step, handoff, result)
 
-    dispatched_agent_run_ids = [
-        int(result["agent_run_id"])
-        for result in step_results
-        if result.get("agent_run_id") is not None
-    ]
-    if dispatched_agent_run_ids:
-        agent_run_id = dispatched_agent_run_ids[-1]
-        run.agent_run_id = agent_run_id
-        run.trace_id = trace_id_for_run_id(agent_run_id)
-        run.status = RUN_STATUS_EXECUTING
-        run.result_summary = {
-            "steps": step_results,
-            "agent_run": {
-                "run_id": agent_run_id,
-                "status": "dispatched",
-            },
-        }
-        run.error_text = None
-        run.finished_at = None
-        if run.lease_id:
-            await async_release_lease(
-                session,
-                run.lease_id,
-                reason="agent_run_dispatched",
-                now=now,
-            )
-        await session.flush()
-        return run
+    if detached_dispatch is not None:
+        detached_step, handoff, step_result = detached_dispatch
+        return await async_mark_detached_run_dispatched(
+            session,
+            run,
+            detached_step,
+            handoff=handoff,
+            step_result=step_result,
+            step_results=step_results,
+            now=now,
+        )
 
     await async_finish_run(
         session,
@@ -1191,130 +1152,6 @@ async def async_set_scheduler_job_load_shed(
     return updated
 
 
-def _agent_run_finished_at(agent_run: AgentRunRow, *, now: datetime) -> datetime:
-    for attr_name in ("completed_at", "failed_at", "canceled_at"):
-        value = getattr(agent_run, attr_name, None)
-        if value is not None:
-            return _utcnow(value)
-    return now
-
-
-async def async_reconcile_scheduler_agent_runs(
-    session: AsyncSession,
-    *,
-    now: datetime | None = None,
-) -> list[dict[str, Any]]:
-    """Settle detached scheduler runs from their linked AgentRun outcomes."""
-    now = _utcnow(now)
-    runs = (
-        await session.scalars(
-            select(SchedulerRun)
-            .where(
-                SchedulerRun.status == RUN_STATUS_EXECUTING,
-                SchedulerRun.agent_run_id.is_not(None),
-            )
-            .order_by(SchedulerRun.id.asc())
-        )
-    ).all()
-    reconciled: list[dict[str, Any]] = []
-    for run in runs:
-        agent_run = await session.get(AgentRunRow, int(run.agent_run_id))
-        if agent_run is None:
-            continue
-        agent_status = coerce_agent_run_status(agent_run.status)
-        if agent_status not in TERMINAL_AGENT_RUN_STATUSES:
-            continue
-
-        terminal_scheduler_status = (
-            RUN_STATUS_SETTLED_SUCCESS
-            if agent_status == AgentRunStatus.COMPLETED
-            else RUN_STATUS_SETTLED_FAILURE
-        )
-        job = await session.get(SchedulerJob, run.job_id)
-        error_text = None
-        if terminal_scheduler_status == RUN_STATUS_SETTLED_FAILURE:
-            error_text = (
-                f"Agent run {run.agent_run_id} ended with status "
-                f"{agent_status.value}"
-            )
-        summary = {
-            **(run.result_summary or {}),
-            "agent_run": {
-                "run_id": int(run.agent_run_id),
-                "status": agent_status.value,
-                "reconciled_at": now.isoformat(),
-            },
-        }
-        scheduler_status = terminal_scheduler_status
-        if terminal_scheduler_status == RUN_STATUS_SETTLED_FAILURE and job is not None:
-            scheduler_status, summary = _retryable_failure_summary(
-                job,
-                run,
-                base_summary=summary,
-                now=now,
-            )
-        step = await session.scalar(
-            select(SchedulerRunStep)
-            .where(
-                SchedulerRunStep.run_id == run.id,
-                SchedulerRunStep.agent_run_id == run.agent_run_id,
-            )
-            .order_by(SchedulerRunStep.sequence_no.desc())
-            .limit(1)
-        )
-        if step is not None:
-            await async_update_run_step(
-                session,
-                step,
-                status=(
-                    RUN_STATUS_SETTLED_SUCCESS
-                    if terminal_scheduler_status == RUN_STATUS_SETTLED_SUCCESS
-                    else scheduler_status
-                ),
-                finished_at=_agent_run_finished_at(agent_run, now=now),
-                result_summary={
-                    **(step.result_summary or {}),
-                    "agent_run": summary["agent_run"],
-                },
-                error_text=error_text,
-                agent_run_id=int(run.agent_run_id),
-            )
-        finished_at = _agent_run_finished_at(agent_run, now=now)
-        await async_finish_run(
-            session,
-            run,
-            status=scheduler_status,
-            result_summary=summary,
-            error_text=error_text,
-            now=finished_at,
-        )
-        if job is not None:
-            if scheduler_status == RUN_STATUS_SETTLED_SUCCESS:
-                await async_reset_scheduler_job_failure_guard(
-                    session,
-                    job,
-                    now=now,
-                )
-            else:
-                await _async_apply_failure_guard(
-                    session,
-                    job,
-                    run,
-                    failure_key="detached_agent_run",
-                    error_text=error_text or "Detached agent run failed",
-                    now=now,
-                )
-        reconciled.append(
-            {
-                "run_id": run.id,
-                "agent_run_id": int(run.agent_run_id),
-                "agent_run_status": agent_status.value,
-                "status": scheduler_status,
-            }
-        )
-    return reconciled
-
-
 async def async_drain_scheduler(
     session: AsyncSession,
     *,
@@ -1326,22 +1163,27 @@ async def async_drain_scheduler(
     runner: Runner = _async_run_command,
     now: datetime | None = None,
     allowed_owner_modes: tuple[str, ...] | None = None,
-    execution_budget_seconds: float | None = None,
+    admission_budget_seconds: float | None = None,
 ) -> dict[str, Any]:
     """Start due runs within one bounded scheduler-tick admission budget."""
     now = _utcnow(now)
     modes = allowed_owner_modes or (normalize_owner_mode(owner_mode),)
     budget_seconds = (
-        DEFAULT_DRAIN_EXECUTION_BUDGET_SECONDS
-        if execution_budget_seconds is None
-        else float(execution_budget_seconds)
+        DEFAULT_DRAIN_ADMISSION_BUDGET_SECONDS
+        if admission_budget_seconds is None
+        else float(admission_budget_seconds)
     )
     if budget_seconds <= 0:
-        raise ValueError("execution_budget_seconds must be greater than zero")
+        raise ValueError("admission_budget_seconds must be greater than zero")
     loop = asyncio.get_running_loop()
     admission_deadline = loop.time() + budget_seconds
 
-    await async_reconcile_scheduler_agent_runs(session, now=now)
+    await async_reconcile_detached_runs(
+        session,
+        retryable_failure_summary=_retryable_failure_summary,
+        apply_failure_guard=_async_apply_failure_guard,
+        now=now,
+    )
 
     await async_materialize_due_runs(
         session,

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -1,7 +1,9 @@
 """Scheduler executor loop and control helpers."""
 from __future__ import annotations
 
+import asyncio
 import inspect
+import json
 import logging
 import os
 import shlex
@@ -19,7 +21,8 @@ from brain.kernel.common.time import ensure_utc
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from brain.platform.async_io import run_blocking, run_subprocess
+from brain.platform.async_io import run_blocking
+from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.scheduler import (
     OWNER_MODE_SCHEDULER,
     SchedulerJob,
@@ -56,6 +59,7 @@ from brain.app.scheduler.programs import (
 from brain.app.scheduler.runtime import (
     LEASE_TTL_SECONDS,
     RUN_STATUS_CLAIMED,
+    RUN_STATUS_EXECUTING,
     RUN_STATUS_PAUSED,
     RUN_STATUS_RECORDED,
     RUN_STATUS_RETRYABLE,
@@ -68,6 +72,7 @@ from brain.app.scheduler.runtime import (
     async_finish_run,
     async_find_scheduler_job,
     async_heartbeat_lease,
+    async_release_lease,
     async_retry_run,
     async_set_scheduler_job_load_shed as async_set_scheduler_job_load_shed_state,
     async_set_scheduler_job_owner_mode as async_set_scheduler_job_owner_mode_state,
@@ -79,10 +84,29 @@ from brain.app.scheduler.runtime import (
     trace_id_for_run_id,
     trace_id_for_scheduler_run_id,
 )
+from brain.systems.runs.status import (
+    TERMINAL_RUN_STATUSES as TERMINAL_AGENT_RUN_STATUSES,
+    RunStatus as AgentRunStatus,
+    coerce_run_status as coerce_agent_run_status,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 Runner = Callable[..., Any]
 logger = logging.getLogger(__name__)
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+DEFAULT_DRAIN_EXECUTION_BUDGET_SECONDS = _positive_float_env(
+    "SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS",
+    30.0,
+)
 
 _FINAL_RUN_STATUSES = {
     RUN_STATUS_SETTLED_SUCCESS,
@@ -97,6 +121,10 @@ _SUCCESS_HANDLER_STATUSES = {"ok", "recorded", "skipped", "success", "succeeded"
 _BLOCKED_HANDLER_STATUSES = {"blocked"}
 
 
+class SchedulerDrainBudgetExceeded(TimeoutError):
+    """Raised after an in-flight scheduler command exhausts its drain budget."""
+
+
 def _utcnow(now: datetime | None = None) -> datetime:
     return ensure_utc(now)
 
@@ -108,14 +136,50 @@ async def _async_run_command(
     env: dict[str, str] | None = None,
     timeout_seconds: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    return await run_subprocess(
-        list(command),
+    argv = list(command)
+    process = await asyncio.create_subprocess_exec(
+        *argv,
         cwd=str(cwd or REPO_ROOT),
         env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=timeout_seconds,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    communicate = asyncio.create_task(process.communicate())
+    try:
+        if timeout_seconds is None:
+            stdout_bytes, stderr_bytes = await asyncio.shield(communicate)
+        else:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                asyncio.shield(communicate),
+                timeout=max(0.0, float(timeout_seconds)),
+            )
+    except asyncio.TimeoutError:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        stdout_bytes, stderr_bytes = await communicate
+        raise subprocess.TimeoutExpired(
+            argv,
+            timeout_seconds,
+            output=stdout_bytes.decode(errors="replace"),
+            stderr=stderr_bytes.decode(errors="replace"),
+        ) from None
+    except asyncio.CancelledError:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        await communicate
+        raise
+
+    return subprocess.CompletedProcess(
+        argv,
+        int(process.returncode or 0),
+        stdout_bytes.decode(errors="replace"),
+        stderr_bytes.decode(errors="replace"),
     )
 
 
@@ -179,6 +243,26 @@ def _command_summary(proc: Any) -> dict[str, Any]:
         "stdout_tail": _tail(getattr(proc, "stdout", None)),
         "stderr_tail": _tail(getattr(proc, "stderr", None)),
     }
+
+
+def _scheduler_agent_run_id(proc: Any) -> int | None:
+    """Read the explicit detached-run handoff emitted by a scheduler command."""
+    stdout = str(getattr(proc, "stdout", "") or "")
+    for line in reversed(stdout.splitlines()):
+        try:
+            payload = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        value = payload.get("scheduler_agent_run_id")
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
 
 
 def _python_one_liner(code: str) -> list[str]:
@@ -517,6 +601,7 @@ async def _async_run_step(
     runner: Runner,
     now: datetime,
     resume: bool,
+    execution_deadline: float | None = None,
 ) -> dict[str, Any]:
     if step.status == RUN_STATUS_SETTLED_SUCCESS and resume:
         return {"ok": True, "step_key": step.step_key, "skipped": True, "results": []}
@@ -550,14 +635,37 @@ async def _async_run_step(
 
     env = _shell_env(job, run, step.step_key)
     results: list[dict[str, Any]] = []
+    dispatched_agent_run_id: int | None = None
     for command in commands:
         try:
-            proc = await _call_runner(
+            runner_call = _call_runner(
                 runner,
                 command,
                 env=env,
                 timeout_seconds=job.timeout_seconds,
             )
+            if execution_deadline is None:
+                proc = await runner_call
+            else:
+                remaining = execution_deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    runner_call.close()
+                    raise SchedulerDrainBudgetExceeded
+                runner_task = asyncio.create_task(runner_call)
+                done, _pending = await asyncio.wait(
+                    (runner_task,),
+                    timeout=remaining,
+                )
+                if not done:
+                    runner_task.cancel()
+                    try:
+                        await runner_task
+                    except asyncio.CancelledError:
+                        pass
+                    raise SchedulerDrainBudgetExceeded
+                proc = runner_task.result()
+        except SchedulerDrainBudgetExceeded:
+            raise
         except Exception as exc:
             error_text = f"{type(exc).__name__}: {exc}"
             results.append(
@@ -582,6 +690,12 @@ async def _async_run_step(
                 "error": error_text,
             }
         summary = {"command": list(command), **_command_summary(proc)}
+        agent_run_id = _scheduler_agent_run_id(proc)
+        if agent_run_id is not None:
+            dispatched_agent_run_id = agent_run_id
+            run.agent_run_id = agent_run_id
+            run.trace_id = trace_id_for_run_id(agent_run_id)
+            summary["scheduler_agent_run_id"] = agent_run_id
         results.append(summary)
         if int(getattr(proc, "returncode", 1)) != 0:
             error_text = summary["stderr_tail"] or summary["stdout_tail"] or "step failed"
@@ -602,8 +716,12 @@ async def _async_run_step(
         finished_at=now,
         result_summary={"results": results},
         error_text=None,
+        agent_run_id=dispatched_agent_run_id,
     )
-    return {"ok": True, "step_key": step.step_key, "results": results}
+    result = {"ok": True, "step_key": step.step_key, "results": results}
+    if dispatched_agent_run_id is not None:
+        result["agent_run_id"] = dispatched_agent_run_id
+    return result
 
 
 async def async_run_scheduler_run(
@@ -614,6 +732,7 @@ async def async_run_scheduler_run(
     runner: Runner = _async_run_command,
     resume: bool = True,
     now: datetime | None = None,
+    execution_deadline: float | None = None,
 ) -> SchedulerRun:
     now = _utcnow(now)
     run = await session.get(SchedulerRun, run_id)
@@ -687,6 +806,7 @@ async def async_run_scheduler_run(
             runner=runner,
             now=now,
             resume=resume,
+            execution_deadline=execution_deadline,
         )
         step_results.append(result)
         if not result["ok"]:
@@ -717,6 +837,35 @@ async def async_run_scheduler_run(
                 now=now,
             )
             return run
+
+    dispatched_agent_run_ids = [
+        int(result["agent_run_id"])
+        for result in step_results
+        if result.get("agent_run_id") is not None
+    ]
+    if dispatched_agent_run_ids:
+        agent_run_id = dispatched_agent_run_ids[-1]
+        run.agent_run_id = agent_run_id
+        run.trace_id = trace_id_for_run_id(agent_run_id)
+        run.status = RUN_STATUS_EXECUTING
+        run.result_summary = {
+            "steps": step_results,
+            "agent_run": {
+                "run_id": agent_run_id,
+                "status": "dispatched",
+            },
+        }
+        run.error_text = None
+        run.finished_at = None
+        if run.lease_id:
+            await async_release_lease(
+                session,
+                run.lease_id,
+                reason="agent_run_dispatched",
+                now=now,
+            )
+        await session.flush()
+        return run
 
     await async_finish_run(
         session,
@@ -1071,6 +1220,184 @@ async def async_set_scheduler_job_load_shed(
     return updated
 
 
+def _agent_run_finished_at(agent_run: AgentRunRow, *, now: datetime) -> datetime:
+    for attr_name in ("completed_at", "failed_at", "canceled_at"):
+        value = getattr(agent_run, attr_name, None)
+        if value is not None:
+            return _utcnow(value)
+    return now
+
+
+async def async_reconcile_scheduler_agent_runs(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Settle detached scheduler runs from their linked AgentRun outcomes."""
+    now = _utcnow(now)
+    runs = (
+        await session.scalars(
+            select(SchedulerRun)
+            .where(
+                SchedulerRun.status == RUN_STATUS_EXECUTING,
+                SchedulerRun.agent_run_id.is_not(None),
+            )
+            .order_by(SchedulerRun.id.asc())
+        )
+    ).all()
+    reconciled: list[dict[str, Any]] = []
+    for run in runs:
+        agent_run = await session.get(AgentRunRow, int(run.agent_run_id))
+        if agent_run is None:
+            continue
+        agent_status = coerce_agent_run_status(agent_run.status)
+        if agent_status not in TERMINAL_AGENT_RUN_STATUSES:
+            continue
+
+        terminal_scheduler_status = (
+            RUN_STATUS_SETTLED_SUCCESS
+            if agent_status == AgentRunStatus.COMPLETED
+            else RUN_STATUS_SETTLED_FAILURE
+        )
+        job = await session.get(SchedulerJob, run.job_id)
+        error_text = None
+        if terminal_scheduler_status == RUN_STATUS_SETTLED_FAILURE:
+            error_text = (
+                f"Agent run {run.agent_run_id} ended with status "
+                f"{agent_status.value}"
+            )
+        summary = {
+            **(run.result_summary or {}),
+            "agent_run": {
+                "run_id": int(run.agent_run_id),
+                "status": agent_status.value,
+                "reconciled_at": now.isoformat(),
+            },
+        }
+        scheduler_status = terminal_scheduler_status
+        if terminal_scheduler_status == RUN_STATUS_SETTLED_FAILURE and job is not None:
+            scheduler_status, summary = _retryable_failure_summary(
+                job,
+                run,
+                base_summary=summary,
+                now=now,
+            )
+        step = await session.scalar(
+            select(SchedulerRunStep)
+            .where(
+                SchedulerRunStep.run_id == run.id,
+                SchedulerRunStep.agent_run_id == run.agent_run_id,
+            )
+            .order_by(SchedulerRunStep.sequence_no.desc())
+            .limit(1)
+        )
+        if step is not None:
+            await async_update_run_step(
+                session,
+                step,
+                status=(
+                    RUN_STATUS_SETTLED_SUCCESS
+                    if terminal_scheduler_status == RUN_STATUS_SETTLED_SUCCESS
+                    else scheduler_status
+                ),
+                finished_at=_agent_run_finished_at(agent_run, now=now),
+                result_summary={
+                    **(step.result_summary or {}),
+                    "agent_run": summary["agent_run"],
+                },
+                error_text=error_text,
+                agent_run_id=int(run.agent_run_id),
+            )
+        finished_at = _agent_run_finished_at(agent_run, now=now)
+        await async_finish_run(
+            session,
+            run,
+            status=scheduler_status,
+            result_summary=summary,
+            error_text=error_text,
+            now=finished_at,
+        )
+        if job is not None:
+            if scheduler_status == RUN_STATUS_SETTLED_SUCCESS:
+                await async_reset_scheduler_job_failure_guard(
+                    session,
+                    job,
+                    now=now,
+                )
+            else:
+                await _async_apply_failure_guard(
+                    session,
+                    job,
+                    run,
+                    failure_key="detached_agent_run",
+                    error_text=error_text or "Detached agent run failed",
+                    now=now,
+                )
+        reconciled.append(
+            {
+                "run_id": run.id,
+                "agent_run_id": int(run.agent_run_id),
+                "agent_run_status": agent_status.value,
+                "status": scheduler_status,
+            }
+        )
+    return reconciled
+
+
+async def _async_finish_drain_budget_overrun(
+    session: AsyncSession,
+    run: SchedulerRun,
+    *,
+    budget_seconds: float,
+    now: datetime,
+) -> str:
+    error_text = (
+        f"Scheduler drain execution budget of {budget_seconds:g}s exceeded"
+    )
+    step = await session.scalar(
+        select(SchedulerRunStep)
+        .where(
+            SchedulerRunStep.run_id == run.id,
+            SchedulerRunStep.status == RUN_STATUS_RUNNING,
+        )
+        .order_by(SchedulerRunStep.sequence_no.desc())
+        .limit(1)
+    )
+    if step is not None:
+        await async_update_run_step(
+            session,
+            step,
+            status=RUN_STATUS_SETTLED_FAILURE,
+            finished_at=now,
+            result_summary={
+                **(step.result_summary or {}),
+                "drain_budget_exceeded": True,
+                "budget_seconds": budget_seconds,
+            },
+            error_text=error_text,
+        )
+    await async_finish_run(
+        session,
+        run,
+        status=RUN_STATUS_SETTLED_FAILURE,
+        result_summary={
+            **(run.result_summary or {}),
+            "drain_budget_exceeded": True,
+            "budget_seconds": budget_seconds,
+        },
+        error_text=error_text,
+        now=now,
+    )
+    logger.error(
+        "Scheduler drain execution budget exceeded: run_id=%s job_id=%s "
+        "budget_seconds=%s",
+        run.id,
+        run.job_id,
+        budget_seconds,
+    )
+    return error_text
+
+
 async def async_drain_scheduler(
     session: AsyncSession,
     *,
@@ -1082,9 +1409,23 @@ async def async_drain_scheduler(
     runner: Runner = _async_run_command,
     now: datetime | None = None,
     allowed_owner_modes: tuple[str, ...] | None = None,
+    execution_budget_seconds: float | None = None,
 ) -> dict[str, Any]:
+    """Execute due runs within one bounded scheduler-tick budget."""
     now = _utcnow(now)
     modes = allowed_owner_modes or (normalize_owner_mode(owner_mode),)
+    budget_seconds = (
+        DEFAULT_DRAIN_EXECUTION_BUDGET_SECONDS
+        if execution_budget_seconds is None
+        else float(execution_budget_seconds)
+    )
+    if budget_seconds <= 0:
+        raise ValueError("execution_budget_seconds must be greater than zero")
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    execution_deadline = started_at + budget_seconds
+
+    await async_reconcile_scheduler_agent_runs(session, now=now)
 
     await async_materialize_due_runs(
         session,
@@ -1095,7 +1436,12 @@ async def async_drain_scheduler(
 
     results: list[dict[str, Any]] = []
     executed = 0
+    budget_exhausted = False
+    budget_overrun: dict[str, Any] | None = None
     while executed < max_runs:
+        if loop.time() >= execution_deadline:
+            budget_exhausted = True
+            break
         candidate = await async_claim_next_due_run(
             session,
             allowed_owner_modes=modes,
@@ -1107,7 +1453,40 @@ async def async_drain_scheduler(
         if candidate is None:
             break
         run, _lease = candidate
-        await async_run_scheduler_run(session, run.id, owner_id=owner_id, runner=runner, resume=resume, now=now)
+        try:
+            await async_run_scheduler_run(
+                session,
+                run.id,
+                owner_id=owner_id,
+                runner=runner,
+                resume=resume,
+                now=now,
+                execution_deadline=execution_deadline,
+            )
+        except SchedulerDrainBudgetExceeded:
+            error_text = await _async_finish_drain_budget_overrun(
+                session,
+                run,
+                budget_seconds=budget_seconds,
+                now=now,
+            )
+            budget_exhausted = True
+            budget_overrun = {
+                "run_id": run.id,
+                "job_id": run.job_id,
+                "budget_seconds": budget_seconds,
+                "elapsed_seconds": round(loop.time() - started_at, 3),
+            }
+            results.append(
+                {
+                    "run_id": run.id,
+                    "job_id": run.job_id,
+                    "status": run.status,
+                    "error_text": error_text,
+                }
+            )
+            executed += 1
+            break
         results.append(
             {
                 "run_id": run.id,
@@ -1118,4 +1497,9 @@ async def async_drain_scheduler(
         )
         executed += 1
     await session.flush()
-    return {"ok": True, "executed": executed, "results": results}
+    result = {"ok": True, "executed": executed, "results": results}
+    if budget_exhausted:
+        result["budget_exhausted"] = True
+        if budget_overrun is not None:
+            result["budget_overrun"] = budget_overrun
+    return result

--- a/brain/app/scheduler/programs.py
+++ b/brain/app/scheduler/programs.py
@@ -8,9 +8,11 @@ from datetime import date
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from brain.contracts.scheduler_handoff import AGENT_RUN_COMPLETION_MODE
 from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 
 DEFAULT_STEP_KIND = "single"
+DEFAULT_COMPLETION_MODE = "command"
 WRAPPER_STEP_KEY = "nightly_wrapper"
 ILLO_EXTERNAL_HEARTBEAT_COMMAND = [
     "python3",
@@ -60,6 +62,7 @@ class SingleCommandProgram:
     command: tuple[str, ...]
     step_key: str
     description: str
+    completion_mode: str = DEFAULT_COMPLETION_MODE
 
     def build_step_plan(
         self,
@@ -99,6 +102,7 @@ SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
         command=("python3", "-m", "brain.jobs.pipelines.aws_health_scan"),
         step_key="uwear_aws_health_scan",
         description="Uwear AWS production health scan",
+        completion_mode=AGENT_RUN_COMPLETION_MODE,
     ),
     "uwear_staging_promotion_pr": SingleCommandProgram(
         command=("python3", "-m", "brain.jobs.pipelines.staging_promotion_pr"),
@@ -106,6 +110,14 @@ SINGLE_COMMAND_PROGRAM_REGISTRY: dict[str, SingleCommandProgram] = {
         description="Ensure Uwear staging promotion pull requests exist",
     ),
 }
+
+
+def scheduler_program_completion_mode(job: SchedulerJob) -> str:
+    """Return the completion lifecycle declared by an exact-key program."""
+    definition = SINGLE_COMMAND_PROGRAM_REGISTRY.get(job.program_key)
+    if definition is None:
+        return DEFAULT_COMPLETION_MODE
+    return definition.completion_mode
 
 
 @dataclass(frozen=True)
@@ -570,17 +582,18 @@ def build_scheduler_step_plan(job: SchedulerJob) -> list[dict[str, object]]:
             if not isinstance(step, dict):
                 continue
             step_key = str(step.get("step_key") or step.get("key") or f"step_{index}")
-            plan.append(
-                {
-                    "step_key": step_key,
-                    "sequence_no": int(step.get("sequence_no") or index),
-                    "kind": str(step.get("kind") or DEFAULT_STEP_KIND),
-                    "handler_ref": step.get("handler_ref") or job.handler_ref,
-                    "payload": step.get("payload") or {},
-                    "command": step.get("command"),
-                    "commands": step.get("commands"),
-                }
-            )
+            projected_step: dict[str, object] = {
+                "step_key": step_key,
+                "sequence_no": int(step.get("sequence_no") or index),
+                "kind": str(step.get("kind") or DEFAULT_STEP_KIND),
+                "handler_ref": step.get("handler_ref") or job.handler_ref,
+                "payload": step.get("payload") or {},
+                "command": step.get("command"),
+                "commands": step.get("commands"),
+            }
+            if step.get("completion_mode"):
+                projected_step["completion_mode"] = str(step["completion_mode"])
+            plan.append(projected_step)
         if plan:
             return plan
 

--- a/brain/contracts/scheduler_handoff.py
+++ b/brain/contracts/scheduler_handoff.py
@@ -1,0 +1,112 @@
+"""Typed transport contract for scheduler-to-AgentRun handoffs."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+AGENT_RUN_COMPLETION_MODE = "agent_run"
+HANDOFF_TYPE = "scheduler.detached_agent_run"
+HANDOFF_VERSION = 1
+HANDOFF_STATUS_DISPATCHED = "dispatched"
+_HANDOFF_FIELDS = frozenset(
+    {
+        "type",
+        "version",
+        "status",
+        "scheduler_agent_run_id",
+    }
+)
+
+
+class DetachedAgentRunHandoffError(ValueError):
+    """Raised when a declared detached-run command emits an invalid handoff."""
+
+
+@dataclass(frozen=True)
+class DetachedAgentRunHandoff:
+    """Validated scheduler-to-AgentRun dispatch envelope."""
+
+    agent_run_id: int
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.agent_run_id, bool)
+            or not isinstance(self.agent_run_id, int)
+            or self.agent_run_id <= 0
+        ):
+            raise DetachedAgentRunHandoffError(
+                "scheduler_agent_run_id must be a positive integer"
+            )
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "type": HANDOFF_TYPE,
+            "version": HANDOFF_VERSION,
+            "status": HANDOFF_STATUS_DISPATCHED,
+            "scheduler_agent_run_id": self.agent_run_id,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> DetachedAgentRunHandoff:
+        fields = frozenset(payload)
+        if fields != _HANDOFF_FIELDS:
+            missing = sorted(_HANDOFF_FIELDS - fields)
+            unexpected = sorted(fields - _HANDOFF_FIELDS)
+            details = []
+            if missing:
+                details.append(f"missing fields: {', '.join(missing)}")
+            if unexpected:
+                details.append(f"unexpected fields: {', '.join(unexpected)}")
+            raise DetachedAgentRunHandoffError(
+                "invalid detached AgentRun handoff envelope"
+                + (f" ({'; '.join(details)})" if details else "")
+            )
+        if payload["type"] != HANDOFF_TYPE:
+            raise DetachedAgentRunHandoffError(
+                f"handoff type must be {HANDOFF_TYPE!r}"
+            )
+        if (
+            isinstance(payload["version"], bool)
+            or not isinstance(payload["version"], int)
+            or payload["version"] != HANDOFF_VERSION
+        ):
+            raise DetachedAgentRunHandoffError(
+                f"handoff version must be {HANDOFF_VERSION}"
+            )
+        if payload["status"] != HANDOFF_STATUS_DISPATCHED:
+            raise DetachedAgentRunHandoffError(
+                f"handoff status must be {HANDOFF_STATUS_DISPATCHED!r}"
+            )
+        agent_run_id = payload["scheduler_agent_run_id"]
+        if isinstance(agent_run_id, bool) or not isinstance(agent_run_id, int):
+            raise DetachedAgentRunHandoffError(
+                "scheduler_agent_run_id must be a positive integer"
+            )
+        return cls(agent_run_id=agent_run_id)
+
+
+def emit_detached_agent_run_handoff(agent_run_id: int) -> str:
+    """Serialize the one supported detached AgentRun handoff envelope."""
+    handoff = DetachedAgentRunHandoff(agent_run_id=agent_run_id)
+    return json.dumps(handoff.as_payload(), sort_keys=True)
+
+
+def parse_detached_agent_run_handoff(stdout: str | None) -> DetachedAgentRunHandoff:
+    """Parse and fully validate a declared detached-run command's stdout."""
+    for line in reversed(str(stdout or "").splitlines()):
+        try:
+            payload = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if (
+            payload.get("type") != HANDOFF_TYPE
+            and "scheduler_agent_run_id" not in payload
+        ):
+            continue
+        return DetachedAgentRunHandoff.from_payload(payload)
+    raise DetachedAgentRunHandoffError(
+        "declared detached AgentRun command did not emit a handoff envelope"
+    )

--- a/brain/jobs/pipelines/aws_health_scan.py
+++ b/brain/jobs/pipelines/aws_health_scan.py
@@ -1,13 +1,16 @@
 """Run the hourly Uwear AWS health scan as one headless AgentRun."""
 from __future__ import annotations
 
-import json
+import asyncio
 import sys
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
+from brain.contracts.scheduler_handoff import (
+    emit_detached_agent_run_handoff,
+)
 from brain.platform.db.enums import SettlementState
 from brain.platform.db.models.org import User
 from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
@@ -163,15 +166,7 @@ async def async_main() -> int:
         print(f"AWS health scan spawn failed: {exc}", file=sys.stderr)
         return 1
 
-    print(
-        json.dumps(
-            {
-                "scheduler_agent_run_id": run_id,
-                "status": "dispatched",
-            },
-            sort_keys=True,
-        )
-    )
+    print(emit_detached_agent_run_handoff(run_id))
     return 0
 
 

--- a/brain/jobs/pipelines/aws_health_scan.py
+++ b/brain/jobs/pipelines/aws_health_scan.py
@@ -1,7 +1,6 @@
 """Run the hourly Uwear AWS health scan as one headless AgentRun."""
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 import uuid
@@ -10,18 +9,14 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 
 from brain.platform.db.enums import SettlementState
-from brain.platform.db.models.agent_run import AgentRunRow
 from brain.platform.db.models.org import User
 from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
 from brain.platform.db.models.skill_bundle import SkillInstallation
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.runtime_settings import display as runtime_display
-from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_run_status
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 
 SKILL_NAME = "uwear-aws-health-scan"
-RUN_TIMEOUT_SECONDS = 840
-POLL_INTERVAL_SECONDS = 2.0
 
 
 def _timestamp_rendering_contract(
@@ -161,53 +156,22 @@ async def spawn_health_scan_run(*, now: datetime | None = None) -> int:
         return int(result.run_id)
 
 
-async def _read_run_status(run_id: int) -> RunStatus:
-    async with UnitOfWork() as uow:
-        run = await uow.session.get(AgentRunRow, int(run_id))
-        if run is None:
-            raise LookupError(f"Agent run {run_id} not found")
-        return coerce_run_status(run.status)
-
-
-async def wait_for_terminal_run(
-    run_id: int,
-    *,
-    timeout_seconds: float = RUN_TIMEOUT_SECONDS,
-    poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
-) -> RunStatus:
-    """Poll the admitted run until it settles or the pipeline wait budget expires."""
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + max(0.0, float(timeout_seconds))
-    while True:
-        status = await _read_run_status(run_id)
-        if status in TERMINAL_RUN_STATUSES:
-            return status
-
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            raise TimeoutError(
-                f"Agent run {run_id} did not reach a terminal state within {timeout_seconds:g}s"
-            )
-        await asyncio.sleep(min(max(0.01, poll_interval_seconds), remaining))
-
-
-async def async_main(*, timeout_seconds: float = RUN_TIMEOUT_SECONDS) -> int:
+async def async_main() -> int:
     try:
         run_id = await spawn_health_scan_run()
     except Exception as exc:  # noqa: BLE001 - process boundary must fail cleanly
         print(f"AWS health scan spawn failed: {exc}", file=sys.stderr)
         return 1
 
-    try:
-        status = await wait_for_terminal_run(run_id, timeout_seconds=timeout_seconds)
-    except Exception as exc:  # noqa: BLE001 - process boundary must fail cleanly
-        print(f"AWS health scan run {run_id} wait failed: {exc}", file=sys.stderr)
-        return 1
-
-    print(json.dumps({"run_id": run_id, "status": status.value}, sort_keys=True))
-    if status != RunStatus.COMPLETED:
-        print(f"AWS health scan run {run_id} ended with status {status.value}", file=sys.stderr)
-        return 1
+    print(
+        json.dumps(
+            {
+                "scheduler_agent_run_id": run_id,
+                "status": "dispatched",
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/tests/test_detached_agent_runs.py
+++ b/tests/test_detached_agent_runs.py
@@ -1,0 +1,67 @@
+"""Typed detached AgentRun handoff contract tests."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brain.contracts.scheduler_handoff import (
+    DetachedAgentRunHandoff,
+    DetachedAgentRunHandoffError,
+    emit_detached_agent_run_handoff,
+    parse_detached_agent_run_handoff,
+)
+
+
+def test_detached_agent_run_handoff_round_trips_the_complete_envelope():
+    encoded = emit_detached_agent_run_handoff(321)
+
+    assert json.loads(encoded) == {
+        "type": "scheduler.detached_agent_run",
+        "version": 1,
+        "status": "dispatched",
+        "scheduler_agent_run_id": 321,
+    }
+    assert parse_detached_agent_run_handoff(encoded) == DetachedAgentRunHandoff(
+        agent_run_id=321
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "type": "scheduler.detached_agent_run",
+            "version": 1,
+            "scheduler_agent_run_id": 321,
+        },
+        {
+            "type": "scheduler.detached_agent_run",
+            "version": 1,
+            "status": "completed",
+            "scheduler_agent_run_id": 321,
+        },
+        {
+            "type": "scheduler.detached_agent_run",
+            "version": 2,
+            "status": "dispatched",
+            "scheduler_agent_run_id": 321,
+        },
+        {
+            "type": "scheduler.detached_agent_run",
+            "version": 1,
+            "status": "dispatched",
+            "scheduler_agent_run_id": "321",
+        },
+        {
+            "type": "scheduler.detached_agent_run",
+            "version": 1,
+            "status": "dispatched",
+            "scheduler_agent_run_id": 321,
+            "extra": True,
+        },
+    ],
+)
+def test_detached_agent_run_handoff_rejects_any_malformed_envelope(payload):
+    with pytest.raises(DetachedAgentRunHandoffError):
+        parse_detached_agent_run_handoff(json.dumps(payload))

--- a/tests/test_scheduler_drain_budget.py
+++ b/tests/test_scheduler_drain_budget.py
@@ -46,15 +46,19 @@ def _due_job(job_key: str, *, priority: int) -> SchedulerJob:
     )
 
 
-async def test_budget_overrun_returns_and_sibling_runs_on_next_drain(session):
+async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
     blocker = _due_job("blocking_job", priority=200)
+    blocker.timeout_seconds = 60
     sibling = _due_job("sibling_job", priority=100)
     session.add_all([blocker, sibling])
     await session.flush()
 
+    runner_timeouts = []
+
     async def runner(command, **_kwargs):
+        runner_timeouts.append(_kwargs["timeout_seconds"])
         if command == ["blocking_job"]:
-            await asyncio.Event().wait()
+            await asyncio.sleep(0.3)
         return SimpleNamespace(returncode=0, stdout="ok", stderr="")
 
     now = datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc)
@@ -63,23 +67,30 @@ async def test_budget_overrun_returns_and_sibling_runs_on_next_drain(session):
             session,
             max_runs=2,
             runner=runner,
-            execution_budget_seconds=0.05,
+            execution_budget_seconds=0.25,
             now=now,
         ),
-        timeout=0.5,
+        timeout=1.5,
     )
 
     assert first["executed"] == 1
     assert first["budget_exhausted"] is True
-    assert first["budget_overrun"]["job_id"] == blocker.id
     assert first["results"] == [
         {
-            "run_id": first["budget_overrun"]["run_id"],
+            "run_id": first["results"][0]["run_id"],
             "job_id": blocker.id,
-            "status": "settled_failure",
-            "error_text": "Scheduler drain execution budget of 0.05s exceeded",
+            "status": "settled_success",
+            "error_text": None,
         }
     ]
+    assert runner_timeouts == [blocker.timeout_seconds]
+
+    sibling_run = await session.scalar(
+        select(SchedulerRun).where(SchedulerRun.job_id == sibling.id)
+    )
+    assert sibling_run is not None
+    assert sibling_run.status == "recorded"
+    assert sibling_run.lease_id is None
 
     second = await async_drain_scheduler(
         session,
@@ -94,10 +105,7 @@ async def test_budget_overrun_returns_and_sibling_runs_on_next_drain(session):
     assert second["results"][0]["status"] == "settled_success"
     assert "budget_exhausted" not in second
 
-    sibling_run = await session.scalar(
-        select(SchedulerRun).where(SchedulerRun.job_id == sibling.id)
-    )
-    assert sibling_run is not None
+    await session.refresh(sibling_run)
     assert sibling_run.status == "settled_success"
 
 

--- a/tests/test_scheduler_drain_budget.py
+++ b/tests/test_scheduler_drain_budget.py
@@ -5,20 +5,27 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.schema import CreateTable
 
+from brain.contracts.scheduler_handoff import (
+    emit_detached_agent_run_handoff,
+)
 from brain.app.scheduler.executor import (
     async_drain_scheduler,
-    async_reconcile_scheduler_agent_runs,
     async_run_scheduler_run,
 )
 from brain.app.scheduler.planner import async_materialize_due_runs
 from brain.jobs.pipelines import aws_health_scan
 from brain.platform.db.models.agent_run import AgentRunRow
-from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
+from brain.platform.db.models.scheduler import (
+    SchedulerJob,
+    SchedulerRun,
+    SchedulerRunStep,
+)
 from tests.scheduler_test_support import (
     make_scheduler_job,
     make_scheduler_test_session,
@@ -67,7 +74,7 @@ async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
             session,
             max_runs=2,
             runner=runner,
-            execution_budget_seconds=0.25,
+            admission_budget_seconds=0.25,
             now=now,
         ),
         timeout=1.5,
@@ -96,7 +103,7 @@ async def test_drain_budget_bounds_admission_not_in_flight_execution(session):
         session,
         max_runs=2,
         runner=runner,
-        execution_budget_seconds=1,
+        admission_budget_seconds=1,
         now=now,
     )
 
@@ -120,7 +127,7 @@ async def test_healthy_drain_keeps_existing_result_shape(session):
     result = await async_drain_scheduler(
         session,
         runner=runner,
-        execution_budget_seconds=1,
+        admission_budget_seconds=1,
         now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
     )
 
@@ -136,6 +143,76 @@ async def test_healthy_drain_keeps_existing_result_shape(session):
             }
         ],
     }
+
+
+async def test_undeclared_command_output_cannot_activate_detached_lifecycle(session):
+    job = _due_job("ordinary_json_job", priority=100)
+    session.add(job)
+    await session.flush()
+
+    async def runner(_command, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=emit_detached_agent_run_handoff(321),
+            stderr="",
+        )
+
+    result = await async_drain_scheduler(
+        session,
+        runner=runner,
+        admission_budget_seconds=1,
+        now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+
+    scheduler_run = await session.get(SchedulerRun, result["results"][0]["run_id"])
+    assert scheduler_run is not None
+    step = await session.scalar(
+        select(SchedulerRunStep).where(SchedulerRunStep.run_id == scheduler_run.id)
+    )
+    assert step is not None
+    assert scheduler_run.status == "settled_success"
+    assert scheduler_run.agent_run_id is None
+    assert step.status == "settled_success"
+    assert step.agent_run_id is None
+
+
+async def test_declared_detached_command_rejects_malformed_handoff(session):
+    now = datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc)
+    job = make_scheduler_job(
+        job_key="uwear_aws_health_scan",
+        family="uwear_aws_health_scan",
+        program_key="uwear_aws_health_scan",
+        handler_ref="brain.app.scheduler.programs:uwear_aws_health_scan",
+        retry_policy={"max_attempts": 1, "backoff_seconds": 0},
+        next_run_at=now,
+    )
+    session.add(job)
+    await session.flush()
+
+    async def runner(_command, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {"scheduler_agent_run_id": 321, "status": "dispatched"}
+            ),
+            stderr="",
+        )
+
+    result = await async_drain_scheduler(
+        session,
+        runner=runner,
+        admission_budget_seconds=1,
+        now=now,
+    )
+
+    assert result["results"][0]["status"] == "settled_failure"
+    scheduler_run = await session.get(
+        SchedulerRun,
+        result["results"][0]["run_id"],
+    )
+    assert scheduler_run is not None
+    assert scheduler_run.agent_run_id is None
+    assert "invalid detached AgentRun handoff envelope" in scheduler_run.error_text
 
 
 async def test_structured_dispatch_leaves_scheduler_run_for_reconciliation(session):
@@ -159,9 +236,7 @@ async def test_structured_dispatch_leaves_scheduler_run_for_reconciliation(sessi
     async def runner(_command, **_kwargs):
         return SimpleNamespace(
             returncode=0,
-            stdout=json.dumps(
-                {"scheduler_agent_run_id": 321, "status": "dispatched"}
-            ),
+            stdout=emit_detached_agent_run_handoff(321),
             stderr="",
         )
 
@@ -176,86 +251,109 @@ async def test_structured_dispatch_leaves_scheduler_run_for_reconciliation(sessi
     assert dispatched.agent_run_id == 321
     assert dispatched.lease_id is None
     assert dispatched.finished_at is None
+    step = await session.scalar(
+        select(SchedulerRunStep).where(SchedulerRunStep.run_id == dispatched.id)
+    )
+    assert step is not None
+    assert step.status == "executing"
+    assert step.finished_at is None
     assert dispatched.result_summary["agent_run"] == {
         "run_id": 321,
         "status": "dispatched",
     }
 
 
-async def test_terminal_agent_run_is_recorded_on_scheduler_run(monkeypatch):
-    now = datetime(2026, 7, 28, 19, 44, tzinfo=timezone.utc)
-    scheduler_run = SimpleNamespace(
-        id=17,
-        job_id=9,
-        status="executing",
-        agent_run_id=321,
-        trace_id="run:321",
-        result_summary={
-            "steps": [],
-            "agent_run": {"run_id": 321, "status": "dispatched"},
-        },
-        error_text=None,
-        finished_at=None,
-        lease_id=None,
-    )
-    job = SimpleNamespace(
-        id=9,
+@pytest.mark.parametrize(
+    ("agent_status", "scheduler_status", "finished_at_field"),
+    [
+        ("completed", "settled_success", "completed_at"),
+        ("failed", "settled_failure", "failed_at"),
+        ("canceled", "settled_failure", "canceled_at"),
+    ],
+)
+async def test_later_drain_reconciles_detached_agent_run_and_step(
+    session,
+    agent_status,
+    scheduler_status,
+    finished_at_field,
+):
+    await session.execute(CreateTable(AgentRunRow.__table__, if_not_exists=True))
+
+    now = datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc)
+    job = make_scheduler_job(
         job_key="uwear_aws_health_scan",
-        enabled=True,
-        pause_reason=None,
-        last_finished_at=None,
+        family="uwear_aws_health_scan",
+        program_key="uwear_aws_health_scan",
+        handler_ref="brain.app.scheduler.programs:uwear_aws_health_scan",
+        retry_policy={"max_attempts": 1, "backoff_seconds": 0},
+        next_run_at=now,
     )
-    agent_run = SimpleNamespace(
-        id=321,
-        status="completed",
-        completed_at=now,
-        failed_at=None,
-        canceled_at=None,
-    )
-    scalar_result = MagicMock()
-    scalar_result.all.return_value = [scheduler_run]
-    mock_session = MagicMock()
-    mock_session.scalars = AsyncMock(return_value=scalar_result)
-    mock_session.scalar = AsyncMock(return_value=None)
-    mock_session.flush = AsyncMock()
+    session.add(job)
+    await session.flush()
 
-    async def get(model, row_id):
-        if model is AgentRunRow:
-            assert row_id == 321
-            return agent_run
-        if model is SchedulerJob:
-            assert row_id == 9
-            return job
-        raise AssertionError(f"Unexpected model lookup: {model}")
+    async def runner(_command, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=emit_detached_agent_run_handoff(321),
+            stderr="",
+        )
 
-    mock_session.get = AsyncMock(side_effect=get)
-    reset_guard = AsyncMock()
-    monkeypatch.setattr(
-        "brain.app.scheduler.executor.async_reset_scheduler_job_failure_guard",
-        reset_guard,
-    )
-
-    reconciled = await async_reconcile_scheduler_agent_runs(
-        mock_session,
+    first_drain = await async_drain_scheduler(
+        session,
+        job_key=job.job_key,
+        runner=runner,
+        admission_budget_seconds=1,
         now=now,
     )
+    assert first_drain["executed"] == 1
 
-    assert reconciled == [
-        {
-            "run_id": 17,
-            "agent_run_id": 321,
-            "agent_run_status": "completed",
-            "status": "settled_success",
-        }
-    ]
-    assert scheduler_run.status == "settled_success"
-    assert scheduler_run.finished_at == now
-    assert scheduler_run.result_summary["agent_run"] == {
-        "run_id": 321,
-        "status": "completed",
-        "reconciled_at": now.isoformat(),
-    }
-    reset_guard.assert_awaited_once_with(mock_session, job, now=now)
+    scheduler_run = await session.scalar(
+        select(SchedulerRun).where(SchedulerRun.job_id == job.id)
+    )
+    assert scheduler_run is not None
+    scheduler_step = await session.scalar(
+        select(SchedulerRunStep).where(SchedulerRunStep.run_id == scheduler_run.id)
+    )
+    assert scheduler_step is not None
+    assert scheduler_run.status == "executing"
+    assert scheduler_step.status == "executing"
+
+    terminal_at = datetime(2026, 7, 28, 19, 35, tzinfo=timezone.utc)
+    session.add(
+        AgentRunRow(
+            id=321,
+            thread_id=f"headless:health-scan:{agent_status}",
+            profile="fast",
+            recipe="fast",
+            status=agent_status,
+            input_message="Run the AWS health scan.",
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={},
+            **{finished_at_field: terminal_at},
+        )
+    )
+    await session.flush()
+
+    second_drain = await async_drain_scheduler(
+        session,
+        job_key=job.job_key,
+        runner=runner,
+        admission_budget_seconds=1,
+        now=terminal_at,
+    )
+    assert second_drain["executed"] == 0
+
+    await session.refresh(scheduler_run)
+    await session.refresh(scheduler_step)
+    assert scheduler_run.status == scheduler_status
+    assert scheduler_step.status == scheduler_status
+    assert scheduler_run.finished_at is not None
+    assert scheduler_step.finished_at == scheduler_run.finished_at
+    assert scheduler_run.finished_at.replace(tzinfo=timezone.utc) == terminal_at
+    assert scheduler_run.result_summary["agent_run"]["status"] == agent_status
+    assert scheduler_step.result_summary["agent_run"]["status"] == agent_status
 
 
 async def test_aws_health_scan_returns_immediately_after_dispatch(monkeypatch, capsys):
@@ -267,6 +365,8 @@ async def test_aws_health_scan_returns_immediately_after_dispatch(monkeypatch, c
     assert exit_code == 0
     spawn.assert_awaited_once_with()
     assert json.loads(capsys.readouterr().out) == {
+        "type": "scheduler.detached_agent_run",
+        "version": 1,
         "scheduler_agent_run_id": 321,
         "status": "dispatched",
     }

--- a/tests/test_scheduler_drain_budget.py
+++ b/tests/test_scheduler_drain_budget.py
@@ -1,0 +1,264 @@
+"""Regression tests for bounded scheduler drains and detached agent runs."""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from brain.app.scheduler.executor import (
+    async_drain_scheduler,
+    async_reconcile_scheduler_agent_runs,
+    async_run_scheduler_run,
+)
+from brain.app.scheduler.planner import async_materialize_due_runs
+from brain.jobs.pipelines import aws_health_scan
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.scheduler import SchedulerJob, SchedulerRun
+from tests.scheduler_test_support import (
+    make_scheduler_job,
+    make_scheduler_test_session,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory):
+    return await make_scheduler_test_session(async_sqlite_session_factory)
+
+
+def _due_job(job_key: str, *, priority: int) -> SchedulerJob:
+    return make_scheduler_job(
+        job_key=job_key,
+        family=job_key,
+        program_key=job_key,
+        handler_kind="command",
+        handler_ref=job_key,
+        priority=priority,
+        retry_policy={"max_attempts": 1, "backoff_seconds": 0},
+        default_payload={"name": job_key.replace("_", " ").title()},
+        next_run_at=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+
+
+async def test_budget_overrun_returns_and_sibling_runs_on_next_drain(session):
+    blocker = _due_job("blocking_job", priority=200)
+    sibling = _due_job("sibling_job", priority=100)
+    session.add_all([blocker, sibling])
+    await session.flush()
+
+    async def runner(command, **_kwargs):
+        if command == ["blocking_job"]:
+            await asyncio.Event().wait()
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    now = datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc)
+    first = await asyncio.wait_for(
+        async_drain_scheduler(
+            session,
+            max_runs=2,
+            runner=runner,
+            execution_budget_seconds=0.05,
+            now=now,
+        ),
+        timeout=0.5,
+    )
+
+    assert first["executed"] == 1
+    assert first["budget_exhausted"] is True
+    assert first["budget_overrun"]["job_id"] == blocker.id
+    assert first["results"] == [
+        {
+            "run_id": first["budget_overrun"]["run_id"],
+            "job_id": blocker.id,
+            "status": "settled_failure",
+            "error_text": "Scheduler drain execution budget of 0.05s exceeded",
+        }
+    ]
+
+    second = await async_drain_scheduler(
+        session,
+        max_runs=2,
+        runner=runner,
+        execution_budget_seconds=1,
+        now=now,
+    )
+
+    assert second["executed"] == 1
+    assert second["results"][0]["job_id"] == sibling.id
+    assert second["results"][0]["status"] == "settled_success"
+    assert "budget_exhausted" not in second
+
+    sibling_run = await session.scalar(
+        select(SchedulerRun).where(SchedulerRun.job_id == sibling.id)
+    )
+    assert sibling_run is not None
+    assert sibling_run.status == "settled_success"
+
+
+async def test_healthy_drain_keeps_existing_result_shape(session):
+    job = _due_job("healthy_job", priority=100)
+    session.add(job)
+    await session.flush()
+
+    async def runner(_command, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    result = await async_drain_scheduler(
+        session,
+        runner=runner,
+        execution_budget_seconds=1,
+        now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+
+    assert result == {
+        "ok": True,
+        "executed": 1,
+        "results": [
+            {
+                "run_id": result["results"][0]["run_id"],
+                "job_id": job.id,
+                "status": "settled_success",
+                "error_text": None,
+            }
+        ],
+    }
+
+
+async def test_structured_dispatch_leaves_scheduler_run_for_reconciliation(session):
+    job = make_scheduler_job(
+        job_key="uwear_aws_health_scan",
+        family="uwear_aws_health_scan",
+        program_key="uwear_aws_health_scan",
+        handler_ref="brain.app.scheduler.programs:uwear_aws_health_scan",
+        retry_policy={"max_attempts": 1, "backoff_seconds": 0},
+        next_run_at=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+    session.add(job)
+    await session.flush()
+    run = (
+        await async_materialize_due_runs(
+            session,
+            now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+        )
+    )[0]
+
+    async def runner(_command, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {"scheduler_agent_run_id": 321, "status": "dispatched"}
+            ),
+            stderr="",
+        )
+
+    dispatched = await async_run_scheduler_run(
+        session,
+        run.id,
+        runner=runner,
+        now=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+
+    assert dispatched.status == "executing"
+    assert dispatched.agent_run_id == 321
+    assert dispatched.lease_id is None
+    assert dispatched.finished_at is None
+    assert dispatched.result_summary["agent_run"] == {
+        "run_id": 321,
+        "status": "dispatched",
+    }
+
+
+async def test_terminal_agent_run_is_recorded_on_scheduler_run(monkeypatch):
+    now = datetime(2026, 7, 28, 19, 44, tzinfo=timezone.utc)
+    scheduler_run = SimpleNamespace(
+        id=17,
+        job_id=9,
+        status="executing",
+        agent_run_id=321,
+        trace_id="run:321",
+        result_summary={
+            "steps": [],
+            "agent_run": {"run_id": 321, "status": "dispatched"},
+        },
+        error_text=None,
+        finished_at=None,
+        lease_id=None,
+    )
+    job = SimpleNamespace(
+        id=9,
+        job_key="uwear_aws_health_scan",
+        enabled=True,
+        pause_reason=None,
+        last_finished_at=None,
+    )
+    agent_run = SimpleNamespace(
+        id=321,
+        status="completed",
+        completed_at=now,
+        failed_at=None,
+        canceled_at=None,
+    )
+    scalar_result = MagicMock()
+    scalar_result.all.return_value = [scheduler_run]
+    mock_session = MagicMock()
+    mock_session.scalars = AsyncMock(return_value=scalar_result)
+    mock_session.scalar = AsyncMock(return_value=None)
+    mock_session.flush = AsyncMock()
+
+    async def get(model, row_id):
+        if model is AgentRunRow:
+            assert row_id == 321
+            return agent_run
+        if model is SchedulerJob:
+            assert row_id == 9
+            return job
+        raise AssertionError(f"Unexpected model lookup: {model}")
+
+    mock_session.get = AsyncMock(side_effect=get)
+    reset_guard = AsyncMock()
+    monkeypatch.setattr(
+        "brain.app.scheduler.executor.async_reset_scheduler_job_failure_guard",
+        reset_guard,
+    )
+
+    reconciled = await async_reconcile_scheduler_agent_runs(
+        mock_session,
+        now=now,
+    )
+
+    assert reconciled == [
+        {
+            "run_id": 17,
+            "agent_run_id": 321,
+            "agent_run_status": "completed",
+            "status": "settled_success",
+        }
+    ]
+    assert scheduler_run.status == "settled_success"
+    assert scheduler_run.finished_at == now
+    assert scheduler_run.result_summary["agent_run"] == {
+        "run_id": 321,
+        "status": "completed",
+        "reconciled_at": now.isoformat(),
+    }
+    reset_guard.assert_awaited_once_with(mock_session, job, now=now)
+
+
+async def test_aws_health_scan_returns_immediately_after_dispatch(monkeypatch, capsys):
+    spawn = AsyncMock(return_value=321)
+    monkeypatch.setattr(aws_health_scan, "spawn_health_scan_run", spawn)
+
+    exit_code = await asyncio.wait_for(aws_health_scan.async_main(), timeout=0.1)
+
+    assert exit_code == 0
+    spawn.assert_awaited_once_with()
+    assert json.loads(capsys.readouterr().out) == {
+        "scheduler_agent_run_id": 321,
+        "status": "dispatched",
+    }

--- a/tests/test_scheduler_programs.py
+++ b/tests/test_scheduler_programs.py
@@ -71,6 +71,13 @@ def test_pinned_program_set_equals_scheduler_catalog():
     assert set(_PINNED_PROJECTION_HASHES) == set(_CATALOG_BY_JOB_KEY)
 
 
+def test_aws_health_scan_declares_detached_agent_run_completion():
+    assert (
+        SINGLE_COMMAND_PROGRAM_REGISTRY["uwear_aws_health_scan"].completion_mode
+        == "agent_run"
+    )
+
+
 def test_catalog_programs_do_not_reach_legacy_substring_fallback(monkeypatch):
     def fail_if_called(*_args, **_kwargs):
         raise AssertionError("catalog program reached legacy substring fallback")


### PR DESCRIPTION
Closes #566

## What was happening

The scheduler executes due jobs **inline in its tick loop**, so any job whose program *blocks* freezes every other job on the box. `uwear_aws_health_scan` (`30 * * * *`) waited up to 840s for an agent run to finish. On illo-dev on 2026-07-28 that froze the scheduler for ~14 minutes: the last tick was at `19:29:59`, the next at ~`19:44`, and the `*/5` heartbeat silently missed its 19:30, 19:35 and 19:40 slots. Nothing noticed — `docker ps`, `/api/health` and the deploy doctor were all green throughout.

## What this changes

**1. `aws_health_scan` dispatches instead of waiting.** It admits the work, emits a validated handoff envelope, and exits. A later drain reconciles the scheduler run against the agent run's terminal state. This is the part that fixes the observed incident.

**2. The drain gets an *admission* budget.** Past the deadline `async_drain_scheduler` stops claiming **new** runs and returns `budget_exhausted`; the remaining due runs are picked up by the next tick instead of being silently skipped. A run that has already been claimed is **not** interrupted — it keeps running under its own `job.timeout_seconds`.

## Honest limitation — read this before merging

**This does not make scheduler ticks unstallable.** A single legitimately long job (`nightly_sleep` is configured for 4 hours) still occupies the loop for as long as it runs. Genuinely isolating that requires running jobs out-of-process, which is outside this change. What this PR removes is the *specific* 14-minute-per-hour stall and the silent slot-dropping that came with it.

## Review surface

```bash
git fetch origin && git checkout illo-qa/566-scheduler-tick-starvation
venv/bin/python -m pytest -q tests/test_scheduler_drain_budget.py tests/test_detached_agent_runs.py tests/test_scheduler_programs.py
```

Acceptance checks:
1. A job that outlives the admission budget still **completes successfully**, and is handed its own `job.timeout_seconds` — not the budget. (`test_scheduler_drain_budget.py`; this is the regression test for the defect described below.)
2. A second due run in the same drain is left unclaimed and settles on the **next** drain — not skipped, not lost — with `budget_exhausted` reported on the first.
3. Two-drain lifecycle over a real database: dispatch → terminal AgentRun → reconcile, parameterized across `completed` / `failed` / `canceled`.
4. A malformed or undeclared handoff envelope fails **loudly** rather than half-activating the detached lifecycle.

## Two defects were caught and fixed before this opened — both invisible in a green suite

**The first attempt would have killed every scheduled job in production.** It enforced the budget by *cancelling the in-flight command* at 30s and marking the run failed. Every job in `catalog.py` has a longer configured `timeout_seconds` — `nightly_sleep` 14400s, `curiosity_cron` 7200s, two at 900s, one at 300s, one at 60s — so the nightly pipeline would have died 30 seconds in, every night. 4373 tests passed, because they inject synthetic timings and share the code's own assumption.

**A code-quality review then returned REQUEST CHANGES on five findings**, all fixed here:
- The detached lifecycle was *accidental protocol*: any command whose stdout JSON happened to contain `scheduler_agent_run_id` silently became a detached run, and the `dispatched` status was emitted but never validated. Now a typed, versioned envelope (`brain/contracts/scheduler_handoff.py`) with a `completion_mode="agent_run"` declaration on the program, validated in full.
- The step was marked `settled_success` on dispatch while the run said `executing`; it now stays non-terminal until reconciliation settles it.
- `DEFAULT_DRAIN_EXECUTION_BUDGET_SECONDS` still named the *rejected* model. Renamed to admission throughout; canonical env var is now `SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS`, with the old name kept as a deprecated fallback.
- The rejected cancellation design had left a bespoke ~52-line subprocess implementation in `executor.py`, shadowing the canonical `brain.platform.async_io.run_subprocess` wrapper. Deleted; the canonical one is restored.
- Reconciliation was bolted into `executor.py` (1121 → 1392 lines). Extracted into `brain/app/scheduler/detached_agent_runs.py`; `executor.py` is now 1234.

## Deliberately not done — worth follow-up tickets

- The reconciler does sequential per-run lookups (AgentRun, job, step, then `async_finish_run` re-looks-up the job). Fine for one detached job, poor once the lifecycle is reused — should be batch-loaded.
- `SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS` should be retired once deploy config has moved to the admission name.

## Verification

Full suite green on this branch, run outside the Codex sandbox. No new alembic migration (two `0048`s are already outstanding on unmerged branches). Test-merged clean against **all seven** currently-open PRs individually and against the five-PR train together, single alembic head.
