### PR TITLE
refactor(cycles): retire promotion readiness wake loop

### DIFF
--- a/brain/jobs/pipelines/staging_promotion_pr.py
+++ b/brain/jobs/pipelines/staging_promotion_pr.py
@@ -9,32 +9,20 @@ from typing import Any
 
 from sqlalchemy import select
 
-from brain.platform.db.models.domain import Domain, DomainObjectType, DomainRecord
 from brain.platform.db.models.org import User
 from brain.platform.db.models.vault import Secret, VaultProjectBinding
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
-from brain.systems.cortex.project_context.github import async_get_repo_branch_head
 from brain.systems.cortex.project_context.github_promotion import (
     PROMOTION_PULL_REQUEST_POLICY,
     PromotionPullRequestResult,
     async_reconcile_promotion_pull_request,
 )
-from brain.systems.cycles.service import async_wake_cycle_now
 from brain.systems.vault import async_resolve_project_bound_env_tokens
 
 
 logger = logging.getLogger("illo.jobs.staging_promotion_pr")
 
 CONFIGURED_REPOS = tuple(sorted(PROMOTION_PULL_REQUEST_POLICY.repositories))
-
-# The repository whose promotion readiness has an agent-run analysis cycle.
-# When this repo's (staging, main) pair moves past the cycle's last completed
-# evaluation, the detector wakes that cycle instead of waiting for its
-# scheduled backstop slot — small deltas per evaluation, no catch-up storms.
-READINESS_WAKE_REPO = "uwear-ai/uwear-backend"
-READINESS_CYCLE_NAME = "Uwear Backend Promotion Readiness"
-READINESS_STATUS_DOMAIN_SLUG = "promotion-readiness"
-READINESS_STATUS_OBJECT_KEY = "status"
 
 
 @dataclass(frozen=True)
@@ -111,97 +99,10 @@ async def _repo_token(repo: str, actor: PromotionActor) -> str:
     return token
 
 
-async def _async_last_evaluated_pair(org_id: str) -> tuple[str | None, str | None]:
-    """Read the readiness cycle's last evaluated (staging, main) SHA pair.
-
-    The status record is runtime-authored by the cycle (its playbook pins the
-    domain slug and object key), so every miss — no domain, no record, empty
-    fields — reads as "no baseline" and the caller wakes the cycle to evaluate.
-    Domain slugs are only unique per org, so the lookup is scoped to the org
-    that owns the repo's GitHub App binding.
-    """
-    async with UnitOfWork() as uow:
-        record = (
-            await uow.session.scalars(
-                select(DomainRecord)
-                .join(Domain, Domain.id == DomainRecord.domain_id)
-                .join(
-                    DomainObjectType,
-                    DomainObjectType.id == DomainRecord.object_type_id,
-                )
-                .where(
-                    Domain.slug == READINESS_STATUS_DOMAIN_SLUG,
-                    Domain.org_id == org_id,
-                    Domain.archived_at.is_(None),
-                    DomainObjectType.key == READINESS_STATUS_OBJECT_KEY,
-                    DomainObjectType.archived_at.is_(None),
-                    DomainRecord.org_id == org_id,
-                    DomainRecord.archived_at.is_(None),
-                )
-                .order_by(DomainRecord.updated_at.desc())
-                .limit(1)
-            )
-        ).first()
-    if record is None or not isinstance(record.data, dict):
-        return None, None
-    staging = str(record.data.get("last_staging_sha") or "").strip() or None
-    main = str(record.data.get("last_main_sha") or "").strip() or None
-    return staging, main
-
-
-# Wake dispositions that leave the scheduler run green. "not_found" and
-# "ambiguous" are deliberately absent: a wake that can never fire again must
-# fail the run loudly instead of presenting as healthy while doing no work.
-READINESS_WAKE_OK_OUTCOMES = frozenset(
-    {"pair_unchanged", "woken", "already_pending", "run_in_flight"}
-)
-
-
-async def _async_wake_readiness_cycle(token: str, org_id: str) -> dict[str, Any]:
-    """Wake the readiness cycle when the promotable SHA pair has moved.
-
-    Comparing against the cycle's own last completed evaluation (not this
-    job's previous observation) makes the wake self-retrying: an evaluation
-    that failed to complete leaves the baseline unchanged, so the next hourly
-    tick wakes the cycle again until an evaluation lands.
-    """
-    staging_sha = await async_get_repo_branch_head(
-        READINESS_WAKE_REPO, PROMOTION_PULL_REQUEST_POLICY.head, token=token
-    )
-    main_sha = await async_get_repo_branch_head(
-        READINESS_WAKE_REPO, PROMOTION_PULL_REQUEST_POLICY.base, token=token
-    )
-    last_staging, last_main = await _async_last_evaluated_pair(org_id)
-    if (staging_sha, main_sha) == (last_staging, last_main):
-        return {
-            "cycle": READINESS_CYCLE_NAME,
-            "outcome": "pair_unchanged",
-            "staging_sha": staging_sha,
-            "main_sha": main_sha,
-        }
-    disposition = await async_wake_cycle_now(name=READINESS_CYCLE_NAME)
-    logger.info(
-        "Readiness wake for %s: %s (staging %s vs evaluated %s)",
-        READINESS_WAKE_REPO,
-        disposition,
-        staging_sha[:7],
-        (last_staging or "none")[:7],
-    )
-    return {
-        "cycle": READINESS_CYCLE_NAME,
-        "outcome": disposition,
-        "staging_sha": staging_sha,
-        "main_sha": main_sha,
-    }
-
-
 async def run_promotion_job() -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     failures = 0
