### PR TITLE
fix(deploy): fail the checks when the worker is present but drained

### DIFF
--- a/deploy/scripts/compose-runtime-lib.sh
+++ b/deploy/scripts/compose-runtime-lib.sh
@@ -129,6 +129,22 @@ container_running_known() {
   esac
 }
 
+# Read through the contract inside the worker container so its process-generation
+# validation decides whether the published phase is live. Docker/exec failures
+# remain unknown rather than borrowing a stale fact.
+worker_lifecycle_phase_observation() {
+  local id="$1"
+  local phase
+
+  if phase="$(
+    docker exec "$id" python -m brain.contracts.worker_lifecycle read 2>/dev/null
+  )"; then
+    printf '%s\n' "$phase"
+  else
+    printf 'unknown\n'
+  fi
+}
+
 # Combine Docker liveness and the generation-validated lifecycle phase into the
 # only cover answer consumed by swap waits. The Python contract owns the policy:
 # inspect/exec failures and `starting` are pending, a positive `claiming` record
@@ -139,9 +155,7 @@ worker_cover_observation() {
 
   if container_running_known "$id"; then
     container_state=running
-    phase="$(
-      docker exec "$id" python -m brain.contracts.worker_lifecycle read 2>/dev/null
-    )" || phase=unknown
+    phase="$(worker_lifecycle_phase_observation "$id")"
   else
     running_state=$?
     if [ "$running_state" = "1" ]; then
