### PR TITLE
fix(runs): avoid evidence parent lock convoy

### DIFF
--- a/brain/systems/runs/evidence_health.py
+++ b/brain/systems/runs/evidence_health.py
@@ -454,7 +454,11 @@ async def _lock_parent_run(session: Any, parent_run_id: int) -> AgentRunRow | No
     rows = await session.scalars(
         select(AgentRunRow)
         .where(AgentRunRow.id == int(parent_run_id))
-        .with_for_update()
+        # Evidence receipts only mutate non-key parent fields. Keep this
+        # compatible with the FOR KEY SHARE lock held by child event writers;
+        # a stronger FOR UPDATE waiter can otherwise starve behind continuous
+        # child activity and convoy ordered terminal locks behind it.
+        .with_for_update(key_share=True)
         .execution_options(populate_existing=True)
     )
     return rows.one_or_none()

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1212,6 +1212,7 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
     import uuid
 
     from brain.platform.db.models.org import Org
+    from brain.systems.runs.evidence_health import _lock_parent_run
     from brain.systems.runs.events import run_event
 
     factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
@@ -1264,6 +1265,13 @@ async def test_postgres_child_event_key_share_does_not_block_parent_mutation(db_
                 timeout=1,
             )
             assert locked_parent.id == root_id
+            await parent_session.rollback()
+
+            evidence_parent = await asyncio.wait_for(
+                _lock_parent_run(parent_session, root_id),
+                timeout=1,
+            )
+            assert evidence_parent.id == root_id
             await parent_session.rollback()
             await child_session.rollback()
     finally:

--- a/tests/test_worker_continuation.py
+++ b/tests/test_worker_continuation.py
@@ -28,6 +28,7 @@ from brain.systems.runs.engine import AsyncAgentRunEngine
 from brain.systems.runs.evidence_health import (
     WorkerEvidenceFailure,
     WorkerEvidenceReceipt,
+    _lock_parent_run,
     record_parent_evidence_failures,
 )
 from brain.systems.runs.status import RunStatus
@@ -587,6 +588,30 @@ async def test_fanout_anchor_lock_uses_select_for_no_key_update():
         )
     )
     assert "WHERE agent_runs.id = 482" in sql
+    assert sql.rstrip().endswith("FOR NO KEY UPDATE")
+
+
+async def test_evidence_parent_lock_uses_select_for_no_key_update():
+    captured = {}
+    parent = object()
+
+    class _ScalarResult:
+        def one_or_none(self):
+            return parent
+
+    class _CapturingSession:
+        async def scalars(self, statement):
+            captured["statement"] = statement
+            return _ScalarResult()
+
+    assert await _lock_parent_run(_CapturingSession(), 483) is parent
+    sql = str(
+        captured["statement"].compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    assert "WHERE agent_runs.id = 483" in sql
     assert sql.rstrip().endswith("FOR NO KEY UPDATE")
 
 


### PR DESCRIPTION
## Summary
- lock parent evidence receipts with `FOR NO KEY UPDATE`
- remain compatible with child event writers holding `FOR KEY SHARE`
- prevent a waiting evidence receipt from convoying ordered terminal transitions

## Verification
- `59 passed, 5 deselected` across worker continuation/state-machine fast tests
- real PostgreSQL child-event concurrency regression passed

Live CycleRun 2181 exposed the remaining path after #601: a project-context failure receipt waited on the parent with `FOR UPDATE`, while active child event writers continuously held compatible key-share locks. Terminal lock requests queued behind the stronger waiter. This narrows the evidence mutation to the correct lock strength.