### PR TITLE
fix(runtime): retry structured provider stream failures

### DIFF
--- a/brain/platform/integrations/provider_error_sentinel.py
+++ b/brain/platform/integrations/provider_error_sentinel.py
@@ -12,6 +12,7 @@ _PROVIDER_ERROR_KINDS = (
     "overloaded_error",
     "rate_limit_error",
 )
+_RETRYABLE_PROVIDER_ERROR_KINDS = frozenset(_PROVIDER_ERROR_KINDS)
 _PROVIDER_ERROR_KIND_VALUES = frozenset((*_PROVIDER_ERROR_KINDS, "provider_error"))
 _PROVIDER_ERROR_ALIASES = {
     "server_is_overloaded": "overloaded_error",
@@ -75,6 +76,19 @@ def provider_error_kind(
     return _classify_normalized_provider_error(exception_text) or "provider_error"
 
 
+def is_retryable_provider_error(
+    candidate: Any,
+    *,
+    provider_exception: BaseException | str | None = None,
+) -> bool:
+    """Classify retryability through the single provider-error taxonomy."""
+
+    return (
+        provider_error_kind(candidate, provider_exception=provider_exception)
+        in _RETRYABLE_PROVIDER_ERROR_KINDS
+    )
+
+
 def safe_provider_error_sentinel(kind: str | None) -> str:
     """Return a request-ID-free marker safe for internal persistence."""
 
@@ -86,6 +100,7 @@ def safe_provider_error_sentinel(kind: str | None) -> str:
 
 __all__ = [
     "PROVIDER_ERROR_SENTINEL_PREFIX",
+    "is_retryable_provider_error",
     "provider_error_kind",
     "safe_provider_error_sentinel",
 ]

--- a/brain/platform/integrations/providers.py
+++ b/brain/platform/integrations/providers.py
@@ -20,6 +20,9 @@ from brain.platform.integrations.openai_codex_client import (
     OpenAICodexError,
     OpenAICodexRetryableError,
 )
+from brain.platform.integrations.provider_error_sentinel import (
+    is_retryable_provider_error,
+)
 from brain.platform.integrations.transports.anthropic import AnthropicMessagesTransport
 from brain.platform.integrations.transports.base import (
     ContentBlock,
@@ -76,7 +79,7 @@ from brain.platform.provider_health import (
 logger = logging.getLogger("brain.platform.integrations.providers")
 
 
-_RETRYABLE_OPENAI_STREAM_TERMS = (
+_RETRYABLE_OPENAI_FREEFORM_ERROR_TERMS = (
     "429",
     "502",
     "503",
@@ -110,7 +113,35 @@ def _openai_stream_error_message(error: Any) -> str:
 
 def _is_retryable_openai_error_message(message: str) -> bool:
     lowered = str(message or "").lower()
-    return any(term in lowered for term in _RETRYABLE_OPENAI_STREAM_TERMS)
+    return (
+        is_retryable_provider_error(lowered)
+        or any(term in lowered for term in _RETRYABLE_OPENAI_FREEFORM_ERROR_TERMS)
+    )
+
+
+def _openai_stream_failure(event: Any) -> Exception | None:
+    """Translate every terminal OpenAI SSE failure envelope through one path."""
+
+    event_type = str(_block_get(event, "type", "") or "")
+    if event_type == "error":
+        error = _block_get(event, "error", None) or event
+    elif event_type == "response.failed":
+        response = _block_get(event, "response", None) or event
+        error = (
+            _block_get(response, "error", None)
+            or _block_get(event, "error", None)
+            or response
+        )
+    else:
+        return None
+
+    message = _openai_stream_error_message(error) or "OpenAI streaming error"
+    if (
+        is_retryable_provider_error(error)
+        or _is_retryable_openai_error_message(message)
+    ):
+        return OpenAICodexRetryableError(message)
+    return RuntimeError(message)
 
 
 def is_transient_transport_disconnect(error: BaseException | str | None) -> bool:
@@ -479,12 +510,8 @@ class OpenAIProvider(LLMProvider):
                     if event_type == "response.completed":
                         final_response = _block_get(event, "response", None)
                         continue
-                    if event_type == "error":
-                        error = _block_get(event, "error", None)
-                        message = _openai_stream_error_message(error) or "OpenAI streaming error"
-                        if _is_retryable_openai_error_message(message):
-                            raise OpenAICodexRetryableError(message)
-                        raise RuntimeError(message)
+                    if failure := _openai_stream_failure(event):
+                        raise failure
 
                     reasoning_summary_delta = (
                         _extract_openai_reasoning_summary_from_event(event)

--- a/brain/systems/inbound/reconciliation.py
+++ b/brain/systems/inbound/reconciliation.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow, AgentRunRow
 from brain.platform.db.models.inbound import InboundDecisionReceiptRow, InboundEventRow
+from brain.platform.integrations.provider_error_sentinel import (
+    is_retryable_provider_error,
+)
 from brain.platform.integrations.providers import is_transient_transport_disconnect
 from brain.systems.inbound.attribution import summarize_inbound_run_attribution
 from brain.systems.inbound.preservation import (
@@ -319,6 +322,7 @@ async def _readmit_failed_monitored_channel_once(
     if not (
         is_transient_transport_disconnect(failure_reason)
         or is_interactive_transport_fallback(failure_reason)
+        or is_retryable_provider_error(failure_reason)
     ):
         return False
 

--- a/brain/systems/runs/direct_loop/retry.py
+++ b/brain/systems/runs/direct_loop/retry.py
@@ -2,27 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
-import asyncio
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Callable
 
-from brain.platform.integrations.providers import LLMRequest
-from brain.platform.integrations.provider_error_sentinel import provider_error_kind
 from brain.platform.async_io import run_blocking
+from brain.platform.integrations.provider_error_sentinel import (
+    is_retryable_provider_error,
+    provider_error_kind,
+)
+from brain.platform.integrations.providers import LLMRequest
 from brain.systems.runs.tool_catalog.metadata import is_write_side_effect_class
 from brain.systems.runs.tool_catalog.registry import get_tool_registration
 
 logger = logging.getLogger("agent")
 _MAX_RETRY_AFTER_SECONDS = 60.0
-_RETRYABLE_PROVIDER_ERROR_KINDS = frozenset(
-    {"server_error", "overloaded_error", "rate_limit_error"}
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,7 +92,7 @@ def response_text_retry_decision(
     return ResponseTextRetryDecision(
         provider_error_kind=detected_kind,
         should_retry=bool(
-            retry_safe and detected_kind in _RETRYABLE_PROVIDER_ERROR_KINDS
+            retry_safe and is_retryable_provider_error(detected_kind)
         ),
         inspect_response=inspect_response,
         withhold_stream=inspect_response,

--- a/tests/test_direct_agent_async_contract.py
+++ b/tests/test_direct_agent_async_contract.py
@@ -267,10 +267,25 @@ async def test_spawned_read_only_worker_retries_overload_text_and_recovers(
     assert streamed_deltas == ["Recovered repository evidence."]
 
 
-async def test_interactive_slack_transport_disconnect_retries_stream_and_completes(monkeypatch):
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["transport_disconnect", "provider_server_error"],
+)
+async def test_interactive_slack_transient_failure_retries_stream_and_completes(
+    monkeypatch,
+    failure_kind,
+):
     import httpx
 
-    from brain.platform.integrations.providers import is_transient_transport_disconnect
+    from brain.platform.integrations.openai_codex_client import (
+        OpenAICodexRetryableError,
+    )
+    from brain.platform.integrations.provider_error_sentinel import (
+        is_retryable_provider_error,
+    )
+    from brain.platform.integrations.providers import (
+        is_transient_transport_disconnect,
+    )
     from brain.systems.runs import direct_agent
 
     raw_error = (
@@ -292,6 +307,8 @@ async def test_interactive_slack_transport_disconnect_retries_stream_and_complet
         def __iter__(self):
             if self.attempt == 1:
                 yield SimpleNamespace(type="text", text="Partial answer")
+                if failure_kind == "provider_server_error":
+                    raise OpenAICodexRetryableError("server_error")
                 raise httpx.RemoteProtocolError(raw_error)
             yield SimpleNamespace(type="text", text="Recovered answer")
 
@@ -310,7 +327,9 @@ async def test_interactive_slack_transport_disconnect_retries_stream_and_complet
             return False
 
         def is_retryable_error(self, exc):
-            return is_transient_transport_disconnect(exc)
+            return is_transient_transport_disconnect(exc) or is_retryable_provider_error(
+                exc
+            )
 
     monkeypatch.setattr(direct_agent, "get_provider", lambda *_args, **_kwargs: FakeProvider())
     monkeypatch.setattr(direct_agent, "_API_RETRY_DELAYS", (0,))

--- a/tests/test_inbound_reconciliation.py
+++ b/tests/test_inbound_reconciliation.py
@@ -374,7 +374,16 @@ async def test_failed_slack_run_never_mints(session, posts, caplog):
     assert "run_status=failed" in skipped[0].getMessage()
 
 
-async def test_transient_failed_monitor_run_readmits_once_and_replacement_replies(session, posts):
+@pytest.mark.parametrize(
+    "failure_reason",
+    [INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE, "server_error"],
+    ids=["transport_disconnect", "provider_server_error"],
+)
+async def test_transient_failed_monitor_run_readmits_once_and_replacement_replies(
+    session,
+    posts,
+    failure_reason,
+):
     event_id, original_run_id = await _seed_slack_lane(
         session,
         tool_results=[],
@@ -385,7 +394,7 @@ async def test_transient_failed_monitor_run_readmits_once_and_replacement_replie
     await store.set_status(
         original_run_id,
         RunStatus.FAILED,
-        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+        reason=failure_reason,
     )
 
     receipt = (await session.scalars(select(InboundDecisionReceiptRow))).one()
@@ -439,7 +448,16 @@ async def test_transient_failed_monitor_run_readmits_once_and_replacement_replie
     assert [event.payload["tool_name"] for event in reply_events] == ["post_slack_reply"]
 
 
-async def test_second_transient_failure_is_terminal_and_result_shows_retry_lineage(session, posts):
+@pytest.mark.parametrize(
+    "failure_reason",
+    [INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE, "server_error"],
+    ids=["transport_disconnect", "provider_server_error"],
+)
+async def test_second_transient_failure_is_terminal_and_result_shows_retry_lineage(
+    session,
+    posts,
+    failure_reason,
+):
     from brain.systems.inbound.results import read_inbound_submission_result
 
     event_id, original_run_id = await _seed_slack_lane(
@@ -451,7 +469,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     await store.set_status(
         original_run_id,
         RunStatus.FAILED,
-        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+        reason=failure_reason,
     )
     replacement = (await session.scalars(
         select(AgentRunRow).where(AgentRunRow.id != original_run_id)
@@ -459,7 +477,7 @@ async def test_second_transient_failure_is_terminal_and_result_shows_retry_linea
     await store.set_status(
         replacement.id,
         RunStatus.FAILED,
-        reason=INTERACTIVE_TRANSPORT_FALLBACK_MESSAGE,
+        reason=failure_reason,
     )
     await reconcile_inbound_triage_run(session, replacement.id)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -515,7 +515,41 @@ class TestOpenAIProvider:
             )) as stream:
                 stream.get_final_message()
 
-    def test_runtime_retries_openai_stream_overload_error(self):
+    def test_response_failed_server_error_is_retryable(self):
+        client = MagicMock()
+        client.responses.create.return_value = iter([
+            {
+                "type": "response.failed",
+                "response": {
+                    "status": "failed",
+                    "error": {
+                        "code": "server_error",
+                        "message": "The service failed while processing the response.",
+                    },
+                },
+            },
+        ])
+
+        provider = OpenAIProvider(client)
+
+        with pytest.raises(OpenAICodexRetryableError):
+            with provider.stream(LLMRequest(
+                model="openai/gpt-5.5",
+                messages=[{"role": "user", "content": "hi"}],
+            )) as stream:
+                stream.get_final_message()
+
+    @pytest.mark.parametrize(
+        "stream_error",
+        [
+            {
+                "message": "Our servers are currently overloaded. Please try again later."
+            },
+            {"code": "server_error"},
+        ],
+        ids=["overload_message", "structured_server_error"],
+    )
+    def test_runtime_retries_openai_stream_error(self, stream_error):
         from types import SimpleNamespace
 
         from brain.systems.runs.direct_loop.retry import api_call_with_retry
@@ -539,7 +573,7 @@ class TestOpenAIProvider:
             iter([
                 {
                     "type": "error",
-                    "error": {"message": "Our servers are currently overloaded. Please try again later."},
+                    "error": stream_error,
                 },
             ]),
             iter([{"type": "response.completed", "response": mock_resp}]),


### PR DESCRIPTION
Closes #585

## Root cause

Structured provider-error taxonomy and streaming retry classification had separate owners. The canonical sentinel recognized `server_error`, while the OpenAI SSE path maintained a free-form term list and handled only `error` envelopes. As a result, structured `server_error` and `response.failed` could escape as plain `RuntimeError`; monitored-channel re-admission also did not consume the canonical taxonomy.

## What changed

- expose one canonical `is_retryable_provider_error` predicate
- route OpenAI `error` and `response.failed` envelopes through one failure translator
- reuse the same predicate for response-text retry decisions and one-time monitored-channel re-admission
- preserve the existing replay-safety guard for completed write-side effects and the bounded second-failure terminal path

## Verification

- `156 passed, 1 skipped` across providers, OpenAI client, interactive direct-agent retry, inbound reconciliation, run state machine, and open-ask ledger tests
- regression coverage proves first structured `server_error` stream fails retryably, the second succeeds, and the successful response is returned
- coverage includes `response.failed`, interactive Slack recovery, monitored-channel one-time re-admission, and terminal retry lineage

## Operational finding

Production evidence also showed the hourly staging-promotion reconciler repeatedly waking the high-effort promotion-readiness cycle while its completion baseline stayed stale. Provider failures amplified that feedback loop. That obsolete event lane is separate from this runtime classifier fix and should be removed independently so this regression PR stays bisectable.
