### PR TITLE
Prevent child event locks from stalling parent runs

### DIFF
--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -292,6 +292,7 @@ class AsyncAgentRunStore:
         run_ids: Iterable[int | None],
         *,
         key_share: bool,
+        no_key_update: bool = False,
         skip_locked: bool = False,
     ) -> set[int]:
         """Acquire one lock mode across run rows in ascending global order."""
@@ -304,7 +305,7 @@ class AsyncAgentRunStore:
             .order_by(AgentRunRow.id.asc())
             .with_for_update(
                 read=key_share,
-                key_share=key_share,
+                key_share=key_share or no_key_update,
                 skip_locked=skip_locked,
             )
         )
@@ -318,7 +319,13 @@ class AsyncAgentRunStore:
         root_run_id: int | None = None,
         skip_locked: bool = False,
     ) -> AgentRunRow | None:
-        """Lock a root/current pair in id order, with only the current row exclusive."""
+        """Lock a root/current pair in order, with the current row mutable.
+
+        ``FOR NO KEY UPDATE`` still serializes every run mutation while staying
+        compatible with child-event ``FOR KEY SHARE`` locks on the root. Run
+        primary keys are immutable, so the stronger ``FOR UPDATE`` lock only
+        creates unnecessary root/child lock convoys.
+        """
         run_id = int(run_id)
         if self._dialect_name() != "postgresql":
             return await self.refresh_run(run_id)
@@ -333,6 +340,7 @@ class AsyncAgentRunStore:
             locked_ids = await self._acquire_agent_run_locks(
                 [lock_id],
                 key_share=lock_id != run_id,
+                no_key_update=lock_id == run_id,
                 skip_locked=skip_locked,
             )
             if lock_id not in locked_ids:

--- a/tests/test_agent_run_lock_ordering.py
+++ b/tests/test_agent_run_lock_ordering.py
@@ -51,7 +51,8 @@ class _SharedRowLocks:
                 self.contention_observed.set()
                 await self._condition.wait()
             previous_mode = self._holders[run_id].get(transaction)
-            if previous_mode == "update" or previous_mode == mode:
+            strength = {"key_share": 1, "no_key_update": 2, "update": 3}
+            if previous_mode is not None and strength[previous_mode] >= strength[mode]:
                 return
             self._holders[run_id][transaction] = mode
             self.events[transaction].append(("row", run_id))
@@ -73,6 +74,8 @@ class _SharedRowLocks:
         ]
         if mode == "key_share":
             return "update" in other_modes
+        if mode == "no_key_update":
+            return any(held_mode in {"no_key_update", "update"} for held_mode in other_modes)
         return bool(other_modes)
 
 
@@ -99,11 +102,16 @@ class _ContendingPostgresSession:
     async def scalars(self, statement):
         compiled = statement.compile(dialect=postgresql.dialect())
         sql = str(compiled)
-        if "FOR UPDATE" in sql or "FOR KEY SHARE" in sql:
+        if "FOR UPDATE" in sql or "FOR KEY SHARE" in sql or "FOR NO KEY UPDATE" in sql:
             run_ids = next(
                 value for value in compiled.params.values() if isinstance(value, list)
             )
-            mode = "key_share" if "FOR KEY SHARE" in sql else "update"
+            if "FOR KEY SHARE" in sql:
+                mode = "key_share"
+            elif "FOR NO KEY UPDATE" in sql:
+                mode = "no_key_update"
+            else:
+                mode = "update"
             for run_id in sorted(int(value) for value in run_ids):
                 await self._locks.acquire(self._transaction, run_id, mode)
             self._lock_calls += 1
@@ -186,9 +194,13 @@ async def test_agent_run_lock_order_is_transaction_wide_and_precedes_advisory_lo
     outer = asyncio.create_task(
         _write_child_event(outer_session, run_id=3065, root_run_id=3024)
     )
-    await asyncio.wait_for(locks.contention_observed.wait(), timeout=1)
     nested_session.resume.set()
     await asyncio.wait_for(asyncio.gather(nested, outer), timeout=1)
+
+    # The outer transaction only mutates the parent row. FOR NO KEY UPDATE is
+    # compatible with the nested child's key-share protection of that parent,
+    # so child event persistence no longer creates a parent lock convoy.
+    assert not locks.contention_observed.is_set()
 
     for transaction_events in locks.events.values():
         row_lock_ids = [

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1114,6 +1114,86 @@ async def test_postgres_event_boundary_releases_parent_for_isolated_child_uow(db
             await cleanup_session.commit()
 
 
+@pytest.mark.requires_db
+async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_engine):
+    import uuid
+
+    from brain.platform.db.models.org import Org
+    from brain.systems.runs.events import run_event
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    root_id = None
+    child_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Child Event Lock Test",
+                    slug=f"child-event-lock-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            store = AsyncAgentRunStore(setup_session)
+            root = await store.create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="root",
+                )
+            )
+            root_id = root.id
+            child = await store.create_child_run(
+                root,
+                recipe=RunRecipe.WORKER,
+                message="child",
+                step_key="spawn_worker:child-event-lock",
+            )
+            child_id = child.id
+            await setup_session.commit()
+
+        async with factory() as child_session, factory() as parent_session:
+            await AsyncAgentRunStore(child_session).append_event(
+                run_event(
+                    child_id,
+                    "run.activity",
+                    {"label": "Preparing project context"},
+                    root_run_id=root_id,
+                )
+            )
+
+            locked_parent = await asyncio.wait_for(
+                AsyncAgentRunStore(parent_session)._locked_run(
+                    root_id,
+                    root_run_id=root_id,
+                ),
+                timeout=1,
+            )
+            assert locked_parent.id == root_id
+            await parent_session.rollback()
+            await child_session.rollback()
+    finally:
+        async with factory() as cleanup_session:
+            run_ids = [value for value in (root_id, child_id) if value is not None]
+            if run_ids:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id.in_(run_ids))
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
 async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory):
     class UnexpectedRecipe:
         async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:


### PR DESCRIPTION
## Summary
- acquire mutable AgentRun rows with PostgreSQL `FOR NO KEY UPDATE` instead of `FOR UPDATE`
- preserve root/current lock ordering and mutation serialization
- allow child event `FOR KEY SHARE` locks to coexist with parent tool persistence and deadline settlement

## Production evidence
Fresh Cycle 2 acceptance after #598 spawned six workers but later parent tool handlers queued behind child-root key-share locks for more than five minutes. The deadline watchdog also could not settle the parent because the same stronger lock conflicted.

## Verification
- 193 affected runtime/state-machine tests passed
- 73/73 PostgreSQL tests passed
- new real-PostgreSQL regression test holds a child root key-share lock while the parent mutation completes within one second

Follow-up to #598 and #593.