### PR TITLE
feat(knowledge): distill conversational sources

### DIFF
--- a/brain/app/api/routers/agent_mcp.py
+++ b/brain/app/api/routers/agent_mcp.py
@@ -935,6 +935,7 @@ async def _tool_read(
                 "query",
                 capability=capability,
             ),
+            org_id=principal.org_id,
             sources=_clean_string_list(capability_arguments.get("sources")),
             kinds=_clean_string_list(capability_arguments.get("kinds")),
             limit=int(capability_arguments.get("limit") or 10),

--- a/brain/jobs/pipelines/knowledge_index_sync.py
+++ b/brain/jobs/pipelines/knowledge_index_sync.py
@@ -13,6 +13,7 @@ from brain.systems.knowledge.connectors import (
     DomainRecordsConnector,
     GitHubConnector,
     MemoryConnector,
+    SlackKnowledgeConnector,
 )
 from brain.systems.knowledge.connectors.base import KnowledgeConnector
 from brain.systems.knowledge.service import sync_connector
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 CONNECTOR_FACTORIES: tuple[Callable[[], KnowledgeConnector], ...] = (
     DomainRecordsConnector,
     GitHubConnector,
+    SlackKnowledgeConnector,
     MemoryConnector,
 )
 

--- a/brain/jobs/pipelines/knowledge_index_sync.py
+++ b/brain/jobs/pipelines/knowledge_index_sync.py
@@ -9,7 +9,11 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.knowledge.connectors import DomainRecordsConnector, GitHubConnector
+from brain.systems.knowledge.connectors import (
+    DomainRecordsConnector,
+    GitHubConnector,
+    MemoryConnector,
+)
 from brain.systems.knowledge.connectors.base import KnowledgeConnector
 from brain.systems.knowledge.service import sync_connector
 
@@ -18,6 +22,7 @@ logger = logging.getLogger(__name__)
 CONNECTOR_FACTORIES: tuple[Callable[[], KnowledgeConnector], ...] = (
     DomainRecordsConnector,
     GitHubConnector,
+    MemoryConnector,
 )
 
 

--- a/brain/systems/knowledge/connectors/__init__.py
+++ b/brain/systems/knowledge/connectors/__init__.py
@@ -2,5 +2,6 @@
 
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector
+from brain.systems.knowledge.connectors.memory import MemoryConnector
 
-__all__ = ["DomainRecordsConnector", "GitHubConnector"]
+__all__ = ["DomainRecordsConnector", "GitHubConnector", "MemoryConnector"]

--- a/brain/systems/knowledge/connectors/__init__.py
+++ b/brain/systems/knowledge/connectors/__init__.py
@@ -3,5 +3,11 @@
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector
 from brain.systems.knowledge.connectors.memory import MemoryConnector
+from brain.systems.knowledge.connectors.slack import SlackKnowledgeConnector
 
-__all__ = ["DomainRecordsConnector", "GitHubConnector", "MemoryConnector"]
+__all__ = [
+    "DomainRecordsConnector",
+    "GitHubConnector",
+    "MemoryConnector",
+    "SlackKnowledgeConnector",
+]

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
+import logging
 import re
 from typing import Any
 
@@ -18,6 +20,8 @@ from brain.platform.db.models.idea import ProjectProfile
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.systems.cortex.project_context.github import (
+    GithubIssueClosure,
+    async_get_issue_closure_info,
     async_list_repo_issues,
     parse_github_repo_slug,
 )
@@ -34,6 +38,15 @@ _READ_PERMISSIONS = {
     "issues": "read",
     "pull_requests": "read",
 }
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _GitHubAuthority:
+    token: str | None
+    org_id: str | None
+    actor_user_id: str | None
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -111,7 +124,7 @@ async def _configured_repositories(session: AsyncSession) -> list[str]:
     return repositories
 
 
-async def _github_token(session: AsyncSession, repo: str) -> str | None:
+async def _github_authority(session: AsyncSession, repo: str) -> _GitHubAuthority:
     binding = await session.scalar(
         select(VaultProjectBinding)
         .join(Secret, Secret.id == VaultProjectBinding.secret_id)
@@ -124,7 +137,7 @@ async def _github_token(session: AsyncSession, repo: str) -> str | None:
         .limit(1)
     )
     if binding is None:
-        return None
+        return _GitHubAuthority(token=None, org_id=None, actor_user_id=None)
     actor = None
     if binding.created_by_user_id:
         actor = await session.get(User, str(binding.created_by_user_id))
@@ -138,7 +151,11 @@ async def _github_token(session: AsyncSession, repo: str) -> str | None:
             )
         ).first()
     if actor is None:
