### PR TITLE
fix(knowledge): mirror the memory node kind that ingestion actually writes

### DIFF
--- a/brain/systems/knowledge/connectors/memory.py
+++ b/brain/systems/knowledge/connectors/memory.py
@@ -1,7 +1,7 @@
-"""Bounded mirror of shared consolidated memory into Illo Knowledge.
+"""Bounded mirror of shared source-backed memory into Illo Knowledge.
 
 Knowledge search does not yet enforce per-user memory visibility.  This
-connector therefore mirrors only ``org`` and ``team`` summaries; private
+connector therefore mirrors only ``org`` and ``team`` content nodes; private
 memory remains exclusively owned by the memory subsystem until the knowledge
 index has an ACL-aware read path.  The mirror is derived and additive: it reads
 ``MemoryNode`` rows and never participates in memory recall or mutation.
@@ -21,6 +21,7 @@ from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, Memor
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 
 _SHARED_VISIBILITIES = ("org", "team")
+_KNOWLEDGE_NODE_KINDS = ("content",)
 
 
 def _cursor_datetime(value: Any) -> datetime | None:
@@ -46,7 +47,7 @@ def _draft_for_memory(
     *,
     superseded_by: int | None,
 ) -> KnowledgeDraft:
-    summary = str(node.text or node.canonical_label).strip()
+    content = str(node.text or node.canonical_label).strip()
     memory_kind = str(node.content_kind or node.node_kind).strip()
     scope = str(node.scope_key or "default").strip()
     superseded = node.truth_status == "superseded" or superseded_by is not None
