### PR TITLE
fix(deploy): fail the doctor when AgentRuns are queued and nothing is claiming (part of #549)

### DIFF
--- a/brain/app/cli/agent_run_queue_health.py
+++ b/brain/app/cli/agent_run_queue_health.py
@@ -1,0 +1,82 @@
+"""Deploy-facing AgentRun queue-starvation check."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Sequence
+
+from brain.systems.runs.cortex.queue_health import (
+    QueueHealth,
+    queued_backlog_health_snapshot_async,
+)
+
+
+def _queue_health_message(queue_health: QueueHealth) -> str:
+    age = queue_health.oldest_queued_age_seconds
+    age_label = f"{age}s" if age is not None else "unknown"
+    threshold_label = f"{queue_health.watchdog_after_seconds:g}s"
+    detail = (
+        f"{queue_health.queued} run(s) queued; oldest queued for {age_label} "
+        f"(threshold {threshold_label}); "
+        f"{queue_health.recent_active_runs}/"
+        f"{queue_health.configured_concurrency} runner slot(s) "
+        "have recent claim activity"
+    )
+    if queue_health.stale_queued_backlog:
+        return (
+            f"AgentRun queue starvation: {detail}. "
+            "No worker is claiming the queued backlog."
+        )
+    return f"AgentRun queue healthy: {detail}."
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check the shared AgentRun queue-starvation predicate.",
+    )
+    parser.add_argument(
+        "--stale-after-seconds",
+        type=float,
+        default=None,
+        help=(
+            "Alarm after this many seconds without enough recent claims "
+            "(default: ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS or 15)."
+        ),
+    )
+    parser.add_argument(
+        "--runner-concurrency",
+        type=int,
+        required=True,
+        help="Configured concurrency of the worker service.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        queue_health = asyncio.run(
+            queued_backlog_health_snapshot_async(
+                stale_after_seconds=args.stale_after_seconds,
+                configured_concurrency=args.runner_concurrency,
+            )
+        )
+    except Exception as exc:
+        print(
+            "AgentRun queue health check failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    message = _queue_health_message(queue_health)
+    if queue_health.stale_queued_backlog:
+        print(message, file=sys.stderr)
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/systems/cortex/worker.py
+++ b/brain/systems/cortex/worker.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import asdict
 import logging
 import os
 import signal
@@ -228,7 +229,14 @@ def main() -> None:
                         logger.error(
                             "agent-run worker queue stalled; exiting for restart",
                             extra={
-                                "queue_health": queue_health,
+                                "queue_health": {
+                                    **asdict(queue_health),
+                                    "oldest_queued_at": (
+                                        queue_health.oldest_queued_at.isoformat()
+                                        if queue_health.oldest_queued_at
+                                        else None
+                                    ),
+                                },
                                 "stale_for_seconds": stale_for_seconds,
                             },
                         )

--- a/brain/systems/runs/cortex/queue_health.py
+++ b/brain/systems/runs/cortex/queue_health.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import os
+import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any
+from datetime import datetime, timedelta, timezone
+from typing import Any, Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import case, func, or_, select
 
 from brain.contracts.statuses import PROCESSING_RUN_STATUS_VALUES
 from brain.platform.db.models.agent_run import AgentRunRow
@@ -62,20 +65,76 @@ def queued_watchdog_after_seconds() -> float:
     )
 
 
-async def queued_backlog_snapshot_async() -> tuple[int, datetime | None, int]:
+def _resolved_stale_after_seconds(value: Any = None) -> float:
+    default = queued_watchdog_after_seconds()
+    return _coerce_float(value, default=default, minimum=1.0)
+
+
+def _queued_since_expression():
+    """Return the timestamp for the current stay in the queue.
+
+    A valid interrupted requeue can only come from a processing state. Those
+    rows have either started once or acquired an execution attempt, and the
+    interruption transition atomically stamps ``updated_at`` to the same time
+    recorded in ``metadata.interruption.interrupted_at``. Newly admitted rows
+    have neither marker, so their queue age still begins at creation.
+    """
+
+    was_previously_processed = or_(
+        AgentRunRow.started_at.is_not(None),
+        AgentRunRow.execution_attempt > 0,
+    )
+    return case(
+        (
+            was_previously_processed,
+            func.coalesce(AgentRunRow.updated_at, AgentRunRow.created_at),
+        ),
+        else_=AgentRunRow.created_at,
+    )
+
+
+async def queued_backlog_snapshot_async(
+    *,
+    stale_after_seconds: float | None = None,
+) -> tuple[int, datetime | None, int]:
+    """Return queued count, oldest queued-since time, and recent active claims.
+
+    The optional threshold defaults to the existing in-worker watchdog setting,
+    keeping no-argument callers on the current ~15 second behavior. Processing
+    rows only count toward capacity when their durable liveness was refreshed
+    inside that same window; stale rows cannot make a dead queue look saturated.
+    """
+
+    threshold_seconds = _resolved_stale_after_seconds(stale_after_seconds)
+    active_cutoff = datetime.now(timezone.utc) - timedelta(
+        seconds=threshold_seconds
+    )
     async with _unit_of_work_factory()() as uow:
         queued_result = await uow.session.execute(
-            select(func.count(AgentRunRow.id), func.min(AgentRunRow.created_at)).where(
+            select(
+                func.count(AgentRunRow.id),
+                func.min(_queued_since_expression()),
+            ).where(
                 AgentRunRow.status == RunStatus.QUEUED.value
             )
         )
-        queued_count, oldest_created_at = queued_result.one()
+        queued_count, oldest_queued_at = queued_result.one()
         active_count = await uow.session.scalar(
             select(func.count(AgentRunRow.id)).where(
-                AgentRunRow.status.in_(PROCESSING_RUN_STATUS_VALUES)
+                AgentRunRow.status.in_(PROCESSING_RUN_STATUS_VALUES),
+                func.coalesce(
+                    AgentRunRow.updated_at,
+                    AgentRunRow.started_at,
+                    AgentRunRow.created_at,
+                )
+                >= active_cutoff,
             )
         )
-    return int(queued_count or 0), _normalize_datetime(oldest_created_at), int(active_count or 0)
+    return (
+        int(queued_count or 0),
+        _normalize_datetime(oldest_queued_at),
+        int(active_count or 0),
+    )
 
 
 def _normalize_datetime(value: Any) -> datetime | None:
@@ -88,33 +147,108 @@ def _normalize_datetime(value: Any) -> datetime | None:
     return value.astimezone(timezone.utc)
 
 
-async def queued_backlog_health_snapshot_async() -> dict[str, Any]:
-    queued_count, oldest_queued_at, active_count = await queued_backlog_snapshot_async()
+async def queued_backlog_health_snapshot_async(
+    *,
+    stale_after_seconds: float | None = None,
+) -> dict[str, Any]:
+    watchdog_after_seconds = _resolved_stale_after_seconds(stale_after_seconds)
+    if stale_after_seconds is None:
+        # Keep the long-standing no-argument seam for the worker and tests that
+        # replace its database snapshot.
+        queued_count, oldest_queued_at, active_count = (
+            await queued_backlog_snapshot_async()
+        )
+    else:
+        queued_count, oldest_queued_at, active_count = (
+            await queued_backlog_snapshot_async(
+                stale_after_seconds=watchdog_after_seconds,
+            )
+        )
     configured_concurrency = runner_concurrency()
-    watchdog_after_seconds = queued_watchdog_after_seconds()
     oldest_queued_age_seconds = None
     if oldest_queued_at is not None:
         oldest_queued_age_seconds = max(
             0.0,
             (datetime.now(timezone.utc) - oldest_queued_at).total_seconds(),
         )
-    stale_queued_backlog = (
+    queue_past_threshold = (
         queued_count > 0
         and oldest_queued_age_seconds is not None
         and oldest_queued_age_seconds >= watchdog_after_seconds
-        and active_count < configured_concurrency
     )
+    # Recency is resolved before capacity: only claims with current liveness
+    # count as occupied slots. Saturation can excuse an old queue only when all
+    # configured slots are demonstrably still moving.
+    queue_moving_at_capacity = active_count >= configured_concurrency
+    stale_queued_backlog = queue_past_threshold and not queue_moving_at_capacity
     return {
         "queued": queued_count,
         "active_runs": active_count,
+        "recent_active_runs": active_count,
         "configured_concurrency": configured_concurrency,
         "oldest_queued_at": oldest_queued_at.isoformat() if oldest_queued_at else None,
         "oldest_queued_age_seconds": int(oldest_queued_age_seconds)
         if oldest_queued_age_seconds is not None
         else None,
         "watchdog_after_seconds": int(watchdog_after_seconds),
+        "queue_moving_at_capacity": queue_moving_at_capacity,
         "stale_queued_backlog": stale_queued_backlog,
     }
+
+
+def _queue_health_message(queue_health: dict[str, Any]) -> str:
+    queued = int(queue_health.get("queued") or 0)
+    active_runs = int(queue_health.get("recent_active_runs") or 0)
+    concurrency = int(queue_health.get("configured_concurrency") or 0)
+    threshold = int(queue_health.get("watchdog_after_seconds") or 0)
+    age = queue_health.get("oldest_queued_age_seconds")
+    age_label = f"{int(age)}s" if age is not None else "unknown"
+    detail = (
+        f"{queued} run(s) queued; oldest queued for {age_label} "
+        f"(threshold {threshold}s); {active_runs}/{concurrency} runner slot(s) "
+        "have recent claim activity"
+    )
+    if queue_health.get("stale_queued_backlog"):
+        return (
+            f"AgentRun queue starvation: {detail}. "
+            "No worker is claiming the queued backlog."
+        )
+    return f"AgentRun queue healthy: {detail}."
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check the shared AgentRun queue-starvation predicate.",
+    )
+    parser.add_argument(
+        "--stale-after-seconds",
+        type=float,
+        default=None,
+        help=(
+            "Alarm after this many seconds without enough recent claims "
+            "(default: ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS or 15)."
+        ),
+    )
+    args = parser.parse_args(argv)
+    try:
+        queue_health = asyncio.run(
+            queued_backlog_health_snapshot_async(
+                stale_after_seconds=args.stale_after_seconds,
+            )
+        )
+    except Exception as exc:
+        print(
+            "AgentRun queue health check failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+    message = _queue_health_message(queue_health)
+    if queue_health.get("stale_queued_backlog"):
+        print(message, file=sys.stderr)
+        return 1
+    print(message)
+    return 0
 
 
 @dataclass
@@ -147,3 +281,7 @@ __all__ = [
     "queued_watchdog_after_seconds",
     "runner_concurrency",
 ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brain/systems/runs/cortex/queue_health.py
+++ b/brain/systems/runs/cortex/queue_health.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import argparse
-import asyncio
 import os
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Sequence
+from typing import Any
 
-from sqlalchemy import case, func, or_, select
+from sqlalchemy import DateTime, case, cast, func, or_, select, type_coerce
 
 from brain.contracts.statuses import PROCESSING_RUN_STATUS_VALUES
 from brain.platform.db.models.agent_run import AgentRunRow
@@ -21,6 +18,31 @@ UnitOfWork = None
 _DEFAULT_RUNNER_CONCURRENCY = 4
 _MAX_RUNNER_CONCURRENCY = 32
 _DEFAULT_QUEUED_WATCHDOG_AFTER_SEC = 15.0
+
+
+@dataclass(frozen=True, slots=True)
+class QueuedBacklogSnapshot:
+    queued: int
+    oldest_queued_at: datetime | None
+    recent_active_runs: int
+
+
+@dataclass(frozen=True, slots=True)
+class QueueHealthPolicy:
+    watchdog_after_seconds: float
+    configured_concurrency: int
+
+
+@dataclass(frozen=True, slots=True)
+class QueueHealth:
+    queued: int
+    recent_active_runs: int
+    configured_concurrency: int
+    oldest_queued_at: datetime | None
+    oldest_queued_age_seconds: int | None
+    watchdog_after_seconds: float
+    queue_moving_at_capacity: bool
+    stale_queued_backlog: bool
 
 
 def _unit_of_work_factory():
@@ -70,24 +92,35 @@ def _resolved_stale_after_seconds(value: Any = None) -> float:
     return _coerce_float(value, default=default, minimum=1.0)
 
 
-def _queued_since_expression():
+def _queued_since_expression(*, dialect_name: str):
     """Return the timestamp for the current stay in the queue.
 
-    A valid interrupted requeue can only come from a processing state. Those
-    rows have either started once or acquired an execution attempt, and the
-    interruption transition atomically stamps ``updated_at`` to the same time
-    recorded in ``metadata.interruption.interrupted_at``. Newly admitted rows
-    have neither marker, so their queue age still begins at creation.
+    Previously processed rows use the timestamp recorded by
+    ``interrupt_and_requeue`` in ``metadata.interruption.interrupted_at``.
+    Unprocessed rows, and historical requeues without that record, fall back to
+    ``created_at``. The fallback can overstate queue tenure for a requeued row
+    whose mutable interruption metadata is missing, but unrelated writes cannot
+    reset tenure through ``updated_at``.
     """
 
     was_previously_processed = or_(
         AgentRunRow.started_at.is_not(None),
         AgentRunRow.execution_attempt > 0,
     )
+    interrupted_at_text = (
+        AgentRunRow.metadata_["interruption"]["interrupted_at"].as_string()
+    )
+    if dialect_name == "sqlite":
+        interrupted_at = type_coerce(
+            func.datetime(interrupted_at_text),
+            DateTime(timezone=True),
+        )
+    else:
+        interrupted_at = cast(interrupted_at_text, DateTime(timezone=True))
     return case(
         (
             was_previously_processed,
-            func.coalesce(AgentRunRow.updated_at, AgentRunRow.created_at),
+            func.coalesce(interrupted_at, AgentRunRow.created_at),
         ),
         else_=AgentRunRow.created_at,
     )
@@ -96,7 +129,7 @@ def _queued_since_expression():
 async def queued_backlog_snapshot_async(
     *,
     stale_after_seconds: float | None = None,
-) -> tuple[int, datetime | None, int]:
+) -> QueuedBacklogSnapshot:
     """Return queued count, oldest queued-since time, and recent active claims.
 
     The optional threshold defaults to the existing in-worker watchdog setting,
@@ -110,10 +143,13 @@ async def queued_backlog_snapshot_async(
         seconds=threshold_seconds
     )
     async with _unit_of_work_factory()() as uow:
+        dialect_name = uow.session.get_bind().dialect.name
         queued_result = await uow.session.execute(
             select(
                 func.count(AgentRunRow.id),
-                func.min(_queued_since_expression()),
+                func.min(
+                    _queued_since_expression(dialect_name=dialect_name)
+                ),
             ).where(
                 AgentRunRow.status == RunStatus.QUEUED.value
             )
@@ -130,10 +166,10 @@ async def queued_backlog_snapshot_async(
                 >= active_cutoff,
             )
         )
-    return (
-        int(queued_count or 0),
-        _normalize_datetime(oldest_queued_at),
-        int(active_count or 0),
+    return QueuedBacklogSnapshot(
+        queued=int(queued_count or 0),
+        oldest_queued_at=_normalize_datetime(oldest_queued_at),
+        recent_active_runs=int(active_count or 0),
     )
 
 
@@ -147,108 +183,73 @@ def _normalize_datetime(value: Any) -> datetime | None:
     return value.astimezone(timezone.utc)
 
 
-async def queued_backlog_health_snapshot_async(
+def evaluate_queue_health(
+    snapshot: QueuedBacklogSnapshot,
+    policy: QueueHealthPolicy,
     *,
-    stale_after_seconds: float | None = None,
-) -> dict[str, Any]:
-    watchdog_after_seconds = _resolved_stale_after_seconds(stale_after_seconds)
-    if stale_after_seconds is None:
-        # Keep the long-standing no-argument seam for the worker and tests that
-        # replace its database snapshot.
-        queued_count, oldest_queued_at, active_count = (
-            await queued_backlog_snapshot_async()
-        )
-    else:
-        queued_count, oldest_queued_at, active_count = (
-            await queued_backlog_snapshot_async(
-                stale_after_seconds=watchdog_after_seconds,
-            )
-        )
-    configured_concurrency = runner_concurrency()
+    now: datetime,
+) -> QueueHealth:
     oldest_queued_age_seconds = None
-    if oldest_queued_at is not None:
+    if snapshot.oldest_queued_at is not None:
         oldest_queued_age_seconds = max(
             0.0,
-            (datetime.now(timezone.utc) - oldest_queued_at).total_seconds(),
+            (now - snapshot.oldest_queued_at).total_seconds(),
         )
     queue_past_threshold = (
-        queued_count > 0
+        snapshot.queued > 0
         and oldest_queued_age_seconds is not None
-        and oldest_queued_age_seconds >= watchdog_after_seconds
+        and oldest_queued_age_seconds >= policy.watchdog_after_seconds
     )
     # Recency is resolved before capacity: only claims with current liveness
     # count as occupied slots. Saturation can excuse an old queue only when all
     # configured slots are demonstrably still moving.
-    queue_moving_at_capacity = active_count >= configured_concurrency
-    stale_queued_backlog = queue_past_threshold and not queue_moving_at_capacity
-    return {
-        "queued": queued_count,
-        "active_runs": active_count,
-        "recent_active_runs": active_count,
-        "configured_concurrency": configured_concurrency,
-        "oldest_queued_at": oldest_queued_at.isoformat() if oldest_queued_at else None,
-        "oldest_queued_age_seconds": int(oldest_queued_age_seconds)
-        if oldest_queued_age_seconds is not None
-        else None,
-        "watchdog_after_seconds": int(watchdog_after_seconds),
-        "queue_moving_at_capacity": queue_moving_at_capacity,
-        "stale_queued_backlog": stale_queued_backlog,
-    }
-
-
-def _queue_health_message(queue_health: dict[str, Any]) -> str:
-    queued = int(queue_health.get("queued") or 0)
-    active_runs = int(queue_health.get("recent_active_runs") or 0)
-    concurrency = int(queue_health.get("configured_concurrency") or 0)
-    threshold = int(queue_health.get("watchdog_after_seconds") or 0)
-    age = queue_health.get("oldest_queued_age_seconds")
-    age_label = f"{int(age)}s" if age is not None else "unknown"
-    detail = (
-        f"{queued} run(s) queued; oldest queued for {age_label} "
-        f"(threshold {threshold}s); {active_runs}/{concurrency} runner slot(s) "
-        "have recent claim activity"
+    queue_moving_at_capacity = (
+        snapshot.recent_active_runs >= policy.configured_concurrency
     )
-    if queue_health.get("stale_queued_backlog"):
-        return (
-            f"AgentRun queue starvation: {detail}. "
-            "No worker is claiming the queued backlog."
-        )
-    return f"AgentRun queue healthy: {detail}."
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Check the shared AgentRun queue-starvation predicate.",
-    )
-    parser.add_argument(
-        "--stale-after-seconds",
-        type=float,
-        default=None,
-        help=(
-            "Alarm after this many seconds without enough recent claims "
-            "(default: ILLO_AGENT_RUN_QUEUED_WATCHDOG_SECONDS or 15)."
+    return QueueHealth(
+        queued=snapshot.queued,
+        recent_active_runs=snapshot.recent_active_runs,
+        configured_concurrency=policy.configured_concurrency,
+        oldest_queued_at=snapshot.oldest_queued_at,
+        oldest_queued_age_seconds=(
+            int(oldest_queued_age_seconds)
+            if oldest_queued_age_seconds is not None
+            else None
         ),
+        watchdog_after_seconds=policy.watchdog_after_seconds,
+        queue_moving_at_capacity=queue_moving_at_capacity,
+        stale_queued_backlog=queue_past_threshold
+        and not queue_moving_at_capacity,
     )
-    args = parser.parse_args(argv)
-    try:
-        queue_health = asyncio.run(
-            queued_backlog_health_snapshot_async(
-                stale_after_seconds=args.stale_after_seconds,
+
+
+async def queued_backlog_health_snapshot_async(
+    *,
+    stale_after_seconds: float | None = None,
+    configured_concurrency: int | None = None,
+) -> QueueHealth:
+    watchdog_after_seconds = _resolved_stale_after_seconds(stale_after_seconds)
+    snapshot = await queued_backlog_snapshot_async(
+        stale_after_seconds=watchdog_after_seconds,
+    )
+    if configured_concurrency is None:
+        configured_concurrency = runner_concurrency()
+    else:
+        configured_concurrency = (
+            _coerce_concurrency(
+                configured_concurrency,
+                default=_DEFAULT_RUNNER_CONCURRENCY,
             )
+            or _DEFAULT_RUNNER_CONCURRENCY
         )
-    except Exception as exc:
-        print(
-            "AgentRun queue health check failed: "
-            f"{type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
-        return 2
-    message = _queue_health_message(queue_health)
-    if queue_health.get("stale_queued_backlog"):
-        print(message, file=sys.stderr)
-        return 1
-    print(message)
-    return 0
+    return evaluate_queue_health(
+        snapshot,
+        QueueHealthPolicy(
+            watchdog_after_seconds=watchdog_after_seconds,
+            configured_concurrency=configured_concurrency,
+        ),
+        now=datetime.now(timezone.utc),
+    )
 
 
 @dataclass
@@ -261,9 +262,9 @@ class QueueStallMonitor:
     def should_check(self, *, now: float) -> bool:
         return now - self.last_checked_at >= self.check_interval_seconds
 
-    def observe(self, queue_health: dict[str, Any], *, now: float) -> int | None:
+    def observe(self, queue_health: QueueHealth, *, now: float) -> int | None:
         self.last_checked_at = now
-        if not queue_health.get("stale_queued_backlog"):
+        if not queue_health.stale_queued_backlog:
             self.stale_since = None
             return None
         if self.stale_since is None:
@@ -275,13 +276,13 @@ class QueueStallMonitor:
 
 
 __all__ = [
+    "QueueHealth",
+    "QueueHealthPolicy",
     "QueueStallMonitor",
+    "QueuedBacklogSnapshot",
+    "evaluate_queue_health",
     "queued_backlog_health_snapshot_async",
     "queued_backlog_snapshot_async",
     "queued_watchdog_after_seconds",
     "runner_concurrency",
 ]
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -51,6 +51,7 @@ from brain.systems.runs.status import RunStatus, TERMINAL_RUN_STATUSES, coerce_r
 from brain.systems.runs.store import AsyncAgentRunStore
 from brain.systems.runs.stream import RunStream
 from brain.systems.runs.cortex.queue_health import (
+    QueuedBacklogSnapshot,
     queued_backlog_snapshot_async as _shared_queued_backlog_snapshot_async,
     queued_watchdog_after_seconds as _shared_queued_watchdog_after_seconds,
     runner_concurrency as _shared_runner_concurrency,
@@ -1125,7 +1126,7 @@ async def _reap_stale_runs_if_due_async(*, force: bool = False) -> int:
         return 0
 
 
-async def _queued_backlog_snapshot_async() -> tuple[int, datetime | None, int]:
+async def _queued_backlog_snapshot_async() -> QueuedBacklogSnapshot:
     return await _shared_queued_backlog_snapshot_async()
 
 
@@ -1153,25 +1154,27 @@ async def _nudge_stale_queued_runs_if_due_async(*, force: bool = False) -> bool:
         return False
 
     try:
-        queued_count, oldest_queued_at, active_count = await _queued_backlog_snapshot_async()
+        snapshot = await _queued_backlog_snapshot_async()
     except Exception:
         logger.exception("agent_run_queued_watchdog_snapshot_failed")
         return False
-    if queued_count <= 0 or oldest_queued_at is None:
+    if snapshot.queued <= 0 or snapshot.oldest_queued_at is None:
         return False
-    if active_count >= _runner_concurrency():
+    if snapshot.recent_active_runs >= _runner_concurrency():
         return False
 
-    age_seconds = (datetime.now(timezone.utc) - oldest_queued_at).total_seconds()
+    age_seconds = (
+        datetime.now(timezone.utc) - snapshot.oldest_queued_at
+    ).total_seconds()
     if age_seconds < _queued_watchdog_after_seconds():
         return False
 
     logger.warning(
         "agent_run_queued_watchdog_nudge",
         extra={
-            "queued": queued_count,
+            "queued": snapshot.queued,
             "oldest_queued_age_seconds": int(age_seconds),
-            "active_runs": active_count,
+            "recent_active_runs": snapshot.recent_active_runs,
         },
     )
     task = asyncio.create_task(

--- a/deploy/compose/.env.production.example
+++ b/deploy/compose/.env.production.example
@@ -74,3 +74,6 @@ CORTEX_MAX_CONCURRENT=10
 CORTEX_MAX_RUNTIME=600
 CORTEX_EMBEDDING_READY_TIMEOUT_SECONDS=300
 ILLO_AGENT_RUNNER_DRAIN_TIMEOUT_SECONDS=infinity
+# Operator checks alarm when queued AgentRuns have no recent claim activity for
+# this long. The in-worker watchdog keeps its separate ~15 second nudge window.
+ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS=600

--- a/deploy/scripts/agent-run-queue-health-lib.sh
+++ b/deploy/scripts/agent-run-queue-health-lib.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 # Thin Compose caller for the Python-owned AgentRun queue-starvation predicate.
-# The caller supplies the doctor's slower operational threshold; all queue age,
-# claim recency, and saturation decisions remain in queue_health.py.
+# The CLI stays in api so the check still works when worker is dead or drained.
+# Because worker concurrency exists only in worker's container environment, the
+# caller passes the value explicitly from the sourced deploy env that Compose
+# uses to configure worker.
 
 assert_agent_run_queue_not_starved() {
   local stale_after_seconds="${ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS:-600}"
+  local runner_concurrency="${ILLO_AGENT_RUNNER_CONCURRENCY:-4}"
   compose exec -T api \
-    python -m brain.systems.runs.cortex.queue_health \
-    --stale-after-seconds "$stale_after_seconds"
+    python -m brain.app.cli.agent_run_queue_health \
+    --stale-after-seconds "$stale_after_seconds" \
+    --runner-concurrency "$runner_concurrency"
 }

--- a/deploy/scripts/agent-run-queue-health-lib.sh
+++ b/deploy/scripts/agent-run-queue-health-lib.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Thin Compose caller for the Python-owned AgentRun queue-starvation predicate.
+# The caller supplies the doctor's slower operational threshold; all queue age,
+# claim recency, and saturation decisions remain in queue_health.py.
+
+assert_agent_run_queue_not_starved() {
+  local stale_after_seconds="${ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS:-600}"
+  compose exec -T api \
+    python -m brain.systems.runs.cortex.queue_health \
+    --stale-after-seconds "$stale_after_seconds"
+}

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -9,6 +9,7 @@ ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$COMPOSE_DIR/.env}"
 
 # Provides compose() plus the shared stack invariants (assert_stack_not_inert).
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
+source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"
 
 # Doctor runs after a deploy, so it holds the updater to the same standard as
 # the always-on services; a bare monitor does not (a missing updater does not
@@ -239,6 +240,15 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
           ;;
       esac
     done
+
+    queue_health_output=""
+    queue_health_status=0
+    queue_health_output="$(assert_agent_run_queue_not_starved 2>&1)" || queue_health_status=$?
+    if [ "$queue_health_status" -eq 0 ]; then
+      pass "$queue_health_output"
+    else
+      fail "$queue_health_output"
+    fi
 
     if printf '%s\n' "$running" | grep -qx postgres; then
       if compose exec -T postgres psql -U "${DB_USER:-}" -d "${DB_NAME:-}" -tAc "SELECT extname FROM pg_extension WHERE extname = 'vector'" 2>/dev/null | grep -qx vector; then

--- a/deploy/scripts/inert-stack-check.sh
+++ b/deploy/scripts/inert-stack-check.sh
@@ -13,6 +13,7 @@ COMPOSE_FILE="$ROOT/deploy/compose/docker-compose.yml"
 ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$ROOT/deploy/compose/.env}"
 
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
+source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"
 
 usage() {
   cat <<EOF
@@ -20,16 +21,17 @@ Usage: ./illo deploy inert-check
        deploy/scripts/inert-stack-check.sh
 
 Asserts that every always-on Compose service is running whenever the stack is up
-at all. The worker is the service this exists for: it owns AgentRun execution and
-the cycle-scheduler thread, so its absence leaves the stack answering health
-checks normally while Illo does nothing.
+at all, then checks that old queued AgentRuns still have recent claim activity.
+The worker owns AgentRun execution and the cycle-scheduler thread, so its absence
+or a wedged runner can leave the stack answering HTTP health checks normally
+while Illo does nothing.
 
 Required services: $STACK_REQUIRED_SERVICES
   (override with STACK_REQUIRED_SERVICES="postgres api worker")
 
 Exit codes:
   0  every required service is running
-  1  the check could not inspect Compose
+  1  the check could not inspect Compose or the AgentRun queue is starved
   $STACK_INERT_EXIT_CODE  INERT   - stack is up but a required service is absent
   $STACK_DOWN_EXIT_CODE  DOWN    - no Compose services are running at all
 EOF
@@ -54,9 +56,17 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
 status=0
 assert_stack_not_inert || status=$?
 if [ "$status" -eq 0 ]; then
-  echo "OK:    every required Compose service is running ($STACK_REQUIRED_SERVICES)"
+  assert_agent_run_queue_not_starved || status=1
+fi
+if [ "$status" -eq 0 ]; then
+  echo "OK:    every required Compose service is running and the AgentRun queue is moving ($STACK_REQUIRED_SERVICES)"
 fi
 exit "$status"

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -339,6 +339,28 @@ async def test_queued_backlog_health_snapshot_respects_full_capacity(monkeypatch
     assert health["stale_queued_backlog"] is False
 
 
+async def test_queued_backlog_health_snapshot_accepts_doctor_threshold(monkeypatch):
+    from brain.systems.runs.cortex import queue_health
+
+    oldest = datetime.now(timezone.utc) - timedelta(seconds=900)
+    received_thresholds = []
+
+    async def fake_snapshot(*, stale_after_seconds):
+        received_thresholds.append(stale_after_seconds)
+        return 1, oldest, 0
+
+    monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
+    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
+
+    health = await queue_health.queued_backlog_health_snapshot_async(
+        stale_after_seconds=600,
+    )
+
+    assert received_thresholds == [600.0]
+    assert health["watchdog_after_seconds"] == 600
+    assert health["stale_queued_backlog"] is True
+
+
 async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(monkeypatch):
     from brain.systems.runs.cortex import runner
 

--- a/tests/test_agent_run_runner.py
+++ b/tests/test_agent_run_runner.py
@@ -303,11 +303,13 @@ def test_runner_health_snapshot_requires_supervisor_and_slots(monkeypatch):
 
 async def test_queued_backlog_health_snapshot_marks_stale_queue(monkeypatch):
     from brain.systems.runs.cortex import queue_health
+    from brain.systems.runs.cortex.queue_health import QueuedBacklogSnapshot
 
     oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
 
-    async def fake_snapshot():
-        return 2, oldest, 0
+    async def fake_snapshot(*, stale_after_seconds):
+        assert stale_after_seconds == 10
+        return QueuedBacklogSnapshot(2, oldest, 0)
 
     monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
     monkeypatch.setattr(queue_health, "queued_watchdog_after_seconds", lambda: 10)
@@ -315,18 +317,20 @@ async def test_queued_backlog_health_snapshot_marks_stale_queue(monkeypatch):
 
     health = await queue_health.queued_backlog_health_snapshot_async()
 
-    assert health["queued"] == 2
-    assert health["active_runs"] == 0
-    assert health["stale_queued_backlog"] is True
+    assert health.queued == 2
+    assert health.recent_active_runs == 0
+    assert health.stale_queued_backlog is True
 
 
 async def test_queued_backlog_health_snapshot_respects_full_capacity(monkeypatch):
     from brain.systems.runs.cortex import queue_health
+    from brain.systems.runs.cortex.queue_health import QueuedBacklogSnapshot
 
     oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
 
-    async def fake_snapshot():
-        return 2, oldest, 4
+    async def fake_snapshot(*, stale_after_seconds):
+        assert stale_after_seconds == 10
+        return QueuedBacklogSnapshot(2, oldest, 4)
 
     monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
     monkeypatch.setattr(queue_health, "queued_watchdog_after_seconds", lambda: 10)
@@ -334,20 +338,21 @@ async def test_queued_backlog_health_snapshot_respects_full_capacity(monkeypatch
 
     health = await queue_health.queued_backlog_health_snapshot_async()
 
-    assert health["queued"] == 2
-    assert health["active_runs"] == 4
-    assert health["stale_queued_backlog"] is False
+    assert health.queued == 2
+    assert health.recent_active_runs == 4
+    assert health.stale_queued_backlog is False
 
 
 async def test_queued_backlog_health_snapshot_accepts_doctor_threshold(monkeypatch):
     from brain.systems.runs.cortex import queue_health
+    from brain.systems.runs.cortex.queue_health import QueuedBacklogSnapshot
 
     oldest = datetime.now(timezone.utc) - timedelta(seconds=900)
     received_thresholds = []
 
     async def fake_snapshot(*, stale_after_seconds):
         received_thresholds.append(stale_after_seconds)
-        return 1, oldest, 0
+        return QueuedBacklogSnapshot(1, oldest, 0)
 
     monkeypatch.setattr(queue_health, "queued_backlog_snapshot_async", fake_snapshot)
     monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
@@ -357,8 +362,8 @@ async def test_queued_backlog_health_snapshot_accepts_doctor_threshold(monkeypat
     )
 
     assert received_thresholds == [600.0]
-    assert health["watchdog_after_seconds"] == 600
-    assert health["stale_queued_backlog"] is True
+    assert health.watchdog_after_seconds == 600
+    assert health.stale_queued_backlog is True
 
 
 async def test_supervisor_starts_runner_slots_before_stale_reconcile_finishes(monkeypatch):
@@ -427,13 +432,14 @@ async def test_runner_slot_logs_and_survives_queue_errors(monkeypatch, caplog):
 
 async def test_queued_watchdog_nudges_stale_queue_when_capacity_available(monkeypatch, caplog):
     from brain.systems.runs.cortex import runner
+    from brain.systems.runs.cortex.queue_health import QueuedBacklogSnapshot
 
     calls = 0
     oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
     release = asyncio.Event()
 
     async def fake_snapshot():
-        return 1, oldest, 0
+        return QueuedBacklogSnapshot(1, oldest, 0)
 
     async def fake_run_queued_once(*, limit=1):
         nonlocal calls
@@ -464,11 +470,12 @@ async def test_queued_watchdog_nudges_stale_queue_when_capacity_available(monkey
 
 async def test_queued_watchdog_respects_configured_capacity(monkeypatch):
     from brain.systems.runs.cortex import runner
+    from brain.systems.runs.cortex.queue_health import QueuedBacklogSnapshot
 
     oldest = datetime.now(timezone.utc) - timedelta(seconds=60)
 
     async def fake_snapshot():
-        return 1, oldest, 4
+        return QueuedBacklogSnapshot(1, oldest, 4)
 
     async def fail_run_queued_once(*, limit=1):
         raise AssertionError("watchdog should not run when capacity is full")

--- a/tests/test_cortex_worker.py
+++ b/tests/test_cortex_worker.py
@@ -5,6 +5,21 @@ import pytest
 from unittest.mock import patch
 
 
+def _queue_health(*, stale_queued_backlog: bool):
+    from brain.systems.runs.cortex.queue_health import QueueHealth
+
+    return QueueHealth(
+        queued=1 if stale_queued_backlog else 0,
+        recent_active_runs=0,
+        configured_concurrency=4,
+        oldest_queued_at=None,
+        oldest_queued_age_seconds=None,
+        watchdog_after_seconds=15,
+        queue_moving_at_capacity=False,
+        stale_queued_backlog=stale_queued_backlog,
+    )
+
+
 def test_require_embedding_backend_ready_skips_non_gpu():
     from brain.systems.cortex.worker import _require_embedding_backend_ready
 
@@ -85,7 +100,7 @@ def test_queue_stall_monitor_checks_on_interval():
 
     assert monitor.should_check(now=4.0) is False
     assert monitor.should_check(now=5.0) is True
-    monitor.observe({"stale_queued_backlog": False}, now=5.0)
+    monitor.observe(_queue_health(stale_queued_backlog=False), now=5.0)
     assert monitor.should_check(now=9.0) is False
     assert monitor.should_check(now=10.0) is True
 
@@ -95,11 +110,14 @@ def test_queue_stall_monitor_tracks_stale_backlog():
 
     monitor = QueueStallMonitor(check_interval_seconds=5.0, stall_grace_seconds=10.0)
 
-    assert monitor.observe({"stale_queued_backlog": True}, now=10.0) is None
+    stalled = _queue_health(stale_queued_backlog=True)
+    healthy = _queue_health(stale_queued_backlog=False)
+
+    assert monitor.observe(stalled, now=10.0) is None
     assert monitor.stale_since == 10.0
-    assert monitor.observe({"stale_queued_backlog": True}, now=19.0) is None
-    assert monitor.observe({"stale_queued_backlog": True}, now=20.0) == 10
-    assert monitor.observe({"stale_queued_backlog": False}, now=21.0) is None
+    assert monitor.observe(stalled, now=19.0) is None
+    assert monitor.observe(stalled, now=20.0) == 10
+    assert monitor.observe(healthy, now=21.0) is None
     assert monitor.stale_since is None
 
 

--- a/tests/test_deploy_doctor.py
+++ b/tests/test_deploy_doctor.py
@@ -72,7 +72,7 @@ def test_strict_credentials_uses_current_db_tables_without_legacy_user_keys(tmp_
                   echo 2
                   exit 0
                   ;;
-                *"brain.systems.runs.cortex.queue_health"*"--stale-after-seconds 600"*)
+                *"brain.app.cli.agent_run_queue_health"*"--stale-after-seconds 600"*"--runner-concurrency 4"*)
                   echo "AgentRun queue healthy: no stale queued backlog."
                   exit 0
                   ;;

--- a/tests/test_deploy_doctor.py
+++ b/tests/test_deploy_doctor.py
@@ -72,6 +72,10 @@ def test_strict_credentials_uses_current_db_tables_without_legacy_user_keys(tmp_
                   echo 2
                   exit 0
                   ;;
+                *"brain.systems.runs.cortex.queue_health"*"--stale-after-seconds 600"*)
+                  echo "AgentRun queue healthy: no stale queued backlog."
+                  exit 0
+                  ;;
               esac
             fi
 

--- a/tests/test_deploy_queue_health.py
+++ b/tests/test_deploy_queue_health.py
@@ -1,0 +1,150 @@
+"""Behavioral tests for the deploy-facing AgentRun queue health check."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import textwrap
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QUEUE_STARVATION_DIAGNOSTIC = (
+    "AgentRun queue starvation: fake queued backlog has no recent claims."
+)
+
+
+def _deploy_env_file(tmp_path: Path) -> Path:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ILLO_PUBLIC_URL=http://illospace.local",
+                "SECRET_KEY=secret-key",
+                "VAULT_MASTER_KEY=MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+                "DB_NAME=illospace",
+                "DB_USER=illo",
+                "DB_PASSWORD=db-password",
+                "ILLO_AGENT_RUNNER_CONCURRENCY=8",
+                "ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS=725",
+                "ILLO_DOCTOR_SKIP_LOCAL_HTTP_PROBES=1",
+            ]
+        )
+        + "\n"
+    )
+    return env_file
+
+
+def _fake_docker(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            args="$*"
+            if [ "${{1:-}}" = "info" ]; then
+              exit 0
+            fi
+            if [ "${{1:-}}" = "inspect" ]; then
+              echo healthy
+              exit 0
+            fi
+            if [ "${{1:-}}" = "compose" ]; then
+              case "$args" in
+                *" config")
+                  exit 0
+                  ;;
+                *" ps --services --status running")
+                  printf '%s\\n' postgres api web worker scheduler updater
+                  exit 0
+                  ;;
+                *" ps -q "*)
+                  echo container-id
+                  exit 0
+                  ;;
+                *"brain.app.cli.agent_run_queue_health"*"--stale-after-seconds 725"*"--runner-concurrency 8")
+                  echo "{QUEUE_STARVATION_DIAGNOSTIC}" >&2
+                  exit 1
+                  ;;
+                *"pg_extension"*)
+                  echo vector
+                  exit 0
+                  ;;
+                *"org_api_keys"*"vault_config"*)
+                  echo 1
+                  exit 0
+                  ;;
+              esac
+            fi
+
+            echo "unexpected docker invocation: $*" >&2
+            exit 2
+            """
+        )
+    )
+    docker.chmod(0o755)
+    return bin_dir
+
+
+def _entrypoint_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["ILLO_COMPOSE_ENV_FILE"] = str(_deploy_env_file(tmp_path))
+    env["PATH"] = f"{_fake_docker(tmp_path)}:{env['PATH']}"
+    return env
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    [
+        "deploy/scripts/doctor.sh",
+        "deploy/scripts/inert-stack-check.sh",
+    ],
+)
+def test_deploy_entrypoint_fails_when_agent_run_queue_is_starved(
+    entrypoint: str,
+    tmp_path: Path,
+):
+    result = subprocess.run(
+        [str(ROOT / entrypoint)],
+        cwd=ROOT,
+        env=_entrypoint_env(tmp_path),
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert QUEUE_STARVATION_DIAGNOSTIC in result.stderr
+
+
+def test_queue_health_adapter_passes_deploy_policy_to_api_cli():
+    queue_health_lib = (
+        ROOT / "deploy" / "scripts" / "agent-run-queue-health-lib.sh"
+    )
+    script = f'''
+source "{queue_health_lib}"
+compose() {{
+  printf '%s\\n' "$*"
+}}
+ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS=725
+ILLO_AGENT_RUNNER_CONCURRENCY=8
+assert_agent_run_queue_not_starved
+'''
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "exec -T api python -m brain.app.cli.agent_run_queue_health "
+        "--stale-after-seconds 725 --runner-concurrency 8"
+    )
+    assert "psql" not in queue_health_lib.read_text()

--- a/tests/test_queue_health.py
+++ b/tests/test_queue_health.py
@@ -35,6 +35,7 @@ def _run(
     updated_at: datetime,
     started_at: datetime | None = None,
     execution_attempt: int = 0,
+    metadata: dict | None = None,
 ) -> AgentRunRow:
     return AgentRunRow(
         thread_id=thread_id,
@@ -46,10 +47,11 @@ def _run(
         updated_at=updated_at,
         started_at=started_at,
         execution_attempt=execution_attempt,
+        metadata_=metadata or {},
     )
 
 
-async def test_requeued_run_age_starts_at_requeue(
+async def test_requeued_run_age_uses_interruption_after_later_metadata_write(
     queue_health_session,
     monkeypatch,
 ):
@@ -58,12 +60,56 @@ async def test_requeued_run_age_starts_at_requeue(
     now = datetime.now(timezone.utc)
     created_at = now - timedelta(hours=4)
     requeued_at = now - timedelta(seconds=30)
+    metadata_written_again_at = now - timedelta(seconds=5)
     queue_health_session.add(
         _run(
             thread_id="requeued",
             status="queued",
             created_at=created_at,
-            updated_at=requeued_at,
+            updated_at=metadata_written_again_at,
+            started_at=created_at,
+            execution_attempt=1,
+            metadata={
+                "interruption": {
+                    "interrupted_at": requeued_at.isoformat(),
+                    "from_status": "running",
+                },
+                "interruption_count": 1,
+                "later_write": True,
+            },
+        )
+    )
+    await queue_health_session.flush()
+    monkeypatch.setattr(
+        queue_health,
+        "UnitOfWork",
+        lambda: _SessionUnitOfWork(queue_health_session),
+    )
+
+    snapshot = await queue_health.queued_backlog_snapshot_async(
+        stale_after_seconds=60,
+    )
+
+    assert snapshot.queued == 1
+    assert snapshot.oldest_queued_at is not None
+    assert 25 <= (now - snapshot.oldest_queued_at).total_seconds() <= 35
+    assert snapshot.recent_active_runs == 0
+
+
+async def test_requeued_run_without_interruption_record_falls_back_to_creation(
+    queue_health_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import queue_health
+
+    now = datetime.now(timezone.utc)
+    created_at = now - timedelta(hours=4)
+    queue_health_session.add(
+        _run(
+            thread_id="historical-requeue",
+            status="queued",
+            created_at=created_at,
+            updated_at=now,
             started_at=created_at,
             execution_attempt=1,
         )
@@ -75,16 +121,14 @@ async def test_requeued_run_age_starts_at_requeue(
         lambda: _SessionUnitOfWork(queue_health_session),
     )
 
-    queued, oldest_queued_at, recent_active = (
-        await queue_health.queued_backlog_snapshot_async(
-            stale_after_seconds=60,
-        )
+    snapshot = await queue_health.queued_backlog_snapshot_async(
+        stale_after_seconds=60,
     )
 
-    assert queued == 1
-    assert oldest_queued_at is not None
-    assert 25 <= (now - oldest_queued_at).total_seconds() <= 35
-    assert recent_active == 0
+    assert snapshot.oldest_queued_at is not None
+    assert 3.9 * 60 * 60 <= (
+        now - snapshot.oldest_queued_at
+    ).total_seconds() <= 4.1 * 60 * 60
 
 
 async def test_stale_processing_rows_do_not_hide_queue_starvation(
@@ -121,15 +165,14 @@ async def test_stale_processing_rows_do_not_hide_queue_starvation(
         "UnitOfWork",
         lambda: _SessionUnitOfWork(queue_health_session),
     )
-    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
-
     health = await queue_health.queued_backlog_health_snapshot_async(
         stale_after_seconds=60,
+        configured_concurrency=4,
     )
 
-    assert health["active_runs"] == 0
-    assert health["queue_moving_at_capacity"] is False
-    assert health["stale_queued_backlog"] is True
+    assert health.recent_active_runs == 0
+    assert health.queue_moving_at_capacity is False
+    assert health.stale_queued_backlog is True
 
 
 async def test_recent_processing_claims_excuse_saturated_queue(
@@ -166,41 +209,79 @@ async def test_recent_processing_claims_excuse_saturated_queue(
         "UnitOfWork",
         lambda: _SessionUnitOfWork(queue_health_session),
     )
-    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
-
     health = await queue_health.queued_backlog_health_snapshot_async(
         stale_after_seconds=60,
+        configured_concurrency=4,
     )
 
-    assert health["active_runs"] == 4
-    assert health["queue_moving_at_capacity"] is True
-    assert health["stale_queued_backlog"] is False
+    assert health.recent_active_runs == 4
+    assert health.queue_moving_at_capacity is True
+    assert health.stale_queued_backlog is False
+
+
+def test_explicit_worker_capacity_keeps_partial_claims_starved():
+    from brain.systems.runs.cortex.queue_health import (
+        QueuedBacklogSnapshot,
+        QueueHealthPolicy,
+        evaluate_queue_health,
+    )
+
+    now = datetime.now(timezone.utc)
+    health = evaluate_queue_health(
+        QueuedBacklogSnapshot(
+            queued=1,
+            oldest_queued_at=now - timedelta(minutes=15),
+            recent_active_runs=4,
+        ),
+        QueueHealthPolicy(
+            watchdog_after_seconds=600,
+            configured_concurrency=8,
+        ),
+        now=now,
+    )
+
+    assert health.queue_moving_at_capacity is False
+    assert health.stale_queued_backlog is True
 
 
 def test_queue_health_cli_fails_with_legible_starvation_message(
     monkeypatch,
     capsys,
 ):
-    from brain.systems.runs.cortex import queue_health
+    from brain.app.cli import agent_run_queue_health
+    from brain.systems.runs.cortex.queue_health import QueueHealth
 
-    async def fake_health(*, stale_after_seconds):
+    async def fake_health(*, stale_after_seconds, configured_concurrency):
         assert stale_after_seconds == 600
-        return {
-            "queued": 3,
-            "recent_active_runs": 0,
-            "configured_concurrency": 4,
-            "oldest_queued_age_seconds": 900,
-            "watchdog_after_seconds": 600,
-            "stale_queued_backlog": True,
-        }
+        assert configured_concurrency == 8
+        return QueueHealth(
+            queued=3,
+            recent_active_runs=0,
+            configured_concurrency=8,
+            oldest_queued_at=None,
+            oldest_queued_age_seconds=900,
+            watchdog_after_seconds=600,
+            queue_moving_at_capacity=False,
+            stale_queued_backlog=True,
+        )
 
     monkeypatch.setattr(
-        queue_health,
+        agent_run_queue_health,
         "queued_backlog_health_snapshot_async",
         fake_health,
     )
 
-    assert queue_health.main(["--stale-after-seconds", "600"]) == 1
+    assert (
+        agent_run_queue_health.main(
+            [
+                "--stale-after-seconds",
+                "600",
+                "--runner-concurrency",
+                "8",
+            ]
+        )
+        == 1
+    )
     captured = capsys.readouterr()
     assert "AgentRun queue starvation" in captured.err
     assert "No worker is claiming the queued backlog" in captured.err

--- a/tests/test_queue_health.py
+++ b/tests/test_queue_health.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brain.platform.db.models.agent_run import AgentRunRow
+
+
+@pytest.fixture
+async def queue_health_session(
+    async_sqlite_session_factory,
+    sqlite_postgres_ddl_patch,
+):
+    return await async_sqlite_session_factory([AgentRunRow.__table__])
+
+
+class _SessionUnitOfWork:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        await self.session.flush()
+        return False
+
+
+def _run(
+    *,
+    thread_id: str,
+    status: str,
+    created_at: datetime,
+    updated_at: datetime,
+    started_at: datetime | None = None,
+    execution_attempt: int = 0,
+) -> AgentRunRow:
+    return AgentRunRow(
+        thread_id=thread_id,
+        profile="fast",
+        recipe="fast",
+        status=status,
+        input_message=thread_id,
+        created_at=created_at,
+        updated_at=updated_at,
+        started_at=started_at,
+        execution_attempt=execution_attempt,
+    )
+
+
+async def test_requeued_run_age_starts_at_requeue(
+    queue_health_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import queue_health
+
+    now = datetime.now(timezone.utc)
+    created_at = now - timedelta(hours=4)
+    requeued_at = now - timedelta(seconds=30)
+    queue_health_session.add(
+        _run(
+            thread_id="requeued",
+            status="queued",
+            created_at=created_at,
+            updated_at=requeued_at,
+            started_at=created_at,
+            execution_attempt=1,
+        )
+    )
+    await queue_health_session.flush()
+    monkeypatch.setattr(
+        queue_health,
+        "UnitOfWork",
+        lambda: _SessionUnitOfWork(queue_health_session),
+    )
+
+    queued, oldest_queued_at, recent_active = (
+        await queue_health.queued_backlog_snapshot_async(
+            stale_after_seconds=60,
+        )
+    )
+
+    assert queued == 1
+    assert oldest_queued_at is not None
+    assert 25 <= (now - oldest_queued_at).total_seconds() <= 35
+    assert recent_active == 0
+
+
+async def test_stale_processing_rows_do_not_hide_queue_starvation(
+    queue_health_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import queue_health
+
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(minutes=10)
+    rows = [
+        _run(
+            thread_id="queued",
+            status="queued",
+            created_at=old,
+            updated_at=old,
+        )
+    ]
+    rows.extend(
+        _run(
+            thread_id=f"zombie-{index}",
+            status="running",
+            created_at=old,
+            updated_at=old,
+            started_at=old,
+            execution_attempt=1,
+        )
+        for index in range(4)
+    )
+    queue_health_session.add_all(rows)
+    await queue_health_session.flush()
+    monkeypatch.setattr(
+        queue_health,
+        "UnitOfWork",
+        lambda: _SessionUnitOfWork(queue_health_session),
+    )
+    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
+
+    health = await queue_health.queued_backlog_health_snapshot_async(
+        stale_after_seconds=60,
+    )
+
+    assert health["active_runs"] == 0
+    assert health["queue_moving_at_capacity"] is False
+    assert health["stale_queued_backlog"] is True
+
+
+async def test_recent_processing_claims_excuse_saturated_queue(
+    queue_health_session,
+    monkeypatch,
+):
+    from brain.systems.runs.cortex import queue_health
+
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(minutes=10)
+    rows = [
+        _run(
+            thread_id="queued",
+            status="queued",
+            created_at=old,
+            updated_at=old,
+        )
+    ]
+    rows.extend(
+        _run(
+            thread_id=f"active-{index}",
+            status="running",
+            created_at=old,
+            updated_at=now,
+            started_at=old,
+            execution_attempt=1,
+        )
+        for index in range(4)
+    )
+    queue_health_session.add_all(rows)
+    await queue_health_session.flush()
+    monkeypatch.setattr(
+        queue_health,
+        "UnitOfWork",
+        lambda: _SessionUnitOfWork(queue_health_session),
+    )
+    monkeypatch.setattr(queue_health, "runner_concurrency", lambda: 4)
+
+    health = await queue_health.queued_backlog_health_snapshot_async(
+        stale_after_seconds=60,
+    )
+
+    assert health["active_runs"] == 4
+    assert health["queue_moving_at_capacity"] is True
+    assert health["stale_queued_backlog"] is False
+
+
+def test_queue_health_cli_fails_with_legible_starvation_message(
+    monkeypatch,
+    capsys,
+):
+    from brain.systems.runs.cortex import queue_health
+
+    async def fake_health(*, stale_after_seconds):
+        assert stale_after_seconds == 600
+        return {
+            "queued": 3,
+            "recent_active_runs": 0,
+            "configured_concurrency": 4,
+            "oldest_queued_age_seconds": 900,
+            "watchdog_after_seconds": 600,
+            "stale_queued_backlog": True,
+        }
+
+    monkeypatch.setattr(
+        queue_health,
+        "queued_backlog_health_snapshot_async",
+        fake_health,
+    )
+
+    assert queue_health.main(["--stale-after-seconds", "600"]) == 1
+    captured = capsys.readouterr()
+    assert "AgentRun queue starvation" in captured.err
+    assert "No worker is claiming the queued backlog" in captured.err

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -827,7 +827,10 @@ def test_inert_stack_check_is_reachable_as_a_standalone_monitor_entrypoint():
     assert check.exists()
     content = check.read_text()
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in content
+    assert 'source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"' in content
+    assert '. "$ENV_FILE"' in content
     assert "assert_stack_not_inert" in content
+    assert "assert_agent_run_queue_not_starved" in content
     # The entrypoint may document the override, but must not define its own list.
     assert not re.search(r"^STACK_REQUIRED_SERVICES=", content, flags=re.MULTILINE)
     assert "deploy/scripts/inert-stack-check.sh" in launcher
@@ -838,10 +841,41 @@ def test_deploy_doctor_delegates_stack_presence_to_the_shared_invariant():
     doctor = (root / "deploy" / "scripts" / "doctor.sh").read_text()
 
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in doctor
+    assert 'source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"' in doctor
     assert "assert_stack_not_inert $DOCTOR_REQUIRED_SERVICES" in doctor
+    assert "assert_agent_run_queue_not_starved" in doctor
+    assert 'fail "$queue_health_output"' in doctor
     # Presence has exactly one owner; doctor only grades health of what is present.
     assert "service is not running" not in doctor
     assert "compose() {" not in doctor
+
+
+def test_deploy_queue_health_calls_the_python_predicate_with_doctor_threshold():
+    root = Path(__file__).resolve().parents[1]
+    queue_health_lib = (
+        root / "deploy" / "scripts" / "agent-run-queue-health-lib.sh"
+    )
+    script = f'''
+source "{queue_health_lib}"
+compose() {{
+  printf '%s\\n' "$*"
+}}
+ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS=725
+assert_agent_run_queue_not_starved
+'''
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "exec -T api python -m brain.systems.runs.cortex.queue_health "
+        "--stale-after-seconds 725"
+    )
+    assert "psql" not in queue_health_lib.read_text()
 
 
 def test_boot_unit_binds_to_the_docker_unit_that_actually_exists(tmp_path):

--- a/tests/test_safe_deploy.py
+++ b/tests/test_safe_deploy.py
@@ -827,10 +827,7 @@ def test_inert_stack_check_is_reachable_as_a_standalone_monitor_entrypoint():
     assert check.exists()
     content = check.read_text()
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in content
-    assert 'source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"' in content
-    assert '. "$ENV_FILE"' in content
     assert "assert_stack_not_inert" in content
-    assert "assert_agent_run_queue_not_starved" in content
     # The entrypoint may document the override, but must not define its own list.
     assert not re.search(r"^STACK_REQUIRED_SERVICES=", content, flags=re.MULTILINE)
     assert "deploy/scripts/inert-stack-check.sh" in launcher
@@ -841,41 +838,10 @@ def test_deploy_doctor_delegates_stack_presence_to_the_shared_invariant():
     doctor = (root / "deploy" / "scripts" / "doctor.sh").read_text()
 
     assert 'source "$SCRIPT_DIR/compose-runtime-lib.sh"' in doctor
-    assert 'source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"' in doctor
     assert "assert_stack_not_inert $DOCTOR_REQUIRED_SERVICES" in doctor
-    assert "assert_agent_run_queue_not_starved" in doctor
-    assert 'fail "$queue_health_output"' in doctor
     # Presence has exactly one owner; doctor only grades health of what is present.
     assert "service is not running" not in doctor
     assert "compose() {" not in doctor
-
-
-def test_deploy_queue_health_calls_the_python_predicate_with_doctor_threshold():
-    root = Path(__file__).resolve().parents[1]
-    queue_health_lib = (
-        root / "deploy" / "scripts" / "agent-run-queue-health-lib.sh"
-    )
-    script = f'''
-source "{queue_health_lib}"
-compose() {{
-  printf '%s\\n' "$*"
-}}
-ILLO_AGENT_RUN_QUEUED_DOCTOR_SECONDS=725
-assert_agent_run_queue_not_starved
-'''
-
-    result = subprocess.run(
-        ["bash", "-c", script],
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == (
-        "exec -T api python -m brain.systems.runs.cortex.queue_health "
-        "--stale-after-seconds 725"
-    )
-    assert "psql" not in queue_health_lib.read_text()
 
 
 def test_boot_unit_binds_to_the_docker_unit_that_actually_exists(tmp_path):


### PR DESCRIPTION
Part of #549 — the **consequence** half only. The issue's own body splits it ("Depends on #548 for the cause check; the consequence check is independent"), so this deliberately does **not** close it. The cause half (fail when the worker reports a *drained* lifecycle phase) was blocked behind #548 when this started; #548 has since merged as #558, so that half is now workable as a follow-up.

## What it does

`deploy/scripts/doctor.sh` passed with 0 warnings during the illo-dev deploy that left **zero AgentRun capacity**. Every service was present and healthy; the worker just could not work. This adds the cause-independent assertion: **runs queued past a threshold with nothing claiming them** now fails the doctor, and `inert-stack-check.sh` catches it continuously rather than only after a deploy.

One owner for the predicate: `brain/systems/runs/cortex/queue_health.py` already owned it for the in-worker ~15s watchdog. The doctor became a second **caller** at ~10min, not a second implementation — no parallel rule, and no SQL copy in the shell.

Two traps the issue documents, both handled:
- **Saturation cannot silence the alarm.** Only claims with *recent* liveness count as occupied slots, so four zombie `running` rows plus an old queued run still reports starvation — instead of reading as "4/4 slots busy" and going quiet during the outage.
- **Queue age measures from the requeue**, read from the exact `metadata.interruption.interrupted_at` the interrupt path records — so a run requeued 30s ago no longer looks hours overdue.

## How to check it (no diff reading required)

Run the suite — this is the whole verification surface:

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-549-fix1 && ../../illospace-project/venv/bin/python -m pytest tests/ -q
```

**4451 passed / 85 skipped / 0 failed**, run outside the Codex sandbox. (Inside the sandbox 6 unrelated tests fail on `bind(127.0.0.1)` — that is a sandbox restriction, not this change.)

### Acceptance checks
1. Zombie slots do not suppress the alarm: N `running` rows with **stale** claims + an old queued run ⇒ starvation reported (`tests/test_queue_health.py`).
2. A moving queue still suppresses the false positive: N running rows with **fresh** claims + a recently queued run ⇒ no alarm.
3. A run requeued 30 seconds ago does not read as hours overdue.
4. `doctor.sh` and `inert-stack-check.sh` **exit non-zero with a legible diagnostic** when the predicate reports starvation (`tests/test_deploy_queue_health.py`) — asserted on exit status, not on shell source text.
5. `worker.py`/`runner.py` behaviour is unchanged for the existing 15s watchdog.

## A real bug this caught, after review

The first implementation ran the check as `compose exec -T api`, but `ILLO_AGENT_RUNNER_CONCURRENCY` is declared **only inside the `worker` service block** (`deploy/compose/docker-compose.yml:147`). Concurrency silently fell back to 4 inside `api`, so an operator running the worker at 8 would get a doctor that treats 4 recent claims as full capacity and **goes silent during a real starvation** — exactly the false negative this ticket exists to prevent.

Fixed by passing concurrency explicitly from the sourced deploy env (the same file Compose uses to configure the worker). It deliberately does **not** run the CLI inside the `worker` container: that would fail precisely when the worker is dead or drained, turning the starvation alarm into a connection error.

A code-quality review pass raised five further blocking findings, all folded in: typed `QueuedBacklogSnapshot`/`QueueHealthPolicy`/`QueueHealth` records replacing a dict with two names for one value, the CLI moved out of the domain module into `brain/app/cli/agent_run_queue_health.py`, a production branch that existed only to satisfy mock arity deleted, and the deploy tests rewritten to assert exit status instead of shell spelling.

## Known limitation, stated deliberately

Queue tenure for a previously-processed row falls back to `created_at` when interruption metadata is absent, which can *overstate* tenure for historical rows. The durable fix is an explicit `queued_at` column; that needs a migration, and #569 already carries a competing `0048`, so it is deliberately out of scope here.

## Merge notes

- Cuts cleanly against current `main` (`560f59f1`).
- Touches **no** file owned by an open PR. Its earlier additions to `tests/test_safe_deploy.py` were moved into a focused `tests/test_deploy_queue_health.py`, which also **removes the collision with #564**.

<sub>Opened as a draft by Routine R3. Not for merge until Reda reviews.</sub>
