### PR TITLE
perf(scheduler): bulk-project failure-guard state instead of per-job round trips

### DIFF
--- a/brain/app/scheduler/catalog.py
+++ b/brain/app/scheduler/catalog.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.scheduler import OWNER_MODE_SCHEDULER, SchedulerJob, SchedulerRun
 from brain.app.scheduler.scheduler_failure_guard import (
-    async_read_scheduler_failure_guard,
+    async_read_scheduler_failure_guards,
     scheduler_failure_guard_registry,
 )
 from brain.systems.failure_guard.core import (
@@ -523,16 +523,17 @@ async def async_list_scheduler_jobs(
     result = await session.scalars(
         select(SchedulerJob).order_by(SchedulerJob.family.asc(), SchedulerJob.id.asc())
     )
-    jobs = []
-    for job in result.all():
-        failure_guard = await async_read_scheduler_failure_guard(
-            session,
-            job,
-            now=now,
-            registry=registry,
-        )
-        jobs.append(_serialize_job(job, failure_guard))
-    return jobs
+    job_rows = result.all()
+    failure_guards = await async_read_scheduler_failure_guards(
+        session,
+        job_rows,
+        now=now,
+        registry=registry,
+    )
+    return [
+        _serialize_job(job, failure_guards[job.id])
+        for job in job_rows
+    ]
 
 
 async def async_list_scheduler_runs(

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import os
-from typing import Callable, Literal, Protocol, TypeAlias
+from typing import (
+    Callable,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeAlias,
+    runtime_checkable,
+)
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -173,6 +181,47 @@ class RollingWindowFailuresTrigger:
             )
             or 0
         )
+        return self._result(count)
+
+    async def evaluate_many(
+        self,
+        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+    ) -> Mapping[int, FailureGuardTriggerResult]:
+        """Evaluate one rolling-window count query for a job projection."""
+        if not contexts:
+            return {}
+        session = contexts[0].session
+        now = contexts[0].now
+        if any(
+            context.session is not session or context.now != now
+            for context in contexts
+        ):
+            raise ValueError(
+                "Bulk scheduler trigger contexts must share a session and time"
+            )
+        job_ids = [context.job.id for context in contexts]
+        result = await session.execute(
+            select(SchedulerRun.job_id, func.count())
+            .where(
+                SchedulerRun.job_id.in_(job_ids),
+                SchedulerRun.status == "settled_failure",
+                SchedulerRun.started_at
+                > now - timedelta(hours=self.window_hours),
+            )
+            .group_by(SchedulerRun.job_id)
+        )
+        counts = {
+            int(job_id): int(count)
+            for job_id, count in result.all()
+        }
+        return {
+            context.job.id: self._result(
+                counts.get(context.job.id, 0)
+            )
+            for context in contexts
+        }
+
+    def _result(self, count: int) -> FailureGuardTriggerResult:
         return FailureGuardTriggerResult(
             kind=self.kind,
             active=count >= self.threshold,
@@ -227,6 +276,19 @@ class SchedulerFailureGuardStatefulTrigger(
     Protocol,
 ):
     """One state-owning scheduler failure trigger."""
+
+
+@runtime_checkable
+class SchedulerFailureGuardBulkTrigger(Protocol):
+    """A stateless trigger that can batch its catalog projection reads."""
+
+    kind: FailureGuardTriggerKind
+
+    async def evaluate_many(
+        self,
+        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+    ) -> Mapping[int, FailureGuardTriggerResult]:
+        """Evaluate this trigger for every projected job."""
 
 
 SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
@@ -331,6 +393,144 @@ def _scheduler_failure_guard_state_store(
             )
         ),
     )