@@ -294,10 +308,40 @@ assert_single_running_worker() {
 # infers it.
 STACK_REQUIRED_SERVICES="${STACK_REQUIRED_SERVICES:-postgres api web worker scheduler}"
 
-# Distinct exit codes so a monitor can tell an invisible failure from an obvious
-# one: 3 = inert (stack up, required service missing), 4 = fully down.
+# Distinct exit codes so a monitor can tell the failure modes apart:
+# 3 = inert (stack up, required service missing), 4 = fully down,
+# 5 = worker present but drained.
 STACK_INERT_EXIT_CODE=3
 STACK_DOWN_EXIT_CODE=4
+STACK_DRAINED_EXIT_CODE=5
+
+# Presence and effective worker capacity are shared deploy invariants. Keeping
+# both verdicts here means the post-deploy doctor and the continuous monitor
+# cannot disagree about a container that exists but has permanently stopped
+# claiming. The lifecycle contract owns both generation-safe phase reads and
+# phase policy; this assertion only turns its observation into an operator
+# verdict.
+assert_worker_not_drained() {
+  local worker_id phase observation
+
+  worker_id="$(worker_container_id)"
+  if [ -z "$worker_id" ]; then
+    echo "Worker lifecycle check failed: could not identify the Compose-managed worker container." >&2
+    return 1
+  fi
+
+  phase="$(worker_lifecycle_phase_observation "$worker_id")"
+  if ! observation="$(worker_lifecycle_cover_observe running "$phase")"; then
+    echo "Worker lifecycle check failed: could not evaluate container $worker_id phase '${phase:-unknown}'." >&2
+    return 1
+  fi
+  if [ "$observation" = "definitively_not_claiming" ]; then
+    echo "Stack is DRAINED: worker container $worker_id reports lifecycle phase '${phase:-unknown}' and cannot claim new AgentRuns." >&2
+    echo "Recovery: inspect the worker logs, then recreate it with: docker compose --env-file \"$ENV_FILE\" -f \"$COMPOSE_FILE\" up -d --force-recreate --no-deps worker" >&2
+    return "$STACK_DRAINED_EXIT_CODE"
+  fi
+  return 0
+}
 
 assert_stack_not_inert() {
   local required="${*:-$STACK_REQUIRED_SERVICES}"

--- a/deploy/scripts/doctor.sh
+++ b/deploy/scripts/doctor.sh
@@ -7,7 +7,7 @@ COMPOSE_DIR="$ROOT/deploy/compose"
 COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
 ENV_FILE="${ILLO_COMPOSE_ENV_FILE:-$COMPOSE_DIR/.env}"
 
-# Provides compose() plus the shared stack invariants (assert_stack_not_inert).
+# Provides compose() plus the shared stack invariants.
 source "$SCRIPT_DIR/compose-runtime-lib.sh"
 source "$SCRIPT_DIR/agent-run-queue-health-lib.sh"
 
@@ -223,6 +223,16 @@ elif tmp_running="$(mktemp "${TMPDIR:-/tmp}/illospace-compose-running.XXXXXX")" 
       pass "every always-on service is running"
     else
       fail "Compose stack is missing an always-on service; see the report above"
+    fi
+
+    if printf '%s\n' "$running" | grep -qx worker; then
+      worker_lifecycle_status=0
+      assert_worker_not_drained || worker_lifecycle_status=$?
+      if [ "$worker_lifecycle_status" -eq 0 ]; then
+        pass "worker lifecycle phase is not drained"
+      else
+        fail "worker cannot claim new AgentRuns; see the lifecycle report above"
+      fi
     fi
 
     for service in $DOCTOR_REQUIRED_SERVICES; do

--- a/deploy/scripts/inert-stack-check.sh
+++ b/deploy/scripts/inert-stack-check.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fails loudly when the Compose stack is up but a required service is absent --
-# the "healthy but inert" state, where every HTTP probe passes while Illo cannot
-# do any work (#527). Cheap enough for a cron entry or systemd timer, and the
-# exit codes are distinct so an external watcher (#512) can tell an invisible
-# failure from an obvious one.
+# Fails loudly when the Compose stack is up but a required service is absent or
+# its worker has drained -- states where every HTTP probe passes while Illo
+# cannot do any work (#527, #549). Cheap enough for a cron entry or systemd
+# timer, with distinct exit codes for an external watcher (#512).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -21,8 +20,9 @@ Usage: ./illo deploy inert-check
        deploy/scripts/inert-stack-check.sh
 
 Asserts that every always-on Compose service is running whenever the stack is up
-at all, then checks that old queued AgentRuns still have recent claim activity.
-The worker owns AgentRun execution and the cycle-scheduler thread, so its absence
+at all, that the worker has not entered a drained lifecycle phase, then checks
+that old queued AgentRuns still have recent claim activity. The worker owns
+AgentRun execution and the cycle-scheduler thread, so its absence, drained phase,
 or a wedged runner can leave the stack answering HTTP health checks normally
 while Illo does nothing.
 
@@ -34,6 +34,7 @@ Exit codes:
   1  the check could not inspect Compose or the AgentRun queue is starved
   $STACK_INERT_EXIT_CODE  INERT   - stack is up but a required service is absent
   $STACK_DOWN_EXIT_CODE  DOWN    - no Compose services are running at all
+  $STACK_DRAINED_EXIT_CODE  DRAINED - worker is present but cannot claim new runs
 EOF
 }
 
@@ -64,9 +65,12 @@ set +a
 status=0
 assert_stack_not_inert || status=$?
 if [ "$status" -eq 0 ]; then
+  assert_worker_not_drained || status=$?
+fi
+if [ "$status" -eq 0 ]; then
   assert_agent_run_queue_not_starved || status=1
 fi
 if [ "$status" -eq 0 ]; then
-  echo "OK:    every required Compose service is running and the AgentRun queue is moving ($STACK_REQUIRED_SERVICES)"
+  echo "OK:    every required Compose service is running, the worker is not drained, and the AgentRun queue is moving ($STACK_REQUIRED_SERVICES)"
 fi
 exit "$status"

--- a/tests/test_deploy_queue_health.py
+++ b/tests/test_deploy_queue_health.py
@@ -168,15 +168,25 @@ def test_deploy_entrypoint_fails_when_worker_is_draining(
 
 
 def test_drained_worker_verdict_has_one_owner_and_both_entrypoints_call_it():
+    """Both entrypoints must reach the drained verdict through the shared owner.
+
+    Asserted as a dependency boundary, not as phase spelling: an entrypoint that
+    read the lifecycle phase itself could reimplement the policy under any name
+    (`stopped`, `shutting_down`) and evade a check for the word "draining".
+    """
+
     runtime_lib = (ROOT / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
     doctor = (ROOT / "deploy" / "scripts" / "doctor.sh").read_text()
     inert_check = (ROOT / "deploy" / "scripts" / "inert-stack-check.sh").read_text()
 
     assert runtime_lib.count("assert_worker_not_drained() {") == 1
-    assert "assert_worker_not_drained" in doctor
-    assert "assert_worker_not_drained" in inert_check
-    assert "draining" not in doctor
-    assert "draining" not in inert_check
+    for entrypoint in (doctor, inert_check):
+        assert "assert_worker_not_drained" in entrypoint
+        # The lifecycle contract and its shell adapter are the owner's dependencies,
+        # never an entrypoint's -- reaching for either means the policy was forked.
+        assert "brain.contracts.worker_lifecycle" not in entrypoint
+        assert "worker_lifecycle_cover_observe" not in entrypoint
+        assert "worker_lifecycle_phase_observation" not in entrypoint
     assert "$STACK_DRAINED_EXIT_CODE  DRAINED" in inert_check
 
 

--- a/tests/test_deploy_queue_health.py
+++ b/tests/test_deploy_queue_health.py
@@ -55,6 +55,10 @@ def _fake_docker(tmp_path: Path) -> Path:
               echo healthy
               exit 0
             fi
+            if [ "${{1:-}}" = "exec" ] && [[ "$args" == *"brain.contracts.worker_lifecycle read"* ]]; then
+              echo "${{FAKE_WORKER_PHASE:-claiming}}"
+              exit 0
+            fi
             if [ "${{1:-}}" = "compose" ]; then
               case "$args" in
                 *" config")
@@ -69,8 +73,12 @@ def _fake_docker(tmp_path: Path) -> Path:
                   exit 0
                   ;;
                 *"brain.app.cli.agent_run_queue_health"*"--stale-after-seconds 725"*"--runner-concurrency 8")
-                  echo "{QUEUE_STARVATION_DIAGNOSTIC}" >&2
-                  exit 1
+                  if [ "${{FAKE_QUEUE_STARVED:-1}}" = "1" ]; then
+                    echo "{QUEUE_STARVATION_DIAGNOSTIC}" >&2
+                    exit 1
+                  fi
+                  echo "AgentRun queue healthy: no stale queued backlog."
+                  exit 0
                   ;;
                 *"pg_extension"*)
                   echo vector
