### PR TITLE
perf(scheduler): batch detached-run reconciliation lookups

### DIFF
--- a/brain/app/scheduler/detached_agent_runs.py
+++ b/brain/app/scheduler/detached_agent_runs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -41,6 +42,14 @@ RetryableFailureSummary = Callable[
     tuple[str, dict[str, Any]],
 ]
 ApplyFailureGuard = Callable[..., Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class _DetachedRunCandidate:
+    run: SchedulerRun
+    agent_run: AgentRunRow | None
+    job: SchedulerJob | None
+    step: SchedulerRunStep | None
 
 
 def _agent_run_summary(
@@ -121,15 +130,9 @@ def _terminal_scheduler_status(agent_status: AgentRunStatus) -> str:
     return RUN_STATUS_SETTLED_FAILURE
 
 
-async def async_reconcile_detached_runs(
+async def _async_load_detached_run_candidates(
     session: AsyncSession,
-    *,
-    retryable_failure_summary: RetryableFailureSummary,
-    apply_failure_guard: ApplyFailureGuard,
-    now: datetime | None = None,
-) -> list[dict[str, Any]]:
-    """Settle detached scheduler runs from their linked AgentRun outcomes."""
-    clock = ensure_utc(now)
+) -> list[_DetachedRunCandidate]:
     runs = (
         await session.scalars(
             select(SchedulerRun)
@@ -140,10 +143,74 @@ async def async_reconcile_detached_runs(
             .order_by(SchedulerRun.id.asc())
         )
     ).all()
+    if not runs:
+        return []
+
+    agent_run_ids = tuple(
+        sorted({int(run.agent_run_id) for run in runs})
+    )
+    job_ids = tuple(sorted({run.job_id for run in runs}))
+    run_ids = tuple(run.id for run in runs)
+    agent_runs = (
+        await session.scalars(
+            select(AgentRunRow).where(AgentRunRow.id.in_(agent_run_ids))
+        )
+    ).all()
+    jobs = (
+        await session.scalars(
+            select(SchedulerJob).where(SchedulerJob.id.in_(job_ids))
+        )
+    ).all()
+    steps = (
+        await session.scalars(
+            select(SchedulerRunStep)
+            .where(
+                SchedulerRunStep.run_id.in_(run_ids),
+                SchedulerRunStep.agent_run_id.in_(agent_run_ids),
+            )
+            .order_by(
+                SchedulerRunStep.run_id.asc(),
+                SchedulerRunStep.sequence_no.desc(),
+            )
+        )
+    ).all()
+
+    agent_runs_by_id = {agent_run.id: agent_run for agent_run in agent_runs}
+    jobs_by_id = {job.id: job for job in jobs}
+    steps_by_link: dict[tuple[int, int], SchedulerRunStep] = {}
+    for step in steps:
+        if step.agent_run_id is None:
+            continue
+        steps_by_link.setdefault(
+            (step.run_id, int(step.agent_run_id)),
+            step,
+        )
+    return [
+        _DetachedRunCandidate(
+            run=run,
+            agent_run=agent_runs_by_id.get(int(run.agent_run_id)),
+            job=jobs_by_id.get(run.job_id),
+            step=steps_by_link.get((run.id, int(run.agent_run_id))),
+        )
+        for run in runs
+    ]
+
+
+async def async_reconcile_detached_runs(
+    session: AsyncSession,
+    *,
+    retryable_failure_summary: RetryableFailureSummary,
+    apply_failure_guard: ApplyFailureGuard,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Settle detached scheduler runs from their linked AgentRun outcomes."""
+    clock = ensure_utc(now)
+    candidates = await _async_load_detached_run_candidates(session)
     reconciled: list[dict[str, Any]] = []
-    for run in runs:
+    for candidate in candidates:
+        run = candidate.run
         agent_run_id = int(run.agent_run_id)
-        agent_run = await session.get(AgentRunRow, agent_run_id)
+        agent_run = candidate.agent_run
         if agent_run is None:
             continue
         agent_status = coerce_agent_run_status(agent_run.status)
@@ -151,7 +218,7 @@ async def async_reconcile_detached_runs(
             continue
 
         terminal_status = _terminal_scheduler_status(agent_status)
-        job = await session.get(SchedulerJob, run.job_id)
+        job = candidate.job
         error_text = None
         if terminal_status == RUN_STATUS_SETTLED_FAILURE:
             error_text = (
@@ -176,15 +243,7 @@ async def async_reconcile_detached_runs(
             )
 
         finished_at = _agent_run_finished_at(agent_run, now=clock)
-        step = await session.scalar(
-            select(SchedulerRunStep)
-            .where(
-                SchedulerRunStep.run_id == run.id,
-                SchedulerRunStep.agent_run_id == agent_run_id,
-            )
-            .order_by(SchedulerRunStep.sequence_no.desc())
-            .limit(1)
-        )
+        step = candidate.step
         if step is not None:
             step.status = (
                 RUN_STATUS_SETTLED_SUCCESS
@@ -204,6 +263,7 @@ async def async_reconcile_detached_runs(
         await async_finish_run(
             session,
             run,
+            job=job,
             status=scheduler_status,
             result_summary=summary,
             error_text=error_text,

--- a/brain/app/scheduler/detached_agent_runs.py
+++ b/brain/app/scheduler/detached_agent_runs.py
@@ -48,7 +48,7 @@ ApplyFailureGuard = Callable[..., Awaitable[None]]
 class _DetachedRunCandidate:
     run: SchedulerRun
     agent_run: AgentRunRow | None
-    job: SchedulerJob | None
+    job: SchedulerJob
     step: SchedulerRunStep | None
 
 
@@ -161,6 +161,12 @@ async def _async_load_detached_run_candidates(
             select(SchedulerJob).where(SchedulerJob.id.in_(job_ids))
         )
     ).all()
+    jobs_by_id = {job.id: job for job in jobs}
+    for run in runs:
+        if run.job_id not in jobs_by_id:
+            raise ValueError(
+                f"Scheduler job {run.job_id} not found for detached run {run.id}"
+            )
     steps = (
         await session.scalars(
             select(SchedulerRunStep)
@@ -176,7 +182,6 @@ async def _async_load_detached_run_candidates(
     ).all()
 
     agent_runs_by_id = {agent_run.id: agent_run for agent_run in agent_runs}
-    jobs_by_id = {job.id: job for job in jobs}
     steps_by_link: dict[tuple[int, int], SchedulerRunStep] = {}
     for step in steps:
         if step.agent_run_id is None:
@@ -189,7 +194,7 @@ async def _async_load_detached_run_candidates(
         _DetachedRunCandidate(
             run=run,
             agent_run=agent_runs_by_id.get(int(run.agent_run_id)),
-            job=jobs_by_id.get(run.job_id),
+            job=jobs_by_id[run.job_id],
             step=steps_by_link.get((run.id, int(run.agent_run_id))),
         )
         for run in runs
@@ -234,7 +239,7 @@ async def async_reconcile_detached_runs(
             "agent_run": agent_summary,
         }
         scheduler_status = terminal_status
-        if terminal_status == RUN_STATUS_SETTLED_FAILURE and job is not None:
+        if terminal_status == RUN_STATUS_SETTLED_FAILURE:
             scheduler_status, summary = retryable_failure_summary(
                 job,
                 run,
@@ -269,22 +274,21 @@ async def async_reconcile_detached_runs(
             error_text=error_text,
             now=finished_at,
         )
-        if job is not None:
-            if scheduler_status == RUN_STATUS_SETTLED_SUCCESS:
-                await async_reset_scheduler_job_failure_guard(
-                    session,
-                    job,
-                    now=clock,
-                )
-            else:
-                await apply_failure_guard(
-                    session,
-                    job,
-                    run,
-                    failure_key="detached_agent_run",
-                    error_text=error_text or "Detached agent run failed",
-                    now=clock,
-                )
+        if scheduler_status == RUN_STATUS_SETTLED_SUCCESS:
+            await async_reset_scheduler_job_failure_guard(
+                session,
+                job,
+                now=clock,
+            )
+        else:
+            await apply_failure_guard(
+                session,
+                job,
+                run,
+                failure_key="detached_agent_run",
+                error_text=error_text or "Detached agent run failed",
+                now=clock,
+            )
         reconciled.append(
             {
                 "run_id": run.id,

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -263,6 +263,7 @@ def _final_status_from_handler_result(result: dict[str, Any]) -> str:
 
 async def _async_block_invalid_contract_run(
     session: AsyncSession,
+    job: SchedulerJob,
     run: SchedulerRun,
     *,
     contract: dict[str, Any],
@@ -273,6 +274,7 @@ async def _async_block_invalid_contract_run(
     await async_finish_run(
         session,
         run,
+        job=job,
         status="blocked",
         result_summary={
             "reason": "contract_invalid",
@@ -693,6 +695,7 @@ async def async_run_scheduler_run(
     if contract_errors:
         return await _async_block_invalid_contract_run(
             session,
+            job,
             run,
             contract=contract,
             contract_errors=contract_errors,
@@ -770,6 +773,7 @@ async def async_run_scheduler_run(
             await async_finish_run(
                 session,
                 run,
+                job=job,
                 status=failure_status,
                 result_summary=failure_summary,
                 error_text=result["error"],
@@ -802,6 +806,7 @@ async def async_run_scheduler_run(
     await async_finish_run(
         session,
         run,
+        job=job,
         status=RUN_STATUS_SETTLED_SUCCESS,
         result_summary={"steps": step_results},
         error_text=None,
@@ -899,6 +904,7 @@ async def async_execute_scheduler_run(
     if contract_errors:
         return await _async_block_invalid_contract_run(
             session,
+            job,
             run,
             contract=contract,
             contract_errors=contract_errors,

--- a/brain/app/scheduler/runtime.py
+++ b/brain/app/scheduler/runtime.py
@@ -477,12 +477,16 @@ async def async_finish_run(
     session: AsyncSession,
     run: SchedulerRun,
     *,
-    job: SchedulerJob | None,
+    job: SchedulerJob,
     status: str,
     result_summary: dict[str, Any] | None = None,
     error_text: str | None = None,
     now: datetime | None = None,
 ) -> SchedulerRun:
+    if job.id != run.job_id:
+        raise ValueError(
+            f"Scheduler job {job.id} does not match run {run.id} job_id {run.job_id}"
+        )
     now = _utcnow(now)
     run.status = status
     run.result_summary = result_summary or {}
@@ -492,10 +496,9 @@ async def async_finish_run(
         run.trace_id = trace_id_for_run_id(run.agent_run_id)
     elif not run.trace_id:
         run.trace_id = trace_id_for_scheduler_run_id(run.id)
-    if job is not None:
-        job.last_finished_at = now
-        if status == RUN_STATUS_SETTLED_SUCCESS:
-            job.pause_reason = None if job.enabled else job.pause_reason
+    job.last_finished_at = now
+    if status == RUN_STATUS_SETTLED_SUCCESS:
+        job.pause_reason = None if job.enabled else job.pause_reason
     if run.lease_id:
         await async_release_lease(session, run.lease_id, reason=f"run {status}", now=now)
     await session.flush()

--- a/brain/app/scheduler/runtime.py
+++ b/brain/app/scheduler/runtime.py
@@ -477,6 +477,7 @@ async def async_finish_run(
     session: AsyncSession,
     run: SchedulerRun,
     *,
+    job: SchedulerJob | None,
     status: str,
     result_summary: dict[str, Any] | None = None,
     error_text: str | None = None,
@@ -491,7 +492,6 @@ async def async_finish_run(
         run.trace_id = trace_id_for_run_id(run.agent_run_id)
     elif not run.trace_id:
         run.trace_id = trace_id_for_scheduler_run_id(run.id)
-    job = await session.get(SchedulerJob, run.job_id)
     if job is not None:
         job.last_finished_at = now
         if status == RUN_STATUS_SETTLED_SUCCESS:

--- a/tests/test_detached_agent_runs.py
+++ b/tests/test_detached_agent_runs.py
@@ -2,15 +2,104 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy.schema import CreateTable
 
+from brain.app.scheduler.detached_agent_runs import async_reconcile_detached_runs
 from brain.contracts.scheduler_handoff import (
     DetachedAgentRunHandoff,
     DetachedAgentRunHandoffError,
     emit_detached_agent_run_handoff,
     parse_detached_agent_run_handoff,
 )
+from brain.platform.db.models.agent_run import AgentRunRow
+from brain.platform.db.models.scheduler import SchedulerRun, SchedulerRunStep
+from tests.scheduler_test_support import (
+    make_scheduler_job,
+    make_scheduler_test_session,
+)
+
+
+@pytest.fixture
+async def scheduler_session(async_sqlite_session_factory):
+    session = await make_scheduler_test_session(async_sqlite_session_factory)
+    await session.execute(CreateTable(AgentRunRow.__table__, if_not_exists=True))
+    return session
+
+
+async def _add_detached_candidate(
+    session,
+    *,
+    candidate_id: int,
+    agent_status: str | None,
+    terminal_at: datetime | None = None,
+    attempt: int = 1,
+):
+    job = make_scheduler_job(
+        job_key=f"detached_job_{candidate_id}",
+        family=f"detached_job_{candidate_id}",
+        program_key=f"detached_job_{candidate_id}",
+        retry_policy={"max_attempts": 2, "backoff_seconds": 60},
+        next_run_at=None,
+    )
+    session.add(job)
+    await session.flush()
+
+    agent_run_id = 1000 + candidate_id
+    run = SchedulerRun(
+        job_id=job.id,
+        scheduled_for=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+        window_start=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+        window_end=datetime(2026, 7, 28, 19, 31, tzinfo=timezone.utc),
+        status="executing",
+        attempt=attempt,
+        idempotency_key=f"detached-candidate-{candidate_id}",
+        result_summary={"candidate": candidate_id},
+        agent_run_id=agent_run_id,
+        trace_id=f"run:{agent_run_id}",
+        started_at=datetime(2026, 7, 28, 19, 30, tzinfo=timezone.utc),
+    )
+    session.add(run)
+    await session.flush()
+
+    step = SchedulerRunStep(
+        run_id=run.id,
+        step_key="detached",
+        sequence_no=1,
+        status="executing",
+        attempt=attempt,
+        agent_run_id=agent_run_id,
+        trace_id=f"run:{agent_run_id}",
+        started_at=run.started_at,
+        result_summary={"candidate": candidate_id},
+    )
+    session.add(step)
+
+    agent_run = None
+    if agent_status is not None:
+        terminal_field = {
+            "completed": "completed_at",
+            "failed": "failed_at",
+            "canceled": "canceled_at",
+        }.get(agent_status)
+        agent_run = AgentRunRow(
+            id=agent_run_id,
+            thread_id=f"headless:detached:{candidate_id}",
+            profile="fast",
+            recipe="fast",
+            status=agent_status,
+            input_message=f"Run detached candidate {candidate_id}.",
+            target_ref={},
+            workspace_ref={},
+            model_policy={},
+            metadata_={},
+            **({terminal_field: terminal_at} if terminal_field else {}),
+        )
+        session.add(agent_run)
+    await session.flush()
+    return job, run, step, agent_run
 
 
 def test_detached_agent_run_handoff_round_trips_the_complete_envelope():
@@ -65,3 +154,140 @@ def test_detached_agent_run_handoff_round_trips_the_complete_envelope():
 def test_detached_agent_run_handoff_rejects_any_malformed_envelope(payload):
     with pytest.raises(DetachedAgentRunHandoffError):
         parse_detached_agent_run_handoff(json.dumps(payload))
+
+
+@pytest.mark.asyncio
+async def test_reconcile_detached_runs_preserves_mixed_candidate_outcomes(
+    scheduler_session,
+):
+    terminal_at = datetime(2026, 7, 28, 19, 35, tzinfo=timezone.utc)
+    reconciled_at = datetime(2026, 7, 28, 19, 40, tzinfo=timezone.utc)
+    completed = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=1,
+        agent_status="completed",
+        terminal_at=terminal_at,
+    )
+    retryable = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=2,
+        agent_status="failed",
+        terminal_at=terminal_at,
+    )
+    failed = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=3,
+        agent_status="canceled",
+        terminal_at=terminal_at,
+        attempt=2,
+    )
+    active = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=4,
+        agent_status="running",
+    )
+    missing = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=5,
+        agent_status=None,
+    )
+    guarded_run_ids: list[int] = []
+
+    def retryable_failure_summary(job, run, *, base_summary, now):
+        del job
+        summary = {
+            **base_summary,
+            "retry_exhausted": run.attempt >= 2,
+            "next_retry_at": now.isoformat() if run.attempt < 2 else None,
+        }
+        if run.attempt < 2:
+            return "retryable", summary
+        return "settled_failure", summary
+
+    async def apply_failure_guard(_session, _job, run, **_kwargs):
+        guarded_run_ids.append(run.id)
+
+    reconciled = await async_reconcile_detached_runs(
+        scheduler_session,
+        retryable_failure_summary=retryable_failure_summary,
+        apply_failure_guard=apply_failure_guard,
+        now=reconciled_at,
+    )
+
+    completed_job, completed_run, completed_step, _ = completed
+    retryable_job, retryable_run, retryable_step, _ = retryable
+    failed_job, failed_run, failed_step, _ = failed
+    _, active_run, active_step, _ = active
+    _, missing_run, missing_step, _ = missing
+    assert reconciled == [
+        {
+            "run_id": completed_run.id,
+            "agent_run_id": completed_run.agent_run_id,
+            "agent_run_status": "completed",
+            "status": "settled_success",
+        },
+        {
+            "run_id": retryable_run.id,
+            "agent_run_id": retryable_run.agent_run_id,
+            "agent_run_status": "failed",
+            "status": "retryable",
+        },
+        {
+            "run_id": failed_run.id,
+            "agent_run_id": failed_run.agent_run_id,
+            "agent_run_status": "canceled",
+            "status": "settled_failure",
+        },
+    ]
+    assert guarded_run_ids == [retryable_run.id, failed_run.id]
+
+    assert completed_run.status == completed_step.status == "settled_success"
+    assert completed_run.error_text is None
+    assert completed_step.error_text is None
+    assert completed_run.finished_at == completed_step.finished_at == terminal_at
+    assert completed_job.last_finished_at == terminal_at
+
+    assert retryable_run.status == retryable_step.status == "retryable"
+    assert retryable_run.error_text == (
+        f"Agent run {retryable_run.agent_run_id} ended with status failed"
+    )
+    assert retryable_step.error_text == retryable_run.error_text
+    assert retryable_run.finished_at == retryable_step.finished_at == terminal_at
+    assert retryable_job.last_finished_at == terminal_at
+    assert retryable_run.result_summary["retry_exhausted"] is False
+    assert retryable_run.result_summary["next_retry_at"] == reconciled_at.isoformat()
+
+    assert failed_run.status == failed_step.status == "settled_failure"
+    assert failed_run.error_text == (
+        f"Agent run {failed_run.agent_run_id} ended with status canceled"
+    )
+    assert failed_step.error_text == failed_run.error_text
+    assert failed_run.finished_at == failed_step.finished_at == terminal_at
+    assert failed_job.last_finished_at == terminal_at
+    assert failed_run.result_summary["retry_exhausted"] is True
+    assert failed_run.result_summary["next_retry_at"] is None
+
+    for candidate_id, run, step, agent_status in (
+        (1, completed_run, completed_step, "completed"),
+        (2, retryable_run, retryable_step, "failed"),
+        (3, failed_run, failed_step, "canceled"),
+    ):
+        expected_agent_summary = {
+            "run_id": run.agent_run_id,
+            "status": agent_status,
+            "reconciled_at": reconciled_at.isoformat(),
+        }
+        assert run.result_summary["candidate"] == candidate_id
+        assert run.result_summary["agent_run"] == expected_agent_summary
+        assert step.result_summary == {
+            "candidate": candidate_id,
+            "agent_run": expected_agent_summary,
+        }
+
+    for run, step in (
+        (active_run, active_step),
+        (missing_run, missing_step),
+    ):
+        assert run.status == step.status == "executing"
+        assert run.finished_at is None
+        assert step.finished_at is None

--- a/tests/test_detached_agent_runs.py
+++ b/tests/test_detached_agent_runs.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.schema import CreateTable
 
 from brain.app.scheduler.detached_agent_runs import async_reconcile_detached_runs
@@ -291,3 +292,58 @@ async def test_reconcile_detached_runs_preserves_mixed_candidate_outcomes(
         assert run.status == step.status == "executing"
         assert run.finished_at is None
         assert step.finished_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("candidate_count", [1, 4])
+async def test_reconcile_detached_runs_uses_four_selects_for_any_batch_size(
+    scheduler_session,
+    candidate_count,
+):
+    terminal_at = datetime(2026, 7, 28, 19, 35, tzinfo=timezone.utc)
+    for candidate_id in range(100, 100 + candidate_count):
+        await _add_detached_candidate(
+            scheduler_session,
+            candidate_id=candidate_id,
+            agent_status="failed",
+            terminal_at=terminal_at,
+            attempt=2,
+        )
+    await scheduler_session.commit()
+    scheduler_session.expunge_all()
+
+    select_statements: list[str] = []
+
+    def count_selects(
+        _connection,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ):
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_statements.append(statement)
+
+    engine = scheduler_session.bind
+    event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+
+    def retryable_failure_summary(_job, _run, *, base_summary, now):
+        del now
+        return "settled_failure", base_summary
+
+    async def apply_failure_guard(*_args, **_kwargs):
+        return None
+
+    try:
+        reconciled = await async_reconcile_detached_runs(
+            scheduler_session,
+            retryable_failure_summary=retryable_failure_summary,
+            apply_failure_guard=apply_failure_guard,
+            now=terminal_at,
+        )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+
+    assert len(reconciled) == candidate_count
+    assert len(select_statements) == 4

--- a/tests/test_detached_agent_runs.py
+++ b/tests/test_detached_agent_runs.py
@@ -9,6 +9,7 @@ from sqlalchemy import event
 from sqlalchemy.schema import CreateTable
 
 from brain.app.scheduler.detached_agent_runs import async_reconcile_detached_runs
+from brain.app.scheduler.runtime import async_finish_run
 from brain.contracts.scheduler_handoff import (
     DetachedAgentRunHandoff,
     DetachedAgentRunHandoffError,
@@ -158,6 +159,68 @@ def test_detached_agent_run_handoff_rejects_any_malformed_envelope(payload):
 
 
 @pytest.mark.asyncio
+async def test_finish_run_rejects_a_job_for_a_different_run(scheduler_session):
+    job, run, _, _ = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=10,
+        agent_status="completed",
+    )
+    wrong_job = make_scheduler_job(
+        job_key="wrong_detached_job",
+        family="wrong_detached_job",
+        program_key="wrong_detached_job",
+    )
+    scheduler_session.add(wrong_job)
+    await scheduler_session.flush()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"Scheduler job {wrong_job.id} does not match run {run.id} "
+            rf"job_id {job.id}"
+        ),
+    ):
+        await async_finish_run(
+            scheduler_session,
+            run,
+            job=wrong_job,
+            status="settled_success",
+        )
+
+    assert run.status == "executing"
+    assert run.finished_at is None
+    assert job.last_finished_at is None
+    assert wrong_job.last_finished_at is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_detached_runs_rejects_a_missing_job(scheduler_session):
+    job, run, _, _ = await _add_detached_candidate(
+        scheduler_session,
+        candidate_id=11,
+        agent_status="completed",
+    )
+    job_id = job.id
+    run_id = run.id
+    await scheduler_session.delete(job)
+    await scheduler_session.commit()
+    scheduler_session.expunge_all()
+
+    with pytest.raises(
+        ValueError,
+        match=rf"Scheduler job {job_id} not found for detached run {run_id}",
+    ):
+        await async_reconcile_detached_runs(
+            scheduler_session,
+            retryable_failure_summary=lambda *_args, **_kwargs: (
+                "settled_failure",
+                {},
+            ),
+            apply_failure_guard=lambda *_args, **_kwargs: None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_reconcile_detached_runs_preserves_mixed_candidate_outcomes(
     scheduler_session,
 ):
@@ -295,38 +358,10 @@ async def test_reconcile_detached_runs_preserves_mixed_candidate_outcomes(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("candidate_count", [1, 4])
-async def test_reconcile_detached_runs_uses_four_selects_for_any_batch_size(
+async def test_reconcile_detached_runs_select_count_is_constant_with_batch_size(
     scheduler_session,
-    candidate_count,
 ):
     terminal_at = datetime(2026, 7, 28, 19, 35, tzinfo=timezone.utc)
-    for candidate_id in range(100, 100 + candidate_count):
-        await _add_detached_candidate(
-            scheduler_session,
-            candidate_id=candidate_id,
-            agent_status="failed",
-            terminal_at=terminal_at,
-            attempt=2,
-        )
-    await scheduler_session.commit()
-    scheduler_session.expunge_all()
-
-    select_statements: list[str] = []
-
-    def count_selects(
-        _connection,
-        _cursor,
-        statement,
-        _parameters,
-        _context,
-        _executemany,
-    ):
-        if statement.lstrip().upper().startswith("SELECT"):
-            select_statements.append(statement)
-
-    engine = scheduler_session.bind
-    event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
 
     def retryable_failure_summary(_job, _run, *, base_summary, now):
         del now
@@ -335,15 +370,54 @@ async def test_reconcile_detached_runs_uses_four_selects_for_any_batch_size(
     async def apply_failure_guard(*_args, **_kwargs):
         return None
 
-    try:
-        reconciled = await async_reconcile_detached_runs(
-            scheduler_session,
-            retryable_failure_summary=retryable_failure_summary,
-            apply_failure_guard=apply_failure_guard,
-            now=terminal_at,
-        )
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+    async def reconcile_and_count_selects(candidate_ids: range) -> int:
+        for candidate_id in candidate_ids:
+            await _add_detached_candidate(
+                scheduler_session,
+                candidate_id=candidate_id,
+                agent_status="failed",
+                terminal_at=terminal_at,
+                attempt=2,
+            )
+        await scheduler_session.commit()
+        scheduler_session.expunge_all()
 
-    assert len(reconciled) == candidate_count
-    assert len(select_statements) == 4
+        select_count = 0
+
+        def count_selects(
+            _connection,
+            _cursor,
+            statement,
+            _parameters,
+            _context,
+            _executemany,
+        ):
+            nonlocal select_count
+            if statement.lstrip().upper().startswith("SELECT"):
+                select_count += 1
+
+        engine = scheduler_session.bind
+        event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+        try:
+            reconciled = await async_reconcile_detached_runs(
+                scheduler_session,
+                retryable_failure_summary=retryable_failure_summary,
+                apply_failure_guard=apply_failure_guard,
+                now=terminal_at,
+            )
+        finally:
+            event.remove(
+                engine.sync_engine,
+                "before_cursor_execute",
+                count_selects,
+            )
+
+        assert len(reconciled) == len(candidate_ids)
+        return select_count
+
+    single_candidate_selects = await reconcile_and_count_selects(range(100, 101))
+    larger_batch_selects = await reconcile_and_count_selects(range(200, 208))
+
+    assert single_candidate_selects <= 4
+    assert larger_batch_selects <= 4
+    assert larger_batch_selects <= single_candidate_selects


### PR DESCRIPTION
Closes #571.

## What it does

`async_reconcile_detached_runs` resolved every candidate with separate AgentRun, job and step lookups, and `async_finish_run` then looked the job up **again**. That was fine while exactly one job (`uwear_aws_health_scan`) used the detached lifecycle — but #570 made dispatch-and-reconcile a declared, reusable mode, so the cost would grow at the front of every drain precisely as the lifecycle succeeded.

**Before: `1 + 3N` SELECTs** (4 for one run, 13 for four). **After: a constant 4** for any non-empty batch, 1 for an empty one. The duplicate job lookup in `async_finish_run` is removed outright rather than moved.

`_terminal_scheduler_status` and `_agent_run_finished_at` stay pure projections over loaded rows; all I/O is contained in the batch loader.

## How to check it (no diff reading required)

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-571-fix1 && ../../illospace-project/venv/bin/python -m pytest tests/ -q
```

**4445 passed / 85 skipped / 0 failed**, run outside the Codex sandbox. (Inside it, 6 unrelated tests fail on `bind(127.0.0.1)` — a sandbox restriction, not this change.)

### Acceptance checks
1. **Reconciled outcomes are unchanged** — pinned by a test committed *before* the refactor, then re-run through the batched path.
2. **Constant scaling**: reconciling 8 candidates issues no more SELECTs than reconciling 1, and both stay within a budget of 4.
3. Every `async_finish_run` call site passes the owning job; a mismatched job raises rather than silently skipping bookkeeping.
4. Scheduler suite green (59 focused tests).

## What the code-quality review changed

The first version made `job` a **required but nullable** parameter on `async_finish_run`. `SchedulerRun.job_id` is a non-null foreign key, so `None` invented a state the domain cannot be in — and nothing stopped a caller passing `None`, or the *wrong* job, which would silently skip `last_finished_at`, retry policy and failure-guard bookkeeping. Pushing the load onto callers is the right ownership move; accepting `None` was not.

Now `job: SchedulerJob` is non-null, `job.id == run.job_id` is validated before any mutation, the batch loader fails fast when a job cannot be resolved, and the dead `if job is not None:` branches are gone.

The review also flagged the query test asserting `== 4` exactly, which would reject a future improvement to three queries. It now pins the *property* the ticket asked for — constant scaling under a bounded budget — instead of freezing a number.

## Merge notes

- Cuts cleanly against current `main` (`560f59f1`).
- Touches no file owned by an open PR. Test-merged together with #539 and open PR #575: clean, **4455 passed**.

<sub>Opened as a draft by Routine R3. Not for merge until Reda reviews.</sub>