-    wake: dict[str, Any] | None = None
     for repo in CONFIGURED_REPOS:
-        token: str | None = None
-        actor: PromotionActor | None = None
         try:
             target = PROMOTION_PULL_REQUEST_POLICY.target_for(repo)
             actor = await _promotion_actor(repo)
@@ -217,36 +118,12 @@ async def run_promotion_job() -> dict[str, Any]:
             logger.error("Promotion PR reconciliation failed for %s: %s", repo, error)
             result = {"repo": repo, "outcome": "error", "error": error}
         results.append(result)
-
-        if (
-            repo == READINESS_WAKE_REPO
-            and token is not None
-            and actor is not None
-            and result["outcome"] in ("created", "already_open")
-        ):
-            try:
-                wake = await _async_wake_readiness_cycle(token, actor.org_id)
-                if wake["outcome"] not in READINESS_WAKE_OK_OUTCOMES:
-                    failures += 1
-                    logger.error(
-                        "Readiness cycle wake settled dead for %s: %s",
-                        repo,
-                        wake["outcome"],
-                    )
-            except Exception as exc:  # noqa: BLE001 - a broken wake path must be visible, not silent
-                failures += 1
-                error = str(getattr(exc, "message", None) or exc)
-                logger.error("Readiness cycle wake failed for %s: %s", repo, error)
-                wake = {"cycle": READINESS_CYCLE_NAME, "outcome": "error", "error": error}
-    payload: dict[str, Any] = {
+    return {
         "job": "uwear_staging_promotion_pr",
         "ok": failures == 0,
         "failures": failures,
         "results": results,
     }
-    if wake is not None:
-        payload["readiness_wake"] = wake
-    return payload
 
 
 async def async_main() -> int:

--- a/tests/test_staging_promotion_pr.py
+++ b/tests/test_staging_promotion_pr.py
@@ -553,182 +553,18 @@ def _patch_reconcile_plumbing(monkeypatch, reconcile):
 
 
 @pytest.mark.asyncio
-async def test_moved_sha_pair_wakes_the_readiness_cycle(monkeypatch):
+async def test_existing_promotion_pr_does_not_wake_readiness_cycle(monkeypatch):
     _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
-    heads = AsyncMock(side_effect=["staging-new-sha", "main-new-sha"])
-    monkeypatch.setattr(staging_promotion_pr, "async_get_repo_branch_head", heads)
+    wake = AsyncMock(side_effect=AssertionError("hourly job must not wake agent cycle"))
     monkeypatch.setattr(
         staging_promotion_pr,
-        "_async_last_evaluated_pair",
-        AsyncMock(return_value=("staging-old-sha", "main-new-sha")),
+        "_async_wake_readiness_cycle",
+        wake,
+        raising=False,
     )
-    wake = AsyncMock(return_value="woken")
-    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
-
-    result = await staging_promotion_pr.run_promotion_job()
-
-    assert result["ok"] is True
-    assert result["readiness_wake"] == {
-        "cycle": staging_promotion_pr.READINESS_CYCLE_NAME,
-        "outcome": "woken",
-        "staging_sha": "staging-new-sha",
-        "main_sha": "main-new-sha",
-    }
-    wake.assert_awaited_once_with(name=staging_promotion_pr.READINESS_CYCLE_NAME)
-    assert heads.await_args_list[0].args == (REPO, "staging")
-    assert heads.await_args_list[1].args == (REPO, "main")
-
-
-@pytest.mark.asyncio
-async def test_unchanged_sha_pair_does_not_wake(monkeypatch):
-    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "async_get_repo_branch_head",
-        AsyncMock(side_effect=["same-staging", "same-main"]),
-    )
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_async_last_evaluated_pair",
-        AsyncMock(return_value=("same-staging", "same-main")),
-    )
-    wake = AsyncMock()
-    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
-
-    result = await staging_promotion_pr.run_promotion_job()
-
-    assert result["ok"] is True
-    assert result["readiness_wake"]["outcome"] == "pair_unchanged"
-    wake.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_no_diff_backend_skips_the_wake_probe_entirely(monkeypatch):
-    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("no_diff"))
-    heads = AsyncMock()
-    monkeypatch.setattr(staging_promotion_pr, "async_get_repo_branch_head", heads)
-    wake = AsyncMock()
-    monkeypatch.setattr(staging_promotion_pr, "async_wake_cycle_now", wake)
 
     result = await staging_promotion_pr.run_promotion_job()
 
     assert result["ok"] is True
     assert "readiness_wake" not in result