@@ -92,10 +100,17 @@ def _fake_docker(tmp_path: Path) -> Path:
     return bin_dir
 
 
-def _entrypoint_env(tmp_path: Path) -> dict[str, str]:
+def _entrypoint_env(
+    tmp_path: Path,
+    *,
+    worker_phase: str = "claiming",
+    queue_starved: bool = True,
+) -> dict[str, str]:
     env = os.environ.copy()
     env["ILLO_COMPOSE_ENV_FILE"] = str(_deploy_env_file(tmp_path))
     env["PATH"] = f"{_fake_docker(tmp_path)}:{env['PATH']}"
+    env["FAKE_WORKER_PHASE"] = worker_phase
+    env["FAKE_QUEUE_STARVED"] = "1" if queue_starved else "0"
     return env
 
 
@@ -120,6 +135,49 @@ def test_deploy_entrypoint_fails_when_agent_run_queue_is_starved(
 
     assert result.returncode == 1, result.stdout + result.stderr
     assert QUEUE_STARVATION_DIAGNOSTIC in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "expected_exit_code"),
+    [
+        ("deploy/scripts/doctor.sh", 1),
+        ("deploy/scripts/inert-stack-check.sh", 5),
+    ],
+)
+def test_deploy_entrypoint_fails_when_worker_is_draining(
+    entrypoint: str,
+    expected_exit_code: int,
+    tmp_path: Path,
+):
+    result = subprocess.run(
+        [str(ROOT / entrypoint)],
+        cwd=ROOT,
+        env=_entrypoint_env(
+            tmp_path,
+            worker_phase="draining",
+            queue_starved=False,
+        ),
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == expected_exit_code, result.stdout + result.stderr
+    assert "container-id" in result.stderr
+    assert "draining" in result.stderr
+    assert "cannot claim new AgentRuns" in result.stderr
+
+
+def test_drained_worker_verdict_has_one_owner_and_both_entrypoints_call_it():
+    runtime_lib = (ROOT / "deploy" / "scripts" / "compose-runtime-lib.sh").read_text()
+    doctor = (ROOT / "deploy" / "scripts" / "doctor.sh").read_text()
+    inert_check = (ROOT / "deploy" / "scripts" / "inert-stack-check.sh").read_text()
+
+    assert runtime_lib.count("assert_worker_not_drained() {") == 1
+    assert "assert_worker_not_drained" in doctor
+    assert "assert_worker_not_drained" in inert_check
+    assert "draining" not in doctor
+    assert "draining" not in inert_check
+    assert "$STACK_DRAINED_EXIT_CODE  DRAINED" in inert_check
 
 
 def test_queue_health_adapter_passes_deploy_policy_to_api_cli():

--- a/tests/test_worker_swap_deploy.py
+++ b/tests/test_worker_swap_deploy.py
@@ -465,6 +465,55 @@ def test_restarted_container_cannot_reuse_a_stale_claiming_record(tmp_path):
     assert "last cover observation: pending" in result.stderr
 
 
+def test_draining_worker_fails_the_shared_capacity_assertion(tmp_path):
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "publish_phase worker-1 draining\n"
+            "assert_worker_not_drained"
+        ),
+    )
+    result = _run(script)
+
+    assert "STATUS=5" in result.stdout
+    assert "worker-1" in result.stderr
+    assert "draining" in result.stderr
+    assert "cannot claim new AgentRuns" in result.stderr
+
+
+def test_claiming_worker_passes_the_shared_capacity_assertion(tmp_path):
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "publish_phase worker-1 claiming\n"
+            "assert_worker_not_drained"
+        ),
+    )
+    result = _run(script)
+
+    assert "STATUS=0" in result.stdout
+    assert result.stderr == ""
+
+
+def test_stale_draining_record_is_not_accepted_as_the_live_worker_phase(tmp_path):
+    state = tmp_path / "s"
+    script = _simulator(
+        state,
+        body=(
+            "publish_phase worker-1 draining\n"
+            'printf "worker-generation-2\\n" > "$STATE/worker-1.generation"\n'
+            "assert_worker_not_drained"
+        ),
+    )
+    result = _run(script)
+
+    assert "STATUS=0" in result.stdout
+    assert "DRAINED" not in result.stderr
+    assert "draining" not in result.stderr
+
+
 def test_a_confirmed_handoff_exit_ends_the_drain_wait(tmp_path):
     """A definite Docker exit is lost cover; only an unanswered inspect is pending."""
 