+
+
+async def _async_load_scheduler_failure_guard_latches(
+    session: AsyncSession,
+    job_ids: Sequence[int],
+) -> dict[
+    int,
+    dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch],
+]:
+    latches_by_job: dict[
+        int,
+        dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch],
+    ] = {job_id: {} for job_id in job_ids}
+    result = await session.scalars(
+        select(SchedulerFailureGuardLatch).where(
+            SchedulerFailureGuardLatch.job_id.in_(job_ids)
+        )
+    )
+    for latch in result.all():
+        latches_by_job[latch.job_id][
+            FailureGuardTriggerKind(latch.trigger_kind)
+        ] = latch
+    return latches_by_job
+
+
+async def _async_load_scheduler_failure_guard_trigger_states(
+    session: AsyncSession,
+    job_ids: Sequence[int],
+) -> dict[
+    int,
+    dict[FailureGuardTriggerKind, FailureGuardTriggerState],
+]:
+    states_by_job: dict[
+        int,
+        dict[FailureGuardTriggerKind, FailureGuardTriggerState],
+    ] = {job_id: {} for job_id in job_ids}
+    result = await session.scalars(
+        select(SchedulerFailureGuardTriggerState).where(
+            SchedulerFailureGuardTriggerState.job_id.in_(job_ids)
+        )
+    )
+    for state in result.all():
+        states_by_job[state.job_id][
+            FailureGuardTriggerKind(state.trigger_kind)
+        ] = dict(state.trigger_state)
+    return states_by_job
+
+
+async def async_read_scheduler_failure_guards(
+    session: AsyncSession,
+    jobs: Sequence[SchedulerJob],
+    *,
+    now: datetime | None = None,
+    registry: SchedulerFailureGuardRegistry | None = None,
+) -> dict[int, FailureGuardEvaluation]:
+    """Project every job's guard from bulk-loaded state and latches."""
+    jobs = tuple(jobs)
+    if not jobs:
+        return {}
+
+    now = ensure_utc(now)
+    registry = registry or scheduler_failure_guard_registry()
+    job_ids = [job.id for job in jobs]
+    contexts = tuple(
+        SchedulerFailureGuardLifecycleContext(
+            session=session,
+            job=job,
+            now=now,
+            record=None,
+        )
+        for job in jobs
+    )
+    latches_by_job = await _async_load_scheduler_failure_guard_latches(
+        session,
+        job_ids,
+    )
+    states_by_job = (
+        await _async_load_scheduler_failure_guard_trigger_states(
+            session,
+            job_ids,
+        )
+    )
+
+    bulk_results: dict[
+        FailureGuardTriggerKind,
+        Mapping[int, FailureGuardTriggerResult],
+    ] = {}
+    for trigger in registry.triggers:
+        if isinstance(trigger, FailureGuardStatefulTrigger):
+            continue
+        if isinstance(trigger, SchedulerFailureGuardBulkTrigger):
+            results = dict(await trigger.evaluate_many(contexts))
+            missing_job_ids = set(job_ids).difference(results)
+            if missing_job_ids:
+                raise ValueError(
+                    f"Bulk scheduler trigger {trigger.kind} omitted jobs: "
+                    + ", ".join(
+                        str(job_id)
+                        for job_id in sorted(missing_job_ids)
+                    )
+                )
+            bulk_results[trigger.kind] = results
+
+    non_bulk_triggers = tuple(
+        trigger
+        for trigger in registry.triggers
+        if trigger.kind not in bulk_results
+    )
+    evaluations: dict[int, FailureGuardEvaluation] = {}
+    for job, context in zip(jobs, contexts, strict=True):
+        results_by_kind = {
+            result.kind: result
+            for result in await async_evaluate_failure_guard_triggers(
+                triggers=non_bulk_triggers,
+                context=context,
+                store=_scheduler_failure_guard_state_store(session, job.id),
+                states=states_by_job[job.id],
+            )
+        }
+        for kind, results in bulk_results.items():
+            results_by_kind[kind] = results[job.id]
+        ordered_results = tuple(
+            results_by_kind[trigger.kind]
+            for trigger in registry.triggers
+        )
+        evaluations[job.id] = await async_evaluate_failure_edges(
+            results=ordered_results,
+            failure_signature=job.failure_signature,
+            last_error=job.last_failure_error,
+            now=now,
+            store=SchedulerFailureGuardStore(
+                session=session,
+                job_id=job.id,
+            ),
+            latch_new_edges=False,
+            latches=latches_by_job[job.id],
+        )
+    return evaluations
 
 
 async def async_read_scheduler_failure_guard(

--- a/brain/app/scheduler/scheduler_failure_guard.py
+++ b/brain/app/scheduler/scheduler_failure_guard.py
@@ -11,7 +11,6 @@ from typing import (
     Protocol,
     Sequence,
     TypeAlias,
-    runtime_checkable,
 )
 
 from sqlalchemy import delete, func, select
@@ -168,20 +167,7 @@ class RollingWindowFailuresTrigger:
         self,
         context: SchedulerFailureGuardLifecycleContext,
     ) -> FailureGuardTriggerResult:
-        count = int(
-            await context.session.scalar(
-                select(func.count())
-                .select_from(SchedulerRun)
-                .where(
-                    SchedulerRun.job_id == context.job.id,
-                    SchedulerRun.status == "settled_failure",
-                    SchedulerRun.started_at
-                    > context.now - timedelta(hours=self.window_hours),
-                )
-            )
-            or 0
-        )
-        return self._result(count)
+        return (await self.evaluate_many((context,)))[context.job.id]
 
     async def evaluate_many(
         self,
@@ -267,7 +253,13 @@ class SchedulerFailureGuardTrigger(
     FailureGuardTrigger[SchedulerFailureGuardLifecycleContext],
     Protocol,
 ):
-    """One stateless scheduler failure trigger."""
+    """One stateless scheduler trigger with mandatory bulk projection."""
+
+    async def evaluate_many(
+        self,
+        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
+    ) -> Mapping[int, FailureGuardTriggerResult]:
+        """Evaluate this trigger for every projected job."""
 
 
 class SchedulerFailureGuardStatefulTrigger(
@@ -276,19 +268,6 @@ class SchedulerFailureGuardStatefulTrigger(
     Protocol,
 ):
     """One state-owning scheduler failure trigger."""
-
-
-@runtime_checkable
-class SchedulerFailureGuardBulkTrigger(Protocol):
-    """A stateless trigger that can batch its catalog projection reads."""
-
-    kind: FailureGuardTriggerKind
-
-    async def evaluate_many(
-        self,
-        contexts: Sequence[SchedulerFailureGuardLifecycleContext],
-    ) -> Mapping[int, FailureGuardTriggerResult]:
-        """Evaluate this trigger for every projected job."""
 
 
 SchedulerRegisteredFailureGuardTrigger: TypeAlias = (
@@ -331,25 +310,61 @@ def scheduler_failure_guard_registry() -> SchedulerFailureGuardRegistry:
     )
 
 
-@dataclass(frozen=True)
+@dataclass
 class SchedulerFailureGuardStore:
     """Persist scheduler trigger latches behind the shared store contract."""
 
     session: AsyncSession
     job_id: int
+    _latches: dict[
+        FailureGuardTriggerKind,
+        SchedulerFailureGuardLatch,
+    ] | None = field(default=None, init=False, repr=False)
+
+    @staticmethod
+    def _statement(job_ids: Sequence[int]):
+        return select(SchedulerFailureGuardLatch).where(
+            SchedulerFailureGuardLatch.job_id.in_(job_ids)
+        )
+
+    @staticmethod
+    def _index_latches(
+        latches: Sequence[SchedulerFailureGuardLatch],
+    ) -> dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch]:
+        return {
+            FailureGuardTriggerKind(latch.trigger_kind): latch
+            for latch in latches
+        }
+
+    @classmethod
+    async def preload_many(
+        cls,
+        session: AsyncSession,
+        job_ids: Sequence[int],
+    ) -> dict[int, SchedulerFailureGuardStore]:
+        """Return per-job stores hydrated by one latch query."""
+        stores = {
+            job_id: cls(session=session, job_id=job_id)
+            for job_id in job_ids
+        }
+        latches_by_job: dict[int, list[SchedulerFailureGuardLatch]] = {
+            job_id: []
+            for job_id in job_ids
+        }
+        result = await session.scalars(cls._statement(job_ids))
+        for latch in result.all():
+            latches_by_job[latch.job_id].append(latch)
+        for job_id, store in stores.items():
+            store._latches = store._index_latches(latches_by_job[job_id])
+        return stores
 
     async def load_latches(
         self,
     ) -> dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch]:
-        result = await self.session.scalars(
-            select(SchedulerFailureGuardLatch).where(
-                SchedulerFailureGuardLatch.job_id == self.job_id,
-            )
-        )
-        return {
-            FailureGuardTriggerKind(latch.trigger_kind): latch
-            for latch in result.all()
-        }
+        if self._latches is None:
+            result = await self.session.scalars(self._statement((self.job_id,)))
+            self._latches = self._index_latches(result.all())
+        return dict(self._latches)
 
     async def create_latch(
         self,
@@ -362,6 +377,8 @@ class SchedulerFailureGuardStore:
             alerted_at=alerted_at,
         )
         self.session.add(latch)
+        if self._latches is not None:
+            self._latches[trigger_kind] = latch
         return latch
 
     async def delete_latch(
@@ -374,71 +391,63 @@ class SchedulerFailureGuardStore:
                 SchedulerFailureGuardLatch.trigger_kind == str(trigger_kind),
             )
         )
+        if self._latches is not None:
+            self._latches.pop(trigger_kind, None)
 
 
-def _scheduler_failure_guard_state_store(
-    session: AsyncSession,
-    job_id: int,
-) -> SqlAlchemyFailureGuardStateStore[SchedulerFailureGuardTriggerState]:
-    return SqlAlchemyFailureGuardStateStore(
-        session=session,
-        statement=select(SchedulerFailureGuardTriggerState).where(
-            SchedulerFailureGuardTriggerState.job_id == job_id
-        ),
-        create_record=lambda trigger_kind, trigger_state: (
-            SchedulerFailureGuardTriggerState(
-                job_id=job_id,
-                trigger_kind=trigger_kind,
-                trigger_state=trigger_state,
-            )
-        ),
-    )
+class SchedulerFailureGuardStateStore(
+    SqlAlchemyFailureGuardStateStore[SchedulerFailureGuardTriggerState]
+):
+    """Persist scheduler trigger state through singular or prehydrated reads."""
 
