### PR TITLE
Scope AgentRun event serialization to database sessions

### DIFF
--- a/brain/systems/runs/store.py
+++ b/brain/systems/runs/store.py
@@ -10,10 +10,8 @@ from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 import logging
 import os
-import threading
 from typing import Any
 import uuid
-import weakref
 
 from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import DBAPIError, IntegrityError
@@ -101,24 +99,32 @@ class ExecutionClaimLost(RuntimeError):
     """Raised when an execution owner loses its durable fencing claim."""
 
 
-_EVENT_LOCKS_GUARD = threading.Lock()
-_EVENT_LOCKS: weakref.WeakKeyDictionary[
-    asyncio.AbstractEventLoop,
-    weakref.WeakValueDictionary[int, asyncio.Lock],
-] = weakref.WeakKeyDictionary()
+_SESSION_EVENT_LOCKS_KEY = "agent_run_event_locks"
 
 
-def _event_lock(run_id: int) -> asyncio.Lock:
-    """Return a coroutine-aware lock scoped to the active event loop and run."""
+def _event_lock(session: AsyncSession, run_id: int) -> asyncio.Lock:
+    """Serialize one run's event writes that share an AsyncSession.
 
-    loop = asyncio.get_running_loop()
-    with _EVENT_LOCKS_GUARD:
-        loop_locks = _EVENT_LOCKS.setdefault(loop, weakref.WeakValueDictionary())
-        lock = loop_locks.get(int(run_id))
-        if lock is None:
-            lock = asyncio.Lock()
-            loop_locks[int(run_id)] = lock
-        return lock
+    PostgreSQL's advisory lock serializes different sessions.  A process-wide
+    run lock cannot safely wrap that database wait: another session may retain
+    the advisory lock across event appends and need the process lock again,
+    creating a cross-layer cycle.  Session-local locks still protect SQLAlchemy
+    from concurrent use while leaving cross-session ordering to PostgreSQL.
+    """
+
+    session_info = getattr(session, "info", None)
+    if session_info is not None:
+        locks = session_info.setdefault(_SESSION_EVENT_LOCKS_KEY, {})
+    else:
+        locks = getattr(session, _SESSION_EVENT_LOCKS_KEY, None)
+        if locks is None:
+            locks = {}
+            setattr(session, _SESSION_EVENT_LOCKS_KEY, locks)
+    lock = locks.get(int(run_id))
+    if lock is None:
+        lock = asyncio.Lock()
+        locks[int(run_id)] = lock
+    return lock
 
 
 def _creatable_run_status(value: RunStatus | str) -> RunStatus:
@@ -1406,7 +1412,7 @@ class AsyncAgentRunStore:
         return messages
 
     async def append_event(self, event: AgentRunEvent) -> AgentRunEventRow:
-        async with _event_lock(int(event.run_id)):
+        async with _event_lock(self.session, int(event.run_id)):
             return await self._append_event_locked(event)
 
     async def commit_event_boundary(self, run_id: int) -> None:
@@ -1423,7 +1429,7 @@ class AsyncAgentRunStore:
         closing.
         """
 
-        async with _event_lock(int(run_id)):
+        async with _event_lock(self.session, int(run_id)):
             await self.session.commit()
 
     async def _append_event_locked(self, event: AgentRunEvent) -> AgentRunEventRow:
@@ -1526,7 +1532,7 @@ class AsyncAgentRunStore:
         return safe_provider_error_sentinel(detected_provider_error)
 
     async def append_artifact(self, artifact: AgentRunArtifact) -> AgentRunArtifactRow:
-        async with _event_lock(int(artifact.run_id)):
+        async with _event_lock(self.session, int(artifact.run_id)):
             artifact_type = (
                 artifact.artifact_type.value
                 if isinstance(artifact.artifact_type, ArtifactType)

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1115,6 +1115,99 @@ async def test_postgres_event_boundary_releases_parent_for_isolated_child_uow(db
 
 
 @pytest.mark.requires_db
+async def test_postgres_waiting_event_session_does_not_block_advisory_lock_owner(db_engine):
+    """A DB advisory-lock waiter must not own another session's Python lock."""
+
+    import uuid
+
+    from brain.platform.db.models.org import Org
+    from brain.systems.runs.events import run_event
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    run_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Event Session Lock Test",
+                    slug=f"event-session-lock-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            run = await AsyncAgentRunStore(setup_session).create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="event session lock",
+                )
+            )
+            run_id = run.id
+            await setup_session.commit()
+
+        async with factory() as owner_session, factory() as waiter_session:
+            owner_store = AsyncAgentRunStore(owner_session)
+            waiter_store = AsyncAgentRunStore(waiter_session)
+            first = await owner_store.append_event(
+                run_event(run_id, "run.owner_first")
+            )
+
+            waiter_entered_advisory_lock = asyncio.Event()
+            original_waiter_lock = waiter_store.lock_event_stream
+
+            async def observed_waiter_lock(locked_run_id: int):
+                waiter_entered_advisory_lock.set()
+                await original_waiter_lock(locked_run_id)
+
+            waiter_store.lock_event_stream = observed_waiter_lock
+            waiter_task = asyncio.create_task(
+                waiter_store.append_event(run_event(run_id, "run.waiter"))
+            )
+            try:
+                await asyncio.wait_for(waiter_entered_advisory_lock.wait(), timeout=1)
+                await asyncio.sleep(0.05)
+                assert not waiter_task.done()
+
+                # The owner retains PostgreSQL's transaction-scoped advisory
+                # lock. It must still be able to take its own session lock and
+                # append; a process-wide run lock deadlocks at this point.
+                second = await asyncio.wait_for(
+                    owner_store.append_event(run_event(run_id, "run.owner_second")),
+                    timeout=1,
+                )
+                await owner_session.commit()
+                waited = await asyncio.wait_for(waiter_task, timeout=1)
+                await waiter_session.commit()
+            finally:
+                waiter_task.cancel()
+                await asyncio.gather(waiter_task, return_exceptions=True)
+                await owner_session.rollback()
+                await waiter_session.rollback()
+
+            assert second.sequence_no == first.sequence_no + 1
+            assert waited.sequence_no == second.sequence_no + 1
+    finally:
+        async with factory() as cleanup_session:
+            if run_id is not None:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id == run_id)
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
+@pytest.mark.requires_db
 async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_engine):
     import uuid
 


### PR DESCRIPTION
## Summary
- serialize concurrent event writes per AsyncSession instead of globally per process/run
- leave cross-session serialization to PostgreSQL's transaction advisory lock
- remove the Python-lock → database-lock inversion that can deadlock a lock owner against its waiter

## Regression
A real PostgreSQL test holds the advisory lock in session A, starts a same-run waiter in session B, then proves session A can append again and release the database lock. The former process-wide lock deadlocks at that exact point.

## Verification
- full fast suite: 4,535 passed, 11 skipped
- full PostgreSQL suite: 75 passed
- focused cross-session and terminal-order regressions passed

Follow-up to #593, exposed by live restart recovery after #600.