### PR DESCRIPTION
Part of #549 — the **cause** half. Does not close the issue on its own; #579 shipped the consequence half.

## Why there are two checks, not one

`deploy/scripts/doctor.sh` passed with **0 warnings** during the illo-dev deploy that left zero AgentRun capacity. Every service was present, every HTTP probe healthy — the worker just could not claim. The issue split the missing assertions deliberately, because they fire at different times:

- **The consequence** — runs queued past a threshold with nothing claiming them. Shipped in #579, on `main` now. It needs a backlog to have accumulated before it can speak.
- **The cause** — the worker is present but reports a *drained* lifecycle phase. **This PR.** It fires immediately, before any run has had time to queue.

Both can now fail independently, which is the point: the cause check catches the deploy that just broke capacity, the consequence check catches a wedged runner or a worker that never started.

## Where the verdict lives, and why there

Beside `assert_stack_not_inert` in `deploy/scripts/compose-runtime-lib.sh` — **not** in `doctor.sh`. That file already documents why presence has exactly one owner: *a monitor and a deploy cannot disagree about whether the stack is inert.* Effective worker capacity is the same class of shared invariant, so `assert_worker_not_drained()` is defined once and called by both `doctor.sh` (post-deploy) and `inert-stack-check.sh` (continuously, cron/timer).

