### PR TITLE
chore(scheduler): retire execution budget alias

### DIFF
--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -107,8 +107,7 @@ def _positive_float_env(name: str, default: float) -> float:
 
 DEFAULT_DRAIN_ADMISSION_BUDGET_SECONDS = _positive_float_env(
     "SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS",
-    # Deprecated fallback; remove after deploy configuration uses the admission name.
-    _positive_float_env("SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS", 30.0),
+    30.0,
 )
 
 _FINAL_RUN_STATUSES = {

--- a/tests/test_scheduler_drain_budget.py
+++ b/tests/test_scheduler_drain_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -32,6 +33,24 @@ from tests.scheduler_test_support import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_only_admission_budget_environment_name_remains(monkeypatch):
+    source = (
+        Path(__file__).parents[1] / "brain/app/scheduler/executor.py"
+    ).read_text(encoding="utf-8")
+    deprecated_name = "_".join(
+        ("SCHEDULER", "DRAIN", "EXECUTION", "BUDGET", "SECONDS")
+    )
+    assert deprecated_name not in source
+
+    monkeypatch.setenv("SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS", "12.5")
+    from brain.app.scheduler import executor
+
+    assert executor._positive_float_env(
+        "SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS",
+        30.0,
+    ) == 12.5
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- remove the deprecated `SCHEDULER_DRAIN_EXECUTION_BUDGET_SECONDS` fallback
- keep `SCHEDULER_DRAIN_ADMISSION_BUDGET_SECONDS` as the only drain-budget configuration
- pin the canonical environment behavior and source-level absence of the old name

## Verification

- scheduler suites: 54 passed
- focused drain-budget suite: 10 passed
- repository search: no deprecated-name references
- `git diff --check`: clean

Closes #572
