### PR TITLE
fix(deploy-state): constrain #474 backfill to its 35 intended records

### DIFF
--- a/scripts/backfill_deploy_fix_refs.py
+++ b/scripts/backfill_deploy_fix_refs.py
@@ -51,6 +51,9 @@ _MERGE_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _NEEDS_HUMAN_NOTE = "needs-human: no fix PR reference"
 _READ_ONLY_GITHUB_APP_PERMISSIONS = {"pull_requests": "read"}
 _ALLOWED_PATCH_FIELDS = {"fix_pr", "fix_merge_sha", "progress_note"}
+_ACTIVE_BACKFILL_STATES = frozenset({"staging", "prod_pending"})
+_NORMALIZE_ONLY_STATE = "deployed"
+_BACKFILL_STATES = _ACTIVE_BACKFILL_STATES | {_NORMALIZE_ONLY_STATE}
 
 
 class BackfillPatch(TypedDict, total=False):
@@ -61,6 +64,7 @@ class BackfillPatch(TypedDict, total=False):
 
 class BackfillReportRow(TypedDict):
     record_id: int
+    deploy_state: str
     old_fix_pr: str | None
     new_fix_pr: str | None
     sha_found: bool
@@ -127,6 +131,7 @@ async def _plan_backfill_record(
     record: DomainRecord,
     *,
     pull_request_lookup: PullRequestLookup | None,
+    normalize_only: bool = False,
 ) -> BackfillPlan:
     """Interpret one record, enrich it when needed, and build its plan."""
     data = record.data or {}
