### PR TITLE
Restore Cycle runtime admission, sequencing, and failure fidelity

### DIFF
--- a/.github/workflows/brain-ci.yml
+++ b/.github/workflows/brain-ci.yml
@@ -43,6 +43,7 @@ jobs:
               # script-only change that breaks its own guard test would otherwise
               # skip the suite that guards it and only fail once it reaches main.
               - "brain/**"
+              - "deploy/**"
               - "tests/**"
               - "scripts/**"
               - "requirements*.txt"
@@ -103,6 +104,9 @@ jobs:
 
       - name: Install dependencies
         run: python3 -m pip install -r requirements.txt pytest pytest-asyncio
+
+      - name: Check enabled Cycle context admission
+        run: python3 -m brain.jobs.check_cycle_context_admission
 
       - name: Run backend fast suite
         run: >-

--- a/brain/app/scheduler/executor.py
+++ b/brain/app/scheduler/executor.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 import os
+import re
 import shlex
 import socket
 import subprocess
@@ -200,11 +202,82 @@ def _tail(text: str | None, limit: int = 2000) -> str | None:
 
 
 def _command_summary(proc: Any) -> dict[str, Any]:
-    return {
+    summary = {
         "returncode": int(getattr(proc, "returncode", 1)),
         "stdout_tail": _tail(getattr(proc, "stdout", None)),
         "stderr_tail": _tail(getattr(proc, "stderr", None)),
     }
+    exception = _command_exception(
+        stdout=getattr(proc, "stdout", None),
+        stderr=getattr(proc, "stderr", None),
+    )
+    if exception:
+        summary["exception"] = exception
+    return summary
+
+
+def _json_objects(text_value: str | None) -> list[dict[str, Any]]:
+    objects: list[dict[str, Any]] = []
+    for line in reversed(str(text_value or "").splitlines()):
+        try:
+            value = json.loads(line.strip())
+        except (TypeError, ValueError):
+            continue
+        if isinstance(value, dict):
+            objects.append(value)
+    return objects
+
+
+def _failed_result(payload: dict[str, Any]) -> dict[str, Any] | None:
+    results = payload.get("results")
+    if isinstance(results, list):
+        for item in reversed(results):
+            if isinstance(item, dict) and str(item.get("status") or "").lower() in {
+                "error",
+                "failed",
+            }:
+                nested = _failed_result(item)
+                return nested or item
+    if str(payload.get("status") or "").lower() in {"error", "failed"}:
+        return payload
+    if payload.get("error") and payload.get("ok") is False:
+        return payload
+    return None
+
+
+_TRACEBACK_EXCEPTION_LINE = re.compile(
+    r"^(?P<type>[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception)):\s*(?P<message>.+)$"
+)
+
+
+def _command_exception(*, stdout: str | None, stderr: str | None) -> dict[str, str] | None:
+    for payload in _json_objects(stdout):
+        failure = _failed_result(payload)
+        if failure is None:
+            continue
+        message = str(failure.get("error") or "").strip()
+        if not message:
+            continue
+        exception_type = str(failure.get("exception_type") or "").strip()
+        return {
+            **({"type": exception_type} if exception_type else {}),
+            "message": message,
+        }
+    for line in reversed(str(stderr or "").splitlines()):
+        match = _TRACEBACK_EXCEPTION_LINE.match(line.strip())
+        if match:
+            return {"type": match.group("type"), "message": match.group("message")}
+    return None
+
+
+def _command_failure_error_text(summary: dict[str, Any]) -> str:
+    exception = summary.get("exception")
+    if isinstance(exception, dict):
+        message = str(exception.get("message") or "").strip()
+        exception_type = str(exception.get("type") or "").strip()
+        if message:
+            return f"{exception_type}: {message}" if exception_type else message
+    return f"Command exited with status {int(summary.get('returncode') or 1)}"
 
 
 def _python_one_liner(code: str) -> list[str]:
@@ -616,7 +689,7 @@ async def _async_run_step(
         summary = {"command": list(command), **_command_summary(proc)}
         results.append(summary)
         if int(getattr(proc, "returncode", 1)) != 0:
-            error_text = summary["stderr_tail"] or summary["stdout_tail"] or "step failed"
+            error_text = _command_failure_error_text(summary)
             await async_update_run_step(
                 session,
                 step,

--- a/brain/jobs/check_cycle_context_admission.py
+++ b/brain/jobs/check_cycle_context_admission.py
@@ -1,0 +1,282 @@
+"""Read-only deploy gate for enabled Cycle context admission."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Sequence
+
+from sqlalchemy import select
+
+from brain.platform.db.models.cycle import (
+    Cycle,
+    CycleGuidance,
+    CycleOutputTarget,
+    CycleRun,
+)
+from brain.platform.db.repositories.unit_of_work import UnitOfWork
+from brain.platform.providers.model_policy import (
+    async_get_default_model,
+    async_get_default_thinking,
+    infer_provider_from_model,
+)
+from brain.systems.context.errors import ContextFloorExceedsBudgetError
+from brain.systems.context.window_policy import ContextWindowPolicy
+from brain.systems.cycles.prompts import cycle_run_message
+from brain.systems.runs.direct_agent import _build_reasoning_effort
+from brain.systems.runs.direct_loop.request import build_system_blocks
+from brain.systems.runs.recipes.fast import (
+    build_fast_system_prompt,
+    fast_agent_tools_for_request,
+)
+
+DEFAULT_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "enabled_cycles_context_admission.json"
+)
+DEFAULT_HEADROOM_WARNING_RATIO = 0.80
+
+
+@dataclass(frozen=True, slots=True)
+class CycleAdmissionSpec:
+    cycle_id: int
+    name: str
+    prompt: str
+    model: str
+    thinking: str
+    timezone_name: str = "UTC"
+    target_idea_id: str | None = None
+    guidance_snapshot: list[dict[str, Any]] = field(default_factory=list)
+    output_targets_snapshot: list[dict[str, Any]] = field(default_factory=list)
+    context_snapshot: dict[str, Any] = field(default_factory=dict)
+
+
+def _cycle_message(spec: CycleAdmissionSpec) -> str:
+    scheduled_for = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    idea_id = spec.target_idea_id or f"cycle-context-gate-{spec.cycle_id}"
+    idea = SimpleNamespace(id=idea_id, title=spec.name)
+    cycle = SimpleNamespace(
+        id=spec.cycle_id,
+        name=spec.name,
+        prompt=spec.prompt,
+        timezone=spec.timezone_name,
+        model_override=spec.model,
+        thinking_override=spec.thinking,
+    )
+    run = SimpleNamespace(
+        id=-abs(spec.cycle_id),
+        revision_id=None,
+        scheduled_for=scheduled_for,
+        guidance_snapshot=spec.guidance_snapshot,
+        output_targets_snapshot=spec.output_targets_snapshot,
+        context_snapshot=spec.context_snapshot,
+    )
+    return cycle_run_message(idea, cycle, run)
+
+
+def check_cycle_context_admission(
+    spec: CycleAdmissionSpec,
+    *,
+    warning_ratio: float = DEFAULT_HEADROOM_WARNING_RATIO,
+) -> dict[str, Any]:
+    """Measure one Cycle with the Fast recipe's real prompt and tool scaffold."""
+
+    metadata = {"source": "cycle", "origin": "cycle", "cycle_id": spec.cycle_id}
+    target_ref = {"kind": "cortex_idea", "idea_id": spec.target_idea_id}
+    tools = fast_agent_tools_for_request(
+        metadata=metadata,
+        target_ref=target_ref,
+        thread_id=str(spec.target_idea_id or f"cycle:{spec.cycle_id}"),
+    )
+    system = build_system_blocks(None, build_fast_system_prompt(), False)
+    reasoning_effort, max_output_tokens = _build_reasoning_effort(spec.thinking)
+    policy = ContextWindowPolicy.resolve(
+        model=spec.model,
+        provider=infer_provider_from_model(spec.model),
+        reasoning_effort=reasoning_effort,
+        max_output_tokens=max_output_tokens,
+        tools=tools,
+    )
+    try:
+        admission = policy.admit(
+            [{"role": "user", "content": _cycle_message(spec)}],
+            system=system,
+            tools=tools,
+            session_id=f"cycle-context-gate-{spec.cycle_id}",
+            phase="deploy_gate",
+        )
+    except ContextFloorExceedsBudgetError as exc:
+        return {
+            "cycle_id": spec.cycle_id,
+            "cycle_name": spec.name,
+            "status": "failed",
+            "model": spec.model,
+            "thinking": spec.thinking,
+            "floor": exc.floor,
+            "ceiling": exc.ceiling,
+            "tools": exc.tools,
+            "diagnostic": str(exc),
+        }
+
+    ratio = admission.floor_tokens / admission.budget.auto_compact_threshold_tokens
+    return {
+        "cycle_id": spec.cycle_id,
+        "cycle_name": spec.name,
+        "status": "warning" if ratio > warning_ratio else "passed",
+        "model": spec.model,
+        "thinking": spec.thinking,
+        "floor": admission.floor_tokens,
+        "ceiling": admission.budget.auto_compact_threshold_tokens,
+        "tools": admission.tool_count,
+        "headroom_ratio": round(1.0 - ratio, 6),
+    }
+
+
+def load_fixture_specs(path: Path = DEFAULT_FIXTURE_PATH) -> list[CycleAdmissionSpec]:
+    payload = json.loads(path.read_text())
+    specs: list[CycleAdmissionSpec] = []
+    for item in payload.get("cycles", []):
+        prompt_chars = max(0, int(item.get("prompt_chars") or 0))
+        guidance_chars = max(0, int(item.get("guidance_chars") or 0))
+        specs.append(
+            CycleAdmissionSpec(
+                cycle_id=int(item["cycle_id"]),
+                name=str(item["name"]),
+                prompt="P" * prompt_chars,
+                model=str(item["model"]),
+                thinking=str(item["thinking"]),
+                timezone_name=str(item.get("timezone") or "UTC"),
+                guidance_snapshot=(
+                    [{"guidance": "G" * guidance_chars}] if guidance_chars else []
+                ),
+            )
+        )
+    return specs
+
+
+async def load_live_specs() -> list[CycleAdmissionSpec]:
+    """Read every enabled Cycle and its current persisted memory without writes."""
+
+    specs: list[CycleAdmissionSpec] = []
+    async with UnitOfWork() as uow:
+        cycles = (
+            await uow.session.scalars(
+                select(Cycle)
+                .where(Cycle.enabled.is_(True), Cycle.deleted_at.is_(None))
+                .order_by(Cycle.id.asc())
+            )
+        ).all()
+        for cycle in cycles:
+            latest_run = await uow.session.scalar(
+                select(CycleRun)
+                .where(CycleRun.cycle_id == int(cycle.id))
+                .order_by(CycleRun.scheduled_for.desc(), CycleRun.id.desc())
+                .limit(1)
+            )
+            guidances = (
+                await uow.session.scalars(
+                    select(CycleGuidance)
+                    .where(
+                        CycleGuidance.cycle_id == int(cycle.id),
+                        CycleGuidance.is_active.is_(True),
+                    )
+                    .order_by(CycleGuidance.created_at.asc(), CycleGuidance.id.asc())
+                )
+            ).all()
+            output_targets = (
+                await uow.session.scalars(
+                    select(CycleOutputTarget)
+                    .where(
+                        CycleOutputTarget.cycle_id == int(cycle.id),
+                        CycleOutputTarget.is_active.is_(True),
+                    )
+                    .order_by(CycleOutputTarget.created_at.asc(), CycleOutputTarget.id.asc())
+                )
+            ).all()
+            model = str(cycle.model_override or "").strip() or await async_get_default_model(
+                uow.session,
+                include_provider_prefix=True,
+                user_id=str(cycle.user_id),
+                org_id=str(cycle.org_id or "") or None,
+            )
+            thinking = str(cycle.thinking_override or "").strip() or await async_get_default_thinking(
+                uow.session,
+                user_id=str(cycle.user_id),
+                org_id=str(cycle.org_id or "") or None,
+            )
+            specs.append(
+                CycleAdmissionSpec(
+                    cycle_id=int(cycle.id),
+                    name=str(cycle.name),
+                    prompt=str(cycle.prompt),
+                    model=model,
+                    thinking=thinking,
+                    timezone_name=str(cycle.timezone or "UTC"),
+                    target_idea_id=str(cycle.target_idea_id or "") or None,
+                    guidance_snapshot=[
+                        {
+                            "id": item.id,
+                            "guidance": item.guidance,
+                            "rationale": item.rationale,
+                        }
+                        for item in guidances
+                    ],
+                    output_targets_snapshot=[
+                        {
+                            "id": item.id,
+                            "target_type": item.target_type,
+                            "target_id": item.target_id,
+                            "label": item.label,
+                            "config": dict(item.config or {}),
+                        }
+                        for item in output_targets
+                    ],
+                    context_snapshot=dict(getattr(latest_run, "context_snapshot", None) or {}),
+                )
+            )
+        await uow.session.rollback()
+    return specs
+
+
+def evaluate_specs(specs: Sequence[CycleAdmissionSpec]) -> dict[str, Any]:
+    results = [check_cycle_context_admission(spec) for spec in specs]
+    return {
+        "ok": bool(results) and all(item["status"] != "failed" for item in results),
+        "cycle_count": len(results),
+        "results": results,
+    }
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    specs = await load_live_specs() if args.live else load_fixture_specs(args.fixtures)
+    report = evaluate_specs(specs)
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--live", action="store_true", help="Read enabled Cycles from the live DB")
+    source.add_argument("--fixtures", type=Path, default=DEFAULT_FIXTURE_PATH)
+    return asyncio.run(_async_main(parser.parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CycleAdmissionSpec",
+    "check_cycle_context_admission",
+    "evaluate_specs",
+    "load_fixture_specs",
+    "load_live_specs",
+]

--- a/brain/jobs/pipelines/knowledge_index_sync.py
+++ b/brain/jobs/pipelines/knowledge_index_sync.py
@@ -52,6 +52,7 @@ async def run_knowledge_index_sync(
                     "failed": 1,
                     "truncated": 0,
                 },
+                "exception_type": type(exc).__name__,
                 "error": str(exc),
             }
         results.append(payload)

--- a/brain/platform/model_catalog.py
+++ b/brain/platform/model_catalog.py
@@ -43,7 +43,9 @@ MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
         description="Organization default; falls back to GPT-5.5 when unavailable.",
         supported_effort_tiers=_ALL_EFFORT_TIERS,
         availability_fallback="openai/gpt-5.5",
-        context_window_tokens=128_000,
+        # https://developers.openai.com/api/docs/models/gpt-5.6-sol
+        # Provider contract: 1,050,000 total tokens (922,000 input + 128,000 output).
+        context_window_tokens=1_050_000,
         input_price_per_million=5.0,
         output_price_per_million=30.0,
         provider_default=True,

--- a/brain/systems/cycles/auth_preflight.py
+++ b/brain/systems/cycles/auth_preflight.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from brain.platform.integrations.provider_auth_preflight import (
     ProviderAuthPreflightResult,
     async_probe_provider_auth,
-    skipped_provider_auth_preflight,
 )
 from brain.platform.providers.model_policy import (
     async_get_default_model,
@@ -22,11 +21,18 @@ def _with_cycle_presentation(
 ) -> ProviderAuthPreflightResult:
     if not result.blocked:
         return result
-    repair_action = (
-        "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
-        "then rerun the Cycle or wait for its next scheduled run."
-    )
-    credential = result.credential or "OpenAI"
+    if result.provider == "anthropic":
+        repair_action = (
+            "Add an Anthropic API key in Settings > Access, then rerun the Cycle or "
+            "choose an available OpenAI model."
+        )
+        credential = result.credential or "Anthropic API key"
+    else:
+        repair_action = (
+            "Reconnect OpenAI in Settings > Access by signing in to Codex / ChatGPT again, "
+            "then rerun the Cycle or wait for its next scheduled run."
+        )
+        credential = result.credential or "OpenAI"
     return result.with_presentation(
         repair_action=repair_action,
         visible_message=(
@@ -42,7 +48,7 @@ async def async_preflight_cycle_external_auth(
     *,
     cycle: Any,
 ) -> ProviderAuthPreflightResult:
-    """Apply the Cycle's OpenAI-only probe and scheduled-run wording."""
+    """Probe the Cycle's selected provider before admitting an agent run."""
 
     user_id = str(getattr(cycle, "user_id", "") or "") or None
     org_id = str(getattr(cycle, "org_id", "") or "") or None
@@ -56,11 +62,6 @@ async def async_preflight_cycle_external_auth(
         )
 
     provider = infer_provider_from_model(model)
-    if provider != "openai":
-        return skipped_provider_auth_preflight(
-            provider=provider,
-            model=model,
-        )
     result = await async_probe_provider_auth(
         session,
         user_id=user_id,

--- a/brain/systems/cycles/contract_gate.py
+++ b/brain/systems/cycles/contract_gate.py
@@ -497,7 +497,7 @@ def _repair_prompt(
     ]
 
 
-def _repair_model(agent_run: AgentRunRow) -> str:
+async def _repair_model(session: Any, agent_run: AgentRunRow) -> str:
     model_policy = _json_dict(getattr(agent_run, "model_policy", None))
     metadata = _json_dict(getattr(agent_run, "metadata_", None))
     for container in (model_policy, metadata):
@@ -505,21 +505,19 @@ def _repair_model(agent_run: AgentRunRow) -> str:
             value = str(container.get(key) or "").strip()
             if value:
                 return value
-    from brain.platform.providers.model_policy import get_default_model, resolve_default_provider
+    from brain.platform.providers.model_policy import async_get_default_model
 
-    provider = resolve_default_provider(
+    return await async_get_default_model(
+        session,
+        include_provider_prefix=True,
         user_id=str(getattr(agent_run, "user_id", "") or "") or None,
         org_id=str(getattr(agent_run, "org_id", "") or "") or None,
-    )
-    return get_default_model(
-        provider=provider,
-        include_provider_prefix=False,
-        user_id=str(getattr(agent_run, "user_id", "") or "") or None,
     )
 
 
 async def _async_repair_cycle_contract_answer(
     *,
+    session: Any,
     agent_run: AgentRunRow,
     mission: str,
     result_contract: dict[str, Any],
@@ -530,19 +528,33 @@ async def _async_repair_cycle_contract_answer(
     """Run exactly one bounded LLM repair pass for a failed Cycle contract answer."""
 
     try:
-        from brain.platform.integrations.llm import resolve_llm_client
+        from brain.platform.integrations.llm import async_resolve_llm_client
         from brain.platform.integrations.providers import get_provider
-        from brain.platform.providers.model_policy import infer_provider_from_model, resolve_default_provider
+        from brain.platform.providers.model_policy import (
+            infer_provider_from_model,
+            required_openai_auth_mode,
+            resolve_default_provider,
+        )
         from brain.systems.runs.direct_loop.request import build_api_request
         from brain.systems.sessions import _content_to_dicts
         from brain.systems.sessions.harvest import _extract_text
 
         user_id = str(getattr(agent_run, "user_id", "") or "") or None
         org_id = str(getattr(agent_run, "org_id", "") or "") or None
-        model = _repair_model(agent_run)
+        model = await _repair_model(session, agent_run)
         default_provider = resolve_default_provider(user_id=user_id, org_id=org_id)
         requested_provider = infer_provider_from_model(model, default=default_provider)
-        llm = resolve_llm_client(user_id=user_id, org_id=org_id, provider=requested_provider)
+        llm = await async_resolve_llm_client(
+            user_id=user_id,
+            org_id=org_id,
+            provider=requested_provider,
+            auth_mode=(
+                required_openai_auth_mode(model)
+                if requested_provider == "openai"
+                else None
+            ),
+            session=session,
+        )
         provider = get_provider(llm.provider, llm.client)
         session_id = f"cycle-contract-repair-{int(agent_run.id)}"
         request = build_api_request(
@@ -760,6 +772,7 @@ async def async_prepare_cycle_run_visible_finalization(
     verdict["repair_mode"] = "append_missing_outputs" if append_only else "replace_invalid_answer"
     try:
         repair_answer = await _async_repair_cycle_contract_answer(
+            session=session,
             agent_run=agent_run,
             mission=mission,
             result_contract=result_contract,

--- a/brain/systems/cycles/service.py
+++ b/brain/systems/cycles/service.py
@@ -73,6 +73,7 @@ from brain.systems.cycles.execution import (
 from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
 from brain.platform.db.models.cycle import Cycle, CycleRun
 from brain.platform.db.models.run import AgentRun
+from brain.platform.db.models.agent_run import AgentRunEventRow
 from brain.platform.db.models.idea import Idea
 from brain.platform.db.models.org import User
 from brain.platform.db.repositories.unit_of_work import UnitOfWork
@@ -938,6 +939,28 @@ async def async_finalize_cycle_run_from_run(
                 int(run_id),
                 provider_errors_only=True,
             )
+        if effective_status == "failed" and not str(error or "").strip():
+            failure_event = (
+                await uow.session.scalars(
+                    select(AgentRunEventRow)
+                    .where(
+                        AgentRunEventRow.run_id == int(run_id),
+                        AgentRunEventRow.event_type.in_(("run.failed", "run.status_changed")),
+                    )
+                    .order_by(
+                        (AgentRunEventRow.event_type == "run.failed").desc(),
+                        AgentRunEventRow.sequence_no.desc(),
+                        AgentRunEventRow.id.desc(),
+                    )
+                    .limit(1)
+                )
+            ).first()
+            failure_payload = dict(getattr(failure_event, "payload", None) or {})
+            error = str(
+                failure_payload.get("error")
+                or failure_payload.get("reason")
+                or ""
+            ).strip() or None
         final_status, final_error = cycle_finalization_status_from_verdict(
             effective_status,
             verdict=verdict,

--- a/brain/systems/runs/recipes/fast.py
+++ b/brain/systems/runs/recipes/fast.py
@@ -78,17 +78,19 @@ def _disabled_tool_names(runtime: RunRuntime) -> set[str]:
     return disabled
 
 
-def _runtime_context_maps(runtime: RunRuntime):
-    for container in (
-        getattr(runtime.request, "metadata", None),
-        getattr(runtime.request, "target_ref", None),
-    ):
+def _request_context_maps(metadata: dict, target_ref: dict):
+    for container in (metadata, target_ref):
         if isinstance(container, dict):
             yield container
 
 
-def _runtime_originated_from_thread_discussion(runtime: RunRuntime) -> bool:
-    for container in _runtime_context_maps(runtime):
+def _originated_from_thread_discussion(
+    *,
+    metadata: dict,
+    target_ref: dict,
+    thread_id: str,
+) -> bool:
+    for container in _request_context_maps(metadata, target_ref):
         if container.get("kind") == _THREAD_DISCUSSION_SURFACE:
             return True
         if container.get("originating_surface") == _THREAD_DISCUSSION_SURFACE:
@@ -99,19 +101,41 @@ def _runtime_originated_from_thread_discussion(runtime: RunRuntime) -> bool:
             return True
         if isinstance(container.get("discussion_trigger"), dict):
             return True
-    thread_id = str(getattr(runtime.request, "thread_id", "") or "")
     return thread_id.startswith(_THREAD_DISCUSSION_THREAD_PREFIX)
 
 
-def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
-    hidden = _FAST_HIDDEN_TOOL_NAMES | _disabled_tool_names(runtime)
-    if not _runtime_originated_from_thread_discussion(runtime):
+def fast_agent_tools_for_request(
+    *,
+    metadata: dict | None = None,
+    target_ref: dict | None = None,
+    thread_id: str = "",
+) -> list[dict]:
+    """Return the exact Fast model-visible tool surface for a request shape."""
+
+    metadata = dict(metadata or {})
+    target_ref = dict(target_ref or {})
+    hidden = _FAST_HIDDEN_TOOL_NAMES | disabled_tool_names_from_metadata(metadata)
+    if metadata.get("slack_monitor"):
+        hidden.add("react_to_slack_message")
+    if not _originated_from_thread_discussion(
+        metadata=metadata,
+        target_ref=target_ref,
+        thread_id=str(thread_id or ""),
+    ):
         hidden.add(_THREAD_DISCUSSION_REPLY_TOOL)
     return [
         tool
         for tool in build_agent_tools("coordinator")
         if str(tool.get("name") or "") not in hidden
     ]
+
+
+def _agent_tools_for_runtime(runtime: RunRuntime) -> list[dict]:
+    return fast_agent_tools_for_request(
+        metadata=getattr(runtime.request, "metadata", None),
+        target_ref=getattr(runtime.request, "target_ref", None),
+        thread_id=str(getattr(runtime.request, "thread_id", "") or ""),
+    )
 
 
 def _thread_attachment_context(runtime: RunRuntime) -> dict[str, Any] | None:

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
@@ -13,6 +13,7 @@ import os
 import threading
 from typing import Any
 import uuid
+import weakref
 
 from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import DBAPIError, IntegrityError
@@ -101,15 +102,22 @@ class ExecutionClaimLost(RuntimeError):
 
 
 _EVENT_LOCKS_GUARD = threading.Lock()
-_EVENT_LOCKS: dict[int, threading.RLock] = {}
+_EVENT_LOCKS: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop,
+    weakref.WeakValueDictionary[int, asyncio.Lock],
+] = weakref.WeakKeyDictionary()
 
 
-def _event_lock(run_id: int) -> threading.RLock:
+def _event_lock(run_id: int) -> asyncio.Lock:
+    """Return a coroutine-aware lock scoped to the active event loop and run."""
+
+    loop = asyncio.get_running_loop()
     with _EVENT_LOCKS_GUARD:
-        lock = _EVENT_LOCKS.get(int(run_id))
+        loop_locks = _EVENT_LOCKS.setdefault(loop, weakref.WeakValueDictionary())
+        lock = loop_locks.get(int(run_id))
         if lock is None:
-            lock = threading.RLock()
-            _EVENT_LOCKS[int(run_id)] = lock
+            lock = asyncio.Lock()
+            loop_locks[int(run_id)] = lock
         return lock
 
 
@@ -1340,16 +1348,20 @@ class AsyncAgentRunStore:
         return messages
 
     async def append_event(self, event: AgentRunEvent) -> AgentRunEventRow:
-        with _event_lock(int(event.run_id)):
-            await self._acquire_agent_run_locks(
-                [event.root_run_id or event.run_id, event.run_id],
-                key_share=True,
-            )
-            await self.lock_event_stream(
-                int(event.run_id),
-            )
-            sequence_no = event.sequence_no
-            if sequence_no is None:
+        async with _event_lock(int(event.run_id)):
+            return await self._append_event_locked(event)
+
+    async def _append_event_locked(self, event: AgentRunEvent) -> AgentRunEventRow:
+        await self._acquire_agent_run_locks(
+            [event.root_run_id or event.run_id, event.run_id],
+            key_share=True,
+        )
+        await self.lock_event_stream(
+            int(event.run_id),
+        )
+        sequence_no = event.sequence_no
+        if sequence_no is None:
+            with getattr(self.session, "no_autoflush", nullcontext()):
                 sequence_no = int(
                     await self.session.scalar(
                         select(func.coalesce(func.max(AgentRunEventRow.sequence_no), 0)).where(
@@ -1358,22 +1370,22 @@ class AsyncAgentRunStore:
                     )
                     or 0
                 ) + 1
-            row = AgentRunEventRow(
-                run_id=event.run_id,
-                root_run_id=event.root_run_id or event.run_id,
-                sequence_no=sequence_no,
-                event_type=event.event_type,
-                payload=dict(event.payload or {}),
-                producer=event.producer,
-                visibility=(
-                    event.visibility.value if isinstance(event.visibility, EventVisibility) else str(event.visibility)
-                ),
-            )
-            self.session.add(row)
-            await self.session.flush()
-            if self.auto_commit:
-                await self.session.commit()
-            return row
+        row = AgentRunEventRow(
+            run_id=event.run_id,
+            root_run_id=event.root_run_id or event.run_id,
+            sequence_no=sequence_no,
+            event_type=event.event_type,
+            payload=dict(event.payload or {}),
+            producer=event.producer,
+            visibility=(
+                event.visibility.value if isinstance(event.visibility, EventVisibility) else str(event.visibility)
+            ),
+        )
+        self.session.add(row)
+        await self.session.flush()
+        if self.auto_commit:
+            await self.session.commit()
+        return row
 
     async def lock_event_stream(self, run_id: int) -> None:
         """Serialize event writers for one run."""
@@ -1439,46 +1451,47 @@ class AsyncAgentRunStore:
         return safe_provider_error_sentinel(detected_provider_error)
 
     async def append_artifact(self, artifact: AgentRunArtifact) -> AgentRunArtifactRow:
-        artifact_type = (
-            artifact.artifact_type.value
-            if isinstance(artifact.artifact_type, ArtifactType)
-            else str(artifact.artifact_type)
-        )
-        artifact_text = artifact.text
-        if artifact_type == ArtifactType.FINAL_ANSWER.value and artifact_text is not None:
-            artifact_text = await self.safe_cycle_provider_error_text(
-                int(artifact.run_id),
-                str(artifact_text),
+        async with _event_lock(int(artifact.run_id)):
+            artifact_type = (
+                artifact.artifact_type.value
+                if isinstance(artifact.artifact_type, ArtifactType)
+                else str(artifact.artifact_type)
             )
-        await self._acquire_agent_run_locks(
-            [artifact.root_run_id or artifact.run_id, artifact.run_id],
-            key_share=True,
-        )
-        row = AgentRunArtifactRow(
-            run_id=artifact.run_id,
-            root_run_id=artifact.root_run_id or artifact.run_id,
-            artifact_type=artifact_type,
-            title=artifact.title,
-            payload=dict(artifact.payload or {}),
-            text=artifact_text,
-            uri=artifact.uri,
-            visibility=(
-                artifact.visibility.value
-                if isinstance(artifact.visibility, EventVisibility)
-                else str(artifact.visibility)
-            ),
-        )
-        self.session.add(row)
-        await self.session.flush()
-        await self.append_event(
-            run_event(
-                artifact.run_id,
-                "run.artifact_created",
-                {"artifact_id": row.id, "artifact_type": row.artifact_type, "title": row.title},
-                root_run_id=row.root_run_id,
+            artifact_text = artifact.text
+            if artifact_type == ArtifactType.FINAL_ANSWER.value and artifact_text is not None:
+                artifact_text = await self.safe_cycle_provider_error_text(
+                    int(artifact.run_id),
+                    str(artifact_text),
+                )
+            await self._acquire_agent_run_locks(
+                [artifact.root_run_id or artifact.run_id, artifact.run_id],
+                key_share=True,
             )
-        )
-        return row
+            row = AgentRunArtifactRow(
+                run_id=artifact.run_id,
+                root_run_id=artifact.root_run_id or artifact.run_id,
+                artifact_type=artifact_type,
+                title=artifact.title,
+                payload=dict(artifact.payload or {}),
+                text=artifact_text,
+                uri=artifact.uri,
+                visibility=(
+                    artifact.visibility.value
+                    if isinstance(artifact.visibility, EventVisibility)
+                    else str(artifact.visibility)
+                ),
+            )
+            self.session.add(row)
+            await self.session.flush()
+            await self._append_event_locked(
+                run_event(
+                    artifact.run_id,
+                    "run.artifact_created",
+                    {"artifact_id": row.id, "artifact_type": row.artifact_type, "title": row.title},
+                    root_run_id=row.root_run_id,
+                )
+            )
+            return row
 
     async def append_final_answer_once(
         self,

--- a/brain/systems/runs/work_intake.py
+++ b/brain/systems/runs/work_intake.py
@@ -11,7 +11,12 @@ from typing import Any
 from sqlalchemy import text
 
 from brain.platform.db.models.idea import Idea
-from brain.platform.providers.model_policy import EFFORT_TIER_SET
+from brain.platform.integrations.provider_auth_preflight import async_probe_provider_auth
+from brain.platform.providers.model_policy import (
+    EFFORT_TIER_SET,
+    async_get_default_model,
+    infer_provider_from_model,
+)
 from brain.systems.cortex.project_context.resolution import resolve_effective_project_context
 from brain.systems.cortex.thread_context import async_build_agent_visible_thread_context
 from brain.systems.runs.direct_targets import (
@@ -1061,6 +1066,37 @@ async def admit_work(
 ) -> WorkIntakeResult:
     try:
         request = await build_agent_run_request(session, event)
+        model_policy = dict(request.model_policy or {})
+        model = str(
+            model_policy.get("model")
+            or model_policy.get("model_override")
+            or ""
+        ).strip()
+        requested_provider = str(model_policy.get("provider") or "").strip().lower()
+        if not model:
+            model = await async_get_default_model(
+                session,
+                provider=requested_provider or None,
+                include_provider_prefix=True,
+                user_id=request.user_id,
+                org_id=request.org_id,
+            )
+        provider = infer_provider_from_model(model, default=requested_provider or None)
+        if provider == "anthropic":
+            auth_preflight = await async_probe_provider_auth(
+                session,
+                user_id=request.user_id,
+                org_id=request.org_id,
+                provider=provider,
+                model=model,
+            )
+            if auth_preflight.blocked:
+                reason = (
+                    f"{auth_preflight.error_code}: provider={provider} model={model} "
+                    f"credential={auth_preflight.credential or 'unavailable'}"
+                )
+                logger.warning("Work admission blocked before run creation: %s", reason)
+                return WorkIntakeResult(ok=False, skipped_reason=reason)
         from brain.systems.runs.open_asks import (
             annotate_request_with_open_ask,
             record_open_ask,

--- a/deploy/scripts/upgrade.sh
+++ b/deploy/scripts/upgrade.sh
@@ -126,4 +126,6 @@ if [ "$WORKER_RESTART_STATUS" -ne 0 ]; then
 fi
 
 "$SCRIPT_DIR/doctor.sh"
+echo "Cycle context admission: checking every enabled live Cycle."
+compose exec -T api python3 -m brain.jobs.check_cycle_context_admission --live
 schedule_updater_refresh_after_self_update

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,6 +95,20 @@ contract.
 
 - Keep `deploy/compose/.env`, `.env`, database dumps, uploads, logs, and
   operator notes out of git.
+- Before shipping, run the checked-in enabled-Cycle admission fixture gate:
+  `python3 -m brain.jobs.check_cycle_context_admission`. After the stack is
+  upgraded, run the same gate inside the API container with `--live`; it reads
+  every enabled Cycle plus its current prompt, guidance, output targets, model,
+  and thinking configuration from Postgres without writing. A failed result is
+  a deployment failure; a warning means the minimum prompt is above 80% of its
+  admission ceiling.
+
+  ```bash
+  docker compose --env-file deploy/compose/.env \
+    -f deploy/compose/docker-compose.yml \
+    exec -T api python3 -m brain.jobs.check_cycle_context_admission --live
+  ```
+
 - Prefer `EMBEDDING_BACKEND=api` for the simplest team-server install.
 - Use GPU workers only when the host has the right CUDA/PyTorch stack.
 - Let the `migrate` service run Alembic migrations before API, worker, and

--- a/tests/fixtures/enabled_cycles_context_admission.json
+++ b/tests/fixtures/enabled_cycles_context_admission.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "description": "Content-free size mirrors of every enabled production Cycle observed on 2026-07-29; padding preserves the measured high-water admission floors without storing mission text.",
+  "cycles": [
+    {
+      "cycle_id": 2,
+      "name": "Uwear Ticket Coordinator Check-ins",
+      "model": "openai/gpt-5.6-sol",
+      "thinking": "xhigh",
+      "timezone": "America/Toronto",
+      "prompt_chars": 6276,
+      "guidance_chars": 64000,
+      "observed_floor_tokens": 52230
+    },
+    {
+      "cycle_id": 8,
+      "name": "GitHub Reflex — event fast lane",
+      "model": "openai/gpt-5.4-mini",
+      "thinking": "low",
+      "timezone": "America/Toronto",
+      "prompt_chars": 4138,
+      "guidance_chars": 12000
+    },
+    {
+      "cycle_id": 9,
+      "name": "Uwear Backend Promotion Readiness",
+      "model": "openai/gpt-5.6-sol",
+      "thinking": "high",
+      "timezone": "America/Toronto",
+      "prompt_chars": 5083,
+      "guidance_chars": 90000,
+      "observed_floor_tokens": 61604
+    }
+  ]
+}

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -334,6 +334,62 @@ async def test_run_admission_marks_idea_working_without_worker_details(monkeypat
     assert added[0].trigger == "agent_run_admitted"
 
 
+async def test_run_admission_rejects_uncredentialed_anthropic_before_creation(monkeypatch):
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
+    from brain.systems.runs.domain import AgentRunRequest
+    from brain.systems.runs import work_intake
+
+    request = AgentRunRequest(
+        org_id="org-1",
+        user_id="user-1",
+        thread_id="thread-1",
+        message="run",
+        model_policy={"model": "anthropic/claude-sonnet-5"},
+    )
+    create_calls = []
+
+    async def build_request(*_args, **_kwargs):
+        return request
+
+    async def blocked_probe(_session, **kwargs):
+        return ProviderAuthPreflightResult(
+            status="auth_blocked",
+            provider="anthropic",
+            model=kwargs["model"],
+            credential="Anthropic API key",
+            error_code="provider_credential_unavailable",
+        )
+
+    class FailStore:
+        def __init__(self, _session):
+            create_calls.append("constructed")
+
+    monkeypatch.setattr(work_intake, "build_agent_run_request", build_request)
+    monkeypatch.setattr(work_intake, "async_probe_provider_auth", blocked_probe)
+    monkeypatch.setattr(work_intake, "AsyncAgentRunStore", FailStore)
+
+    result = await work_intake.admit_work(
+        object(),
+        work_intake.WorkIntakeEvent(
+            source="test",
+            event_type="test.run",
+            org_id="org-1",
+            actor=None,
+            target={"kind": "direct", "thread_id": "thread-1"},
+        ),
+    )
+
+    assert result.ok is False
+    assert result.run_id is None
+    assert result.skipped_reason == (
+        "provider_credential_unavailable: provider=anthropic "
+        "model=anthropic/claude-sonnet-5 credential=Anthropic API key"
+    )
+    assert create_calls == []
+
+
 async def test_run_admission_preserves_protected_idea_statuses(monkeypatch):
     from brain.platform.db.models.idea import Idea
     from brain.systems.runs.work_intake import WorkIntakeEvent, admit_work
@@ -2112,16 +2168,28 @@ async def test_spawn_worker_auth_policy_probes_anthropic_and_owns_wording(
     )
 
 
-async def test_cycle_auth_policy_skips_anthropic_without_probing(monkeypatch):
+async def test_cycle_auth_policy_blocks_anthropic_without_credentials(monkeypatch):
     from brain.systems.cycles import auth_preflight
+    from brain.platform.integrations.provider_auth_preflight import (
+        ProviderAuthPreflightResult,
+    )
 
-    async def unexpected_probe(*_args, **_kwargs):
-        raise AssertionError("Cycle policy must remain OpenAI-only")
+    probes = []
+
+    async def blocked_probe(*_args, **kwargs):
+        probes.append(kwargs)
+        return ProviderAuthPreflightResult(
+            status="auth_blocked",
+            provider="anthropic",
+            model=kwargs["model"],
+            credential="Anthropic API key",
+            error_code="provider_credential_unavailable",
+        )
 
     monkeypatch.setattr(
         auth_preflight,
         "async_probe_provider_auth",
-        unexpected_probe,
+        blocked_probe,
     )
 
     result = await auth_preflight.async_preflight_cycle_external_auth(
@@ -2133,8 +2201,10 @@ async def test_cycle_auth_policy_skips_anthropic_without_probing(monkeypatch):
         ),
     )
 
-    assert result.status == "skipped"
+    assert result.status == "auth_blocked"
     assert result.provider == "anthropic"
+    assert probes[0]["provider"] == "anthropic"
+    assert "Add an Anthropic API key" in result.visible_message
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import event, select
+from sqlalchemy import event, func, select
 from sqlalchemy.dialects.sqlite.base import SQLiteDDLCompiler, SQLiteTypeCompiler
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -92,6 +92,48 @@ def test_interrupted_requeue_transition_is_declared_but_scoped(from_status: RunS
     ) == (from_status, RunStatus.QUEUED)
     with pytest.raises(RunTransitionError, match="outside interrupted requeue"):
         ensure_run_transition(from_status, RunStatus.QUEUED)
+
+
+async def test_concurrent_event_appends_are_sequential_and_leave_session_usable(session_factory):
+    from brain.systems.runs.events import run_event
+
+    session = session_factory()
+    store = AsyncAgentRunStore(session)
+    run = await store.create_run(_run_request(thread_id="thread-event-race", message="run"))
+    baseline = int(
+        await session.scalar(
+            select(func.max(AgentRunEventRow.sequence_no)).where(
+                AgentRunEventRow.run_id == run.id
+            )
+        )
+        or 0
+    )
+    active_writers = 0
+    max_active_writers = 0
+    original_acquire = store._acquire_agent_run_locks
+
+    async def observed_acquire(*args, **kwargs):
+        nonlocal active_writers, max_active_writers
+        active_writers += 1
+        max_active_writers = max(max_active_writers, active_writers)
+        try:
+            await asyncio.sleep(0)
+            return await original_acquire(*args, **kwargs)
+        finally:
+            active_writers -= 1
+
+    store._acquire_agent_run_locks = observed_acquire
+    first, second = await asyncio.gather(
+        store.append_event(run_event(run.id, "run.concurrent_first")),
+        store.append_event(run_event(run.id, "run.concurrent_second")),
+    )
+
+    assert max_active_writers == 1
+    assert sorted((first.sequence_no, second.sequence_no)) == [baseline + 1, baseline + 2]
+
+    third = await store.append_event(run_event(run.id, "run.after_concurrent_append"))
+    assert third.sequence_no == baseline + 3
+    assert await session.scalar(select(func.count()).select_from(AgentRunEventRow)) >= 4
 
 
 async def test_inline_child_is_atomically_owned_before_parent_executes_it(session_factory):

--- a/tests/test_cycle_context_admission_gate.py
+++ b/tests/test_cycle_context_admission_gate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_enabled_cycle_fixture_gate_passes_with_healthy_catalog(monkeypatch):
+    from brain.jobs.check_cycle_context_admission import evaluate_specs, load_fixture_specs
+
+    monkeypatch.delenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", raising=False)
+    report = evaluate_specs(load_fixture_specs())
+
+    assert report["ok"] is True
+    assert {item["cycle_id"] for item in report["results"]} == {2, 8, 9}
+    assert all(item["status"] == "passed" for item in report["results"])
+    assert all(item["tools"] == 87 for item in report["results"])
+
+
+def test_enabled_cycle_fixture_gate_names_cycles_killed_by_128k_regression(monkeypatch):
+    from brain.jobs.check_cycle_context_admission import evaluate_specs, load_fixture_specs
+
+    monkeypatch.setenv("AGENT_MODEL_CONTEXT_WINDOW_TOKENS", "128000")
+    report = evaluate_specs(load_fixture_specs())
+
+    assert report["ok"] is False
+    failures = {
+        item["cycle_id"]: item
+        for item in report["results"]
+        if item["status"] == "failed"
+    }
+    assert set(failures) == {2, 9}
+    assert all("floor=" in item["diagnostic"] for item in failures.values())
+    assert "ceiling=50486" in failures[2]["diagnostic"]
+    assert "ceiling=57859" in failures[9]["diagnostic"]
+    assert all("tools=87" in item["diagnostic"] for item in failures.values())
+
+
+def test_compose_upgrade_runs_live_cycle_gate_after_doctor():
+    source = Path("deploy/scripts/upgrade.sh").read_text()
+
+    doctor = source.index('"$SCRIPT_DIR/doctor.sh"')
+    live_gate = source.index(
+        "compose exec -T api python3 -m brain.jobs.check_cycle_context_admission --live"
+    )
+    assert live_gate > doctor

--- a/tests/test_cycles_service.py
+++ b/tests/test_cycles_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -31,6 +32,8 @@ from brain.platform.db.models.cycle import (
 from brain.platform.db.models.agent_run import AgentRunArtifactRow, AgentRunEventRow
 from brain.platform.db.models.run import AgentRun
 from brain.platform.db.models.idea import Idea
+from brain.platform.integrations.provider_auth_preflight import ProviderAuthPreflightResult
+from brain.platform.providers.model_policy import infer_provider_from_model
 
 
 RAW_PROVIDER_ERROR = (
@@ -59,6 +62,15 @@ REFLEX_ANSWER = (
     "Next action: inspect new GitHub events at the next scheduled run.\n"
     "Self-review: the mission and advertised result contract are satisfied."
 )
+
+
+async def _passed_cycle_auth(_session, *, cycle):
+    model = str(cycle.model_override or "openai/gpt-5.6-sol")
+    return ProviderAuthPreflightResult(
+        status="passed",
+        provider=infer_provider_from_model(model),
+        model=model,
+    )
 
 
 def _result_contract(required_outputs=None):
@@ -1815,6 +1827,7 @@ async def test_execute_cycle_run_logs_uuid_idea_id_without_slicing_error(monkeyp
         "UnitOfWork",
         _AsyncUnitOfWorkFactory([session]),
     )
+    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     admissions = []
 
     async def fake_admit(*args, **kwargs):
@@ -1922,6 +1935,7 @@ async def test_async_execute_cycle_run_uses_native_uow_without_sync_bridges(monk
         return 77
 
     monkeypatch.setattr(service, "UnitOfWork", factory)
+    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_async_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
     monkeypatch.setattr(service, "open_unit_of_work", _fail_sync_bridge, raising=False)
@@ -2147,6 +2161,7 @@ async def test_execute_cycle_run_creates_execution_thread_when_target_thread_is_
         return True
 
     monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr(service, "async_preflight_cycle_external_auth", _passed_cycle_auth)
     monkeypatch.setattr(cycle_execution, "_async_idea_has_active_run", fake_idea_has_active_run)
     monkeypatch.setattr(service, "_async_admit_cycle_run", fake_async_admit)
     monkeypatch.setattr(service, "publish", lambda *args, **kwargs: None)
@@ -2614,6 +2629,65 @@ def test_cycle_contract_rejects_raw_provider_error_as_visible_answer():
     assert review["missing_outputs"] == ["visible_final_answer"]
     assert review["provider_error"] == "server_error"
     assert "help.openai.com" not in review["candidate_summary"]
+
+
+@pytest.mark.asyncio
+async def test_cycle_contract_repair_resolves_codex_auth_asynchronously(monkeypatch):
+    from brain.platform.integrations import llm as llm_integration
+    from brain.platform.integrations import providers as provider_integration
+    from brain.systems.cycles import contract_gate
+
+    session = object()
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.user_id = "user-1"
+    agent_run.org_id = "org-1"
+    agent_run.model_policy = {"model": "openai/gpt-5.6-sol"}
+    agent_run.metadata_ = {}
+    resolver_calls = []
+    provider_requests = []
+
+    class ResolvedLLM:
+        provider = "openai"
+        client = object()
+
+        @staticmethod
+        def build_request_headers(**_kwargs):
+            return {}
+
+    async def resolve_async(**kwargs):
+        resolver_calls.append(kwargs)
+        return ResolvedLLM()
+
+    class FakeProvider:
+        def create(self, request):
+            provider_requests.append(request)
+            return SimpleNamespace(content=[{"type": "text", "text": "Repaired answer"}])
+
+    monkeypatch.setattr(llm_integration, "async_resolve_llm_client", resolve_async)
+    monkeypatch.setattr(provider_integration, "get_provider", lambda *_args: FakeProvider())
+
+    answer = await contract_gate._async_repair_cycle_contract_answer(
+        session=session,
+        agent_run=agent_run,
+        mission="Report the result",
+        result_contract={"kind": "autonomous_cycle_run_result"},
+        evidence_packet={},
+        missing_outputs=["visible_final_answer"],
+        candidate_answer="",
+    )
+
+    assert answer == "Repaired answer"
+    assert resolver_calls == [
+        {
+            "user_id": "user-1",
+            "org_id": "org-1",
+            "provider": "openai",
+            "auth_mode": "chatgpt",
+            "session": session,
+        }
+    ]
+    assert len(provider_requests) == 1
 
 
 def test_cycle_contract_rejects_empty_answer_with_captured_provider_exception():
@@ -3365,6 +3439,46 @@ def test_finalize_cycle_run_from_run_ignores_non_cycle_run(monkeypatch):
 
     assert cycle_run.status == "running"
     assert cycle.last_status is None
+
+
+def test_finalize_cycle_failure_uses_original_run_failed_event(monkeypatch):
+    agent_run = AgentRun()
+    agent_run.id = 44
+    agent_run.metadata_ = {"source": "cycle", "cycle_run_id": 12}
+
+    cycle_run = CycleRun()
+    cycle_run.id = 12
+    cycle_run.cycle_id = 5
+    cycle_run.status = "running"
+    cycle = Cycle()
+    cycle.id = 5
+    failure_event = AgentRunEventRow(
+        id=9,
+        run_id=44,
+        root_run_id=44,
+        sequence_no=9,
+        event_type="run.failed",
+        payload={"error": "RuntimeError: provider request exploded"},
+    )
+    session = _AsyncFakeSession(
+        agent_run=agent_run,
+        run=cycle_run,
+        cycle=cycle,
+        events=[failure_event],
+    )
+    finalized = []
+
+    async def capture_finalize(run, active_cycle, *, status, error, session):
+        finalized.append((run, active_cycle, status, error, session))
+
+    monkeypatch.setattr(service, "UnitOfWork", _AsyncUnitOfWorkFactory([session]))
+    monkeypatch.setattr(service, "_finalize_cycle_run", capture_finalize)
+
+    service.finalize_cycle_run_from_run(44, status="failed")
+
+    assert finalized[0][2] == "failed"
+    assert finalized[0][3] == "RuntimeError: provider request exploded"
+    assert "Cycle ended with failed status" not in finalized[0][3]
 
 
 def test_cycle_route_scope_uses_workspace_when_available():

--- a/tests/test_model_catalog_contract.py
+++ b/tests/test_model_catalog_contract.py
@@ -46,3 +46,31 @@ def test_composer_consumes_runtime_catalog_instead_of_owning_model_options():
     assert "MODEL_OPTIONS" not in source
     assert "modelCatalog" in source
     assert "RuntimeModelCatalogEntry" in source
+
+
+def test_gpt_5_6_sol_uses_provider_context_contract(monkeypatch):
+    from brain.platform.model_catalog import get_model_catalog_entry
+    from brain.systems.context.budget import resolve_model_context_budget
+
+    for name in (
+        "AGENT_MODEL_CONTEXT_WINDOW_TOKENS",
+        "AGENT_CONTEXT_RESERVED_OUTPUT_TOKENS",
+        "AGENT_CONTEXT_RESERVED_REASONING_TOKENS",
+        "AGENT_CONTEXT_RESERVED_TOOL_TOKENS",
+        "AGENT_CONTEXT_SAFETY_MARGIN_TOKENS",
+        "AGENT_AUTO_COMPACT_TOKEN_LIMIT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    entry = get_model_catalog_entry("openai/gpt-5.6-sol")
+    assert entry is not None
+    assert entry.context_window_tokens == 1_050_000
+
+    budget = resolve_model_context_budget(
+        model=entry.id,
+        reasoning_effort="xhigh",
+        max_output_tokens=32_768,
+        tools=[{"name": f"tool-{index}"} for index in range(87)],
+    )
+    assert budget.context_window_tokens == 1_050_000
+    assert budget.auto_compact_threshold_tokens == 863_690

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -100,6 +100,41 @@ async def test_sync_scheduler_catalog_seeds_scheduler_jobs_without_cron_table(se
         assert "legacy_cron_retired" not in job["default_payload"]
 
 
+async def test_command_failure_prefers_structured_exception_over_log_tail():
+    proc = SimpleNamespace(
+        returncode=1,
+        stdout=json.dumps(
+            {
+                "job": "knowledge_index_sync",
+                "ok": False,
+                "results": [
+                    {
+                        "source": "github",
+                        "status": "failed",
+                        "exception_type": "RuntimeError",
+                        "error": "connector exploded",
+                    }
+                ],
+            }
+        ),
+        stderr=(
+            "INFO:httpx:HTTP Request: POST https://example.test HTTP/1.1 201 Created\n"
+            "INFO:knowledge:continuing with remaining connectors\n"
+        ),
+    )
+
+    summary = scheduler_executor._command_summary(proc)
+
+    assert scheduler_executor._command_failure_error_text(summary) == (
+        "RuntimeError: connector exploded"
+    )
+    assert summary["exception"] == {
+        "type": "RuntimeError",
+        "message": "connector exploded",
+    }
+    assert "HTTP/1.1 201 Created" in summary["stderr_tail"]
+
+
 async def test_knowledge_index_sync_catalog_config(session):
     now = datetime(2026, 4, 21, 0, 0, tzinfo=timezone.utc)
 
@@ -1185,7 +1220,8 @@ async def test_scheduler_daemon_tick_emits_new_failure_once_without_historical_s
     assert len(first_tick["drain"]["results"]) == 1
     failure = first_tick["drain"]["results"][0]
     assert failure["status"] == "settled_failure"
-    assert "NEW_FAILURE_418" in failure["error_text"]
+    assert failure["error_text"] == "Command exited with status 1"
+    assert "NEW_FAILURE_418" not in failure["error_text"]
     new_failure_text = failure["error_text"]
 
     run = await session.get(SchedulerRun, failure["run_id"])

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1202,7 +1202,10 @@ async def test_scheduler_daemon_tick_emits_new_failure_once_without_historical_s
         handler_kind="command",
         handler_ref=(
             'python3 -c "import sys; '
-            "sys.stderr.write('NEW_FAILURE_418'); sys.exit(1)\""
+            "sys.stdout.write('{\\\"ok\\\": false, \\\"results\\\": [{\\\"status\\\": "
+            "\\\"failed\\\", \\\"exception_type\\\": \\\"RuntimeError\\\", "
+            "\\\"error\\\": \\\"NEW_FAILURE_418\\\"}]}\\n'); "
+            "sys.stderr.write('INFO httpx HTTP/1.1 201 Created'); sys.exit(1)\""
         ),
         default_payload={"name": "Scheduler Tick Failure"},
         retry_policy={"max_attempts": 1, "backoff_seconds": 0},
@@ -1220,12 +1223,13 @@ async def test_scheduler_daemon_tick_emits_new_failure_once_without_historical_s
     assert len(first_tick["drain"]["results"]) == 1
     failure = first_tick["drain"]["results"][0]
     assert failure["status"] == "settled_failure"
-    assert failure["error_text"] == "Command exited with status 1"
-    assert "NEW_FAILURE_418" not in failure["error_text"]
+    assert failure["error_text"] == "RuntimeError: NEW_FAILURE_418"
+    assert "HTTP/1.1 201 Created" not in failure["error_text"]
     new_failure_text = failure["error_text"]
 
     run = await session.get(SchedulerRun, failure["run_id"])
     assert run is not None
+    assert run.error_text == "RuntimeError: NEW_FAILURE_418"
     historical_traceback = "Traceback: historical failure\n" * 10_000
     run.error_text = historical_traceback
     await session.flush()


### PR DESCRIPTION
## Summary

- correct GPT-5.6 Sol to the provider's current 1,050,000-token context contract
- add a Fast-recipe-shaped context admission gate for every enabled Cycle fixture in CI and every live enabled Cycle after Compose upgrades
- serialize same-run event/artifact writes with coroutine-aware locks so shared AsyncSession flushes cannot race
- preserve structured scheduler exceptions and propagate the original `run.failed` error into Cycle alerts
- reject uncredentialed Anthropic routes before run creation and migrate Cycle contract repair to async Codex credential resolution

## Verification

- 333 focused tests passed, 1 skipped
- 71 Postgres tests passed
- full backend fast suite: 4,532 passed, 11 skipped; its sole failure was the synthetic-session `no_autoflush` compatibility case fixed afterward, and the complete affected lock-ordering file passes 9/9
- healthy Cycle gate passes cycles 2, 8, and 9
- forcing `AGENT_MODEL_CONTEXT_WINDOW_TOKENS=128000` fails the gate for cycles 2 and 9 at ceilings 50,486 and 57,859

Closes #592
Closes #593
Closes #594
Closes #595
Closes #596
