### PR TITLE
fix(runs): scope the open-ask reply lock away from agent_runs (#609)

### DIFF
--- a/brain/systems/runs/open_asks.py
+++ b/brain/systems/runs/open_asks.py
@@ -760,7 +760,7 @@ async def record_inbound_slack_obligation_answer(
                     OpenAsk.status == OPEN_ASK_STATUS,
                 )
                 .order_by(OpenAsk.id.asc())
-                .with_for_update()
+                .with_for_update(of=[OpenAsk, ObligationNotice])
             )
         ).all()
     )

--- a/tests/test_agent_run_lock_ordering.py
+++ b/tests/test_agent_run_lock_ordering.py
@@ -38,6 +38,32 @@ class _PostgresBind:
     dialect = postgresql.dialect()
 
 
+async def test_inbound_slack_obligation_answer_only_locks_mutated_tables():
+    from brain.systems.runs.open_asks import (
+        record_inbound_slack_obligation_answer,
+    )
+
+    session = SimpleNamespace(execute=AsyncMock(return_value=_Rows([])))
+
+    settled = await record_inbound_slack_obligation_answer(
+        session,
+        org_id="11111111-1111-4111-8111-111111111111",
+        channel_id="CALERTS",
+        thread_ts="1784741786.046759",
+        slack_user_id="UREDA",
+        message_ts="1784743141.000100",
+        answer_text="Issue #1221 is filed.",
+    )
+
+    statement = session.execute.await_args.args[0]
+    sql = str(statement.compile(dialect=postgresql.dialect()))
+    lock_clause = sql.rsplit("FOR UPDATE", maxsplit=1)[1].strip()
+
+    assert settled == 0
+    assert "FOR UPDATE OF open_asks, obligation_notices" in sql
+    assert lock_clause == "OF open_asks, obligation_notices"
+
+
 class _SharedRowLocks:
     def __init__(self):
         self._condition = asyncio.Condition()


### PR DESCRIPTION
Closes #609.

## What it does

One line. The inbound-Slack-reply path that closes typed obligations
(`brain/systems/runs/open_asks.py`) ran a three-table joined `select` ending in a
**bare** `.with_for_update()`. On PostgreSQL that locks the selected rows of *every*
joined table — so answering an open ask in Slack took an `agent_runs` row lock that
this code neither needs nor declares. It only *reads* `AgentRunRow.metadata_`.

```diff
-                .with_for_update()
+                .with_for_update(of=[OpenAsk, ObligationNotice])
```

Rendered SQL goes from `FOR UPDATE` to `FOR UPDATE OF open_asks, obligation_notices`.
`agent_runs` is left unlocked. This narrows a lock — it does not change what is mutated,
and no behavior changes.

## Why it matters

#575 established one lock order for `agent_runs` (ascending run id, rows before advisory
locks), enforced for locks taken *through* `AsyncAgentRunStore`'s helpers. This lock was
taken outside that owner, in `OpenAsk.id` order, so it could interleave against the
ordered path — the deadlock class #567 hit in production.

It was also invisible to the acceptance criterion of #573 ("no `FOR UPDATE` on
`AgentRunRow` outside the lock owner"), because the call site never names `AgentRunRow`
in a `with_for_update` — the lock is implied by the join. Any grep-shaped audit passes it.

## Verification

- **New regression test** `test_inbound_slack_obligation_answer_only_locks_mutated_tables`
  in `tests/test_agent_run_lock_ordering.py`, asserting on the statement compiled against
  the **PostgreSQL dialect** (SQLite ignores `FOR UPDATE` entirely, so a default-dialect
  test would prove nothing). It asserts the lock clause is *exactly*
  `OF open_asks, obligation_notices`, so a future unscoped `FOR UPDATE` fails it.
- **RED → GREEN proven**, not assumed: with the fix stashed the test fails (SQL ends in a
  bare `FOR UPDATE`); restored, it passes.
- **Full suite: 4,539 passed, 92 skipped, 0 failed** — run by the orchestrator outside the
  Codex sandbox. (Inside the sandbox the same suite reports 1 failed + 5 errors; those are
  socket-bind and Docker-socket denials in `test_openai_user_auth_connect.py` /
  `test_gpu_integration.py`, a sandbox artifact confirmed on three prior runs, not a
  regression.)
- Audited the rest of the file: no second bare `with_for_update()` on a joined select —
  the remaining ones are single-table selects and correctly scoped.

## Acceptance checks

1. `FOR UPDATE OF open_asks, obligation_notices` is the rendered lock clause; `agent_runs`
   is not in it.
2. Answering an open ask in Slack still closes the obligation exactly as before — the
   existing open-ask/obligation tests are untouched and green.
3. The new test fails if anyone re-broadens the lock.

## Out of scope, deliberately

The same blind spot exists at three other call sites — `evidence_health.py` (a bare
`.with_for_update()` at ~:483), `chantier_continuation.py` and `deadlines.py` (a
row-level write lock via bare `UPDATE … WHERE`, with no `with_for_update` anywhere).
Those belong to **#573**, whose re-scoped brief is a cross-cutting change to the lock
owner in `store.py`. Fixing them here would collide with that work. See the R3 report for
the #573 verdict.

<sub>Draft opened by Routine R3. Implemented by a Codex worker, reviewed and verified by
the orchestrator. No thermo-nuclear structure review was run: the production diff is a
single line, below the threshold where a maintainability pass earns its cost.</sub>