-        return None
+        return _GitHubAuthority(
+            token=None,
+            org_id=str(binding.org_id),
+            actor_user_id=None,
+        )
     env = await async_resolve_project_bound_env_tokens(
         actor_user_id=str(actor.id),
         org_id=str(actor.org_id),
@@ -149,11 +166,30 @@ async def _github_token(session: AsyncSession, repo: str) -> str | None:
     for key in ("GITHUB_TOKEN", "GH_TOKEN"):
         token = str(env.get(key) or "").strip()
         if token:
-            return token
-    return next((str(value).strip() for value in env.values() if str(value).strip()), None)
+            return _GitHubAuthority(
+                token=token,
+                org_id=str(actor.org_id),
+                actor_user_id=str(actor.id),
+            )
+    token = next(
+        (str(value).strip() for value in env.values() if str(value).strip()),
+        None,
+    )
+    return _GitHubAuthority(
+        token=token,
+        org_id=str(actor.org_id),
+        actor_user_id=str(actor.id),
+    )
 
 
-def _draft_for_issue(repo: str, issue: Mapping[str, Any]) -> KnowledgeDraft:
+def _draft_for_issue(
+    repo: str,
+    issue: Mapping[str, Any],
+    *,
+    closure: GithubIssueClosure | None = None,
+    org_id: str | None = None,
+    actor_user_id: str | None = None,
+) -> KnowledgeDraft:
     labels = [
         str(label.get("name") or "").strip()
         for label in issue.get("labels") or []
@@ -169,13 +205,49 @@ def _draft_for_issue(repo: str, issue: Mapping[str, Any]) -> KnowledgeDraft:
         summary_prefix += f" Labels: {', '.join(labels)}."
     summary = f"{summary_prefix}\n{body}".strip()
     resolution = None
+    closure_extra: dict[str, Any] = {}
     if state == "closed":
         if kind == "pr" and issue.get("merged_at"):
             resolution = f"Merged at {issue['merged_at']}"
+        elif kind == "issue" and closure is not None:
+            fixing_pull_requests = [
+                {
+                    "repo": fixing.repo,
+                    "number": fixing.number,
+                    "base_ref_name": fixing.base_ref_name,
+                    "merge_commit_sha": fixing.merge_commit_sha,
+                    "merged_at": (
+                        fixing.merged_at.isoformat()
+                        if fixing.merged_at is not None
+                        else None
+                    ),
+                }
+                for fixing in closure.fixing_pull_requests
+            ]
+            closure_extra = {
+                "closed_by": closure.closed_by,
+                "fixing_pull_requests": fixing_pull_requests,
+            }
+            if closure.fixing_pull_requests:
+                fixing = closure.fixing_pull_requests[0]
+                resolution = f"Resolved by merged PR {fixing.canonical_ref}"
+                if fixing.merge_commit_sha:
+                    resolution += f" (commit {fixing.merge_commit_sha})"
+                if fixing.merged_at is not None:
+                    resolution += f" at {fixing.merged_at.isoformat()}"
+            elif closure.closed_at is not None:
+                resolution = f"Closed at {closure.closed_at.isoformat()}"
+            else:
+                resolution = "Closed"
         elif issue.get("closed_at"):
             resolution = f"Closed at {issue['closed_at']}"
         else:
             resolution = "Closed"
+    closure_refs = (
+        [fixing.canonical_ref for fixing in closure.fixing_pull_requests]
+        if closure is not None
+        else []
+    )
     return KnowledgeDraft(
         source="github",
         kind=kind,
@@ -183,7 +255,11 @@ def _draft_for_issue(repo: str, issue: Mapping[str, Any]) -> KnowledgeDraft:
         title=str(issue.get("title") or f"{repo}#{number}"),
         summary=summary,
         resolution=resolution,
-        entities=[*labels, *_linked_references(body, repo)],
+        entities=[
+            *labels,
+            *_linked_references(body, repo),
+            *closure_refs,
+        ],
         raw_text=body,
         extra={
             "repo": repo,
@@ -194,9 +270,13 @@ def _draft_for_issue(repo: str, issue: Mapping[str, Any]) -> KnowledgeDraft:
             "url": issue.get("html_url"),
             "body_truncated": bool(issue.get("body_truncated")),
             "body_total_chars": int(issue.get("body_total_chars") or len(body)),
+            **closure_extra,
+            **({"org_id": org_id} if org_id else {}),
+            **({"actor_user_id": actor_user_id} if actor_user_id else {}),
         },
         source_created_at=_parse_timestamp(issue.get("created_at")),
         source_updated_at=_parse_timestamp(issue.get("updated_at")),
+        distill=True,
     )
 
 
@@ -245,7 +325,8 @@ class GitHubConnector:
             remaining = self.max_items - len(drafts)
             if remaining <= 0:
                 break
-            token = await _github_token(session, repo)
+            authority = await _github_authority(session, repo)
+            token = authority.token
             payload = await async_list_repo_issues(
                 repo,
                 token=token,
@@ -265,7 +346,34 @@ class GitHubConnector:
                 high_key = max(high_key, issue_key)
                 if not state.get("next_page") and state.get("watermark") and issue_key <= watermark_key:
                     continue
-                drafts.append(_draft_for_issue(repo, issue))
+                kind = "pr" if issue.get("type") == "pull_request" else "issue"
+                closure = None
+                if (
+                    str(issue.get("state") or "").lower() == "closed"
+                    and kind == "issue"
+                ):
+                    try:
+                        closure = await async_get_issue_closure_info(
+                            repo,
+                            int(issue.get("number") or 0),
+                            token=token,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "GitHub closure enrichment unavailable for %s#%s: %s",
+                            repo,
+                            issue.get("number"),
+                            exc,
+                        )
+                drafts.append(
+                    _draft_for_issue(
+                        repo,
+                        issue,
+                        closure=closure,
+                        org_id=authority.org_id,
+                        actor_user_id=authority.actor_user_id,
+                    )
+                )
 
             next_page = payload.get("next_page")
             if next_page:

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -188,6 +188,7 @@ def _draft_for_issue(
     issue: Mapping[str, Any],
     *,
     closure: GithubIssueClosure | None = None,
+    closure_unavailable_reason: str | None = None,
     org_id: str | None = None,
     actor_user_id: str | None = None,
 ) -> KnowledgeDraft:
@@ -249,6 +250,11 @@ def _draft_for_issue(
         if closure is not None
         else []
     )
+    if closure_unavailable_reason:
+        closure_extra["closure_enrichment"] = {
+            "status": "unavailable",
+            "reason": closure_unavailable_reason,
+        }
     return KnowledgeDraft(
         source="github",
         kind=kind,
@@ -351,29 +357,40 @@ class GitHubConnector:
                     continue
                 kind = "pr" if issue.get("type") == "pull_request" else "issue"
                 closure = None
+                closure_unavailable_reason = None
                 if (
                     str(issue.get("state") or "").lower() == "closed"
                     and kind == "issue"
                 ):
-                    try:
-                        closure = await async_get_issue_closure_info(
-                            repo,
-                            int(issue.get("number") or 0),
-                            token=token,
-                        )
-                    except Exception as exc:
-                        logger.exception(
-                            "GitHub closure enrichment unavailable for %s#%s: %s",
+                    if not token:
+                        closure_unavailable_reason = "authentication_required"
+                        logger.warning(
+                            "GitHub closure enrichment skipped for %s#%s: "
+                            "authenticated GraphQL access is unavailable",
                             repo,
                             issue.get("number"),
-                            exc,
                         )
-                        raise
+                    else:
+                        try:
+                            closure = await async_get_issue_closure_info(
+                                repo,
+                                int(issue.get("number") or 0),
+                                token=token,
+                            )
+                        except Exception as exc:
+                            logger.exception(
+                                "GitHub closure enrichment unavailable for %s#%s: %s",
+                                repo,
+                                issue.get("number"),
+                                exc,
+                            )
+                            raise
                 drafts.append(
                     _draft_for_issue(
                         repo,
                         issue,
                         closure=closure,
+                        closure_unavailable_reason=closure_unavailable_reason,
                         org_id=authority.org_id,
                         actor_user_id=authority.actor_user_id,
                     )

--- a/brain/systems/knowledge/connectors/github.py
+++ b/brain/systems/knowledge/connectors/github.py
@@ -38,6 +38,7 @@ _READ_PERMISSIONS = {
     "issues": "read",
     "pull_requests": "read",
 }
+_CURSOR_VERSION = 2
 
 logger = logging.getLogger(__name__)
 
@@ -297,9 +298,11 @@ class GitHubConnector:
         session: AsyncSession,
         cursor: dict[str, Any],
     ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        if int(cursor.get("version") or 0) != _CURSOR_VERSION:
+            cursor = {}
         repositories = list(self.repositories or await _configured_repositories(session))
         if not repositories:
-            return [], dict(cursor)
+            return [], {**dict(cursor), "version": _CURSOR_VERSION}
         repo_states = {
             str(key): dict(value)
             for key, value in (cursor.get("repositories") or {}).items()
@@ -359,12 +362,13 @@ class GitHubConnector:
                             token=token,
                         )
                     except Exception as exc:
-                        logger.warning(
+                        logger.exception(
                             "GitHub closure enrichment unavailable for %s#%s: %s",
                             repo,
                             issue.get("number"),
                             exc,
                         )
+                        raise
                 drafts.append(
                     _draft_for_issue(
                         repo,
@@ -384,6 +388,7 @@ class GitHubConnector:
                     "high_watermark_id": high_key[1],
                 }
                 return drafts, {
+                    "version": _CURSOR_VERSION,
                     "active_repository": repo_index,
                     "repositories": repo_states,
                 }
@@ -394,11 +399,13 @@ class GitHubConnector:
             }
             if len(drafts) >= self.max_items:
                 return drafts, {
+                    "version": _CURSOR_VERSION,
                     "active_repository": min(repo_index + 1, len(repositories) - 1),
                     "repositories": repo_states,
                 }
 
         return drafts, {
+            "version": _CURSOR_VERSION,
             "active_repository": 0,
             "repositories": repo_states,
         }

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -95,6 +95,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
             "archived": True,
             "mirror_status": "visibility_withdrawn",
             "node_kind": node.node_kind,
+            "org_id": str(node.org_id) if node.org_id is not None else None,
             "truth_status": node.truth_status,
             "visibility": node.visibility,
         },

--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -1,0 +1,185 @@
+"""Bounded mirror of shared consolidated memory into Illo Knowledge.
+
+Knowledge search does not yet enforce per-user memory visibility.  This
+connector therefore mirrors only ``org`` and ``team`` summaries; private
+memory remains exclusively owned by the memory subsystem until the knowledge
+index has an ACL-aware read path.  The mirror is derived and additive: it reads
+``MemoryNode`` rows and never participates in memory recall or mutation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
+from brain.platform.db.models.knowledge import KnowledgeItem
+from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.systems.knowledge.connectors.base import KnowledgeDraft
+
+_SHARED_VISIBILITIES = ("org", "team")
+
+
+def _cursor_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _draft_for_memory(
+    node: MemoryNode,
+    *,
+    superseded_by: int | None,
+) -> KnowledgeDraft:
+    summary = str(node.text or node.canonical_label).strip()
+    memory_kind = str(node.content_kind or node.node_kind).strip()
+    scope = str(node.scope_key or "default").strip()
+    superseded = node.truth_status == "superseded" or superseded_by is not None
+    archived_at = node.archived_at or (node.updated_at if superseded else None)
+    return KnowledgeDraft(
+        source="memory",
+        kind="memory",
+        source_ref=f"memory_node:{node.id}",
+        title=str(node.canonical_label).strip(),
+        summary=summary,
+        entities=list(dict.fromkeys((memory_kind, scope))),
+        raw_text=summary,
+        extra={
+            "archived": node.archived_at is not None,
+            "consolidated": True,
+            "confidence": float(node.confidence or 0.0),
+            "freshness_status": node.freshness_status,
+            "memory_type": memory_kind,
+            "node_kind": node.node_kind,
+            "org_id": str(node.org_id) if node.org_id is not None else None,
+            "scope": scope,
+            "sensitivity": node.sensitivity,
+            "source_type": "reconstructive_memory_node",
+            "superseded": superseded,
+            "superseded_by": superseded_by,
+            "truth_status": node.truth_status,
+            "visibility": node.visibility,
+        },
+        source_created_at=node.created_at,
+        source_updated_at=node.updated_at,
+        archived_at=archived_at,
+    )
+
+
+def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
+    """Scrub a formerly shared mirror after its source becomes private."""
+
+    return KnowledgeDraft(
+        source="memory",
+        kind="memory",
+        source_ref=f"memory_node:{node.id}",
+        title="Memory no longer shared",
+        summary="This consolidated memory is no longer shared with the workspace.",
+        raw_text="",
+        extra={
+            "archived": True,
+            "mirror_status": "visibility_withdrawn",
+            "node_kind": node.node_kind,
+            "truth_status": node.truth_status,
+            "visibility": node.visibility,
+        },
+        source_created_at=node.created_at,
+        source_updated_at=node.updated_at,
+        archived_at=node.archived_at or node.updated_at,
+    )
+
+
+class MemoryConnector:
+    """Enumerate shared consolidated memory nodes by update watermark."""
+
+    source_key = "memory"
+
+    def __init__(self, *, max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE):
+        self.max_items = max(1, int(max_items))
+
+    async def enumerate_changed(
+        self,
+        session: AsyncSession,
+        cursor: dict[str, Any],
+    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        marker = _cursor_datetime(cursor.get("updated_at"))
+        marker_id = max(0, int(cursor.get("id") or 0))
+        statement = (
+            select(MemoryNode)
+            .where(MemoryNode.node_kind == "summary")
+            .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
+            .limit(self.max_items)
+        )
+        if marker is not None:
+            statement = statement.where(
+                or_(
+                    MemoryNode.updated_at > marker,
+                    and_(
+                        MemoryNode.updated_at == marker,
+                        MemoryNode.id > marker_id,
+                    ),
+                )
+            )
+
+        rows = list((await session.scalars(statement)).all())
+        if not rows:
+            return [], dict(cursor)
+        source_refs = [f"memory_node:{node.id}" for node in rows]
+        existing_refs = set(
+            (
+                await session.scalars(
+                    select(KnowledgeItem.source_ref).where(
+                        KnowledgeItem.source == self.source_key,
+                        KnowledgeItem.source_ref.in_(source_refs),
+                    )
+                )
+            ).all()
+        )
+        supersession_rows = (
+            await session.execute(
+                select(
+                    MemoryEdgeNode.source_node_id,
+                    MemoryEdgeNode.target_node_id,
+                )
+                .where(
+                    MemoryEdgeNode.source_node_id.in_([node.id for node in rows])
+                )
+                .where(MemoryEdgeNode.edge_kind == "superseded_by")
+                .order_by(MemoryEdgeNode.id.asc())
+            )
+        ).all()
+        superseded_by = {
+            source_node_id: target_node_id
+            for source_node_id, target_node_id in supersession_rows
+        }
+        drafts = [
+            _draft_for_memory(node, superseded_by=superseded_by.get(node.id))
+            if node.visibility in _SHARED_VISIBILITIES
+            else _withdrawn_draft(node)
+            for node in rows
+            if node.visibility in _SHARED_VISIBILITIES
+            or f"memory_node:{node.id}" in existing_refs
+        ]
+        last = rows[-1]
+        return drafts, {
+            "updated_at": _utc_iso(last.updated_at),
+            "id": last.id,
+        }
+
+
+__all__ = ["MemoryConnector"]

--- a/brain/systems/knowledge/connectors/slack.py
+++ b/brain/systems/knowledge/connectors/slack.py
@@ -1,0 +1,497 @@
+"""Bounded Slack-thread backfill and event-driven incremental indexing."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+import hashlib
+from typing import Any
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.kernel.config import KNOWLEDGE_CONNECTOR_BATCH_SIZE
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.platform.db.models.inbound import InboundEventRow
+from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.slack.monitored_intakes import visible_slack_content
+from brain.systems.slack.monitors import monitored_channels
+
+
+_CURSOR_VERSION = 1
+_SLACK_MESSAGE_KIND = "slack_message"
+_THREAD_PAGE_SIZE = 200
+
+
+@dataclass(frozen=True, slots=True)
+class _Channel:
+    id: str
+    name: str | None
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _event_cursor_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    return _utc(parsed)
+
+
+def _slack_datetime(value: Any) -> datetime | None:
+    try:
+        timestamp = Decimal(_clean(value))
+    except InvalidOperation:
+        return None
+    seconds = int(timestamp)
+    micros = int((timestamp - seconds) * 1_000_000)
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc).replace(
+            microsecond=micros
+        )
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _slack_timestamp_key(message: Mapping[str, Any]) -> tuple[Decimal, str]:
+    raw = _clean(message.get("ts"))
+    try:
+        return Decimal(raw), raw
+    except InvalidOperation:
+        return Decimal(0), raw
+
+
+def _message_author(message: Mapping[str, Any]) -> str:
+    return _clean(
+        message.get("user")
+        or message.get("bot_id")
+        or message.get("username")
+    ) or "unknown"
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    # Knowledge needs the source text before the shared 20k row bound. The
+    # monitor's default 4k prompt budget is intentionally disabled here.
+    visible = visible_slack_content(message, limit=None)
+    return visible.message_text or visible.block_text
+
+
+def _thread_transcript(messages: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for message in messages:
+        text = _message_text(message)
+        if not text:
+            continue
+        timestamp = _slack_datetime(message.get("ts"))
+        rendered_timestamp = timestamp.isoformat() if timestamp else _clean(message.get("ts"))
+        lines.append(f"[{rendered_timestamp}] {_message_author(message)}: {text}")
+    return "\n".join(lines)
+
+
+def _channel_set_digest(channels: list[_Channel]) -> str:
+    """Bounded marker that restarts backfill when monitor configuration changes."""
+
+    payload = "\n".join(channel.id for channel in channels)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _slack_metadata(connection: ExternalAgentConnectionRow) -> dict[str, Any]:
+    metadata = dict(connection.metadata_ or {})
+    slack = metadata.get("slack")
+    return dict(slack) if isinstance(slack, Mapping) else {}
+
+
+def _team_id(connection: ExternalAgentConnectionRow) -> str:
+    return _clean(_slack_metadata(connection).get("team_id") or connection.remote_agent_id)
+
+
+def _configured_channels(connection: ExternalAgentConnectionRow) -> list[_Channel]:
+    channels = [
+        _Channel(
+            id=_clean(entry.get("channel_id")),
+            name=_clean(entry.get("channel_name")) or None,
+        )
+        for entry in monitored_channels(connection)
+        if entry.get("enabled", True) and _clean(entry.get("channel_id"))
+    ]
+    return sorted(channels, key=lambda channel: channel.id)
+
+
+async def _monitored_connection(
+    session: AsyncSession,
+) -> tuple[ExternalAgentConnectionRow | None, list[_Channel]]:
+    rows = list(
+        (
+            await session.scalars(
+                select(ExternalAgentConnectionRow)
+                .where(
+                    ExternalAgentConnectionRow.agent_kind == "slack",
+                    ExternalAgentConnectionRow.transport == "slack_socket_mode",
+                    ExternalAgentConnectionRow.disabled_at.is_(None),
+                )
+                .order_by(
+                    ExternalAgentConnectionRow.created_at.asc(),
+                    ExternalAgentConnectionRow.id.asc(),
+                )
+            )
+        ).all()
+    )
+    rows.sort(
+        key=lambda connection: (
+            _clean(connection.status) not in {"online", "connected"},
+            connection.created_at,
+            str(connection.id),
+        )
+    )
+    for connection in rows:
+        channels = _configured_channels(connection)
+        if channels:
+            return connection, channels
+    return None, []
+
+
+def _next_cursor(
+    *,
+    connection_id: str,
+    channel_set_digest: str,
+    phase: str,
+    channel_id: str | None,
+    history_cursor: str | None,
+    event_created_at: str | None,
+    event_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "version": _CURSOR_VERSION,
+        "connection_id": connection_id,
+        "channel_set_digest": channel_set_digest,
+        "phase": phase,
+        "channel_id": channel_id,
+        "history_cursor": history_cursor,
+        "event_created_at": event_created_at,
+        "event_id": event_id,
+    }
+
+
+class SlackKnowledgeConnector:
+    """Index monitored Slack channels as complete, replaceable threads.
+
+    A cursor-paged history sweep owns the initial backfill. Once complete,
+    durable Slack inbound events identify changed thread roots; each event
+    causes the canonical parent and every reply to be fetched again. When that
+    event queue is caught up, the same bounded history cursor continuously
+    refreshes monitored channels so message edits and Illo-authored replies that
+    intake intentionally ignores cannot leave the index stale forever.
+    """
+
+    source_key = "slack"
+
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        max_items: int = KNOWLEDGE_CONNECTOR_BATCH_SIZE,
+    ) -> None:
+        self._client = client
+        self.max_items = max(1, int(max_items))
+
+    async def _resolve_client(self, connection: ExternalAgentConnectionRow) -> Any:
+        if self._client is None:
+            from brain.systems.slack.client import slack_web_client_from_runtime
+
+            self._client = await slack_web_client_from_runtime(
+                requested_by="knowledge_index_sync",
+                reason="Backfill and incrementally refresh monitored Slack threads.",
+                org_id=str(connection.org_id),
+                owner_user_id=str(connection.owner_user_id),
+            )
+        return self._client
+
+    async def enumerate_changed(
+        self,
+        session: AsyncSession,
+        cursor: dict[str, Any],
+    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        connection, channels = await _monitored_connection(session)
+        if connection is None:
+            return [], dict(cursor)
+
+        connection_id = str(connection.id)
+        if not _team_id(connection):
+            raise RuntimeError("Monitored Slack connection has no stable team_id")
+        current_channel_set_digest = _channel_set_digest(channels)
+        cursor_is_current = (
+            cursor.get("version") == _CURSOR_VERSION
+            and _clean(cursor.get("connection_id")) == connection_id
+            and _clean(cursor.get("channel_set_digest"))
+            == current_channel_set_digest
+        )
+        state = dict(cursor) if cursor_is_current else _next_cursor(
+            connection_id=connection_id,
+            channel_set_digest=current_channel_set_digest,
+            phase="backfill",
+            channel_id=channels[0].id,
+            history_cursor=None,
+            event_created_at=None,
+            event_id=None,
+        )
+        client = await self._resolve_client(connection)
+        if state.get("phase") != "incremental":
+            return await self._backfill(
+                client=client,
+                connection=connection,
+                channels=channels,
+                state=state,
+            )
+        return await self._incremental(
+            session=session,
+            client=client,
+            connection=connection,
+            channels=channels,
+            state=state,
+        )
+
+    async def _backfill(
+        self,
+        *,
+        client: Any,
+        connection: ExternalAgentConnectionRow,
+        channels: list[_Channel],
+        state: dict[str, Any],
+    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        channel_ids = [channel.id for channel in channels]
+        active_channel = _clean(state.get("channel_id"))
+        try:
+            active_index = channel_ids.index(active_channel)
+        except ValueError:
+            active_index = 0
+        drafts: list[KnowledgeDraft] = []
+        history_cursor = _clean(state.get("history_cursor")) or None
+
+        for channel_index in range(active_index, len(channels)):
+            channel = channels[channel_index]
+            remaining = self.max_items - len(drafts)
+            if remaining <= 0:
+                return drafts, {
+                    **state,
+                    "channel_id": channel.id,
+                    "history_cursor": history_cursor,
+                }
+            payload = await client.conversation_history(
+                channel=channel.id,
+                limit=remaining,
+                cursor=history_cursor,
+            )
+            roots = [
+                dict(message)
+                for message in payload.get("messages") or []
+                if isinstance(message, Mapping) and _clean(message.get("ts"))
+            ]
+            for root in roots[:remaining]:
+                drafts.append(
+                    await self._draft_for_thread(
+                        client=client,
+                        connection=connection,
+                        channel=channel,
+                        thread_ts=_clean(root.get("thread_ts") or root.get("ts")),
+                        root_fallback=root,
+                    )
+                )
+            next_history_cursor = _clean(
+                (payload.get("response_metadata") or {}).get("next_cursor")
+            )
+            if next_history_cursor:
+                return drafts, {
+                    **state,
+                    "channel_id": channel.id,
+                    "history_cursor": next_history_cursor,
+                }
+            history_cursor = None
+            if len(drafts) >= self.max_items and channel_index + 1 < len(channels):
+                return drafts, {
+                    **state,
+                    "channel_id": channels[channel_index + 1].id,
+                    "history_cursor": None,
+                }
+
+        return drafts, _next_cursor(
+            connection_id=str(connection.id),
+            channel_set_digest=_channel_set_digest(channels),
+            phase="incremental",
+            channel_id=None,
+            history_cursor=None,
+            event_created_at=state.get("event_created_at"),
+            event_id=state.get("event_id"),
+        )
+
+    async def _incremental(
+        self,
+        *,
+        session: AsyncSession,
+        client: Any,
+        connection: ExternalAgentConnectionRow,
+        channels: list[_Channel],
+        state: dict[str, Any],
+    ) -> tuple[list[KnowledgeDraft], dict[str, Any]]:
+        stmt = (
+            select(InboundEventRow)
+            .where(
+                InboundEventRow.connection_id == str(connection.id),
+                InboundEventRow.kind == _SLACK_MESSAGE_KIND,
+            )
+            .order_by(InboundEventRow.created_at.asc(), InboundEventRow.id.asc())
+            .limit(self.max_items)
+        )
+        event_created_at = _event_cursor_datetime(state.get("event_created_at"))
+        event_id = _clean(state.get("event_id"))
+        if event_created_at is not None:
+            stmt = stmt.where(
+                or_(
+                    InboundEventRow.created_at > event_created_at,
+                    and_(
+                        InboundEventRow.created_at == event_created_at,
+                        InboundEventRow.id > event_id,
+                    ),
+                )
+            )
+        events = list((await session.scalars(stmt)).all())
+        if not events:
+            refresh_state = {
+                **state,
+                "channel_id": _clean(state.get("channel_id")) or channels[0].id,
+            }
+            return await self._backfill(
+                client=client,
+                connection=connection,
+                channels=channels,
+                state=refresh_state,
+            )
+
+        channels_by_id = {channel.id: channel for channel in channels}
+        seen_threads: set[tuple[str, str]] = set()
+        drafts: list[KnowledgeDraft] = []
+        for event in events:
+            normalized = dict(event.normalized_payload or {})
+            payload = normalized.get("payload")
+            payload = dict(payload) if isinstance(payload, Mapping) else {}
+            channel_id = _clean(payload.get("channel_id"))
+            thread_ts = _clean(payload.get("thread_ts") or payload.get("message_ts"))
+            thread_key = (channel_id, thread_ts)
+            if (
+                channel_id not in channels_by_id
+                or not thread_ts
+                or thread_key in seen_threads
+            ):
+                continue
+            seen_threads.add(thread_key)
+            drafts.append(
+                await self._draft_for_thread(
+                    client=client,
+                    connection=connection,
+                    channel=channels_by_id[channel_id],
+                    thread_ts=thread_ts,
+                )
+            )
+
+        last_event = events[-1]
+        return drafts, {
+            **state,
+            "event_created_at": _utc(last_event.created_at).isoformat(),
+            "event_id": str(last_event.id),
+        }
+
+    async def _draft_for_thread(
+        self,
+        *,
+        client: Any,
+        connection: ExternalAgentConnectionRow,
+        channel: _Channel,
+        thread_ts: str,
+        root_fallback: Mapping[str, Any] | None = None,
+    ) -> KnowledgeDraft:
+        messages_by_ts: dict[str, dict[str, Any]] = {}
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while True:
+            response = await client.conversation_replies(
+                channel=channel.id,
+                thread_ts=thread_ts,
+                limit=_THREAD_PAGE_SIZE,
+                cursor=cursor,
+            )
+            for message in response.get("messages") or []:
+                if isinstance(message, Mapping) and _clean(message.get("ts")):
+                    messages_by_ts[_clean(message.get("ts"))] = dict(message)
+            next_cursor = _clean(
+                (response.get("response_metadata") or {}).get("next_cursor")
+            )
+            if not next_cursor:
+                break
+            if next_cursor in seen_cursors:
+                raise RuntimeError("Slack returned a repeated conversations.replies cursor")
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        if root_fallback is not None:
+            root_ts = _clean(root_fallback.get("ts"))
+            if root_ts:
+                messages_by_ts.setdefault(root_ts, dict(root_fallback))
+        messages = sorted(messages_by_ts.values(), key=_slack_timestamp_key)
+        if not messages:
+            raise RuntimeError(
+                f"Slack returned no messages for {channel.id}:{thread_ts}"
+            )
+
+        root = messages[0]
+        participants = sorted({_message_author(message) for message in messages})
+        root_text = _message_text(root)
+        title_lede = " ".join(root_text.split())[:160] or f"Thread {thread_ts}"
+        channel_label = f"#{channel.name}" if channel.name else channel.id
+        message_count = len(messages)
+        summary = (
+            f"Slack thread in {channel_label} with {message_count} message"
+            f"{'s' if message_count != 1 else ''} from {len(participants)} participant"
+            f"{'s' if len(participants) != 1 else ''}. Root: {title_lede}"
+        )
+        team_id = _team_id(connection)
+        source_created_at = _slack_datetime(root.get("ts"))
+        source_updated_at = _slack_datetime(messages[-1].get("ts"))
+        return KnowledgeDraft(
+            source=self.source_key,
+            kind="slack_thread",
+            source_ref=f"slack:{team_id}:{channel.id}:{thread_ts}",
+            title=f"Slack {channel_label}: {title_lede}",
+            summary=summary,
+            entities=[channel.id, *([channel.name] if channel.name else []), *participants],
+            raw_text=_thread_transcript(messages),
+            extra={
+                "org_id": str(connection.org_id),
+                "actor_user_id": str(connection.owner_user_id),
+                "connection_id": str(connection.id),
+                "team_id": team_id,
+                "channel_id": channel.id,
+                "channel_name": channel.name,
+                "thread_ts": thread_ts,
+                "participants": participants,
+                "message_count": message_count,
+                "last_activity_ts": _clean(messages[-1].get("ts")),
+            },
+            source_created_at=source_created_at,
+            source_updated_at=source_updated_at,
+            distill=True,
+        )
+
+
+__all__ = ["SlackKnowledgeConnector"]

--- a/brain/systems/knowledge/distillation.py
+++ b/brain/systems/knowledge/distillation.py
@@ -246,6 +246,14 @@ async def admit_distillation(
     attempt: int,
 ) -> DistillationEntry:
     actor = await _resolve_actor(session, draft)
+    scoped_draft = replace(
+        draft,
+        extra={
+            **dict(draft.extra or {}),
+            "org_id": str(actor.org_id),
+            "actor_user_id": str(actor.id),
+        },
+    )
     attempt = max(1, int(attempt))
     idempotency_key = _idempotency_key(
         draft,
@@ -261,12 +269,12 @@ async def admit_distillation(
             actor={"id": str(actor.id), "org_id": str(actor.org_id)},
             target={
                 "kind": "knowledge_distillation",
-                "thread_id": f"knowledge-distillation:{_source_ref_hash(draft)}",
+                "thread_id": f"knowledge-distillation:{_source_ref_hash(scoped_draft)}",
                 "headless": True,
                 "final_answer_target_surface": "headless",
             },
             payload={
-                "message": _distillation_prompt(draft),
+                "message": _distillation_prompt(scoped_draft),
                 "workspace_ref": {"source": "knowledge_index", "mode": "headless"},
                 "metadata": {
                     "origin": "knowledge_index",
@@ -279,7 +287,7 @@ async def admit_distillation(
                     "knowledge_distillation": {
                         "input_digest": input_digest,
                         "attempt": attempt,
-                        "draft": serialize_draft(draft),
+                        "draft": serialize_draft(scoped_draft),
                     },
                 },
             },
@@ -350,7 +358,7 @@ def _apply_fields(
     return replace(
         draft,
         summary=fields.summary,
-        resolution=fields.resolution,
+        resolution=fields.resolution or draft.resolution,
         entities=entities,
         extra=extra,
         distill=False,

--- a/brain/systems/knowledge/distillation.py
+++ b/brain/systems/knowledge/distillation.py
@@ -1,0 +1,437 @@
+"""Restart-safe headless distillation for conversational knowledge drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunRow
+from brain.platform.db.models.org import User
+from brain.systems.knowledge.connectors.base import KnowledgeDraft
+from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
+
+
+DISTILLATION_CURSOR_KEY = "_distillation_pending"
+DISTILLATION_MAX_ATTEMPTS = 2
+DISTILLATION_MANIFEST_VERSION = 1
+_TERMINAL_FAILURE_STATUSES = {
+    "blocked",
+    "canceled",
+    "cancelled",
+    "error",
+    "expired",
+    "failed",
+}
+_FENCED_JSON_RE = re.compile(r"\A```(?:json)?\s*(\{.*\})\s*```\Z", re.DOTALL | re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class DistilledFields:
+    question: str
+    summary: str
+    resolution: str | None
+    systems: list[str]
+    code_references: list[str]
+
+
+@dataclass(frozen=True)
+class DistillationEntry:
+    run_id: int
+    input_digest: str
+    attempt: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "input_digest": self.input_digest,
+            "attempt": self.attempt,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "DistillationEntry":
+        return cls(
+            run_id=int(value["run_id"]),
+            input_digest=str(value["input_digest"]),
+            attempt=max(1, int(value.get("attempt") or 1)),
+        )
+
+
+@dataclass(frozen=True)
+class DistillationOutcome:
+    status: str
+    entry: DistillationEntry
+    draft: KnowledgeDraft | None = None
+    error: str | None = None
+
+
+def _bounded_text(value: Any, *, limit: int, required: bool = False) -> str:
+    if value is not None and not isinstance(value, str):
+        raise ValueError("distillation text fields must be strings")
+    text = str(value or "").strip()
+    if required and not text:
+        raise ValueError("required distillation text is empty")
+    return text[:limit]
+
+
+def _bounded_string_list(value: Any, *, field: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"distillation field {field} must be a list")
+    output: list[str] = []
+    for candidate in value[:30]:
+        text = _bounded_text(candidate, limit=300)
+        if text and text not in output:
+            output.append(text)
+    return output
+
+
+def parse_distillation_artifact(text: str) -> DistilledFields:
+    """Parse the exact bounded artifact contract, accepting one JSON fence."""
+
+    payload_text = str(text or "").strip()
+    fenced = _FENCED_JSON_RE.fullmatch(payload_text)
+    if fenced is not None:
+        payload_text = fenced.group(1)
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("distillation artifact is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("distillation artifact must be a JSON object")
+    required_keys = {
+        "question",
+        "summary",
+        "resolution",
+        "systems",
+        "code_references",
+    }
+    if set(payload) != required_keys:
+        raise ValueError("distillation artifact fields do not match the contract")
+    resolution_value = payload["resolution"]
+    if resolution_value is not None and not isinstance(resolution_value, str):
+        raise ValueError("distillation field resolution must be a string or null")
+    return DistilledFields(
+        question=_bounded_text(payload["question"], limit=500, required=True),
+        summary=_bounded_text(payload["summary"], limit=6_000, required=True),
+        resolution=(
+            _bounded_text(resolution_value, limit=6_000) if resolution_value is not None else None
+        ),
+        systems=_bounded_string_list(payload["systems"], field="systems"),
+        code_references=_bounded_string_list(
+            payload["code_references"],
+            field="code_references",
+        ),
+    )
+
+
+def serialize_draft(draft: KnowledgeDraft) -> dict[str, Any]:
+    def timestamp(value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    return {
+        "source": draft.source,
+        "kind": draft.kind,
+        "source_ref": draft.source_ref,
+        "title": draft.title,
+        "summary": draft.summary,
+        "resolution": draft.resolution,
+        "entities": list(draft.entities),
+        "raw_text": draft.raw_text,
+        "extra": dict(draft.extra),
+        "source_created_at": timestamp(draft.source_created_at),
+        "source_updated_at": timestamp(draft.source_updated_at),
+        "archived_at": timestamp(draft.archived_at),
+        "distill": True,
+    }
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def deserialize_draft(value: Mapping[str, Any]) -> KnowledgeDraft:
+    return KnowledgeDraft(
+        source=str(value["source"]),
+        kind=str(value["kind"]),
+        source_ref=str(value["source_ref"]),
+        title=str(value["title"]),
+        summary=str(value["summary"]),
+        resolution=(str(value["resolution"]) if value.get("resolution") is not None else None),
+        entities=list(value.get("entities") or []),
+        raw_text=str(value.get("raw_text") or ""),
+        extra=dict(value.get("extra") or {}),
+        source_created_at=_parse_timestamp(value.get("source_created_at")),
+        source_updated_at=_parse_timestamp(value.get("source_updated_at")),
+        archived_at=_parse_timestamp(value.get("archived_at")),
+        distill=True,
+    )
+
+
+def _source_ref_hash(draft: KnowledgeDraft) -> str:
+    return hashlib.sha256(
+        f"{draft.source}:{draft.source_ref}".encode("utf-8")
+    ).hexdigest()[:20]
+
+
+def _idempotency_key(
+    draft: KnowledgeDraft,
+    *,
+    input_digest: str,
+    attempt: int,
+) -> str:
+    return f"knowledge:distill:{_source_ref_hash(draft)}:{input_digest}:a{attempt}"
+
+
+def _distillation_prompt(draft: KnowledgeDraft) -> str:
+    source_payload = {
+        "source": draft.source,
+        "kind": draft.kind,
+        "source_ref": draft.source_ref,
+        "title": draft.title,
+        "structural_summary": draft.summary,
+        "structural_resolution": draft.resolution,
+        "entities": list(draft.entities),
+        "raw_text": draft.raw_text,
+    }
+    return (
+        "Distill this source-backed knowledge item. Return exactly one JSON object and no "
+        "commentary. Required keys: question (string), summary (string), resolution "
+        "(string or null), systems (string array), code_references (string array). "
+        "State only facts supported by the source. Preserve concrete identifiers, error "
+        "messages, decisions, and the actual resolution when present.\n\nSOURCE:\n"
+        + json.dumps(source_payload, ensure_ascii=False, sort_keys=True)
+    )
+
+
+async def _resolve_actor(session: AsyncSession, draft: KnowledgeDraft) -> User:
+    extra = dict(draft.extra or {})
+    actor_user_id = str(extra.get("actor_user_id") or "").strip()
+    org_id = str(extra.get("org_id") or "").strip()
+    actor = await session.get(User, actor_user_id) if actor_user_id else None
+    if actor is not None and org_id and str(actor.org_id) != org_id:
+        raise ValueError("knowledge distillation actor does not belong to draft org")
+    if actor is None and org_id:
+        actor = (
+            await session.scalars(
+                select(User)
+                .where(User.org_id == org_id)
+                .order_by(User.created_at.asc(), User.id.asc())
+                .limit(1)
+            )
+        ).first()
+    if actor is None and not org_id:
+        actor = (
+            await session.scalars(
+                select(User).order_by(User.created_at.asc(), User.id.asc()).limit(1)
+            )
+        ).first()
+    if actor is None:
+        raise LookupError("No workspace user is available for knowledge distillation")
+    return actor
+
+
+async def admit_distillation(
+    session: AsyncSession,
+    draft: KnowledgeDraft,
+    *,
+    input_digest: str,
+    attempt: int,
+) -> DistillationEntry:
+    actor = await _resolve_actor(session, draft)
+    attempt = max(1, int(attempt))
+    idempotency_key = _idempotency_key(
+        draft,
+        input_digest=input_digest,
+        attempt=attempt,
+    )
+    result = await admit_work(
+        session,
+        WorkIntakeEvent(
+            source="knowledge",
+            event_type="knowledge.distillation",
+            org_id=str(actor.org_id),
+            actor={"id": str(actor.id), "org_id": str(actor.org_id)},
+            target={
+                "kind": "knowledge_distillation",
+                "thread_id": f"knowledge-distillation:{_source_ref_hash(draft)}",
+                "headless": True,
+                "final_answer_target_surface": "headless",
+            },
+            payload={
+                "message": _distillation_prompt(draft),
+                "workspace_ref": {"source": "knowledge_index", "mode": "headless"},
+                "metadata": {
+                    "origin": "knowledge_index",
+                    "originating_surface": "scheduler",
+                    "source_surface": "scheduler",
+                    "final_answer_target_surface": "headless",
+                    "headless": True,
+                    "execution_profile": "fast",
+                    "recipe": "fast",
+                    "knowledge_distillation": {
+                        "input_digest": input_digest,
+                        "attempt": attempt,
+                        "draft": serialize_draft(draft),
+                    },
+                },
+            },
+            policy={
+                "producer": "knowledge_index",
+                "idempotency_key": idempotency_key,
+                "run_event": "knowledge_distillation",
+            },
+        ),
+    )
+    if not result.ok or result.run_id is None:
+        raise RuntimeError(result.skipped_reason or "knowledge distillation admission failed")
+    return DistillationEntry(
+        run_id=int(result.run_id),
+        input_digest=input_digest,
+        attempt=attempt,
+    )
+
+
+async def _latest_final_answer(session: AsyncSession, run_id: int) -> str:
+    artifact = (
+        await session.scalars(
+            select(AgentRunArtifactRow)
+            .where(
+                AgentRunArtifactRow.run_id == int(run_id),
+                AgentRunArtifactRow.artifact_type == "final_answer",
+            )
+            .order_by(
+                AgentRunArtifactRow.created_at.desc(),
+                AgentRunArtifactRow.id.desc(),
+            )
+            .limit(1)
+        )
+    ).first()
+    return str(artifact.text or "") if artifact is not None else ""
+
+
+def _draft_from_run(run: AgentRunRow) -> KnowledgeDraft:
+    metadata = dict(run.metadata_ or {})
+    distillation = metadata.get("knowledge_distillation")
+    if not isinstance(distillation, Mapping) or not isinstance(
+        distillation.get("draft"), Mapping
+    ):
+        raise ValueError("knowledge distillation run is missing its draft snapshot")
+    return deserialize_draft(distillation["draft"])
+
+
+def _apply_fields(
+    draft: KnowledgeDraft,
+    fields: DistilledFields,
+    *,
+    input_digest: str,
+    attempt: int,
+) -> KnowledgeDraft:
+    entities: list[Any] = []
+    for value in [*draft.entities, *fields.systems, *fields.code_references]:
+        if value not in entities:
+            entities.append(value)
+    extra = dict(draft.extra or {})
+    extra["distillation"] = {
+        "status": "completed",
+        "input_digest": input_digest,
+        "attempt": attempt,
+        "question": fields.question,
+        "systems": fields.systems,
+        "code_references": fields.code_references,
+    }
+    return replace(
+        draft,
+        summary=fields.summary,
+        resolution=fields.resolution,
+        entities=entities,
+        extra=extra,
+        distill=False,
+    )
+
+
+def fallback_draft(
+    draft: KnowledgeDraft,
+    *,
+    input_digest: str,
+    attempt: int,
+    error: str,
+) -> KnowledgeDraft:
+    extra = dict(draft.extra or {})
+    extra["distillation"] = {
+        "status": "failed",
+        "input_digest": input_digest,
+        "attempt": attempt,
+        "error": _bounded_text(error, limit=1_000),
+    }
+    return replace(draft, extra=extra, distill=False)
+
+
+async def inspect_distillation(
+    session: AsyncSession,
+    entry: DistillationEntry,
+) -> DistillationOutcome:
+    run = await session.get(AgentRunRow, int(entry.run_id))
+    if run is None:
+        return DistillationOutcome(
+            status="retry",
+            entry=entry,
+            error="knowledge distillation run is missing",
+        )
+    try:
+        draft = _draft_from_run(run)
+    except ValueError as exc:
+        return DistillationOutcome(status="retry", entry=entry, error=str(exc))
+    status = str(run.status or "").strip().lower()
+    if status == "completed":
+        try:
+            fields = parse_distillation_artifact(
+                await _latest_final_answer(session, int(run.id))
+            )
+        except ValueError as exc:
+            return DistillationOutcome(
+                status="retry",
+                entry=entry,
+                draft=draft,
+                error=str(exc),
+            )
+        return DistillationOutcome(
+            status="completed",
+            entry=entry,
+            draft=_apply_fields(
+                draft,
+                fields,
+                input_digest=entry.input_digest,
+                attempt=entry.attempt,
+            ),
+        )
+    if status in _TERMINAL_FAILURE_STATUSES:
+        return DistillationOutcome(
+            status="retry",
+            entry=entry,
+            draft=draft,
+            error=f"knowledge distillation run ended with {status}",
+        )
+    return DistillationOutcome(status="pending", entry=entry, draft=draft)
+
+
+__all__ = [
+    "DISTILLATION_CURSOR_KEY",
+    "DISTILLATION_MANIFEST_VERSION",
+    "DISTILLATION_MAX_ATTEMPTS",
+    "DistillationEntry",
+    "DistillationOutcome",
+    "admit_distillation",
+    "deserialize_draft",
+    "fallback_draft",
+    "inspect_distillation",
+    "parse_distillation_artifact",
+    "serialize_draft",
+]

--- a/brain/systems/knowledge/search.py
+++ b/brain/systems/knowledge/search.py
@@ -135,10 +135,17 @@ def reciprocal_rank_fusion(
 
 def _item_filters(
     *,
+    org_id: str,
     sources: Sequence[str] | None,
     kinds: Sequence[str] | None,
 ) -> list[Any]:
-    filters: list[Any] = [KnowledgeItem.archived_at.is_(None)]
+    clean_org_id = str(org_id or "").strip()
+    if not clean_org_id:
+        raise ValueError("org_id is required for knowledge search")
+    filters: list[Any] = [
+        KnowledgeItem.archived_at.is_(None),
+        KnowledgeItem.extra["org_id"].as_string() == clean_org_id,
+    ]
     clean_sources = [str(value).strip() for value in sources or [] if str(value).strip()]
     clean_kinds = [str(value).strip() for value in kinds or [] if str(value).strip()]
     if clean_sources:
@@ -334,6 +341,7 @@ async def search_knowledge(
     session: AsyncSession,
     query: str,
     *,
+    org_id: str,
     sources: Sequence[str] | None = None,
     kinds: Sequence[str] | None = None,
     limit: int = 10,
@@ -345,7 +353,12 @@ async def search_knowledge(
         raise ValueError("query is required")
     max_results = max(1, min(int(limit or 10), 50))
     channel_limit = min(200, max(20, max_results * 4))
-    filters = _item_filters(sources=sources, kinds=kinds)
+    clean_org_id = str(org_id or "").strip()
+    filters = _item_filters(
+        org_id=clean_org_id,
+        sources=sources,
+        kinds=kinds,
+    )
 
     lexical_items, lexical_scores = await _lexical_channel(
         session,
@@ -383,6 +396,7 @@ async def search_knowledge(
     ]
     return {
         "query": clean_query,
+        "org_id": clean_org_id,
         "sources": [str(value) for value in sources or []],
         "kinds": [str(value) for value in kinds or []],
         "semantic_available": semantic_error is None,

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -109,6 +109,7 @@ def content_digest(draft: KnowledgeDraft, *, raw_text: str, extra: dict[str, Any
 
 def build_search_text(
     *,
+    question: str,
     title: str,
     summary: str,
     resolution: str | None,
@@ -116,6 +117,7 @@ def build_search_text(
     raw_text: str,
 ) -> str:
     values = [
+        question,
         title,
         summary,
         resolution or "",
@@ -136,8 +138,7 @@ def build_embedding_text(item: KnowledgeItem) -> str:
         else ""
     )
     values = [
-        question,
-        item.title,
+        question or item.title,
         item.summary,
         item.resolution or "",
         " ".join(str(entity) for entity in item.entities),
@@ -195,15 +196,77 @@ def _pending_cursor(
 async def _start_distillations(
     session: AsyncSession,
     drafts: list[KnowledgeDraft],
-) -> tuple[list[dict[str, Any]], list[KnowledgeDraft]]:
+) -> tuple[list[dict[str, Any]], list[KnowledgeDraft], int]:
     entries: list[dict[str, Any]] = []
     fallbacks: list[KnowledgeDraft] = []
+    skipped = 0
+    existing_by_ref: dict[str, KnowledgeItem] = {}
+    embedded_item_ids: set[int] = set()
+    if drafts:
+        source_refs = [draft.source_ref for draft in drafts]
+        existing_items = list(
+            (
+                await session.scalars(
+                    select(KnowledgeItem).where(
+                        KnowledgeItem.source == drafts[0].source,
+                        KnowledgeItem.source_ref.in_(source_refs),
+                    )
+                )
+            ).all()
+        )
+        existing_by_ref = {item.source_ref: item for item in existing_items}
+        if existing_items:
+            try:
+                runtime = await runtime_settings.async_get_embedding_runtime_config(
+                    session,
+                    include_secret=True,
+                )
+                model = embedding_model_identity(runtime)
+            except Exception:
+                model = None
+            if model is not None:
+                embedded_item_ids = set(
+                    (
+                        await session.scalars(
+                            select(KnowledgeItemEmbedding.item_id)
+                            .join(
+                                KnowledgeItem,
+                                KnowledgeItem.id == KnowledgeItemEmbedding.item_id,
+                            )
+                            .where(
+                                KnowledgeItem.id.in_(
+                                    [item.id for item in existing_items]
+                                ),
+                                KnowledgeItemEmbedding.model == model,
+                                KnowledgeItemEmbedding.content_digest
+                                == KnowledgeItem.content_digest,
+                            )
+                        )
+                    ).all()
+                )
     for draft in drafts:
         digest = content_digest(
             draft,
             raw_text=draft.raw_text,
             extra=dict(draft.extra or {}),
         )
+        existing = existing_by_ref.get(draft.source_ref)
+        distillation = (
+            dict(existing.extra or {}).get("distillation")
+            if existing is not None
+            else None
+        )
+        if (
+            isinstance(distillation, dict)
+            and str(distillation.get("input_digest") or "") == digest
+            and str(distillation.get("status") or "") in {"completed", "failed"}
+            and (
+                str(distillation.get("status") or "") == "failed"
+                or existing.id in embedded_item_ids
+            )
+        ):
+            skipped += 1
+            continue
         try:
             entry = await admit_distillation(
                 session,
@@ -227,7 +290,7 @@ async def _start_distillations(
             )
             continue
         entries.append(entry.to_dict())
-    return entries, fallbacks
+    return entries, fallbacks, skipped
 
 
 async def _harvest_distillations(
@@ -313,7 +376,14 @@ async def _upsert_item(
         )
     )
     changed = item is None or item.content_digest != digest
+    distillation = extra.get("distillation")
+    question = (
+        str(distillation.get("question") or "").strip()
+        if isinstance(distillation, dict)
+        else ""
+    )
     search_text = build_search_text(
+        question=question,
         title=draft.title,
         summary=draft.summary,
         resolution=draft.resolution,
@@ -514,6 +584,16 @@ async def sync_connector(
             list(manifest.get("entries") or []),
         )
         stats.failed += failures
+        stats.distilled = sum(
+            1 for _draft, should_embed in resolved if should_embed
+        )
+        await _ingest_drafts(
+            session,
+            source=source,
+            drafts=resolved,
+            stats=stats,
+            run_at=run_at,
+        )
         if pending:
             stats.pending = len(pending)
             await _sync_state(
@@ -535,14 +615,6 @@ async def sync_connector(
                 cursor=committed_cursor,
             )
 
-        stats.distilled = sum(1 for _draft, should_embed in resolved if should_embed)
-        await _ingest_drafts(
-            session,
-            source=source,
-            drafts=resolved,
-            stats=stats,
-            run_at=run_at,
-        )
         status = "ok" if stats.failed == 0 else "degraded"
         await _sync_state(
             session,
@@ -607,7 +679,10 @@ async def sync_connector(
         stats=stats,
         run_at=run_at,
     )
-    entries, admission_fallbacks = await _start_distillations(session, distillable)
+    entries, admission_fallbacks, unchanged_distillations = (
+        await _start_distillations(session, distillable)
+    )
+    stats.skipped += unchanged_distillations
     if entries:
         stats.failed += len(admission_fallbacks)
         stats.pending = len(entries)

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -125,6 +125,26 @@ def build_search_text(
     return "\n".join(value.strip() for value in values if value and value.strip())
 
 
+def build_embedding_text(item: KnowledgeItem) -> str:
+    """Render every distilled field, while deliberately excluding raw text."""
+
+    extra = dict(item.extra or {})
+    distillation = extra.get("distillation")
+    question = (
+        str(distillation.get("question") or "").strip()
+        if isinstance(distillation, dict)
+        else ""
+    )
+    values = [
+        question,
+        item.title,
+        item.summary,
+        item.resolution or "",
+        " ".join(str(entity) for entity in item.entities),
+    ]
+    return "\n".join(value.strip() for value in values if value and value.strip())
+
+
 def _bounded_raw_text(draft: KnowledgeDraft) -> tuple[str, dict[str, Any], bool]:
     raw_text = str(draft.raw_text or "")
     extra = dict(draft.extra or {})
@@ -359,7 +379,7 @@ async def _ensure_embedding(
 
     vector = np.asarray(
         embedding_client.embed_document(
-            f"{item.title}\n{item.summary}",
+            build_embedding_text(item),
             runtime_config=runtime,
         ),
         dtype=np.float32,
@@ -648,6 +668,7 @@ __all__ = [
     "KnowledgeSyncResult",
     "KnowledgeSyncStats",
     "RAW_TEXT_MAX_CHARS",
+    "build_embedding_text",
     "build_search_text",
     "content_digest",
     "sync_connector",

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -20,6 +20,15 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.systems.knowledge.connectors.base import KnowledgeConnector, KnowledgeDraft
+from brain.systems.knowledge.distillation import (
+    DISTILLATION_CURSOR_KEY,
+    DISTILLATION_MANIFEST_VERSION,
+    DISTILLATION_MAX_ATTEMPTS,
+    DistillationEntry,
+    admit_distillation,
+    fallback_draft,
+    inspect_distillation,
+)
 from brain.systems.memory import embeddings as embedding_client
 from brain.systems.reconstructive_memory.embeddings import embedding_model_identity
 from brain.systems.runtime_settings import memory as runtime_settings
@@ -36,14 +45,21 @@ class KnowledgeSyncStats:
     skipped: int = 0
     failed: int = 0
     truncated: int = 0
+    pending: int = 0
+    distilled: int = 0
 
     def to_dict(self) -> dict[str, int]:
-        return {
+        payload = {
             "ingested": self.ingested,
             "skipped": self.skipped,
             "failed": self.failed,
             "truncated": self.truncated,
         }
+        if self.pending:
+            payload["pending"] = self.pending
+        if self.distilled:
+            payload["distilled"] = self.distilled
+        return payload
 
 
 @dataclass(frozen=True)
@@ -113,7 +129,9 @@ def _bounded_raw_text(draft: KnowledgeDraft) -> tuple[str, dict[str, Any], bool]
     raw_text = str(draft.raw_text or "")
     extra = dict(draft.extra or {})
     if len(raw_text) <= RAW_TEXT_MAX_CHARS:
-        return raw_text, extra, bool(extra.get("body_truncated"))
+        return raw_text, extra, bool(
+            extra.get("body_truncated") or extra.get("raw_text_truncated")
+        )
     extra.update(
         {
             "raw_text_truncated": True,
@@ -121,6 +139,141 @@ def _bounded_raw_text(draft: KnowledgeDraft) -> tuple[str, dict[str, Any], bool]
         }
     )
     return raw_text[:RAW_TEXT_MAX_CHARS], extra, True
+
+
+def _bounded_draft(draft: KnowledgeDraft) -> tuple[KnowledgeDraft, bool]:
+    raw_text, extra, truncated = _bounded_raw_text(draft)
+    return replace(draft, raw_text=raw_text, extra=extra), truncated
+
+
+def _distillation_manifest(cursor: dict[str, Any]) -> dict[str, Any] | None:
+    value = cursor.get(DISTILLATION_CURSOR_KEY)
+    return dict(value) if isinstance(value, dict) else None
+
+
+def _manifest_cursor(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _pending_cursor(
+    *,
+    committed_cursor: dict[str, Any],
+    proposed_cursor: dict[str, Any],
+    entries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        **committed_cursor,
+        DISTILLATION_CURSOR_KEY: {
+            "version": DISTILLATION_MANIFEST_VERSION,
+            "committed_cursor": dict(committed_cursor),
+            "proposed_cursor": dict(proposed_cursor),
+            "entries": entries,
+        },
+    }
+
+
+async def _start_distillations(
+    session: AsyncSession,
+    drafts: list[KnowledgeDraft],
+) -> tuple[list[dict[str, Any]], list[KnowledgeDraft]]:
+    entries: list[dict[str, Any]] = []
+    fallbacks: list[KnowledgeDraft] = []
+    for draft in drafts:
+        digest = content_digest(
+            draft,
+            raw_text=draft.raw_text,
+            extra=dict(draft.extra or {}),
+        )
+        try:
+            entry = await admit_distillation(
+                session,
+                draft,
+                input_digest=digest,
+                attempt=1,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Knowledge distillation admission failed for %s %s",
+                draft.source,
+                draft.source_ref,
+            )
+            fallbacks.append(
+                fallback_draft(
+                    draft,
+                    input_digest=digest,
+                    attempt=1,
+                    error=str(exc),
+                )
+            )
+            continue
+        entries.append(entry.to_dict())
+    return entries, fallbacks
+
+
+async def _harvest_distillations(
+    session: AsyncSession,
+    raw_entries: list[Any],
+) -> tuple[list[dict[str, Any]], list[tuple[KnowledgeDraft, bool]], int]:
+    pending: list[dict[str, Any]] = []
+    resolved: list[tuple[KnowledgeDraft, bool]] = []
+    failures = 0
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            failures += 1
+            logger.error("Ignoring malformed knowledge distillation manifest entry")
+            continue
+        try:
+            entry = DistillationEntry.from_mapping(raw_entry)
+            outcome = await inspect_distillation(session, entry)
+        except Exception as exc:
+            logger.exception("Knowledge distillation harvest failed")
+            failures += 1
+            continue
+        else:
+            error = str(outcome.error or "")
+
+        if outcome is not None and outcome.status == "completed" and outcome.draft:
+            resolved.append((outcome.draft, True))
+            continue
+        if outcome is not None and outcome.status == "pending":
+            pending.append(entry.to_dict())
+            continue
+
+        retry_draft = outcome.draft if outcome is not None else None
+        if retry_draft is None:
+            failures += 1
+            logger.error(
+                "Knowledge distillation run %s cannot be retried without its draft snapshot",
+                entry.run_id,
+            )
+            continue
+        if entry.attempt < DISTILLATION_MAX_ATTEMPTS:
+            try:
+                replacement = await admit_distillation(
+                    session,
+                    retry_draft,
+                    input_digest=entry.input_digest,
+                    attempt=entry.attempt + 1,
+                )
+            except Exception as exc:
+                error = str(exc)
+            else:
+                pending.append(replacement.to_dict())
+                continue
+
+        failures += 1
+        resolved.append(
+            (
+                fallback_draft(
+                    retry_draft,
+                    input_digest=entry.input_digest,
+                    attempt=entry.attempt,
+                    error=error or "knowledge distillation attempts exhausted",
+                ),
+                False,
+            )
+        )
+    return pending, resolved, failures
 
 
 async def _upsert_item(
@@ -252,19 +405,141 @@ async def _sync_state(
     await session.flush()
 
 
+async def _ingest_drafts(
+    session: AsyncSession,
+    *,
+    source: str,
+    drafts: list[tuple[KnowledgeDraft, bool]],
+    stats: KnowledgeSyncStats,
+    run_at: datetime,
+) -> None:
+    if not drafts:
+        return
+    runtime: EmbeddingRuntimeConfig | None = None
+    runtime_error: Exception | None = None
+    if any(should_embed for _draft, should_embed in drafts):
+        try:
+            runtime = await runtime_settings.async_get_embedding_runtime_config(
+                session,
+                include_secret=True,
+            )
+        except Exception as exc:
+            runtime_error = exc
+            logger.warning(
+                "Knowledge embeddings unavailable for %s; items remain lexical-searchable: %s",
+                source,
+                exc,
+            )
+
+    for draft, should_embed in drafts:
+        try:
+            async with session.begin_nested():
+                item, changed, truncated = await _upsert_item(
+                    session,
+                    draft=draft,
+                    ingested_at=run_at,
+                )
+                if changed:
+                    stats.ingested += 1
+                else:
+                    stats.skipped += 1
+                if truncated:
+                    stats.truncated += 1
+                if should_embed:
+                    if runtime is None:
+                        raise runtime_error or RuntimeError(
+                            "embedding runtime unavailable"
+                        )
+                    await _ensure_embedding(session, item=item, runtime=runtime)
+        except Exception as exc:
+            # A nested transaction only surrounds this draft. Re-land the item
+            # without its vector if the savepoint rolled back an embedding error.
+            try:
+                async with session.begin_nested():
+                    await _upsert_item(session, draft=draft, ingested_at=run_at)
+            except Exception:
+                logger.exception(
+                    "Knowledge item write failed for %s %s",
+                    source,
+                    draft.source_ref,
+                )
+            stats.failed += 1
+            logger.warning(
+                "Knowledge embedding/write degraded for %s %s; lexical row retained: %s",
+                source,
+                draft.source_ref,
+                exc,
+            )
+
+
 async def sync_connector(
     session: AsyncSession,
     connector: KnowledgeConnector,
 ) -> KnowledgeSyncResult:
-    """Run one connector without allowing embedding outages to hide rows."""
+    """Run one connector with restart-safe distillation and honest accounting."""
 
     source = str(connector.source_key).strip()
     if not source:
         raise ValueError("Knowledge connectors require source_key")
     run_at = datetime.now(timezone.utc)
     state = await session.get(KnowledgeSyncState, source)
-    cursor = dict(state.cursor or {}) if state is not None else {}
+    stored_cursor = dict(state.cursor or {}) if state is not None else {}
     stats = KnowledgeSyncStats()
+    manifest = _distillation_manifest(stored_cursor)
+    if manifest is not None:
+        committed_cursor = _manifest_cursor(manifest.get("committed_cursor"))
+        proposed_cursor = _manifest_cursor(manifest.get("proposed_cursor"))
+        pending, resolved, failures = await _harvest_distillations(
+            session,
+            list(manifest.get("entries") or []),
+        )
+        stats.failed += failures
+        if pending:
+            stats.pending = len(pending)
+            await _sync_state(
+                session,
+                source=source,
+                cursor=_pending_cursor(
+                    committed_cursor=committed_cursor,
+                    proposed_cursor=proposed_cursor,
+                    entries=pending,
+                ),
+                status="pending",
+                stats=stats,
+                run_at=run_at,
+            )
+            return KnowledgeSyncResult(
+                source=source,
+                status="pending",
+                stats=stats.to_dict(),
+                cursor=committed_cursor,
+            )
+
+        stats.distilled = sum(1 for _draft, should_embed in resolved if should_embed)
+        await _ingest_drafts(
+            session,
+            source=source,
+            drafts=resolved,
+            stats=stats,
+            run_at=run_at,
+        )
+        status = "ok" if stats.failed == 0 else "degraded"
+        await _sync_state(
+            session,
+            source=source,
+            cursor=proposed_cursor,
+            status=status,
+            stats=stats,
+            run_at=run_at,
+        )
+        return KnowledgeSyncResult(
+            source=source,
+            status=status,
+            stats=stats.to_dict(),
+            cursor=proposed_cursor,
+        )
+
+    cursor = dict(stored_cursor)
     try:
         drafts, new_cursor = await connector.enumerate_changed(session, cursor)
     except Exception as exc:
@@ -286,22 +561,10 @@ async def sync_connector(
             error=str(exc),
         )
 
-    runtime: EmbeddingRuntimeConfig | None = None
-    runtime_error: Exception | None = None
-    try:
-        runtime = await runtime_settings.async_get_embedding_runtime_config(
-            session,
-            include_secret=True,
-        )
-    except Exception as exc:
-        runtime_error = exc
-        logger.warning(
-            "Knowledge embeddings unavailable for %s; items remain lexical-searchable: %s",
-            source,
-            exc,
-        )
-
-    for draft in drafts:
+    structural: list[tuple[KnowledgeDraft, bool]] = []
+    distillable: list[KnowledgeDraft] = []
+    for original_draft in drafts:
+        draft, truncated = _bounded_draft(original_draft)
         if draft.source != source:
             stats.failed += 1
             logger.error(
@@ -310,41 +573,59 @@ async def sync_connector(
                 draft.source,
             )
             continue
-        try:
-            async with session.begin_nested():
-                item, changed, truncated = await _upsert_item(
-                    session,
-                    draft=draft,
-                    ingested_at=run_at,
-                )
-                if changed:
-                    stats.ingested += 1
-                else:
-                    stats.skipped += 1
-                if truncated:
-                    stats.truncated += 1
-                if runtime is None:
-                    raise runtime_error or RuntimeError("embedding runtime unavailable")
-                await _ensure_embedding(session, item=item, runtime=runtime)
-        except Exception as exc:
-            # A nested transaction only surrounds this draft. Re-land the item
-            # without its vector if the savepoint rolled back an embedding error.
-            try:
-                async with session.begin_nested():
-                    await _upsert_item(session, draft=draft, ingested_at=run_at)
-            except Exception:
-                logger.exception(
-                    "Knowledge item write failed for %s %s",
-                    source,
-                    draft.source_ref,
-                )
-            stats.failed += 1
-            logger.warning(
-                "Knowledge embedding/write degraded for %s %s; lexical row retained: %s",
-                source,
-                draft.source_ref,
-                exc,
-            )
+        if draft.distill:
+            if truncated:
+                stats.truncated += 1
+            distillable.append(draft)
+        else:
+            structural.append((draft, True))
+
+    await _ingest_drafts(
+        session,
+        source=source,
+        drafts=structural,
+        stats=stats,
+        run_at=run_at,
+    )
+    entries, admission_fallbacks = await _start_distillations(session, distillable)
+    if entries:
+        stats.failed += len(admission_fallbacks)
+        stats.pending = len(entries)
+        await _ingest_drafts(
+            session,
+            source=source,
+            drafts=[(draft, False) for draft in admission_fallbacks],
+            stats=stats,
+            run_at=run_at,
+        )
+        await _sync_state(
+            session,
+            source=source,
+            cursor=_pending_cursor(
+                committed_cursor=cursor,
+                proposed_cursor=dict(new_cursor),
+                entries=entries,
+            ),
+            status="pending",
+            stats=stats,
+            run_at=run_at,
+        )
+        return KnowledgeSyncResult(
+            source=source,
+            status="pending",
+            stats=stats.to_dict(),
+            cursor=cursor,
+        )
+
+    if admission_fallbacks:
+        stats.failed += len(admission_fallbacks)
+        await _ingest_drafts(
+            session,
+            source=source,
+            drafts=[(draft, False) for draft in admission_fallbacks],
+            stats=stats,
+            run_at=run_at,
+        )
 
     status = "ok" if stats.failed == 0 else "degraded"
     await _sync_state(

--- a/brain/systems/runs/direct_targets.py
+++ b/brain/systems/runs/direct_targets.py
@@ -32,6 +32,7 @@ DIRECT_TARGET_KINDS: frozenset[str] = frozenset(
         "app_report",
         "external_agent_headless_ask",
         "inbound_submission",
+        "knowledge_distillation",
     }
 )
 

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -199,7 +199,9 @@ def _source_idempotency_parts(request: AgentRunRequest) -> tuple[str | None, str
     # chantier and opted-in worker continuation hooks can race across terminal
     # workers. Lock those canonical event identities at the run boundary
     # without changing idempotency semantics for unrelated sources.
-    if not key.startswith(("slack:", "chantier:", "worker:continuation:")):
+    if not key.startswith(
+        ("slack:", "chantier:", "worker:continuation:", "knowledge:")
+    ):
         return None, None
 
     work_intake = metadata.get("work_intake")

--- a/brain/systems/runs/tool_catalog/handlers/knowledge.py
+++ b/brain/systems/runs/tool_catalog/handlers/knowledge.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
 from brain.systems.knowledge.search import search_knowledge
+from brain.systems.runs.tool_catalog.handlers.common import _agent_context
 
 
 async def _handle_search_knowledge(
@@ -18,10 +19,14 @@ async def _handle_search_knowledge(
     clean_query = str(query or "").strip()
     if not clean_query:
         return json.dumps({"error": "search_knowledge requires query"})
+    org_id = str(getattr(_agent_context, "org_id", "") or "").strip()
+    if not org_id:
+        return json.dumps({"error": "search_knowledge requires workspace context"})
     async with UnitOfWork() as uow:
         result = await search_knowledge(
             uow.session,
             clean_query,
+            org_id=org_id,
             sources=sources,
             kinds=kinds,
             limit=max(1, min(int(limit or 10), 50)),

--- a/brain/systems/slack/client.py
+++ b/brain/systems/slack/client.py
@@ -588,6 +588,7 @@ class SlackWebClient:
         channel: str,
         limit: int = 50,
         latest: str | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "channel": channel,
@@ -596,6 +597,8 @@ class SlackWebClient:
         if latest:
             payload["latest"] = latest
             payload["inclusive"] = True
+        if cursor:
+            payload["cursor"] = cursor
         return await self._post("conversations.history", payload)
 
     async def conversations_list(
@@ -641,6 +644,8 @@ async def slack_web_client_from_runtime(
     *,
     requested_by: str,
     reason: str,
+    org_id: str | None = None,
+    owner_user_id: str | None = None,
 ) -> SlackWebClient:
     """Backend Slack client with Vault-first bot-token resolution.
 
@@ -651,6 +656,8 @@ async def slack_web_client_from_runtime(
     that (2026-07-16). Resolution order mirrors the connector's
     ``SlackConnectorConfig.from_runtime``: env when set, else the runtime
     secret under the connector authority. One owner for the secret.
+    Durable connection consumers should pass that row's org/user authority so
+    token resolution and the source being read cannot drift apart.
     """
     token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
     if not token:
@@ -660,9 +667,14 @@ async def slack_web_client_from_runtime(
             read_runtime_secret,
         )
 
-        org_id = os.environ.get("ILLO_SLACK_ORG_ID") or os.environ.get("ILLO_ORG_ID")
+        org_id = (
+            org_id
+            or os.environ.get("ILLO_SLACK_ORG_ID")
+            or os.environ.get("ILLO_ORG_ID")
+        )
         owner_user_id = (
-            os.environ.get("ILLO_SLACK_OWNER_USER_ID")
+            owner_user_id
+            or os.environ.get("ILLO_SLACK_OWNER_USER_ID")
             or os.environ.get("ILLO_OWNER_USER_ID")
         )
         if not org_id or not owner_user_id:

--- a/brain/systems/slack/monitored_intakes.py
+++ b/brain/systems/slack/monitored_intakes.py
@@ -119,12 +119,16 @@ class MonitoredIntakePolicy:
     allowed_ignored_subtypes: frozenset[str] = frozenset()
 
 
-def visible_slack_content(event: Mapping[str, Any]) -> SlackVisibleContent:
+def visible_slack_content(
+    event: Mapping[str, Any],
+    *,
+    limit: int | None = 4000,
+) -> SlackVisibleContent:
     """Decode Slack text and blocks once without changing the alert fallback."""
 
     return SlackVisibleContent(
-        message_text=_event_message_text(event),
-        block_text=_slack_block_text(event.get("blocks")),
+        message_text=_event_message_text(event, limit=limit),
+        block_text=_slack_block_text(event.get("blocks"), limit=limit),
     )
 
 
@@ -461,14 +465,19 @@ MONITORED_INTAKE_POLICIES: tuple[MonitoredIntakePolicy, ...] = (
 )
 
 
-def _bounded_text(value: Any, *, limit: int = 4000) -> str:
-    return str(value or "")[:limit]
+def _bounded_text(value: Any, *, limit: int | None = 4000) -> str:
+    text = str(value or "")
+    return text if limit is None else text[:limit]
 
 
-def _event_message_text(event: Mapping[str, Any]) -> str:
+def _event_message_text(
+    event: Mapping[str, Any],
+    *,
+    limit: int | None = 4000,
+) -> str:
     """Preserve origin/main's alert text and attachment fallback byte-for-byte."""
 
-    text = _bounded_text(event.get("text"))
+    text = _bounded_text(event.get("text"), limit=limit)
     if text.strip():
         return text
     previews: list[str] = []
@@ -479,13 +488,14 @@ def _event_message_text(event: Mapping[str, Any]) -> str:
         if not isinstance(attachment, Mapping):
             continue
         preview = attachment.get("fallback") or attachment.get("title")
-        bounded = _bounded_text(preview, limit=500).strip()
+        preview_limit = 500 if limit is not None else None
+        bounded = _bounded_text(preview, limit=preview_limit).strip()
         if bounded:
             previews.append(bounded)
-    return _bounded_text("\n".join(previews))
+    return _bounded_text("\n".join(previews), limit=limit)
 
 
-def _slack_block_text(blocks: Any) -> str:
+def _slack_block_text(blocks: Any, *, limit: int | None = 4000) -> str:
     parts: list[str] = []
 
     def _collect(value: Any) -> None:
@@ -502,7 +512,7 @@ def _slack_block_text(blocks: Any) -> str:
                 _collect(item)
 
     _collect(blocks)
-    return _bounded_text("\n".join(parts))
+    return _bounded_text("\n".join(parts), limit=limit)
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/brain/systems/slack/monitors.py
+++ b/brain/systems/slack/monitors.py
@@ -65,13 +65,19 @@ def _normalize_entries(raw: Any) -> list[dict[str, Any]]:
     return entries
 
 
+def monitored_channels(connection: ExternalAgentConnectionRow) -> list[dict[str, Any]]:
+    """Return normalized monitored-channel configuration without a DB read."""
+
+    return _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+
+
 def monitored_channel_ids(connection: ExternalAgentConnectionRow) -> set[str]:
     """Return the set of enabled monitored channel ids for a connection.
 
     Pure read helper (no session) used by the connector on the hot path.
     """
 
-    entries = _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+    entries = monitored_channels(connection)
     return {entry["channel_id"] for entry in entries if entry.get("enabled", True)}
 
 
@@ -105,7 +111,7 @@ async def list_monitored_channels(
     org_id: str | None = None,
 ) -> list[dict[str, Any]]:
     connection = await _connection_for_org(session, connection_id, org_id)
-    return _normalize_entries(_slack_metadata(connection).get("monitored_channels"))
+    return monitored_channels(connection)
 
 
 async def add_monitored_channel(
@@ -173,5 +179,6 @@ __all__ = [
     "add_monitored_channel",
     "list_monitored_channels",
     "monitored_channel_ids",
+    "monitored_channels",
     "remove_monitored_channel",
 ]

--- a/specs/knowledge-base/README.md
+++ b/specs/knowledge-base/README.md
@@ -1,0 +1,47 @@
+# Illo Knowledge — live implementation handoff
+
+Read [north-star.md](north-star.md) before changing the implementation. The
+temporary build plan lives in [prd.md](prd.md).
+
+## Status
+
+- Slice 1 is shipped: the derived index, structural Domain Records and GitHub
+  connectors, hybrid search, scheduler wiring, and MCP/in-run exposure exist.
+- Slice 2 is in progress under issue #577.
+- Slice 3 is blocked on slice 2 and tracked by issue #578.
+
+## Dependency graph
+
+```text
+slice 1 (shipped)
+  -> slice 2a Slack thread connector ---------+
+  -> slice 2b headless LLM distillation -----+-> slice 2 integration (#577)
+  -> slice 2c additive memory mirror --------+
+                                                  -> slice 3 eval + R2 retarget (#578)
+                                                  -> memory strangler only after measured win
+```
+
+## Slice 2 invariants
+
+- Conversational sources remain lexically searchable as bounded raw text, but
+  only distilled fields are embedded.
+- Distillation is admitted through `admit_work`; it must survive scheduler
+  restarts, remain idempotent per source version, and expose pending, failed,
+  and completed accounting.
+- A Slack reply re-pulls its parent and all siblings and produces one knowledge
+  row per thread.
+- Memory mirroring is additive. Mirror only workspace-visible consolidated
+  memories; never expose private/user-scoped memory through the workspace-wide
+  knowledge index.
+- GitHub uses the same distillation path as Slack.
+- Do not change existing memory recall in slice 2.
+
+## Next Agent Prompt
+
+Complete issue #577 by integrating the Slack connector, restart-safe headless
+distillation, GitHub distillation opt-in, and the additive privacy-preserving
+memory mirror. Use TDD, run focused and full verification, update this handoff,
+then publish and merge the PR. After #577 is merged, implement #578's golden
+question harness and routine retarget; only perform the memory strangler swap
+if the measured evaluation demonstrates a win. Finally deploy and verify the
+knowledge sync operationally.

--- a/specs/knowledge-base/README.md
+++ b/specs/knowledge-base/README.md
@@ -7,8 +7,8 @@ temporary build plan lives in [prd.md](prd.md).
 
 - Slice 1 is shipped: the derived index, structural Domain Records and GitHub
   connectors, hybrid search, scheduler wiring, and MCP/in-run exposure exist.
-- Slice 2 is in progress under issue #577.
-- Slice 3 is blocked on slice 2 and tracked by issue #578.
+- Slice 2 is implemented under issue #577 and awaiting merge/deploy.
+- Slice 3 is tracked by issue #578 and begins after slice 2 merges.
 
 ## Dependency graph
 
@@ -38,10 +38,9 @@ slice 1 (shipped)
 
 ## Next Agent Prompt
 
-Complete issue #577 by integrating the Slack connector, restart-safe headless
-distillation, GitHub distillation opt-in, and the additive privacy-preserving
-memory mirror. Use TDD, run focused and full verification, update this handoff,
-then publish and merge the PR. After #577 is merged, implement #578's golden
-question harness and routine retarget; only perform the memory strangler swap
-if the measured evaluation demonstrates a win. Finally deploy and verify the
-knowledge sync operationally.
+Publish and merge issue #577 after its full verification completes. Then
+implement #578's golden-question harness and routine retarget. Record baseline
+and candidate scores against the north-star contract; only perform the memory
+strangler swap if the measured evaluation demonstrates a win. Finally deploy
+and verify Slack, GitHub, and memory connector accounting plus distillation
+dispatch/harvest operationally.

--- a/specs/knowledge-base/prd.md
+++ b/specs/knowledge-base/prd.md
@@ -5,7 +5,7 @@
 After shipping, this doc gets closed into a rationale (close-spec) and the code
 becomes the reference.*
 
-Status: slice 1 ready to implement. Slices 2–3 sketched, not scoped.
+Status: slices 1–2 implemented. Slice 3 is tracked by issue #578.
 
 ## What we're building
 
@@ -198,7 +198,7 @@ caller's job: follow `source_ref` to the canonical system for the full thing.
 Out of scope for slice 1: any change to the memory subsystem, Slack, LLM
 distillation, backfill tuning, deploy.
 
-## Slice 2 (sketch)
+## Slice 2 (implemented by #577)
 
 Slack connector (thread-level re-pull, one row per thread) + LLM distillation
 via headless Illo runs (`admit_work`, effort from the routing ladder) for
@@ -210,6 +210,21 @@ knowledge read path has no item-level ACL. Private/user-scoped summaries still
 advance the connector watermark but never land in the index; if a previously
 shared summary becomes private, its derived row is scrubbed and archived. The
 memory recall and mutation paths remain untouched.
+
+Delivered:
+
+- [x] One bounded, cursor-paged Slack connector row per complete thread.
+- [x] Restart-safe headless distillation through `admit_work`, using workspace
+      routing defaults and final-answer artifacts as the return path.
+- [x] Durable two-phase connector cursors; upstream watermarks advance only
+      after every admitted item is distilled or explicitly degraded.
+- [x] Slack and GitHub raw text remains lexical; only successful distilled
+      fields are embedded.
+- [x] Closed GitHub issues carry fixing-PR, merge-commit, closer, and merge-time
+      provenance when GitHub exposes it, with a structural fallback otherwise.
+- [x] Additive workspace-visible consolidated-memory mirror with private/user
+      exclusion and visibility-withdrawal scrubbing.
+- [x] Honest pending, distilled, failed, and truncation accounting.
 
 ## Slice 3 (sketch)
 

--- a/specs/knowledge-base/prd.md
+++ b/specs/knowledge-base/prd.md
@@ -204,6 +204,13 @@ Slack connector (thread-level re-pull, one row per thread) + LLM distillation
 via headless Illo runs (`admit_work`, effort from the routing ladder) for
 Slack and upgraded GitHub resolution-extraction + memory mirror connector.
 
+The memory mirror is workspace-visible by construction: it indexes only
+consolidated `MemoryNode` summaries with `org` or `team` visibility while the
+knowledge read path has no item-level ACL. Private/user-scoped summaries still
+advance the connector watermark but never land in the index; if a previously
+shared summary becomes private, its derived row is scrubbed and archived. The
+memory recall and mutation paths remain untouched.
+
 ## Slice 3 (sketch)
 
 Golden-question eval harness + R2 routine retarget (scores against

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -175,6 +175,7 @@ def test_default_knowledge_sync_includes_the_memory_mirror():
     assert [factory.source_key for factory in CONNECTOR_FACTORIES] == [
         "domain_records",
         "github",
+        "slack",
         "memory",
     ]
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -1377,3 +1377,56 @@ async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
     assert drafts == []
     assert list_issues.await_args.kwargs["since"] is None
     assert cursor["version"] == 2
+
+
+async def test_public_github_closure_uses_accounted_structural_fallback(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    repo = "Illospace/illospace"
+    issue = {
+        "id": 577,
+        "number": 577,
+        "title": "Knowledge slice 2",
+        "state": "closed",
+        "body": "Implement the conversational knowledge layer.",
+        "labels": [],
+        "user": {"login": "redawear"},
+        "created_at": "2026-07-28T18:00:00Z",
+        "updated_at": "2026-07-28T20:10:00Z",
+        "closed_at": "2026-07-28T20:10:00Z",
+    }
+    list_issues = AsyncMock(return_value={"issues": [issue], "next_page": None})
+    get_closure = AsyncMock()
+    authority = SimpleNamespace(token=None, org_id=None, actor_user_id=None)
+    connector = GitHubConnector(repositories=[repo])
+
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=list_issues,
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_get_issue_closure_info",
+        new=get_closure,
+    ):
+        result = await sync_connector(session, connector)
+
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source_ref == "github:Illospace/illospace#577"
+        )
+    )
+    assert result.status == "degraded"
+    assert result.cursor["version"] == 2
+    assert result.stats["failed"] == 1
+    assert get_closure.await_count == 0
+    assert item is not None
+    assert item.resolution == "Closed at 2026-07-28T20:10:00Z"
+    assert item.extra["closure_enrichment"] == {
+        "status": "unavailable",
+        "reason": "authentication_required",
+    }
+    assert item.extra["distillation"]["status"] == "failed"

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -16,12 +16,18 @@ from brain.app.api.auth import get_current_user
 from brain.app.api.deps import get_db, rate_limit
 from brain.app.api.main import app
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
+from brain.platform.db.models.agent_run import (
+    AgentRunArtifactRow,
+    AgentRunEventRow,
+    AgentRunRow,
+)
 from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
 from brain.platform.db.models.knowledge import (
     KnowledgeItem,
     KnowledgeItemEmbedding,
     KnowledgeSyncState,
 )
+from brain.platform.db.models.org import Org, User
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
@@ -165,6 +171,11 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
     SQLiteTypeCompiler.visit_Vector = lambda self, type_, **kw: "TEXT"
     return await async_sqlite_session_factory(
         [
+            Org.__table__,
+            User.__table__,
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
             Domain.__table__,
             DomainObjectType.__table__,
             DomainRecord.__table__,
@@ -486,3 +497,172 @@ async def test_sync_connector_accounts_for_truncated_raw_text(
     }
     assert state is not None
     assert state.last_stats == result.stats
+
+
+async def test_distillation_admission_is_restart_safe_and_holds_cursor_until_harvest(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "22222222-2222-4222-8222-222222222222"
+    session.add(Org(id=_ORG_ID, name="Knowledge Org", slug="knowledge-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Knowledge Worker",
+            email="knowledge@example.com",
+        )
+    )
+    await session.flush()
+    connector = _StubConnector(
+        source_key="slack",
+        drafts=[
+            KnowledgeDraft(
+                source="slack",
+                kind="slack_thread",
+                source_ref="slack:T1:C1:1700000000.000001",
+                title="Release thread",
+                summary="Structural fallback summary",
+                raw_text="Why did release 42 fail? It was fixed in deploy.py.",
+                extra={"org_id": _ORG_ID, "actor_user_id": user_id},
+                distill=True,
+            )
+        ],
+        new_cursor={"latest_reply": "1700000001.000001"},
+    )
+
+    dispatched = await sync_connector(session, connector)
+    repeated = await sync_connector(session, connector)
+    runs = list((await session.scalars(select(AgentRunRow))).all())
+    state = await session.get(KnowledgeSyncState, "slack")
+
+    assert dispatched.status == "pending"
+    assert dispatched.cursor == {}
+    assert dispatched.stats["pending"] == 1
+    assert repeated.status == "pending"
+    assert connector.seen_cursors == [{}]
+    assert len(runs) == 1
+    assert runs[0].model_policy == {}
+    assert runs[0].source_idempotency_scope == "knowledge"
+    assert state is not None
+    assert state.cursor["_distillation_pending"]["proposed_cursor"] == {
+        "latest_reply": "1700000001.000001"
+    }
+
+    runs[0].status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=runs[0].id,
+            root_run_id=runs[0].root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "Why did release 42 fail?",
+                    "summary": "Release 42 failed during deployment.",
+                    "resolution": "The deployment path was fixed.",
+                    "systems": ["deployment"],
+                    "code_references": ["deploy.py"],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    harvested = await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source_ref == "slack:T1:C1:1700000000.000001"
+        )
+    )
+
+    assert harvested.status == "ok"
+    assert harvested.cursor == {"latest_reply": "1700000001.000001"}
+    assert harvested.stats["distilled"] == 1
+    assert connector.seen_cursors == [{}]
+    assert item is not None
+    assert item.summary == "Release 42 failed during deployment."
+    assert item.resolution == "The deployment path was fixed."
+    assert item.entities == ["deployment", "deploy.py"]
+    assert "Why did release 42 fail?" in item.search_text
+    assert (
+        await session.scalar(
+            select(func.count()).select_from(KnowledgeItemEmbedding)
+        )
+        == 1
+    )
+
+
+async def test_distillation_exhaustion_lands_lexical_fallback_without_embedding(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "33333333-3333-4333-8333-333333333333"
+    session.add(Org(id=_ORG_ID, name="Fallback Org", slug="fallback-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Fallback Worker",
+            email="fallback@example.com",
+        )
+    )
+    await session.flush()
+    connector = _StubConnector(
+        source_key="github",
+        drafts=[
+            KnowledgeDraft(
+                source="github",
+                kind="issue",
+                source_ref="github:Illospace/illospace#577",
+                title="Distill this issue",
+                summary="Structural fallback survives poison output.",
+                raw_text="Original issue body remains lexically searchable.",
+                extra={"org_id": _ORG_ID, "actor_user_id": user_id},
+                distill=True,
+            )
+        ],
+        new_cursor={"id": 577},
+    )
+
+    await sync_connector(session, connector)
+    first = (await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id))).one()
+    first.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=first.id,
+            root_run_id=first.root_run_id,
+            artifact_type="final_answer",
+            text="This is not JSON.",
+        )
+    )
+    await session.flush()
+
+    retry = await sync_connector(session, connector)
+    runs = list((await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id))).all())
+    assert retry.status == "pending"
+    assert len(runs) == 2
+    runs[-1].status = "failed"
+    await session.flush()
+
+    exhausted = await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source_ref == "github:Illospace/illospace#577"
+        )
+    )
+
+    assert exhausted.status == "degraded"
+    assert exhausted.cursor == {"id": 577}
+    assert exhausted.stats["failed"] == 1
+    assert item is not None
+    assert item.summary == "Structural fallback survives poison output."
+    assert "Original issue body" in item.search_text
+    assert item.extra["distillation"]["status"] == "failed"
+    assert (
+        await session.scalar(
+            select(func.count()).select_from(KnowledgeItemEmbedding)
+        )
+        == 0
+    )

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -32,11 +32,16 @@ from brain.platform.db.models.org import Org, User
 from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
+from brain.systems.knowledge.connectors.github import _draft_for_issue
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+from brain.systems.cortex.project_context.github import (
+    GithubFixingPullRequest,
+    GithubIssueClosure,
+)
 
 
 _ORG_ID = "11111111-1111-4111-8111-111111111111"
@@ -178,6 +183,62 @@ def test_default_knowledge_sync_includes_the_memory_mirror():
         "slack",
         "memory",
     ]
+
+
+def test_github_closed_issue_draft_carries_closure_facts_into_distillation():
+    merged_at = datetime(2026, 7, 28, 20, 10, tzinfo=timezone.utc)
+    draft = _draft_for_issue(
+        "Illospace/illospace",
+        {
+            "id": 577,
+            "number": 577,
+            "title": "Knowledge slice 2",
+            "state": "closed",
+            "body": "Implement the conversational knowledge layer.",
+            "labels": [],
+            "user": {"login": "redawear"},
+            "created_at": "2026-07-28T18:00:00Z",
+            "updated_at": "2026-07-28T20:10:00Z",
+            "closed_at": "2026-07-28T20:10:00Z",
+        },
+        closure=GithubIssueClosure(
+            repo="Illospace/illospace",
+            number=577,
+            title="Knowledge slice 2",
+            state="closed",
+            closed_at=merged_at,
+            closed_by="redawear",
+            fixing_pull_requests=(
+                GithubFixingPullRequest(
+                    repo="Illospace/illospace",
+                    number=583,
+                    base_ref_name="main",
+                    merge_commit_sha="a" * 40,
+                    merged_at=merged_at,
+                ),
+            ),
+        ),
+        org_id=_ORG_ID,
+        actor_user_id="22222222-2222-4222-8222-222222222222",
+    )
+
+    assert draft.distill is True
+    assert draft.resolution == (
+        "Resolved by merged PR Illospace/illospace#583 "
+        f"(commit {'a' * 40}) at {merged_at.isoformat()}"
+    )
+    assert "Illospace/illospace#583" in draft.entities
+    assert draft.extra["closed_by"] == "redawear"
+    assert draft.extra["fixing_pull_requests"] == [
+        {
+            "repo": "Illospace/illospace",
+            "number": 583,
+            "base_ref_name": "main",
+            "merge_commit_sha": "a" * 40,
+            "merged_at": merged_at.isoformat(),
+        }
+    ]
+    assert draft.extra["org_id"] == _ORG_ID
 
 
 @pytest.fixture

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -868,8 +868,19 @@ async def test_sync_connector_accounts_for_truncated_raw_text(
 async def test_distillation_admission_is_restart_safe_and_holds_cursor_until_harvest(
     session,
     embedding_runtime,
+    monkeypatch,
 ):
     del embedding_runtime
+    from brain.systems.memory import embeddings as embedding_client
+
+    embedded_documents: list[str] = []
+
+    def capture_embedding(text, runtime_config=None):
+        del runtime_config
+        embedded_documents.append(text)
+        return _unit_vector()
+
+    monkeypatch.setattr(embedding_client, "embed_document", capture_embedding)
     user_id = "22222222-2222-4222-8222-222222222222"
     session.add(Org(id=_ORG_ID, name="Knowledge Org", slug="knowledge-org"))
     session.add(
@@ -951,6 +962,13 @@ async def test_distillation_admission_is_restart_safe_and_holds_cursor_until_har
     assert item.resolution == "The deployment path was fixed."
     assert item.entities == ["deployment", "deploy.py"]
     assert "Why did release 42 fail?" in item.search_text
+    assert embedded_documents == [
+        "Why did release 42 fail?\n"
+        "Release thread\n"
+        "Release 42 failed during deployment.\n"
+        "The deployment path was fixed.\n"
+        "deployment deploy.py"
+    ]
     assert (
         await session.scalar(
             select(func.count()).select_from(KnowledgeItemEmbedding)

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
@@ -32,7 +33,7 @@ from brain.platform.db.models.org import Org, User
 from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
-from brain.systems.knowledge.connectors.github import _draft_for_issue
+from brain.systems.knowledge.connectors.github import GitHubConnector, _draft_for_issue
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
@@ -660,6 +661,7 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
         "archived": True,
         "mirror_status": "visibility_withdrawn",
         "node_kind": "summary",
+        "org_id": _ORG_ID,
         "truth_status": "active",
         "visibility": "private",
     }
@@ -711,6 +713,7 @@ async def test_embedding_failures_degrade_to_lexical_ingest_and_search(
                 title="Lexical lighthouse",
                 summary="This row survives an embedding outage.",
                 raw_text="lexical lighthouse fallback",
+                extra={"org_id": "org-degraded"},
             )
         ],
     )
@@ -739,7 +742,11 @@ async def test_embedding_failures_degrade_to_lexical_ingest_and_search(
         "embed_query",
         fail_query_embedding,
     )
-    search_result = await search_knowledge(session, "lexical lighthouse")
+    search_result = await search_knowledge(
+        session,
+        "lexical lighthouse",
+        org_id="org-degraded",
+    )
 
     assert search_result["semantic_available"] is False
     assert search_result["semantic_degraded_reason"] == "query embedding offline"
@@ -767,11 +774,12 @@ async def test_agent_mcp_exposes_and_dispatches_knowledge_search():
     session = _McpAsyncSession()
     captured: dict[str, object] = {}
 
-    async def fake_search_knowledge(db, query, *, sources, kinds, limit):
+    async def fake_search_knowledge(db, query, *, org_id, sources, kinds, limit):
         captured.update(
             {
                 "db": db,
                 "query": query,
+                "org_id": org_id,
                 "sources": sources,
                 "kinds": kinds,
                 "limit": limit,
@@ -815,6 +823,7 @@ async def test_agent_mcp_exposes_and_dispatches_knowledge_search():
     assert captured == {
         "db": session,
         "query": "roadmap",
+        "org_id": "org-1",
         "sources": ["github", "domain_records"],
         "kinds": ["issue"],
         "limit": 7,
@@ -958,23 +967,34 @@ async def test_distillation_admission_is_restart_safe_and_holds_cursor_until_har
     assert harvested.stats["distilled"] == 1
     assert connector.seen_cursors == [{}]
     assert item is not None
+    assert item.title == "Release thread"
     assert item.summary == "Release 42 failed during deployment."
     assert item.resolution == "The deployment path was fixed."
     assert item.entities == ["deployment", "deploy.py"]
     assert "Why did release 42 fail?" in item.search_text
     assert embedded_documents == [
         "Why did release 42 fail?\n"
-        "Release thread\n"
         "Release 42 failed during deployment.\n"
         "The deployment path was fixed.\n"
         "deployment deploy.py"
     ]
+    assert "Release thread" not in embedded_documents[0]
     assert (
         await session.scalar(
             select(func.count()).select_from(KnowledgeItemEmbedding)
         )
         == 1
     )
+
+    unchanged = await sync_connector(session, connector)
+    assert unchanged.status == "ok"
+    assert unchanged.stats == {
+        "ingested": 0,
+        "skipped": 1,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert len(list((await session.scalars(select(AgentRunRow))).all())) == 1
 
 
 async def test_distillation_exhaustion_lands_lexical_fallback_without_embedding(
@@ -1050,3 +1070,310 @@ async def test_distillation_exhaustion_lands_lexical_fallback_without_embedding(
         )
         == 0
     )
+
+
+async def test_mixed_distillation_batch_persists_completed_rows_while_others_wait(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "44444444-4444-4444-8444-444444444444"
+    session.add(Org(id=_ORG_ID, name="Mixed Org", slug="mixed-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Mixed Worker",
+            email="mixed@example.com",
+        )
+    )
+    await session.flush()
+    connector = _StubConnector(
+        source_key="slack",
+        drafts=[
+            KnowledgeDraft(
+                source="slack",
+                kind="slack_thread",
+                source_ref=f"slack:T1:C1:{index}",
+                title=f"Thread {index}",
+                summary=f"Fallback {index}",
+                raw_text=f"Raw thread {index}",
+                extra={"org_id": _ORG_ID, "actor_user_id": user_id},
+                distill=True,
+            )
+            for index in (1, 2)
+        ],
+        new_cursor={"position": 2},
+    )
+
+    dispatched = await sync_connector(session, connector)
+    runs = list((await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id))).all())
+    assert dispatched.stats["pending"] == 2
+    runs[0].status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=runs[0].id,
+            root_run_id=runs[0].root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "Question one?",
+                    "summary": "Distilled one.",
+                    "resolution": None,
+                    "systems": [],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    partial = await sync_connector(session, connector)
+    assert partial.status == "pending"
+    assert partial.cursor == {}
+    assert partial.stats["pending"] == 1
+    assert partial.stats["distilled"] == 1
+    assert list((await session.scalars(select(KnowledgeItem.source_ref))).all()) == [
+        "slack:T1:C1:1"
+    ]
+
+    runs[1].status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=runs[1].id,
+            root_run_id=runs[1].root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "Question two?",
+                    "summary": "Distilled two.",
+                    "resolution": None,
+                    "systems": [],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    finished = await sync_connector(session, connector)
+    assert finished.status == "ok"
+    assert finished.cursor == {"position": 2}
+    assert set((await session.scalars(select(KnowledgeItem.source_ref))).all()) == {
+        "slack:T1:C1:1",
+        "slack:T1:C1:2",
+    }
+
+
+async def test_knowledge_search_scopes_lexical_and_semantic_candidates_to_org(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    connector = _StubConnector(
+        source_key="scoped",
+        drafts=[
+            KnowledgeDraft(
+                source="scoped",
+                kind="record",
+                source_ref=f"scoped:{suffix}",
+                title="Shared deployment keyword",
+                summary=f"Secret for org {suffix}",
+                raw_text="shared deployment keyword",
+                extra={"org_id": org_id},
+            )
+            for suffix, org_id in (("a", "org-a"), ("b", "org-b"))
+        ],
+    )
+    await sync_connector(session, connector)
+
+    result = await search_knowledge(
+        session,
+        "shared deployment keyword",
+        org_id="org-a",
+    )
+
+    assert result["org_id"] == "org-a"
+    assert result["semantic_available"] is True
+    assert [item["source_ref"] for item in result["results"]] == ["scoped:a"]
+
+
+async def test_distillation_preserves_verified_github_resolution_when_model_omits_it(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "55555555-5555-4555-8555-555555555555"
+    structural_resolution = "Resolved by merged PR Illospace/illospace#583"
+    session.add(Org(id=_ORG_ID, name="Closure Org", slug="closure-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Closure Worker",
+            email="closure@example.com",
+        )
+    )
+    await session.flush()
+    connector = _StubConnector(
+        source_key="github",
+        drafts=[
+            KnowledgeDraft(
+                source="github",
+                kind="issue",
+                source_ref="github:Illospace/illospace#577",
+                title="Quasarlexeme closure title",
+                summary="Closed issue awaiting distillation.",
+                resolution=structural_resolution,
+                raw_text="Implement the conversational knowledge layer.",
+                extra={"org_id": _ORG_ID, "actor_user_id": user_id},
+                distill=True,
+            )
+        ],
+        new_cursor={"version": 2},
+    )
+
+    await sync_connector(session, connector)
+    run = (await session.scalars(select(AgentRunRow))).one()
+    run.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=run.id,
+            root_run_id=run.root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "How was knowledge slice 2 completed?",
+                    "summary": "The conversational knowledge layer shipped.",
+                    "resolution": None,
+                    "systems": ["knowledge"],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
+
+    result = await sync_connector(session, connector)
+    item = await session.scalar(
+        select(KnowledgeItem).where(
+            KnowledgeItem.source_ref == "github:Illospace/illospace#577"
+        )
+    )
+
+    assert result.status == "ok"
+    assert item is not None
+    assert item.title == "Quasarlexeme closure title"
+    assert item.resolution == structural_resolution
+    search_result = await search_knowledge(
+        session,
+        "quasarlexeme",
+        org_id=_ORG_ID,
+    )
+    assert [row["source_ref"] for row in search_result["results"]] == [
+        "github:Illospace/illospace#577"
+    ]
+
+
+async def test_github_closure_enrichment_failure_retries_without_advancing_cursor(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    user_id = "66666666-6666-4666-8666-666666666666"
+    repo = "Illospace/illospace"
+    session.add(Org(id=_ORG_ID, name="Retry Org", slug="retry-org"))
+    session.add(
+        User(
+            id=user_id,
+            org_id=_ORG_ID,
+            name="Retry Worker",
+            email="retry@example.com",
+        )
+    )
+    await session.flush()
+    issue = {
+        "id": 577,
+        "number": 577,
+        "title": "Knowledge slice 2",
+        "state": "closed",
+        "body": "Implement the conversational knowledge layer.",
+        "labels": [],
+        "user": {"login": "redawear"},
+        "created_at": "2026-07-28T18:00:00Z",
+        "updated_at": "2026-07-28T20:10:00Z",
+        "closed_at": "2026-07-28T20:10:00Z",
+    }
+    closure = GithubIssueClosure(
+        repo=repo,
+        number=577,
+        title="Knowledge slice 2",
+        state="closed",
+        closed_at=datetime(2026, 7, 28, 20, 10, tzinfo=timezone.utc),
+        closed_by="redawear",
+        fixing_pull_requests=(),
+    )
+    list_issues = AsyncMock(return_value={"issues": [issue], "next_page": None})
+    get_closure = AsyncMock(side_effect=[RuntimeError("temporary"), closure])
+    authority = SimpleNamespace(
+        token="token",
+        org_id=_ORG_ID,
+        actor_user_id=user_id,
+    )
+    connector = GitHubConnector(repositories=[repo])
+
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=list_issues,
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_get_issue_closure_info",
+        new=get_closure,
+    ):
+        failed = await sync_connector(session, connector)
+        retried = await sync_connector(session, connector)
+
+    assert failed.status == "failed"
+    assert failed.cursor == {}
+    assert failed.stats["failed"] == 1
+    assert retried.status == "pending"
+    assert retried.cursor == {}
+    assert get_closure.await_count == 2
+    state = await session.get(KnowledgeSyncState, "github")
+    assert state is not None
+    assert state.cursor["_distillation_pending"]["proposed_cursor"]["version"] == 2
+
+
+async def test_github_legacy_cursor_is_reset_for_org_scope_backfill(session):
+    repo = "Illospace/illospace"
+    list_issues = AsyncMock(return_value={"issues": [], "next_page": None})
+    authority = SimpleNamespace(
+        token="token",
+        org_id=_ORG_ID,
+        actor_user_id="77777777-7777-4777-8777-777777777777",
+    )
+    connector = GitHubConnector(repositories=[repo])
+    legacy_cursor = {
+        "active_repository": 0,
+        "repositories": {
+            repo: {
+                "watermark": "2026-07-28T20:10:00+00:00",
+                "watermark_id": 577,
+            }
+        },
+    }
+
+    with patch(
+        "brain.systems.knowledge.connectors.github._github_authority",
+        new=AsyncMock(return_value=authority),
+    ), patch(
+        "brain.systems.knowledge.connectors.github.async_list_repo_issues",
+        new=list_issues,
+    ):
+        drafts, cursor = await connector.enumerate_changed(session, legacy_cursor)
+
+    assert drafts == []
+    assert list_issues.await_args.kwargs["since"] is None
+    assert cursor["version"] == 2

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -15,6 +15,7 @@ from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 from brain.app.api.auth import get_current_user
 from brain.app.api.deps import get_db, rate_limit
 from brain.app.api.main import app
+from brain.jobs.pipelines.knowledge_index_sync import CONNECTOR_FACTORIES
 from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
 from brain.platform.db.models.agent_run import (
     AgentRunArtifactRow,
@@ -28,8 +29,10 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
+from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
+from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
 from brain.systems.external_agents import service as external_agents
@@ -134,6 +137,48 @@ def _unit_vector(axis: int = 0) -> np.ndarray:
     return vector
 
 
+def _memory_node(
+    node_id: int,
+    at: datetime,
+    *,
+    node_kind: str = "summary",
+    content_kind: str = "decision",
+    title: str | None = None,
+    text: str | None = None,
+    scope: str = "engineering",
+    org_id: str | None = _ORG_ID,
+    user_id: str | None = None,
+    visibility: str = "org",
+    confidence: float = 0.8,
+) -> MemoryNode:
+    label = title or f"Memory {node_id}"
+    return MemoryNode(
+        id=node_id,
+        node_kind=node_kind,
+        content_kind=content_kind,
+        canonical_label=label,
+        text=text or f"Memory body {node_id}",
+        normalized_key=label.casefold(),
+        scope_key=scope,
+        org_id=org_id,
+        user_id=user_id,
+        visibility=visibility,
+        confidence=confidence,
+        truth_status="active",
+        freshness_status="fresh",
+        created_at=at,
+        updated_at=at,
+    )
+
+
+def test_default_knowledge_sync_includes_the_memory_mirror():
+    assert [factory.source_key for factory in CONNECTOR_FACTORIES] == [
+        "domain_records",
+        "github",
+        "memory",
+    ]
+
+
 @pytest.fixture
 def embedding_runtime(monkeypatch):
     from brain.systems.memory import embeddings as embedding_client
@@ -182,6 +227,8 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
+            MemoryNode.__table__,
+            MemoryEdgeNode.__table__,
         ]
     )
 
@@ -297,6 +344,263 @@ async def test_domain_records_connector_advances_and_resumes_watermark_with_id_t
             )
         ).all()
     ) == ["domain_record:1", "domain_record:2", "domain_record:3"]
+
+
+async def test_memory_connector_mirrors_only_shared_consolidated_memories(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    updated_at = datetime(2026, 7, 18, 14, 0, tzinfo=timezone.utc)
+    session.add_all(
+        [
+            _memory_node(
+                11,
+                updated_at,
+                content_kind="decision",
+                title="Queue ownership rule",
+                text="An in-progress ticket belongs to the agent already working it.",
+                visibility="org",
+                confidence=0.92,
+            ),
+            _memory_node(
+                12,
+                updated_at,
+                node_kind="content",
+                content_kind="decision",
+                title="Unconsolidated source",
+                text="This source memory must not be mirrored yet.",
+                visibility="org",
+                confidence=0.7,
+            ),
+            _memory_node(
+                13,
+                updated_at,
+                content_kind="preference",
+                title="Private preference",
+                text="This user-private summary must remain in memory only.",
+                scope="personal",
+                org_id=None,
+                user_id="22222222-2222-4222-8222-222222222222",
+                visibility="private",
+                confidence=0.8,
+            ),
+        ]
+    )
+    await session.flush()
+
+    result = await sync_connector(session, MemoryConnector(max_items=10))
+    items = list((await session.scalars(select(KnowledgeItem))).all())
+
+    assert result.status == "ok"
+    assert result.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert result.cursor == {"updated_at": updated_at.isoformat(), "id": 13}
+    assert [item.source_ref for item in items] == ["memory_node:11"]
+    assert items[0].source == "memory"
+    assert items[0].kind == "memory"
+    assert items[0].title == "Queue ownership rule"
+    assert (
+        items[0].summary
+        == "An in-progress ticket belongs to the agent already working it."
+    )
+    assert items[0].raw_text == items[0].summary
+    assert items[0].entities == ["decision", "engineering"]
+    assert items[0].extra == {
+        "archived": False,
+        "consolidated": True,
+        "confidence": 0.92,
+        "freshness_status": "fresh",
+        "memory_type": "decision",
+        "node_kind": "summary",
+        "org_id": _ORG_ID,
+        "scope": "engineering",
+        "sensitivity": "low",
+        "source_type": "reconstructive_memory_node",
+        "superseded": False,
+        "superseded_by": None,
+        "truth_status": "active",
+        "visibility": "org",
+    }
+
+
+async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    updated_at = datetime(2026, 7, 19, 9, 30, tzinfo=timezone.utc)
+    session.add_all(
+        [
+            _memory_node(
+                node_id,
+                updated_at,
+                content_kind="lesson",
+                title=f"Consolidated lesson {node_id}",
+                text=f"Durable lesson body {node_id}",
+                visibility="team",
+            )
+            for node_id in (21, 22, 23)
+        ]
+    )
+    await session.flush()
+    connector = MemoryConnector(max_items=2)
+
+    first = await sync_connector(session, connector)
+    second = await sync_connector(session, connector)
+    exhausted = await sync_connector(session, connector)
+
+    assert first.stats["ingested"] == 2
+    assert first.cursor == {"updated_at": updated_at.isoformat(), "id": 22}
+    assert second.stats["ingested"] == 1
+    assert second.cursor == {"updated_at": updated_at.isoformat(), "id": 23}
+    assert exhausted.stats == {
+        "ingested": 0,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert exhausted.cursor == second.cursor
+    assert list(
+        (
+            await session.scalars(
+                select(KnowledgeItem.source_ref).order_by(KnowledgeItem.source_ref)
+            )
+        ).all()
+    ) == ["memory_node:21", "memory_node:22", "memory_node:23"]
+
+
+async def test_memory_connector_propagates_archived_and_superseded_state(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    created_at = datetime(2026, 7, 20, 8, 0, tzinfo=timezone.utc)
+    nodes = [
+        _memory_node(
+            node_id,
+            created_at,
+            content_kind="decision",
+            title=f"Decision {node_id}",
+            text=f"Decision body {node_id}",
+        )
+        for node_id in (31, 32)
+    ]
+    replacement = _memory_node(
+        33,
+        created_at,
+        node_kind="content",
+        title="Replacement decision",
+    )
+    session.add_all([*nodes, replacement])
+    await session.flush()
+    connector = MemoryConnector(max_items=10)
+    await sync_connector(session, connector)
+
+    retired_at = datetime(2026, 7, 20, 9, 0, tzinfo=timezone.utc)
+    nodes[0].archived_at = retired_at
+    nodes[0].updated_at = retired_at
+    nodes[1].truth_status = "superseded"
+    nodes[1].freshness_status = "stale"
+    nodes[1].updated_at = retired_at
+    session.add(
+        MemoryEdgeNode(
+            source_node_id=32,
+            target_node_id=33,
+            edge_kind="superseded_by",
+            org_id=_ORG_ID,
+            visibility="org",
+            created_by="test",
+        )
+    )
+    await session.flush()
+
+    result = await sync_connector(session, connector)
+    mirrored = {
+        item.source_ref: item
+        for item in (await session.scalars(select(KnowledgeItem))).all()
+    }
+
+    assert result.stats == {
+        "ingested": 2,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert (
+        mirrored["memory_node:31"].archived_at.replace(tzinfo=timezone.utc)
+        == retired_at
+    )
+    assert mirrored["memory_node:31"].extra["archived"] is True
+    assert mirrored["memory_node:31"].extra["superseded"] is False
+    assert (
+        mirrored["memory_node:32"].archived_at.replace(tzinfo=timezone.utc)
+        == retired_at
+    )
+    assert mirrored["memory_node:32"].extra["archived"] is False
+    assert mirrored["memory_node:32"].extra["superseded"] is True
+    assert mirrored["memory_node:32"].extra["superseded_by"] == 33
+    assert mirrored["memory_node:32"].extra["truth_status"] == "superseded"
+
+
+async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    created_at = datetime(2026, 7, 21, 10, 0, tzinfo=timezone.utc)
+    node = _memory_node(
+        41,
+        created_at,
+        content_kind="decision",
+        title="Shared launch decision",
+        text="The private launch detail must disappear if visibility changes.",
+        scope="launch",
+        visibility="team",
+        confidence=0.9,
+    )
+    session.add(node)
+    await session.flush()
+    connector = MemoryConnector(max_items=10)
+    await sync_connector(session, connector)
+
+    withdrawn_at = datetime(2026, 7, 21, 11, 0, tzinfo=timezone.utc)
+    node.visibility = "private"
+    node.updated_at = withdrawn_at
+    await session.flush()
+
+    result = await sync_connector(session, connector)
+    mirrored = await session.scalar(
+        select(KnowledgeItem).where(KnowledgeItem.source_ref == "memory_node:41")
+    )
+
+    assert result.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert result.cursor == {"updated_at": withdrawn_at.isoformat(), "id": 41}
+    assert mirrored is not None
+    assert mirrored.archived_at.replace(tzinfo=timezone.utc) == withdrawn_at
+    assert mirrored.title == "Memory no longer shared"
+    assert (
+        mirrored.summary
+        == "This consolidated memory is no longer shared with the workspace."
+    )
+    assert mirrored.raw_text == ""
+    assert "launch detail" not in mirrored.search_text
+    assert mirrored.extra == {
+        "archived": True,
+        "mirror_status": "visibility_withdrawn",
+        "node_kind": "summary",
+        "truth_status": "active",
+        "visibility": "private",
+    }
 
 
 def test_reciprocal_rank_fusion_uses_recency_as_weight_not_candidate_gate():

--- a/tests/test_knowledge_slack_connector.py
+++ b/tests/test_knowledge_slack_connector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import hashlib
+import json
 
 import numpy as np
 import pytest
@@ -11,6 +12,11 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
 from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.platform.db.models.agent_run import (
+    AgentRunArtifactRow,
+    AgentRunEventRow,
+    AgentRunRow,
+)
 from brain.platform.db.models.inbound import InboundEventRow
 from brain.platform.db.models.knowledge import (
     KnowledgeItem,
@@ -44,6 +50,9 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             User.__table__,
             ExternalAgentConnectionRow.__table__,
             InboundEventRow.__table__,
+            AgentRunRow.__table__,
+            AgentRunEventRow.__table__,
+            AgentRunArtifactRow.__table__,
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
@@ -208,22 +217,72 @@ async def test_slack_backfill_is_bounded_and_reports_each_page_through_shared_st
     await _seed_monitored_slack(session)
     connector = SlackKnowledgeConnector(client=_PagedSlackHistory(), max_items=1)
 
+    first_dispatch = await sync_connector(session, connector)
+    first_run = (await session.scalars(select(AgentRunRow))).one()
+    first_run.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=first_run.id,
+            root_run_id=first_run.root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "What happened in the first thread?",
+                    "summary": "The first Slack thread was distilled.",
+                    "resolution": None,
+                    "systems": ["slack"],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
     first = await sync_connector(session, connector)
+
+    second_dispatch = await sync_connector(session, connector)
+    second_run = (
+        await session.scalars(select(AgentRunRow).order_by(AgentRunRow.id.desc()))
+    ).first()
+    assert second_run is not None
+    second_run.status = "completed"
+    session.add(
+        AgentRunArtifactRow(
+            run_id=second_run.id,
+            root_run_id=second_run.root_run_id,
+            artifact_type="final_answer",
+            text=json.dumps(
+                {
+                    "question": "What happened in the second thread?",
+                    "summary": "The second Slack thread was distilled.",
+                    "resolution": None,
+                    "systems": ["slack"],
+                    "code_references": [],
+                }
+            ),
+        )
+    )
+    await session.flush()
     second = await sync_connector(session, connector)
 
+    assert first_dispatch.status == "pending"
+    assert first_dispatch.stats["pending"] == 1
     assert first.stats == {
         "ingested": 1,
         "skipped": 0,
         "failed": 0,
         "truncated": 0,
+        "distilled": 1,
     }
     assert first.cursor["phase"] == "backfill"
     assert first.cursor["history_cursor"] == "history-2"
+    assert second_dispatch.status == "pending"
+    assert second_dispatch.stats["pending"] == 1
     assert second.stats == {
         "ingested": 1,
         "skipped": 0,
         "failed": 0,
         "truncated": 0,
+        "distilled": 1,
     }
     assert second.cursor["phase"] == "incremental"
     assert await session.scalar(select(func.count()).select_from(KnowledgeItem)) == 2

--- a/tests/test_knowledge_slack_connector.py
+++ b/tests/test_knowledge_slack_connector.py
@@ -1,0 +1,393 @@
+"""Behavioral coverage for thread-level Slack knowledge ingestion."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+
+import numpy as np
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+from brain.platform.db.models.external_agent import ExternalAgentConnectionRow
+from brain.platform.db.models.inbound import InboundEventRow
+from brain.platform.db.models.knowledge import (
+    KnowledgeItem,
+    KnowledgeItemEmbedding,
+    KnowledgeSyncState,
+)
+from brain.platform.db.models.org import Org, User
+from brain.jobs.pipelines.knowledge_index_sync import CONNECTOR_FACTORIES
+from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
+from brain.systems.knowledge.connectors.slack import SlackKnowledgeConnector
+from brain.systems.knowledge.service import sync_connector
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+
+_ORG_ID = "11111111-1111-4111-8111-111111111111"
+_USER_ID = "22222222-2222-4222-8222-222222222222"
+_CONNECTION_ID = "33333333-3333-4333-8333-333333333333"
+
+
+def test_slack_connector_runs_in_the_shared_knowledge_sync_pipeline():
+    assert SlackKnowledgeConnector in CONNECTOR_FACTORIES
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    del sqlite_postgres_ddl_patch
+    SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "VARCHAR(36)"
+    return await async_sqlite_session_factory(
+        [
+            Org.__table__,
+            User.__table__,
+            ExternalAgentConnectionRow.__table__,
+            InboundEventRow.__table__,
+            KnowledgeItem.__table__,
+            KnowledgeItemEmbedding.__table__,
+            KnowledgeSyncState.__table__,
+        ]
+    )
+
+
+async def _seed_monitored_slack(session) -> None:
+    session.add(Org(id=_ORG_ID, name="Test Org", slug="test-org"))
+    session.add(
+        User(
+            id=_USER_ID,
+            org_id=_ORG_ID,
+            name="Reda",
+            email="reda@example.com",
+        )
+    )
+    session.add(
+        ExternalAgentConnectionRow(
+            id=_CONNECTION_ID,
+            org_id=_ORG_ID,
+            owner_user_id=_USER_ID,
+            display_name="Slack",
+            agent_kind="slack",
+            transport="slack_socket_mode",
+            status="online",
+            remote_agent_id="T789",
+            remote_agent_card={},
+            capabilities={"slack": {"socket_mode": True}},
+            auth_metadata={
+                "bot_token_ref": "runtime:SLACK_BOT_TOKEN",
+                "app_token_ref": "runtime:SLACK_APP_TOKEN",
+            },
+            metadata_={
+                "slack": {
+                    "team_id": "T789",
+                    "monitored_channels": [
+                        {
+                            "channel_id": "CINCIDENTS",
+                            "channel_name": "incidents",
+                            "enabled": True,
+                        }
+                    ],
+                }
+            },
+        )
+    )
+    await session.flush()
+
+
+class _SlackHistory:
+    def __init__(self) -> None:
+        self.messages = [
+            {"ts": "1785283200.000100", "user": "U1", "text": "Checkout is failing"},
+            {"ts": "1785283260.000200", "user": "U2", "text": "Payment API is timing out"},
+        ]
+        self.history_calls: list[dict] = []
+        self.reply_calls: list[str | None] = []
+
+    async def conversation_history(self, **kwargs):
+        self.history_calls.append(dict(kwargs))
+        return {
+            "messages": [
+                {
+                    **self.messages[0],
+                    "reply_count": len(self.messages) - 1,
+                    "latest_reply": self.messages[-1]["ts"],
+                }
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    async def conversation_replies(
+        self,
+        *,
+        channel,
+        thread_ts,
+        limit,
+        cursor=None,
+    ):
+        del channel, thread_ts, limit
+        self.reply_calls.append(cursor)
+        if cursor is None:
+            return {
+                "messages": [self.messages[0]],
+                "response_metadata": {"next_cursor": "replies-2"},
+            }
+        return {
+            "messages": list(self.messages[1:]),
+            "response_metadata": {"next_cursor": ""},
+        }
+
+
+class _PagedSlackHistory:
+    def __init__(self) -> None:
+        self.roots = [
+            {"ts": "1785283200.000100", "user": "U1", "text": "First thread"},
+            {"ts": "1785283260.000200", "user": "U2", "text": "Second thread"},
+        ]
+
+    async def conversation_history(self, *, channel, limit, cursor=None):
+        del channel
+        assert limit == 1
+        if cursor is None:
+            return {
+                "messages": [self.roots[0]],
+                "response_metadata": {"next_cursor": "history-2"},
+            }
+        assert cursor == "history-2"
+        return {
+            "messages": [self.roots[1]],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    async def conversation_replies(self, *, channel, thread_ts, limit, cursor=None):
+        del channel, limit
+        assert cursor is None
+        return {
+            "messages": [root for root in self.roots if root["ts"] == thread_ts],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+
+@pytest.fixture
+def embedding_runtime(monkeypatch):
+    from brain.systems.memory import embeddings as embedding_client
+    from brain.systems.runtime_settings import memory as runtime_settings
+
+    runtime = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="test-knowledge-embedding",
+        cpu_model="unused",
+        dimensions=KNOWLEDGE_EMBEDDING_DIM,
+        api_key="test-key",
+    )
+
+    async def fake_runtime_config(session, *, include_secret=True):
+        del session, include_secret
+        return runtime
+
+    vector = np.zeros(KNOWLEDGE_EMBEDDING_DIM, dtype=np.float32)
+    vector[0] = 1.0
+    monkeypatch.setattr(
+        runtime_settings,
+        "async_get_embedding_runtime_config",
+        fake_runtime_config,
+    )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_document",
+        lambda text, runtime_config=None: vector,
+    )
+    return runtime
+
+
+async def test_slack_backfill_is_bounded_and_reports_each_page_through_shared_stats(
+    session,
+    embedding_runtime,
+):
+    del embedding_runtime
+    await _seed_monitored_slack(session)
+    connector = SlackKnowledgeConnector(client=_PagedSlackHistory(), max_items=1)
+
+    first = await sync_connector(session, connector)
+    second = await sync_connector(session, connector)
+
+    assert first.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert first.cursor["phase"] == "backfill"
+    assert first.cursor["history_cursor"] == "history-2"
+    assert second.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+    assert second.cursor["phase"] == "incremental"
+    assert await session.scalar(select(func.count()).select_from(KnowledgeItem)) == 2
+    state = await session.get(KnowledgeSyncState, "slack")
+    assert state.cursor == second.cursor
+    assert state.last_stats == second.stats
+    rows = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem).order_by(KnowledgeItem.source_ref)
+            )
+        ).all()
+    )
+    assert {row.extra["org_id"] for row in rows} == {_ORG_ID}
+    assert {row.extra["actor_user_id"] for row in rows} == {_USER_ID}
+
+
+async def test_slack_connector_does_not_inherit_the_monitor_prompt_text_cap(session):
+    await _seed_monitored_slack(session)
+    slack = _SlackHistory()
+    slack.messages = [
+        {
+            "ts": "1785283200.000100",
+            "user": "U1",
+            "text": f"{'x' * 5000}TAIL_MARKER",
+        }
+    ]
+
+    drafts, _cursor = await SlackKnowledgeConnector(
+        client=slack,
+        max_items=1,
+    ).enumerate_changed(session, {})
+
+    assert len(drafts) == 1
+    assert drafts[0].raw_text.endswith("TAIL_MARKER")
+    assert len(drafts[0].raw_text) > 5000
+
+
+async def test_slack_connector_reuses_runtime_transport_under_connection_authority(
+    session,
+    monkeypatch,
+):
+    from brain.systems.slack import client as slack_client
+
+    await _seed_monitored_slack(session)
+    calls: list[dict] = []
+
+    async def fake_runtime_client(**kwargs):
+        calls.append(dict(kwargs))
+        return _SlackHistory()
+
+    monkeypatch.setattr(
+        slack_client,
+        "slack_web_client_from_runtime",
+        fake_runtime_client,
+    )
+
+    drafts, _cursor = await SlackKnowledgeConnector(max_items=1).enumerate_changed(
+        session,
+        {},
+    )
+
+    assert len(drafts) == 1
+    assert calls == [
+        {
+            "requested_by": "knowledge_index_sync",
+            "reason": "Backfill and incrementally refresh monitored Slack threads.",
+            "org_id": _ORG_ID,
+            "owner_user_id": _USER_ID,
+        }
+    ]
+
+
+async def test_slack_connector_repulls_one_complete_thread_when_a_reply_arrives(session):
+    await _seed_monitored_slack(session)
+    slack = _SlackHistory()
+    connector = SlackKnowledgeConnector(client=slack, max_items=1)
+
+    first, cursor = await connector.enumerate_changed(session, {})
+
+    assert len(first) == 1
+    assert first[0].source_ref == "slack:T789:CINCIDENTS:1785283200.000100"
+    assert first[0].kind == "slack_thread"
+    assert first[0].distill is True
+    assert first[0].raw_text == (
+        "[2026-07-29T00:00:00.000100+00:00] U1: Checkout is failing\n"
+        "[2026-07-29T00:01:00.000200+00:00] U2: Payment API is timing out"
+    )
+    assert first[0].extra["participants"] == ["U1", "U2"]
+    assert first[0].extra["message_count"] == 2
+    assert first[0].source_updated_at == datetime(
+        2026, 7, 29, 0, 1, tzinfo=timezone.utc
+    ).replace(microsecond=200)
+    assert cursor == {
+        "version": 1,
+        "connection_id": _CONNECTION_ID,
+        "channel_set_digest": hashlib.sha256(b"CINCIDENTS").hexdigest(),
+        "phase": "incremental",
+        "channel_id": None,
+        "history_cursor": None,
+        "event_created_at": None,
+        "event_id": None,
+    }
+
+    slack.messages.append(
+        {
+            "ts": "1785283320.000300",
+            "user": "U1",
+            "text": "Resolved by raising the upstream timeout",
+        }
+    )
+    session.add(
+        InboundEventRow(
+            id="44444444-4444-4444-8444-444444444444",
+            org_id=_ORG_ID,
+            connection_id=_CONNECTION_ID,
+            kind="slack_message",
+            origin="slack.channel_message",
+            idempotency_key="slack:T789:CINCIDENTS:1785283320.000300",
+            raw_payload={},
+            normalized_payload={
+                "kind": "slack_message",
+                "origin": "slack.channel_message",
+                "payload": {
+                    "team_id": "T789",
+                    "channel_id": "CINCIDENTS",
+                    "thread_ts": "1785283200.000100",
+                    "message_ts": "1785283320.000300",
+                },
+            },
+            envelope={},
+            ingress_context={},
+            source_actor={},
+            status="processed",
+            created_at=datetime(2026, 7, 29, 0, 2, tzinfo=timezone.utc),
+        )
+    )
+    await session.flush()
+
+    second, new_cursor = await connector.enumerate_changed(session, cursor)
+
+    assert len(second) == 1
+    assert second[0].source_ref == first[0].source_ref
+    assert second[0].extra["message_count"] == 3
+    assert "Resolved by raising the upstream timeout" in second[0].raw_text
+    assert slack.reply_calls == [None, "replies-2", None, "replies-2"]
+    assert new_cursor["phase"] == "incremental"
+    assert new_cursor["event_created_at"] == "2026-07-29T00:02:00+00:00"
+    assert new_cursor["event_id"] == "44444444-4444-4444-8444-444444444444"
+
+    # Illo's own Slack posts are intentionally ignored by monitored intake.
+    # The bounded refresh sweep still makes the canonical thread complete.
+    slack.messages.append(
+        {
+            "ts": "1785283380.000400",
+            "user": "BILLO",
+            "text": "Confirmed healthy after the timeout change",
+        }
+    )
+
+    refreshed, refresh_cursor = await connector.enumerate_changed(session, new_cursor)
+
+    assert len(refreshed) == 1
+    assert refreshed[0].extra["message_count"] == 4
+    assert refreshed[0].extra["participants"] == ["BILLO", "U1", "U2"]
+    assert "Confirmed healthy after the timeout change" in refreshed[0].raw_text
+    assert refresh_cursor["phase"] == "incremental"

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -86,6 +86,32 @@ async def test_slack_client_reads_thread_context_with_query_params(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slack_client_pages_channel_history_through_existing_transport(monkeypatch):
+    calls: list[tuple[str, dict[str, Any]]] = []
+    client = SlackWebClient("xoxb-test")
+
+    async def fake_post(method: str, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append((method, payload))
+        return {"ok": True, "messages": []}
+
+    monkeypatch.setattr(client, "_post", fake_post)
+
+    result = await client.conversation_history(
+        channel="C456",
+        limit=500,
+        cursor="history-2",
+    )
+
+    assert result["ok"] is True
+    assert calls == [
+        (
+            "conversations.history",
+            {"channel": "C456", "limit": 200, "cursor": "history-2"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_slack_client_surfaces_response_metadata_errors(monkeypatch):
     _patch_http_client(
         monkeypatch,


### PR DESCRIPTION
Closes #577

## Summary

- add restart-safe headless distillation for Slack threads and GitHub issues through the existing work-intake/run pipeline
- add complete Slack-thread pagination, incremental/edit refresh, and one distilled row per thread
- add an additive workspace-visible consolidated-memory mirror with visibility-withdrawal scrubbing
- preserve raw content for lexical recall while embedding only distilled question, summary, resolution, systems, and code references
- enrich closed GitHub issues with closure provenance when authenticated GraphQL is available and use an explicit structural fallback otherwise
- scope every knowledge search channel to the authenticated workspace organization
- make cursor advancement two-phase, mixed-batch harvest durable, unchanged refreshes idempotent, and authenticated closure failures retryable

## Safety invariants

- no change to existing reconstructive-memory recall or mutation paths
- private/user-scoped memories never enter workspace knowledge
- source raw text is never embedded
- upstream cursors do not advance past unresolved distillation work
- public tokenless GitHub repositories retain closed-at resolution and record closure enrichment as unavailable

## Verification

- focused knowledge/scheduler/Slack regression set: 85 passed
- knowledge index after final fallback fix: 20 passed
- full fast backend suite: 4,463 passed, 14 skipped, 71 deselected; the 6 loopback-socket cases blocked by the sandbox all passed when rerun outside it (effective 4,469 passed)
- independent static review: no remaining actionable findings
- `git diff --check`: clean
