### PR TITLE
Fix terminal run lock ordering

### DIFF
--- a/brain/systems/runs/chantier_continuation.py
+++ b/brain/systems/runs/chantier_continuation.py
@@ -257,7 +257,7 @@ async def _lock_run(session: AsyncSession, run_id: int) -> AgentRunRow | None:
     stmt = (
         select(AgentRunRow)
         .where(AgentRunRow.id == int(run_id))
-        .with_for_update()
+        .with_for_update(key_share=True)
         .execution_options(populate_existing=True)
     )
     return (await session.scalars(stmt)).one_or_none()

--- a/brain/systems/runs/cortex/runner.py
+++ b/brain/systems/runs/cortex/runner.py
@@ -1267,6 +1267,11 @@ async def _mark_run_failed_after_runner_error_async(
         store = AsyncAgentRunStore(uow.session)
         row = await store.require_run(int(run_id))
         if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
+            row = await store.lock_terminal_boundary(
+                int(run_id),
+                anchor_run_id=row.parent_run_id or row.id,
+            )
+        if coerce_run_status(row.status, default=RunStatus.FAILED) not in TERMINAL_RUN_STATUSES:
             category = failure_category_for_error(error)
             failure = public_run_failure(RunStatus.FAILED, category)
             await store.update_metadata(

--- a/brain/systems/runs/deadlines.py
+++ b/brain/systems/runs/deadlines.py
@@ -132,6 +132,17 @@ async def _expire_after_closeout(
     if closeout_expires_at is None or _as_utc(closeout_expires_at) > now:
         return False
     store = AsyncAgentRunStore(session)
+    anchor_run_id = int(row.parent_run_id or row.id)
+    await store.commit_event_boundary(int(run_id))
+    row = await store.lock_terminal_boundary(
+        int(run_id),
+        anchor_run_id=anchor_run_id,
+    )
+    if str(row.status or "") not in _OPEN_STATUS_VALUES:
+        return False
+    closeout_expires_at = row.closeout_expires_at
+    if closeout_expires_at is None or _as_utc(closeout_expires_at) > now:
+        return False
     expired, changed = await store.set_status_with_result(
         int(run_id),
         RunStatus.EXPIRED,

--- a/brain/systems/runs/engine.py
+++ b/brain/systems/runs/engine.py
@@ -384,8 +384,8 @@ class AsyncAgentRunEngine:
                     root_run_id=row.root_run_id,
                 )
             )
+        row = await self._prepare_terminal_write(run_id)
         async with self._atomic_terminal_write():
-            row = await self.store.require_run(run_id)
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             completed = await self.store.set_status(
@@ -426,8 +426,8 @@ class AsyncAgentRunEngine:
         failure_category: RunFailureCategory | str | None = None,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
+        row = await self._prepare_terminal_write(run_id)
         async with self._atomic_terminal_write():
-            row = await self.store.require_run(run_id)
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             category = coerce_failure_category(failure_category or failure_category_for_error(error))
@@ -481,8 +481,8 @@ class AsyncAgentRunEngine:
         reason: str | None = None,
         execution_claim: ExecutionClaim | None = None,
     ) -> AgentRun:
+        row = await self._prepare_terminal_write(run_id)
         async with self._atomic_terminal_write():
-            row = await self.store.require_run(run_id)
             if coerce_run_status(row.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
                 return to_domain(row)
             canceled = await self.store.set_status(
@@ -507,6 +507,19 @@ class AsyncAgentRunEngine:
         return await queue_chantier_continuation_for_terminal_run(
             self.store.session,
             terminal_run_id=run_id,
+        )
+
+    async def _prepare_terminal_write(self, run_id: int):
+        """Start terminal work from a clean, globally ordered lock boundary."""
+
+        snapshot = await self.store.require_run(run_id)
+        if coerce_run_status(snapshot.status, default=RunStatus.FAILED) in TERMINAL_RUN_STATUSES:
+            return snapshot
+        anchor_run_id = int(snapshot.parent_run_id or snapshot.id)
+        await self.store.commit_event_boundary(run_id)
+        return await self.store.lock_terminal_boundary(
+            run_id,
+            anchor_run_id=anchor_run_id,
         )
 
     @asynccontextmanager

--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -347,6 +347,31 @@ class AsyncAgentRunStore:
                 return None
         return await self.refresh_run(run_id)
 
+    async def lock_terminal_boundary(
+        self,
+        run_id: int,
+        *,
+        anchor_run_id: int | None = None,
+    ) -> AgentRunRow:
+        """Lock a terminal run and its fan-out anchor in global order.
+
+        Terminal hooks inspect and may mutate the fan-out anchor after changing
+        the terminal child.  Both rows therefore need the same mutable lock,
+        acquired together before either is changed, so concurrent root/child
+        finalizers cannot acquire the pair in opposite orders.
+        """
+
+        run_id = int(run_id)
+        anchor_run_id = int(anchor_run_id or run_id)
+        locked_ids = await self._acquire_agent_run_locks(
+            [anchor_run_id, run_id],
+            key_share=False,
+            no_key_update=True,
+        )
+        if self._dialect_name() == "postgresql" and run_id not in locked_ids:
+            raise LookupError(f"Run {run_id} not found")
+        return await self.refresh_run(run_id)
+
     async def _run_for_source_idempotency(
         self,
         *,
@@ -1011,11 +1036,36 @@ class AsyncAgentRunStore:
         preserved instead of looping forever.
         """
 
-        row = await self._locked_run(run_id)
+        snapshot = await self.require_run(run_id)
+        snapshot_metadata = snapshot.metadata_ if isinstance(snapshot.metadata_, dict) else {}
+        terminal_interruption = _coerce_int(
+            snapshot_metadata.get("interruption_count"),
+            default=0,
+        ) >= _agent_run_max_interruption_requeues()
+        if terminal_interruption:
+            anchor_run_id = int(snapshot.parent_run_id or snapshot.id)
+            await self.commit_event_boundary(run_id)
+            row = await self.lock_terminal_boundary(
+                run_id,
+                anchor_run_id=anchor_run_id,
+            )
+        else:
+            row = await self._locked_run(run_id)
         current = coerce_run_status(row.status, default=RunStatus.FAILED)
         metadata = dict(row.metadata_ or {})
         previous_count = _coerce_int(metadata.get("interruption_count"), default=0)
         requeue_allowed = previous_count < _agent_run_max_interruption_requeues()
+        if not requeue_allowed and not terminal_interruption:
+            anchor_run_id = int(row.parent_run_id or row.id)
+            await self.commit_event_boundary(run_id)
+            row = await self.lock_terminal_boundary(
+                run_id,
+                anchor_run_id=anchor_run_id,
+            )
+            current = coerce_run_status(row.status, default=RunStatus.FAILED)
+            metadata = dict(row.metadata_ or {})
+            previous_count = _coerce_int(metadata.get("interruption_count"), default=0)
+            requeue_allowed = previous_count < _agent_run_max_interruption_requeues()
         target_status = RunStatus.QUEUED if requeue_allowed else RunStatus.EXPIRED
         try:
             current, target = ensure_run_transition(
@@ -1360,15 +1410,17 @@ class AsyncAgentRunStore:
             return await self._append_event_locked(event)
 
     async def commit_event_boundary(self, run_id: int) -> None:
-        """Publish pre-action events before a tool opens an isolated UoW.
+        """Publish prior run work before crossing into a new lock boundary.
 
         Tool handlers such as ``spawn_worker`` deliberately persist through a
         separate session.  Keeping the runner transaction open after
         ``run.tool_started`` leaves both the AgentRun row lock and its advisory
         event-stream lock held while that handler tries to lock the same run,
-        producing a cross-session lock cycle.  Serialize the commit with event
-        appends so parallel tool calls cannot operate on the shared
-        ``AsyncSession`` while its transaction is closing.
+        producing a cross-session lock cycle. Terminal writes likewise release
+        prior child locks here before acquiring their root/child pair in global
+        order. Serialize the commit with event appends so parallel tool calls
+        cannot operate on the shared ``AsyncSession`` while its transaction is
+        closing.
         """
 
         async with _event_lock(int(run_id)):

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1194,6 +1194,116 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
             await cleanup_session.commit()
 
 
+@pytest.mark.requires_db
+async def test_postgres_terminal_child_releases_then_locks_parent_first(db_engine):
+    """A terminal child must not hold child while waiting on its parent."""
+
+    import uuid
+
+    from brain.platform.db.models.org import Org
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    root_id = None
+    child_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Terminal Lock Order Test",
+                    slug=f"terminal-lock-order-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            store = AsyncAgentRunStore(setup_session)
+            root = await store.create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="root",
+                )
+            )
+            root_id = root.id
+            await store.set_status(root_id, RunStatus.STARTING)
+            await store.set_status(root_id, RunStatus.RUNNING)
+            child = await store.create_child_run(
+                root,
+                recipe=RunRecipe.WORKER,
+                message="child",
+                step_key="spawn_worker:terminal-lock-order",
+                metadata={"spawned_by_tool": True},
+            )
+            child_id = child.id
+            await store.set_status(child_id, RunStatus.STARTING)
+            await store.set_status(child_id, RunStatus.RUNNING)
+            await setup_session.commit()
+
+        async with factory() as child_session, factory() as parent_session:
+            child_store = AsyncAgentRunStore(child_session)
+            parent_store = AsyncAgentRunStore(parent_session)
+
+            # Mirror the runner transaction immediately before completion: it
+            # has already mutated the child and therefore holds the child row.
+            await child_store._locked_run(child_id, root_run_id=root_id)
+
+            parent_locked = asyncio.Event()
+
+            async def mutate_parent_then_child():
+                await parent_store._locked_run(root_id, root_run_id=root_id)
+                parent_locked.set()
+                await parent_store._locked_run(child_id, root_run_id=root_id)
+                await parent_session.commit()
+
+            parent_task = asyncio.create_task(mutate_parent_then_child())
+            await asyncio.wait_for(parent_locked.wait(), timeout=1)
+
+            # Completion must publish the prior child transaction first. That
+            # lets the parent transaction finish before completion reacquires
+            # both rows as parent -> child and invokes the continuation hook.
+            child_task = asyncio.create_task(
+                AsyncAgentRunEngine(child_session, recipes={}).complete(
+                    child_id,
+                    output="done",
+                )
+            )
+            try:
+                completed = await asyncio.wait_for(asyncio.shield(child_task), timeout=3)
+                await child_session.commit()
+                await asyncio.wait_for(parent_task, timeout=1)
+                assert completed.status == RunStatus.COMPLETED
+            finally:
+                child_task.cancel()
+                parent_task.cancel()
+                await child_session.rollback()
+                await parent_session.rollback()
+                await asyncio.gather(child_task, parent_task, return_exceptions=True)
+
+        async with factory() as inspection_session:
+            stored_child = await inspection_session.get(AgentRunRow, child_id)
+            assert stored_child is not None
+            assert stored_child.status == RunStatus.COMPLETED.value
+    finally:
+        async with factory() as cleanup_session:
+            run_ids = [value for value in (root_id, child_id) if value is not None]
+            if run_ids:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id.in_(run_ids)
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id.in_(run_ids))
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
 async def test_runtime_fails_legacy_run_without_workspace_org_id(session_factory):
     class UnexpectedRecipe:
         async def execute(self, _runtime: RunRuntime) -> RunRecipeResult:

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -566,7 +566,7 @@ def test_spawn_worker_schema_exposes_opt_in_join_flag():
     assert join_parent["default"] is False
 
 
-async def test_fanout_anchor_lock_uses_select_for_update():
+async def test_fanout_anchor_lock_uses_select_for_no_key_update():
     captured = {}
     anchor = object()
 
@@ -587,7 +587,7 @@ async def test_fanout_anchor_lock_uses_select_for_update():
         )
     )
     assert "WHERE agent_runs.id = 482" in sql
-    assert sql.rstrip().endswith("FOR UPDATE")
+    assert sql.rstrip().endswith("FOR NO KEY UPDATE")
 
 
 async def test_evidence_locks_refresh_preloaded_parent_and_cycle_after_concurrent_commit(


### PR DESCRIPTION
## Summary
- publish pre-terminal runner work before finalization
- acquire fan-out anchor and terminal child locks together in global order
- use `FOR NO KEY UPDATE` for immutable AgentRun keys
- apply the same boundary to failures, cancellation, deadline expiry, and interruption-cap expiry

## Verification
- 74/74 PostgreSQL-marked tests passed
- 319 affected run/cycle tests passed
- real PostgreSQL parent↔child reversal regression passed
- full fast suite: 4,535 passed, 11 skipped

Follow-up to #593 after live Cycle 2 stress exposed the terminal child finalizer lock reversal.