-
-async def _async_load_scheduler_failure_guard_latches(
-    session: AsyncSession,
-    job_ids: Sequence[int],
-) -> dict[
-    int,
-    dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch],
-]:
-    latches_by_job: dict[
-        int,
-        dict[FailureGuardTriggerKind, SchedulerFailureGuardLatch],
-    ] = {job_id: {} for job_id in job_ids}
-    result = await session.scalars(
-        select(SchedulerFailureGuardLatch).where(
-            SchedulerFailureGuardLatch.job_id.in_(job_ids)
-        )
-    )
-    for latch in result.all():
-        latches_by_job[latch.job_id][
-            FailureGuardTriggerKind(latch.trigger_kind)
-        ] = latch
-    return latches_by_job
-
-
-async def _async_load_scheduler_failure_guard_trigger_states(
-    session: AsyncSession,
-    job_ids: Sequence[int],
-) -> dict[
-    int,
-    dict[FailureGuardTriggerKind, FailureGuardTriggerState],
-]:
-    states_by_job: dict[
-        int,
-        dict[FailureGuardTriggerKind, FailureGuardTriggerState],
-    ] = {job_id: {} for job_id in job_ids}
-    result = await session.scalars(
-        select(SchedulerFailureGuardTriggerState).where(
+    @staticmethod
+    def _statement(job_ids: Sequence[int]):
+        return select(SchedulerFailureGuardTriggerState).where(
             SchedulerFailureGuardTriggerState.job_id.in_(job_ids)
         )
-    )
-    for state in result.all():
-        states_by_job[state.job_id][
-            FailureGuardTriggerKind(state.trigger_kind)
-        ] = dict(state.trigger_state)
-    return states_by_job
+
+    @classmethod
+    def for_job(
+        cls,
+        session: AsyncSession,
+        job_id: int,
+    ) -> SchedulerFailureGuardStateStore:
+        return cls(
+            session=session,
+            statement=cls._statement((job_id,)),
+            create_record=lambda trigger_kind, trigger_state: (
+                SchedulerFailureGuardTriggerState(
+                    job_id=job_id,
+                    trigger_kind=trigger_kind,
+                    trigger_state=trigger_state,
+                )
+            ),
+        )
+
+    @classmethod
+    async def preload_many(
+        cls,
+        session: AsyncSession,
+        job_ids: Sequence[int],
+    ) -> dict[int, SchedulerFailureGuardStateStore]:
+        """Return per-job stores hydrated by one trigger-state query."""
+        stores = {
+            job_id: cls.for_job(session, job_id)
+            for job_id in job_ids
+        }
+        records_by_job: dict[
+            int,
+            list[SchedulerFailureGuardTriggerState],
+        ] = {
+            job_id: []
+            for job_id in job_ids
+        }
+        result = await session.scalars(cls._statement(job_ids))
+        for record in result.all():
+            records_by_job[record.job_id].append(record)
+        for job_id, store in stores.items():
+            store.preload_records(records_by_job[job_id])
+        return stores
 
 
 async def async_read_scheduler_failure_guards(
@@ -465,57 +474,53 @@ async def async_read_scheduler_failure_guards(
         )
         for job in jobs
     )
-    latches_by_job = await _async_load_scheduler_failure_guard_latches(
+    latch_stores = await SchedulerFailureGuardStore.preload_many(
         session,
         job_ids,
     )
-    states_by_job = (
-        await _async_load_scheduler_failure_guard_trigger_states(
-            session,
-            job_ids,
-        )
+    state_stores = await SchedulerFailureGuardStateStore.preload_many(
+        session,
+        job_ids,
     )
 
-    bulk_results: dict[
-        FailureGuardTriggerKind,
-        Mapping[int, FailureGuardTriggerResult],
-    ] = {}
+    results_by_job: dict[
+        int,
+        dict[FailureGuardTriggerKind, FailureGuardTriggerResult],
+    ] = {
+        job_id: {}
+        for job_id in job_ids
+    }
     for trigger in registry.triggers:
         if isinstance(trigger, FailureGuardStatefulTrigger):
             continue
-        if isinstance(trigger, SchedulerFailureGuardBulkTrigger):
-            results = dict(await trigger.evaluate_many(contexts))
-            missing_job_ids = set(job_ids).difference(results)
-            if missing_job_ids:
-                raise ValueError(
-                    f"Bulk scheduler trigger {trigger.kind} omitted jobs: "
-                    + ", ".join(
-                        str(job_id)
-                        for job_id in sorted(missing_job_ids)
-                    )
+        trigger_results = dict(await trigger.evaluate_many(contexts))
+        missing_job_ids = set(job_ids).difference(trigger_results)
+        if missing_job_ids:
+            raise ValueError(
+                f"Bulk scheduler trigger {trigger.kind} omitted jobs: "
+                + ", ".join(
+                    str(job_id)
+                    for job_id in sorted(missing_job_ids)
                 )
-            bulk_results[trigger.kind] = results
+            )
+        for job_id in job_ids:
+            results_by_job[job_id][trigger.kind] = trigger_results[job_id]
 
-    non_bulk_triggers = tuple(
+    stateful_triggers = tuple(
         trigger
         for trigger in registry.triggers
-        if trigger.kind not in bulk_results
+        if isinstance(trigger, FailureGuardStatefulTrigger)
     )
     evaluations: dict[int, FailureGuardEvaluation] = {}
     for job, context in zip(jobs, contexts, strict=True):
-        results_by_kind = {
-            result.kind: result
-            for result in await async_evaluate_failure_guard_triggers(
-                triggers=non_bulk_triggers,
-                context=context,
-                store=_scheduler_failure_guard_state_store(session, job.id),
-                states=states_by_job[job.id],
-            )
-        }
-        for kind, results in bulk_results.items():
-            results_by_kind[kind] = results[job.id]
+        for result in await async_evaluate_failure_guard_triggers(
+            triggers=stateful_triggers,
+            context=context,
+            store=state_stores[job.id],
+        ):
+            results_by_job[job.id][result.kind] = result
         ordered_results = tuple(
-            results_by_kind[trigger.kind]
+            results_by_job[job.id][trigger.kind]
             for trigger in registry.triggers
         )
         evaluations[job.id] = await async_evaluate_failure_edges(
@@ -523,12 +528,8 @@ async def async_read_scheduler_failure_guards(
             failure_signature=job.failure_signature,
             last_error=job.last_failure_error,
             now=now,
-            store=SchedulerFailureGuardStore(
-                session=session,
-                job_id=job.id,
-            ),
+            store=latch_stores[job.id],
             latch_new_edges=False,
-            latches=latches_by_job[job.id],
         )
     return evaluations
 
@@ -540,29 +541,14 @@ async def async_read_scheduler_failure_guard(
     now: datetime | None = None,
     registry: SchedulerFailureGuardRegistry | None = None,
 ) -> FailureGuardEvaluation:
-    """Evaluate scheduler triggers and read their durable latch edges."""
-    now = ensure_utc(now)
-    registry = registry or scheduler_failure_guard_registry()
-    latch_store = SchedulerFailureGuardStore(session=session, job_id=job.id)
-    context = SchedulerFailureGuardLifecycleContext(
-        session=session,
-        job=job,
+    """Evaluate one scheduler guard through the canonical bulk reader."""
+    evaluations = await async_read_scheduler_failure_guards(
+        session,
+        (job,),
         now=now,
-        record=None,
+        registry=registry,
     )
-    results = await async_evaluate_failure_guard_triggers(
-        triggers=registry.triggers,
-        context=context,
-        store=_scheduler_failure_guard_state_store(session, job.id),
-    )
-    return await async_evaluate_failure_edges(
-        results=results,
-        failure_signature=job.failure_signature,
-        last_error=job.last_failure_error,
-        now=now,
-        store=latch_store,
-        latch_new_edges=False,
-    )
+    return evaluations[job.id]
 
 
 async def async_record_scheduler_job_failure(
@@ -593,7 +579,10 @@ async def async_record_scheduler_job_failure(
         session=session,
         job_id=locked_job.id,
     )
-    state_store = _scheduler_failure_guard_state_store(session, locked_job.id)
+    state_store = SchedulerFailureGuardStateStore.for_job(
+        session,
+        locked_job.id,
+    )
     context = SchedulerFailureGuardLifecycleContext(
         session=session,
         job=locked_job,
@@ -664,7 +653,10 @@ async def async_reset_scheduler_job_failure_guard(
         session=session,
         job_id=locked_job.id,
     )
-    state_store = _scheduler_failure_guard_state_store(session, locked_job.id)
+    state_store = SchedulerFailureGuardStateStore.for_job(
+        session,
+        locked_job.id,
+    )
     context = SchedulerFailureGuardLifecycleContext(
         session=session,
         job=locked_job,

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -173,16 +173,25 @@ async def async_evaluate_failure_guard_triggers(
     ],
     context: FailureGuardContextT,
     store: FailureGuardStateStore,
+    states: Mapping[
+        FailureGuardTriggerKind,
+        FailureGuardTriggerState,
+    ]
+    | None = None,
 ) -> tuple[FailureGuardTriggerResult, ...]:
     """Evaluate registered triggers through their declared public contract."""
-    states = dict(await store.load_trigger_states())
+    loaded_states = dict(
+        await store.load_trigger_states()
+        if states is None
+        else states
+    )
     results: list[FailureGuardTriggerResult] = []
     for trigger in triggers:
         if isinstance(trigger, FailureGuardStatefulTrigger):
             results.append(
                 await trigger.evaluate_with_state(
                     context,
-                    state=dict(states.get(trigger.kind, {})),
+                    state=dict(loaded_states.get(trigger.kind, {})),
                 )
             )
         else:
@@ -294,20 +303,29 @@ async def async_evaluate_failure_edges(
     now: datetime,
     store: FailureGuardStore,
     latch_new_edges: bool,
+    latches: Mapping[
+        FailureGuardTriggerKind,
+        FailureGuardLatch,
+    ]
+    | None = None,
 ) -> FailureGuardEvaluation:
     """Apply durable latches to caller-evaluated trigger results."""
     kinds = [str(result.kind) for result in results]
     if len(kinds) != len(set(kinds)):
         raise ValueError("Failure-guard trigger kinds must be unique")
 
-    latches = dict(await store.load_latches())
+    loaded_latches = dict(
+        await store.load_latches()
+        if latches is None
+        else latches
+    )
     edges: list[FailureGuardEdge] = []
     for result in results:
-        latch = latches.get(result.kind)
+        latch = loaded_latches.get(result.kind)
         crossed = latch_new_edges and result.active and latch is None
         if crossed:
             latch = await store.create_latch(result.kind, now)
-            latches[result.kind] = latch
+            loaded_latches[result.kind] = latch
         edges.append(
             FailureGuardEdge(
                 kind=result.kind,

--- a/brain/systems/failure_guard/core.py
+++ b/brain/systems/failure_guard/core.py
@@ -173,25 +173,16 @@ async def async_evaluate_failure_guard_triggers(
     ],
     context: FailureGuardContextT,
     store: FailureGuardStateStore,
-    states: Mapping[
-        FailureGuardTriggerKind,
-        FailureGuardTriggerState,
-    ]
-    | None = None,
 ) -> tuple[FailureGuardTriggerResult, ...]:
     """Evaluate registered triggers through their declared public contract."""
-    loaded_states = dict(
-        await store.load_trigger_states()
-        if states is None
-        else states
-    )
+    states = dict(await store.load_trigger_states())
     results: list[FailureGuardTriggerResult] = []
     for trigger in triggers:
         if isinstance(trigger, FailureGuardStatefulTrigger):
             results.append(
                 await trigger.evaluate_with_state(
                     context,
-                    state=dict(loaded_states.get(trigger.kind, {})),
+                    state=dict(states.get(trigger.kind, {})),
                 )
             )
         else:
@@ -303,29 +294,20 @@ async def async_evaluate_failure_edges(
     now: datetime,
     store: FailureGuardStore,
     latch_new_edges: bool,
-    latches: Mapping[
-        FailureGuardTriggerKind,
-        FailureGuardLatch,
-    ]
-    | None = None,
 ) -> FailureGuardEvaluation:
     """Apply durable latches to caller-evaluated trigger results."""
     kinds = [str(result.kind) for result in results]
     if len(kinds) != len(set(kinds)):
         raise ValueError("Failure-guard trigger kinds must be unique")
 
-    loaded_latches = dict(
-        await store.load_latches()
-        if latches is None
-        else latches
-    )
+    latches = dict(await store.load_latches())
     edges: list[FailureGuardEdge] = []
     for result in results:
-        latch = loaded_latches.get(result.kind)
+        latch = latches.get(result.kind)
         crossed = latch_new_edges and result.active and latch is None
         if crossed:
             latch = await store.create_latch(result.kind, now)
-            loaded_latches[result.kind] = latch
+            latches[result.kind] = latch
         edges.append(
             FailureGuardEdge(
                 kind=result.kind,

--- a/brain/systems/failure_guard/state_repository.py
+++ b/brain/systems/failure_guard/state_repository.py
@@ -1,7 +1,7 @@
 """Shared SQLAlchemy repository for failure-guard trigger state."""
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 import json
 from typing import Generic, Protocol, TypeVar, cast
@@ -49,15 +49,27 @@ class SqlAlchemyFailureGuardStateStore(Generic[RecordT]):
         init=False,
     )
 
+    @staticmethod
+    def _index_records(
+        records: Iterable[RecordT],
+    ) -> dict[FailureGuardTriggerKind, RecordT]:
+        return {
+            FailureGuardTriggerKind(record.trigger_kind): record
+            for record in records
+        }
+
+    def preload_records(self, records: Iterable[RecordT]) -> None:
+        """Hydrate this store from a repository-owned bulk read."""
+        if self._records is not None:
+            raise RuntimeError("Failure-guard trigger states are already loaded")
+        self._records = self._index_records(records)
+
     async def _load_records(
         self,
     ) -> dict[FailureGuardTriggerKind, RecordT]:
         if self._records is None:
             result = await self.session.scalars(self.statement)
-            self._records = {
-                FailureGuardTriggerKind(record.trigger_kind): record
-                for record in result.all()
-            }
+            self._records = self._index_records(result.all())
         return self._records
 
     async def load_trigger_states(

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -30,6 +30,8 @@ from brain.app.scheduler.programs import nightly_heuristic_review_command
 from brain.app.scheduler.runtime import RUN_STATUS_SETTLED_SUCCESS
 from brain.app.scheduler.executor import async_run_scheduler_run
 from brain.platform.db.models.scheduler import (
+    SchedulerFailureGuardLatch,
+    SchedulerFailureGuardTriggerState,
     SchedulerRun,
 )
 from tests.scheduler_test_support import (
@@ -61,6 +63,154 @@ RuntimeError: worker=<Worker object at 0x8e23cd01> coroutine=<coroutine object r
 """
 
     assert scheduler_failure_signature(first) == scheduler_failure_signature(second)
+
+
+async def test_health_projection_preserves_each_jobs_latches_and_trigger_output(
+    session,
+    monkeypatch,
+):
+    monkeypatch.setenv("SCHEDULER_FAILURE_ALERT_THRESHOLD", "3")
+    monkeypatch.setenv("SCHEDULER_FAILURE_RATE_THRESHOLD", "2")
+    monkeypatch.setenv("SCHEDULER_FAILURE_RATE_WINDOW_HOURS", "24")
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
+    consecutive_alerted_at = now - timedelta(hours=2)
+    rolling_alerted_at = now - timedelta(hours=1)
+    consecutive_job = _make_scheduler_job(
+        job_key="consecutive_failure",
+        family="consecutive_failure",
+        failure_signature="consecutive-signature",
+        last_failure_error="RuntimeError: repeated failure",
+        next_run_at=now + timedelta(hours=1),
+    )
+    rolling_job = _make_scheduler_job(
+        job_key="rolling_failure",
+        family="rolling_failure",
+        failure_signature="rolling-signature",
+        last_failure_error="TimeoutError: intermittent failure",
+        next_run_at=now + timedelta(hours=2),
+    )
+    session.add_all([consecutive_job, rolling_job])
+    await session.flush()
+    session.add_all(
+        [
+            SchedulerFailureGuardTriggerState(
+                job_id=consecutive_job.id,
+                trigger_kind="consecutive",
+                trigger_state={"count": 3},
+            ),
+            SchedulerFailureGuardTriggerState(
+                job_id=rolling_job.id,
+                trigger_kind="consecutive",
+                trigger_state={"count": 1},
+            ),
+            SchedulerFailureGuardLatch(
+                job_id=consecutive_job.id,
+                trigger_kind="consecutive",
+                alerted_at=consecutive_alerted_at,
+            ),
+            SchedulerFailureGuardLatch(
+                job_id=rolling_job.id,
+                trigger_kind="rolling_window",
+                alerted_at=rolling_alerted_at,
+            ),
+        ]
+    )
+    for job, offset in (
+        (consecutive_job, 3),
+        (rolling_job, 4),
+        (rolling_job, 5),
+    ):
+        started_at = now - timedelta(hours=offset)
+        session.add(
+            SchedulerRun(
+                job_id=job.id,
+                scheduled_for=started_at,
+                window_start=started_at,
+                window_end=started_at + timedelta(hours=1),
+                status="settled_failure",
+                idempotency_key=f"projection-pin:{job.id}:{offset}",
+                started_at=started_at,
+                finished_at=started_at,
+            )
+        )
+    await session.flush()
+
+    snapshot = await async_scheduler_health_snapshot(session, now=now)
+    guards = {
+        job["job_key"]: job["failure_guard"]
+        for job in snapshot["jobs"]
+    }
+
+    assert guards == {
+        "consecutive_failure": {
+            "failure_signature": "consecutive-signature",
+            "last_error": "RuntimeError: repeated failure",
+            "triggers": [
+                {
+                    "kind": "consecutive",
+                    "count": 3,
+                    "threshold": 3,
+                    "window_hours": None,
+                    "alerted_at": consecutive_alerted_at.replace(
+                        tzinfo=None
+                    ).isoformat(),
+                    "crossed": False,
+                },
+                {
+                    "kind": "rolling_window",
+                    "count": 1,
+                    "threshold": 2,
+                    "window_hours": 24,
+                    "alerted_at": None,
+                    "crossed": False,
+                },
+            ],
+        },
+        "rolling_failure": {
+            "failure_signature": "rolling-signature",
+            "last_error": "TimeoutError: intermittent failure",
+            "triggers": [
+                {
+                    "kind": "consecutive",
+                    "count": 1,
+                    "threshold": 3,
+                    "window_hours": None,
+                    "alerted_at": None,
+                    "crossed": False,
+                },
+                {
+                    "kind": "rolling_window",
+                    "count": 2,
+                    "threshold": 2,
+                    "window_hours": 24,
+                    "alerted_at": rolling_alerted_at.replace(
+                        tzinfo=None
+                    ).isoformat(),
+                    "crossed": False,
+                },
+            ],
+        },
+    }
+    assert snapshot["alerts"] == [
+        {
+            "type": "scheduler_job_failure_guard",
+            "job_key": "consecutive_failure",
+            "failure_signature": "consecutive-signature",
+            "last_error": "RuntimeError: repeated failure",
+            "triggers": [
+                guards["consecutive_failure"]["triggers"][0],
+            ],
+        },
+        {
+            "type": "scheduler_job_failure_guard",
+            "job_key": "rolling_failure",
+            "failure_signature": "rolling-signature",
+            "last_error": "TimeoutError: intermittent failure",
+            "triggers": [
+                guards["rolling_failure"]["triggers"][1],
+            ],
+        },
+    ]
 
 
 async def test_scheduler_failure_alert_bytes_are_unchanged_through_shared_delivery(

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -8,9 +8,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import event
 
 import brain.app.scheduler.executor as scheduler_executor
 import brain.app.scheduler.scheduler_failure_guard as scheduler_failure_guard
+from brain.app.scheduler.catalog import async_list_scheduler_jobs
 from brain.app.scheduler.daemon import (
     async_scheduler_health_snapshot,
 )
@@ -211,6 +213,73 @@ async def test_health_projection_preserves_each_jobs_latches_and_trigger_output(
             ],
         },
     ]
+
+
+async def test_catalog_projection_batches_failure_guard_queries_across_jobs(
+    session,
+    monkeypatch,
+):
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        scheduler_failure_guard,
+        "_FAILURE_GUARD_TRIGGER_PROVIDERS",
+        (
+            *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
+            lambda: _RuntimeDurationTrigger(
+                minimum_runtime_minutes=30
+            ),
+        ),
+    )
+    session.add_all(
+        [
+            _make_scheduler_job(
+                job_key=f"batch-query-{index}",
+                family=f"batch-query-{index}",
+                last_started_at=now - timedelta(minutes=index),
+                next_run_at=now + timedelta(hours=index),
+            )
+            for index in range(1, 4)
+        ]
+    )
+    await session.flush()
+    statements: list[str] = []
+
+    def capture_statement(
+        conn,
+        cursor,
+        statement,
+        parameters,
+        context,
+        executemany,
+    ):
+        del conn, cursor, parameters, context, executemany
+        statements.append(statement)
+
+    engine = session.get_bind()
+    event.listen(engine, "before_cursor_execute", capture_statement)
+    try:
+        jobs = await async_list_scheduler_jobs(session, now=now)
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_statement)
+
+    assert len(jobs) == 3
+    assert all(
+        len(job["failure_guard"]["triggers"]) == 3
+        for job in jobs
+    )
+    guard_queries = {
+        table: sum(table in statement for statement in statements)
+        for table in (
+            "scheduler_failure_guard_trigger_states",
+            "scheduler_runs",
+            "scheduler_failure_guard_latches",
+        )
+    }
+    assert guard_queries == {
+        "scheduler_failure_guard_trigger_states": 1,
+        "scheduler_runs": 1,
+        "scheduler_failure_guard_latches": 1,
+    }
 
 
 async def test_scheduler_failure_alert_bytes_are_unchanged_through_shared_delivery(

--- a/tests/test_scheduler_failure_guard.py
+++ b/tests/test_scheduler_failure_guard.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy import event
+from sqlalchemy import event, select
 
 import brain.app.scheduler.executor as scheduler_executor
 import brain.app.scheduler.scheduler_failure_guard as scheduler_failure_guard
@@ -34,6 +34,7 @@ from brain.app.scheduler.executor import async_run_scheduler_run
 from brain.platform.db.models.scheduler import (
     SchedulerFailureGuardLatch,
     SchedulerFailureGuardTriggerState,
+    SchedulerJob,
     SchedulerRun,
 )
 from tests.scheduler_test_support import (
@@ -215,33 +216,7 @@ async def test_health_projection_preserves_each_jobs_latches_and_trigger_output(
     ]
 
 
-async def test_catalog_projection_batches_failure_guard_queries_across_jobs(
-    session,
-    monkeypatch,
-):
-    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
-    monkeypatch.setattr(
-        scheduler_failure_guard,
-        "_FAILURE_GUARD_TRIGGER_PROVIDERS",
-        (
-            *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
-            lambda: _RuntimeDurationTrigger(
-                minimum_runtime_minutes=30
-            ),
-        ),
-    )
-    session.add_all(
-        [
-            _make_scheduler_job(
-                job_key=f"batch-query-{index}",
-                family=f"batch-query-{index}",
-                last_started_at=now - timedelta(minutes=index),
-                next_run_at=now + timedelta(hours=index),
-            )
-            for index in range(1, 4)
-        ]
-    )
-    await session.flush()
+async def _list_scheduler_jobs_with_statement_count(session, *, now):
     statements: list[str] = []
 
     def capture_statement(
@@ -261,25 +236,94 @@ async def test_catalog_projection_batches_failure_guard_queries_across_jobs(
         jobs = await async_list_scheduler_jobs(session, now=now)
     finally:
         event.remove(engine, "before_cursor_execute", capture_statement)
+    return jobs, len(statements)
 
-    assert len(jobs) == 3
-    assert all(
-        len(job["failure_guard"]["triggers"]) == 3
-        for job in jobs
-    )
-    guard_queries = {
-        table: sum(table in statement for statement in statements)
-        for table in (
-            "scheduler_failure_guard_trigger_states",
-            "scheduler_runs",
-            "scheduler_failure_guard_latches",
+
+async def test_catalog_projection_batches_failure_guard_queries_across_jobs(
+    session,
+):
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
+    session.add(
+        _make_scheduler_job(
+            job_key="batch-query-1",
+            family="batch-query-1",
+            last_started_at=now - timedelta(minutes=1),
+            next_run_at=now + timedelta(hours=1),
         )
-    }
-    assert guard_queries == {
-        "scheduler_failure_guard_trigger_states": 1,
-        "scheduler_runs": 1,
-        "scheduler_failure_guard_latches": 1,
-    }
+    )
+    await session.flush()
+    single_job_projection, single_job_statements = (
+        await _list_scheduler_jobs_with_statement_count(session, now=now)
+    )
+
+    session.add_all(
+        [
+            _make_scheduler_job(
+                job_key=f"batch-query-{index}",
+                family=f"batch-query-{index}",
+                last_started_at=now - timedelta(minutes=index),
+                next_run_at=now + timedelta(hours=index),
+            )
+            for index in range(2, 5)
+        ]
+    )
+    await session.flush()
+    several_job_projection, several_job_statements = (
+        await _list_scheduler_jobs_with_statement_count(session, now=now)
+    )
+
+    assert len(single_job_projection) == 1
+    assert len(several_job_projection) == 4
+    assert all(
+        len(job["failure_guard"]["triggers"]) == 2
+        for job in several_job_projection
+    )
+    assert single_job_statements == several_job_statements == 4
+
+
+async def test_registered_database_trigger_projects_once_across_jobs(
+    session,
+    monkeypatch,
+):
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc)
+    database_trigger = _DatabaseBackedTrigger(projected_job_counts=[])
+    monkeypatch.setattr(
+        scheduler_failure_guard,
+        "_FAILURE_GUARD_TRIGGER_PROVIDERS",
+        (
+            *scheduler_failure_guard._FAILURE_GUARD_TRIGGER_PROVIDERS,
+            lambda: database_trigger,
+        ),
+    )
+    session.add(
+        _make_scheduler_job(
+            job_key="database-trigger-query-1",
+            family="database-trigger-query-1",
+            next_run_at=now + timedelta(hours=1),
+        )
+    )
+    await session.flush()
+    _, single_job_statements = (
+        await _list_scheduler_jobs_with_statement_count(session, now=now)
+    )
+
+    session.add_all(
+        [
+            _make_scheduler_job(
+                job_key=f"database-trigger-query-{index}",
+                family=f"database-trigger-query-{index}",
+                next_run_at=now + timedelta(hours=index),
+            )
+            for index in range(2, 5)
+        ]
+    )
+    await session.flush()
+    _, several_job_statements = (
+        await _list_scheduler_jobs_with_statement_count(session, now=now)
+    )
+
+    assert single_job_statements == several_job_statements == 5
+    assert database_trigger.projected_job_counts == [1, 4]
 
 
 async def test_scheduler_failure_alert_bytes_are_unchanged_through_shared_delivery(
@@ -888,6 +932,55 @@ async def test_consecutive_and_rate_edges_coexist_without_duplicate_delivery(
     ] == ["consecutive", "rolling_window"]
 
 
+_DATABASE_BACKED_TRIGGER_KIND = FailureGuardTriggerKind("database_backed")
+
+
+@dataclass(frozen=True)
+class _DatabaseBackedTrigger:
+    """A proof trigger whose facts require one database projection."""
+
+    projected_job_counts: list[int]
+    kind: FailureGuardTriggerKind = field(
+        default=_DATABASE_BACKED_TRIGGER_KIND,
+        init=False,
+    )
+
+    async def evaluate(self, context) -> FailureGuardTriggerResult:
+        return (await self.evaluate_many((context,)))[context.job.id]
+
+    async def evaluate_many(self, contexts):
+        self.projected_job_counts.append(len(contexts))
+        if not contexts:
+            return {}
+        session = contexts[0].session
+        job_ids = [context.job.id for context in contexts]
+        result = await session.scalars(
+            select(SchedulerJob.id).where(SchedulerJob.id.in_(job_ids))
+        )
+        loaded_job_ids = set(result.all())
+        return {
+            context.job.id: FailureGuardTriggerResult(
+                kind=self.kind,
+                active=context.job.id in loaded_job_ids,
+                public_details={
+                    "database_row_loaded": context.job.id in loaded_job_ids,
+                },
+                alert_title="Scheduler job row loaded",
+                alert_summary="Scheduler job exists in the projection",
+            )
+            for context in contexts
+        }
+
+    async def should_reset(
+        self,
+        context,
+        *,
+        event: SchedulerFailureGuardResetEvent,
+    ) -> bool:
+        del context, event
+        return True
+
+
 _RUNTIME_DURATION_TRIGGER_KIND = FailureGuardTriggerKind("runtime_duration")
 
 
@@ -905,6 +998,15 @@ class _RuntimeDurationTrigger:
         self,
         context,
     ) -> FailureGuardTriggerResult:
+        return (await self.evaluate_many((context,)))[context.job.id]
+
+    async def evaluate_many(self, contexts):
+        return {
+            context.job.id: self._result(context)
+            for context in contexts
+        }
+
+    def _result(self, context) -> FailureGuardTriggerResult:
         assert context.job.last_started_at is not None
         started_at = context.job.last_started_at
         if started_at.tzinfo is None:


### PR DESCRIPTION
Closes #539.

## What it does

After #499 normalized the failure-guard latches and #559 gave triggers mutable persisted state, the catalog and health paths loaded latches and ran every trigger's counter **per job, sequentially** — `jobs × triggers` queries. The normalization made the guard extensible; this is the bill that extensibility was sending on every health projection.

**Before: `1 + 3N`.** **After: a constant 4**, independent of job count.

The more important half is what it prevents. A **DB-backed trigger** now also runs once for the whole job set instead of once per job — measured at **5 statements for 1 job and 5 for 4 jobs**, where the pre-fix shape scaled 5 → 8. Bulk evaluation is now *mandatory* for registered stateless triggers, so a new trigger cannot silently reintroduce per-job scaling.

## How to check it (no diff reading required)

```
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-539-fix1 && ../../illospace-project/venv/bin/python -m pytest tests/ -q
```

**4444 passed / 85 skipped / 0 failed**, run outside the Codex sandbox. (Inside it, 6 unrelated tests fail on `bind(127.0.0.1)` — a sandbox restriction, not this change.)

### Acceptance checks
1. **Latch semantics and alert output are unchanged** — pinned by a test committed *before* the optimization, asserting literal serialized guards, latch timestamps, ordering, `crossed`, and health-alert payloads. It passes untouched through the new path.
2. **Constant scaling, measured on totals**: 1 job vs 4 jobs issue the same number of statements — for the default registry (4 vs 4) *and* for an added DB-backed trigger (5 vs 5).
3. A DB-backed trigger registered through the canonical bulk contract executes **once** regardless of job count.
4. Cycle behaviour is unchanged — `cycle_failure_guard.py` shares this core and was deliberately left untouched.

## What the code-quality review changed

The first version optimized the happy path but left the old one standing, which would have quietly undone the ticket:

- **The per-job implementation survived.** `RollingWindowFailuresTrigger` had two SQL implementations of the same count predicate; the reader discovered `evaluate_many()` *dynamically* and silently fell back to per-job evaluation, and the bulk trigger type sat outside the registered-trigger contract — so a valid new DB-backed trigger could restore N-queries-per-job without breaking any API. Now `evaluate()` delegates to `evaluate_many()`, one predicate and one `WHERE` clause, with capability detection and fallback deleted.
- **`core.py` had grown a dual-mode acquisition API** (`states=None` ⇒ use the store; mappings supplied ⇒ bypass the mandatory store), with the store's SQL and row-to-kind conversion duplicated in the scheduler. That is a seam where a future persistence fix lands in one path and is missed by the other. Resolved by batch-loading into **prehydrated per-job stores**, after which core always calls `store.load_*()` — `core.py` ends up **completely unchanged** by this PR, and stores keep sole ownership of that SQL.
- **The query test could not catch its own regression.** It counted statements against three hard-coded table names, so a new trigger querying a *different* table per job passed unchanged. It now measures totals for 1 vs several jobs and proves a DB-backed trigger runs once.

## Merge notes

- Cuts cleanly against current `main` (`f24f4cae`, post-#580/#582).
- Touches no file owned by an open PR. Test-merged with #579 and #581 on current `main`: clean, **4466 passed / 0 failed**.

<sub>Opened as a draft by Routine R3. Not for merge until Reda reviews.</sub>
