### PR TITLE
fix: release tool event locks and sanitize actionable handoffs

### DIFF
--- a/brain/systems/briefing/compose.py
+++ b/brain/systems/briefing/compose.py
@@ -156,6 +156,8 @@ def _shorten_item(item: DossierItem, cap: int) -> str:
 
 def _narrative_item(dossier: Dossier) -> DossierItem | None:
     for section in dossier.sections:
+        if section.source == "internal_record":
+            continue
         for item in section.items:
             if item.excerpt or item.truncated:
                 return item

--- a/brain/systems/briefing/gather.py
+++ b/brain/systems/briefing/gather.py
@@ -516,19 +516,17 @@ async def _chantier_pieces_for_record(
 
 def _idea_piece(idea: Any) -> SourcePiece:
     details = dict(getattr(idea, "agent_details", None) or {})
-    assignment = details.get("assignment") or {}
-    body_bits = [_text(getattr(idea, "description", ""))]
-    if details.get("task_domain"):
-        body_bits.append(f"task_domain: {details['task_domain']}")
-    if assignment:
-        body_bits.append(
-            f"owner: {assignment.get('owner_id') or 'unclaimed'} (basis: {assignment.get('basis', '?')})"
-        )
+    inbound = dict(details.get("inbound_triage") or {})
+    actionable_job_home = inbound.get("reason") == "actionable_run_completion"
     return SourcePiece(
-        source="record",
+        # The actionable lane creates a synthetic idea only as a durable
+        # anchor for the coding-agent packet. It is bookkeeping, not human
+        # narrative, so keep it in context_parts without letting it outrank
+        # the real Slack/GitHub evidence in the posted brief.
+        source="internal_record" if actionable_job_home else "record",
         ref=f"{JOB_REF_IDEA_PREFIX}{getattr(idea, 'id', '')}",
         title=_text(getattr(idea, "title", "")) or "triaged item",
-        body="; ".join(bit for bit in body_bits if bit),
+        body=_text(getattr(idea, "description", "")),
         ts=getattr(idea, "updated_at", None),
         weight=8,  # below the event-summary piece: the raw signal reads better
     )

--- a/brain/systems/briefing/mint.py
+++ b/brain/systems/briefing/mint.py
@@ -49,7 +49,12 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from brain.systems.briefing.compose import PacketRender, compose_packet, fill_launch_url
+from brain.systems.briefing.compose import (
+    UNCLAIMED_LABEL,
+    PacketRender,
+    compose_packet,
+    fill_launch_url,
+)
 from brain.systems.briefing.core import Dossier, DossierBudget, assemble_dossier
 from brain.systems.briefing.deliver import (
     DeliveryTarget,
@@ -115,8 +120,9 @@ def _member_targets() -> dict[str, str]:
 async def _owner_label(session: Any, owner_user_id: str | None) -> str | None:
     """Best-effort uuid → display name (the _fill_owner_labels pattern).
 
-    Degrades to the RAW ID — never to None — so a transient lookup failure
-    can't render an assigned item as "unclaimed" in the brief.
+    Degrades to a human-safe label — never to a raw internal UUID and never
+    to None — so a transient lookup failure can't leak serialization or
+    render an assigned item as "unclaimed" in the brief.
     """
     if not owner_user_id or session is None:
         return None
@@ -127,10 +133,32 @@ async def _owner_label(session: Any, owner_user_id: str | None) -> str | None:
             await session.execute(select(User.id, User.name, User.email).where(User.id == str(owner_user_id)))
         ).first()
         if row is None:
-            return str(owner_user_id)
-        return row.name or row.email or str(row.id)
-    except Exception:  # noqa: BLE001 — degrade to the raw id, never break a mint
-        return str(owner_user_id)
+            return "assigned teammate"
+        return row.name or row.email or "assigned teammate"
+    except Exception:  # noqa: BLE001 — labels must never break a mint
+        return "assigned teammate"
+
+
+def _preferred_actionable_title(pieces: list[Any]) -> str | None:
+    """Choose human-authored work truth over the inbound alert serialization."""
+    for source in ("github_issue", "github_pr", "slack_thread"):
+        for piece in pieces:
+            title = str(getattr(piece, "title", "") or "").strip()
+            if getattr(piece, "source", None) == source and title:
+                return title
+    return None
+
+
+def _delivery_brief(
+    packet: PacketRender,
+    *,
+    launch_url: str,
+    owner_label: str | None,
+    source_ref: dict[str, Any] | None,
+) -> str:
+    if (source_ref or {}).get("brief_mode") == "compact_follow_up":
+        return f"→ {owner_label or UNCLAIMED_LABEL} · Launch: {launch_url}"
+    return fill_launch_url(packet.human_brief, launch_url)
 
 
 def _repo_origin_hint(dossier: Dossier) -> str | None:
@@ -180,23 +208,31 @@ async def build_packet_for_job(
         github=active_readers.github,
         budget=active_budget,
     )
+    packet_source_ref = dict(source_ref or {})
+    actionable_title = (
+        _preferred_actionable_title(gathered.pieces)
+        if packet_source_ref.get("origin_lane") == "actionable"
+        else None
+    )
     dossier = assemble_dossier(
         gathered.pieces,
         job_ref=job_ref,
         budget=active_budget,
+        headline=actionable_title,
         source_notes=gathered.source_notes,
     )
+    effective_ask = f"Pick up this issue: {actionable_title}" if actionable_title else ask
     packet = compose_packet(
         dossier,
         org_id=org_id,
-        ask=ask,
+        ask=effective_ask,
         acceptance_criteria=list(_ACCEPTANCE_CRITERIA_V1),
         owner_user_id=owner_user_id,
         owner_label=owner_label,
         target_tool=target_tool,
         repo_origin_url=_repo_origin_hint(dossier),
         source_surface=source_surface,
-        source_ref=dict(source_ref or {}),
+        source_ref=packet_source_ref,
     )
     return packet, dossier
 
@@ -358,8 +394,11 @@ async def mint_packet_for_job(
                 else {}
             )
             row, created = await create_launch_handoff_with_status(session, packet.handoff_input)
-            filled_brief = fill_launch_url(
-                packet.human_brief, launch_handoff_url_for_id(row.id, target_tool=row.target_tool)
+            filled_brief = _delivery_brief(
+                packet,
+                launch_url=launch_handoff_url_for_id(row.id, target_tool=row.target_tool),
+                owner_label=owner_label,
+                source_ref=source_ref,
             )
             if created:
                 if deliver_to is not None:
@@ -380,9 +419,13 @@ async def mint_packet_for_job(
                 # Refilled AFTER the repair: it may have rotated target_tool,
                 # which changes the launch URL an undelivered brief carries.
                 await refresh_pending_delivery_brief(
-                    session, handoff_id=str(row.id), brief=fill_launch_url(
-                        packet.human_brief,
-                        launch_handoff_url_for_id(row.id, target_tool=row.target_tool),
+                    session,
+                    handoff_id=str(row.id),
+                    brief=_delivery_brief(
+                        packet,
+                        launch_url=launch_handoff_url_for_id(row.id, target_tool=row.target_tool),
+                        owner_label=owner_label,
+                        source_ref=source_ref,
                     ),
                 )
             if locked_idea is not None:
@@ -415,7 +458,12 @@ async def mint_packet_for_job(
         created=created,
         delivery=delivery,
         handoff=row,
-        human_brief=fill_launch_url(packet.human_brief, launch_url),
+        human_brief=_delivery_brief(
+            packet,
+            launch_url=launch_url,
+            owner_label=owner_label,
+            source_ref=source_ref,
+        ),
         launch_url=launch_url,
         reason="minted" if created else "reused",
         source_notes=list(dossier.source_notes),
@@ -586,6 +634,18 @@ async def _mint_for_idea_and_event(
     owner_label = await _owner_label(session, owner_user_id)
     target_tool = agent_target_for_member(owner_user_id, _member_targets())
     deliver_to, delivery_skip = _delivery_target_for_event(event)
+    actionable_lane = (
+        dict(details.get("inbound_triage") or {}).get("reason")
+        == "actionable_run_completion"
+    )
+    tool_names = {
+        str(name) for name in (attribution or {}).get("tool_names") or []
+    }
+    packet_source_ref: dict[str, Any] = {"inbound_event_id": str(event.id)}
+    if actionable_lane:
+        packet_source_ref["origin_lane"] = "actionable"
+        if "post_slack_reply" in tool_names:
+            packet_source_ref["brief_mode"] = "compact_follow_up"
 
     result = await mint_packet_for_job(
         session,
@@ -597,7 +657,7 @@ async def _mint_for_idea_and_event(
         owner_label=owner_label,
         target_tool=target_tool,
         source_surface="inbound_triage",
-        source_ref={"inbound_event_id": str(event.id)},
+        source_ref=packet_source_ref,
         readers=readers,
         reader_user_id=str(getattr(event, "authority_user_id", "") or "") or None,
         deliver_to=deliver_to,

--- a/brain/systems/runs/tools.py
+++ b/brain/systems/runs/tools.py
@@ -159,13 +159,12 @@ class AsyncRunToolExecutor:
         await self._append_event(
             run_event(run_id, "run.tool_started", _event_payload(tool.name, safe_args), root_run_id=root_run_id)
         )
-        commit_event_boundary = getattr(self.store, "commit_event_boundary", None)
-        if callable(commit_event_boundary):
+        if callable(getattr(self.store, "commit_event_boundary", None)):
             # The handler may use an isolated UnitOfWork that writes to this
             # same run (spawn_worker is the canonical example).  Make the
             # started marker durable and release the parent transaction's row
             # and advisory locks before invoking it.
-            await commit_event_boundary(run_id)
+            await self._commit_event_boundary(run_id)
         manifest = None
         manifest_id = None
         try:
@@ -283,6 +282,7 @@ class AsyncRunToolExecutor:
                 )
             if collector is not None:
                 collector.append(record)
+            await self._commit_event_boundary(run_id)
             raise
         except asyncio.CancelledError:
             if manifest_id:
@@ -330,6 +330,7 @@ class AsyncRunToolExecutor:
                 payload=record.to_payload(),
                 text=error_text[:4000],
             )
+            await self._commit_event_boundary(run_id)
             raise
         failure = result_failure_summary(result)
         if manifest_id:
@@ -379,6 +380,7 @@ class AsyncRunToolExecutor:
                 payload=record.to_payload(),
                 text=failure[:4000],
             )
+            await self._commit_event_boundary(run_id)
             return result
         safe_result = redact_tool_result(tool.name, result)
         await self._append_event(
@@ -407,7 +409,18 @@ class AsyncRunToolExecutor:
             payload=record.to_payload(),
             text=safe_result[:4000],
         )
+        # Make the completed marker and its artifact durable before the caller
+        # can wait on another session that appends to this run. PostgreSQL's
+        # event-stream advisory lock is transaction-scoped; returning with this
+        # transaction open can deadlock terminal settlement behind an otherwise
+        # successful tool call.
+        await self._commit_event_boundary(run_id)
         return result
+
+    async def _commit_event_boundary(self, run_id: int) -> None:
+        commit_event_boundary = getattr(self.store, "commit_event_boundary", None)
+        if callable(commit_event_boundary):
+            await commit_event_boundary(run_id)
 
     async def _action_context(self, run_id: int, *, root_run_id: int | None = None) -> dict[str, Any]:
         require_run = getattr(self.store, "require_run", None)
@@ -498,6 +511,7 @@ class AsyncRunToolExecutor:
             payload=record.to_payload(),
             text=policy_failure[:4000],
         )
+        await self._commit_event_boundary(run_id)
         return result
 
     async def _append_event(self, event) -> None:

--- a/tests/test_agent_run_runtime.py
+++ b/tests/test_agent_run_runtime.py
@@ -2552,17 +2552,17 @@ async def test_runtime_tool_executor_records_public_events_and_redacted_artifact
     assert _stream_has(runtime.stream.messages, "run.tool_completed", completed.payload | {"run_id": 42})
 
 
-async def test_runtime_tool_executor_commits_started_event_before_handler():
+async def test_runtime_tool_executor_commits_event_boundaries_around_handler():
     from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
 
     runtime = _runtime("worker")
     observed = []
 
     async def commit_event_boundary(run_id):
-        assert runtime.store.events[-1].event_type == "run.tool_started"
-        observed.append(("commit", run_id))
+        observed.append(("commit", run_id, runtime.store.events[-1].event_type))
 
     async def handler(**_kwargs):
+        assert observed == [("commit", 42, "run.tool_started")]
         observed.append(("handler", 42))
         return {"ok": True}
 
@@ -2576,7 +2576,11 @@ async def test_runtime_tool_executor_commits_started_event_before_handler():
     )
 
     assert result == {"ok": True}
-    assert observed == [("commit", 42), ("handler", 42)]
+    assert observed == [
+        ("commit", 42, "run.tool_started"),
+        ("handler", 42),
+        ("commit", 42, "run.tool_completed"),
+    ]
 
 
 async def test_agent_execution_context_is_isolated_between_parallel_tool_tasks():

--- a/tests/test_agent_run_state_machine.py
+++ b/tests/test_agent_run_state_machine.py
@@ -1115,6 +1115,174 @@ async def test_postgres_event_boundary_releases_parent_for_isolated_child_uow(db
 
 
 @pytest.mark.requires_db
+async def test_postgres_completed_tool_releases_event_stream_for_follow_up_writer(db_engine):
+    """A completed tool call must not retain the run's event-stream lock."""
+
+    import uuid
+
+    from brain.platform.db.models.org import Org
+    from brain.systems.runs.events import run_event
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    run_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Completed Tool Boundary Test",
+                    slug=f"completed-tool-boundary-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            run = await AsyncAgentRunStore(setup_session).create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="completed tool boundary",
+                )
+            )
+            run_id = run.id
+            await setup_session.commit()
+
+        async with factory() as tool_session, factory() as follow_up_session:
+            tool_store = AsyncAgentRunStore(tool_session)
+            executor = AsyncRunToolExecutor(tool_store)
+
+            async def handler(**_kwargs):
+                return {"ok": True}
+
+            result = await executor.execute(
+                run_id,
+                ToolExecution(
+                    name="read_file",
+                    args={"path": "README.md"},
+                    handler=handler,
+                ),
+            )
+            assert result == {"ok": True}
+
+            follow_up = await asyncio.wait_for(
+                AsyncAgentRunStore(follow_up_session).append_event(
+                    run_event(run_id, "run.follow_up")
+                ),
+                timeout=1,
+            )
+            await follow_up_session.commit()
+
+            assert follow_up.event_type == "run.follow_up"
+    finally:
+        async with factory() as cleanup_session:
+            if run_id is not None:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id == run_id)
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
+@pytest.mark.requires_db
+@pytest.mark.parametrize("failure_mode", ("raises", "returns_error"))
+async def test_postgres_failed_tool_releases_event_stream_for_follow_up_writer(
+    db_engine,
+    failure_mode,
+):
+    """A failed tool call must not poison later event writers for the run."""
+
+    import uuid
+
+    from brain.platform.db.models.org import Org
+    from brain.systems.runs.events import run_event
+    from brain.systems.runs.tools import AsyncRunToolExecutor, ToolExecution
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    org_id = str(uuid.uuid4())
+    run_id = None
+    try:
+        async with factory() as setup_session:
+            setup_session.add(
+                Org(
+                    id=org_id,
+                    name="Failed Tool Boundary Test",
+                    slug=f"failed-tool-boundary-{uuid.uuid4().hex[:12]}",
+                )
+            )
+            await setup_session.flush()
+            run = await AsyncAgentRunStore(setup_session).create_run(
+                _run_request(
+                    org_id=org_id,
+                    thread_id=f"thread-{uuid.uuid4().hex}",
+                    message="failed tool boundary",
+                )
+            )
+            run_id = run.id
+            await setup_session.commit()
+
+        async with factory() as tool_session, factory() as follow_up_session:
+            tool_store = AsyncAgentRunStore(tool_session)
+            executor = AsyncRunToolExecutor(tool_store)
+
+            async def handler(**_kwargs):
+                if failure_mode == "raises":
+                    raise RuntimeError("tool exploded")
+                return {"error": "tool returned failure"}
+
+            execution = executor.execute(
+                run_id,
+                ToolExecution(
+                    name="read_file",
+                    args={"path": "README.md"},
+                    handler=handler,
+                ),
+            )
+            if failure_mode == "raises":
+                with pytest.raises(RuntimeError, match="tool exploded"):
+                    await execution
+            else:
+                assert await execution == {"error": "tool returned failure"}
+
+            follow_up = await asyncio.wait_for(
+                AsyncAgentRunStore(follow_up_session).append_event(
+                    run_event(run_id, "run.follow_up_after_failure")
+                ),
+                timeout=1,
+            )
+            await follow_up_session.commit()
+
+            assert follow_up.event_type == "run.follow_up_after_failure"
+    finally:
+        async with factory() as cleanup_session:
+            if run_id is not None:
+                await cleanup_session.execute(
+                    AgentRunArtifactRow.__table__.delete().where(
+                        AgentRunArtifactRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunEventRow.__table__.delete().where(
+                        AgentRunEventRow.run_id == run_id
+                    )
+                )
+                await cleanup_session.execute(
+                    AgentRunRow.__table__.delete().where(AgentRunRow.id == run_id)
+                )
+            await cleanup_session.execute(Org.__table__.delete().where(Org.id == org_id))
+            await cleanup_session.commit()
+
+
+@pytest.mark.requires_db
 async def test_postgres_waiting_event_session_does_not_block_advisory_lock_owner(db_engine):
     """A DB advisory-lock waiter must not own another session's Python lock."""
 

--- a/tests/test_briefing_mint.py
+++ b/tests/test_briefing_mint.py
@@ -473,14 +473,15 @@ async def test_stamp_reads_go_through_a_row_locked_idea(posts):
     assert getattr(session, "locked_idea_selects", 0) >= 1  # spec-pinned serialization
 
 
-async def test_owner_label_lookup_failure_degrades_to_id_not_unclaimed(posts):
+async def test_owner_label_lookup_failure_uses_human_safe_fallback(posts):
     idea = _idea()
     session = FakeSession(ideas=[idea], events=[_event()], users=[])  # no User row
     result = await mint_packet_after_triage(
         session, event=_event(), run_row=SimpleNamespace(id=1), readers=_readers())
     header = result.human_brief.splitlines()[0]
     assert "unclaimed" not in header  # assigned item never reads as unclaimed
-    assert _OWNER[:8] in header  # raw id (possibly shortened by the cap) shows
+    assert "assigned teammate" in header
+    assert _OWNER not in result.human_brief
 
 
 class CleanGithub:
@@ -688,6 +689,67 @@ async def test_actionable_run_mints_job_home_and_records_delivery(posts):
     assert session.deliveries[0].channel == "C0PROD"
     assert session.deliveries[0].thread_ts == "1751964840.0"
     assert session.deliveries[0].state == "pending"
+    brief = session.deliveries[0].brief
+    assert "half the batch melted" in brief
+    assert "Illo run" not in brief
+    assert "task_domain:" not in brief
+    assert "basis:" not in brief
+    assert _RUN_USER not in brief
+
+
+async def test_actionable_run_with_existing_reply_records_compact_human_follow_up(posts):
+    from brain.systems.briefing.mint import mint_packet_after_actionable_run
+
+    issue_title = "[Prod][Batch] POST /batch exceeds 25s while inner task keeps running"
+    raw_alert = '<rollbar-link|#2333 New error: {"active_after_504": 1, "route": "/batch"}>'
+    event = _actionable_event()
+    event.envelope["summary"] = raw_alert
+
+    class RollbarThread:
+        async def read_thread(self, *, channel, thread_ts, limit):
+            return SlackThreadRead(
+                messages=({"ts": thread_ts, "user": "rollbar", "text": raw_alert},),
+                total=1,
+                channel=channel,
+            )
+
+    class FiledIssue:
+        async def read_ref(self, *, repo_slug, number):
+            assert (repo_slug, number) == ("uwear-ai/uwear-backend", 616)
+            return {
+                "kind": "github_issue",
+                "title": issue_title,
+                "body": "The request times out while work continues in the background.",
+                "state": "open",
+                "body_total_chars": 63,
+            }
+
+    attribution = _attribution()
+    attribution["tool_names"] = ["post_slack_reply", "create_github_issue"]
+    session = FakeSession(
+        events=[event],
+        users=[SimpleNamespace(id=_RUN_USER, name="Axel", email=None)],
+    )
+    result = await mint_packet_after_actionable_run(
+        session,
+        event=event,
+        run_row=_run_row(),
+        attribution=attribution,
+        readers=Readers(slack=RollbarThread(), github=FiledIssue()),
+    )
+
+    assert result.ok and result.created and result.delivery == "recorded"
+    assert result.handoff.title == issue_title
+    assert issue_title in result.handoff.instructions
+    assert raw_alert not in result.handoff.instructions
+
+    brief = session.deliveries[0].brief
+    assert brief == f"→ Axel · Launch: {result.launch_url}"
+    assert "Illo run" not in brief
+    assert "task_domain:" not in brief
+    assert "basis:" not in brief
+    assert _RUN_USER not in brief
+    assert raw_alert not in brief
 
 
 async def test_actionable_run_without_durable_work_skips(posts):


### PR DESCRIPTION
## What changed

- commit the AgentRun event transaction after every terminal tool outcome, including success, returned errors, raised errors, cancellation, and policy blocks
- add real-PostgreSQL regressions proving a follow-up writer can append immediately after successful and failed tools
- keep synthetic actionable job-home records out of human narratives
- prefer the filed GitHub issue title for actionable handoff headlines and asks
- use a compact `→ owner · Launch: URL` follow-up when the run already replied in Slack
- replace UUID owner fallbacks with a human-safe label

## Why

A completed tool could return while its transaction still held the run's advisory event lock. Follow-up settlement then waited forever, poisoning Cycle and scheduler sessions. Separately, actionable handoff delivery promoted Illo's synthetic bookkeeping over the actual issue and leaked internal serialization into Slack.

## Validation

- 4,539 non-database tests passed; 13 skipped
- 54 database tests passed; 24 environment-dependent tests skipped
- focused briefing and AgentRun suites: 312 passed
- enabled-Cycle admission fixture: all 3 configurations passed
- compile and diff checks passed

Fixes #593
Fixes #605