-    heads.assert_not_awaited()
     wake.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_wake_failure_fails_the_job_but_keeps_reconciliation_results(
-    monkeypatch, caplog
-):
-    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("created"))
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_async_wake_readiness_cycle",
-        AsyncMock(side_effect=RuntimeError("status record unreadable")),
-    )
-
-    result = await staging_promotion_pr.run_promotion_job()
-
-    assert result["ok"] is False
-    assert result["failures"] == 1
-    assert [r["outcome"] for r in result["results"]] == ["created", "no_diff"]
-    assert result["readiness_wake"]["outcome"] == "error"
-    assert "Readiness cycle wake failed" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_last_evaluated_pair_reads_the_cycle_status_record(
-    async_sqlite_session_factory,
-    sqlite_postgres_ddl_patch,
-    monkeypatch,
-):
-    from brain.platform.db.models.domain import (
-        Domain,
-        DomainObjectType,
-        DomainRecord,
-    )
-
-    session = await async_sqlite_session_factory(
-        [
-            Org.__table__,
-            Domain.__table__,
-            DomainObjectType.__table__,
-            DomainRecord.__table__,
-        ],
-        connect_listener=_register_sqlite_functions,
-    )
-    org_id = "bbbbbbbb-0000-4000-8000-000000000002"
-    session.add(Org(id=org_id, name="Readiness Org", slug="readiness-org"))
-    domain = Domain(org_id=org_id, slug="promotion-readiness", name="Promotion Readiness")
-    session.add(domain)
-    await session.flush()
-    object_type = DomainObjectType(domain_id=domain.id, key="status", name="Status")
-    session.add(object_type)
-    await session.flush()
-    session.add(
-        DomainRecord(
-            org_id=org_id,
-            domain_id=domain.id,
-            object_type_id=object_type.id,
-            title="status",
-            data={
-                "last_staging_sha": "7bc4dd27c554",
-                "last_main_sha": "762e2b48f7d9",
-            },
-        )
-    )
-    await session.commit()
-
-    class TestUnitOfWork:
-        def __init__(self):
-            self.session = session
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    monkeypatch.setattr(staging_promotion_pr, "UnitOfWork", TestUnitOfWork)
-
-    pair = await staging_promotion_pr._async_last_evaluated_pair(org_id)
-
-    assert pair == ("7bc4dd27c554", "762e2b48f7d9")
-
-    # Another org's identically-slugged domain must not leak in.
-    assert await staging_promotion_pr._async_last_evaluated_pair(
-        "bbbbbbbb-0000-4000-8000-000000000099"
-    ) == (None, None)
-
-    # An archived object type reads as "no baseline", never as evidence.
-    object_type.archived_at = datetime.now(timezone.utc)
-    await session.commit()
-    assert await staging_promotion_pr._async_last_evaluated_pair(org_id) == (None, None)
-
-
-@pytest.mark.asyncio
-async def test_dead_wake_disposition_fails_the_job(monkeypatch, caplog):
-    """A wake that can never fire again (cycle gone) must not stay green."""
-    _patch_reconcile_plumbing(monkeypatch, _reconcile_pair("already_open"))
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "async_get_repo_branch_head",
-        AsyncMock(side_effect=["staging-new", "main-new"]),
-    )
-    monkeypatch.setattr(
-        staging_promotion_pr,
-        "_async_last_evaluated_pair",
-        AsyncMock(return_value=(None, None)),
-    )
-    monkeypatch.setattr(
-        staging_promotion_pr, "async_wake_cycle_now", AsyncMock(return_value="not_found")
-    )
-
-    result = await staging_promotion_pr.run_promotion_job()
-
-    assert result["ok"] is False
-    assert result["failures"] == 1
-    assert result["readiness_wake"]["outcome"] == "not_found"
-    assert "settled dead" in caplog.text


### PR DESCRIPTION
Closes #588

## Root cause

The hourly promotion reconciler used the high-effort readiness cycle's last completed SHA-pair as both a work watermark and retry latch. Any incomplete evaluation kept the watermark stale, so the hourly job re-admitted another analysis while the system was already under pressure. Production created 12 cycle runs from 03:00–14:00 UTC on July 29 despite the cycle's weekday 11:00 backstop; multiple runs failed on `server_error` or degraded after long, tool-heavy execution.

## Simplification

- keep hourly promotion-PR reconciliation unchanged
- remove the readiness wake, its extra branch-head and status-domain reads, wake-specific result payload, and failure accounting
- keep the readiness cycle's configured weekday backstop, which catches up from its own persisted SHA pair
- delete wake-only implementation and tests instead of adding cooldown/retry state

Net: 293 lines removed.

## Verification

- RED: an already-open promotion PR invoked the readiness wake and failed the new no-wake contract
- GREEN: 59 promotion/scheduler tests passed
- bytecode compilation and `git diff --check` passed