@@ -142,12 +147,13 @@ async def _plan_backfill_record(
 
     if canonical_fix_pr is None:
         unresolvable_reason = "no fix PR reference"
-        patch.update(_progress_note_patch(data))
+        if not normalize_only:
+            patch.update(_progress_note_patch(data))
     else:
         if old_fix_pr != canonical_fix_pr:
             patch["fix_pr"] = canonical_fix_pr
         existing_sha = str(data.get("fix_merge_sha") or "").strip()
-        if not _MERGE_SHA_RE.fullmatch(existing_sha):
+        if not normalize_only and not _MERGE_SHA_RE.fullmatch(existing_sha):
             if pull_request_lookup is None:
                 raise ValueError(
                     "actor_user_id is required when pull_request_lookup is not supplied"
@@ -173,6 +179,7 @@ async def _plan_backfill_record(
         patch=patch,
         report_row={
             "record_id": record.id,
+            "deploy_state": str(data.get("deploy_state") or "").strip(),
             "old_fix_pr": old_fix_pr,
             "new_fix_pr": canonical_fix_pr or old_fix_pr,
             "sha_found": sha_found,
@@ -191,10 +198,15 @@ async def backfill_deploy_fix_refs(
 ) -> dict[str, object]:
     """Build and optionally apply the deploy fix-reference backfill."""
 
-    records = await list_deploy_ticket_records(
-        session,
-        org_id=org_id,
-    )
+    records = [
+        record
+        for record in await list_deploy_ticket_records(
+            session,
+            org_id=org_id,
+        )
+        if str((record.data or {}).get("deploy_state") or "").strip()
+        in _BACKFILL_STATES
+    ]
     lookup = pull_request_lookup
     if lookup is None and actor_user_id:
         lookup = github_app_pull_request_lookup(
@@ -205,6 +217,10 @@ async def backfill_deploy_fix_refs(
         await _plan_backfill_record(
             record,
             pull_request_lookup=lookup,
+            normalize_only=(
+                str((record.data or {}).get("deploy_state") or "").strip()
+                == _NORMALIZE_ONLY_STATE
+            ),
         )
         for record in records
     ]

--- a/tests/test_backfill_deploy_fix_refs.py
+++ b/tests/test_backfill_deploy_fix_refs.py
@@ -88,6 +88,11 @@ async def _domain(session):
                     {"key": "fix_pr", "field_type": "text"},
                     {"key": "fix_merge_sha", "field_type": "text"},
                     {
+                        "key": "deploy_state",
+                        "field_type": "enum",
+                        "options": ["staging", "prod_pending", "deployed"],
+                    },
+                    {
                         "key": "status",
                         "field_type": "enum",
                         "options": ["Todo", "In Progress", "In Review", "Done"],
@@ -109,6 +114,7 @@ async def _record(session, domain, *, title, **data):
             "title": title,
             "repo": REPO,
             "status": "Todo",
+            "deploy_state": "staging",
             "progress_note": "investigating",
             **data,
         },
@@ -159,6 +165,14 @@ async def _seed_backfill_records(session) -> dict[str, DomainRecord]:
             domain,
             title="Already deployed",
             fix_pr=f"https://github.com/{REPO}/pull/999",
+            deploy_state="deployed",
+        ),
+        "unrelated": await _record(
+            session,
+            domain,
+            title="Not in deploy backfill scope",
+            fix_pr=f"https://github.com/{REPO}/pull/888",
+            deploy_state=None,
         ),
         "archived": await _record(
             session,
@@ -243,6 +257,9 @@ async def test_backfill_dry_run_writes_nothing(session):
     assert records["archived"].id not in {
         row["record_id"] for row in report["records"]
     }
+    assert records["unrelated"].id not in {
+        row["record_id"] for row in report["records"]
+    }
     for name, record in records.items():
         await session.refresh(record)
         assert record.data == before_data[name]
@@ -291,7 +308,10 @@ async def test_backfill_apply_normalizes_enriches_and_stays_in_scope(session):
         "no fix PR reference"
     )
     assert rows_by_id[records["deployed"].id]["sha_found"] is False
-    assert any(call.args == (REPO, 999) for call in github_lookup.await_args_list)
+    assert not any(
+        call.args == (REPO, 999)
+        for call in github_lookup.await_args_list
+    )
 
     for name, record in records.items():
         await session.refresh(record)
@@ -309,6 +329,8 @@ async def test_backfill_apply_normalizes_enriches_and_stays_in_scope(session):
     assert records["no_reference"].data["progress_note"].splitlines().count(
         "needs-human: no fix PR reference"
     ) == 1
+    assert records["deployed"].data.get("fix_merge_sha") is None
+    assert records["unrelated"].data == before_data["unrelated"]
     assert records["archived"].data == before_data["archived"]
 
     events = (
@@ -382,10 +404,16 @@ async def test_backfill_validates_every_plan_before_first_write(session, monkeyp
     }
     original_planner = backfill._plan_backfill_record
 
-    async def out_of_scope_second_plan(record, *, pull_request_lookup):
+    async def out_of_scope_second_plan(
+        record,
+        *,
+        pull_request_lookup,
+        normalize_only=False,
+    ):
         plan = await original_planner(
             record,
             pull_request_lookup=pull_request_lookup,
+            normalize_only=normalize_only,
         )
         if record.id == second.id:
             return replace(plan, patch={"verified": True})


### PR DESCRIPTION
## Problem

The production dry run for #474 selected every live `ticket`/`github_ticket` record: 508 rows, including 473 unrelated records with no legacy deploy state. Applying it would have appended `needs-human: no fix PR reference` to hundreds of unrelated tickets, violating #474's scope guard.

## Fix

- Select only legacy `deploy_state` values `staging`, `prod_pending`, or `deployed`.
- Treat `deployed` rows as normalization-only, matching the ticket runbook: do not backfill SHA or append missing-reference notes there.
- Include `deploy_state` in the dry-run report so scope is directly auditable.
- Add a regression fixture proving an unrelated ticket is excluded and unchanged.

## Production evidence

- Live distribution: 18 `staging` + 3 `prod_pending` + 14 `deployed` + 473 with no deploy state.
- Patched dry run selected exactly the intended 35 records and no others.
- No production writes have been made.

## Verification

`python -m pytest -q tests/test_backfill_deploy_fix_refs.py tests/test_deploy_state.py tests/test_deploy_state_batch.py`

26 passed.

Related to #474; do not close until the corrected backfill is merged, deployed, applied, independently verified, and its before/after report posted.
