### PR TITLE
fix(websocket): stop replaying all run events after API restart

### DIFF
--- a/brain/app/api/ws/run_events.py
+++ b/brain/app/api/ws/run_events.py
@@ -68,6 +68,27 @@ async def async_run_event_backbone_status(
     )
 
 
+async def initialize_live_fanout_cursor(
+    *,
+    logger: logging.Logger = logger,
+) -> int:
+    """Start live websocket delivery after events that predate this process."""
+    global _last_event_id
+    async with UnitOfWork() as uow:
+        max_event_id = int(
+            await uow.session.scalar(
+                select(func.coalesce(func.max(AgentRunEventRow.id), 0))
+            )
+            or 0
+        )
+    _last_event_id = max_event_id
+    logger.info(
+        "run_event_fanout_cursor_initialized last_event_id=%s",
+        max_event_id,
+    )
+    return max_event_id
+
+
 async def fanout_run_events_once(
     ws_manager,
     *,
@@ -129,6 +150,7 @@ async def fanout_run_events(
     logger: logging.Logger = logger,
     **kwargs: Any,
 ) -> None:
+    await initialize_live_fanout_cursor(logger=logger)
     while True:
         try:
             delivered, had_error = await fanout_run_events_once(
@@ -151,4 +173,5 @@ __all__ = [
     "async_run_event_backbone_status",
     "fanout_run_events",
     "fanout_run_events_once",
+    "initialize_live_fanout_cursor",
 ]

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -38,6 +38,17 @@ class _AsyncUoW:
         return False
 
 
+class _AsyncScalarUoW:
+    def __init__(self, value):
+        self.session = SimpleNamespace(scalar=AsyncMock(return_value=value))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_record_run_event_allocates_next_sequence_and_normalizes_payload():
     session = MagicMock()
@@ -615,6 +626,55 @@ async def test_run_event_backbone_status_reports_lag_and_health(monkeypatch):
     assert status["lag"] == 3
     assert status["caught_up"] is False
     assert status["replay_safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_fanout_starts_after_existing_history(monkeypatch):
+    import brain.app.api.ws.run_events as run_events
+
+    event = SimpleNamespace(
+        id=11,
+        run_id=42,
+        root_run_id=42,
+        sequence_no=2,
+        event_type="run.activity",
+        payload={"label": "New work"},
+    )
+    run = SimpleNamespace(id=42, org_id="org-1", thread_id="idea-1", profile="fast")
+    cursor_uow = _AsyncScalarUoW(10)
+    fanout_uow = _AsyncUoW([(event, run)])
+    uows = iter((cursor_uow, fanout_uow))
+    monkeypatch.setattr(run_events, "UnitOfWork", lambda: next(uows))
+    monkeypatch.setattr(run_events, "_last_event_id", 0)
+    ws_manager = SimpleNamespace(broadcast_run_event=AsyncMock())
+
+    initialized_at = await run_events.initialize_live_fanout_cursor()
+    delivered, had_error = await run_events.fanout_run_events_once(ws_manager)
+
+    assert initialized_at == 10
+    statement = fanout_uow.session.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert "agent_run_events.id > 10" in sql
+    assert delivered == 1
+    assert had_error is False
+    ws_manager.broadcast_run_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_fanout_initializes_cursor_before_polling(monkeypatch):
+    import brain.app.api.ws.run_events as run_events
+
+    initialize = AsyncMock(return_value=10)
+    poll_once = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr(run_events, "initialize_live_fanout_cursor", initialize)
+    monkeypatch.setattr(run_events, "fanout_run_events_once", poll_once)
+    ws_manager = SimpleNamespace()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_events.fanout_run_events(ws_manager)
+
+    initialize.assert_awaited_once()
+    poll_once.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #590

## Root cause

The in-process websocket broadcaster reused the durable event log but kept its live cursor only in `_last_event_id`, initialized to zero. Every API restart therefore selected and projected the full historical table before it could reach new events. The 2026-07-29 deploy showed 940,688 historical rows and was still 482,383 rows behind after roughly nine minutes.

Websocket connections do not survive the API process restart, so there is no live audience that can benefit from pre-start delivery. Explicit authenticated client replay already has a separate caller-provided cursor and remains unchanged.

## Fix

- Take one current-max event watermark before the live fanout poll loop begins.
- Keep the existing `id > cursor` path, so every event committed after the watermark is delivered normally.
- Log the initialized watermark for operations.
- Pin both the startup ordering and the resulting SQL boundary in regression tests.

## Verification

```
python -m pytest tests/test_run_events.py tests/test_api_main.py tests/test_health_tiers.py -q
61 passed
```

`git diff --check` and compile checks pass.
