### PR TITLE
Release AgentRun locks before isolated tool handlers

### DIFF
--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -1351,6 +1351,21 @@ class AsyncAgentRunStore:
         async with _event_lock(int(event.run_id)):
             return await self._append_event_locked(event)
 
+    async def commit_event_boundary(self, run_id: int) -> None:
+        """Publish pre-action events before a tool opens an isolated UoW.
+
+        Tool handlers such as ``spawn_worker`` deliberately persist through a
+        separate session.  Keeping the runner transaction open after
+        ``run.tool_started`` leaves both the AgentRun row lock and its advisory
+        event-stream lock held while that handler tries to lock the same run,
+        producing a cross-session lock cycle.  Serialize the commit with event
+        appends so parallel tool calls cannot operate on the shared
+        ``AsyncSession`` while its transaction is closing.
+        """
+
+        async with _event_lock(int(run_id)):
+            await self.session.commit()
+
     async def _append_event_locked(self, event: AgentRunEvent) -> AgentRunEventRow:
         await self._acquire_agent_run_locks(
             [event.root_run_id or event.run_id, event.run_id],

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -159,6 +159,13 @@ class AsyncRunToolExecutor:
         await self._append_event(
             run_event(run_id, "run.tool_started", _event_payload(tool.name, safe_args), root_run_id=root_run_id)
         )
+        commit_event_boundary = getattr(self.store, "commit_event_boundary", None)
+        if callable(commit_event_boundary):
+            # The handler may use an isolated UnitOfWork that writes to this
+            # same run (spawn_worker is the canonical example).  Make the
+            # started marker durable and release the parent transaction's row
+            # and advisory locks before invoking it.
+            await commit_event_boundary(run_id)
         manifest = None
         manifest_id = None
         try:

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2552,6 +2552,33 @@ async def test_runtime_tool_executor_records_public_events_and_redacted_artifact
     assert _stream_has(runtime.stream.messages, "run.tool_completed", completed.payload | {"run_id": 42})
 
 
+async def test_runtime_tool_executor_commits_started_event_before_handler():
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    runtime = _runtime("worker")
+    observed = []
+
+    async def commit_event_boundary(run_id):
+        assert runtime.store.events[-1].event_type == "run.tool_started"
+        observed.append(("commit", run_id))
+
+    async def handler(**_kwargs):
+        observed.append(("handler", 42))
+        return {"ok": True}
+
+    runtime.store.commit_event_boundary = commit_event_boundary
+    executor = AsyncRunToolExecutor(runtime.store, stream=runtime.stream)
+
+    result = await executor.execute(
+        42,
+        ToolExecution(name="spawn_worker", args={"objective": "check"}, handler=handler),
+        root_run_id=42,
+    )
+
+    assert result == {"ok": True}
+    assert observed == [("commit", 42), ("handler", 42)]
+
+
 async def test_agent_execution_context_is_isolated_between_parallel_tool_tasks():
     from brain.systems.runs.execution_context import bind_agent_context, current_agent_context
 

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1037,6 +1037,83 @@ async def test_postgres_execution_token_allows_one_recipe_attempt(db_engine):
             await cleanup_session.commit()
 
 
+@pytest.mark.requires_db
+async def test_postgres_event_boundary_releases_parent_for_isolated_child_uow(db_engine):
+    import uuid
+
+    from brain.platform.db.models.org import Org
+    from brain.systems.runs.events import run_event
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    root_id = None
+    child_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Tool Boundary Test",
+                    slug=f"tool-boundary-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            root = await AsyncAgentRunStore(setup_session).create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="root",
+                )
+            )
+            root_id = root.id
+            await setup_session.commit()
+
+        async with factory() as parent_session, factory() as child_session:
+            parent_store = AsyncAgentRunStore(parent_session)
+            await parent_store.append_event(
+                run_event(root_id, "run.tool_started", {"tool_name": "spawn_worker"})
+            )
+            await parent_store.commit_event_boundary(root_id)
+
+            child_store = AsyncAgentRunStore(child_session)
+            parent = await child_store.require_run(root_id)
+            child = await asyncio.wait_for(
+                child_store.create_child_run(
+                    parent,
+                    recipe=RunRecipe.WORKER,
+                    message="child",
+                    step_key="spawn_worker:tool-boundary",
+                ),
+                timeout=1,
+            )
+            child_id = child.id
+            await child_session.commit()
+
+        async with factory() as inspection_session:
+            stored_child = await inspection_session.get(AgentRunRow, child_id)
+            assert stored_child is not None
+            assert stored_child.parent_run_id == root_id
+    finally:
+        async with factory() as cleanup_session:
+            run_ids = [value for value in (root_id, child_id) if value is not None]
+            if run_ids:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id.in_(run_ids))
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
 async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory):
     class UnexpectedRecipe:
         async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:


### PR DESCRIPTION
## Summary

- commit the durable `run.tool_started` event boundary before invoking a tool handler
- serialize that commit with per-run event appends so parallel calls cannot concurrently operate on the shared `AsyncSession`
- release the parent AgentRun row/advisory locks before handlers such as `spawn_worker` open an isolated UnitOfWork against the same run

## Production evidence

Post-deploy acceptance runs for PR #597 reached real 87K/75K Sol turns, then both `spawn_worker` calls waited indefinitely. `pg_stat_activity` showed each handler blocked on `SELECT agent_runs.id ... FOR UPDATE`, behind the parent runner transaction that had inserted `run.tool_started` and remained idle in transaction.

## Verification

- affected runtime/state-machine suite: 181 passed, 2 skipped
- Postgres DB contract lane: 72 passed
- added a real-Postgres regression proving an isolated child UoW can acquire the parent immediately after the event boundary