@@ -56,12 +57,11 @@ def _draft_for_memory(
         kind="memory",
         source_ref=f"memory_node:{node.id}",
         title=str(node.canonical_label).strip(),
-        summary=summary,
+        summary=content,
         entities=list(dict.fromkeys((memory_kind, scope))),
-        raw_text=summary,
+        raw_text=content,
         extra={
             "archived": node.archived_at is not None,
-            "consolidated": True,
             "confidence": float(node.confidence or 0.0),
             "freshness_status": node.freshness_status,
             "memory_type": memory_kind,
@@ -69,6 +69,7 @@ def _draft_for_memory(
             "org_id": str(node.org_id) if node.org_id is not None else None,
             "scope": scope,
             "sensitivity": node.sensitivity,
+            "source_backed": True,
             "source_type": "reconstructive_memory_node",
             "superseded": superseded,
             "superseded_by": superseded_by,
@@ -89,7 +90,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
         kind="memory",
         source_ref=f"memory_node:{node.id}",
         title="Memory no longer shared",
-        summary="This consolidated memory is no longer shared with the workspace.",
+        summary="This memory is no longer shared with the workspace.",
         raw_text="",
         extra={
             "archived": True,
@@ -106,7 +107,7 @@ def _withdrawn_draft(node: MemoryNode) -> KnowledgeDraft:
 
 
 class MemoryConnector:
-    """Enumerate shared consolidated memory nodes by update watermark."""
+    """Enumerate shared source-backed memory content by update watermark."""
 
     source_key = "memory"
 
@@ -122,7 +123,7 @@ class MemoryConnector:
         marker_id = max(0, int(cursor.get("id") or 0))
         statement = (
             select(MemoryNode)
-            .where(MemoryNode.node_kind == "summary")
+            .where(MemoryNode.node_kind.in_(_KNOWLEDGE_NODE_KINDS))
             .order_by(MemoryNode.updated_at.asc(), MemoryNode.id.asc())
             .limit(self.max_items)
         )

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -45,6 +45,7 @@ class KnowledgeSyncStats:
     skipped: int = 0
     failed: int = 0
     truncated: int = 0
+    empty: int = 0
     pending: int = 0
     distilled: int = 0
 
@@ -59,6 +60,8 @@ class KnowledgeSyncStats:
             payload["pending"] = self.pending
         if self.distilled:
             payload["distilled"] = self.distilled
+        if self.empty:
+            payload["empty"] = self.empty
         return payload
 
 
@@ -495,6 +498,25 @@ async def _sync_state(
     await session.flush()
 
 
+async def _record_empty_corpus(
+    session: AsyncSession,
+    *,
+    source: str,
+    stats: KnowledgeSyncStats,
+) -> None:
+    """Expose a successfully scanned source with no searchable index rows."""
+
+    active_item_id = await session.scalar(
+        select(KnowledgeItem.id)
+        .where(
+            KnowledgeItem.source == source,
+            KnowledgeItem.archived_at.is_(None),
+        )
+        .limit(1)
+    )
+    stats.empty = int(active_item_id is None)
+
+
 async def _ingest_drafts(
     session: AsyncSession,
     *,
@@ -616,6 +638,7 @@ async def sync_connector(
             )
 
         status = "ok" if stats.failed == 0 else "degraded"
+        await _record_empty_corpus(session, source=source, stats=stats)
         await _sync_state(
             session,
             source=source,
@@ -723,6 +746,7 @@ async def sync_connector(
         )
 
     status = "ok" if stats.failed == 0 else "degraded"
+    await _record_empty_corpus(session, source=source, stats=stats)
     await _sync_state(
         session,
         source=source,

--- a/brain/systems/knowledge/service.py
+++ b/brain/systems/knowledge/service.py
@@ -45,7 +45,6 @@ class KnowledgeSyncStats:
     skipped: int = 0
     failed: int = 0
     truncated: int = 0
-    empty: int = 0
     pending: int = 0
     distilled: int = 0
 
@@ -60,8 +59,6 @@ class KnowledgeSyncStats:
             payload["pending"] = self.pending
         if self.distilled:
             payload["distilled"] = self.distilled
-        if self.empty:
-            payload["empty"] = self.empty
         return payload
 
 
@@ -71,6 +68,7 @@ class KnowledgeSyncResult:
     status: str
     stats: dict[str, int]
     cursor: dict[str, Any]
+    corpus_empty: bool
     error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -79,6 +77,7 @@ class KnowledgeSyncResult:
             "status": self.status,
             "stats": self.stats,
             "cursor": self.cursor,
+            "corpus_empty": self.corpus_empty,
         }
         if self.error:
             payload["error"] = self.error
@@ -484,7 +483,7 @@ async def _sync_state(
     source: str,
     cursor: dict[str, Any],
     status: str,
-    stats: KnowledgeSyncStats,
+    stats: dict[str, int],
     run_at: datetime,
 ) -> None:
     state = await session.get(KnowledgeSyncState, source)
@@ -494,18 +493,24 @@ async def _sync_state(
     state.cursor = dict(cursor)
     state.last_run_at = run_at
     state.last_status = status
-    state.last_stats = stats.to_dict()
+    state.last_stats = dict(stats)
     await session.flush()
 
 
-async def _record_empty_corpus(
+async def _finalize_sync(
     session: AsyncSession,
     *,
     source: str,
+    state_cursor: dict[str, Any],
+    result_cursor: dict[str, Any],
+    status: str,
     stats: KnowledgeSyncStats,
-) -> None:
-    """Expose a successfully scanned source with no searchable index rows."""
+    run_at: datetime,
+    error: str | None = None,
+) -> KnowledgeSyncResult:
+    """Persist one sync outcome and expose its current searchable corpus state."""
 
+    stats_payload = stats.to_dict()
     active_item_id = await session.scalar(
         select(KnowledgeItem.id)
         .where(
@@ -514,7 +519,23 @@ async def _record_empty_corpus(
         )
         .limit(1)
     )
-    stats.empty = int(active_item_id is None)
+    corpus_empty = active_item_id is None
+    await _sync_state(
+        session,
+        source=source,
+        cursor=state_cursor,
+        status=status,
+        stats=stats_payload,
+        run_at=run_at,
+    )
+    return KnowledgeSyncResult(
+        source=source,
+        status=status,
+        stats=stats_payload,
+        cursor=result_cursor,
+        corpus_empty=corpus_empty,
+        error=error,
+    )
 
 
 async def _ingest_drafts(
@@ -618,40 +639,29 @@ async def sync_connector(
         )
         if pending:
             stats.pending = len(pending)
-            await _sync_state(
+            return await _finalize_sync(
                 session,
                 source=source,
-                cursor=_pending_cursor(
+                state_cursor=_pending_cursor(
                     committed_cursor=committed_cursor,
                     proposed_cursor=proposed_cursor,
                     entries=pending,
                 ),
+                result_cursor=committed_cursor,
                 status="pending",
                 stats=stats,
                 run_at=run_at,
             )
-            return KnowledgeSyncResult(
-                source=source,
-                status="pending",
-                stats=stats.to_dict(),
-                cursor=committed_cursor,
-            )
 
         status = "ok" if stats.failed == 0 else "degraded"
-        await _record_empty_corpus(session, source=source, stats=stats)
-        await _sync_state(
+        return await _finalize_sync(
             session,
             source=source,
-            cursor=proposed_cursor,
+            state_cursor=proposed_cursor,
+            result_cursor=proposed_cursor,
             status=status,
             stats=stats,
             run_at=run_at,
-        )
-        return KnowledgeSyncResult(
-            source=source,
-            status=status,
-            stats=stats.to_dict(),
-            cursor=proposed_cursor,
         )
 
     cursor = dict(stored_cursor)
@@ -659,20 +669,15 @@ async def sync_connector(
         drafts, new_cursor = await connector.enumerate_changed(session, cursor)
     except Exception as exc:
         stats.failed = 1
-        await _sync_state(
+        logger.exception("Knowledge connector %s enumeration failed", source)
+        return await _finalize_sync(
             session,
             source=source,
-            cursor=cursor,
+            state_cursor=cursor,
+            result_cursor=cursor,
             status="failed",
             stats=stats,
             run_at=run_at,
-        )
-        logger.exception("Knowledge connector %s enumeration failed", source)
-        return KnowledgeSyncResult(
-            source=source,
-            status="failed",
-            stats=stats.to_dict(),
-            cursor=cursor,
             error=str(exc),
         )
 
@@ -716,23 +721,18 @@ async def sync_connector(
             stats=stats,
             run_at=run_at,
         )
-        await _sync_state(
+        return await _finalize_sync(
             session,
             source=source,
-            cursor=_pending_cursor(
+            state_cursor=_pending_cursor(
                 committed_cursor=cursor,
                 proposed_cursor=dict(new_cursor),
                 entries=entries,
             ),
+            result_cursor=cursor,
             status="pending",
             stats=stats,
             run_at=run_at,
-        )
-        return KnowledgeSyncResult(
-            source=source,
-            status="pending",
-            stats=stats.to_dict(),
-            cursor=cursor,
         )
 
     if admission_fallbacks:
@@ -746,20 +746,14 @@ async def sync_connector(
         )
 
     status = "ok" if stats.failed == 0 else "degraded"
-    await _record_empty_corpus(session, source=source, stats=stats)
-    await _sync_state(
+    return await _finalize_sync(
         session,
         source=source,
-        cursor=dict(new_cursor),
+        state_cursor=dict(new_cursor),
+        result_cursor=dict(new_cursor),
         status=status,
         stats=stats,
         run_at=run_at,
-    )
-    return KnowledgeSyncResult(
-        source=source,
-        status=status,
-        stats=stats.to_dict(),
-        cursor=dict(new_cursor),
     )
 
 

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -30,21 +30,13 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.reconstructive_memory import (
-    MemoryAssertionNode,
-    MemoryEdgeNode,
-    MemoryNode,
-    MemoryNodeEmbedding,
-    MemorySource,
-    MemorySpan,
-)
+from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector, _draft_for_issue
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
-from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
@@ -298,11 +290,7 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
-            MemorySource.__table__,
-            MemorySpan.__table__,
             MemoryNode.__table__,
-            MemoryNodeEmbedding.__table__,
-            MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
         ]
     )
@@ -453,7 +441,7 @@ async def test_memory_connector_mirrors_only_shared_source_backed_memories(
                 updated_at,
                 content_kind="preference",
                 title="Private preference",
-                text="This user-private summary must remain in memory only.",
+                text="This private content must remain in memory only.",
                 scope="personal",
                 org_id=None,
                 user_id="22222222-2222-4222-8222-222222222222",
@@ -474,6 +462,7 @@ async def test_memory_connector_mirrors_only_shared_source_backed_memories(
         "failed": 0,
         "truncated": 0,
     }
+    assert result.to_dict()["corpus_empty"] is False
     assert result.cursor == {"updated_at": updated_at.isoformat(), "id": 13}
     assert [item.source_ref for item in items] == ["memory_node:11"]
     assert items[0].source == "memory"
@@ -513,78 +502,11 @@ async def test_memory_connector_reports_an_empty_searchable_corpus(session):
         "skipped": 0,
         "failed": 0,
         "truncated": 0,
-        "empty": 1,
     }
+    assert result.corpus_empty is True
+    assert result.to_dict()["corpus_empty"] is True
     assert state is not None
     assert state.last_stats == result.stats
-
-
-async def test_memory_connector_indexes_the_content_kind_produced_by_ingestion(
-    session,
-    embedding_runtime,
-    monkeypatch,
-):
-    del embedding_runtime
-    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
-
-    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
-    ingested = await ingest_memory_source(
-        session,
-        content=(
-            "Release ownership stays with the agent already working the ticket. "
-            "New workers must inspect active assignments before claiming it."
-        ),
-        content_kind="decision",
-        source_kind="contract_test",
-        source_ref="knowledge-memory-contract",
-        org_id=_ORG_ID,
-        visibility="team",
-        scope_key="engineering",
-        confidence=0.9,
-    )
-
-    first = await sync_connector(session, MemoryConnector(max_items=20))
-    mirrored_refs = list(
-        (
-            await session.scalars(
-                select(KnowledgeItem.source_ref).where(
-                    KnowledgeItem.source == "memory"
-                )
-            )
-        ).all()
-    )
-    produced_kinds = set(
-        (
-            await session.scalars(
-                select(MemoryNode.node_kind).where(
-                    MemoryNode.id.in_(
-                        [
-                            ingested.content_node_id,
-                            *ingested.tag_node_ids,
-                            *ingested.cue_node_ids,
-                        ]
-                    )
-                )
-            )
-        ).all()
-    )
-
-    assert produced_kinds == {"content", "tag", "cue"}
-    assert mirrored_refs == [f"memory_node:{ingested.content_node_id}"]
-    assert first.stats == {
-        "ingested": 1,
-        "skipped": 0,
-        "failed": 0,
-        "truncated": 0,
-    }
-
-    unchanged = await sync_connector(session, MemoryConnector(max_items=20))
-    assert unchanged.stats == {
-        "ingested": 0,
-        "skipped": 0,
-        "failed": 0,
-        "truncated": 0,
-    }
 
 
 async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(
@@ -599,7 +521,7 @@ async def test_memory_connector_resumes_a_bounded_same_timestamp_backfill(
                 node_id,
                 updated_at,
                 content_kind="lesson",
-                title=f"Consolidated lesson {node_id}",
+                title=f"Source-backed lesson {node_id}",
                 text=f"Durable lesson body {node_id}",
                 visibility="team",
             )
@@ -742,8 +664,8 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
         "skipped": 0,
         "failed": 0,
         "truncated": 0,
-        "empty": 1,
     }
+    assert result.corpus_empty is True
     assert result.cursor == {"updated_at": withdrawn_at.isoformat(), "id": 41}
     assert mirrored is not None
     assert mirrored.archived_at.replace(tzinfo=timezone.utc) == withdrawn_at

--- a/tests/test_knowledge_index.py
+++ b/tests/test_knowledge_index.py
@@ -30,13 +30,21 @@ from brain.platform.db.models.knowledge import (
     KnowledgeSyncState,
 )
 from brain.platform.db.models.org import Org, User
-from brain.platform.db.models.reconstructive_memory import MemoryEdgeNode, MemoryNode
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemoryNodeEmbedding,
+    MemorySource,
+    MemorySpan,
+)
 from brain.systems.knowledge.connectors.base import KnowledgeDraft
 from brain.systems.knowledge.connectors.domain_records import DomainRecordsConnector
 from brain.systems.knowledge.connectors.github import GitHubConnector, _draft_for_issue
 from brain.systems.knowledge.connectors.memory import MemoryConnector
 from brain.systems.knowledge.search import reciprocal_rank_fusion, search_knowledge
 from brain.systems.knowledge.service import RAW_TEXT_MAX_CHARS, sync_connector
+from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
 from brain.systems.external_agents import service as external_agents
 from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
 from brain.systems.cortex.project_context.github import (
@@ -147,7 +155,7 @@ def _memory_node(
     node_id: int,
     at: datetime,
     *,
-    node_kind: str = "summary",
+    node_kind: str = "content",
     content_kind: str = "decision",
     title: str | None = None,
     text: str | None = None,
@@ -290,7 +298,11 @@ async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
             KnowledgeItem.__table__,
             KnowledgeItemEmbedding.__table__,
             KnowledgeSyncState.__table__,
+            MemorySource.__table__,
+            MemorySpan.__table__,
             MemoryNode.__table__,
+            MemoryNodeEmbedding.__table__,
+            MemoryAssertionNode.__table__,
             MemoryEdgeNode.__table__,
         ]
     )
@@ -409,7 +421,7 @@ async def test_domain_records_connector_advances_and_resumes_watermark_with_id_t
     ) == ["domain_record:1", "domain_record:2", "domain_record:3"]
 
 
-async def test_memory_connector_mirrors_only_shared_consolidated_memories(
+async def test_memory_connector_mirrors_only_shared_source_backed_memories(
     session,
     embedding_runtime,
 ):
@@ -429,10 +441,10 @@ async def test_memory_connector_mirrors_only_shared_consolidated_memories(
             _memory_node(
                 12,
                 updated_at,
-                node_kind="content",
+                node_kind="summary",
                 content_kind="decision",
-                title="Unconsolidated source",
-                text="This source memory must not be mirrored yet.",
+                title="Unproduced derived summary",
+                text="This hypothetical derived node must not define the mirror contract.",
                 visibility="org",
                 confidence=0.7,
             ),
@@ -475,19 +487,103 @@ async def test_memory_connector_mirrors_only_shared_consolidated_memories(
     assert items[0].entities == ["decision", "engineering"]
     assert items[0].extra == {
         "archived": False,
-        "consolidated": True,
         "confidence": 0.92,
         "freshness_status": "fresh",
         "memory_type": "decision",
-        "node_kind": "summary",
+        "node_kind": "content",
         "org_id": _ORG_ID,
         "scope": "engineering",
         "sensitivity": "low",
+        "source_backed": True,
         "source_type": "reconstructive_memory_node",
         "superseded": False,
         "superseded_by": None,
         "truth_status": "active",
         "visibility": "org",
+    }
+
+
+async def test_memory_connector_reports_an_empty_searchable_corpus(session):
+    result = await sync_connector(session, MemoryConnector(max_items=10))
+    state = await session.get(KnowledgeSyncState, "memory")
+
+    assert result.status == "ok"
+    assert result.stats == {
+        "ingested": 0,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+        "empty": 1,
+    }
+    assert state is not None
+    assert state.last_stats == result.stats
+
+
+async def test_memory_connector_indexes_the_content_kind_produced_by_ingestion(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    ingested = await ingest_memory_source(
+        session,
+        content=(
+            "Release ownership stays with the agent already working the ticket. "
+            "New workers must inspect active assignments before claiming it."
+        ),
+        content_kind="decision",
+        source_kind="contract_test",
+        source_ref="knowledge-memory-contract",
+        org_id=_ORG_ID,
+        visibility="team",
+        scope_key="engineering",
+        confidence=0.9,
+    )
+
+    first = await sync_connector(session, MemoryConnector(max_items=20))
+    mirrored_refs = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem.source_ref).where(
+                    KnowledgeItem.source == "memory"
+                )
+            )
+        ).all()
+    )
+    produced_kinds = set(
+        (
+            await session.scalars(
+                select(MemoryNode.node_kind).where(
+                    MemoryNode.id.in_(
+                        [
+                            ingested.content_node_id,
+                            *ingested.tag_node_ids,
+                            *ingested.cue_node_ids,
+                        ]
+                    )
+                )
+            )
+        ).all()
+    )
+
+    assert produced_kinds == {"content", "tag", "cue"}
+    assert mirrored_refs == [f"memory_node:{ingested.content_node_id}"]
+    assert first.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+
+    unchanged = await sync_connector(session, MemoryConnector(max_items=20))
+    assert unchanged.stats == {
+        "ingested": 0,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
     }
 
 
@@ -646,6 +742,7 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
         "skipped": 0,
         "failed": 0,
         "truncated": 0,
+        "empty": 1,
     }
     assert result.cursor == {"updated_at": withdrawn_at.isoformat(), "id": 41}
     assert mirrored is not None
@@ -653,14 +750,14 @@ async def test_memory_connector_scrubs_a_mirror_when_visibility_becomes_private(
     assert mirrored.title == "Memory no longer shared"
     assert (
         mirrored.summary
-        == "This consolidated memory is no longer shared with the workspace."
+        == "This memory is no longer shared with the workspace."
     )
     assert mirrored.raw_text == ""
     assert "launch detail" not in mirrored.search_text
     assert mirrored.extra == {
         "archived": True,
         "mirror_status": "visibility_withdrawn",
-        "node_kind": "summary",
+        "node_kind": "content",
         "org_id": _ORG_ID,
         "truth_status": "active",
         "visibility": "private",

--- a/tests/test_knowledge_memory_contract.py
+++ b/tests/test_knowledge_memory_contract.py
@@ -1,0 +1,151 @@
+"""Writer-to-reader contract tests for the reconstructive-memory mirror."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+from brain.kernel.config import KNOWLEDGE_EMBEDDING_DIM
+from brain.platform.db.models.knowledge import (
+    KnowledgeItem,
+    KnowledgeItemEmbedding,
+    KnowledgeSyncState,
+)
+from brain.platform.db.models.reconstructive_memory import (
+    MemoryAssertionNode,
+    MemoryEdgeNode,
+    MemoryNode,
+    MemorySource,
+    MemorySpan,
+)
+from brain.systems.knowledge.connectors.memory import MemoryConnector
+from brain.systems.knowledge.service import sync_connector
+from brain.systems.reconstructive_memory.ingestion import ingest_memory_source
+from brain.systems.runtime_settings.memory import EmbeddingRuntimeConfig
+
+
+_ORG_ID = "11111111-1111-4111-8111-111111111111"
+
+
+@pytest.fixture
+async def session(async_sqlite_session_factory, sqlite_postgres_ddl_patch):
+    del sqlite_postgres_ddl_patch
+    SQLiteTypeCompiler.visit_VECTOR = lambda self, type_, **kw: "TEXT"
+    SQLiteTypeCompiler.visit_Vector = lambda self, type_, **kw: "TEXT"
+    return await async_sqlite_session_factory(
+        [
+            MemorySource.__table__,
+            MemorySpan.__table__,
+            MemoryNode.__table__,
+            MemoryAssertionNode.__table__,
+            MemoryEdgeNode.__table__,
+            KnowledgeItem.__table__,
+            KnowledgeItemEmbedding.__table__,
+            KnowledgeSyncState.__table__,
+        ]
+    )
+
+
+@pytest.fixture
+def embedding_runtime(monkeypatch):
+    from brain.systems.memory import embeddings as embedding_client
+    from brain.systems.runtime_settings import memory as runtime_settings
+
+    runtime = EmbeddingRuntimeConfig(
+        backend="api",
+        provider="gemini",
+        api_model="test-knowledge-embedding",
+        cpu_model="unused",
+        dimensions=KNOWLEDGE_EMBEDDING_DIM,
+        api_key="test-key",
+    )
+    vector = np.zeros(KNOWLEDGE_EMBEDDING_DIM, dtype=np.float32)
+    vector[0] = 1.0
+
+    async def fake_runtime_config(session, *, include_secret=True):
+        del session, include_secret
+        return runtime
+
+    monkeypatch.setattr(
+        runtime_settings,
+        "async_get_embedding_runtime_config",
+        fake_runtime_config,
+    )
+    monkeypatch.setattr(
+        embedding_client,
+        "embed_document",
+        lambda text, runtime_config=None: vector,
+    )
+    return runtime
+
+
+async def test_memory_connector_indexes_the_content_kind_produced_by_ingestion(
+    session,
+    embedding_runtime,
+    monkeypatch,
+):
+    del embedding_runtime
+    from brain.systems.reconstructive_memory import embeddings as memory_embeddings
+
+    monkeypatch.setattr(memory_embeddings, "embed_node_texts", AsyncMock())
+    ingested = await ingest_memory_source(
+        session,
+        content=(
+            "Release ownership stays with the agent already working the ticket. "
+            "New workers must inspect active assignments before claiming it."
+        ),
+        content_kind="decision",
+        source_kind="contract_test",
+        source_ref="knowledge-memory-contract",
+        org_id=_ORG_ID,
+        visibility="team",
+        scope_key="engineering",
+        confidence=0.9,
+    )
+
+    first = await sync_connector(session, MemoryConnector(max_items=20))
+    mirrored_refs = list(
+        (
+            await session.scalars(
+                select(KnowledgeItem.source_ref).where(
+                    KnowledgeItem.source == "memory"
+                )
+            )
+        ).all()
+    )
+    produced_kinds = set(
+        (
+            await session.scalars(
+                select(MemoryNode.node_kind).where(
+                    MemoryNode.id.in_(
+                        [
+                            ingested.content_node_id,
+                            *ingested.tag_node_ids,
+                            *ingested.cue_node_ids,
+                        ]
+                    )
+                )
+            )
+        ).all()
+    )
+
+    assert produced_kinds == {"content", "tag", "cue"}
+    assert mirrored_refs == [f"memory_node:{ingested.content_node_id}"]
+    assert first.stats == {
+        "ingested": 1,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }
+
+    unchanged = await sync_connector(session, MemoryConnector(max_items=20))
+    assert unchanged.stats == {
+        "ingested": 0,
+        "skipped": 0,
+        "failed": 0,
+        "truncated": 0,
+    }


### PR DESCRIPTION
Closes #586.

## The bug in one line

The memory mirror shipped in #584 selected `node_kind == "summary"` — a kind **no code in the repo ever writes** — so on a real database it indexes **zero rows**, silently, with a green test suite.

The three sites that write a node kind (`brain/systems/reconstructive_memory/ingestion.py`) produce `content`, `tag`, `cue`. `summary` is *recognised* by `EMBEDDABLE_NODE_KINDS` but never *produced*. The connector's own tests hand-built `summary` rows as fixtures, so they proved the connector works given such rows — never that such rows exist. That is the gap between a green suite and a working feature.

## The decision the ticket asked for

The ticket demanded a deliberate choice, not the easier one:

- **(a)** teach consolidation to emit `summary` nodes, or
- **(b)** make the mirror select the kinds that actually exist.

**This takes (b).** `content` is the assertion-backed, human-searchable node; `tag` and `cue` are retrieval scaffolding and should not be searchable knowledge. Option (a) would add a production kind consumed by nothing but this mirror. The independent code-quality review agreed with the seam and specifically rejected reusing `EMBEDDABLE_NODE_KINDS`, which also contains `summary`/`procedure`/`policy` and would silently broaden what gets shared into the org-wide index.

`_KNOWLEDGE_NODE_KINDS = ("content",)` is default-deny: adding a kind to the mirror is now an explicit edit.

## Also in here

- **An empty corpus is now visible.** "0 ingested, no error" read identically to "nothing changed" — the exact failure mode that let this ship. `KnowledgeSyncResult.corpus_empty` is a typed boolean, always present, and lands in the per-source JSON the sync job already logs. It sits *beside* `stats`, not inside it: the counters bucket stays counters-only.
- **A real contract test.** `tests/test_knowledge_memory_contract.py` drives the actual `ingest_memory_source` path and asserts the kinds it produces are exactly `{content, tag, cue}` and that only the content node gets mirrored. It fails if the connector ever again selects a kind the writer does not emit — which a fixture-fed test cannot do.
- **One `_finalize_sync` owner** for all five terminal paths of `sync_connector`, so a future exit cannot skip persisting state or computing corpus health.
- **No migration.** Deliberate: `knowledge_sync_state` needs no new column, and migration numbering is contested across concurrent branches in this repo.

## How to check it without reading the diff

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-586-memory-mirror
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_knowledge_index.py tests/test_knowledge_memory_contract.py \
  tests/test_architecture_boundaries.py -q
```

- **Targeted: 24 passed.**
- **Full suite** (`-m "not requires_db"`): **4540 passed, 14 skipped, 0 failed** — identical count before and after the review fix pass, and run outside the Codex sandbox so the usual `127.0.0.1` bind errors do not appear at all.

The one thing tests cannot prove is the live corpus. After this deploys, on illo-dev:

```sql
SELECT node_kind, count(*) FROM memory_nodes GROUP BY node_kind;
SELECT count(*) FROM knowledge_items WHERE source = 'memory';
```

The first should show `content`/`tag`/`cue` and **no** `summary`; the second should be non-zero after a sync — it is zero today. The `knowledge_index_sync` job log will now carry `"corpus_empty": false` for the `memory` source; if it still says `true` with `content` rows present, that is a real failure and worth reopening.

## Assumptions I made

- `content` is the only kind that should be shared today. If org/team `procedure` or `policy` nodes ever get produced, they are a deliberate one-line addition to `_KNOWLEDGE_NODE_KINDS`, not an oversight.
- The ground-truth query above was **never run** — the live-database read was blocked by a permission gate in both sessions that touched this ticket. The argument rests on an exhaustive code search for `node_kind=` writes (three sites, none `summary`), which is sound on its own, but the query is still worth 10 seconds of your time after deploy.
- Visibility filtering is unchanged: only `org`/`team` nodes mirror; private nodes still produce the withdrawn-mirror scrub.

## Acceptance checks

1. A memory node produced by real ingestion (`content`, visibility `org`/`team`) appears in `knowledge_items` after a sync; `tag` and `cue` nodes do not.
2. A source that scans cleanly with nothing searchable reports `corpus_empty: true` in the job log — distinguishable from an idle no-op sync.
3. A node whose visibility flips to `private` is still scrubbed to the withdrawn mirror.
4. `KnowledgeSyncStats` holds only accumulating counters — no flags.

<sub>Built by a Codex worker under Routine R3, reviewed by the orchestrator (correctness) and a separate Codex code-quality pass (structure — 2 blocking findings, both folded into the second commit).</sub>