Phase *policy* stays where #558 put it — `brain/contracts/worker_lifecycle.py`, which owns generation-safe reads so a stale record from a previous process generation is never mistaken for the live phase. The shell only turns the contract's cover observation into an operator verdict; neither entrypoint interprets a lifecycle phase itself, and a test enforces that as a dependency boundary.

`inert-stack-check.sh` gets **exit code 5 (DRAINED)** beside 3 (inert) and 4 (down), documented in its `usage()`, so an external watcher can tell the three apart. `doctor.sh` folds it into its existing aggregate `fail` (exit 1) — the same convention #579 used for queue starvation.

Incidentally, this **removed** a duplication rather than adding one: the inline `docker exec … worker_lifecycle read` was extracted to `worker_lifecycle_phase_observation()`, and the pre-existing `worker_cover_observation` now shares it.

## How to check it without reading the diff

```bash
cd /Users/redamjahed/Documents/UwearDev/.codex-worktrees/illospace-549-drained-cause
/Users/redamjahed/Documents/UwearDev/illospace-project/venv/bin/python -m pytest \
  tests/test_worker_swap_deploy.py tests/test_deploy_queue_health.py -q
```

**27 passed.** Full suite (`-m "not requires_db"`): **4544 passed, 14 skipped, 0 failed** — 4538 on `main` plus the 6 tests added here. `bash -n` clean on all three scripts.

To see the verdict itself, with a worker whose phase you control:

```bash
deploy/scripts/inert-stack-check.sh; echo "exit=$?"
```

A drained worker prints `Stack is DRAINED: worker container <id> reports lifecycle phase 'draining' and cannot claim new AgentRuns`, names the recreate command, and exits **5**. A claiming worker prints the OK line and exits 0.

## Acceptance checks

1. Worker present and healthy but **drained** → `inert-stack-check.sh` exits 5 and the doctor fails, both naming the container and the phase.
2. Worker present and **claiming** → both pass; the inert (3), down (4) and queue-starvation verdicts are unaffected.
3. A **stale** phase record from a previous process generation is not accepted as the live phase (asserted through the existing container simulator).
4. The predicate has exactly one definition, and both entrypoints reach it through that owner rather than reading the lifecycle contract themselves.

## Assumptions and known gaps

- `shellcheck` is **not installed** on this host, so the shell is `bash -n`-clean but unlinted. Worth a lint pass in CI if it runs there.
- The check reads the phase via `docker exec` into the worker; an exec failure yields `unknown`, which the contract treats as pending — a Docker outage will not be reported as "drained".
- **Follow-up named by the code-quality review, not done here:** `tests/test_deploy_queue_health.py` now covers both queue starvation and drained-worker health, so its name has drifted — it wants to be `test_deploy_runtime_health.py`. Left alone deliberately: a shared-test-file rename is pure churn against every branch in flight right now.

<sub>Built by a Codex worker under Routine R3, reviewed by the orchestrator (correctness, contract vocabulary verified against `brain/contracts/worker_lifecycle.py`) and a separate Codex code-quality pass (structure: APPROVE WITH NITS, no blocking findings; one nit fixed in the second commit, the other named above).</sub>
